### PR TITLE
fix: let google-vertex fall back to ADC auth

### DIFF
--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -247,7 +247,7 @@ export async function runBtwSideQuestion(
     throw new Error("No active session context.");
   }
 
-  const { model, authProfileId } = await resolveRuntimeModel({
+  const { model, authProfileId, authProfileIdSource } = await resolveRuntimeModel({
     cfg: params.cfg,
     provider: params.provider,
     model: params.model,
@@ -262,6 +262,7 @@ export async function runBtwSideQuestion(
     model,
     cfg: params.cfg,
     profileId: authProfileId,
+    allowGoogleVertexAdcFallbackForExplicitProfile: authProfileIdSource !== "user",
     agentDir: params.agentDir,
   });
   const apiKey = requireApiKey(apiKeyInfo, model.provider);

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -228,6 +228,74 @@ describe("getApiKeyForModel", () => {
     );
   });
 
+  it("falls back to ADC env auth when an explicit google-vertex profile is stale", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-adc-"));
+    const adcPath = path.join(tempDir, "application_default_credentials.json");
+    await fs.writeFile(adcPath, "{}\n", "utf8");
+
+    try {
+      await withEnvAsync(
+        {
+          GOOGLE_APPLICATION_CREDENTIALS: adcPath,
+          GOOGLE_CLOUD_PROJECT: "vertex-test-project",
+          GCLOUD_PROJECT: undefined,
+          GOOGLE_CLOUD_LOCATION: "global",
+          GOOGLE_CLOUD_API_KEY: undefined,
+        },
+        async () => {
+          const resolved = await resolveApiKeyForProvider({
+            provider: "google-vertex",
+            profileId: "google-vertex:default",
+            store: {
+              version: 1,
+              profiles: {
+                "google-vertex:default": {
+                  type: "token",
+                  provider: "google-vertex",
+                  token: "stale-token",
+                  expires: Date.now() - 60_000,
+                },
+              },
+            },
+          });
+
+          expect(resolved.apiKey).toBe("<authenticated>");
+          expect(resolved.source).toBe("gcloud adc");
+          expect(resolved.profileId).toBeUndefined();
+        },
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps explicit profile failures strict for non-google-vertex providers", async () => {
+    await withEnvAsync(
+      {
+        OPENAI_API_KEY: "openai-env-test-key", // pragma: allowlist secret
+      },
+      async () => {
+        await expect(
+          resolveApiKeyForProvider({
+            provider: "openai",
+            profileId: "openai:default",
+            store: {
+              version: 1,
+              profiles: {
+                "openai:default": {
+                  type: "token",
+                  provider: "openai",
+                  token: "stale-token",
+                  expires: Date.now() - 60_000,
+                },
+              },
+            },
+          }),
+        ).rejects.toThrow('No credentials found for profile "openai:default".');
+      },
+    );
+  });
+
   it("hasAvailableAuthForProvider returns false when no provider auth is available", async () => {
     await withEnvAsync(
       {

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -246,6 +246,7 @@ describe("getApiKeyForModel", () => {
           const resolved = await resolveApiKeyForProvider({
             provider: "google-vertex",
             profileId: "google-vertex:default",
+            allowGoogleVertexAdcFallbackForExplicitProfile: true,
             store: {
               version: 1,
               profiles: {
@@ -283,6 +284,7 @@ describe("getApiKeyForModel", () => {
           resolveApiKeyForProvider({
             provider: "google-vertex",
             profileId: "google-vertex:default",
+            allowGoogleVertexAdcFallbackForExplicitProfile: true,
             store: {
               version: 1,
               profiles: {
@@ -298,6 +300,45 @@ describe("getApiKeyForModel", () => {
         ).rejects.toThrow('No credentials found for profile "google-vertex:default".');
       },
     );
+  });
+
+  it("keeps explicit google-vertex profile locks strict by default", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-locked-"));
+    const adcPath = path.join(tempDir, "application_default_credentials.json");
+    await fs.writeFile(adcPath, "{}\n", "utf8");
+
+    try {
+      await withEnvAsync(
+        {
+          GOOGLE_APPLICATION_CREDENTIALS: adcPath,
+          GOOGLE_CLOUD_PROJECT: "vertex-test-project",
+          GCLOUD_PROJECT: undefined,
+          GOOGLE_CLOUD_LOCATION: "global",
+          GOOGLE_CLOUD_API_KEY: undefined,
+        },
+        async () => {
+          await expect(
+            resolveApiKeyForProvider({
+              provider: "google-vertex",
+              profileId: "google-vertex:default",
+              store: {
+                version: 1,
+                profiles: {
+                  "google-vertex:default": {
+                    type: "token",
+                    provider: "google-vertex",
+                    token: "stale-token",
+                    expires: Date.now() - 60_000,
+                  },
+                },
+              },
+            }),
+          ).rejects.toThrow('No credentials found for profile "google-vertex:default".');
+        },
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps explicit profile failures strict for non-google-vertex providers", async () => {

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -269,6 +269,37 @@ describe("getApiKeyForModel", () => {
     }
   });
 
+  it("preserves the explicit google-vertex profile error when ADC fallback is unavailable", async () => {
+    await withEnvAsync(
+      {
+        GOOGLE_APPLICATION_CREDENTIALS: undefined,
+        GOOGLE_CLOUD_PROJECT: undefined,
+        GCLOUD_PROJECT: undefined,
+        GOOGLE_CLOUD_LOCATION: undefined,
+        GOOGLE_CLOUD_API_KEY: undefined,
+      },
+      async () => {
+        await expect(
+          resolveApiKeyForProvider({
+            provider: "google-vertex",
+            profileId: "google-vertex:default",
+            store: {
+              version: 1,
+              profiles: {
+                "google-vertex:default": {
+                  type: "token",
+                  provider: "google-vertex",
+                  token: "stale-token",
+                  expires: Date.now() - 60_000,
+                },
+              },
+            },
+          }),
+        ).rejects.toThrow('No credentials found for profile "google-vertex:default".');
+      },
+    );
+  });
+
   it("keeps explicit profile failures strict for non-google-vertex providers", async () => {
     await withEnvAsync(
       {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -284,6 +284,7 @@ export async function resolveApiKeyForProvider(params: {
   cfg?: OpenClawConfig;
   profileId?: string;
   preferredProfile?: string;
+  allowGoogleVertexAdcFallbackForExplicitProfile?: boolean;
   store?: AuthProfileStore;
   agentDir?: string;
 }): Promise<ResolvedProviderAuth> {
@@ -301,7 +302,10 @@ export async function resolveApiKeyForProvider(params: {
     });
     if (!resolved) {
       explicitProfileError = new Error(`No credentials found for profile "${profileId}".`);
-      if (normalized !== "google-vertex") {
+      if (
+        normalized !== "google-vertex" ||
+        !params.allowGoogleVertexAdcFallbackForExplicitProfile
+      ) {
         throw explicitProfileError;
       }
     } else {
@@ -555,6 +559,7 @@ export async function getApiKeyForModel(params: {
   cfg?: OpenClawConfig;
   profileId?: string;
   preferredProfile?: string;
+  allowGoogleVertexAdcFallbackForExplicitProfile?: boolean;
   store?: AuthProfileStore;
   agentDir?: string;
 }): Promise<ResolvedProviderAuth> {
@@ -563,6 +568,8 @@ export async function getApiKeyForModel(params: {
     cfg: params.cfg,
     profileId: params.profileId,
     preferredProfile: params.preferredProfile,
+    allowGoogleVertexAdcFallbackForExplicitProfile:
+      params.allowGoogleVertexAdcFallbackForExplicitProfile,
     store: params.store,
     agentDir: params.agentDir,
   });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -289,6 +289,8 @@ export async function resolveApiKeyForProvider(params: {
 }): Promise<ResolvedProviderAuth> {
   const { provider, cfg, profileId, preferredProfile } = params;
   const store = params.store ?? ensureAuthProfileStore(params.agentDir);
+  const normalized = normalizeProviderId(provider);
+  let explicitProfileError: Error | null = null;
 
   if (profileId) {
     const resolved = await resolveApiKeyForProfile({
@@ -298,15 +300,19 @@ export async function resolveApiKeyForProvider(params: {
       agentDir: params.agentDir,
     });
     if (!resolved) {
-      throw new Error(`No credentials found for profile "${profileId}".`);
+      explicitProfileError = new Error(`No credentials found for profile "${profileId}".`);
+      if (normalized !== "google-vertex") {
+        throw explicitProfileError;
+      }
+    } else {
+      const mode = store.profiles[profileId]?.type;
+      return {
+        apiKey: resolved.apiKey,
+        profileId,
+        source: `profile:${profileId}`,
+        mode: mode === "oauth" ? "oauth" : mode === "token" ? "token" : "api-key",
+      };
     }
-    const mode = store.profiles[profileId]?.type;
-    return {
-      apiKey: resolved.apiKey,
-      profileId,
-      source: `profile:${profileId}`,
-      mode: mode === "oauth" ? "oauth" : mode === "token" ? "token" : "api-key",
-    };
   }
 
   const authOverride = resolveProviderAuthOverride(cfg, provider);
@@ -314,31 +320,35 @@ export async function resolveApiKeyForProvider(params: {
     return resolveAwsSdkAuthInfo();
   }
 
-  const order = resolveAuthProfileOrder({
-    cfg,
-    store,
-    provider,
-    preferredProfile,
-  });
-  for (const candidate of order) {
-    try {
-      const resolved = await resolveApiKeyForProfile({
-        cfg,
-        store,
-        profileId: candidate,
-        agentDir: params.agentDir,
-      });
-      if (resolved) {
-        const mode = store.profiles[candidate]?.type;
-        return {
-          apiKey: resolved.apiKey,
+  if (!profileId) {
+    const order = resolveAuthProfileOrder({
+      cfg,
+      store,
+      provider,
+      preferredProfile,
+    });
+    for (const candidate of order) {
+      try {
+        const resolved = await resolveApiKeyForProfile({
+          cfg,
+          store,
           profileId: candidate,
-          source: `profile:${candidate}`,
-          mode: mode === "oauth" ? "oauth" : mode === "token" ? "token" : "api-key",
-        };
+          agentDir: params.agentDir,
+        });
+        if (resolved) {
+          const mode = store.profiles[candidate]?.type;
+          return {
+            apiKey: resolved.apiKey,
+            profileId: candidate,
+            source: `profile:${candidate}`,
+            mode: mode === "oauth" ? "oauth" : mode === "token" ? "token" : "api-key",
+          };
+        }
+      } catch (err) {
+        log.debug?.(
+          `auth profile "${candidate}" failed for provider "${provider}": ${String(err)}`,
+        );
       }
-    } catch (err) {
-      log.debug?.(`auth profile "${candidate}" failed for provider "${provider}": ${String(err)}`);
     }
   }
 
@@ -361,7 +371,6 @@ export async function resolveApiKeyForProvider(params: {
     return syntheticLocalAuth;
   }
 
-  const normalized = normalizeProviderId(provider);
   if (authOverride === undefined && normalized === "amazon-bedrock") {
     return resolveAwsSdkAuthInfo();
   }
@@ -380,6 +389,10 @@ export async function resolveApiKeyForProvider(params: {
   });
   if (pluginMissingAuthMessage) {
     throw new Error(pluginMissingAuthMessage);
+  }
+
+  if (explicitProfileError) {
+    throw explicitProfileError;
   }
 
   const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -647,6 +647,7 @@ export async function runEmbeddedPiAgent(
           model: runtimeModel,
           cfg: params.config,
           profileId: candidate,
+          allowGoogleVertexAdcFallbackForExplicitProfile: !lockedProfileId,
           store: authStore,
           agentDir,
         });


### PR DESCRIPTION
## Summary

- Problem: `google-vertex` runs could fail with `No credentials found for profile "google-vertex:default"` even when ADC was valid and configured.
- Root cause: `resolveApiKeyForProvider()` treated an explicit `profileId` as terminal. Once `google-vertex:default` went stale, it threw immediately and never reached the existing ADC/env fallback path.
- What changed: when an explicit `google-vertex` profile cannot be resolved, auth resolution now preserves that failure but continues to try the existing ADC/env fallback chain. Other providers keep the original strict explicit-profile behavior.
- Why this fix: it is the narrowest change that restores the intended Vertex auth fallback without weakening explicit profile semantics for unrelated providers.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Integrations
- [x] Auth / tokens
- [ ] UI / DX
- [ ] API / contracts
- [ ] CI/CD / infra

## Linked Issue

- Closes #49885

## User-visible Behavior

If `google-vertex:default` is stale or expired but ADC is still valid, OpenClaw now falls back to ADC instead of failing early with `No credentials found for profile "google-vertex:default"`.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Reproduction

1. Configure `google-vertex` with an explicit default profile.
2. Let that stored profile become stale/expired.
3. Keep ADC valid via `GOOGLE_APPLICATION_CREDENTIALS` or `gcloud auth application-default login`, plus `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION`.
4. Run an embedded/session request through `google-vertex`.

### Expected

OpenClaw should continue using ADC.

### Actual before this change

Auth resolution failed immediately on the stale explicit profile and never reached ADC fallback.

## Testing

- `git diff --check -- src/agents/model-auth.ts src/agents/model-auth.profiles.test.ts`
- `pnpm exec oxfmt --check src/agents/model-auth.ts src/agents/model-auth.profiles.test.ts`
- `pnpm exec vitest run src/agents/model-auth.profiles.test.ts -t "google-vertex|non-google-vertex"`
  - Result before the 10s guard stopped the command tail: `1 passed` file, `2 passed` tests
- `codex review --base origin/main`
  - Not usable in this environment because local Codex config has an unsupported `approvals_reviewer=never` value
- `pnpm check`
  - Exceeded the local 10s execution guard before producing a stable result, so it was stopped rather than left hanging

## Risk / Compatibility

- Narrow behavior change: only explicit `google-vertex` profile failures now fall through to existing ADC/env auth.
- Explicit stale profiles for other providers still fail fast.
- If ADC/env auth is not actually available, the original explicit-profile error is still preserved.
