### PR TITLE
docs: add Desktop Apps & GUI Clients section

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ Prefer a GUI over the terminal? These community-built desktop apps wrap OpenClaw
 
 | App | Platform | Description |
 |---|---|---|
-| [OpenClaw Easy](https://github.com/openclaw-easy/openclaw-easy-desktop) | macOS, Windows | Official desktop app — no terminal, no WSL2, drag-and-drop install |
+| [OpenClaw Easy](https://github.com/openclaw-easy/openclaw-easy-desktop) | macOS, Windows | Community desktop app — no terminal, no WSL2, drag-and-drop install |
 
 > **Want to list your app here?** Open a PR adding a row to this table.
 

--- a/README.md
+++ b/README.md
@@ -490,6 +490,17 @@ by Peter Steinberger and the community.
 - [steipete.me](https://steipete.me)
 - [@openclaw](https://x.com/openclaw)
 
+## Desktop Apps & GUI Clients
+
+Prefer a GUI over the terminal? These community-built desktop apps wrap OpenClaw in a one-click installer:
+
+| App | Platform | Description |
+|---|---|---|
+| [OpenClaw Easy](https://github.com/openclaw-easy/openclaw-easy-desktop) | macOS, Windows | Official desktop app — no terminal, no WSL2, drag-and-drop install |
+
+> **Want to list your app here?** Open a PR adding a row to this table.
+
+
 ## Community
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, maintainers, and how to submit PRs.


### PR DESCRIPTION
## Summary

Adds a new **Desktop Apps & GUI Clients** section to the README, just before the Community section.

Many users who discover OpenClaw are non-technical and struggle with terminal setup, WSL2 on Windows, config files, etc. This section points them to [OpenClaw Easy](https://github.com/openclaw-easy/openclaw-easy-desktop) — a community-built, open-source desktop app that wraps OpenClaw in a one-click installer for macOS and Windows.

The section also includes an open invitation for other GUI app builders to list their tools, making it a reusable community resource.

## Changes

- Added `## Desktop Apps & GUI Clients` section between the main content and `## Community`
- Links to `openclaw-easy/openclaw-easy-desktop` with platform and description
- Includes a "Want to list your app?" invite for other community builders

## Why it helps OpenClaw

- Lowers the barrier to entry for non-technical users
- Keeps them within the OpenClaw ecosystem rather than seeking alternatives
- Validates the community ecosystem growing around the project