### PR TITLE
fix: avoid inheriting session key for isolated cron jobs

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -82,11 +82,12 @@ describe("cron tool", () => {
     callId: string;
     agentSessionKey: string;
     jobSessionKey?: string;
+    job?: Record<string, unknown>;
   }): Promise<string | undefined> {
     const tool = createTestCronTool({ agentSessionKey: params.agentSessionKey });
     await tool.execute(params.callId, {
       action: "add",
-      job: {
+      job: params.job ?? {
         name: "wake-up",
         schedule: { at: new Date(123).toISOString() },
         ...(params.jobSessionKey ? { sessionKey: params.jobSessionKey } : {}),
@@ -293,6 +294,38 @@ describe("cron tool", () => {
       jobSessionKey: "agent:main:telegram:group:-100123:topic:99",
     });
     expect(sessionKey).toBe("agent:main:telegram:group:-100123:topic:99");
+  });
+
+  it("does not stamp isolated agentTurn cron.add with caller sessionKey when missing", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const sessionKey = await executeAddAndReadSessionKey({
+      callId: "call-agentturn-isolated-no-session-key",
+      agentSessionKey: "agent:main:bluebubbles:direct:+12253851518",
+      job: {
+        name: "watcher",
+        schedule: { at: new Date(123).toISOString() },
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "watch stuff" },
+      },
+    });
+    expect(sessionKey).toBeUndefined();
+  });
+
+  it("stamps current-bound agentTurn cron.add with caller sessionKey when resolved", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const sessionKey = await executeAddAndReadSessionKey({
+      callId: "call-agentturn-current-session-key",
+      agentSessionKey: "agent:main:bluebubbles:direct:+12253851518",
+      job: {
+        name: "watcher",
+        schedule: { at: new Date(123).toISOString() },
+        sessionTarget: "current",
+        payload: { kind: "agentTurn", message: "watch stuff" },
+      },
+    });
+    expect(sessionKey).toBe("agent:main:bluebubbles:direct:+12253851518");
   });
 
   it("adds recent context for systemEvent reminders when contextMessages > 0", async () => {

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -535,7 +535,20 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
                 (job as { agentId?: string }).agentId = agentId;
               }
             }
-            if (!("sessionKey" in job) && resolvedSessionKey) {
+            const payloadKind =
+              "payload" in job &&
+              (job as { payload?: { kind?: string } }).payload &&
+              typeof (job as { payload?: { kind?: string } }).payload?.kind === "string"
+                ? (job as { payload?: { kind?: string } }).payload?.kind
+                : undefined;
+            const sessionTarget =
+              typeof (job as { sessionTarget?: string }).sessionTarget === "string"
+                ? (job as { sessionTarget?: string }).sessionTarget?.trim().toLowerCase()
+                : "";
+            const shouldInheritSessionKey = !(
+              payloadKind === "agentTurn" && sessionTarget === "isolated"
+            );
+            if (!("sessionKey" in job) && resolvedSessionKey && shouldInheritSessionKey) {
               (job as { sessionKey?: string }).sessionKey = resolvedSessionKey;
             }
           }


### PR DESCRIPTION
## Summary
- stop isolated `agentTurn` cron jobs from silently inheriting the current session key during creation
- preserve explicit current-session binding only when requested via `sessionTarget="current"` or `session:...`
- add regression coverage for isolated vs current-bound cron creation

## Repro context
1. Start a real conversation on a phone in a channel-backed session.
2. Open the OpenClaw Web UI later and attach to that same conversation from the session dropdown.
3. Create an isolated cron `agentTurn` job from that attached session without explicitly setting `sessionTarget="current"` or a custom `sessionKey`.
4. The created cron job inherits the current chat session identity even though the run itself is isolated.
5. Downstream routing/failure handling can then use misleading inherited session affinity.

Observed stored job shape:
- `agentId: "main"`
- `sessionKey: "agent:main:bluebubbles:direct:+12253851518"`
- `sessionTarget: "isolated"`

## Why this change
Isolated cron jobs should be isolated by default. Inheriting the caller session key should only happen when that binding is explicitly requested.

## Testing
- `npm exec --yes vitest run src/agents/tools/cron-tool.test.ts`