### PR TITLE
security: clarify fail-open denyCommands audit warning

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1026,7 +1026,7 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
     severity: "warn",
     title: "Some gateway.nodes.denyCommands entries are ineffective",
     detail:
-      "gateway.nodes.denyCommands uses exact node command-name matching only (for example `system.run`), not shell-text filtering inside a command payload.\n" +
+      "gateway.nodes.denyCommands uses exact node command-name matching only (for example `system.run`), not shell-text filtering inside a command payload. Typos and pattern-like entries silently fail open, so commands you expected to block may still run.\n" +
       detailParts.map((entry) => `- ${entry}`).join("\n"),
     remediation:
       `Use exact command names (for example: ${examples.join(", ")}). ` +
@@ -1304,7 +1304,7 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
       title: "Open groupPolicy with elevated tools enabled",
       detail:
         `Found groupPolicy="open" at:\n${openGroups.map((p) => `- ${p}`).join("\n")}\n` +
-        "With tools.elevated enabled, a prompt injection in those rooms can become a high-impact incident.",
+        "With tools.elevated enabled, a prompt injection in those rooms can become a high-impact incident. Mention gates reduce noise, but they are not a trust boundary.",
       remediation: `Set groupPolicy="allowlist" and keep elevated allowlists extremely tight.`,
     });
   }


### PR DESCRIPTION
## Summary
- clarify that ineffective `gateway.nodes.denyCommands` entries fail open
- make the audit warning explicit about typos and pattern-like entries leaving commands runnable

## Why
It is easy to read the current warning as a lint issue instead of a security boundary issue. If a deny entry is misspelled or written as a pattern, the command is still allowed. The audit should say that plainly.

## Testing
- pnpm vitest run src/security/audit.test.ts