### PR TITLE
security: clarify mention gates are not a trust boundary

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1304,7 +1304,7 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
       title: "Open groupPolicy with elevated tools enabled",
       detail:
         `Found groupPolicy="open" at:\n${openGroups.map((p) => `- ${p}`).join("\n")}\n` +
-        "With tools.elevated enabled, a prompt injection in those rooms can become a high-impact incident.",
+        "With tools.elevated enabled, a prompt injection in those rooms can become a high-impact incident. Mention gates reduce noise, but they are not a trust boundary.",
       remediation: `Set groupPolicy="allowlist" and keep elevated allowlists extremely tight.`,
     });
   }


### PR DESCRIPTION
## Summary
- strengthen the open-group elevated-tools audit message
- make it explicit that mention gates reduce noise but are not a trust boundary

## Why
The current wording is directionally correct, but it is still easy to rationalize an open group as safe because it is mention-gated. That is not enough once elevated/runtime/fs tooling is exposed. The audit should say that directly.

## Testing
- pnpm vitest run src/security/audit.test.ts
- pnpm vitest run src/channels/plugins/group-policy-warnings.test.ts