### PR TITLE
fix(discord): add WebSocket handshake timeout to prevent stuck reconnects

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -9,6 +9,7 @@ import WebSocket from "ws";
 
 const DISCORD_GATEWAY_BOT_URL = "https://discord.com/api/v10/gateway/bot";
 const DEFAULT_DISCORD_GATEWAY_URL = "wss://gateway.discord.gg/";
+const DISCORD_GATEWAY_HANDSHAKE_TIMEOUT_MS = 30_000;
 const DISCORD_GATEWAY_INFO_TIMEOUT_MS = 10_000;
 
 type DiscordGatewayMetadataResponse = Pick<Response, "ok" | "status" | "text">;
@@ -255,10 +256,10 @@ function createGatewayPlugin(params: {
     }
 
     override createWebSocket(url: string) {
-      if (!params.wsAgent) {
-        return super.createWebSocket(url);
-      }
-      return new WebSocket(url, { agent: params.wsAgent });
+      return new WebSocket(url, {
+        handshakeTimeout: DISCORD_GATEWAY_HANDSHAKE_TIMEOUT_MS,
+        ...(params.wsAgent ? { agent: params.wsAgent } : {}),
+      });
     }
   }
 

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -256,6 +256,9 @@ function createGatewayPlugin(params: {
     }
 
     override createWebSocket(url: string) {
+      if (!url) {
+        throw new Error("Gateway URL is required");
+      }
       return new WebSocket(url, {
         handshakeTimeout: DISCORD_GATEWAY_HANDSHAKE_TIMEOUT_MS,
         ...(params.wsAgent ? { agent: params.wsAgent } : {}),


### PR DESCRIPTION
When the Discord WebSocket drops during a network transition (switching between Wi-Fi and Ethernet, ISP blip, VPN reconnect), the reconnect loop can hang forever.

**What happens:**
1. WebSocket closes with code 1006
2. Carbon schedules a reconnect and creates a new WebSocket
3. If the network is in a weird state (blackholed route, stalled TLS), the socket sits in CONNECTING forever
4. No `open`, `close`, or `error` event fires
5. The retry loop waits for a `close` event that never comes
6. Bot goes silent until manually restarted

**Root cause:**
The `ws` library supports a `handshakeTimeout` option, but neither Carbon nor OpenClaw sets it. Without a timeout, a stuck handshake blocks the entire reconnect chain. Carbon has 50 retry attempts configured but they never get a chance to fire.

**Fix:**
Set `handshakeTimeout: 30_000` (30 seconds) on all WebSocket connections created by `SafeGatewayPlugin.createWebSocket()`. After 30 seconds of no handshake, `ws` emits error + close, and Carbon's existing retry loop continues to the next attempt.

This also simplifies the `createWebSocket` override by always constructing the WebSocket with options, merging the proxy agent when present instead of branching.

The upstream fix belongs in Carbon's `GatewayPlugin.createWebSocket()` -- I'll file an issue there too. This patches it on the OpenClaw side so users don't have to wait for a Carbon release.

**Tested by:** Reproducing the issue by switching a Mac Mini between Starlink (Wi-Fi) and a LAN subnet (Ethernet) while the gateway was running. Without the fix, one network switch killed Discord for 18+ minutes until manual restart. With the fix, the reconnect loop would timeout after 30s and retry.