### PR TITLE
fix: prevent ghost media attachments from debounce buffer flatMap

### DIFF
--- a/extensions/telegram/src/bot-handlers.buffers.ts
+++ b/extensions/telegram/src/bot-handlers.buffers.ts
@@ -305,8 +305,11 @@ export function createTelegramInboundBufferRuntime(params: {
       const combinedText = entries
         .map((entry) => entry.msg.text ?? entry.msg.caption ?? "")
         .filter(Boolean)
-        .join("\n");
-      const combinedMedia = entries.flatMap((entry) => entry.allMedia);
+        .join("
+");
+      // Fix: only use last entry's media to prevent ghost attachments from debounce buffer
+      // See: https://github.com/openclaw/openclaw/issues/46655
+      const combinedMedia = entries.at(-1)?.allMedia ?? [];
       if (!combinedText.trim() && combinedMedia.length === 0) {
         return;
       }

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -227,7 +227,9 @@ export const registerTelegramHandlers = ({
         .map((entry) => entry.msg.text ?? entry.msg.caption ?? "")
         .filter(Boolean)
         .join("\n");
-      const combinedMedia = entries.flatMap((entry) => entry.allMedia);
+      // Fix: only use last entry's media to prevent ghost attachments from debounce buffer
+      // See: https://github.com/openclaw/openclaw/issues/46655
+      const combinedMedia = entries.at(-1)?.allMedia ?? [];
       if (!combinedText.trim() && combinedMedia.length === 0) {
         return;
       }


### PR DESCRIPTION
## Summary

Fixes #46655 — Ghost media from previous messages re-attaching to subsequent text-only messages.

## Root Cause

In the debounce flush handler, `entries.flatMap((entry) => entry.allMedia)` merges media from ALL buffered entries. When a photo message and a subsequent text message share the same debounce window, the photo's media ghost-attaches to the text message.

## Fix

Use only the last entry's `allMedia` instead of flatMapping all entries:

```typescript
// Before (bug):
const combinedMedia = entries.flatMap((entry) => entry.allMedia);

// After (fix):
const combinedMedia = entries.at(-1)?.allMedia ?? [];
```

This matches the existing pattern where `last.ctx` is already used as the authoritative context for the flushed message.

## Files Changed

- `extensions/telegram/src/bot-handlers.buffers.ts` — line 309
- `extensions/telegram/src/bot-handlers.runtime.ts` — line 230

## Impact

- Affects all channels using the shared debounce/dispatch layer (Telegram, WhatsApp, etc.)
- Observed on WhatsApp: gym photos ghost-attaching to subsequent voice messages
- The `entries.length === 1` fast path was already correct (using `last.allMedia`)

## Testing Notes

Reproduction: Send a photo, then quickly send a text/voice message. Before fix, the photo re-appears in the second message's context. After fix, only the second message's actual media (if any) is passed.