### PR TITLE
fix(feishu): gate @所有人 (@all) mentions behind respondToAtAll config

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -244,12 +244,18 @@ export function parseMergeForwardContent(params: {
   return lines.join("\n");
 }
 
-export function checkBotMentioned(event: FeishuMessageLike, botOpenId?: string): boolean {
+export function checkBotMentioned(
+  event: FeishuMessageLike,
+  botOpenId?: string,
+  respondToAtAll?: boolean,
+): boolean {
   if (!botOpenId) {
     return false;
   }
+  // @_all (@所有人) only triggers this bot when respondToAtAll is explicitly true.
+  // Default false prevents every bot in the group from responding simultaneously.
   if ((event.message.content ?? "").includes("@_all")) {
-    return true;
+    return respondToAtAll === true;
   }
   const mentions = event.message.mentions ?? [];
   if (mentions.length > 0) {

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { checkBotMentioned } from "./bot-content.js";
 import { parseFeishuMessageEvent } from "./bot.js";
 
 // Helper to build a minimal FeishuMessageEvent for testing
@@ -189,5 +190,72 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     });
     const ctx = parseFeishuMessageEvent(event as any, "ou_bot_123");
     expect(ctx.content).toBe("[Forwarded message: sc_abc123]");
+  });
+});
+
+describe("checkBotMentioned – @_all / respondToAtAll gating", () => {
+  const BOT_OPEN_ID = "ou_bot_123";
+
+  function makeMinimalEvent(content: string) {
+    return {
+      message: {
+        content,
+        message_type: "text",
+        mentions: [] as Array<{ key: string; name: string; id: { open_id?: string } }>,
+        chat_id: "oc_chat1",
+        message_id: "msg_1",
+      },
+      sender: {
+        sender_id: { open_id: "ou_sender", user_id: "u1" },
+      },
+    };
+  }
+
+  it("@_all returns false when respondToAtAll is undefined (default)", () => {
+    const event = makeMinimalEvent(JSON.stringify({ text: "@_all hello" }));
+    expect(checkBotMentioned(event, BOT_OPEN_ID)).toBe(false);
+  });
+
+  it("@_all returns false when respondToAtAll is false", () => {
+    const event = makeMinimalEvent(JSON.stringify({ text: "@_all hello" }));
+    expect(checkBotMentioned(event, BOT_OPEN_ID, false)).toBe(false);
+  });
+
+  it("@_all returns true when respondToAtAll is true", () => {
+    const event = makeMinimalEvent(JSON.stringify({ text: "@_all hello" }));
+    expect(checkBotMentioned(event, BOT_OPEN_ID, true)).toBe(true);
+  });
+
+  it("direct bot mention still works regardless of respondToAtAll", () => {
+    const event = makeMinimalEvent(JSON.stringify({ text: "hello" }));
+    event.message.mentions = [{ key: "@_user_1", name: "Bot", id: { open_id: BOT_OPEN_ID } }];
+    // Works without respondToAtAll
+    expect(checkBotMentioned(event, BOT_OPEN_ID)).toBe(true);
+    // Works with respondToAtAll=false
+    expect(checkBotMentioned(event, BOT_OPEN_ID, false)).toBe(true);
+    // Works with respondToAtAll=true
+    expect(checkBotMentioned(event, BOT_OPEN_ID, true)).toBe(true);
+  });
+});
+
+describe("parseFeishuMessageEvent – @_all respondToAtAll integration", () => {
+  const BOT_OPEN_ID = "ou_bot_123";
+
+  it("@_all message returns mentionedBot=false by default (no respondToAtAll)", () => {
+    const event = makeEvent("group", [], "@_all hello everyone");
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("@_all message returns mentionedBot=true when respondToAtAll=true is passed", () => {
+    const event = makeEvent("group", [], "@_all hello everyone");
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID, undefined, true);
+    expect(ctx.mentionedBot).toBe(true);
+  });
+
+  it("@_all message returns mentionedBot=false when respondToAtAll=false is passed", () => {
+    const event = makeEvent("group", [], "@_all hello everyone");
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID, undefined, false);
+    expect(ctx.mentionedBot).toBe(false);
   });
 });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -131,9 +131,10 @@ export function parseFeishuMessageEvent(
   event: FeishuMessageEvent,
   botOpenId?: string,
   _botName?: string,
+  respondToAtAll?: boolean,
 ): FeishuMessageContext {
   const rawContent = parseMessageContent(event.message.content, event.message.message_type);
-  const mentionedBot = checkBotMentioned(event, botOpenId);
+  const mentionedBot = checkBotMentioned(event, botOpenId, respondToAtAll);
   const hasAnyMention = (event.message.mentions?.length ?? 0) > 0;
   // Strip the bot's own mention so slash commands like @Bot /help retain
   // the leading /. This applies in both p2p *and* group contexts — the
@@ -259,7 +260,20 @@ export async function handleFeishuMessage(params: {
     return;
   }
 
-  let ctx = parseFeishuMessageEvent(event, botOpenId, botName);
+  // Resolve respondToAtAll before parsing so @_all gating applies during
+  // checkBotMentioned. We pass it as a parameter rather than resolving it
+  // inside checkBotMentioned because that function is a pure predicate with
+  // no access to config — keeping config resolution in the caller (here)
+  // preserves separation of concerns and testability.
+  // Uses event.message.chat_id directly (same value as ctx.chatId) because
+  // ctx isn't built yet at this point.
+  const earlyGroupConfig = resolveFeishuGroupConfig({
+    cfg: feishuCfg,
+    groupId: event.message.chat_id,
+  });
+  const respondToAtAll = earlyGroupConfig?.respondToAtAll ?? feishuCfg?.respondToAtAll ?? false;
+
+  let ctx = parseFeishuMessageEvent(event, botOpenId, botName, respondToAtAll);
   const isGroup = ctx.chatType === "group";
   const isDirect = !isGroup;
   const senderUserId = event.sender.sender_id.user_id?.trim() || undefined;
@@ -334,9 +348,7 @@ export async function handleFeishuMessage(params: {
     0,
     feishuCfg?.historyLimit ?? cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
   );
-  const groupConfig = isGroup
-    ? resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: ctx.chatId })
-    : undefined;
+  const groupConfig = isGroup ? earlyGroupConfig : undefined;
   const groupSession = isGroup
     ? resolveFeishuGroupSession({
         chatId: ctx.chatId,

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -141,6 +141,7 @@ const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
+    respondToAtAll: z.boolean().optional(),
     tools: ToolPolicySchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
@@ -164,6 +165,7 @@ const FeishuSharedConfigShape = {
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupSenderAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   requireMention: z.boolean().optional(),
+  respondToAtAll: z.boolean().optional(),
   groups: z.record(z.string(), FeishuGroupSchema.optional()).optional(),
   historyLimit: z.number().int().min(0).optional(),
   dmHistoryLimit: z.number().int().min(0).optional(),


### PR DESCRIPTION
## Summary

When a user sends @所有人 (@all) in a Feishu group chat, **all bots** in the group respond simultaneously because `checkBotMentioned()` unconditionally returns `true` for any message containing `@_all`.

Fixes #49761

## Root Cause

In `bot-content.ts`, `checkBotMentioned()` had:

```typescript
if ((event.message.content ?? '').includes('@_all')) {
    return true;  // ALL bots think they were mentioned
}
```

This treats @所有人 as a direct mention for every bot, causing all bots to respond at once.

## Fix

1. **Added `respondToAtAll` config option** (default: `false`) to both `FeishuSharedConfigShape` and `FeishuGroupSchema` in `config-schema.ts`

2. **Modified `checkBotMentioned()`** to accept an optional `respondToAtAll` parameter:
   - When `@_all` is detected and `respondToAtAll !== true` → returns `false` (bot ignores @所有人)
   - When `respondToAtAll === true` → returns `true` (opt-in behavior)

3. **Updated callsite in `bot.ts`** to resolve `respondToAtAll` from group config → account config → default `false`, following the same pattern as `requireMention`

### Config example

```yaml
channels:
  feishu:
    respondToAtAll: false  # default, bot ignores @所有人
    groups:
      "oc_xxx":
        respondToAtAll: true  # opt-in for specific group
```

## Testing

Added 4 new tests (22 total pass):
- @_all returns false when respondToAtAll is undefined (default)
- @_all returns false when respondToAtAll is explicitly false
- @_all returns true when respondToAtAll is true
- Direct bot mention still works regardless of respondToAtAll

Made-with: Claude Code (Claude Opus 4.6)