### PR TITLE
fix(feishu): fallback to type=media when file download returns 502

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -252,10 +252,16 @@ export async function downloadMessageResourceFeishu(params: {
       console.warn(
         `feishu: download with type=file returned 502, retrying with type=media (message=${messageId})`,
       );
-      response = await client.im.messageResource.get({
-        path: { message_id: messageId, file_key: normalizedFileKey },
-        params: { type: "media" },
-      });
+      try {
+        response = await client.im.messageResource.get({
+          path: { message_id: messageId, file_key: normalizedFileKey },
+          params: { type: "media" },
+        });
+      } catch {
+        // Retry also failed — throw the original 502 error so callers see
+        // the root cause rather than a potentially confusing secondary error.
+        throw err;
+      }
     } else {
       throw err;
     }

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -236,10 +236,30 @@ export async function downloadMessageResourceFeishu(params: {
   }
   const { client } = createConfiguredFeishuMediaClient({ cfg, accountId });
 
-  const response = await client.im.messageResource.get({
-    path: { message_id: messageId, file_key: normalizedFileKey },
-    params: { type },
-  });
+  let response: unknown;
+  try {
+    response = await client.im.messageResource.get({
+      path: { message_id: messageId, file_key: normalizedFileKey },
+      params: { type },
+    });
+  } catch (err) {
+    // iOS Feishu sends videos from the photo library as message_type "file"
+    // instead of "video". The messageResource API returns 502 for longer
+    // videos when called with type=file; retry with type=media which matches
+    // the download path used for direct video sends.
+    const httpStatus = (err as { response?: { status?: number } })?.response?.status;
+    if (type === "file" && httpStatus === 502) {
+      console.warn(
+        `feishu: download with type=file returned 502, retrying with type=media (message=${messageId})`,
+      );
+      response = await client.im.messageResource.get({
+        path: { message_id: messageId, file_key: normalizedFileKey },
+        params: { type: "media" },
+      });
+    } else {
+      throw err;
+    }
+  }
 
   const buffer = await readFeishuResponseBuffer({
     response,


### PR DESCRIPTION
## Summary

Fixes video download failures when iOS Feishu sends videos via the photo album as message_type 'file' instead of 'video'.

## Root Cause

When iOS Feishu users send videos from their photo library, the message arrives with message_type='file' rather than 'video'. The messageResource API is called with type=file, which returns HTTP 502 for longer videos (>1 min). The same video downloads successfully with type=media.

## Fix

Add a fallback in downloadMessageResourceFeishu: when the initial type=file call returns 502, automatically retry with type=media. If the retry also fails, the original error is thrown.

## Changes

- extensions/feishu/src/media.ts: 24 lines added, 4 removed

Fixes #49855