### PR TITLE
github-copilot: enable xhigh for gpt-5.4

### DIFF
--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -7,7 +7,9 @@ import { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotApiToken } from "./token.js
 import { fetchCopilotUsage } from "./usage.js";
 
 const COPILOT_ENV_VARS = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
-const COPILOT_XHIGH_MODEL_IDS = ["gpt-5.2", "gpt-5.2-codex"] as const;
+const CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
+const CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
+const COPILOT_XHIGH_MODEL_IDS = ["gpt-5.4", "gpt-5.4-mini", "gpt-5.2", "gpt-5.2-codex"] as const;
 
 function resolveFirstGithubToken(params: { agentDir?: string; env: NodeJS.ProcessEnv }): {
   githubToken: string;

--- a/src/auto-reply/thinking.shared.ts
+++ b/src/auto-reply/thinking.shared.ts
@@ -27,7 +27,7 @@ const OPENAI_CODEX_XHIGH_MODEL_IDS = [
   "gpt-5.2-codex",
   "gpt-5.1-codex",
 ] as const;
-const GITHUB_COPILOT_XHIGH_MODEL_IDS = ["gpt-5.2", "gpt-5.2-codex"] as const;
+const GITHUB_COPILOT_XHIGH_MODEL_IDS = ["gpt-5.4", "gpt-5.4-mini", "gpt-5.2", "gpt-5.2-codex"] as const;
 
 function matchesExactOrPrefix(modelId: string, ids: readonly string[]): boolean {
   return ids.some((candidate) => modelId === candidate || modelId.startsWith(`${candidate}-`));

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -85,8 +85,10 @@ describe("listThinkingLevels", () => {
     providerRuntimeMocks.resolveProviderXHighThinking.mockImplementation(({ provider, context }) =>
       (provider === "openai" && ["gpt-5.2", "gpt-5.4", "gpt-5.4-pro"].includes(context.modelId)) ||
       (provider === "openai-codex" &&
-        ["gpt-5.2-codex", "gpt-5.4", "gpt-5.3-codex-spark"].includes(context.modelId)) ||
-      (provider === "github-copilot" && ["gpt-5.2", "gpt-5.2-codex"].includes(context.modelId))
+        ["gpt-5.2-codex", "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.4"].includes(
+          context.modelId,
+        )) ||
+      (provider === "github-copilot" && ["gpt-5.4", "gpt-5.4-mini", "gpt-5.2", "gpt-5.2-codex"].includes(context.modelId))
         ? true
         : undefined,
     );
@@ -98,6 +100,8 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("openai", "gpt-5.4")).toContain("xhigh");
     expect(listThinkingLevels("openai", "gpt-5.4-pro")).toContain("xhigh");
     expect(listThinkingLevels("openai-codex", "gpt-5.4")).toContain("xhigh");
+    expect(listThinkingLevels("github-copilot", "gpt-5.4")).toContain("xhigh");
+    expect(listThinkingLevels("github-copilot", "gpt-5.4-mini")).toContain("xhigh");
     expect(listThinkingLevels("github-copilot", "gpt-5.2")).toContain("xhigh");
     expect(listThinkingLevels("github-copilot", "gpt-5.2-codex")).toContain("xhigh");
   });


### PR DESCRIPTION
## Summary
- enable `xhigh` for `github-copilot/gpt-5.4`
- update thinking tests to cover the Copilot GPT-5.4 path
- update the unsupported-model help text to include `github-copilot/gpt-5.4`

## Why
`openai/gpt-5.4` already supports `xhigh`, but `github-copilot/gpt-5.4` was still excluded by the Copilot provider allowlist. This makes Copilot GPT-5.4 behave inconsistently with the rest of the GPT-5.4 family.

## Testing
- `pnpm exec vitest run src/auto-reply/thinking.test.ts`
- `node scripts/tsdown-build.mjs`
