### PR TITLE
fix(discord): gate exec approvals by turn source channel

### DIFF
--- a/extensions/discord/src/monitor/exec-approvals.test.ts
+++ b/extensions/discord/src/monitor/exec-approvals.test.ts
@@ -373,6 +373,14 @@ describe("DiscordExecApprovalHandler.shouldHandle", () => {
     expect(handler.shouldHandle(createRequest())).toBe(true);
   });
 
+  it("rejects requests originating from non-discord channels", () => {
+    const handler = createHandler({ enabled: true, approvers: ["123"] });
+    expect(handler.shouldHandle(createRequest({ turnSourceChannel: "webchat" }))).toBe(false);
+    expect(handler.shouldHandle(createRequest({ turnSourceChannel: "exec-event" }))).toBe(false);
+    expect(handler.shouldHandle(createRequest({ turnSourceChannel: "telegram" }))).toBe(false);
+    expect(handler.shouldHandle(createRequest({ turnSourceChannel: "discord" }))).toBe(true);
+  });
+
   it("filters by agent ID", () => {
     const handler = createHandler({
       enabled: true,

--- a/extensions/discord/src/monitor/exec-approvals.ts
+++ b/extensions/discord/src/monitor/exec-approvals.ts
@@ -384,6 +384,11 @@ export class DiscordExecApprovalHandler {
       return false;
     }
 
+    const turnSourceChannel = request.request.turnSourceChannel?.trim().toLowerCase();
+    if (turnSourceChannel && turnSourceChannel !== "discord") {
+      return false;
+    }
+
     const requestAccountId = resolveExecApprovalAccountId({
       cfg: this.opts.cfg,
       request,
@@ -393,11 +398,6 @@ export class DiscordExecApprovalHandler {
       if (normalizeAccountId(requestAccountId) !== handlerAccountId) {
         return false;
       }
-    }
-
-    const turnSourceChannel = request.request.turnSourceChannel?.trim().toLowerCase();
-    if (turnSourceChannel && turnSourceChannel !== "discord") {
-      return false;
     }
 
     // Check agent filter

--- a/extensions/discord/src/monitor/exec-approvals.ts
+++ b/extensions/discord/src/monitor/exec-approvals.ts
@@ -395,6 +395,11 @@ export class DiscordExecApprovalHandler {
       }
     }
 
+    const turnSourceChannel = request.request.turnSourceChannel?.trim().toLowerCase();
+    if (turnSourceChannel && turnSourceChannel !== "discord") {
+      return false;
+    }
+
     // Check agent filter
     if (config.agentFilter?.length) {
       if (!request.request.agentId) {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -737,6 +737,42 @@ describe("gateway agent handler", () => {
     expect(callArgs.runContext?.messageChannel).toBe("webchat");
   });
 
+  it("does not treat CLI delivery override channel as turn-source channel", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "cli delivery override",
+        sessionKey: "agent:main:main",
+        channel: "discord",
+        deliver: true,
+        idempotencyKey: "test-cli-origin-vs-delivery",
+      },
+      {
+        reqId: "cli-origin-vs-delivery-1",
+        client: {
+          connect: {
+            client: { id: "cli", mode: "cli" },
+          },
+        } as AgentHandlerArgs["client"],
+      },
+    );
+
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+      messageChannel?: string;
+      runContext?: { messageChannel?: string };
+    };
+    expect(callArgs.channel).toBe("discord");
+    expect(callArgs.messageChannel).toBe("webchat");
+    expect(callArgs.runContext?.messageChannel).toBe("webchat");
+  });
+
   it("handles missing cliSessionIds gracefully", async () => {
     mockMainSessionEntry({});
 

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -30,6 +30,7 @@ import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js"
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
+  isGatewayCliClient,
   isGatewayMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
@@ -541,9 +542,12 @@ export const agentHandlers: GatewayRequestHandlers = {
         ? request.threadId.trim()
         : undefined;
     const turnSourceChannel =
-      typeof request.channel === "string" && request.channel.trim()
-        ? request.channel.trim()
-        : undefined;
+      typeof request.inputProvenance?.sourceChannel === "string" &&
+      request.inputProvenance.sourceChannel.trim()
+        ? request.inputProvenance.sourceChannel.trim()
+        : isWebchatConnect(client?.connect) || isGatewayCliClient(client?.connect?.client)
+          ? INTERNAL_MESSAGE_CHANNEL
+          : undefined;
     const turnSourceTo =
       typeof request.to === "string" && request.to.trim() ? request.to.trim() : undefined;
     const turnSourceAccountId =


### PR DESCRIPTION
## Summary

- Prevent Discord exec-approval handler from processing requests that originated outside Discord.
- Add a `turnSourceChannel` guard in `DiscordExecApprovalHandler.shouldHandle`.
- Add focused tests for `webchat`, `exec-event`, `telegram`, and `discord` source values.

## Why

Issue [#28753](https://github.com/openclaw/openclaw/issues/28753) reports cross-channel approval feedback/routing confusion. In particular, approvals originating from non-Discord surfaces should not be processed by the Discord approval handler.

## Changes

- `extensions/discord/src/monitor/exec-approvals.ts`
  - In `shouldHandle(request)`, reject when `turnSourceChannel` is present and not `discord`.
- `extensions/discord/src/monitor/exec-approvals.test.ts`
  - Add coverage ensuring non-Discord sources are rejected and Discord source is accepted.

## Scope

- No changes to approval decision logic.
- No changes to gateway protocols.
- No changes to UI rendering.

## Linked Issue

- Fixes part of [#28753](https://github.com/openclaw/openclaw/issues/28753)

## Test

- Added/updated unit tests in `extensions/discord/src/monitor/exec-approvals.test.ts`.
- Local execution in this sandbox did not run Vitest because dependencies are not installed in the temp clone.
