### PR TITLE
feat(bluebubbles): resolve exec approvals from tapback reactions

### DIFF
--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -883,12 +883,12 @@ export async function processMessage(
   }
 
   if (isTapbackMessage && tapbackParsed?.action !== "removed" && replyToBody) {
+    const tapbackEmoji = tapbackParsed.emoji;
     const approvalId =
       replyToBody.match(/Full id:\s*`?([^\s`]+)`?/i)?.[1]?.trim() ||
       replyToBody.match(/\/approve\s+([^\s`]+)\s+allow-(?:once|always)/i)?.[1]?.trim() ||
       replyToBody.match(/Approval required \(id ([a-z0-9-]{8,})(?:,|\))/i)?.[1]?.trim();
-    const decision =
-      tapbackParsed.emoji === "👍" ? "allow-once" : tapbackParsed.emoji === "👎" ? "deny" : null;
+    const decision = tapbackEmoji === "👍" ? "allow-once" : tapbackEmoji === "👎" ? "deny" : null;
     if (approvalId && decision) {
       if (!commandAuthorized) {
         logInboundDrop({
@@ -909,7 +909,7 @@ export async function processMessage(
         logVerbose(
           core,
           runtime,
-          `bluebubbles: resolved exec approval ${approvalId} via tapback ${tapbackParsed.emoji}`,
+          `bluebubbles: resolved exec approval ${approvalId} via tapback ${tapbackEmoji}`,
         );
         return;
       } catch (err) {

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -3,6 +3,7 @@ import {
   resolveTextChunksWithFallback,
   sendMediaWithLeadingCaption,
 } from "openclaw/plugin-sdk/reply-payload";
+import { callGateway } from "openclaw/plugin-sdk/gateway-runtime";
 import { downloadBlueBubblesAttachment } from "./attachments.js";
 import { markBlueBubblesChatRead, sendBlueBubblesTyping } from "./chat.js";
 import { fetchBlueBubblesHistory } from "./history.js";
@@ -879,6 +880,48 @@ export async function processMessage(
   // If no cached short ID, try to get one from the UUID directly
   if (replyToId && !replyToShortId) {
     replyToShortId = getShortIdForUuid(replyToId);
+  }
+
+  if (isTapbackMessage && tapbackParsed?.action !== "removed" && replyToBody) {
+    const approvalId =
+      replyToBody.match(/Approval required \(id ([a-z0-9-]{8,})(?:,|\))/i)?.[1]?.trim() ||
+      replyToBody.match(/\/approve\s+([^\s`]+)\s+allow-(?:once|always)/i)?.[1]?.trim() ||
+      replyToBody.match(/Full id:\s*`?([^\s`]+)`?/i)?.[1]?.trim();
+    const decision =
+      tapbackParsed.emoji === "👍"
+        ? "allow-always"
+        : tapbackParsed.emoji === "👎"
+          ? "deny"
+          : null;
+    if (approvalId && decision) {
+      if (!commandAuthorized) {
+        logInboundDrop({
+          log: (msg) => logVerbose(core, runtime, msg),
+          channel: "bluebubbles",
+          reason: "exec approval tapback (unauthorized)",
+          target: message.senderId,
+        });
+        return;
+      }
+      try {
+        await callGateway({
+          config,
+          method: "exec.approval.resolve",
+          params: { id: approvalId, decision },
+          clientDisplayName: `BlueBubbles approval (${message.senderId})`,
+        });
+        logVerbose(
+          core,
+          runtime,
+          `bluebubbles: resolved exec approval ${approvalId} via tapback ${tapbackParsed.emoji}`,
+        );
+      } catch (err) {
+        runtime.error?.(
+          `[bluebubbles] approval tapback resolve failed id=${approvalId}: ${String(err)}`,
+        );
+      }
+      return;
+    }
   }
 
   // Use inline [[reply_to:N]] tag format

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -882,7 +882,7 @@ export async function processMessage(
     replyToShortId = getShortIdForUuid(replyToId);
   }
 
-  if (isTapbackMessage && tapbackParsed?.action !== "removed" && replyToBody) {
+  if (isTapbackMessage && tapbackParsed && tapbackParsed.action !== "removed" && replyToBody) {
     const tapbackEmoji = tapbackParsed.emoji;
     const approvalId =
       replyToBody.match(/Full id:\s*`?([^\s`]+)`?/i)?.[1]?.trim() ||

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1,9 +1,9 @@
+import { callGateway } from "openclaw/plugin-sdk/gateway-runtime";
 import {
   resolveOutboundMediaUrls,
   resolveTextChunksWithFallback,
   sendMediaWithLeadingCaption,
 } from "openclaw/plugin-sdk/reply-payload";
-import { callGateway } from "openclaw/plugin-sdk/gateway-runtime";
 import { downloadBlueBubblesAttachment } from "./attachments.js";
 import { markBlueBubblesChatRead, sendBlueBubblesTyping } from "./chat.js";
 import { fetchBlueBubblesHistory } from "./history.js";
@@ -884,15 +884,11 @@ export async function processMessage(
 
   if (isTapbackMessage && tapbackParsed?.action !== "removed" && replyToBody) {
     const approvalId =
-      replyToBody.match(/Approval required \(id ([a-z0-9-]{8,})(?:,|\))/i)?.[1]?.trim() ||
+      replyToBody.match(/Full id:\s*`?([^\s`]+)`?/i)?.[1]?.trim() ||
       replyToBody.match(/\/approve\s+([^\s`]+)\s+allow-(?:once|always)/i)?.[1]?.trim() ||
-      replyToBody.match(/Full id:\s*`?([^\s`]+)`?/i)?.[1]?.trim();
+      replyToBody.match(/Approval required \(id ([a-z0-9-]{8,})(?:,|\))/i)?.[1]?.trim();
     const decision =
-      tapbackParsed.emoji === "👍"
-        ? "allow-always"
-        : tapbackParsed.emoji === "👎"
-          ? "deny"
-          : null;
+      tapbackParsed.emoji === "👍" ? "allow-once" : tapbackParsed.emoji === "👎" ? "deny" : null;
     if (approvalId && decision) {
       if (!commandAuthorized) {
         logInboundDrop({
@@ -915,12 +911,12 @@ export async function processMessage(
           runtime,
           `bluebubbles: resolved exec approval ${approvalId} via tapback ${tapbackParsed.emoji}`,
         );
+        return;
       } catch (err) {
         runtime.error?.(
           `[bluebubbles] approval tapback resolve failed id=${approvalId}: ${String(err)}`,
         );
       }
-      return;
     }
   }
 

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -14,6 +14,10 @@ import {
 } from "./monitor.js";
 import { setBlueBubblesRuntime } from "./runtime.js";
 
+const hoisted = vi.hoisted(() => ({
+  callGatewayMock: vi.fn(),
+}));
+
 // Mock dependencies
 vi.mock("./send.js", () => ({
   resolveChatGuidForTarget: vi.fn().mockResolvedValue("iMessage;-;+15551234567"),
@@ -43,6 +47,16 @@ vi.mock("./reactions.js", async () => {
 vi.mock("./history.js", () => ({
   fetchBlueBubblesHistory: vi.fn().mockResolvedValue({ entries: [], resolved: true }),
 }));
+
+vi.mock("openclaw/plugin-sdk/gateway-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/gateway-runtime")>(
+    "openclaw/plugin-sdk/gateway-runtime",
+  );
+  return {
+    ...actual,
+    callGateway: (...args: unknown[]) => hoisted.callGatewayMock(...args),
+  };
+});
 
 // Mock runtime
 const mockEnqueueSystemEvent = vi.fn();
@@ -1465,6 +1479,56 @@ describe("BlueBubbles webhook monitor", () => {
       expect(callArgs.ctx.RawBody).toBe("reacted with 😅");
       expect(callArgs.ctx.Body).toContain("reacted with 😅");
       expect(callArgs.ctx.Body).not.toContain("[[reply_to:");
+    });
+
+    it("resolves exec approvals from thumbs-up tapbacks and skips agent dispatch", async () => {
+      hoisted.callGatewayMock.mockResolvedValue({ ok: true });
+      const account = createMockAccount({
+        dmPolicy: "open",
+        allowFrom: ["+15551234567"],
+      });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: 'Liked "run this"',
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-approval-1",
+          chatGuid: "iMessage;-;+15551234567",
+          date: Date.now(),
+          replyTo: {
+            guid: "approval-origin-1",
+            text: "Approval required (id 1a2b3c4d, full 1a2b3c4d-1234-5678-90ab-cdef01234567).",
+          },
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(hoisted.callGatewayMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "exec.approval.resolve",
+          params: { id: "1a2b3c4d", decision: "allow-always" },
+        }),
+      );
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
     });
   });
 

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -1499,6 +1499,17 @@ describe("BlueBubbles webhook monitor", () => {
         path: "/bluebubbles-webhook",
       });
 
+      const approvalReplyText = [
+        "Approval required.",
+        "",
+        "Run:",
+        "```txt",
+        "/approve 1a2b3c4d allow-once",
+        "```",
+        "",
+        "Full id: `1a2b3c4d-1234-5678-90ab-cdef01234567`",
+      ].join("\n");
+
       const payload = {
         type: "new-message",
         data: {
@@ -1511,7 +1522,7 @@ describe("BlueBubbles webhook monitor", () => {
           date: Date.now(),
           replyTo: {
             guid: "approval-origin-1",
-            text: "Approval required (id 1a2b3c4d, full 1a2b3c4d-1234-5678-90ab-cdef01234567).",
+            text: approvalReplyText,
           },
         },
       };
@@ -1525,10 +1536,153 @@ describe("BlueBubbles webhook monitor", () => {
       expect(hoisted.callGatewayMock).toHaveBeenCalledWith(
         expect.objectContaining({
           method: "exec.approval.resolve",
-          params: { id: "1a2b3c4d", decision: "allow-always" },
+          params: { id: "1a2b3c4d-1234-5678-90ab-cdef01234567", decision: "allow-once" },
         }),
       );
       expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    });
+
+    it("resolves exec approvals from thumbs-down tapbacks as deny", async () => {
+      hoisted.callGatewayMock.mockResolvedValue({ ok: true });
+      const account = createMockAccount({
+        dmPolicy: "open",
+        allowFrom: ["+15551234567"],
+      });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: 'Disliked "run this"',
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-approval-2",
+          chatGuid: "iMessage;-;+15551234567",
+          date: Date.now(),
+          replyTo: {
+            guid: "approval-origin-2",
+            text: "Approval required.\n\nRun:\n```txt\n/approve 1a2b3c4d allow-once\n```\n\nFull id: `1a2b3c4d-1234-5678-90ab-cdef01234567`",
+          },
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(hoisted.callGatewayMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "exec.approval.resolve",
+          params: { id: "1a2b3c4d-1234-5678-90ab-cdef01234567", decision: "deny" },
+        }),
+      );
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    });
+
+    it("drops unauthorized approval tapbacks without calling gateway", async () => {
+      const account = createMockAccount({
+        dmPolicy: "open",
+        allowFrom: ["+15550000000"],
+      });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: 'Liked "run this"',
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-approval-3",
+          chatGuid: "iMessage;-;+15551234567",
+          date: Date.now(),
+          replyTo: {
+            guid: "approval-origin-3",
+            text: "Approval required.\n\nRun:\n```txt\n/approve 1a2b3c4d allow-once\n```\n\nFull id: `1a2b3c4d-1234-5678-90ab-cdef01234567`",
+          },
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    });
+
+    it("falls through to agent dispatch when approval tapback resolve fails", async () => {
+      hoisted.callGatewayMock.mockRejectedValueOnce(new Error("gateway down"));
+      const account = createMockAccount({
+        dmPolicy: "open",
+        allowFrom: ["+15551234567"],
+      });
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      const runtime = { log: vi.fn(), error: vi.fn() };
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime,
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: 'Liked "run this"',
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-approval-4",
+          chatGuid: "iMessage;-;+15551234567",
+          date: Date.now(),
+          replyTo: {
+            guid: "approval-origin-4",
+            text: "Approval required.\n\nRun:\n```txt\n/approve 1a2b3c4d allow-once\n```\n\nFull id: `1a2b3c4d-1234-5678-90ab-cdef01234567`",
+          },
+        },
+      };
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(hoisted.callGatewayMock).toHaveBeenCalled();
+      expect(runtime.error).toHaveBeenCalled();
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+      const callArgs = getFirstDispatchCall();
+      expect(callArgs.ctx.RawBody).toContain("reacted with 👍");
     });
   });
 

--- a/src/plugin-sdk/gateway-runtime.ts
+++ b/src/plugin-sdk/gateway-runtime.ts
@@ -1,6 +1,7 @@
 // Public gateway/client helpers for plugins that talk to the host gateway surface.
 
 export * from "../gateway/channel-status-patches.js";
+export { callGateway } from "../gateway/call.js";
 export { GatewayClient } from "../gateway/client.js";
 export { createOperatorApprovalsGatewayClient } from "../gateway/operator-approvals-client.js";
 export type { EventFrame } from "../gateway/protocol/index.js";


### PR DESCRIPTION
## Summary

- Add BlueBubbles tapback-based exec approval resolution for thumbs-up/thumbs-down reactions.
- Map `👍` tapback to `allow-always` and `👎` tapback to `deny` when reacting to an approval prompt.
- Skip normal agent dispatch once a tapback is consumed as an approval action.

## Why

Issue [#24639](https://github.com/openclaw/openclaw/issues/24639) asks for reaction/tapback approval flow so users can approve/deny from chat quickly without typing full `/approve` commands.

## Changes

- `extensions/bluebubbles/src/monitor-processing.ts`
  - Detect tapback reactions on messages whose `replyToBody` looks like an exec approval prompt.
  - Extract approval id from common prompt formats:
    - `Approval required (id ...)`
    - `/approve <id> allow-*`
    - `Full id: ...`
  - Resolve via `exec.approval.resolve`:
    - `👍` -> `allow-always`
    - `👎` -> `deny`
  - Enforce existing command authorization gate before resolving.
  - Return early (no agent dispatch) after approval tapback handling.
- `src/plugin-sdk/gateway-runtime.ts`
  - Export `callGateway` for extension-side gateway calls.
- `extensions/bluebubbles/src/monitor.test.ts`
  - Add test covering thumbs-up approval resolution and dispatch suppression.

## Scope

- BlueBubbles-only reaction handling in this PR.
- No behavior changes for non-approval tapbacks.
- No protocol/schema changes.

## Linked Issue

- Addresses [#24639](https://github.com/openclaw/openclaw/issues/24639)

## Test

- Added/updated unit tests in `extensions/bluebubbles/src/monitor.test.ts`.
- Local execution in this sandbox did not run Vitest because dependencies are not installed in the temp clone.
