### PR TITLE
fix(agents): ignore historical replies when subscribing to embedded sessions

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -34,6 +34,16 @@ const stripTrailingDirective = (text: string): string => {
   return text.slice(0, openIndex);
 };
 
+function shouldIgnoreAssistantMessage(
+  ctx: EmbeddedPiSubscribeContext,
+  message: AgentMessage | undefined,
+): boolean {
+  if (!message || message.role !== "assistant") {
+    return true;
+  }
+  return ctx.state.preexistingMessages.has(message);
+}
+
 function emitReasoningEnd(ctx: EmbeddedPiSubscribeContext) {
   if (!ctx.state.reasoningStreamOpen) {
     return;
@@ -85,7 +95,7 @@ export function handleMessageStart(
   evt: AgentEvent & { message: AgentMessage },
 ) {
   const msg = evt.message;
-  if (msg?.role !== "assistant") {
+  if (shouldIgnoreAssistantMessage(ctx, msg)) {
     return;
   }
 
@@ -104,7 +114,7 @@ export function handleMessageUpdate(
   evt: AgentEvent & { message: AgentMessage; assistantMessageEvent?: unknown },
 ) {
   const msg = evt.message;
-  if (msg?.role !== "assistant") {
+  if (shouldIgnoreAssistantMessage(ctx, msg)) {
     return;
   }
 
@@ -274,7 +284,7 @@ export function handleMessageEnd(
   evt: AgentEvent & { message: AgentMessage },
 ) {
   const msg = evt.message;
-  if (msg?.role !== "assistant") {
+  if (shouldIgnoreAssistantMessage(ctx, msg)) {
     return;
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -32,6 +32,7 @@ export type ToolCallSummary = {
 
 export type EmbeddedPiSubscribeState = {
   assistantTexts: string[];
+  preexistingMessages: Set<AgentMessage>;
   toolMetas: Array<{ toolName?: string; meta?: string }>;
   toolMetaById: Map<string, ToolCallSummary>;
   toolSummaryById: Set<string>;

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -12,6 +12,32 @@ import {
 import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
 
 describe("subscribeEmbeddedPiSession", () => {
+  function createReplayingAgentEventHarness(params: {
+    replayEvents: unknown[];
+    existingMessages?: unknown[];
+  }) {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session = {
+      messages: params.existingMessages ?? [],
+      subscribe: (fn: (evt: unknown) => void) => {
+        handler = fn;
+        for (const evt of params.replayEvents) {
+          fn(evt);
+        }
+        return () => {};
+      },
+    } as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"];
+    const onAgentEvent = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+    });
+
+    return { emit: (evt: unknown) => handler?.(evt), onAgentEvent };
+  }
+
   function createAgentEventHarness(options?: { runId?: string; sessionKey?: string }) {
     const { session, emit } = createStubSessionHarness();
     const onAgentEvent = vi.fn();
@@ -291,6 +317,30 @@ describe("subscribeEmbeddedPiSession", () => {
     });
     emitMessageStartAndEndForAssistantText({ emit, text: "Hello world" });
     expectSingleAgentEventText(onAgentEvent.mock.calls, "Hello world");
+  });
+
+  it("does not replay historical assistant finals when subscribing to an existing session", () => {
+    const historicalAssistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "Earlier reply" }],
+    } as AssistantMessage;
+    const { emit, onAgentEvent } = createReplayingAgentEventHarness({
+      existingMessages: [historicalAssistantMessage],
+      replayEvents: [
+        { type: "agent_start" },
+        { type: "message_start", message: historicalAssistantMessage },
+        { type: "message_end", message: historicalAssistantMessage },
+        { type: "agent_end" },
+      ],
+    });
+
+    emitMessageStartAndEndForAssistantText({ emit, text: "Current reply" });
+
+    const replyPayloads = extractAgentEventPayloads(onAgentEvent.mock.calls).filter(
+      (payload) => typeof payload.text === "string",
+    );
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe("Current reply");
   });
 
   it("does not emit duplicate agent events when message_end repeats", () => {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -37,6 +37,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const useMarkdown = toolResultFormat === "markdown";
   const state: EmbeddedPiSubscribeState = {
     assistantTexts: [],
+    preexistingMessages: new Set(params.session.messages ?? []),
     toolMetas: [],
     toolMetaById: new Map(),
     toolSummaryById: new Set(),


### PR DESCRIPTION
## Summary
- ignore assistant messages that already exist in `session.messages` when an embedded session subscription is attached
- keep new assistant replies flowing normally after subscription
- add a regression test covering subscription to an existing session with historical assistant output

## Problem
When `subscribeEmbeddedPiSession()` attaches to an existing session, some integrations can replay historical assistant lifecycle events from earlier turns. Those preexisting assistant messages then re-enter the outward delivery path and can look like duplicate replies being sent again.

This is adjacent to transcript-only duplicate suppression, but it is a different failure mode: the repeated delivery comes from historical session replay, not from transcript-only injected assistant messages.

## Testing
- `pnpm test -- src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts -t "does not replay historical assistant finals when subscribing to an existing session"`