### PR TITLE
fix: pass vision-capable models image attachments as ImageContent (#28744)

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -5,6 +5,7 @@ import {
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
 import type { ImageContent } from "../../agents/command/types.js";
+import { modelSupportsVision } from "../../agents/model-catalog.js";
 import { resolveModelRefFromString } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
@@ -145,37 +146,48 @@ export async function getReplyFromConfig(
 
     // If the model supports vision natively, read image attachments and pass them directly
     // to the agent instead of relying on OCR text extraction.
-    if (!isFastTestEnv && !resolvedOpts?.images) {
+    if (!resolvedOpts?.images) {
       const attachments = normalizeAttachments(finalized);
       const imageAttachments = attachments.filter(isImageAttachment);
       if (imageAttachments.length > 0) {
-        const images: ImageContent[] = [];
-        const cache = createMediaAttachmentCache(attachments, {
-          localPathRoots: resolveMediaAttachmentLocalRoots({ cfg, ctx: finalized }),
-        });
-        for (const attachment of imageAttachments) {
-          if (attachment.index === undefined) {
-            continue;
+        // Check if the model supports vision before loading images
+        const catalog = await import("../../agents/model-catalog.js").then((m) =>
+          m.loadModelCatalog({ config: cfg }),
+        );
+        const modelEntry = catalog.find(
+          (entry) =>
+            entry.provider.toLowerCase() === provider.toLowerCase() &&
+            entry.id.toLowerCase() === model.toLowerCase(),
+        );
+        if (modelSupportsVision(modelEntry)) {
+          const images: ImageContent[] = [];
+          const cache = createMediaAttachmentCache(attachments, {
+            localPathRoots: resolveMediaAttachmentLocalRoots({ cfg, ctx: finalized }),
+          });
+          for (const attachment of imageAttachments) {
+            if (attachment.index === undefined) {
+              continue;
+            }
+            try {
+              const pathResult = await cache.getPath({
+                attachmentIndex: attachment.index,
+                timeoutMs: 10000,
+              });
+              const fs = await import("node:fs/promises");
+              const buffer = await fs.readFile(pathResult.path);
+              // Use bare base64 without data: URI prefix (chat-attachments.ts strips the prefix)
+              images.push({
+                type: "image",
+                data: buffer.toString("base64"),
+                mimeType: attachment.mime ?? "image/jpeg",
+              });
+            } catch {
+              // Skip images that can't be read
+            }
           }
-          try {
-            const pathResult = await cache.getPath({
-              attachmentIndex: attachment.index,
-              timeoutMs: 10000,
-            });
-            const fs = await import("node:fs/promises");
-            const buffer = await fs.readFile(pathResult.path);
-            const mimeType = attachment.mime ?? "image/jpeg";
-            images.push({
-              type: "image",
-              data: `data:${mimeType};base64,${buffer.toString("base64")}`,
-              mimeType,
-            });
-          } catch {
-            // Skip images that can't be read
+          if (images.length > 0) {
+            resolvedOpts = { ...resolvedOpts, images };
           }
-        }
-        if (images.length > 0) {
-          resolvedOpts = { ...resolvedOpts, images };
         }
       }
     }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -144,53 +144,8 @@ export async function getReplyFromConfig(
       cfg,
     });
 
-    // If the model supports vision natively, read image attachments and pass them directly
-    // to the agent instead of relying on OCR text extraction.
-    if (!resolvedOpts?.images) {
-      const attachments = normalizeAttachments(finalized);
-      const imageAttachments = attachments.filter(isImageAttachment);
-      if (imageAttachments.length > 0) {
-        // Check if the model supports vision before loading images
-        const catalog = await import("../../agents/model-catalog.js").then((m) =>
-          m.loadModelCatalog({ config: cfg }),
-        );
-        const modelEntry = catalog.find(
-          (entry) =>
-            entry.provider.toLowerCase() === provider.toLowerCase() &&
-            entry.id.toLowerCase() === model.toLowerCase(),
-        );
-        if (modelSupportsVision(modelEntry)) {
-          const images: ImageContent[] = [];
-          const cache = createMediaAttachmentCache(attachments, {
-            localPathRoots: resolveMediaAttachmentLocalRoots({ cfg, ctx: finalized }),
-          });
-          for (const attachment of imageAttachments) {
-            if (attachment.index === undefined) {
-              continue;
-            }
-            try {
-              const pathResult = await cache.getPath({
-                attachmentIndex: attachment.index,
-                timeoutMs: 10000,
-              });
-              const fs = await import("node:fs/promises");
-              const buffer = await fs.readFile(pathResult.path);
-              // Use bare base64 without data: URI prefix (chat-attachments.ts strips the prefix)
-              images.push({
-                type: "image",
-                data: buffer.toString("base64"),
-                mimeType: attachment.mime ?? "image/jpeg",
-              });
-            } catch {
-              // Skip images that can't be read
-            }
-          }
-          if (images.length > 0) {
-            resolvedOpts = { ...resolvedOpts, images };
-          }
-        }
-      }
-    }
+    // Vision check is deferred until after all model overrides are resolved (P2-1).
+    // The final provider/model values are available only after resolveReplyDirectives.
   }
   emitPreAgentMessageHooks({
     ctx: finalized,
@@ -458,4 +413,74 @@ export async function getReplyFromConfig(
     workspaceDir,
     abortedLastRun,
   });
+
+  // After all model overrides are resolved, check if we should send images directly to vision-capable models.
+  // This runs after applyMediaUnderstanding (which skips OCR for vision models) and after all model/channel/directive overrides.
+  // We intentionally only populate opts.images for non-CLI, non-embedded runs here because:
+  // - CLI runs forward opts.images unconditionally to CLI backends that may not support images (P2-4)
+  // - Embedded runs handle images through detectAndLoadPromptImages separately (P2-3)
+  if (
+    !resolvedOpts?.images &&
+    !isFastTestEnv &&
+    !execOverrides?.isDirectCli &&
+    !directives?.piEmbedded
+  ) {
+    const attachments = normalizeAttachments(finalized);
+    const imageAttachments = attachments.filter(isImageAttachment);
+    if (imageAttachments.length > 0) {
+      // Check scope policy before loading images (P1)
+      const { resolveScopeDecision } = await import("../../media-understanding/resolve.js");
+      const scopeDecision = resolveScopeDecision({
+        scope: cfg.tools?.media?.image?.scope,
+        ctx: finalized,
+      });
+      if (scopeDecision === "deny") {
+        // Scope policy denies image handling; do not send images
+      } else {
+        // Check if the final resolved model supports vision (P2-1: after all overrides)
+        const catalog = await import("../../agents/model-catalog.js").then((m) =>
+          m.loadModelCatalog({ config: cfg }),
+        );
+        const modelEntry = catalog.find(
+          (entry) =>
+            entry.provider.toLowerCase() === provider.toLowerCase() &&
+            entry.id.toLowerCase() === model.toLowerCase(),
+        );
+        if (modelSupportsVision(modelEntry)) {
+          const images: ImageContent[] = [];
+          const cache = createMediaAttachmentCache(attachments, {
+            localPathRoots: resolveMediaAttachmentLocalRoots({ cfg, ctx: finalized }),
+          });
+          try {
+            for (const attachment of imageAttachments) {
+              if (attachment.index === undefined) {
+                continue;
+              }
+              try {
+                const pathResult = await cache.getPath({
+                  attachmentIndex: attachment.index,
+                  timeoutMs: 10000,
+                });
+                const fs = await import("node:fs/promises");
+                const buffer = await fs.readFile(pathResult.path);
+                images.push({
+                  type: "image",
+                  data: buffer.toString("base64"),
+                  mimeType: attachment.mime ?? "image/jpeg",
+                });
+              } catch {
+                // Skip images that can't be read
+              }
+            }
+          } finally {
+            // Clean up temp files created for URL-backed attachments (P2-2)
+            void cache.cleanup();
+          }
+          if (images.length > 0) {
+            resolvedOpts = { ...resolvedOpts, images };
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -155,20 +155,21 @@ export async function getReplyFromConfig(
           if (attachment.index === undefined) {
             continue;
           }
-          const cached = cache.get(attachment.index);
-          if (cached?.resolvedPath) {
-            try {
-              const fs = await import("node:fs/promises");
-              const buffer = await fs.readFile(cached.resolvedPath);
-              const mimeType = cached.mime ?? "image/jpeg";
-              images.push({
-                type: "image",
-                data: `data:${mimeType};base64,${buffer.toString("base64")}`,
-                mimeType,
-              });
-            } catch {
-              // Skip images that can't be read
-            }
+          try {
+            const pathResult = await cache.getPath({
+              attachmentIndex: attachment.index,
+              timeoutMs: 10000,
+            });
+            const fs = await import("node:fs/promises");
+            const buffer = await fs.readFile(pathResult.path);
+            const mimeType = attachment.mime ?? "image/jpeg";
+            images.push({
+              type: "image",
+              data: `data:${mimeType};base64,${buffer.toString("base64")}`,
+              mimeType,
+            });
+          } catch {
+            // Skip images that can't be read
           }
         }
         if (images.length > 0) {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -13,7 +13,10 @@ import { type OpenClawConfig, loadConfig } from "../../config/config.js";
 import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { isImageAttachment, normalizeAttachments } from "../../media-understanding/attachments.js";
-import { resolveMediaAttachmentLocalRoots } from "../../media-understanding/runner.js";
+import {
+  createMediaAttachmentCache,
+  resolveMediaAttachmentLocalRoots,
+} from "../../media-understanding/runner.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
@@ -147,7 +150,6 @@ export async function getReplyFromConfig(
       const imageAttachments = attachments.filter(isImageAttachment);
       if (imageAttachments.length > 0) {
         const images: ImageContent[] = [];
-        const { createMediaAttachmentCache } = await import("../../media-understanding/runner.js");
         const cache = createMediaAttachmentCache(attachments, {
           localPathRoots: resolveMediaAttachmentLocalRoots({ cfg, ctx: finalized }),
         });

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -4,6 +4,7 @@ import {
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
+import type { ImageContent } from "../../agents/command/types.js";
 import { resolveModelRefFromString } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
@@ -11,6 +12,8 @@ import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
 import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
+import { isImageAttachment, normalizeAttachments } from "../../media-understanding/attachments.js";
+import { resolveMediaAttachmentLocalRoots } from "../../media-understanding/runner.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
@@ -72,7 +75,7 @@ export async function getReplyFromConfig(
     opts?.skillFilter,
     resolveAgentSkillsFilter(cfg, agentId),
   );
-  const resolvedOpts =
+  let resolvedOpts =
     mergedSkillFilter !== undefined ? { ...opts, skillFilter: mergedSkillFilter } : opts;
   const agentCfg = cfg.agents?.defaults;
   const sessionCfg = cfg.session;
@@ -136,6 +139,43 @@ export async function getReplyFromConfig(
       ctx: finalized,
       cfg,
     });
+
+    // If the model supports vision natively, read image attachments and pass them directly
+    // to the agent instead of relying on OCR text extraction.
+    if (!isFastTestEnv && !resolvedOpts?.images) {
+      const attachments = normalizeAttachments(finalized);
+      const imageAttachments = attachments.filter(isImageAttachment);
+      if (imageAttachments.length > 0) {
+        const images: ImageContent[] = [];
+        const { createMediaAttachmentCache } = await import("../../media-understanding/runner.js");
+        const cache = createMediaAttachmentCache(attachments, {
+          localPathRoots: resolveMediaAttachmentLocalRoots({ cfg, ctx: finalized }),
+        });
+        for (const attachment of imageAttachments) {
+          if (attachment.index === undefined) {
+            continue;
+          }
+          const cached = cache.get(attachment.index);
+          if (cached?.resolvedPath) {
+            try {
+              const fs = await import("node:fs/promises");
+              const buffer = await fs.readFile(cached.resolvedPath);
+              const mimeType = cached.mime ?? "image/jpeg";
+              images.push({
+                type: "image",
+                data: `data:${mimeType};base64,${buffer.toString("base64")}`,
+                mimeType,
+              });
+            } catch {
+              // Skip images that can't be read
+            }
+          }
+        }
+        if (images.length > 0) {
+          resolvedOpts = { ...resolvedOpts, images };
+        }
+      }
+    }
   }
   emitPreAgentMessageHooks({
     ctx: finalized,


### PR DESCRIPTION
## Summary

When the active model supports vision natively (e.g. MiniMax-M2.7 with `input: ["text", "image"]`), read image files from `MediaPath` and convert them to `ImageContent[]` (base64 data URIs) so the agent can see the images directly.

## Problem

Previously `applyMediaUnderstanding()` would skip OCR for vision-capable models, but the images were never passed to the agent, resulting in the agent only seeing `[Image]` placeholder text.

This affected all channels (Feishu, Telegram, etc.) when sending images.

## Solution

In `getReplyFromConfig()`:
1. After `applyMediaUnderstanding()` completes
2. Check if model supports vision natively (via `modelSupportsVision()`)
3. If so, read image files from `MediaPath` and convert to base64 data URIs
4. Set `opts.images` so the agent receives the actual image content

## Changes

- **File**: `src/auto-reply/reply/get-reply.ts`
- Added imports for `ImageContent`, `isImageAttachment`, `normalizeAttachments`, `resolveMediaAttachmentLocalRoots`
- Added vision-to-image conversion logic when model supports vision

## Testing

- [ ] Send image via Telegram → agent should see the image
- [ ] Send image via Feishu → agent should see the image
- [ ] Models without vision support continue to use OCR text

Fixes openclaw/openclaw#28744