### PR TITLE
fix(slack): fetch fresh download URL via files.info for DM file attachments

### DIFF
--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -303,6 +303,83 @@ describe("resolveSlackMedia", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("falls back to files.info when url_private is missing but file id is available", async () => {
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue(
+      createSavedMedia("/tmp/dm-file.jpg", "image/jpeg"),
+    );
+    mockFetch.mockResolvedValueOnce(
+      new Response(Buffer.from("image data"), {
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+      }),
+    );
+
+    const mockClient = {
+      files: {
+        info: vi.fn().mockResolvedValue({
+          file: {
+            id: "F123",
+            name: "dm-file.jpg",
+            mimetype: "image/jpeg",
+            url_private_download: "https://files.slack.com/fresh-download.jpg",
+          },
+        }),
+      },
+    } as unknown as import("@slack/web-api").WebClient;
+
+    const result = await resolveSlackMedia({
+      files: [{ id: "F123", name: "dm-file.jpg", mimetype: "image/jpeg" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+      client: mockClient,
+    });
+
+    expect(mockClient.files.info).toHaveBeenCalledWith({ file: "F123" });
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://files.slack.com/fresh-download.jpg",
+      expect.anything(),
+    );
+  });
+
+  it("skips file when files.info also has no download URL", async () => {
+    const mockClient = {
+      files: {
+        info: vi.fn().mockResolvedValue({ file: { id: "F123", name: "dm-file.jpg" } }),
+      },
+    } as unknown as import("@slack/web-api").WebClient;
+
+    const result = await resolveSlackMedia({
+      files: [{ id: "F123", name: "dm-file.jpg" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+      client: mockClient,
+    });
+
+    expect(mockClient.files.info).toHaveBeenCalledWith({ file: "F123" });
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("skips file when files.info call fails", async () => {
+    const mockClient = {
+      files: {
+        info: vi.fn().mockRejectedValue(new Error("slack_api_error")),
+      },
+    } as unknown as import("@slack/web-api").WebClient;
+
+    const result = await resolveSlackMedia({
+      files: [{ id: "F123", name: "dm-file.jpg" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+      client: mockClient,
+    });
+
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("rejects HTML auth pages for non-HTML files", async () => {
     const saveMediaBufferMock = vi.spyOn(mediaStore, "saveMediaBuffer");
     mockFetch.mockResolvedValueOnce(

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -215,6 +215,7 @@ export async function resolveSlackMedia(params: {
   files?: SlackFile[];
   token: string;
   maxBytes: number;
+  client?: SlackWebClient;
 }): Promise<SlackMediaResult[] | null> {
   const files = params.files ?? [];
   const limitedFiles =
@@ -224,7 +225,20 @@ export async function resolveSlackMedia(params: {
     limitedFiles,
     MAX_SLACK_MEDIA_CONCURRENCY,
     async (file) => {
-      const url = file.url_private_download ?? file.url_private;
+      let url = file.url_private_download ?? file.url_private;
+      // DM file events may omit download URLs. Fall back to files.info API
+      // to fetch a fresh url_private_download when a client is available.
+      if (!url && file.id && params.client) {
+        try {
+          const info = await params.client.files.info({ file: file.id });
+          const fresh = info.file as
+            | { url_private_download?: string; url_private?: string }
+            | undefined;
+          url = fresh?.url_private_download ?? fresh?.url_private;
+        } catch {
+          // files.info failed — skip this file
+        }
+      }
       if (!url) {
         return null;
       }
@@ -285,6 +299,7 @@ export async function resolveSlackAttachmentContent(params: {
   attachments?: SlackAttachment[];
   token: string;
   maxBytes: number;
+  client?: SlackWebClient;
 }): Promise<{ text: string; media: SlackMediaResult[] } | null> {
   const attachments = params.attachments;
   if (!attachments || attachments.length === 0) {
@@ -345,6 +360,7 @@ export async function resolveSlackAttachmentContent(params: {
         files: att.files,
         token: params.token,
         maxBytes: params.maxBytes,
+        client: params.client,
       });
       if (fileMedia) {
         allMedia.push(...fileMedia);

--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -43,6 +43,7 @@ export async function resolveSlackMessageContent(params: {
   isBotMessage: boolean;
   botToken: string;
   mediaMaxBytes: number;
+  client?: import("@slack/web-api").WebClient;
 }): Promise<SlackResolvedMessageContent | null> {
   const ownFiles = filterInheritedParentFiles({
     files: params.message.files,
@@ -54,12 +55,14 @@ export async function resolveSlackMessageContent(params: {
     files: ownFiles,
     token: params.botToken,
     maxBytes: params.mediaMaxBytes,
+    client: params.client,
   });
 
   const attachmentContent = await resolveSlackAttachmentContent({
     attachments: params.message.attachments,
     token: params.botToken,
     maxBytes: params.mediaMaxBytes,
+    client: params.client,
   });
 
   const mergedMedia = [...(media ?? []), ...(attachmentContent?.media ?? [])];

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -111,6 +111,7 @@ export async function resolveSlackThreadContextData(params: {
         files: starter.files,
         token: params.ctx.botToken,
         maxBytes: params.ctx.mediaMaxBytes,
+        client: params.ctx.app.client,
       });
       if (threadStarterMedia) {
         const starterPlaceholders = threadStarterMedia.map((item) => item.placeholder).join(", ");

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -556,6 +556,7 @@ export async function prepareSlackMessage(params: {
     isBotMessage,
     botToken: ctx.botToken,
     mediaMaxBytes: ctx.mediaMaxBytes,
+    client: ctx.app.client,
   });
   if (!resolvedMessageContent) {
     return null;


### PR DESCRIPTION
## Summary

Slack DM message events may omit `url_private_download` and `url_private` on file objects in the event payload, causing all DM file attachments to be silently dropped — no download attempt, no error logged.

**Root cause:** `resolveSlackMedia` only checked `file.url_private_download ?? file.url_private` and returned `null` when both were missing. The existing `downloadSlackFile` in `actions.ts` already solved this by calling `files.info` to fetch fresh metadata, but the inbound message pipeline did not.

**Fix:** When both URLs are missing but `file.id` is present and a Slack `WebClient` is available, call `files.info` to retrieve a fresh download URL before giving up. This matches the pattern already used by `downloadSlackFile`.

### Changes
- `extensions/slack/src/monitor/media.ts`: Add optional `client` param to `resolveSlackMedia` and `resolveSlackAttachmentContent`; call `files.info` as fallback when download URLs are missing
- `extensions/slack/src/monitor/message-handler/prepare-content.ts`: Pass `client` through to media resolvers
- `extensions/slack/src/monitor/message-handler/prepare.ts`: Pass `ctx.app.client` to `resolveSlackMessageContent`
- `extensions/slack/src/monitor/message-handler/prepare-thread-context.ts`: Pass `client` to thread starter media resolution
- 3 new tests covering: successful fallback, fallback with no URL in `files.info`, and `files.info` API failure

## Test plan
- [x] `pnpm test:extensions` — all 2680 tests pass (including 3 new tests)
- [x] `pnpm tsgo` — no type errors
- [ ] Manual: send a file attachment via Slack DM and verify it appears in `~/.openclaw/media/inbound/`

Closes #50129