### PR TITLE
fix: accept camelCase edit tool aliases

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.e2e.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.e2e.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import { createOpenClawCodingTools } from "./pi-tools.js";
+import { normalizeToolParams } from "./pi-tools.read.js";
 
 describe("createOpenClawCodingTools", () => {
   it("uses workspaceDir for Read tool path resolution", async () => {
@@ -146,6 +147,67 @@ describe("createOpenClawCodingTools", () => {
 
       const result = await readTool?.execute("tool-camel-alias-3", {
         filePath,
+      });
+
+      const textBlocks = result?.content?.filter((block) => block.type === "text") as
+        | Array<{ text?: string }>
+        | undefined;
+      const combinedText = textBlocks?.map((block) => block.text ?? "").join("\n");
+      expect(combinedText).toContain("hello universe");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("promotes non-empty aliases when canonical fields are blank and cleans alias keys", async () => {
+    expect(
+      normalizeToolParams({
+        path: "",
+        file_path: "snake-path.txt",
+        filePath: "camel-path.txt",
+        oldText: "",
+        old_string: "snake-old",
+        oldString: "camel-old",
+        newText: "",
+        new_string: "snake-new",
+        newString: "camel-new",
+      }),
+    ).toEqual({
+      path: "snake-path.txt",
+      oldText: "snake-old",
+      newText: "snake-new",
+    });
+  });
+
+  it("accepts blank canonical fields when aliases carry the real values", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-blank-canonical-"));
+    try {
+      const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
+      const readTool = tools.find((tool) => tool.name === "read");
+      const writeTool = tools.find((tool) => tool.name === "write");
+      const editTool = tools.find((tool) => tool.name === "edit");
+      expect(readTool).toBeDefined();
+      expect(writeTool).toBeDefined();
+      expect(editTool).toBeDefined();
+
+      await writeTool?.execute("tool-blank-canonical-1", {
+        path: "",
+        filePath: "blank-canonical.txt",
+        content: "hello world",
+      });
+
+      await editTool?.execute("tool-blank-canonical-2", {
+        path: "",
+        filePath: "blank-canonical.txt",
+        oldText: "",
+        oldString: "world",
+        newText: "",
+        newString: "universe",
+      });
+
+      const result = await readTool?.execute("tool-blank-canonical-3", {
+        path: "",
+        filePath: "blank-canonical.txt",
       });
 
       const textBlocks = result?.content?.filter((block) => block.type === "text") as

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.e2e.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.e2e.test.ts
@@ -121,6 +121,43 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
+  it("accepts camelCase alias variants for read/write/edit", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-camel-alias-"));
+    try {
+      const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
+      const readTool = tools.find((tool) => tool.name === "read");
+      const writeTool = tools.find((tool) => tool.name === "write");
+      const editTool = tools.find((tool) => tool.name === "edit");
+      expect(readTool).toBeDefined();
+      expect(writeTool).toBeDefined();
+      expect(editTool).toBeDefined();
+
+      const filePath = "camel-alias-test.txt";
+      await writeTool?.execute("tool-camel-alias-1", {
+        filePath,
+        content: "hello world",
+      });
+
+      await editTool?.execute("tool-camel-alias-2", {
+        filePath,
+        oldString: "world",
+        newString: "universe",
+      });
+
+      const result = await readTool?.execute("tool-camel-alias-3", {
+        filePath,
+      });
+
+      const textBlocks = result?.content?.filter((block) => block.type === "text") as
+        | Array<{ text?: string }>
+        | undefined;
+      const combinedText = textBlocks?.map((block) => block.text ?? "").join("\n");
+      expect(combinedText).toContain("hello universe");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("coerces structured content blocks for write", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-structured-write-"));
     try {

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.e2e.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.e2e.test.ts
@@ -153,6 +153,20 @@ describe("createOpenClawCodingTools", () => {
       );
     });
 
+    it("promotes alias text when canonical structured text normalizes blank", () => {
+      const normalized = __testing.normalizeToolParams({
+        oldText: [{ type: "text", text: "   " }],
+        oldString: "needle",
+        newText: [{ type: "text", text: "replacement" }],
+      });
+
+      expect(normalized).toMatchObject({
+        oldText: "needle",
+        newText: "replacement",
+      });
+      expect(normalized).not.toHaveProperty("oldString");
+    });
+
     it("adds apply_patch guidance to the edit tool description", () => {
       const base: AgentTool = {
         name: "edit",
@@ -205,6 +219,11 @@ describe("createOpenClawCodingTools", () => {
     const schema = browser.parameters as { type?: unknown; anyOf?: unknown };
     expect(schema.type).toBe("object");
     expect(schema.anyOf).toBeUndefined();
+  });
+  it("routes the default unsandboxed edit tool through OpenClaw edit guidance", () => {
+    const edit = defaultTools.find((tool) => tool.name === "edit");
+    expect(edit).toBeDefined();
+    expect(edit?.description).toMatch(/prefer apply_patch/i);
   });
   it("mentions Chrome extension relay in browser tool description", () => {
     const browser = createBrowserTool();

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.e2e.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.e2e.test.ts
@@ -7,7 +7,11 @@ import { describe, expect, it, vi } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 import { __testing, createOpenClawCodingTools } from "./pi-tools.js";
-import { createOpenClawReadTool, createSandboxedReadTool } from "./pi-tools.read.js";
+import {
+  createOpenClawEditTool,
+  createOpenClawReadTool,
+  createSandboxedReadTool,
+} from "./pi-tools.read.js";
 import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge.js";
 import { createBrowserTool } from "./tools/browser-tool.js";
 
@@ -147,6 +151,52 @@ describe("createOpenClawCodingTools", () => {
       await expect(wrapped.execute("tool-4", {})).rejects.toThrow(
         /Supply correct parameters before retrying\./,
       );
+    });
+
+    it("adds apply_patch guidance to the edit tool description", () => {
+      const base: AgentTool = {
+        name: "edit",
+        label: "edit",
+        description:
+          "Edit a file by replacing exact text. The oldText must match exactly (including whitespace). Use this for precise, surgical edits.",
+        parameters: Type.Object({
+          path: Type.String(),
+          oldText: Type.String(),
+          newText: Type.String(),
+        }),
+        execute: vi.fn(),
+      };
+
+      const wrapped = createOpenClawEditTool(
+        base as unknown as Parameters<typeof createOpenClawEditTool>[0],
+      );
+      expect(wrapped.description).toMatch(/prefer apply_patch/i);
+      expect(wrapped.description).toMatch(/known exactly/i);
+    });
+
+    it("augments exact-match edit failures with remediation guidance", async () => {
+      const base: AgentTool = {
+        name: "edit",
+        label: "edit",
+        description: "edit",
+        parameters: Type.Object({
+          path: Type.String(),
+          oldText: Type.String(),
+          newText: Type.String(),
+        }),
+        execute: vi.fn(async () => {
+          throw new Error(
+            "Could not find the exact text in demo.txt. The old text must match exactly including all whitespace and newlines.",
+          );
+        }),
+      };
+
+      const wrapped = createOpenClawEditTool(
+        base as unknown as Parameters<typeof createOpenClawEditTool>[0],
+      );
+      await expect(
+        wrapped.execute("tool-err", { path: "demo.txt", oldText: "a", newText: "b" }),
+      ).rejects.toThrow(/use apply_patch|retry with a unique exact oldText/i);
     });
   });
 

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -337,20 +337,20 @@ function parameterValidationError(message: string): Error {
 }
 
 export const CLAUDE_PARAM_GROUPS = {
-  read: [{ keys: ["path", "file_path"], label: "path (path or file_path)" }],
+  read: [{ keys: ["path", "file_path", "filePath"], label: "path (path, file_path, or filePath)" }],
   write: [
-    { keys: ["path", "file_path"], label: "path (path or file_path)" },
+    { keys: ["path", "file_path", "filePath"], label: "path (path, file_path, or filePath)" },
     { keys: ["content"], label: "content" },
   ],
   edit: [
-    { keys: ["path", "file_path"], label: "path (path or file_path)" },
+    { keys: ["path", "file_path", "filePath"], label: "path (path, file_path, or filePath)" },
     {
-      keys: ["oldText", "old_string"],
-      label: "oldText (oldText or old_string)",
+      keys: ["oldText", "old_string", "oldString"],
+      label: "oldText (oldText, old_string, or oldString)",
     },
     {
-      keys: ["newText", "new_string"],
-      label: "newText (newText or new_string)",
+      keys: ["newText", "new_string", "newString"],
+      label: "newText (newText, new_string, or newString)",
     },
   ],
 } as const;
@@ -414,20 +414,32 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
   }
   const record = params as Record<string, unknown>;
   const normalized = { ...record };
-  // file_path → path (read, write, edit)
+  // file_path/filePath → path (read, write, edit)
   if ("file_path" in normalized && !("path" in normalized)) {
     normalized.path = normalized.file_path;
     delete normalized.file_path;
   }
-  // old_string → oldText (edit)
+  if ("filePath" in normalized && !("path" in normalized)) {
+    normalized.path = normalized.filePath;
+    delete normalized.filePath;
+  }
+  // old_string/oldString → oldText (edit)
   if ("old_string" in normalized && !("oldText" in normalized)) {
     normalized.oldText = normalized.old_string;
     delete normalized.old_string;
   }
-  // new_string → newText (edit)
+  if ("oldString" in normalized && !("oldText" in normalized)) {
+    normalized.oldText = normalized.oldString;
+    delete normalized.oldString;
+  }
+  // new_string/newString → newText (edit)
   if ("new_string" in normalized && !("newText" in normalized)) {
     normalized.newText = normalized.new_string;
     delete normalized.new_string;
+  }
+  if ("newString" in normalized && !("newText" in normalized)) {
+    normalized.newText = normalized.newString;
+    delete normalized.newString;
   }
   // Some providers/models emit text payloads as structured blocks instead of raw strings.
   // Normalize these for write/edit so content matching and writes stay deterministic.
@@ -455,8 +467,11 @@ export function patchToolSchemaForClaudeCompatibility(tool: AnyAgentTool): AnyAg
 
   const aliasPairs: Array<{ original: string; alias: string }> = [
     { original: "path", alias: "file_path" },
+    { original: "path", alias: "filePath" },
     { original: "oldText", alias: "old_string" },
+    { original: "oldText", alias: "oldString" },
     { original: "newText", alias: "new_string" },
+    { original: "newText", alias: "newString" },
   ];
 
   for (const { original, alias } of aliasPairs) {

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -331,6 +331,10 @@ type RequiredParamGroup = {
 };
 
 const RETRY_GUIDANCE_SUFFIX = " Supply correct parameters before retrying.";
+const EDIT_TOOL_DESCRIPTION_HINT =
+  " Use this only when the target text is known exactly and is unique in the file. If the surrounding text may have drifted or the change spans broader context, prefer apply_patch instead.";
+const EDIT_TOOL_REMEDIATION_HINT =
+  " Read the current file contents and retry with a unique exact oldText snippet, or use apply_patch for context-based edits.";
 
 function parameterValidationError(message: string): Error {
   return new Error(`${message}.${RETRY_GUIDANCE_SUFFIX}`);
@@ -596,6 +600,45 @@ export function wrapToolParamNormalization(
   };
 }
 
+function augmentEditToolError(error: unknown): never {
+  if (!(error instanceof Error)) {
+    throw error;
+  }
+
+  if (/prefer apply_patch instead|use apply_patch/i.test(error.message)) {
+    throw error;
+  }
+
+  if (
+    /Could not find the exact text|No changes made to .*replacement produced identical content|Found \d+ occurrences of the text/i.test(
+      error.message,
+    )
+  ) {
+    throw new Error(`${error.message} ${EDIT_TOOL_REMEDIATION_HINT}`);
+  }
+
+  throw error;
+}
+
+export function createOpenClawEditTool(base: AnyAgentTool): AnyAgentTool {
+  const wrapped = wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
+  const description = wrapped.description?.includes(EDIT_TOOL_DESCRIPTION_HINT)
+    ? wrapped.description
+    : `${wrapped.description}${EDIT_TOOL_DESCRIPTION_HINT}`;
+
+  return {
+    ...wrapped,
+    description,
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      try {
+        return await wrapped.execute(toolCallId, params, signal, onUpdate);
+      } catch (error) {
+        augmentEditToolError(error);
+      }
+    },
+  };
+}
+
 export function wrapToolWorkspaceRootGuard(tool: AnyAgentTool, root: string): AnyAgentTool {
   return {
     ...tool,
@@ -641,7 +684,7 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
   const base = createEditTool(params.root, {
     operations: createSandboxEditOperations(params),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamNormalization(base, CLAUDE_PARAM_GROUPS.edit);
+  return createOpenClawEditTool(base);
 }
 
 export function createOpenClawReadTool(

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -405,6 +405,64 @@ function normalizeTextLikeParam(record: Record<string, unknown>, key: string) {
   }
 }
 
+function isBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length === 0;
+}
+
+function hasConcreteValue(record: Record<string, unknown>, key: string): boolean {
+  if (!(key in record)) {
+    return false;
+  }
+  const value = record[key];
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (isBlankString(value)) {
+    return false;
+  }
+  return true;
+}
+
+function firstAliasValue(record: Record<string, unknown>, aliases: readonly string[]): unknown {
+  let fallback: unknown;
+  for (const alias of aliases) {
+    if (!(alias in record)) {
+      continue;
+    }
+    const value = record[alias];
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (typeof value === "string") {
+      if (value.trim().length > 0) {
+        return value;
+      }
+      if (fallback === undefined) {
+        fallback = value;
+      }
+      continue;
+    }
+    return value;
+  }
+  return fallback;
+}
+
+function normalizeAliasFamily(
+  record: Record<string, unknown>,
+  canonicalKey: string,
+  aliasKeys: readonly string[],
+): void {
+  if (!hasConcreteValue(record, canonicalKey)) {
+    const candidate = firstAliasValue(record, aliasKeys);
+    if (candidate !== undefined) {
+      record[canonicalKey] = candidate;
+    }
+  }
+  for (const alias of aliasKeys) {
+    delete record[alias];
+  }
+}
+
 // Normalize tool parameters from Claude Code conventions to pi-coding-agent conventions.
 // Claude Code uses file_path/old_string/new_string while pi-coding-agent uses path/oldText/newText.
 // This prevents models trained on Claude Code from getting stuck in tool-call loops.
@@ -414,33 +472,9 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
   }
   const record = params as Record<string, unknown>;
   const normalized = { ...record };
-  // file_path/filePath → path (read, write, edit)
-  if ("file_path" in normalized && !("path" in normalized)) {
-    normalized.path = normalized.file_path;
-    delete normalized.file_path;
-  }
-  if ("filePath" in normalized && !("path" in normalized)) {
-    normalized.path = normalized.filePath;
-    delete normalized.filePath;
-  }
-  // old_string/oldString → oldText (edit)
-  if ("old_string" in normalized && !("oldText" in normalized)) {
-    normalized.oldText = normalized.old_string;
-    delete normalized.old_string;
-  }
-  if ("oldString" in normalized && !("oldText" in normalized)) {
-    normalized.oldText = normalized.oldString;
-    delete normalized.oldString;
-  }
-  // new_string/newString → newText (edit)
-  if ("new_string" in normalized && !("newText" in normalized)) {
-    normalized.newText = normalized.new_string;
-    delete normalized.new_string;
-  }
-  if ("newString" in normalized && !("newText" in normalized)) {
-    normalized.newText = normalized.newString;
-    delete normalized.newString;
-  }
+  normalizeAliasFamily(normalized, "path", ["file_path", "filePath"]);
+  normalizeAliasFamily(normalized, "oldText", ["old_string", "oldString"]);
+  normalizeAliasFamily(normalized, "newText", ["new_string", "newString"]);
   // Some providers/models emit text payloads as structured blocks instead of raw strings.
   // Normalize these for write/edit so content matching and writes stay deterministic.
   normalizeTextLikeParam(normalized, "content");

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -456,6 +456,10 @@ function normalizeAliasFamily(
   canonicalKey: string,
   aliasKeys: readonly string[],
 ): void {
+  normalizeTextLikeParam(record, canonicalKey);
+  for (const alias of aliasKeys) {
+    normalizeTextLikeParam(record, alias);
+  }
   if (!hasConcreteValue(record, canonicalKey)) {
     const candidate = firstAliasValue(record, aliasKeys);
     if (candidate !== undefined) {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -34,6 +34,7 @@ import {
 import {
   assertRequiredParams,
   CLAUDE_PARAM_GROUPS,
+  createOpenClawEditTool,
   createOpenClawReadTool,
   createSandboxedEditTool,
   createSandboxedReadTool,
@@ -340,10 +341,7 @@ export function createOpenClawCodingTools(options?: {
         return [];
       }
       // Wrap with param normalization for Claude Code compatibility
-      const wrapped = wrapToolParamNormalization(
-        createEditTool(workspaceRoot),
-        CLAUDE_PARAM_GROUPS.edit,
-      );
+      const wrapped = createOpenClawEditTool(createEditTool(workspaceRoot) as AnyAgentTool);
       return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
     }
     return [tool];

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -211,7 +211,9 @@ export function resolveWriteDetail(toolKey: string, args: unknown): string | und
         ? record.newText
         : typeof record.new_string === "string"
           ? record.new_string
-          : undefined;
+          : typeof record.newString === "string"
+            ? record.newString
+            : undefined;
 
   if (content && content.length > 0) {
     return `${destinationPrefix} ${path} (${content.length} chars)`;


### PR DESCRIPTION
## Summary

This PR hardens OpenClaw's file-edit tool parameter normalization so model/provider-specific naming variations do not cause avoidable runtime failures.

It adds camelCase compatibility for the same edit/read/write alias families we already support in snake_case:
- `filePath` -> `path`
- `oldString` -> `oldText`
- `newString` -> `newText`

It also tightens the normalization behavior in two important ways:
- if the canonical field exists but is **blank**, a non-empty alias now correctly backfills it
- alias keys are now removed **unconditionally** after normalization, so mixed snake_case + camelCase payloads do not leave stray properties behind

In effect, this PR makes OpenClaw more tolerant of real model output shapes while keeping the canonical internal tool params unchanged.

This complements the existing support for:
- `file_path`
- `old_string`
- `new_string`

## Why

A real tool-call failure surfaced during Finance Mate work:

> `edit failed: Missing required parameter: newText (newText or new_string). Supply correct parameters before retrying.`

The model emitted camelCase alias fields, but the normalization layer only accepted snake_case aliases.

## Changes

- update `normalizeToolParams()` in `src/agents/pi-tools.read.ts`
- widen `CLAUDE_PARAM_GROUPS` compatibility labels/keys
- widen schema alias exposure in `patchToolSchemaForClaudeCompatibility()`
- update tool display detail handling for `newString`
- add focused e2e coverage for camelCase alias variants
- add focused coverage for:
  - blank canonical + non-empty alias payloads
  - mixed alias-family payload cleanup

## Validation

Installed locked deps locally and ran focused tests:

```bash
corepack pnpm exec vitest run --config vitest.e2e.config.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.e2e.test.ts
corepack pnpm exec vitest run --config vitest.e2e.config.ts src/agents/tool-display.e2e.test.ts
```

Result: `2 files passed`, `16 tests passed`.
