### PR TITLE
Auth: fix remote Codex OAuth manual completion

### DIFF
--- a/src/commands/openai-codex-oauth.test.ts
+++ b/src/commands/openai-codex-oauth.test.ts
@@ -13,11 +13,11 @@ vi.mock("@mariozechner/pi-ai/oauth", () => ({
   loginOpenAICodex: mocks.loginOpenAICodex,
 }));
 
-vi.mock("./oauth-flow.js", () => ({
+vi.mock("../plugins/provider-oauth-flow.js", () => ({
   createVpsAwareOAuthHandlers: mocks.createVpsAwareOAuthHandlers,
 }));
 
-vi.mock("./oauth-tls-preflight.js", () => ({
+vi.mock("../plugins/provider-openai-codex-oauth-tls.js", () => ({
   runOpenAIOAuthTlsPreflight: mocks.runOpenAIOAuthTlsPreflight,
   formatOpenAIOAuthTlsPreflightFix: mocks.formatOpenAIOAuthTlsPreflightFix,
 }));
@@ -73,6 +73,7 @@ describe("loginOpenAICodexOAuth", () => {
     mocks.createVpsAwareOAuthHandlers.mockReturnValue({
       onAuth: vi.fn(),
       onPrompt: vi.fn(),
+      onManualCodeInput: vi.fn(),
     });
     mocks.loginOpenAICodex.mockResolvedValue(creds);
 
@@ -80,6 +81,11 @@ describe("loginOpenAICodexOAuth", () => {
 
     expect(result).toEqual(creds);
     expect(mocks.loginOpenAICodex).toHaveBeenCalledOnce();
+    expect(mocks.loginOpenAICodex).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onManualCodeInput: expect.any(Function),
+      }),
+    );
     expect(spin.stop).toHaveBeenCalledWith("OpenAI OAuth complete");
     expect(runtime.error).not.toHaveBeenCalled();
   });
@@ -96,6 +102,7 @@ describe("loginOpenAICodexOAuth", () => {
     mocks.createVpsAwareOAuthHandlers.mockReturnValue({
       onAuth: onAuthSpy,
       onPrompt: vi.fn(),
+      onManualCodeInput: vi.fn(),
     });
     mocks.loginOpenAICodex.mockImplementation(
       async (opts: { onAuth: (event: { url: string }) => Promise<void> }) => {
@@ -119,6 +126,7 @@ describe("loginOpenAICodexOAuth", () => {
     mocks.createVpsAwareOAuthHandlers.mockReturnValue({
       onAuth: vi.fn(),
       onPrompt: vi.fn(),
+      onManualCodeInput: vi.fn(),
     });
     mocks.loginOpenAICodex.mockRejectedValue(new Error("oauth failed"));
 
@@ -157,6 +165,7 @@ describe("loginOpenAICodexOAuth", () => {
     mocks.createVpsAwareOAuthHandlers.mockReturnValue({
       onAuth: vi.fn(),
       onPrompt: vi.fn(),
+      onManualCodeInput: vi.fn(),
     });
     mocks.loginOpenAICodex.mockResolvedValue(creds);
 

--- a/src/plugins/provider-oauth-flow.ts
+++ b/src/plugins/provider-oauth-flow.ts
@@ -16,21 +16,29 @@ export function createVpsAwareOAuthHandlers(params: {
 }): {
   onAuth: (event: { url: string }) => Promise<void>;
   onPrompt: (prompt: OAuthPrompt) => Promise<string>;
+  onManualCodeInput: () => Promise<string>;
 } {
   const manualPromptMessage = params.manualPromptMessage ?? "Paste the redirect URL";
   let manualCodePromise: Promise<string> | undefined;
+
+  const getManualCode = async () => {
+    if (!manualCodePromise) {
+      manualCodePromise = params.prompter
+        .text({
+          message: manualPromptMessage,
+          validate: validateRequiredInput,
+        })
+        .then((value) => String(value));
+    }
+    return await manualCodePromise;
+  };
 
   return {
     onAuth: async ({ url }) => {
       if (params.isRemote) {
         params.spin.stop("OAuth URL ready");
         params.runtime.log(`\nOpen this URL in your LOCAL browser:\n\n${url}\n`);
-        manualCodePromise = params.prompter
-          .text({
-            message: manualPromptMessage,
-            validate: validateRequiredInput,
-          })
-          .then((value) => String(value));
+        manualCodePromise = getManualCode();
         return;
       }
 
@@ -49,5 +57,6 @@ export function createVpsAwareOAuthHandlers(params: {
       });
       return String(code);
     },
+    onManualCodeInput: getManualCode,
   };
 }

--- a/src/plugins/provider-openai-codex-oauth.ts
+++ b/src/plugins/provider-openai-codex-oauth.ts
@@ -40,7 +40,11 @@ export async function loginOpenAICodexOAuth(params: {
 
   const spin = prompter.progress("Starting OAuth flow…");
   try {
-    const { onAuth: baseOnAuth, onPrompt } = createVpsAwareOAuthHandlers({
+    const {
+      onAuth: baseOnAuth,
+      onPrompt,
+      onManualCodeInput,
+    } = createVpsAwareOAuthHandlers({
       isRemote,
       prompter,
       runtime,
@@ -52,6 +56,7 @@ export async function loginOpenAICodexOAuth(params: {
     const creds = await loginOpenAICodex({
       onAuth: baseOnAuth,
       onPrompt,
+      onManualCodeInput,
       onProgress: (msg: string) => spin.update(msg),
     });
     spin.stop("OpenAI OAuth complete");


### PR DESCRIPTION
## Summary

- Problem: OpenAI Codex OAuth in remote or containerized shells could hang after the user pasted the final redirect URL back into the terminal.
- Why it matters: Docker, SSH, and VPS operators could complete browser sign-in but never persist auth, which made `openclaw onboard` and `models auth login` look stuck.
- What changed: The shared VPS-aware OAuth handler now exposes a reusable manual redirect input callback, and the OpenAI Codex OAuth flow passes that callback through to `loginOpenAICodex()` so pasted redirect URLs are actually consumed.
- What did NOT change (scope boundary): No redirect URI, token exchange semantics, TLS preflight behavior, or local browser OAuth flow behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41885
- Related #48592

## User-visible / Behavior Changes

- `openclaw models auth login --provider openai-codex` now completes in remote or Docker shells after the pasted redirect URL is submitted.
- `openclaw onboard` can complete OpenAI Codex OAuth inside the Docker CLI container instead of hanging at the manual paste step.
- Local desktop OAuth behavior remains unchanged.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04.3 LTS host
- Runtime/container: Docker Compose CLI container and local Node/Vitest workspace
- Model/provider: OpenAI Codex
- Integration/channel (if any): CLI onboarding / model auth login
- Relevant config (redacted): Docker gateway on a separate state dir and published port (`28789`)

### Steps

1. Start the split Docker setup and run `docker compose run --rm openclaw-cli onboard`.
2. Choose OpenAI Codex auth from the containerized CLI and complete sign-in in a local browser.
3. Paste the final `http://localhost:1455/auth/callback?...` URL back into the Docker shell.

### Expected

- OAuth completes, auth is persisted in the Docker state dir, and onboarding can proceed.

### Actual

- Before this change, the flow stayed stuck after the paste because the manual redirect URL was not wired into the Codex OAuth completion path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Vitest coverage for the Codex OAuth wrapper, and a manual Docker onboarding retry after rebuilding the image from this branch.
- Edge cases checked: existing local-browser flow still receives the same handlers; remote/manual flow reuses one prompt promise instead of opening a second prompt path.
- What you did **not** verify: Windows-specific OAuth behavior and a full repo-wide `pnpm test` run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit.
- Files/config to restore: `src/plugins/provider-oauth-flow.ts`, `src/plugins/provider-openai-codex-oauth.ts`, `src/commands/openai-codex-oauth.test.ts`
- Known bad symptoms reviewers should watch for: Codex OAuth manual entry prompting twice or not accepting a pasted redirect URL in remote shells.

## Risks and Mitigations

- Risk: Other providers could later assume `createVpsAwareOAuthHandlers()` only returns `onAuth` and `onPrompt`.
  - Mitigation: The new callback is additive, typed, and covered by targeted tests for the Codex OAuth caller.
