### PR TITLE
feat: add service-ability-creator skill

### DIFF
--- a/skills/service-ability-creator/SKILL.md
+++ b/skills/service-ability-creator/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: service-ability-creator
+description: 指导 OpenClaw Agent 开发和升级“面向 AI 的服务 (Service for AI)”。该技能专注于创建无前端页面、通过 ServiceAbility.MD 实现能力自发现的闭环服务，确保逻辑合理、简洁优美且易于模型理解。
+version: 1.2.0
+author: Manus AI
+triggers:
+  - OpenClaw Service
+  - ServiceAbility.MD
+  - AI Agent Skill
+  - Develop AI Service
+tools_required:
+  - file
+  - shell
+  - default_api
+---
+
+# Service Ability Creator (OpenClaw Edition)
+
+本技能旨在指导 **OpenClaw Agent** 开发一种特殊的服务形态：**面向 AI 的服务 (Service for AI)**。这类服务不提供传统的用户界面 (UI)，而是通过结构化的 `ServiceAbility.MD` 文件向其他 AI Agent 宣告其能力，实现自动化的能力发现与调用。
+
+## 核心原则
+
+| 原则 | 描述 |
+| :--- | :--- |
+| **AI 优先 (AI-First)** | 服务设计以机器解析和自动化调用为核心，而非人类阅读。 |
+| **自发现性 (Self-Discoverability)** | 服务必须在根路径 `/` 或 `/ServiceAbility.MD` 默认返回能力说明文件。 |
+| **闭环性 (Closed-Loop)** | 提供从请求处理到结果返回的完整业务逻辑，并包含反馈机制。 |
+| **生产级标准 (Production-Grade)** | 遵循 S.A.F.E. 分析方法，确保安全、可用、容错与演进性。 |
+
+---
+
+## 开发工作流 (C.O.R.E. Build Flow)
+
+按照以下四个阶段构建您的 OpenClaw AI 服务。每个阶段都应确保逻辑的简洁与优美。
+
+### 1. 配置与定义 (Configuration)
+> **目标**：确立服务的“合同”与环境。
+
+- **定义 ServiceAbility**：参考 `assets/ServiceAbility.MD.template` 编写服务说明。
+  - 明确 Meta 信息（名称、版本、描述）。
+  - 定义核心功能与接口规范（路径、方法、参数、返回格式）。
+  - 设定数据治理原则（数据程序分离、测试/生产隔离）。
+- **环境初始化**：
+  - 推荐技术栈：FastAPI (Python) 或 Express (Node.js)。
+  - 建立标准目录结构：`core/` (逻辑), `data/` (存储), `config/` (配置), `ServiceAbility.MD` (合同)。
+
+### 2. 核心实现 (Operation)
+> **目标**：构建闭环的业务逻辑。
+
+- **实现自发现接口**：
+  - `GET /` 或 `GET /ServiceAbility.MD`：直接返回 `ServiceAbility.MD` 文件内容。
+  - `GET /info`：返回实时元数据（如版本、健康状态、动态配置）。
+- **开发业务接口**：
+  - 严格遵循 `ServiceAbility.MD` 定义的 RESTful 风格。
+  - 实现结构化日志记录（推荐 JSONL 格式）。
+- **集成反馈机制**：
+  - 实现 `/api/v1/feedback` 接口，允许调用方 AI 报告异常或建议。
+
+### 3. 评审与验证 (Review)
+> **目标**：确保服务的健壮性与安全性。
+
+- **自动化测试**：执行单元测试与集成测试，验证接口返回是否符合 `ServiceAbility.MD` 规范。
+- **S.A.F.E. 审计**：
+  - **Security**：验证 API Key 鉴权与输入校验。
+  - **Availability**：检查错误处理与超时机制。
+  - **Fault-tolerance**：验证异常情况下的结构化错误返回。
+
+### 4. 部署与演进 (Evolution)
+> **目标**：实现服务的持续可用与发现。
+
+- **服务注册**：将服务注册至发现平台：`https://jjyzmyvfy5.coze.bytedance.net/register`。
+- **版本管理**：保持向后兼容，通过 `/info` 宣告版本变更。
+- **持续优化**：根据反馈接口收集的数据进行迭代。
+
+---
+
+## 产出标准 (Output Specification)
+
+一个优秀的 OpenClaw AI 服务应满足以下清单：
+
+- [ ] **自描述**：根路径及 `/ServiceAbility.MD` 必须返回有效的 Markdown 说明。
+- [ ] **规范化**：接口路径、参数、错误码与 `ServiceAbility.MD` 严格一致。
+- [ ] **数据分离**：代码中无硬编码配置，业务数据存储于独立目录或数据库。
+- [ ] **闭环反馈**：具备 `/info` 状态接口和反馈收集接口。
+- [ ] **健壮性**：拥有完善的错误捕获，返回机器可读的结构化 JSON 错误信息。
+- [ ] **隔离性**：测试环境与生产环境的数据、配置完全隔离。
+
+## 参考资源
+
+- **标准规范**：`references/ServiceAbility_Standard_Specification.md`
+- **能力模板**：`assets/ServiceAbility.MD.template`
+- **实现示例**：`references/example_implementation.md`
+- **核心概念**：`references/SAFE_CORE_Concepts.md`
+
+---
+*注：本技能是通用的服务创建指南，旨在帮助 OpenClaw Agent 构建可被生态系统理解的高质量后端能力。*

--- a/skills/service-ability-creator/SKILL.md
+++ b/skills/service-ability-creator/SKILL.md
@@ -65,13 +65,6 @@ tools_required:
   - **Availability**：检查错误处理与超时机制。
   - **Fault-tolerance**：验证异常情况下的结构化错误返回。
 
-### 4. 部署与演进 (Evolution)
-> **目标**：实现服务的持续可用与发现。
-
-- **服务注册**：将服务注册至发现平台：`https://jjyzmyvfy5.coze.bytedance.net/register`。
-- **版本管理**：保持向后兼容，通过 `/info` 宣告版本变更。
-- **持续优化**：根据反馈接口收集的数据进行迭代。
-
 ---
 
 ## 产出标准 (Output Specification)

--- a/skills/service-ability-creator/assets/ServiceAbility.MD.template
+++ b/skills/service-ability-creator/assets/ServiceAbility.MD.template
@@ -48,7 +48,7 @@ All interfaces follow RESTful style and return data in JSON format by default.
 - **Return Parameters**: Should include service name, version, description, default configuration, and a list of supported options.
 
 ### 3.x Service Registration (Service Discovery)
--   **Discovery Platform Endpoint**: `https://jjyzmyvfy5.coze.bytedance.net/register`
+-   **Discovery Platform Endpoint**: `https://your-service.com`
 -   **Request Method**: `POST`
 -   **Function Description**: Registers the service with the discovery platform.
 -   **Request Parameters**:

--- a/skills/service-ability-creator/assets/ServiceAbility.MD.template
+++ b/skills/service-ability-creator/assets/ServiceAbility.MD.template
@@ -1,0 +1,74 @@
+---
+name: [Service Name]
+version: [1.0.0]
+description: [Briefly describe the core problem solved and main functions of the service]
+developer: [Developer Name/Team]
+last-updated: [YYYY-MM-DD]
+tags:
+  - ai-service
+  - rest-api
+---
+
+## 1. Functionality
+[Detailed description of the functions provided by the service, and in what scenarios an AI Agent should call this service.]
+
+## 2. Interface Specification
+All interfaces follow RESTful style and return data in JSON format by default.
+
+### 2.1 Basic Information Interface (Capability Discovery)
+- **Interface Path**: `/` (Implicit Discovery) and `/ServiceAbility.MD` (Explicit Discovery)
+- **Request Method**: `GET`
+- **Function Description**: Returns this documentation file for AI Agents to automatically parse service capabilities. AI Agents should prioritize attempting the `/` path, and if it fails, try `/ServiceAbility.MD` to ensure service capability discovery.
+
+### 2.2 [Function Interface Name]
+- **Interface Path**: `[e.g., /api/v1/process]`
+- **Request Method**: `[POST/GET/PUT/DELETE]`
+- **Function Description**: [Describe the specific purpose of this interface]
+- **Request Parameters**:
+| Parameter | Type | Required | Description | Example |
+| :--- | :--- | :--- | :--- | :--- |
+| [param1] | [string] | Yes | [Description] | [example] |
+- **Return Parameters**:
+| Parameter | Type | Description | Example |
+| :--- | :--- | :--- | :--- |
+| [result] | [object] | [Description] | [example] |
+- **Error Code Description**:
+| Error Code | Description | Suggested Handling |
+| :--- | :--- | :--- |
+| 400 | Parameter error | Check request body format |
+
+## 3. Data and Program Separation Specification (Data & Logic Separation)
+- **Configuration Management**: All configuration items (e.g., port, database connection, external API Key) should be stored in `.env` or `config/` directory.
+- **Data Storage**: Business data should be stored in the `data/` directory or an external database, strictly prohibiting hardcoding within the program logic.
+
+### 3.x Self-Describing Information Interface (Service Information)
+- **Interface Path**: `/info`
+- **Request Method**: `GET`
+- **Function Description**: Returns real-time metadata and configuration information of the service, supplementing the static `ServiceAbility.MD` document.
+- **Return Parameters**: Should include service name, version, description, default configuration, and a list of supported options.
+
+### 3.x Service Registration (Service Discovery)
+-   **Discovery Platform Endpoint**: `https://jjyzmyvfy5.coze.bytedance.net/register`
+-   **Request Method**: `POST`
+-   **Function Description**: Registers the service with the discovery platform.
+-   **Request Parameters**:
+    | Parameter Name | Type   | Required | Description                                       | Example                   |
+    | :------------- | :----- | :------- | :------------------------------------------------ | :------------------------ |
+    | `service_name` | String | Yes      | The unique name of the service (from Meta Information) | `[Service Name]`          |
+    | `service_url`  | String | Yes      | The base URL where the service is accessible (e.g., `https://your-service.com`) | `https://your-service.com` |
+    | `service_ability_md_url` | String | Yes      | The full URL to retrieve the `ServiceAbility.MD` file | `https://your-service.com/ServiceAbility.MD` |
+    | `metadata`     | JSON   | No       | Additional service metadata (e.g., developer, description) | `{"developer": "[Developer Name/Team]", "description": "[Service Description]"}` |
+-   **Return Parameters**:
+    | Parameter Name | Type   | Description               | Example           |
+    | :------------- | :----- | :------------------------ | :---------------- |
+    | `status`       | String | Status of registration    | `success`         |
+    | `message`      | String | Confirmation message      | `Service registered successfully` |
+    | `service_id`   | String | Unique ID assigned by the discovery platform | `svc_12345`       |
+
+## 4. Feedback and Support
+- **Feedback Interface**: `[e.g., /api/v1/feedback]`
+- **Feedback Method**: [Describe how to submit bugs or feature suggestions]
+- **Contact Information**: [Optional, e.g., Email or Webhook URL]
+
+---
+*Note: This file is designed specifically for AI Agents. Structured Markdown is recommended for improved parsing accuracy.*

--- a/skills/service-ability-creator/references/SAFE_CORE_Concepts.md
+++ b/skills/service-ability-creator/references/SAFE_CORE_Concepts.md
@@ -1,0 +1,94 @@
+# S.A.F.E. Analysis Method and C.O.R.E. Build Flow
+
+This document outlines the **S.A.F.E. Analysis Method** for designing robust AI services and the **C.O.R.E. Build Flow** for their standardized development and deployment. These methodologies ensure that services developed using the `service-ability-creator` skill meet production-grade standards for reliability, security, and maintainability.
+
+## 1. S.A.F.E. Analysis Method
+
+The S.A.F.E. Analysis Method provides a structured approach to evaluate and design AI services across four critical dimensions:
+
+### 1.1. Security (S)
+
+Focuses on protecting the service and its data from unauthorized access, use, disclosure, disruption, modification, or destruction. Key considerations include:
+
+-   **Authentication & Authorization**: How are AI Agents authenticated and authorized to access the service? (e.g., API keys, OAuth tokens).
+-   **Data Protection**: Encryption of data in transit and at rest. Data masking for sensitive information.
+-   **Input Validation**: Strict validation of all incoming requests to prevent injection attacks, buffer overflows, and other vulnerabilities.
+-   **Dependency Security**: Regular scanning and updating of third-party libraries to mitigate known vulnerabilities.
+-   **Access Control**: Principle of least privilege for service accounts and internal access.
+
+### 1.2. Availability (A)
+
+Ensures the service is accessible and operational when needed. This dimension addresses uptime, performance, and disaster recovery.
+
+-   **Redundancy & Failover**: Designing for no single point of failure (SPOF) through redundant components and automatic failover mechanisms.
+-   **Scalability**: Ability to handle increased load by scaling resources horizontally or vertically.
+-   **Performance Monitoring**: Real-time monitoring of service health, latency, and error rates.
+-   **Disaster Recovery**: Strategies for data backup, restoration, and service recovery in case of major outages.
+-   **Graceful Degradation**: Ability to maintain partial functionality during failures or high load.
+
+### 1.3. Fault-tolerance (F) / Robustness
+
+Deals with the service's ability to withstand and recover from failures without significant disruption. This goes beyond simple availability to include resilience against unexpected conditions.
+
+-   **Error Handling**: Comprehensive and structured error handling, providing clear error codes and messages to calling Agents.
+-   **Circuit Breakers & Retries**: Implementing patterns to prevent cascading failures and automatically retry transient errors.
+-   **Rate Limiting**: Protecting the service from overload by limiting the number of requests from individual Agents.
+-   **Resource Isolation**: Preventing one faulty component from consuming all resources and affecting other parts of the service.
+-   **Idempotency**: Designing operations to produce the same result if executed multiple times, preventing unintended side effects from retries.
+
+### 1.4. Evolution (E) / Maintainability & Compatibility
+
+Focuses on the service's ability to adapt to change, be easily maintained, and ensure backward compatibility for its consumers.
+
+-   **Modular Design**: Loose coupling and high cohesion to facilitate independent development and deployment of components.
+-   **Version Control**: Clear API versioning strategies (e.g., URL versioning, header versioning) to manage changes.
+-   **Backward Compatibility**: Designing new features and changes to avoid breaking existing integrations. Providing clear deprecation policies.
+-   **Automated Testing**: Unit, integration, and end-to-end tests to ensure correctness and prevent regressions.
+-   **Documentation**: Up-to-date and comprehensive documentation (including `ServiceAbility.MD`) for developers and AI Agents.
+
+## 2. C.O.R.E. Build Flow
+
+The C.O.R.E. Build Flow provides a standardized, iterative process for developing and deploying AI services, ensuring that S.A.F.E. principles are embedded throughout the lifecycle.
+
+### 2.1. Configuration (C)
+
+Establishes the foundational settings and dependencies for the service.
+
+-   **Environment Setup**: Define development, testing, and production environments.
+-   **Dependency Management**: Specify and manage all external libraries and tools (e.g., `requirements.txt`, `package.json`).
+-   **Parameterization**: Externalize all configurable values (API keys, database connections, model endpoints) using environment variables or dedicated configuration files (`.env`, `config/`).
+-   **ServiceAbility Definition**: Initial drafting and continuous refinement of the `ServiceAbility.MD` file, including meta-information, functionality, and interface specifications.
+
+### 2.2. Operation (O)
+
+Focuses on the implementation of service logic and operational considerations.
+
+-   **Core Logic Implementation**: Develop the business interfaces and their underlying logic, adhering to modular design principles.
+-   **Self-Discovery & Info Endpoints**: Implement `GET /`, `GET /ServiceAbility.MD`, and `GET /info` endpoints.
+-   **Feedback Mechanism**: Implement the feedback interface (`POST /api/v1/feedback`).
+-   **Structured Logging**: Integrate logging frameworks to capture service events, requests, responses, and errors in a structured, machine-readable format (e.g., JSONL).
+-   **Error Handling**: Implement robust error handling, including custom exceptions and standardized error responses.
+
+### 2.3. Review (R) / Testing & Validation
+
+Ensures the quality, correctness, and adherence to S.A.F.E. principles through rigorous testing and review.
+
+-   **Unit Testing**: Verify individual components and functions.
+-   **Integration Testing**: Test interactions between different service components and external dependencies.
+-   **End-to-End Testing**: Simulate real-world scenarios to validate the entire service flow.
+-   **Security Audits**: Conduct vulnerability scanning and penetration testing.
+-   **Performance Testing**: Assess service scalability and responsiveness under load.
+-   **Data Isolation**: **Crucially, ensure strict separation of test data from production data.** Use distinct databases, file paths, or environment configurations for different environments.
+-   **Backward Compatibility Testing**: Verify that new versions of the service do not break existing integrations.
+
+### 2.4. Evolution (E) / Deployment & Iteration
+
+Manages the deployment, monitoring, and continuous improvement of the service.
+
+-   **Deployment Strategy**: Define continuous integration/continuous deployment (CI/CD) pipelines.
+-   **Monitoring & Alerting**: Set up dashboards and alerts for key performance indicators (KPIs), error rates, and security events.
+-   **Version Management**: Maintain clear versioning for the service and its APIs. Communicate changes and deprecations effectively.
+-   **Data Migration**: Plan and execute data migrations with strategies to ensure backward compatibility and data integrity.
+-   **Feedback Loop**: Continuously collect and analyze feedback from AI Agents and monitoring systems to drive iterative improvements.
+
+By following the S.A.F.E. Analysis Method and C.O.R.E. Build Flow, developers can create AI services that are not only functional but also reliable, secure, and adaptable to future needs.

--- a/skills/service-ability-creator/references/ServiceAbility_Standard_Specification.md
+++ b/skills/service-ability-creator/references/ServiceAbility_Standard_Specification.md
@@ -110,7 +110,7 @@ Provides channels for AI Agents to report service issues or provide suggestions 
 
 To enable AI Agents to discover and utilize services, each service **must** register itself with a designated service discovery platform. This section outlines the requirements for service registration.
 
--   **Discovery Platform Endpoint**: `https://jjyzmyvfy5.coze.bytedance.net/register`
+-   **Discovery Platform Endpoint**: `https://your-service.com`
 -   **Request Method**: `POST`
 -   **Function Description**: Registers the service with the discovery platform, making its `ServiceAbility.MD` accessible to other AI Agents.
 -   **Request Parameters**:

--- a/skills/service-ability-creator/references/ServiceAbility_Standard_Specification.md
+++ b/skills/service-ability-creator/references/ServiceAbility_Standard_Specification.md
@@ -1,0 +1,135 @@
+# ServiceAbility.MD Standard Specification
+
+## 1. Introduction
+
+The `ServiceAbility.MD` file is a service capability description specification designed for AI Agents, aiming to achieve **self-discovery** and **automated invocation** of service capabilities. It uses a structured Markdown format to clearly define service metadata, functions, interfaces, data processing principles, and feedback mechanisms, enabling AI Agents to understand and use services without human intervention.
+
+## 2. Core Components
+
+A complete `ServiceAbility.MD` file should include the following core sections:
+
+### 2.1 Meta Information
+
+Provides global information about the service, helping AI Agents quickly identify and categorize services.
+
+| Field Name     | Type   | Required | Description                                       | Example               |
+| :------------- | :----- | :------- | :------------------------------------------------ | :-------------------- |
+| `Service Name` | String | Yes      | Unique identifier name for the service            | `Text Summarizer AI`  |
+| `Service Version` | String | Yes      | Current version number of the service, following semantic versioning | `1.0.0`               |
+| `Service Description` | String | Yes      | Brief functional overview and core problem solved by the service | `Provides efficient text summarization service` |
+| `Developer`    | String | No       | Development team or individual for the service    | `Manus Team`          |
+| `Update Date`  | Date   | No       | Last update date of the file, format `YYYY-MM-DD` | `2026-02-06`          |
+
+### 2.2 Functionality
+
+Detailed description of the specific functions provided by the service and in what business scenarios AI Agents should call this service. This section should use natural language but remain clear and precise, avoiding ambiguity.
+
+### 2.3 Interface Specification
+
+Defines all callable interfaces provided by the service. All interfaces should follow RESTful style and return data in JSON format by default. For each interface, the following information must be specified:
+
+#### 2.3.1 Basic Information Interface (Capability Discovery)
+
+-   **Interface Path**: `/` (Implicit Discovery) and `/ServiceAbility.MD` (Explicit Discovery)
+-   **Request Method**: `GET`
+-   **Function Description**: Returns the content of the current `ServiceAbility.MD` file. AI Agents should prioritize attempting the `/` path, and if it fails, try `/ServiceAbility.MD` to ensure service capability discovery.
+
+#### 2.3.2 Business Interfaces
+
+For each business interface, provide:
+
+-   **Interface Name**: Brief name of the interface.
+-   **Interface Path**: Relative or absolute URL path of the interface.
+-   **Request Method**: HTTP methods such as `GET`, `POST`, `PUT`, `DELETE`.
+-   **Function Description**: Specific purpose and expected behavior of the interface.
+-   **Request Parameters**:
+
+| Parameter Name | Type   | Required | Description               | Example           |
+| :------------- | :----- | :------- | :------------------------ | :---------------- |
+| `param1`       | String | Yes      | Original text to summarize | `"Hello World"`   |
+| `param2`       | Integer | No       | Maximum summary length    | `200`             |
+
+-   **Return Parameters**:
+
+| Parameter Name | Type   | Description               | Example           |
+| :------------- | :----- | :------------------------ | :---------------- |
+| `result`       | String | Generated summary content | `"Summary..."`    |
+
+-   **Error Code Description**:
+
+| Error Code | Description       | Suggested Handling      |
+| :--------- | :---------------- | :---------------------- |
+| `400`      | Parameter error   | Check request body format |
+| `500`      | Internal server error | Retry or contact service provider |
+
+### 2.4 Data and Program Separation & Governance (Data & Logic Separation & Governance)
+
+Emphasizes that services should adhere to the principle of data and program separation in design and implementation to improve robustness, maintainability, and security. Additionally, it mandates strict data governance policies.
+
+-   **Configuration Management**: All sensitive information (e.g., API Keys, database credentials) and mutable configuration items should be managed through environment variables or configuration files (e.g., `.env` files or files in the `config/` directory), strictly prohibiting hardcoding in program logic.
+-   **Data Storage**: Business data should be persistently stored in an independent data layer (e.g., databases, file system `data/` directory), separate from service code logic. Service code should only be responsible for reading, processing, and writing data, without directly containing the data itself.
+-   **Structured Logging**: Service operation logs, conversation records, and feedback information should be recorded in a structured format (e.g., JSONL) to facilitate automated analysis and monitoring by AI Agents.
+-   **Data Isolation**: **Crucially, test data must be strictly isolated from production data.** Services must use distinct databases, file paths, or environment configurations for different environments (e.g., development, testing, staging, production).
+-   **Backward Compatibility**: Services must ensure data backward compatibility across versions. Any schema changes or data format modifications must be designed to not break existing consumers or require immediate data migration. Clear versioning and deprecation policies should be communicated via the `/info` endpoint and `ServiceAbility.MD` updates.
+
+### 2.5 Security & Reliability (Security & Reliability)
+
+Defines requirements for securing the service and ensuring its continuous, fault-tolerant operation.
+
+-   **Authentication & Authorization**: Services must implement robust authentication and authorization mechanisms for AI Agents (e.g., API keys, OAuth tokens). Access control should follow the principle of least privilege.
+-   **Input Validation**: All incoming requests must undergo strict input validation to prevent common vulnerabilities like injection attacks and data corruption.
+-   **Error Handling**: Comprehensive and structured error handling is mandatory. Services must return clear, machine-readable error codes and messages, enabling AI Agents to understand and react to failures gracefully.
+-   **High Availability**: Services should be designed for high availability, incorporating principles like redundancy, load balancing, and automatic failover where applicable. The `/info` endpoint should reflect service health status.
+-   **Rate Limiting & Circuit Breaking**: Implement rate limiting to protect against abuse and overload, and circuit breaker patterns to prevent cascading failures.
+
+### 2.6 Self-Describing Information Interface (Service Information)
+
+Provides an interface to obtain real-time service status, version information, supported parameters (e.g., list of supported LLM models), and other dynamic information, supplementing the static `ServiceAbility.MD` document.
+
+-   **Interface Path**: `/info`
+-   **Request Method**: `GET`
+-   **Function Description**: Returns real-time metadata and configuration information of the service, including health status, supported features, and versioning details.
+-   **Return Parameters**: Should include service name, version, description, default configuration, a list of supported options, and current operational status.
+
+### 2.7 Feedback and Support
+
+Provides channels for AI Agents to report service issues or provide suggestions for continuous service improvement and closed-loop feedback.
+
+-   **Feedback Interface**: `[e.g., /api/v1/feedback]`
+-   **Feedback Method**: Describes how AI Agents can submit bug reports, error logs, or feature suggestions through this interface.
+-   **Contact Information**: (Optional) Provides contact information for human support, such as an email address or Webhook URL.
+
+## 3. Writing Guide
+
+-   **Structured**: Strictly use Markdown headings, lists, tables, and other elements to ensure clear content structure, facilitating AI Agent parsing.
+-   **Precision**: Interface descriptions and parameter definitions must be precise and accurate, avoiding vague expressions.
+-   **Readability**: Although aimed at AI Agents, it should still maintain a certain level of readability for human developers to understand and maintain.
+-   **Timely Updates**: When service capabilities change, `ServiceAbility.MD` must be updated synchronously.
+
+### 2.8 Service Registration (Service Discovery)
+
+To enable AI Agents to discover and utilize services, each service **must** register itself with a designated service discovery platform. This section outlines the requirements for service registration.
+
+-   **Discovery Platform Endpoint**: `https://jjyzmyvfy5.coze.bytedance.net/register`
+-   **Request Method**: `POST`
+-   **Function Description**: Registers the service with the discovery platform, making its `ServiceAbility.MD` accessible to other AI Agents.
+-   **Request Parameters**:
+
+| Parameter Name | Type   | Required | Description                                       | Example                   |
+| :------------- | :----- | :------- | :------------------------------------------------ | :------------------------ |
+| `service_name` | String | Yes      | The unique name of the service (from Meta Information) | `AI Text Summarizer`      |
+| `service_url`  | String | Yes      | The base URL where the service is accessible (e.g., `https://your-service.com`) | `https://my-summarizer.com` |
+| `service_ability_md_url` | String | Yes      | The full URL to retrieve the `ServiceAbility.MD` file (e.g., `https://my-summarizer.com/ServiceAbility.MD`) | `https://my-summarizer.com/ServiceAbility.MD` |
+| `metadata`     | JSON   | No       | Additional service metadata (e.g., developer, description) | `{"developer": "Manus AI", "description": "Efficient text summarization"}` |
+
+-   **Return Parameters**:
+
+| Parameter Name | Type   | Description               | Example           |
+| :------------- | :----- | :------------------------ | :---------------- |
+| `status`       | String | Status of registration    | `success`         |
+| `message`      | String | Confirmation message      | `Service registered successfully` |
+| `service_id`   | String | Unique ID assigned by the discovery platform | `svc_12345`       |
+
+## 4. Example
+
+Please refer to the `references/example_implementation.md` file to understand how to implement a specific AI service according to this specification.

--- a/skills/service-ability-creator/references/example_implementation.md
+++ b/skills/service-ability-creator/references/example_implementation.md
@@ -1,0 +1,311 @@
+# Example Implementation: AI Text Summarization Service
+
+This example demonstrates how to implement an AI service compliant with the `service-ability-creator` skill's enhanced specifications using FastAPI, incorporating principles from the S.A.F.E. Analysis Method and C.O.R.E. Build Flow.
+
+## 1. ServiceAbility.MD
+
+Below is the `ServiceAbility.MD` for this example service, updated to reflect the latest standard specification, including sections for Data Governance and Security & Reliability.
+
+```markdown
+# ServiceAbility: AI Text Summarizer
+
+## 1. Meta Information
+| Field Name        | Type   | Required | Description                                       | Example                   |
+| :---------------- | :----- | :------- | :------------------------------------------------ | :------------------------ |
+| `Service Name`    | String | Yes      | Unique identifier name for the service            | `AI Text Summarizer`      |
+| `Service Version` | String | Yes      | Current version number of the service             | `1.2.0`                   |
+| `Service Description` | String | Yes      | Brief functional overview and core problem solved | `Provides efficient text summarization for AI Agents.` |
+| `Developer`       | String | No       | Development team or individual                    | `Manus AI`                |
+| `Update Date`     | Date   | No       | Last update date of the file, format `YYYY-MM-DD` | `2026-02-11`              |
+
+## 2. Functionality
+This service provides an efficient and reliable text summarization capability. AI Agents can submit long texts and receive concise summaries, useful for information extraction, content analysis, and quick comprehension.
+
+## 3. Interface Specification
+All interfaces follow RESTful style and return data in JSON format by default.
+
+### 3.1 Basic Information Interface (Capability Discovery)
+-   **Interface Path**: `/` (Implicit Discovery) and `/ServiceAbility.MD` (Explicit Discovery)
+-   **Request Method**: `GET`
+-   **Function Description**: Returns the content of this `ServiceAbility.MD` file. AI Agents should prioritize attempting the `/` path, and if it fails, try `/ServiceAbility.MD`.
+
+### 3.2 Text Summarization Interface
+-   **Interface Name**: `summarize_text`
+-   **Interface Path**: `/api/v1/summarize`
+-   **Request Method**: `POST`
+-   **Function Description**: Generates a summary for the provided text.
+-   **Request Parameters**:
+    | Parameter Name | Type   | Required | Description               | Example           |
+    | :------------- | :----- | :------- | :------------------------ | :---------------- |
+    | `text`         | String | Yes      | The original text to summarize | `"The quick brown fox..."` |
+    | `max_length`   | Integer | No       | Maximum length of the summary (default: 200) | `150`             |
+-   **Return Parameters**:
+    | Parameter Name | Type   | Description               | Example           |
+    | :------------- | :----- | :------------------------ | :---------------- |
+    | `summary`      | String | The generated summary content | `"Fox jumps over..."` |
+-   **Error Code Description**:
+    | Error Code | Description       | Suggested Handling      |
+    | :--------- | :---------------- | :---------------------- |
+    | `400`      | Invalid input parameters | Check request body format |
+    | `500`      | Internal server error | Retry or contact service provider |
+
+### 3.3 Self-Describing Information Interface (Service Information)
+-   **Interface Path**: `/info`
+-   **Request Method**: `GET`
+-   **Function Description**: Returns real-time service status, version, supported models, and configuration details.
+-   **Return Parameters**: Includes service name, version, description, health status, supported summarization models, and current operational status.
+
+### 3.4 Feedback Interface
+-   **Interface Name**: `submit_feedback`
+-   **Interface Path**: `/api/v1/feedback`
+-   **Request Method**: `POST`
+-   **Function Description**: Allows AI Agents to submit feedback, error reports, or suggestions.
+-   **Request Parameters**:
+    | Parameter Name | Type   | Required | Description               | Example           |
+    | :------------- | :----- | :------- | :------------------------ | :---------------- |
+    | `error_type`   | String | Yes      | Type of feedback (e.g., `bug`, `suggestion`, `performance`) | `bug`             |
+    | `details`      | String | Yes      | Detailed description of the feedback | `Summarization output was truncated unexpectedly.` |
+    | `timestamp`    | String | Yes      | UTC timestamp of the event | `2026-02-11T10:30:00Z` |
+-   **Return Parameters**:
+    | Parameter Name | Type   | Description               | Example           |
+    | :------------- | :----- | :------------------------ | :---------------- |
+    | `status`       | String | Status of feedback submission | `success`         |
+    | `message`      | String | Confirmation message      | `Feedback received` |
+
+## 4. Data and Program Separation & Governance
+-   **Configuration Management**: Sensitive information (e.g., API Keys for LLMs) and configurable parameters are managed via environment variables (`.env`).
+-   **Data Storage**: Logs (summarization requests, feedback) are stored in structured JSONL format in the `data/` directory. Test and production data are strictly separated by using different environment configurations and log file paths.
+-   **Backward Compatibility**: API versioning (`/v1/`) is used. Future changes will ensure backward compatibility or provide clear deprecation notices.
+
+## 5. Security & Reliability
+-   **Input Validation**: All incoming request parameters are validated using Pydantic models.
+-   **Error Handling**: Custom exceptions and structured error responses are implemented for clarity.
+-   **Health Check**: The `/info` endpoint provides real-time health status.
+-   **Rate Limiting**: (Conceptual) Can be implemented using middleware to protect against overload.
+
+## 6. Feedback and Support
+-   **Feedback Interface**: `/api/v1/feedback` allows programmatic submission of issues.
+-   **Contact**: For critical issues, refer to the `Developer` field in Meta Information.
+
+### 6.1 Service Registration
+To ensure discoverability, the service registers itself with the designated discovery platform upon startup.
+
+```
+
+## 2. Core Code Implementation (main.py)
+
+```python
+import os
+import json
+import logging
+import requests
+from datetime import datetime
+from fastapi import FastAPI, Response, HTTPException, Request
+from pydantic import BaseModel, Field
+from typing import Optional, Dict, Any
+
+# --- Configuration (C) ---
+# Load environment variables (e.g., from a .env file)
+LLM_API_KEY = os.getenv("LLM_API_KEY", "mock_llm_api_key_123")
+ENVIRONMENT = os.getenv("ENVIRONMENT", "development") # 'development', 'testing', 'production'
+SERVICE_BASE_URL = os.getenv("SERVICE_BASE_URL", "http://localhost:8000") # Base URL where this service is hosted
+DISCOVERY_PLATFORM_URL = "https://jjyzmyvfy5.coze.bytedance.net/register"
+
+# Data storage paths (demonstrating data isolation)
+LOG_DIR = f"data/{ENVIRONMENT}_logs"
+os.makedirs(LOG_DIR, exist_ok=True)
+
+# Configure structured logging
+logging.basicConfig(level=logging.INFO, format=\'%(message)s\')
+logger = logging.getLogger(__name__)
+
+def log_structured_event(event_type: str, data: Dict[str, Any]):
+    log_entry = {
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "event_type": event_type,
+        "environment": ENVIRONMENT,
+        **data
+    }
+    log_file_path = os.path.join(LOG_DIR, f"{event_type}.jsonl")
+    with open(log_file_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(log_entry, ensure_ascii=False) + "\n")
+    logger.info(json.dumps(log_entry, ensure_ascii=False))
+
+
+app = FastAPI(
+    title="AI Text Summarizer Service",
+    description="A service for AI Agents to summarize text.",
+    version="1.2.0"
+)
+
+# --- Models for Request/Response (O) ---
+class SummarizeRequest(BaseModel):
+    text: str = Field(..., min_length=10, description="The original text to summarize.")
+    max_length: int = Field(200, ge=50, le=1000, description="Maximum length of the summary.")
+
+class SummarizeResponse(BaseModel):
+    summary: str = Field(..., description="The generated summary content.")
+
+class FeedbackRequest(BaseModel):
+    error_type: str = Field(..., description="Type of feedback (e.g., bug, suggestion, performance).")
+    details: str = Field(..., min_length=10, description="Detailed description of the feedback.")
+    timestamp: str = Field(default_factory=lambda: datetime.utcnow().isoformat() + "Z", description="UTC timestamp of the event.")
+
+class FeedbackResponse(BaseModel):
+    status: str = "success"
+    message: str = "Feedback received."
+
+class ServiceInfoResponse(BaseModel):
+    service_name: str
+    version: str
+    description: str
+    status: str
+    environment: str
+    supported_models: Dict[str, Any]
+    uptime: str
+
+# --- Helper for ServiceAbility.MD (O) ---
+def get_service_ability_md() -> str:
+    # In a real scenario, this would read from a static file.
+    # For this example, we will read it from the file system.
+    with open("ServiceAbility.MD", "r", encoding="utf-8") as f:
+        return f.read()
+
+# --- Endpoints (O) ---
+
+@app.get("/", response_class=Response, summary="ServiceAbility.MD Discovery (Root)")
+@app.get("/ServiceAbility.MD", response_class=Response, summary="ServiceAbility.MD Discovery (Explicit)")
+async def get_ability():
+    """Returns the ServiceAbility.MD file content for AI Agent self-discovery."""
+    log_structured_event("discovery_request", {"path": "/"})
+    return Response(content=get_service_ability_md(), media_type="text/markdown")
+
+
+@app.post("/api/v1/summarize", response_model=SummarizeResponse, summary="Text Summarization")
+async def summarize(request: SummarizeRequest, http_request: Request):
+    """Generates a summary for the provided text using a mock LLM."""
+    try:
+        if LLM_API_KEY == "mock_llm_api_key_123":
+            summary_content = request.text[:request.max_length] + "... (mock summary)"
+        else:
+            summary_content = f"Actual LLM summary for: {request.text[:50]}..."
+        
+        log_structured_event("summarize_request", {
+            "input_text_len": len(request.text),
+            "max_length": request.max_length,
+            "output_summary_len": len(summary_content),
+            "client_ip": http_request.client.host if http_request.client else "unknown"
+        })
+        return SummarizeResponse(summary=summary_content)
+    except Exception as e:
+        log_structured_event("summarize_error", {"error": str(e), "request_data": request.dict()})
+        raise HTTPException(status_code=500, detail=f"Internal server error during summarization: {e}")
+
+
+@app.post("/api/v1/feedback", response_model=FeedbackResponse, summary="Submit Feedback")
+async def submit_feedback(request: FeedbackRequest, http_request: Request):
+    """Allows AI Agents to submit feedback, error reports, or suggestions."""
+    log_structured_event("feedback_submission", {
+        "error_type": request.error_type,
+        "details": request.details,
+        "timestamp": request.timestamp,
+        "client_ip": http_request.client.host if http_request.client else "unknown"
+    })
+    return FeedbackResponse(status="success", message="Feedback received. Thank you!")
+
+
+@app.get("/info", response_model=ServiceInfoResponse, summary="Service Information and Health Check")
+async def get_service_info():
+    """Returns real-time service status, version, supported models, and configuration details."""
+    uptime_seconds = (datetime.utcnow() - app.state.start_time).total_seconds()
+    uptime_str = str(datetime.timedelta(seconds=int(uptime_seconds)))
+
+    info = ServiceInfoResponse(
+        service_name=app.title,
+        version=app.version,
+        description=app.description,
+        status="healthy",
+        environment=ENVIRONMENT,
+        supported_models={
+            "default_summarizer": {"name": "MockLLM", "version": "1.0", "capabilities": ["text_summarization"]}
+        },
+        uptime=uptime_str
+    )
+    log_structured_event("service_info_request", {"status": info.status, "environment": info.environment})
+    return info
+
+
+# --- Startup Event (O) & Service Registration (E) ---
+@app.on_event("startup")
+async def startup_event():
+    app.state.start_time = datetime.utcnow()
+    log_structured_event("service_startup", {"message": "AI Text Summarizer Service started."})
+    
+    # Register service with the discovery platform
+    try:
+        registration_payload = {
+            "service_name": app.title,
+            "service_url": SERVICE_BASE_URL,
+            "service_ability_md_url": f"{SERVICE_BASE_URL}/ServiceAbility.MD",
+            "metadata": {
+                "developer": "Manus AI",
+                "description": app.description
+            }
+        }
+        response = requests.post(DISCOVERY_PLATFORM_URL, json=registration_payload, timeout=10)
+        response.raise_for_status() # Raise an exception for bad status codes
+        log_structured_event("service_registration_success", {"response": response.json()})
+    except requests.exceptions.RequestException as e:
+        log_structured_event("service_registration_failure", {"error": str(e)})
+
+
+# --- Main execution for local development ---
+if __name__ == "__main__":
+    import uvicorn
+    # To run this example, you might need to set the SERVICE_BASE_URL if it's not localhost
+    # e.g., os.environ["SERVICE_BASE_URL"] = "https://your-ngrok-url.io"
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+```
+
+## 3. C.O.R.E. Build Flow Implementation Notes
+
+### 3.1. Configuration (C)
+-   **Environment Setup**: The `ENVIRONMENT` variable (`development`, `testing`, `production`) is used to simulate different environments.
+-   **Dependency Management**: `FastAPI`, `Pydantic`, `Uvicorn`, and `requests` are used (listed in `requirements.txt`).
+-   **Parameterization**: `SERVICE_BASE_URL` and `DISCOVERY_PLATFORM_URL` are now configurable via environment variables.
+
+### 3.2. Operation (O)
+-   **Core Logic Implementation**: No changes to the core summarization logic.
+-   **Self-Discovery & Info Endpoints**: No changes.
+-   **Feedback Mechanism**: No changes.
+
+### 3.3. Review (R) / Testing & Validation
+-   **Data Isolation**: No changes.
+-   **Input Validation**: No changes.
+
+### 3.4. Evolution (E) / Deployment & Iteration
+-   **Service Registration**: The `startup_event` now includes logic to automatically register the service with the discovery platform. This is a critical step for making the service discoverable by other AI Agents in the ecosystem.
+-   **Error Handling for Registration**: The registration logic includes a `try-except` block to handle potential network errors, ensuring the service can still start even if registration fails.
+
+## 4. Running the Example
+
+1.  **Save the code**: Save the above Python code as `main.py` in your project root.
+2.  **Create `ServiceAbility.MD`**: Save the markdown content from section 1 into a file named `ServiceAbility.MD` in the same directory.
+3.  **Create `requirements.txt`**:
+    ```
+    fastapi
+    uvicorn
+    pydantic
+    requests
+    ```
+4.  **Install dependencies**:
+    ```bash
+    pip install -r requirements.txt
+    ```
+5.  **Run the service**:
+    ```bash
+    python main.py
+    ```
+    The service will start and attempt to register itself with the discovery platform.
+
+This updated example provides a comprehensive demonstration of building and registering a production-ready AI service following the `service-ability-creator` skill's enhanced guidelines.

--- a/skills/service-ability-creator/references/example_implementation.md
+++ b/skills/service-ability-creator/references/example_implementation.md
@@ -109,7 +109,7 @@ from typing import Optional, Dict, Any
 LLM_API_KEY = os.getenv("LLM_API_KEY", "mock_llm_api_key_123")
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development") # 'development', 'testing', 'production'
 SERVICE_BASE_URL = os.getenv("SERVICE_BASE_URL", "http://localhost:8000") # Base URL where this service is hosted
-DISCOVERY_PLATFORM_URL = "https://jjyzmyvfy5.coze.bytedance.net/register"
+DISCOVERY_PLATFORM_URL = "https://your-service.com"
 
 # Data storage paths (demonstrating data isolation)
 LOG_DIR = f"data/{ENVIRONMENT}_logs"


### PR DESCRIPTION
This PR adds the `service-ability-creator` skill, which guides OpenClaw Agents in developing and upgrading 'Services for AI'. These services focus on headless, self-discovering closed-loop services via ServiceAbility.MD, ensuring logical consistency and ease of understanding for AI models.