### PR TITLE
fix: preserve thinking signatures for all anthropic-messages API providers

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -115,7 +115,11 @@ export function resolveTranscriptPolicy(params: {
       (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
     toolCallIdMode,
     repairToolUseResultPairing,
-    preserveSignatures: isAnthropic && preservesAnthropicThinkingSignatures(provider),
+    // Preserve thinking signatures for all Anthropic-compatible API providers,
+    // not just recognized ones. Unrecognized providers (e.g. custom enterprise
+    // proxies) that speak anthropic-messages still require intact signatures,
+    // otherwise thinking blocks get stripped and the API returns an error.
+    preserveSignatures: isAnthropic,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks,

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -3,7 +3,6 @@ import { isGoogleModelApi } from "./pi-embedded-helpers/google.js";
 import {
   isAnthropicProviderFamily,
   isOpenAiProviderFamily,
-  preservesAnthropicThinkingSignatures,
   resolveTranscriptToolCallIdMode,
   shouldDropThinkingBlocksForModel,
   shouldSanitizeGeminiThoughtSignaturesForModel,


### PR DESCRIPTION
## Summary
- Fix thinking block signatures being incorrectly stripped for custom Anthropic-compatible providers (e.g. internal enterprise proxies like `custom-idealab-alibaba-inc-com`)
- Simplify `preserveSignatures` check from `isAnthropic && preservesAnthropicThinkingSignatures(provider)` to just `isAnthropic`

## Bug
Custom providers that speak `anthropic-messages` API but aren't in the recognized provider list cause `preservesAnthropicThinkingSignatures()` to return `false`. This strips thinking block signatures via `stripThoughtSignatures`, leading to the API error:

> "thinking or redacted_thinking blocks in the latest assistant message cannot be modified."

## Root Cause
In `src/agents/transcript-policy.ts`:
```typescript
preserveSignatures: isAnthropic && preservesAnthropicThinkingSignatures(provider),
```
`preservesAnthropicThinkingSignatures(provider)` returns `false` for unrecognized providers, even when `modelApi === "anthropic-messages"`.

## Fix
Since `isAnthropic` is already only `true` when `modelApi` is `anthropic-messages` or `bedrock-converse-stream` (i.e., the request is going to an Anthropic-compatible endpoint), we simplify to:
```typescript
preserveSignatures: isAnthropic,
```
Any endpoint that speaks the Anthropic messages protocol requires intact thinking signatures. The previous `preservesAnthropicThinkingSignatures` guard was overly restrictive and broke custom/enterprise proxy deployments.

## Test plan
- [x] Verify custom Anthropic-compatible providers no longer get thinking signatures stripped
- [x] Confirm existing Anthropic and Bedrock providers continue working correctly
- [x] Verify non-Anthropic providers (OpenAI, Google) are unaffected