### PR TITLE
Fix session transcript timestamps to use local timezone offsets

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -5,6 +5,7 @@ import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../ac
 import { toAcpRuntimeError } from "../acp/runtime/errors.js";
 import { resolveAcpSessionCwd } from "../acp/runtime/session-identifiers.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { wrapSessionManagerWithLocalTimestamps } from "../sessions/local-session-timestamps.js";
 
 const log = createSubsystemLogger("agents/agent-command");
 import { normalizeReplyPayload } from "../auto-reply/reply/normalize-reply.js";
@@ -315,7 +316,7 @@ async function persistAcpTurnTranscript(params: {
     .access(sessionFile)
     .then(() => true)
     .catch(() => false);
-  const sessionManager = SessionManager.open(sessionFile);
+  const sessionManager = wrapSessionManagerWithLocalTimestamps(SessionManager.open(sessionFile));
   await prepareSessionManagerForRun({
     sessionManager,
     sessionFile,

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
+import { formatLocalSessionTimestamp } from "../../sessions/local-session-timestamps.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import type { WorkspaceBootstrapFile } from "../workspace.js";
 import type { EmbeddedContextFile } from "./types.js";
@@ -189,7 +190,7 @@ export async function ensureSessionHeader(params: {
     type: "session",
     version: sessionVersion,
     id: params.sessionId,
-    timestamp: new Date().toISOString(),
+    timestamp: formatLocalSessionTimestamp(),
     cwd: params.cwd,
   };
   await fs.writeFile(file, `${JSON.stringify(entry)}\n`, "utf-8");

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -28,6 +28,7 @@ import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { prepareProviderRuntimeAuth } from "../../plugins/provider-runtime.js";
 import { type enqueueCommand, enqueueCommandInLane } from "../../process/command-queue.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
+import { wrapSessionManagerWithLocalTimestamps } from "../../sessions/local-session-timestamps.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 import { resolveUserPath } from "../../utils.js";
@@ -775,12 +776,15 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
       });
-      const sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
-        agentId: sessionAgentId,
-        sessionKey: params.sessionKey,
-        allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
-        allowedToolNames,
-      });
+      const sessionManager = guardSessionManager(
+        wrapSessionManagerWithLocalTimestamps(SessionManager.open(params.sessionFile)),
+        {
+          agentId: sessionAgentId,
+          sessionKey: params.sessionKey,
+          allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
+          allowedToolNames,
+        },
+      );
       trackSessionManagerAccess(params.sessionFile);
       const settingsManager = createPreparedEmbeddedPiSettingsManager({
         cwd: effectiveWorkspace,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -28,6 +28,7 @@ import type {
   PluginHookBeforePromptBuildResult,
 } from "../../../plugins/types.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
+import { wrapSessionManagerWithLocalTimestamps } from "../../../sessions/local-session-timestamps.js";
 import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
 import { buildTtsSystemPromptHint } from "../../../tts/tts.js";
 import { resolveUserPath } from "../../../utils.js";
@@ -1793,13 +1794,16 @@ export async function runEmbeddedAttempt(
       });
 
       await prewarmSessionFile(params.sessionFile);
-      sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
-        agentId: sessionAgentId,
-        sessionKey: params.sessionKey,
-        inputProvenance: params.inputProvenance,
-        allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
-        allowedToolNames,
-      });
+      sessionManager = guardSessionManager(
+        wrapSessionManagerWithLocalTimestamps(SessionManager.open(params.sessionFile)),
+        {
+          agentId: sessionAgentId,
+          sessionKey: params.sessionKey,
+          inputProvenance: params.inputProvenance,
+          allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
+          allowedToolNames,
+        },
+      );
       trackSessionManagerAccess(params.sessionFile);
 
       if (hadSessionFile && params.contextEngine?.bootstrap) {

--- a/src/agents/pi-embedded-runner/tool-result-truncation.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { TextContent } from "@mariozechner/pi-ai";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { wrapSessionManagerWithLocalTimestamps } from "../../sessions/local-session-timestamps.js";
 import { log } from "./logger.js";
 
 /**
@@ -213,7 +214,7 @@ export async function truncateOversizedToolResultsInSession(params: {
   const maxChars = calculateMaxToolResultChars(contextWindowTokens);
 
   try {
-    const sessionManager = SessionManager.open(sessionFile);
+    const sessionManager = wrapSessionManagerWithLocalTimestamps(SessionManager.open(sessionFile));
     const branch = sessionManager.getBranch();
 
     if (branch.length === 0) {

--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveSessionFilePath, type SessionEntry } from "../../config/sessions.js";
+import {
+  formatLocalSessionTimestamp,
+  wrapSessionManagerWithLocalTimestamps,
+} from "../../sessions/local-session-timestamps.js";
 
 /**
  * Default max parent token count beyond which thread/session parent forking is skipped.
@@ -34,7 +38,7 @@ export function forkSessionFromParent(params: {
     return null;
   }
   try {
-    const manager = SessionManager.open(parentSessionFile);
+    const manager = wrapSessionManagerWithLocalTimestamps(SessionManager.open(parentSessionFile));
     const leafId = manager.getLeafId();
     if (leafId) {
       const sessionFile = manager.createBranchedSession(leafId) ?? manager.getSessionFile();
@@ -51,7 +55,7 @@ export function forkSessionFromParent(params: {
       type: "session",
       version: CURRENT_SESSION_VERSION,
       id: sessionId,
-      timestamp,
+      timestamp: formatLocalSessionTimestamp(),
       cwd: manager.getCwd(),
       parentSession: parentSessionFile,
     };

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { upsertAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import * as jsonFiles from "../../infra/json-files.js";
+import { formatLocalSessionTimestamp } from "../../sessions/local-session-timestamps.js";
 import type { OpenClawConfig } from "../config.js";
 import {
   clearSessionStoreCacheForTest,
@@ -397,6 +398,15 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     );
   }
 
+  it("formats helper timestamps with a local offset while preserving the instant", () => {
+    const source = new Date("2026-03-19T04:34:13.123Z");
+    const formatted = formatLocalSessionTimestamp(source);
+
+    expect(formatted).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/);
+    expect(formatted.endsWith("Z")).toBe(false);
+    expect(Date.parse(formatted)).toBe(source.getTime());
+  });
+
   it("creates transcript file and appends message for valid session", async () => {
     writeTranscriptStore();
 
@@ -420,9 +430,17 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       const header = JSON.parse(lines[0]);
       expect(header.type).toBe("session");
       expect(header.id).toBe(sessionId);
+      expect(header.timestamp).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/,
+      );
+      expect(header.timestamp.endsWith("Z")).toBe(false);
 
       const messageLine = JSON.parse(lines[1]);
       expect(messageLine.type).toBe("message");
+      expect(messageLine.timestamp).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/,
+      );
+      expect(messageLine.timestamp.endsWith("Z")).toBe(false);
       expect(messageLine.message.role).toBe("assistant");
       expect(messageLine.message.content[0].type).toBe("text");
       expect(messageLine.message.content[0].text).toBe("Hello from delivery mirror!");

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
+import {
+  formatLocalSessionTimestamp,
+  wrapSessionManagerWithLocalTimestamps,
+} from "../../sessions/local-session-timestamps.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { parseSessionThreadInfo } from "./delivery-info.js";
 import {
@@ -76,7 +80,7 @@ async function ensureSessionHeader(params: {
     type: "session",
     version: CURRENT_SESSION_VERSION,
     id: params.sessionId,
-    timestamp: new Date().toISOString(),
+    timestamp: formatLocalSessionTimestamp(),
     cwd: process.cwd(),
   };
   await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
@@ -212,7 +216,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     timestamp: Date.now(),
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
   } as Parameters<SessionManager["appendMessage"]>[0];
-  const sessionManager = SessionManager.open(sessionFile);
+  const sessionManager = wrapSessionManagerWithLocalTimestamps(SessionManager.open(sessionFile));
   const messageId = sessionManager.appendMessage(message);
 
   emitSessionTranscriptUpdate({ sessionFile, sessionKey, message, messageId });

--- a/src/gateway/server-methods/chat-transcript-inject.ts
+++ b/src/gateway/server-methods/chat-transcript-inject.ts
@@ -1,4 +1,5 @@
 import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { wrapSessionManagerWithLocalTimestamps } from "../../sessions/local-session-timestamps.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 
 type AppendMessageArg = Parameters<SessionManager["appendMessage"]>[0];
@@ -67,7 +68,9 @@ export function appendInjectedAssistantMessageToTranscript(params: {
   try {
     // IMPORTANT: Use SessionManager so the entry is attached to the current leaf via parentId.
     // Raw jsonl appends break the parent chain and can hide compaction summaries from context.
-    const sessionManager = SessionManager.open(params.transcriptPath);
+    const sessionManager = wrapSessionManagerWithLocalTimestamps(
+      SessionManager.open(params.transcriptPath),
+    );
     const messageId = sessionManager.appendMessage(messageBody);
     emitSessionTranscriptUpdate({
       sessionFile: params.transcriptPath,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -13,6 +13,7 @@ import { resolveSessionFilePath } from "../../config/sessions.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { createChannelReplyPipeline } from "../../plugin-sdk/channel-reply-pipeline.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
+import { formatLocalSessionTimestamp } from "../../sessions/local-session-timestamps.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
@@ -624,7 +625,7 @@ function ensureTranscriptFile(params: { transcriptPath: string; sessionId: strin
       type: "session",
       version: CURRENT_SESSION_VERSION,
       id: params.sessionId,
-      timestamp: new Date().toISOString(),
+      timestamp: formatLocalSessionTimestamp(),
       cwd: process.cwd(),
     };
     fs.writeFileSync(params.transcriptPath, `${JSON.stringify(header)}\n`, {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -323,6 +323,7 @@ describe("gateway chat transcript writes (guardrail)", () => {
     expect(chatSrc).toContain("appendInjectedAssistantMessageToTranscript(");
 
     expect(helperSrc.includes("fs.appendFileSync(params.transcriptPath")).toBe(false);
+    expect(helperSrc).toContain("wrapSessionManagerWithLocalTimestamps(");
     expect(helperSrc).toContain("SessionManager.open(params.transcriptPath)");
     expect(helperSrc).toContain("appendMessage(messageBody)");
   });

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -23,6 +23,7 @@ import {
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
+import { formatLocalSessionTimestamp } from "../../sessions/local-session-timestamps.js";
 import { GATEWAY_CLIENT_IDS } from "../protocol/client-info.js";
 import {
   ErrorCodes,
@@ -219,7 +220,7 @@ function ensureSessionTranscriptFile(params: {
         type: "session",
         version: CURRENT_SESSION_VERSION,
         id: params.sessionId,
-        timestamp: new Date().toISOString(),
+        timestamp: formatLocalSessionTimestamp(),
         cwd: process.cwd(),
       };
       fs.writeFileSync(transcriptPath, `${JSON.stringify(header)}\n`, {

--- a/src/sessions/local-session-timestamps.test.ts
+++ b/src/sessions/local-session-timestamps.test.ts
@@ -116,7 +116,7 @@ describe("local session timestamps", () => {
       timestamp: 2,
     });
 
-    const branchedFile = sessionManager.createBranchedSession(sessionManager.getLeafId());
+    const branchedFile = sessionManager.createBranchedSession(sessionManager.getLeafId()!);
     expect(branchedFile).toBeTruthy();
     const entries = readJsonl(String(branchedFile));
 

--- a/src/sessions/local-session-timestamps.test.ts
+++ b/src/sessions/local-session-timestamps.test.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  formatLocalSessionTimestamp,
+  wrapSessionManagerWithLocalTimestamps,
+} from "./local-session-timestamps.js";
+
+function readJsonl(filePath: string): Array<Record<string, unknown>> {
+  return fs
+    .readFileSync(filePath, "utf-8")
+    .trim()
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("local session timestamps", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  it("formats a local ISO string with an explicit offset", () => {
+    const source = "2026-03-19T04:34:13.123Z";
+    const formatted = formatLocalSessionTimestamp(source);
+
+    expect(formatted).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/);
+    expect(formatted.endsWith("Z")).toBe(false);
+    expect(Date.parse(formatted)).toBe(Date.parse(source));
+  });
+
+  it("writes local-offset timestamps for new session headers and entries", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-ts-"));
+    tempDirs.push(tempDir);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const sessionManager = wrapSessionManagerWithLocalTimestamps(SessionManager.open(sessionFile));
+
+    sessionManager.appendMessage({
+      role: "user",
+      content: "hello",
+      timestamp: 1,
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "hi" }],
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "test-model",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+
+    const entries = readJsonl(sessionFile);
+    expect(entries).toHaveLength(3);
+    for (const entry of entries) {
+      expect(entry.timestamp).toEqual(
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}T.*[+-]\d{2}:\d{2}$/),
+      );
+      expect(String(entry.timestamp).endsWith("Z")).toBe(false);
+    }
+  });
+
+  it("normalizes branched session rewrites to local-offset timestamps", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-branch-ts-"));
+    tempDirs.push(tempDir);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const sessionManager = wrapSessionManagerWithLocalTimestamps(SessionManager.open(sessionFile));
+
+    sessionManager.appendMessage({
+      role: "user",
+      content: "first",
+      timestamp: 1,
+    });
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "reply" }],
+      api: "openai-responses",
+      provider: "openclaw",
+      model: "test-model",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason: "stop",
+      timestamp: 2,
+    });
+
+    const branchedFile = sessionManager.createBranchedSession(sessionManager.getLeafId());
+    expect(branchedFile).toBeTruthy();
+    const entries = readJsonl(String(branchedFile));
+
+    for (const entry of entries) {
+      expect(entry.timestamp).toEqual(
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}T.*[+-]\d{2}:\d{2}$/),
+      );
+      expect(String(entry.timestamp).endsWith("Z")).toBe(false);
+    }
+  });
+});

--- a/src/sessions/local-session-timestamps.ts
+++ b/src/sessions/local-session-timestamps.ts
@@ -17,10 +17,12 @@ type MutableSessionManager = SessionManager & {
 
 const SESSION_MANAGER_WRAPPED = Symbol("openclaw.session-manager-local-timestamps");
 const NORMALIZE_ON_REWRITE = Symbol("openclaw.session-manager-normalize-on-rewrite");
+const HEADER_NORMALIZED = Symbol("openclaw.session-manager-header-normalized");
 
 type MutableSessionManagerWithFlags = MutableSessionManager & {
   [SESSION_MANAGER_WRAPPED]?: boolean;
   [NORMALIZE_ON_REWRITE]?: boolean;
+  [HEADER_NORMALIZED]?: boolean;
 };
 
 function toDate(value: SessionTimestampInput): Date {
@@ -62,11 +64,12 @@ function normalizeEntryTimestamp(entry: SessionEntryLike | undefined): void {
 }
 
 function normalizePendingHeader(sessionManager: MutableSessionManagerWithFlags): void {
-  if (sessionManager.flushed) {
+  if (sessionManager.flushed || sessionManager[HEADER_NORMALIZED]) {
     return;
   }
   const header = sessionManager.fileEntries?.find((entry) => entry?.type === "session");
   normalizeEntryTimestamp(header);
+  sessionManager[HEADER_NORMALIZED] = true;
 }
 
 function normalizeAllEntries(sessionManager: MutableSessionManagerWithFlags): void {
@@ -82,6 +85,9 @@ export function wrapSessionManagerWithLocalTimestamps(
   }
   mutableSessionManager[SESSION_MANAGER_WRAPPED] = true;
 
+  // Normalize any header already written during SessionManager.open() recovery
+  normalizePendingHeader(mutableSessionManager);
+
   const originalAppendEntry = mutableSessionManager._appendEntry?.bind(mutableSessionManager);
   if (originalAppendEntry) {
     mutableSessionManager._appendEntry = ((entry: SessionEntryLike) => {
@@ -89,6 +95,10 @@ export function wrapSessionManagerWithLocalTimestamps(
       normalizeEntryTimestamp(entry);
       return originalAppendEntry(entry);
     }) as typeof mutableSessionManager._appendEntry;
+  } else {
+    console.warn(
+      "[openclaw] wrapSessionManagerWithLocalTimestamps: _appendEntry not found — local timestamp normalisation is a no-op",
+    );
   }
 
   const originalRewriteFile = mutableSessionManager._rewriteFile?.bind(mutableSessionManager);
@@ -99,6 +109,10 @@ export function wrapSessionManagerWithLocalTimestamps(
       }
       return originalRewriteFile();
     }) as typeof mutableSessionManager._rewriteFile;
+  } else {
+    console.warn(
+      "[openclaw] wrapSessionManagerWithLocalTimestamps: _rewriteFile not found — rewrite-time normalisation is a no-op",
+    );
   }
 
   const originalCreateBranchedSession =
@@ -106,6 +120,8 @@ export function wrapSessionManagerWithLocalTimestamps(
   if (originalCreateBranchedSession) {
     mutableSessionManager.createBranchedSession = ((leafId?: string | null) => {
       mutableSessionManager[NORMALIZE_ON_REWRITE] = true;
+      normalizeAllEntries(mutableSessionManager);
+      mutableSessionManager[HEADER_NORMALIZED] = false;
       try {
         return originalCreateBranchedSession(leafId);
       } finally {

--- a/src/sessions/local-session-timestamps.ts
+++ b/src/sessions/local-session-timestamps.ts
@@ -1,0 +1,118 @@
+import type { SessionManager } from "@mariozechner/pi-coding-agent";
+
+type SessionTimestampInput = Date | number | string;
+
+type SessionEntryLike = {
+  timestamp?: unknown;
+  type?: string;
+};
+
+type MutableSessionManager = SessionManager & {
+  flushed?: boolean;
+  fileEntries?: SessionEntryLike[];
+  _appendEntry?: (entry: SessionEntryLike) => unknown;
+  _rewriteFile?: () => void;
+  createBranchedSession?: (leafId?: string | null) => string | undefined;
+};
+
+const SESSION_MANAGER_WRAPPED = Symbol("openclaw.session-manager-local-timestamps");
+const NORMALIZE_ON_REWRITE = Symbol("openclaw.session-manager-normalize-on-rewrite");
+
+type MutableSessionManagerWithFlags = MutableSessionManager & {
+  [SESSION_MANAGER_WRAPPED]?: boolean;
+  [NORMALIZE_ON_REWRITE]?: boolean;
+};
+
+function toDate(value: SessionTimestampInput): Date {
+  const date = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new RangeError(`Invalid session timestamp: ${String(value)}`);
+  }
+  return date;
+}
+
+function pad(value: number, length = 2): string {
+  return String(value).padStart(length, "0");
+}
+
+export function formatLocalSessionTimestamp(value: SessionTimestampInput = new Date()): string {
+  const date = toDate(value);
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? "+" : "-";
+  const absoluteOffsetMinutes = Math.abs(offsetMinutes);
+  const offsetHours = Math.floor(absoluteOffsetMinutes / 60);
+  const offsetRemainderMinutes = absoluteOffsetMinutes % 60;
+
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}` +
+    `.${pad(date.getMilliseconds(), 3)}${sign}${pad(offsetHours)}:${pad(offsetRemainderMinutes)}`
+  );
+}
+
+function normalizeEntryTimestamp(entry: SessionEntryLike | undefined): void {
+  if (!entry) {
+    return;
+  }
+  const value = entry.timestamp;
+  if (typeof value !== "string" && typeof value !== "number" && !(value instanceof Date)) {
+    return;
+  }
+  entry.timestamp = formatLocalSessionTimestamp(value);
+}
+
+function normalizePendingHeader(sessionManager: MutableSessionManagerWithFlags): void {
+  if (sessionManager.flushed) {
+    return;
+  }
+  const header = sessionManager.fileEntries?.find((entry) => entry?.type === "session");
+  normalizeEntryTimestamp(header);
+}
+
+function normalizeAllEntries(sessionManager: MutableSessionManagerWithFlags): void {
+  sessionManager.fileEntries?.forEach((entry) => normalizeEntryTimestamp(entry));
+}
+
+export function wrapSessionManagerWithLocalTimestamps(
+  sessionManager: SessionManager,
+): SessionManager {
+  const mutableSessionManager = sessionManager as MutableSessionManagerWithFlags;
+  if (mutableSessionManager[SESSION_MANAGER_WRAPPED]) {
+    return sessionManager;
+  }
+  mutableSessionManager[SESSION_MANAGER_WRAPPED] = true;
+
+  const originalAppendEntry = mutableSessionManager._appendEntry?.bind(mutableSessionManager);
+  if (originalAppendEntry) {
+    mutableSessionManager._appendEntry = ((entry: SessionEntryLike) => {
+      normalizePendingHeader(mutableSessionManager);
+      normalizeEntryTimestamp(entry);
+      return originalAppendEntry(entry);
+    }) as typeof mutableSessionManager._appendEntry;
+  }
+
+  const originalRewriteFile = mutableSessionManager._rewriteFile?.bind(mutableSessionManager);
+  if (originalRewriteFile) {
+    mutableSessionManager._rewriteFile = (() => {
+      if (mutableSessionManager[NORMALIZE_ON_REWRITE]) {
+        normalizeAllEntries(mutableSessionManager);
+      }
+      return originalRewriteFile();
+    }) as typeof mutableSessionManager._rewriteFile;
+  }
+
+  const originalCreateBranchedSession =
+    mutableSessionManager.createBranchedSession?.bind(mutableSessionManager);
+  if (originalCreateBranchedSession) {
+    mutableSessionManager.createBranchedSession = ((leafId?: string | null) => {
+      mutableSessionManager[NORMALIZE_ON_REWRITE] = true;
+      try {
+        return originalCreateBranchedSession(leafId);
+      } finally {
+        mutableSessionManager[NORMALIZE_ON_REWRITE] = false;
+      }
+    }) as typeof mutableSessionManager.createBranchedSession;
+  }
+
+  return sessionManager;
+}

--- a/src/sessions/local-session-timestamps.ts
+++ b/src/sessions/local-session-timestamps.ts
@@ -7,23 +7,21 @@ type SessionEntryLike = {
   type?: string;
 };
 
-type MutableSessionManager = SessionManager & {
+// Declared as a standalone interface (not intersected with SessionManager)
+// because SessionManager has private members like `flushed` that cause
+// the intersection to collapse to `never` under strict type checkers.
+interface MutableSessionManagerInternals {
   flushed?: boolean;
   fileEntries?: SessionEntryLike[];
   _appendEntry?: (entry: SessionEntryLike) => unknown;
   _rewriteFile?: () => void;
   createBranchedSession?: (leafId?: string | null) => string | undefined;
-};
+  [key: symbol]: unknown;
+}
 
 const SESSION_MANAGER_WRAPPED = Symbol("openclaw.session-manager-local-timestamps");
 const NORMALIZE_ON_REWRITE = Symbol("openclaw.session-manager-normalize-on-rewrite");
 const HEADER_NORMALIZED = Symbol("openclaw.session-manager-header-normalized");
-
-type MutableSessionManagerWithFlags = MutableSessionManager & {
-  [SESSION_MANAGER_WRAPPED]?: boolean;
-  [NORMALIZE_ON_REWRITE]?: boolean;
-  [HEADER_NORMALIZED]?: boolean;
-};
 
 function toDate(value: SessionTimestampInput): Date {
   const date = value instanceof Date ? new Date(value.getTime()) : new Date(value);
@@ -63,7 +61,7 @@ function normalizeEntryTimestamp(entry: SessionEntryLike | undefined): void {
   entry.timestamp = formatLocalSessionTimestamp(value);
 }
 
-function normalizePendingHeader(sessionManager: MutableSessionManagerWithFlags): void {
+function normalizePendingHeader(sessionManager: MutableSessionManagerInternals): void {
   if (sessionManager.flushed || sessionManager[HEADER_NORMALIZED]) {
     return;
   }
@@ -72,14 +70,14 @@ function normalizePendingHeader(sessionManager: MutableSessionManagerWithFlags):
   sessionManager[HEADER_NORMALIZED] = true;
 }
 
-function normalizeAllEntries(sessionManager: MutableSessionManagerWithFlags): void {
+function normalizeAllEntries(sessionManager: MutableSessionManagerInternals): void {
   sessionManager.fileEntries?.forEach((entry) => normalizeEntryTimestamp(entry));
 }
 
 export function wrapSessionManagerWithLocalTimestamps(
   sessionManager: SessionManager,
 ): SessionManager {
-  const mutableSessionManager = sessionManager as MutableSessionManagerWithFlags;
+  const mutableSessionManager = sessionManager as unknown as MutableSessionManagerInternals;
   if (mutableSessionManager[SESSION_MANAGER_WRAPPED]) {
     return sessionManager;
   }


### PR DESCRIPTION
## Summary

- Problem: session transcript headers and newly appended entries were persisted as `...Z` UTC timestamps, which made local-time inspection misleading for users outside UTC.
- Why it matters: users reading `~/.openclaw/agents/main/sessions/*.jsonl` saw timestamps shifted away from their machine-local wall clock.
- What changed: added a local-offset session timestamp formatter and wrapped OpenClaw's `SessionManager` write paths so new transcript entries are persisted as ISO 8601 strings with an explicit local offset; manual transcript header creation paths now use the same formatter.
- What did NOT change: existing on-disk transcripts are not batch-migrated, and session file naming stays unchanged.

## Change Type

- [x] Bug fix

## Scope

- [x] Memory / storage
- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #50201

## User-visible / Behavior Changes

Newly created session headers and newly persisted session entries now use local-time ISO timestamps with an explicit offset, for example `2026-03-19T12:34:56.789+08:00`.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps

1. Create or append to a session transcript.
2. Open the resulting `*.jsonl` file.
3. Inspect the `timestamp` fields in the header and appended entries.

### Expected

- Timestamps use the machine-local wall clock and include an explicit timezone offset.

### Actual

- New timestamps are written as local-offset ISO strings instead of `...Z`.

## Evidence

- [x] Failing behavior reproduced from issue description
- [x] Passing regression test/log after fix

## Human Verification

- Verified scenarios: local timestamp formatting helper, new session transcript writes, branched session rewrites, gateway transcript injection append.
- Edge cases checked: explicit offset formatting preserves the same instant when parsed back.
- What I did **not** verify: broader existing suite execution in this workspace is blocked by a missing `@modelcontextprotocol/sdk` dependency.
