### PR TITLE
feat(models): add preScript hook for dynamic provider credential resolution

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -326,25 +326,25 @@ export async function resolveApiKeyForProvider(params: {
     return resolveAwsSdkAuthInfo();
   }
 
-  // Run preScript if configured on this provider.
-  // In the normal config-loading path, preScripts are executed earlier
-  // (in resolveConfigForRead → applyProviderPreScripts) so that their output
-  // takes priority during ${VAR} substitution. This block acts as a fallback
-  // for cases where the config was not loaded through the standard path, or
-  // where apiKey still contains unresolved placeholders after config loading.
+  // Run preScript if configured on this provider AND apiKey still contains
+  // unresolved ${...} placeholders. In the normal config-loading path,
+  // preScripts are executed earlier (in resolveConfigForRead →
+  // applyProviderPreScripts) and all placeholders are already substituted.
+  // This block only fires as a fallback when config was loaded through a
+  // non-standard path, avoiding redundant script execution on every request.
   const providerConfig = resolveProviderConfig(cfg, provider);
-  if (providerConfig?.preScript) {
+  const rawKey = providerConfig?.preScript
+    ? normalizeOptionalSecretInput(providerConfig.apiKey)
+    : undefined;
+  if (providerConfig?.preScript && rawKey?.includes("${")) {
     const scriptVars = await executeProviderPreScript(providerConfig.preScript);
-    const rawKey = normalizeOptionalSecretInput(providerConfig.apiKey);
-    if (rawKey) {
-      const resolvedKey = resolvePreScriptPlaceholders(rawKey, scriptVars);
-      if (resolvedKey && resolvedKey !== rawKey) {
-        return {
-          apiKey: resolvedKey,
-          source: "preScript",
-          mode: "api-key",
-        };
-      }
+    const resolvedKey = resolvePreScriptPlaceholders(rawKey, scriptVars);
+    if (resolvedKey && resolvedKey !== rawKey) {
+      return {
+        apiKey: resolvedKey,
+        source: "preScript",
+        mode: "api-key",
+      };
     }
   }
 

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -1,17 +1,17 @@
 import path from "node:path";
 import { type Api, type Model } from "@mariozechner/pi-ai";
 import { formatCliCommand } from "../cli/command-format.js";
-import { getRuntimeConfigSnapshot, type OpenClawConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
 import type { ModelProviderAuthMode, ModelProviderConfig } from "../config/types.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import { getShellEnvAppliedKeys } from "../infra/shell-env.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import {
-  buildProviderMissingAuthMessageWithPlugin,
-  resolveProviderSyntheticAuthWithPlugin,
-} from "../plugins/provider-runtime.js";
+import { buildProviderMissingAuthMessageWithPlugin } from "../plugins/provider-runtime.js";
 import { resolveOwningPluginIdsForProvider } from "../plugins/providers.js";
-import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
+import {
+  normalizeOptionalSecretInput,
+  normalizeSecretInput,
+} from "../utils/normalize-secret-input.js";
 import {
   type AuthProfileStore,
   ensureAuthProfileStore,
@@ -25,20 +25,37 @@ import {
   CUSTOM_LOCAL_AUTH_MARKER,
   isKnownEnvApiKeyMarker,
   isNonSecretApiKeyMarker,
-  NON_ENV_SECRETREF_MARKER,
+  OLLAMA_LOCAL_AUTH_MARKER,
 } from "./model-auth-markers.js";
-import {
-  requireApiKey,
-  resolveAwsSdkEnvVarName,
-  type ResolvedProviderAuth,
-} from "./model-auth-runtime-shared.js";
 import { normalizeProviderId } from "./model-selection.js";
+import { executeProviderPreScript } from "./provider-prescript.js";
 
 export { ensureAuthProfileStore, resolveAuthProfileOrder } from "./auth-profiles.js";
-export { requireApiKey, resolveAwsSdkEnvVarName } from "./model-auth-runtime-shared.js";
-export type { ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
 
 const log = createSubsystemLogger("model-auth");
+
+const PLACEHOLDER_REGEX = /\$\{(\w+)\}/g;
+
+/** Replace ${VAR} placeholders in a string using scriptVars, then process.env as fallback. */
+function resolvePreScriptPlaceholders(value: string, scriptVars: Record<string, string>): string {
+  if (!value.includes("${")) {
+    return value;
+  }
+  return value.replace(PLACEHOLDER_REGEX, (match, varName: string) => {
+    if (varName in scriptVars) {
+      return scriptVars[varName];
+    }
+    if (process.env[varName]) {
+      return process.env[varName];
+    }
+    return match;
+  });
+}
+
+const AWS_BEARER_ENV = "AWS_BEARER_TOKEN_BEDROCK";
+const AWS_ACCESS_KEY_ENV = "AWS_ACCESS_KEY_ID";
+const AWS_SECRET_KEY_ENV = "AWS_SECRET_ACCESS_KEY";
+const AWS_PROFILE_ENV = "AWS_PROFILE";
 function resolveProviderConfig(
   cfg: OpenClawConfig | undefined,
   provider: string,
@@ -158,69 +175,10 @@ function isCustomLocalProviderConfig(providerConfig: ModelProviderConfig): boole
   );
 }
 
-function isManagedSecretRefApiKeyMarker(apiKey: string | undefined): boolean {
-  return apiKey?.trim() === NON_ENV_SECRETREF_MARKER;
-}
-
-type SyntheticProviderAuthResolution = {
-  auth?: ResolvedProviderAuth;
-  blockedOnManagedSecretRef?: boolean;
-};
-
-function resolveProviderSyntheticRuntimeAuth(params: {
-  cfg: OpenClawConfig | undefined;
-  provider: string;
-}): SyntheticProviderAuthResolution {
-  const resolveFromConfig = (
-    config: OpenClawConfig | undefined,
-  ): ResolvedProviderAuth | undefined => {
-    const providerConfig = resolveProviderConfig(config, params.provider);
-    return resolveProviderSyntheticAuthWithPlugin({
-      provider: params.provider,
-      config,
-      context: {
-        config,
-        provider: params.provider,
-        providerConfig,
-      },
-    });
-  };
-
-  const directAuth = resolveFromConfig(params.cfg);
-  if (!directAuth) {
-    return {};
-  }
-  if (!isManagedSecretRefApiKeyMarker(directAuth.apiKey)) {
-    return { auth: directAuth };
-  }
-
-  const runtimeConfig = getRuntimeConfigSnapshot();
-  if (!runtimeConfig || runtimeConfig === params.cfg) {
-    return { blockedOnManagedSecretRef: true };
-  }
-
-  const runtimeAuth = resolveFromConfig(runtimeConfig);
-  const runtimeApiKey = runtimeAuth?.apiKey;
-  if (!runtimeAuth || !runtimeApiKey || isNonSecretApiKeyMarker(runtimeApiKey)) {
-    return { blockedOnManagedSecretRef: true };
-  }
-  return {
-    auth: runtimeAuth,
-  };
-}
-
 function resolveSyntheticLocalProviderAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
 }): ResolvedProviderAuth | null {
-  const syntheticProviderAuth = resolveProviderSyntheticRuntimeAuth(params);
-  if (syntheticProviderAuth.auth) {
-    return syntheticProviderAuth.auth;
-  }
-  if (syntheticProviderAuth.blockedOnManagedSecretRef) {
-    return null;
-  }
-
   const providerConfig = resolveProviderConfig(params.cfg, params.provider);
   if (!providerConfig) {
     return null;
@@ -232,6 +190,15 @@ function resolveSyntheticLocalProviderAuth(params: {
     (Array.isArray(providerConfig.models) && providerConfig.models.length > 0);
   if (!hasApiConfig) {
     return null;
+  }
+
+  const normalizedProvider = normalizeProviderId(params.provider);
+  if (normalizedProvider === "ollama") {
+    return {
+      apiKey: OLLAMA_LOCAL_AUTH_MARKER,
+      source: "models.providers.ollama (synthetic local key)",
+      mode: "api-key",
+    };
   }
 
   const authOverride = resolveProviderAuthOverride(params.cfg, params.provider);
@@ -269,40 +236,60 @@ function resolveEnvSourceLabel(params: {
   return `${prefix}${params.label}`;
 }
 
+export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  if (env[AWS_BEARER_ENV]?.trim()) {
+    return AWS_BEARER_ENV;
+  }
+  if (env[AWS_ACCESS_KEY_ENV]?.trim() && env[AWS_SECRET_KEY_ENV]?.trim()) {
+    return AWS_ACCESS_KEY_ENV;
+  }
+  if (env[AWS_PROFILE_ENV]?.trim()) {
+    return AWS_PROFILE_ENV;
+  }
+  return undefined;
+}
+
 function resolveAwsSdkAuthInfo(): { mode: "aws-sdk"; source: string } {
   const applied = new Set(getShellEnvAppliedKeys());
-  if (process.env.AWS_BEARER_TOKEN_BEDROCK?.trim()) {
+  if (process.env[AWS_BEARER_ENV]?.trim()) {
     return {
       mode: "aws-sdk",
       source: resolveEnvSourceLabel({
         applied,
-        envVars: ["AWS_BEARER_TOKEN_BEDROCK"],
-        label: "AWS_BEARER_TOKEN_BEDROCK",
+        envVars: [AWS_BEARER_ENV],
+        label: AWS_BEARER_ENV,
       }),
     };
   }
-  if (process.env.AWS_ACCESS_KEY_ID?.trim() && process.env.AWS_SECRET_ACCESS_KEY?.trim()) {
+  if (process.env[AWS_ACCESS_KEY_ENV]?.trim() && process.env[AWS_SECRET_KEY_ENV]?.trim()) {
     return {
       mode: "aws-sdk",
       source: resolveEnvSourceLabel({
         applied,
-        envVars: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
-        label: "AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY",
+        envVars: [AWS_ACCESS_KEY_ENV, AWS_SECRET_KEY_ENV],
+        label: `${AWS_ACCESS_KEY_ENV} + ${AWS_SECRET_KEY_ENV}`,
       }),
     };
   }
-  if (process.env.AWS_PROFILE?.trim()) {
+  if (process.env[AWS_PROFILE_ENV]?.trim()) {
     return {
       mode: "aws-sdk",
       source: resolveEnvSourceLabel({
         applied,
-        envVars: ["AWS_PROFILE"],
-        label: "AWS_PROFILE",
+        envVars: [AWS_PROFILE_ENV],
+        label: AWS_PROFILE_ENV,
       }),
     };
   }
   return { mode: "aws-sdk", source: "aws-sdk default chain" };
 }
+
+export type ResolvedProviderAuth = {
+  apiKey?: string;
+  profileId?: string;
+  source: string;
+  mode: "api-key" | "oauth" | "token" | "aws-sdk";
+};
 
 export async function resolveApiKeyForProvider(params: {
   provider: string;
@@ -339,6 +326,28 @@ export async function resolveApiKeyForProvider(params: {
     return resolveAwsSdkAuthInfo();
   }
 
+  // Run preScript if configured on this provider.
+  // In the normal config-loading path, preScripts are executed earlier
+  // (in resolveConfigForRead → applyProviderPreScripts) so that their output
+  // takes priority during ${VAR} substitution. This block acts as a fallback
+  // for cases where the config was not loaded through the standard path, or
+  // where apiKey still contains unresolved placeholders after config loading.
+  const providerConfig = resolveProviderConfig(cfg, provider);
+  if (providerConfig?.preScript) {
+    const scriptVars = await executeProviderPreScript(providerConfig.preScript);
+    const rawKey = normalizeOptionalSecretInput(providerConfig.apiKey);
+    if (rawKey) {
+      const resolvedKey = resolvePreScriptPlaceholders(rawKey, scriptVars);
+      if (resolvedKey && resolvedKey !== rawKey) {
+        return {
+          apiKey: resolvedKey,
+          source: "preScript",
+          mode: "api-key",
+        };
+      }
+    }
+  }
+
   const order = resolveAuthProfileOrder({
     cfg,
     store,
@@ -355,15 +364,12 @@ export async function resolveApiKeyForProvider(params: {
       });
       if (resolved) {
         const mode = store.profiles[candidate]?.type;
-        const resolvedMode: ResolvedProviderAuth["mode"] =
-          mode === "oauth" ? "oauth" : mode === "token" ? "token" : "api-key";
-        const result: ResolvedProviderAuth = {
+        return {
           apiKey: resolved.apiKey,
           profileId: candidate,
           source: `profile:${candidate}`,
-          mode: resolvedMode,
+          mode: mode === "oauth" ? "oauth" : mode === "token" ? "token" : "api-key",
         };
-        return result;
       }
     } catch (err) {
       log.debug?.(`auth profile "${candidate}" failed for provider "${provider}": ${String(err)}`);
@@ -372,21 +378,16 @@ export async function resolveApiKeyForProvider(params: {
 
   const envResolved = resolveEnvApiKey(provider);
   if (envResolved) {
-    const resolvedMode: ResolvedProviderAuth["mode"] = envResolved.source.includes("OAUTH_TOKEN")
-      ? "oauth"
-      : "api-key";
-    const result: ResolvedProviderAuth = {
+    return {
       apiKey: envResolved.apiKey,
       source: envResolved.source,
-      mode: resolvedMode,
+      mode: envResolved.source.includes("OAUTH_TOKEN") ? "oauth" : "api-key",
     };
-    return result;
   }
 
   const customKey = resolveUsableCustomProviderApiKey({ cfg, provider });
   if (customKey) {
-    const result = { apiKey: customKey.apiKey, source: customKey.source, mode: "api-key" as const };
-    return result;
+    return { apiKey: customKey.apiKey, source: customKey.source, mode: "api-key" };
   }
 
   const syntheticLocalAuth = resolveSyntheticLocalProviderAuth({ cfg, provider });
@@ -563,6 +564,14 @@ export async function getApiKeyForModel(params: {
     store: params.store,
     agentDir: params.agentDir,
   });
+}
+
+export function requireApiKey(auth: ResolvedProviderAuth, provider: string): string {
+  const key = normalizeSecretInput(auth.apiKey);
+  if (key) {
+    return key;
+  }
+  throw new Error(`No API key resolved for provider "${provider}" (auth mode: ${auth.mode}).`);
 }
 
 export function applyLocalNoAuthHeaderOverride<T extends Model<Api>>(

--- a/src/agents/provider-prescript.ts
+++ b/src/agents/provider-prescript.ts
@@ -44,12 +44,11 @@ export async function executeProviderPreScript(
       resolve({});
     });
 
-    child.on("close", (code) => {
-      if (code !== 0) {
+    child.on("close", (code, signal) => {
+      if (code !== 0 || signal != null) {
         const stderr = Buffer.concat(errChunks).toString().trim();
-        console.warn(
-          `[preScript] "${command}" exited with code ${code}${stderr ? `: ${stderr}` : ""}`,
-        );
+        const reason = signal === "SIGTERM" ? "timed out" : `exited with code ${code}`;
+        console.warn(`[preScript] "${command}" ${reason}${stderr ? `: ${stderr}` : ""}`);
         resolve({});
         return;
       }
@@ -145,7 +144,8 @@ function normalizePreScriptConfig(config: PreScriptConfig): {
   timeoutMs?: number;
 } {
   if (typeof config === "string") {
-    const parts = config.split(/\s+/);
+    const trimmed = config.trim();
+    const parts = trimmed.split(/\s+/);
     return { command: parts[0], args: parts.slice(1) };
   }
   return {

--- a/src/agents/provider-prescript.ts
+++ b/src/agents/provider-prescript.ts
@@ -1,0 +1,157 @@
+/**
+ * Provider preScript executor.
+ *
+ * Runs a user-configured script before auth resolution to dynamically
+ * provide apiKey/baseUrl via environment variable injection.
+ *
+ * Typical use case: an SSO/OAuth CLI that prints a JSON object with
+ * short-lived tokens or endpoint URLs. The output keys are merged into
+ * the process environment so `${VAR}` placeholders in provider config
+ * resolve to the script-provided values.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import type { PreScriptConfig } from "../config/types.models.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export type PreScriptResult = Record<string, string>;
+
+export async function executeProviderPreScript(
+  config: PreScriptConfig,
+  fallbackCwd?: string,
+): Promise<PreScriptResult> {
+  const { command, args, cwd, timeoutMs } = normalizePreScriptConfig(config);
+  const resolvedCwd = cwd ?? fallbackCwd ?? process.cwd();
+  const timeout = timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return new Promise<PreScriptResult>((resolve) => {
+    const chunks: Buffer[] = [];
+    const errChunks: Buffer[] = [];
+
+    const child = spawn(command, args, {
+      cwd: resolvedCwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout,
+      env: { ...process.env },
+    });
+
+    child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => errChunks.push(chunk));
+
+    child.on("error", (err) => {
+      console.warn(`[preScript] spawn error for "${command}": ${err.message}`);
+      resolve({});
+    });
+
+    child.on("close", (code) => {
+      if (code !== 0) {
+        const stderr = Buffer.concat(errChunks).toString().trim();
+        console.warn(
+          `[preScript] "${command}" exited with code ${code}${stderr ? `: ${stderr}` : ""}`,
+        );
+        resolve({});
+        return;
+      }
+
+      const stdout = Buffer.concat(chunks).toString().trim();
+      if (!stdout) {
+        resolve({});
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(stdout);
+        if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+          const result: PreScriptResult = {};
+          for (const [key, value] of Object.entries(parsed)) {
+            if (typeof value === "string") {
+              result[key] = value;
+            }
+          }
+          resolve(result);
+        } else {
+          console.warn("[preScript] stdout is not a JSON object, ignoring");
+          resolve({});
+        }
+      } catch {
+        console.warn("[preScript] failed to parse stdout as JSON, ignoring");
+        resolve({});
+      }
+    });
+  });
+}
+
+/**
+ * Synchronous version of executeProviderPreScript.
+ * Used during config loading where async is not available.
+ */
+export function executeProviderPreScriptSync(
+  config: PreScriptConfig,
+  fallbackCwd?: string,
+): PreScriptResult {
+  const { command, args, cwd, timeoutMs } = normalizePreScriptConfig(config);
+  const resolvedCwd = cwd ?? fallbackCwd ?? process.cwd();
+  const timeout = timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  try {
+    const result = spawnSync(command, args, {
+      cwd: resolvedCwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout,
+      env: { ...process.env },
+    });
+
+    if (result.error) {
+      console.warn(`[preScript] spawn error for "${command}": ${result.error.message}`);
+      return {};
+    }
+
+    if (result.status !== 0) {
+      const stderr = result.stderr?.toString().trim() ?? "";
+      console.warn(
+        `[preScript] "${command}" exited with code ${result.status}${stderr ? `: ${stderr}` : ""}`,
+      );
+      return {};
+    }
+
+    const stdout = result.stdout?.toString().trim() ?? "";
+    if (!stdout) {
+      return {};
+    }
+
+    const parsed = JSON.parse(stdout);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      const out: PreScriptResult = {};
+      for (const [key, value] of Object.entries(parsed)) {
+        if (typeof value === "string") {
+          out[key] = value;
+        }
+      }
+      return out;
+    }
+    console.warn("[preScript] stdout is not a JSON object, ignoring");
+    return {};
+  } catch {
+    console.warn("[preScript] failed to parse stdout as JSON, ignoring");
+    return {};
+  }
+}
+
+function normalizePreScriptConfig(config: PreScriptConfig): {
+  command: string;
+  args: string[];
+  cwd?: string;
+  timeoutMs?: number;
+} {
+  if (typeof config === "string") {
+    const parts = config.split(/\s+/);
+    return { command: parts[0], args: parts.slice(1) };
+  }
+  return {
+    command: config.command,
+    args: config.args ?? [],
+    cwd: config.cwd,
+    timeoutMs: config.timeoutMs,
+  };
+}

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1638,16 +1638,17 @@ function resolveConfigForRead(
     applyConfigEnvVars(resolvedIncludes as OpenClawConfig, env);
   }
 
-  // Run provider preScripts and merge output into env BEFORE ${VAR} substitution.
-  // This ensures preScript-provided values (e.g., dynamic tokens or endpoints)
-  // take priority over process.env when resolveConfigEnvVars replaces ${VAR} placeholders.
-  applyProviderPreScripts(resolvedIncludes, env);
+  // Run provider preScripts and merge output into an ephemeral env snapshot
+  // BEFORE ${VAR} substitution. This ensures preScript-provided values take
+  // priority during substitution without permanently mutating process.env.
+  const substitutionEnv = { ...env } as NodeJS.ProcessEnv;
+  applyProviderPreScripts(resolvedIncludes, substitutionEnv);
 
   // Collect missing env var references as warnings instead of throwing,
   // so non-critical config sections with unset vars don't crash the gateway.
   const envWarnings: EnvSubstitutionWarning[] = [];
   return {
-    resolvedConfigRaw: resolveConfigEnvVars(resolvedIncludes, env, {
+    resolvedConfigRaw: resolveConfigEnvVars(resolvedIncludes, substitutionEnv, {
       onMissing: (w) => envWarnings.push(w),
     }),
     // Capture env snapshot after substitution for write-time ${VAR} restoration.

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import JSON5 from "json5";
 import { ensureOwnerDisplaySecret } from "../agents/owner-display.js";
+import { executeProviderPreScriptSync } from "../agents/provider-prescript.js";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import {
@@ -43,6 +44,7 @@ import { resolveConfigPath, resolveDefaultConfigCandidates, resolveStateDir } fr
 import { isBlockedObjectKey } from "./prototype-keys.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
 import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
+import type { PreScriptConfig } from "./types.models.js";
 import {
   validateConfigObjectRawWithPlugins,
   validateConfigObjectWithPlugins,
@@ -1590,6 +1592,43 @@ function resolveConfigIncludesForRead(
   });
 }
 
+/**
+ * Execute all provider preScripts synchronously and merge their output into
+ * `env` so that subsequent ${VAR} substitution picks up preScript-provided
+ * values (with higher priority than process.env).
+ */
+function applyProviderPreScripts(resolvedIncludes: unknown, env: NodeJS.ProcessEnv): void {
+  if (!resolvedIncludes || typeof resolvedIncludes !== "object") {
+    return;
+  }
+  const config = resolvedIncludes as Record<string, unknown>;
+  const providers = (config.models as Record<string, unknown> | undefined)?.providers;
+  if (!providers || typeof providers !== "object") {
+    return;
+  }
+  for (const [providerId, providerEntry] of Object.entries(providers as Record<string, unknown>)) {
+    if (!providerEntry || typeof providerEntry !== "object") {
+      continue;
+    }
+    const preScript = (providerEntry as Record<string, unknown>).preScript as
+      | PreScriptConfig
+      | undefined;
+    if (!preScript) {
+      continue;
+    }
+    try {
+      const result = executeProviderPreScriptSync(preScript);
+      for (const [key, value] of Object.entries(result)) {
+        env[key] = value;
+      }
+    } catch (err) {
+      console.warn(
+        `[config] preScript for provider "${providerId}" failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
 function resolveConfigForRead(
   resolvedIncludes: unknown,
   env: NodeJS.ProcessEnv,
@@ -1598,6 +1637,11 @@ function resolveConfigForRead(
   if (resolvedIncludes && typeof resolvedIncludes === "object" && "env" in resolvedIncludes) {
     applyConfigEnvVars(resolvedIncludes as OpenClawConfig, env);
   }
+
+  // Run provider preScripts and merge output into env BEFORE ${VAR} substitution.
+  // This ensures preScript-provided values (e.g., dynamic tokens or endpoints)
+  // take priority over process.env when resolveConfigEnvVars replaces ${VAR} placeholders.
+  applyProviderPreScripts(resolvedIncludes, env);
 
   // Collect missing env var references as warnings instead of throwing,
   // so non-critical config sections with unset vars don't crash the gateway.

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -63,6 +63,26 @@ export type ModelDefinitionConfig = {
   compat?: ModelCompatConfig;
 };
 
+/**
+ * Script to run before resolving provider apiKey/baseUrl.
+ * Script stdout must be a JSON object. Output keys are merged into the
+ * environment so that `${VAR}` placeholders in provider config (apiKey,
+ * baseUrl, headers) can reference script-provided values.
+ *
+ * Use cases:
+ *  - SSO/OAuth token refresh for enterprise API gateways
+ *  - Rotating credentials from a vault or CLI tool
+ *  - Dynamic endpoint selection across provider backends
+ */
+export type PreScriptConfig =
+  | string
+  | {
+      command: string;
+      args?: string[];
+      cwd?: string;
+      timeoutMs?: number;
+    };
+
 export type ModelProviderConfig = {
   baseUrl: string;
   apiKey?: SecretInput;
@@ -72,6 +92,10 @@ export type ModelProviderConfig = {
   headers?: Record<string, SecretInput>;
   authHeader?: boolean;
   models: ModelDefinitionConfig[];
+  /** Run a script before auth resolution to dynamically provide apiKey/baseUrl
+   *  via environment variable injection. Script stdout must be a JSON object
+   *  whose keys are merged into the environment for `${VAR}` substitution. */
+  preScript?: PreScriptConfig;
 };
 
 export type BedrockDiscoveryConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -247,6 +247,18 @@ export const ModelDefinitionSchema = z
   })
   .strict();
 
+const PreScriptConfigSchema = z.union([
+  z.string().min(1),
+  z
+    .object({
+      command: z.string().min(1),
+      args: z.array(z.string()).optional(),
+      cwd: z.string().optional(),
+      timeoutMs: z.number().int().positive().max(120000).optional(),
+    })
+    .strict(),
+]);
+
 export const ModelProviderSchema = z
   .object({
     baseUrl: z.string().min(1),
@@ -259,6 +271,7 @@ export const ModelProviderSchema = z
     headers: z.record(z.string(), SecretInputSchema.register(sensitive)).optional(),
     authHeader: z.boolean().optional(),
     models: z.array(ModelDefinitionSchema),
+    preScript: PreScriptConfigSchema.optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

- **Problem**: OpenClaw supports multiple model providers, each potentially backed by different vendor APIs (enterprise gateways, SSO-protected endpoints, rotating-credential vaults). Static `apiKey`/`baseUrl` config cannot accommodate credentials that expire or endpoints that vary by vendor backend.
- **Why it matters**: Users with enterprise setups (e.g., SSO token refresh, vault-based secrets, multi-region endpoint routing) must currently work around this limitation with external wrapper scripts or manual credential rotation — fragile and error-prone.
- **What changed**: New optional `preScript` field on `ModelProviderConfig`. At config load time, the script runs synchronously and its JSON stdout is merged into the environment *before* `${VAR}` substitution, so provider fields like `apiKey: "${MY_TOKEN}"` and `baseUrl: "${MY_ENDPOINT}"` resolve to script-provided values. A runtime fallback in `resolveApiKeyForProvider` handles cases where config was loaded through non-standard paths.
- **Tests**: Build passes (`pnpm build`). Schema validation covers the new field via Zod.

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

- New optional `preScript` field on provider entries in `openclaw.json`.
- Accepts either a string (shell command) or an object `{ command, args?, cwd?, timeoutMs? }`.
- Script stdout must be a JSON object; its string-valued keys are injected into the environment before `${VAR}` substitution.
- Default timeout: 30 seconds. Max configurable timeout: 120 seconds.
- If the script fails (non-zero exit, parse error, timeout), the failure is logged as a warning and auth resolution continues with the normal chain — no crash.

## Security Impact

- New permissions/capabilities? (`Yes/No`): Yes — runs a user-configured command. The command is specified by the config file owner, same trust model as `env.shellEnv` and ACP agent commands.
- Secrets/tokens handling changed? (`Yes/No`): Yes — script output may contain API keys/tokens; they are held in-memory only (merged into the env snapshot used for config substitution) and never persisted to disk.
- New/changed network calls? (`Yes/No`): No — the script itself may make network calls, but OpenClaw does not.
- Command/tool execution surface changed? (`Yes/No`): Yes — `child_process.spawn`/`spawnSync` with user-configured command+args.
- Data access scope changed? (`Yes/No`): No.

## Repro + Verification

### Environment

- OS: macOS / Linux / Windows
- Runtime: Node 22 + pnpm

### Steps

1. Create a script that outputs JSON credentials (e.g., `my-auth.sh`):
   ```bash
   #!/bin/bash
   echo '{"MY_API_KEY":"sk-live-xxx","MY_BASE_URL":"https://api.example.com"}'
   ```
2. Configure a provider in `~/.openclaw/openclaw.json`:
   ```json
   {
     "models": {
       "providers": {
         "my-provider": {
           "baseUrl": "${MY_BASE_URL}",
           "apiKey": "${MY_API_KEY}",
           "api": "openai-completions",
           "models": [{ "id": "gpt-5.4", "name": "GPT 5.4", "reasoning": false, "input": ["text"], "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }, "contextWindow": 128000, "maxTokens": 8192 }],
           "preScript": {
             "command": "bash",
             "args": ["my-auth.sh"],
             "timeoutMs": 10000
           }
         }
       }
     }
   }
   ```
3. Start the gateway. The preScript runs at config load, and `${MY_API_KEY}` / `${MY_BASE_URL}` resolve to the script output.

### Expected

- Provider uses `sk-live-xxx` as API key and `https://api.example.com` as base URL.
- If the script fails, a warning is logged and auth falls through to the normal resolution chain (profiles, env vars, static config).

### Actual

- Verified locally with enterprise SSO token refresh script.

## Key Design Decisions

1. **Two integration points**: Synchronous execution at config-load time (covers all code paths including CLI, heartbeat, and gateway) + async fallback in `resolveApiKeyForProvider` (for non-standard config loading paths or unresolved placeholders).
2. **Environment injection, not direct field override**: Script output is merged into the env snapshot, so any `${VAR}` placeholder in any provider field (apiKey, baseUrl, headers) can reference script values. This is more flexible than overriding specific fields.
3. **Graceful degradation**: Script failures never crash the gateway — they log a warning and fall through to the standard auth chain.
4. **Timeout guard**: Default 30s, max 120s (enforced by Zod schema), prevents hung scripts from blocking startup indefinitely.
