### PR TITLE
[AI-assisted] CLI: log gateway lock check at startup

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -394,6 +394,27 @@ describe("runGatewayLoop", () => {
     });
   });
 
+  it("logs lock acquisition before waiting for the gateway lock", async () => {
+    vi.clearAllMocks();
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const lockRelease = vi.fn(async () => {});
+      acquireGatewayLock.mockResolvedValueOnce({
+        release: lockRelease,
+      });
+
+      const { start, exited } = await createSignaledLoopHarness();
+      const sigterm = captureSignal("SIGTERM");
+
+      expect(gatewayLog.info).toHaveBeenCalledWith("checking gateway lock");
+      expect(acquireGatewayLock).toHaveBeenCalledTimes(1);
+      expect(start).toHaveBeenCalledTimes(1);
+
+      sigterm();
+      await expect(exited).resolves.toBe(0);
+    });
+  });
+
   it("exits when lock reacquire fails during in-process restart fallback", async () => {
     vi.clearAllMocks();
 

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -385,6 +385,7 @@ describe("runGatewayLoop", () => {
       sigusr1();
 
       await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(gatewayLog.info).toHaveBeenCalledWith("checking gateway lock on port 18789");
       expect(acquireGatewayLock).toHaveBeenNthCalledWith(1, { port: 18789 });
       expect(acquireGatewayLock).toHaveBeenNthCalledWith(2, { port: 18789 });
       expect(acquireGatewayLock).toHaveBeenNthCalledWith(3, { port: 18789 });

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -31,6 +31,11 @@ export async function runGatewayLoop(params: {
   runtime: typeof defaultRuntime;
   lockPort?: number;
 }) {
+  gatewayLog.info(
+    params.lockPort != null
+      ? `checking gateway lock on port ${params.lockPort}`
+      : "checking gateway lock",
+  );
   let lock = await acquireGatewayLock({ port: params.lockPort });
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
   let shuttingDown = false;


### PR DESCRIPTION
## Summary

Add a small startup log line before gateway lock acquisition so `openclaw gateway start` no longer appears completely silent while it waits for the lock.

## Why

This helps the Windows `gateway start` flow in #50330 by giving immediate feedback that startup has begun, even if the lock wait takes a moment.

## What changed

- log `checking gateway lock` before acquiring the gateway lock
- cover the log line with a small `runGatewayLoop` test

## Testing

- `npx pnpm@10.23.0 vitest run src/cli/gateway-cli/run-loop.test.ts`

## AI assistance

This PR was AI-assisted. I reviewed the change and understand what it does.
