### PR TITLE
fix(telegram): preserve default replyToId when replyToMode is all

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -454,6 +454,7 @@ export const dispatchTelegramMessage = async ({
     bot,
     mediaLocalRoots,
     replyToMode,
+    defaultReplyToId: draftReplyToMessageId,
     textLimit,
     thread: threadSpec,
     tableMode,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -635,7 +635,8 @@ export async function deliverReplies(params: {
       const replyToId =
         params.replyToMode === "off"
           ? undefined
-          : (resolveTelegramReplyId(reply.replyToId) ?? params.defaultReplyToId);
+          : (resolveTelegramReplyId(reply.replyToId) ??
+            (reply.replyToCurrent === false ? undefined : params.defaultReplyToId));
       const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
       const shouldPinFirstMessage = telegramData?.pin === true;
       const replyMarkup = buildInlineKeyboard(telegramData?.buttons);

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -636,7 +636,9 @@ export async function deliverReplies(params: {
         params.replyToMode === "off"
           ? undefined
           : (resolveTelegramReplyId(reply.replyToId) ??
-            (reply.replyToCurrent === false ? undefined : params.defaultReplyToId));
+            (params.replyToMode !== "all" || reply.replyToCurrent === false
+              ? undefined
+              : params.defaultReplyToId));
       const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
       const shouldPinFirstMessage = telegramData?.pin === true;
       const replyMarkup = buildInlineKeyboard(telegramData?.buttons);

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -569,6 +569,8 @@ export async function deliverReplies(params: {
   silent?: boolean;
   /** Optional quote text for Telegram reply_parameters. */
   replyQuoteText?: string;
+  /** Fallback reply-to message ID when reply.replyToId is absent (e.g. inbound message ID). */
+  defaultReplyToId?: number;
 }): Promise<{ delivered: boolean }> {
   const progress: DeliveryProgress = {
     hasReplied: false,
@@ -631,7 +633,9 @@ export async function deliverReplies(params: {
     try {
       const deliveredCountBeforeReply = progress.deliveredCount;
       const replyToId =
-        params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
+        params.replyToMode === "off"
+          ? undefined
+          : (resolveTelegramReplyId(reply.replyToId) ?? params.defaultReplyToId);
       const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;
       const shouldPinFirstMessage = telegramData?.pin === true;
       const replyMarkup = buildInlineKeyboard(telegramData?.buttons);

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -632,11 +632,14 @@ export async function deliverReplies(params: {
 
     try {
       const deliveredCountBeforeReply = progress.deliveredCount;
+      const explicitReplyToId = resolveTelegramReplyId(reply.replyToId);
       const replyToId =
         params.replyToMode === "off"
           ? undefined
-          : (resolveTelegramReplyId(reply.replyToId) ??
-            (params.replyToMode !== "all" || reply.replyToCurrent === false
+          : (explicitReplyToId ??
+            (params.replyToMode !== "all" ||
+            reply.replyToCurrent === false ||
+            (reply.replyToId != null && reply.replyToId.length > 0)
               ? undefined
               : params.defaultReplyToId));
       const telegramData = reply.channelData?.telegram as TelegramReplyChannelData | undefined;

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -639,6 +639,75 @@ describe("deliverReplies", () => {
     );
   });
 
+  it("falls back to defaultReplyToId when reply.replyToId is absent and replyToMode is all", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 10,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [{ text: "Hello there" }],
+      runtime,
+      bot,
+      replyToMode: "all",
+      defaultReplyToId: 999,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.any(String),
+      expect.objectContaining({ reply_to_message_id: 999 }),
+    );
+  });
+
+  it("prefers reply.replyToId over defaultReplyToId", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 10,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [{ text: "Hello there", replyToId: "500" }],
+      runtime,
+      bot,
+      replyToMode: "all",
+      defaultReplyToId: 999,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.any(String),
+      expect.objectContaining({ reply_to_message_id: 500 }),
+    );
+  });
+
+  it("does not use defaultReplyToId when replyToMode is off", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 10,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [{ text: "Hello there" }],
+      runtime,
+      bot,
+      replyToMode: "off",
+      defaultReplyToId: 999,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.any(String),
+      expect.not.objectContaining({ reply_to_message_id: 999 }),
+    );
+  });
+
   it("falls back to text when sendVoice fails with VOICE_MESSAGES_FORBIDDEN", async () => {
     const { runtime, sendVoice, sendMessage, bot } = createVoiceFailureHarness({
       voiceError: createVoiceMessagesForbiddenError(),

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -708,6 +708,29 @@ describe("deliverReplies", () => {
     );
   });
 
+  it("does not use defaultReplyToId when replyToCurrent is false", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 10,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [{ text: "Hello there", replyToCurrent: false }],
+      runtime,
+      bot,
+      replyToMode: "all",
+      defaultReplyToId: 999,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.any(String),
+      expect.not.objectContaining({ reply_to_message_id: 999 }),
+    );
+  });
+
   it("falls back to text when sendVoice fails with VOICE_MESSAGES_FORBIDDEN", async () => {
     const { runtime, sendVoice, sendMessage, bot } = createVoiceFailureHarness({
       voiceError: createVoiceMessagesForbiddenError(),

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -731,6 +731,29 @@ describe("deliverReplies", () => {
     );
   });
 
+  it("does not fallback to defaultReplyToId when replyToId is non-numeric", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 10,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [{ text: "Hello there", replyToId: "abc" }],
+      runtime,
+      bot,
+      replyToMode: "all",
+      defaultReplyToId: 999,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "123",
+      expect.any(String),
+      expect.not.objectContaining({ reply_to_message_id: 999 }),
+    );
+  });
+
   it("falls back to text when sendVoice fails with VOICE_MESSAGES_FORBIDDEN", async () => {
     const { runtime, sendVoice, sendMessage, bot } = createVoiceFailureHarness({
       voiceError: createVoiceMessagesForbiddenError(),


### PR DESCRIPTION
## Summary

In group/forum topics, the Telegram delivery path dropped the inbound message ID before the final send step. When `replyToMode` is set to `"all"` but no explicit `reply.replyToId` is set on the AI reply payload (i.e. the agent didn't use `[[reply_to_current]]`), the bot message was sent as a plain message instead of being attached to the triggering message.

## Root Cause

In `deliverReplies()` (`bot/delivery.replies.ts`), the `replyToId` was resolved solely from `reply.replyToId` (the AI reply payload). When this was absent, `replyToId` became `undefined` even though `replyToMode: "all"` was configured.

The inbound message ID (`msg.message_id`) was already available in `dispatchTelegramMessage()` as `draftReplyToMessageId` for streaming previews, but it was not passed through to the final delivery pipeline.

## Fix

1. Add `defaultReplyToId` parameter to `deliverReplies()`
2. In `dispatchTelegramMessage()`, pass `draftReplyToMessageId` as `defaultReplyToId`
3. In `deliverReplies()`, fall back to `defaultReplyToId` when `reply.replyToId` is absent

## Changes

- `extensions/telegram/src/bot/delivery.replies.ts`: +5 lines (new param + fallback logic)
- `extensions/telegram/src/bot-message-dispatch.ts`: +1 line (pass inbound message ID)

Fixes #50326