### PR TITLE
fix: refresh skillsSnapshot when snapshotVersion changes

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -905,8 +905,11 @@ async function agentCommandInternal(
       });
     }
 
-    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
+    const needsSkillsSnapshot =
+      isNewSession ||
+      !sessionEntry?.skillsSnapshot ||
+      sessionEntry.skillsSnapshot.snapshotVersion !== skillsSnapshotVersion;
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -909,7 +909,7 @@ async function agentCommandInternal(
     const needsSkillsSnapshot =
       isNewSession ||
       !sessionEntry?.skillsSnapshot ||
-      sessionEntry.skillsSnapshot.snapshotVersion !== skillsSnapshotVersion;
+      sessionEntry.skillsSnapshot.version !== skillsSnapshotVersion;
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {


### PR DESCRIPTION
## Summary

- `needsSkillsSnapshot` now also checks whether `snapshotVersion` has changed, so adding/removing skills is picked up on the next `/new` or session creation
- The `snapshotVersion` field was already computed and stored but never used for staleness detection — this adds the missing comparison

## Root Cause

`/new` generates a new `sessionId` and passes it via `opts.sessionId`, so `isNewSession = !fresh && !opts.sessionId` evaluates to `false`. Since the session already has a `skillsSnapshot` field from the previous reset, the old snapshot is silently reused.

## Fix

```typescript
// Before:
const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;

// After:
const needsSkillsSnapshot =
  isNewSession ||
  !sessionEntry?.skillsSnapshot ||
  sessionEntry.skillsSnapshot.snapshotVersion !== skillsSnapshotVersion;
```

## Test plan

- [ ] Add a new skill to `~/.openclaw/skills/` while a session is active
- [ ] Run `/new` in that session
- [ ] Verify the new skill appears in the agent's available skills
- [ ] Verify existing sessions without skill changes are not affected (no unnecessary rebuilds)

Closes #47832

🤖 Generated with [Claude Code](https://claude.com/claude-code)