### PR TITLE
[codex] normalize Feishu duplicate final dedupe

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -327,6 +327,21 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
+  it("skips normalized duplicate final text after streaming close", async () => {
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+    await options.deliver({ text: "```md\n同一条回复\n```" }, { kind: "final" });
+    await options.deliver({ text: "```md\r\n同一条回复\u200B \r\n```  " }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\n同一条回复\n```", {
+      note: "Agent: agent",
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
   it("suppresses duplicate final text while still sending media", async () => {
     const options = setupNonStreamingAutoDispatcher();
     await options.deliver({ text: "plain final" }, { kind: "final" });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -42,6 +42,14 @@ function normalizeEpochMs(timestamp: number | undefined): number | undefined {
   return timestamp < MS_EPOCH_MIN ? timestamp * 1000 : timestamp;
 }
 
+function fingerprintFinalText(text: string): string {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .replace(/[\u200B-\u200D\uFEFF]/g, "")
+    .replace(/[ \t]+\n/g, "\n")
+    .trim();
+}
+
 /** Build a card header from agent identity config. */
 function resolveCardHeader(
   agentId: string,
@@ -327,7 +335,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       });
     }
     if (params.infoKind === "final") {
-      deliveredFinalTexts.add(params.text);
+      deliveredFinalTexts.add(fingerprintFinalText(params.text));
     }
   };
 
@@ -365,8 +373,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         const text = reply.text;
         const hasText = reply.hasText;
         const hasMedia = reply.hasMedia;
+        const finalTextFingerprint = hasText ? fingerprintFinalText(text) : "";
         const skipTextForDuplicateFinal =
-          info?.kind === "final" && hasText && deliveredFinalTexts.has(text);
+          info?.kind === "final" && hasText && deliveredFinalTexts.has(finalTextFingerprint);
         const shouldDeliverText = hasText && !skipTextForDuplicateFinal;
 
         if (!shouldDeliverText && !hasMedia) {
@@ -404,7 +413,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (info?.kind === "final") {
               streamText = mergeStreamingText(streamText, text);
               await closeStreaming();
-              deliveredFinalTexts.add(text);
+              deliveredFinalTexts.add(finalTextFingerprint);
             }
             // Send media even when streaming handled the text
             if (hasMedia) {


### PR DESCRIPTION
## Summary

This change hardens Feishu final-reply deduplication for streaming card flows.

OpenClaw already suppresses exact duplicate final payloads within a single dispatch cycle, but the current logic compares raw strings only. In practice, the first streamed Feishu reply can still render twice when two final payloads are visually identical but differ only by line endings, trailing whitespace, or zero-width characters.

## User impact

When this happens, Feishu users can see two cards with what looks like the same final answer, even though only one inbound message was received. The duplicate is confusing because it looks like the bot repeated itself on the very first streamed response.

## Root cause

`reply-dispatcher.ts` stores delivered final replies in a `Set<string>` keyed by the raw final text. That covers byte-for-byte duplicates, but it does not cover semantically identical payloads that differ only by formatting artifacts introduced by upstream model/runtime delivery.

## Fix

This patch introduces a small `fingerprintFinalText()` helper that normalizes:

- CRLF vs LF line endings
- zero-width characters
- trailing horizontal whitespace before newlines
- leading/trailing outer whitespace

The dispatcher now uses that normalized fingerprint when:

- checking whether a final reply has already been delivered
- recording a delivered final reply after sending or closing a stream

This keeps the existing behavior for distinct final payloads while closing the gap for formatting-equivalent duplicates.

## Validation

I added a regression test that sends two final replies which render the same content but differ in newline format, zero-width characters, and trailing spaces. The test asserts that only one streaming session is closed and no duplicate text message/card is sent.

Executed locally:

```bash
pnpm install --frozen-lockfile
pnpm exec vitest run --config vitest.extensions.config.ts extensions/feishu/src/reply-dispatcher.test.ts
```

Result:

- `1` test file passed
- `30` tests passed
