### PR TITLE
CLI: log gateway lock checks during startup

### DIFF
--- a/fix.txt
+++ b/fix.txt
@@ -1,1 +1,0 @@
-guard participant field

--- a/fix.txt
+++ b/fix.txt
@@ -1,0 +1,1 @@
+guard participant field

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -154,6 +154,7 @@ describe("runGatewayLoop", () => {
         reason: "gateway stopping",
         restartExpectedMs: null,
       });
+      expect(gatewayLog.info).toHaveBeenCalledWith("checking gateway lock before startup");
       expect(runtime.exit).toHaveBeenCalledWith(0);
     });
   });
@@ -298,6 +299,16 @@ describe("runGatewayLoop", () => {
       expect(acquireGatewayLock).toHaveBeenNthCalledWith(1, { port: 18789 });
       expect(acquireGatewayLock).toHaveBeenNthCalledWith(2, { port: 18789 });
       expect(acquireGatewayLock).toHaveBeenNthCalledWith(3, { port: 18789 });
+      expect(
+        gatewayLog.info.mock.calls.filter(
+          ([msg]) => msg === "checking gateway lock on port 18789 before startup",
+        ),
+      ).toHaveLength(1);
+      expect(
+        gatewayLog.info.mock.calls.filter(
+          ([msg]) => msg === "checking gateway lock on port 18789 before in-process restart",
+        ),
+      ).toHaveLength(2);
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -25,6 +25,11 @@ export async function runGatewayLoop(params: {
   runtime: typeof defaultRuntime;
   lockPort?: number;
 }) {
+  gatewayLog.info(
+    params.lockPort != null
+      ? `checking gateway lock on port ${params.lockPort} before startup`
+      : "checking gateway lock before startup",
+  );
   let lock = await acquireGatewayLock({ port: params.lockPort });
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
   let shuttingDown = false;
@@ -49,6 +54,11 @@ export async function runGatewayLoop(params: {
   };
   const reacquireLockForInProcessRestart = async (): Promise<boolean> => {
     try {
+      gatewayLog.info(
+        params.lockPort != null
+          ? `checking gateway lock on port ${params.lockPort} before in-process restart`
+          : "checking gateway lock before in-process restart",
+      );
       lock = await acquireGatewayLock({ port: params.lockPort });
       return true;
     } catch (err) {


### PR DESCRIPTION
## Summary\n\nAdd an explicit gateway-lock check log at startup and during in-process reacquire so the command does not appear silent while waiting on lock acquisition.\n\n## Testing\n\n- npx pnpm@10.23.0 vitest run src/cli/gateway-cli/run-loop.test.ts