### PR TITLE
fix: inherit exec policy for /bash chat sessions

### DIFF
--- a/src/auto-reply/reply/bash-command.test.ts
+++ b/src/auto-reply/reply/bash-command.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { MsgContext } from "../templating.js";
+
+const createExecToolMock = vi.hoisted(() => vi.fn());
+const execToolExecuteMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/bash-tools.js", () => ({
+  createExecTool: createExecToolMock,
+}));
+
+const { handleBashChatCommand, resetBashChatCommandForTests } = await import("./bash-command.js");
+
+describe("handleBashChatCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetBashChatCommandForTests();
+    createExecToolMock.mockReturnValue({
+      execute: execToolExecuteMock.mockResolvedValue({
+        content: [{ type: "text", text: "host ok" }],
+        details: {
+          status: "completed",
+          exitCode: 0,
+          durationMs: 1,
+          aggregated: "host ok",
+        },
+      }),
+    });
+  });
+
+  it("inherits configured exec policy for /bash sessions", async () => {
+    const cfg = {
+      commands: { bash: true, text: true },
+      tools: {
+        exec: {
+          security: "full",
+          ask: "off",
+          pathPrepend: ["/opt/host/bin"],
+          safeBins: ["journalctl"],
+          safeBinTrustedDirs: ["/usr/bin"],
+          safeBinProfiles: {
+            journalctl: {
+              argvPolicy: "exact",
+            },
+          },
+          timeoutSec: 90,
+          notifyOnExit: true,
+          notifyOnExitEmptySuccess: false,
+        },
+      },
+    } as OpenClawConfig;
+    const ctx = {
+      Body: "/bash journalctl -n 5",
+      CommandBody: "/bash journalctl -n 5",
+      Provider: "feishu",
+      Surface: "feishu",
+      SessionKey: "agent:shoudeng:main",
+    } as MsgContext;
+
+    const result = await handleBashChatCommand({
+      ctx,
+      cfg,
+      agentId: "shoudeng",
+      sessionKey: "agent:shoudeng:main",
+      isGroup: false,
+      elevated: {
+        enabled: true,
+        allowed: true,
+        failures: [],
+      },
+    });
+
+    expect(createExecToolMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeKey: "chat:bash",
+        allowBackground: true,
+        security: "full",
+        ask: "off",
+        pathPrepend: ["/opt/host/bin"],
+        safeBins: ["journalctl"],
+        safeBinTrustedDirs: ["/usr/bin"],
+        safeBinProfiles: {
+          journalctl: {
+            argvPolicy: "exact",
+          },
+        },
+        timeoutSec: 90,
+        sessionKey: "agent:shoudeng:main",
+        notifyOnExit: true,
+        notifyOnExitEmptySuccess: false,
+        elevated: {
+          enabled: true,
+          allowed: true,
+          defaultLevel: "on",
+        },
+      }),
+    );
+    expect(execToolExecuteMock).toHaveBeenCalledWith(
+      "chat-bash",
+      expect.objectContaining({
+        command: "journalctl -n 5",
+        elevated: true,
+      }),
+    );
+    expect(result.text).toContain("host ok");
+  });
+});

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -333,12 +333,19 @@ export async function handleBashChatCommand(params: {
   try {
     const foregroundMs = resolveForegroundMs(params.cfg);
     const shouldBackgroundImmediately = foregroundMs <= 0;
+    const execPolicy = params.cfg.tools?.exec;
     const timeoutSec = params.cfg.tools?.exec?.timeoutSec;
     const notifyOnExit = params.cfg.tools?.exec?.notifyOnExit;
     const notifyOnExitEmptySuccess = params.cfg.tools?.exec?.notifyOnExitEmptySuccess;
     const execTool = createExecTool({
       scopeKey: CHAT_BASH_SCOPE_KEY,
       allowBackground: true,
+      security: execPolicy?.security,
+      ask: execPolicy?.ask,
+      pathPrepend: execPolicy?.pathPrepend,
+      safeBins: execPolicy?.safeBins,
+      safeBinTrustedDirs: execPolicy?.safeBinTrustedDirs,
+      safeBinProfiles: execPolicy?.safeBinProfiles,
       timeoutSec,
       sessionKey: params.sessionKey,
       notifyOnExit,


### PR DESCRIPTION
## Summary
- inherit `tools.exec` policy in `/bash` chat sessions
- pass security, ask, PATH prepend, and safe-bin policy into `createExecTool(...)`
- add a regression test for `/bash` policy inheritance

## Problem
`/bash` created an exec tool with elevated defaults but did not inherit configured `tools.exec` policy. In host-troubleshooting setups this caused `/bash` to fall back to approval-pending behavior even when the instance was explicitly configured with host exec policy such as `tools.exec.security=full` and `tools.exec.ask=off`.

## Testing
- ran a targeted Vitest regression for `src/auto-reply/reply/bash-command.test.ts`
