### PR TITLE
fix(feishu): stop treating @all as a direct bot mention in group chats

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -248,9 +248,6 @@ export function checkBotMentioned(event: FeishuMessageLike, botOpenId?: string):
   if (!botOpenId) {
     return false;
   }
-  if ((event.message.content ?? "").includes("@_all")) {
-    return true;
-  }
   const mentions = event.message.mentions ?? [];
   if (mentions.length > 0) {
     return mentions.some((mention) => mention.id.open_id === botOpenId);

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -108,6 +108,16 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.mentionedBot).toBe(false);
   });
 
+  it("returns mentionedBot=false when @_all is used in a group chat (regression #49761)", () => {
+    const event = makeEvent(
+      "group",
+      [{ key: "@_all", name: "所有人", id: { open_id: "all" } }],
+      "@_all hey everyone",
+    );
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
   it("treats mention.name regex metacharacters as literals when stripping", () => {
     const event = makeEvent(
       "group",


### PR DESCRIPTION
## Summary

- Remove the unconditional `@_all` → `return true` shortcut in `checkBotMentioned()` that caused every bot in a Feishu group to respond when someone sent `@所有人`
- Only explicit `@bot` mentions now trigger bot responses, even with `requireMention: true`

Fixes #49761

## Test plan

- [ ] In a Feishu group with multiple bots and `requireMention: true`, send `@所有人` — no bot should respond
- [ ] In the same group, send `@BotName <message>` — only the mentioned bot should respond
- [ ] In p2p chat, send a message — bot responds normally (no regression)
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)