### PR TITLE
fix(telegram): use trigger message id as reply-to fallback for replyToMode

### DIFF
--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -65,14 +65,14 @@ marketplace source with `--marketplace`.
 
 These are published to npm and installed with `openclaw plugins install`:
 
-| Plugin          | Package                | Docs                               |
-| --------------- | ---------------------- | ---------------------------------- |
-| Matrix          | `@openclaw/matrix`     | [Matrix](/channels/matrix)         |
+| Plugin          | Package                | Docs                                 |
+| --------------- | ---------------------- | ------------------------------------ |
+| Matrix          | `@openclaw/matrix`     | [Matrix](/channels/matrix)           |
 | Microsoft Teams | `@openclaw/msteams`    | [Microsoft Teams](/channels/msteams) |
-| Nostr           | `@openclaw/nostr`      | [Nostr](/channels/nostr)           |
-| Voice Call      | `@openclaw/voice-call` | [Voice Call](/plugins/voice-call)  |
-| Zalo            | `@openclaw/zalo`       | [Zalo](/channels/zalo)             |
-| Zalo Personal   | `@openclaw/zalouser`   | [Zalo Personal](/plugins/zalouser) |
+| Nostr           | `@openclaw/nostr`      | [Nostr](/channels/nostr)             |
+| Voice Call      | `@openclaw/voice-call` | [Voice Call](/plugins/voice-call)    |
+| Zalo            | `@openclaw/zalo`       | [Zalo](/channels/zalo)               |
+| Zalo Personal   | `@openclaw/zalouser`   | [Zalo Personal](/plugins/zalouser)   |
 
 Microsoft Teams is plugin-only as of 2026.1.15.
 


### PR DESCRIPTION
## Summary

- **Problem:** `channels.telegram.replyToMode: "all"` does not cause bot replies to quote/reply to the triggering message in supergroup forum topics. Replies are sent as plain messages without `reply_to_message_id`.
- **Root cause:** `deliverReplies()` only uses `reply.replyToId` from each individual reply payload. Most replies do not carry their own `replyToId` (only explicit `[[reply_to_current]]` tags set it), so `resolveTelegramReplyId(reply.replyToId)` returns `undefined` and no reply-to is set even when `replyToMode` is `"all"`.
- **Fix:** Add a `replyToId` parameter to `deliverReplies()` as a fallback. When the reply payload has no `replyToId`, the function falls back to `params.replyToId`. The caller (`bot-message-dispatch.ts`) now passes `msg.message_id` (the inbound trigger message) as the default.

## Change Type

- [x] Bug fix

## Scope

- [x] Telegram channel

## Linked Issue

- Closes #50326

## User-visible / Behavior Changes

**Before:** `replyToMode: "all"` → bot sends plain message, no reply-to:
```
telegram sendMessage ok chat=<id> message=130 reply=-
```

**After:** `replyToMode: "all"` → bot reply quotes the triggering message:
```
telegram sendMessage ok chat=<id> message=132 reply=131
```

## Security Impact

None.

## Evidence

- [x] 33 tests passing (31 existing + 2 new replyToId-fallback tests)

```
✓ uses params.replyToId as fallback when reply payload has no replyToId
✓ prefers reply payload replyToId over params.replyToId
```

## Compatibility

- Backward compatible. The new `replyToId` parameter is optional.
- Existing behavior (reply.replyToId from `[[reply_to_current]]`) takes precedence.

## Risks

Minimal — the change only adds a fallback for an already-expected behavior.

[AI-assisted development by OpenClaw agent 虾干 🦐]