### PR TITLE
fix(feishu): recover Chinese filenames from Latin-1 mojibake in Content-Disposition

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -608,4 +608,50 @@ describe("downloadMessageResourceFeishu", () => {
       fileName: "clip.mp4",
     });
   });
+
+  it("recovers Chinese filenames from Latin-1 mojibake in Content-Disposition", async () => {
+    // Simulate what Node.js HTTP parser does: UTF-8 bytes decoded as Latin-1
+    // "何不同舟渡_2.txt" in UTF-8 → bytes → interpreted as Latin-1 characters
+    const originalName = "何不同舟渡_2.txt";
+    const utf8Bytes = Buffer.from(originalName, "utf-8");
+    const latin1Garbled = Array.from(utf8Bytes)
+      .map((b) => String.fromCharCode(b))
+      .join("");
+
+    messageResourceGetMock.mockResolvedValueOnce({
+      data: Buffer.from("file-content"),
+      headers: {
+        "content-type": "text/plain",
+        "content-disposition": `attachment; filename="${latin1Garbled}"`,
+      },
+    });
+
+    const result = await downloadMessageResourceFeishu({
+      cfg: {} as any,
+      messageId: "om_chinese_file",
+      fileKey: "file_key_cn",
+      type: "file",
+    });
+
+    expect(result.fileName).toBe(originalName);
+  });
+
+  it("preserves ASCII filenames without modification", async () => {
+    messageResourceGetMock.mockResolvedValueOnce({
+      data: Buffer.from("data"),
+      headers: {
+        "content-type": "application/pdf",
+        "content-disposition": `attachment; filename="report.pdf"`,
+      },
+    });
+
+    const result = await downloadMessageResourceFeishu({
+      cfg: {} as any,
+      messageId: "om_ascii_file",
+      fileKey: "file_key_ascii",
+      type: "file",
+    });
+
+    expect(result.fileName).toBe("report.pdf");
+  });
 });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -123,6 +123,31 @@ function readHeaderValue(
   return undefined;
 }
 
+/**
+ * Attempt to recover a UTF-8 filename that was incorrectly decoded as Latin-1
+ * by the HTTP parser (Node.js decodes header values as ISO-8859-1 per RFC 7230).
+ * If every code-point is in the Latin-1 range and the resulting bytes form valid
+ * UTF-8, return the corrected string; otherwise return the original unchanged.
+ */
+function tryRecoverLatin1AsUtf8(text: string): string {
+  // Fast path: all ASCII — no recovery needed
+  if (/^[\x00-\x7F]*$/.test(text)) {
+    return text;
+  }
+  // Only attempt recovery when every char is in the Latin-1 range (U+0000–U+00FF).
+  // Characters outside that range mean the string was NOT decoded as Latin-1.
+  if (/[^\x00-\xFF]/.test(text)) {
+    return text;
+  }
+  try {
+    const bytes = new Uint8Array([...text].map((ch) => ch.charCodeAt(0)));
+    const decoded = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    return decoded;
+  } catch {
+    return text;
+  }
+}
+
 function decodeDispositionFileName(value: string): string | undefined {
   const utf8Match = value.match(/filename\*=UTF-8''([^;]+)/i);
   if (utf8Match?.[1]) {
@@ -134,7 +159,11 @@ function decodeDispositionFileName(value: string): string | undefined {
   }
 
   const plainMatch = value.match(/filename="?([^";]+)"?/i);
-  return plainMatch?.[1]?.trim();
+  if (plainMatch?.[1]) {
+    const raw = plainMatch[1].trim();
+    return tryRecoverLatin1AsUtf8(raw);
+  }
+  return undefined;
 }
 
 function extractFeishuDownloadMetadata(response: FeishuDownloadResponse): {


### PR DESCRIPTION
## Summary

- **Problem:** When receiving files via Feishu with Chinese characters in the filename (e.g. "何不同舟渡_2.txt"), the saved filename is garbled (e.g. "æµ_è_æ_ä_2.txt"). This is a classic UTF-8 → Latin-1 mojibake.
- **Root cause:** Node.js HTTP parser decodes header values as ISO-8859-1 per RFC 7230. When Feishu returns `Content-Disposition: attachment; filename="何不同舟渡_2.txt"` using the plain `filename` parameter (without RFC 5987 `filename*=UTF-8'...`), each 3-byte UTF-8 Chinese character becomes 3 separate Latin-1 characters.
- **Fix:** Add `tryRecoverLatin1AsUtf8()` which detects the mojibake pattern (all chars in U+0000–U+00FF range, contains non-ASCII) and reconstructs the original UTF-8 string. The recovery is safely skipped for pure ASCII strings and strings with genuine non-Latin-1 Unicode characters.

## Change Type

- [x] Bug fix

## Scope

- [x] Feishu/Lark channel

## Linked Issue

- Closes #48388

## User-visible / Behavior Changes

**Before:** File "何不同舟渡_2.txt" → saved as "æµ_è_æ_ä_2---uuid.txt"

**After:** File "何不同舟渡_2.txt" → saved as "何不同舟渡_2---uuid.txt"

## Security Impact

None. Pure string transformation with no external I/O.

## Evidence

- [x] 32 tests passing (30 existing + 2 new filename recovery tests)

```
✓ recovers Chinese filenames from Latin-1 mojibake in Content-Disposition
✓ preserves ASCII filenames without modification
```

## Compatibility

- Backward compatible. ASCII filenames are unchanged (fast path).
- The `filename*=UTF-8'...` path (already correct) is tried first.

## Risks

Minimal. The recovery only fires when ALL characters are in the Latin-1 range AND the bytes form valid UTF-8. If the bytes are not valid UTF-8, the original string is returned unchanged.

[AI-assisted development by OpenClaw agent 虾干 🦐]