### PR TITLE
Plugins: add a before-dispatch hook to the reply pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Discord/auto threads: add optional `autoThreadName: "generated"` naming so new auto-created threads can be renamed asynchronously with concise LLM-generated titles while keeping the existing message-based naming as the default. (#43366) Thanks @davidguttman.
 - Slack/interactive replies: restore rich reply parity for direct deliveries, auto-render simple trailing `Options:` lines as buttons/selects, improve Slack interactive setup defaults, and isolate reply controls from plugin interactive handlers. (#53389) Thanks @vincentkoc.
 - Gateway/OpenAI compatibility: add `/v1/models` and `/v1/embeddings`, and forward explicit model overrides through `/v1/chat/completions` and `/v1/responses` for broader client and RAG compatibility. Thanks @vincentkoc.
+- Plugins/hooks: add `before_dispatch` with canonical inbound metadata and route handled replies through the normal final-delivery path, preserving TTS and routed delivery semantics. (#50444) Thanks @gfzhx.
 
 ### Fixes
 

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2733,16 +2733,29 @@ describe("dispatchReplyFromConfig", () => {
 });
 
 describe("before_dispatch hook", () => {
-  const hookCtx = {
-    Body: "hello",
-    BodyForAgent: "hello",
-    From: "user1",
-    Surface: "telegram",
-    ChatType: "private",
-  } as DispatchReplyArgs["ctx"];
+  const createHookCtx = (overrides: Partial<MsgContext> = {}) =>
+    buildTestCtx({
+      Body: "hello",
+      BodyForAgent: "hello",
+      BodyForCommands: "hello",
+      From: "user1",
+      Surface: "telegram",
+      ChatType: "private",
+      ...overrides,
+    });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));
+    ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
+    resetInboundDedupe();
+    mocks.routeReply.mockReset();
+    mocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
+    ttsMocks.state.synthesizeFinalAudio = false;
+    ttsMocks.maybeApplyTtsToPayload.mockClear();
     setNoAbort();
+    hookMocks.runner.runBeforeDispatch.mockClear();
+    hookMocks.runner.runBeforeDispatch.mockResolvedValue(undefined);
     hookMocks.runner.hasHooks.mockImplementation(
       (hookName?: string) => hookName === "before_dispatch",
     );
@@ -2751,7 +2764,11 @@ describe("before_dispatch hook", () => {
   it("skips model dispatch when hook returns handled", async () => {
     hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true, text: "Blocked" });
     const dispatcher = createDispatcher();
-    const result = await dispatchReplyFromConfig({ ctx: hookCtx, cfg: emptyConfig, dispatcher });
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+    });
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Blocked" });
     expect(result.queuedFinal).toBe(true);
   });
@@ -2759,16 +2776,70 @@ describe("before_dispatch hook", () => {
   it("silently short-circuits when hook returns handled without text", async () => {
     hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true });
     const dispatcher = createDispatcher();
-    const result = await dispatchReplyFromConfig({ ctx: hookCtx, cfg: emptyConfig, dispatcher });
+    const result = await dispatchReplyFromConfig({
+      ctx: createHookCtx(),
+      cfg: emptyConfig,
+      dispatcher,
+    });
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
     expect(result.queuedFinal).toBe(false);
+  });
+
+  it("uses canonical hook metadata and shared routed final delivery", async () => {
+    ttsMocks.state.synthesizeFinalAudio = true;
+    hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true, text: "Blocked" });
+    const dispatcher = createDispatcher();
+    const ctx = createHookCtx({
+      Body: "raw body",
+      BodyForAgent: "agent body",
+      BodyForCommands: "command body",
+      Provider: "slack",
+      Surface: "slack",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:999",
+      From: "signal:group:ops-room",
+      SenderId: "signal:user:alice",
+      GroupChannel: "ops-room",
+      ChatType: "direct",
+      Timestamp: 123,
+    });
+
+    const result = await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher });
+
+    expect(hookMocks.runner.runBeforeDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "command body",
+        body: "agent body",
+        channel: "telegram",
+        senderId: "signal:user:alice",
+        isGroup: true,
+        timestamp: 123,
+      }),
+      expect.objectContaining({
+        channelId: "telegram",
+        senderId: "signal:user:alice",
+      }),
+    );
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "telegram:999",
+        payload: expect.objectContaining({
+          text: "Blocked",
+          mediaUrl: "https://example.com/tts-synth.opus",
+          audioAsVoice: true,
+        }),
+      }),
+    );
+    expect(result.queuedFinal).toBe(true);
   });
 
   it("continues default dispatch when hook returns not handled", async () => {
     hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: false });
     const dispatcher = createDispatcher();
     await dispatchReplyFromConfig({
-      ctx: hookCtx,
+      ctx: createHookCtx(),
       cfg: emptyConfig,
       dispatcher,
       replyResolver: async () => ({ text: "model reply" }),

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2733,76 +2733,46 @@ describe("dispatchReplyFromConfig", () => {
 });
 
 describe("before_dispatch hook", () => {
-  it("skips model dispatch when hook returns handled", async () => {
+  const hookCtx = {
+    Body: "hello",
+    BodyForAgent: "hello",
+    From: "user1",
+    Surface: "telegram",
+    ChatType: "private",
+  } as DispatchReplyArgs["ctx"];
+
+  beforeEach(() => {
     setNoAbort();
     hookMocks.runner.hasHooks.mockImplementation(
       (hookName?: string) => hookName === "before_dispatch",
     );
-    hookMocks.runner.runBeforeDispatch.mockResolvedValue({
-      handled: true,
-      text: "Blocked by plugin",
-    });
+  });
+
+  it("skips model dispatch when hook returns handled", async () => {
+    hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true, text: "Blocked" });
     const dispatcher = createDispatcher();
-    const ctx = {
-      Body: "hello",
-      BodyForAgent: "hello",
-      From: "user1",
-      Surface: "telegram",
-      ChatType: "private",
-    } as DispatchReplyArgs["ctx"];
-    const result = await dispatchReplyFromConfig({
-      ctx,
-      cfg: emptyConfig,
-      dispatcher,
-    });
-    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Blocked by plugin" });
+    const result = await dispatchReplyFromConfig({ ctx: hookCtx, cfg: emptyConfig, dispatcher });
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Blocked" });
     expect(result.queuedFinal).toBe(true);
   });
 
   it("silently short-circuits when hook returns handled without text", async () => {
-    setNoAbort();
-    hookMocks.runner.hasHooks.mockImplementation(
-      (hookName?: string) => hookName === "before_dispatch",
-    );
     hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true });
     const dispatcher = createDispatcher();
-    const ctx = {
-      Body: "hello",
-      BodyForAgent: "hello",
-      From: "user1",
-      Surface: "telegram",
-      ChatType: "private",
-    } as DispatchReplyArgs["ctx"];
-    const result = await dispatchReplyFromConfig({
-      ctx,
-      cfg: emptyConfig,
-      dispatcher,
-    });
+    const result = await dispatchReplyFromConfig({ ctx: hookCtx, cfg: emptyConfig, dispatcher });
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
     expect(result.queuedFinal).toBe(false);
   });
 
   it("continues default dispatch when hook returns not handled", async () => {
-    setNoAbort();
-    hookMocks.runner.hasHooks.mockImplementation(
-      (hookName?: string) => hookName === "before_dispatch",
-    );
     hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: false });
     const dispatcher = createDispatcher();
-    const ctx = {
-      Body: "hello",
-      BodyForAgent: "hello",
-      From: "user1",
-      Surface: "telegram",
-      ChatType: "private",
-    } as DispatchReplyArgs["ctx"];
     await dispatchReplyFromConfig({
-      ctx,
+      ctx: hookCtx,
       cfg: emptyConfig,
       dispatcher,
       replyResolver: async () => ({ text: "model reply" }),
     });
-    // sendFinalReply should be called with model reply, not plugin text
     expect(hookMocks.runner.runBeforeDispatch).toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "model reply" });
   });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -42,6 +42,7 @@ const hookMocks = vi.hoisted(() => ({
       async () => ({ status: "no_handler" as const }),
     ),
     runMessageReceived: vi.fn(async () => {}),
+    runBeforeDispatch: vi.fn(async () => undefined),
   },
 }));
 const internalHookMocks = vi.hoisted(() => ({
@@ -331,6 +332,8 @@ describe("dispatchReplyFromConfig", () => {
       status: "no_handler",
     });
     hookMocks.runner.runMessageReceived.mockClear();
+    hookMocks.runner.runBeforeDispatch.mockClear();
+    hookMocks.runner.runBeforeDispatch.mockResolvedValue(undefined);
     hookMocks.registry.plugins = [];
     internalHookMocks.createInternalHookEvent.mockClear();
     internalHookMocks.createInternalHookEvent.mockImplementation(createInternalHookEventPayload);
@@ -2721,5 +2724,75 @@ describe("dispatchReplyFromConfig", () => {
     await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
     expect(blockReplySentTexts).not.toContain("Reasoning:\n_thinking..._");
     expect(blockReplySentTexts).toContain("The answer is 42");
+  });
+});
+
+describe("before_dispatch hook", () => {
+  it("skips model dispatch when hook returns handled", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "before_dispatch");
+    hookMocks.runner.runBeforeDispatch.mockResolvedValue({
+      handled: true,
+      text: "Blocked by plugin",
+    });
+    const dispatcher = createDispatcher();
+    const ctx = {
+      Body: "hello",
+      BodyForAgent: "hello",
+      From: "user1",
+      Surface: "telegram",
+      ChatType: "private",
+    } as DispatchReplyArgs["ctx"];
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+    });
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "Blocked by plugin" });
+    expect(result.queuedFinal).toBe(true);
+  });
+
+  it("silently short-circuits when hook returns handled without text", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "before_dispatch");
+    hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true });
+    const dispatcher = createDispatcher();
+    const ctx = {
+      Body: "hello",
+      BodyForAgent: "hello",
+      From: "user1",
+      Surface: "telegram",
+      ChatType: "private",
+    } as DispatchReplyArgs["ctx"];
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+    });
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(result.queuedFinal).toBe(false);
+  });
+
+  it("continues default dispatch when hook returns not handled", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "before_dispatch");
+    hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: false });
+    const dispatcher = createDispatcher();
+    const ctx = {
+      Body: "hello",
+      BodyForAgent: "hello",
+      From: "user1",
+      Surface: "telegram",
+      ChatType: "private",
+    } as DispatchReplyArgs["ctx"];
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "model reply" }),
+    });
+    // sendFinalReply should be called with model reply, not plugin text
+    expect(hookMocks.runner.runBeforeDispatch).toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "model reply" });
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
-import type { PluginTargetedInboundClaimOutcome } from "../../plugins/hooks.js";
+import type {
+  PluginHookBeforeDispatchResult,
+  PluginTargetedInboundClaimOutcome,
+} from "../../plugins/hooks.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
@@ -35,14 +38,16 @@ const hookMocks = vi.hoisted(() => ({
     }>,
   },
   runner: {
-    hasHooks: vi.fn(() => false),
+    hasHooks: vi.fn<(hookName?: string) => boolean>(() => false),
     runInboundClaim: vi.fn(async () => undefined),
     runInboundClaimForPlugin: vi.fn(async () => undefined),
     runInboundClaimForPluginOutcome: vi.fn<() => Promise<PluginTargetedInboundClaimOutcome>>(
       async () => ({ status: "no_handler" as const }),
     ),
     runMessageReceived: vi.fn(async () => {}),
-    runBeforeDispatch: vi.fn(async () => undefined),
+    runBeforeDispatch: vi.fn<
+      (_event: unknown, _ctx: unknown) => Promise<PluginHookBeforeDispatchResult | undefined>
+    >(async () => undefined),
   },
 }));
 const internalHookMocks = vi.hoisted(() => ({
@@ -2730,7 +2735,9 @@ describe("dispatchReplyFromConfig", () => {
 describe("before_dispatch hook", () => {
   it("skips model dispatch when hook returns handled", async () => {
     setNoAbort();
-    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "before_dispatch");
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "before_dispatch",
+    );
     hookMocks.runner.runBeforeDispatch.mockResolvedValue({
       handled: true,
       text: "Blocked by plugin",
@@ -2754,7 +2761,9 @@ describe("before_dispatch hook", () => {
 
   it("silently short-circuits when hook returns handled without text", async () => {
     setNoAbort();
-    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "before_dispatch");
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "before_dispatch",
+    );
     hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true });
     const dispatcher = createDispatcher();
     const ctx = {
@@ -2775,7 +2784,9 @@ describe("before_dispatch hook", () => {
 
   it("continues default dispatch when hook returns not handled", async () => {
     setNoAbort();
-    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "before_dispatch");
+    hookMocks.runner.hasHooks.mockImplementation(
+      (hookName?: string) => hookName === "before_dispatch",
+    );
     hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: false });
     const dispatcher = createDispatcher();
     const ctx = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -510,6 +510,60 @@ export async function dispatchReplyFromConfig(params: {
       return { queuedFinal: false, counts };
     }
 
+    // Run before_dispatch hook — let plugins inspect or handle before model dispatch.
+    if (hookRunner?.hasHooks("before_dispatch")) {
+      const beforeDispatchResult = await hookRunner.runBeforeDispatch(
+        {
+          content: ctx.Body ?? "",
+          body: ctx.BodyForAgent ?? ctx.Body,
+          channel: ctx.Surface ?? ctx.Provider,
+          sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+          senderId: ctx.From,
+          isGroup: ctx.ChatType === "group",
+          timestamp,
+        },
+        {
+          channelId: hookContext.channelId,
+          accountId: hookContext.accountId,
+          conversationId: hookContext.conversationId,
+          sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
+          senderId: ctx.From,
+        },
+      );
+      if (beforeDispatchResult?.handled) {
+        const text = beforeDispatchResult.text;
+        let queuedFinal = false;
+        let routedFinalCount = 0;
+        if (text) {
+          const payload = { text } satisfies ReplyPayload;
+          if (shouldRouteToOriginating && originatingChannel && originatingTo) {
+            const result = await routeReply({
+              payload,
+              channel: originatingChannel,
+              to: originatingTo,
+              sessionKey: ctx.SessionKey,
+              accountId: ctx.AccountId,
+              threadId: routeThreadId,
+              cfg,
+              isGroup,
+              groupId,
+            });
+            queuedFinal = result.ok;
+            if (result.ok) {
+              routedFinalCount += 1;
+            }
+          } else {
+            queuedFinal = dispatcher.sendFinalReply(payload);
+          }
+        }
+        const counts = dispatcher.getQueuedCounts();
+        counts.final += routedFinalCount;
+        recordProcessed("completed", { reason: "before_dispatch_handled" });
+        markIdle("message_completed");
+        return { queuedFinal, counts };
+      }
+    }
+
     const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
     const acpDispatch = await dispatchAcpRuntime.tryDispatchAcpReply({
       ctx,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -537,7 +537,7 @@ export async function dispatchReplyFromConfig(params: {
         if (text) {
           const payload = { text } satisfies ReplyPayload;
           if (shouldRouteToOriginating && originatingChannel && originatingTo) {
-            const result = await routeReply({
+            const result = await routeReplyRuntime.routeReply({
               payload,
               channel: originatingChannel,
               to: originatingTo,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -510,24 +510,64 @@ export async function dispatchReplyFromConfig(params: {
       return { queuedFinal: false, counts };
     }
 
+    const { maybeApplyTtsToPayload } = await loadTtsRuntime();
+    const sendFinalPayload = async (
+      payload: ReplyPayload,
+    ): Promise<{ queuedFinal: boolean; routedFinalCount: number }> => {
+      const ttsPayload = await maybeApplyTtsToPayload({
+        payload,
+        cfg,
+        channel: ttsChannel,
+        kind: "final",
+        inboundAudio,
+        ttsAuto: sessionTtsAuto,
+      });
+      if (shouldRouteToOriginating && originatingChannel && originatingTo) {
+        const result = await routeReplyRuntime.routeReply({
+          payload: ttsPayload,
+          channel: originatingChannel,
+          to: originatingTo,
+          sessionKey: ctx.SessionKey,
+          accountId: ctx.AccountId,
+          threadId: routeThreadId,
+          cfg,
+          isGroup,
+          groupId,
+        });
+        if (!result.ok) {
+          logVerbose(
+            `dispatch-from-config: route-reply (final) failed: ${result.error ?? "unknown error"}`,
+          );
+        }
+        return {
+          queuedFinal: result.ok,
+          routedFinalCount: result.ok ? 1 : 0,
+        };
+      }
+      return {
+        queuedFinal: dispatcher.sendFinalReply(ttsPayload),
+        routedFinalCount: 0,
+      };
+    };
+
     // Run before_dispatch hook — let plugins inspect or handle before model dispatch.
     if (hookRunner?.hasHooks("before_dispatch")) {
       const beforeDispatchResult = await hookRunner.runBeforeDispatch(
         {
-          content: ctx.Body ?? "",
-          body: ctx.BodyForAgent ?? ctx.Body,
-          channel: ctx.Surface ?? ctx.Provider,
+          content: hookContext.content,
+          body: hookContext.bodyForAgent ?? hookContext.body,
+          channel: hookContext.channelId,
           sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
-          senderId: ctx.From,
-          isGroup: ctx.ChatType === "group",
-          timestamp,
+          senderId: hookContext.senderId,
+          isGroup: hookContext.isGroup,
+          timestamp: hookContext.timestamp,
         },
         {
           channelId: hookContext.channelId,
           accountId: hookContext.accountId,
           conversationId: hookContext.conversationId,
           sessionKey: sessionStoreEntry.sessionKey ?? sessionKey,
-          senderId: ctx.From,
+          senderId: hookContext.senderId,
         },
       );
       if (beforeDispatchResult?.handled) {
@@ -535,26 +575,9 @@ export async function dispatchReplyFromConfig(params: {
         let queuedFinal = false;
         let routedFinalCount = 0;
         if (text) {
-          const payload = { text } satisfies ReplyPayload;
-          if (shouldRouteToOriginating && originatingChannel && originatingTo) {
-            const result = await routeReplyRuntime.routeReply({
-              payload,
-              channel: originatingChannel,
-              to: originatingTo,
-              sessionKey: ctx.SessionKey,
-              accountId: ctx.AccountId,
-              threadId: routeThreadId,
-              cfg,
-              isGroup,
-              groupId,
-            });
-            queuedFinal = result.ok;
-            if (result.ok) {
-              routedFinalCount += 1;
-            }
-          } else {
-            queuedFinal = dispatcher.sendFinalReply(payload);
-          }
+          const handledReply = await sendFinalPayload({ text });
+          queuedFinal = handledReply.queuedFinal;
+          routedFinalCount += handledReply.routedFinalCount;
         }
         const counts = dispatcher.getQueuedCounts();
         counts.final += routedFinalCount;
@@ -592,7 +615,6 @@ export async function dispatchReplyFromConfig(params: {
     // TTS audio separately from the accumulated block content.
     let accumulatedBlockText = "";
     let blockCount = 0;
-    const { maybeApplyTtsToPayload } = await loadTtsRuntime();
 
     const resolveToolDeliveryPayload = (payload: ReplyPayload): ReplyPayload | null => {
       if (
@@ -737,39 +759,9 @@ export async function dispatchReplyFromConfig(params: {
       if (reply.isReasoning === true) {
         continue;
       }
-      const ttsReply = await maybeApplyTtsToPayload({
-        payload: reply,
-        cfg,
-        channel: ttsChannel,
-        kind: "final",
-        inboundAudio,
-        ttsAuto: sessionTtsAuto,
-      });
-      if (shouldRouteToOriginating && originatingChannel && originatingTo) {
-        // Route final reply to originating channel.
-        const result = await routeReplyRuntime.routeReply({
-          payload: ttsReply,
-          channel: originatingChannel,
-          to: originatingTo,
-          sessionKey: ctx.SessionKey,
-          accountId: ctx.AccountId,
-          threadId: routeThreadId,
-          cfg,
-          isGroup,
-          groupId,
-        });
-        if (!result.ok) {
-          logVerbose(
-            `dispatch-from-config: route-reply (final) failed: ${result.error ?? "unknown error"}`,
-          );
-        }
-        queuedFinal = result.ok || queuedFinal;
-        if (result.ok) {
-          routedFinalCount += 1;
-        }
-      } else {
-        queuedFinal = dispatcher.sendFinalReply(ttsReply) || queuedFinal;
-      }
+      const finalReply = await sendFinalPayload(reply);
+      queuedFinal = finalReply.queuedFinal || queuedFinal;
+      routedFinalCount += finalReply.routedFinalCount;
     }
 
     const ttsMode = resolveConfiguredTtsMode(cfg);

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -14,6 +14,9 @@ import type {
   PluginHookAgentEndEvent,
   PluginHookBeforeAgentStartEvent,
   PluginHookBeforeAgentStartResult,
+  PluginHookBeforeDispatchContext,
+  PluginHookBeforeDispatchEvent,
+  PluginHookBeforeDispatchResult,
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildEvent,
@@ -60,6 +63,9 @@ export type {
   PluginHookAgentContext,
   PluginHookBeforeAgentStartEvent,
   PluginHookBeforeAgentStartResult,
+  PluginHookBeforeDispatchContext,
+  PluginHookBeforeDispatchEvent,
+  PluginHookBeforeDispatchResult,
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildEvent,
@@ -615,6 +621,22 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   }
 
   /**
+   * Run before_dispatch hook.
+   * Allows plugins to inspect or handle a message before model dispatch.
+   * First handler returning { handled: true } wins.
+   */
+  async function runBeforeDispatch(
+    event: PluginHookBeforeDispatchEvent,
+    ctx: PluginHookBeforeDispatchContext,
+  ): Promise<PluginHookBeforeDispatchResult | undefined> {
+    return runClaimingHook<"before_dispatch", PluginHookBeforeDispatchResult>(
+      "before_dispatch",
+      event,
+      ctx,
+    );
+  }
+
+  /**
    * Run message_sending hook.
    * Allows plugins to modify or cancel outgoing messages.
    * Runs sequentially.
@@ -975,6 +997,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runInboundClaimForPlugin,
     runInboundClaimForPluginOutcome,
     runMessageReceived,
+    runBeforeDispatch,
     runMessageSending,
     runMessageSent,
     // Tool hooks

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1424,7 +1424,8 @@ export type PluginHookName =
   | "subagent_spawned"
   | "subagent_ended"
   | "gateway_start"
-  | "gateway_stop";
+  | "gateway_stop"
+  | "before_dispatch";
 
 export const PLUGIN_HOOK_NAMES = [
   "before_model_resolve",
@@ -1452,6 +1453,7 @@ export const PLUGIN_HOOK_NAMES = [
   "subagent_ended",
   "gateway_start",
   "gateway_stop",
+  "before_dispatch",
 ] as const satisfies readonly PluginHookName[];
 
 type MissingPluginHookNames = Exclude<PluginHookName, (typeof PLUGIN_HOOK_NAMES)[number]>;
@@ -1674,6 +1676,39 @@ export type PluginHookInboundClaimEvent = {
 
 export type PluginHookInboundClaimResult = {
   handled: boolean;
+};
+
+// before_dispatch hook
+export type PluginHookBeforeDispatchEvent = {
+  /** Message text content. */
+  content: string;
+  /** Body text prepared for agent (after command parsing). */
+  body?: string;
+  /** Channel identifier (e.g. "telegram", "discord"). */
+  channel?: string;
+  /** Session key for this message. */
+  sessionKey?: string;
+  /** Sender identifier. */
+  senderId?: string;
+  /** Whether this is a group message. */
+  isGroup?: boolean;
+  /** Message timestamp. */
+  timestamp?: number;
+};
+
+export type PluginHookBeforeDispatchContext = {
+  channelId?: string;
+  accountId?: string;
+  conversationId?: string;
+  sessionKey?: string;
+  senderId?: string;
+};
+
+export type PluginHookBeforeDispatchResult = {
+  /** Whether the plugin handled this message (skips default dispatch). */
+  handled: boolean;
+  /** Plugin-defined reply text (used when handled=true). */
+  text?: string;
 };
 
 // message_received hook
@@ -1936,6 +1971,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookInboundClaimEvent,
     ctx: PluginHookInboundClaimContext,
   ) => Promise<PluginHookInboundClaimResult | void> | PluginHookInboundClaimResult | void;
+  before_dispatch: (
+    event: PluginHookBeforeDispatchEvent,
+    ctx: PluginHookBeforeDispatchContext,
+  ) => Promise<PluginHookBeforeDispatchResult | void> | PluginHookBeforeDispatchResult | void;
   message_received: (
     event: PluginHookMessageReceivedEvent,
     ctx: PluginHookMessageContext,


### PR DESCRIPTION
## Summary

- Problem: Plugins currently have no typed hook at the point just before model/provider dispatch, after routing and policy decisions are finalized.
- Why it matters: Logic that needs to run after send policy and command parsing, but before the agent/model call, currently has no dedicated extension point in the reply pipeline.
- What changed: Added `before_dispatch` to the typed plugin hook system (`PluginHookName`, event/context/result types, `runBeforeDispatch` runner method) and wired it into `dispatchReplyFromConfig()` at a single call site.
- What did NOT change (scope boundary): Default behavior is unchanged when no plugin registers this hook. Existing hook semantics and other dispatch surfaces are unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: none (new capability)

## User-visible / Behavior Changes

None. When no plugin registers a `before_dispatch` handler, the reply path behaves as before. No config changes are required.

## Security Impact (required)

- New permissions/capabilities? `No` — plugins already have hook registration via `api.on()`; this adds one more hook name.
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — the hook only exposes dispatch-time message/session metadata already available in this pipeline; no new secrets or tokens are introduced.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / Bun
- Model/provider: any
- Integration/channel: any channel (Telegram, Discord, etc.)

### Steps

1. Register a plugin with `api.on("before_dispatch", handler)` where handler returns `{ handled: true, text: "Blocked" }`.
2. Send a message through any channel.
3. Observe the plugin reply is returned instead of the default model dispatch.

### Expected

- When handler returns `{ handled: true, text }`, the pipeline short-circuits and sends the plugin-provided text.
- When handler returns `{ handled: false }` or `undefined`, the existing dispatch flow continues unchanged.

### Actual

- Observed behavior matches the expected handled/continue semantics.

## Evidence

- [x] Targeted unit tests added and passing

Unit tests: 56 passed total, including 3 new cases covering handled with text, handled without text / silent short-circuit, and not-handled / continue.

## Human Verification (required)

- Verified scenarios: (1) `handled: true` with text sends the plugin reply and skips model dispatch; (2) `handled: true` without text short-circuits silently; (3) `handled: false` continues through the existing dispatch flow; (4) with no registered hook, behavior is unchanged.
- Edge cases checked: cross-provider routing (`shouldRouteToOriginating`) is preserved in the handled branch.
- Not verified: end-to-end behavior against a production gateway deployment.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — no behavior change when unused.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR. Because the hook is only active when registered by a plugin, reverting restores the previous behavior.
- Files/config to restore: `src/plugins/types.ts`, `src/plugins/hooks.ts`, `src/auto-reply/reply/dispatch-from-config.ts`, `src/auto-reply/reply/dispatch-from-config.test.ts`
- Known bad symptoms reviewers should watch for: unexpected early return from `dispatchReplyFromConfig` if a plugin incorrectly returns `{ handled: true }` for all messages.

## Risks and Mitigations

- Risk: A misbehaving plugin returning `{ handled: true }` for every message would block all model dispatch.
  - Mitigation: This is the same trust model as existing claiming hooks — plugin authors control their handler logic. The hook uses `runClaimingHook` (first-claim-wins, fail-open on error), consistent with existing patterns.

## Files Changed

| File | Change |
|------|--------|
| `src/plugins/types.ts` | add `before_dispatch` to `PluginHookName`, event/context/result types, and the handler map |
| `src/plugins/hooks.ts` | add `runBeforeDispatch()` using `runClaimingHook` |
| `src/auto-reply/reply/dispatch-from-config.ts` | add the hook call site after send policy and before ACP/model dispatch |
| `src/auto-reply/reply/dispatch-from-config.test.ts` | add tests for handled, silent handled, and continue paths |

## Design Notes

### Hook position in dispatch pipeline

```text
... (routing, session lookup, command parsing, send policy)
  ↓
★ before_dispatch ★
  ↓
ACP / model dispatch
```