### PR TITLE
fix(ui): disambiguate chat model picker model refs

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -552,7 +552,6 @@ function resolveDefaultModelValue(state: AppViewState): string {
 function buildChatModelOptions(
   catalog: ModelCatalogEntry[],
   currentOverride: string,
-  defaultModel: string,
 ): Array<{ value: string; label: string }> {
   const seen = new Set<string>();
   const options: Array<{ value: string; label: string }> = [];
@@ -574,11 +573,8 @@ function buildChatModelOptions(
     addOption(option.value, option.label);
   }
 
-  if (currentOverride) {
+  if (createChatModelOverride(currentOverride)?.kind === "qualified") {
     addOption(currentOverride);
-  }
-  if (defaultModel) {
-    addOption(defaultModel);
   }
   return options;
 }
@@ -586,11 +582,7 @@ function buildChatModelOptions(
 function renderChatModelSelect(state: AppViewState) {
   const currentOverride = resolveModelOverrideValue(state);
   const defaultModel = resolveDefaultModelValue(state);
-  const options = buildChatModelOptions(
-    state.chatModelCatalog ?? [],
-    currentOverride,
-    defaultModel,
-  );
+  const options = buildChatModelOptions(state.chatModelCatalog ?? [], currentOverride);
   const defaultDisplay = formatChatModelDisplay(defaultModel);
   const defaultLabel = defaultModel ? `Default (${defaultDisplay})` : "Default model";
   const busy =

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -706,6 +706,51 @@ describe("chat view", () => {
     vi.unstubAllGlobals();
   });
 
+  it("keeps same-id models from different providers distinct in the chat header picker", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+      } satisfies Partial<Response>),
+    );
+    const { state, request } = createChatHeaderState({
+      models: [
+        { id: "baseline-model", name: "Baseline Model", provider: "provider-main" },
+        { id: "shared-model", name: "Shared Model", provider: "provider-alpha" },
+        { id: "shared-model", name: "Shared Model", provider: "provider-beta" },
+      ],
+    });
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    expect(modelSelect).not.toBeNull();
+
+    const optionValues = Array.from(modelSelect?.querySelectorAll("option") ?? []).map(
+      (option) => option.value,
+    );
+    expect(optionValues).toContain("provider-alpha/shared-model");
+    expect(optionValues).toContain("provider-beta/shared-model");
+    expect(optionValues).not.toContain("shared-model");
+
+    modelSelect!.value = "provider-beta/shared-model";
+    modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+    await flushTasks();
+    render(renderChatSessionSelect(state), container);
+
+    expect(request).toHaveBeenCalledWith("sessions.patch", {
+      key: "main",
+      model: "provider-beta/shared-model",
+    });
+    const rerendered = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    expect(rerendered?.value).toBe("provider-beta/shared-model");
+    vi.unstubAllGlobals();
+  });
+
   it("clears the session model override back to the default model", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
## Summary
- use provider-qualified model refs in the chat header model picker
- keep same model ids from different providers as distinct options
- stop leaking bare fallback model ids into the selectable list
- update chat header tests to cover provider-qualified patching and duplicate model ids

## Validation
- `node --check ui/src/ui/app-render.helpers.ts`
- local browser verification against the running Control UI bundle

## Notes
- full Vitest execution was not available in the local environment because `jsdom` is currently missing there
