### PR TITLE
fix: keep bundled plugin skills inside dist-runtime

### DIFF
--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -20,14 +20,21 @@ function shouldWrapRuntimeJsFile(sourcePath) {
   return path.extname(sourcePath) === ".js";
 }
 
-function shouldCopyRuntimeFile(sourcePath) {
-  const relativePath = sourcePath.replace(/\\/g, "/");
+function isBundledSkillRuntimePath(relativePath) {
+  const normalized = relativePath.replace(/\\/g, "/");
+  return normalized === "skills" || normalized.startsWith("skills/");
+}
+
+function shouldCopyRuntimeFile(sourcePath, relativePath) {
+  const normalizedRelativePath = relativePath.replace(/\\/g, "/");
+  const normalizedSourcePath = sourcePath.replace(/\\/g, "/");
   return (
-    relativePath.endsWith("/package.json") ||
-    relativePath.endsWith("/openclaw.plugin.json") ||
-    relativePath.endsWith("/.codex-plugin/plugin.json") ||
-    relativePath.endsWith("/.claude-plugin/plugin.json") ||
-    relativePath.endsWith("/.cursor-plugin/plugin.json")
+    isBundledSkillRuntimePath(normalizedRelativePath) ||
+    normalizedSourcePath.endsWith("/package.json") ||
+    normalizedSourcePath.endsWith("/openclaw.plugin.json") ||
+    normalizedSourcePath.endsWith("/.codex-plugin/plugin.json") ||
+    normalizedSourcePath.endsWith("/.claude-plugin/plugin.json") ||
+    normalizedSourcePath.endsWith("/.cursor-plugin/plugin.json")
   );
 }
 
@@ -46,7 +53,7 @@ function writeRuntimeModuleWrapper(sourcePath, targetPath) {
   );
 }
 
-function stagePluginRuntimeOverlay(sourceDir, targetDir) {
+function stagePluginRuntimeOverlay(sourceDir, targetDir, relativeDir = "") {
   fs.mkdirSync(targetDir, { recursive: true });
 
   for (const dirent of fs.readdirSync(sourceDir, { withFileTypes: true })) {
@@ -56,9 +63,10 @@ function stagePluginRuntimeOverlay(sourceDir, targetDir) {
 
     const sourcePath = path.join(sourceDir, dirent.name);
     const targetPath = path.join(targetDir, dirent.name);
+    const relativePath = relativeDir ? path.join(relativeDir, dirent.name) : dirent.name;
 
     if (dirent.isDirectory()) {
-      stagePluginRuntimeOverlay(sourcePath, targetPath);
+      stagePluginRuntimeOverlay(sourcePath, targetPath, relativePath);
       continue;
     }
 
@@ -76,7 +84,7 @@ function stagePluginRuntimeOverlay(sourceDir, targetDir) {
       continue;
     }
 
-    if (shouldCopyRuntimeFile(sourcePath)) {
+    if (shouldCopyRuntimeFile(sourcePath, relativePath)) {
       fs.copyFileSync(sourcePath, targetPath);
       continue;
     }

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -4,10 +4,15 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { stageBundledPluginRuntime } from "../../scripts/stage-bundled-plugin-runtime.mjs";
-import { discoverOpenClawPlugins } from "./discovery.js";
-import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import { loadWorkspaceSkillEntries } from "../agents/skills/workspace.js";
+import { clearPluginDiscoveryCache, discoverOpenClawPlugins } from "./discovery.js";
+import {
+  clearPluginManifestRegistryCache,
+  loadPluginManifestRegistry,
+} from "./manifest-registry.js";
 
 const tempDirs: string[] = [];
+const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
 
 function makeRepoRoot(prefix: string): string {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -18,6 +23,13 @@ function makeRepoRoot(prefix: string): string {
 afterEach(() => {
   for (const dir of tempDirs.splice(0, tempDirs.length)) {
     fs.rmSync(dir, { recursive: true, force: true });
+  }
+  clearPluginDiscoveryCache();
+  clearPluginManifestRegistryCache();
+  if (originalBundledPluginsDir === undefined) {
+    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+  } else {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = originalBundledPluginsDir;
   }
 });
 
@@ -305,6 +317,106 @@ describe("stageBundledPluginRuntime", () => {
     );
     expect(manifestRegistry.plugins[0]?.startupDeferConfiguredChannelFullLoadUntilAfterListen).toBe(
       true,
+    );
+  });
+
+  it("copies bundled skill files into dist-runtime so plugin skill roots stay self-contained", () => {
+    const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-skills-");
+    const distPluginDir = path.join(repoRoot, "dist", "extensions", "demo");
+    const runtimeExtensionsDir = path.join(repoRoot, "dist-runtime", "extensions");
+    const distSkillPath = path.join(distPluginDir, "skills", "demo-skill", "SKILL.md");
+    const distReferencePath = path.join(
+      distPluginDir,
+      "skills",
+      "demo-skill",
+      "references",
+      "guide.md",
+    );
+    const runtimeSkillPath = path.join(
+      runtimeExtensionsDir,
+      "demo",
+      "skills",
+      "demo-skill",
+      "SKILL.md",
+    );
+    const runtimeReferencePath = path.join(
+      runtimeExtensionsDir,
+      "demo",
+      "skills",
+      "demo-skill",
+      "references",
+      "guide.md",
+    );
+    fs.mkdirSync(path.join(distPluginDir, "skills", "demo-skill", "references"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(distPluginDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "@openclaw/demo",
+          openclaw: {
+            extensions: ["./index.js"],
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(distPluginDir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "demo",
+          configSchema: { type: "object" },
+          skills: ["./skills"],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    fs.writeFileSync(path.join(distPluginDir, "index.js"), "export default {};\n", "utf8");
+    fs.writeFileSync(
+      distSkillPath,
+      [
+        "---",
+        "name: demo-skill",
+        "description: Demo skill for runtime staging tests.",
+        "---",
+        "",
+        "# Demo skill",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    fs.writeFileSync(distReferencePath, "reference\n", "utf8");
+
+    stageBundledPluginRuntime({ repoRoot });
+
+    expect(fs.lstatSync(runtimeSkillPath).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(runtimeSkillPath, "utf8")).toContain("name: demo-skill");
+    expect(fs.lstatSync(runtimeReferencePath).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(runtimeReferencePath, "utf8")).toBe("reference\n");
+
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = runtimeExtensionsDir;
+
+    const entries = loadWorkspaceSkillEntries(path.join(repoRoot, "workspace"), {
+      config: {
+        plugins: {
+          enabled: true,
+          allow: ["demo"],
+          entries: {
+            demo: { enabled: true },
+          },
+        },
+      },
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("demo-skill");
+    expect(entries.find((entry) => entry.skill.name === "demo-skill")?.skill.filePath).toBe(
+      runtimeSkillPath,
     );
   });
 


### PR DESCRIPTION
## Summary
- copy bundled plugin `skills/` trees into `dist-runtime` instead of symlinking them back into `dist`
- keep plugin skill roots self-contained so realpaths stay under the configured runtime root
- add a regression test that stages a demo plugin skill and verifies it loads from `dist-runtime`

## Testing
- corepack pnpm -C /home/banko/workspace/github/openclaw.partial exec vitest run src/plugins/stage-bundled-plugin-runtime.test.ts --maxWorkers=1
- OPENCLAW_INCLUDE_OPTIONAL_BUNDLED=1 corepack pnpm -C /home/banko/workspace/github/openclaw.partial build
- corepack pnpm -C /home/banko/workspace/github/openclaw.partial ui:build
- sudo -u shoudeng -H env HOME=/home/shoudeng /usr/bin/openclaw config validate
- local installed runtime verification via `/usr/lib/node_modules/openclaw/dist/index.js` and `/bash cat /etc/hostname`
