### PR TITLE
fix: make initializeGlobalHookRunner idempotent (#50025)

### DIFF
--- a/src/plugins/hook-runner-global.test.ts
+++ b/src/plugins/hook-runner-global.test.ts
@@ -46,4 +46,54 @@ describe("hook-runner-global", () => {
     expect(modC.getGlobalHookRunner()).toBeNull();
     expect(modC.getGlobalPluginRegistry()).toBeNull();
   });
+
+  it("does not replace an existing runner that has typed hooks", async () => {
+    const mod = await importHookRunnerGlobalModule();
+    const registryWithHooks = createMockPluginRegistry([
+      { hookName: "llm_input", handler: vi.fn() },
+    ]);
+    const emptyRegistry = createMockPluginRegistry([]);
+
+    mod.initializeGlobalHookRunner(registryWithHooks);
+    const originalRunner = mod.getGlobalHookRunner();
+    expect(originalRunner?.hasHooks("llm_input")).toBe(true);
+
+    // Second call with empty registry should be a no-op
+    mod.initializeGlobalHookRunner(emptyRegistry);
+    expect(mod.getGlobalHookRunner()).toBe(originalRunner);
+    expect(mod.getGlobalPluginRegistry()).toBe(registryWithHooks);
+    expect(mod.getGlobalHookRunner()?.hasHooks("llm_input")).toBe(true);
+  });
+
+  it("allows replacing a runner that has no typed hooks", async () => {
+    const mod = await importHookRunnerGlobalModule();
+    const emptyRegistry = createMockPluginRegistry([]);
+    const registryWithHooks = createMockPluginRegistry([
+      { hookName: "llm_input", handler: vi.fn() },
+    ]);
+
+    mod.initializeGlobalHookRunner(emptyRegistry);
+    expect(mod.getGlobalHookRunner()?.hasHooks("llm_input")).toBe(false);
+
+    // Second call with hooks should replace
+    mod.initializeGlobalHookRunner(registryWithHooks);
+    expect(mod.getGlobalHookRunner()?.hasHooks("llm_input")).toBe(true);
+    expect(mod.getGlobalPluginRegistry()).toBe(registryWithHooks);
+  });
+
+  it("allows re-initialization after reset", async () => {
+    const mod = await importHookRunnerGlobalModule();
+    const registryA = createMockPluginRegistry([{ hookName: "llm_input", handler: vi.fn() }]);
+    const registryB = createMockPluginRegistry([{ hookName: "llm_output", handler: vi.fn() }]);
+
+    mod.initializeGlobalHookRunner(registryA);
+    expect(mod.getGlobalHookRunner()?.hasHooks("llm_input")).toBe(true);
+
+    mod.resetGlobalHookRunner();
+    expect(mod.getGlobalHookRunner()).toBeNull();
+
+    mod.initializeGlobalHookRunner(registryB);
+    expect(mod.getGlobalHookRunner()?.hasHooks("llm_output")).toBe(true);
+    expect(mod.getGlobalHookRunner()?.hasHooks("llm_input")).toBe(false);
+  });
 });

--- a/src/plugins/hook-runner-global.ts
+++ b/src/plugins/hook-runner-global.ts
@@ -35,6 +35,14 @@ function getHookRunnerGlobalState(): HookRunnerGlobalState {
  */
 export function initializeGlobalHookRunner(registry: PluginRegistry): void {
   const state = getHookRunnerGlobalState();
+  // Preserve an existing hook runner that has registered hooks.
+  // Subsequent ensureRuntimePluginsLoaded calls (e.g. from non-default agent runs)
+  // may build a fresh registry with fewer/no hooks due to cache key divergence;
+  // replacing the working runner would silently drop all plugin hooks.
+  if (state.hookRunner && state.registry && state.registry.typedHooks.length > 0) {
+    log.debug("hook runner already initialized with hooks; skipping re-initialization");
+    return;
+  }
   state.registry = registry;
   state.hookRunner = createHookRunner(registry, {
     logger: {


### PR DESCRIPTION
## Summary

- Fixes #50025 — plugin hooks (`llm_input`, `llm_output`, `agent_end`) now fire for all agents, not just the default agent
- `initializeGlobalHookRunner` was unconditionally replacing the process-wide singleton hook runner every time `activatePluginRegistry` was called. When a non-default agent triggered `ensureRuntimePluginsLoaded`, a cache key mismatch caused a fresh (empty) registry to be built, clobbering the gateway's working hook runner
- Added a guard clause: if a hook runner already exists with registered typed hooks, skip re-initialization

## Changes

- `src/plugins/hook-runner-global.ts` — guard clause + debug log in `initializeGlobalHookRunner`
- `src/plugins/hook-runner-global.test.ts` — 3 new tests covering idempotency, upgrade-from-hookless, and reset-clears-guard

## Test plan

- [x] All 5 hook-runner-global tests pass (2 existing + 3 new)
- [x] Full plugin test suite passes (605 tests)
- [x] Embedded runner test suite passes
- [x] Build succeeds with no errors