### PR TITLE
fix(telegram): avoid self-sustaining polling 409 conflicts

### DIFF
--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -539,6 +539,8 @@ describe("telegramPlugin duplicate token guard", () => {
   });
 
   it("does not crash startup when a resolved account token is undefined", async () => {
+    probeTelegramMock.mockClear();
+    monitorTelegramProviderMock.mockClear();
     const { monitorTelegramProvider, probeTelegram } = installGatewayRuntime({
       probeOk: false,
     });
@@ -557,17 +559,14 @@ describe("telegramPlugin duplicate token guard", () => {
     } as ResolvedTelegramAccount;
 
     await expect(telegramPlugin.gateway!.startAccount!(ctx)).resolves.toBeUndefined();
-    expect(probeTelegramMock).toHaveBeenCalledWith("", 2500, {
-      accountId: "ops",
-      proxyUrl: undefined,
-      network: undefined,
-    });
+    expect(probeTelegramMock).not.toHaveBeenCalled();
     expect(monitorTelegramProviderMock).toHaveBeenCalledWith(
       expect.objectContaining({
         token: "",
+        useWebhook: false,
       }),
     );
-    expect(probeTelegram).toHaveBeenCalled();
+    expect(probeTelegram).not.toHaveBeenCalled();
     expect(monitorTelegramProvider).toHaveBeenCalled();
   });
 });

--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -242,6 +242,31 @@ describe("telegramPlugin duplicate token guard", () => {
     expect(monitorTelegramProvider).not.toHaveBeenCalled();
   });
 
+  it("skips startup probe before polling begins", async () => {
+    const { monitorTelegramProvider, probeTelegram } = installGatewayRuntime({
+      probeOk: true,
+      botUsername: "opsbot",
+    });
+    monitorTelegramProviderMock.mockResolvedValue(undefined);
+
+    await telegramPlugin.gateway!.startAccount!(
+      createStartAccountCtx({
+        cfg: createCfg(),
+        accountId: "ops",
+        runtime: createRuntimeEnv(),
+      }),
+    );
+
+    expect(probeTelegramMock).not.toHaveBeenCalled();
+    expect(monitorTelegramProviderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useWebhook: false,
+      }),
+    );
+    expect(probeTelegram).not.toHaveBeenCalled();
+    expect(monitorTelegramProvider).toHaveBeenCalled();
+  });
+
   it("passes webhookPort through to monitor startup options", async () => {
     const { monitorTelegramProvider, probeTelegram } = installGatewayRuntime({
       probeOk: true,

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -693,20 +693,23 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         throw new Error(reason);
       }
       const token = (account.token ?? "").trim();
+      const useWebhook = Boolean(account.config.webhookUrl);
       let telegramBotLabel = "";
-      try {
-        const probe = await probeTelegram(token, 2500, {
-          accountId: account.accountId,
-          proxyUrl: account.config.proxy,
-          network: account.config.network,
-        });
-        const username = probe.ok ? probe.bot?.username?.trim() : null;
-        if (username) {
-          telegramBotLabel = ` (@${username})`;
-        }
-      } catch (err) {
-        if (getTelegramRuntime().logging.shouldLogVerbose()) {
-          ctx.log?.debug?.(`[${account.accountId}] bot probe failed: ${String(err)}`);
+      if (useWebhook) {
+        try {
+          const probe = await probeTelegram(token, 2500, {
+            accountId: account.accountId,
+            proxyUrl: account.config.proxy,
+            network: account.config.network,
+          });
+          const username = probe.ok ? probe.bot?.username?.trim() : null;
+          if (username) {
+            telegramBotLabel = ` (@${username})`;
+          }
+        } catch (err) {
+          if (getTelegramRuntime().logging.shouldLogVerbose()) {
+            ctx.log?.debug?.(`[${account.accountId}] bot probe failed: ${String(err)}`);
+          }
         }
       }
       ctx.log?.info(`[${account.accountId}] starting provider${telegramBotLabel}`);
@@ -716,7 +719,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         config: ctx.cfg,
         runtime: ctx.runtime,
         abortSignal: ctx.abortSignal,
-        useWebhook: Boolean(account.config.webhookUrl),
+        useWebhook,
         webhookUrl: account.config.webhookUrl,
         webhookSecret: account.config.webhookSecret,
         webhookPath: account.config.webhookPath,

--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -408,6 +408,9 @@ describe("monitorTelegramProvider (grammY)", () => {
           silent: true,
           maxRetryTime: 60 * 60 * 1000,
           retryInterval: "exponential",
+          fetch: expect.objectContaining({
+            timeout: 10,
+          }),
         }),
       }),
     );

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -42,7 +42,8 @@ export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unk
     },
     runner: {
       fetch: {
-        // Match grammY defaults
+        // Shorter than grammY's 30s default to avoid retry overlap with
+        // the previous server-side getUpdates window.
         timeout: 10,
         // Request reactions without dropping default update types.
         allowed_updates: resolveTelegramAllowedUpdates(),

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -43,7 +43,7 @@ export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unk
     runner: {
       fetch: {
         // Match grammY defaults
-        timeout: 30,
+        timeout: 10,
         // Request reactions without dropping default update types.
         allowed_updates: resolveTelegramAllowedUpdates(),
       },


### PR DESCRIPTION
## Summary

Fix a Telegram polling failure mode where `getUpdates` can fall into a self-sustaining 409 conflict loop.

This change tackles two parts of the issue:
- skip the startup bot probe before polling begins, so polling owns `getUpdates` from the start
- reduce grammY long-poll fetch timeout from 30s to 10s, so retry attempts do not overlap the previous server-side `getUpdates` window

## Root cause

Issue #50064 describes a failure mode where Telegram probe and polling behavior can combine into repeated `409 Conflict: terminated by other getUpdates request` errors.

The key pieces are:
- startup probe runs before polling starts
- polling retries can line up with the previous 30s long-poll window
- once a 409 is triggered, the 30s fetch timeout can keep the overlap going

By removing the startup probe from the polling path and shortening the polling timeout, polling no longer competes with an immediate pre-start probe and retry cycles recover instead of re-triggering the same overlap.

## What changed

- in `channel.ts`, only run the startup probe for webhook accounts
  - polling accounts now go straight to `monitorTelegramProvider(...)`
- in `monitor.ts`, reduce grammY polling `fetch.timeout` from `30` to `10`
- add a regression test that verifies polling startup skips the probe
- update the runner-options test to lock the new timeout

## Why this is different from nearby Telegram PRs

This is specifically about the **startup probe / polling ownership** conflict and the **30s long-poll = 30s retry overlap** described in #50064.

It is not the same as:
- #49910: graceful stop timeout / shutdown cleanup race
- #50368: startup persisted-offset confirmation timeout

## Testing

- `pnpm test extensions/telegram/src/monitor.test.ts`
- added coverage in `extensions/telegram/src/channel.test.ts`

`channel.test.ts` currently trips an unrelated repo test-environment import problem in this checkout (`fake-indexeddb/auto` via Matrix runtime mocking), but the new assertion is narrow and the Telegram monitor suite passes locally.

Closes #50064
