### PR TITLE
security: add missing response headers to media server

### DIFF
--- a/src/media/server.test.ts
+++ b/src/media/server.test.ts
@@ -62,6 +62,12 @@ describe("media server", () => {
     const res = await fetch(mediaUrl("file1"));
     expect(res.status).toBe(200);
     expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("x-frame-options")).toBe("DENY");
+    expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(res.headers.get("content-security-policy")).toBe(
+      "default-src 'none'; style-src 'unsafe-inline'; sandbox",
+    );
+    expect(res.headers.get("cache-control")).toBe("no-store");
     expect(await res.text()).toBe("hello");
     await waitForFileRemoval(file);
   });

--- a/src/media/server.ts
+++ b/src/media/server.ts
@@ -34,6 +34,13 @@ export function attachMediaRoutes(
 
   app.get("/media/:id", async (req, res) => {
     res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("X-Frame-Options", "DENY");
+    res.setHeader("Referrer-Policy", "no-referrer");
+    res.setHeader(
+      "Content-Security-Policy",
+      "default-src 'none'; style-src 'unsafe-inline'; sandbox",
+    );
+    res.setHeader("Cache-Control", "no-store");
     const id = req.params.id;
     if (!isValidMediaId(id)) {
       res.status(400).send("invalid path");


### PR DESCRIPTION
## Problem

The media server endpoint at `/media/:id` serves potentially untrusted user-uploaded content (images, audio, etc.) but only sets `X-Content-Type-Options: nosniff`. The gateway's `setDefaultSecurityHeaders()` applies a broader set of security headers elsewhere, but the media server was not covered.

This leaves the endpoint without protections against clickjacking, referrer leakage, and content injection for served media files.

## Fix

Added the following headers to all media server responses:

- **`X-Frame-Options: DENY`** — prevents media from being embedded in frames (clickjacking mitigation)
- **`Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; sandbox`** — sandboxes served content, blocking script execution and external resource loading. The restrictive `sandbox` directive ensures even if content is rendered directly, it cannot run scripts or navigate the parent page. `style-src 'unsafe-inline'` is kept to allow basic rendering of content-type-detected HTML without breaking browsers.
- **`Referrer-Policy: no-referrer`** — prevents the media URL from leaking to external origins if the content triggers navigation
- **`Cache-Control: no-store`** — media files are ephemeral (cleaned up after first access or TTL expiry), so caching is inappropriate

## Testing

Updated the existing media server test to validate all new headers are present on successful responses. All 9 tests pass.