### PR TITLE
feat(whatsapp): support native location messages via message tool

### DIFF
--- a/extensions/whatsapp/src/active-listener.test.ts
+++ b/extensions/whatsapp/src/active-listener.test.ts
@@ -22,6 +22,7 @@ describe("active WhatsApp listener singleton", () => {
       sendMessage: vi.fn(async () => ({ messageId: "msg-1" })),
       sendPoll: vi.fn(async () => ({ messageId: "poll-1" })),
       sendReaction: vi.fn(async () => {}),
+      sendLocation: vi.fn(async () => ({ messageId: "loc-1" })),
       sendComposingTo: vi.fn(async () => {}),
     };
 

--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -24,6 +24,12 @@ export type ActiveWebListener = {
     fromMe: boolean,
     participant?: string,
   ) => Promise<void>;
+  sendLocation: (
+    to: string,
+    latitude: number,
+    longitude: number,
+    options?: { name?: string; address?: string; accuracyInMeters?: number },
+  ) => Promise<{ messageId: string }>;
   sendComposingTo: (to: string) => Promise<void>;
   close?: () => Promise<void>;
 };

--- a/extensions/whatsapp/src/auto-reply.test-harness.ts
+++ b/extensions/whatsapp/src/auto-reply.test-harness.ts
@@ -24,6 +24,7 @@ type MockWebListener = {
   sendMessage: () => Promise<{ messageId: string }>;
   sendPoll: () => Promise<{ messageId: string }>;
   sendReaction: () => Promise<void>;
+  sendLocation: () => Promise<{ messageId: string }>;
   sendComposingTo: () => Promise<void>;
 };
 
@@ -183,6 +184,7 @@ export function createMockWebListener(): MockWebListener {
     sendMessage: vi.fn(async () => ({ messageId: "msg-1" })),
     sendPoll: vi.fn(async () => ({ messageId: "poll-1" })),
     sendReaction: vi.fn(async () => undefined),
+    sendLocation: vi.fn(async () => ({ messageId: "loc-1" })),
     sendComposingTo: vi.fn(async () => undefined),
   };
 }

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -151,6 +151,55 @@ describe("createWebSendApi", () => {
     );
   });
 
+  it("sends location with required latitude and longitude", async () => {
+    const res = await api.sendLocation("+1555", 40.7128, -74.006);
+    expect(sendMessage).toHaveBeenCalledWith(
+      "1555@s.whatsapp.net",
+      expect.objectContaining({
+        location: expect.objectContaining({
+          degreesLatitude: 40.7128,
+          degreesLongitude: -74.006,
+        }),
+      }),
+    );
+    expect(res.messageId).toBe("msg-1");
+    expect(recordChannelActivity).toHaveBeenCalledWith({
+      channel: "whatsapp",
+      accountId: "main",
+      direction: "outbound",
+    });
+  });
+
+  it("includes optional location fields when provided", async () => {
+    await api.sendLocation("+1555", 28.2723, -16.6424, {
+      name: "Teide",
+      address: "Parque Nacional del Teide, Tenerife",
+      accuracyInMeters: 10,
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      "1555@s.whatsapp.net",
+      expect.objectContaining({
+        location: expect.objectContaining({
+          degreesLatitude: 28.2723,
+          degreesLongitude: -16.6424,
+          name: "Teide",
+          address: "Parque Nacional del Teide, Tenerife",
+          accuracyInMeters: 10,
+        }),
+      }),
+    );
+  });
+
+  it("omits undefined optional location fields from payload", async () => {
+    await api.sendLocation("+1555", 0, 0);
+    expect(sendMessage).toHaveBeenCalledWith(
+      "1555@s.whatsapp.net",
+      expect.objectContaining({
+        location: { degreesLatitude: 0, degreesLongitude: 0 },
+      }),
+    );
+  });
+
   it("sends composing presence updates to the recipient JID", async () => {
     await api.sendComposingTo("+1555");
     expect(sendPresenceUpdate).toHaveBeenCalledWith("composing", "1555@s.whatsapp.net");

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -105,6 +105,29 @@ export function createWebSendApi(params: {
         },
       } as AnyMessageContent);
     },
+    sendLocation: async (
+      to: string,
+      latitude: number,
+      longitude: number,
+      options?: { name?: string; address?: string; accuracyInMeters?: number },
+    ): Promise<{ messageId: string }> => {
+      const jid = toWhatsappJid(to);
+      const locationPayload: Record<string, unknown> = {
+        degreesLatitude: latitude,
+        degreesLongitude: longitude,
+      };
+      if (options?.name) locationPayload.name = options.name;
+      if (options?.address) locationPayload.address = options.address;
+      if (options?.accuracyInMeters != null) {
+        locationPayload.accuracyInMeters = options.accuracyInMeters;
+      }
+      const result = await params.sock.sendMessage(jid, {
+        location: locationPayload,
+      } as AnyMessageContent);
+      recordWhatsAppOutbound(params.defaultAccountId);
+      const messageId = resolveOutboundMessageId(result);
+      return { messageId };
+    },
     sendComposingTo: async (to: string): Promise<void> => {
       const jid = toWhatsappJid(to);
       await params.sock.sendPresenceUpdate("composing", jid);

--- a/extensions/whatsapp/src/outbound-adapter.ts
+++ b/extensions/whatsapp/src/outbound-adapter.ts
@@ -9,7 +9,7 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import { chunkText } from "openclaw/plugin-sdk/reply-runtime";
 import { shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveWhatsAppOutboundTarget } from "./runtime-api.js";
-import { sendMessageWhatsApp, sendPollWhatsApp } from "./send.js";
+import { sendLocationWhatsApp, sendMessageWhatsApp, sendPollWhatsApp } from "./send.js";
 
 function trimLeadingWhitespace(text: string | undefined): string {
   return text?.trimStart() ?? "";
@@ -88,4 +88,23 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
         cfg,
       }),
   }),
+  sendLocation: async ({
+    cfg,
+    to,
+    latitude,
+    longitude,
+    name,
+    address,
+    accuracyInMeters,
+    accountId,
+  }) =>
+    await sendLocationWhatsApp(
+      to,
+      { latitude, longitude, name, address, accuracyInMeters },
+      {
+        verbose: shouldLogVerbose(),
+        accountId: accountId ?? undefined,
+        cfg,
+      },
+    ),
 };

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -20,6 +20,7 @@ describe("web outbound", () => {
   const sendMessage = vi.fn(async () => ({ messageId: "msg123" }));
   const sendPoll = vi.fn(async () => ({ messageId: "poll123" }));
   const sendReaction = vi.fn(async () => {});
+  const sendLocation = vi.fn(async () => ({ messageId: "loc123" }));
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -28,6 +29,7 @@ describe("web outbound", () => {
       sendMessage,
       sendPoll,
       sendReaction,
+      sendLocation,
     });
   });
 
@@ -176,6 +178,7 @@ describe("web outbound", () => {
       sendMessage,
       sendPoll,
       sendReaction,
+      sendLocation,
     });
     loadWebMediaMock.mockResolvedValueOnce({
       buffer: Buffer.from("img"),

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -157,6 +157,51 @@ export async function sendReactionWhatsApp(
   }
 }
 
+export async function sendLocationWhatsApp(
+  to: string,
+  location: {
+    latitude: number;
+    longitude: number;
+    name?: string;
+    address?: string;
+    accuracyInMeters?: number;
+  },
+  options: { verbose: boolean; accountId?: string; cfg?: OpenClawConfig },
+): Promise<{ messageId: string; toJid: string }> {
+  const correlationId = generateSecureUuid();
+  const startedAt = Date.now();
+  const { listener: active } = requireActiveWebListener(options.accountId);
+  const redactedTo = redactIdentifier(to);
+  const logger = getChildLogger({
+    module: "web-outbound",
+    correlationId,
+    to: redactedTo,
+  });
+  try {
+    const jid = toWhatsappJid(to);
+    const redactedJid = redactIdentifier(jid);
+    outboundLog.info(`Sending location -> ${redactedJid}`);
+    logger.info(
+      { jid: redactedJid, latitude: location.latitude, longitude: location.longitude },
+      "sending location",
+    );
+    await active.sendComposingTo(to);
+    const result = await active.sendLocation(to, location.latitude, location.longitude, {
+      name: location.name,
+      address: location.address,
+      accuracyInMeters: location.accuracyInMeters,
+    });
+    const messageId = (result as { messageId?: string })?.messageId ?? "unknown";
+    const durationMs = Date.now() - startedAt;
+    outboundLog.info(`Sent location ${messageId} -> ${redactedJid} (${durationMs}ms)`);
+    logger.info({ jid: redactedJid, messageId }, "sent location");
+    return { messageId, toJid: jid };
+  } catch (err) {
+    logger.error({ err: String(err), to: redactedTo }, "failed to send location via web session");
+    throw err;
+  }
+}
+
 export async function sendPollWhatsApp(
   to: string,
   poll: PollInput,

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -122,6 +122,18 @@ function buildSendSchema(options: { includeInteractive: boolean }) {
         description: "Send image/GIF as document to avoid Telegram compression (Telegram only).",
       }),
     ),
+    latitude: Type.Optional(
+      Type.Number({ description: "Latitude for location messages (-90 to 90)." }),
+    ),
+    longitude: Type.Optional(
+      Type.Number({ description: "Longitude for location messages (-180 to 180)." }),
+    ),
+    locationName: Type.Optional(
+      Type.String({ description: "Place name shown on the location pin." }),
+    ),
+    locationAddress: Type.Optional(
+      Type.String({ description: "Address text shown below the location pin." }),
+    ),
     interactive: Type.Optional(interactiveMessageSchema),
   };
   if (!options.includeInteractive) {

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -55,6 +55,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "set-presence",
   "set-profile",
   "download-file",
+  "location",
 ] as const;
 
 export type ChannelMessageActionName = (typeof CHANNEL_MESSAGE_ACTION_NAMES)[number];

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -16,6 +16,8 @@ import type {
   ChannelHeartbeatDeps,
   ChannelLogSink,
   ChannelOutboundTargetMode,
+  ChannelLocationContext,
+  ChannelLocationResult,
   ChannelPollContext,
   ChannelPollResult,
   ChannelSecurityContext,
@@ -178,6 +180,7 @@ export type ChannelOutboundAdapter = {
   sendText?: (ctx: ChannelOutboundContext) => Promise<OutboundDeliveryResult>;
   sendMedia?: (ctx: ChannelOutboundContext) => Promise<OutboundDeliveryResult>;
   sendPoll?: (ctx: ChannelPollContext) => Promise<ChannelPollResult>;
+  sendLocation?: (ctx: ChannelLocationContext) => Promise<ChannelLocationResult>;
 };
 
 export type ChannelStatusAdapter<ResolvedAccount, Probe = unknown, Audit = unknown> = {

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -542,6 +542,22 @@ export type ChannelPollContext = {
   isAnonymous?: boolean;
 };
 
+export type ChannelLocationResult = {
+  messageId: string;
+  toJid?: string;
+};
+
+export type ChannelLocationContext = {
+  cfg: OpenClawConfig;
+  to: string;
+  latitude: number;
+  longitude: number;
+  name?: string;
+  address?: string;
+  accuracyInMeters?: number;
+  accountId?: string | null;
+};
+
 /** Minimal base for all channel probe results. Channel-specific probes extend this. */
 export type BaseProbeResult<TError = string | null> = {
   ok: boolean;

--- a/src/channels/plugins/types.ts
+++ b/src/channels/plugins/types.ts
@@ -63,6 +63,8 @@ export type {
   ChannelMeta,
   ChannelMessageToolSchemaContribution,
   ChannelOutboundTargetMode,
+  ChannelLocationContext,
+  ChannelLocationResult,
   ChannelPollContext,
   ChannelPollResult,
   ChannelSecurityContext,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -40,7 +40,7 @@ import {
   readBooleanParam,
   resolveAttachmentMediaPolicy,
 } from "./message-action-params.js";
-import type { MessagePollResult, MessageSendResult } from "./message.js";
+import type { MessageLocationResult, MessagePollResult, MessageSendResult } from "./message.js";
 import {
   applyCrossContextDecoration,
   buildCrossContextDecoration,
@@ -48,7 +48,11 @@ import {
   enforceCrossContextPolicy,
   shouldApplyCrossContextMarker,
 } from "./outbound-policy.js";
-import { executePollAction, executeSendAction } from "./outbound-send-service.js";
+import {
+  executeLocationAction,
+  executePollAction,
+  executeSendAction,
+} from "./outbound-send-service.js";
 import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbound-session.js";
 import { resolveChannelTarget, type ResolvedMessagingTarget } from "./target-resolver.js";
 import { extractToolPayload } from "./tool-payload.js";
@@ -147,9 +151,20 @@ export type MessageActionRunResult =
       dryRun: boolean;
     }
   | {
+      kind: "location";
+      channel: ChannelId;
+      action: "location";
+      to: string;
+      handledBy: "plugin" | "core";
+      payload: unknown;
+      toolResult?: AgentToolResult<unknown>;
+      locationResult?: MessageLocationResult;
+      dryRun: boolean;
+    }
+  | {
       kind: "action";
       channel: ChannelId;
-      action: Exclude<ChannelMessageActionName, "send" | "poll">;
+      action: Exclude<ChannelMessageActionName, "send" | "poll" | "location">;
       handledBy: "plugin" | "dry-run";
       payload: unknown;
       toolResult?: AgentToolResult<unknown>;
@@ -661,10 +676,73 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
   };
 }
 
+async function handleLocationAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
+  const { cfg, params, channel, accountId, dryRun, gateway, abortSignal } = ctx;
+  throwIfAborted(abortSignal);
+  const action: ChannelMessageActionName = "location";
+  const to = readStringParam(params, "to", { required: true });
+
+  const latitudeRaw = readNumberParam(params, "latitude", { required: true });
+  const longitudeRaw = readNumberParam(params, "longitude", { required: true });
+  if (
+    latitudeRaw == null ||
+    !Number.isFinite(latitudeRaw) ||
+    latitudeRaw < -90 ||
+    latitudeRaw > 90
+  ) {
+    throw new Error("latitude must be a finite number between -90 and 90.");
+  }
+  if (
+    longitudeRaw == null ||
+    !Number.isFinite(longitudeRaw) ||
+    longitudeRaw < -180 ||
+    longitudeRaw > 180
+  ) {
+    throw new Error("longitude must be a finite number between -180 and 180.");
+  }
+  const latitude: number = latitudeRaw;
+  const longitude: number = longitudeRaw;
+
+  const locationName = readStringParam(params, "locationName");
+  const locationAddress = readStringParam(params, "locationAddress");
+
+  throwIfAborted(abortSignal);
+  const location = await executeLocationAction({
+    ctx: {
+      cfg,
+      channel,
+      params,
+      accountId: accountId ?? undefined,
+      gateway,
+      dryRun,
+    },
+    to,
+    latitude,
+    longitude,
+    name: locationName ?? undefined,
+    address: locationAddress ?? undefined,
+  });
+
+  return {
+    kind: "location",
+    channel,
+    action,
+    to,
+    handledBy: location.handledBy,
+    payload: location.payload,
+    toolResult: location.toolResult,
+    locationResult: location.locationResult,
+    dryRun,
+  };
+}
+
 async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
   const { cfg, params, channel, accountId, dryRun, gateway, input, abortSignal, agentId } = ctx;
   throwIfAborted(abortSignal);
-  const action = input.action as Exclude<ChannelMessageActionName, "send" | "poll" | "broadcast">;
+  const action = input.action as Exclude<
+    ChannelMessageActionName,
+    "send" | "poll" | "location" | "broadcast"
+  >;
   if (dryRun) {
     return {
       kind: "action",
@@ -807,6 +885,19 @@ export async function runMessageAction(
 
   if (action === "poll") {
     return handlePollAction({
+      cfg,
+      params,
+      channel,
+      accountId,
+      dryRun,
+      gateway,
+      input,
+      abortSignal: input.abortSignal,
+    });
+  }
+
+  if (action === "location") {
+    return handleLocationAction({
       cfg,
       params,
       channel,

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -6,6 +6,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
   {
     send: "to",
     broadcast: "none",
+    location: "to",
     poll: "to",
     "poll-vote": "to",
     react: "to",

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -360,3 +360,90 @@ export async function sendPoll(params: MessagePollParams): Promise<MessagePollRe
     result,
   });
 }
+
+type MessageLocationParams = {
+  to: string;
+  latitude: number;
+  longitude: number;
+  name?: string;
+  address?: string;
+  accuracyInMeters?: number;
+  channel?: string;
+  accountId?: string;
+  dryRun?: boolean;
+  cfg?: OpenClawConfig;
+  gateway?: MessageGatewayOptions;
+};
+
+export type MessageLocationResult = {
+  channel: string;
+  to: string;
+  latitude: number;
+  longitude: number;
+  name?: string;
+  address?: string;
+  via: "gateway";
+  result?: {
+    messageId: string;
+    toJid?: string;
+    channelId?: string;
+    conversationId?: string;
+  };
+  dryRun?: boolean;
+};
+
+export async function sendLocation(params: MessageLocationParams): Promise<MessageLocationResult> {
+  const cfg = params.cfg ?? loadConfig();
+  const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
+
+  const plugin = resolveRequiredPlugin(channel, cfg);
+  const outbound = plugin?.outbound;
+  if (!outbound?.sendLocation) {
+    throw new Error(`Unsupported location channel: ${channel}`);
+  }
+
+  if (params.dryRun) {
+    return {
+      channel,
+      to: params.to,
+      latitude: params.latitude,
+      longitude: params.longitude,
+      name: params.name,
+      address: params.address,
+      via: "gateway",
+      dryRun: true,
+    };
+  }
+
+  const result = await callMessageGateway<{
+    messageId: string;
+    toJid?: string;
+    channelId?: string;
+    conversationId?: string;
+  }>({
+    gateway: params.gateway,
+    method: "location",
+    params: {
+      to: params.to,
+      latitude: params.latitude,
+      longitude: params.longitude,
+      name: params.name,
+      address: params.address,
+      accuracyInMeters: params.accuracyInMeters,
+      channel,
+      accountId: params.accountId,
+      idempotencyKey: randomIdempotencyKey(),
+    },
+  });
+
+  return {
+    channel,
+    to: params.to,
+    latitude: params.latitude,
+    longitude: params.longitude,
+    name: params.name,
+    address: params.address,
+    via: "gateway",
+    result,
+  };
+}

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -7,8 +7,8 @@ import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import type { GatewayClientMode, GatewayClientName } from "../../utils/message-channel.js";
 import { throwIfAborted } from "./abort.js";
 import type { OutboundSendDeps } from "./deliver.js";
-import type { MessagePollResult, MessageSendResult } from "./message.js";
-import { sendMessage, sendPoll } from "./message.js";
+import type { MessageLocationResult, MessagePollResult, MessageSendResult } from "./message.js";
+import { sendLocation, sendMessage, sendPoll } from "./message.js";
 import type { OutboundMirror } from "./mirror.js";
 import { extractToolPayload } from "./tool-payload.js";
 
@@ -45,7 +45,7 @@ type PluginHandledResult = {
 
 async function tryHandleWithPluginAction(params: {
   ctx: OutboundSendContext;
-  action: "send" | "poll";
+  action: "send" | "poll" | "location";
   onHandled?: () => Promise<void> | void;
 }): Promise<PluginHandledResult | null> {
   if (params.ctx.dryRun) {
@@ -198,5 +198,47 @@ export async function executePollAction(params: {
     handledBy: "core",
     payload: result,
     pollResult: result,
+  };
+}
+
+export async function executeLocationAction(params: {
+  ctx: OutboundSendContext;
+  to: string;
+  latitude: number;
+  longitude: number;
+  name?: string;
+  address?: string;
+}): Promise<{
+  handledBy: "plugin" | "core";
+  payload: unknown;
+  toolResult?: AgentToolResult<unknown>;
+  locationResult?: MessageLocationResult;
+}> {
+  throwIfAborted(params.ctx.abortSignal);
+  const pluginHandled = await tryHandleWithPluginAction({
+    ctx: params.ctx,
+    action: "location",
+  });
+  if (pluginHandled) {
+    return pluginHandled;
+  }
+
+  const result: MessageLocationResult = await sendLocation({
+    cfg: params.ctx.cfg,
+    to: params.to,
+    latitude: params.latitude,
+    longitude: params.longitude,
+    name: params.name,
+    address: params.address,
+    channel: params.ctx.channel,
+    accountId: params.ctx.accountId ?? undefined,
+    dryRun: params.ctx.dryRun,
+    gateway: params.ctx.gateway,
+  });
+
+  return {
+    handledBy: "core",
+    payload: result,
+    locationResult: result,
   };
 }


### PR DESCRIPTION
## Context

Closes #2214. Picks up where #2298 left off (closed due to merge conflicts).

WhatsApp supports native location pins (interactive map previews), but the message tool currently has no way to send them. Agents resort to plain-text coordinates, which aren't tappable and don't show a map preview.

## Changes

Threads location sending through the existing message tool pipeline, following the same pattern used by polls:

**Message tool schema** (`src/agents/tools/message-tool.ts`)
- Added `latitude`, `longitude`, `locationName`, `locationAddress` parameters to `buildSendSchema()`

**Core outbound pipeline**
- Registered `"location"` as a recognized action name
- Added `handleLocationAction()` in the message action runner with coordinate validation (lat ±90, lon ±180)
- Added `executeLocationAction()` in the outbound send service (plugin-first, core fallback)
- Added `sendLocation()` in `message.ts` for gateway routing
- Added `ChannelLocationContext` and `ChannelLocationResult` types to the adapter interface

**WhatsApp extension**
- Added `sendLocation` to `ActiveWebListener` type
- Added `sendLocation` method to `createWebSendApi()` — builds the Baileys-native `{ location: { degreesLatitude, degreesLongitude, name?, address?, accuracyInMeters? } }` payload
- Added `sendLocationWhatsApp()` high-level send function with logging and error handling
- Added `sendLocation` to the WhatsApp outbound adapter

**Addresses PR #2298 review feedback:**
- Coordinate validation rejects NaN, Infinity, and out-of-range values with a clear error
- Location is a separate action (`"location"`) rather than overloading `"send"`, so there is no silent conflict with media or text parameters

## Test plan

- [x] Added 3 unit tests for `createWebSendApi().sendLocation()` (required fields, optional fields, omitted fields)
- [x] Updated existing test mocks to include `sendLocation` on `ActiveWebListener`
- [x] All 27 WhatsApp extension tests pass
- [x] TypeScript strict check passes (no new errors)