### PR TITLE
security: use crypto.timingSafeEqual for Nextcloud Talk webhook signatures

### DIFF
--- a/extensions/nextcloud-talk/src/signature.test.ts
+++ b/extensions/nextcloud-talk/src/signature.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractNextcloudTalkHeaders,
+  generateNextcloudTalkSignature,
+  verifyNextcloudTalkSignature,
+} from "./signature.js";
+
+const TEST_SECRET = "nextcloud-secret"; // pragma: allowlist secret
+
+describe("verifyNextcloudTalkSignature", () => {
+  it("accepts a valid signature", () => {
+    const body = '{"type":"Create"}';
+    const { random, signature } = generateNextcloudTalkSignature({ body, secret: TEST_SECRET });
+    expect(verifyNextcloudTalkSignature({ signature, random, body, secret: TEST_SECRET })).toBe(
+      true,
+    );
+  });
+
+  it("rejects a tampered body", () => {
+    const body = '{"type":"Create"}';
+    const { random, signature } = generateNextcloudTalkSignature({ body, secret: TEST_SECRET });
+    expect(
+      verifyNextcloudTalkSignature({
+        signature,
+        random,
+        body: '{"type":"Delete"}',
+        secret: TEST_SECRET,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a wrong secret", () => {
+    const body = '{"type":"Create"}';
+    const { random, signature } = generateNextcloudTalkSignature({ body, secret: TEST_SECRET });
+    expect(verifyNextcloudTalkSignature({ signature, random, body, secret: "wrong-secret" })).toBe(
+      false,
+    );
+  });
+
+  it("rejects a tampered signature", () => {
+    const body = '{"type":"Create"}';
+    const { random, signature } = generateNextcloudTalkSignature({ body, secret: TEST_SECRET });
+    const tampered = "a".repeat(signature.length);
+    expect(
+      verifyNextcloudTalkSignature({ signature: tampered, random, body, secret: TEST_SECRET }),
+    ).toBe(false);
+  });
+
+  it("rejects a signature with wrong length", () => {
+    const body = '{"type":"Create"}';
+    const { random } = generateNextcloudTalkSignature({ body, secret: TEST_SECRET });
+    expect(
+      verifyNextcloudTalkSignature({ signature: "tooshort", random, body, secret: TEST_SECRET }),
+    ).toBe(false);
+  });
+
+  it("rejects empty signature", () => {
+    expect(
+      verifyNextcloudTalkSignature({ signature: "", random: "r", body: "b", secret: TEST_SECRET }),
+    ).toBe(false);
+  });
+
+  it("rejects empty random", () => {
+    expect(
+      verifyNextcloudTalkSignature({ signature: "s", random: "", body: "b", secret: TEST_SECRET }),
+    ).toBe(false);
+  });
+
+  it("rejects empty secret", () => {
+    expect(
+      verifyNextcloudTalkSignature({ signature: "s", random: "r", body: "b", secret: "" }),
+    ).toBe(false);
+  });
+});
+
+describe("extractNextcloudTalkHeaders", () => {
+  it("extracts all three headers", () => {
+    const result = extractNextcloudTalkHeaders({
+      "x-nextcloud-talk-signature": "sig",
+      "x-nextcloud-talk-random": "rand",
+      "x-nextcloud-talk-backend": "https://nc.example",
+    });
+    expect(result).toEqual({
+      signature: "sig",
+      random: "rand",
+      backend: "https://nc.example",
+    });
+  });
+
+  it("returns null when signature is missing", () => {
+    expect(
+      extractNextcloudTalkHeaders({
+        "x-nextcloud-talk-random": "rand",
+        "x-nextcloud-talk-backend": "https://nc.example",
+      }),
+    ).toBeNull();
+  });
+
+  it("handles array header values by taking the first element", () => {
+    const result = extractNextcloudTalkHeaders({
+      "x-nextcloud-talk-signature": ["sig1", "sig2"],
+      "x-nextcloud-talk-random": "rand",
+      "x-nextcloud-talk-backend": "https://nc.example",
+    });
+    expect(result?.signature).toBe("sig1");
+  });
+});
+
+describe("generateNextcloudTalkSignature", () => {
+  it("produces a valid hex signature", () => {
+    const { random, signature } = generateNextcloudTalkSignature({
+      body: "test",
+      secret: TEST_SECRET,
+    });
+    expect(random).toMatch(/^[0-9a-f]{64}$/);
+    expect(signature).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("generates different randoms on each call", () => {
+    const a = generateNextcloudTalkSignature({ body: "test", secret: TEST_SECRET });
+    const b = generateNextcloudTalkSignature({ body: "test", secret: TEST_SECRET });
+    expect(a.random).not.toBe(b.random);
+  });
+});

--- a/extensions/nextcloud-talk/src/signature.ts
+++ b/extensions/nextcloud-talk/src/signature.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomBytes } from "node:crypto";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import type { NextcloudTalkWebhookHeaders } from "./types.js";
 
 const SIGNATURE_HEADER = "x-nextcloud-talk-signature";
@@ -24,14 +24,15 @@ export function verifyNextcloudTalkSignature(params: {
     .update(random + body)
     .digest("hex");
 
-  if (signature.length !== expected.length) {
+  const sigBuf = Buffer.from(signature);
+  const expBuf = Buffer.from(expected);
+  if (sigBuf.length !== expBuf.length) {
+    // Perform a dummy comparison so the total execution time is constant
+    // regardless of whether the lengths match, preventing timing side-channels.
+    timingSafeEqual(expBuf, expBuf);
     return false;
   }
-  let result = 0;
-  for (let i = 0; i < signature.length; i++) {
-    result |= signature.charCodeAt(i) ^ expected.charCodeAt(i);
-  }
-  return result === 0;
+  return timingSafeEqual(sigBuf, expBuf);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace the hand-rolled constant-time comparison loop in `verifyNextcloudTalkSignature` with Node's native `crypto.timingSafeEqual`
- Add a dummy `timingSafeEqual(expBuf, expBuf)` call on length mismatch to keep total execution time constant, preventing timing side-channel leakage of whether the submitted signature had the correct length

**Motivation:** The previous implementation used a manual XOR loop with an early return on length mismatch. While the XOR loop itself is constant-time, the early return on `signature.length !== expected.length` leaks whether the attacker-supplied signature has the expected length (64 hex chars for SHA-256). Using `crypto.timingSafeEqual` is both more robust and consistent with the rest of the codebase (e.g., `src/security/secret-equal.ts`, `extensions/voice-call/src/webhook-security.ts`).

## Test plan

- [x] New `extensions/nextcloud-talk/src/signature.test.ts` with 13 test cases covering:
  - Valid signature acceptance
  - Tampered body/secret/signature rejection
  - Wrong-length signature rejection
  - Empty parameter rejection
  - Header extraction (including array values)
  - Signature generation (hex format, uniqueness)
- [x] Existing Nextcloud Talk tests still pass (`pnpm test -- extensions/nextcloud-talk/`)