### PR TITLE
security: replace Math.random with crypto.randomInt in session slug generation

### DIFF
--- a/src/agents/session-slug.test.ts
+++ b/src/agents/session-slug.test.ts
@@ -1,5 +1,11 @@
+import { randomInt } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createSessionSlug } from "./session-slug.js";
+
+vi.mock("node:crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:crypto")>();
+  return { ...actual, randomInt: vi.fn(actual.randomInt) };
+});
 
 describe("session slug", () => {
   afterEach(() => {
@@ -7,19 +13,19 @@ describe("session slug", () => {
   });
 
   it("generates a two-word slug by default", () => {
-    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.mocked(randomInt).mockReturnValue(0);
     const slug = createSessionSlug();
     expect(slug).toBe("amber-atlas");
   });
 
   it("adds a numeric suffix when the base slug is taken", () => {
-    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.mocked(randomInt).mockReturnValue(0);
     const slug = createSessionSlug((id) => id === "amber-atlas");
     expect(slug).toBe("amber-atlas-2");
   });
 
   it("falls back to three words when collisions persist", () => {
-    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.mocked(randomInt).mockReturnValue(0);
     const slug = createSessionSlug((id) => /^amber-atlas(-\d+)?$/.test(id));
     expect(slug).toBe("amber-atlas-atlas");
   });

--- a/src/agents/session-slug.ts
+++ b/src/agents/session-slug.ts
@@ -1,3 +1,5 @@
+import { randomInt } from "node:crypto";
+
 const SLUG_ADJECTIVES = [
   "amber",
   "briny",
@@ -101,7 +103,7 @@ const SLUG_NOUNS = [
 ];
 
 function randomChoice(values: string[], fallback: string) {
-  return values[Math.floor(Math.random() * values.length)] ?? fallback;
+  return values[randomInt(values.length)] ?? fallback;
 }
 
 function createSlugBase(words = 2) {
@@ -141,6 +143,6 @@ export function createSessionSlug(isTaken?: (id: string) => boolean): string {
   if (threeWord) {
     return threeWord;
   }
-  const fallback = `${createSlugBase(3)}-${Math.random().toString(36).slice(2, 5)}`;
+  const fallback = `${createSlugBase(3)}-${randomInt(46656).toString(36).padStart(3, "0")}`;
   return isIdTaken(fallback) ? `${fallback}-${Date.now().toString(36)}` : fallback;
 }


### PR DESCRIPTION
## Summary

- Replace `Math.random()` with `crypto.randomInt()` in `src/agents/session-slug.ts` for session slug generation
- Update test mocking to use `vi.mock("node:crypto")` instead of `vi.spyOn(Math, "random")`

**Motivation:** `Math.random()` uses a PRNG that is not cryptographically secure and its output can be predicted if an attacker observes enough values. While session slugs are primarily for human-readable identification, using `crypto.randomInt()` eliminates predictability as a concern and is consistent with the project's security-first approach. The change is trivial since this is Node.js-only code where `crypto.randomInt()` is always available.

## Test plan

- [x] Existing `src/agents/session-slug.test.ts` tests updated and passing (3/3)
- [x] Tests verify deterministic behavior via `vi.mock("node:crypto")`
- [x] No functional change to slug format or collision handling