### PR TITLE
security: add periodic cleanup to control plane rate limiter

### DIFF
--- a/src/gateway/control-plane-rate-limit.ts
+++ b/src/gateway/control-plane-rate-limit.ts
@@ -2,6 +2,7 @@ import type { GatewayClient } from "./server-methods/types.js";
 
 const CONTROL_PLANE_RATE_LIMIT_MAX_REQUESTS = 3;
 const CONTROL_PLANE_RATE_LIMIT_WINDOW_MS = 60_000;
+const PRUNE_INTERVAL_MS = 60_000;
 
 type Bucket = {
   count: number;
@@ -9,6 +10,18 @@ type Bucket = {
 };
 
 const controlPlaneBuckets = new Map<string, Bucket>();
+
+// Periodic cleanup to avoid unbounded map growth from distinct client keys.
+const pruneTimer = setInterval(() => {
+  const now = Date.now();
+  for (const [key, bucket] of controlPlaneBuckets) {
+    if (now - bucket.windowStartMs >= CONTROL_PLANE_RATE_LIMIT_WINDOW_MS) {
+      controlPlaneBuckets.delete(key);
+    }
+  }
+}, PRUNE_INTERVAL_MS);
+// Allow the Node.js process to exit even if the timer is still active.
+pruneTimer.unref();
 
 function normalizePart(value: unknown, fallback: string): string {
   if (typeof value !== "string") {


### PR DESCRIPTION
## Summary

- Add periodic pruning of expired buckets in the control plane rate limiter (`src/gateway/control-plane-rate-limit.ts`)
- Expired entries (older than the 60-second window) are removed every 60 seconds
- Timer is unref'd so it doesn't prevent process exit

**Motivation:** The `controlPlaneBuckets` Map accumulates entries for each unique device/IP combination but never removes expired entries. In a scenario with many distinct clients (different IPs or device IDs), the map grows without bound, consuming memory indefinitely. This follows the same pattern already established in `auth-rate-limit.ts` (lines 104-109) which has proper pruning.

## Test plan

- [x] Existing `server-methods.control-plane-rate-limit.test.ts` tests pass (4/4)
- [x] Pruning logic is straightforward: delete entries where `now - windowStartMs >= WINDOW_MS`
- [x] Timer uses `unref()` to avoid blocking process exit
- [x] No functional change to rate limiting behavior — only memory cleanup