### PR TITLE
Plugins: fix source plugin-sdk alias resolution

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -676,6 +676,21 @@ function resolvePluginRuntimeModule(params: {
   return params.env ? withEnv(params.env, run) : run();
 }
 
+function buildPluginLoaderCacheKey(params: {
+  modulePath: string;
+  tryNative: boolean;
+  aliasMap: Record<string, string>;
+  env?: NodeJS.ProcessEnv;
+}) {
+  const run = () =>
+    __testing.buildPluginLoaderCacheKey({
+      modulePath: params.modulePath,
+      tryNative: params.tryNative,
+      aliasMap: params.aliasMap,
+    });
+  return params.env ? withEnv(params.env, run) : run();
+}
+
 afterEach(() => {
   clearPluginLoaderCache();
   if (prevBundledDir === undefined) {
@@ -3492,6 +3507,44 @@ module.exports = {
     expect(options.extensions).toContain(".js");
     expect(options.extensions).toContain(".ts");
     expect("alias" in options).toBe(false);
+  });
+
+  it("keys plugin loader caches by resolved alias map so different roots do not share a loader", () => {
+    const first = createPluginSdkAliasFixture({
+      packageExports: {
+        "./plugin-sdk/channel-runtime": { default: "./dist/plugin-sdk/channel-runtime.js" },
+      },
+      srcFile: "channel-runtime.ts",
+      distFile: "channel-runtime.js",
+    });
+    const second = createPluginSdkAliasFixture({
+      packageExports: {
+        "./plugin-sdk/channel-runtime": { default: "./dist/plugin-sdk/channel-runtime.js" },
+      },
+      srcFile: "channel-runtime.ts",
+      distFile: "channel-runtime.js",
+    });
+
+    const firstKey = buildPluginLoaderCacheKey({
+      modulePath: path.join(first.root, "src", "plugins", "loader.ts"),
+      tryNative: false,
+      aliasMap: {
+        "openclaw/plugin-sdk": first.srcFile,
+        "openclaw/plugin-sdk/channel-runtime": first.srcFile,
+      },
+      env: { NODE_ENV: undefined },
+    });
+    const secondKey = buildPluginLoaderCacheKey({
+      modulePath: path.join(second.root, "src", "plugins", "loader.ts"),
+      tryNative: false,
+      aliasMap: {
+        "openclaw/plugin-sdk": second.srcFile,
+        "openclaw/plugin-sdk/channel-runtime": second.srcFile,
+      },
+      env: { NODE_ENV: undefined },
+    });
+
+    expect(firstKey).not.toBe(secondKey);
   });
 
   it("uses transpiled Jiti loads for source TypeScript plugin entries", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -104,8 +104,12 @@ function resolveLoaderModulePath(params: LoaderModuleResolveParams = {}): string
   return params.modulePath ?? fileURLToPath(params.moduleUrl ?? import.meta.url);
 }
 
-const resolvePluginSdkAlias = (): string | null =>
-  resolvePluginSdkAliasFile({ srcFile: "root-alias.cjs", distFile: "root-alias.cjs" });
+const resolvePluginSdkAlias = (params: LoaderModuleResolveParams = {}): string | null =>
+  resolvePluginSdkAliasFile({
+    srcFile: "root-alias.cjs",
+    distFile: "root-alias.cjs",
+    ...params,
+  });
 
 function resolvePluginRuntimeModulePath(params: LoaderModuleResolveParams = {}): string | null {
   try {
@@ -704,17 +708,22 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   }
 
   // Lazy: avoid creating the Jiti loader when all plugins are disabled (common in unit tests).
-  const jitiLoaders = new Map<boolean, ReturnType<typeof createJiti>>();
+  const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
   const getJiti = (modulePath: string) => {
     const tryNative = shouldPreferNativeJiti(modulePath);
-    const cached = jitiLoaders.get(tryNative);
+    const aliasOrderKey = resolvePluginSdkAliasCandidateOrder({
+      modulePath,
+      isProduction: process.env.NODE_ENV === "production",
+    }).join(">");
+    const cacheKey = `${tryNative ? "native" : "jiti"}:${aliasOrderKey}`;
+    const cached = jitiLoaders.get(cacheKey);
     if (cached) {
       return cached;
     }
-    const pluginSdkAlias = resolvePluginSdkAlias();
+    const pluginSdkAlias = resolvePluginSdkAlias({ modulePath });
     const aliasMap = {
       ...(pluginSdkAlias ? { "openclaw/plugin-sdk": pluginSdkAlias } : {}),
-      ...resolvePluginSdkScopedAliasMap(),
+      ...resolvePluginSdkScopedAliasMap({ modulePath }),
     };
     const loader = createJiti(import.meta.url, {
       ...buildPluginLoaderJitiOptions(aliasMap),
@@ -724,7 +733,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       // loading for the canonical built module graph.
       tryNative,
     });
-    jitiLoaders.set(tryNative, loader);
+    jitiLoaders.set(cacheKey, loader);
     return loader;
   };
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -142,6 +142,7 @@ function resolvePluginRuntimeModulePath(params: LoaderModuleResolveParams = {}):
 
 export const __testing = {
   buildPluginLoaderJitiOptions,
+  buildPluginLoaderCacheKey,
   listPluginSdkAliasCandidates,
   listPluginSdkExportedSubpaths,
   resolvePluginSdkScopedAliasMap,
@@ -151,6 +152,21 @@ export const __testing = {
   shouldPreferNativeJiti,
   maxPluginRegistryCacheEntries: MAX_PLUGIN_REGISTRY_CACHE_ENTRIES,
 };
+
+function buildPluginLoaderCacheKey(params: {
+  modulePath: string;
+  tryNative: boolean;
+  aliasMap: Record<string, string>;
+}): string {
+  const aliasOrderKey = resolvePluginSdkAliasCandidateOrder({
+    modulePath: params.modulePath,
+    isProduction: process.env.NODE_ENV === "production",
+  }).join(">");
+  const aliasEntries = Object.entries(params.aliasMap).toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  return `${params.tryNative ? "native" : "jiti"}:${aliasOrderKey}:${JSON.stringify(aliasEntries)}`;
+}
 
 function getCachedPluginRegistry(cacheKey: string): PluginRegistry | undefined {
   const cached = registryCache.get(cacheKey);
@@ -711,20 +727,20 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
   const getJiti = (modulePath: string) => {
     const tryNative = shouldPreferNativeJiti(modulePath);
-    const aliasOrderKey = resolvePluginSdkAliasCandidateOrder({
-      modulePath,
-      isProduction: process.env.NODE_ENV === "production",
-    }).join(">");
-    const cacheKey = `${tryNative ? "native" : "jiti"}:${aliasOrderKey}`;
-    const cached = jitiLoaders.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
     const pluginSdkAlias = resolvePluginSdkAlias({ modulePath });
     const aliasMap = {
       ...(pluginSdkAlias ? { "openclaw/plugin-sdk": pluginSdkAlias } : {}),
       ...resolvePluginSdkScopedAliasMap({ modulePath }),
     };
+    const cacheKey = buildPluginLoaderCacheKey({
+      modulePath,
+      tryNative,
+      aliasMap,
+    });
+    const cached = jitiLoaders.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
     const loader = createJiti(import.meta.url, {
       ...buildPluginLoaderJitiOptions(aliasMap),
       // Source .ts runtime shims import sibling ".js" specifiers that only exist


### PR DESCRIPTION
## Summary

- Problem: when source plugins are loaded from a repo checkout, the plugin loader can still resolve `openclaw/plugin-sdk/*` aliases from the loader module path instead of the plugin module path.
- Why it matters: a globally installed `openclaw` run from a checkout can mix source plugin entries with the built `dist/plugin-sdk/*` graph, reintroducing wrong runtime imports during plugin loading.
- What changed: make plugin-sdk alias resolution and the Jiti loader cache key depend on the module being loaded, so source and built plugin graphs stay consistent.
- What did NOT change (scope boundary): no provider behavior, Matrix runtime behavior, or config behavior outside this alias-resolution fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `openclaw configure` no longer hits the plugin-sdk source/dist alias mismatch path when the CLI is globally installed but run from a source checkout.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / local checkout
- Model/provider: N/A
- Integration/channel (if any): plugin loader / provider plugins
- Relevant config (redacted): globally installed `openclaw`, command run from a repo checkout with bundled source plugins

### Steps

1. Install `openclaw` globally.
2. Run `openclaw configure` from a source checkout containing bundled source plugins.
3. Observe plugin loading.

### Expected

- Plugin loading stays on a consistent source or dist graph and configure starts normally.

### Actual

- Before this change, source plugin loading could resolve plugin-sdk aliases against the wrong graph.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `OPENCLAW_TEST_PROFILE=low pnpm test -- src/plugins/loader.test.ts -t "loads git-style package extension entries through the plugin loader when they import plugin-sdk channel-runtime"`
  - `timeout 20s openclaw configure` reached the interactive configure UI after updating the patched CLI globally.
- Edge cases checked:
  - plugin-sdk alias resolution now follows the loaded module path.
  - Jiti loader instances no longer reuse a cache entry across different source/dist alias orders.
- What you did **not** verify:
  - full suite / full build in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR commit.
- Files/config to restore:
  - `src/plugins/loader.ts`
- Known bad symptoms reviewers should watch for:
  - source plugins importing from the wrong plugin-sdk graph
  - source/dist plugin loader behavior differing unexpectedly

## Risks and Mitigations

- Risk:
  - different loader cache buckets could change module reuse behavior.
  - Mitigation:
    - the cache split is intentionally scoped to source/dist alias order, and the focused plugin-loader regression test passes.
