### PR TITLE
fix(diagnostics-otel): fix log transport module isolation and add opt-in content capture

### DIFF
--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -782,7 +782,10 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         // Content capture: standard gen_ai.* attrs (primary), Langfuse compat (secondary).
         // All content is redacted then truncated to MAX_CONTENT_ATTR_BYTES before export
         // to avoid silent drops or rejections by OTEL backends with attribute size limits.
-        // Gated by captureContent policy.
+        // Guard on captureContent policy here as a defense-in-depth check — the event
+        // emitter in agent-runner.ts gates content at the source, but the diagnostic
+        // event bus is shared across all plugin listeners, so we also enforce the
+        // opt-in at the exporter to prevent accidental content export.
         if (contentCapturePolicy.inputMessages && evt.inputText) {
           const redactedInput = truncateToBytes(
             redactSensitiveText(evt.inputText),

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -106,6 +106,23 @@ function formatError(err: unknown): string {
   }
 }
 
+/** Truncate a string to at most `maxBytes` UTF-8 bytes, avoiding mid-codepoint cuts. */
+function truncateToBytes(text: string, maxBytes: number): string {
+  const buf = Buffer.from(text, "utf8");
+  if (buf.length <= maxBytes) {
+    return text;
+  }
+  // Decode back to avoid splitting a multi-byte character.
+  return (
+    buf
+      .subarray(0, maxBytes)
+      .toString("utf8")
+      .replace(/\uFFFD$/, "") + "…[truncated]"
+  );
+}
+
+const MAX_CONTENT_ATTR_BYTES = 32 * 1024; // 32 KB per content attribute
+
 function redactOtelAttributes(attributes: Record<string, string | number | boolean>) {
   const redactedAttributes: Record<string, string | number | boolean> = {};
   for (const [key, value] of Object.entries(attributes)) {
@@ -755,14 +772,22 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           spanAttrs["gen_ai.usage.cost"] = evt.costUsd;
         }
         // Content capture: standard gen_ai.* attrs (primary), Langfuse compat (secondary).
-        // All content is redacted before export; gated by captureContent policy.
+        // All content is redacted then truncated to MAX_CONTENT_ATTR_BYTES before export
+        // to avoid silent drops or rejections by OTEL backends with attribute size limits.
+        // Gated by captureContent policy.
         if (contentCapturePolicy.inputMessages && evt.inputText) {
-          const redactedInput = redactSensitiveText(evt.inputText);
+          const redactedInput = truncateToBytes(
+            redactSensitiveText(evt.inputText),
+            MAX_CONTENT_ATTR_BYTES,
+          );
           spanAttrs["gen_ai.prompt"] = redactedInput;
           spanAttrs["langfuse.observation.input"] = redactedInput;
         }
         if (contentCapturePolicy.outputMessages && evt.outputText) {
-          const redactedOutput = redactSensitiveText(evt.outputText);
+          const redactedOutput = truncateToBytes(
+            redactSensitiveText(evt.outputText),
+            MAX_CONTENT_ATTR_BYTES,
+          );
           spanAttrs["gen_ai.completion"] = redactedOutput;
           spanAttrs["langfuse.observation.output"] = redactedOutput;
         }

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -742,7 +742,30 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           "openclaw.tokens.cache_read": usage.cacheRead ?? 0,
           "openclaw.tokens.cache_write": usage.cacheWrite ?? 0,
           "openclaw.tokens.total": usage.total ?? 0,
+          // OpenTelemetry GenAI semantic conventions (primary)
+          "gen_ai.request.model": evt.model ?? "unknown",
+          "gen_ai.system": evt.provider ?? "unknown",
+          "gen_ai.usage.input_tokens": usage.input ?? 0,
+          "gen_ai.usage.output_tokens": usage.output ?? 0,
         };
+        if (evt.sessionKey) {
+          spanAttrs["langfuse.session.id"] = evt.sessionKey;
+        }
+        if (evt.costUsd) {
+          spanAttrs["gen_ai.usage.cost"] = evt.costUsd;
+        }
+        // Content capture: standard gen_ai.* attrs (primary), Langfuse compat (secondary).
+        // All content is redacted before export; gated by captureContent policy.
+        if (contentCapturePolicy.inputMessages && evt.inputText) {
+          const redactedInput = redactSensitiveText(evt.inputText);
+          spanAttrs["gen_ai.prompt"] = redactedInput;
+          spanAttrs["langfuse.observation.input"] = redactedInput;
+        }
+        if (contentCapturePolicy.outputMessages && evt.outputText) {
+          const redactedOutput = redactSensitiveText(evt.outputText);
+          spanAttrs["gen_ai.completion"] = redactedOutput;
+          spanAttrs["langfuse.observation.output"] = redactedOutput;
+        }
 
         const span = spanWithDuration("openclaw.model.usage", spanAttrs, evt.durationMs);
         span.end();

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -770,7 +770,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           // Current GenAI registry attributes (gen_ai.system is deprecated)
           "gen_ai.provider.name": evt.provider ?? "unknown",
           "gen_ai.operation.name": "chat",
-          "gen_ai.usage.input_tokens": usage.promptTokens ?? usage.input ?? 0,
+          "gen_ai.usage.input_tokens":
+            usage.promptTokens ??
+            (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0),
           "gen_ai.usage.output_tokens": usage.output ?? 0,
         };
         if (evt.sessionKey) {

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -767,7 +767,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           // OpenTelemetry GenAI semantic conventions (primary)
           "gen_ai.request.model": evt.model ?? "unknown",
           "gen_ai.system": evt.provider ?? "unknown",
-          "gen_ai.usage.input_tokens": usage.input ?? 0,
+          "gen_ai.usage.input_tokens": usage.promptTokens ?? usage.input ?? 0,
           "gen_ai.usage.output_tokens": usage.output ?? 0,
         };
         if (evt.sessionKey) {

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -767,6 +767,9 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           // OpenTelemetry GenAI semantic conventions (primary)
           "gen_ai.request.model": evt.model ?? "unknown",
           "gen_ai.system": evt.provider ?? "unknown",
+          // Current GenAI registry attributes (gen_ai.system is deprecated)
+          "gen_ai.provider.name": evt.provider ?? "unknown",
+          "gen_ai.operation.name": "chat",
           "gen_ai.usage.input_tokens": usage.promptTokens ?? usage.input ?? 0,
           "gen_ai.usage.output_tokens": usage.output ?? 0,
         };

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -106,18 +106,23 @@ function formatError(err: unknown): string {
   }
 }
 
-/** Truncate a string to at most `maxBytes` UTF-8 bytes, avoiding mid-codepoint cuts. */
+const TRUNCATION_MARKER = "…[truncated]";
+const TRUNCATION_MARKER_BYTES = Buffer.byteLength(TRUNCATION_MARKER, "utf8");
+
+/** Truncate a string to at most `maxBytes` UTF-8 bytes (including the marker), avoiding mid-codepoint cuts. */
 function truncateToBytes(text: string, maxBytes: number): string {
   const buf = Buffer.from(text, "utf8");
   if (buf.length <= maxBytes) {
     return text;
   }
+  // Reserve space for the marker so the total stays within maxBytes.
+  const cutoff = Math.max(0, maxBytes - TRUNCATION_MARKER_BYTES);
   // Decode back to avoid splitting a multi-byte character.
   return (
     buf
-      .subarray(0, maxBytes)
+      .subarray(0, cutoff)
       .toString("utf8")
-      .replace(/\uFFFD$/, "") + "…[truncated]"
+      .replace(/\uFFFD$/, "") + TRUNCATION_MARKER
   );
 }
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -770,10 +770,20 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           // Current GenAI registry attributes (gen_ai.system is deprecated)
           "gen_ai.provider.name": evt.provider ?? "unknown",
           "gen_ai.operation.name": "chat",
-          "gen_ai.usage.input_tokens":
-            usage.promptTokens ??
-            (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0),
-          "gen_ai.usage.output_tokens": usage.output ?? 0,
+          // Only emit GenAI split token counts when the components are actually
+          // known. Total-only payloads (e.g. CLI runner) would otherwise report
+          // misleading zeros that skew dashboards.
+          ...(usage.promptTokens != null ||
+          usage.input != null ||
+          usage.cacheRead != null ||
+          usage.cacheWrite != null
+            ? {
+                "gen_ai.usage.input_tokens":
+                  usage.promptTokens ??
+                  (usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0),
+              }
+            : {}),
+          ...(usage.output != null ? { "gen_ai.usage.output_tokens": usage.output } : {}),
         };
         if (evt.sessionKey) {
           spanAttrs["langfuse.session.id"] = evt.sessionKey;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1396,12 +1396,16 @@ export async function runReplyAgent(params: {
     // Emit model.usage before the replyPayloads early return so streamed runs
     // (where buildReplyPayloads suppresses the final array) still get usage events.
     if (isDiagnosticsEnabled(cfg) && hasNonzeroUsage(usage)) {
-      const input = usage.input ?? 0;
-      const output = usage.output ?? 0;
-      const cacheRead = usage.cacheRead ?? 0;
-      const cacheWrite = usage.cacheWrite ?? 0;
-      const promptTokens = input + cacheRead + cacheWrite;
-      const totalTokens = usage.total ?? promptTokens + output;
+      const input = usage.input;
+      const output = usage.output;
+      const cacheRead = usage.cacheRead;
+      const cacheWrite = usage.cacheWrite;
+      // Only synthesize promptTokens when at least one component is known.
+      const hasSplitComponents = input != null || cacheRead != null || cacheWrite != null;
+      const promptTokens = hasSplitComponents
+        ? (input ?? 0) + (cacheRead ?? 0) + (cacheWrite ?? 0)
+        : undefined;
+      const totalTokens = usage.total ?? (promptTokens ?? 0) + (output ?? 0);
       const costConfig = resolveModelCostConfig({
         provider: providerUsed,
         model: modelUsed,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1433,7 +1433,7 @@ export async function runReplyAgent(params: {
         config: cfg,
       });
       const costUsd = estimateUsageCost({ usage, cost: costConfig });
-      emitDiagnosticEvent({
+      const usageEvent: Parameters<typeof emitDiagnosticEvent>[0] & { type: "model.usage" } = {
         type: "model.usage",
         ...(runResult.diagnosticTrace
           ? { trace: freezeDiagnosticTraceContext(runResult.diagnosticTrace) }
@@ -1458,7 +1458,23 @@ export async function runReplyAgent(params: {
         },
         costUsd,
         durationMs: Date.now() - runStartedAt,
-      });
+      };
+      // Include user-facing content when explicitly opted in via captureContent config.
+      const cc = cfg.diagnostics?.otel?.captureContent;
+      if (cc === true || (typeof cc === "object" && cc && "enabled" in cc && cc.enabled)) {
+        if (typeof followupRun.prompt === "string") {
+          usageEvent.inputText = followupRun.prompt;
+        }
+        const outputTexts = replyPayloads
+          ?.filter(
+            (p): p is typeof p & { text: string } => typeof p.text === "string" && !p.isError,
+          )
+          .map((p) => p.text);
+        if (outputTexts && outputTexts.length > 0) {
+          usageEvent.outputText = outputTexts.join("\n");
+        }
+      }
+      emitDiagnosticEvent(usageEvent);
     }
 
     const responseUsageRaw =

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1393,33 +1393,8 @@ export async function runReplyAgent(params: {
     const { replyPayloads } = payloadResult;
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
 
-    if (replyPayloads.length === 0) {
-      return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
-    }
-
-    const successfulCronAdds = runResult.successfulCronAdds ?? 0;
-    const hasReminderCommitment = replyPayloads.some(
-      (payload) =>
-        !payload.isError &&
-        typeof payload.text === "string" &&
-        hasUnbackedReminderCommitment(payload.text),
-    );
-    // Suppress the guard note when an existing cron job (created in a prior
-    // turn) already covers the commitment — avoids false positives (#32228).
-    const coveredByExistingCron =
-      hasReminderCommitment && successfulCronAdds === 0
-        ? await hasSessionRelatedCronJobs({
-            cronStorePath: cfg.cron?.store,
-            sessionKey,
-          })
-        : false;
-    const guardedReplyPayloads =
-      hasReminderCommitment && successfulCronAdds === 0 && !coveredByExistingCron
-        ? appendUnscheduledReminderNote(replyPayloads)
-        : replyPayloads;
-
-    await signalTypingIfNeeded(guardedReplyPayloads, typingSignals);
-
+    // Emit model.usage before the replyPayloads early return so streamed runs
+    // (where buildReplyPayloads suppresses the final array) still get usage events.
     if (isDiagnosticsEnabled(cfg) && hasNonzeroUsage(usage)) {
       const input = usage.input ?? 0;
       const output = usage.output ?? 0;
@@ -1460,9 +1435,10 @@ export async function runReplyAgent(params: {
         durationMs: Date.now() - runStartedAt,
       };
       // Include model-originated content when explicitly opted in via captureContent config.
-      // Intentionally uses replyPayloads (pre-guard) rather than guardedReplyPayloads:
-      // gen_ai.completion should capture model-originated output, not system-injected
-      // post-processing like reminder notes or usage lines.
+      // Uses payloadArray (pre-suppression) rather than replyPayloads so that
+      // streamed runs still capture content even when replyPayloads is empty.
+      // Excludes isError and isReasoning payloads: errors aren't model output,
+      // and reasoning/CoT is stripped before delivery and should not leak to OTEL.
       // Note: followupRun.prompt is the queue body, which may diverge from the
       // effective prompt the model actually sees (attempt.ts adds bootstrap warnings,
       // hook context, thread-history notes, etc.). This is a known approximation at
@@ -1473,8 +1449,11 @@ export async function runReplyAgent(params: {
         if (typeof followupRun.prompt === "string") {
           usageEvent.inputText = followupRun.prompt;
         }
-        const outputTexts = replyPayloads
-          .filter((p): p is typeof p & { text: string } => typeof p.text === "string" && !p.isError)
+        const outputTexts = payloadArray
+          .filter(
+            (p): p is typeof p & { text: string } =>
+              typeof p.text === "string" && !p.isError && p.isReasoning !== true,
+          )
           .map((p) => p.text);
         if (outputTexts.length > 0) {
           usageEvent.outputText = outputTexts.join("\n");
@@ -1482,6 +1461,33 @@ export async function runReplyAgent(params: {
       }
       emitDiagnosticEvent(usageEvent);
     }
+
+    if (replyPayloads.length === 0) {
+      return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
+    }
+
+    const successfulCronAdds = runResult.successfulCronAdds ?? 0;
+    const hasReminderCommitment = replyPayloads.some(
+      (payload) =>
+        !payload.isError &&
+        typeof payload.text === "string" &&
+        hasUnbackedReminderCommitment(payload.text),
+    );
+    // Suppress the guard note when an existing cron job (created in a prior
+    // turn) already covers the commitment — avoids false positives (#32228).
+    const coveredByExistingCron =
+      hasReminderCommitment && successfulCronAdds === 0
+        ? await hasSessionRelatedCronJobs({
+            cronStorePath: cfg.cron?.store,
+            sessionKey,
+          })
+        : false;
+    const guardedReplyPayloads =
+      hasReminderCommitment && successfulCronAdds === 0 && !coveredByExistingCron
+        ? appendUnscheduledReminderNote(replyPayloads)
+        : replyPayloads;
+
+    await signalTypingIfNeeded(guardedReplyPayloads, typingSignals);
 
     const responseUsageRaw =
       activeSessionEntry?.responseUsage ??

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1463,6 +1463,11 @@ export async function runReplyAgent(params: {
       // Intentionally uses replyPayloads (pre-guard) rather than guardedReplyPayloads:
       // gen_ai.completion should capture model-originated output, not system-injected
       // post-processing like reminder notes or usage lines.
+      // Note: followupRun.prompt is the queue body, which may diverge from the
+      // effective prompt the model actually sees (attempt.ts adds bootstrap warnings,
+      // hook context, thread-history notes, etc.). This is a known approximation at
+      // the reply layer; the model.content event in attempt.ts captures the true
+      // effectivePrompt when the extended content-telemetry path is enabled.
       const cc = cfg.diagnostics?.otel?.captureContent;
       if (cc === true || (typeof cc === "object" && cc && "enabled" in cc && cc.enabled)) {
         if (typeof followupRun.prompt === "string") {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1459,18 +1459,19 @@ export async function runReplyAgent(params: {
         costUsd,
         durationMs: Date.now() - runStartedAt,
       };
-      // Include user-facing content when explicitly opted in via captureContent config.
+      // Include model-originated content when explicitly opted in via captureContent config.
+      // Intentionally uses replyPayloads (pre-guard) rather than guardedReplyPayloads:
+      // gen_ai.completion should capture model-originated output, not system-injected
+      // post-processing like reminder notes or usage lines.
       const cc = cfg.diagnostics?.otel?.captureContent;
       if (cc === true || (typeof cc === "object" && cc && "enabled" in cc && cc.enabled)) {
         if (typeof followupRun.prompt === "string") {
           usageEvent.inputText = followupRun.prompt;
         }
         const outputTexts = replyPayloads
-          ?.filter(
-            (p): p is typeof p & { text: string } => typeof p.text === "string" && !p.isError,
-          )
+          .filter((p): p is typeof p & { text: string } => typeof p.text === "string" && !p.isError)
           .map((p) => p.text);
-        if (outputTexts && outputTexts.length > 0) {
+        if (outputTexts.length > 0) {
           usageEvent.outputText = outputTexts.join("\n");
         }
       }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1437,14 +1437,18 @@ export async function runReplyAgent(params: {
       // Include model-originated content when explicitly opted in via captureContent config.
       // Prefer replyPayloads (sanitized by buildReplyPayloads: control tokens,
       // heartbeat markers, messaging-tool duplicates, and reply directives are
-      // stripped). Fall back to payloadArray (raw) only for streamed runs where
-      // replyPayloads is empty because the block pipeline already delivered text.
+      // stripped). Fall back to payloadArray (raw, pre-sanitization) when
+      // replyPayloads is empty — this happens for streamed runs (block pipeline
+      // already delivered text) and messaging-tool-suppressed replies (text was
+      // sent via the tool path, not the final reply). The fallback captures
+      // model-originated content for observability even when the reply layer
+      // suppresses final delivery.
       // Excludes isError and isReasoning payloads in both paths.
       // Note: followupRun.prompt is the queue body, which may diverge from the
-      // effective prompt the model actually sees (attempt.ts adds bootstrap warnings,
-      // hook context, thread-history notes, etc.). This is a known approximation at
-      // the reply layer; the model.content event in attempt.ts captures the true
-      // effectivePrompt when the extended content-telemetry path is enabled.
+      // effective prompt the model actually sees (attempt.ts adds bootstrap
+      // warnings, hook context, thread-history notes, etc.). Capturing the true
+      // effectivePrompt requires instrumentation at the model call boundary
+      // (attempt.ts), which is not yet implemented.
       const cc = cfg.diagnostics?.otel?.captureContent;
       if (cc === true || (typeof cc === "object" && cc && "enabled" in cc && cc.enabled)) {
         if (typeof followupRun.prompt === "string") {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1435,10 +1435,11 @@ export async function runReplyAgent(params: {
         durationMs: Date.now() - runStartedAt,
       };
       // Include model-originated content when explicitly opted in via captureContent config.
-      // Uses payloadArray (pre-suppression) rather than replyPayloads so that
-      // streamed runs still capture content even when replyPayloads is empty.
-      // Excludes isError and isReasoning payloads: errors aren't model output,
-      // and reasoning/CoT is stripped before delivery and should not leak to OTEL.
+      // Prefer replyPayloads (sanitized by buildReplyPayloads: control tokens,
+      // heartbeat markers, messaging-tool duplicates, and reply directives are
+      // stripped). Fall back to payloadArray (raw) only for streamed runs where
+      // replyPayloads is empty because the block pipeline already delivered text.
+      // Excludes isError and isReasoning payloads in both paths.
       // Note: followupRun.prompt is the queue body, which may diverge from the
       // effective prompt the model actually sees (attempt.ts adds bootstrap warnings,
       // hook context, thread-history notes, etc.). This is a known approximation at
@@ -1449,7 +1450,8 @@ export async function runReplyAgent(params: {
         if (typeof followupRun.prompt === "string") {
           usageEvent.inputText = followupRun.prompt;
         }
-        const outputTexts = payloadArray
+        const contentSource = replyPayloads.length > 0 ? replyPayloads : payloadArray;
+        const outputTexts = contentSource
           .filter(
             (p): p is typeof p & { text: string } =>
               typeof p.text === "string" && !p.isError && p.isReasoning !== true,

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -37,6 +37,10 @@ export type DiagnosticUsageEvent = DiagnosticBaseEvent & {
   };
   costUsd?: number;
   durationMs?: number;
+  /** User-facing input text. Only populated when diagnostics.otel.captureContent is enabled. */
+  inputText?: string;
+  /** User-facing output text. Only populated when diagnostics.otel.captureContent is enabled. */
+  outputText?: string;
 };
 
 export type DiagnosticWebhookReceivedEvent = DiagnosticBaseEvent & {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -109,6 +109,24 @@ const DIAGNOSTIC_LOG_ATTRIBUTE_KEY_RE = /^[A-Za-z0-9_.:-]{1,64}$/u;
 
 type DiagnosticLogAttributes = Record<string, string | number | boolean>;
 
+// Publish the active logger to globalThis so plugins loaded via jiti can find it
+// when calling registerLogTransport after the logger is already built.
+// Only overwrite if the current module instance owns the active logger (i.e. it was
+// our previous cachedLogger) or no logger has been published yet. This prevents
+// plugin loggers loaded via jiti from overwriting the gateway's primary logger,
+// which would cause registerLogTransport to attach to the wrong logger instance.
+function publishActiveLogger(logger: TsLogger<LogObj>): void {
+  const globalState = getLogTransportGlobalState();
+  if (!globalState.activeLogger || globalState.activeLogger === loggingState.cachedLogger) {
+    globalState.activeLogger = logger;
+  }
+}
+
+function shouldSkipLoadConfigFallback(argv: string[] = process.argv): boolean {
+  const [primary, secondary] = getCommandPathWithRootOptions(argv, 2);
+  return primary === "config" && secondary === "validate";
+}
+
 function attachExternalTransport(logger: TsLogger<LogObj>, transport: LogTransport): void {
   logger.attachTransport((logObj: LogObj) => {
     if (!externalTransports.has(transport)) {
@@ -450,7 +468,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
     for (const transport of externalTransports) {
       attachExternalTransport(logger, transport);
     }
-    getLogTransportGlobalState().activeLogger = logger;
+    publishActiveLogger(logger);
     return logger;
   }
 
@@ -497,9 +515,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
     attachExternalTransport(logger, transport);
   }
 
-  // Publish the active logger to globalThis so plugins loaded via jiti can find it
-  // when calling registerLogTransport after the logger is already built.
-  getLogTransportGlobalState().activeLogger = logger;
+  publishActiveLogger(logger);
 
   return logger;
 }

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -77,6 +77,10 @@ export type LogTransport = (logObj: LogTransportRecord) => void;
 type LogTransportGlobalState = {
   transports: Set<LogTransport>;
   activeLogger: unknown; // TsLogger<LogObj> — stored as unknown to avoid type import in global
+  // Registry of all loggers built across module instances (gateway + jiti plugins).
+  // registerLogTransport() iterates this to late-attach transports to every logger,
+  // not just activeLogger. Entries are long-lived (one per module instance).
+  allLoggers: Set<unknown>;
 };
 
 function getLogTransportGlobalState(): LogTransportGlobalState {
@@ -87,6 +91,7 @@ function getLogTransportGlobalState(): LogTransportGlobalState {
     g.__openclawLogTransportState = {
       transports: new Set<LogTransport>(),
       activeLogger: null,
+      allLoggers: new Set(),
     };
   }
   return g.__openclawLogTransportState;
@@ -117,6 +122,11 @@ type DiagnosticLogAttributes = Record<string, string | number | boolean>;
 // which would cause registerLogTransport to attach to the wrong logger instance.
 function publishActiveLogger(logger: TsLogger<LogObj>): void {
   const globalState = getLogTransportGlobalState();
+  // Remove the previous logger from this module instance (if rebuilding) to avoid stale refs.
+  if (loggingState.cachedLogger) {
+    globalState.allLoggers.delete(loggingState.cachedLogger);
+  }
+  globalState.allLoggers.add(logger);
   if (!globalState.activeLogger || globalState.activeLogger === loggingState.cachedLogger) {
     globalState.activeLogger = logger;
   }
@@ -609,29 +619,37 @@ export function getResolvedLoggerSettings(): LoggerResolvedSettings {
 
 // Test helpers
 export function setLoggerOverride(settings: LoggerSettings | null) {
+  const globalState = getLogTransportGlobalState();
+  if (loggingState.cachedLogger) {
+    globalState.allLoggers.delete(loggingState.cachedLogger);
+  }
   loggingState.overrideSettings = settings;
   loggingState.cachedLogger = null;
   loggingState.cachedSettings = null;
   loggingState.cachedConsoleSettings = null;
-  getLogTransportGlobalState().activeLogger = null;
+  globalState.activeLogger = null;
 }
 
 export function resetLogger() {
+  const globalState = getLogTransportGlobalState();
+  if (loggingState.cachedLogger) {
+    globalState.allLoggers.delete(loggingState.cachedLogger);
+  }
   loggingState.cachedLogger = null;
   loggingState.cachedSettings = null;
   loggingState.cachedConsoleSettings = null;
   loggingState.overrideSettings = null;
-  getLogTransportGlobalState().activeLogger = null;
+  globalState.activeLogger = null;
 }
 
 export function registerLogTransport(transport: LogTransport): () => void {
   const globalState = getLogTransportGlobalState();
   globalState.transports.add(transport);
-  // Use the globally-published active logger so plugins loaded via jiti (separate module
-  // instance) can still attach to the gateway's logger after it has been built.
-  const logger = globalState.activeLogger as TsLogger<LogObj> | null;
-  if (logger) {
-    attachExternalTransport(logger, transport);
+  // Late-attach to every logger built across all module instances (gateway + jiti plugins).
+  // This ensures channel-plugin loggers created before diagnostics-otel starts also get
+  // the OTLP transport, not just the gateway's activeLogger.
+  for (const logger of globalState.allLoggers) {
+    attachExternalTransport(logger as TsLogger<LogObj>, transport);
   }
   return () => {
     globalState.transports.delete(transport);

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -71,7 +71,29 @@ export type LoggerResolvedSettings = ResolvedSettings;
 export type LogTransportRecord = Record<string, unknown>;
 export type LogTransport = (logObj: LogTransportRecord) => void;
 
-const externalTransports = new Set<LogTransport>();
+// Log transports must survive dual module loading (host ESM bundle + jiti plugin instance).
+// Use a globalThis-based singleton so plugins loaded via jiti register in the same Set
+// that the gateway's logger reads. Mirrors the pattern in diagnostic-events.ts.
+type LogTransportGlobalState = {
+  transports: Set<LogTransport>;
+  activeLogger: unknown; // TsLogger<LogObj> — stored as unknown to avoid type import in global
+};
+
+function getLogTransportGlobalState(): LogTransportGlobalState {
+  const g = globalThis as typeof globalThis & {
+    __openclawLogTransportState?: LogTransportGlobalState;
+  };
+  if (!g.__openclawLogTransportState) {
+    g.__openclawLogTransportState = {
+      transports: new Set<LogTransport>(),
+      activeLogger: null,
+    };
+  }
+  return g.__openclawLogTransportState;
+}
+
+// Keep a module-level alias for hot-path reads (avoids repeated globalThis lookup).
+const externalTransports = getLogTransportGlobalState().transports;
 
 type DiagnosticLogCode = {
   line?: number;
@@ -428,6 +450,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
     for (const transport of externalTransports) {
       attachExternalTransport(logger, transport);
     }
+    getLogTransportGlobalState().activeLogger = logger;
     return logger;
   }
 
@@ -473,6 +496,10 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   for (const transport of externalTransports) {
     attachExternalTransport(logger, transport);
   }
+
+  // Publish the active logger to globalThis so plugins loaded via jiti can find it
+  // when calling registerLogTransport after the logger is already built.
+  getLogTransportGlobalState().activeLogger = logger;
 
   return logger;
 }
@@ -570,6 +597,7 @@ export function setLoggerOverride(settings: LoggerSettings | null) {
   loggingState.cachedLogger = null;
   loggingState.cachedSettings = null;
   loggingState.cachedConsoleSettings = null;
+  getLogTransportGlobalState().activeLogger = null;
 }
 
 export function resetLogger() {
@@ -577,16 +605,20 @@ export function resetLogger() {
   loggingState.cachedSettings = null;
   loggingState.cachedConsoleSettings = null;
   loggingState.overrideSettings = null;
+  getLogTransportGlobalState().activeLogger = null;
 }
 
 export function registerLogTransport(transport: LogTransport): () => void {
-  externalTransports.add(transport);
-  const logger = loggingState.cachedLogger as TsLogger<LogObj> | null;
+  const globalState = getLogTransportGlobalState();
+  globalState.transports.add(transport);
+  // Use the globally-published active logger so plugins loaded via jiti (separate module
+  // instance) can still attach to the gateway's logger after it has been built.
+  const logger = globalState.activeLogger as TsLogger<LogObj> | null;
   if (logger) {
     attachExternalTransport(logger, transport);
   }
   return () => {
-    externalTransports.delete(transport);
+    globalState.transports.delete(transport);
   };
 }
 


### PR DESCRIPTION
## Summary

This PR builds on #71250 (which moved OTEL log export to diagnostic events and added the `captureContent` config surface) to complete the OTEL observability story with content capture and logger module isolation:

1. **Logger global state registry for jiti module isolation** — `registerLogTransport` in the plugin SDK operates on a module-scoped `externalTransports` Set and reads `loggingState.cachedLogger`, both of which are isolated from the daemon's copies when the plugin is loaded via jiti. This PR moves the transport registry and the active logger reference to a `globalThis.__openclawLogTransportState` singleton, mirroring the pattern in `diagnostic-events.ts`. Adds `publishActiveLogger()` (only overwrites if the current module instance owns the active logger), `allLoggers` set (late-attaches to every logger across module instances), and `shouldSkipLoadConfigFallback()`.

2. **Content capture exporter** — Reads `inputText`/`outputText` from diagnostic events, redacts via `redactSensitiveText`, truncates to 32 KB via `truncateToBytes`, and emits as standard GenAI semantic convention attributes (`gen_ai.prompt`, `gen_ai.completion`) with Langfuse compatibility fields (`langfuse.observation.input`, `langfuse.observation.output`). Defense-in-depth gating at both the event emission layer (agent-runner) and the exporter layer (via `contentCapturePolicy`).

3. **GenAI semantic conventions** — Adds `gen_ai.provider.name`, `gen_ai.operation.name`, smart `gen_ai.usage.input_tokens` synthesis (from `promptTokens` or split components), `langfuse.session.id`, and `gen_ai.usage.cost`.

4. **Content population in agent-runner** — Populates `inputText`/`outputText` on `model.usage` diagnostic events when `captureContent` is enabled. Prefers sanitized `replyPayloads` (control tokens/heartbeat markers stripped) with fallback to raw `payloadArray` for streamed runs. Excludes `isError` and `isReasoning` payloads.

## Changes since initial submission

- Rebased onto main including #71250, adopted the richer `captureContent` config surface (replaces the original `includeContent` boolean)
- Content capture now gated by `contentCapturePolicy.inputMessages`/`outputMessages` at the exporter (defense-in-depth)
- Addressed 19 review findings across 5 rounds of AI review (Greptile + Codex)

### Key correctness fixes from review
- Gateway logger preserved from jiti plugin overwrite via `publishActiveLogger()` ownership check
- All-loggers registry for late transport attachment across module instances
- Streamed runs emit usage events (moved emission above `replyPayloads.length === 0` early return)
- Reasoning blocks excluded from OTEL content
- Smart `promptTokens` synthesis only when split components are known (preserves `undefined` for total-only providers)
- Truncation marker reserves space so total stays within `MAX_CONTENT_ATTR_BYTES`

## Related

- Builds on #71250 (log diagnostic events + `captureContent` config)
- Continues the OTEL split plan from #28166 and #21290
- Related to #39156

## Verification

- `pnpm test src/logging/logger.test.ts extensions/diagnostics-otel/src/service.test.ts`
- `pnpm check`