### PR TITLE
fix(exec): use gbk encoding for Windows cmd.exe wrapper [AI-assisted]

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -102,6 +102,23 @@ export async function runExec(
   args: string[],
   opts: number | { timeoutMs?: number; maxBuffer?: number; cwd?: string } = 10_000,
 ): Promise<{ stdout: string; stderr: string }> {
+  const argv = [command, ...args];
+  let execCommand: string;
+  let execArgs: string[];
+  if (process.platform === "win32") {
+    const resolved = resolveNpmArgvForWindows(argv);
+    if (resolved) {
+      execCommand = resolved[0] ?? "";
+      execArgs = resolved.slice(1);
+    } else {
+      execCommand = resolveCommand(command);
+      execArgs = args;
+    }
+  } else {
+    execCommand = resolveCommand(command);
+    execArgs = args;
+  }
+  const useCmdWrapper = isWindowsBatchCommand(execCommand);
   const options =
     typeof opts === "number"
       ? { timeout: opts, encoding: "utf8" as const }
@@ -112,27 +129,18 @@ export async function runExec(
           encoding: "utf8" as const,
         };
   try {
-    const argv = [command, ...args];
-    let execCommand: string;
-    let execArgs: string[];
-    if (process.platform === "win32") {
-      const resolved = resolveNpmArgvForWindows(argv);
-      if (resolved) {
-        execCommand = resolved[0] ?? "";
-        execArgs = resolved.slice(1);
-      } else {
-        execCommand = resolveCommand(command);
-        execArgs = args;
-      }
-    } else {
-      execCommand = resolveCommand(command);
-      execArgs = args;
-    }
-    const useCmdWrapper = isWindowsBatchCommand(execCommand);
+    // Windows cmd.exe uses a locale-specific code page by default (e.g., GBK on
+    // Chinese Windows, CP932 on Japanese Windows). This causes garbled output
+    // for non-ASCII characters. We prepend "chcp 65001" to force UTF-8 mode,
+    // which works correctly with our utf8 encoding option.
+    // See: https://github.com/openclaw/openclaw/issues/50519
+    const cmdExeCommandLine = useCmdWrapper
+      ? `chcp 65001 > nul && ${buildCmdExeCommandLine(execCommand, execArgs)}`
+      : buildCmdExeCommandLine(execCommand, execArgs);
     const { stdout, stderr } = useCmdWrapper
       ? await execFileAsync(
           process.env.ComSpec ?? "cmd.exe",
-          ["/d", "/s", "/c", buildCmdExeCommandLine(execCommand, execArgs)],
+          ["/d", "/s", "/c", cmdExeCommandLine],
           { ...options, windowsVerbatimArguments: true },
         )
       : await execFileAsync(execCommand, execArgs, options);
@@ -224,11 +232,20 @@ export async function runCommandWithTimeout(
   const finalArgv = process.platform === "win32" ? (resolveNpmArgvForWindows(argv) ?? argv) : argv;
   const resolvedCommand = finalArgv !== argv ? (finalArgv[0] ?? "") : resolveCommand(argv[0] ?? "");
   const useCmdWrapper = isWindowsBatchCommand(resolvedCommand);
+  // Windows cmd.exe uses a locale-specific code page by default. Force UTF-8
+  // mode to properly handle non-ASCII characters in output.
+  // See: https://github.com/openclaw/openclaw/issues/50519
+  const cmdExeArgs = useCmdWrapper
+    ? [
+        "/d",
+        "/s",
+        "/c",
+        `chcp 65001 > nul && ${buildCmdExeCommandLine(resolvedCommand, finalArgv.slice(1))}`,
+      ]
+    : finalArgv.slice(1);
   const child = spawn(
     useCmdWrapper ? (process.env.ComSpec ?? "cmd.exe") : resolvedCommand,
-    useCmdWrapper
-      ? ["/d", "/s", "/c", buildCmdExeCommandLine(resolvedCommand, finalArgv.slice(1))]
-      : finalArgv.slice(1),
+    cmdExeArgs,
     {
       stdio,
       cwd,

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -137,7 +137,12 @@ export async function runExec(
     const { stdout, stderr } = useCmdWrapper
       ? await execFileAsync(
           process.env.ComSpec ?? "cmd.exe",
-          ["/d", "/s", "/c", `chcp 65001 > nul && ${buildCmdExeCommandLine(execCommand, execArgs)}`],
+          [
+            "/d",
+            "/s",
+            "/c",
+            `chcp 65001 > nul && ${buildCmdExeCommandLine(execCommand, execArgs)}`,
+          ],
           { ...options, windowsVerbatimArguments: true },
         )
       : await execFileAsync(execCommand, execArgs, options);

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -134,13 +134,10 @@ export async function runExec(
     // for non-ASCII characters. We prepend "chcp 65001" to force UTF-8 mode,
     // which works correctly with our utf8 encoding option.
     // See: https://github.com/openclaw/openclaw/issues/50519
-    const cmdExeCommandLine = useCmdWrapper
-      ? `chcp 65001 > nul && ${buildCmdExeCommandLine(execCommand, execArgs)}`
-      : buildCmdExeCommandLine(execCommand, execArgs);
     const { stdout, stderr } = useCmdWrapper
       ? await execFileAsync(
           process.env.ComSpec ?? "cmd.exe",
-          ["/d", "/s", "/c", cmdExeCommandLine],
+          ["/d", "/s", "/c", `chcp 65001 > nul && ${buildCmdExeCommandLine(execCommand, execArgs)}`],
           { ...options, windowsVerbatimArguments: true },
         )
       : await execFileAsync(execCommand, execArgs, options);

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
@@ -94,6 +95,26 @@ describe("windows command wrapper behavior", () => {
     }
   });
 
+  it("prepends chcp 65001 to cmd.exe commands in runCommandWithTimeout", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    spawnMock.mockImplementation(
+      (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
+    );
+
+    try {
+      // pnpm.cmd will trigger the cmd.exe wrapper
+      await runCommandWithTimeout(["pnpm", "--version"], { timeoutMs: 1000 });
+      const captured = spawnMock.mock.calls[0] as SpawnCall | undefined;
+      expect(captured?.[0]).toBe(process.env.ComSpec ?? "cmd.exe");
+      // Verify chcp 65001 is prepended to force UTF-8 mode
+      expect(captured?.[1][3]).toContain("chcp 65001");
+      expect(captured?.[1][3]).toContain("pnpm.cmd");
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
   it("uses cmd.exe wrapper with windowsVerbatimArguments in runExec for .cmd shims", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
@@ -115,6 +136,61 @@ describe("windows command wrapper behavior", () => {
       expectCmdWrappedInvocation({ captured, expectedComSpec });
     } finally {
       platformSpy.mockRestore();
+    }
+  });
+
+  it("prepends chcp 65001 to cmd.exe commands for UTF-8 support", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        cb(null, "ok", "");
+      },
+    );
+
+    try {
+      // pnpm.cmd will trigger the cmd.exe wrapper
+      await runExec("pnpm", ["--version"], 1000);
+      const captured = execFileMock.mock.calls[0] as ExecCall | undefined;
+      expect(captured?.[0]).toBe(expectedComSpec);
+      // Verify chcp 65001 is prepended to force UTF-8 mode
+      expect(captured?.[1][3]).toContain("chcp 65001");
+      expect(captured?.[1][3]).toContain("pnpm.cmd");
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("uses utf8 encoding for non-cmd executables on Windows", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const pathSepSpy = vi.spyOn(path, "extname").mockReturnValue(".exe");
+
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        options: Record<string, unknown>,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        // Verify that utf8 encoding is used for non-cmd executables
+        expect(options.encoding).toBe("utf8");
+        cb(null, "ok", "");
+      },
+    );
+
+    try {
+      // node.exe should not trigger cmd.exe wrapper, so utf8 should be used
+      await runExec("node", ["--version"], 1000);
+      expect(execFileMock).toHaveBeenCalled();
+    } finally {
+      platformSpy.mockRestore();
+      pathSepSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Summary

Fixes #50519

Windows cmd.exe defaults to a locale-specific code page (e.g., GBK on Chinese Windows, CP932 on Japanese Windows), causing garbled output for non-ASCII characters. 

This PR fixes the issue by prepending `chcp 65001 > nul &&` to force UTF-8 mode in cmd.exe, which works correctly with Node.js's utf8 encoding.

## Changes

- **runExec**: Detect when cmd.exe wrapper is used (for .cmd/.bat files) and prepend `chcp 65001 > nul &&`
- **runCommandWithTimeout**: Apply the same chcp fix for consistency
- Keep utf8 encoding (Node.js native support)
- Added unit tests to verify chcp command is prepended in both functions

## Why chcp 65001?

- Works for **all locales** (Chinese, Japanese, European, etc.)
- No external dependencies needed
- Standard Windows approach used by many tools

## AI Disclosure 🤖

- [x] AI-assisted (Claude Code)
- [x] I understand what the code does
- [x] Fully tested locally
- [x] All CI checks pass

## Test Plan

- [x] `pnpm test src/process/exec.windows.test.ts` - 5 tests pass
- [x] `pnpm check` - All checks pass
- [x] `pnpm oxfmt` - Formatting passes

## Related

- Issue: #50519

## Review Response

Updated based on reviewer feedback from @greptile-apps:
- Changed from hardcoded 'gbk' encoding (not supported by Node.js) to 'chcp 65001' approach
- Applied the same fix to both `runExec` and `runCommandWithTimeout` for consistency
- This solution works for all Windows locales, not just Chinese