### PR TITLE
fix(reply): pass inbound images from MediaPaths to agent as ImageContent[]

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -101,6 +101,10 @@ async function resolveInboundImages(ctx: FinalizedMsgContext): Promise<ImageCont
   for (let i = 0; i < paths.length; i++) {
     const path = paths[i];
     const mimeType = (types[i] ?? ctx.MediaType ?? "image/jpeg").split(";")[0].trim();
+    if (!mimeType.startsWith("image/")) {
+      logVerbose(`resolveInboundImages: skipping non-image file ${path} (${mimeType})`);
+      continue;
+    }
     try {
       const data = await fs.readFile(path);
       results.push({

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1,5 +1,7 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import type { ImageContent } from "../../agents/command/types.js";
+import fs from "node:fs/promises";
 import {
   resolveConversationBindingRecord,
   touchConversationBindingRecord,
@@ -87,6 +89,31 @@ const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
   }
   return AUDIO_HEADER_RE.test(trimmed);
 };
+
+/** Convert local MediaPaths to ImageContent[] so the agent can see inbound images. */
+async function resolveInboundImages(ctx: FinalizedMsgContext): Promise<ImageContent[] | undefined> {
+  const paths = ctx.MediaPaths ?? (ctx.MediaPath ? [ctx.MediaPath] : []);
+  if (paths.length === 0) {
+    return undefined;
+  }
+  const types = ctx.MediaTypes ?? (ctx.MediaType ? [ctx.MediaType] : []);
+  const results: ImageContent[] = [];
+  for (let i = 0; i < paths.length; i++) {
+    const path = paths[i];
+    const mimeType = (types[i] ?? ctx.MediaType ?? "image/jpeg").split(";")[0].trim();
+    try {
+      const data = await fs.readFile(path);
+      results.push({
+        type: "image",
+        data: data.toString("base64"),
+        mimeType,
+      });
+    } catch (err) {
+      logVerbose(`resolveInboundImages: failed to read ${path}: ${String(err)}`);
+    }
+  }
+  return results.length > 0 ? results : undefined;
+}
 
 const resolveSessionStoreLookup = (
   ctx: FinalizedMsgContext,
@@ -546,12 +573,18 @@ export async function dispatchReplyFromConfig(params: {
       systemEvent: shouldRouteToOriginating,
     });
 
+    // Convert local MediaPaths to ImageContent[] so the agent can see inbound images.
+    const inboundImages = await resolveInboundImages(ctx);
+
     const replyResult = await (params.replyResolver ?? getReplyFromConfig)(
       ctx,
       {
         ...params.replyOptions,
         typingPolicy: typing.typingPolicy,
         suppressTyping: typing.suppressTyping,
+        images: params.replyOptions?.images
+          ? [...params.replyOptions.images, ...(inboundImages ?? [])]
+          : inboundImages,
         onToolResult: (payload: ReplyPayload) => {
           const run = async () => {
             const ttsPayload = await maybeApplyTtsToPayload({

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -176,6 +176,13 @@ function extractTextContent(content: unknown): string {
         if (typeof inputText === "string") {
           return inputText;
         }
+        // Preserve image_url parts as text references so the model sees them
+        if (type === "image_url") {
+          const url = resolveImageUrlPart(part);
+          if (url) {
+            return `[image: ${url}]`;
+          }
+        }
         return "";
       })
       .filter(Boolean)

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -179,7 +179,7 @@ function extractTextContent(content: unknown): string {
         // Preserve image_url parts as text references so the model sees them
         if (type === "image_url") {
           const url = resolveImageUrlPart(part);
-          if (url) {
+          if (url && !url.startsWith("data:")) {
             return `[image: ${url}]`;
           }
         }


### PR DESCRIPTION
## Summary

Telegram photos were downloaded to local files and stored in `MediaPath`, but the agent command never received the actual image data — only a text placeholder like `[media attached: 1 file]`.

This change reads local `MediaPath` files and passes them as `ImageContent[]` to the agent via `GetReplyOptions.images`, so vision-capable models can actually see inbound images.

## Root Cause

In `src/auto-reply/reply/dispatch-from-config.ts`, when a Telegram message with a photo arrives:

1. The photo is downloaded to a local file (e.g., `F:\OpenclawData\media\inbound\file_xxx.jpg`)
2. `MediaPath` is set on the `MsgContext`
3. `dispatchReplyFromConfig` calls `getReplyFromConfig` with `replyOptions` that has **no `images` field**
4. The agent receives only a text prompt with `[media attached: 1 file]` — no actual image data

The infrastructure to pass images to the agent exists (`GetReplyOptions.images?: ImageContent[]`), it just wasn't being used.

## Fix

Added `resolveInboundImages()` helper in `dispatch-from-config.ts`:

```typescript
async function resolveInboundImages(ctx: FinalizedMsgContext): Promise<ImageContent[] | undefined> {
  const paths = ctx.MediaPaths ?? (ctx.MediaPath ? [ctx.MediaPath] : []);
  if (paths.length === 0) return undefined;
  const types = ctx.MediaTypes ?? (ctx.MediaType ? [ctx.MediaType] : []);
  const results: ImageContent[] = [];
  for (let i = 0; i < paths.length; i++) {
    const path = paths[i];
    const mimeType = (types[i] ?? ctx.MediaType ?? "image/jpeg").split(";")[0].trim();
    try {
      const data = await fs.readFile(path);
      results.push({ type: "image", data: data.toString("base64"), mimeType });
    } catch (err) {
      logVerbose(`resolveInboundImages: failed to read ${path}: ${String(err)}`);
    }
  }
  return results.length > 0 ? results : undefined;
}
```

Then in the call to `getReplyFromConfig`, we now pass the images:

```typescript
const inboundImages = await resolveInboundImages(ctx);
// ...
const replyResult = await getReplyFromConfig(ctx, {
  ...params.replyOptions,
  images: params.replyOptions?.images
    ? [...params.replyOptions.images, ...(inboundImages ?? [])]
    : inboundImages,
  // ...
});
```

## Behavior

- **Before**: Agent sees only `[media attached: 1 file]` in the prompt
- **After**: Agent receives actual image data as `ImageContent[]` via the images parameter

## Backwards Compatibility

- Existing `replyOptions.images` (e.g., from webchat) is preserved and merged
- Files that cannot be read are silently skipped (logged)
- Audio files are not affected (they go through a separate transcription path)

## Related Issues

- Fixes openclaw/openclaw#23452
- Fixes openclaw/openclaw#7564