### PR TITLE
cleanup: remove leftover debug log in iOS e2e script

### DIFF
--- a/scripts/dev/ios-node-e2e.ts
+++ b/scripts/dev/ios-node-e2e.ts
@@ -261,8 +261,6 @@ async function main() {
     }));
     const width = Math.min(64, Math.max(12, ...rows.map((r) => r.cmd.length)));
     // eslint-disable-next-line no-console
-    console.log(`node: ${node.displayName ?? node.nodeId} (${node.platform ?? "unknown"})`);
-    // eslint-disable-next-line no-console
     console.log(`dangerous: ${dangerous ? "on" : "off"}`);
     // eslint-disable-next-line no-console
     console.log("");


### PR DESCRIPTION
The iOS Node e2e test script contained a leftover debug log statement that printed node information during test execution.

Changes:
- Removed \`console.log(\`node: ${node.displayName ?? node.nodeId} (${node.platform ?? "unknown"})\`);\` from line 263
- Preserved the surrounding pretty-print table formatting logic
- This was development-era debug code that was never removed

Pattern from PR #46515