### PR TITLE
docs: add ackReaction config examples and scope options

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -784,6 +784,58 @@ Default slash command settings:
     - Discord accepts unicode emoji or custom emoji names.
     - Use `""` to disable the reaction for a channel or account.
 
+    ### Scope configuration
+
+    `messages.ackReactionScope` controls when the ack reaction is sent:
+
+    | Value | Behavior |
+    |-------|----------|
+    | `group-mentions` | React only to @mentions in group channels (default) |
+    | `group-all` | React to all messages in group channels |
+    | `direct` | React only in DMs |
+    | `all` | React to all messages everywhere |
+
+    ### Remove after reply
+
+    Set `messages.removeAckAfterReply: true` to automatically remove the ack reaction after the agent sends a reply.
+
+    ### Example configuration
+
+    ```json5
+    {
+      messages: {
+        ackReaction: "👀",
+        ackReactionScope: "group-mentions",
+        removeAckAfterReply: false,
+      },
+      channels: {
+        discord: {
+          // Per-channel override
+          ackReaction: "🦞",
+        },
+      },
+    }
+    ```
+
+    Per-account override example:
+
+    ```json5
+    {
+      channels: {
+        discord: {
+          accounts: {
+            default: {
+              ackReaction: "👀",
+            },
+            work: {
+              ackReaction: "💼",
+            },
+          },
+        },
+      },
+    }
+    ```
+
   </Accordion>
 
   <Accordion title="Config writes">

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -786,7 +786,7 @@ Default slash command settings:
 
     ### Scope configuration
 
-    `messages.ackReactionScope` controls when the ack reaction is sent:
+    `messages.ackReactionScope` controls when the ack reaction is sent. Supports the same resolution order as `ackReaction`: `channels.discord.accounts.<id>.ackReactionScope` → `channels.discord.ackReactionScope` → `messages.ackReactionScope`.
 
     | Value | Behavior |
     |-------|----------|
@@ -794,6 +794,7 @@ Default slash command settings:
     | `group-all` | React to all messages in group channels |
     | `direct` | React only in DMs |
     | `all` | React to all messages everywhere |
+    | `off` / `none` | Disable ack reactions entirely |
 
     ### Remove after reply
 
@@ -810,7 +811,7 @@ Default slash command settings:
       },
       channels: {
         discord: {
-          // Per-channel override
+          // Discord-wide override (overrides messages.ackReaction for all Discord accounts)
           ackReaction: "🦞",
         },
       },


### PR DESCRIPTION
## Summary

The Discord channel docs mentioned `ackReaction` per-channel/account overrides but didn't show concrete examples or explain `ackReactionScope` values.

## Changes

- Added table explaining `ackReactionScope` values (`group-mentions`, `group-all`, `direct`, `all`)
- Added `removeAckAfterReply` documentation
- Added example config for global and per-channel overrides
- Added example config for per-account overrides

## Before

```markdown
`ackReaction` sends an acknowledgement emoji while OpenClaw is processing an inbound message.

Resolution order:
- `channels.discord.accounts.<accountId>.ackReaction`
- `channels.discord.ackReaction`
- `messages.ackReaction`
- agent identity emoji fallback

Notes:
- Discord accepts unicode emoji or custom emoji names.
- Use `""` to disable.
```

## After

Now includes:
- Scope value explanations (table)
- `removeAckAfterReply` option
- Full JSON5 config examples for global, per-channel, and per-account overrides

## Testing

- Verified config syntax matches existing patterns in docs
- Checked that all scope values are accurate per `messages.ackReactionScope` implementation