### PR TITLE
[codex] Fix restart probe auth and rate-limit fallback rotation

### DIFF
--- a/src/agents/pi-embedded-runner/run.failover-rotation.test.ts
+++ b/src/agents/pi-embedded-runner/run.failover-rotation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldRotateAuthProfileOnAssistantFailover,
+  shouldRotateAuthProfileOnPromptFailover,
+} from "./run.js";
+
+describe("auth profile rotation failover guards", () => {
+  it("skips prompt profile rotation on rate limits when a fallback model is configured", () => {
+    expect(
+      shouldRotateAuthProfileOnPromptFailover({
+        promptFailoverFailure: true,
+        promptFailoverReason: "rate_limit",
+        fallbackConfigured: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("still rotates prompt profiles on rate limits when no fallback model is configured", () => {
+    expect(
+      shouldRotateAuthProfileOnPromptFailover({
+        promptFailoverFailure: true,
+        promptFailoverReason: "rate_limit",
+        fallbackConfigured: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("still rotates prompt profiles for non-timeout transient failures", () => {
+    expect(
+      shouldRotateAuthProfileOnPromptFailover({
+        promptFailoverFailure: true,
+        promptFailoverReason: "overloaded",
+        fallbackConfigured: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not rotate prompt profiles for timeouts", () => {
+    expect(
+      shouldRotateAuthProfileOnPromptFailover({
+        promptFailoverFailure: true,
+        promptFailoverReason: "timeout",
+        fallbackConfigured: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("skips assistant profile rotation on rate limits when a fallback model is configured", () => {
+    expect(
+      shouldRotateAuthProfileOnAssistantFailover({
+        assistantFailoverReason: "rate_limit",
+        fallbackConfigured: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("still rotates assistant profiles on rate limits when no fallback model is configured", () => {
+    expect(
+      shouldRotateAuthProfileOnAssistantFailover({
+        assistantFailoverReason: "rate_limit",
+        fallbackConfigured: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("still rotates assistant profiles for non-rate-limit failover reasons", () => {
+    expect(
+      shouldRotateAuthProfileOnAssistantFailover({
+        assistantFailoverReason: "overloaded",
+        fallbackConfigured: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -157,6 +157,25 @@ function resolveMaxRunRetryIterations(profileCandidateCount: number): number {
   return Math.min(MAX_RUN_RETRY_ITERATIONS, Math.max(MIN_RUN_RETRY_ITERATIONS, scaled));
 }
 
+export function shouldRotateAuthProfileOnPromptFailover(params: {
+  promptFailoverFailure: boolean;
+  promptFailoverReason: FailoverReason | null;
+  fallbackConfigured: boolean;
+}): boolean {
+  return (
+    params.promptFailoverFailure &&
+    params.promptFailoverReason !== "timeout" &&
+    (params.promptFailoverReason !== "rate_limit" || !params.fallbackConfigured)
+  );
+}
+
+export function shouldRotateAuthProfileOnAssistantFailover(params: {
+  assistantFailoverReason: FailoverReason | null;
+  fallbackConfigured: boolean;
+}): boolean {
+  return params.assistantFailoverReason !== "rate_limit" || !params.fallbackConfigured;
+}
+
 const hasUsageValues = (
   usage: ReturnType<typeof normalizeUsage>,
 ): usage is NonNullable<ReturnType<typeof normalizeUsage>> =>
@@ -1400,8 +1419,11 @@ export async function runEmbeddedPiAgent(
               aborted,
             });
             if (
-              promptFailoverFailure &&
-              promptFailoverReason !== "timeout" &&
+              shouldRotateAuthProfileOnPromptFailover({
+                promptFailoverFailure,
+                promptFailoverReason,
+                fallbackConfigured,
+              }) &&
               (await advanceAuthProfile())
             ) {
               logPromptFailoverDecision("rotate_profile");
@@ -1534,7 +1556,11 @@ export async function runEmbeddedPiAgent(
               }
             }
 
-            const rotated = await advanceAuthProfile();
+            const rotated =
+              shouldRotateAuthProfileOnAssistantFailover({
+                assistantFailoverReason,
+                fallbackConfigured,
+              }) && (await advanceAuthProfile());
             if (rotated) {
               logAssistantFailoverDecision("rotate_profile");
               await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -7,6 +7,8 @@ const classifyPortListener = vi.hoisted(() =>
   vi.fn<(_listener: unknown, _port: number) => PortListenerKind>(() => "gateway"),
 );
 const probeGateway = vi.hoisted(() => vi.fn());
+const createConfigIO = vi.hoisted(() => vi.fn());
+const resolveGatewayProbeAuthSafe = vi.hoisted(() => vi.fn());
 
 vi.mock("../../infra/ports.js", () => ({
   classifyPortListener: (listener: unknown, port: number) => classifyPortListener(listener, port),
@@ -16,6 +18,16 @@ vi.mock("../../infra/ports.js", () => ({
 
 vi.mock("../../gateway/probe.js", () => ({
   probeGateway: (opts: unknown) => probeGateway(opts),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  createConfigIO: (opts: unknown) => createConfigIO(opts),
+  resolveConfigPath: vi.fn(() => "C:\\mock\\openclaw.json"),
+  resolveStateDir: vi.fn(() => "C:\\mock"),
+}));
+
+vi.mock("../../gateway/probe-auth.js", () => ({
+  resolveGatewayProbeAuthSafe: (params: unknown) => resolveGatewayProbeAuthSafe(params),
 }));
 
 const originalPlatform = process.platform;
@@ -94,6 +106,14 @@ describe("inspectGatewayRestart", () => {
     probeGateway.mockResolvedValue({
       ok: false,
       close: null,
+    });
+    createConfigIO.mockReset();
+    createConfigIO.mockReturnValue({
+      loadConfig: vi.fn(() => ({ gateway: { auth: { mode: "token", token: "cfg-token" } } })),
+    });
+    resolveGatewayProbeAuthSafe.mockReset();
+    resolveGatewayProbeAuthSafe.mockReturnValue({
+      auth: { token: "cfg-token" },
     });
   });
 
@@ -217,6 +237,25 @@ describe("inspectGatewayRestart", () => {
     });
 
     expect(snapshot.healthy).toBe(true);
+  });
+
+  it("resolves config-backed gateway auth before probing reachability", async () => {
+    await inspectAmbiguousOwnershipWithProbe({
+      ok: false,
+      close: { code: 1008, reason: "auth required" },
+    });
+
+    expect(resolveGatewayProbeAuthSafe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: { gateway: { auth: { mode: "token", token: "cfg-token" } } },
+        mode: "local",
+      }),
+    );
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: { token: "cfg-token" },
+      }),
+    );
   });
 
   it("treats busy ports with unavailable listener details as healthy when runtime is running", async () => {

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -1,5 +1,7 @@
+import { createConfigIO, resolveConfigPath, resolveStateDir } from "../../config/config.js";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
 import type { GatewayService } from "../../daemon/service.js";
+import { resolveGatewayProbeAuthSafe } from "../../gateway/probe-auth.js";
 import { probeGateway } from "../../gateway/probe.js";
 import {
   classifyPortListener,
@@ -60,11 +62,37 @@ function looksLikeAuthClose(code: number | undefined, reason: string | undefined
 }
 
 async function confirmGatewayReachable(port: number): Promise<boolean> {
-  const token = process.env.OPENCLAW_GATEWAY_TOKEN?.trim() || undefined;
-  const password = process.env.OPENCLAW_GATEWAY_PASSWORD?.trim() || undefined;
+  const env = process.env;
+  const envToken = env.OPENCLAW_GATEWAY_TOKEN?.trim() || undefined;
+  const envPassword = env.OPENCLAW_GATEWAY_PASSWORD?.trim() || undefined;
+  let auth =
+    envToken || envPassword
+      ? {
+          token: envToken,
+          password: envPassword,
+        }
+      : undefined;
+  try {
+    const configPath = resolveConfigPath(env, resolveStateDir(env));
+    const cfg = createConfigIO({ env, configPath }).loadConfig();
+    const resolved = resolveGatewayProbeAuthSafe({
+      cfg,
+      mode: "local",
+      env,
+    }).auth;
+    auth =
+      resolved.token || resolved.password
+        ? {
+            token: resolved.token,
+            password: resolved.password,
+          }
+        : auth;
+  } catch {
+    // Fall back to env-only probing if config-backed auth resolution fails here.
+  }
   const probe = await probeGateway({
     url: `ws://127.0.0.1:${port}`,
-    auth: token || password ? { token, password } : undefined,
+    auth,
     timeoutMs: 3_000,
     includeDetails: false,
   });


### PR DESCRIPTION
This PR fixes two separate failover and operability issues that showed up in real OpenClaw usage.

The first issue affects `openclaw gateway restart`. On installations where gateway auth is configured in the daemon config rather than exported in the calling shell, the restart health probe could incorrectly treat a healthy restarted gateway as unavailable. In practice this looks like restart timing out even though the gateway is back and `openclaw health` works immediately afterwards. The root cause was that `restart-health.ts` only probed with `OPENCLAW_GATEWAY_TOKEN` / `OPENCLAW_GATEWAY_PASSWORD` from the CLI environment, while other gateway checks already resolve auth from config-backed probe credentials. This change makes restart health use the same config-aware probe auth resolution path, with env-only probing kept as a fallback if config resolution fails.

The second issue affects embedded model failover under rate limiting. When an auth profile hit a provider `rate_limit` error and a fallback model was already configured, the runner would still try rotating to another auth profile first. That burns time on the same provider path and delays the more useful model fallback that the operator explicitly configured. This was especially visible in cron and background jobs because one rate-limited provider could hold the lane longer than necessary. This change makes the auth-profile rotation guards skip profile rotation for `rate_limit` when a fallback model is configured, while preserving the previous behavior for overloads, auth failures, and the no-fallback case.

The failover change is covered with a focused unit test on the rotation guards so the intended branch behavior stays protected without relying on a slow end-to-end harness. The restart change adds a regression test proving that config-backed gateway auth is resolved before the reachability probe runs.

Validation:
- `pnpm exec vitest run src/cli/daemon-cli/restart-health.test.ts`
- `pnpm exec vitest run src/agents/pi-embedded-runner/run.failover-rotation.test.ts`
