### PR TITLE
Compaction safeguard: prefer runtime compaction model over chat-selected model

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -749,7 +749,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       identifierInstructions: runtime?.identifierInstructions,
     };
     const identifierPolicy = runtime?.identifierPolicy ?? "strict";
-    const model = ctx.model ?? runtime?.model;
+    const model = runtime?.model ?? ctx.model;
     if (!model) {
       // Log warning once per session when both models are missing (diagnostic for future issues).
       // Use a WeakSet to track which session managers have already logged the warning.

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -737,8 +737,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     ]);
     const toolFailureSection = formatToolFailuresSection(toolFailures);
 
-    // Model resolution: ctx.model is undefined in compact.ts workflow (extensionRunner.initialize() is never called).
-    // Fall back to runtime.model which is explicitly passed when building extension paths.
+    // Model resolution: prefer runtime.model for compact workflow (passed explicitly via runtime).
+    // Fall back to ctx.model for non-compact paths where extensionRunner.initialize() populates it.
     const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
     const customInstructions = resolveCompactionInstructions(
       eventInstructions,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: in compaction safeguard, fallback preferred `ctx.model` before runtime fallback, which could bypass the intended compaction runtime model in compact workflows
- Why it matters: `agents.defaults.compaction.model` could be effectively ignored in some safeguard compaction paths
- What changed: changed fallback order to `runtime?.model ?? ctx.model` in `src/agents/pi-extensions/compaction-safeguard.ts`
- What did NOT change (scope boundary): no changes to auth routing, no changes to tool execution, no new config fields

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Compaction model selection in safeguard path now prefers runtime compaction model over chat-selected model fallback.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local OpenClaw dev workspace
- Model/provider: mixed (compaction safeguard path)
- Integration/channel (if any): n/a
- Relevant config (redacted): `agents.defaults.compaction.model`

### Steps

1. Set compaction safeguard mode and compaction model override in config
2. Trigger compaction path where `ctx.model` may not represent compaction target
3. Observe model chosen by safeguard

### Expected

- Safeguard respects compaction runtime model first

### Actual

- After fix, safeguard selects runtime compaction model before `ctx.model` fallback

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted vitest for compaction safeguard model fallback
- Edge cases checked: both runtime present and both missing (`cancel` path)
- What you did **not** verify: full end-to-end long-session production compaction under all providers

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `3db559f301`
- Files/config to restore: `src/agents/pi-extensions/compaction-safeguard.ts`
- Known bad symptoms reviewers should watch for: compaction unexpectedly using chat-selected context model instead of runtime compaction model

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: fallback ordering may alter model choice in niche mixed-model setups
  - Mitigation: limited 1-line change, targeted fallback tests, codex review clean


## AI Assistance Disclosure

- AI-assisted: **Yes** (OpenAI Codex used for code suggestions/review)
- Testing degree: **Lightly tested** (targeted vitest scenarios listed above)
- Codex review: `codex review --base origin/main` run and findings addressed
- Author accountability: I verified and understand the final code path and fallback behavior change
- Prompts/session logs: available on request

