### PR TITLE
fix: import ordering mismatches for oxfmt compliance

### DIFF
--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -1,12 +1,12 @@
 import { markdownToText, truncateText } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { withTrustedWebToolsEndpoint } from "openclaw/plugin-sdk/provider-web-search";
 import {
   DEFAULT_CACHE_TTL_MINUTES,
   normalizeCacheKey,
   readCache,
   readResponseText,
   resolveCacheTtlMs,
+  withTrustedWebToolsEndpoint,
   writeCache,
 } from "openclaw/plugin-sdk/provider-web-search";
 import { wrapExternalContent, wrapWebContent } from "openclaw/plugin-sdk/security-runtime";

--- a/extensions/qwen-portal-auth/index.ts
+++ b/extensions/qwen-portal-auth/index.ts
@@ -1,5 +1,8 @@
-import { ensureAuthProfileStore, listProfilesForProvider } from "openclaw/plugin-sdk/agent-runtime";
-import { QWEN_OAUTH_MARKER } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  ensureAuthProfileStore,
+  listProfilesForProvider,
+  QWEN_OAUTH_MARKER,
+} from "openclaw/plugin-sdk/agent-runtime";
 import { buildQwenPortalProvider, QWEN_PORTAL_BASE_URL } from "./provider-catalog.js";
 import {
   buildOauthProviderAuthResult,

--- a/src/plugin-sdk/compat.ts
+++ b/src/plugin-sdk/compat.ts
@@ -24,6 +24,7 @@ export { delegateCompactionToRuntime } from "../context-engine/delegate.js";
 export { createAccountStatusSink } from "./channel-lifecycle.js";
 export { createPluginRuntimeStore } from "./runtime-store.js";
 export { KeyedAsyncQueue } from "./keyed-async-queue.js";
+export { formatAllowFromLowercase, formatNormalizedAllowFromEntries } from "./allow-from.js";
 
 export {
   createHybridChannelConfigAdapter,
@@ -36,7 +37,7 @@ export {
   createTopLevelChannelConfigBase,
   mapAllowFromEntries,
 } from "./channel-config-helpers.js";
-export { formatAllowFromLowercase, formatNormalizedAllowFromEntries } from "./allow-from.js";
+
 export * from "./channel-config-schema.js";
 export * from "./channel-policy.js";
 export * from "./reply-history.js";

--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -10,9 +10,9 @@ import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { applyAuthProfileConfig } from "./provider-auth-helpers.js";
 import type {
-  ProviderDiscoveryContext,
-  ProviderAuthResult,
   ProviderAuthMethodNonInteractiveContext,
+  ProviderAuthResult,
+  ProviderDiscoveryContext,
   ProviderNonInteractiveApiKeyResult,
 } from "./types.js";
 


### PR DESCRIPTION
Multiple files had imports in incorrect order that violated oxfmt's alphabetical import ordering rules.

Changes:

- extensions/qwen-portal-auth/index.ts: Merged SDK imports into single block
- src/plugin-sdk/compat.ts: Moved export statement to correct position alphabetically  
- src/plugins/provider-self-hosted-setup.ts: Reordered type imports alphabetically
- extensions/firecrawl/src/firecrawl-client.ts: Moved \`withTrustedWebToolsEndpoint\` to top of import block

All changes follow oxfmt style guide for alphabetical import ordering.
No semantic changes—only import reordering.

Pattern from PRs #48758, #49470, #48998