### PR TITLE
fix(extensions/feishu/src/reply-dispatcher.ts): missing cleanup in error path

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -288,23 +288,26 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   };
 
   const closeStreaming = async () => {
-    if (streamingStartPromise) {
-      await streamingStartPromise;
-    }
-    await partialUpdateQueue;
-    if (streaming?.isActive()) {
-      let text = buildCombinedStreamText(reasoningText, streamText);
-      if (mentionTargets?.length) {
-        text = buildMentionedCardContent(mentionTargets, text);
+    try {
+      if (streamingStartPromise) {
+        await streamingStartPromise;
       }
-      const finalNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-      await streaming.close(text, { note: finalNote });
+      await partialUpdateQueue;
+      if (streaming?.isActive()) {
+        let text = buildCombinedStreamText(reasoningText, streamText);
+        if (mentionTargets?.length) {
+          text = buildMentionedCardContent(mentionTargets, text);
+        }
+        const finalNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+        await streaming.close(text, { note: finalNote });
+      }
+    } finally {
+      streaming = null;
+      streamingStartPromise = null;
+      streamText = "";
+      lastPartial = "";
+      reasoningText = "";
     }
-    streaming = null;
-    streamingStartPromise = null;
-    streamText = "";
-    lastPartial = "";
-    reasoningText = "";
   };
 
   const sendChunkedTextReply = async (params: {


### PR DESCRIPTION
The \`closeStreaming\` function in \`extensions/feishu/src/reply-dispatcher.ts\` could skip cleanup if any async operation threw an exception.

Changes:

- Wrapped async operations in \`try\` block
- Moved all variable nullifications and state resets to \`finally\` block
- Guarantees cleanup (\`streaming = null\`, \`streamingStartPromise = null\`, state resets) executes even if errors occur
- Prevents memory leaks and state corruption in retry scenarios
- Pattern from PR #47902
- No semantic changes—only added error-path safety