### PR TITLE
fix(directives): preserve xhigh thinking level in session entry

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -686,17 +686,6 @@ async function agentCommandInternal(
         throw new Error(`Thinking level "xhigh" is only supported for ${formatXHighModelHint()}.`);
       }
       resolvedThinkLevel = "high";
-      if (sessionEntry && sessionStore && sessionKey && sessionEntry.thinkingLevel === "xhigh") {
-        const entry = sessionEntry;
-        entry.thinkingLevel = "high";
-        entry.updatedAt = Date.now();
-        await persistSessionEntry({
-          sessionStore,
-          sessionKey,
-          storePath,
-          entry,
-        });
-      }
     }
     let sessionFile: string | undefined;
     if (sessionStore && sessionKey) {

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -351,7 +351,10 @@ export async function handleDirectiveOnly(
       sessionEntry.fastMode = directives.fastMode;
     }
     if (shouldDowngradeXHigh) {
-      sessionEntry.thinkingLevel = "high";
+      // Keep sessionEntry.thinkingLevel as "xhigh" so it is preserved when
+      // the user switches back to a model that supports it.  The runtime
+      // resolvedThinkLevel is already downgraded to "high" for the current
+      // request without persisting the change.
     }
     if (
       directives.hasVerboseDirective &&
@@ -532,7 +535,7 @@ export async function handleDirectiveOnly(
   }
   if (shouldDowngradeXHigh) {
     parts.push(
-      `Thinking level set to high (xhigh not supported for ${resolvedProvider}/${resolvedModel}).`,
+      `Using high thinking for this reply (xhigh not supported for ${resolvedProvider}/${resolvedModel}).`,
     );
   }
   if (modelSelection) {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -53,10 +53,6 @@ let agentRunnerRuntimePromise: Promise<typeof import("./agent-runner.runtime.js"
 let routeReplyRuntimePromise: Promise<typeof import("./route-reply.runtime.js")> | null = null;
 let sessionUpdatesRuntimePromise: Promise<typeof import("./session-updates.runtime.js")> | null =
   null;
-let sessionStoreRuntimePromise: Promise<
-  typeof import("../../config/sessions/store.runtime.js")
-> | null = null;
-
 function loadPiEmbeddedRuntime() {
   piEmbeddedRuntimePromise ??= import("../../agents/pi-embedded.runtime.js");
   return piEmbeddedRuntimePromise;
@@ -75,11 +71,6 @@ function loadRouteReplyRuntime() {
 function loadSessionUpdatesRuntime() {
   sessionUpdatesRuntimePromise ??= import("./session-updates.runtime.js");
   return sessionUpdatesRuntimePromise;
-}
-
-function loadSessionStoreRuntime() {
-  sessionStoreRuntimePromise ??= import("../../config/sessions/store.runtime.js");
-  return sessionStoreRuntimePromise;
 }
 
 function buildResetSessionNoticeText(params: {
@@ -441,17 +432,6 @@ export async function runPreparedReply(
       };
     }
     resolvedThinkLevel = "high";
-    if (sessionEntry && sessionStore && sessionKey && sessionEntry.thinkingLevel === "xhigh") {
-      sessionEntry.thinkingLevel = "high";
-      sessionEntry.updatedAt = Date.now();
-      sessionStore[sessionKey] = sessionEntry;
-      if (storePath) {
-        const { updateSessionStore } = await loadSessionStoreRuntime();
-        await updateSessionStore(storePath, (store) => {
-          store[sessionKey] = sessionEntry;
-        });
-      }
-    }
   }
   if (resetTriggered && command.isAuthorizedSender) {
     await sendResetSessionNotice({


### PR DESCRIPTION
## Summary
- When a model doesn't support xhigh natively, every subsequent message overwrote the persisted `sessionEntry.thinkingLevel` from `xhigh` to `high`
- This caused status/reporting to show `high` even though the user explicitly set `xhigh` via `/think:xhigh`
- Removed the persistence mutation — the runtime already handles xhigh→high downgrade for the API call
- The user-visible status message still informs that runtime uses `high` for incompatible models

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway

## Linked Issue/PR
Closes #50601

## User-visible Changes
- `/think:xhigh` now persists correctly — session status shows `xhigh` instead of silently downgrading to `high` on subsequent messages

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
- **Environment:** macOS, Node 25.5.0
- **Reproduction:** Set `agents.defaults.thinkingDefault = "xhigh"`, use a model that doesn't support xhigh natively, send any message — status reports `high` instead of `xhigh`
- **Expected:** Status shows `xhigh` (the user's intent), runtime uses `high` (the effective level)
- **Actual (before fix):** `sessionEntry.thinkingLevel` overwritten to `high` on every message when `shouldDowngradeXHigh` is true

## Evidence
- 2/2 directive-handling level tests pass
- Type-check clean on changed file
- The `shouldDowngradeXHigh` flag is still used at line 472 to display the runtime downgrade message to the user

## Human Verification
- Verified `shouldDowngradeXHigh` is still referenced for the user-facing status message (line 472)
- Verified the runtime thinking level resolution happens independently of `sessionEntry.thinkingLevel`
- Did NOT verify against a live gateway with xhigh-compatible and incompatible models

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- Revert this single commit to restore previous behavior

## Risks and Mitigations
- None — the runtime already downgrades xhigh to high for incompatible models independently of the persisted value