### PR TITLE
fix(session-model): prefer model overrides over stale runtime fields

### DIFF
--- a/src/agents/subagent-control.ts
+++ b/src/agents/subagent-control.ts
@@ -191,20 +191,6 @@ function resolveRunStatus(entry: SubagentRunRecord, options?: { pendingDescendan
 }
 
 function resolveModelRef(entry?: SessionEntry) {
-  const model = typeof entry?.model === "string" ? entry.model.trim() : "";
-  const provider = typeof entry?.modelProvider === "string" ? entry.modelProvider.trim() : "";
-  if (model.includes("/")) {
-    return model;
-  }
-  if (model && provider) {
-    return `${provider}/${model}`;
-  }
-  if (model) {
-    return model;
-  }
-  if (provider) {
-    return provider;
-  }
   const overrideModel = typeof entry?.modelOverride === "string" ? entry.modelOverride.trim() : "";
   const overrideProvider =
     typeof entry?.providerOverride === "string" ? entry.providerOverride.trim() : "";
@@ -217,7 +203,22 @@ function resolveModelRef(entry?: SessionEntry) {
   if (overrideModel) {
     return overrideModel;
   }
-  return overrideProvider || undefined;
+  if (overrideProvider) {
+    return overrideProvider;
+  }
+
+  const model = typeof entry?.model === "string" ? entry.model.trim() : "";
+  const provider = typeof entry?.modelProvider === "string" ? entry.modelProvider.trim() : "";
+  if (model.includes("/")) {
+    return model;
+  }
+  if (model && provider) {
+    return `${provider}/${model}`;
+  }
+  if (model) {
+    return model;
+  }
+  return provider || undefined;
 }
 
 function resolveModelDisplay(entry?: SessionEntry, fallbackModel?: string) {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -454,6 +454,23 @@ describe("resolveSessionModelRef", () => {
     expect(resolved).toEqual({ provider: "openai-codex", model: "gpt-5.3-codex" });
   });
 
+  test("prefers stored override over stale runtime fields", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "openai-codex/gpt-5.4",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "override-wins",
+      updatedAt: Date.now(),
+      model: "gpt-5.4",
+      modelProvider: "openai-codex",
+      modelOverride: "gpt-4.1-mini",
+      providerOverride: "openai",
+    });
+
+    expect(resolved).toEqual({ provider: "openai", model: "gpt-4.1-mini" });
+  });
+
   test("falls back to resolved provider for unprefixed legacy runtime model", () => {
     const cfg = createModelDefaultsConfig({
       primary: "google-gemini-cli/gemini-3-pro-preview",
@@ -537,6 +554,23 @@ describe("resolveSessionModelIdentityRef", () => {
     const resolved = resolveLegacyIdentityRef(cfg);
 
     expect(resolved).toEqual({ model: "claude-sonnet-4-6" });
+  });
+
+  test("prefers stored override over stale runtime fields", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "openai-codex/gpt-5.4",
+    });
+
+    const resolved = resolveSessionModelIdentityRef(cfg, {
+      sessionId: "override-wins",
+      updatedAt: Date.now(),
+      model: "gpt-5.4",
+      modelProvider: "openai-codex",
+      modelOverride: "gpt-4.1-mini",
+      providerOverride: "openai",
+    });
+
+    expect(resolved).toEqual({ provider: "openai", model: "gpt-4.1-mini" });
   });
 
   test("preserves provider from slash-prefixed runtime model", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -923,10 +923,32 @@ export function resolveSessionModelRef(
         defaultModel: DEFAULT_MODEL,
       });
 
-  // Prefer the last runtime model recorded on the session entry.
-  // This is the actual model used by the latest run and must win over defaults.
+  // Prefer explicit per-session overrides first. They are the user's active
+  // selection and represent the effective model the session should resolve to
+  // across all surfaces.
   let provider = resolved.provider;
   let model = resolved.model;
+  const storedModelOverride = entry?.modelOverride?.trim();
+  const storedProviderOverride = entry?.providerOverride?.trim();
+  if (storedModelOverride || storedProviderOverride) {
+    const overrideProvider = storedProviderOverride || provider || DEFAULT_PROVIDER;
+    if (storedModelOverride) {
+      const parsedOverride = parseModelRef(storedModelOverride, overrideProvider);
+      if (parsedOverride) {
+        provider = parsedOverride.provider;
+        model = parsedOverride.model;
+      } else {
+        provider = overrideProvider;
+        model = storedModelOverride;
+      }
+    } else {
+      provider = overrideProvider;
+    }
+    return { provider, model };
+  }
+
+  // Otherwise prefer the last runtime model recorded on the session entry.
+  // This is the actual model used by the latest run and must win over defaults.
   const runtimeModel = entry?.model?.trim();
   const runtimeProvider = entry?.modelProvider?.trim();
   if (runtimeModel) {
@@ -946,22 +968,6 @@ export function resolveSessionModelRef(
     } else {
       model = runtimeModel;
     }
-    return { provider, model };
-  }
-
-  // Fall back to explicit per-session override (set at spawn/model-patch time),
-  // then finally to configured defaults.
-  const storedModelOverride = entry?.modelOverride?.trim();
-  if (storedModelOverride) {
-    const overrideProvider = entry?.providerOverride?.trim() || provider || DEFAULT_PROVIDER;
-    const parsedOverride = parseModelRef(storedModelOverride, overrideProvider);
-    if (parsedOverride) {
-      provider = parsedOverride.provider;
-      model = parsedOverride.model;
-    } else {
-      provider = overrideProvider;
-      model = storedModelOverride;
-    }
   }
   return { provider, model };
 }
@@ -974,6 +980,20 @@ export function resolveSessionModelIdentityRef(
   agentId?: string,
   fallbackModelRef?: string,
 ): { provider?: string; model: string } {
+  const storedModelOverride = entry?.modelOverride?.trim();
+  const storedProviderOverride = entry?.providerOverride?.trim();
+  if (storedModelOverride || storedProviderOverride) {
+    const resolvedOverride = resolveSessionModelRef(
+      cfg,
+      {
+        modelOverride: storedModelOverride,
+        providerOverride: storedProviderOverride,
+      },
+      agentId,
+    );
+    return { provider: resolvedOverride.provider, model: resolvedOverride.model };
+  }
+
   const runtimeModel = entry?.model?.trim();
   const runtimeProvider = entry?.modelProvider?.trim();
   if (runtimeModel) {


### PR DESCRIPTION
Title
fix(session-model): prefer model overrides over stale runtime fields

Summary
This fixes inconsistent model reporting after a session model switch.

Problem
OpenClaw session state can contain both:
- base/runtime fields: `modelProvider` + `model`
- active override fields: `providerOverride` + `modelOverride`

Several shared resolvers preferred the runtime/base fields first. After switching models, some surfaces would therefore display the stale base model instead of the effective override.

Observed impact
- TUI/footer could show the wrong model
- `session_status` and session listings could disagree with each other
- reset/switch behavior looked broken or confusing
- daemon-backed surfaces could appear inconsistent even though the override was active

Root cause
Effective session model resolution was using the wrong precedence order.

Correct precedence
1. `providerOverride` / `modelOverride`
2. `modelProvider` / `model`
3. configured default model

Proposed fix
Update the shared session model resolvers to prefer override fields first, and update `resolveModelRef(entry)` used by session listing/display code to do the same.

Files / functions affected
- `resolveSessionModelRef(...)`
- `resolveSessionModelIdentityRef(...)`
- `resolveModelRef(entry)`

Why this is safe
- No schema change
- No new persisted state
- Reset behavior already clears override fields correctly
- This only fixes precedence during effective model resolution and display

Validation
1. Switch active session to `openai/gpt-4.1-mini`
2. Confirm `/status` shows `gpt-4.1-mini`
3. Confirm session listings/status tables also show `gpt-4.1-mini`
4. Reset to default
5. Confirm overrides are cleared and all surfaces return to the configured default model

Notes
I verified this locally by applying the equivalent runtime patch to the installed bundles and testing:
- switch to `gpt-4.1-mini`
- confirm session store contains only override fields
- confirm status/session table shows `gpt-4.1-mini`
- reset to default
- confirm overrides are cleared and displays return to `gpt-5.4`

Suggested commit message
fix(session-model): prefer active override over stale runtime model
