### PR TITLE
fix(ollama): send think: false when thinking is off

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -434,6 +434,24 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
+  it("sends think: false when reasoning is not set", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+        });
+
+        const [, requestInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const requestBody = JSON.parse(requestInit.body as string) as { think?: boolean };
+        expect(requestBody.think).toBe(false);
+      },
+    );
+  });
+
   it("preserves an explicit Authorization header when apiKey is a local marker", async () => {
     await withMockNdjsonFetch(
       [

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -452,6 +452,25 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
+  it("omits think when reasoning is truthy", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          options: { reasoning: "medium" } as never,
+        });
+
+        const [, requestInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const requestBody = JSON.parse(requestInit.body as string) as Record<string, unknown>;
+        expect(requestBody).not.toHaveProperty("think");
+      },
+    );
+  });
+
   it("preserves an explicit Authorization header when apiKey is a local marker", async () => {
     await withMockNdjsonFetch(
       [

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -44,6 +44,7 @@ interface OllamaChatRequest {
   stream: boolean;
   tools?: OllamaTool[];
   options?: Record<string, unknown>;
+  think?: boolean;
 }
 
 interface OllamaChatMessage {
@@ -465,6 +466,7 @@ export function createOllamaStreamFn(
           stream: true,
           ...(ollamaTools.length > 0 ? { tools: ollamaTools } : {}),
           options: ollamaOptions,
+          ...(!options?.reasoning ? { think: false } : {}),
         };
 
         const headers: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Ollama models with native thinking (e.g. qwen3.5:9b) default to thinking ON
- When thinking is off, OpenClaw never sent `think: false` in the request body
- Without `think: false`, the model puts its response in the `thinking` field instead of `content`, and OpenClaw drops it — user sees empty response
- Now sends `think: false` in the Ollama API request when `options.reasoning` is not set

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway

## Linked Issue/PR
Closes #50702

## User-visible Changes
- Ollama thinking models now return visible responses when thinking is configured off

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
- **Environment:** macOS, Node 25.5.0, vitest
- **Reproduction:** Configure agent with Ollama thinking model, set thinking off, send message — model returns empty response
- **Expected:** Response appears in `content` field
- **Actual (before fix):** Response goes to `thinking` field, gets dropped

## Evidence
- 31/31 ollama-stream tests pass
- Type-check clean

## Human Verification
- Verified `options.reasoning` is `undefined` when thinkingLevel is `"off"` (set in pi-agent-core agent.js:349)
- Verified `think` is a top-level Ollama API parameter (not inside `options`)
- Did NOT verify against a live Ollama instance

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- Revert this single commit

## Risks and Mitigations
- Models without thinking support ignore the `think` parameter — no side effects