### PR TITLE
fix(cron): use agent-turn safety timeout for systemEvent jobs with wakeMode=now

### DIFF
--- a/src/cron/service/timeout-policy.test.ts
+++ b/src/cron/service/timeout-policy.test.ts
@@ -23,9 +23,28 @@ function makeJob(payload: CronJob["payload"]): CronJob {
 }
 
 describe("timeout-policy", () => {
-  it("uses default timeout for non-agent jobs", () => {
+  it("uses default timeout for systemEvent jobs with wakeMode=next-heartbeat", () => {
     const timeout = resolveCronJobTimeoutMs(makeJob({ kind: "systemEvent", text: "hello" }));
     expect(timeout).toBe(DEFAULT_JOB_TIMEOUT_MS);
+  });
+
+  it("uses expanded safety timeout for systemEvent jobs targeting main with wakeMode=now", () => {
+    // wakeMode="now" + sessionTarget="main" blocks until the full agent turn completes
+    // via runHeartbeatOnce(), so it needs the same generous ceiling as agentTurn jobs.
+    const job: CronJob = {
+      id: "job-1",
+      name: "job",
+      createdAtMs: 0,
+      updatedAtMs: 0,
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "check in" },
+      state: {},
+    };
+    const timeout = resolveCronJobTimeoutMs(job);
+    expect(timeout).toBe(AGENT_TURN_SAFETY_TIMEOUT_MS);
   });
 
   it("uses expanded safety timeout for agentTurn jobs without explicit timeout", () => {

--- a/src/cron/service/timeout-policy.ts
+++ b/src/cron/service/timeout-policy.ts
@@ -19,7 +19,25 @@ export function resolveCronJobTimeoutMs(job: CronJob): number | undefined {
       ? Math.floor(job.payload.timeoutSeconds * 1_000)
       : undefined;
   if (configuredTimeoutMs === undefined) {
-    return job.payload.kind === "agentTurn" ? AGENT_TURN_SAFETY_TIMEOUT_MS : DEFAULT_JOB_TIMEOUT_MS;
+    // agentTurn jobs get the large safety ceiling since turns can run for a long time.
+    if (job.payload.kind === "agentTurn") {
+      return AGENT_TURN_SAFETY_TIMEOUT_MS;
+    }
+    // systemEvent jobs targeting "main" with wakeMode="now" call runHeartbeatOnce(),
+    // which blocks until the full agent turn completes. The turn duration is
+    // unbounded, so apply the same generous ceiling as agentTurn jobs instead of
+    // the short DEFAULT_JOB_TIMEOUT_MS that was incorrectly timing out long-running
+    // main-session heartbeats. See: https://github.com/openclaw/openclaw/issues/50621
+    if (
+      job.payload.kind === "systemEvent" &&
+      job.sessionTarget === "main" &&
+      job.wakeMode === "now"
+    ) {
+      return AGENT_TURN_SAFETY_TIMEOUT_MS;
+    }
+    // All other systemEvent jobs (wakeMode !== "now") are fire-and-forget:
+    // they enqueue the event and return immediately, so the short default is fine.
+    return DEFAULT_JOB_TIMEOUT_MS;
   }
   return configuredTimeoutMs <= 0 ? undefined : configuredTimeoutMs;
 }


### PR DESCRIPTION
## Problem

Closes #50621

When a cron job has `sessionTarget: "main"`, `payload.kind: "systemEvent"`, and `wakeMode: "now"`, `executeJobCore()` calls `runHeartbeatOnce()` which **blocks until the full agent turn completes**. Multi-step tasks (file I/O, web search, git push, etc.) can take 30+ minutes.

However, `resolveCronJobTimeoutMs()` was returning `DEFAULT_JOB_TIMEOUT_MS` (10 minutes) for **all** `systemEvent` jobs, regardless of `wakeMode`. This caused legitimate long-running main-session heartbeats to be killed with `error: "cron: job execution timed out"`.

### Root cause

```
// Before: both wakeMode paths got DEFAULT_JOB_TIMEOUT_MS (10 min)
systemEvent → DEFAULT_JOB_TIMEOUT_MS  // 10 min ❌
agentTurn   → AGENT_TURN_SAFETY_TIMEOUT_MS  // 60 min ✓
```

The two `wakeMode` paths have fundamentally different blocking behaviour:

| wakeMode | behaviour | appropriate timeout |
|---|---|---|
| `next-heartbeat` | fire-and-forget via `requestHeartbeatNow()`, returns immediately | `DEFAULT_JOB_TIMEOUT_MS` (10 min) is fine |
| `now` | blocks in `runHeartbeatOnce()` until turn finishes | needs `AGENT_TURN_SAFETY_TIMEOUT_MS` (60 min) |

## Fix

In `resolveCronJobTimeoutMs()`, detect the `systemEvent + sessionTarget=main + wakeMode=now` combination and return `AGENT_TURN_SAFETY_TIMEOUT_MS` (60 min) instead of the short default.

Jobs with `wakeMode !== "now"` are unaffected — they remain fire-and-forget and keep the 10-minute ceiling.

## Testing

- Added a new unit test for the `wakeMode=now` case in `timeout-policy.test.ts`
- All existing tests continue to pass (`5 tests passed`)