### PR TITLE
fix: use openai-responses API for self-hosted providers

### DIFF
--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -67,7 +67,7 @@ function buildOpenAICompatibleSelfHostedProviderConfig(params: {
           ...params.cfg.models?.providers,
           [params.providerId]: {
             baseUrl: params.baseUrl,
-            api: "openai-completions",
+            api: "openai-responses",
             apiKey: params.providerApiKey,
             models: [
               {


### PR DESCRIPTION
## Summary

Local OpenAI-compatible providers (vLLM, Ollama, LocalAI, etc.) use the modern `/v1/chat/completions` endpoint, not the legacy `/v1/completions` endpoint. The recent refactoring in commit 3b79494 inadvertently hardcoded the API type to `openai-completions` which targets the wrong endpoint, causing 404 errors for providers like vLLM.

## Changes

- Changed API type from `openai-completions` to `openai-responses` in `src/plugins/provider-self-hosted-setup.ts`
- This ensures self-hosted OpenAI-compatible providers correctly target `/v1/chat/completions`

## Testing

The fix addresses the regression where:
- Version 2026.3.13 breaks with "404 status code (no body)" for local GLM 4.7 Flash model via vLLM
- Version 2026.3.12 works correctly
- The root cause is the API endpoint mismatch introduced in commit 3b79494

Fixes openclaw/openclaw#50719