### PR TITLE
fix(control-ui): hide relevant-memories scaffolding in chat output

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -28,6 +28,25 @@ describe("stripInlineDirectiveTagsForDisplay", () => {
 });
 
 describe("stripInlineDirectiveTagsFromMessageForDisplay", () => {
+  test("strips assistant internal relevant-memories scaffolding from text blocks", () => {
+    const input = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: [
+            "Visible answer",
+            "<relevant-memories>",
+            "private context",
+            "</relevant-memories>",
+          ].join("\n"),
+        },
+      ],
+    };
+    const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
+    expect(result?.content).toEqual([{ type: "text", text: "Visible answer\n" }]);
+  });
+
   test("strips inline directives from text content blocks", () => {
     const input = {
       role: "assistant",

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -1,3 +1,5 @@
+import { stripAssistantInternalScaffolding } from "../shared/text/assistant-visible-text.js";
+
 export type InlineDirectiveParseResult = {
   text: string;
   audioAsVoice: boolean;
@@ -77,7 +79,8 @@ export function stripInlineDirectiveTagsFromMessageForDisplay(
     if (!isMessageTextPart(record)) {
       return part;
     }
-    return { ...record, text: stripInlineDirectiveTagsForDisplay(record.text).text };
+    const strippedDirectives = stripInlineDirectiveTagsForDisplay(record.text).text;
+    return { ...record, text: stripAssistantInternalScaffolding(strippedDirectives) };
   });
   return { ...message, content: cleaned };
 }


### PR DESCRIPTION
## Summary
Fixes leaked internal memory scaffolding in Control UI chat output by sanitizing assistant text blocks before broadcast.

- apply `stripAssistantInternalScaffolding` in `stripInlineDirectiveTagsFromMessageForDisplay`
- add regression test for `<relevant-memories>...</relevant-memories>` leakage

## Why
Issue #50788 reports Control UI showing internal `relevant-memories` metadata to end users.

## Notes
- This keeps existing message shape and only sanitizes text content for display.
- Could not run tests in this environment because `pnpm` is unavailable.
