### PR TITLE
fix(ui): use totalTokens for context usage display (#50196) - [REBASED]

### DIFF
--- a/ui/src/ui/views/chat.browser.test.ts
+++ b/ui/src/ui/views/chat.browser.test.ts
@@ -80,4 +80,40 @@ describe("chat context notice", () => {
     expect(iconStyle.height).toBe("16px");
     expect(icon.getBoundingClientRect().width).toBeLessThan(24);
   });
+
+  it("totalTokens takes precedence over inputTokens when both present", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    
+    // Session where inputTokens would fire the warning but totalTokens would not
+    render(
+      renderChat(
+        createProps({
+          sessions: {
+            ts: 0,
+            path: "",
+            count: 1,
+            defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: null,
+                inputTokens: 3_800,   // 95% of 4k — would show notice
+                totalTokens: 1_000,   // 25% of 4k — should suppress notice
+                contextTokens: 4_000,
+              },
+            ],
+          },
+        })
+      ),
+      container
+    );
+    
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    
+    // .context-notice should be absent when totalTokens is low, even if inputTokens is high
+    const notice = container.querySelector(".context-notice");
+    expect(notice).toBeNull();
+  });
 });

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -255,7 +255,10 @@ function renderContextNotice(
   session: GatewaySessionRow | undefined,
   defaultContextTokens: number | null,
 ) {
-  const used = session?.inputTokens ?? 0;
+  // Use totalTokens for context utilization display. inputTokens accumulates
+  // all API calls in a run (tool loops, compaction retries), overstating
+  // actual context size. totalTokens reflects the final API call's context.
+  const used = session?.totalTokens ?? session?.inputTokens ?? 0;
   const limit = session?.contextTokens ?? defaultContextTokens ?? 0;
   if (!used || !limit) {
     return nothing;


### PR DESCRIPTION
## Problem

Control UI incorrectly displays context usage as 510.4k/128k (100%) when actual usage is only 109k/128k (86%). The incorrect display persists until the page is refreshed.

## Root Cause

The `renderContextNotice` function in `ui/src/ui/views/chat.ts` was using `session.inputTokens` to display context utilization. However, `inputTokens` accumulates all API call input tokens across an entire run (including tool-use loops and compaction retries), which significantly overstates the actual context window utilization.

## Solution

Use `totalTokens` instead of `inputTokens` for context usage display. The `totalTokens` field is calculated using `lastCallUsage`, which reflects only the final API call's context size - the true context window utilization.

## Changes

- `ui/src/ui/views/chat.ts`: Updated `renderContextNotice` to use `totalTokens` with fallback to `inputTokens`

## Testing

- Context usage indicator now shows accurate utilization percentage
- Matches `/status` command output
- No more discrepancy between UI and actual session state

Fixes #50196