### PR TITLE
Add sms.read command and SMS messaging channel

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.SEND_SMS" />
     <uses-permission android:name="android.permission.READ_SMS" />
+    <uses-permission android:name="android.permission.RECEIVE_SMS" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
     <uses-permission
@@ -55,6 +56,14 @@
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>
         </service>
+        <receiver
+            android:name=".node.SmsBroadcastReceiver"
+            android:exported="true"
+            android:permission="android.permission.BROADCAST_SMS">
+            <intent-filter>
+                <action android:name="android.provider.Telephony.SMS_RECEIVED" />
+            </intent-filter>
+        </receiver>
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -312,6 +312,11 @@ class NodeRuntime(
         nodeSession.sendNodeEvent(event = event, payloadJson = payloadJson)
       }
     }
+    SmsChannelBridge.setEventSink { event, payloadJson ->
+      scope.launch {
+        nodeSession.sendNodeEvent(event = event, payloadJson = payloadJson)
+      }
+    }
   }
 
   private val chat: ChatController =

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
@@ -202,6 +202,10 @@ object InvokeCommandRegistry {
         availability = InvokeCommandAvailability.ReadSmsAvailable,
       ),
       InvokeCommandSpec(
+        name = OpenClawSmsCommand.Read.rawValue,
+        availability = InvokeCommandAvailability.ReadSmsAvailable,
+      ),
+      InvokeCommandSpec(
         name = OpenClawCallLogCommand.Search.rawValue,
         availability = InvokeCommandAvailability.CallLogAvailable,
       ),

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
@@ -165,6 +165,7 @@ class InvokeDispatcher(
       // SMS command
       OpenClawSmsCommand.Send.rawValue -> smsHandler.handleSmsSend(paramsJson)
       OpenClawSmsCommand.Search.rawValue -> smsHandler.handleSmsSearch(paramsJson)
+      OpenClawSmsCommand.Read.rawValue -> smsHandler.handleSmsRead(paramsJson)
 
       // CallLog command
       OpenClawCallLogCommand.Search.rawValue -> callLogHandler.handleCallLogSearch(paramsJson)

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/SmsBroadcastReceiver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/SmsBroadcastReceiver.kt
@@ -1,0 +1,41 @@
+package ai.openclaw.app.node
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.provider.Telephony
+
+/**
+ * Receives incoming SMS messages and forwards them to the gateway via [SmsChannelBridge].
+ *
+ * Registered in AndroidManifest.xml with the SMS_RECEIVED action and BROADCAST_SMS permission.
+ */
+class SmsBroadcastReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Telephony.Sms.Intents.SMS_RECEIVED_ACTION) return
+
+        val messages = Telephony.Sms.Intents.getMessagesFromIntent(intent) ?: return
+        if (messages.isEmpty()) return
+
+        // Group message parts by originating address (multi-part SMS)
+        val grouped = mutableMapOf<String, StringBuilder>()
+        val timestamps = mutableMapOf<String, Long>()
+
+        for (smsMessage in messages) {
+            val address = smsMessage.originatingAddress ?: continue
+            val body = smsMessage.messageBody ?: continue
+            grouped.getOrPut(address) { StringBuilder() }.append(body)
+            if (smsMessage.timestampMillis > (timestamps[address] ?: 0L)) {
+                timestamps[address] = smsMessage.timestampMillis
+            }
+        }
+
+        for ((address, body) in grouped) {
+            SmsChannelBridge.onSmsReceived(
+                address = address,
+                body = body.toString(),
+                timestampMs = timestamps[address] ?: System.currentTimeMillis(),
+            )
+        }
+    }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/SmsChannelBridge.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/SmsChannelBridge.kt
@@ -1,0 +1,30 @@
+package ai.openclaw.app.node
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Singleton bridge between the SMS BroadcastReceiver (which has no access to
+ * the gateway session) and the NodeRuntime event sink.
+ */
+object SmsChannelBridge {
+    private const val MAX_SMS_BODY_CHARS = 4000
+
+    @Volatile
+    private var eventSink: ((event: String, payloadJson: String?) -> Unit)? = null
+
+    fun setEventSink(sink: ((event: String, payloadJson: String?) -> Unit)?) {
+        eventSink = sink
+    }
+
+    fun onSmsReceived(address: String, body: String, timestampMs: Long) {
+        val payload = JsonObject(
+            mapOf(
+                "from" to JsonPrimitive(address),
+                "body" to JsonPrimitive(body.take(MAX_SMS_BODY_CHARS)),
+                "timestampMs" to JsonPrimitive(timestampMs),
+            )
+        ).toString()
+        eventSink?.invoke("sms.received", payload)
+    }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/SmsHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/SmsHandler.kt
@@ -28,4 +28,16 @@ class SmsHandler(
       return GatewaySession.InvokeResult.error(code = code, message = error)
     }
   }
+
+  suspend fun handleSmsRead(paramsJson: String?): GatewaySession.InvokeResult {
+    val res = sms.read(paramsJson)
+    if (res.ok) {
+      return GatewaySession.InvokeResult.ok(res.payloadJson)
+    } else {
+      val error = res.error ?: "SMS_READ_FAILED"
+      val idx = error.indexOf(':')
+      val code = if (idx > 0) error.substring(0, idx).trim() else "SMS_READ_FAILED"
+      return GatewaySession.InvokeResult.error(code = code, message = error)
+    }
+  }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/SmsManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/SmsManager.kt
@@ -76,6 +76,24 @@ class SmsManager(private val context: Context) {
         ) : ParseResult()
     }
 
+    data class ReadResult(
+        val ok: Boolean,
+        val messages: List<SmsMessage>,
+        val error: String? = null,
+        val payloadJson: String,
+    )
+
+    internal data class ReadParams(
+        val id: Long? = null,
+        val threadId: Long? = null,
+        val limit: Int = DEFAULT_READ_LIMIT,
+    )
+
+    internal sealed class ReadParseResult {
+        data class Ok(val params: ReadParams) : ReadParseResult()
+        data class Error(val error: String) : ReadParseResult()
+    }
+
     internal data class QueryParams(
         val startTime: Long? = null,
         val endTime: Long? = null,
@@ -100,7 +118,22 @@ class SmsManager(private val context: Context) {
 
     companion object {
         private const val DEFAULT_SMS_LIMIT = 25
+        private const val DEFAULT_READ_LIMIT = 50
+        private const val MAX_READ_LIMIT = 200
         internal val JsonConfig = Json { ignoreUnknownKeys = true }
+
+        private val SMS_PROJECTION = arrayOf(
+            Telephony.Sms._ID,
+            Telephony.Sms.THREAD_ID,
+            Telephony.Sms.ADDRESS,
+            Telephony.Sms.PERSON,
+            Telephony.Sms.DATE,
+            Telephony.Sms.DATE_SENT,
+            Telephony.Sms.READ,
+            Telephony.Sms.TYPE,
+            Telephony.Sms.BODY,
+            Telephony.Sms.STATUS,
+        )
 
         internal fun parseParams(paramsJson: String?, json: Json = JsonConfig): ParseResult {
             val params = paramsJson?.trim().orEmpty()
@@ -136,6 +169,30 @@ class SmsManager(private val context: Context) {
             }
 
             return ParseResult.Ok(ParsedParams(to = to, message = message))
+        }
+
+        internal fun parseReadParams(paramsJson: String?, json: Json = JsonConfig): ReadParseResult {
+            val params = paramsJson?.trim().orEmpty()
+            if (params.isEmpty()) {
+                return ReadParseResult.Error("INVALID_REQUEST: id or threadId required")
+            }
+
+            val obj = try {
+                json.parseToJsonElement(params).jsonObject
+            } catch (_: Throwable) {
+                return ReadParseResult.Error("INVALID_REQUEST: expected JSON object")
+            }
+
+            val id = (obj["id"] as? JsonPrimitive)?.content?.toLongOrNull()
+            val threadId = (obj["threadId"] as? JsonPrimitive)?.content?.toLongOrNull()
+            val limit = ((obj["limit"] as? JsonPrimitive)?.content?.toIntOrNull() ?: DEFAULT_READ_LIMIT)
+                .coerceIn(1, MAX_READ_LIMIT)
+
+            if (id == null && threadId == null) {
+                return ReadParseResult.Error("INVALID_REQUEST: id or threadId required")
+            }
+
+            return ReadParseResult.Ok(ReadParams(id = id, threadId = threadId, limit = limit))
         }
 
         internal fun parseQueryParams(paramsJson: String?, json: Json = JsonConfig): QueryParseResult {
@@ -181,7 +238,7 @@ class SmsManager(private val context: Context) {
         }
 
         private fun normalizePhoneNumber(phone: String): String {
-            return phone.replace(Regex("""[\s\-()]"""), "")
+            return phone.replace(Regex("""[\s\-.()]"""), "")
         }
 
         internal fun buildSendPlan(
@@ -285,6 +342,9 @@ class SmsManager(private val context: Context) {
             )
         }
 
+        // Also request RECEIVE_SMS so inbound SMS delivery works via SmsBroadcastReceiver.
+        ensureReceiveSmsPermission()
+
         val parseResult = parseParams(paramsJson, json)
         if (parseResult is ParseResult.Error) {
             return errorResult(
@@ -346,6 +406,16 @@ class SmsManager(private val context: Context) {
         val requester = permissionRequester ?: return false
         val results = requester.requestIfMissing(listOf(Manifest.permission.READ_SMS))
         return results[Manifest.permission.READ_SMS] == true
+    }
+
+    private fun hasReceiveSmsPermission(): Boolean =
+        context.checkSelfPermission(Manifest.permission.RECEIVE_SMS) == PackageManager.PERMISSION_GRANTED
+
+    private suspend fun ensureReceiveSmsPermission(): Boolean {
+        if (hasReceiveSmsPermission()) return true
+        val requester = permissionRequester ?: return false
+        val results = requester.requestIfMissing(listOf(Manifest.permission.RECEIVE_SMS))
+        return results[Manifest.permission.RECEIVE_SMS] == true
     }
 
     private suspend fun ensureReadContactsPermission(): Boolean {
@@ -458,6 +528,136 @@ class SmsManager(private val context: Context) {
                 payloadJson = buildQueryPayloadJson(json, ok = false, messages = emptyList(), error = "SMS_QUERY_FAILED: ${e.message ?: "unknown error"}")
             )
         }
+    }
+
+    /**
+     * Read SMS messages by ID or thread ID.
+     *
+     * @param paramsJson JSON with fields:
+     *   - id (Long): Single message ID to fetch
+     *   - threadId (Long): Thread ID to fetch conversation
+     *   - limit (Int): Max messages for thread query (default: 50, max: 200)
+     * @return ReadResult containing the list of SMS messages or an error
+     */
+    suspend fun read(paramsJson: String?): ReadResult = withContext(Dispatchers.IO) {
+        if (!hasTelephonyFeature()) {
+            return@withContext ReadResult(
+                ok = false,
+                messages = emptyList(),
+                error = "SMS_UNAVAILABLE: telephony not available",
+                payloadJson = buildQueryPayloadJson(json, ok = false, messages = emptyList(), error = "SMS_UNAVAILABLE: telephony not available")
+            )
+        }
+
+        if (!ensureReadSmsPermission()) {
+            return@withContext ReadResult(
+                ok = false,
+                messages = emptyList(),
+                error = "SMS_PERMISSION_REQUIRED: grant READ_SMS permission",
+                payloadJson = buildQueryPayloadJson(json, ok = false, messages = emptyList(), error = "SMS_PERMISSION_REQUIRED: grant READ_SMS permission")
+            )
+        }
+
+        val parseResult = parseReadParams(paramsJson, json)
+        if (parseResult is ReadParseResult.Error) {
+            return@withContext ReadResult(
+                ok = false,
+                messages = emptyList(),
+                error = parseResult.error,
+                payloadJson = buildQueryPayloadJson(json, ok = false, messages = emptyList(), error = parseResult.error)
+            )
+        }
+        val params = (parseResult as ReadParseResult.Ok).params
+
+        return@withContext try {
+            val messages = if (params.id != null) {
+                // Fetch single message by ID
+                querySmsById(params.id)
+            } else {
+                // Fetch thread by threadId
+                querySmsThread(params.threadId!!, params.limit)
+            }
+            ReadResult(
+                ok = true,
+                messages = messages,
+                error = null,
+                payloadJson = buildQueryPayloadJson(json, ok = true, messages = messages)
+            )
+        } catch (e: SecurityException) {
+            ReadResult(
+                ok = false,
+                messages = emptyList(),
+                error = "SMS_PERMISSION_REQUIRED: ${e.message}",
+                payloadJson = buildQueryPayloadJson(json, ok = false, messages = emptyList(), error = "SMS_PERMISSION_REQUIRED: ${e.message}")
+            )
+        } catch (e: Throwable) {
+            ReadResult(
+                ok = false,
+                messages = emptyList(),
+                error = "SMS_READ_FAILED: ${e.message ?: "unknown error"}",
+                payloadJson = buildQueryPayloadJson(json, ok = false, messages = emptyList(), error = "SMS_READ_FAILED: ${e.message ?: "unknown error"}")
+            )
+        }
+    }
+
+    private fun querySmsById(id: Long): List<SmsMessage> {
+        val messages = mutableListOf<SmsMessage>()
+        val cursor = context.contentResolver.query(
+            Telephony.Sms.CONTENT_URI,
+            SMS_PROJECTION,
+            "${Telephony.Sms._ID} = ?",
+            arrayOf(id.toString()),
+            null
+        )
+        cursor?.use {
+            if (it.moveToFirst()) {
+                messages.add(cursorToSmsMessage(it))
+            }
+        }
+        return messages
+    }
+
+    private fun querySmsThread(threadId: Long, limit: Int): List<SmsMessage> {
+        val messages = mutableListOf<SmsMessage>()
+        val sortOrder = "${Telephony.Sms.DATE} DESC LIMIT $limit"
+        val cursor = context.contentResolver.query(
+            Telephony.Sms.CONTENT_URI,
+            SMS_PROJECTION,
+            "${Telephony.Sms.THREAD_ID} = ?",
+            arrayOf(threadId.toString()),
+            sortOrder
+        )
+        cursor?.use {
+            while (it.moveToNext()) {
+                messages.add(cursorToSmsMessage(it))
+            }
+        }
+        return messages
+    }
+
+    private fun cursorToSmsMessage(cursor: Cursor): SmsMessage {
+        val idIndex = cursor.getColumnIndex(Telephony.Sms._ID)
+        val threadIdIndex = cursor.getColumnIndex(Telephony.Sms.THREAD_ID)
+        val addressIndex = cursor.getColumnIndex(Telephony.Sms.ADDRESS)
+        val personIndex = cursor.getColumnIndex(Telephony.Sms.PERSON)
+        val dateIndex = cursor.getColumnIndex(Telephony.Sms.DATE)
+        val dateSentIndex = cursor.getColumnIndex(Telephony.Sms.DATE_SENT)
+        val readIndex = cursor.getColumnIndex(Telephony.Sms.READ)
+        val typeIndex = cursor.getColumnIndex(Telephony.Sms.TYPE)
+        val bodyIndex = cursor.getColumnIndex(Telephony.Sms.BODY)
+        val statusIndex = cursor.getColumnIndex(Telephony.Sms.STATUS)
+        return SmsMessage(
+            id = cursor.getLong(idIndex),
+            threadId = cursor.getLong(threadIdIndex),
+            address = cursor.getString(addressIndex),
+            person = cursor.getString(personIndex),
+            date = cursor.getLong(dateIndex),
+            dateSent = cursor.getLong(dateSentIndex),
+            read = cursor.getInt(readIndex) == 1,
+            type = cursor.getInt(typeIndex),
+            body = cursor.getString(bodyIndex),
+            status = cursor.getInt(statusIndex)
+        )
     }
 
     /**

--- a/apps/android/app/src/main/java/ai/openclaw/app/protocol/OpenClawProtocolConstants.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/protocol/OpenClawProtocolConstants.kt
@@ -54,6 +54,7 @@ enum class OpenClawCameraCommand(val rawValue: String) {
 enum class OpenClawSmsCommand(val rawValue: String) {
   Send("sms.send"),
   Search("sms.search"),
+  Read("sms.read"),
   ;
 
   companion object {

--- a/apps/android/app/src/play/AndroidManifest.xml
+++ b/apps/android/app/src/play/AndroidManifest.xml
@@ -10,4 +10,7 @@
     <uses-permission
         android:name="android.permission.READ_CALL_LOG"
         tools:node="remove" />
+    <uses-permission
+        android:name="android.permission.RECEIVE_SMS"
+        tools:node="remove" />
 </manifest>

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1638,6 +1638,24 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
 
 </Accordion>
 
+### SMS (Android node)
+
+SMS messaging via a connected Android node. DM-only (no group support).
+
+```json5
+{
+  channels: {
+    sms: {
+      allowFrom: ["+15551234567"], // phone numbers allowed to send SMS to the agent
+    },
+  },
+}
+```
+
+- `allowFrom`: phone number allowlist. Normalized (spaces, dashes, parens stripped). Empty list rejects all inbound SMS.
+- Outbound delivery routes through the connected Android node's SMS manager.
+- Use `/allowlist add sms +15551234567` to manage the allowlist at runtime.
+
 ---
 
 ## Messages

--- a/src/channels/ids.ts
+++ b/src/channels/ids.ts
@@ -11,6 +11,7 @@ export const CHAT_CHANNEL_ORDER = [
   "signal",
   "imessage",
   "line",
+  "sms",
 ] as const;
 
 export type ChatChannelId = (typeof CHAT_CHANNEL_ORDER)[number];

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -17,6 +17,7 @@ import { synologyChatPlugin } from "../../../extensions/synology-chat/index.js";
 import { telegramPlugin, setTelegramRuntime } from "../../../extensions/telegram/index.js";
 import { telegramSetupPlugin } from "../../../extensions/telegram/setup-entry.js";
 import { zaloPlugin } from "../../../extensions/zalo/index.js";
+import { smsPlugin } from "../sms/channel.js";
 import type { ChannelId, ChannelPlugin } from "./types.js";
 
 export const bundledChannelPlugins = [
@@ -30,6 +31,7 @@ export const bundledChannelPlugins = [
   nextcloudTalkPlugin,
   signalPlugin,
   slackPlugin,
+  smsPlugin,
   synologyChatPlugin,
   telegramPlugin,
   zaloPlugin,

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -133,6 +133,16 @@ const CHAT_CHANNEL_META: Record<ChatChannelId, ChannelMeta> = {
     blurb: "LINE Messaging API webhook bot.",
     systemImage: "message",
   },
+  sms: {
+    id: "sms",
+    label: "SMS",
+    selectionLabel: "SMS (Android node)",
+    detailLabel: "SMS",
+    docsPath: "/channels/sms",
+    docsLabel: "sms",
+    blurb: "send and receive SMS via a connected Android device.",
+    systemImage: "message",
+  },
 };
 
 export const CHAT_CHANNEL_ALIASES: Record<string, ChatChannelId> = {

--- a/src/channels/sms/channel.ts
+++ b/src/channels/sms/channel.ts
@@ -1,0 +1,91 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import { buildLegacyDmAccountAllowlistAdapter } from "../../plugin-sdk/allowlist-config-edit.js";
+import type { ChannelConfigAdapter, ChannelOutboundAdapter } from "../plugins/types.adapters.js";
+import type { ChannelCapabilities, ChannelMeta } from "../plugins/types.core.js";
+import type { ChannelPlugin } from "../plugins/types.plugin.js";
+import { sendSmsViaNode } from "./outbound.js";
+
+const SMS_CHANNEL_ID = "sms";
+const DEFAULT_ACCOUNT_ID = "default";
+
+type ResolvedSmsAccount = {
+  accountId: string;
+  config: {
+    allowFrom?: Array<string | number>;
+  };
+};
+
+const smsMeta: ChannelMeta = {
+  id: SMS_CHANNEL_ID,
+  label: "SMS",
+  selectionLabel: "SMS (Android node)",
+  detailLabel: "SMS",
+  docsPath: "/channels/sms",
+  docsLabel: "sms",
+  blurb: "send and receive SMS via a connected Android device.",
+  systemImage: "message",
+};
+
+const smsCapabilities: ChannelCapabilities = {
+  chatTypes: ["direct"],
+};
+
+const smsConfig: ChannelConfigAdapter<ResolvedSmsAccount> = {
+  listAccountIds: () => [DEFAULT_ACCOUNT_ID],
+  resolveAccount: (cfg: OpenClawConfig, accountId?: string | null) => {
+    const id = accountId || DEFAULT_ACCOUNT_ID;
+    const channels = (cfg as Record<string, unknown>).channels as
+      | Record<string, unknown>
+      | undefined;
+    const smsChannelConfig = channels?.sms as Record<string, unknown> | undefined;
+    const allowFrom = smsChannelConfig?.allowFrom as Array<string | number> | undefined;
+    return {
+      accountId: id,
+      config: {
+        allowFrom,
+      },
+    };
+  },
+  resolveAllowFrom: (params) => {
+    const channels = (params.cfg as Record<string, unknown>).channels as
+      | Record<string, unknown>
+      | undefined;
+    const smsChannelConfig = channels?.sms as Record<string, unknown> | undefined;
+    return smsChannelConfig?.allowFrom as Array<string | number> | undefined;
+  },
+};
+
+const smsOutbound: ChannelOutboundAdapter = {
+  deliveryMode: "gateway",
+  textChunkLimit: 1600,
+  sendText: async ({ to, text, deps, accountId }) => {
+    const result = await sendSmsViaNode({ to, text, nodeId: accountId, deps });
+    if (!result.ok) {
+      throw new Error(result.error ?? "SMS send failed");
+    }
+    return {
+      channel: SMS_CHANNEL_ID,
+      messageId: result.messageId ?? `sms-${Date.now()}`,
+    };
+  },
+};
+
+function normalizePhoneNumber(raw: string): string {
+  return raw.replace(/[\s\-.()]/g, "");
+}
+
+const smsAllowlist = buildLegacyDmAccountAllowlistAdapter<ResolvedSmsAccount>({
+  channelId: SMS_CHANNEL_ID,
+  resolveAccount: ({ cfg, accountId }) => smsConfig.resolveAccount(cfg, accountId),
+  normalize: ({ values }) => values.map((v) => normalizePhoneNumber(String(v))),
+  resolveDmAllowFrom: (account) => account.config.allowFrom,
+});
+
+export const smsPlugin: ChannelPlugin<ResolvedSmsAccount> = {
+  id: SMS_CHANNEL_ID,
+  meta: smsMeta,
+  capabilities: smsCapabilities,
+  config: smsConfig,
+  outbound: smsOutbound,
+  allowlist: smsAllowlist,
+};

--- a/src/channels/sms/inbound.ts
+++ b/src/channels/sms/inbound.ts
@@ -1,0 +1,80 @@
+import { agentCommandFromIngress } from "../../agents/agent-command.js";
+import { loadConfig } from "../../config/config.js";
+import type { NodeEventContext } from "../../gateway/server-node-events-types.js";
+import { resolveAgentRoute } from "../../routing/resolve-route.js";
+import { defaultRuntime } from "../../runtime.js";
+import { isSenderIdAllowed, mergeDmAllowFromSources } from "../allow-from.js";
+
+const SMS_CHANNEL_ID = "sms";
+
+function normalizePhoneNumber(raw: string): string {
+  return raw.replace(/[\s\-.()]/g, "");
+}
+
+export async function handleIncomingSms(
+  ctx: NodeEventContext,
+  nodeId: string,
+  payload: { from: string; body: string; timestampMs: number },
+) {
+  const from = normalizePhoneNumber(payload.from);
+  if (!from || !payload.body) {
+    return;
+  }
+
+  const cfg = loadConfig();
+
+  // Allowlist gating: only route SMS from allowed phone numbers
+  const channels = (cfg as Record<string, unknown>).channels as Record<string, unknown> | undefined;
+  const smsConfig = channels?.sms as Record<string, unknown> | undefined;
+  const rawAllowFrom = mergeDmAllowFromSources({
+    allowFrom: smsConfig?.allowFrom as Array<string | number> | undefined,
+  });
+  // Normalize allowFrom entries with the same phone normalization so formats like
+  // "+1 (555) 123-4567" match the normalized sender "+15551234567".
+  const allowFrom = rawAllowFrom.map((entry) =>
+    entry === "*" ? entry : normalizePhoneNumber(entry),
+  );
+  const allowed = isSenderIdAllowed(
+    {
+      entries: allowFrom,
+      hasWildcard: allowFrom.includes("*"),
+      hasEntries: allowFrom.length > 0,
+    },
+    from,
+    false, // reject when allowlist is empty
+  );
+  if (!allowed) {
+    return;
+  }
+
+  const route = resolveAgentRoute({
+    cfg,
+    channel: SMS_CHANNEL_ID,
+    accountId: "default",
+    peer: { kind: "direct", id: from },
+  });
+
+  void agentCommandFromIngress(
+    {
+      message: payload.body,
+      sessionKey: route.sessionKey,
+      thinking: "low",
+      deliver: true,
+      to: from,
+      channel: SMS_CHANNEL_ID,
+      accountId: nodeId,
+      messageChannel: SMS_CHANNEL_ID,
+      inputProvenance: {
+        kind: "external_user",
+        sourceChannel: SMS_CHANNEL_ID,
+        sourceTool: "gateway.sms.received",
+      },
+      senderIsOwner: false,
+      allowModelOverride: false,
+    },
+    defaultRuntime,
+    ctx.deps,
+  ).catch((err) => {
+    ctx.logGateway.warn(`sms inbound agent failed node=${nodeId} from=${from}: ${String(err)}`);
+  });
+}

--- a/src/channels/sms/outbound.ts
+++ b/src/channels/sms/outbound.ts
@@ -1,0 +1,65 @@
+import type { NodeRegistry } from "../../gateway/node-registry.js";
+import type { OutboundSendDeps } from "../../infra/outbound/deliver.js";
+
+let smsNodeRegistry: NodeRegistry | null = null;
+
+/**
+ * Called by the gateway server to wire the node registry into the SMS outbound
+ * adapter so it can invoke `sms.send` on connected Android nodes.
+ */
+export function setSmsNodeRegistry(registry: NodeRegistry | null) {
+  smsNodeRegistry = registry;
+}
+
+function findAndroidNodeWithSms(registry: NodeRegistry): { nodeId: string } | null {
+  const connected = registry.listConnected();
+  for (const node of connected) {
+    const isAndroid =
+      node.platform?.toLowerCase().startsWith("android") ||
+      node.deviceFamily?.toLowerCase().includes("android");
+    if (isAndroid && node.commands?.includes("sms.send")) {
+      return { nodeId: node.nodeId };
+    }
+  }
+  return null;
+}
+
+export async function sendSmsViaNode(params: {
+  to: string;
+  text: string;
+  nodeId?: string | null;
+  deps?: OutboundSendDeps | null;
+}): Promise<{ ok: boolean; messageId?: string; error?: string }> {
+  const registry = smsNodeRegistry;
+  if (!registry) {
+    return { ok: false, error: "SMS gateway not initialized" };
+  }
+
+  // Prefer the specific node that received the inbound SMS (passed via accountId),
+  // falling back to any connected Android node with SMS capability.
+  let targetNodeId = params.nodeId?.trim() || null;
+  if (targetNodeId && !registry.get(targetNodeId)) {
+    targetNodeId = null; // node disconnected, fall back
+  }
+  const node = targetNodeId ? { nodeId: targetNodeId } : findAndroidNodeWithSms(registry);
+  if (!node) {
+    return { ok: false, error: "No Android node with SMS capability connected" };
+  }
+
+  const result = await registry.invoke({
+    nodeId: node.nodeId,
+    command: "sms.send",
+    params: { to: params.to, message: params.text },
+    timeoutMs: 30_000,
+  });
+
+  if (!result.ok) {
+    const errorMsg = result.error?.message ?? "sms.send failed";
+    return { ok: false, error: errorMsg };
+  }
+
+  return {
+    ok: true,
+    messageId: `sms-${Date.now()}`,
+  };
+}

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -45,7 +45,7 @@ const PHOTOS_COMMANDS = ["photos.latest"];
 
 const MOTION_COMMANDS = ["motion.activity", "motion.pedometer"];
 
-const SMS_COMMANDS = ["sms.search"];
+const SMS_COMMANDS = ["sms.search", "sms.read"];
 const SMS_DANGEROUS_COMMANDS = ["sms.send"];
 
 // iOS nodes don't implement system.run/which, but they do support notifications.

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -580,6 +580,24 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       requestHeartbeatNow(scopedHeartbeatWakeOptions(sessionKey, { reason: "exec-event" }));
       return;
     }
+    case "sms.received": {
+      const obj = parsePayloadObject(evt.payloadJSON);
+      if (!obj) {
+        return;
+      }
+      const from = typeof obj.from === "string" ? obj.from.trim() : "";
+      const body = typeof obj.body === "string" ? obj.body.trim() : "";
+      if (!from || !body) {
+        return;
+      }
+      const timestampMs =
+        typeof obj.timestampMs === "number" && Number.isFinite(obj.timestampMs)
+          ? obj.timestampMs
+          : Date.now();
+      const { handleIncomingSms } = await import("../channels/sms/inbound.js");
+      await handleIncomingSms(ctx, nodeId, { from, body, timestampMs });
+      return;
+    }
     case "push.apns.register": {
       const obj = parsePayloadObject(evt.payloadJSON);
       if (!obj) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -776,6 +776,11 @@ export async function startGatewayServer(
     setSkillsRemoteRegistry(nodeRegistry);
     void primeRemoteSkillsCache();
   }
+  // Wire SMS channel outbound to the node registry so sms.send can reach Android nodes.
+  {
+    const { setSmsNodeRegistry } = await import("../channels/sms/outbound.js");
+    setSmsNodeRegistry(nodeRegistry);
+  }
   // Debounce skills-triggered node probes to avoid feedback loops and rapid-fire invokes.
   // Skills changes can happen in bursts (e.g., file watcher events), and each probe
   // takes time to complete. A 30-second delay ensures we batch changes together.


### PR DESCRIPTION
## Summary

- Add `sms.read` invoke command to the Android app for fetching SMS messages by ID or thread ID
- Add SMS as a full OpenClaw messaging channel: incoming texts are routed to agents, agent replies are sent back as SMS via the connected Android node

## Part 1: `sms.read` command

Extends the existing SMS infrastructure (`sms.send`, `sms.search`) with a new `sms.read` command:
- Accepts `{ id?: Long, threadId?: Long, limit?: Int }` parameters
- If `id` is provided: returns a single message by `_ID`
- If `threadId` is provided: returns conversation messages ordered by date (default 50, max 200)
- Reuses existing `SmsMessage` data class and `buildQueryPayloadJson()` helper
- Added to gateway node command policy allowlist for Android nodes

## Part 2: SMS channel

Node-mediated channel architecture:
```
Incoming SMS → SmsBroadcastReceiver → SmsChannelBridge → gateway sendNodeEvent("sms.received")
→ handleNodeEvent() → handleIncomingSms() → resolveAgentRoute() → agentCommandFromIngress()
→ agent reply → sms.send invoke → Android node sends SMS
```

### Android side
- `SmsBroadcastReceiver`: listens for `SMS_RECEIVED`, groups multi-part messages, forwards to bridge
- `SmsChannelBridge`: static singleton bridging receiver to gateway session event sink
- `RECEIVE_SMS` permission added to manifest

### Gateway side
- `src/channels/sms/inbound.ts`: handles `sms.received` events with allowlist gating and agent routing
- `src/channels/sms/outbound.ts`: sends replies via `sms.send` node invoke on connected Android nodes
- `src/channels/sms/channel.ts`: channel plugin registration (text-only, DMs only)
- SMS registered as a built-in channel in IDs, registry metadata, and bundled plugins

### Allowlist gating
- Only SMS from numbers in `sms.allowFrom` config are routed to agents
- Unknown numbers are silently dropped
- Managed via `openclaw allowlist add sms <phone>` / `openclaw allowlist remove sms <phone>`

## Test plan

- [ ] `pnpm build` passes
- [ ] `pnpm check` passes
- [ ] Scoped tests pass (gateway-misc, allow-from, registry, resolve-route)
- [ ] Build Android app: verify no compile errors
- [ ] Test `sms.read` on a real Android device with SMS messages
- [ ] Test SMS channel end-to-end: send a text → verify agent receives → verify reply sent as SMS