### PR TITLE
fix(hooks): recover session-memory transcript on timed-out /new (#50752)

### DIFF
--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -518,30 +518,84 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("assistant: Recovered by sessionId fallback");
   });
 
-  it("recovers transcript when previousSessionEntry is missing (timed-out /new)", async () => {
-    const { tempDir, sessionsDir } = await createSessionMemoryWorkspace();
+  it("recovers the newest recent reset transcript when previousSessionEntry is missing", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-02-16T22:26:35.000Z"));
 
-    const oldSessionId = "old-stale-session";
-    const newEphemeralSessionId = "new-ephemeral-session";
+      const { tempDir, sessionsDir } = await createSessionMemoryWorkspace();
+      const newEphemeralSessionId = "new-ephemeral-session";
 
-    await writeWorkspaceFile({
-      dir: sessionsDir,
-      name: `${oldSessionId}.jsonl.reset.2026-02-16T22-26-33.000Z`,
-      content: createMockSessionContent([
-        { role: "user", content: "Recovered after timed-out /new (from latest reset)" },
-        { role: "assistant", content: "Recovered summary" },
-      ]),
-    });
+      await writeWorkspaceFile({
+        dir: sessionsDir,
+        name: "zzz-older-session.jsonl.reset.2026-02-16T22-25-20.000Z",
+        content: createMockSessionContent([
+          { role: "user", content: "Older reset transcript" },
+          { role: "assistant", content: "Should not be selected by file name" },
+        ]),
+      });
+      await writeWorkspaceFile({
+        dir: sessionsDir,
+        name: "aaa-fresh-session.jsonl.reset.2026-02-16T22-26-34.000Z",
+        content: createMockSessionContent([
+          { role: "user", content: "Recovered after timed-out /new (recent reset)" },
+          { role: "assistant", content: "Recovered summary" },
+        ]),
+      });
 
-    const { memoryContent } = await runNewWithSessionEntryOnly({
-      tempDir,
-      cfg: makeSessionMemoryConfig(tempDir),
-      sessionEntry: { sessionId: newEphemeralSessionId },
-      action: "new",
-    });
+      const { memoryContent } = await runNewWithSessionEntryOnly({
+        tempDir,
+        cfg: makeSessionMemoryConfig(tempDir),
+        sessionEntry: { sessionId: newEphemeralSessionId },
+        action: "new",
+      });
 
-    expect(memoryContent).toContain("user: Recovered after timed-out /new (from latest reset)");
-    expect(memoryContent).toContain("assistant: Recovered summary");
+      expect(memoryContent).toContain("user: Recovered after timed-out /new (recent reset)");
+      expect(memoryContent).toContain("assistant: Recovered summary");
+      expect(memoryContent).not.toContain("Older reset transcript");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("skips timed-out /new recovery when multiple recent reset transcripts make it ambiguous", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-02-16T22:26:35.000Z"));
+
+      const { tempDir, sessionsDir } = await createSessionMemoryWorkspace();
+
+      await writeWorkspaceFile({
+        dir: sessionsDir,
+        name: "alpha-session.jsonl.reset.2026-02-16T22-26-34.000Z",
+        content: createMockSessionContent([
+          { role: "user", content: "Ambiguous recent reset A" },
+          { role: "assistant", content: "Should not be recovered" },
+        ]),
+      });
+      await writeWorkspaceFile({
+        dir: sessionsDir,
+        name: "beta-session.jsonl.reset.2026-02-16T22-26-20.000Z",
+        content: createMockSessionContent([
+          { role: "user", content: "Ambiguous recent reset B" },
+          { role: "assistant", content: "Should not be recovered either" },
+        ]),
+      });
+
+      const { files, memoryContent } = await runNewWithSessionEntryOnly({
+        tempDir,
+        cfg: makeSessionMemoryConfig(tempDir),
+        sessionEntry: { sessionId: "new-ephemeral-session" },
+        action: "new",
+      });
+
+      expect(files.length).toBe(1);
+      expect(memoryContent).not.toContain("## Conversation Summary");
+      expect(memoryContent).not.toContain("Ambiguous recent reset A");
+      expect(memoryContent).not.toContain("Ambiguous recent reset B");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("prefers the newest reset transcript when multiple reset candidates exist", async () => {

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -92,6 +92,38 @@ async function runNewWithPreviousSessionEntry(params: {
   return { files, memoryContent };
 }
 
+async function runNewWithSessionEntryOnly(params: {
+  tempDir: string;
+  sessionEntry: { sessionId: string; sessionFile?: string };
+  cfg?: OpenClawConfig;
+  action?: "new" | "reset";
+  sessionKey?: string;
+  workspaceDirOverride?: string;
+}): Promise<{ files: string[]; memoryContent: string }> {
+  const event = createHookEvent(
+    "command",
+    params.action ?? "new",
+    params.sessionKey ?? "agent:main:main",
+    {
+      cfg:
+        params.cfg ??
+        ({
+          agents: { defaults: { workspace: params.tempDir } },
+        } satisfies OpenClawConfig),
+      sessionEntry: params.sessionEntry,
+      ...(params.workspaceDirOverride ? { workspaceDir: params.workspaceDirOverride } : {}),
+    },
+  );
+
+  await handler(event);
+
+  const memoryDir = path.join(params.tempDir, "memory");
+  const files = await fs.readdir(memoryDir);
+  const memoryContent =
+    files.length > 0 ? await fs.readFile(path.join(memoryDir, files[0]), "utf-8") : "";
+  return { files, memoryContent };
+}
+
 async function runNewWithPreviousSession(params: {
   sessionContent: string;
   cfg?: (tempDir: string) => OpenClawConfig;
@@ -484,6 +516,32 @@ describe("session-memory hook", () => {
 
     expect(memoryContent).toContain("user: Recovered with missing sessionFile pointer");
     expect(memoryContent).toContain("assistant: Recovered by sessionId fallback");
+  });
+
+  it("recovers transcript when previousSessionEntry is missing (timed-out /new)", async () => {
+    const { tempDir, sessionsDir } = await createSessionMemoryWorkspace();
+
+    const oldSessionId = "old-stale-session";
+    const newEphemeralSessionId = "new-ephemeral-session";
+
+    await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: `${oldSessionId}.jsonl.reset.2026-02-16T22-26-33.000Z`,
+      content: createMockSessionContent([
+        { role: "user", content: "Recovered after timed-out /new (from latest reset)" },
+        { role: "assistant", content: "Recovered summary" },
+      ]),
+    });
+
+    const { memoryContent } = await runNewWithSessionEntryOnly({
+      tempDir,
+      cfg: makeSessionMemoryConfig(tempDir),
+      sessionEntry: { sessionId: newEphemeralSessionId },
+      action: "new",
+    });
+
+    expect(memoryContent).toContain("user: Recovered after timed-out /new (from latest reset)");
+    expect(memoryContent).toContain("assistant: Recovered summary");
   });
 
   it("prefers the newest reset transcript when multiple reset candidates exist", async () => {

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveStateDir } from "../../../config/paths.js";
+import { parseSessionArchiveTimestamp } from "../../../config/sessions/artifacts.js";
 import { writeFileWithinRoot } from "../../../infra/fs-safe.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import {
@@ -27,6 +28,13 @@ import type { HookHandler } from "../../hooks.js";
 import { generateSlugViaLLM } from "../../llm-slug-generator.js";
 
 const log = createSubsystemLogger("hooks/session-memory");
+const RESET_RECOVERY_MAX_AGE_MS = 30_000;
+const RESET_RECOVERY_AMBIGUITY_GAP_MS = 30_000;
+
+type ResetTranscriptCandidate = {
+  name: string;
+  archivedAtMs: number;
+};
 
 function resolveDisplaySessionKey(params: {
   cfg?: OpenClawConfig;
@@ -139,6 +147,30 @@ function stripResetSuffix(fileName: string): string {
   return resetIndex === -1 ? fileName : fileName.slice(0, resetIndex);
 }
 
+function listResetTranscriptCandidates(files: string[]): ResetTranscriptCandidate[] {
+  return files
+    .filter((name) => name.includes(".jsonl.reset."))
+    .map((name) => ({
+      name,
+      archivedAtMs: parseSessionArchiveTimestamp(name, "reset") ?? Number.NaN,
+    }))
+    .filter((candidate) => Number.isFinite(candidate.archivedAtMs))
+    .toSorted((a, b) => b.archivedAtMs - a.archivedAtMs);
+}
+
+function findLatestResetForSessionId(
+  candidates: ResetTranscriptCandidate[],
+  sessionId: string,
+): ResetTranscriptCandidate | undefined {
+  return candidates.find((candidate) => {
+    const name = candidate.name;
+    return (
+      name.startsWith(`${sessionId}.jsonl.reset.`) ||
+      (name.startsWith(`${sessionId}-topic-`) && name.includes(".jsonl.reset."))
+    );
+  });
+}
+
 async function findPreviousSessionFile(params: {
   sessionsDir: string;
   currentSessionFile?: string;
@@ -147,6 +179,7 @@ async function findPreviousSessionFile(params: {
   try {
     const files = await fs.readdir(params.sessionsDir);
     const fileSet = new Set(files);
+    const resetCandidates = listResetTranscriptCandidates(files);
 
     const baseFromReset = params.currentSessionFile
       ? stripResetSuffix(path.basename(params.currentSessionFile))
@@ -174,6 +207,11 @@ async function findPreviousSessionFile(params: {
       if (topicVariants.length > 0) {
         return path.join(params.sessionsDir, topicVariants[0]);
       }
+
+      const latestResetForSession = findLatestResetForSessionId(resetCandidates, trimmedSessionId);
+      if (latestResetForSession) {
+        return path.join(params.sessionsDir, latestResetForSession.name);
+      }
     }
 
     if (!params.currentSessionFile) {
@@ -193,17 +231,35 @@ async function findPreviousSessionFile(params: {
   return undefined;
 }
 
-async function findLatestResetTranscriptFile(sessionsDir: string): Promise<string | undefined> {
+async function findRecentResetTranscriptFile(params: {
+  sessionsDir: string;
+  eventTimestampMs: number;
+}): Promise<string | undefined> {
   try {
-    const files = await fs.readdir(sessionsDir);
-    // reset transcripts keep the base session file name but with an extra `.reset.<timestamp>` suffix
-    const resetFiles = files.filter((name) => name.includes(".jsonl.reset."));
-    if (resetFiles.length === 0) {
+    const candidates = listResetTranscriptCandidates(await fs.readdir(params.sessionsDir));
+    const latest = candidates[0];
+    if (!latest) {
       return undefined;
     }
-    // ISO timestamps make lexicographic ordering align with recency.
-    const latest = resetFiles.toSorted().at(-1);
-    return latest ? path.join(sessionsDir, latest) : undefined;
+
+    const ageMs = params.eventTimestampMs - latest.archivedAtMs;
+    if (ageMs < 0 || ageMs > RESET_RECOVERY_MAX_AGE_MS) {
+      return undefined;
+    }
+
+    const nextLatest = candidates[1];
+    if (
+      nextLatest &&
+      latest.archivedAtMs - nextLatest.archivedAtMs < RESET_RECOVERY_AMBIGUITY_GAP_MS
+    ) {
+      log.debug("Skipping timed-out /new reset recovery because the latest archive is ambiguous", {
+        latest: latest.name,
+        nextLatest: nextLatest.name,
+      });
+      return undefined;
+    }
+
+    return path.join(params.sessionsDir, latest.name);
   } catch {
     return undefined;
   }
@@ -278,9 +334,12 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
         // Special case: for `/new` triggered after a timed-out session, `previousSessionEntry` can be missing.
         // In that case, the "current" session points to an ephemeral session without a matching transcript file,
-        // while the old transcript is already rotated into the latest `*.jsonl.reset.*` in `sessions/`.
+        // while the old transcript is already rotated into a freshly archived `*.jsonl.reset.*` in `sessions/`.
         if (event.action === "new" && !hasPreviousSessionEntry) {
-          const latestReset = await findLatestResetTranscriptFile(sessionsDir);
+          const latestReset = await findRecentResetTranscriptFile({
+            sessionsDir,
+            eventTimestampMs: event.timestamp.getTime(),
+          });
           if (latestReset) {
             currentSessionFile = latestReset;
             const baseName = path.basename(latestReset);

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -193,6 +193,22 @@ async function findPreviousSessionFile(params: {
   return undefined;
 }
 
+async function findLatestResetTranscriptFile(sessionsDir: string): Promise<string | undefined> {
+  try {
+    const files = await fs.readdir(sessionsDir);
+    // reset transcripts keep the base session file name but with an extra `.reset.<timestamp>` suffix
+    const resetFiles = files.filter((name) => name.includes(".jsonl.reset."));
+    if (resetFiles.length === 0) {
+      return undefined;
+    }
+    // ISO timestamps make lexicographic ordering align with recency.
+    const latest = resetFiles.toSorted().at(-1);
+    return latest ? path.join(sessionsDir, latest) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Save session context to memory when /new or /reset command is triggered
  */
@@ -207,6 +223,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
     log.debug("Hook triggered for reset/new command", { action: event.action });
 
     const context = event.context || {};
+    const hasPreviousSessionEntry = Boolean(context.previousSessionEntry);
     const cfg = context.cfg as OpenClawConfig | undefined;
     const contextWorkspaceDir =
       typeof context.workspaceDir === "string" && context.workspaceDir.trim().length > 0
@@ -236,7 +253,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
       string,
       unknown
     >;
-    const currentSessionId = sessionEntry.sessionId as string;
+    let currentSessionId = sessionEntry.sessionId as string;
     let currentSessionFile = (sessionEntry.sessionFile as string) || undefined;
 
     // If sessionFile is empty or looks like a new/reset file, try to find the previous session file.
@@ -253,12 +270,31 @@ const saveSessionToMemory: HookHandler = async (event) => {
           currentSessionFile,
           sessionId: currentSessionId,
         });
-        if (!recoveredSessionFile) {
-          continue;
+        if (recoveredSessionFile) {
+          currentSessionFile = recoveredSessionFile;
+          log.debug("Found previous session file", { file: currentSessionFile });
+          break;
         }
-        currentSessionFile = recoveredSessionFile;
-        log.debug("Found previous session file", { file: currentSessionFile });
-        break;
+
+        // Special case: for `/new` triggered after a timed-out session, `previousSessionEntry` can be missing.
+        // In that case, the "current" session points to an ephemeral session without a matching transcript file,
+        // while the old transcript is already rotated into the latest `*.jsonl.reset.*` in `sessions/`.
+        if (event.action === "new" && !hasPreviousSessionEntry) {
+          const latestReset = await findLatestResetTranscriptFile(sessionsDir);
+          if (latestReset) {
+            currentSessionFile = latestReset;
+            const baseName = path.basename(latestReset);
+            const match = baseName.match(/^(.+)\.jsonl\.reset\./);
+            if (match?.[1]) {
+              currentSessionId = match[1];
+            }
+            log.debug("Recovered session content from latest reset transcript", {
+              file: currentSessionFile,
+              recoveredSessionId: currentSessionId,
+            });
+            break;
+          }
+        }
       }
     }
 
@@ -323,7 +359,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const timeStr = now.toISOString().split("T")[1].split(".")[0];
 
     // Extract context details
-    const sessionId = (sessionEntry.sessionId as string) || "unknown";
+    const sessionId = currentSessionId || "unknown";
     const source = (context.commandSource as string) || "unknown";
 
     // Build Markdown entry


### PR DESCRIPTION
lobster-biscuit

## Summary
Fixes `session-memory` hook writing empty memory files when `/new` is triggered after a session has timed out and `previousSessionEntry` is missing.

When the hook cannot resolve the previous session transcript from the provided session pointers, it now falls back to the latest `*.jsonl.reset.*` transcript in `sessions/` and recovers conversation content.

## What changed
- `src/hooks/bundled/session-memory/handler.ts`
  - For `/new` with missing `previousSessionEntry`, recover transcript from the latest reset transcript file.
- `src/hooks/bundled/session-memory/handler.test.ts`
  - Added a regression test for the missing-`previousSessionEntry` timed-out `/new` scenario.

## Validation
- `pnpm exec vitest run src/hooks/bundled/session-memory/handler.test.ts`

Closes #50752
