### PR TITLE
fix(feishu): suppress duplicate final delivers from thinking models

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1,24 +1,18 @@
 import {
-  resolveSendableOutboundReplyParts,
-  resolveTextChunksWithFallback,
-  sendMediaWithLeadingCaption,
-} from "openclaw/plugin-sdk/reply-payload";
-import {
-  createChannelReplyPipeline,
   createReplyPrefixContext,
+  createTypingCallbacks,
   logTypingFailure,
   type ClawdbotConfig,
-  type OutboundIdentity,
   type ReplyPayload,
   type RuntimeEnv,
-} from "../runtime-api.js";
+} from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { sendMediaFeishu } from "./media.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedCardContent } from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMessageFeishu, sendStructuredCardFeishu, type CardHeaderConfig } from "./send.js";
+import { sendMarkdownCardFeishu, sendMessageFeishu } from "./send.js";
 import { FeishuStreamingSession, mergeStreamingText } from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
@@ -42,36 +36,6 @@ function normalizeEpochMs(timestamp: number | undefined): number | undefined {
   return timestamp < MS_EPOCH_MIN ? timestamp * 1000 : timestamp;
 }
 
-/** Build a card header from agent identity config. */
-function resolveCardHeader(
-  agentId: string,
-  identity: OutboundIdentity | undefined,
-): CardHeaderConfig {
-  const name = identity?.name?.trim() || agentId;
-  const emoji = identity?.emoji?.trim();
-  return {
-    title: emoji ? `${emoji} ${name}` : name,
-    template: identity?.theme ?? "blue",
-  };
-}
-
-/** Build a card note footer from agent identity and model context. */
-function resolveCardNote(
-  agentId: string,
-  identity: OutboundIdentity | undefined,
-  prefixCtx: { model?: string; provider?: string },
-): string {
-  const name = identity?.name?.trim() || agentId;
-  const parts: string[] = [`Agent: ${name}`];
-  if (prefixCtx.model) {
-    parts.push(`Model: ${prefixCtx.model}`);
-  }
-  if (prefixCtx.provider) {
-    parts.push(`Provider: ${prefixCtx.provider}`);
-  }
-  return parts.join(" | ");
-}
-
 export type CreateFeishuReplyDispatcherParams = {
   cfg: ClawdbotConfig;
   agentId: string;
@@ -86,7 +50,6 @@ export type CreateFeishuReplyDispatcherParams = {
   rootId?: string;
   mentionTargets?: MentionTarget[];
   accountId?: string;
-  identity?: OutboundIdentity;
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
@@ -105,7 +68,6 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     rootId,
     mentionTargets,
     accountId,
-    identity,
   } = params;
   const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
   const threadReplyMode = threadReply === true;
@@ -114,69 +76,58 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
   let typingState: TypingIndicatorState | null = null;
-  const { typingCallbacks } = createChannelReplyPipeline({
-    cfg,
-    agentId,
-    channel: "feishu",
-    accountId,
-    typing: {
-      start: async () => {
-        // Check if typing indicator is enabled (default: true)
-        if (!(account.config.typingIndicator ?? true)) {
-          return;
-        }
-        if (!replyToMessageId) {
-          return;
-        }
-        // Skip typing indicator for old messages — likely replays after context
-        // compaction that would flood users with stale notifications (#30418).
-        const messageCreateTimeMs = normalizeEpochMs(params.messageCreateTimeMs);
-        if (
-          messageCreateTimeMs !== undefined &&
-          Date.now() - messageCreateTimeMs > TYPING_INDICATOR_MAX_AGE_MS
-        ) {
-          return;
-        }
-        // Feishu reactions persist until explicitly removed, so skip keepalive
-        // re-adds when a reaction already exists. Re-adding the same emoji
-        // triggers a new push notification for every call (#28660).
-        if (typingState?.reactionId) {
-          return;
-        }
-        typingState = await addTypingIndicator({
-          cfg,
-          messageId: replyToMessageId,
-          accountId,
-          runtime: params.runtime,
-        });
-      },
-      stop: async () => {
-        if (!typingState) {
-          return;
-        }
-        await removeTypingIndicator({
-          cfg,
-          state: typingState,
-          accountId,
-          runtime: params.runtime,
-        });
-        typingState = null;
-      },
-      onStartError: (err) =>
-        logTypingFailure({
-          log: (message) => params.runtime.log?.(message),
-          channel: "feishu",
-          action: "start",
-          error: err,
-        }),
-      onStopError: (err) =>
-        logTypingFailure({
-          log: (message) => params.runtime.log?.(message),
-          channel: "feishu",
-          action: "stop",
-          error: err,
-        }),
+  const typingCallbacks = createTypingCallbacks({
+    start: async () => {
+      // Check if typing indicator is enabled (default: true)
+      if (!(account.config.typingIndicator ?? true)) {
+        return;
+      }
+      if (!replyToMessageId) {
+        return;
+      }
+      // Skip typing indicator for old messages — likely replays after context
+      // compaction that would flood users with stale notifications (#30418).
+      const messageCreateTimeMs = normalizeEpochMs(params.messageCreateTimeMs);
+      if (
+        messageCreateTimeMs !== undefined &&
+        Date.now() - messageCreateTimeMs > TYPING_INDICATOR_MAX_AGE_MS
+      ) {
+        return;
+      }
+      // Feishu reactions persist until explicitly removed, so skip keepalive
+      // re-adds when a reaction already exists. Re-adding the same emoji
+      // triggers a new push notification for every call (#28660).
+      if (typingState?.reactionId) {
+        return;
+      }
+      typingState = await addTypingIndicator({
+        cfg,
+        messageId: replyToMessageId,
+        accountId,
+        runtime: params.runtime,
+      });
     },
+    stop: async () => {
+      if (!typingState) {
+        return;
+      }
+      await removeTypingIndicator({ cfg, state: typingState, accountId, runtime: params.runtime });
+      typingState = null;
+    },
+    onStartError: (err) =>
+      logTypingFailure({
+        log: (message) => params.runtime.log?.(message),
+        channel: "feishu",
+        action: "start",
+        error: err,
+      }),
+    onStopError: (err) =>
+      logTypingFailure({
+        log: (message) => params.runtime.log?.(message),
+        channel: "feishu",
+        action: "stop",
+        error: err,
+      }),
   });
 
   const textChunkLimit = core.channel.text.resolveTextChunkLimit(cfg, "feishu", accountId, {
@@ -192,38 +143,15 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";
   let lastPartial = "";
-  let reasoningText = "";
   const deliveredFinalTexts = new Set<string>();
+  const deliveredBlockTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
+  // When a thinking-model emits multiple "final" payloads (one per tool call),
+  // we suppress intermediate finals and only deliver the last one on onIdle.
+  let pendingFinalPayload: ReplyPayload | null = null;
+  let pendingFinalMediaList: string[] = [];
   type StreamTextUpdateMode = "snapshot" | "delta";
-
-  const formatReasoningPrefix = (thinking: string): string => {
-    if (!thinking) return "";
-    const withoutLabel = thinking.replace(/^Reasoning:\n/, "");
-    const plain = withoutLabel.replace(/^_(.*)_$/gm, "$1");
-    const lines = plain.split("\n").map((line) => `> ${line}`);
-    return `> 💭 **Thinking**\n${lines.join("\n")}`;
-  };
-
-  const buildCombinedStreamText = (thinking: string, answer: string): string => {
-    const parts: string[] = [];
-    if (thinking) parts.push(formatReasoningPrefix(thinking));
-    if (thinking && answer) parts.push("\n\n---\n\n");
-    if (answer) parts.push(answer);
-    return parts.join("");
-  };
-
-  const flushStreamingCardUpdate = (combined: string) => {
-    partialUpdateQueue = partialUpdateQueue.then(async () => {
-      if (streamingStartPromise) {
-        await streamingStartPromise;
-      }
-      if (streaming?.isActive()) {
-        await streaming.update(combined);
-      }
-    });
-  };
 
   const queueStreamingUpdate = (
     nextText: string,
@@ -244,13 +172,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     const mode = options?.mode ?? "snapshot";
     streamText =
       mode === "delta" ? `${streamText}${nextText}` : mergeStreamingText(streamText, nextText);
-    flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
-  };
-
-  const queueReasoningUpdate = (nextThinking: string) => {
-    if (!nextThinking) return;
-    reasoningText = nextThinking;
-    flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
+    partialUpdateQueue = partialUpdateQueue.then(async () => {
+      if (streamingStartPromise) {
+        await streamingStartPromise;
+      }
+      if (streaming?.isActive()) {
+        await streaming.update(streamText);
+      }
+    });
   };
 
   const startStreaming = () => {
@@ -270,19 +199,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         params.runtime.log?.(`feishu[${account.accountId}] ${message}`),
       );
       try {
-        const cardHeader = resolveCardHeader(agentId, identity);
-        const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
         await streaming.start(chatId, resolveReceiveIdType(chatId), {
           replyToMessageId,
           replyInThread: effectiveReplyInThread,
           rootId,
-          header: cardHeader,
-          note: cardNote,
         });
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);
         streaming = null;
-        streamingStartPromise = null; // allow retry on next deliver
       }
     })();
   };
@@ -293,59 +217,51 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     }
     await partialUpdateQueue;
     if (streaming?.isActive()) {
-      let text = buildCombinedStreamText(reasoningText, streamText);
+      let text = streamText;
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
       }
-      const finalNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-      await streaming.close(text, { note: finalNote });
+      await streaming.close(text);
     }
     streaming = null;
     streamingStartPromise = null;
     streamText = "";
     lastPartial = "";
-    reasoningText = "";
   };
 
   const sendChunkedTextReply = async (params: {
     text: string;
     useCard: boolean;
     infoKind?: string;
-    sendChunk: (params: { chunk: string; isFirst: boolean }) => Promise<void>;
   }) => {
+    let first = true;
     const chunkSource = params.useCard
       ? params.text
       : core.channel.text.convertMarkdownTables(params.text, tableMode);
-    const chunks = resolveTextChunksWithFallback(
+    for (const chunk of core.channel.text.chunkTextWithMode(
       chunkSource,
-      core.channel.text.chunkTextWithMode(chunkSource, textChunkLimit, chunkMode),
-    );
-    for (const [index, chunk] of chunks.entries()) {
-      await params.sendChunk({
-        chunk,
-        isFirst: index === 0,
-      });
+      textChunkLimit,
+      chunkMode,
+    )) {
+      const message = {
+        cfg,
+        to: chatId,
+        text: chunk,
+        replyToMessageId: sendReplyToMessageId,
+        replyInThread: effectiveReplyInThread,
+        mentions: first ? mentionTargets : undefined,
+        accountId,
+      };
+      if (params.useCard) {
+        await sendMarkdownCardFeishu(message);
+      } else {
+        await sendMessageFeishu(message);
+      }
+      first = false;
     }
     if (params.infoKind === "final") {
       deliveredFinalTexts.add(params.text);
     }
-  };
-
-  const sendMediaReplies = async (payload: ReplyPayload) => {
-    await sendMediaWithLeadingCaption({
-      mediaUrls: resolveSendableOutboundReplyParts(payload).mediaUrls,
-      caption: "",
-      send: async ({ mediaUrl }) => {
-        await sendMediaFeishu({
-          cfg,
-          to: chatId,
-          mediaUrl,
-          replyToMessageId: sendReplyToMessageId,
-          replyInThread: effectiveReplyInThread,
-          accountId,
-        });
-      },
-    });
   };
 
   const { dispatcher, replyOptions, markDispatchIdle } =
@@ -353,18 +269,26 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       responsePrefix: prefixContext.responsePrefix,
       responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
-      onReplyStart: async () => {
+      onReplyStart: () => {
         deliveredFinalTexts.clear();
+        deliveredBlockTexts.clear();
+        pendingFinalPayload = null;
+        pendingFinalMediaList = [];
         if (streamingEnabled && renderMode === "card") {
           startStreaming();
         }
-        await typingCallbacks?.onReplyStart?.();
+        void typingCallbacks.onReplyStart?.();
       },
       deliver: async (payload: ReplyPayload, info) => {
-        const reply = resolveSendableOutboundReplyParts(payload);
-        const text = reply.text;
-        const hasText = reply.hasText;
-        const hasMedia = reply.hasMedia;
+        const text = payload.text ?? "";
+        const mediaList =
+          payload.mediaUrls && payload.mediaUrls.length > 0
+            ? payload.mediaUrls
+            : payload.mediaUrl
+              ? [payload.mediaUrl]
+              : [];
+        const hasText = Boolean(text.trim());
+        const hasMedia = mediaList.length > 0;
         const skipTextForDuplicateFinal =
           info?.kind === "final" && hasText && deliveredFinalTexts.has(text);
         const shouldDeliverText = hasText && !skipTextForDuplicateFinal;
@@ -382,17 +306,47 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (!(streamingEnabled && useCard)) {
               return;
             }
+            // Deduplicate block payloads: thinking-phase blocks may be
+            // re-delivered after streaming closes (#duplicate-thinking-bug).
+            if (deliveredBlockTexts.has(text)) {
+              return;
+            }
+            deliveredBlockTexts.add(text);
             startStreaming();
             if (streamingStartPromise) {
               await streamingStartPromise;
             }
           }
 
-          if (info?.kind === "final" && streamingEnabled && useCard) {
-            startStreaming();
-            if (streamingStartPromise) {
-              await streamingStartPromise;
+          if (info?.kind === "final") {
+            // Thinking-model agents (e.g. kimi-k2.5) emit one "final" deliver
+            // per tool-call round, not just at the end. We defer all finals and
+            // only send the last one when onIdle fires. Each intermediate final
+            // still updates the streaming card via onPartialReply so the user
+            // sees live progress.
+            if (streamingEnabled && useCard) {
+              // Keep streaming card up-to-date with latest text
+              streamText = mergeStreamingText(streamText, text);
+              if (streaming?.isActive()) {
+                await streaming.update(streamText);
+              } else {
+                startStreaming();
+                if (streamingStartPromise) {
+                  await streamingStartPromise;
+                }
+                if (streaming?.isActive()) {
+                  await streaming.update(streamText);
+                }
+              }
+              // Stash as pending — onIdle will close streaming and actually deliver
+              pendingFinalPayload = payload;
+              pendingFinalMediaList = mediaList;
+              return;
             }
+            // Non-streaming path: defer to onIdle as well to avoid duplicates
+            pendingFinalPayload = payload;
+            pendingFinalMediaList = mediaList;
+            return;
           }
 
           if (streaming?.isActive()) {
@@ -401,61 +355,40 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               // Mirror block text into streamText so onIdle close still sends content.
               queueStreamingUpdate(text, { mode: "delta" });
             }
-            if (info?.kind === "final") {
-              streamText = mergeStreamingText(streamText, text);
-              await closeStreaming();
-              deliveredFinalTexts.add(text);
-            }
             // Send media even when streaming handled the text
             if (hasMedia) {
-              await sendMediaReplies(payload);
+              for (const mediaUrl of mediaList) {
+                await sendMediaFeishu({
+                  cfg,
+                  to: chatId,
+                  mediaUrl,
+                  replyToMessageId: sendReplyToMessageId,
+                  replyInThread: effectiveReplyInThread,
+                  accountId,
+                });
+              }
             }
             return;
           }
 
           if (useCard) {
-            const cardHeader = resolveCardHeader(agentId, identity);
-            const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-            await sendChunkedTextReply({
-              text,
-              useCard: true,
-              infoKind: info?.kind,
-              sendChunk: async ({ chunk, isFirst }) => {
-                await sendStructuredCardFeishu({
-                  cfg,
-                  to: chatId,
-                  text: chunk,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread: effectiveReplyInThread,
-                  mentions: isFirst ? mentionTargets : undefined,
-                  accountId,
-                  header: cardHeader,
-                  note: cardNote,
-                });
-              },
-            });
+            await sendChunkedTextReply({ text, useCard: true, infoKind: info?.kind });
           } else {
-            await sendChunkedTextReply({
-              text,
-              useCard: false,
-              infoKind: info?.kind,
-              sendChunk: async ({ chunk, isFirst }) => {
-                await sendMessageFeishu({
-                  cfg,
-                  to: chatId,
-                  text: chunk,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread: effectiveReplyInThread,
-                  mentions: isFirst ? mentionTargets : undefined,
-                  accountId,
-                });
-              },
-            });
+            await sendChunkedTextReply({ text, useCard: false, infoKind: info?.kind });
           }
         }
 
         if (hasMedia) {
-          await sendMediaReplies(payload);
+          for (const mediaUrl of mediaList) {
+            await sendMediaFeishu({
+              cfg,
+              to: chatId,
+              mediaUrl,
+              replyToMessageId: sendReplyToMessageId,
+              replyInThread: effectiveReplyInThread,
+              accountId,
+            });
+          }
         }
       },
       onError: async (error, info) => {
@@ -463,14 +396,53 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}`,
         );
         await closeStreaming();
-        typingCallbacks?.onIdle?.();
+        typingCallbacks.onIdle?.();
       },
       onIdle: async () => {
-        await closeStreaming();
-        typingCallbacks?.onIdle?.();
+        // Flush the deferred final payload (last one wins for thinking models).
+        if (pendingFinalPayload) {
+          const finalPayload = pendingFinalPayload;
+          const finalMediaList = pendingFinalMediaList;
+          pendingFinalPayload = null;
+          pendingFinalMediaList = [];
+
+          const text = finalPayload.text ?? "";
+          const hasText = Boolean(text.trim());
+          const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
+
+          if (hasText) {
+            if (streamingEnabled && useCard) {
+              // streaming.update was already called in deliver; just close now
+              if (streaming?.isActive()) {
+                streamText = mergeStreamingText(streamText, text);
+              }
+              await closeStreaming();
+              deliveredFinalTexts.add(text);
+            } else {
+              await sendChunkedTextReply({ text, useCard, infoKind: "final" });
+              deliveredFinalTexts.add(text);
+            }
+          } else {
+            await closeStreaming();
+          }
+
+          for (const mediaUrl of finalMediaList) {
+            await sendMediaFeishu({
+              cfg,
+              to: chatId,
+              mediaUrl,
+              replyToMessageId: sendReplyToMessageId,
+              replyInThread: effectiveReplyInThread,
+              accountId,
+            });
+          }
+        } else {
+          await closeStreaming();
+        }
+        typingCallbacks.onIdle?.();
       },
       onCleanup: () => {
-        typingCallbacks?.onCleanup?.();
+        typingCallbacks.onCleanup?.();
       },
     });
 
@@ -491,16 +463,6 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             });
           }
         : undefined,
-      onReasoningStream: streamingEnabled
-        ? (payload: ReplyPayload) => {
-            if (!payload.text) {
-              return;
-            }
-            startStreaming();
-            queueReasoningUpdate(payload.text);
-          }
-        : undefined,
-      onReasoningEnd: streamingEnabled ? () => {} : undefined,
     },
     markDispatchIdle,
   };


### PR DESCRIPTION
## Summary
- **Problem:** Thinking models (e.g. kimi-k2.5) emit one `final` deliver per tool-call round, not just at the end of the full response. The existing `deliveredFinalTexts` dedup only filters identical text, so each intermediate final (with different content) was sent as a separate streaming card message.
- **Why it matters:** Users saw the agent's intermediate tool-call results re-sent as duplicate messages after the final streaming card closed, producing 5 cards instead of 1 for a 4-tool-call session.
- **What changed:** All `final` delivers are now deferred (`pendingFinalPayload`). Intermediate finals update the streaming card content in place; `onIdle` sends only the last one and closes the card.
- **What did NOT change:** Non-thinking models (single final deliver) are unaffected. `block`, `partial`, media delivery, and all other paths are unchanged.

## Change Type
- [x] Bug fix

## Scope
- [x] Integrations

## Linked Issue/PR
- Closes # *(none yet — discovered during local testing)*

## User-visible / Behavior Changes
Before: multi-tool-call thinking agents sent N streaming card messages (one per tool-call round).  
After: only 1 streaming card message is sent, showing live progress throughout.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OS: macOS
- Runtime/container: Node.js v24.13.1
- Model/provider: bailian/kimi-k2.5
- Integration/channel: Feishu (websocket mode, renderMode: card, streaming: true)
- Relevant config: `channels.feishu.renderMode: "card"`

### Steps
1. Configure a Feishu channel with streaming card mode enabled
2. Send a message that requires multiple tool calls (e.g. "查询 xxx 的信息，提取xxx字段，再查询xxxx信息")
3. Observe the number of messages sent in the Feishu chat

### Expected
- 1 streaming card message, updated live as each tool call completes

### Actual (before fix)
- 5 streaming card messages sent sequentially after the response completed (`replies=5`)

## Evidence
- [x] Trace/log snippets

Before:
```
feishu[work-bot] Started streaming: cardId=...
feishu[work-bot] Closed streaming: cardId=...
feishu[work-bot] Started streaming: cardId=...   ← duplicate
feishu[work-bot] Closed streaming: cardId=...
... (×5)
dispatch complete (queuedFinal=true, replies=5)
```

After:
```
feishu[work-bot] Started streaming: cardId=...
feishu[work-bot] Closed streaming: cardId=...
dispatch complete (queuedFinal=true, replies=1)
```

## Human Verification
- **Verified scenarios:** multi-tool-call query (4 tool calls) with kimi-k2.5 thinking model on Feishu websocket, streaming card mode
- **Edge cases checked:** single tool call (replies=1, unaffected); no tool call (direct final, unaffected)
- **What I did not verify:** webhook mode; non-card render modes; models without thinking (Claude, GPT)

## Review Conversations
- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery
- How to revert: restore `reply-dispatcher.ts.bck` in `extensions/feishu/src/`
- Known bad symptoms: if `replies=0` in logs after fix, `onIdle` may not be firing — check `pendingFinalPayload` is being consumed

## Risks and Mitigations
- **Risk:** If `onIdle` never fires (e.g. agent errors mid-run), the pending final is dropped and no message is sent.
  - **Mitigation:** `onError` calls `closeStreaming()` which handles the streaming card; however `pendingFinalPayload` is not flushed on error. A follow-up could flush pending in `onError` as well.