### PR TITLE
fix: resolve axios missing module on startup (#50800)

### DIFF
--- a/package.json
+++ b/package.json
@@ -696,6 +696,7 @@
     "@mozilla/readability": "^0.6.0",
     "@sinclair/typebox": "0.34.48",
     "ajv": "^8.18.0",
+    "axios": "^1.13.5",
     "chalk": "^5.6.2",
     "chokidar": "^5.0.0",
     "cli-highlight": "^2.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
+      axios:
+        specifier: ^1.13.5
+        version: 1.13.6
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -8350,7 +8353,7 @@ snapshots:
     dependencies:
       '@types/node': 24.12.0
     optionalDependencies:
-      axios: 1.13.5
+      axios: 1.13.6
     transitivePeerDependencies:
       - debug
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- [cite_start]**Problem:** Self-built Docker runtime images fail during startup with `ERR_MODULE_NOT_FOUND` for `axios` because `@line/bot-sdk` requires it, but it's missing from the production dependency graph[cite: 43, 100, 110, 161].
- [cite_start]**Why it matters:** The container exits immediately on boot, making self-built OpenClaw deployments unusable[cite: 44, 172].
- [cite_start]**What changed:** Added `axios` as a direct dependency in `package.json` [cite: 151, 162] [cite_start]and, crucially, regenerated `pnpm-lock.yaml` to prevent the `frozen-lockfile` build failure seen in previous attempts[cite: 173, 179, 212].
- [cite_start]**What did NOT change (scope boundary):** No changes to LINE webhook behavior, authentication, or non-Docker application logic[cite: 47].

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- [cite_start]Closes #50800 [cite: 69]
- [cite_start]Related #50807 (Addressing incomplete fix) [cite: 13, 182]

## User-visible / Behavior Changes

Self-built Docker images no longer crash at startup. [cite_start]No configuration or default behavior changes[cite: 72, 74].

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- [cite_start]**OS:** Ubuntu 24.04 (Docker Runtime) [cite: 83]
- [cite_start]**Runtime/container:** Docker locally built image [cite: 84]

### Steps

1. Build a runtime image from the current source tree.
2. Start the `openclaw` container.
3. Inspect `docker logs -f openclaw`.

### Expected

[cite_start]Container starts successfully and proceeds past CLI startup without module errors[cite: 96, 98].

### Actual

[cite_start]Before this fix, the container failed with: `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'axios'`[cite: 100, 110].

## Evidence

- [x] Trace/log snippets (Included in summary)
- [x] Manual verification of `pnpm-lock.yaml` consistency.

## Human Verification (required)

- [cite_start]**Verified scenarios:** Ran `pnpm install` locally to ensure `pnpm-lock.yaml` is in sync with `package.json`[cite: 173, 212].
- **Edge cases checked:** Verified that `axios` is placed alphabetically in `package.json` to maintain project standards.

## Review Conversations

- [x] [cite_start]I addressed the `pnpm-lock.yaml` missing update noted by bots in previous PR attempts[cite: 154, 164, 194].

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- **How to disable/revert:** Revert commit and remove `axios` from `package.json`.
- **Files to restore:** `package.json`, `pnpm-lock.yaml`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- **Risk:** Introducing a new direct dependency might lead to version conflicts if other internal packages require a different version of `axios`.
  - [cite_start]**Mitigation:** The version added (`^1.13.5`) matches the one currently being resolved transitively by `@line/bot-sdk`, as seen in the previous build logs, ensuring compatibility with existing code[cite: 161, 162].