### PR TITLE
fix(delivery-queue): add TTL expiry and ack failure logging to prevent infinite re-delivery

### DIFF
--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -492,6 +492,7 @@ export async function deliverOutboundPayloads(
         channel,
         to,
         accountId: params.accountId,
+        sessionId: params.session?.key,
         payloads,
         threadId: params.threadId,
         replyToId: params.replyToId,
@@ -523,14 +524,18 @@ export async function deliverOutboundPayloads(
       if (hadPartialFailure) {
         await failDelivery(queueId, "partial delivery failure (bestEffort)").catch(() => {});
       } else {
-        await ackDelivery(queueId).catch(() => {}); // Best-effort cleanup.
+        await ackDelivery(queueId).catch((err) => {
+          log.warn(`Failed to ack delivery ${queueId}: ${String(err)}`);
+        });
       }
     }
     return results;
   } catch (err) {
     if (queueId) {
       if (isAbortError(err)) {
-        await ackDelivery(queueId).catch(() => {});
+        await ackDelivery(queueId).catch((ackErr) => {
+          log.warn(`Failed to ack delivery ${queueId} after abort: ${String(ackErr)}`);
+        });
       } else {
         await failDelivery(queueId, err instanceof Error ? err.message : String(err)).catch(
           () => {},

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -8,11 +8,15 @@ import {
   type QueuedDeliveryPayload,
 } from "./delivery-queue-storage.js";
 
+/** Maximum age (in ms) before a pending delivery entry is considered expired. Default: 24 hours. */
+export const DEFAULT_MAX_AGE_MS = 86_400_000;
+
 export type RecoverySummary = {
   recovered: number;
   failed: number;
   skippedMaxRetries: number;
   deferredBackoff: number;
+  expiredAge: number;
 };
 
 export type DeliverFn = (
@@ -57,6 +61,7 @@ function createEmptyRecoverySummary(): RecoverySummary {
     failed: 0,
     skippedMaxRetries: 0,
     deferredBackoff: 0,
+    expiredAge: 0,
   };
 }
 
@@ -150,6 +155,8 @@ export async function recoverPendingDeliveries(opts: {
   stateDir?: string;
   /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next startup. Default: 60 000. */
   maxRecoveryMs?: number;
+  /** Maximum age in ms before a pending entry is expired. Default: 24 hours. */
+  maxAgeMs?: number;
 }): Promise<RecoverySummary> {
   const pending = await loadPendingDeliveries(opts.stateDir);
   if (pending.length === 0) {
@@ -161,6 +168,7 @@ export async function recoverPendingDeliveries(opts: {
 
   const deadline = Date.now() + (opts.maxRecoveryMs ?? 60_000);
   const summary = createEmptyRecoverySummary();
+  const maxAge = opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
 
   for (let i = 0; i < pending.length; i++) {
     const entry = pending[i];
@@ -176,6 +184,16 @@ export async function recoverPendingDeliveries(opts: {
       );
       await moveEntryToFailedWithLogging(entry.id, opts.log, opts.stateDir);
       summary.skippedMaxRetries += 1;
+      continue;
+    }
+
+    const ageMs = now - entry.enqueuedAt;
+    if (ageMs > maxAge) {
+      opts.log.warn(
+        `Delivery ${entry.id} expired (age: ${Math.round(ageMs / 3_600_000)}h, max: ${Math.round(maxAge / 3_600_000)}h) — moving to failed/`,
+      );
+      await moveEntryToFailedWithLogging(entry.id, opts.log, opts.stateDir);
+      summary.expiredAge += 1;
       continue;
     }
 
@@ -212,7 +230,7 @@ export async function recoverPendingDeliveries(opts: {
   }
 
   opts.log.info(
-    `Delivery recovery complete: ${summary.recovered} recovered, ${summary.failed} failed, ${summary.skippedMaxRetries} skipped (max retries), ${summary.deferredBackoff} deferred (backoff)`,
+    `Delivery recovery complete: ${summary.recovered} recovered, ${summary.failed} failed, ${summary.skippedMaxRetries} skipped (max retries), ${summary.deferredBackoff} deferred (backoff), ${summary.expiredAge} expired (age)`,
   );
   return summary;
 }

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -13,6 +13,8 @@ export type QueuedDeliveryPayload = {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  /** Session key for future orphan-detection (not yet used in recovery). */
+  sessionId?: string;
   /**
    * Original payloads before plugin hooks. On recovery, hooks re-run on these
    * payloads — this is intentional since hooks are stateless transforms and
@@ -134,6 +136,7 @@ export async function enqueueDelivery(
     channel: params.channel,
     to: params.to,
     accountId: params.accountId,
+    sessionId: params.sessionId,
     payloads: params.payloads,
     threadId: params.threadId,
     replyToId: params.replyToId,

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   enqueueDelivery,
+  DEFAULT_MAX_AGE_MS,
   loadPendingDeliveries,
   MAX_RETRIES,
   recoverPendingDeliveries,
@@ -27,10 +28,12 @@ describe("delivery-queue recovery", () => {
     deliver,
     log = createRecoveryLog(),
     maxRecoveryMs,
+    maxAgeMs,
   }: {
     deliver: ReturnType<typeof vi.fn>;
     log?: ReturnType<typeof createRecoveryLog>;
     maxRecoveryMs?: number;
+    maxAgeMs?: number;
   }) => {
     const result = await recoverPendingDeliveries({
       deliver: asDeliverFn(deliver),
@@ -38,6 +41,7 @@ describe("delivery-queue recovery", () => {
       cfg: baseCfg,
       stateDir: tmpDir(),
       ...(maxRecoveryMs === undefined ? {} : { maxRecoveryMs }),
+      ...(maxAgeMs === undefined ? {} : { maxAgeMs }),
     });
     return { result, log };
   };
@@ -53,6 +57,7 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 0,
+      expiredAge: 0,
     });
 
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
@@ -167,6 +172,7 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 0,
+      expiredAge: 0,
     });
 
     const remaining = await loadPendingDeliveries(tmpDir());
@@ -194,6 +200,7 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 1,
+      expiredAge: 0,
     });
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(1);
     expect(log.info).toHaveBeenCalledWith(expect.stringContaining("not ready for retry yet"));
@@ -225,6 +232,7 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 1,
+      expiredAge: 0,
     });
     expect(deliver).toHaveBeenCalledTimes(1);
     expect(deliver).toHaveBeenCalledWith(
@@ -254,6 +262,7 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 1,
+      expiredAge: 0,
     });
     expect(firstDeliver).not.toHaveBeenCalled();
 
@@ -265,6 +274,7 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 0,
+      expiredAge: 0,
     });
     expect(secondDeliver).toHaveBeenCalledTimes(1);
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
@@ -281,7 +291,88 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 0,
+      expiredAge: 0,
     });
     expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("expires entries older than DEFAULT_MAX_AGE_MS and moves them to failed/", async () => {
+    const id = await enqueueDelivery(
+      { channel: "whatsapp", to: "+1", payloads: [{ text: "stale" }] },
+      tmpDir(),
+    );
+    // Set enqueuedAt to 25 hours ago (beyond 24h TTL)
+    setQueuedEntryState(tmpDir(), id, {
+      retryCount: 0,
+      enqueuedAt: Date.now() - DEFAULT_MAX_AGE_MS - 3_600_000,
+    });
+
+    const deliver = vi.fn().mockResolvedValue([]);
+    const log = createRecoveryLog();
+    const { result } = await runRecovery({ deliver, log });
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(result.expiredAge).toBe(1);
+    expect(result.recovered).toBe(0);
+
+    const failedDir = path.join(tmpDir(), "delivery-queue", "failed");
+    expect(fs.existsSync(path.join(failedDir, `${id}.json`))).toBe(true);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("expired"));
+  });
+
+  it("retries entries younger than DEFAULT_MAX_AGE_MS normally", async () => {
+    const id = await enqueueDelivery(
+      { channel: "whatsapp", to: "+1", payloads: [{ text: "fresh" }] },
+      tmpDir(),
+    );
+    // Set enqueuedAt to 1 hour ago (well within 24h TTL)
+    setQueuedEntryState(tmpDir(), id, { retryCount: 0, enqueuedAt: Date.now() - 3_600_000 });
+
+    const deliver = vi.fn().mockResolvedValue([]);
+    const { result } = await runRecovery({ deliver });
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(result.recovered).toBe(1);
+    expect(result.expiredAge).toBe(0);
+  });
+
+  it("respects custom maxAgeMs override", async () => {
+    const id = await enqueueDelivery(
+      { channel: "telegram", to: "99", payloads: [{ text: "custom-ttl" }] },
+      tmpDir(),
+    );
+    // Set enqueuedAt to 2 hours ago
+    setQueuedEntryState(tmpDir(), id, { retryCount: 0, enqueuedAt: Date.now() - 7_200_000 });
+
+    const deliver = vi.fn().mockResolvedValue([]);
+    const { result } = await runRecovery({ deliver, maxAgeMs: 3_600_000 }); // 1h TTL
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(result.expiredAge).toBe(1);
+
+    const failedDir = path.join(tmpDir(), "delivery-queue", "failed");
+    expect(fs.existsSync(path.join(failedDir, `${id}.json`))).toBe(true);
+  });
+
+  it("counts expiredAge in RecoverySummary alongside other counters", async () => {
+    const expiredId = await enqueueDelivery(
+      { channel: "whatsapp", to: "+1", payloads: [{ text: "expired" }] },
+      tmpDir(),
+    );
+    const freshId = await enqueueDelivery(
+      { channel: "telegram", to: "2", payloads: [{ text: "fresh" }] },
+      tmpDir(),
+    );
+    setQueuedEntryState(tmpDir(), expiredId, {
+      retryCount: 0,
+      enqueuedAt: Date.now() - DEFAULT_MAX_AGE_MS - 3_600_000,
+    });
+    setQueuedEntryState(tmpDir(), freshId, { retryCount: 0, enqueuedAt: Date.now() - 1_000 });
+
+    const deliver = vi.fn().mockResolvedValue([]);
+    const { result } = await runRecovery({ deliver });
+
+    expect(result.expiredAge).toBe(1);
+    expect(result.recovered).toBe(1);
   });
 });

--- a/src/infra/outbound/delivery-queue.storage.test.ts
+++ b/src/infra/outbound/delivery-queue.storage.test.ts
@@ -88,6 +88,35 @@ describe("delivery-queue storage", () => {
       expect(fs.existsSync(path.join(queueDir, `${id}.delivered`))).toBe(false);
     });
 
+    it("persists sessionId when provided", async () => {
+      const id = await enqueueDelivery(
+        {
+          channel: "whatsapp",
+          to: "+1555",
+          payloads: [{ text: "with-session" }],
+          sessionId: "agent:main:abc123",
+        },
+        tmpDir(),
+      );
+
+      const entry = readQueuedEntry(tmpDir(), id);
+      expect(entry.sessionId).toBe("agent:main:abc123");
+    });
+
+    it("omits sessionId when not provided (backward compat)", async () => {
+      const id = await enqueueDelivery(
+        {
+          channel: "whatsapp",
+          to: "+1555",
+          payloads: [{ text: "no-session" }],
+        },
+        tmpDir(),
+      );
+
+      const entry = readQueuedEntry(tmpDir(), id);
+      expect(entry.sessionId).toBeUndefined();
+    });
+
     it("loadPendingDeliveries cleans up stale .delivered markers without replaying", async () => {
       const id = await enqueueDelivery(
         { channel: "telegram", to: "99", payloads: [{ text: "stale" }] },

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -9,6 +9,7 @@ export {
 export type { QueuedDelivery, QueuedDeliveryPayload } from "./delivery-queue-storage.js";
 export {
   computeBackoffMs,
+  DEFAULT_MAX_AGE_MS,
   isEntryEligibleForRecoveryRetry,
   isPermanentDeliveryError,
   MAX_RETRIES,


### PR DESCRIPTION
## Summary

Fixes #50496 — Trashed session delivery-queue entries are re-delivered on every gateway restart, causing infinite duplicate messages.

## Root Cause

The delivery queue (`src/infra/outbound/delivery-queue.ts`) has three independent failure modes that combine to produce infinite re-delivery:

1. **Silent ack failure**: `ackDelivery().catch(() => {})` in `deliver.ts` swallows all errors. If ack fails after successful delivery, the queue entry persists and is re-delivered on every restart.
2. **No TTL/expiry**: Successfully-delivered-but-unacked entries have `retryCount=0`, so the `MAX_RETRIES` guard never triggers. Entries can persist indefinitely.
3. **No session lifecycle coupling**: Session GC does not clean up corresponding delivery-queue entries.

## Changes

### Layer 1: TTL Expiry in Recovery (Primary Fix)
- Added `DEFAULT_MAX_AGE_MS` constant (24 hours) to `delivery-queue.ts`
- `recoverPendingDeliveries()` now checks entry age before attempting retry
- Expired entries are moved to `failed/` with a warning log
- Configurable via `maxAgeMs` option for flexibility
- Added `expiredAge` counter to `RecoverySummary`

### Layer 2: Log Ack Failures (Diagnostic)
- Replaced silent `.catch(() => {})` on `ackDelivery` calls in `deliver.ts` with `.catch((err) => log.warn(...))`
- Makes ack failures visible in logs so the root cause can be diagnosed

### Layer 3: `sessionId` Field (Future-Proofing)
- Added optional `sessionId` field to `QueuedDeliveryPayload`
- Threaded through `enqueueDelivery()` and `deliverOutboundPayloads()`
- Persists `session.key` in queue entries for future session-aware orphan detection
- Fully backward compatible — old entries without `sessionId` work normally

## Testing

- 6 new test cases added to `delivery-queue.test.ts`
- All 42 existing + new tests passing
- Tests cover: TTL expiry, custom maxAgeMs, sessionId persistence, backward compatibility

## Backward Compatibility

- Old queue entries without `sessionId` are handled normally
- Old entries older than 24h are expired on next restart (desired behavior)
- No configuration changes required
- No breaking API changes