### PR TITLE
process: fix Windows runExec garbled CJK output [AI-assisted]

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -21,6 +21,10 @@ function isWindowsBatchCommand(resolvedCommand: string): boolean {
   return ext === ".cmd" || ext === ".bat";
 }
 
+function isUtf8Encoding(encoding: BufferEncoding): boolean {
+  return encoding.toLowerCase().replaceAll("-", "") === "utf8";
+}
+
 function escapeForCmdExe(arg: string): string {
   // Reject cmd metacharacters to avoid injection when we must pass a single command line.
   if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(arg)) {
@@ -137,7 +141,7 @@ export async function runExec(
         return null;
       }
       const cmdCommandLine = buildCmdExeCommandLine(execCommand, execArgs);
-      return process.platform === "win32" && encoding.toLowerCase() === "utf8"
+      return process.platform === "win32" && isUtf8Encoding(encoding)
         ? `chcp 65001>nul && ${cmdCommandLine}`
         : cmdCommandLine;
     })();

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -132,15 +132,19 @@ export async function runExec(
       execArgs = args;
     }
     const useCmdWrapper = isWindowsBatchCommand(execCommand);
-    const cmdCommandLine = buildCmdExeCommandLine(execCommand, execArgs);
-    const wrappedCommandLine =
-      process.platform === "win32" && useCmdWrapper && encoding.toLowerCase() === "utf8"
+    const wrappedCommandLine = (() => {
+      if (!useCmdWrapper) {
+        return null;
+      }
+      const cmdCommandLine = buildCmdExeCommandLine(execCommand, execArgs);
+      return process.platform === "win32" && encoding.toLowerCase() === "utf8"
         ? `chcp 65001>nul && ${cmdCommandLine}`
         : cmdCommandLine;
+    })();
     const { stdout, stderr } = useCmdWrapper
       ? await execFileAsync(
           process.env.ComSpec ?? "cmd.exe",
-          ["/d", "/s", "/c", wrappedCommandLine],
+          ["/d", "/s", "/c", wrappedCommandLine ?? ""],
           { ...options, windowsVerbatimArguments: true },
         )
       : await execFileAsync(execCommand, execArgs, options);
@@ -232,11 +236,15 @@ export async function runCommandWithTimeout(
   const finalArgv = process.platform === "win32" ? (resolveNpmArgvForWindows(argv) ?? argv) : argv;
   const resolvedCommand = finalArgv !== argv ? (finalArgv[0] ?? "") : resolveCommand(argv[0] ?? "");
   const useCmdWrapper = isWindowsBatchCommand(resolvedCommand);
+  const wrappedCommandLine =
+    useCmdWrapper && process.platform === "win32"
+      ? `chcp 65001>nul && ${buildCmdExeCommandLine(resolvedCommand, finalArgv.slice(1))}`
+      : useCmdWrapper
+        ? buildCmdExeCommandLine(resolvedCommand, finalArgv.slice(1))
+        : null;
   const child = spawn(
     useCmdWrapper ? (process.env.ComSpec ?? "cmd.exe") : resolvedCommand,
-    useCmdWrapper
-      ? ["/d", "/s", "/c", buildCmdExeCommandLine(resolvedCommand, finalArgv.slice(1))]
-      : finalArgv.slice(1),
+    useCmdWrapper ? ["/d", "/s", "/c", wrappedCommandLine ?? ""] : finalArgv.slice(1),
     {
       stdio,
       cwd,

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -100,16 +100,19 @@ export function shouldSpawnWithShell(params: {
 export async function runExec(
   command: string,
   args: string[],
-  opts: number | { timeoutMs?: number; maxBuffer?: number; cwd?: string } = 10_000,
+  opts:
+    | number
+    | { timeoutMs?: number; maxBuffer?: number; cwd?: string; encoding?: BufferEncoding } = 10_000,
 ): Promise<{ stdout: string; stderr: string }> {
+  const encoding = typeof opts === "number" ? "utf8" : (opts.encoding ?? "utf8");
   const options =
     typeof opts === "number"
-      ? { timeout: opts, encoding: "utf8" as const }
+      ? { timeout: opts, encoding }
       : {
           timeout: opts.timeoutMs,
           maxBuffer: opts.maxBuffer,
           cwd: opts.cwd,
-          encoding: "utf8" as const,
+          encoding,
         };
   try {
     const argv = [command, ...args];
@@ -129,10 +132,15 @@ export async function runExec(
       execArgs = args;
     }
     const useCmdWrapper = isWindowsBatchCommand(execCommand);
+    const cmdCommandLine = buildCmdExeCommandLine(execCommand, execArgs);
+    const wrappedCommandLine =
+      process.platform === "win32" && useCmdWrapper && encoding.toLowerCase() === "utf8"
+        ? `chcp 65001>nul && ${cmdCommandLine}`
+        : cmdCommandLine;
     const { stdout, stderr } = useCmdWrapper
       ? await execFileAsync(
           process.env.ComSpec ?? "cmd.exe",
-          ["/d", "/s", "/c", buildCmdExeCommandLine(execCommand, execArgs)],
+          ["/d", "/s", "/c", wrappedCommandLine],
           { ...options, windowsVerbatimArguments: true },
         )
       : await execFileAsync(execCommand, execArgs, options);

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -89,6 +89,31 @@ describe("windows command wrapper behavior", () => {
       expect(result.code).toBe(0);
       const captured = spawnMock.mock.calls[0] as SpawnCall | undefined;
       expectCmdWrappedInvocation({ captured, expectedComSpec });
+      expect(captured?.[1][3]).toContain("chcp 65001>nul &&");
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("does not build cmd.exe command line for non-wrapper runExec calls", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+
+    execFileMock.mockImplementation((...params: unknown[]) => {
+      const maybeCallback = params.at(-1);
+      if (typeof maybeCallback === "function") {
+        (maybeCallback as (err: Error | null, stdout: string, stderr: string) => void)(
+          null,
+          "ok",
+          "",
+        );
+      }
+    });
+
+    try {
+      await expect(runExec("grep", ["-P", "a|b"], 1000)).resolves.toBeDefined();
+      const captured = execFileMock.mock.calls[0] as ExecCall | undefined;
+      expect(captured?.[0]).toBe("grep");
+      expect(captured?.[1]).toEqual(["-P", "a|b"]);
     } finally {
       platformSpy.mockRestore();
     }

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -143,4 +143,27 @@ describe("windows command wrapper behavior", () => {
       platformSpy.mockRestore();
     }
   });
+
+  it("treats utf-8 encoding alias as UTF-8 for runExec cmd wrapper", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        cb(null, "ok", "");
+      },
+    );
+
+    try {
+      await runExec("pnpm", ["--version"], { timeoutMs: 1000, encoding: "utf-8" });
+      const captured = execFileMock.mock.calls[0] as ExecCall | undefined;
+      expect(captured?.[1][3]).toContain("chcp 65001>nul &&");
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
 });

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -113,6 +113,7 @@ describe("windows command wrapper behavior", () => {
       await runExec("pnpm", ["--version"], 1000);
       const captured = execFileMock.mock.calls[0] as ExecCall | undefined;
       expectCmdWrappedInvocation({ captured, expectedComSpec });
+      expect(captured?.[1][3]).toContain("chcp 65001>nul &&");
     } finally {
       platformSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary

- Problem: Windows `.cmd`/`.bat` execution through `cmd.exe` wrapper could produce garbled CJK output because the active code page is often not UTF-8.
- Why it matters: Windows users running commands with Chinese/Japanese/Korean output (or non-ASCII paths/args) get unreadable results.
- What changed:
  - `runExec` now prepends `chcp 65001>nul &&` on Windows cmd-wrapper paths when output decoding is UTF-8.
  - `runCommandWithTimeout` gets the same UTF-8 code-page prefix for cmd-wrapper consistency.
  - Fixed a regression by moving cmd command-line building back behind the `useCmdWrapper` gate (avoids spurious throws on non-wrapper paths).
  - Added UTF-8 alias handling so both `utf8` and `utf-8` trigger the UTF-8 code-page path.
  - Added/updated regression tests in `src/process/exec.windows.test.ts`.
- Scope boundary: this PR only updates Windows cmd-wrapper encoding behavior and related guardrails; it does not change non-wrapper execution semantics.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #50519

## User-visible / Behavior Changes

- CJK output from Windows `.cmd`/`.bat` wrapper execution is no longer mojibake in UTF-8 decode scenarios.
- `runExec(..., { encoding: "utf8" })` and `runExec(..., { encoding: "utf-8" })` now behave consistently for wrapper code-page setup.
- Non-wrapper execution no longer accidentally trips cmd.exe argument safety checks.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux CI + Windows lanes in repo CI
- Runtime: Node 22 / pnpm workspace
- Area: process execution (`runExec`, `runCommandWithTimeout`)

### Steps

1. Execute a `.cmd` command through Windows cmd-wrapper path with CJK output.
2. Verify output decoding in UTF-8 mode.
3. Verify non-wrapper commands are not validated as cmd command-lines.
4. Verify UTF-8 alias handling (`utf8` and `utf-8`).

### Result

- Regression tests pass: `pnpm test -- src/process/exec.windows.test.ts`
- PR CI checks are green.

## Risks and Mitigations

- Risk: behavior change is specific to Windows cmd-wrapper path and could alter edge-case shell output formatting.
  - Mitigation: changes are tightly scoped and covered by focused regression tests for wrapper/non-wrapper and encoding alias cases.


Closes #50519
