### PR TITLE
fix(daemon): auto-bootstrap service on `start` when not loaded

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -190,4 +190,41 @@ describe("runServiceRestart token drift", () => {
     expect(payload.result).toBe("scheduled");
     expect(payload.message).toBe("restart scheduled, gateway will restart momentarily");
   });
+
+  it("auto-bootstraps when service start finds service not loaded (#50869)", async () => {
+    service.isLoaded
+      .mockResolvedValueOnce(false) // initial check: not loaded
+      .mockResolvedValueOnce(true); // post-restart check: now loaded
+    service.restart.mockResolvedValue({ outcome: "completed" });
+
+    await runServiceStart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+    });
+
+    expect(service.restart).toHaveBeenCalledTimes(1);
+    const payload = readJsonLog<{ ok?: boolean; result?: string }>();
+    expect(payload.ok).toBe(true);
+    expect(payload.result).toBe("started");
+  });
+
+  it("falls back to install hints when not-loaded restart recovery fails (#50869)", async () => {
+    service.isLoaded.mockResolvedValue(false);
+    service.restart.mockRejectedValue(new Error("bootstrap failed"));
+
+    await runServiceStart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => ["openclaw gateway install"],
+      opts: { json: true },
+    });
+
+    expect(service.restart).toHaveBeenCalledTimes(1);
+    const payload = readJsonLog<{ ok?: boolean; result?: string; hints?: string[] }>();
+    expect(payload.ok).toBe(true);
+    expect(payload.result).toBe("not-loaded");
+    expect(payload.hints).toEqual(expect.arrayContaining(["openclaw gateway install"]));
+  });
 });

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -202,18 +202,7 @@ export async function runServiceStart(params: {
   if (loaded === null) {
     return;
   }
-  if (!loaded) {
-    await handleServiceNotLoaded({
-      serviceNoun: params.serviceNoun,
-      service: params.service,
-      loaded,
-      renderStartHints: params.renderStartHints,
-      json,
-      emit,
-    });
-    return;
-  }
-  // Pre-flight config validation (#35862)
+  // Pre-flight config validation (#35862) — check before any start/restart action.
   {
     const configError = await getConfigValidationError();
     if (configError) {
@@ -224,6 +213,9 @@ export async function runServiceStart(params: {
     }
   }
 
+  // When the service is not loaded (e.g. after `stop` which uses launchctl
+  // bootout), attempt `restart` which handles re-bootstrap internally, rather
+  // than requiring the user to manually run `install` first. (#50869)
   try {
     const restartResult = await params.service.restart({ env: process.env, stdout });
     const restartStatus = describeGatewayServiceRestart(params.serviceNoun, restartResult);
@@ -232,7 +224,7 @@ export async function runServiceStart(params: {
         ok: true,
         result: restartStatus.daemonActionResult,
         message: restartStatus.message,
-        service: buildDaemonServiceSnapshot(params.service, loaded),
+        service: buildDaemonServiceSnapshot(params.service, loaded || true),
       });
       if (!json) {
         defaultRuntime.log(restartStatus.message);
@@ -240,6 +232,19 @@ export async function runServiceStart(params: {
       return;
     }
   } catch (err) {
+    if (!loaded) {
+      // Service was not loaded and restart recovery (bootstrap) also failed.
+      // Fall back to friendly install hints.
+      await handleServiceNotLoaded({
+        serviceNoun: params.serviceNoun,
+        service: params.service,
+        loaded,
+        renderStartHints: params.renderStartHints,
+        json,
+        emit,
+      });
+      return;
+    }
     const hints = params.renderStartHints();
     fail(`${params.serviceNoun} start failed: ${String(err)}`, hints);
     return;

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -224,7 +224,7 @@ export async function runServiceStart(params: {
         ok: true,
         result: restartStatus.daemonActionResult,
         message: restartStatus.message,
-        service: buildDaemonServiceSnapshot(params.service, loaded || true),
+        service: buildDaemonServiceSnapshot(params.service, true),
       });
       if (!json) {
         defaultRuntime.log(restartStatus.message);


### PR DESCRIPTION
Closes #50869

## The Problem

After `openclaw daemon stop` → `openclaw daemon start`, the CLI prints "service not loaded" with install hints instead of recovering:

```
$ openclaw daemon stop
Stopped LaunchAgent: gui/501/ai.openclaw.gateway

$ openclaw daemon start
Gateway service not loaded.
Start with: openclaw gateway install
```

I hit this on a Mac Mini M4 (OpenClaw 2026.3.13) while troubleshooting session lock files — ran `daemon stop`, cleaned up locks, then `daemon start` refused to come back. Had to manually run `launchctl bootstrap gui/501 ~/Library/LaunchAgents/ai.openclaw.gateway.plist` to recover, which is exactly what `restart` does internally via `restartLaunchAgent`.

This breaks the universal stop → start mental model (systemctl, docker, pm2, etc.).

## Root Cause

`stop` uses `launchctl bootout` to fully unregister the LaunchAgent (necessary because `KeepAlive` would respawn it). But `runServiceStart` bails early when `isLoaded()` returns false, never giving `restart()` a chance to recover — even though `restartLaunchAgent` (launchd.ts:530) already handles exactly this case by calling `bootstrapLaunchAgentOrThrow` before kickstart.

## The Fix

- Remove the early bail on `!loaded` in `runServiceStart`
- Let `service.restart()` attempt bootstrap recovery (the machinery already exists in `restartLaunchAgent`)
- If restart recovery also fails, fall back to the same friendly install hints as before — no behavior change for truly broken states
- Move config validation before the loaded check so invalid configs are caught regardless of service state

The change is minimal (~30 lines net) and leverages existing recovery logic rather than adding new code paths.

## Test Plan

- [x] Added test: not-loaded → `restart()` succeeds → emits "started" (the new happy path)
- [x] Added test: not-loaded → `restart()` throws → falls back to "not-loaded" hints (graceful degradation)
- [x] Existing tests pass (scheduled restart, token drift, unmanaged process flows)
- [ ] Manual: `openclaw daemon stop && openclaw daemon start` recovers without requiring `install`