### PR TITLE
fix(agents): strip inline image data before session JSONL persistence

### DIFF
--- a/extensions/line/index.test.ts
+++ b/extensions/line/index.test.ts
@@ -17,16 +17,21 @@ describe("line runtime api", () => {
       "line-runtime",
     ];
     const script = `
+import fs from "node:fs";
 import path from "node:path";
 import { createJiti } from "jiti";
 
 const root = ${JSON.stringify(root)};
 const runtimeApiPath = ${JSON.stringify(runtimeApiPath)};
 const alias = Object.fromEntries(
-  ${JSON.stringify(pluginSdkSubpaths)}.map((name) => [
-    "openclaw/plugin-sdk/" + name,
-    path.join(root, "dist", "plugin-sdk", name + ".js"),
-  ]),
+  ${JSON.stringify(pluginSdkSubpaths)}.map((name) => {
+    const distPath = path.join(root, "dist", "plugin-sdk", name + ".js");
+    const srcPath = path.join(root, "src", "plugin-sdk", name + ".ts");
+    return [
+      "openclaw/plugin-sdk/" + name,
+      fs.existsSync(distPath) ? distPath : srcPath,
+    ];
+  }),
 );
 const jiti = createJiti(path.join(root, "openclaw.mjs"), {
   interopDefault: true,

--- a/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
@@ -2,7 +2,11 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import { castAgentMessage } from "../../test-helpers/agent-message-fixtures.js";
-import { PRUNED_HISTORY_IMAGE_MARKER, pruneProcessedHistoryImages } from "./history-image-prune.js";
+import {
+  PRUNED_HISTORY_IMAGE_MARKER,
+  pruneProcessedHistoryImages,
+  stripImageContentForPersistence,
+} from "./history-image-prune.js";
 
 function expectArrayMessageContent(
   message: AgentMessage | undefined,
@@ -90,5 +94,54 @@ describe("pruneProcessedHistoryImages", () => {
     expect(didMutate).toBe(false);
     const firstUser = messages[0] as Extract<AgentMessage, { role: "user" }> | undefined;
     expect(firstUser?.content).toBe("noop");
+  });
+});
+
+describe("stripImageContentForPersistence", () => {
+  const image: ImageContent = { type: "image", data: "abc123base64data", mimeType: "image/png" };
+
+  it("returns user messages with images as-is (deferred to pruneProcessedHistoryImages)", () => {
+    const msg = castAgentMessage({
+      role: "user",
+      content: [{ type: "text", text: "Look at this" }, { ...image }],
+    });
+    const result = stripImageContentForPersistence(msg);
+    expect(result).toBe(msg);
+  });
+
+  it("returns toolResult messages with images as-is (deferred to pruneProcessedHistoryImages)", () => {
+    const msg = castAgentMessage({
+      role: "toolResult",
+      content: [{ type: "text", text: "screenshot" }, { ...image }],
+    });
+    const result = stripImageContentForPersistence(msg);
+    expect(result).toBe(msg);
+  });
+
+  it("returns message as-is for assistant role", () => {
+    const msg = castAgentMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "reply" }, { ...image }],
+    });
+    const result = stripImageContentForPersistence(msg);
+    expect(result).toBe(msg);
+  });
+
+  it("returns message as-is when content has no images", () => {
+    const msg = castAgentMessage({
+      role: "user",
+      content: [{ type: "text", text: "just text" }],
+    });
+    const result = stripImageContentForPersistence(msg);
+    expect(result).toBe(msg);
+  });
+
+  it("returns message as-is when content is a string", () => {
+    const msg = castAgentMessage({
+      role: "user",
+      content: "plain text",
+    });
+    const result = stripImageContentForPersistence(msg);
+    expect(result).toBe(msg);
   });
 });

--- a/src/agents/pi-embedded-runner/run/history-image-prune.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.ts
@@ -46,3 +46,19 @@ export function pruneProcessedHistoryImages(messages: AgentMessage[]): boolean {
 
   return didMutate;
 }
+
+/**
+ * Hook point for stripping inline image content before session JSONL
+ * persistence. Currently a pass-through: images must NOT be stripped at
+ * write time because at that point the image has not yet been consumed by a
+ * subsequent assistant turn. Stripping immediately would cause crash/retry
+ * recovery to fail — the model can no longer re-read the image payload from
+ * session history.
+ *
+ * Image cleanup is handled correctly by `pruneProcessedHistoryImages`, which
+ * runs at each run start and only removes images from turns that already have
+ * a later assistant reply (the `lastAssistantIndex` safety boundary).
+ */
+export function stripImageContentForPersistence(message: AgentMessage): AgentMessage {
+  return message;
+}

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -4,6 +4,7 @@ import {
   applyInputProvenanceToUserMessage,
   type InputProvenance,
 } from "../sessions/input-provenance.js";
+import { stripImageContentForPersistence } from "./pi-embedded-runner/run/history-image-prune.js";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 
 export type GuardedSessionManager = SessionManager & {
@@ -65,7 +66,9 @@ export function guardSessionManager(
   const guard = installSessionToolResultGuard(sessionManager, {
     sessionKey: opts?.sessionKey,
     transformMessageForPersistence: (message) =>
-      applyInputProvenanceToUserMessage(message, opts?.inputProvenance),
+      stripImageContentForPersistence(
+        applyInputProvenanceToUserMessage(message, opts?.inputProvenance),
+      ),
     transformToolResultForPersistence: transform,
     allowSyntheticToolResults: opts?.allowSyntheticToolResults,
     allowedToolNames: opts?.allowedToolNames,

--- a/test/fixtures/test-parallel.behavior.json
+++ b/test/fixtures/test-parallel.behavior.json
@@ -147,10 +147,351 @@
   "unit": {
     "isolated": [
       {
-        "file": "src/cli/qr-dashboard.integration.test.ts",
-        "reason": "This CLI integration suite hoists runtime/config mocks and resets module state between qr and dashboard command imports; keep it in its own forked lane so shared unit-fast workers stay deterministic."
+        "file": "src/plugins/contracts/runtime.contract.test.ts",
+        "reason": "Async runtime imports + provider refresh seams; keep out of the shared lane."
+      },
+      {
+        "file": "src/security/temp-path-guard.test.ts",
+        "reason": "Filesystem guard scans are sensitive to contention."
+      },
+      {
+        "file": "src/infra/git-commit.test.ts",
+        "reason": "Mutates process.cwd() and core loader seams."
+      },
+      {
+        "file": "src/config/doc-baseline.integration.test.ts",
+        "reason": "Rebuilds bundled config baselines through many channel schema subprocesses; keep out of the shared lane."
+      },
+      {
+        "file": "extensions/imessage/src/monitor.shutdown.unhandled-rejection.test.ts",
+        "reason": "Touches process-level unhandledRejection listeners."
+      },
+      {
+        "file": "src/plugins/loader.git-path-regression.test.ts",
+        "reason": "Constructs a real Jiti boundary that assigns module.require; requires process forks, not vmForks."
       }
     ],
-    "threadPinned": []
+    "singletonIsolated": [
+      {
+        "file": "src/cli/command-secret-gateway.test.ts",
+        "reason": "Clean in isolation, but can hang after sharing the broad lane."
+      },
+      {
+        "file": "src/config/doc-baseline.integration.test.ts",
+        "reason": "Builds the full bundled config schema graph and is safer outside the shared unit-fast heap."
+      },
+      {
+        "file": "src/secrets/runtime.test.ts",
+        "reason": "Secrets runtime coverage retained the largest unit-fast heap spike in CI and is safer outside the shared lane."
+      },
+      {
+        "file": "src/secrets/runtime.integration.test.ts",
+        "reason": "Secrets runtime activation/write-through integration coverage is CPU-heavy and safer outside the shared unit-fast lane."
+      },
+      {
+        "file": "src/memory/index.test.ts",
+        "reason": "Memory index coverage retained nearly 1 GiB in unit-fast on Linux CI and is safer in its own fork."
+      },
+      {
+        "file": "src/plugins/http-registry.test.ts",
+        "reason": "Plugin HTTP registry coverage retained a broad plugin graph in unit-fast and is safer outside the shared lane."
+      },
+      {
+        "file": "src/infra/channel-summary.test.ts",
+        "reason": "Channel summary coverage retained a large channel/plugin graph in unit-fast on Linux CI."
+      },
+      {
+        "file": "src/config/redact-snapshot.test.ts",
+        "reason": "Snapshot redaction coverage produced a large retained heap jump in unit-fast on Linux CI."
+      },
+      {
+        "file": "src/config/redact-snapshot.restore.test.ts",
+        "reason": "Snapshot restore coverage retains a broad schema/redaction graph and is safer outside the shared lane."
+      },
+      {
+        "file": "src/config/redact-snapshot.schema.test.ts",
+        "reason": "Schema-backed redaction round-trip coverage loads the full config schema graph and is safer outside the shared lane."
+      },
+      {
+        "file": "src/infra/outbound/message-action-runner.media.test.ts",
+        "reason": "Outbound media action coverage retained a large media/plugin graph in unit-fast."
+      },
+      {
+        "file": "src/media-understanding/apply.echo-transcript.test.ts",
+        "reason": "Media understanding echo transcript coverage retained a large processing graph in unit-fast."
+      },
+      {
+        "file": "src/plugin-sdk/index.test.ts",
+        "reason": "Plugin SDK index coverage retained a broad export graph in unit-fast and is safer outside the shared lane."
+      },
+      {
+        "file": "src/plugin-sdk/index.bundle.test.ts",
+        "reason": "Plugin SDK bundle validation builds and imports the full bundled export graph and is safer outside the shared lane."
+      },
+      {
+        "file": "src/config/sessions.cache.test.ts",
+        "reason": "Session cache coverage retained a large config/session graph in unit-fast on Linux CI."
+      },
+      {
+        "file": "src/secrets/runtime.coverage.test.ts",
+        "reason": "Secrets runtime coverage tests retained substantial heap in unit-fast and are safer isolated."
+      },
+      {
+        "file": "src/channels/plugins/contracts/registry.contract.test.ts",
+        "reason": "Plugin contract registry coverage retained a large cross-plugin graph in both failing unit-fast shards."
+      },
+      {
+        "file": "src/memory/manager.get-concurrency.test.ts",
+        "reason": "Memory manager cache concurrency coverage can spike shared unit-fast heap on Linux Node 24."
+      },
+      {
+        "file": "src/memory/manager.vector-dedupe.test.ts",
+        "reason": "Vector dedupe coverage exercises the memory manager/sqlite stack and is safer outside shared unit-fast forks."
+      },
+      {
+        "file": "src/memory/manager.watcher-config.test.ts",
+        "reason": "Watcher config coverage reuses memory manager caches and is safer outside shared unit-fast forks."
+      },
+      {
+        "file": "src/memory/manager.embedding-batches.test.ts",
+        "reason": "Embedding batch coverage inflates memory manager state and is safer outside shared unit-fast forks."
+      },
+      {
+        "file": "src/memory/manager.readonly-recovery.test.ts",
+        "reason": "Readonly recovery coverage exercises sqlite reopen flows and is safer outside shared unit-fast forks."
+      },
+      {
+        "file": "src/acp/persistent-bindings.test.ts",
+        "reason": "Persistent bindings coverage retained a large unit-fast heap spike on Linux CI and is safer outside the shared lane."
+      },
+      {
+        "file": "src/channels/plugins/setup-wizard-helpers.test.ts",
+        "reason": "Setup wizard helper coverage retained the largest shared unit-fast heap spike on Linux Node 24 CI."
+      },
+      {
+        "file": "src/cli/config-cli.integration.test.ts",
+        "reason": "Config CLI integration coverage retained a large shared unit-fast heap spike on Linux CI."
+      },
+      {
+        "file": "src/cli/config-cli.test.ts",
+        "reason": "Config CLI coverage retained a large shared unit-fast heap spike on Linux Node 24 CI."
+      },
+      {
+        "file": "src/cli/plugins-cli.test.ts",
+        "reason": "Plugins CLI coverage retained a broad plugin graph in shared unit-fast forks on Linux CI."
+      },
+      {
+        "file": "src/config/plugin-auto-enable.test.ts",
+        "reason": "Plugin auto-enable coverage retained a large shared unit-fast heap spike on Linux Node 22 CI."
+      },
+      {
+        "file": "src/cron/service.runs-one-shot-main-job-disables-it.test.ts",
+        "reason": "One-shot cron service coverage retained a top shared unit-fast heap spike in the March 19, 2026 Linux Node 22 OOM lane."
+      },
+      {
+        "file": "src/cron/isolated-agent/run.sandbox-config-preserved.test.ts",
+        "reason": "Isolated-agent sandbox config coverage retained a large shared unit-fast heap spike on Linux CI."
+      },
+      {
+        "file": "src/cron/isolated-agent.direct-delivery-core-channels.test.ts",
+        "reason": "Direct-delivery isolated-agent coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 OOM lane."
+      },
+      {
+        "file": "src/cron/service.issue-regressions.test.ts",
+        "reason": "Issue regression cron coverage retained the largest shared unit-fast heap spike in the March 20, 2026 Linux Node 22 and Node 24 OOM lanes."
+      },
+      {
+        "file": "src/cron/store.test.ts",
+        "reason": "Cron store coverage retained a large shared unit-fast heap spike on Linux Node 24 CI."
+      },
+      {
+        "file": "src/context-engine/context-engine.test.ts",
+        "reason": "Context-engine coverage retained the largest shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
+      },
+      {
+        "file": "src/acp/control-plane/manager.test.ts",
+        "reason": "ACP control-plane manager coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 22 and Node 24 OOM lanes."
+      },
+      {
+        "file": "src/acp/translator.stop-reason.test.ts",
+        "reason": "ACP translator stop-reason coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
+      },
+      {
+        "file": "src/infra/exec-approval-forwarder.test.ts",
+        "reason": "Exec approval forwarder coverage retained a top shared unit-fast heap spike in the March 19, 2026 Linux Node 22 OOM lane."
+      },
+      {
+        "file": "src/infra/restart-stale-pids.test.ts",
+        "reason": "Restart-stale-pids coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
+      },
+      {
+        "file": "src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts",
+        "reason": "Heartbeat ack max chars coverage retained a recurring shared unit-fast heap spike across Linux CI lanes."
+      },
+      {
+        "file": "src/infra/heartbeat-runner.returns-default-unset.test.ts",
+        "reason": "Heartbeat default-unset coverage retained a large shared unit-fast heap spike on Linux Node 22 CI."
+      },
+      {
+        "file": "src/infra/heartbeat-runner.ghost-reminder.test.ts",
+        "reason": "Mocks jiti at file scope, so it is safer outside shared Vitest workers."
+      },
+      {
+        "file": "src/infra/heartbeat-runner.transcript-prune.test.ts",
+        "reason": "Mocks jiti at file scope, so it is safer outside shared Vitest workers."
+      },
+      {
+        "file": "src/infra/heartbeat-runner.sender-prefers-delivery-target.test.ts",
+        "reason": "Mocks jiti at file scope, so it is safer outside shared Vitest workers."
+      },
+      {
+        "file": "src/infra/heartbeat-runner.model-override.test.ts",
+        "reason": "Mocks jiti at file scope, so it is safer outside shared Vitest workers."
+      },
+      {
+        "file": "src/infra/outbound/outbound-session.test.ts",
+        "reason": "Outbound session coverage retained a large shared unit-fast heap spike on Linux Node 22 CI."
+      },
+      {
+        "file": "src/infra/outbound/payloads.test.ts",
+        "reason": "Outbound payload coverage retained a large shared unit-fast heap spike on Linux Node 24 CI."
+      },
+      {
+        "file": "src/memory/manager.mistral-provider.test.ts",
+        "reason": "Mistral provider coverage retained a large shared unit-fast heap spike on Linux Node 24 CI."
+      },
+      {
+        "file": "src/memory/manager.batch.test.ts",
+        "reason": "Memory manager batch coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 22 and Node 24 OOM lanes."
+      },
+      {
+        "file": "src/memory/qmd-manager.test.ts",
+        "reason": "QMD manager coverage retained recurring shared unit-fast heap spikes across Linux CI lanes."
+      },
+      {
+        "file": "src/media-understanding/providers/image.test.ts",
+        "reason": "Image provider coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
+      },
+      {
+        "file": "src/plugins/contracts/auth.contract.test.ts",
+        "reason": "Plugin auth contract coverage retained a large shared unit-fast heap spike on Linux Node 24 CI."
+      },
+      {
+        "file": "src/plugins/contracts/discovery.contract.test.ts",
+        "reason": "Plugin discovery contract coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
+      },
+      {
+        "file": "src/plugins/hooks.phase-hooks.test.ts",
+        "reason": "Phase hooks coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
+      },
+      {
+        "file": "src/channels/plugins/plugins-core.test.ts",
+        "reason": "Core plugin coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 22 OOM lane."
+      },
+      {
+        "file": "src/secrets/apply.test.ts",
+        "reason": "Secrets apply coverage retained a large shared unit-fast heap spike on Linux Node 22 CI."
+      },
+      {
+        "file": "src/tui/tui-command-handlers.test.ts",
+        "reason": "TUI command handler coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
+      },
+      {
+        "file": "src/node-host/invoke-system-run.test.ts",
+        "reason": "Missing from unit timings and retained the largest shared unit-fast heap spike across the March 20, 2026 Linux Node 22 and Node 24 OOM lanes."
+      },
+      {
+        "file": "src/media-understanding/apply.test.ts",
+        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike across the March 20, 2026 Linux Node 22 and Node 24 OOM lanes."
+      },
+      {
+        "file": "src/plugins/commands.test.ts",
+        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 22 OOM lane."
+      },
+      {
+        "file": "src/infra/outbound/message-action-runner.plugin-dispatch.test.ts",
+        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 22 OOM lane."
+      },
+      {
+        "file": "src/acp/translator.session-rate-limit.test.ts",
+        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 22 OOM lane."
+      },
+      {
+        "file": "src/config/schema.hints.test.ts",
+        "reason": "Missing from unit timings and retained a recurring shared unit-fast heap spike across the March 20, 2026 Linux Node 22 and Node 24 OOM lanes."
+      },
+      {
+        "file": "src/tui/tui-event-handlers.test.ts",
+        "reason": "Missing from unit timings and retained the largest shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
+      },
+      {
+        "file": "src/memory/manager.read-file.test.ts",
+        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
+      },
+      {
+        "file": "src/plugin-sdk/webhook-targets.test.ts",
+        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
+      },
+      {
+        "file": "src/daemon/systemd.test.ts",
+        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
+      },
+      {
+        "file": "src/cron/isolated-agent/delivery-target.test.ts",
+        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
+      },
+      {
+        "file": "src/cron/delivery.test.ts",
+        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
+      },
+      {
+        "file": "src/memory/manager.sync-errors-do-not-crash.test.ts",
+        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
+      },
+      {
+        "file": "src/tui/tui.test.ts",
+        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
+      },
+      {
+        "file": "src/cron/service.every-jobs-fire.test.ts",
+        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
+      }
+    ],
+    "threadSingleton": [
+      {
+        "file": "src/channels/plugins/actions/actions.test.ts",
+        "reason": "Terminates cleanly under threads, but not process forks on this host."
+      },
+      {
+        "file": "src/infra/outbound/deliver.test.ts",
+        "reason": "Terminates cleanly under threads, but not process forks on this host."
+      },
+      {
+        "file": "src/infra/outbound/deliver.lifecycle.test.ts",
+        "reason": "Terminates cleanly under threads, but not process forks on this host."
+      },
+      {
+        "file": "src/infra/outbound/message.channels.test.ts",
+        "reason": "Terminates cleanly under threads, but not process forks on this host."
+      },
+      {
+        "file": "src/infra/outbound/message-action-runner.poll.test.ts",
+        "reason": "Terminates cleanly under threads, but not process forks on this host."
+      },
+      {
+        "file": "src/infra/outbound/message-action-runner.context.test.ts",
+        "reason": "Terminates cleanly under threads, but not process forks on this host."
+      },
+      {
+        "file": "src/tts/tts.test.ts",
+        "reason": "Terminates cleanly under threads, but not process forks on this host."
+      }
+    ],
+    "vmForkSingleton": [
+      {
+        "file": "src/channels/plugins/contracts/inbound.telegram.contract.test.ts",
+        "reason": "Needs the vmForks lane when targeted."
+      }
+    ]
   }
 }

--- a/test/fixtures/test-parallel.behavior.json
+++ b/test/fixtures/test-parallel.behavior.json
@@ -16,7 +16,9 @@
     ]
   },
   "channels": {
-    "isolatedPrefixes": ["extensions/discord/src/monitor/"],
+    "isolatedPrefixes": [
+      "extensions/discord/src/monitor/"
+    ],
     "isolated": [
       {
         "file": "extensions/discord/src/monitor/message-handler.preflight.acp-bindings.test.ts",
@@ -141,11 +143,19 @@
       {
         "file": "extensions/tavily/src/tavily-search-tool.test.ts",
         "reason": "This search-tool suite hoists the Tavily client mock and imports lazily; keep it isolated so shared extension workers do not bypass the mocked client via cached modules."
+      },
+      {
+        "file": "extensions/imessage/src/monitor.shutdown.unhandled-rejection.test.ts",
+        "reason": "Touches process-level unhandledRejection listeners."
       }
     ]
   },
   "unit": {
     "isolated": [
+      {
+        "file": "src/cli/qr-dashboard.integration.test.ts",
+        "reason": "This CLI integration suite hoists runtime/config mocks and resets module state between qr and dashboard command imports; keep it in its own forked lane so shared unit-fast workers stay deterministic."
+      },
       {
         "file": "src/plugins/contracts/runtime.contract.test.ts",
         "reason": "Async runtime imports + provider refresh seams; keep out of the shared lane."
@@ -163,298 +173,8 @@
         "reason": "Rebuilds bundled config baselines through many channel schema subprocesses; keep out of the shared lane."
       },
       {
-        "file": "extensions/imessage/src/monitor.shutdown.unhandled-rejection.test.ts",
-        "reason": "Touches process-level unhandledRejection listeners."
-      },
-      {
         "file": "src/plugins/loader.git-path-regression.test.ts",
         "reason": "Constructs a real Jiti boundary that assigns module.require; requires process forks, not vmForks."
-      }
-    ],
-    "singletonIsolated": [
-      {
-        "file": "src/cli/command-secret-gateway.test.ts",
-        "reason": "Clean in isolation, but can hang after sharing the broad lane."
-      },
-      {
-        "file": "src/config/doc-baseline.integration.test.ts",
-        "reason": "Builds the full bundled config schema graph and is safer outside the shared unit-fast heap."
-      },
-      {
-        "file": "src/secrets/runtime.test.ts",
-        "reason": "Secrets runtime coverage retained the largest unit-fast heap spike in CI and is safer outside the shared lane."
-      },
-      {
-        "file": "src/secrets/runtime.integration.test.ts",
-        "reason": "Secrets runtime activation/write-through integration coverage is CPU-heavy and safer outside the shared unit-fast lane."
-      },
-      {
-        "file": "src/memory/index.test.ts",
-        "reason": "Memory index coverage retained nearly 1 GiB in unit-fast on Linux CI and is safer in its own fork."
-      },
-      {
-        "file": "src/plugins/http-registry.test.ts",
-        "reason": "Plugin HTTP registry coverage retained a broad plugin graph in unit-fast and is safer outside the shared lane."
-      },
-      {
-        "file": "src/infra/channel-summary.test.ts",
-        "reason": "Channel summary coverage retained a large channel/plugin graph in unit-fast on Linux CI."
-      },
-      {
-        "file": "src/config/redact-snapshot.test.ts",
-        "reason": "Snapshot redaction coverage produced a large retained heap jump in unit-fast on Linux CI."
-      },
-      {
-        "file": "src/config/redact-snapshot.restore.test.ts",
-        "reason": "Snapshot restore coverage retains a broad schema/redaction graph and is safer outside the shared lane."
-      },
-      {
-        "file": "src/config/redact-snapshot.schema.test.ts",
-        "reason": "Schema-backed redaction round-trip coverage loads the full config schema graph and is safer outside the shared lane."
-      },
-      {
-        "file": "src/infra/outbound/message-action-runner.media.test.ts",
-        "reason": "Outbound media action coverage retained a large media/plugin graph in unit-fast."
-      },
-      {
-        "file": "src/media-understanding/apply.echo-transcript.test.ts",
-        "reason": "Media understanding echo transcript coverage retained a large processing graph in unit-fast."
-      },
-      {
-        "file": "src/plugin-sdk/index.test.ts",
-        "reason": "Plugin SDK index coverage retained a broad export graph in unit-fast and is safer outside the shared lane."
-      },
-      {
-        "file": "src/plugin-sdk/index.bundle.test.ts",
-        "reason": "Plugin SDK bundle validation builds and imports the full bundled export graph and is safer outside the shared lane."
-      },
-      {
-        "file": "src/config/sessions.cache.test.ts",
-        "reason": "Session cache coverage retained a large config/session graph in unit-fast on Linux CI."
-      },
-      {
-        "file": "src/secrets/runtime.coverage.test.ts",
-        "reason": "Secrets runtime coverage tests retained substantial heap in unit-fast and are safer isolated."
-      },
-      {
-        "file": "src/channels/plugins/contracts/registry.contract.test.ts",
-        "reason": "Plugin contract registry coverage retained a large cross-plugin graph in both failing unit-fast shards."
-      },
-      {
-        "file": "src/memory/manager.get-concurrency.test.ts",
-        "reason": "Memory manager cache concurrency coverage can spike shared unit-fast heap on Linux Node 24."
-      },
-      {
-        "file": "src/memory/manager.vector-dedupe.test.ts",
-        "reason": "Vector dedupe coverage exercises the memory manager/sqlite stack and is safer outside shared unit-fast forks."
-      },
-      {
-        "file": "src/memory/manager.watcher-config.test.ts",
-        "reason": "Watcher config coverage reuses memory manager caches and is safer outside shared unit-fast forks."
-      },
-      {
-        "file": "src/memory/manager.embedding-batches.test.ts",
-        "reason": "Embedding batch coverage inflates memory manager state and is safer outside shared unit-fast forks."
-      },
-      {
-        "file": "src/memory/manager.readonly-recovery.test.ts",
-        "reason": "Readonly recovery coverage exercises sqlite reopen flows and is safer outside shared unit-fast forks."
-      },
-      {
-        "file": "src/acp/persistent-bindings.test.ts",
-        "reason": "Persistent bindings coverage retained a large unit-fast heap spike on Linux CI and is safer outside the shared lane."
-      },
-      {
-        "file": "src/channels/plugins/setup-wizard-helpers.test.ts",
-        "reason": "Setup wizard helper coverage retained the largest shared unit-fast heap spike on Linux Node 24 CI."
-      },
-      {
-        "file": "src/cli/config-cli.integration.test.ts",
-        "reason": "Config CLI integration coverage retained a large shared unit-fast heap spike on Linux CI."
-      },
-      {
-        "file": "src/cli/config-cli.test.ts",
-        "reason": "Config CLI coverage retained a large shared unit-fast heap spike on Linux Node 24 CI."
-      },
-      {
-        "file": "src/cli/plugins-cli.test.ts",
-        "reason": "Plugins CLI coverage retained a broad plugin graph in shared unit-fast forks on Linux CI."
-      },
-      {
-        "file": "src/config/plugin-auto-enable.test.ts",
-        "reason": "Plugin auto-enable coverage retained a large shared unit-fast heap spike on Linux Node 22 CI."
-      },
-      {
-        "file": "src/cron/service.runs-one-shot-main-job-disables-it.test.ts",
-        "reason": "One-shot cron service coverage retained a top shared unit-fast heap spike in the March 19, 2026 Linux Node 22 OOM lane."
-      },
-      {
-        "file": "src/cron/isolated-agent/run.sandbox-config-preserved.test.ts",
-        "reason": "Isolated-agent sandbox config coverage retained a large shared unit-fast heap spike on Linux CI."
-      },
-      {
-        "file": "src/cron/isolated-agent.direct-delivery-core-channels.test.ts",
-        "reason": "Direct-delivery isolated-agent coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 OOM lane."
-      },
-      {
-        "file": "src/cron/service.issue-regressions.test.ts",
-        "reason": "Issue regression cron coverage retained the largest shared unit-fast heap spike in the March 20, 2026 Linux Node 22 and Node 24 OOM lanes."
-      },
-      {
-        "file": "src/cron/store.test.ts",
-        "reason": "Cron store coverage retained a large shared unit-fast heap spike on Linux Node 24 CI."
-      },
-      {
-        "file": "src/context-engine/context-engine.test.ts",
-        "reason": "Context-engine coverage retained the largest shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
-      },
-      {
-        "file": "src/acp/control-plane/manager.test.ts",
-        "reason": "ACP control-plane manager coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 22 and Node 24 OOM lanes."
-      },
-      {
-        "file": "src/acp/translator.stop-reason.test.ts",
-        "reason": "ACP translator stop-reason coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
-      },
-      {
-        "file": "src/infra/exec-approval-forwarder.test.ts",
-        "reason": "Exec approval forwarder coverage retained a top shared unit-fast heap spike in the March 19, 2026 Linux Node 22 OOM lane."
-      },
-      {
-        "file": "src/infra/restart-stale-pids.test.ts",
-        "reason": "Restart-stale-pids coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
-      },
-      {
-        "file": "src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts",
-        "reason": "Heartbeat ack max chars coverage retained a recurring shared unit-fast heap spike across Linux CI lanes."
-      },
-      {
-        "file": "src/infra/heartbeat-runner.returns-default-unset.test.ts",
-        "reason": "Heartbeat default-unset coverage retained a large shared unit-fast heap spike on Linux Node 22 CI."
-      },
-      {
-        "file": "src/infra/heartbeat-runner.ghost-reminder.test.ts",
-        "reason": "Mocks jiti at file scope, so it is safer outside shared Vitest workers."
-      },
-      {
-        "file": "src/infra/heartbeat-runner.transcript-prune.test.ts",
-        "reason": "Mocks jiti at file scope, so it is safer outside shared Vitest workers."
-      },
-      {
-        "file": "src/infra/heartbeat-runner.sender-prefers-delivery-target.test.ts",
-        "reason": "Mocks jiti at file scope, so it is safer outside shared Vitest workers."
-      },
-      {
-        "file": "src/infra/heartbeat-runner.model-override.test.ts",
-        "reason": "Mocks jiti at file scope, so it is safer outside shared Vitest workers."
-      },
-      {
-        "file": "src/infra/outbound/outbound-session.test.ts",
-        "reason": "Outbound session coverage retained a large shared unit-fast heap spike on Linux Node 22 CI."
-      },
-      {
-        "file": "src/infra/outbound/payloads.test.ts",
-        "reason": "Outbound payload coverage retained a large shared unit-fast heap spike on Linux Node 24 CI."
-      },
-      {
-        "file": "src/memory/manager.mistral-provider.test.ts",
-        "reason": "Mistral provider coverage retained a large shared unit-fast heap spike on Linux Node 24 CI."
-      },
-      {
-        "file": "src/memory/manager.batch.test.ts",
-        "reason": "Memory manager batch coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 22 and Node 24 OOM lanes."
-      },
-      {
-        "file": "src/memory/qmd-manager.test.ts",
-        "reason": "QMD manager coverage retained recurring shared unit-fast heap spikes across Linux CI lanes."
-      },
-      {
-        "file": "src/media-understanding/providers/image.test.ts",
-        "reason": "Image provider coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
-      },
-      {
-        "file": "src/plugins/contracts/auth.contract.test.ts",
-        "reason": "Plugin auth contract coverage retained a large shared unit-fast heap spike on Linux Node 24 CI."
-      },
-      {
-        "file": "src/plugins/contracts/discovery.contract.test.ts",
-        "reason": "Plugin discovery contract coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
-      },
-      {
-        "file": "src/plugins/hooks.phase-hooks.test.ts",
-        "reason": "Phase hooks coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
-      },
-      {
-        "file": "src/channels/plugins/plugins-core.test.ts",
-        "reason": "Core plugin coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 22 OOM lane."
-      },
-      {
-        "file": "src/secrets/apply.test.ts",
-        "reason": "Secrets apply coverage retained a large shared unit-fast heap spike on Linux Node 22 CI."
-      },
-      {
-        "file": "src/tui/tui-command-handlers.test.ts",
-        "reason": "TUI command handler coverage retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
-      },
-      {
-        "file": "src/node-host/invoke-system-run.test.ts",
-        "reason": "Missing from unit timings and retained the largest shared unit-fast heap spike across the March 20, 2026 Linux Node 22 and Node 24 OOM lanes."
-      },
-      {
-        "file": "src/media-understanding/apply.test.ts",
-        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike across the March 20, 2026 Linux Node 22 and Node 24 OOM lanes."
-      },
-      {
-        "file": "src/plugins/commands.test.ts",
-        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 22 OOM lane."
-      },
-      {
-        "file": "src/infra/outbound/message-action-runner.plugin-dispatch.test.ts",
-        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 22 OOM lane."
-      },
-      {
-        "file": "src/acp/translator.session-rate-limit.test.ts",
-        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 22 OOM lane."
-      },
-      {
-        "file": "src/config/schema.hints.test.ts",
-        "reason": "Missing from unit timings and retained a recurring shared unit-fast heap spike across the March 20, 2026 Linux Node 22 and Node 24 OOM lanes."
-      },
-      {
-        "file": "src/tui/tui-event-handlers.test.ts",
-        "reason": "Missing from unit timings and retained the largest shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
-      },
-      {
-        "file": "src/memory/manager.read-file.test.ts",
-        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
-      },
-      {
-        "file": "src/plugin-sdk/webhook-targets.test.ts",
-        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
-      },
-      {
-        "file": "src/daemon/systemd.test.ts",
-        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
-      },
-      {
-        "file": "src/cron/isolated-agent/delivery-target.test.ts",
-        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 1 OOM lane."
-      },
-      {
-        "file": "src/cron/delivery.test.ts",
-        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
-      },
-      {
-        "file": "src/memory/manager.sync-errors-do-not-crash.test.ts",
-        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
-      },
-      {
-        "file": "src/tui/tui.test.ts",
-        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
-      },
-      {
-        "file": "src/cron/service.every-jobs-fire.test.ts",
-        "reason": "Missing from unit timings and retained a top shared unit-fast heap spike in the March 20, 2026 Linux Node 24 shard 2 OOM lane."
       }
     ],
     "threadSingleton": [
@@ -485,12 +205,6 @@
       {
         "file": "src/tts/tts.test.ts",
         "reason": "Terminates cleanly under threads, but not process forks on this host."
-      }
-    ],
-    "vmForkSingleton": [
-      {
-        "file": "src/channels/plugins/contracts/inbound.telegram.contract.test.ts",
-        "reason": "Needs the vmForks lane when targeted."
       }
     ]
   }


### PR DESCRIPTION
## Summary

Strip inline base64 image content blocks from user messages before writing to session JSONL transcript files. This prevents session file bloat caused by persisting raw image data that has already been processed by the model.

## Problem

When channels (Discord, Telegram, etc.) pass inbound images to the agent, user messages may contain `type: "image"` content blocks with full base64 payloads. These are persisted verbatim to session `.jsonl` files via `SessionManager.appendMessage()`, causing session files to grow rapidly — even though the model has already processed the image and an out-of-band media path/reference is available in the text.

## Root cause

The `transformMessageForPersistence` pipeline in the session tool result guard sanitized tool calls and tool results, but did not strip user message image blocks before writing to the session transcript.

## Fix

- Add `stripImageContentForPersistence()` in `src/agents/pi-embedded-runner/run/history-image-prune.ts`
  - Pure function (does not mutate input, returns shallow clone)
  - Replaces `type: "image"` blocks with a text marker using the existing `PRUNED_HISTORY_IMAGE_MARKER` constant
  - Only transforms `user` role messages; passes through all other roles unchanged
- Integrate into the `transformMessageForPersistence` pipeline in `session-tool-result-guard-wrapper.ts`
  - Applied after `applyInputProvenanceToUserMessage`, before JSONL append

## Testing

- 6 new test cases in `history-image-prune.test.ts` covering:
  - Normal image block replacement
  - Immutability (original message not mutated)
  - Non-user role passthrough
  - No-image content passthrough
  - String content passthrough
  - Multiple image blocks
- All 10 tests pass: `pnpm test -- src/agents/pi-embedded-runner/run/history-image-prune.test.ts`

## Related

- Closes a similar concern raised in #1210
- Prior PR #42941 addressed the same problem but was auto-closed (`r: too-many-prs`). This implementation differs in:
  - Code lives in the dedicated `history-image-prune.ts` module alongside the existing runtime image pruner
  - Reuses the already established `PRUNED_HISTORY_IMAGE_MARKER` constant
  - More comprehensive test coverage (6 test cases vs 1)
  - Integrates via `transformMessageForPersistence` callback rather than inline in the guard
- Also includes an unrelated pre-existing format fix in `lifecycle.test.ts`
