### PR TITLE
fix(ui): suppress leaked TUI debug lines in chat

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -78,6 +78,26 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Hello");
   });
 
+  it("ignores leaked TUI debug delta updates", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Hello",
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "[TUI] evt=health sk=undefined cur=agent:main:main" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(state.chatStream).toBe("Hello");
+  });
+
   it("appends final payload from another run without clearing active stream", () => {
     const state = createState({
       sessionKey: "main",
@@ -123,6 +143,30 @@ describe("handleChatEvent", () => {
     expect(state.chatRunId).toBe("run-user");
     expect(state.chatStream).toBe("Working...");
     expect(state.chatStreamStartedAt).toBe(123);
+    expect(state.chatMessages).toEqual([]);
+  });
+
+  it("drops assistant command messages from another run without clearing active stream", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-user",
+      chatStream: "Working...",
+      chatStreamStartedAt: 123,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-announce",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        command: true,
+        content: [{ type: "text", text: "[TUI] evt=chat sk=undefined cur=agent:main:main" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatRunId).toBe("run-user");
+    expect(state.chatStream).toBe("Working...");
     expect(state.chatMessages).toEqual([]);
   });
 
@@ -421,6 +465,29 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe(null);
   });
 
+  it("drops leaked TUI debug messages from own run", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "[TUI] evt=health sk=undefined cur=agent:main:main" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([]);
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+  });
+
   it("does not persist NO_REPLY stream text on final without message", () => {
     const state = createState({
       sessionKey: "main",
@@ -438,11 +505,50 @@ describe("handleChatEvent", () => {
     expect(state.chatMessages).toEqual([]);
   });
 
+  it("does not persist leaked TUI debug stream text on final", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "[TUI] evt=health sk=undefined cur=agent:main:main",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "[TUI] evt=health sk=undefined cur=agent:main:main" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([]);
+  });
+
   it("does not persist NO_REPLY stream text on abort", () => {
     const state = createState({
       sessionKey: "main",
       chatRunId: "run-1",
       chatStream: "NO_REPLY",
+      chatStreamStartedAt: 100,
+    });
+    const payload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "aborted",
+      message: "not-an-assistant-message",
+    } as unknown as ChatEventPayload;
+
+    expect(handleChatEvent(state, payload)).toBe("aborted");
+    expect(state.chatMessages).toEqual([]);
+  });
+
+  it("does not persist leaked TUI debug stream text on abort", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "[TUI] evt=health sk=undefined cur=agent:main:main",
       chatStreamStartedAt: 100,
     });
     const payload = {
@@ -509,6 +615,15 @@ describe("loadChatHistory", () => {
       { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
       { role: "assistant", content: [{ type: "text", text: "Real answer" }] },
       { role: "assistant", text: "  NO_REPLY  " },
+      {
+        role: "assistant",
+        command: true,
+        content: [{ type: "text", text: "[TUI] evt=agent sk=agent:main:main cur=agent:main:main" }],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[TUI] evt=health sk=undefined cur=agent:main:main" }],
+      },
     ];
     const mockClient = {
       request: vi.fn().mockResolvedValue({ messages, thinkingLevel: "low" }),

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -6,26 +6,68 @@ import type { ChatAttachment } from "../ui-types.ts";
 import { generateUUID } from "../uuid.ts";
 
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
+const TUI_DEBUG_EVENT_PATTERN = /^\s*\[TUI\]\s+evt=[a-z0-9_.:-]+(?:\s+[a-z0-9_.:-]+=[^\n]+)*\s*$/i;
 
 function isSilentReplyStream(text: string): boolean {
   return SILENT_REPLY_PATTERN.test(text);
 }
+
+function extractAssistantVisibleText(message: unknown): string | null {
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+  const entry = message as Record<string, unknown>;
+  const role = typeof entry.role === "string" ? entry.role.toLowerCase() : "";
+  if (role !== "assistant") {
+    return null;
+  }
+  if (typeof entry.text === "string") {
+    return entry.text;
+  }
+  const text = extractText(message);
+  return typeof text === "string" ? text : null;
+}
+
 /** Client-side defense-in-depth: detect assistant messages whose text is purely NO_REPLY. */
 function isAssistantSilentReply(message: unknown): boolean {
+  const text = extractAssistantVisibleText(message);
+  return typeof text === "string" && isSilentReplyStream(text);
+}
+
+function isAssistantCommandMessage(message: unknown): boolean {
   if (!message || typeof message !== "object") {
     return false;
   }
   const entry = message as Record<string, unknown>;
   const role = typeof entry.role === "string" ? entry.role.toLowerCase() : "";
-  if (role !== "assistant") {
+  return role === "assistant" && entry.command === true;
+}
+
+function isAssistantTuiDebugMessage(message: unknown): boolean {
+  const text = extractAssistantVisibleText(message);
+  if (!text) {
     return false;
   }
-  // entry.text takes precedence — matches gateway extractAssistantTextForSilentCheck
-  if (typeof entry.text === "string") {
-    return isSilentReplyStream(entry.text);
-  }
-  const text = extractText(message);
-  return typeof text === "string" && isSilentReplyStream(text);
+  // Some gateway/TUI debug event lines can leak through as assistant text.
+  // Keep them out of the Control UI chat transcript even if the server emitted them.
+  return TUI_DEBUG_EVENT_PATTERN.test(text);
+}
+
+function isTuiDebugStream(text: string): boolean {
+  const trimmed = text.trimStart();
+  return trimmed.startsWith("[TUI]") || TUI_DEBUG_EVENT_PATTERN.test(text);
+}
+
+function shouldHideAssistantStream(text: string): boolean {
+  return isSilentReplyStream(text) || isTuiDebugStream(text);
+}
+
+function shouldHideAssistantMessage(message: unknown): boolean {
+  return (
+    isAssistantSilentReply(message) ||
+    isAssistantCommandMessage(message) ||
+    isAssistantTuiDebugMessage(message)
+  );
 }
 
 export type ChatState = {
@@ -79,7 +121,7 @@ export async function loadChatHistory(state: ChatState) {
       },
     );
     const messages = Array.isArray(res.messages) ? res.messages : [];
-    state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
+    state.chatMessages = messages.filter((message) => !shouldHideAssistantMessage(message));
     state.chatThinkingLevel = res.thinkingLevel ?? null;
     // Clear all streaming state — history includes tool results and text
     // inline, so keeping streaming artifacts would cause duplicates.
@@ -273,7 +315,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (payload.runId && state.chatRunId && payload.runId !== state.chatRunId) {
     if (payload.state === "final") {
       const finalMessage = normalizeFinalAssistantMessage(payload.message);
-      if (finalMessage && !isAssistantSilentReply(finalMessage)) {
+      if (finalMessage && !shouldHideAssistantMessage(finalMessage)) {
         state.chatMessages = [...state.chatMessages, finalMessage];
         return null;
       }
@@ -284,7 +326,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
 
   if (payload.state === "delta") {
     const next = extractText(payload.message);
-    if (typeof next === "string" && !isSilentReplyStream(next)) {
+    if (typeof next === "string" && !shouldHideAssistantStream(next)) {
       const current = state.chatStream ?? "";
       if (!current || next.length >= current.length) {
         state.chatStream = next;
@@ -292,9 +334,9 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
-    if (finalMessage && !isAssistantSilentReply(finalMessage)) {
+    if (finalMessage && !shouldHideAssistantMessage(finalMessage)) {
       state.chatMessages = [...state.chatMessages, finalMessage];
-    } else if (state.chatStream?.trim() && !isSilentReplyStream(state.chatStream)) {
+    } else if (state.chatStream?.trim() && !shouldHideAssistantStream(state.chatStream)) {
       state.chatMessages = [
         ...state.chatMessages,
         {
@@ -309,11 +351,11 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     state.chatStreamStartedAt = null;
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
-    if (normalizedMessage && !isAssistantSilentReply(normalizedMessage)) {
+    if (normalizedMessage && !shouldHideAssistantMessage(normalizedMessage)) {
       state.chatMessages = [...state.chatMessages, normalizedMessage];
     } else {
       const streamedText = state.chatStream ?? "";
-      if (streamedText.trim() && !isSilentReplyStream(streamedText)) {
+      if (streamedText.trim() && !shouldHideAssistantStream(streamedText)) {
         state.chatMessages = [
           ...state.chatMessages,
           {


### PR DESCRIPTION
## Summary

- Problem: Control UI could render leaked assistant text like `[TUI] evt=health ...` / `[TUI] evt=chat ...` inside the chat transcript.
- Why it matters: these internal debug/event lines are noisy, user-visible, and look like broken chat output.
- What changed: hide assistant command/debug messages in Control UI chat history and live chat events; add focused regression coverage for command-flagged and leaked `[TUI] evt=...` payloads.
- What did NOT change (scope boundary): no gateway protocol changes, no TUI behavior changes, and no transcript persistence changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50905
- Related #50905

## User-visible / Behavior Changes

- Control UI no longer shows leaked assistant command/debug lines such as `[TUI] evt=...` in the chat transcript.
- Existing NO_REPLY filtering remains intact.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS host / Codex workspace
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): Control UI / webchat
- Relevant config (redacted): default main session (`agent:main:main`)

### Steps

1. Open Control UI and connect to a gateway session.
2. Receive assistant messages shaped like leaked TUI debug lines (for example `[TUI] evt=health ...`).
3. Observe whether they render in the chat transcript/history.

### Expected

- Internal command/debug lines stay hidden from the Control UI chat transcript.

### Actual

- Before this patch they could show up as normal assistant messages.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed both live `chat` event handling and `chat.history` filtering paths to ensure leaked assistant command/debug lines are suppressed in both flows.
- Edge cases checked: preserved NO_REPLY filtering, preserved real assistant text when present, kept filtering limited to assistant command/debug payloads.
- What you did **not** verify: could not execute the new scoped Vitest in this container because `node_modules` is absent and `pnpm` bootstrap via Corepack failed to fetch `pnpm-10.23.0` from the npm registry (`ECONNRESET`).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restore `ui/src/ui/controllers/chat.ts` to the previous filter behavior.
- Files/config to restore: `ui/src/ui/controllers/chat.ts`, `ui/src/ui/controllers/chat.test.ts`
- Known bad symptoms reviewers should watch for: legitimate assistant messages being hidden when they intentionally mimic the `[TUI] evt=...` debug pattern.

## Risks and Mitigations

- Risk: over-filtering a legitimate assistant reply that exactly matches the leaked TUI debug-event shape.
  - Mitigation: keep filtering assistant-only, preserve non-debug text, and cover the intended hidden-message shapes with regression tests.
