### PR TITLE
fix(telegram): emit sent hooks for preview finals

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -11,6 +11,7 @@ import {
 const createTelegramDraftStream = vi.hoisted(() => vi.fn());
 const dispatchReplyWithBufferedBlockDispatcher = vi.hoisted(() => vi.fn());
 const deliverReplies = vi.hoisted(() => vi.fn());
+const emitDeliveredReplyHooks = vi.hoisted(() => vi.fn());
 const createForumTopicTelegram = vi.hoisted(() => vi.fn());
 const deleteMessageTelegram = vi.hoisted(() => vi.fn());
 const editForumTopicTelegram = vi.hoisted(() => vi.fn());
@@ -46,6 +47,7 @@ vi.mock("./draft-stream.js", () => ({
 
 vi.mock("./bot/delivery.js", () => ({
   deliverReplies,
+  emitDeliveredReplyHooks,
 }));
 
 vi.mock("./send.js", () => ({
@@ -103,6 +105,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     createTelegramDraftStream.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
     deliverReplies.mockClear();
+    emitDeliveredReplyHooks.mockClear();
     createForumTopicTelegram.mockClear();
     deleteMessageTelegram.mockClear();
     editForumTopicTelegram.mockClear();
@@ -2261,6 +2264,63 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     expect(finalTextSentViaDeliverReplies).toBe(false);
   });
+
+  it.each([
+    {
+      label: "preview-finalized",
+      configureEdit: () => {
+        editMessageTelegram.mockResolvedValue(undefined);
+      },
+    },
+    {
+      label: "preview-retained",
+      configureEdit: () => {
+        editMessageTelegram.mockRejectedValue(
+          new Error("timeout: request timed out after 30000ms"),
+        );
+      },
+    },
+  ])(
+    "emits message:sent hooks when the final answer stays visible via %s",
+    async ({ configureEdit }) => {
+      const draftStream = createDraftStream(999);
+      createTelegramDraftStream.mockReturnValue(draftStream);
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+        async ({ dispatcherOptions, replyOptions }) => {
+          await replyOptions?.onPartialReply?.({ text: "Streaming..." });
+          await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+          return { queuedFinal: true };
+        },
+      );
+      deliverReplies.mockResolvedValue({ delivered: true });
+      configureEdit();
+
+      await dispatchWithContext({
+        context: createContext({
+          ctxPayload: { SessionKey: "agent:main:main" } as never,
+        }),
+      });
+
+      expect(emitDeliveredReplyHooks).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKeyForInternalHooks: "agent:main:main",
+          chatId: "123",
+          accountId: "default",
+          content: "Final answer",
+          success: true,
+          messageId: 999,
+          isGroup: false,
+          groupId: undefined,
+        }),
+      );
+      const finalTextSentViaDeliverReplies = deliverReplies.mock.calls.some((call: unknown[]) =>
+        (call[0] as { replies?: Array<{ text?: string }> })?.replies?.some(
+          (r: { text?: string }) => r.text === "Final answer",
+        ),
+      );
+      expect(finalTextSentViaDeliverReplies).toBe(false);
+    },
+  );
 
   it("falls back to sendPayload on pre-connect error during final edit", async () => {
     const draftStream = createDraftStream(999);

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -551,6 +551,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
         replies: [expect.objectContaining({ text: "⚠️ Recovered tool error details" })],
       }),
     );
+    expect(emitDeliveredReplyHooks).not.toHaveBeenCalled();
     expect(draftStream.clear).not.toHaveBeenCalled();
     expect(draftStream.stop).toHaveBeenCalled();
   });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -508,7 +508,7 @@ export const dispatchTelegramMessage = async ({
     markDelivered: () => {
       deliveryState.markDelivered();
     },
-    onFinalPreviewDelivered: async ({ text, messageId }) => {
+    onFinalPreviewDelivered: ({ text, messageId }) => {
       emitDeliveredReplyHooks({
         sessionKeyForInternalHooks: ctxPayload.SessionKey,
         chatId: String(chatId),

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -30,7 +30,7 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramBotOptions } from "./bot.js";
-import { deliverReplies } from "./bot/delivery.js";
+import { deliverReplies, emitDeliveredReplyHooks } from "./bot/delivery.js";
 import type { TelegramStreamMode } from "./bot/types.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
@@ -507,6 +507,18 @@ export const dispatchTelegramMessage = async ({
     log: logVerbose,
     markDelivered: () => {
       deliveryState.markDelivered();
+    },
+    onFinalPreviewDelivered: async ({ text, messageId }) => {
+      emitDeliveredReplyHooks({
+        sessionKeyForInternalHooks: ctxPayload.SessionKey,
+        chatId: String(chatId),
+        accountId: route.accountId,
+        content: text,
+        success: true,
+        messageId,
+        isGroup,
+        groupId: isGroup ? String(chatId) : undefined,
+      });
     },
   });
 

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -546,6 +546,25 @@ function emitMessageSentHooks(params: {
   );
 }
 
+export function emitDeliveredReplyHooks(params: {
+  sessionKeyForInternalHooks?: string;
+  chatId: string;
+  accountId?: string;
+  content: string;
+  success: boolean;
+  error?: string;
+  messageId?: number;
+  isGroup?: boolean;
+  groupId?: string;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+  emitMessageSentHooks({
+    hookRunner,
+    enabled: hookRunner?.hasHooks("message_sent") ?? false,
+    ...params,
+  });
+}
+
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
   chatId: string;
@@ -581,7 +600,6 @@ export async function deliverReplies(params: {
   const mediaLoader = params.mediaLoader ?? loadWebMedia;
   const hookRunner = getGlobalHookRunner();
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
-  const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
   const chunkText = buildChunkTextResolver({
     textLimit: params.textLimit,
     chunkMode: params.chunkMode ?? "length",
@@ -686,9 +704,7 @@ export async function deliverReplies(params: {
         firstDeliveredMessageId,
       });
 
-      emitMessageSentHooks({
-        hookRunner,
-        enabled: hasMessageSentHooks,
+      emitDeliveredReplyHooks({
         sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
         chatId: params.chatId,
         accountId: params.accountId,
@@ -699,9 +715,7 @@ export async function deliverReplies(params: {
         groupId: params.mirrorGroupId,
       });
     } catch (error) {
-      emitMessageSentHooks({
-        hookRunner,
-        enabled: hasMessageSentHooks,
+      emitDeliveredReplyHooks({
         sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
         chatId: params.chatId,
         accountId: params.accountId,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -557,6 +557,9 @@ export function emitDeliveredReplyHooks(params: {
   isGroup?: boolean;
   groupId?: string;
 }): void {
+  // Keep this fire-and-forget path self-contained for both standard replies and
+  // preview-finalization callbacks; getGlobalHookRunner() resolves the shared
+  // singleton runner, so re-looking it up here does not add blocking work.
   const hookRunner = getGlobalHookRunner();
   emitMessageSentHooks({
     hookRunner,

--- a/extensions/telegram/src/bot/delivery.ts
+++ b/extensions/telegram/src/bot/delivery.ts
@@ -1,2 +1,2 @@
-export { deliverReplies } from "./delivery.replies.js";
+export { deliverReplies, emitDeliveredReplyHooks } from "./delivery.replies.js";
 export { resolveMedia } from "./delivery.resolve-media.js";

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -83,6 +83,11 @@ type CreateLaneTextDelivererParams = {
   deletePreviewMessage: (messageId: number) => Promise<void>;
   log: (message: string) => void;
   markDelivered: () => void;
+  onFinalPreviewDelivered?: (params: {
+    laneName: LaneName;
+    text: string;
+    messageId?: number;
+  }) => Promise<void> | void;
 };
 
 type DeliverLaneTextParams = {
@@ -167,6 +172,17 @@ function resolvePreviewTarget(params: ResolvePreviewTargetParams): PreviewTarget
 }
 
 export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
+  const notifyFinalPreviewDelivered = async (
+    laneName: LaneName,
+    text: string,
+    messageId?: number,
+  ) => {
+    await params.onFinalPreviewDelivered?.({
+      laneName,
+      text,
+      messageId,
+    });
+  };
   const getLanePreviewText = (lane: DraftLaneState) => lane.lastPartialText;
   const markActivePreviewComplete = (laneName: LaneName) => {
     params.activePreviewLifecycleByLane[laneName] = "complete";
@@ -206,6 +222,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
     args.lane.lastPartialText = args.text;
     params.markDelivered();
+    await notifyFinalPreviewDelivered(args.laneName, args.text, materializedMessageId);
     return true;
   };
 
@@ -232,6 +249,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         args.lane.lastPartialText = args.text;
       }
       params.markDelivered();
+      if (args.context === "final") {
+        await notifyFinalPreviewDelivered(args.laneName, args.text, args.messageId);
+      }
       return "edited";
     } catch (err) {
       if (isMessageNotModifiedError(err)) {
@@ -239,6 +259,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           `telegram: ${args.laneName} preview ${args.context} edit returned "message is not modified"; treating as delivered`,
         );
         params.markDelivered();
+        if (args.context === "final") {
+          await notifyFinalPreviewDelivered(args.laneName, args.text, args.messageId);
+        }
         return "edited";
       }
       if (args.context === "final") {
@@ -247,6 +270,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
             `telegram: ${args.laneName} preview final edit failed after stop flush; keeping existing preview (${String(err)})`,
           );
           params.markDelivered();
+          await notifyFinalPreviewDelivered(args.laneName, args.text, args.messageId);
           return "retained";
         }
         if (isSafeToRetrySendError(err)) {
@@ -261,6 +285,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
               `telegram: ${args.laneName} preview final edit target missing; keeping alternate preview without fallback (${String(err)})`,
             );
             params.markDelivered();
+            await notifyFinalPreviewDelivered(args.laneName, args.text, args.messageId);
             return "retained";
           }
           params.log(
@@ -273,6 +298,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
             `telegram: ${args.laneName} preview final edit may have landed despite network error; keeping existing preview (${String(err)})`,
           );
           params.markDelivered();
+          await notifyFinalPreviewDelivered(args.laneName, args.text, args.messageId);
           return "retained";
         }
         if (isTelegramClientRejection(err)) {
@@ -286,6 +312,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           `telegram: ${args.laneName} preview final edit failed with ambiguous error; keeping existing preview to avoid duplicate (${String(err)})`,
         );
         params.markDelivered();
+        await notifyFinalPreviewDelivered(args.laneName, args.text, args.messageId);
         return "retained";
       }
       params.log(
@@ -323,12 +350,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         finalTextAlreadyLanded,
         retainAlternatePreviewOnMissingTarget,
       });
-    const finalizePreview = (
+    const finalizePreview = async (
       previewMessageId: number,
       finalTextAlreadyLanded: boolean,
       hadPreviewMessage: boolean,
       retainAlternatePreviewOnMissingTarget = false,
-    ): PreviewEditResult | Promise<PreviewEditResult> => {
+    ): Promise<PreviewEditResult> => {
       const currentPreviewText = previewTextSnapshot ?? getLanePreviewText(lane);
       const shouldSkipRegressive = shouldSkipRegressivePreviewUpdate({
         currentPreviewText,
@@ -338,6 +365,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       });
       if (shouldSkipRegressive) {
         params.markDelivered();
+        if (context === "final") {
+          await notifyFinalPreviewDelivered(laneName, text, previewMessageId);
+        }
         return "edited";
       }
       return editPreview(
@@ -389,6 +419,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           `telegram: ${laneName} preview send may have landed despite missing message id; keeping to avoid duplicate`,
         );
         params.markDelivered();
+        await notifyFinalPreviewDelivered(laneName, text);
         return "retained";
       }
       return "fallback";

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -365,9 +365,6 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       });
       if (shouldSkipRegressive) {
         params.markDelivered();
-        if (context === "final") {
-          await notifyFinalPreviewDelivered(laneName, text, previewMessageId);
-        }
         return "edited";
       }
       return editPreview(
@@ -419,7 +416,6 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           `telegram: ${laneName} preview send may have landed despite missing message id; keeping to avoid duplicate`,
         );
         params.markDelivered();
-        await notifyFinalPreviewDelivered(laneName, text);
         return "retained";
       }
       return "fallback";

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -44,6 +44,7 @@ function createHarness(params?: {
   const deletePreviewMessage = vi.fn().mockResolvedValue(undefined);
   const log = vi.fn();
   const markDelivered = vi.fn();
+  const onFinalPreviewDelivered = vi.fn();
   const activePreviewLifecycleByLane = { answer: "transient", reasoning: "transient" } as const;
   const retainPreviewOnCleanupByLane = { answer: false, reasoning: false } as const;
   const archivedAnswerPreviews: Array<{
@@ -66,6 +67,7 @@ function createHarness(params?: {
     deletePreviewMessage,
     log,
     markDelivered,
+    onFinalPreviewDelivered,
   });
 
   return {
@@ -82,6 +84,7 @@ function createHarness(params?: {
     deletePreviewMessage,
     log,
     markDelivered,
+    onFinalPreviewDelivered,
     archivedAnswerPreviews,
   };
 }
@@ -295,6 +298,7 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.editPreview).not.toHaveBeenCalled();
     expect(harness.sendPayload).not.toHaveBeenCalled();
     expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+    expect(harness.onFinalPreviewDelivered).not.toHaveBeenCalled();
   });
 
   it("falls back to normal delivery when final text exceeds preview edit limit", async () => {
@@ -529,6 +533,7 @@ describe("createLaneTextDeliverer", () => {
       harness,
       expectedLogSnippet: "preview send may have landed despite missing message id",
     });
+    expect(harness.onFinalPreviewDelivered).not.toHaveBeenCalled();
   });
 
   it("deletes consumed boundary previews after fallback final send", async () => {


### PR DESCRIPTION
## Summary

- Problem: Telegram DM replies that finish by finalizing or retaining a streaming preview never emit `message:sent` hooks because they do not go through `deliverReplies`.
- Why it matters: internal or plugin hooks that rely on `message:sent` miss normal Telegram DM deliveries when preview streaming is active, so logging and automations silently lose visibility.
- What changed: exported the existing Telegram `message:sent` hook emitter, added a final-preview delivery callback in the lane deliverer, and invoked the hook emitter from the Telegram dispatch path whenever a final preview becomes the delivered message.
- What did NOT change (scope boundary): no gateway protocol changes, no preview rendering behavior changes, and no changes to non-final streaming updates.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50878
- Related #50878

## User-visible / Behavior Changes

- Telegram `message:sent` hooks now fire when a DM reply completes by finalizing or retaining a streaming preview instead of sending a new payload.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11 host
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): Telegram extension DM delivery
- Relevant config (redacted): default preview streaming path in Telegram DM delivery

### Steps

1. Enable a `message:sent` internal or plugin hook for Telegram.
2. Send a Telegram DM that is delivered through the preview-finalize path.
3. Observe whether the hook fires after the final preview becomes the delivered message.

### Expected

- `message:sent` fires for final preview deliveries just as it does for `deliverReplies` sends.

### Actual

- Before this change, preview-finalized and preview-retained DM replies never emitted `message:sent`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: final preview edit success emits the hook; retained preview after ambiguous post-connect edit failure still emits the hook; ordinary `deliverReplies` path still uses the same shared emitter.
- Edge cases checked: no hook emission for non-final preview updates, no new payload send on preview-retained/finalized paths, and existing Telegram extension tests remain green.
- What you did **not** verify: live Telegram delivery against a real bot token.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit.
- Files/config to restore: `extensions/telegram/src/bot-message-dispatch.ts`, `extensions/telegram/src/bot/delivery.replies.ts`, `extensions/telegram/src/lane-delivery-text-deliverer.ts`
- Known bad symptoms reviewers should watch for: duplicate hook emissions on final Telegram DM deliveries.

## Risks and Mitigations

- Risk: preview-finalized paths could emit duplicate hooks if they later also flowed through `deliverReplies`.
  - Mitigation: the callback only runs on final preview delivery branches where no final `deliverReplies` payload is sent, and the regression tests assert the final text is not re-sent via `deliverReplies`.

AI-assisted: yes. Context preparation used ContextForge before implementation.
