### PR TITLE
Codex/fix 50833 stale doc version note clean

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2149,7 +2149,7 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
   <Accordion title='Why do I see "Unknown model: minimax/MiniMax-M2.7"?'>
     This means the **provider isn't configured** (no MiniMax provider config or auth
     profile was found), so the model can't be resolved. A fix for this detection is
-    in **2026.1.12** (unreleased at the time of writing).
+    shipped in **2026.1.12**.
 
     Fix checklist:
 

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -203,7 +203,7 @@ Use the interactive config wizard to set MiniMax without editing JSON:
 
 This usually means the **MiniMax provider isn’t configured** (no provider entry
 and no MiniMax auth profile/env key found). A fix for this detection is in
-**2026.1.12** (unreleased at the time of writing). Fix by:
+**2026.1.12**. Fix by:
 
 - Upgrading to **2026.1.12** (or run from source `main`), then restarting the gateway.
 - Running `openclaw configure` and selecting a **MiniMax** auth option, or


### PR DESCRIPTION
## Summary
- remove outdated “unreleased at the time of writing” wording for OpenClaw `2026.1.12`
- keep the troubleshooting guidance intact while updating the version status wording

## Why
Issue #50833 reports that two docs pages still describe `2026.1.12` as unreleased, but that version has already shipped.

This is now stale and potentially confusing for readers following the troubleshooting guidance.

## Changes
- `docs/providers/minimax.md`
  - replace the outdated “unreleased at the time of writing” note with shipped-version wording
- `docs/help/faq.md`
  - replace the same stale wording in the MiniMax troubleshooting entry

## Validation
- verified both reported references were updated
- verified the old phrase no longer appears in the touched docs

Closes #50833
