### PR TITLE
fix(cli): keep nodes list consistent with live paired nodes

### DIFF
--- a/src/cli/nodes-cli/register.status.ts
+++ b/src/cli/nodes-cli/register.status.ts
@@ -8,7 +8,7 @@ import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
 import { formatPermissions, parseNodeList, parsePairingList } from "./format.js";
 import { renderPendingPairingRequestsTable } from "./pairing-render.js";
 import { callGatewayCli, nodesCallOpts, resolveNodeId } from "./rpc.js";
-import type { NodesRpcOpts } from "./types.js";
+import type { NodeListNode, NodesRpcOpts, PairedNode } from "./types.js";
 
 function formatVersionLabel(raw: string) {
   const trimmed = raw.trim();
@@ -95,6 +95,31 @@ function parseSinceMs(raw: unknown, label: string): number | undefined {
     defaultRuntime.exit(1);
     return undefined;
   }
+}
+
+function mergePairedNodes(pairingPaired: PairedNode[], liveNodes: NodeListNode[]): PairedNode[] {
+  if (liveNodes.length === 0) {
+    return pairingPaired;
+  }
+  const pairedById = new Map(pairingPaired.map((node) => [node.nodeId, node] as const));
+  const merged = [...pairingPaired];
+  for (const live of liveNodes) {
+    if (!live.paired || pairedById.has(live.nodeId)) {
+      continue;
+    }
+    merged.push({
+      nodeId: live.nodeId,
+      displayName: live.displayName,
+      platform: live.platform,
+      version: live.version,
+      coreVersion: live.coreVersion,
+      uiVersion: live.uiVersion,
+      remoteIp: live.remoteIp,
+      permissions: live.permissions,
+      lastConnectedAtMs: live.connectedAtMs,
+    });
+  }
+  return merged;
 }
 
 export function registerNodesStatusCommands(nodes: Command) {
@@ -311,15 +336,10 @@ export function registerNodesStatusCommands(nodes: Command) {
           const now = Date.now();
           const hasFilters = connectedOnly || sinceMs !== undefined;
           const pendingRows = hasFilters ? [] : pending;
-          const connectedById = hasFilters
-            ? new Map(
-                parseNodeList(await callGatewayCli("node.list", opts, {})).map((node) => [
-                  node.nodeId,
-                  node,
-                ]),
-              )
-            : null;
-          const filteredPaired = paired.filter((node) => {
+          const liveNodes = parseNodeList(await callGatewayCli("node.list", opts, {}));
+          const connectedById = new Map(liveNodes.map((node) => [node.nodeId, node] as const));
+          const pairedNodes = mergePairedNodes(paired, liveNodes);
+          const filteredPaired = pairedNodes.filter((node) => {
             if (connectedOnly) {
               const live = connectedById?.get(node.nodeId);
               if (!live?.connected) {
@@ -344,7 +364,9 @@ export function registerNodesStatusCommands(nodes: Command) {
             return true;
           });
           const filteredLabel =
-            hasFilters && filteredPaired.length !== paired.length ? ` (of ${paired.length})` : "";
+            hasFilters && filteredPaired.length !== pairedNodes.length
+              ? ` (of ${pairedNodes.length})`
+              : "";
           defaultRuntime.log(
             `Pending: ${pendingRows.length} · Paired: ${filteredPaired.length}${filteredLabel}`,
           );

--- a/src/cli/nodes-cli/register.status.ts
+++ b/src/cli/nodes-cli/register.status.ts
@@ -341,13 +341,13 @@ export function registerNodesStatusCommands(nodes: Command) {
           const pairedNodes = mergePairedNodes(paired, liveNodes);
           const filteredPaired = pairedNodes.filter((node) => {
             if (connectedOnly) {
-              const live = connectedById?.get(node.nodeId);
+              const live = connectedById.get(node.nodeId);
               if (!live?.connected) {
                 return false;
               }
             }
             if (sinceMs !== undefined) {
-              const live = connectedById?.get(node.nodeId);
+              const live = connectedById.get(node.nodeId);
               const lastConnectedAtMs =
                 typeof node.lastConnectedAtMs === "number"
                   ? node.lastConnectedAtMs
@@ -392,7 +392,7 @@ export function registerNodesStatusCommands(nodes: Command) {
 
           if (filteredPaired.length > 0) {
             const pairedRows = filteredPaired.map((n) => {
-              const live = connectedById?.get(n.nodeId);
+              const live = connectedById.get(n.nodeId);
               const lastConnectedAtMs =
                 typeof n.lastConnectedAtMs === "number"
                   ? n.lastConnectedAtMs

--- a/src/cli/program.nodes-basic.e2e.test.ts
+++ b/src/cli/program.nodes-basic.e2e.test.ts
@@ -100,6 +100,43 @@ describe("cli program (nodes basics)", () => {
     expect(output).not.toContain("Two");
   });
 
+  it("runs nodes list and falls back to live paired nodes when pairing list is stale", async () => {
+    const now = Date.now();
+    callGateway.mockImplementation(async (...args: unknown[]) => {
+      const opts = (args[0] ?? {}) as { method?: string };
+      if (opts.method === "node.pair.list") {
+        return {
+          pending: [],
+          paired: [],
+        };
+      }
+      if (opts.method === "node.list") {
+        return {
+          ts: now,
+          nodes: [
+            {
+              nodeId: "n1",
+              displayName: "One",
+              remoteIp: "10.0.0.1",
+              paired: true,
+              connected: true,
+              connectedAtMs: now - 1_000,
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    });
+
+    await runProgram(["nodes", "list"]);
+
+    expect(callGateway).toHaveBeenCalledWith(expect.objectContaining({ method: "node.pair.list" }));
+    expect(callGateway).toHaveBeenCalledWith(expect.objectContaining({ method: "node.list" }));
+    const output = getRuntimeOutput();
+    expect(output).toContain("Pending: 0 · Paired: 1");
+    expect(output).toContain("One");
+  });
+
   it("runs nodes status --last-connected and filters by age", async () => {
     const now = Date.now();
     callGateway.mockImplementation(async (...args: unknown[]) => {


### PR DESCRIPTION
Fixes #50847.

Keeps `openclaw nodes list` consistent with `openclaw nodes status` by merging live paired nodes from `node.list` when `node.pair.list` is stale or temporarily missing a paired entry.

Includes an e2e regression test covering the case where `nodes status` sees a paired live node but `nodes list` would otherwise report `Paired: 0`.
