### PR TITLE
fix(feishu): use app_name from bot_info API for bot name resolution

### DIFF
--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -20,8 +20,8 @@ export type ProbeFeishuOptions = {
 type FeishuBotInfoResponse = {
   code: number;
   msg?: string;
-  bot?: { bot_name?: string; open_id?: string };
-  data?: { bot?: { bot_name?: string; open_id?: string } };
+  bot?: { bot_name?: string; app_name?: string; open_id?: string };
+  data?: { bot?: { bot_name?: string; app_name?: string; open_id?: string } };
 };
 
 function setCachedProbeResult(
@@ -132,7 +132,7 @@ export async function probeFeishu(
       {
         ok: true,
         appId: creds.appId,
-        botName: bot?.bot_name,
+        botName: bot?.app_name || bot?.bot_name,
         botOpenId: bot?.open_id,
       },
       PROBE_SUCCESS_TTL_MS,


### PR DESCRIPTION
## Problem

The Feishu `bot/v3/info` API returns the bot display name in the `app_name` field:

```json
{
  "bot": {
    "app_name": "MyBot",
    "open_id": "ou_xxx"
  }
}
```

However, `probe.ts` reads `bot?.bot_name`, which doesn't exist in the API response. This causes `botName` to always be `undefined`.

## Fix

- Read `app_name` with a fallback to `bot_name` for backward compatibility
- Add `app_name` to the `FeishuBotInfoResponse` type definition

## Impact

Minimal — `botName` was previously always `undefined` and no existing code depended on it having a value. This fix makes the field correctly populated for future use.