### PR TITLE
fix(ui): keep exec approval actions reachable

### DIFF
--- a/test/vitest-unit-paths.test.ts
+++ b/test/vitest-unit-paths.test.ts
@@ -6,6 +6,7 @@ describe("isUnitConfigTestFile", () => {
     expect(isUnitConfigTestFile("src/infra/git-commit.test.ts")).toBe(true);
     expect(isUnitConfigTestFile("test/format-error.test.ts")).toBe(true);
     expect(isUnitConfigTestFile("ui/src/ui/views/chat.test.ts")).toBe(true);
+    expect(isUnitConfigTestFile("ui/src/ui/views/exec-approval.test.ts")).toBe(true);
   });
 
   it("rejects files excluded from the unit config", () => {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2763,6 +2763,10 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: 20px;
+  display: flex;
+  flex-direction: column;
+  max-height: min(720px, calc(100vh - 48px));
+  overflow: hidden;
   animation: scale-in 0.2s var(--ease-out);
 }
 
@@ -2793,20 +2797,28 @@
   padding: 4px 10px;
 }
 
-.exec-approval-command {
+.exec-approval-body {
   margin-top: 12px;
+  display: grid;
+  gap: 12px;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.exec-approval-command {
   padding: 10px 12px;
   background: var(--secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   word-break: break-word;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
   font-family: var(--mono);
   font-size: 13px;
 }
 
 .exec-approval-meta {
-  margin-top: 12px;
   display: grid;
   gap: 6px;
   font-size: 13px;
@@ -2825,7 +2837,6 @@
 }
 
 .exec-approval-error {
-  margin-top: 10px;
   font-size: 13px;
   color: var(--danger);
 }
@@ -2835,6 +2846,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  flex-shrink: 0;
 }
 
 /* ===========================================

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -55,7 +55,9 @@ describe("exec approval modal", () => {
     expect(actions).not.toBeNull();
     expect(card?.children[1]).toBe(body);
     expect(card?.lastElementChild).toBe(actions);
-    expect(body?.querySelector(".exec-approval-command")?.textContent).toContain("very long command");
+    expect(body?.querySelector(".exec-approval-command")?.textContent).toContain(
+      "very long command",
+    );
     expect(body?.querySelector(".exec-approval-error")?.textContent).toContain("Approval failed");
   });
 

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -1,0 +1,79 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import type { AppViewState } from "../app-view-state.ts";
+import { renderExecApprovalPrompt } from "./exec-approval.ts";
+import { renderGatewayUrlConfirmation } from "./gateway-url-confirmation.ts";
+
+function createState(overrides: Partial<AppViewState> = {}): AppViewState {
+  const now = Date.now();
+  return {
+    execApprovalQueue: [
+      {
+        id: "req-1",
+        createdAtMs: now - 1_000,
+        expiresAtMs: now + 60_000,
+        request: {
+          command:
+            "python - <<'PY'\nprint('very long command body')\nprint('still going')\nprint('done')\nPY",
+          host: "gateway.local",
+          agentId: "agent:main",
+          sessionKey: "main",
+          cwd: "/workspace",
+          resolvedPath: "/usr/bin/python",
+          security: "allowlist",
+          ask: "on-miss",
+        },
+      },
+    ],
+    execApprovalBusy: false,
+    execApprovalError: "Approval failed",
+    pendingGatewayUrl: "https://example.invalid/ws",
+    handleExecApprovalDecision: vi.fn(),
+    handleGatewayUrlConfirm: vi.fn(),
+    handleGatewayUrlCancel: vi.fn(),
+    ...overrides,
+  } as unknown as AppViewState;
+}
+
+describe("exec approval modal", () => {
+  it("renders scrollable content separately from the action row", () => {
+    const state = createState();
+    const container = document.createElement("div");
+
+    render(renderExecApprovalPrompt(state), container);
+
+    const overlay = container.querySelector(".exec-approval-overlay");
+    const card = container.querySelector(".exec-approval-card");
+    const body = container.querySelector(".exec-approval-body");
+    const actions = container.querySelector(".exec-approval-actions");
+
+    expect(overlay?.getAttribute("aria-modal")).toBe("true");
+    expect(card).not.toBeNull();
+    expect(body).not.toBeNull();
+    expect(actions).not.toBeNull();
+    expect(card?.children[1]).toBe(body);
+    expect(card?.lastElementChild).toBe(actions);
+    expect(body?.querySelector(".exec-approval-command")?.textContent).toContain("very long command");
+    expect(body?.querySelector(".exec-approval-error")?.textContent).toContain("Approval failed");
+  });
+
+  it("uses the same scrollable body structure for gateway URL confirmation", () => {
+    const state = createState({ execApprovalQueue: [] });
+    const container = document.createElement("div");
+
+    render(renderGatewayUrlConfirmation(state), container);
+
+    const card = container.querySelector(".exec-approval-card");
+    const body = container.querySelector(".exec-approval-body");
+    const actions = container.querySelector(".exec-approval-actions");
+
+    expect(body).not.toBeNull();
+    expect(card?.children[1]).toBe(body);
+    expect(card?.lastElementChild).toBe(actions);
+    expect(body?.querySelector(".exec-approval-command")?.textContent).toContain(
+      "https://example.invalid/ws",
+    );
+  });
+});

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -32,7 +32,7 @@ export function renderExecApprovalPrompt(state: AppViewState) {
   const remaining = remainingMs > 0 ? `expires in ${formatRemaining(remainingMs)}` : "expired";
   const queueCount = state.execApprovalQueue.length;
   return html`
-    <div class="exec-approval-overlay" role="dialog" aria-live="polite">
+    <div class="exec-approval-overlay" role="dialog" aria-modal="true" aria-live="polite">
       <div class="exec-approval-card">
         <div class="exec-approval-header">
           <div>
@@ -45,21 +45,23 @@ export function renderExecApprovalPrompt(state: AppViewState) {
               : nothing
           }
         </div>
-        <div class="exec-approval-command mono">${request.command}</div>
-        <div class="exec-approval-meta">
-          ${renderMetaRow("Host", request.host)}
-          ${renderMetaRow("Agent", request.agentId)}
-          ${renderMetaRow("Session", request.sessionKey)}
-          ${renderMetaRow("CWD", request.cwd)}
-          ${renderMetaRow("Resolved", request.resolvedPath)}
-          ${renderMetaRow("Security", request.security)}
-          ${renderMetaRow("Ask", request.ask)}
+        <div class="exec-approval-body">
+          <div class="exec-approval-command mono">${request.command}</div>
+          <div class="exec-approval-meta">
+            ${renderMetaRow("Host", request.host)}
+            ${renderMetaRow("Agent", request.agentId)}
+            ${renderMetaRow("Session", request.sessionKey)}
+            ${renderMetaRow("CWD", request.cwd)}
+            ${renderMetaRow("Resolved", request.resolvedPath)}
+            ${renderMetaRow("Security", request.security)}
+            ${renderMetaRow("Ask", request.ask)}
+          </div>
+          ${
+            state.execApprovalError
+              ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
+              : nothing
+          }
         </div>
-        ${
-          state.execApprovalError
-            ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
-            : nothing
-        }
         <div class="exec-approval-actions">
           <button
             class="btn primary"

--- a/ui/src/ui/views/gateway-url-confirmation.ts
+++ b/ui/src/ui/views/gateway-url-confirmation.ts
@@ -16,9 +16,11 @@ export function renderGatewayUrlConfirmation(state: AppViewState) {
             <div class="exec-approval-sub">This will reconnect to a different gateway server</div>
           </div>
         </div>
-        <div class="exec-approval-command mono">${pendingGatewayUrl}</div>
-        <div class="callout danger" style="margin-top: 12px;">
-          Only confirm if you trust this URL. Malicious URLs can compromise your system.
+        <div class="exec-approval-body">
+          <div class="exec-approval-command mono">${pendingGatewayUrl}</div>
+          <div class="callout danger">
+            Only confirm if you trust this URL. Malicious URLs can compromise your system.
+          </div>
         </div>
         <div class="exec-approval-actions">
           <button

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
       "ui/src/ui/app-chat.test.ts",
       "ui/src/ui/views/agents-utils.test.ts",
       "ui/src/ui/views/chat.test.ts",
+      "ui/src/ui/views/exec-approval.test.ts",
       "ui/src/ui/views/nodes.devices.test.ts",
       "ui/src/ui/views/usage-render-details.test.ts",
       "ui/src/ui/controllers/agents.test.ts",

--- a/vitest.unit-paths.mjs
+++ b/vitest.unit-paths.mjs
@@ -6,6 +6,7 @@ export const unitTestIncludePatterns = [
   "ui/src/ui/app-chat.test.ts",
   "ui/src/ui/views/agents-utils.test.ts",
   "ui/src/ui/views/chat.test.ts",
+  "ui/src/ui/views/exec-approval.test.ts",
   "ui/src/ui/views/usage-render-details.test.ts",
   "ui/src/ui/controllers/agents.test.ts",
   "ui/src/ui/controllers/chat.test.ts",


### PR DESCRIPTION
Fixes #40619.

Keeps the Control UI exec approval actions reachable by turning the modal body into a scrollable content area while keeping the action row outside the scroll region.

Also applies the same modal body structure to the gateway URL confirmation dialog and adds a UI regression test covering the new layout.