### PR TITLE
feat(feishu): add cross-bot relay for bot-to-bot messaging in groups

### DIFF
--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -182,6 +182,7 @@ const FeishuSharedConfigShape = {
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),
+  crossBotRelay: z.boolean().optional(),
 };
 
 /**

--- a/extensions/feishu/src/cross-bot-relay.ts
+++ b/extensions/feishu/src/cross-bot-relay.ts
@@ -48,6 +48,8 @@ export type RelayOutboundParams = {
   text: string;
   /** Message ID returned by Feishu API after sending */
   messageId?: string;
+  /** Thread/topic ID for topic group messages (root_id in Feishu events) */
+  threadId?: string;
   /** Bot's open_id (sender identity) */
   senderBotOpenId?: string;
   /** Bot's display name */
@@ -55,7 +57,8 @@ export type RelayOutboundParams = {
 };
 
 export async function relayOutboundToOtherBots(params: RelayOutboundParams): Promise<void> {
-  const { senderAccountId, chatId, text, messageId, senderBotOpenId, senderBotName } = params;
+  const { senderAccountId, chatId, text, messageId, threadId, senderBotOpenId, senderBotName } =
+    params;
 
   // Only relay to group chats
   if (!chatId) return;
@@ -123,6 +126,8 @@ export async function relayOutboundToOtherBots(params: RelayOutboundParams): Pro
           content: JSON.stringify({ text }),
           create_time: String(Date.now()),
           mentions,
+          // Preserve thread/topic metadata so relay messages stay in the correct topic
+          ...(threadId ? { root_id: threadId, thread_id: threadId } : {}),
         },
       };
       const log = target.runtime?.log ?? console.log;

--- a/extensions/feishu/src/cross-bot-relay.ts
+++ b/extensions/feishu/src/cross-bot-relay.ts
@@ -6,7 +6,7 @@
  * This works around Feishu's platform limitation where bot messages
  * do not trigger im.message.receive_v1 events for other bots.
  */
-import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "openclaw/plugin-sdk/feishu";
+import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "../runtime-api.js";
 import { handleFeishuMessage, type FeishuMessageEvent } from "./bot.js";
 
 // --- Account registry ---

--- a/extensions/feishu/src/cross-bot-relay.ts
+++ b/extensions/feishu/src/cross-bot-relay.ts
@@ -1,0 +1,155 @@
+/**
+ * Cross-bot relay: when one bot sends a message to a group chat,
+ * construct a synthetic inbound event and dispatch it to other bot
+ * accounts monitoring the same group.
+ *
+ * This works around Feishu's platform limitation where bot messages
+ * do not trigger im.message.receive_v1 events for other bots.
+ */
+import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "openclaw/plugin-sdk/feishu";
+import { handleFeishuMessage, type FeishuMessageEvent } from "./bot.js";
+
+// --- Account registry ---
+// Each monitoring account registers itself so the relay can dispatch to it.
+
+type RegisteredAccount = {
+  accountId: string;
+  cfg: ClawdbotConfig;
+  runtime?: RuntimeEnv;
+  chatHistories: Map<string, HistoryEntry[]>;
+  botOpenId?: string;
+  botName?: string;
+};
+
+const registeredAccounts = new Map<string, RegisteredAccount>();
+
+export function registerRelayAccount(account: RegisteredAccount): void {
+  registeredAccounts.set(account.accountId, account);
+}
+
+export function unregisterRelayAccount(accountId: string): void {
+  registeredAccounts.delete(accountId);
+}
+
+// --- Relay dispatch ---
+
+// Track message IDs currently being relayed to prevent re-entry.
+// When Bot A's outbound triggers relay → Bot B processes → Bot B replies →
+// Bot B's outbound triggers relay → we must not re-relay to Bot A in the
+// same chain. We use a Set of "synthetic message IDs" that are in-flight.
+const activeRelayMessageIds = new Set<string>();
+
+export type RelayOutboundParams = {
+  /** Account ID of the bot that sent the message */
+  senderAccountId: string;
+  /** Chat ID (group) where the message was sent */
+  chatId: string;
+  /** The text content that was sent */
+  text: string;
+  /** Message ID returned by Feishu API after sending */
+  messageId?: string;
+  /** Bot's open_id (sender identity) */
+  senderBotOpenId?: string;
+  /** Bot's display name */
+  senderBotName?: string;
+};
+
+export async function relayOutboundToOtherBots(params: RelayOutboundParams): Promise<void> {
+  const { senderAccountId, chatId, text, messageId, senderBotOpenId, senderBotName } = params;
+
+  // Only relay to group chats
+  if (!chatId) return;
+
+  // Use the real message ID for replies to work, but track with relay prefix for dedup
+  const syntheticMessageId = messageId
+    ? `relay:${messageId}`
+    : `relay:${senderAccountId}:${Date.now()}`;
+  // The actual message_id in the event uses the REAL id so reply_to works with Feishu API
+  const eventMessageId = messageId || `relay:${senderAccountId}:${Date.now()}`;
+
+  // Prevent re-entry: if this message is already being relayed, skip
+  if (activeRelayMessageIds.has(syntheticMessageId)) return;
+
+  // Extract mentioned names from <at user_id="xxx">name</at> tags in the text
+  const mentionedNames = new Set<string>();
+  const atPattern = /<at\s+user_id="[^"]+">([^<]+)<\/at>/g;
+  let match: RegExpExecArray | null;
+  while ((match = atPattern.exec(text)) !== null) {
+    mentionedNames.add(match[1].trim().toLowerCase());
+  }
+
+  // Filter targets: match mentioned names against registered bot names (case-insensitive)
+  const allOtherAccounts = Array.from(registeredAccounts.values()).filter(
+    (account) => account.accountId !== senderAccountId,
+  );
+  // Only relay to explicitly mentioned bots — no fallback broadcast
+  if (mentionedNames.size === 0) return;
+  const targets = allOtherAccounts.filter((account) => {
+    const name = account.botName?.trim()?.toLowerCase();
+    return name ? mentionedNames.has(name) : false;
+  });
+
+  if (targets.length === 0) return;
+
+  activeRelayMessageIds.add(syntheticMessageId);
+
+  try {
+    const dispatches = targets.map(async (target) => {
+      // Build synthetic event per target, including a mention of the target bot
+      // so it passes requireMention checks in group chats.
+      const targetBotOpenId = target.botOpenId?.trim();
+      const mentions = targetBotOpenId
+        ? [
+            {
+              key: `@_user_relay_${target.accountId}`,
+              id: { open_id: targetBotOpenId },
+              name: target.botName ?? target.accountId,
+            },
+          ]
+        : undefined;
+
+      const syntheticEvent: FeishuMessageEvent = {
+        sender: {
+          sender_id: {
+            open_id: senderBotOpenId || `bot:${senderAccountId}`,
+          },
+          sender_type: "bot",
+        },
+        message: {
+          message_id: eventMessageId,
+          chat_id: chatId,
+          chat_type: "group",
+          message_type: "text",
+          content: JSON.stringify({ text }),
+          create_time: String(Date.now()),
+          mentions,
+        },
+      };
+      const log = target.runtime?.log ?? console.log;
+      try {
+        log(
+          `feishu[${target.accountId}]: cross-bot relay from ${senderAccountId}, ` +
+            `chat=${chatId}, msgId=${syntheticMessageId}`,
+        );
+        await handleFeishuMessage({
+          cfg: target.cfg,
+          event: syntheticEvent,
+          botOpenId: target.botOpenId,
+          botName: target.botName,
+          runtime: target.runtime,
+          chatHistories: target.chatHistories,
+          accountId: target.accountId,
+        });
+      } catch (err) {
+        log(`feishu[${target.accountId}]: cross-bot relay dispatch failed: ${String(err)}`);
+      }
+    });
+
+    await Promise.allSettled(dispatches);
+  } finally {
+    // Clean up after a delay to handle any late re-entry attempts
+    setTimeout(() => {
+      activeRelayMessageIds.delete(syntheticMessageId);
+    }, 120_000);
+  }
+}

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -12,6 +12,7 @@ import {
 import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
 import { maybeHandleFeishuQuickActionMenu } from "./card-ux-launcher.js";
 import { createEventDispatcher } from "./client.js";
+import { registerRelayAccount, unregisterRelayAccount } from "./cross-bot-relay.js";
 import {
   hasProcessedFeishuMessage,
   recordProcessedFeishuMessage,
@@ -670,6 +671,19 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
     const chatHistories = new Map<string, HistoryEntry[]>();
     threadBindingManager = createFeishuThreadBindingManager({ accountId, cfg });
 
+    // Cross-bot relay: register this account if enabled
+    const feishuCfg = account.config;
+    if (feishuCfg.crossBotRelay) {
+      registerRelayAccount({
+        accountId,
+        cfg,
+        runtime,
+        chatHistories,
+        botOpenId: botOpenId ?? undefined,
+        botName: botName ?? undefined,
+      });
+    }
+
     registerEventHandlers(eventDispatcher, {
       cfg,
       accountId,
@@ -684,5 +698,6 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
     return await monitorWebSocket({ account, accountId, runtime, abortSignal, eventDispatcher });
   } finally {
     threadBindingManager?.stop();
+    unregisterRelayAccount(accountId);
   }
 }

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -120,6 +120,25 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       const account = resolveFeishuAccount({ cfg, accountId: accountId ?? undefined });
       const renderMode = account.config?.renderMode ?? "auto";
       const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
+      // Cross-bot relay helper — extracted to avoid duplication between card and text paths
+      const triggerRelay = (result: { messageId?: string }) => {
+        const feishuCfg = resolveFeishuAccount({ cfg, accountId: accountId ?? undefined }).config;
+        const effectiveAccountId = accountId ?? undefined;
+        if (feishuCfg?.crossBotRelay && to.startsWith("oc_") && text?.trim()) {
+          void relayOutboundToOtherBots({
+            senderAccountId: effectiveAccountId ?? "default",
+            chatId: to,
+            text,
+            messageId: result.messageId,
+            threadId: threadId != null ? String(threadId) : undefined,
+            senderBotOpenId: botOpenIds.get(effectiveAccountId ?? "default"),
+            senderBotName: botNames.get(effectiveAccountId ?? "default"),
+          }).catch((err) => {
+            console.error(`[feishu] cross-bot relay failed:`, err);
+          });
+        }
+      };
+
       if (useCard) {
         const header = identity
           ? {
@@ -129,7 +148,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
               template: "blue" as const,
             }
           : undefined;
-        return await sendStructuredCardFeishu({
+        const cardResult = await sendStructuredCardFeishu({
           cfg,
           to,
           text,
@@ -138,6 +157,9 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           accountId: accountId ?? undefined,
           header: header?.title ? header : undefined,
         });
+        // Relay card messages too — previously skipped by early return
+        triggerRelay(cardResult);
+        return cardResult;
       }
       const result = await sendOutboundText({
         cfg,
@@ -147,21 +169,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         replyToMessageId,
       });
 
-      // Cross-bot relay: notify other bots in the same group
-      const feishuCfg = resolveFeishuAccount({ cfg, accountId: accountId ?? undefined }).config;
-      if (feishuCfg?.crossBotRelay && to.startsWith("oc_") && text?.trim()) {
-        const effectiveAccountId = accountId ?? undefined;
-        void relayOutboundToOtherBots({
-          senderAccountId: effectiveAccountId ?? "default",
-          chatId: to,
-          text,
-          messageId: result.messageId,
-          senderBotOpenId: botOpenIds.get(effectiveAccountId ?? "default"),
-          senderBotName: botNames.get(effectiveAccountId ?? "default"),
-        }).catch((err) => {
-          console.error(`[feishu] cross-bot relay failed:`, err);
-        });
-      }
+      triggerRelay(result);
 
       return result;
     },

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -3,7 +3,9 @@ import path from "path";
 import { createAttachedChannelResultAdapter } from "openclaw/plugin-sdk/channel-send-result";
 import type { ChannelOutboundAdapter } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
+import { relayOutboundToOtherBots } from "./cross-bot-relay.js";
 import { sendMediaFeishu } from "./media.js";
+import { botOpenIds, botNames } from "./monitor.state.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMarkdownCardFeishu, sendMessageFeishu, sendStructuredCardFeishu } from "./send.js";
 
@@ -137,13 +139,31 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           header: header?.title ? header : undefined,
         });
       }
-      return await sendOutboundText({
+      const result = await sendOutboundText({
         cfg,
         to,
         text,
         accountId: accountId ?? undefined,
         replyToMessageId,
       });
+
+      // Cross-bot relay: notify other bots in the same group
+      const feishuCfg = resolveFeishuAccount({ cfg, accountId: accountId ?? undefined }).config;
+      if (feishuCfg?.crossBotRelay && to.startsWith("oc_") && text?.trim()) {
+        const effectiveAccountId = accountId ?? undefined;
+        void relayOutboundToOtherBots({
+          senderAccountId: effectiveAccountId ?? "default",
+          chatId: to,
+          text,
+          messageId: result.messageId,
+          senderBotOpenId: botOpenIds.get(effectiveAccountId ?? "default"),
+          senderBotName: botNames.get(effectiveAccountId ?? "default"),
+        }).catch((err) => {
+          console.error(`[feishu] cross-bot relay failed:`, err);
+        });
+      }
+
+      return result;
     },
     sendMedia: async ({
       cfg,

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -20,8 +20,8 @@ export type ProbeFeishuOptions = {
 type FeishuBotInfoResponse = {
   code: number;
   msg?: string;
-  bot?: { bot_name?: string; open_id?: string };
-  data?: { bot?: { bot_name?: string; open_id?: string } };
+  bot?: { bot_name?: string; app_name?: string; open_id?: string };
+  data?: { bot?: { bot_name?: string; app_name?: string; open_id?: string } };
 };
 
 function setCachedProbeResult(
@@ -132,7 +132,7 @@ export async function probeFeishu(
       {
         ok: true,
         appId: creds.appId,
-        botName: bot?.bot_name,
+        botName: bot?.app_name || bot?.bot_name,
         botOpenId: bot?.open_id,
       },
       PROBE_SUCCESS_TTL_MS,

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -41,6 +41,7 @@ vi.mock("./streaming-card.js", async () => {
         this.active = false;
       });
       isActive = vi.fn(() => this.active);
+      getMessageId = vi.fn(() => undefined);
 
       constructor() {
         streamingInstances.push(this);

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -344,6 +344,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             chatId,
             text: params.text,
             messageId: lastMessageId,
+            threadId: rootId,
             senderBotOpenId: botOpenIds.get(accountId ?? "default"),
             senderBotName: botNames.get(accountId ?? "default"),
           });
@@ -426,18 +427,20 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             }
             if (info?.kind === "final") {
               streamText = mergeStreamingText(streamText, text);
+              // Save messageId before closeStreaming() clears the streaming object
+              const streamingMsgId = streaming?.getMessageId();
               await closeStreaming();
               deliveredFinalTexts.add(text);
               // Cross-bot relay: trigger after streaming final
               const feishuCfg = resolveFeishuAccount({ cfg, accountId }).config;
               if (feishuCfg?.crossBotRelay && chatId?.startsWith("oc_") && text?.trim()) {
                 try {
-                  const streamingMsgId = (streaming as any)?.state?.messageId;
                   await relayOutboundToOtherBots({
                     senderAccountId: accountId ?? "default",
                     chatId,
                     text,
                     messageId: streamingMsgId,
+                    threadId: rootId,
                     senderBotOpenId: botOpenIds.get(accountId ?? "default"),
                     senderBotName: botNames.get(accountId ?? "default"),
                   });
@@ -461,7 +464,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               useCard: true,
               infoKind: info?.kind,
               sendChunk: async ({ chunk, isFirst }) => {
-                await sendStructuredCardFeishu({
+                return sendStructuredCardFeishu({
                   cfg,
                   to: chatId,
                   text: chunk,
@@ -480,7 +483,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               useCard: false,
               infoKind: info?.kind,
               sendChunk: async ({ chunk, isFirst }) => {
-                await sendMessageFeishu({
+                return sendMessageFeishu({
                   cfg,
                   to: chatId,
                   text: chunk,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -14,9 +14,11 @@ import {
 } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { relayOutboundToOtherBots } from "./cross-bot-relay.js";
 import { sendMediaFeishu } from "./media.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedCardContent } from "./mention.js";
+import { botOpenIds, botNames } from "./monitor.state.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMessageFeishu, sendStructuredCardFeishu, type CardHeaderConfig } from "./send.js";
 import { FeishuStreamingSession, mergeStreamingText } from "./streaming-card.js";
@@ -311,7 +313,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     text: string;
     useCard: boolean;
     infoKind?: string;
-    sendChunk: (params: { chunk: string; isFirst: boolean }) => Promise<void>;
+    sendChunk: (params: {
+      chunk: string;
+      isFirst: boolean;
+    }) => Promise<{ messageId?: string } | void>;
   }) => {
     const chunkSource = params.useCard
       ? params.text
@@ -320,14 +325,32 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       chunkSource,
       core.channel.text.chunkTextWithMode(chunkSource, textChunkLimit, chunkMode),
     );
+    let lastMessageId: string | undefined;
     for (const [index, chunk] of chunks.entries()) {
-      await params.sendChunk({
+      const result = await params.sendChunk({
         chunk,
         isFirst: index === 0,
       });
+      if (result?.messageId) lastMessageId = result.messageId;
     }
     if (params.infoKind === "final") {
       deliveredFinalTexts.add(params.text);
+      // Cross-bot relay: trigger after final reply
+      const feishuCfg = resolveFeishuAccount({ cfg, accountId }).config;
+      if (feishuCfg?.crossBotRelay && chatId?.startsWith("oc_") && params.text?.trim()) {
+        try {
+          await relayOutboundToOtherBots({
+            senderAccountId: accountId ?? "default",
+            chatId,
+            text: params.text,
+            messageId: lastMessageId,
+            senderBotOpenId: botOpenIds.get(accountId ?? "default"),
+            senderBotName: botNames.get(accountId ?? "default"),
+          });
+        } catch (err) {
+          console.error(`[feishu] cross-bot relay (reply-dispatcher) failed:`, err);
+        }
+      }
     }
   };
 
@@ -405,6 +428,23 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               streamText = mergeStreamingText(streamText, text);
               await closeStreaming();
               deliveredFinalTexts.add(text);
+              // Cross-bot relay: trigger after streaming final
+              const feishuCfg = resolveFeishuAccount({ cfg, accountId }).config;
+              if (feishuCfg?.crossBotRelay && chatId?.startsWith("oc_") && text?.trim()) {
+                try {
+                  const streamingMsgId = (streaming as any)?.state?.messageId;
+                  await relayOutboundToOtherBots({
+                    senderAccountId: accountId ?? "default",
+                    chatId,
+                    text,
+                    messageId: streamingMsgId,
+                    senderBotOpenId: botOpenIds.get(accountId ?? "default"),
+                    senderBotName: botNames.get(accountId ?? "default"),
+                  });
+                } catch (err) {
+                  console.error(`[feishu] cross-bot relay (streaming final) failed:`, err);
+                }
+              }
             }
             // Send media even when streaming handled the text
             if (hasMedia) {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -447,4 +447,9 @@ export class FeishuStreamingSession {
   isActive(): boolean {
     return this.state !== null && !this.closed;
   }
+
+  /** Returns the Feishu message_id of the streaming card, or undefined if not started. */
+  getMessageId(): string | undefined {
+    return this.state?.messageId;
+  }
 }


### PR DESCRIPTION
## Problem

Feishu's `im.message.receive_v1` event does not deliver bot messages to other bots (by design, to prevent loops). When multiple bots are configured in the same Feishu group, they cannot collaborate by @-mentioning each other — the target bot simply never receives the message.

## Solution

This PR adds an opt-in **cross-bot relay** mechanism that enables bot-to-bot messaging within the same OpenClaw instance.

### How it works

1. **Outbound interception**: After a bot sends a message to a Feishu group (via outbound or reply-dispatcher), the relay logic checks for `<at>` mention tags in the text.
2. **Name-based matching**: Extracts display names from `<at user_id="...">name</at>` tags and matches them (case-insensitive) against registered bot names (`app_name` from Feishu's `bot/v3/info` API).
3. **Synthetic event dispatch**: For each matched bot, constructs a `FeishuMessageEvent` and calls `handleFeishuMessage` in-process — no additional API calls, no network round-trips.
4. **Targeted delivery**: Only explicitly @-mentioned bots receive the relay. No broadcast.

### Why name-based matching?

Feishu `open_id` is scoped per app — the same bot has different `open_id` values when viewed from different apps. Name matching via `app_name` is reliable across apps within the same tenant.

### Configuration

```json
{
  "channels": {
    "feishu": {
      "crossBotRelay": true
    }
  }
}
```

- `false` (default): No relay code executes. Zero impact on existing behavior.
- `true`: Enables relay for all accounts under this feishu channel config.

### Files changed

| File | Change |
|---|---|
| `cross-bot-relay.ts` | **New** — core relay module (register/unregister accounts, filter by mention, dispatch synthetic events) |
| `outbound.ts` | Trigger relay after `sendText` (message tool path) |
| `reply-dispatcher.ts` | Trigger relay after final reply (agent reply path, both chunked and streaming) |
| `monitor.account.ts` | Register/unregister relay accounts on startup/shutdown |
| `config-schema.ts` | Add `crossBotRelay` boolean option |
| `probe.ts` | Fix: read `app_name` from bot_info API (was reading non-existent `bot_name`) |

### Use case

Multi-agent collaboration in a single Feishu group:
- User @PM "analyze this feature" → PM writes PRD and @Dev
- Dev receives relay → implements and @QA  
- QA receives relay → tests and reports back

### Anti-loop protection

- Relay uses `activeRelayMessageIds` set with 120s TTL to prevent re-entry
- `sender_type` is set to `"bot"` in synthetic events
- Only explicitly mentioned bots are targeted (no cascade)