### PR TITLE
feat(plugin-sdk): expose steer/abort APIs for active agent runs

### DIFF
--- a/src/plugin-sdk/agent-runtime.ts
+++ b/src/plugin-sdk/agent-runtime.ts
@@ -25,6 +25,16 @@ export * from "../agents/vllm-defaults.js";
 export * from "../agents/agent-command.js";
 export * from "../tts/tts.js";
 
+// Steer/abort APIs for active agent runs — allows external plugins to inject
+// messages into a streaming run, abort runs, or check run state.
+export {
+  queueEmbeddedPiMessage,
+  abortEmbeddedPiRun,
+  isEmbeddedPiRunActive,
+  isEmbeddedPiRunStreaming,
+  waitForEmbeddedPiRunEnd,
+} from "../agents/pi-embedded-runner/runs.js";
+
 export {
   CLAUDE_CLI_PROFILE_ID,
   CODEX_CLI_PROFILE_ID,


### PR DESCRIPTION
## Problem

External plugins installed via npm cannot access the steer/abort APIs for active agent runs. The functions exist in `src/agents/pi-embedded-runner/runs.ts` and are re-exported via `src/agents/pi-embedded-runner.ts`, but they are not reachable from external plugins because:

1. There is no `plugin-sdk` export path that includes them
2. The JS is bundled into internal chunks in `dist/`
3. `jiti` alias resolution only covers entries in the `package.json` exports map

Built-in extensions work around this via relative source imports, but external plugins only have `dist/`.

## Solution

Add a named export block to `src/plugin-sdk/agent-runtime.ts` for the five public functions from `runs.ts`:

- `queueEmbeddedPiMessage(sessionId, text)` — inject a message into an active streaming run (steer)
- `abortEmbeddedPiRun(sessionId)` — abort a running agent
- `isEmbeddedPiRunActive(sessionId)` — check if a run is active
- `isEmbeddedPiRunStreaming(sessionId)` — check if a run is streaming
- `waitForEmbeddedPiRunEnd(sessionId, timeoutMs?)` — wait for run completion

This is option B from #49624 — appending to the existing `agent-runtime` barrel rather than creating a new sub-path. The functions are already part of the internal public surface via `pi-embedded-runner.ts`, so this just extends the same exports to the plugin SDK boundary.

## Use Case

Building a voice channel plugin where:
- Voice input triggers an agent run via system events
- The plugin needs to stream the agent's response back in real-time for TTS
- If the user speaks while the agent is streaming, the plugin needs to either steer (inject) or abort and redispatch

All of these require the steer/abort APIs, which currently only work for built-in extensions.

## Changes

- `src/plugin-sdk/agent-runtime.ts`: Added named exports for the five steer/abort functions

Fixes #49624