### PR TITLE
fix(ui): preserve model provider switches in chat picker

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -539,14 +539,22 @@ function resolveModelOverrideValue(state: AppViewState): string {
   // Include provider prefix so the value matches option keys (provider/model).
   const activeRow = resolveActiveSessionRow(state);
   if (activeRow && typeof activeRow.model === "string" && activeRow.model.trim()) {
-    return resolveServerChatModelValue(activeRow.model, activeRow.modelProvider);
+    return resolveServerChatModelValue(
+      activeRow.model,
+      activeRow.modelProvider,
+      state.chatModelCatalog,
+    );
   }
   return "";
 }
 
 function resolveDefaultModelValue(state: AppViewState): string {
   const defaults = state.sessionsResult?.defaults;
-  return resolveServerChatModelValue(defaults?.model, defaults?.modelProvider);
+  return resolveServerChatModelValue(
+    defaults?.model,
+    defaults?.modelProvider,
+    state.chatModelCatalog,
+  );
 }
 
 function buildChatModelOptions(

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -19,6 +19,37 @@ export function buildQualifiedChatModelValue(model: string, provider?: string | 
   return trimmedProvider ? `${trimmedProvider}/${trimmedModel}` : trimmedModel;
 }
 
+function hasCatalogMatch(
+  catalog: ModelCatalogEntry[] | undefined,
+  provider: string | null | undefined,
+  model: string,
+): boolean {
+  const trimmedProvider = provider?.trim();
+  const trimmedModel = model.trim();
+  if (!trimmedProvider || !trimmedModel) {
+    return false;
+  }
+  return (
+    catalog?.some(
+      (entry) =>
+        entry.provider.trim().toLowerCase() === trimmedProvider.toLowerCase() &&
+        entry.id.trim().toLowerCase() === trimmedModel.toLowerCase(),
+    ) ?? false
+  );
+}
+
+function hasQualifiedCatalogMatch(
+  catalog: ModelCatalogEntry[] | undefined,
+  value: string,
+): boolean {
+  const trimmed = value.trim();
+  const slashIndex = trimmed.indexOf("/");
+  if (slashIndex <= 0 || slashIndex === trimmed.length - 1) {
+    return false;
+  }
+  return hasCatalogMatch(catalog, trimmed.slice(0, slashIndex), trimmed.slice(slashIndex + 1));
+}
+
 export function createChatModelOverride(value: string): ChatModelOverride | null {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -65,11 +96,22 @@ export function normalizeChatModelOverrideValue(
 export function resolveServerChatModelValue(
   model?: string | null,
   provider?: string | null,
+  catalog?: ModelCatalogEntry[],
 ): string {
   if (typeof model !== "string") {
     return "";
   }
-  return buildQualifiedChatModelValue(model, provider);
+  const trimmedModel = model.trim();
+  if (!trimmedModel) {
+    return "";
+  }
+  if (hasCatalogMatch(catalog, provider, trimmedModel)) {
+    return buildQualifiedChatModelValue(trimmedModel, provider);
+  }
+  if (hasQualifiedCatalogMatch(catalog, trimmedModel)) {
+    return trimmedModel;
+  }
+  return buildQualifiedChatModelValue(trimmedModel, provider);
 }
 
 export function formatChatModelDisplay(value: string): string {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -735,6 +735,73 @@ describe("chat view", () => {
     vi.unstubAllGlobals();
   });
 
+  it("prefers the embedded provider prefix when the server session row already includes one", () => {
+    const models: ModelCatalogEntry[] = [
+      { id: "qwen3.5-plus", name: "Qwen 3.5 Plus", provider: "moonshot" },
+      { id: "qwen3.5-plus", name: "Qwen 3.5 Plus", provider: "dashscope" },
+    ];
+    const { state } = createChatHeaderState({ models, model: "qwen3.5-plus" });
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: "moonshot", model: "qwen3.5-plus", contextTokens: null },
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: null,
+          modelProvider: "moonshot",
+          model: "dashscope/qwen3.5-plus",
+        },
+      ],
+    };
+    const container = document.createElement("div");
+
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    expect(modelSelect).not.toBeNull();
+    expect(modelSelect?.value).toBe("dashscope/qwen3.5-plus");
+  });
+
+  it("keeps the recorded provider when the model id itself contains a slash", () => {
+    const models: ModelCatalogEntry[] = [
+      { id: "moonshotai/Kimi-K2.5", name: "Kimi K2.5", provider: "openrouter" },
+    ];
+    const { state } = createChatHeaderState({ models });
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: {
+        modelProvider: "openrouter",
+        model: "moonshotai/Kimi-K2.5",
+        contextTokens: null,
+      },
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: null,
+          modelProvider: "openrouter",
+          model: "moonshotai/Kimi-K2.5",
+        },
+      ],
+    };
+    const container = document.createElement("div");
+
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    expect(modelSelect).not.toBeNull();
+    expect(modelSelect?.value).toBe("openrouter/moonshotai/Kimi-K2.5");
+  });
+
   it("disables the chat header model picker while a run is active", () => {
     const { state } = createChatHeaderState();
     state.chatRunId = "run-123";


### PR DESCRIPTION
Fixes #50939.
Related #50197.

Preserves the correct provider/model selection in the Control UI chat model picker when the server session row temporarily carries a stale `modelProvider` alongside an already-qualified `model` value.

Uses the current model catalog to disambiguate whether a slash in `session.model` is an embedded provider prefix or part of the model id, so provider switches like `dashscope/qwen3.5-plus` render correctly without regressing providers such as `openrouter/moonshotai/Kimi-K2.5`.

Includes chat view regression coverage for both the stale-provider switch case and the slashful model-id case.
