### PR TITLE
fix(cron): preserve empty expr field instead of silently deleting

### DIFF
--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -452,6 +452,108 @@ describe("normalizeCronJobCreate", () => {
   });
 });
 
+describe("cron schedule coercion", () => {
+  it("preserves expr when explicitly set to empty string (regression test for issue #50942)", () => {
+    // Before fix: { kind: "cron", expr: "" } had expr silently deleted,
+    // causing "invalid cron schedule: expr is required" at runtime.
+    // After fix: expr field is preserved so validation gives a clear error.
+    const normalized = normalizeCronJobCreate({
+      name: "empty-expr",
+      enabled: true,
+      schedule: { kind: "cron", expr: "" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+    }) as unknown as Record<string, unknown>;
+
+    const schedule = normalized.schedule as Record<string, unknown>;
+    expect(schedule.kind).toBe("cron");
+    // expr field should be preserved (empty string) so validation throws clear error
+    expect("expr" in schedule).toBe(true);
+    expect(schedule.expr).toBe("");
+  });
+
+  it("normalizes whitespace-only expr to empty string for cron kind", () => {
+    // Whitespace-only expr should be normalized to "" so minLength validation catches it
+    const normalized = normalizeCronJobCreate({
+      name: "whitespace-expr",
+      enabled: true,
+      schedule: { kind: "cron", expr: "   " },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+    }) as unknown as Record<string, unknown>;
+
+    const schedule = normalized.schedule as Record<string, unknown>;
+    expect(schedule.kind).toBe("cron");
+    expect("expr" in schedule).toBe(true);
+    expect(schedule.expr).toBe("");
+  });
+
+  it("deletes non-string expr values", () => {
+    // Non-string expr values should be deleted
+    const normalized = normalizeCronJobCreate({
+      name: "numeric-expr",
+      enabled: true,
+      schedule: { kind: "cron", expr: 42 } as unknown as Record<string, unknown>,
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+    }) as unknown as Record<string, unknown>;
+
+    const schedule = normalized.schedule as Record<string, unknown>;
+    expect(schedule.kind).toBe("cron");
+    expect("expr" in schedule).toBe(false);
+  });
+
+  it("deletes blank expr from non-cron schedule types (at)", () => {
+    // Non-cron types with blank expr should have it deleted before schema validation
+    const normalized = normalizeCronJobCreate({
+      name: "at-with-blank-expr",
+      enabled: true,
+      schedule: { kind: "at", at: "2026-01-12T18:00:00Z", expr: "" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+    }) as unknown as Record<string, unknown>;
+
+    const schedule = normalized.schedule as Record<string, unknown>;
+    expect(schedule.kind).toBe("at");
+    expect("expr" in schedule).toBe(false);
+  });
+
+  it("deletes blank expr from non-cron schedule types (every)", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "every-with-blank-expr",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60000, expr: "" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+    }) as unknown as Record<string, unknown>;
+
+    const schedule = normalized.schedule as Record<string, unknown>;
+    expect(schedule.kind).toBe("every");
+    expect("expr" in schedule).toBe(false);
+  });
+
+  it("does not infer expr when kind is cron with no expr", () => {
+    // { kind: "cron" } with no expr should not get an expr added
+    const normalized = normalizeCronJobCreate({
+      name: "no-expr",
+      enabled: true,
+      schedule: { kind: "cron" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+    }) as unknown as Record<string, unknown>;
+
+    const schedule = normalized.schedule as Record<string, unknown>;
+    expect(schedule.kind).toBe("cron");
+    expect("expr" in schedule).toBe(false);
+  });
+});
+
 describe("normalizeCronJobPatch", () => {
   it("infers agentTurn kind for model-only payload patches", () => {
     const normalized = normalizeCronJobPatch({

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -66,7 +66,13 @@ function coerceSchedule(schedule: UnknownRecord) {
   if (normalizedExpr) {
     next.expr = normalizedExpr;
   } else if ("expr" in next) {
-    delete next.expr;
+    if (typeof next.expr !== "string" || next.kind !== "cron") {
+      delete next.expr;
+    } else {
+      // Preserve empty-string expr for cron kind (triggers validation error),
+      // but normalize whitespace-only to empty string so minLength check catches it.
+      next.expr = "";
+    }
   }
   if ("cron" in next) {
     delete next.cron;


### PR DESCRIPTION
## Summary

Fixes issue #50942 where `{ kind: "cron", expr: "" }` had the `expr` field silently deleted by `coerceSchedule()`, causing "invalid cron schedule: expr is required" at runtime.

## Root Cause

In `src/cron/normalize.ts` `coerceSchedule()`:
```typescript
if (normalizedExpr) {
  next.expr = normalizedExpr;
} else if ("expr" in next) {
  delete next.expr;  // BUG: deleted user's explicit empty expr
}
```

When user explicitly set `expr: ""`, the `else if` branch deleted it, making the error message confusing.

## Fix

Improved fix that addresses all review feedback:

```typescript
if (normalizedExpr) {
  next.expr = normalizedExpr;
} else if ("expr" in next) {
  if (typeof next.expr !== "string" || next.kind !== "cron") {
    delete next.expr;
  } else {
    // Preserve empty-string expr for cron kind (triggers validation error),
    // but normalize whitespace-only to empty string so minLength check catches it.
    next.expr = "";
  }
}
```

- **Cron with `""`**: expr preserved → clear validation error
- **Cron with whitespace**: normalized to `""` → minLength validation catches it
- **Non-string expr**: deleted
- **Non-cron types (at/every)**: blank expr deleted before schema validation

## Test Plan

- [x] All 521 cron tests pass
- [x] Added 6 regression tests covering all edge cases
- [x] 36/36 normalize tests pass

🤖 Generated with [Claude Code](https://claude.ai)