### PR TITLE
fix(cron): preserve parent session updatedAt for isolated cron jobs

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -42,6 +42,7 @@ import {
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
+  mergeSessionEntryPreserveActivity,
   resolveSessionTranscriptPath,
   setSessionRuntimeModel,
   updateSessionStore,
@@ -380,12 +381,21 @@ export async function runCronIsolatedAgentTurn(params: {
     if (isFastTestEnv) {
       return;
     }
-    cronSession.store[agentSessionKey] = cronSession.sessionEntry;
+    // For the agent session key (which may be the parent session key), preserve activity
+    // to avoid overwriting the parent session's updatedAt. This prevents isolated cron
+    // jobs from blocking daily session resets. See: #51000
+    cronSession.store[agentSessionKey] = mergeSessionEntryPreserveActivity(
+      cronSession.store[agentSessionKey],
+      cronSession.sessionEntry,
+    );
     if (runSessionKey !== agentSessionKey) {
       cronSession.store[runSessionKey] = cronSession.sessionEntry;
     }
     await updateSessionStore(cronSession.storePath, (store) => {
-      store[agentSessionKey] = cronSession.sessionEntry;
+      store[agentSessionKey] = mergeSessionEntryPreserveActivity(
+        store[agentSessionKey],
+        cronSession.sessionEntry,
+      );
       if (runSessionKey !== agentSessionKey) {
         store[runSessionKey] = cronSession.sessionEntry;
       }


### PR DESCRIPTION
## Problem

Isolated cron jobs with `sessionKey` matching the main session key were overwriting the parent session's `updatedAt`, preventing daily session reset from triggering. This caused users to get previous day's session with stale context instead of a fresh start.

## Solution

Use `mergeSessionEntryPreserveActivity` when writing to the agent session key to preserve the parent session's activity timestamp. This prevents isolated cron jobs from bumping the `updatedAt` past the daily reset boundary.

## Changes

- Import `mergeSessionEntryPreserveActivity` from sessions module
- Update `persistSessionEntry` to merge entries preserving activity
- Add comment explaining the fix and referencing issue #51000

## Testing

Manual testing needed: Configure an isolated cron job with `sessionKey: "agent:main:main"` that runs after the daily reset hour, then verify that the daily reset still triggers correctly.

Fixes #51000