### PR TITLE
fix: skip path escape validation for bundled extensions on npm installs

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -680,4 +680,31 @@ describe("discoverOpenClawPlugins", () => {
     expect(first.candidates.map((candidate) => candidate.idHint)).toEqual(["alpha", "beta"]);
     expect(second.candidates.map((candidate) => candidate.idHint)).toEqual(["beta", "alpha"]);
   });
+
+  it("skips bundled extension entries with missing entry files (npm stripping) without error", async () => {
+    const stateDir = makeTempDir();
+    const bundledDir = path.join(stateDir, "bundled");
+    const packDir = path.join(bundledDir, "stripped-pack");
+    mkdirSafe(packDir);
+
+    writePluginPackageManifest({
+      packageDir: packDir,
+      packageName: "@openclaw/stripped-pack",
+      extensions: ["./index.ts"],
+    });
+
+    const result = discoverOpenClawPlugins({
+      env: {
+        ...process.env,
+        OPENCLAW_STATE_DIR: stateDir,
+        CLAWDBOT_STATE_DIR: undefined,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+      },
+    });
+
+    expect(result.candidates.some((candidate) => candidate.idHint === "stripped-pack")).toBe(false);
+    expect(
+      result.diagnostics.some((diag) => diag.message.includes("escapes package directory")),
+    ).toBe(false);
+  });
 });

--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -681,7 +681,7 @@ describe("discoverOpenClawPlugins", () => {
     expect(second.candidates.map((candidate) => candidate.idHint)).toEqual(["beta", "alpha"]);
   });
 
-  it("skips bundled extension entries with missing entry files (npm stripping) without error", async () => {
+  it("skips bundled extension entries with missing entry files (npm stripping) without error", () => {
     const stateDir = makeTempDir();
     const bundledDir = path.join(stateDir, "bundled");
     const packDir = path.join(bundledDir, "stripped-pack");
@@ -706,5 +706,10 @@ describe("discoverOpenClawPlugins", () => {
     expect(
       result.diagnostics.some((diag) => diag.message.includes("escapes package directory")),
     ).toBe(false);
+    const warnDiag = result.diagnostics.find((diag) =>
+      diag.message.includes("bundled extension entry skipped"),
+    );
+    expect(warnDiag).toBeDefined();
+    expect(warnDiag?.level).toBe("warn");
   });
 });

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -467,6 +467,11 @@ function resolvePackageEntrySource(params: {
   });
   if (!opened.ok) {
     if (params.origin === "bundled" && opened.reason === "path") {
+      params.diagnostics.push({
+        level: "warn",
+        message: `bundled extension entry skipped — file not found (likely npm stripping): ${params.sourceLabel}/${params.entryPath}; install via pnpm or use the pre-built Docker image`,
+        source: params.sourceLabel,
+      });
       return null;
     }
     params.diagnostics.push({

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -456,6 +456,7 @@ function resolvePackageEntrySource(params: {
   sourceLabel: string;
   diagnostics: PluginDiagnostic[];
   rejectHardlinks?: boolean;
+  origin?: PluginOrigin;
 }): string | null {
   const source = path.resolve(params.packageDir, params.entryPath);
   const opened = openBoundaryFileSync({
@@ -465,6 +466,9 @@ function resolvePackageEntrySource(params: {
     rejectHardlinks: params.rejectHardlinks ?? true,
   });
   if (!opened.ok) {
+    if (params.origin === "bundled" && opened.reason === "path") {
+      return null;
+    }
     params.diagnostics.push({
       level: "error",
       message: `extension entry escapes package directory: ${params.entryPath}`,
@@ -539,6 +543,7 @@ function discoverInDirectory(params: {
             sourceLabel: fullPath,
             diagnostics: params.diagnostics,
             rejectHardlinks,
+            origin: params.origin,
           })
         : null;
 
@@ -550,6 +555,7 @@ function discoverInDirectory(params: {
           sourceLabel: fullPath,
           diagnostics: params.diagnostics,
           rejectHardlinks,
+          origin: params.origin,
         });
         if (!resolved) {
           continue;
@@ -669,6 +675,7 @@ function discoverFromPath(params: {
             sourceLabel: resolved,
             diagnostics: params.diagnostics,
             rejectHardlinks,
+            origin: params.origin,
           })
         : null;
 
@@ -680,6 +687,7 @@ function discoverFromPath(params: {
           sourceLabel: resolved,
           diagnostics: params.diagnostics,
           rejectHardlinks,
+          origin: params.origin,
         });
         if (!source) {
           continue;


### PR DESCRIPTION
When npm installs the openclaw package, it can strip .ts source files from bundled extension subdirectories, leaving orphaned package.json files whose openclaw.extensions entries (pointing to ./index.ts) then fail the isPathInsideWithRealpath() validation in resolvePackageEntrySource().

This fix adds an origin parameter to resolvePackageEntrySource() and gracefully skips validation for bundled extensions (origin === 'bundled') when the entry file is missing (opened.reason === 'path'), rather than emitting a misleading 'escapes package directory' error.

This is a runtime fix rather than a publish-time fix because it is more robust against future packaging changes (e.g., different npm versions, different packaging strategies, etc.).

Fixes: #23417, #23439

## Summary

- Problem: When npm installs the openclaw package, it can strip .ts source files from bundled extension subdirectories, leaving orphaned package.json files whose openclaw.extensions entries (pointing to ./index.ts) then fail the isPathInsideWithRealpath() validation in resolvePackageEntrySource(). This crashes the gateway on Docker/npm installs with a misleading "extension entry escapes package directory" error.
- Why it matters: This is a fatal startup failure for Docker container deployments and npm install -g openclaw users, blocking the gateway from starting at all. The error message was misleading, pointing to a path traversal security concern when the actual issue was simply a missing file due to npm stripping.
- What changed: Added an optional origin?: PluginOrigin parameter to resolvePackageEntrySource(). When origin === 'bundled' AND opened.reason === 'path' (file not found), the function returns null silently instead of emitting an error. Updated all 4 call sites in discoverInDirectory and discoverFromPath to pass the origin parameter through.
- What did NOT change (scope boundary): The security guardrail remains fully intact for user-installed plugins (global/workspace/config origins). Only bundled extensions (origin bundled) receive this graceful skip behavior. The path traversal validation itself was not weakened—only the error handling for the specific "file not found" case was made non-fatal for bundled extensions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #23417, #23439
- Related #

## User-visible / Behavior Changes

When npm strips bundled extension entry files, the gateway now starts cleanly instead of crashing with a fatal validation error. No user-visible behavior change for normal operation where entry files are present.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (applies to Linux Docker containers as well)
- Runtime/container: Docker, npm global install
- Model/provider: Any
- Integration/channel (if any): Bundled extensions (all channel plugins)
- Relevant config (redacted): OPENCLAW_BUNDLED_PLUGINS_DIR pointing to npm-installed bundled extensions

### Steps

1. Create a fresh environment with npm install -g openclaw or a Docker image built with npm (not pnpm)
2. Observe that bundled extension directories under the bundled plugins root may have package.json but missing ./index.ts files
3. Start the gateway
4. Observe startup crash with error "extension entry escapes package directory: ./index.ts"

### Expected

With fix: Gateway starts cleanly, bundled extensions with missing entry files are skipped silently.

### Actual

Before fix: Gateway crashes on startup.
After fix: Gateway starts cleanly.

## Evidence

- [x] Failing test/log before + passing after
Added test skips bundled extension entries with missing entry files (npm stripping) without error that verifies:
- No "escapes package directory" diagnostic is emitted for bundled extensions with missing entry files
- The extension is not added to candidates

## Human Verification (required)

What you personally verified (and how):
- Verified scenarios: Ran the new test case and all 25 discovery tests — all pass
- Edge cases checked: The fix only triggers when origin === 'bundled' AND opened.reason === 'path'; other origins and other failure reasons (e.g., actual path traversal attempts) still produce errors
- What you did NOT verify: Full Docker image build, npm global install end-to-end, interaction with specific channel plugins

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: git revert <commit> or set OPENCLAW_BUNDLED_PLUGINS_DIR to a known-good path
- Files/config to restore: src/plugins/discovery.ts, src/plugins/discovery.test.ts
- Known bad symptoms reviewers should watch for: Bundled extensions failing to load when they should load; actual path traversal attempts not being blocked

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Silently skipping bundled extensions with missing files could mask other issues
  - Mitigation: Only skips when opened.reason === 'path' (file not found), not for actual validation failures. User-visible diagnostics still warn about other issues.
- Risk: Reducing security for bundled extensions could be exploited
  - Mitigation: Only skips for "file not found" case, which is not a security issue (file doesn't exist to exploit). Actual path traversal attempts still blocked. User-installed plugins unaffected.
