### PR TITLE
fix(agents): Ollama local provider always returns synthetic auth when no config exists

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -167,6 +167,18 @@ function resolveSyntheticLocalProviderAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
 }): ResolvedProviderAuth | null {
+  // Check for known local providers first — these should always get synthetic auth,
+  // even when the user sets models.primary without running the provider setup wizard
+  // (i.e., no explicit models.providers.{name} config entry exists).
+  const normalizedProvider = normalizeProviderId(params.provider);
+  if (normalizedProvider === "ollama") {
+    return {
+      apiKey: OLLAMA_LOCAL_AUTH_MARKER,
+      source: "models.providers.ollama (synthetic local key)",
+      mode: "api-key",
+    };
+  }
+
   const providerConfig = resolveProviderConfig(params.cfg, params.provider);
   if (!providerConfig) {
     return null;
@@ -178,15 +190,6 @@ function resolveSyntheticLocalProviderAuth(params: {
     (Array.isArray(providerConfig.models) && providerConfig.models.length > 0);
   if (!hasApiConfig) {
     return null;
-  }
-
-  const normalizedProvider = normalizeProviderId(params.provider);
-  if (normalizedProvider === "ollama") {
-    return {
-      apiKey: OLLAMA_LOCAL_AUTH_MARKER,
-      source: "models.providers.ollama (synthetic local key)",
-      mode: "api-key",
-    };
   }
 
   const authOverride = resolveProviderAuthOverride(params.cfg, params.provider);


### PR DESCRIPTION

## Summary

When a user sets `models.primary = "ollama/..."` directly in `openclaw.json` without running the provider setup wizard, the auth resolver throws:

```
No API key found for provider "ollama".
```

This is a **regression in v2026.3.13** — it made Ollama local models unusable via direct config alone.

## Root Cause

`resolveSyntheticLocalProviderAuth()` returned `null` early when `providerConfig` was `undefined` (i.e., no `models.providers.ollama` entry existed). The function checked for `ollama` *after* the `providerConfig` guard, not before.

## Fix

Move the Ollama check to the **top** of `resolveSyntheticLocalProviderAuth()`. For known local providers like `ollama`, return synthetic auth **regardless of config state**.

```ts
// Before: returned null when no config existed
const providerConfig = resolveProviderConfig(params.cfg, params.provider);
if (!providerConfig) { return null; }  // ← blocked ollama here
// ... later
if (normalizedProvider === "ollama") { return syntheticAuth; }

// After: check ollama first
const normalizedProvider = normalizeProviderId(params.provider);
if (normalizedProvider === "ollama") {
  return { apiKey: OLLAMA_LOCAL_AUTH_MARKER, source: "...", mode: "api-key" };
}
// rest of function unchanged
```

## Testing

- [x] Unit test: `resolveSyntheticLocalProviderAuth({ cfg: {}, provider: "ollama" })` returns synthetic auth when no config
- [x] Regression: confirms other providers still require real auth when config is absent
- [ ] Manual: tested with `models.primary = "ollama/llama3.1:8b"` in openclaw.json without provider setup

## Issue

Fixes #50759
