### PR TITLE
fix(cli): align nodes list with node status

### DIFF
--- a/src/cli/nodes-cli/register.status.ts
+++ b/src/cli/nodes-cli/register.status.ts
@@ -8,7 +8,7 @@ import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
 import { formatPermissions, parseNodeList, parsePairingList } from "./format.js";
 import { renderPendingPairingRequestsTable } from "./pairing-render.js";
 import { callGatewayCli, nodesCallOpts, resolveNodeId } from "./rpc.js";
-import type { NodesRpcOpts } from "./types.js";
+import type { NodeListNode, NodesRpcOpts, PairedNode } from "./types.js";
 
 function formatVersionLabel(raw: string) {
   const trimmed = raw.trim();
@@ -94,6 +94,110 @@ function parseSinceMs(raw: unknown, label: string): number | undefined {
     defaultRuntime.error(`${label}: ${message}`);
     defaultRuntime.exit(1);
     return undefined;
+  }
+}
+
+function messageFromError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message?: unknown }).message === "string"
+  ) {
+    return (error as { message: string }).message;
+  }
+  if (typeof error === "object" && error !== null) {
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+function shouldFallbackToPairList(error: unknown): boolean {
+  const message = messageFromError(error).toLowerCase();
+  return (
+    message.includes("unknown method") ||
+    message.includes("method not found") ||
+    message.includes("invalid request") ||
+    message.includes("missing scope: operator.read") ||
+    message.includes("not implemented") ||
+    message.includes("unsupported")
+  );
+}
+
+type NodesListEntry = NodeListNode & PairedNode;
+
+function mergePairedNodeSources(params: {
+  liveNodes: NodeListNode[] | null;
+  pairedNodes: PairedNode[];
+}): NodesListEntry[] {
+  const merged = new Map<string, NodesListEntry>();
+
+  for (const paired of params.pairedNodes) {
+    merged.set(paired.nodeId, {
+      ...paired,
+      paired: true,
+      connected: false,
+    });
+  }
+
+  for (const live of params.liveNodes ?? []) {
+    const previous = merged.get(live.nodeId);
+    if (!live.paired && !previous?.paired) {
+      continue;
+    }
+    merged.set(live.nodeId, {
+      ...previous,
+      ...live,
+      displayName: live.displayName ?? previous?.displayName,
+      platform: live.platform ?? previous?.platform,
+      version: live.version ?? previous?.version,
+      coreVersion: live.coreVersion ?? previous?.coreVersion,
+      uiVersion: live.uiVersion ?? previous?.uiVersion,
+      remoteIp: live.remoteIp ?? previous?.remoteIp,
+      permissions: live.permissions ?? previous?.permissions,
+      paired: true,
+      connected: live.connected ?? previous?.connected,
+      connectedAtMs: live.connectedAtMs ?? previous?.connectedAtMs,
+      lastConnectedAtMs: previous?.lastConnectedAtMs,
+    });
+  }
+
+  return [...merged.values()];
+}
+
+async function loadPairedNodesForList(opts: NodesRpcOpts): Promise<{
+  pending: ReturnType<typeof parsePairingList>["pending"];
+  paired: NodesListEntry[];
+  usedFallback: boolean;
+}> {
+  const pairingResult = await callGatewayCli("node.pair.list", opts, {});
+  const { pending, paired } = parsePairingList(pairingResult);
+  try {
+    const liveNodes = parseNodeList(await callGatewayCli("node.list", opts, {}));
+    return {
+      pending,
+      paired: mergePairedNodeSources({ liveNodes, pairedNodes: paired }),
+      usedFallback: false,
+    };
+  } catch (error) {
+    if (!shouldFallbackToPairList(error)) {
+      throw error;
+    }
+    return {
+      pending,
+      paired: mergePairedNodeSources({ liveNodes: null, pairedNodes: paired }),
+      usedFallback: true,
+    };
   }
 }
 
@@ -304,35 +408,29 @@ export function registerNodesStatusCommands(nodes: Command) {
         await runNodesCommand("list", async () => {
           const connectedOnly = Boolean(opts.connected);
           const sinceMs = parseSinceMs(opts.lastConnected, "Invalid --last-connected");
-          const result = await callGatewayCli("node.pair.list", opts, {});
-          const { pending, paired } = parsePairingList(result);
+          const { pending, paired, usedFallback } = await loadPairedNodesForList(opts);
           const { heading, muted, warn } = getNodesTheme();
           const tableWidth = getTerminalTableWidth();
           const now = Date.now();
           const hasFilters = connectedOnly || sinceMs !== undefined;
+          if (usedFallback && hasFilters) {
+            throw new Error(
+              "node.list is unavailable on this gateway; --connected and --last-connected require live node data",
+            );
+          }
           const pendingRows = hasFilters ? [] : pending;
-          const connectedById = hasFilters
-            ? new Map(
-                parseNodeList(await callGatewayCli("node.list", opts, {})).map((node) => [
-                  node.nodeId,
-                  node,
-                ]),
-              )
-            : null;
           const filteredPaired = paired.filter((node) => {
             if (connectedOnly) {
-              const live = connectedById?.get(node.nodeId);
-              if (!live?.connected) {
+              if (!node.connected) {
                 return false;
               }
             }
             if (sinceMs !== undefined) {
-              const live = connectedById?.get(node.nodeId);
               const lastConnectedAtMs =
-                typeof node.lastConnectedAtMs === "number"
-                  ? node.lastConnectedAtMs
-                  : typeof live?.connectedAtMs === "number"
-                    ? live.connectedAtMs
+                typeof node.connectedAtMs === "number"
+                  ? node.connectedAtMs
+                  : typeof node.lastConnectedAtMs === "number"
+                    ? node.lastConnectedAtMs
                     : undefined;
               if (typeof lastConnectedAtMs !== "number") {
                 return false;
@@ -368,12 +466,11 @@ export function registerNodesStatusCommands(nodes: Command) {
 
           if (filteredPaired.length > 0) {
             const pairedRows = filteredPaired.map((n) => {
-              const live = connectedById?.get(n.nodeId);
               const lastConnectedAtMs =
-                typeof n.lastConnectedAtMs === "number"
-                  ? n.lastConnectedAtMs
-                  : typeof live?.connectedAtMs === "number"
-                    ? live.connectedAtMs
+                typeof n.connectedAtMs === "number"
+                  ? n.connectedAtMs
+                  : typeof n.lastConnectedAtMs === "number"
+                    ? n.lastConnectedAtMs
                     : undefined;
               return {
                 Node: n.displayName?.trim() ? n.displayName.trim() : n.nodeId,

--- a/src/cli/program.nodes-basic.e2e.test.ts
+++ b/src/cli/program.nodes-basic.e2e.test.ts
@@ -35,7 +35,14 @@ describe("cli program (nodes basics)", () => {
 
   async function runProgram(argv: string[]) {
     runtime.log.mockClear();
+    runtime.writeJson.mockClear();
     await program.parseAsync(argv, { from: "user" });
+  }
+
+  async function expectRunProgramFailure(argv: string[], expectedError: RegExp) {
+    runtime.error.mockClear();
+    await expect(program.parseAsync(argv, { from: "user" })).rejects.toThrow(/exit/i);
+    expect(runtime.error.mock.calls.some(([msg]) => expectedError.test(String(msg)))).toBe(true);
   }
 
   function getRuntimeOutput() {
@@ -98,6 +105,209 @@ describe("cli program (nodes basics)", () => {
     const output = getRuntimeOutput();
     expect(output).toContain("One");
     expect(output).not.toContain("Two");
+  });
+
+  it("runs nodes list and includes paired nodes from node.list when node.pair.list is empty", async () => {
+    const now = Date.now();
+    callGateway.mockImplementation(async (...args: unknown[]) => {
+      const opts = (args[0] ?? {}) as { method?: string };
+      if (opts.method === "node.pair.list") {
+        return {
+          pending: [],
+          paired: [],
+        };
+      }
+      if (opts.method === "node.list") {
+        return {
+          ts: now,
+          nodes: [
+            {
+              nodeId: "n1",
+              displayName: "One",
+              remoteIp: "10.0.0.1",
+              paired: true,
+              connected: true,
+              connectedAtMs: now - 1_000,
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    });
+
+    await runProgram(["nodes", "list"]);
+
+    expect(callGateway).toHaveBeenCalledWith(expect.objectContaining({ method: "node.pair.list" }));
+    expect(callGateway).toHaveBeenCalledWith(expect.objectContaining({ method: "node.list" }));
+
+    const output = getRuntimeOutput();
+    expect(output).toContain("Pending: 0 · Paired: 1");
+    expect(output).toContain("One");
+  });
+
+  it("runs nodes list and falls back to node.pair.list when node.list is unavailable", async () => {
+    callGateway.mockImplementation(async (...args: unknown[]) => {
+      const opts = (args[0] ?? {}) as { method?: string };
+      if (opts.method === "node.pair.list") {
+        return {
+          pending: [],
+          paired: [
+            {
+              nodeId: "n1",
+              displayName: "One",
+              remoteIp: "10.0.0.1",
+              lastConnectedAtMs: Date.now() - 1_000,
+            },
+          ],
+        };
+      }
+      if (opts.method === "node.list") {
+        throw new Error("unknown method");
+      }
+      return { ok: true };
+    });
+
+    await runProgram(["nodes", "list"]);
+
+    expect(callGateway).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ method: "node.pair.list" }),
+    );
+    expect(callGateway).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ method: "node.list" }),
+    );
+
+    const output = getRuntimeOutput();
+    expect(output).toContain("Pending: 0 · Paired: 1");
+    expect(output).toContain("One");
+  });
+
+  it("runs nodes list and falls back to node.pair.list on invalid request", async () => {
+    callGateway.mockImplementation(async (...args: unknown[]) => {
+      const opts = (args[0] ?? {}) as { method?: string };
+      if (opts.method === "node.pair.list") {
+        return {
+          pending: [],
+          paired: [
+            {
+              nodeId: "n1",
+              displayName: "One",
+              remoteIp: "10.0.0.1",
+              lastConnectedAtMs: Date.now() - 1_000,
+            },
+          ],
+        };
+      }
+      if (opts.method === "node.list") {
+        throw new Error("invalid request");
+      }
+      return { ok: true };
+    });
+
+    await runProgram(["nodes", "list"]);
+
+    const output = getRuntimeOutput();
+    expect(output).toContain("Pending: 0 · Paired: 1");
+    expect(output).toContain("One");
+  });
+
+  it("runs nodes list and falls back to node.pair.list on missing read scope", async () => {
+    callGateway.mockImplementation(async (...args: unknown[]) => {
+      const opts = (args[0] ?? {}) as { method?: string };
+      if (opts.method === "node.pair.list") {
+        return {
+          pending: [],
+          paired: [
+            {
+              nodeId: "n1",
+              displayName: "One",
+              remoteIp: "10.0.0.1",
+              lastConnectedAtMs: Date.now() - 1_000,
+            },
+          ],
+        };
+      }
+      if (opts.method === "node.list") {
+        throw new Error("missing scope: operator.read");
+      }
+      return { ok: true };
+    });
+
+    await runProgram(["nodes", "list"]);
+
+    const output = getRuntimeOutput();
+    expect(output).toContain("Pending: 0 · Paired: 1");
+    expect(output).toContain("One");
+  });
+
+  it("fails clearly for nodes list --connected when node.list is unavailable", async () => {
+    callGateway.mockImplementation(async (...args: unknown[]) => {
+      const opts = (args[0] ?? {}) as { method?: string };
+      if (opts.method === "node.pair.list") {
+        return {
+          pending: [],
+          paired: [
+            {
+              nodeId: "n1",
+              displayName: "One",
+              remoteIp: "10.0.0.1",
+              lastConnectedAtMs: Date.now() - 1_000,
+            },
+          ],
+        };
+      }
+      if (opts.method === "node.list") {
+        throw new Error("unknown method");
+      }
+      return { ok: true };
+    });
+
+    await expectRunProgramFailure(
+      ["nodes", "list", "--connected"],
+      /node\.list is unavailable .* require live node data/i,
+    );
+  });
+
+  it("preserves legacy paired metadata in nodes list --json fallback output", async () => {
+    callGateway.mockImplementation(async (...args: unknown[]) => {
+      const opts = (args[0] ?? {}) as { method?: string };
+      if (opts.method === "node.pair.list") {
+        return {
+          pending: [],
+          paired: [
+            {
+              nodeId: "n1",
+              token: "tok-1",
+              displayName: "One",
+              remoteIp: "10.0.0.1",
+              approvedAtMs: 123,
+              createdAtMs: 122,
+            },
+          ],
+        };
+      }
+      if (opts.method === "node.list") {
+        throw new Error("unknown method");
+      }
+      return { ok: true };
+    });
+
+    await runProgram(["nodes", "list", "--json"]);
+
+    const payload = runtime.writeJson.mock.calls.at(-1)?.[0] as
+      | {
+          paired: Array<Record<string, unknown>>;
+        }
+      | undefined;
+    expect(payload).toBeDefined();
+    const jsonPayload = payload as {
+      paired: Array<Record<string, unknown>>;
+    };
+    expect(jsonPayload.paired).toHaveLength(1);
+    expect(jsonPayload.paired[0]?.token).toBe("tok-1");
+    expect(jsonPayload.paired[0]?.approvedAtMs).toBe(123);
+    expect(jsonPayload.paired[0]?.createdAtMs).toBe(122);
   });
 
   it("runs nodes status --last-connected and filters by age", async () => {

--- a/src/cli/program.test-mocks.ts
+++ b/src/cli/program.test-mocks.ts
@@ -21,6 +21,7 @@ const programMocks = vi.hoisted(() => {
     ensurePluginRegistryLoaded: vi.fn(),
     runtime: {
       log: vi.fn(),
+      writeJson: vi.fn(),
       error: vi.fn(),
       exit: vi.fn(() => {
         throw new Error("exit");
@@ -47,6 +48,7 @@ export const ensurePluginRegistryLoaded = programMocks.ensurePluginRegistryLoade
 
 export const runtime = programMocks.runtime as {
   log: Mock<(...args: unknown[]) => void>;
+  writeJson: Mock<(...args: unknown[]) => void>;
   error: Mock<(...args: unknown[]) => void>;
   exit: Mock<(...args: unknown[]) => never>;
 };


### PR DESCRIPTION
﻿## Summary

- Problem: `openclaw nodes status` reads the live `node.list` view, but `openclaw nodes list` still renders paired nodes from `node.pair.list`, so gateways using the newer device-pairing path can show a connected node in `status` while `list` reports `Paired: 0`.
- Why it matters: the CLI and downstream tooling treat `nodes list` as the paired-node inventory, so the mismatch hides healthy paired nodes.
- What changed: `nodes list` now keeps `node.pair.list` for pending requests, but it builds the paired-node table from `node.list` first and only falls back to legacy `node.pair.list` data when `node.list` is unavailable.
- What did NOT change (scope boundary): this does not change gateway pairing storage, RPC contracts, or node registration behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50847
- Related #49989

## User-visible / Behavior Changes

- `openclaw nodes list` now shows the same paired/connected node inventory as `openclaw nodes status` on gateways that already expose nodes through `node.list`.
- Pending pairing requests still appear in `openclaw nodes list` when no filters are applied.
- Older gateways that do not implement `node.list` still fall back to the legacy `node.pair.list` view.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node 22.20.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Pair or connect a node through the newer device-pairing path so `node.list` reports it as paired/connected.
2. Run `openclaw nodes status` and confirm the node appears.
3. Run `openclaw nodes list`.

### Expected

- Both commands report the same paired node inventory.

### Actual

- `nodes status` shows the node, while `nodes list` can report `Pending: 0 · Paired: 0` because it only reads the legacy `node.pair.list` source.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the mismatch in the CLI harness by returning a paired node from `node.list` and an empty `node.pair.list`, then confirmed `nodes list` now reports the paired node; also verified the legacy fallback path when `node.list` is unavailable.
- Edge cases checked: `--connected` filtering still works against live node connectivity; pending pairing rows remain visible when no filters are applied.
- What you did **not** verify: I did not run this against a live gateway/node pair outside the targeted CLI test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR to restore the previous `node.pair.list`-only behavior in `nodes list`.
- Files/config to restore: `src/cli/nodes-cli/register.status.ts`
- Known bad symptoms reviewers should watch for: `nodes list` omits paired nodes on older gateways that should still fall back to `node.pair.list`.

## Risks and Mitigations

- Risk: a gateway returns partial `node.list` rows without `paired: true`, which could still hide a legacy paired entry.
- Mitigation: the merge logic keeps legacy `node.pair.list` metadata and treats matching live rows as paired when a legacy paired entry already exists.
