### PR TITLE
fix(feishu): route message-tool images through plugin actions

### DIFF
--- a/extensions/feishu/src/actions.test.ts
+++ b/extensions/feishu/src/actions.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const listFeishuAccountIdsMock = vi.hoisted(() => vi.fn());
+const resolveFeishuAccountMock = vi.hoisted(() => vi.fn());
+const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
+const sendOutboundTextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./accounts.js", () => ({
+  listFeishuAccountIds: listFeishuAccountIdsMock,
+  resolveFeishuAccount: resolveFeishuAccountMock,
+}));
+
+vi.mock("./media.js", () => ({
+  sendMediaFeishu: sendMediaFeishuMock,
+}));
+
+vi.mock("./outbound.js", () => ({
+  sendOutboundText: sendOutboundTextMock,
+}));
+
+import { feishuMessageActions } from "./actions.js";
+
+describe("feishuMessageActions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listFeishuAccountIdsMock.mockReturnValue(["default"]);
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "default",
+      enabled: true,
+      configured: true,
+      config: {},
+    });
+    sendMediaFeishuMock.mockResolvedValue({ messageId: "msg_1", chatId: "chat_1" });
+    sendOutboundTextMock.mockResolvedValue({ messageId: "text_1", chatId: "chat_1" });
+  });
+
+  it("advertises send when a configured feishu account exists", () => {
+    expect(feishuMessageActions.listActions?.({ cfg: {} as any })).toEqual(["send"]);
+  });
+
+  it("returns no actions when feishu is not configured", () => {
+    resolveFeishuAccountMock.mockReturnValueOnce({
+      accountId: "default",
+      enabled: true,
+      configured: false,
+      config: {},
+    });
+
+    expect(feishuMessageActions.listActions?.({ cfg: {} as any })).toEqual([]);
+  });
+
+  it("sends buffer-based images through sendMediaFeishu", async () => {
+    const payload = Buffer.from("hello-image").toString("base64");
+
+    const result = await feishuMessageActions.handleAction?.({
+      action: "send",
+      params: {
+        to: "user:ou_target",
+        message: "caption",
+        buffer: payload,
+        mimeType: "image/png",
+      },
+      cfg: {} as any,
+      accountId: "default",
+      mediaLocalRoots: ["/workspace"],
+    } as any);
+
+    expect(sendOutboundTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "user:ou_target",
+        text: "caption",
+        accountId: "default",
+      }),
+    );
+    expect(sendMediaFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "user:ou_target",
+        accountId: "default",
+        fileName: "image.png",
+        mediaBuffer: Buffer.from("hello-image"),
+      }),
+    );
+    expect(result?.details).toEqual(
+      expect.objectContaining({ ok: true, to: "user:ou_target", messageId: "msg_1" }),
+    );
+  });
+
+  it("forwards local-path sends with mediaLocalRoots to sendMediaFeishu", async () => {
+    await feishuMessageActions.handleAction?.({
+      action: "send",
+      params: {
+        to: "user:ou_target",
+        filePath: "/allowed/workspace/pic.png",
+        replyTo: "om_reply_1",
+      },
+      cfg: {} as any,
+      accountId: "default",
+      mediaLocalRoots: ["/allowed/workspace"],
+    } as any);
+
+    expect(sendOutboundTextMock).not.toHaveBeenCalled();
+    expect(sendMediaFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "user:ou_target",
+        mediaUrl: "/allowed/workspace/pic.png",
+        fileName: "pic.png",
+        replyToMessageId: "om_reply_1",
+        mediaLocalRoots: ["/allowed/workspace"],
+      }),
+    );
+  });
+
+  it("returns the text message id for text-only sends", async () => {
+    const result = await feishuMessageActions.handleAction?.({
+      action: "send",
+      params: {
+        to: "user:ou_target",
+        message: "hello",
+      },
+      cfg: {} as any,
+      accountId: "default",
+    } as any);
+
+    expect(sendOutboundTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "user:ou_target",
+        text: "hello",
+        accountId: "default",
+      }),
+    );
+    expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+    expect(result?.details).toEqual(
+      expect.objectContaining({ ok: true, to: "user:ou_target", messageId: "text_1" }),
+    );
+  });
+
+  it("throws when send lacks text and media", async () => {
+    await expect(
+      feishuMessageActions.handleAction?.({
+        action: "send",
+        params: { to: "user:ou_target" },
+        cfg: {} as any,
+      } as any),
+    ).rejects.toThrow("send requires text or media");
+  });
+});

--- a/extensions/feishu/src/actions.ts
+++ b/extensions/feishu/src/actions.ts
@@ -1,0 +1,152 @@
+import type {
+  ChannelMessageActionAdapter,
+  ChannelMessageActionName,
+  ClawdbotConfig,
+} from "openclaw/plugin-sdk/feishu";
+import { extractToolSend, jsonResult, readStringParam } from "openclaw/plugin-sdk/feishu";
+import { listFeishuAccountIds, resolveFeishuAccount } from "./accounts.js";
+import { sendMediaFeishu } from "./media.js";
+import { sendOutboundText } from "./outbound.js";
+
+const providerId = "feishu";
+
+function listEnabledAccounts(cfg: ClawdbotConfig) {
+  return listFeishuAccountIds(cfg)
+    .map((accountId) => resolveFeishuAccount({ cfg, accountId }))
+    .filter((account) => account.enabled && account.configured);
+}
+
+function decodeBase64Payload(raw: string): { buffer: Buffer; contentType?: string } {
+  const trimmed = raw.trim();
+  const dataUrlMatch = /^data:([^;,]+);base64,(.+)$/s.exec(trimmed);
+  const base64 = dataUrlMatch ? dataUrlMatch[2] : trimmed;
+  const contentType = dataUrlMatch?.[1];
+  const buffer = Buffer.from(base64, "base64");
+  if (buffer.length === 0) {
+    throw new Error("buffer decoded to empty payload");
+  }
+  return { buffer, contentType };
+}
+
+function inferImageFileName(params: {
+  fileName?: string;
+  contentType?: string;
+  mediaUrl?: string;
+}): string {
+  if (params.fileName?.trim()) {
+    return params.fileName.trim();
+  }
+
+  const mediaUrl = params.mediaUrl?.trim();
+  if (mediaUrl) {
+    const lastSegment = mediaUrl.split(/[\\/]/).pop()?.trim();
+    if (lastSegment) {
+      return lastSegment;
+    }
+  }
+
+  const type = params.contentType?.toLowerCase();
+  if (type === "image/jpeg") return "image.jpg";
+  if (type === "image/png") return "image.png";
+  if (type === "image/webp") return "image.webp";
+  if (type === "image/gif") return "image.gif";
+  if (type === "image/bmp") return "image.bmp";
+  if (type === "image/tiff") return "image.tiff";
+  if (type === "image/x-icon" || type === "image/vnd.microsoft.icon") return "image.ico";
+  if (type?.startsWith("image/")) {
+    return `image.${type.slice("image/".length)}`;
+  }
+  return "file";
+}
+
+function resolveReplyToMessageId(params: Record<string, unknown>): string | undefined {
+  const replyTo = readStringParam(params, "replyTo");
+  if (replyTo) {
+    return replyTo;
+  }
+  const threadId = readStringParam(params, "threadId");
+  return threadId || undefined;
+}
+
+export const feishuMessageActions: ChannelMessageActionAdapter = {
+  listActions: ({ cfg }) => {
+    const accounts = listEnabledAccounts(cfg);
+    if (accounts.length === 0) {
+      return [];
+    }
+    return ["send"] satisfies ChannelMessageActionName[];
+  },
+  extractToolSend: ({ args }) => extractToolSend(args, "sendMessage"),
+  handleAction: async ({ action, params, cfg, accountId, mediaLocalRoots }) => {
+    if (action !== "send") {
+      throw new Error(`Action ${action} is not supported for provider ${providerId}.`);
+    }
+
+    const to = readStringParam(params, "to", { required: true });
+    const message =
+      readStringParam(params, "message", {
+        allowEmpty: true,
+      }) ?? "";
+    const mediaUrl =
+      readStringParam(params, "media", { trim: false }) ??
+      readStringParam(params, "path", { trim: false }) ??
+      readStringParam(params, "filePath", { trim: false });
+    const rawBuffer = readStringParam(params, "buffer", { trim: false });
+    const fileName = readStringParam(params, "filename");
+    const contentType =
+      readStringParam(params, "contentType") ?? readStringParam(params, "mimeType");
+    const replyToMessageId = resolveReplyToMessageId(params);
+
+    if (!message.trim() && !mediaUrl && !rawBuffer) {
+      throw new Error("send requires text or media");
+    }
+
+    let textResult: Awaited<ReturnType<typeof sendOutboundText>> | undefined;
+    if (message.trim()) {
+      textResult = await sendOutboundText({
+        cfg,
+        to,
+        text: message,
+        accountId: accountId ?? undefined,
+        replyToMessageId,
+      });
+    }
+
+    if (rawBuffer) {
+      const decoded = decodeBase64Payload(rawBuffer);
+      const result = await sendMediaFeishu({
+        cfg,
+        to,
+        mediaBuffer: decoded.buffer,
+        fileName: inferImageFileName({
+          fileName,
+          contentType: contentType ?? decoded.contentType,
+          mediaUrl,
+        }),
+        accountId: accountId ?? undefined,
+        replyToMessageId,
+      });
+      return jsonResult({ ok: true, to, messageId: result.messageId, chatId: result.chatId });
+    }
+
+    if (mediaUrl) {
+      const result = await sendMediaFeishu({
+        cfg,
+        to,
+        mediaUrl,
+        fileName: inferImageFileName({ fileName, contentType, mediaUrl }),
+        accountId: accountId ?? undefined,
+        replyToMessageId,
+        mediaLocalRoots,
+      });
+      return jsonResult({ ok: true, to, messageId: result.messageId, chatId: result.chatId });
+    }
+
+    return jsonResult({
+      ok: true,
+      to,
+      messageId: textResult?.messageId,
+      chatId: textResult?.chatId,
+    });
+  },
+};

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -7,6 +7,7 @@ vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,
 }));
 
+import { feishuMessageActions } from "./actions.js";
 import { feishuPlugin } from "./channel.js";
 
 describe("feishuPlugin.status.probeAccount", () => {
@@ -44,5 +45,11 @@ describe("feishuPlugin.status.probeAccount", () => {
       }),
     );
     expect(result).toMatchObject({ ok: true, appId: "cli_main" });
+  });
+});
+
+describe("feishuPlugin action wiring", () => {
+  it("registers the Feishu message action adapter", () => {
+    expect(feishuPlugin.actions).toBe(feishuMessageActions);
   });
 });

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -17,6 +17,7 @@ import {
   listFeishuAccountIds,
   resolveDefaultFeishuAccountId,
 } from "./accounts.js";
+import { feishuMessageActions } from "./actions.js";
 import {
   listFeishuDirectoryPeers,
   listFeishuDirectoryGroups,
@@ -299,6 +300,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
       hint: "<chatId|user:openId|chat:chatId>",
     },
   },
+  actions: feishuMessageActions,
   directory: {
     self: async () => null,
     listPeers: async ({ cfg, query, limit, accountId }) =>

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -58,7 +58,7 @@ function resolveReplyToMessageId(params: {
   return trimmed || undefined;
 }
 
-async function sendOutboundText(params: {
+export async function sendOutboundText(params: {
   cfg: Parameters<typeof sendMessageFeishu>[0]["cfg"];
   to: string;
   text: string;

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -12,9 +12,14 @@ export type { ReplyPayload } from "../auto-reply/types.js";
 export { logTypingFailure } from "../channels/logging.js";
 export type { AllowlistMatch } from "../channels/plugins/allowlist-match.js";
 export type {
+  ChannelMessageActionAdapter,
+  ChannelMessageActionName,
+} from "../channels/plugins/types.js";
+export type {
   ChannelOnboardingAdapter,
   ChannelOnboardingDmPolicy,
 } from "../channels/plugins/onboarding-types.js";
+export { jsonResult, readStringParam } from "../agents/tools/common.js";
 export {
   buildSingleChannelSecretPromptState,
   addWildcardAllowFrom,
@@ -50,6 +55,7 @@ export {
   normalizeSecretInputString,
 } from "../config/types.secrets.js";
 export { buildSecretInputSchema } from "./secret-input-schema.js";
+export { extractToolSend } from "./tool-send.js";
 export { createDedupeCache } from "../infra/dedupe.js";
 export { installRequestBodyLimitGuard } from "../infra/http-body.js";
 export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";


### PR DESCRIPTION
## Summary
- add a Feishu message action adapter so `message(action=send)` is handled by the plugin before falling back to core outbound
- route base64 `buffer`, local path, and normal media sends through `sendMediaFeishu`, reusing the existing `upload image -> image_key -> msg_type=image` Feishu flow
- expose the helper symbols on the public Feishu plugin SDK surface and add regression coverage for the new wiring

## Root cause
Feishu did not register a plugin `send` action, so message-tool sends fell back to the core outbound path. That path understands `content`/`mediaUrl` but not `buffer` payloads, which caused local image sends to degrade into dropped attachments or plain-text/local-path fallbacks instead of real Feishu image messages.

## Testing
- `./node_modules/.bin/vitest run extensions/feishu/src/actions.test.ts extensions/feishu/src/channel.test.ts extensions/feishu/src/outbound.test.ts extensions/feishu/src/media.test.ts`