### PR TITLE
fix(cli): prevent plugin loading logs from polluting 'openclaw agent --json' stdout

### DIFF
--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -1,4 +1,5 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import { routeLogsToStderr } from "../logging.js";
 import { listAgentIds } from "../agents/agent-scope.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.js";
@@ -179,6 +180,11 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
 }
 
 export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, deps?: CliDeps) {
+  // When --json is set, route all logs to stderr so only the JSON result appears on stdout.
+  if (opts.json) {
+    routeLogsToStderr();
+  }
+
   const localOpts = {
     ...opts,
     agentId: opts.agent,


### PR DESCRIPTION
## Summary

When running `openclaw agent --json`, plugin loading logs were being printed to stdout, corrupting the JSON output.

**Root cause:** The `agentCliCommand` function did not redirect runtime logs to stderr when `--json` was used. This is the same class of bug that was already fixed in `completion-cli.ts` (see the `routeLogsToStderr()` call there).

**Fix:** Call `routeLogsToStderr()` at the start of `agentCliCommand` when `opts.json` is `true`. This redirects all `console.log` / `defaultRuntime.log` calls to stderr, keeping stdout clean for the pure JSON response.

## Changes

- `src/commands/agent-via-gateway.ts`: Import `routeLogsToStderr` and call it when `opts.json` is true

## Testing

```bash
openclaw agent --json --message "hello" --to +15555550123
# Before: stdout was polluted with plugin loading messages
# After: stdout contains only clean JSON
```

Fixes #51076