### PR TITLE
docs: clarify Media Understanding apiKey sources

### DIFF
--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -92,6 +92,19 @@ Each `models[]` entry can be **provider** or **CLI**:
 }
 ```
 
+Provider entries reuse the standard model-provider auth flow. `tools.media`
+model entries do **not** take an inline `apiKey`. Configure credentials through
+one of these supported sources instead:
+
+- an `auth-profiles.json` profile selected by `profile` / `preferredProfile`
+- the provider's standard environment variable (for example `OPENAI_API_KEY`,
+  `GOOGLE_API_KEY`, `GROQ_API_KEY`)
+- `models.providers.<provider>.apiKey` in config, including plaintext,
+  `${ENV_VAR}` substitution, or a SecretRef object
+
+If none of those sources resolve for a provider entry, media understanding skips
+that entry and falls back to the next configured model.
+
 ```json5
 {
   type: "cli",
@@ -151,6 +164,10 @@ working option**:
    - Audio: OpenAI → Groq → Deepgram → Google
    - Image: OpenAI → Anthropic → Google → MiniMax
    - Video: Google
+
+Provider auto-detection uses the same auth sources listed above. A provider only
+counts as available when OpenClaw can resolve its credential from auth
+profiles, env, or `models.providers.<provider>.apiKey`.
 
 To disable auto-detection, set:
 

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -97,10 +97,10 @@ model entries do **not** take an inline `apiKey`. Configure credentials through
 one of these supported sources instead:
 
 - an `auth-profiles.json` profile selected by `profile` / `preferredProfile`
-- the provider's standard environment variable (for example `OPENAI_API_KEY`,
-  `GOOGLE_API_KEY`, `GROQ_API_KEY`)
-- `models.providers.<provider>.apiKey` in config, including plaintext,
-  `${ENV_VAR}` substitution, or a SecretRef object
+- the provider's standard environment variable (for example `GOOGLE_API_KEY`,
+  `GROQ_API_KEY`, `OPENAI_API_KEY`)
+- `models.providers.<provider>.apiKey` in config when it resolves to a usable
+  string value, including plaintext or `${ENV_VAR}` substitution
 
 If none of those sources resolve for a provider entry, media understanding skips
 that entry and falls back to the next configured model.

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -100,7 +100,7 @@ one of these supported sources instead:
 - the provider's standard environment variable (for example `GOOGLE_API_KEY`,
   `GROQ_API_KEY`, `OPENAI_API_KEY`)
 - `models.providers.<provider>.apiKey` in config when it resolves to a usable
-  string value, including plaintext or `${ENV_VAR}` substitution
+  string value via plaintext or `${ENV_VAR}` substitution
 
 If none of those sources resolve for a provider entry, media understanding skips
 that entry and falls back to the next configured model.


### PR DESCRIPTION
## Summary
- document that `tools.media` provider entries do not take inline `apiKey`
- clarify the supported credential sources for Media Understanding provider entries
- explain that provider auto-detection only treats providers as available when auth resolves successfully

## Validation
- attempted `pnpm format:docs:check`, but docs tooling was unavailable in the temp clone because local deps were missing
- attempted `pnpm install`, but registry/network resolution was blocked in this environment

Closes #51054