### PR TITLE
fix(gateway): allow microphone access for control-ui STT (#51085)

### DIFF
--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -14,7 +14,7 @@ export function setDefaultSecurityHeaders(
 ) {
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("Referrer-Policy", "no-referrer");
-  res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  res.setHeader("Permissions-Policy", "camera=(), microphone=(self), geolocation=()");
   const strictTransportSecurity = opts?.strictTransportSecurity;
   if (typeof strictTransportSecurity === "string" && strictTransportSecurity.length > 0) {
     res.setHeader("Strict-Transport-Security", strictTransportSecurity);


### PR DESCRIPTION
## Problem

The control-ui chat has a built-in STT mic button (`ui/src/ui/chat/speech.ts`) wired into the chat view, but clicking it silently fails because the gateway's default security headers block microphone access.

`src/gateway/http-common.ts` sets:
```
Permissions-Policy: camera=(), microphone=(), geolocation=()
```

`microphone=()` tells the browser to deny mic access for **all** origins, including the page itself. The Web Speech API's `SpeechRecognition.start()` then fails with:
> Permissions policy violation: microphone is not allowed in this document.

The STT code catches the error and resets the button state silently — so the button just refuses to stay active with no visible error to the user.

## Fix

Change `microphone=()` → `microphone=(self)` so the gateway's own origin can request mic access while still blocking third-party iframes:

```diff
- res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+ res.setHeader("Permissions-Policy", "camera=(), microphone=(self), geolocation=()");
```

## Testing

1. Open control-ui chat in Chrome
2. Click the mic button
3. Browser should prompt for microphone permission
4. STT should activate and transcribe speech

Closes #51085