### PR TITLE
feat(session-memory): make slug generation timeout configurable

### DIFF
--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -276,6 +276,10 @@ const saveSessionToMemory: HookHandler = async (event) => {
       typeof hookConfig?.messages === "number" && hookConfig.messages > 0
         ? hookConfig.messages
         : 15;
+    const slugTimeoutMs =
+      typeof hookConfig?.slugTimeoutMs === "number" && hookConfig.slugTimeoutMs > 0
+        ? hookConfig.slugTimeoutMs
+        : undefined;
 
     let slug: string | null = null;
     let sessionContent: string | null = null;
@@ -299,7 +303,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
       if (sessionContent && cfg && allowLlmSlug) {
         log.debug("Calling generateSlugViaLLM...");
         // Use LLM to generate a descriptive slug
-        slug = await generateSlugViaLLM({ sessionContent, cfg });
+        slug = await generateSlugViaLLM({ sessionContent, cfg, timeoutMs: slugTimeoutMs });
         log.debug("Generated slug", { slug });
       }
     }

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -25,6 +25,7 @@ const log = createSubsystemLogger("llm-slug-generator");
 export async function generateSlugViaLLM(params: {
   sessionContent: string;
   cfg: OpenClawConfig;
+  timeoutMs?: number;
 }): Promise<string | null> {
   let tempSessionFile: string | null = null;
 
@@ -61,7 +62,7 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       prompt,
       provider,
       model,
-      timeoutMs: 15_000, // 15 second timeout
+      timeoutMs: params.timeoutMs ?? 15_000,
       runId: `slug-gen-${Date.now()}`,
     });
 


### PR DESCRIPTION
## Summary

- Add optional `timeoutMs` parameter to `generateSlugViaLLM()` so callers can override the default 15 s timeout
- Read `slugTimeoutMs` from the `session-memory` hook config and pass it through
- Default behavior is unchanged (15 000 ms) when `slugTimeoutMs` is not set

## Motivation

Slow providers (e.g. `cursor-api-proxy`) regularly exceed the hardcoded 15 s limit, logging "LLM request timed out" and falling back to a timestamp slug. Users can now raise the timeout without patching core code.

## Config example

```json
"session-memory": {
  "enabled": true,
  "slugTimeoutMs": 60000
}
```

## Test plan

- [x] `pnpm test -- src/hooks` — 165 tests pass
- [x] `pnpm tsgo` — no type errors in touched files
