### PR TITLE
fix(sandbox): pull pre-built image from GHCR instead of plain debian:bookworm-slim

### DIFF
--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -261,9 +261,19 @@ export async function ensureDockerImage(image: string) {
     return;
   }
   if (image === DEFAULT_SANDBOX_IMAGE) {
-    await execDocker(["pull", "debian:bookworm-slim"]);
-    await execDocker(["tag", "debian:bookworm-slim", DEFAULT_SANDBOX_IMAGE]);
-    return;
+    // Prefer the pre-built image from GitHub Container Registry (contains python3 + tools).
+    // Falls back to building locally from Dockerfile.sandbox if the registry pull fails.
+    const registryImage = "ghcr.io/openclaw/openclaw:main-slim-amd64";
+    try {
+      await execDocker(["pull", registryImage]);
+      await execDocker(["tag", registryImage, DEFAULT_SANDBOX_IMAGE]);
+      return;
+    } catch {
+      // Registry pull failed; build locally from the included Dockerfile.sandbox
+      const dockerfilePath = process.cwd() + "/Dockerfile.sandbox";
+      await execDocker(["build", "-t", DEFAULT_SANDBOX_IMAGE, "-f", dockerfilePath, "."]);
+      return;
+    }
   }
   throw new Error(`Sandbox image not found: ${image}. Build or pull it first.`);
 }


### PR DESCRIPTION
## Fixes openclaw/openclaw#51099

### Bug
After upgrading to v2026.3.13, file write/edit tools inside the sandbox fail with:
```
moltbot-sandbox-fs: 2: python3: not found
```

### Root cause
`ensureDockerImage()` in `src/agents/sandbox/docker.ts` was creating the `openclaw-sandbox:bookworm-slim` image by pulling `debian:bookworm-slim` directly from Docker Hub — a plain Debian image with **no python3**.

The project includes a `Dockerfile.sandbox` that installs python3, ripgrep, and other tools, but `ensureDockerImage()` was completely bypassing it.

### Fix
1. **Primary**: Pull the pre-built image from GitHub Container Registry () — this is built from  and includes python3
2. **Fallback**: If the registry pull fails, build locally from 

This matches how the docker-release CI workflow actually builds and publishes the image.

### Testing
```bash
openclaw agents run --sandbox  # should start sandbox with python3 available
edit some file via the agent   # should work without 'python3: not found'
```