### PR TITLE
feat(gateway): add --lightweight flag to skip unused channel adapters

### DIFF
--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -54,6 +54,7 @@ type GatewayRunOpts = {
   rawStreamPath?: unknown;
   dev?: boolean;
   reset?: boolean;
+  lightweight?: boolean;
 };
 
 const gatewayLog = createSubsystemLogger("gateway");
@@ -80,6 +81,7 @@ const GATEWAY_RUN_BOOLEAN_KEYS = [
   "claudeCliLogs",
   "compact",
   "rawStream",
+  "lightweight",
 ] as const;
 
 const GATEWAY_AUTH_MODES: readonly GatewayAuthMode[] = [
@@ -427,6 +429,7 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
           bind,
           auth: authOverride,
           tailscale: tailscaleOverride,
+          lightweight: Boolean(opts.lightweight),
         }),
     });
   } catch (err) {
@@ -502,6 +505,7 @@ export function addGatewayRunCommand(cmd: Command): Command {
     .option("--compact", 'Alias for "--ws-log compact"', false)
     .option("--raw-stream", "Log raw model stream events to jsonl", false)
     .option("--raw-stream-path <path>", "Raw stream jsonl path")
+    .option("--lightweight", "Only load configured channel plugins to reduce memory", false)
     .action(async (opts, command) => {
       await runGatewayCommand(resolveGatewayRunOptions(opts, command));
     });

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -3,7 +3,7 @@ import { normalizeModelRef, parseModelRef } from "../agents/model-selection.js";
 import { primeConfiguredBindingRegistry } from "../channels/plugins/binding-registry.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveConfiguredChannelPluginIds } from "../plugins/channel-plugin-ids.js";
-import { normalizePluginsConfig } from "../plugins/config-state.js";
+import { BUNDLED_ENABLED_BY_DEFAULT, normalizePluginsConfig } from "../plugins/config-state.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { setGatewaySubagentRuntime } from "../plugins/runtime/index.js";
@@ -420,7 +420,11 @@ export function loadGatewayPlugins(params: {
       workspaceDir: params.workspaceDir,
       env: process.env,
     });
-    onlyPluginIds = Array.from(new Set([...enabledEntryIds, ...configuredChannelIds]));
+    onlyPluginIds = Array.from(new Set([
+      ...enabledEntryIds,
+      ...configuredChannelIds,
+      ...BUNDLED_ENABLED_BY_DEFAULT,
+    ]));
     params.log.info(
       `[lightweight] loading only ${onlyPluginIds.length} plugin(s): ${onlyPluginIds.join(", ") || "(none)"}`,
     );

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { normalizeModelRef, parseModelRef } from "../agents/model-selection.js";
 import { primeConfiguredBindingRegistry } from "../channels/plugins/binding-registry.js";
 import type { loadConfig } from "../config/config.js";
+import { resolveConfiguredChannelPluginIds } from "../plugins/channel-plugin-ids.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
@@ -396,6 +397,7 @@ export function loadGatewayPlugins(params: {
   baseMethods: string[];
   preferSetupRuntimeForChannelPlugins?: boolean;
   logDiagnostics?: boolean;
+  lightweight?: boolean;
 }) {
   setPluginSubagentOverridePolicies(params.cfg);
   // Set the process-global gateway subagent runtime BEFORE loading plugins.
@@ -404,6 +406,25 @@ export function loadGatewayPlugins(params: {
   // the default subagent behavior for every plugin runtime in the process.
   const gatewaySubagent = createGatewaySubagentRuntime();
   setGatewaySubagentRuntime(gatewaySubagent);
+
+  // In lightweight mode, only load plugins that are explicitly configured and
+  // enabled so that unused channel adapters never consume memory.
+  let onlyPluginIds: string[] | undefined;
+  if (params.lightweight) {
+    const normalized = normalizePluginsConfig(params.cfg.plugins);
+    const enabledEntryIds = Object.entries(normalized.entries)
+      .filter(([, entry]) => entry.enabled !== false)
+      .map(([id]) => id);
+    const configuredChannelIds = resolveConfiguredChannelPluginIds({
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+      env: process.env,
+    });
+    onlyPluginIds = Array.from(new Set([...enabledEntryIds, ...configuredChannelIds]));
+    params.log.info(
+      `[lightweight] loading only ${onlyPluginIds.length} plugin(s): ${onlyPluginIds.join(", ") || "(none)"}`,
+    );
+  }
 
   const pluginRegistry = loadOpenClawPlugins({
     config: params.cfg,
@@ -419,6 +440,7 @@ export function loadGatewayPlugins(params: {
       allowGatewaySubagentBinding: true,
     },
     preferSetupRuntimeForChannelPlugins: params.preferSetupRuntimeForChannelPlugins,
+    onlyPluginIds,
   });
   primeConfiguredBindingRegistry({ cfg: params.cfg });
   const pluginMethods = Object.keys(pluginRegistry.gatewayHandlers);

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -346,6 +346,11 @@ export type GatewayServerOptions = {
    */
   tailscale?: import("../config/config.js").GatewayTailscaleConfig;
   /**
+   * When true, only load channel plugins that are configured and enabled in
+   * the config file.  Reduces memory on constrained hosts.
+   */
+  lightweight?: boolean;
+  /**
    * Test-only: allow canvas host startup even when NODE_ENV/VITEST would disable it.
    */
   allowCanvasHostInTests?: boolean;
@@ -568,6 +573,7 @@ export async function startGatewayServer(
       coreGatewayHandlers,
       baseMethods,
       preferSetupRuntimeForChannelPlugins: deferredConfiguredChannelPluginIds.length > 0,
+      lightweight: opts.lightweight,
     }));
   }
   const channelLogs = Object.fromEntries(
@@ -1191,6 +1197,7 @@ export async function startGatewayServer(
         coreGatewayHandlers,
         baseMethods,
         logDiagnostics: false,
+        lightweight: opts.lightweight,
       }));
     }
     ({ browserControl, pluginServices } = await startGatewaySidecars({


### PR DESCRIPTION
## Summary

- Adds `--lightweight` CLI flag to `openclaw gateway` that only loads channel plugins that are explicitly configured and enabled in `openclaw.json`
- Reuses the existing `onlyPluginIds` filtering in the plugin loader — no changes to core loading logic
- On memory-constrained hosts (2GB RAM), the gateway loads every channel adapter (Discord, Slack, LINE, WhatsApp, MSTeams, DingTalk, QQbot, etc.) consuming 600MB+ even when only one channel is configured, often preventing the gateway from completing initialization

## Motivation

Running the gateway on a small AWS instance (t3.small, 1.9GB RAM) alongside other services (Vault, PM2, Claude Code). After upgrading from v2026.3.2 to v2026.3.13, the gateway could no longer complete initialization — it would consume all available memory loading unused channel adapters and either OOM or sit idle never binding a port.

This flag lets operators on constrained hosts opt into loading only what they need.

## Usage

```bash
openclaw gateway --lightweight
```

## Changes

- `src/cli/gateway-cli/run.ts` — Add `--lightweight` option, pass through to server
- `src/gateway/server.impl.ts` — Accept lightweight flag in `GatewayServerOptions`
- `src/gateway/server-plugins.ts` — When lightweight, compute `onlyPluginIds` from config and pass to `loadOpenClawPlugins()`

## Test plan

- [ ] Verify `openclaw gateway --help` shows `--lightweight` flag
- [ ] Verify `openclaw gateway --lightweight` only loads configured plugins
- [ ] Verify `openclaw gateway` (without flag) loads all plugins as before
- [ ] Verify on a 2GB RAM host that `--lightweight` allows gateway to complete initialization

---

*Born from a real-world OOM incident on the clawdbotworker-union server. Kodiak sends his regards.* 🐻

🤖 Generated with [Claude Code](https://claude.com/claude-code)