### PR TITLE
plugins: wire ACP runtime backends into plugin API

### DIFF
--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -54,6 +54,8 @@ function fakeApi(overrides: Partial<OpenClawPluginApi> = {}): OpenClawPluginApi 
     registerHttpRoute() {},
     registerCommand() {},
     registerContextEngine() {},
+    registerAcpRuntimeBackend() {},
+    unregisterAcpRuntimeBackend() {},
     on() {},
     resolvePath: (p) => p,
     ...overrides,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { registerAcpRuntimeBackend, unregisterAcpRuntimeBackend } from "../acp/runtime/registry.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { registerContextEngineForOwner } from "../context-engine/registry.js";
@@ -979,6 +980,10 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
           });
         }
       },
+      registerAcpRuntimeBackend:
+        registrationMode === "full" ? (backend) => registerAcpRuntimeBackend(backend) : () => {},
+      unregisterAcpRuntimeBackend:
+        registrationMode === "full" ? (id) => unregisterAcpRuntimeBackend(id) : () => {},
       resolvePath: (input: string) => resolveUserPath(input),
       on: (hookName, handler, opts) =>
         registrationMode === "full"

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -4,6 +4,7 @@ import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { Command } from "commander";
+import type { AcpRuntimeBackend } from "../acp/runtime/registry.js";
 import type {
   ApiKeyCredential,
   AuthProfileCredential,
@@ -1341,6 +1342,10 @@ export type OpenClawPluginApi = {
     id: string,
     factory: import("../context-engine/registry.js").ContextEngineFactory,
   ) => void;
+  /** Register an ACP runtime backend (e.g. cursor, acpx). */
+  registerAcpRuntimeBackend: (backend: AcpRuntimeBackend) => void;
+  /** Unregister a previously registered ACP runtime backend by id. */
+  unregisterAcpRuntimeBackend: (id: string) => void;
   resolvePath: (input: string) => string;
   /** Register a lifecycle hook handler */
   on: <K extends PluginHookName>(

--- a/test/helpers/extensions/plugin-api.ts
+++ b/test/helpers/extensions/plugin-api.ts
@@ -23,6 +23,8 @@ export function createTestPluginApi(api: TestPluginApiInput): OpenClawPluginApi 
     onConversationBindingResolved() {},
     registerCommand() {},
     registerContextEngine() {},
+    registerAcpRuntimeBackend() {},
+    unregisterAcpRuntimeBackend() {},
     resolvePath(input: string) {
       return input;
     },


### PR DESCRIPTION
## Summary

- **Problem:** `OpenClawPluginApi` did not expose ACP runtime backend registration; plugins could not align with core ACP registry wiring.
- **Why it matters:** Native plugins that register ACP backends need a typed, supported API surface consistent with the gateway registry.
- **What changed:** Added `registerAcpRuntimeBackend` / `unregisterAcpRuntimeBackend` to `OpenClawPluginApi`, implemented them in `createPluginRegistry` `createApi` (full registration mode), and extended `createTestPluginApi` with no-op stubs.
- **What did NOT change:** ACP registry implementation, registration semantics beyond delegating to existing `../acp/runtime/registry` helpers.

## Change Type (select all)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] API / contracts
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related # (none)

## User-visible / Behavior Changes

None — plugin author / SDK contract only.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: any
- Runtime: Node 22+

### Steps

1. `pnpm tsgo` (or CI typecheck) on branch with this change.

### Expected

Types satisfy `OpenClawPluginApi`; tests using `createTestPluginApi` compile.

### Actual

As expected.

## Evidence

- [x] Failing test/log before + passing after (test helper updated for new required API fields)
