### PR TITLE
fix(acpx): kill child process in runTurn finally block to prevent process leak

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { runAcpRuntimeAdapterContract } from "../../../src/acp/runtime/adapter-contract.testkit.js";
+import type { AcpRuntimeEvent } from "../runtime-api.js";
 import { AcpxRuntime, decodeAcpxRuntimeHandleState } from "./runtime.js";
 import {
   cleanupMockRuntimeFixtures,
@@ -689,6 +690,47 @@ describe("AcpxRuntime", () => {
     } finally {
       delete process.env.MOCK_ACPX_ENSURE_EMPTY;
       delete process.env.MOCK_ACPX_NEW_EMPTY;
+    }
+  });
+
+  it("kills the child process when runTurn completes, even if child hangs after emitting done", async () => {
+    const { runtime, logPath } = await createMockRuntimeFixture({ queueOwnerTtlSeconds: 180 });
+
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:hang-test",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    process.env.MOCK_ACPX_PROMPT_HANG = "1";
+    try {
+      const events: AcpRuntimeEvent[] = [];
+      for await (const event of runtime.runTurn({ handle, text: "hang-test" })) {
+        events.push(event);
+      }
+
+      expect(events.some((e) => e.type === "done")).toBe(true);
+
+      const logs = await readMockRuntimeLogEntries(logPath);
+      const hangEntry = logs.find((e) => e.kind === "prompt-hang");
+      expect(hangEntry).toBeDefined();
+      const pid = hangEntry!.pid as number;
+      expect(pid).toBeGreaterThan(0);
+
+      // Poll until the process is gone — SIGTERM delivery and reaping are async
+      let processStillAlive = true;
+      for (let i = 0; i < 20; i++) {
+        try {
+          process.kill(pid, 0);
+          await new Promise((r) => setTimeout(r, 25));
+        } catch {
+          processStillAlive = false;
+          break;
+        }
+      }
+      expect(processStillAlive).toBe(false);
+    } finally {
+      delete process.env.MOCK_ACPX_PROMPT_HANG;
     }
   });
 });

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -705,7 +705,12 @@ describe("AcpxRuntime", () => {
     process.env.MOCK_ACPX_PROMPT_HANG = "1";
     try {
       const events: AcpRuntimeEvent[] = [];
-      for await (const event of runtime.runTurn({ handle, text: "hang-test", mode: "prompt", requestId: "req-hang-test" })) {
+      for await (const event of runtime.runTurn({
+        handle,
+        text: "hang-test",
+        mode: "prompt",
+        requestId: "req-hang-test",
+      })) {
         events.push(event);
       }
 

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -705,7 +705,7 @@ describe("AcpxRuntime", () => {
     process.env.MOCK_ACPX_PROMPT_HANG = "1";
     try {
       const events: AcpRuntimeEvent[] = [];
-      for await (const event of runtime.runTurn({ handle, text: "hang-test" })) {
+      for await (const event of runtime.runTurn({ handle, text: "hang-test", mode: "prompt", requestId: "req-hang-test" })) {
         events.push(event);
       }
 

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -606,6 +606,12 @@ export class AcpxRuntime implements AcpRuntime {
             continue;
           }
           sawDone = true;
+          yield parsed;
+          // Child emitted done — stop reading stdout and kill the child so
+          // waitForExit does not block on a process that never calls exit(0).
+          lines.close();
+          child.kill("SIGKILL");
+          break;
         }
         if (parsed.type === "error") {
           sawError = true;
@@ -650,6 +656,7 @@ export class AcpxRuntime implements AcpRuntime {
       }
     } finally {
       lines.close();
+      child.kill("SIGKILL");
       if (input.signal) {
         input.signal.removeEventListener("abort", onAbort);
       }

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -297,6 +297,14 @@ if (command === "prompt") {
     process.exit(0);
   }
 
+  if (process.env.MOCK_ACPX_PROMPT_HANG === "1") {
+    writeLog({ kind: "prompt-hang", agent, args, sessionName: sessionFromOption, stdinText, pid: process.pid });
+    emitJson({ type: "done", stopReason: "end_turn" });
+    // Keep process alive — simulates a child that emits done but does not exit naturally
+    setInterval(() => {}, 9999);
+    return;
+  }
+
   emitUpdate(sessionFromOption, {
     sessionUpdate: "agent_thought_chunk",
     content: { type: "text", text: "thinking" },
@@ -399,6 +407,7 @@ export async function cleanupMockRuntimeFixtures(): Promise<void> {
   delete process.env.MOCK_ACPX_ENSURE_EXIT_1;
   delete process.env.MOCK_ACPX_STATUS_STATUS;
   delete process.env.MOCK_ACPX_STATUS_SUMMARY;
+  delete process.env.MOCK_ACPX_PROMPT_HANG;
   sharedMockCliScriptPath = null;
   logFileSequence = 0;
   while (tempDirs.length > 0) {


### PR DESCRIPTION
## Summary

- Adds inline `child.kill("SIGKILL")` when `done` event is received in `AcpxRuntime.runTurn()`, ensuring the child process is terminated even if it hangs after emitting `done`
- Keeps `child.kill("SIGKILL")` in the `finally` block as a safety net for error/abort paths
- Adds regression test that verifies the child process is terminated even when it hangs after emitting `done`
- Adds `MOCK_ACPX_PROMPT_HANG` flag to the mock CLI to simulate this hang scenario

Fixes #44790
Fixes #35886

## Root Cause

`runTurn()` spawns a child process per turn via `spawnWithResolvedCommand()`. The `for await` loop blocked on the child's stdout — if the child emitted `done` but kept stdout open (via open handles like `setInterval`), the loop never exited and the process was never cleaned up. This caused processes to accumulate as orphans (~85 MB RSS each; 35 processes / ~2.9 GB observed after 6 days uptime).

## Test Plan

- [x] New test `"kills the child process when runTurn completes, even if child hangs after emitting done"` — fails before fix, passes after
- [x] 23/23 acpx tests pass
- [x] `pnpm build` passes with no warnings
- [x] `pnpm format:check` passes

## CI Failures (pre-existing, unrelated to this PR)

- **check-docs**: 4 broken links to `/plugins/agent-tools` — docs restructuring issue
- **extension-fast (matrix)** / **checks (extensions)**: Matrix crypto IDB snapshot test failures in `extensions/matrix/` — unrelated to acpx

🤖 Generated with [Claude Code](https://claude.com/claude-code)