### PR TITLE
fix(feishu): destroy ReadStreams on media upload failure

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -280,20 +280,35 @@ export async function uploadImageFeishu(params: {
   // See: https://github.com/larksuite/node-sdk/issues/121
   const imageData = typeof image === "string" ? fs.createReadStream(image) : image;
 
-  const response = await client.im.image.create({
-    data: {
-      image_type: imageType,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
-      image: imageData as any,
-    },
-  });
+  // CERA: when image is a file path, createReadStream() opens an FD.
+  // If the upload throws (network error, auth failure, rate limit), the
+  // stream is never consumed or closed, leaking the descriptor. Ensure
+  // cleanup on all exit paths. Only destroy streams we created -- caller-
+  // owned Buffers must not be touched.
+  const needsCleanup = typeof image === "string";
+  try {
+    const response = await client.im.image.create({
+      data: {
+        image_type: imageType,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
+        image: imageData as any,
+      },
+    });
 
-  return {
-    imageKey: extractFeishuUploadKey(response, {
-      key: "image_key",
-      errorPrefix: "Feishu image upload failed",
-    }),
-  };
+    return {
+      imageKey: extractFeishuUploadKey(response, {
+        key: "image_key",
+        errorPrefix: "Feishu image upload failed",
+      }),
+    };
+  } finally {
+    // ReadStream.destroy() is idempotent and closes the underlying FD.
+    // Safe to call after successful consumption -- Node marks the stream
+    // as destroyed but the FD was already released by read completion.
+    if (needsCleanup && imageData !== image) {
+      (imageData as fs.ReadStream).destroy();
+    }
+  }
 }
 
 /**
@@ -332,22 +347,31 @@ export async function uploadFileFeishu(params: {
 
   const safeFileName = sanitizeFileNameForUpload(fileName);
 
-  const response = await client.im.file.create({
-    data: {
-      file_type: fileType,
-      file_name: safeFileName,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
-      file: fileData as any,
-      ...(duration !== undefined && { duration }),
-    },
-  });
+  // CERA: same FD leak pattern as uploadImageFeishu -- createReadStream()
+  // opens a descriptor that must be released if the SDK call throws.
+  const needsCleanup = typeof file === "string";
+  try {
+    const response = await client.im.file.create({
+      data: {
+        file_type: fileType,
+        file_name: safeFileName,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
+        file: fileData as any,
+        ...(duration !== undefined && { duration }),
+      },
+    });
 
-  return {
-    fileKey: extractFeishuUploadKey(response, {
-      key: "file_key",
-      errorPrefix: "Feishu file upload failed",
-    }),
-  };
+    return {
+      fileKey: extractFeishuUploadKey(response, {
+        key: "file_key",
+        errorPrefix: "Feishu file upload failed",
+      }),
+    };
+  } finally {
+    if (needsCleanup && fileData !== file) {
+      (fileData as fs.ReadStream).destroy();
+    }
+  }
 }
 
 /**

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -305,7 +305,7 @@ export async function uploadImageFeishu(params: {
     // ReadStream.destroy() is idempotent and closes the underlying FD.
     // Safe to call after successful consumption -- Node marks the stream
     // as destroyed but the FD was already released by read completion.
-    if (needsCleanup && imageData !== image) {
+    if (needsCleanup) {
       (imageData as fs.ReadStream).destroy();
     }
   }
@@ -368,7 +368,7 @@ export async function uploadFileFeishu(params: {
       }),
     };
   } finally {
-    if (needsCleanup && fileData !== file) {
+    if (needsCleanup) {
       (fileData as fs.ReadStream).destroy();
     }
   }

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -280,7 +280,7 @@ export async function uploadImageFeishu(params: {
   // See: https://github.com/larksuite/node-sdk/issues/121
   const imageData = typeof image === "string" ? fs.createReadStream(image) : image;
 
-  // CERA: when image is a file path, createReadStream() opens an FD.
+  // FIX: when image is a file path, createReadStream() opens an FD.
   // If the upload throws (network error, auth failure, rate limit), the
   // stream is never consumed or closed, leaking the descriptor. Ensure
   // cleanup on all exit paths. Only destroy streams we created -- caller-
@@ -347,7 +347,7 @@ export async function uploadFileFeishu(params: {
 
   const safeFileName = sanitizeFileNameForUpload(fileName);
 
-  // CERA: same FD leak pattern as uploadImageFeishu -- createReadStream()
+  // FIX: same FD leak pattern as uploadImageFeishu -- createReadStream()
   // opens a descriptor that must be released if the SDK call throws.
   const needsCleanup = typeof file === "string";
   try {


### PR DESCRIPTION
## Summary

`uploadImageFeishu()` and `uploadFileFeishu()` leak file descriptors when Feishu SDK upload calls fail.

## Problem

Both functions create `fs.createReadStream()` when the input is a file path (string), opening a kernel file descriptor. If the subsequent SDK call throws:

```
uploadImageFeishu({ image: "/path/to/photo.jpg", ... })
  → fs.createReadStream("/path/to/photo.jpg")  // FD opened
  → client.im.image.create({ image: stream })   // throws: 401 Unauthorized
  → stream never consumed, never closed          // FD leaked
```

## Proof of bug

`fs.createReadStream()` calls `fs.open()` internally, acquiring a file descriptor from the kernel. The FD is released when:
- The stream is fully consumed (automatic close on EOF), or
- `stream.destroy()` is called explicitly

On the throw path, neither happens. The stream remains in 'open' state with an unreferenced FD. Node.js will eventually GC the stream and close the FD, but:
1. GC timing is unpredictable
2. Under retry loops (upload failure → retry → failure → retry), FDs accumulate faster than GC reclaims them
3. Linux default ulimit is 1024 FDs -- a burst of ~1000 upload failures causes EMFILE

## Fix

Wrap SDK upload calls in `try/finally` to call `stream.destroy()` on all exit paths. `destroy()` is idempotent -- safe to call after successful consumption.

Only destroy streams we own (created from string path input). Caller-provided Buffers are left untouched.

## Test plan

- [ ] Upload image from file path succeeds normally
- [ ] Upload file from file path succeeds normally
- [ ] Upload from Buffer still works (no spurious destroy)
- [ ] Existing Feishu media tests pass

Found by [gnosis-polyglot](https://github.com/forkjoin-ai/gnosis) topological scanner (RESOURCE_LEAK rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)