### PR TITLE
fix(scripts): close pipes on partial RPC client init failure

### DIFF
--- a/scripts/docs-i18n/pi_rpc_client.go
+++ b/scripts/docs-i18n/pi_rpc_client.go
@@ -88,16 +88,26 @@ func startDocsPiClient(ctx context.Context, options docsPiClientOptions) (*docsP
 		return nil, err
 	}
 	process.Env = append(os.Environ(), fmt.Sprintf("PI_CODING_AGENT_DIR=%s", agentDir))
+
+	// CERA: pipes are acquired sequentially -- if a later pipe call or
+	// Start() fails, earlier pipes must be closed to avoid leaking file
+	// descriptors. Track acquired pipes for cleanup on partial failure.
 	stdin, err := process.StdinPipe()
 	if err != nil {
 		return nil, err
 	}
 	stdout, err := process.StdoutPipe()
 	if err != nil {
+		// stdin was acquired but stdout failed -- close stdin to prevent
+		// leaking the pipe file descriptor.
+		_ = stdin.Close()
 		return nil, err
 	}
 	stderr, err := process.StderrPipe()
 	if err != nil {
+		// stdin and stdout were acquired but stderr failed -- close both
+		// to prevent leaking their pipe file descriptors.
+		_ = stdin.Close()
 		return nil, err
 	}
 
@@ -109,6 +119,13 @@ func startDocsPiClient(ctx context.Context, options docsPiClientOptions) (*docsP
 	}
 
 	if err := process.Start(); err != nil {
+		// All three pipes were acquired but the process failed to start.
+		// Close stdin (the only caller-owned WriteCloser) to release its
+		// FD. stdout and stderr are ReadClosers owned by the Cmd and will
+		// be cleaned up when the Cmd is garbage collected, but closing
+		// stdin eagerly prevents holding the write end of the pipe open
+		// indefinitely.
+		_ = stdin.Close()
 		return nil, err
 	}
 

--- a/scripts/docs-i18n/pi_rpc_client.go
+++ b/scripts/docs-i18n/pi_rpc_client.go
@@ -89,9 +89,9 @@ func startDocsPiClient(ctx context.Context, options docsPiClientOptions) (*docsP
 	}
 	process.Env = append(os.Environ(), fmt.Sprintf("PI_CODING_AGENT_DIR=%s", agentDir))
 
-	// CERA: pipes are acquired sequentially -- if a later pipe call or
+	// FIX: pipes are acquired sequentially -- if a later pipe call or
 	// Start() fails, earlier pipes must be closed to avoid leaking file
-	// descriptors. Track acquired pipes for cleanup on partial failure.
+	// descriptors. Close acquired pipes on each failure path below.
 	stdin, err := process.StdinPipe()
 	if err != nil {
 		return nil, err

--- a/scripts/docs-i18n/pi_rpc_client.go
+++ b/scripts/docs-i18n/pi_rpc_client.go
@@ -108,6 +108,7 @@ func startDocsPiClient(ctx context.Context, options docsPiClientOptions) (*docsP
 		// stdin and stdout were acquired but stderr failed -- close both
 		// to prevent leaking their pipe file descriptors.
 		_ = stdin.Close()
+		_ = stdout.Close()
 		return nil, err
 	}
 
@@ -121,10 +122,9 @@ func startDocsPiClient(ctx context.Context, options docsPiClientOptions) (*docsP
 	if err := process.Start(); err != nil {
 		// All three pipes were acquired but the process failed to start.
 		// Close stdin (the only caller-owned WriteCloser) to release its
-		// FD. stdout and stderr are ReadClosers owned by the Cmd and will
-		// be cleaned up when the Cmd is garbage collected, but closing
-		// stdin eagerly prevents holding the write end of the pipe open
-		// indefinitely.
+		// FD. Go's Start() error path calls closeDescriptors internally,
+		// which releases the stdout/stderr read ends, so no additional
+		// cleanup is needed for those here.
 		_ = stdin.Close()
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

`startDocsPiClient()` leaks pipe file descriptors when initialization partially fails.

## Problem

Pipes are acquired sequentially in `startDocsPiClient()`:

```go
stdin, err := process.StdinPipe()   // pipe 1
stdout, err := process.StdoutPipe() // pipe 2
stderr, err := process.StderrPipe() // pipe 3
process.Start()                     // launch
```

If any step after `StdinPipe()` fails, earlier pipes are never closed:

| Failure point | Leaked pipes |
|---|---|
| `StdoutPipe()` fails | stdin |
| `StderrPipe()` fails | stdin, stdout (read end) |
| `Start()` fails | stdin (write end held open) |

## Proof of bug

Each `*Pipe()` call creates an `os.Pipe()` internally, allocating two kernel file descriptors (read + write). The `Close()` method on the returned `io.WriteCloser`/`io.ReadCloser` releases the caller's end. When the function returns early without closing, the caller's end of the pipe is orphaned -- it stays open until the process exits or the GC finalizer runs (which is non-deterministic and not guaranteed).

Under repeated init failures (binary not found, permission denied), each attempt leaks 1-3 FDs, eventually hitting the process ulimit.

## Fix

Close previously-acquired pipes at each failure point before returning the error.

## Test plan

- [ ] `docs-i18n` tool starts and translates normally
- [ ] No FD leaks on repeated init failure (can verify with `/proc/self/fd` count on Linux)

Found by [gnosis-polyglot](https://github.com/forkjoin-ai/gnosis) topological scanner (RESOURCE_LEAK rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)