### PR TITLE
Add Qmemory to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -68,6 +68,22 @@ cost, tokens, errors, and more.
 openclaw plugins install @opik/opik-openclaw
 ```
 
+### Qmemory
+
+Context-engine plugin that gives agents persistent, cross-session graph memory
+powered by SurrealDB. Implements the full `ContextEngine` interface with 12
+lifecycle hooks capturing tool calls, cron outcomes, subagent relationships,
+and session state into a connected graph the agent can search and traverse.
+
+- **npm:** `qmemory`
+- **repo:** [github.com/QusaiiSaleem/qmemory](https://github.com/QusaiiSaleem/qmemory)
+
+```bash
+openclaw plugins install qmemory
+openclaw config set plugins.slots.contextEngine "qmemory"
+openclaw config set tools.alsoAllow '["qmemory"]'
+```
+
 ### QQbot
 
 Connect OpenClaw to QQ via the QQ Bot API. Supports private chats, group

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -80,8 +80,6 @@ and session state into a connected graph the agent can search and traverse.
 
 ```bash
 openclaw plugins install qmemory
-openclaw config set plugins.slots.contextEngine "qmemory"
-openclaw config set tools.alsoAllow '["qmemory"]'
 ```
 
 ### QQbot


### PR DESCRIPTION
## Summary

Adds Qmemory to the community plugins listing, inserted alphabetically between Opik and QQbot.

## What changed

`docs/plugins/community.md` — 16 lines added, 0 removed. Only the new entry.

## About the plugin

Qmemory is a context-engine plugin that gives agents persistent, cross-session graph memory powered by SurrealDB. It implements the full `ContextEngine` interface (`bootstrap`, `ingest`, `assemble`, `compact`, `afterTurn`) with `ownsCompaction: true`.

- **npm:** [`qmemory`](https://www.npmjs.com/package/qmemory)
- **repo:** [github.com/QusaiiSaleem/qmemory](https://github.com/QusaiiSaleem/qmemory)
- **License:** MIT

## Checklist

- [x] Published on npm
- [x] Public GitHub repo with docs and issue tracker
- [x] Follows existing page format
- [x] `tools.alsoAllow` scoped to `"qmemory"` only (not `"group:plugins"`)

## Test plan

- [ ] Community plugins page renders correctly
- [ ] Existing entries unchanged
- [ ] `openclaw plugins install qmemory` works