### PR TITLE
fix(bluebubbles): always use private-api method when Private API is enabled

### DIFF
--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -524,6 +524,46 @@ describe("send", () => {
       ).rejects.toThrow("Private API must be enabled");
     });
 
+    it("uses private-api for plain sends when Private API is enabled", async () => {
+      mockBlueBubblesPrivateApiStatusOnce(
+        privateApiStatusMock,
+        BLUE_BUBBLES_PRIVATE_API_STATUS.enabled,
+      );
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-plain-private" } });
+
+      await sendMessageBlueBubbles("+15551234567", "Hello", {
+        serverUrl: "http://localhost:1234",
+        password: "test",
+      });
+
+      const sendCall = mockFetch.mock.calls[1];
+      const body = JSON.parse(sendCall[1].body);
+      // Plain sends must use private-api on Tahoe where AppleScript is broken
+      expect(body.method).toBe("private-api");
+      // No reply or effect fields should be set
+      expect(body.selectedMessageGuid).toBeUndefined();
+      expect(body.effectId).toBeUndefined();
+    });
+
+    it("omits method for plain sends when Private API is disabled", async () => {
+      mockBlueBubblesPrivateApiStatusOnce(
+        privateApiStatusMock,
+        BLUE_BUBBLES_PRIVATE_API_STATUS.disabled,
+      );
+      mockResolvedHandleTarget();
+      mockSendResponse({ data: { guid: "msg-uuid-plain-noprivate" } });
+
+      await sendMessageBlueBubbles("+15551234567", "Hello", {
+        serverUrl: "http://localhost:1234",
+        password: "test",
+      });
+
+      const sendCall = mockFetch.mock.calls[1];
+      const body = JSON.parse(sendCall[1].body);
+      expect(body.method).toBeUndefined();
+    });
+
     it("uses private-api when reply metadata is present", async () => {
       mockBlueBubblesPrivateApiStatusOnce(
         privateApiStatusMock,

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -90,7 +90,7 @@ function resolvePrivateApiDecision(params: {
   const { privateApiStatus, wantsReplyThread, wantsEffect } = params;
   const needsPrivateApi = wantsReplyThread || wantsEffect;
   const canUsePrivateApi =
-    needsPrivateApi && isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
+    isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
   const throwEffectDisabledError = wantsEffect && privateApiStatus === false;
   if (!needsPrivateApi || privateApiStatus !== null) {
     return { canUsePrivateApi, throwEffectDisabledError };

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -88,24 +88,22 @@ function resolvePrivateApiDecision(params: {
   wantsEffect: boolean;
 }): PrivateApiDecision {
   const { privateApiStatus, wantsReplyThread, wantsEffect } = params;
-  const needsPrivateApi = wantsReplyThread || wantsEffect;
-  const canUsePrivateApi =
-    isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
+  const canUsePrivateApi = isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
   const throwEffectDisabledError = wantsEffect && privateApiStatus === false;
-  if (!needsPrivateApi || privateApiStatus !== null) {
-    return { canUsePrivateApi, throwEffectDisabledError };
+  if (privateApiStatus === null && (wantsReplyThread || wantsEffect)) {
+    const requested = [
+      wantsReplyThread ? "reply threading" : null,
+      wantsEffect ? "message effects" : null,
+    ]
+      .filter(Boolean)
+      .join(" + ");
+    return {
+      canUsePrivateApi,
+      throwEffectDisabledError,
+      warningMessage: `Private API status unknown; sending without ${requested}. Run a status probe to restore private-api features.`,
+    };
   }
-  const requested = [
-    wantsReplyThread ? "reply threading" : null,
-    wantsEffect ? "message effects" : null,
-  ]
-    .filter(Boolean)
-    .join(" + ");
-  return {
-    canUsePrivateApi,
-    throwEffectDisabledError,
-    warningMessage: `Private API status unknown; sending without ${requested}. Run a status probe to restore private-api features.`,
-  };
+  return { canUsePrivateApi, throwEffectDisabledError };
 }
 
 async function parseBlueBubblesMessageResponse(res: Response): Promise<BlueBubblesSendResult> {


### PR DESCRIPTION
## Problem

On macOS 26 (Tahoe), `AppleScript` sending is broken because `Messages.app` no longer has a scripting dictionary. Plain text sends were silently falling back to AppleScript because `needsPrivateApi` was only `true` for reply threads and effects — never for plain messages.

This caused all plain iMessage sends to fail on Tahoe with BB Private API enabled.

## Fix

Decouple `canUsePrivateApi` from `needsPrivateApi` so that `method=private-api` is included in all sends whenever Private API is enabled, not just when special features (effects/replies) are requested.

```diff
- const canUsePrivateApi =
-   needsPrivateApi && isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
+ const canUsePrivateApi =
+   isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
```

## Testing

Confirmed working on macOS 26.2.0 (Tahoe) with BB 1.9.9 and Private API enabled. Plain text sends now correctly use `method=private-api` and deliver successfully.

Fixes #29389
Re-opens stale PR #29447