### PR TITLE
fix: classify HTTP 404 as model_not_found in fallback chain

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -69,6 +69,7 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 499 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
+    expect(resolveFailoverReasonFromError({ status: 404 })).toBe("model_not_found");
     expect(resolveFailoverReasonFromError({ status: 422 })).toBe("format");
     // Keep the status-only path behavior-preserving and conservative.
     expect(resolveFailoverReasonFromError({ status: 500 })).toBeNull();

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -531,6 +531,10 @@ describe("classifyFailoverReasonFromHttpStatus", () => {
     expect(classifyFailoverReasonFromHttpStatus(401, "invalid_api_key")).toBe("auth_permanent");
   });
 
+  it("treats HTTP 404 as model_not_found", () => {
+    expect(classifyFailoverReasonFromHttpStatus(404)).toBe("model_not_found");
+    expect(classifyFailoverReasonFromHttpStatus(404, "Not Found")).toBe("model_not_found");
+  });
   it("treats HTTP 422 as format error", () => {
     expect(classifyFailoverReasonFromHttpStatus(422)).toBe("format");
     expect(classifyFailoverReasonFromHttpStatus(422, "check open ai req parameter error")).toBe(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -436,6 +436,9 @@ export function classifyFailoverReasonFromHttpStatus(
     }
     return "auth";
   }
+  if (status === 404) {
+    return "model_not_found";
+  }
   if (status === 408) {
     return "timeout";
   }


### PR DESCRIPTION
## Problem

`classifyFailoverReasonFromHttpStatus` did not handle HTTP 404, returning `null`. This meant provider 404 errors (bad URL, removed model endpoint) were not recognized as failover-worthy, preventing cascade to the next fallback model. Instead, the session would hang retrying the same broken provider until the 600s timeout.

## Fix

Add HTTP 404 → `model_not_found` classification in `classifyFailoverReasonFromHttpStatus`, alongside the existing 401/429/503 handlers. This ensures 404 errors trigger model fallback like other provider failures.

## Changes

- `src/agents/pi-embedded-helpers/errors.ts`: Add `status === 404 → "model_not_found"` case
- `src/agents/failover-error.test.ts`: Add 404 → model_not_found assertion
- `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`: Add HTTP 404 test case

## Note on 401 behavior

The issue also reports 401 auth errors not cascading. From code analysis, 401 IS already classified as `"auth"` and should cascade after auth profile rotation is exhausted. The 401 case may be environment-specific (multiple auth profiles causing extended retry loops before fallback). This PR addresses the clear 404 gap; the 401 behavior may need separate investigation with reproducer logs.

## Testing

All 104 existing tests pass. The one pre-existing failure (`sanitizes model identifiers in model_not_found warnings`) is unrelated (ANSI color codes in test environment).

Closes part of #51209