### PR TITLE
clear pending tool results after compaction to prevent stale id corruption

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2673,6 +2673,15 @@ export async function runEmbeddedAttempt(
         // compactions that complete during activeSession.prompt() before the delta
         // baseline is sampled.
         const compactionOccurredThisAttempt = getCompactionCount() > 0;
+        // Compaction rewrites the JSONL file, removing any in-flight tool calls from the
+        // transcript. Clear stale pending tool call state so the guard does not later
+        // insert synthetic tool results with IDs that no longer exist in the session file.
+        // Leaving stale pending IDs causes shouldFlushBeforeNewToolCalls() to fire on the
+        // next assistant message, inserting orphaned synthetic results that corrupt the
+        // transcript and cause subsequent tool calls to silently hang. (#51031)
+        if (compactionOccurredThisAttempt) {
+          sessionManager.clearPendingToolResults?.();
+        }
         // Append cache-TTL timestamp AFTER prompt + compaction retry completes.
         // Previously this was before the prompt, which caused a custom entry to be
         // inserted between compaction and the next prompt — breaking the

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -518,4 +518,46 @@ describe("installSessionToolResultGuard", () => {
     );
     expect(syntheticForError).toHaveLength(0);
   });
+
+  it("does not insert synthetic results for stale pending IDs after clearPendingToolResults (post-compaction scenario)", () => {
+    // Regression test for #51031: after compaction rewrites the JSONL, in-flight tool
+    // call IDs no longer exist in the transcript. If clearPendingToolResults() is not
+    // called, the next assistant message triggers shouldFlushBeforeNewToolCalls(), which
+    // inserts synthetic tool results with stale IDs, corrupting the transcript.
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm);
+
+    // Simulate tool call in flight before compaction
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "pre_compaction_call", name: "exec", arguments: {} }],
+      }),
+    );
+    expect(guard.getPendingIds()).toContain("pre_compaction_call");
+
+    // Compaction fires: clears pending state without inserting synthetic results
+    guard.clearPendingToolResults();
+    expect(guard.getPendingIds()).toHaveLength(0);
+
+    // Post-compaction: new assistant message with a new tool call arrives
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "post_compaction_call", name: "read", arguments: {} }],
+      }),
+    );
+
+    // Only the two assistant messages should be in the transcript.
+    // No synthetic tool result for the pre-compaction call should be inserted.
+    const messages = getPersistedMessages(sm);
+    const toolResults = messages.filter((m) => m.role === "toolResult");
+    const staleResult = toolResults.find(
+      (m) => (m as { toolCallId?: string }).toolCallId === "pre_compaction_call",
+    );
+    expect(staleResult).toBeUndefined();
+
+    // The new pending call from post-compaction should be tracked
+    expect(guard.getPendingIds()).toContain("post_compaction_call");
+  });
 });


### PR DESCRIPTION
## Problem

After compaction in extended sessions with `compaction.mode=safeguard`, tool calls silently hang. New sessions work fine.

## Root cause

`guardSessionManager` in `attempt.ts` creates a `pendingState` that tracks in-flight tool call IDs. When compaction fires and rewrites the JSONL file, those tool call IDs are removed from the transcript. But `clearPendingToolResults()` is never called on the attempt's session manager after compaction completes.

After compaction, when the next assistant message arrives with new tool calls, `shouldFlushBeforeNewToolCalls()` sees stale pending IDs (`pending.size > 0`) and calls `flushPendingToolResults()`. This inserts synthetic tool results with IDs that no longer exist in the transcript, corrupting subsequent tool calls.

The compaction handler (`handleAutoCompactionEnd`) has its own separate `guardSessionManager` instance. Its `clearPendingToolResults` only clears *its own* pending state, not the run attempt's.

## Fix

Call `sessionManager.clearPendingToolResults?.()` in `attempt.ts` after compaction completes (`getCompactionCount() > 0`). This clears stale pending IDs before they can corrupt the transcript.

One new line of runtime code, plus a regression test confirming that clearing pending state prevents synthetic result insertion for stale IDs.

## Changes

- `src/agents/pi-embedded-runner/run/attempt.ts`: clear pending tool results when compaction occurred
- `src/agents/session-tool-result-guard.test.ts`: regression test for post-compaction stale ID scenario

Closes #51031