### PR TITLE
fix: guard against malformed text blocks in context truncation

### DIFF
--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts
@@ -1,0 +1,69 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import {
+  createMessageCharEstimateCache,
+  estimateMessageCharsCached,
+  getToolResultText,
+} from "./tool-result-char-estimator.js";
+
+/**
+ * Regression tests for malformed tool result content blocks.
+ * See https://github.com/openclaw/openclaw/issues/34979
+ *
+ * A plugin tool handler returning undefined produces {type: "text"} (no text
+ * property) in the session JSONL. Without guards, this crashes the char
+ * estimator with: TypeError: Cannot read properties of undefined (reading 'length')
+ */
+describe("tool-result-char-estimator", () => {
+  it("does not crash on toolResult with malformed text block (missing text string)", () => {
+    const malformed = {
+      role: "toolResult",
+      toolName: "sentinel_control",
+      content: [{ type: "text" }],
+      isError: false,
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+
+    const cache = createMessageCharEstimateCache();
+    expect(() => estimateMessageCharsCached(malformed, cache)).not.toThrow();
+    // Malformed block should be estimated via the unknown-block fallback, not zero
+    expect(estimateMessageCharsCached(malformed, cache)).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not crash on toolResult with null content entries", () => {
+    const malformed = {
+      role: "toolResult",
+      toolName: "read",
+      content: [null, { type: "text", text: "ok" }],
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+
+    const cache = createMessageCharEstimateCache();
+    expect(() => estimateMessageCharsCached(malformed, cache)).not.toThrow();
+  });
+
+  it("getToolResultText skips malformed text blocks without crashing", () => {
+    const malformed = {
+      role: "toolResult",
+      toolName: "sentinel_control",
+      content: [{ type: "text" }, { type: "text", text: "valid" }],
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+
+    expect(() => getToolResultText(malformed)).not.toThrow();
+    expect(getToolResultText(malformed)).toBe("valid");
+  });
+
+  it("estimates well-formed toolResult correctly", () => {
+    const msg = {
+      role: "toolResult",
+      toolName: "read",
+      content: [{ type: "text", text: "hello world" }],
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+
+    const cache = createMessageCharEstimateCache();
+    const chars = estimateMessageCharsCached(msg, cache);
+    expect(chars).toBeGreaterThanOrEqual(11); // "hello world".length
+  });
+});

--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts
@@ -27,7 +27,7 @@ describe("tool-result-char-estimator", () => {
     const cache = createMessageCharEstimateCache();
     expect(() => estimateMessageCharsCached(malformed, cache)).not.toThrow();
     // Malformed block should be estimated via the unknown-block fallback, not zero
-    expect(estimateMessageCharsCached(malformed, cache)).toBeGreaterThanOrEqual(0);
+    expect(estimateMessageCharsCached(malformed, cache)).toBeGreaterThan(0);
   });
 
   it("does not crash on toolResult with null content entries", () => {

--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
@@ -7,7 +7,12 @@ const IMAGE_CHAR_ESTIMATE = 8_000;
 export type MessageCharEstimateCache = WeakMap<AgentMessage, number>;
 
 function isTextBlock(block: unknown): block is { type: "text"; text: string } {
-  return !!block && typeof block === "object" && (block as { type?: unknown }).type === "text";
+  return (
+    !!block &&
+    typeof block === "object" &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string"
+  );
 }
 
 function isImageBlock(block: unknown): boolean {

--- a/src/agents/pi-hooks/context-pruning/pruner.test.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.test.ts
@@ -223,6 +223,29 @@ describe("pruneContextMessages", () => {
     ).not.toThrow();
   });
 
+  it("does not crash on toolResult with null content entries", () => {
+    const malformedToolResult = {
+      role: "toolResult",
+      toolName: "read",
+      content: [null, { type: "text", text: "ok" }],
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+
+    const messages: AgentMessage[] = [
+      makeUser("hello"),
+      malformedToolResult,
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    expect(() =>
+      pruneContextMessages({
+        messages,
+        settings: DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        ctx: CONTEXT_WINDOW_1M,
+      }),
+    ).not.toThrow();
+  });
+
   it("handles well-formed thinking blocks correctly", () => {
     const messages: AgentMessage[] = [
       makeUser("hello"),

--- a/src/agents/pi-hooks/context-pruning/pruner.test.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.test.ts
@@ -223,6 +223,47 @@ describe("pruneContextMessages", () => {
     ).not.toThrow();
   });
 
+  it("counts malformed non-string text blocks when deciding to trim tool results", () => {
+    const malformedToolResult = {
+      role: "toolResult",
+      toolName: "read",
+      content: [{ type: "text", text: { payload: "X".repeat(5_000) } }],
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+
+    const result = pruneContextMessages({
+      messages: [
+        makeUser("show data"),
+        malformedToolResult,
+        makeAssistant([{ type: "text", text: "done" }]),
+      ],
+      settings: {
+        ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        keepLastAssistants: 1,
+        softTrimRatio: 0,
+        hardClear: {
+          ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear,
+          enabled: false,
+        },
+        softTrim: {
+          maxChars: 200,
+          headChars: 80,
+          tailChars: 40,
+        },
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 1,
+    });
+
+    const toolResult = result.find((message) => message.role === "toolResult") as Extract<
+      AgentMessage,
+      { role: "toolResult" }
+    >;
+    const textBlock = toolResult.content[0] as { type: "text"; text: string };
+    expect(textBlock.text).toContain("[Tool result trimmed:");
+  });
+
   it("does not crash on toolResult with null content entries", () => {
     const malformedToolResult = {
       role: "toolResult",

--- a/src/agents/pi-hooks/context-pruning/pruner.test.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.test.ts
@@ -152,6 +152,77 @@ describe("pruneContextMessages", () => {
     ).not.toThrow();
   });
 
+  it("does not crash on toolResult with malformed text block (missing text string)", () => {
+    // Regression: a plugin returning undefined produces {type: "text"} with no text property,
+    // which crashed estimateTextAndImageChars / collectTextSegments / collectPrunableToolResultSegments.
+    // See https://github.com/openclaw/openclaw/issues/34979
+    const malformedToolResult = {
+      role: "toolResult",
+      toolName: "sentinel_control",
+      content: [{ type: "text" }],
+      isError: false,
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+
+    const messages: AgentMessage[] = [
+      makeUser("remove sentinel"),
+      makeAssistant([
+        { type: "toolCall", toolCallId: "call_1", toolName: "sentinel_control", arguments: {} },
+      ] as unknown as AssistantContentBlock[]),
+      malformedToolResult,
+      makeUser("follow up"),
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    expect(() =>
+      pruneContextMessages({
+        messages,
+        settings: DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        ctx: CONTEXT_WINDOW_1M,
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not crash on toolResult with malformed text block during soft-trim (image path)", () => {
+    // The collectPrunableToolResultSegments path is exercised when the tool result
+    // contains image blocks alongside a malformed text block.
+    const malformedToolResult = {
+      role: "toolResult",
+      toolName: "read",
+      content: [{ type: "text" }, { type: "image", data: "img", mimeType: "image/png" }],
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+
+    const messages: AgentMessage[] = [
+      makeUser("show image"),
+      malformedToolResult,
+      makeAssistant([{ type: "text", text: "here it is" }]),
+    ];
+
+    expect(() =>
+      pruneContextMessages({
+        messages,
+        settings: {
+          ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+          keepLastAssistants: 1,
+          softTrimRatio: 0,
+          hardClear: {
+            ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear,
+            enabled: false,
+          },
+          softTrim: {
+            maxChars: 5_000,
+            headChars: 2_000,
+            tailChars: 2_000,
+          },
+        },
+        ctx: CONTEXT_WINDOW_1M,
+        isToolPrunable: () => true,
+        contextWindowTokensOverride: 1,
+      }),
+    ).not.toThrow();
+  });
+
   it("handles well-formed thinking blocks correctly", () => {
     const messages: AgentMessage[] = [
       makeUser("hello"),

--- a/src/agents/pi-hooks/context-pruning/pruner.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.ts
@@ -16,7 +16,7 @@ function asText(text: string): TextContent {
 function collectTextSegments(content: ReadonlyArray<TextContent | ImageContent>): string[] {
   const parts: string[] = [];
   for (const block of content) {
-    if (block.type === "text") {
+    if (block.type === "text" && typeof block.text === "string") {
       parts.push(block.text);
     }
   }
@@ -28,7 +28,7 @@ function collectPrunableToolResultSegments(
 ): string[] {
   const parts: string[] = [];
   for (const block of content) {
-    if (block.type === "text") {
+    if (block.type === "text" && typeof block.text === "string") {
       parts.push(block.text);
       continue;
     }
@@ -119,7 +119,7 @@ function estimateWeightedTextChars(text: string): number {
 function estimateTextAndImageChars(content: ReadonlyArray<TextContent | ImageContent>): number {
   let chars = 0;
   for (const block of content) {
-    if (block.type === "text") {
+    if (block.type === "text" && typeof block.text === "string") {
       chars += estimateWeightedTextChars(block.text);
     }
     if (block.type === "image") {

--- a/src/agents/pi-hooks/context-pruning/pruner.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.ts
@@ -16,6 +16,7 @@ function asText(text: string): TextContent {
 function collectTextSegments(content: ReadonlyArray<TextContent | ImageContent>): string[] {
   const parts: string[] = [];
   for (const block of content) {
+    if (!block) continue; // guard against null/undefined entries in malformed sessions
     if (block.type === "text" && typeof block.text === "string") {
       parts.push(block.text);
     }
@@ -28,6 +29,7 @@ function collectPrunableToolResultSegments(
 ): string[] {
   const parts: string[] = [];
   for (const block of content) {
+    if (!block) continue; // guard against null/undefined entries in malformed sessions
     if (block.type === "text" && typeof block.text === "string") {
       parts.push(block.text);
       continue;
@@ -105,6 +107,7 @@ function takeTailFromJoinedText(parts: string[], maxChars: number): string {
 
 function hasImageBlocks(content: ReadonlyArray<TextContent | ImageContent>): boolean {
   for (const block of content) {
+    if (!block) continue;
     if (block.type === "image") {
       return true;
     }
@@ -119,6 +122,7 @@ function estimateWeightedTextChars(text: string): number {
 function estimateTextAndImageChars(content: ReadonlyArray<TextContent | ImageContent>): number {
   let chars = 0;
   for (const block of content) {
+    if (!block) continue; // guard against null/undefined entries in malformed sessions
     if (block.type === "text" && typeof block.text === "string") {
       chars += estimateWeightedTextChars(block.text);
     }

--- a/src/agents/pi-hooks/context-pruning/pruner.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.ts
@@ -13,14 +13,36 @@ function asText(text: string): TextContent {
   return { type: "text", text };
 }
 
+function serializeMalformedTextBlock(block: unknown): string {
+  try {
+    const serialized = JSON.stringify(block);
+    return typeof serialized === "string" ? serialized : "[malformed text block]";
+  } catch {
+    return "[malformed text block]";
+  }
+}
+
+function coerceTextBlock(block: unknown): string | null {
+  if (!block || typeof block !== "object") {
+    return null;
+  }
+  if ((block as { type?: unknown }).type !== "text") {
+    return null;
+  }
+  const text = (block as { text?: unknown }).text;
+  return typeof text === "string" ? text : serializeMalformedTextBlock(block);
+}
+
+function isImageBlock(block: unknown): boolean {
+  return !!block && typeof block === "object" && (block as { type?: unknown }).type === "image";
+}
+
 function collectTextSegments(content: ReadonlyArray<TextContent | ImageContent>): string[] {
   const parts: string[] = [];
   for (const block of content) {
-    if (!block) {
-      continue; // guard against null/undefined entries in malformed sessions
-    }
-    if (block.type === "text" && typeof block.text === "string") {
-      parts.push(block.text);
+    const text = coerceTextBlock(block);
+    if (text !== null) {
+      parts.push(text);
     }
   }
   return parts;
@@ -31,14 +53,12 @@ function collectPrunableToolResultSegments(
 ): string[] {
   const parts: string[] = [];
   for (const block of content) {
-    if (!block) {
-      continue; // guard against null/undefined entries in malformed sessions
-    }
-    if (block.type === "text" && typeof block.text === "string") {
-      parts.push(block.text);
+    const text = coerceTextBlock(block);
+    if (text !== null) {
+      parts.push(text);
       continue;
     }
-    if (block.type === "image") {
+    if (isImageBlock(block)) {
       parts.push(PRUNED_CONTEXT_IMAGE_MARKER);
     }
   }
@@ -111,10 +131,7 @@ function takeTailFromJoinedText(parts: string[], maxChars: number): string {
 
 function hasImageBlocks(content: ReadonlyArray<TextContent | ImageContent>): boolean {
   for (const block of content) {
-    if (!block) {
-      continue;
-    }
-    if (block.type === "image") {
+    if (isImageBlock(block)) {
       return true;
     }
   }
@@ -128,13 +145,12 @@ function estimateWeightedTextChars(text: string): number {
 function estimateTextAndImageChars(content: ReadonlyArray<TextContent | ImageContent>): number {
   let chars = 0;
   for (const block of content) {
-    if (!block) {
-      continue; // guard against null/undefined entries in malformed sessions
+    const text = coerceTextBlock(block);
+    if (text !== null) {
+      chars += estimateWeightedTextChars(text);
+      continue;
     }
-    if (block.type === "text" && typeof block.text === "string") {
-      chars += estimateWeightedTextChars(block.text);
-    }
-    if (block.type === "image") {
+    if (isImageBlock(block)) {
       chars += IMAGE_CHAR_ESTIMATE;
     }
   }

--- a/src/agents/pi-hooks/context-pruning/pruner.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.ts
@@ -16,7 +16,9 @@ function asText(text: string): TextContent {
 function collectTextSegments(content: ReadonlyArray<TextContent | ImageContent>): string[] {
   const parts: string[] = [];
   for (const block of content) {
-    if (!block) continue; // guard against null/undefined entries in malformed sessions
+    if (!block) {
+      continue; // guard against null/undefined entries in malformed sessions
+    }
     if (block.type === "text" && typeof block.text === "string") {
       parts.push(block.text);
     }
@@ -29,7 +31,9 @@ function collectPrunableToolResultSegments(
 ): string[] {
   const parts: string[] = [];
   for (const block of content) {
-    if (!block) continue; // guard against null/undefined entries in malformed sessions
+    if (!block) {
+      continue; // guard against null/undefined entries in malformed sessions
+    }
     if (block.type === "text" && typeof block.text === "string") {
       parts.push(block.text);
       continue;
@@ -107,7 +111,9 @@ function takeTailFromJoinedText(parts: string[], maxChars: number): string {
 
 function hasImageBlocks(content: ReadonlyArray<TextContent | ImageContent>): boolean {
   for (const block of content) {
-    if (!block) continue;
+    if (!block) {
+      continue;
+    }
     if (block.type === "image") {
       return true;
     }
@@ -122,7 +128,9 @@ function estimateWeightedTextChars(text: string): number {
 function estimateTextAndImageChars(content: ReadonlyArray<TextContent | ImageContent>): number {
   let chars = 0;
   for (const block of content) {
-    if (!block) continue; // guard against null/undefined entries in malformed sessions
+    if (!block) {
+      continue; // guard against null/undefined entries in malformed sessions
+    }
     if (block.type === "text" && typeof block.text === "string") {
       chars += estimateWeightedTextChars(block.text);
     }


### PR DESCRIPTION
## Summary

- Guard `isTextBlock` type guard to require `typeof block.text === "string"` (not just `block.type === "text"`)
- Guard 3 additional `block.type === "text"` sites in `pruner.ts` (`collectTextSegments`, `collectPrunableToolResultSegments`, `estimateTextAndImageChars`)
- Add regression tests covering malformed `{type: "text"}` blocks in both the char estimator and context pruner

A plugin tool handler returning `undefined`/`void` produces a malformed content block `{type: "text"}` (no `text` property). This block persists to session JSONL and crashes the context truncation pipeline with `TypeError: Cannot read properties of undefined (reading 'length')` on every subsequent message, locking the session into an unrecoverable crash loop.

Closes #34979

## Test plan

- [x] `pnpm test -- src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts` passes (4 new tests)
- [x] `pnpm test -- src/agents/pi-extensions/context-pruning/pruner.test.ts` passes (2 new + 11 existing tests)
- [ ] CI green

Based on prior work by @alvinttang (#39331) and @coffeexcoin (#34980).

🤖 Generated with [Claude Code](https://claude.com/claude-code)