### PR TITLE
feat(cron): add payload.kind "exec" for shell commands without LLM sessions

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -139,8 +139,10 @@ export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "pay
   if (job.sessionTarget === "main" && job.payload.kind !== "systemEvent") {
     throw new Error('main cron jobs require payload.kind="systemEvent"');
   }
-  if (isIsolatedLike && job.payload.kind !== "agentTurn") {
-    throw new Error('isolated/current/session cron jobs require payload.kind="agentTurn"');
+  if (isIsolatedLike && job.payload.kind !== "agentTurn" && job.payload.kind !== "exec") {
+    throw new Error(
+      'isolated/current/session cron jobs require payload.kind="agentTurn" or "exec"',
+    );
   }
 }
 
@@ -669,6 +671,26 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
     return { kind: "systemEvent", text };
   }
 
+  if (patch.kind === "exec") {
+    if (existing.kind !== "exec") {
+      return buildPayloadFromPatch(patch);
+    }
+    const next: Extract<CronPayload, { kind: "exec" }> = { ...existing };
+    if (typeof patch.command === "string") {
+      next.command = patch.command;
+    }
+    if (typeof patch.shell === "string") {
+      next.shell = patch.shell;
+    }
+    if (typeof patch.timeoutSeconds === "number") {
+      next.timeoutSeconds = patch.timeoutSeconds;
+    }
+    if (patch.env !== undefined) {
+      next.env = patch.env;
+    }
+    return next;
+  }
+
   if (existing.kind !== "agentTurn") {
     return buildPayloadFromPatch(patch);
   }
@@ -754,6 +776,19 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
       throw new Error('cron.update payload.kind="systemEvent" requires text');
     }
     return { kind: "systemEvent", text: patch.text };
+  }
+
+  if (patch.kind === "exec") {
+    if (typeof patch.command !== "string" || patch.command.trim().length === 0) {
+      throw new Error('cron.update payload.kind="exec" requires command');
+    }
+    return {
+      kind: "exec",
+      command: patch.command,
+      shell: patch.shell,
+      timeoutSeconds: patch.timeoutSeconds,
+      env: patch.env,
+    };
   }
 
   if (typeof patch.message !== "string" || patch.message.length === 0) {

--- a/src/cron/service/normalize.ts
+++ b/src/cron/service/normalize.ts
@@ -83,5 +83,8 @@ export function normalizePayloadToSystemText(payload: CronPayload) {
   if (payload.kind === "systemEvent") {
     return payload.text.trim();
   }
-  return payload.message.trim();
+  if (payload.kind === "agentTurn") {
+    return payload.message.trim();
+  }
+  return "";
 }

--- a/src/cron/service/timer.exec-payload.test.ts
+++ b/src/cron/service/timer.exec-payload.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CronJob } from "../types.js";
+import { createCronServiceState } from "./state.js";
+import { executeJobCore } from "./timer.js";
+
+function createNoopLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+}
+
+function makeExecJob(
+  overrides: Partial<CronJob> & {
+    command: string;
+    shell?: string;
+    timeoutSeconds?: number;
+    env?: Record<string, string>;
+  },
+): CronJob {
+  const { command, shell, timeoutSeconds, env, ...rest } = overrides;
+  return {
+    id: "test-exec-job",
+    name: "test exec job",
+    enabled: true,
+    createdAtMs: Date.now(),
+    updatedAtMs: Date.now(),
+    schedule: { kind: "cron", expr: "0 3 * * *" },
+    sessionTarget: "isolated",
+    payload: { kind: "exec", command, shell, timeoutSeconds, env },
+    state: {},
+    ...rest,
+  } as CronJob;
+}
+
+function createState() {
+  return createCronServiceState({
+    cronEnabled: true,
+    storePath: "/tmp/test-cron-exec.json",
+    log: createNoopLogger() as never,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeatNow: vi.fn(),
+    runIsolatedAgentJob: vi.fn().mockResolvedValue({ status: "ok" }),
+  });
+}
+
+/**
+ * Tests for payload.kind="exec" in executeJobCore.
+ * Spawns real child processes — each exits immediately (fast).
+ */
+describe("executeJobCore — exec payload", () => {
+  it("returns status ok for exit code 0", async () => {
+    const state = createState();
+    const job = makeExecJob({ command: "exit 0" });
+
+    const result = await executeJobCore(state, job);
+
+    expect(result.status).toBe("ok");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns status error for non-zero exit code", async () => {
+    const state = createState();
+    const job = makeExecJob({ command: "exit 1" });
+
+    const result = await executeJobCore(state, job);
+
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/exit code 1/);
+  });
+
+  it("captures stdout as summary", async () => {
+    const state = createState();
+    const job = makeExecJob({ command: "echo hello-from-exec" });
+
+    const result = await executeJobCore(state, job);
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toContain("hello-from-exec");
+  });
+
+  it("captures stderr in summary on error", async () => {
+    const state = createState();
+    const job = makeExecJob({ command: "echo err-output >&2; exit 1" });
+
+    const result = await executeJobCore(state, job);
+
+    expect(result.status).toBe("error");
+    expect(result.summary).toContain("err-output");
+  });
+
+  it("injects env vars into the process", async () => {
+    const state = createState();
+    const job = makeExecJob({
+      command: "echo $MY_EXEC_TEST_VAR",
+      env: { MY_EXEC_TEST_VAR: "injected-value-xyz" },
+    });
+
+    const result = await executeJobCore(state, job);
+
+    expect(result.status).toBe("ok");
+    expect(result.summary).toContain("injected-value-xyz");
+  });
+
+  it("times out and returns error when timeoutSeconds exceeded", async () => {
+    const state = createState();
+    const job = makeExecJob({ command: "sleep 60", timeoutSeconds: 1 });
+
+    const result = await executeJobCore(state, job);
+
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/timed out/i);
+  }, 10_000);
+
+  it("aborts cleanly when abortSignal fires", async () => {
+    const state = createState();
+    const job = makeExecJob({ command: "sleep 60" });
+
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 150);
+
+    const result = await executeJobCore(state, job, controller.signal);
+
+    expect(result.status).toBe("error");
+    expect(result.error).toMatch(/abort/i);
+  }, 10_000);
+
+  it("returns error for command that does not exist", async () => {
+    const state = createState();
+    const job = makeExecJob({ command: "this-command-definitely-does-not-exist-xyz-abc" });
+
+    const result = await executeJobCore(state, job);
+
+    expect(result.status).toBe("error");
+  });
+});
+
+describe("exec payload — agentTurn guard still rejects unknown kinds", () => {
+  it("returns skipped for unknown payload kind", async () => {
+    const state = createState();
+    const job = {
+      ...makeExecJob({ command: "echo ok" }),
+      payload: { kind: "unknown-future-kind" } as never,
+    };
+
+    const result = await executeJobCore(state, job);
+
+    expect(result.status).toBe("skipped");
+    expect(result.error).toMatch(/agentTurn/);
+  });
+});

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
 import type { CronConfig, CronRetryOn } from "../../config/types.cron.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
@@ -1002,6 +1003,119 @@ export async function runDueJobs(state: CronServiceState) {
   }
 }
 
+/**
+ * Default shell for exec payload jobs.
+ * On Windows, uses `cmd` with `/c` flag. On all other platforms uses `/bin/sh`.
+ */
+function resolveDefaultExecShell(): string {
+  return process.platform === "win32" ? "cmd" : "/bin/sh";
+}
+
+/**
+ * Run a cron job with payload.kind="exec" by spawning a child process.
+ * No LLM session is created — the command runs directly in the gateway process env.
+ *
+ * Exit code 0 → status "ok", stdout+stderr become summary.
+ * Non-zero exit → status "error", error includes exit code.
+ * Timeout → process receives SIGTERM, then SIGKILL after 5s → status "error".
+ */
+async function runExecJob(job: CronJob, abortSignal?: AbortSignal): Promise<CronRunOutcome> {
+  if (job.payload.kind !== "exec") {
+    return { status: "skipped", error: "not an exec job" };
+  }
+
+  const { command, shell, env = {}, timeoutSeconds } = job.payload;
+  const resolvedShell = shell?.trim() || resolveDefaultExecShell();
+  const shellArgs = process.platform === "win32" ? ["/c", command] : ["-c", command];
+  const jobTimeoutMs =
+    typeof timeoutSeconds === "number" && timeoutSeconds > 0
+      ? Math.floor(timeoutSeconds * 1000)
+      : undefined;
+
+  return new Promise<CronRunOutcome>((resolve) => {
+    const mergedEnv: NodeJS.ProcessEnv = { ...process.env, ...env };
+
+    const proc = spawn(resolvedShell, shellArgs, {
+      env: mergedEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    let finished = false;
+    let killTimer: NodeJS.Timeout | undefined;
+    let killForceTimer: NodeJS.Timeout | undefined;
+
+    const finish = (outcome: CronRunOutcome) => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      if (killTimer) {
+        clearTimeout(killTimer);
+      }
+      if (killForceTimer) {
+        clearTimeout(killForceTimer);
+      }
+      abortSignal?.removeEventListener("abort", onAbort);
+      resolve(outcome);
+    };
+
+    const killProcess = (reason: "timeout" | "abort") => {
+      if (finished) {
+        return;
+      }
+      proc.kill("SIGTERM");
+      // Force-kill after 5s if SIGTERM is not enough
+      killForceTimer = setTimeout(() => {
+        if (!finished) {
+          proc.kill("SIGKILL");
+        }
+      }, 5_000);
+      killForceTimer.unref();
+      const combined = [stdout, stderr].filter(Boolean).join("\n").trim();
+      finish({
+        status: "error",
+        error: reason === "timeout" ? timeoutErrorMessage() : "exec: aborted",
+        summary: combined || undefined,
+      });
+    };
+
+    const onAbort = () => killProcess("abort");
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
+
+    if (jobTimeoutMs !== undefined) {
+      killTimer = setTimeout(() => killProcess("timeout"), jobTimeoutMs);
+      killTimer.unref();
+    }
+
+    proc.on("error", (err: Error) => {
+      finish({ status: "error", error: `exec: ${err.message}` });
+    });
+
+    proc.on("close", (code: number | null) => {
+      const combined = [stdout, stderr].filter(Boolean).join("\n").trim();
+      if (code === 0) {
+        finish({ status: "ok", summary: combined || undefined });
+      } else {
+        finish({
+          status: "error",
+          error: `exec: exit code ${code ?? "null"}`,
+          summary: combined || undefined,
+        });
+      }
+    });
+  });
+}
+
 export async function executeJobCore(
   state: CronServiceState,
   job: CronJob,
@@ -1121,6 +1235,24 @@ export async function executeJobCore(
       });
       return { status: "ok", summary: text };
     }
+  }
+
+  if (job.payload.kind === "exec") {
+    if (abortSignal?.aborted) {
+      return resolveAbortError();
+    }
+    const execResult = await runExecJob(job, abortSignal);
+    // Deliver summary to main session via announce if requested and no channel dep available.
+    if (
+      execResult.status === "ok" &&
+      execResult.summary &&
+      resolveCronDeliveryPlan(job).requested
+    ) {
+      const truncated = execResult.summary.slice(0, 4000);
+      state.deps.enqueueSystemEvent(truncated, { agentId: job.agentId });
+      state.deps.requestHeartbeatNow({ reason: `cron:${job.id}:exec-announce` });
+    }
+    return execResult;
   }
 
   if (job.payload.kind !== "agentTurn") {

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -78,9 +78,37 @@ export type CronFailureAlert = {
   accountId?: string;
 };
 
-export type CronPayload = { kind: "systemEvent"; text: string } | CronAgentTurnPayload;
+type CronExecPayloadFields = {
+  /** Shell command to execute directly (no LLM session created). */
+  command: string;
+  /**
+   * Shell to use. Defaults to `/bin/sh` on Unix and `cmd` on Windows.
+   * Use `bash` or `zsh` for shell-specific features.
+   */
+  shell?: string;
+  /** Timeout in seconds. Process is sent SIGTERM, then SIGKILL after 5s. */
+  timeoutSeconds?: number;
+  /** Additional environment variables merged into the gateway process env. */
+  env?: Record<string, string>;
+};
 
-export type CronPayloadPatch = { kind: "systemEvent"; text?: string } | CronAgentTurnPayloadPatch;
+type CronExecPayload = {
+  kind: "exec";
+} & CronExecPayloadFields;
+
+type CronExecPayloadPatch = {
+  kind: "exec";
+} & Partial<CronExecPayloadFields>;
+
+export type CronPayload =
+  | { kind: "systemEvent"; text: string }
+  | CronAgentTurnPayload
+  | CronExecPayload;
+
+export type CronPayloadPatch =
+  | { kind: "systemEvent"; text?: string }
+  | CronAgentTurnPayloadPatch
+  | CronExecPayloadPatch;
 
 type CronAgentTurnPayloadFields = {
   message: string;


### PR DESCRIPTION
## Problem

Maintenance cron jobs that run pure shell scripts are forced to use `agentTurn`, which creates a full isolated session, loads workspace context, and makes an LLM API call just to execute bash. This is expensive in both time and cost.

**Real production numbers from my deployment:**
- `bus-maintenance`: avg **372s/run** (peak 607s) across 22 recorded runs — purely from session overhead
- `skill-obs-scraper`: avg **38s**, 5% timeout rate — a script that scans a directory and writes a JSONL file
- 5 jobs identified as pure-shell candidates, combined ~$10-12/month wasted on LLM API calls

The only workaround is launchd/system cron, but that loses all OpenClaw observability: `consecutiveErrors`, `lastRunStatus`, `lastDurationMs`, `system-health-and-watchdog` coverage, cost tracking, and central management.

Closes #18160 (also relates to #37651, #50558)

## Solution

New `payload.kind: "exec"` that runs a shell command via `child_process.spawn` — no LLM session created.

```json
{
  "name": "bus-maintenance",
  "schedule": { "kind": "cron", "expr": "0 3 * * *", "tz": "America/New_York" },
  "sessionTarget": "isolated",
  "payload": {
    "kind": "exec",
    "command": "bash ~/.openclaw/scripts/bus-rotate.sh",
    "timeoutSeconds": 120,
    "env": { "MY_VAR": "value" }
  },
  "delivery": { "mode": "none" }
}
```

## What changes

**`src/cron/types.ts`**
- Add `CronExecPayload` (`kind: "exec"`, `command`, `shell?`, `timeoutSeconds?`, `env?`) to `CronPayload` and `CronPayloadPatch` unions

**`src/cron/service/jobs.ts`**
- `assertSupportedJobSpec`: allow `exec` on `isolated`/`current`/`session` targets (backward-compatible relaxation — existing `agentTurn` jobs unaffected)
- `mergeCronPayload` + `buildPayloadFromPatch`: handle exec patches

**`src/cron/service/normalize.ts`**
- `normalizePayloadToSystemText`: handle exec kind (returns `""` — exec jobs are not surfaced as main-session system events)

**`src/cron/service/timer.ts`**
- New `runExecJob()`: spawns child process, maps exit code 0 → `"ok"`, non-zero → `"error"`, stdout+stderr captured as `summary`
- Timeout: `SIGTERM` on expiry, `SIGKILL` after 5s — same semantics as existing job timeout
- `AbortSignal` support: kills process on abort
- Windows: defaults to `cmd /c`; Unix: defaults to `/bin/sh -c`
- Exec branch in `executeJobCore()` slots in before the `agentTurn` guard

**`src/cron/service/timer.exec-payload.test.ts`** (new)
- 9 tests: exit 0, exit 1, stdout capture, stderr capture, env injection, timeout, AbortSignal abort, spawn error, unknown-kind guard

## What does NOT change

- Run log format (`CronRunLogEntry` shape) — unchanged
- `consecutiveErrors`, backoff, `failureAlert` — unchanged (read `jobs.json` state, not payload kind)
- `system-health-and-watchdog` coverage — unchanged
- Cost tracking — exec jobs have no model/usage fields (as expected)
- `agentTurn` behavior — completely unaffected

## Delivery

For `delivery.mode: "none"` (the primary use case), nothing extra is needed. For `delivery.mode: "announce"`, stdout is currently enqueued as a system event to the main session — this is intentionally simple for v1. Proper channel delivery (routing stdout through `sendCronFailureAlert`-style dep) can be added in a follow-up if there is demand.

## Testing

```
pnpm tsgo              → clean
pnpm lint              → 0 errors/warnings on touched files
pnpm vitest run src/cron/  → 67 test files, 531 tests, all passing
```

Note: `pnpm check` fails on `lint:plugins:no-extension-imports` for `bundled-web-search-registry.ts` — this is a pre-existing baseline violation present on `origin/main` before this branch and is unrelated to this change.

cc @tyler6204