### PR TITLE
feat(gateway): make handshake timeout configurable via gateway.handshakeTimeoutMs

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -106,6 +106,8 @@ export const FIELD_HELP: Record<string, string> = {
     "How many minutes a connected channel can go without receiving any event before the health monitor treats it as a stale socket and triggers a restart. Default: 30.",
   "gateway.channelMaxRestartsPerHour":
     "Maximum number of health-monitor-initiated channel restarts allowed within a rolling one-hour window. Once hit, further restarts are skipped until the window expires. Default: 10.",
+  "gateway.handshakeTimeoutMs":
+    "WebSocket handshake timeout in milliseconds. Unauthenticated connections that fail to complete the auth handshake within this window are closed. Increase on loaded gateways where the default is too aggressive. Env var OPENCLAW_HANDSHAKE_TIMEOUT_MS takes priority. Default: 10000.",
   "gateway.tailscale":
     "Tailscale integration settings for Serve/Funnel exposure and lifecycle handling on gateway start/exit. Keep off unless your deployment intentionally relies on Tailscale ingress.",
   "gateway.tailscale.mode":

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -450,4 +450,11 @@ export type GatewayConfig = {
    * the rolling window expires. Default: 10.
    */
   channelMaxRestartsPerHour?: number;
+  /**
+   * WebSocket handshake timeout in milliseconds.
+   * Unauthenticated connections that don't complete the handshake within this
+   * window are closed. Increase on loaded gateways where the default may be
+   * too aggressive. Default: 10000 (10 s).
+   */
+  handshakeTimeoutMs?: number;
 };

--- a/src/gateway/server-constants.ts
+++ b/src/gateway/server-constants.ts
@@ -1,3 +1,5 @@
+import { loadConfig } from "../config/config.js";
+
 // Keep server maxPayload aligned with gateway client maxPayload so high-res canvas snapshots
 // don't get disconnected mid-invoke with "Max payload size exceeded".
 export const MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
@@ -23,6 +25,7 @@ export const __setMaxChatHistoryMessagesBytesForTest = (value?: number) => {
 };
 export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10_000;
 export const getHandshakeTimeoutMs = () => {
+  // Priority: env var > config file > default.
   // User-facing env var (works in all environments); test-only var gated behind VITEST
   const envKey =
     process.env.OPENCLAW_HANDSHAKE_TIMEOUT_MS ||
@@ -32,6 +35,16 @@ export const getHandshakeTimeoutMs = () => {
     if (Number.isFinite(parsed) && parsed > 0) {
       return parsed;
     }
+  }
+  // Config file: gateway.handshakeTimeoutMs
+  try {
+    const cfg = loadConfig();
+    const cfgVal = cfg?.gateway?.handshakeTimeoutMs;
+    if (typeof cfgVal === "number" && Number.isFinite(cfgVal) && cfgVal > 0) {
+      return cfgVal;
+    }
+  } catch {
+    // Config not available (e.g. during early init) — fall through to default.
   }
   return DEFAULT_HANDSHAKE_TIMEOUT_MS;
 };


### PR DESCRIPTION
## Summary

Add `gateway.handshakeTimeoutMs` config option so users can tune the WebSocket handshake timeout from their config file, without patching dist files or relying solely on env vars.

## Changes

- **`src/config/types.gateway.ts`**: Add `handshakeTimeoutMs?: number` to `GatewayConfig`
- **`src/gateway/server-constants.ts`**: Read config value in `getHandshakeTimeoutMs()` with priority: env var > config file > default (10s)
- **`src/config/schema.help.ts`**: Add help text for the new field

## Priority Order

1. `OPENCLAW_HANDSHAKE_TIMEOUT_MS` env var (existing, unchanged)
2. `gateway.handshakeTimeoutMs` in config file (**new**)
3. Default: 10,000 ms

## Context

#49262 bumped the default from 3s to 10s, but #51274 reports that loaded gateways (600MB+, 80+ tasks) still need higher values. The reporter currently patches dist files via a systemd drop-in. This PR lets them set it in config instead:

```yaml
gateway:
  handshakeTimeoutMs: 15000
```

Closes #51274