### PR TITLE
feat: configurable exec approval timeout via approvals.timeoutMs

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -90,8 +90,18 @@ export const DEFAULT_PATH =
   process.env.PATH ?? "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 export const DEFAULT_NOTIFY_TAIL_CHARS = 400;
 const DEFAULT_NOTIFY_SNIPPET_CHARS = 180;
-export const DEFAULT_APPROVAL_TIMEOUT_MS = 120_000;
-export const DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS = 130_000;
+function resolveApprovalTimeoutMs(): number {
+  const envVal = process.env.OPENCLAW_EXEC_APPROVAL_TIMEOUT_MS;
+  if (envVal) {
+    const parsed = Number(envVal);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return 120_000;
+}
+export const DEFAULT_APPROVAL_TIMEOUT_MS = resolveApprovalTimeoutMs();
+export const DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS = DEFAULT_APPROVAL_TIMEOUT_MS + 10_000;
 const DEFAULT_APPROVAL_RUNNING_NOTICE_MS = 10_000;
 const APPROVAL_SLUG_LENGTH = 8;
 

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -693,7 +693,16 @@ export function createNodesTool(options?: {
 
             // Node requires approval – create a pending approval request on
             // the gateway and wait for the user to approve/deny via the UI.
-            const APPROVAL_TIMEOUT_MS = 120_000;
+            const APPROVAL_TIMEOUT_MS = (() => {
+              const envVal = process.env.OPENCLAW_EXEC_APPROVAL_TIMEOUT_MS;
+              if (envVal) {
+                const parsed = Number(envVal);
+                if (Number.isFinite(parsed) && parsed > 0) {
+                  return parsed;
+                }
+              }
+              return 120_000;
+            })();
             const approvalId = crypto.randomUUID();
             const approvalResult = await callGatewayTool(
               "exec.approval.request",

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -3,7 +3,7 @@ import { resolveAgentConfig, resolveDefaultAgentId } from "../../agents/agent-sc
 import { loadConfig } from "../../config/config.js";
 import { randomIdempotencyKey } from "../../gateway/call.js";
 import {
-  DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  getExecApprovalTimeoutMs,
   type ExecApprovalsFile,
   type ExecAsk,
   type ExecSecurity,
@@ -203,7 +203,7 @@ async function maybeRequestNodesRunApproval(params: {
   }
 
   approvalId = crypto.randomUUID();
-  const approvalTimeoutMs = DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;
+  const approvalTimeoutMs = getExecApprovalTimeoutMs();
   // Keep client transport alive while the approver decides.
   const transportTimeoutMs = Math.max(
     parseTimeoutMs(params.opts.timeout) ?? 0,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -628,6 +628,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Debounce window in milliseconds for coalescing rapid skill file changes before reload logic runs. Increase to reduce reload churn on frequent writes, or lower for faster edit feedback.",
   approvals:
     "Approval routing controls for forwarding exec approval requests to chat destinations outside the originating session. Keep this disabled unless operators need explicit out-of-band approval visibility.",
+  "approvals.timeoutMs":
+    "Timeout in milliseconds for exec approval requests before they expire (default: 120000 = 2 minutes). Increase this if approvals are frequently missed. Can also be set via OPENCLAW_EXEC_APPROVAL_TIMEOUT_MS environment variable (env var takes priority).",
   "approvals.exec":
     "Groups exec-approval forwarding behavior including enablement, routing mode, filters, and explicit targets. Configure here when approval prompts must reach operational channels instead of only the origin thread.",
   "approvals.exec.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -197,6 +197,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.exec.safeBinTrustedDirs": "Exec Safe Bin Trusted Dirs",
   "tools.exec.safeBinProfiles": "Exec Safe Bin Profiles",
   approvals: "Approvals",
+  "approvals.timeoutMs": "Approval Timeout",
   "approvals.exec": "Exec Approval Forwarding",
   "approvals.exec.enabled": "Forward Exec Approvals",
   "approvals.exec.mode": "Approval Forwarding Mode",

--- a/src/config/types.approvals.ts
+++ b/src/config/types.approvals.ts
@@ -25,5 +25,7 @@ export type ExecApprovalForwardingConfig = {
 };
 
 export type ApprovalsConfig = {
+  /** Timeout in milliseconds for exec approval requests. Can also be set via OPENCLAW_EXEC_APPROVAL_TIMEOUT_MS env var. Default: 120000 (2 minutes). */
+  timeoutMs?: number;
   exec?: ExecApprovalForwardingConfig;
 };

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -1,9 +1,6 @@
 import { sanitizeExecApprovalDisplayText } from "../../infra/exec-approval-command-display.js";
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
-import {
-  DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
-  type ExecApprovalDecision,
-} from "../../infra/exec-approvals.js";
+import { getExecApprovalTimeoutMs, type ExecApprovalDecision } from "../../infra/exec-approvals.js";
 import {
   buildSystemRunApprovalBinding,
   buildSystemRunApprovalEnvBinding,
@@ -21,7 +18,7 @@ import type { GatewayRequestHandlers } from "./types.js";
 
 export function createExecApprovalHandlers(
   manager: ExecApprovalManager,
-  opts?: { forwarder?: ExecApprovalForwarder },
+  opts?: { forwarder?: ExecApprovalForwarder; config?: { approvals?: { timeoutMs?: number } } },
 ): GatewayRequestHandlers {
   return {
     "exec.approval.request": async ({ params, respond, context, client }) => {
@@ -61,7 +58,7 @@ export function createExecApprovalHandlers(
       };
       const twoPhase = p.twoPhase === true;
       const timeoutMs =
-        typeof p.timeoutMs === "number" ? p.timeoutMs : DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;
+        typeof p.timeoutMs === "number" ? p.timeoutMs : getExecApprovalTimeoutMs(opts?.config);
       const explicitId = typeof p.id === "string" && p.id.trim().length > 0 ? p.id.trim() : null;
       const host = typeof p.host === "string" ? p.host.trim() : "";
       const nodeId = typeof p.nodeId === "string" ? p.nodeId.trim() : "";

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1034,6 +1034,7 @@ export async function startGatewayServer(
   const execApprovalForwarder = createExecApprovalForwarder();
   const execApprovalHandlers = createExecApprovalHandlers(execApprovalManager, {
     forwarder: execApprovalForwarder,
+    config: cfg,
   });
   const secretsHandlers = createSecretsHandlers({
     reloadSecrets: async () => {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -146,6 +146,24 @@ export type ExecApprovalsResolved = {
 // Keep CLI + gateway defaults in sync.
 export const DEFAULT_EXEC_APPROVAL_TIMEOUT_MS = 120_000;
 
+/**
+ * Resolve the exec approval timeout from env var > config > default.
+ * Priority: OPENCLAW_EXEC_APPROVAL_TIMEOUT_MS env var > approvals.timeoutMs config > 120s default.
+ */
+export function getExecApprovalTimeoutMs(config?: { approvals?: { timeoutMs?: number } }): number {
+  const envVal = process.env.OPENCLAW_EXEC_APPROVAL_TIMEOUT_MS;
+  if (envVal) {
+    const parsed = Number(envVal);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  if (typeof config?.approvals?.timeoutMs === "number" && config.approvals.timeoutMs > 0) {
+    return config.approvals.timeoutMs;
+  }
+  return DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;
+}
+
 const DEFAULT_SECURITY: ExecSecurity = "deny";
 const DEFAULT_ASK: ExecAsk = "on-miss";
 const DEFAULT_ASK_FALLBACK: ExecSecurity = "deny";


### PR DESCRIPTION
## Summary

Make the exec approval timeout configurable instead of hardcoded at 120 seconds.

Closes #51287

## Changes

**Config option:** `approvals.timeoutMs` in `openclaw.json`
**Environment variable:** `OPENCLAW_EXEC_APPROVAL_TIMEOUT_MS`

Priority chain: env var > config > default (120s).

### Files changed (9 files, +51/-11)

- **`src/config/types.approvals.ts`** — Added `timeoutMs` field to `ApprovalsConfig`
- **`src/infra/exec-approvals.ts`** — Added `getExecApprovalTimeoutMs()` resolver (env > config > default)
- **`src/gateway/server-methods/exec-approval.ts`** — Server-side handler uses config-aware timeout
- **`src/gateway/server.impl.ts`** — Pass config to exec approval handlers
- **`src/agents/bash-tools.exec-runtime.ts`** — Agent-side reads env var for approval timeout
- **`src/agents/tools/nodes-tool.ts`** — Node exec reads env var for approval timeout
- **`src/cli/nodes-cli/register.invoke.ts`** — CLI uses `getExecApprovalTimeoutMs()`
- **`src/config/schema.help.ts`** — Added help text for `approvals.timeoutMs`
- **`src/config/schema.labels.ts`** — Added label for `approvals.timeoutMs`

## Usage

```json
{
  "approvals": {
    "timeoutMs": 300000
  }
}
```

Or via environment variable:
```bash
OPENCLAW_EXEC_APPROVAL_TIMEOUT_MS=300000 openclaw gateway start
```

## Testing

- All existing exec approval tests pass (12/12)
- Schema help quality tests pass (20/20)
- No type errors in changed files