### PR TITLE
fix(discord): add stopAccount to close stale WS on health-monitor restart

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -46,6 +46,8 @@ import {
   resolveDiscordGroupRequireMention,
   resolveDiscordGroupToolPolicy,
 } from "./group-policy.js";
+import { getDiscordGatewayEmitter } from "./monitor.gateway.js";
+import { getGateway, unregisterGateway } from "./monitor/gateway-registry.js";
 import {
   looksLikeDiscordTargetId,
   normalizeDiscordMessagingTarget,
@@ -701,6 +703,25 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
         historyLimit: account.config.historyLimit,
         setStatus: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
       });
+    },
+    stopAccount: async (ctx) => {
+      const accountId = ctx.accountId;
+      const gateway = getGateway(accountId);
+      if (gateway) {
+        try {
+          // Prevent reconnect attempts and forcibly close the WebSocket.
+          // Suppress any error event emitted during disconnect to avoid unhandled rejections.
+          const emitter = getDiscordGatewayEmitter(gateway);
+          emitter?.once("error", () => {});
+          gateway.options.reconnect = { maxAttempts: 0 };
+          gateway.disconnect();
+        } catch (err) {
+          ctx.log?.warn?.(
+            `[${accountId}] discord stopAccount: error during gateway disconnect: ${String(err)}`,
+          );
+        }
+        unregisterGateway(accountId);
+      }
     },
   },
 };

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -705,7 +705,9 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       });
     },
     stopAccount: async (ctx) => {
-      const accountId = ctx.accountId;
+      // Normalize the account ID the same way startAccount does (via resolveDiscordAccount),
+      // because gateways are registered under the normalized ID.
+      const accountId = resolveDiscordAccount({ cfg: ctx.cfg, accountId: ctx.accountId }).accountId;
       const gateway = getGateway(accountId);
       if (gateway) {
         try {


### PR DESCRIPTION
## Summary

The Discord channel plugin's `gateway` object was missing a `stopAccount()` implementation. When the health-monitor triggered a hot restart, the old WebSocket (`GatewayPlugin`) remained connected, causing stale connections to linger and potentially process duplicate events.

## Changes

- Added `stopAccount()` to the `gateway` object in `extensions/discord/src/channel.ts`
- On stop: retrieves the active `GatewayPlugin` via `getGateway(accountId)`, sets `reconnect.maxAttempts = 0` to prevent reconnection, calls `gateway.disconnect()` to close the WebSocket, then calls `unregisterGateway(accountId)` to clean up the registry

## Testing

- Existing tests cover `registerGateway`/`unregisterGateway` lifecycle
- The `stopAccount` path mirrors the existing `onAbort` handler in `provider.lifecycle.ts` which already uses this pattern

## Related

Fixes #50913
