### PR TITLE
fix: support quoted replies in WhatsApp web

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -409,6 +409,8 @@ public struct SendParams: Codable, Sendable {
     public let channel: String?
     public let accountid: String?
     public let agentid: String?
+    public let replyto: String?
+    public let replytoid: String?
     public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
@@ -422,6 +424,8 @@ public struct SendParams: Codable, Sendable {
         channel: String?,
         accountid: String?,
         agentid: String?,
+        replyto: String?,
+        replytoid: String?,
         threadid: String?,
         sessionkey: String?,
         idempotencykey: String)
@@ -434,6 +438,8 @@ public struct SendParams: Codable, Sendable {
         self.channel = channel
         self.accountid = accountid
         self.agentid = agentid
+        self.replyto = replyto
+        self.replytoid = replytoid
         self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
@@ -448,6 +454,8 @@ public struct SendParams: Codable, Sendable {
         case channel
         case accountid = "accountId"
         case agentid = "agentId"
+        case replyto = "replyTo"
+        case replytoid = "replyToId"
         case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -409,6 +409,8 @@ public struct SendParams: Codable, Sendable {
     public let channel: String?
     public let accountid: String?
     public let agentid: String?
+    public let replyto: String?
+    public let replytoid: String?
     public let threadid: String?
     public let sessionkey: String?
     public let idempotencykey: String
@@ -422,6 +424,8 @@ public struct SendParams: Codable, Sendable {
         channel: String?,
         accountid: String?,
         agentid: String?,
+        replyto: String?,
+        replytoid: String?,
         threadid: String?,
         sessionkey: String?,
         idempotencykey: String)
@@ -434,6 +438,8 @@ public struct SendParams: Codable, Sendable {
         self.channel = channel
         self.accountid = accountid
         self.agentid = agentid
+        self.replyto = replyto
+        self.replytoid = replytoid
         self.threadid = threadid
         self.sessionkey = sessionkey
         self.idempotencykey = idempotencykey
@@ -448,6 +454,8 @@ public struct SendParams: Codable, Sendable {
         case channel
         case accountid = "accountId"
         case agentid = "agentId"
+        case replyto = "replyTo"
+        case replytoid = "replyToId"
         case threadid = "threadId"
         case sessionkey = "sessionKey"
         case idempotencykey = "idempotencyKey"

--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -7,6 +7,7 @@ export type ActiveWebSendOptions = {
   accountId?: string;
   fileName?: string;
   replyToId?: string;
+  recordActivity?: boolean;
 };
 
 export type ActiveWebListener = {

--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -6,6 +6,7 @@ export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
   accountId?: string;
   fileName?: string;
+  replyToId?: string;
 };
 
 export type ActiveWebListener = {

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -114,7 +114,7 @@ describe("deliverWebReply", () => {
     const msg = makeMsg();
 
     await deliverWebReply({
-      replyResult: { text: "aaaaaa" },
+      replyResult: { text: "aaaaaa", replyToId: "quoted-1" },
       msg,
       maxMediaBytes: 1024 * 1024,
       textLimit: 3,
@@ -123,8 +123,8 @@ describe("deliverWebReply", () => {
     });
 
     expect(msg.reply).toHaveBeenCalledTimes(2);
-    expect(msg.reply).toHaveBeenNthCalledWith(1, "aaa");
-    expect(msg.reply).toHaveBeenNthCalledWith(2, "aaa");
+    expect(msg.reply).toHaveBeenNthCalledWith(1, "aaa", { replyToId: "quoted-1" });
+    expect(msg.reply).toHaveBeenNthCalledWith(2, "aaa", { replyToId: "quoted-1" });
     expect(replyLogger.info).toHaveBeenCalledWith(expect.any(Object), "auto-reply sent (text)");
   });
 
@@ -155,7 +155,11 @@ describe("deliverWebReply", () => {
     mockLoadedImageMedia();
 
     await deliverWebReply({
-      replyResult: { text: "aaaaaa", mediaUrl: "http://example.com/img.jpg" },
+      replyResult: {
+        text: "aaaaaa",
+        mediaUrl: "http://example.com/img.jpg",
+        replyToId: "quoted-2",
+      },
       msg,
       mediaLocalRoots,
       maxMediaBytes: 1024 * 1024,
@@ -175,8 +179,9 @@ describe("deliverWebReply", () => {
         caption: "aaa",
         mimetype: "image/jpeg",
       }),
+      { replyToId: "quoted-2" },
     );
-    expect(msg.reply).toHaveBeenCalledWith("aaa");
+    expect(msg.reply).toHaveBeenCalledWith("aaa", { replyToId: "quoted-2" });
     expect(replyLogger.info).toHaveBeenCalledWith(expect.any(Object), "auto-reply sent (media)");
     expect(logVerbose).toHaveBeenCalled();
   });

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -46,6 +46,11 @@ export async function deliverWebReply(params: {
 }) {
   const { replyResult, msg, maxMediaBytes, textLimit, replyLogger, connectionId, skipLog } = params;
   const replyStarted = Date.now();
+  const replyToId = replyResult.replyToId?.trim() || undefined;
+  const replyOptions = replyToId ? { replyToId } : undefined;
+  const reply = (text: string) => (replyOptions ? msg.reply(text, replyOptions) : msg.reply(text));
+  const sendMedia = (payload: Parameters<WebInboundMsg["sendMedia"]>[0]) =>
+    replyOptions ? msg.sendMedia(payload, replyOptions) : msg.sendMedia(payload);
   if (shouldSuppressReasoningReply(replyResult)) {
     whatsappOutboundLog.debug(`Suppressed reasoning payload to ${msg.from}`);
     return;
@@ -86,7 +91,7 @@ export async function deliverWebReply(params: {
     const totalChunks = textChunks.length;
     for (const [index, chunk] of textChunks.entries()) {
       const chunkStarted = Date.now();
-      await sendWithRetry(() => msg.reply(chunk), "text");
+      await sendWithRetry(() => reply(chunk), "text");
       if (!skipLog) {
         const durationMs = Date.now() - chunkStarted;
         whatsappOutboundLog.debug(
@@ -100,6 +105,7 @@ export async function deliverWebReply(params: {
         connectionId: connectionId ?? null,
         to: msg.from,
         from: msg.to,
+        replyToId: replyToId ?? null,
         text: elide(replyResult.text, 240),
         mediaUrl: null,
         mediaSizeBytes: null,
@@ -132,7 +138,7 @@ export async function deliverWebReply(params: {
       if (media.kind === "image") {
         await sendWithRetry(
           () =>
-            msg.sendMedia({
+            sendMedia({
               image: media.buffer,
               caption,
               mimetype: media.contentType,
@@ -142,7 +148,7 @@ export async function deliverWebReply(params: {
       } else if (media.kind === "audio") {
         await sendWithRetry(
           () =>
-            msg.sendMedia({
+            sendMedia({
               audio: media.buffer,
               ptt: true,
               mimetype: media.contentType,
@@ -153,7 +159,7 @@ export async function deliverWebReply(params: {
       } else if (media.kind === "video") {
         await sendWithRetry(
           () =>
-            msg.sendMedia({
+            sendMedia({
               video: media.buffer,
               caption,
               mimetype: media.contentType,
@@ -165,7 +171,7 @@ export async function deliverWebReply(params: {
         const mimetype = media.contentType ?? "application/octet-stream";
         await sendWithRetry(
           () =>
-            msg.sendMedia({
+            sendMedia({
               document: media.buffer,
               fileName,
               caption,
@@ -183,6 +189,7 @@ export async function deliverWebReply(params: {
           connectionId: connectionId ?? null,
           to: msg.from,
           from: msg.to,
+          replyToId: replyToId ?? null,
           text: caption ?? null,
           mediaUrl,
           mediaSizeBytes: media.buffer.length,
@@ -206,12 +213,12 @@ export async function deliverWebReply(params: {
         return;
       }
       whatsappOutboundLog.warn(`Media skipped; sent text-only to ${msg.from}`);
-      await msg.reply(fallbackText);
+      await reply(fallbackText);
     },
   });
 
   // Remaining text chunks after media
   for (const chunk of remainingText) {
-    await msg.reply(chunk);
+    await reply(chunk);
   }
 }

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -464,6 +464,8 @@ export async function monitorWebInbox(options: {
 
       const enriched = await enrichInboundMessage(msg);
       if (!enriched) {
+        // Only messages that produced body/media content are cached as quote
+        // targets; unsupported message shapes are intentionally skipped.
         continue;
       }
 
@@ -471,6 +473,8 @@ export async function monitorWebInbox(options: {
         message: msg,
         messageId: inbound.id,
         remoteJid: inbound.remoteJid,
+        // normalizedJid is the outbound JID shape used by the send path; both
+        // forms are stored as aliases so either can resolve the same entry.
         normalizedJid: inbound.group ? inbound.remoteJid : toWhatsappJid(inbound.from),
         participantJid: msg.key?.participant ?? undefined,
         isGroup: inbound.group,

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -322,6 +322,29 @@ export async function monitorWebInbox(options: {
     enriched: EnrichedInboundMessage,
   ) => {
     const chatJid = inbound.remoteJid;
+    const createAutoReplySendOptions = (replyToId?: string) => {
+      const normalizedReplyToId = replyToId?.trim();
+      return normalizedReplyToId
+        ? { replyToId: normalizedReplyToId, recordActivity: false }
+        : { recordActivity: false };
+    };
+    const resolveRawQuotedSendOptions = (replyToId?: string) => {
+      const normalizedReplyToId = replyToId?.trim();
+      if (!normalizedReplyToId) {
+        return undefined;
+      }
+      const quoted = quotedMessageCache.resolve({
+        jid: chatJid,
+        replyToId: normalizedReplyToId,
+      });
+      return quoted ? { quoted } : undefined;
+    };
+    const sendRawMessage = async (payload: AnyMessageContent, options?: { replyToId?: string }) => {
+      const quotedOptions = resolveRawQuotedSendOptions(options?.replyToId);
+      await (quotedOptions
+        ? sock.sendMessage(chatJid, payload, quotedOptions)
+        : sock.sendMessage(chatJid, payload));
+    };
     const sendComposing = async () => {
       try {
         await sock.sendPresenceUpdate("composing", chatJid);
@@ -330,9 +353,13 @@ export async function monitorWebInbox(options: {
       }
     };
     const reply = async (text: string, options?: { replyToId?: string }) => {
-      await sendApi.sendMessage(chatJid, text, undefined, undefined, {
-        ...(options?.replyToId ? { replyToId: options.replyToId } : {}),
-      });
+      await sendApi.sendMessage(
+        chatJid,
+        text,
+        undefined,
+        undefined,
+        createAutoReplySendOptions(options?.replyToId),
+      );
     };
     const sendMedia = async (payload: AnyMessageContent, options?: { replyToId?: string }) => {
       const caption =
@@ -346,7 +373,7 @@ export async function monitorWebInbox(options: {
       if ("image" in payload && payload.image) {
         const imageBuffer = toBuffer(payload.image);
         if (!imageBuffer) {
-          await sock.sendMessage(chatJid, payload);
+          await sendRawMessage(payload, options);
           return;
         }
         await sendApi.sendMessage(
@@ -354,16 +381,14 @@ export async function monitorWebInbox(options: {
           caption,
           imageBuffer,
           typeof payload.mimetype === "string" ? payload.mimetype : "image/jpeg",
-          {
-            ...(options?.replyToId ? { replyToId: options.replyToId } : {}),
-          },
+          createAutoReplySendOptions(options?.replyToId),
         );
         return;
       }
       if ("audio" in payload && payload.audio) {
         const audioBuffer = toBuffer(payload.audio);
         if (!audioBuffer) {
-          await sock.sendMessage(chatJid, payload);
+          await sendRawMessage(payload, options);
           return;
         }
         await sendApi.sendMessage(
@@ -371,16 +396,14 @@ export async function monitorWebInbox(options: {
           caption,
           audioBuffer,
           typeof payload.mimetype === "string" ? payload.mimetype : "audio/ogg",
-          {
-            ...(options?.replyToId ? { replyToId: options.replyToId } : {}),
-          },
+          createAutoReplySendOptions(options?.replyToId),
         );
         return;
       }
       if ("video" in payload && payload.video) {
         const videoBuffer = toBuffer(payload.video);
         if (!videoBuffer) {
-          await sock.sendMessage(chatJid, payload);
+          await sendRawMessage(payload, options);
           return;
         }
         await sendApi.sendMessage(
@@ -390,7 +413,7 @@ export async function monitorWebInbox(options: {
           typeof payload.mimetype === "string" ? payload.mimetype : "video/mp4",
           {
             ...(payload.gifPlayback ? { gifPlayback: true } : {}),
-            ...(options?.replyToId ? { replyToId: options.replyToId } : {}),
+            ...createAutoReplySendOptions(options?.replyToId),
           },
         );
         return;
@@ -398,7 +421,7 @@ export async function monitorWebInbox(options: {
       if ("document" in payload && payload.document) {
         const documentBuffer = toBuffer(payload.document);
         if (!documentBuffer) {
-          await sock.sendMessage(chatJid, payload);
+          await sendRawMessage(payload, options);
           return;
         }
         await sendApi.sendMessage(
@@ -408,12 +431,12 @@ export async function monitorWebInbox(options: {
           typeof payload.mimetype === "string" ? payload.mimetype : "application/octet-stream",
           {
             ...(typeof payload.fileName === "string" ? { fileName: payload.fileName } : {}),
-            ...(options?.replyToId ? { replyToId: options.replyToId } : {}),
+            ...createAutoReplySendOptions(options?.replyToId),
           },
         );
         return;
       }
-      await sock.sendMessage(chatJid, payload);
+      await sendRawMessage(payload, options);
     };
     const timestamp = inbound.messageTimestampMs;
     const mentionedJids = extractMentionedJids(msg.message as proto.IMessage | undefined);

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -331,6 +331,7 @@ export async function monitorWebInbox(options: {
     enriched: EnrichedInboundMessage,
   ) => {
     const chatJid = inbound.remoteJid;
+    const quotedLookupJid = toWhatsappJid(chatJid);
     const createAutoReplySendOptions = (replyToId?: string) => {
       const normalizedReplyToId = replyToId?.trim();
       return normalizedReplyToId
@@ -342,8 +343,10 @@ export async function monitorWebInbox(options: {
       if (!normalizedReplyToId) {
         return undefined;
       }
+      // Keep quote-cache lookups aligned with sendApi.sendMessage(), while still
+      // preserving jid-shaped inputs like @lid/@g.us unchanged.
       const quoted = quotedMessageCache.resolve({
-        jid: chatJid,
+        jid: quotedLookupJid,
         replyToId: normalizedReplyToId,
       });
       return quoted ? { quoted } : undefined;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -120,6 +120,15 @@ export async function monitorWebInbox(options: {
   const GROUP_META_TTL_MS = 5 * 60 * 1000; // 5 minutes
   const lidLookup = sock.signalRepository?.lidMapping;
   const quotedMessageCache = createQuotedMessageCache();
+  const sendApi = createWebSendApi({
+    sock: {
+      sendMessage: (jid: string, content: AnyMessageContent, options?: { quoted?: WAMessage }) =>
+        options ? sock.sendMessage(jid, content, options) : sock.sendMessage(jid, content),
+      sendPresenceUpdate: (presence, jid?: string) => sock.sendPresenceUpdate(presence, jid),
+    },
+    defaultAccountId: options.accountId,
+    resolveQuotedMessage: quotedMessageCache.resolve,
+  });
 
   const resolveInboundJid = async (jid: string | null | undefined): Promise<string | null> =>
     resolveJidToE164(jid, { authDir: options.authDir, lidLookup });
@@ -361,83 +370,9 @@ export async function monitorWebInbox(options: {
         createAutoReplySendOptions(options?.replyToId),
       );
     };
-    const sendMedia = async (payload: AnyMessageContent, options?: { replyToId?: string }) => {
-      const caption =
-        "caption" in payload && typeof payload.caption === "string" ? payload.caption : "";
-      const toBuffer = (value: unknown): Buffer | null => {
-        if (Buffer.isBuffer(value)) {
-          return value;
-        }
-        return value instanceof Uint8Array ? Buffer.from(value) : null;
-      };
-      if ("image" in payload && payload.image) {
-        const imageBuffer = toBuffer(payload.image);
-        if (!imageBuffer) {
-          await sendRawMessage(payload, options);
-          return;
-        }
-        await sendApi.sendMessage(
-          chatJid,
-          caption,
-          imageBuffer,
-          typeof payload.mimetype === "string" ? payload.mimetype : "image/jpeg",
-          createAutoReplySendOptions(options?.replyToId),
-        );
-        return;
-      }
-      if ("audio" in payload && payload.audio) {
-        const audioBuffer = toBuffer(payload.audio);
-        if (!audioBuffer) {
-          await sendRawMessage(payload, options);
-          return;
-        }
-        await sendApi.sendMessage(
-          chatJid,
-          caption,
-          audioBuffer,
-          typeof payload.mimetype === "string" ? payload.mimetype : "audio/ogg",
-          createAutoReplySendOptions(options?.replyToId),
-        );
-        return;
-      }
-      if ("video" in payload && payload.video) {
-        const videoBuffer = toBuffer(payload.video);
-        if (!videoBuffer) {
-          await sendRawMessage(payload, options);
-          return;
-        }
-        await sendApi.sendMessage(
-          chatJid,
-          caption,
-          videoBuffer,
-          typeof payload.mimetype === "string" ? payload.mimetype : "video/mp4",
-          {
-            ...(payload.gifPlayback ? { gifPlayback: true } : {}),
-            ...createAutoReplySendOptions(options?.replyToId),
-          },
-        );
-        return;
-      }
-      if ("document" in payload && payload.document) {
-        const documentBuffer = toBuffer(payload.document);
-        if (!documentBuffer) {
-          await sendRawMessage(payload, options);
-          return;
-        }
-        await sendApi.sendMessage(
-          chatJid,
-          caption,
-          documentBuffer,
-          typeof payload.mimetype === "string" ? payload.mimetype : "application/octet-stream",
-          {
-            ...(typeof payload.fileName === "string" ? { fileName: payload.fileName } : {}),
-            ...createAutoReplySendOptions(options?.replyToId),
-          },
-        );
-        return;
-      }
-      await sendRawMessage(payload, options);
-    };
+    // Preserve the caller's Baileys payload; inbox media helpers only add quote context.
+    const sendMedia = async (payload: AnyMessageContent, options?: { replyToId?: string }) =>
+      sendRawMessage(payload, options);
     const timestamp = inbound.messageTimestampMs;
     const mentionedJids = extractMentionedJids(msg.message as proto.IMessage | undefined);
     const senderName = msg.pushName ?? undefined;
@@ -564,16 +499,6 @@ export async function monitorWebInbox(options: {
     }
   };
   sock.ev.on("connection.update", handleConnectionUpdate);
-
-  const sendApi = createWebSendApi({
-    sock: {
-      sendMessage: (jid: string, content: AnyMessageContent, options?: { quoted?: WAMessage }) =>
-        options ? sock.sendMessage(jid, content, options) : sock.sendMessage(jid, content),
-      sendPresenceUpdate: (presence, jid?: string) => sock.sendPresenceUpdate(presence, jid),
-    },
-    defaultAccountId: options.accountId,
-    resolveQuotedMessage: quotedMessageCache.resolve,
-  });
 
   return {
     close: async () => {

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -7,6 +7,7 @@ import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/text-runtime";
 import { jidToE164, resolveJidToE164 } from "openclaw/plugin-sdk/text-runtime";
+import { toWhatsappJid } from "openclaw/plugin-sdk/text-runtime";
 import { createWaSocket, getStatusCode, waitForWaConnection } from "../session.js";
 import { checkInboundAccessControl } from "./access-control.js";
 import { isRecentInboundMessage } from "./dedupe.js";
@@ -18,6 +19,7 @@ import {
   extractText,
 } from "./extract.js";
 import { downloadInboundMedia } from "./media.js";
+import { createQuotedMessageCache } from "./quoted-message-cache.js";
 import { createWebSendApi } from "./send-api.js";
 import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
 
@@ -117,6 +119,7 @@ export async function monitorWebInbox(options: {
   >();
   const GROUP_META_TTL_MS = 5 * 60 * 1000; // 5 minutes
   const lidLookup = sock.signalRepository?.lidMapping;
+  const quotedMessageCache = createQuotedMessageCache();
 
   const resolveInboundJid = async (jid: string | null | undefined): Promise<string | null> =>
     resolveJidToE164(jid, { authDir: options.authDir, lidLookup });
@@ -326,10 +329,90 @@ export async function monitorWebInbox(options: {
         logVerbose(`Presence update failed: ${String(err)}`);
       }
     };
-    const reply = async (text: string) => {
-      await sock.sendMessage(chatJid, { text });
+    const reply = async (text: string, options?: { replyToId?: string }) => {
+      await sendApi.sendMessage(chatJid, text, undefined, undefined, {
+        ...(options?.replyToId ? { replyToId: options.replyToId } : {}),
+      });
     };
-    const sendMedia = async (payload: AnyMessageContent) => {
+    const sendMedia = async (payload: AnyMessageContent, options?: { replyToId?: string }) => {
+      const caption =
+        "caption" in payload && typeof payload.caption === "string" ? payload.caption : "";
+      const toBuffer = (value: unknown): Buffer | null => {
+        if (Buffer.isBuffer(value)) {
+          return value;
+        }
+        return value instanceof Uint8Array ? Buffer.from(value) : null;
+      };
+      if ("image" in payload && payload.image) {
+        const imageBuffer = toBuffer(payload.image);
+        if (!imageBuffer) {
+          await sock.sendMessage(chatJid, payload);
+          return;
+        }
+        await sendApi.sendMessage(
+          chatJid,
+          caption,
+          imageBuffer,
+          typeof payload.mimetype === "string" ? payload.mimetype : "image/jpeg",
+          {
+            ...(options?.replyToId ? { replyToId: options.replyToId } : {}),
+          },
+        );
+        return;
+      }
+      if ("audio" in payload && payload.audio) {
+        const audioBuffer = toBuffer(payload.audio);
+        if (!audioBuffer) {
+          await sock.sendMessage(chatJid, payload);
+          return;
+        }
+        await sendApi.sendMessage(
+          chatJid,
+          caption,
+          audioBuffer,
+          typeof payload.mimetype === "string" ? payload.mimetype : "audio/ogg",
+          {
+            ...(options?.replyToId ? { replyToId: options.replyToId } : {}),
+          },
+        );
+        return;
+      }
+      if ("video" in payload && payload.video) {
+        const videoBuffer = toBuffer(payload.video);
+        if (!videoBuffer) {
+          await sock.sendMessage(chatJid, payload);
+          return;
+        }
+        await sendApi.sendMessage(
+          chatJid,
+          caption,
+          videoBuffer,
+          typeof payload.mimetype === "string" ? payload.mimetype : "video/mp4",
+          {
+            ...(payload.gifPlayback ? { gifPlayback: true } : {}),
+            ...(options?.replyToId ? { replyToId: options.replyToId } : {}),
+          },
+        );
+        return;
+      }
+      if ("document" in payload && payload.document) {
+        const documentBuffer = toBuffer(payload.document);
+        if (!documentBuffer) {
+          await sock.sendMessage(chatJid, payload);
+          return;
+        }
+        await sendApi.sendMessage(
+          chatJid,
+          caption,
+          documentBuffer,
+          typeof payload.mimetype === "string" ? payload.mimetype : "application/octet-stream",
+          {
+            ...(typeof payload.fileName === "string" ? { fileName: payload.fileName } : {}),
+            ...(options?.replyToId ? { replyToId: options.replyToId } : {}),
+          },
+        );
+        return;
+      }
       await sock.sendMessage(chatJid, payload);
     };
     const timestamp = inbound.messageTimestampMs;
@@ -366,7 +449,7 @@ export async function monitorWebInbox(options: {
       replyToBody: enriched.replyContext?.body,
       replyToSender: enriched.replyContext?.sender,
       replyToSenderJid: enriched.replyContext?.senderJid,
-      replyToSenderE164: enriched.replyContext?.senderE164,
+      replyToSenderE164: enriched.replyContext?.senderE164 ?? undefined,
       groupSubject: inbound.groupSubject,
       groupParticipants: inbound.groupParticipants,
       mentionedJids: mentionedJids ?? undefined,
@@ -426,6 +509,15 @@ export async function monitorWebInbox(options: {
         continue;
       }
 
+      quotedMessageCache.remember({
+        message: msg,
+        messageId: inbound.id,
+        remoteJid: inbound.remoteJid,
+        normalizedJid: inbound.group ? inbound.remoteJid : toWhatsappJid(inbound.from),
+        participantJid: msg.key?.participant ?? undefined,
+        isGroup: inbound.group,
+      });
+
       await enqueueInboundMessage(msg, inbound, enriched);
     }
   };
@@ -452,10 +544,12 @@ export async function monitorWebInbox(options: {
 
   const sendApi = createWebSendApi({
     sock: {
-      sendMessage: (jid: string, content: AnyMessageContent) => sock.sendMessage(jid, content),
+      sendMessage: (jid: string, content: AnyMessageContent, options?: { quoted?: WAMessage }) =>
+        options ? sock.sendMessage(jid, content, options) : sock.sendMessage(jid, content),
       sendPresenceUpdate: (presence, jid?: string) => sock.sendPresenceUpdate(presence, jid),
     },
     defaultAccountId: options.accountId,
+    resolveQuotedMessage: quotedMessageCache.resolve,
   });
 
   return {

--- a/extensions/whatsapp/src/inbound/quoted-message-cache.test.ts
+++ b/extensions/whatsapp/src/inbound/quoted-message-cache.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { createQuotedMessageCache, normalizeQuotedMessage } from "./quoted-message-cache.js";
+
+describe("normalizeQuotedMessage", () => {
+  it("keeps the stored direct-chat jid for quoted replies", () => {
+    const normalized = normalizeQuotedMessage({
+      message: {
+        key: {
+          id: "msg-1",
+          remoteJid: "1234567890@lid",
+          remoteJidAlt: "1555@s.whatsapp.net",
+          addressingMode: "lid",
+          fromMe: false,
+          participant: "1234567890@lid",
+        },
+        message: { conversation: "hello there" },
+      },
+      messageId: "msg-1",
+      remoteJid: "1234567890@lid",
+      isGroup: false,
+    });
+
+    expect(normalized).toEqual({
+      key: {
+        id: "msg-1",
+        remoteJid: "1234567890@lid",
+        remoteJidAlt: "1555@s.whatsapp.net",
+        addressingMode: "lid",
+        fromMe: false,
+      },
+      message: { conversation: "hello there" },
+    });
+  });
+
+  it("preserves group participant identity while keeping the group jid", () => {
+    const normalized = normalizeQuotedMessage({
+      message: {
+        key: {
+          id: "msg-2",
+          remoteJid: "120363158967464097@g.us",
+          fromMe: false,
+          participant: "1555@s.whatsapp.net",
+        },
+        message: { conversation: "group hello" },
+      },
+      messageId: "msg-2",
+      remoteJid: "120363158967464097@g.us",
+      participantJid: "1555@s.whatsapp.net",
+      isGroup: true,
+    });
+
+    expect(normalized).toEqual({
+      key: {
+        id: "msg-2",
+        remoteJid: "120363158967464097@g.us",
+        fromMe: false,
+        participant: "1555@s.whatsapp.net",
+      },
+      message: { conversation: "group hello" },
+    });
+  });
+});
+
+describe("createQuotedMessageCache", () => {
+  it("resolves a remembered direct-chat message by normalized outbound jid", () => {
+    const cache = createQuotedMessageCache();
+    cache.remember({
+      message: {
+        key: {
+          id: "msg-1",
+          remoteJid: "1234567890@lid",
+          fromMe: false,
+        },
+        message: { conversation: "hello there" },
+      },
+      messageId: "msg-1",
+      remoteJid: "1234567890@lid",
+      normalizedJid: "1555@s.whatsapp.net",
+      isGroup: false,
+    });
+
+    expect(
+      cache.resolve({
+        jid: "1555@s.whatsapp.net",
+        replyToId: "msg-1",
+      }),
+    ).toEqual({
+      key: {
+        id: "msg-1",
+        remoteJid: "1555@s.whatsapp.net",
+        remoteJidAlt: "1234567890@lid",
+        fromMe: false,
+      },
+      message: { conversation: "hello there" },
+    });
+  });
+
+  it("preserves extra Baileys key metadata after rebinding", () => {
+    const cache = createQuotedMessageCache();
+    cache.remember({
+      message: {
+        key: {
+          id: "msg-1",
+          remoteJid: "1234567890@lid",
+          remoteJidAlt: "1555@s.whatsapp.net",
+          addressingMode: "lid",
+          fromMe: false,
+        },
+        message: { conversation: "hello there" },
+      },
+      messageId: "msg-1",
+      remoteJid: "1234567890@lid",
+      normalizedJid: "1555@s.whatsapp.net",
+      isGroup: false,
+    });
+
+    expect(
+      cache.resolve({
+        jid: "1555@s.whatsapp.net",
+        replyToId: "msg-1",
+      }),
+    ).toEqual({
+      key: {
+        id: "msg-1",
+        remoteJid: "1555@s.whatsapp.net",
+        remoteJidAlt: "1234567890@lid",
+        addressingMode: "lid",
+        fromMe: false,
+      },
+      message: { conversation: "hello there" },
+    });
+  });
+
+  it("keeps group quotes on the group jid when resolving", () => {
+    const cache = createQuotedMessageCache();
+    cache.remember({
+      message: {
+        key: {
+          id: "msg-2",
+          remoteJid: "120363158967464097@g.us",
+          fromMe: false,
+          participant: "1234567890@lid",
+        },
+        message: { conversation: "group hello" },
+      },
+      messageId: "msg-2",
+      remoteJid: "120363158967464097@g.us",
+      normalizedJid: "120363158967464097@g.us",
+      participantJid: "1234567890@lid",
+      isGroup: true,
+    });
+
+    expect(
+      cache.resolve({
+        jid: "120363158967464097@g.us",
+        replyToId: "msg-2",
+      }),
+    ).toEqual({
+      key: {
+        id: "msg-2",
+        remoteJid: "120363158967464097@g.us",
+        fromMe: false,
+        participant: "1234567890@lid",
+      },
+      message: { conversation: "group hello" },
+    });
+  });
+
+  it("does not resolve the same message id across unrelated chats", () => {
+    const cache = createQuotedMessageCache();
+    cache.remember({
+      message: {
+        key: {
+          id: "msg-1",
+          remoteJid: "1234567890@lid",
+          fromMe: false,
+        },
+        message: { conversation: "hello there" },
+      },
+      messageId: "msg-1",
+      remoteJid: "1234567890@lid",
+      normalizedJid: "1555@s.whatsapp.net",
+      isGroup: false,
+    });
+
+    expect(
+      cache.resolve({
+        jid: "9999@s.whatsapp.net",
+        replyToId: "msg-1",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/whatsapp/src/inbound/quoted-message-cache.test.ts
+++ b/extensions/whatsapp/src/inbound/quoted-message-cache.test.ts
@@ -131,6 +131,52 @@ describe("createQuotedMessageCache", () => {
     });
   });
 
+  it("counts one direct-chat message with two JID aliases as one remembered entry", () => {
+    const cache = createQuotedMessageCache({ limit: 1 });
+    cache.remember({
+      message: {
+        key: {
+          id: "msg-1",
+          remoteJid: "1234567890@lid",
+          fromMe: false,
+        },
+        message: { conversation: "hello there" },
+      },
+      messageId: "msg-1",
+      remoteJid: "1234567890@lid",
+      normalizedJid: "1555@s.whatsapp.net",
+      isGroup: false,
+    });
+
+    expect(
+      cache.resolve({
+        jid: "1234567890@lid",
+        replyToId: "msg-1",
+      }),
+    ).toEqual({
+      key: {
+        id: "msg-1",
+        remoteJid: "1234567890@lid",
+        fromMe: false,
+      },
+      message: { conversation: "hello there" },
+    });
+    expect(
+      cache.resolve({
+        jid: "1555@s.whatsapp.net",
+        replyToId: "msg-1",
+      }),
+    ).toEqual({
+      key: {
+        id: "msg-1",
+        remoteJid: "1555@s.whatsapp.net",
+        remoteJidAlt: "1234567890@lid",
+        fromMe: false,
+      },
+      message: { conversation: "hello there" },
+    });
+  });
+
   it("keeps group quotes on the group jid when resolving", () => {
     const cache = createQuotedMessageCache();
     cache.remember({
@@ -189,5 +235,66 @@ describe("createQuotedMessageCache", () => {
         replyToId: "msg-1",
       }),
     ).toBeUndefined();
+  });
+
+  it("removes every alias when an older message is evicted", () => {
+    const cache = createQuotedMessageCache({ limit: 1 });
+    cache.remember({
+      message: {
+        key: {
+          id: "msg-1",
+          remoteJid: "1234567890@lid",
+          fromMe: false,
+        },
+        message: { conversation: "hello there" },
+      },
+      messageId: "msg-1",
+      remoteJid: "1234567890@lid",
+      normalizedJid: "1555@s.whatsapp.net",
+      isGroup: false,
+    });
+    cache.remember({
+      message: {
+        key: {
+          id: "msg-2",
+          remoteJid: "120363158967464097@g.us",
+          fromMe: false,
+          participant: "1555@s.whatsapp.net",
+        },
+        message: { conversation: "group hello" },
+      },
+      messageId: "msg-2",
+      remoteJid: "120363158967464097@g.us",
+      normalizedJid: "120363158967464097@g.us",
+      participantJid: "1555@s.whatsapp.net",
+      isGroup: true,
+    });
+
+    expect(
+      cache.resolve({
+        jid: "1234567890@lid",
+        replyToId: "msg-1",
+      }),
+    ).toBeUndefined();
+    expect(
+      cache.resolve({
+        jid: "1555@s.whatsapp.net",
+        replyToId: "msg-1",
+      }),
+    ).toBeUndefined();
+    expect(
+      cache.resolve({
+        jid: "120363158967464097@g.us",
+        replyToId: "msg-2",
+      }),
+    ).toEqual({
+      key: {
+        id: "msg-2",
+        remoteJid: "120363158967464097@g.us",
+        fromMe: false,
+        participant: "1555@s.whatsapp.net",
+      },
+      message: { conversation: "group hello" },
+    });
   });
 });

--- a/extensions/whatsapp/src/inbound/quoted-message-cache.test.ts
+++ b/extensions/whatsapp/src/inbound/quoted-message-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createQuotedMessageCache, normalizeQuotedMessage } from "./quoted-message-cache.js";
 
 describe("normalizeQuotedMessage", () => {
@@ -321,5 +321,38 @@ describe("createQuotedMessageCache", () => {
       },
       message: { conversation: "group hello" },
     });
+  });
+
+  it("expires stale entries on resolve without needing another write", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-03-21T00:00:00Z"));
+      const cache = createQuotedMessageCache({ ttlMs: 1_000 });
+      cache.remember({
+        message: {
+          key: {
+            id: "msg-1",
+            remoteJid: "1234567890@lid",
+            fromMe: false,
+          },
+          message: { conversation: "hello there" },
+        },
+        messageId: "msg-1",
+        remoteJid: "1234567890@lid",
+        normalizedJid: "1555@s.whatsapp.net",
+        isGroup: false,
+      });
+
+      vi.setSystemTime(new Date("2026-03-21T00:00:02Z"));
+
+      expect(
+        cache.resolve({
+          jid: "1555@s.whatsapp.net",
+          replyToId: "msg-1",
+        }),
+      ).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/whatsapp/src/inbound/quoted-message-cache.test.ts
+++ b/extensions/whatsapp/src/inbound/quoted-message-cache.test.ts
@@ -32,6 +32,31 @@ describe("normalizeQuotedMessage", () => {
     });
   });
 
+  it("preserves fromMe for self-chat quoted replies", () => {
+    const normalized = normalizeQuotedMessage({
+      message: {
+        key: {
+          id: "msg-self-1",
+          remoteJid: "1555@s.whatsapp.net",
+          fromMe: true,
+        },
+        message: { conversation: "note to self" },
+      },
+      messageId: "msg-self-1",
+      remoteJid: "1555@s.whatsapp.net",
+      isGroup: false,
+    });
+
+    expect(normalized).toEqual({
+      key: {
+        id: "msg-self-1",
+        remoteJid: "1555@s.whatsapp.net",
+        fromMe: true,
+      },
+      message: { conversation: "note to self" },
+    });
+  });
+
   it("preserves group participant identity while keeping the group jid", () => {
     const normalized = normalizeQuotedMessage({
       message: {

--- a/extensions/whatsapp/src/inbound/quoted-message-cache.ts
+++ b/extensions/whatsapp/src/inbound/quoted-message-cache.ts
@@ -96,13 +96,16 @@ export function createQuotedMessageCache(options?: { limit?: number; ttlMs?: num
     }
   };
 
-  const prune = () => {
+  const pruneExpiredEntries = () => {
     const now = Date.now();
     for (const [entryKey, entry] of entries.entries()) {
       if (now - entry.storedAt > ttlMs) {
         deleteEntry(entryKey);
       }
     }
+  };
+
+  const pruneOverflowEntries = () => {
     while (entries.size > limit) {
       const oldestEntryKey = entries.keys().next().value;
       if (!oldestEntryKey) {
@@ -159,11 +162,12 @@ export function createQuotedMessageCache(options?: { limit?: number; ttlMs?: num
     for (const aliasKey of aliasKeys) {
       aliasIndex.set(aliasKey, entryKey);
     }
-    prune();
+    pruneExpiredEntries();
+    pruneOverflowEntries();
   };
 
   const resolve = (params: { jid: string; replyToId: string }): WAMessage | undefined => {
-    prune();
+    pruneExpiredEntries();
     const entryKey = aliasIndex.get(createQuotedMessageAliasKey(params.jid, params.replyToId));
     const message = entryKey ? entries.get(entryKey)?.message : undefined;
     return message ? alignQuotedMessageToJid(message, params.jid) : undefined;

--- a/extensions/whatsapp/src/inbound/quoted-message-cache.ts
+++ b/extensions/whatsapp/src/inbound/quoted-message-cache.ts
@@ -39,7 +39,7 @@ export function normalizeQuotedMessage(params: {
       ...restKey,
       id: messageId,
       remoteJid,
-      fromMe: false,
+      fromMe: params.message.key?.fromMe ?? false,
       ...(participant ? { participant } : {}),
     },
   };

--- a/extensions/whatsapp/src/inbound/quoted-message-cache.ts
+++ b/extensions/whatsapp/src/inbound/quoted-message-cache.ts
@@ -1,0 +1,127 @@
+import type { WAMessage } from "@whiskeysockets/baileys";
+
+const DEFAULT_QUOTED_MESSAGE_CACHE_LIMIT = 512;
+const DEFAULT_QUOTED_MESSAGE_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+type CachedQuotedMessage = {
+  message: WAMessage;
+  storedAt: number;
+};
+
+export function normalizeQuotedMessage(params: {
+  message: WAMessage;
+  messageId?: string;
+  remoteJid?: string;
+  participantJid?: string;
+  isGroup?: boolean;
+}): WAMessage | undefined {
+  const messageId = params.messageId?.trim() || params.message.key?.id?.trim();
+  const remoteJid = params.remoteJid?.trim() || params.message.key?.remoteJid?.trim();
+  if (!messageId || !remoteJid || !params.message.message) {
+    return undefined;
+  }
+
+  const participant = params.isGroup
+    ? params.participantJid?.trim() || params.message.key?.participant?.trim() || undefined
+    : undefined;
+  const { participant: _ignoredParticipant, ...restKey } = params.message.key ?? {};
+
+  return {
+    ...params.message,
+    key: {
+      // Keep the original key metadata from the inbound message so we do not
+      // throw away Baileys addressing hints such as remoteJidAlt/participantAlt.
+      ...restKey,
+      id: messageId,
+      remoteJid,
+      fromMe: false,
+      ...(participant ? { participant } : {}),
+    },
+  };
+}
+
+function alignQuotedMessageToJid(message: WAMessage, jid: string): WAMessage {
+  const cachedRemoteJid = message.key.remoteJid?.trim();
+  if (!cachedRemoteJid || cachedRemoteJid === jid || cachedRemoteJid.endsWith("@g.us")) {
+    return message;
+  }
+  return {
+    ...message,
+    key: {
+      ...message.key,
+      // Baileys compares the outbound jid against quoted.key.remoteJid when
+      // building contextInfo, so direct-chat quotes should follow the actual
+      // send target while retaining the original inbound identifier for future
+      // reconciliation.
+      remoteJid: jid,
+      remoteJidAlt: cachedRemoteJid,
+    },
+  };
+}
+
+export function createQuotedMessageCache(options?: { limit?: number; ttlMs?: number }) {
+  const cache = new Map<string, CachedQuotedMessage>();
+  const limit = options?.limit ?? DEFAULT_QUOTED_MESSAGE_CACHE_LIMIT;
+  const ttlMs = options?.ttlMs ?? DEFAULT_QUOTED_MESSAGE_CACHE_TTL_MS;
+
+  const prune = () => {
+    const now = Date.now();
+    for (const [key, entry] of cache.entries()) {
+      if (now - entry.storedAt > ttlMs) {
+        cache.delete(key);
+      }
+    }
+    while (cache.size > limit) {
+      const oldestKey = cache.keys().next().value;
+      if (!oldestKey) {
+        break;
+      }
+      cache.delete(oldestKey);
+    }
+  };
+
+  const remember = (params: {
+    message: WAMessage;
+    remoteJid?: string;
+    normalizedJid?: string;
+    messageId?: string;
+    participantJid?: string;
+    isGroup?: boolean;
+  }) => {
+    const normalizedMessage = normalizeQuotedMessage({
+      message: params.message,
+      messageId: params.messageId,
+      remoteJid: params.remoteJid,
+      participantJid: params.participantJid,
+      isGroup: params.isGroup,
+    });
+    const messageId = normalizedMessage?.key?.id?.trim();
+    if (!normalizedMessage || !messageId) {
+      return;
+    }
+    const storedAt = Date.now();
+    // Index by both the stored inbound JID and the normalized outbound JID so
+    // direct-chat replies can resolve the same message from either shape.
+    const candidateJids = [params.remoteJid, params.normalizedJid]
+      .map((value) => value?.trim())
+      .filter((value): value is string => Boolean(value));
+    for (const jid of candidateJids) {
+      cache.set(`${jid}:${messageId}`, {
+        message: normalizedMessage,
+        storedAt,
+      });
+    }
+    prune();
+  };
+
+  const resolve = (params: { jid: string; replyToId: string }): WAMessage | undefined => {
+    prune();
+    const message = cache.get(`${params.jid}:${params.replyToId}`)?.message;
+    return message ? alignQuotedMessageToJid(message, params.jid) : undefined;
+  };
+
+  return {
+    remember,
+    resolve,
+  };
+}

--- a/extensions/whatsapp/src/inbound/quoted-message-cache.ts
+++ b/extensions/whatsapp/src/inbound/quoted-message-cache.ts
@@ -6,7 +6,12 @@ const DEFAULT_QUOTED_MESSAGE_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 type CachedQuotedMessage = {
   message: WAMessage;
   storedAt: number;
+  aliasKeys: Set<string>;
 };
+
+function createQuotedMessageAliasKey(jid: string, messageId: string): string {
+  return `${jid}:${messageId}`;
+}
 
 export function normalizeQuotedMessage(params: {
   message: WAMessage;
@@ -60,23 +65,50 @@ function alignQuotedMessageToJid(message: WAMessage, jid: string): WAMessage {
 }
 
 export function createQuotedMessageCache(options?: { limit?: number; ttlMs?: number }) {
-  const cache = new Map<string, CachedQuotedMessage>();
+  const entries = new Map<string, CachedQuotedMessage>();
+  const aliasIndex = new Map<string, string>();
   const limit = options?.limit ?? DEFAULT_QUOTED_MESSAGE_CACHE_LIMIT;
   const ttlMs = options?.ttlMs ?? DEFAULT_QUOTED_MESSAGE_CACHE_TTL_MS;
 
-  const prune = () => {
-    const now = Date.now();
-    for (const [key, entry] of cache.entries()) {
-      if (now - entry.storedAt > ttlMs) {
-        cache.delete(key);
+  const deleteEntry = (entryKey: string) => {
+    const entry = entries.get(entryKey);
+    if (!entry) {
+      return;
+    }
+    entries.delete(entryKey);
+    for (const aliasKey of entry.aliasKeys) {
+      if (aliasIndex.get(aliasKey) === entryKey) {
+        aliasIndex.delete(aliasKey);
       }
     }
-    while (cache.size > limit) {
-      const oldestKey = cache.keys().next().value;
-      if (!oldestKey) {
+  };
+
+  const detachAlias = (entryKey: string, aliasKey: string) => {
+    const entry = entries.get(entryKey);
+    if (!entry) {
+      aliasIndex.delete(aliasKey);
+      return;
+    }
+    entry.aliasKeys.delete(aliasKey);
+    aliasIndex.delete(aliasKey);
+    if (entry.aliasKeys.size === 0) {
+      entries.delete(entryKey);
+    }
+  };
+
+  const prune = () => {
+    const now = Date.now();
+    for (const [entryKey, entry] of entries.entries()) {
+      if (now - entry.storedAt > ttlMs) {
+        deleteEntry(entryKey);
+      }
+    }
+    while (entries.size > limit) {
+      const oldestEntryKey = entries.keys().next().value;
+      if (!oldestEntryKey) {
         break;
       }
-      cache.delete(oldestKey);
+      deleteEntry(oldestEntryKey);
     }
   };
 
@@ -102,21 +134,38 @@ export function createQuotedMessageCache(options?: { limit?: number; ttlMs?: num
     const storedAt = Date.now();
     // Index by both the stored inbound JID and the normalized outbound JID so
     // direct-chat replies can resolve the same message from either shape.
-    const candidateJids = [params.remoteJid, params.normalizedJid]
+    const candidateJids = [params.remoteJid, params.normalizedJid, normalizedMessage.key?.remoteJid]
       .map((value) => value?.trim())
       .filter((value): value is string => Boolean(value));
-    for (const jid of candidateJids) {
-      cache.set(`${jid}:${messageId}`, {
-        message: normalizedMessage,
-        storedAt,
-      });
+    const aliasKeys = Array.from(
+      new Set(candidateJids.map((jid) => createQuotedMessageAliasKey(jid, messageId))),
+    );
+    const entryKey = aliasKeys[0];
+    if (!entryKey) {
+      return;
+    }
+    deleteEntry(entryKey);
+    for (const aliasKey of aliasKeys) {
+      const existingEntryKey = aliasIndex.get(aliasKey);
+      if (existingEntryKey && existingEntryKey !== entryKey) {
+        detachAlias(existingEntryKey, aliasKey);
+      }
+    }
+    entries.set(entryKey, {
+      message: normalizedMessage,
+      storedAt,
+      aliasKeys: new Set(aliasKeys),
+    });
+    for (const aliasKey of aliasKeys) {
+      aliasIndex.set(aliasKey, entryKey);
     }
     prune();
   };
 
   const resolve = (params: { jid: string; replyToId: string }): WAMessage | undefined => {
     prune();
-    const message = cache.get(`${params.jid}:${params.replyToId}`)?.message;
+    const entryKey = aliasIndex.get(createQuotedMessageAliasKey(params.jid, params.replyToId));
+    const message = entryKey ? entries.get(entryKey)?.message : undefined;
     return message ? alignQuotedMessageToJid(message, params.jid) : undefined;
   };
 

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -1,3 +1,4 @@
+import type { WAMessage } from "@whiskeysockets/baileys";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const recordChannelActivity = vi.fn();
@@ -60,6 +61,29 @@ describe("createWebSendApi", () => {
       accountId: "main",
       direction: "outbound",
     });
+  });
+
+  it("attaches a quoted message when replyToId resolves", async () => {
+    const quotedMessage = {
+      key: { id: "msg-quoted", remoteJid: "1555@s.whatsapp.net", fromMe: false },
+      message: { conversation: "hello there" },
+    } satisfies WAMessage;
+    const apiWithQuoted = createWebSendApi({
+      sock: { sendMessage, sendPresenceUpdate },
+      defaultAccountId: "main",
+      resolveQuotedMessage: ({ jid, replyToId }) =>
+        jid === "1555@s.whatsapp.net" && replyToId === "msg-quoted" ? quotedMessage : undefined,
+    });
+
+    await apiWithQuoted.sendMessage("+1555", "reply", undefined, undefined, {
+      replyToId: "msg-quoted",
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "1555@s.whatsapp.net",
+      { text: "reply" },
+      { quoted: quotedMessage },
+    );
   });
 
   it("supports image media with caption", async () => {

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -86,6 +86,12 @@ describe("createWebSendApi", () => {
     );
   });
 
+  it("skips outbound activity recording when recordActivity is false", async () => {
+    await api.sendMessage("+1555", "hello", undefined, undefined, { recordActivity: false });
+    expect(sendMessage).toHaveBeenCalledWith("1555@s.whatsapp.net", { text: "hello" });
+    expect(recordChannelActivity).not.toHaveBeenCalled();
+  });
+
   it("supports image media with caption", async () => {
     const payload = Buffer.from("img");
     await api.sendMessage("+1555", "cap", payload, "image/jpeg");

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -1,4 +1,4 @@
-import type { AnyMessageContent, WAPresence } from "@whiskeysockets/baileys";
+import type { AnyMessageContent, WAMessage, WAPresence } from "@whiskeysockets/baileys";
 import { recordChannelActivity } from "openclaw/plugin-sdk/infra-runtime";
 import { toWhatsappJid } from "openclaw/plugin-sdk/text-runtime";
 import type { ActiveWebSendOptions } from "../active-listener.js";
@@ -19,10 +19,15 @@ function resolveOutboundMessageId(result: unknown): string {
 
 export function createWebSendApi(params: {
   sock: {
-    sendMessage: (jid: string, content: AnyMessageContent) => Promise<unknown>;
+    sendMessage: (
+      jid: string,
+      content: AnyMessageContent,
+      options?: { quoted?: WAMessage },
+    ) => Promise<unknown>;
     sendPresenceUpdate: (presence: WAPresence, jid?: string) => Promise<unknown>;
   };
   defaultAccountId: string;
+  resolveQuotedMessage?: (params: { jid: string; replyToId: string }) => WAMessage | undefined;
 }) {
   return {
     sendMessage: async (
@@ -33,6 +38,13 @@ export function createWebSendApi(params: {
       sendOptions?: ActiveWebSendOptions,
     ): Promise<{ messageId: string }> => {
       const jid = toWhatsappJid(to);
+      const replyToId = sendOptions?.replyToId?.trim() || undefined;
+      const quoted = replyToId
+        ? params.resolveQuotedMessage?.({
+            jid,
+            replyToId,
+          })
+        : undefined;
       let payload: AnyMessageContent;
       if (mediaBuffer && mediaType) {
         if (mediaType.startsWith("image/")) {
@@ -63,7 +75,9 @@ export function createWebSendApi(params: {
       } else {
         payload = { text };
       }
-      const result = await params.sock.sendMessage(jid, payload);
+      const result = quoted
+        ? await params.sock.sendMessage(jid, payload, { quoted })
+        : await params.sock.sendMessage(jid, payload);
       const accountId = sendOptions?.accountId ?? params.defaultAccountId;
       recordWhatsAppOutbound(accountId);
       const messageId = resolveOutboundMessageId(result);

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -11,6 +11,10 @@ function recordWhatsAppOutbound(accountId: string) {
   });
 }
 
+function shouldRecordOutboundActivity(sendOptions?: ActiveWebSendOptions): boolean {
+  return sendOptions?.recordActivity !== false;
+}
+
 function resolveOutboundMessageId(result: unknown): string {
   return typeof result === "object" && result && "key" in result
     ? String((result as { key?: { id?: string } }).key?.id ?? "unknown")
@@ -78,8 +82,10 @@ export function createWebSendApi(params: {
       const result = quoted
         ? await params.sock.sendMessage(jid, payload, { quoted })
         : await params.sock.sendMessage(jid, payload);
-      const accountId = sendOptions?.accountId ?? params.defaultAccountId;
-      recordWhatsAppOutbound(accountId);
+      if (shouldRecordOutboundActivity(sendOptions)) {
+        const accountId = sendOptions?.accountId ?? params.defaultAccountId;
+        recordWhatsAppOutbound(accountId);
+      }
       const messageId = resolveOutboundMessageId(result);
       return { messageId };
     },

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -1,5 +1,6 @@
 import type { AnyMessageContent, WAMessage, WAPresence } from "@whiskeysockets/baileys";
 import { recordChannelActivity } from "openclaw/plugin-sdk/infra-runtime";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { toWhatsappJid } from "openclaw/plugin-sdk/text-runtime";
 import type { ActiveWebSendOptions } from "../active-listener.js";
 
@@ -49,6 +50,9 @@ export function createWebSendApi(params: {
             replyToId,
           })
         : undefined;
+      if (replyToId && !quoted) {
+        logVerbose(`WhatsApp quoted reply target ${replyToId} was not found for ${jid}`);
+      }
       let payload: AnyMessageContent;
       if (mediaBuffer && mediaType) {
         if (mediaType.startsWith("image/")) {

--- a/extensions/whatsapp/src/inbound/types.ts
+++ b/extensions/whatsapp/src/inbound/types.ts
@@ -34,8 +34,8 @@ export type WebInboundMessage = {
   fromMe?: boolean;
   location?: NormalizedLocation;
   sendComposing: () => Promise<void>;
-  reply: (text: string) => Promise<void>;
-  sendMedia: (payload: AnyMessageContent) => Promise<void>;
+  reply: (text: string, options?: { replyToId?: string }) => Promise<void>;
+  sendMedia: (payload: AnyMessageContent, options?: { replyToId?: string }) => Promise<void>;
   mediaPath?: string;
   mediaType?: string;
   mediaFileName?: string;

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
@@ -384,4 +384,75 @@ describe("web monitor inbox", () => {
 
     await listener.close();
   });
+
+  it("preserves caller audio flags when replying with buffered media", async () => {
+    const audioPayload = {
+      audio: Buffer.from("aud"),
+      mimetype: "audio/ogg",
+      ptt: false,
+    } satisfies AnyMessageContent;
+    const onMessage = vi.fn(async (msg) => {
+      await msg.sendMedia(audioPayload, { replyToId: msg.id });
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage);
+    const upsert = buildMessageUpsert({
+      id: "abc",
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+
+    expect(sock.sendMessage).toHaveBeenLastCalledWith("999@s.whatsapp.net", audioPayload, {
+      quoted: expect.objectContaining({
+        key: expect.objectContaining({
+          id: "abc",
+          remoteJid: "999@s.whatsapp.net",
+          fromMe: false,
+        }),
+      }),
+    });
+
+    await listener.close();
+  });
+
+  it("preserves caller media fields when replying with buffered media", async () => {
+    const imagePayload = {
+      image: Buffer.from("img"),
+      caption: "pong",
+      mimetype: "image/jpeg",
+      contextInfo: { mentionedJid: ["123@s.whatsapp.net"] },
+    } satisfies AnyMessageContent;
+    const onMessage = vi.fn(async (msg) => {
+      await msg.sendMedia(imagePayload, { replyToId: msg.id });
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage);
+    const upsert = buildMessageUpsert({
+      id: "abc",
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+
+    expect(sock.sendMessage).toHaveBeenLastCalledWith("999@s.whatsapp.net", imagePayload, {
+      quoted: expect.objectContaining({
+        key: expect.objectContaining({
+          id: "abc",
+          remoteJid: "999@s.whatsapp.net",
+          fromMe: false,
+        }),
+      }),
+    });
+
+    await listener.close();
+  });
 });

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
@@ -3,7 +3,10 @@ import path from "node:path";
 import type { AnyMessageContent } from "@whiskeysockets/baileys";
 import { describe, expect, it, vi } from "vitest";
 
-const recordChannelActivity = vi.fn();
+const { recordChannelActivity } = vi.hoisted(() => ({
+  recordChannelActivity: vi.fn(),
+}));
+
 vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
   return {

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
@@ -1,7 +1,18 @@
 import fsSync from "node:fs";
 import path from "node:path";
-import "./monitor-inbox.test-harness.js";
+import type { AnyMessageContent } from "@whiskeysockets/baileys";
 import { describe, expect, it, vi } from "vitest";
+
+const recordChannelActivity = vi.fn();
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
+  return {
+    ...actual,
+    recordChannelActivity: (...args: unknown[]) => recordChannelActivity(...args),
+  };
+});
+
+import "./monitor-inbox.test-harness.js";
 import { monitorWebInbox } from "./inbound.js";
 import {
   DEFAULT_ACCOUNT_ID,
@@ -137,6 +148,39 @@ describe("web monitor inbox", () => {
     expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("composing", "999@s.whatsapp.net");
     expect(sock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
       text: "pong",
+    });
+
+    await listener.close();
+  });
+
+  it("does not record outbound activity for inbox auto-replies", async () => {
+    const inlineImagePayload = {
+      image: Buffer.from("img"),
+      caption: "cap",
+      mimetype: "image/jpeg",
+    } satisfies AnyMessageContent;
+    const onMessage = vi.fn(async (msg) => {
+      await msg.reply("pong");
+      await msg.sendMedia(inlineImagePayload, { replyToId: msg.id });
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage);
+    const upsert = buildMessageUpsert({
+      id: "abc",
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+
+    expect(recordChannelActivity).toHaveBeenCalledTimes(1);
+    expect(recordChannelActivity).toHaveBeenCalledWith({
+      channel: "whatsapp",
+      accountId: DEFAULT_ACCOUNT_ID,
+      direction: "inbound",
     });
 
     await listener.close();
@@ -300,5 +344,41 @@ describe("web monitor inbox", () => {
         message: { conversation: "original" },
       },
     });
+  });
+
+  it("keeps quoted reply context when media falls back to a raw Baileys send", async () => {
+    const fallbackImagePayload = {
+      image: { url: "file:///tmp/openclaw-fallback.jpg" },
+      caption: "pong",
+      mimetype: "image/jpeg",
+    } satisfies AnyMessageContent;
+    const onMessage = vi.fn(async (msg) => {
+      await msg.sendMedia(fallbackImagePayload, { replyToId: msg.id });
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage);
+    const upsert = buildMessageUpsert({
+      id: "abc",
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+
+    expect(sock.sendMessage).toHaveBeenLastCalledWith("999@s.whatsapp.net", fallbackImagePayload, {
+      quoted: expect.objectContaining({
+        key: expect.objectContaining({
+          id: "abc",
+          remoteJid: "999@s.whatsapp.net",
+          fromMe: false,
+        }),
+        message: { conversation: "ping" },
+      }),
+    });
+
+    await listener.close();
   });
 });

--- a/extensions/whatsapp/src/outbound-adapter.ts
+++ b/extensions/whatsapp/src/outbound-adapter.ts
@@ -45,7 +45,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
   },
   ...createAttachedChannelResultAdapter({
     channel: "whatsapp",
-    sendText: async ({ cfg, to, text, accountId, deps, gifPlayback }) => {
+    sendText: async ({ cfg, to, text, accountId, deps, gifPlayback, replyToId }) => {
       const normalizedText = trimLeadingWhitespace(text);
       if (!normalizedText) {
         return createEmptyChannelResult("whatsapp");
@@ -58,6 +58,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
         cfg,
         accountId: accountId ?? undefined,
         gifPlayback,
+        replyToId: replyToId ?? undefined,
       });
     },
     sendMedia: async ({
@@ -69,6 +70,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
       accountId,
       deps,
       gifPlayback,
+      replyToId,
     }) => {
       const normalizedText = trimLeadingWhitespace(text);
       const send =
@@ -81,6 +83,7 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
         mediaLocalRoots,
         accountId: accountId ?? undefined,
         gifPlayback,
+        replyToId: replyToId ?? undefined,
       });
     },
     sendPoll: async ({ cfg, to, poll, accountId }) =>

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -48,6 +48,16 @@ describe("web outbound", () => {
     expect(sendMessage).toHaveBeenCalledWith("+1555", "hi", undefined, undefined);
   });
 
+  it("forwards replyToId to the active listener", async () => {
+    await sendMessageWhatsApp("+1555", "reply", {
+      verbose: false,
+      replyToId: "quoted-1",
+    });
+    expect(sendMessage).toHaveBeenCalledWith("+1555", "reply", undefined, undefined, {
+      replyToId: "quoted-1",
+    });
+  });
+
   it("trims leading whitespace before sending text and captions", async () => {
     await sendMessageWhatsApp("+1555", "\n \thello", { verbose: false });
     expect(sendMessage).toHaveBeenLastCalledWith("+1555", "hello", undefined, undefined);

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -24,6 +24,7 @@ export async function sendMessageWhatsApp(
     mediaLocalRoots?: readonly string[];
     gifPlayback?: boolean;
     accountId?: string;
+    replyToId?: string;
   },
 ): Promise<{ messageId: string; toJid: string }> {
   let text = body.trimStart();
@@ -88,11 +89,12 @@ export async function sendMessageWhatsApp(
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId || documentFileName
+      options.gifPlayback || accountId || documentFileName || options.replyToId
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
+            ...(accountId ? { accountId } : {}),
             ...(documentFileName ? { fileName: documentFileName } : {}),
-            accountId,
+            ...(options.replyToId ? { replyToId: options.replyToId } : {}),
           }
         : undefined;
     const result = sendOptions

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1630,6 +1630,8 @@ export async function runEmbeddedPiAgent(
             inlineToolResultsAllowed: false,
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
             didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+            currentMessageId:
+              params.currentMessageId != null ? String(params.currentMessageId) : undefined,
           });
 
           // Timeout aborts can leave the run without any assistant payloads.

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -105,7 +105,7 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expect(payloads[0]?.replyToTag).toBe(true);
   });
 
-  it("does not stamp plain assistant replies with replyToCurrent=false", async () => {
+  it("does not stamp plain assistant replies with replyToCurrent", () => {
     const payloads = buildPayloads({
       assistantTexts: ["plain hello"],
       currentMessageId: "wa-msg-123",
@@ -114,6 +114,14 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.text).toBe("plain hello");
     expect(payloads[0]?.replyToCurrent).toBeUndefined();
+    expect(payloads[0]?.replyToId).toBeUndefined();
+  });
+
+  it("buildReplyPayloads stamps replyToId from currentMessageId when replyToMode is all", async () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["plain hello"],
+      currentMessageId: "wa-msg-123",
+    });
 
     const { replyPayloads } = await buildReplyPayloads({
       payloads,

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { buildReplyPayloads } from "../../../auto-reply/reply/agent-runner-payloads.js";
 import { buildPayloads, expectSingleToolErrorPayload } from "./payloads.test-helpers.js";
 
 describe("buildEmbeddedRunPayloads tool-error warnings", () => {
@@ -89,5 +90,43 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
       assistantTexts: ["Approval is needed. Please run /approve abc allow-once"],
       didSendDeterministicApprovalPrompt: true,
     });
+  });
+
+  it("resolves [[reply_to_current]] using currentMessageId", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["[[reply_to_current]] quoted hello"],
+      currentMessageId: "wa-msg-123",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("quoted hello");
+    expect(payloads[0]?.replyToId).toBe("wa-msg-123");
+    expect(payloads[0]?.replyToCurrent).toBe(true);
+    expect(payloads[0]?.replyToTag).toBe(true);
+  });
+
+  it("does not stamp plain assistant replies with replyToCurrent=false", async () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["plain hello"],
+      currentMessageId: "wa-msg-123",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("plain hello");
+    expect(payloads[0]?.replyToCurrent).toBeUndefined();
+
+    const { replyPayloads } = await buildReplyPayloads({
+      payloads,
+      isHeartbeat: false,
+      didLogHeartbeatStrip: false,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      replyToMode: "all",
+      replyToChannel: "whatsapp",
+      currentMessageId: "wa-msg-123",
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.replyToId).toBe("wa-msg-123");
   });
 });

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -104,6 +104,7 @@ export function buildEmbeddedRunPayloads(params: {
   inlineToolResultsAllowed: boolean;
   didSendViaMessagingTool?: boolean;
   didSendDeterministicApprovalPrompt?: boolean;
+  currentMessageId?: string;
 }): Array<{
   text?: string;
   mediaUrl?: string;
@@ -176,7 +177,7 @@ export function buildEmbeddedRunPayloads(params: {
         replyToId,
         replyToTag,
         replyToCurrent,
-      } = parseReplyDirectives(agg);
+      } = parseReplyDirectives(agg, { currentMessageId: params.currentMessageId });
       if (cleanedText) {
         replyItems.push({
           text: cleanedText,
@@ -184,7 +185,7 @@ export function buildEmbeddedRunPayloads(params: {
           audioAsVoice,
           replyToId,
           replyToTag,
-          replyToCurrent,
+          replyToCurrent: replyToCurrent || undefined,
         });
       }
     }
@@ -268,7 +269,7 @@ export function buildEmbeddedRunPayloads(params: {
       replyToId,
       replyToTag,
       replyToCurrent,
-    } = parseReplyDirectives(text);
+    } = parseReplyDirectives(text, { currentMessageId: params.currentMessageId });
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
       continue;
     }
@@ -278,7 +279,7 @@ export function buildEmbeddedRunPayloads(params: {
       audioAsVoice,
       replyToId,
       replyToTag,
-      replyToCurrent,
+      replyToCurrent: replyToCurrent || undefined,
     });
     hasUserFacingAssistantReply = true;
   }

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -40,6 +40,10 @@ export const SendParamsSchema = Type.Object(
     accountId: Type.Optional(Type.String()),
     /** Optional agent id for per-agent media root resolution on gateway sends. */
     agentId: Type.Optional(Type.String()),
+    /** Reply target id for channels that support quoted replies. */
+    replyTo: Type.Optional(Type.String()),
+    /** Legacy/internal alias for reply target id. */
+    replyToId: Type.Optional(Type.String()),
     /** Thread id (channel-specific meaning, e.g. Telegram forum topic id). */
     threadId: Type.Optional(Type.String()),
     /** Optional session key for mirroring delivered output back into the transcript. */

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -426,6 +426,34 @@ describe("gateway send mirroring", () => {
     expect(call.mirror?.sessionKey).toBe(call.session?.key);
   });
 
+  it("derives a threaded session key from replyTo when threadId is omitted", async () => {
+    mockDeliverySuccess("m-reply-thread");
+    vi.mocked(resolveOutboundTarget).mockReturnValue({
+      ok: true,
+      to: "channel:C123",
+    });
+
+    await runSend({
+      to: "channel:C1",
+      message: "hello",
+      channel: "slack",
+      replyTo: "1710000000.9999",
+      idempotencyKey: "idem-reply-thread",
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({
+          key: "agent:main:slack:channel:c123:thread:1710000000.9999",
+        }),
+        mirror: expect.objectContaining({
+          sessionKey: "agent:main:slack:channel:c123:thread:1710000000.9999",
+        }),
+        replyToId: "1710000000.9999",
+      }),
+    );
+  });
+
   it("uses explicit agentId for delivery when sessionKey is not provided", async () => {
     mockDeliverySuccess("m-agent");
 

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -178,6 +178,31 @@ describe("gateway send mirroring", () => {
     );
   });
 
+  it("accepts replyTo fields and forwards a normalized reply target", async () => {
+    mockDeliverySuccess("m-reply");
+
+    const { respond } = await runSend({
+      to: "channel:C1",
+      message: "reply body",
+      channel: "slack",
+      replyTo: " msg-123 ",
+      replyToId: "ignored-legacy-value",
+      idempotencyKey: "idem-reply",
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToId: "msg-123",
+      }),
+    );
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ messageId: "m-reply" }),
+      undefined,
+      expect.objectContaining({ channel: "slack" }),
+    );
+  });
+
   it("rejects empty sends when neither text nor media is present", async () => {
     const { respond } = await runSend({
       to: "channel:C1",
@@ -392,15 +417,13 @@ describe("gateway send mirroring", () => {
       idempotencyKey: "idem-4",
     });
 
-    expect(mocks.recordSessionMetaFromInbound).toHaveBeenCalled();
-    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
-      expect.objectContaining({
-        mirror: expect.objectContaining({
-          sessionKey: "agent:main:slack:channel:resolved",
-          agentId: "main",
-        }),
-      }),
-    );
+    const call = mocks.deliverOutboundPayloads.mock.calls[0]?.[0] as {
+      session?: { key?: string; agentId?: string };
+      mirror?: { sessionKey?: string; agentId?: string };
+    };
+    expect(call.session?.agentId).toBe("main");
+    expect(call.mirror?.agentId).toBe("main");
+    expect(call.mirror?.sessionKey).toBe(call.session?.key);
   });
 
   it("uses explicit agentId for delivery when sessionKey is not provided", async () => {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -111,6 +111,8 @@ export const sendHandlers: GatewayRequestHandlers = {
       channel?: string;
       accountId?: string;
       agentId?: string;
+      replyTo?: string;
+      replyToId?: string;
       threadId?: string;
       sessionKey?: string;
       idempotencyKey: string;
@@ -165,6 +167,12 @@ export const sendHandlers: GatewayRequestHandlers = {
       typeof request.accountId === "string" && request.accountId.trim().length
         ? request.accountId.trim()
         : undefined;
+    const replyToId =
+      typeof request.replyTo === "string" && request.replyTo.trim().length
+        ? request.replyTo.trim()
+        : typeof request.replyToId === "string" && request.replyToId.trim().length
+          ? request.replyToId.trim()
+          : undefined;
     const threadId =
       typeof request.threadId === "string" && request.threadId.trim().length
         ? request.threadId.trim()
@@ -261,6 +269,7 @@ export const sendHandlers: GatewayRequestHandlers = {
           payloads: [{ text: message, mediaUrl, mediaUrls }],
           session: outboundSession,
           gifPlayback: request.gifPlayback,
+          replyToId: replyToId ?? null,
           threadId: threadId ?? null,
           deps: outboundDeps,
           mirror: providedSessionKey

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -244,6 +244,7 @@ export const sendHandlers: GatewayRequestHandlers = {
               accountId,
               target: deliveryTarget,
               resolvedTarget: idLikeTarget,
+              replyToId,
               threadId,
             })
           : null;

--- a/src/infra/outbound/message.channels.test.ts
+++ b/src/infra/outbound/message.channels.test.ts
@@ -303,6 +303,25 @@ describe("gateway url override hardening", () => {
     };
     expect(call.params?.agentId).toBe("work");
   });
+
+  it("forwards replyToId into gateway send params", async () => {
+    setMattermostGatewayRegistry();
+
+    callGatewayMock.mockResolvedValueOnce({ messageId: "m-reply" });
+    await sendMessage({
+      cfg: {},
+      to: "channel:town-square",
+      content: "thread reply",
+      channel: "mattermost",
+      replyToId: "post-root",
+    });
+
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      params?: Record<string, unknown>;
+    };
+    expect(call.params?.replyTo).toBe("post-root");
+    expect(call.params?.replyToId).toBe("post-root");
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -283,6 +283,8 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       gifPlayback: params.gifPlayback,
       accountId: params.accountId,
       agentId: params.agentId,
+      replyTo: params.replyToId,
+      replyToId: params.replyToId,
       channel,
       sessionKey: params.mirror?.sessionKey,
       idempotencyKey: params.idempotencyKey ?? randomIdempotencyKey(),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: WhatsApp Web accepted reply targets in shared send plumbing, but the WhatsApp send path still emitted plain replies instead of native quoted replies.
- Why it matters: manual sends, gateway sends, and web auto-replies lost the quote context users expect in WhatsApp.
- What changed: threaded `replyToId` through gateway and outbound delivery, remembered inbound WhatsApp messages for quote lookup, and aligned direct-chat quote JIDs for Baileys.
- What did NOT change (scope boundary): this does not redesign the repo's broader E.164/LID identity model or claim live-device validation for inbound `@lid` chats.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #42231

## User-visible / Behavior Changes

- WhatsApp Web sends can now produce native quoted replies when a valid `replyToId` is provided through the existing send pipeline.
- Web auto-replies now forward quote targets instead of always sending plain replies.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): WhatsApp Web
- Relevant config (redacted): standard local dev config

### Steps

1. Receive an inbound WhatsApp message that should be replyable by id.
2. Send through the existing OpenClaw outbound path with `replyToId` set to that inbound message id.
3. Verify that the WhatsApp Web send path resolves the remembered inbound message and attaches it as a native quoted reply.

### Expected

- WhatsApp outbound sends use native quote context instead of dropping back to plain text replies.
- Direct-chat and group quote metadata stay aligned with Baileys expectations.

### Actual

- The quote target is threaded through the gateway/outbound stack and resolved in the WhatsApp Web send path.
- Focused regression coverage passes for direct chats, groups, cache lookup, gateway plumbing, runner payloads, and inbox monitor behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ x] Screenshot/recording
- [ ] Perf numbers (if relevant)

<img width="1290" height="660" alt="image" src="https://github.com/user-attachments/assets/9fd2cdc1-5a21-4897-bcbe-17f1d55581f2" />


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm check`; ran focused regression coverage for WhatsApp send/inbound/auto-reply, inbox monitor behavior, gateway send plumbing, runner payloads, outbound message plumbing, and utils.
- Edge cases checked: direct-chat `@lid` to `@s.whatsapp.net` JID rebinding, group quote participant preservation, metadata preservation during rebinding, and no cross-chat quote resolution.
- What you did **not** verify: live-device end-to-end quoting against an inbound `@lid` WhatsApp chat.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `85563d173c`.
- Files/config to restore: restore the previous WhatsApp quote-send path and remove the new quote cache module.
- Known bad symptoms reviewers should watch for: WhatsApp replies sending without native quote context, or direct-chat quotes pointing at the wrong JID shape.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Baileys direct-chat identity handling can still differ on live-device `@lid` traffic.
  - Mitigation: the send path now rebinding quotes to the actual outbound JID preserves the original inbound identifier in metadata, and focused regression coverage exercises both direct and group paths.
