### PR TITLE
fix: redact raw error messages from channel-facing agent failure replies

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
@@ -193,25 +193,23 @@ describe("trigger handling", () => {
     getReplyFromConfig: () => getReplyFromConfig,
   });
 
-  for (const testCase of [
-    {
-      error: "sandbox is not defined.",
-      expected:
-        "⚠️ Agent failed before reply: sandbox is not defined.\nLogs: openclaw logs --follow",
-    },
-    {
-      error: "Context window exceeded",
-      expected:
-        "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model.",
-    },
-  ] as const) {
-    it(`surfaces agent error: ${testCase.error}`, async () => {
-      await withTempHome(async (home) => {
-        const runEmbeddedPiAgentMock = getRunEmbeddedPiAgentMock();
-        runEmbeddedPiAgentMock.mockReset();
-        runEmbeddedPiAgentMock.mockImplementation(async () => {
-          throw new Error(testCase.error);
-        });
+it("handles trigger command and heartbeat flows end-to-end", async () => {
+    await withTempHome(async (home) => {
+      const runEmbeddedPiAgentMock = getRunEmbeddedPiAgentMock();
+      const errorCases = [
+        {
+          error: "sandbox is not defined.",
+          expected: "⚠️ Agent failed before reply. Check `openclaw logs --follow` for details.",
+        },
+        {
+          error: "Context window exceeded",
+          expected:
+            "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model.",
+        },
+      ] as const;
+      for (const testCase of errorCases) {
+        runEmbeddedPiAgentMock.mockClear();
+        runEmbeddedPiAgentMock.mockRejectedValue(new Error(testCase.error));
         const errorRes = await getReplyFromConfig(BASE_MESSAGE, {}, makeCfg(home));
         expect(maybeReplyText(errorRes), testCase.error).toBe(testCase.expected);
         expect(runEmbeddedPiAgentMock, testCase.error).toHaveBeenCalledOnce();

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -563,6 +563,7 @@ export async function runAgentTurnWithFallback(params: {
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
       const isTransientHttp = isTransientHttpError(message);
+      const isSandboxOrSecurity = /sandbox security|outside allowed roots/i.test(message);
 
       if (
         isCompactionFailure &&
@@ -650,17 +651,15 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
-      const safeMessage = isTransientHttp
-        ? sanitizeUserFacingText(message, { errorContext: true })
-        : message;
-      const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
       const fallbackText = isBilling
         ? BILLING_ERROR_USER_MESSAGE
         : isContextOverflow
           ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
           : isRoleOrderingError
             ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+            : isSandboxOrSecurity
+              ? "⚠️ Agent failed to start due to a configuration error. Check `openclaw logs --follow` for details."
+              : "⚠️ Agent failed before reply. Check `openclaw logs --follow` for details.";
 
       return {
         kind: "final",


### PR DESCRIPTION
## Summary

Fixes #51275 — agent preflight errors (sandbox security violations, config issues, etc.) were being forwarded verbatim to channels like Discord, leaking internal filesystem paths, OS usernames, and sandbox configuration details.

## Changes

**`src/auto-reply/reply/agent-runner-execution.ts`:**
- Added `isSandboxOrSecurity` classifier for sandbox security error messages
- Sandbox/security errors now show: *"Agent failed to start due to a configuration error"*
- All other unclassified errors now show: *"Agent failed before reply"* (generic, no raw message)
- Removed unused `safeMessage`/`trimmedMessage` variables (error details are no longer interpolated into user-facing text)
- Full error details are still logged via `defaultRuntime.error()` and visible in `openclaw logs --follow`

**`src/auto-reply/reply.triggers...e2e.test.ts`:**
- Updated expected error text to match new generic format

## Security Impact

Before: channel messages could contain:
- Full filesystem paths including OS username
- Sandbox configuration details (bind mounts, allowed roots)
- Internal workspace directory structure

After: all error details stay in operator logs only.