### PR TITLE
fix(ios): guard sendPing continuation against double-resume crash

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -44,7 +44,14 @@ public struct WebSocketTaskBox: @unchecked Sendable {
 
     public func sendPing() async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let resumed = OSAllocatedUnfairLock(initialState: false)
             self.task.sendPing { error in
+                let alreadyResumed = resumed.withLock { value -> Bool in
+                    if value { return true }
+                    value = true
+                    return false
+                }
+                guard !alreadyResumed else { return }
                 ThrowingContinuationSupport.resumeVoid(continuation, error: error)
             }
         }


### PR DESCRIPTION
URLSessionWebSocketTask.sendPing can invoke its pongReceiveHandler more than once on connection abort, fatally crashing the CheckedContinuation. Use OSAllocatedUnfairLock to ensure only the first callback resumes the continuation.

## Summary

- **Problem:** `URLSessionWebSocketTask.sendPing(pongReceiveHandler:)` can invoke its callback more than once when the underlying TCP connection is aborted (`NSPOSIXErrorDomain Code=53`). `withCheckedThrowingContinuation` fatally traps on the second resume.
- **Why it matters:** This is a runtime crash in the keepalive loop — any connection drop during a ping can kill the app.
- **What changed:** Added an `OSAllocatedUnfairLock<Bool>` guard in `WebSocketTaskBox.sendPing()` so only the first callback resumes the continuation; subsequent invocations are silently ignored.
- **What did NOT change (scope boundary):** No changes to keepalive timing, reconnect logic, or any other WebSocket handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

None. The app no longer crashes when the gateway connection drops during a keepalive ping.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: iOS / macOS (any version supporting `OSAllocatedUnfairLock`, iOS 16+)
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel: Gateway WebSocket keepalive

### Steps

1. Connect to a gateway over WebSocket.
2. Force-kill the gateway or sever the network connection mid-ping (e.g., airplane mode toggle, `kill -9` the gateway process).
3. Observe the keepalive ping fires during the connection abort window.

### Expected

- The `sendPing` throws an error, caught by the keepalive loop's `catch` block. App continues and reconnects.

### Actual (before fix)

- `Fatal error: SWIFT TASK CONTINUATION MISUSE: sendPing() tried to resume its continuation more than once`

## Evidence

- [x] Crash log: `_Concurrency/CheckedContinuation.swift:196: Fatal error: SWIFT TASK CONTINUATION MISUSE: sendPing() tried to resume its continuation more than once, throwing Error Domain=NSPOSIXErrorDomain Code=53 "Software caused connection abort"`

## Human Verification (required)

- Verified scenarios: Code-level review confirms `OSAllocatedUnfairLock` guarantees at-most-once resume semantics regardless of callback count or thread.
- Edge cases checked: Concurrent invocations from multiple threads; normal single-callback path still works identically.
- What I did **not** verify: Full integration test on a physical device (requires gateway setup + network disruption).

## Review Conversations

- [x] N/A — new PR.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert commit `6442a74032`.
- Files to restore: `apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift`
- Known bad symptoms: If reverted, the original double-resume crash returns under connection abort conditions.

## Risks and Mitigations

- **Risk:** Second (dropped) callback could carry a different error than the first — caller only sees the first error.
  - **Mitigation:** The keepalive loop already ignores ping errors (`catch {}`), so the specific error value is irrelevant. The first error is the most accurate one regardless.