### PR TITLE
fix(cron): prevent isolated sessions from rewriting their own config

### DIFF
--- a/src/cron/isolated-agent.config-write-guard.test.ts
+++ b/src/cron/isolated-agent.config-write-guard.test.ts
@@ -1,0 +1,54 @@
+import "./isolated-agent.mocks.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { createCliDeps } from "./isolated-agent.delivery.test-helpers.js";
+import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+import {
+  makeCfg,
+  makeJob,
+  withTempCronHome,
+  writeSessionStore,
+} from "./isolated-agent.test-harness.js";
+import { setupIsolatedAgentTurnMocks } from "./isolated-agent.test-setup.js";
+
+describe("isolated cron sessions must not have config-write tools (#44940)", () => {
+  beforeEach(() => {
+    setupIsolatedAgentTurnMocks({ fast: true });
+  });
+
+  it("passes senderIsOwner=false so cron and gateway tools are stripped", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      vi.mocked(runEmbeddedPiAgent).mockResolvedValue({
+        payloads: [{ text: "done" }],
+        meta: {
+          durationMs: 5,
+          agentMeta: { sessionId: "s", provider: "anthropic", model: "claude-haiku-4-5" },
+        },
+      });
+
+      const cfg = makeCfg(home, storePath);
+
+      const res = await runCronIsolatedAgentTurn({
+        cfg,
+        deps: createCliDeps(),
+        job: makeJob({ kind: "agentTurn", message: "check status", deliver: false }),
+        message: "check status",
+        sessionKey: "cron:job-1",
+        lane: "cron",
+      });
+
+      expect(res.status).toBe("ok");
+      expect(vi.mocked(runEmbeddedPiAgent)).toHaveBeenCalledTimes(1);
+
+      const callArgs = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0] as {
+        senderIsOwner?: boolean;
+      };
+
+      // senderIsOwner must be false for isolated cron sessions to prevent
+      // models from rewriting their own cron job config via cron.update or
+      // config.apply tools.
+      expect(callArgs?.senderIsOwner).toBe(false);
+    });
+  });
+});

--- a/src/cron/isolated-agent/run.owner-auth.test.ts
+++ b/src/cron/isolated-agent/run.owner-auth.test.ts
@@ -52,15 +52,17 @@ describe("runCronIsolatedAgentTurn owner auth", () => {
     restoreFastTestEnv(previousFastTestEnv);
   });
 
-  it("passes senderIsOwner=true to isolated cron agent runs", async () => {
+  it("passes senderIsOwner=false to prevent config-write tools (#44940)", async () => {
     await runCronIsolatedAgentTurn(makeParams());
 
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     const senderIsOwner = runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.senderIsOwner;
-    expect(senderIsOwner).toBe(true);
+    expect(senderIsOwner).toBe(false);
 
+    // With senderIsOwner=false, cron and gateway tools are stripped,
+    // preventing isolated sessions from rewriting their own config.
     const toolNames = createOpenClawCodingTools({ senderIsOwner }).map((tool) => tool.name);
-    expect(toolNames).toContain("cron");
-    expect(toolNames).toContain("gateway");
+    expect(toolNames).not.toContain("cron");
+    expect(toolNames).not.toContain("gateway");
   });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -631,9 +631,11 @@ export async function runCronIsolatedAgentTurn(params: {
             // Cron runs execute inside the gateway process and need the same
             // explicit subagent late-binding as other gateway-owned runners.
             allowGatewaySubagentBinding: true,
-            // Cron jobs are trusted local automation, so isolated runs should
-            // inherit owner-only tooling like local `openclaw agent` runs.
-            senderIsOwner: true,
+            // Isolated cron sessions must NOT have owner-level tool access.
+            // With senderIsOwner=true, the agent gets cron and gateway tools
+            // which let smaller models "helpfully" rewrite their own cron job
+            // config via cron.update or config.apply (#44940).
+            senderIsOwner: false,
             messageChannel,
             agentAccountId: resolvedDelivery.accountId,
             sessionFile,


### PR DESCRIPTION
## Summary

Isolated `agentTurn` cron sessions could modify their own cron job configuration because `senderIsOwner` was unconditionally set to `true`, granting access to `cron` and `gateway` tools. Smaller models (Haiku, Kimi) were particularly prone to "helpfully" normalizing configs via these tools, rewriting `sessionTarget: isolated` back to `sessionTarget: main`.

Fixes #44940.

## What Changed

**`src/cron/isolated-agent/run.ts`:**
- Changed `senderIsOwner: true` → `senderIsOwner: false` for isolated cron sessions
- With `senderIsOwner: false`, `applyOwnerOnlyToolPolicy` strips `cron`, `gateway`, `whatsapp_login`, and `nodes` tools from the agent's tool list
- The `exec` tool is **not** owner-only and remains available for legitimate shell commands

**`src/cron/isolated-agent/run.owner-auth.test.ts`:**
- Updated existing test to verify the new behavior: `senderIsOwner=false` and `cron`/`gateway` tools are **not** present

**`src/cron/isolated-agent.config-write-guard.test.ts`:**
- New regression test confirming isolated cron sessions receive `senderIsOwner=false`

## Linked Issues

- Fixes #44940 — Isolated agentTurn cron session rewrites its own cron job

## Verification

**Automated:**
- All 523 cron tests pass (67 test files, 0 failures)
- `pnpm build` succeeds
- All lint and format checks pass

**Manual:**
- Verified `OWNER_ONLY_TOOL_NAME_FALLBACKS` contains only `whatsapp_login`, `cron`, `gateway`, `nodes` — none needed for cron task execution
- Confirmed `exec` tool is not in this set, so legitimate shell commands remain available

## Known Unrelated Failures

None. CI should be clean for the cron test suite.

## Risks / Mitigations

**Risk:** Isolated cron sessions lose access to `cron`, `gateway`, `whatsapp_login`, and `nodes` tools.

**Mitigation:** None of these tools are needed for isolated cron task execution:
- `cron` tool: config modification (the bug itself)
- `gateway` tool: config.apply/config.patch (same class of bug)
- `whatsapp_login`: irrelevant for cron
- `nodes`: irrelevant for cron

**Note:** The `exec` tool remains available and could theoretically run `openclaw config set` as a shell command. This is a separate, narrower attack surface that could be addressed in a follow-up with exec command filtering.