### PR TITLE
feat(tts): add Azure Speech TTS provider

### DIFF
--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -93,6 +93,16 @@ export type TtsConfig = {
     proxy?: string;
     timeoutMs?: number;
   };
+  /** Azure Speech configuration. */
+  azure?: {
+    apiKey?: SecretInput;
+    region?: string;
+    baseUrl?: string;
+    voice?: string;
+    lang?: string;
+    outputFormat?: string;
+    timeoutMs?: number;
+  };
   /** Optional path for local TTS user preferences JSON. */
   prefsPath?: string;
   /** Hard cap for text sent to TTS (chars). */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -392,6 +392,18 @@ const TtsMicrosoftConfigSchema = z
   })
   .strict()
   .optional();
+const TtsAzureConfigSchema = z
+  .object({
+    apiKey: SecretInputSchema.optional().register(sensitive),
+    region: z.string().optional(),
+    baseUrl: z.string().optional(),
+    voice: z.string().optional(),
+    lang: z.string().optional(),
+    outputFormat: z.string().optional(),
+    timeoutMs: z.number().int().min(1000).max(120000).optional(),
+  })
+  .strict()
+  .optional();
 export const TtsConfigSchema = z
   .object({
     auto: TtsAutoSchema.optional(),
@@ -447,6 +459,7 @@ export const TtsConfigSchema = z
       .optional(),
     edge: TtsMicrosoftConfigSchema,
     microsoft: TtsMicrosoftConfigSchema,
+    azure: TtsAzureConfigSchema,
     prefsPath: z.string().optional(),
     maxTextLength: z.number().int().min(1).optional(),
     timeoutMs: z.number().int().min(1000).max(120000).optional(),

--- a/src/tts/provider-registry.ts
+++ b/src/tts/provider-registry.ts
@@ -3,6 +3,7 @@ import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
 import type { SpeechProviderId } from "./provider-types.js";
+import { buildAzureSpeechProvider } from "./providers/azure.js";
 import { buildElevenLabsSpeechProvider } from "./providers/elevenlabs.js";
 import { buildMicrosoftSpeechProvider } from "./providers/microsoft.js";
 import { buildOpenAISpeechProvider } from "./providers/openai.js";
@@ -11,6 +12,7 @@ const BUILTIN_SPEECH_PROVIDER_BUILDERS = [
   buildOpenAISpeechProvider,
   buildElevenLabsSpeechProvider,
   buildMicrosoftSpeechProvider,
+  buildAzureSpeechProvider,
 ] as const satisfies readonly (() => SpeechProviderPlugin)[];
 
 function trimToUndefined(value: string | undefined): string | undefined {

--- a/src/tts/providers/azure.test.ts
+++ b/src/tts/providers/azure.test.ts
@@ -102,15 +102,17 @@ describe("listAzureVoices", () => {
       .fn()
       .mockResolvedValue(new Response("nope", { status: 503 })) as typeof globalThis.fetch;
 
-    await expect(
-      listAzureVoices({ apiKey: "test-key", region: "eastus" }),
-    ).rejects.toThrow("Azure voices API error (503)");
+    await expect(listAzureVoices({ apiKey: "test-key", region: "eastus" })).rejects.toThrow(
+      "Azure voices API error (503)",
+    );
   });
 
   it("uses custom baseUrl when provided", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify([]), { status: 200 }),
-    ) as typeof globalThis.fetch;
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify([]), { status: 200 }),
+      ) as typeof globalThis.fetch;
 
     await listAzureVoices({
       apiKey: "test-key",

--- a/src/tts/providers/azure.test.ts
+++ b/src/tts/providers/azure.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listAzureVoices } from "./azure.js";
+
+describe("listAzureVoices", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("maps Azure voice metadata into speech voice options", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            Name: "Microsoft Server Speech Text to Speech Voice (zh-HK, HiuMaanNeural)",
+            DisplayName: "HiuMaan Neural (zh-HK)",
+            LocalName: "HiuMaan",
+            ShortName: "zh-HK-HiuMaanNeural",
+            Gender: "Female",
+            Locale: "zh-HK",
+            VoiceType: "Neural",
+            Status: "Available",
+          },
+          {
+            Name: "Microsoft Server Speech Text to Speech Voice (zh-CN, XiaoxiaoNeural)",
+            DisplayName: "Xiaoxiao Neural (zh-CN)",
+            ShortName: "zh-CN-XiaoxiaoNeural",
+            Gender: "Female",
+            Locale: "zh-CN",
+            VoiceType: "Neural",
+            Status: "Available",
+          },
+        ]),
+        { status: 200 },
+      ),
+    ) as typeof globalThis.fetch;
+
+    const voices = await listAzureVoices({
+      apiKey: "test-key",
+      region: "eastus",
+    });
+
+    expect(voices).toEqual([
+      {
+        id: "zh-HK-HiuMaanNeural",
+        name: "HiuMaan Neural (zh-HK)",
+        category: "Neural",
+        locale: "zh-HK",
+        gender: "Female",
+      },
+      {
+        id: "zh-CN-XiaoxiaoNeural",
+        name: "Xiaoxiao Neural (zh-CN)",
+        category: "Neural",
+        locale: "zh-CN",
+        gender: "Female",
+      },
+    ]);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://eastus.tts.speech.microsoft.com/cognitiveservices/voices/list",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Ocp-Apim-Subscription-Key": "test-key",
+        }),
+      }),
+    );
+  });
+
+  it("filters out deprecated voices", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            ShortName: "zh-HK-HiuMaanNeural",
+            Gender: "Female",
+            Locale: "zh-HK",
+            Status: "Available",
+          },
+          {
+            ShortName: "zh-HK-OldVoice",
+            Gender: "Male",
+            Locale: "zh-HK",
+            Status: "Deprecated",
+          },
+        ]),
+        { status: 200 },
+      ),
+    ) as typeof globalThis.fetch;
+
+    const voices = await listAzureVoices({
+      apiKey: "test-key",
+    });
+
+    expect(voices).toHaveLength(1);
+    expect(voices[0].id).toBe("zh-HK-HiuMaanNeural");
+  });
+
+  it("throws on Azure voice list failures", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response("nope", { status: 503 })) as typeof globalThis.fetch;
+
+    await expect(
+      listAzureVoices({ apiKey: "test-key", region: "eastus" }),
+    ).rejects.toThrow("Azure voices API error (503)");
+  });
+
+  it("uses custom baseUrl when provided", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200 }),
+    ) as typeof globalThis.fetch;
+
+    await listAzureVoices({
+      apiKey: "test-key",
+      baseUrl: "https://custom.region.tts.speech.microsoft.com",
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://custom.region.tts.speech.microsoft.com/cognitiveservices/voices/list",
+      expect.any(Object),
+    );
+  });
+});

--- a/src/tts/providers/azure.ts
+++ b/src/tts/providers/azure.ts
@@ -2,6 +2,7 @@ import type { SpeechProviderPlugin } from "../../plugins/types.js";
 import type { SpeechVoiceOption } from "../provider-types.js";
 
 const DEFAULT_AZURE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+const DEFAULT_TIMEOUT_MS = 30000;
 
 type AzureVoiceListEntry = {
   Name?: string;
@@ -20,6 +21,14 @@ function normalizeAzureBaseUrl(baseUrl: string | undefined): string {
     return "https://eastus.tts.speech.microsoft.com";
   }
   return trimmed.replace(/\/+$/, "");
+}
+
+function getFileExtension(outputFormat: string): string {
+  if (outputFormat.includes("mp3")) return ".mp3";
+  if (outputFormat.includes("wav")) return ".wav";
+  if (outputFormat.includes("ogg")) return ".ogg";
+  if (outputFormat.includes("webm")) return ".webm";
+  return ".mp3"; // default to mp3
 }
 
 export async function listAzureVoices(params: {
@@ -91,8 +100,8 @@ export function buildAzureSpeechProvider(): SpeechProviderPlugin {
     },
     isConfigured: ({ config }) =>
       Boolean(
-        (config as any)?.azure?.apiKey ||
-          process.env.AZURE_SPEECH_API_KEY,
+        ((config as any)?.azure?.apiKey || process.env.AZURE_SPEECH_API_KEY) &&
+        ((config as any)?.azure?.voice || (config as any)?.azure?.lang)
       ),
     synthesize: async (req) => {
       const apiKey =
@@ -108,15 +117,21 @@ export function buildAzureSpeechProvider(): SpeechProviderPlugin {
         ? `${normalizeAzureBaseUrl(baseUrl)}/cognitiveservices/v1`
         : `https://${region}.tts.speech.microsoft.com/cognitiveservices/v1`;
 
-      const voice = (req.config as any)?.azure?.voice;
-      const lang = (req.config as any)?.azure?.lang;
+      // Apply directive overrides if provided
+      const azureOverride = (req.overrides as any)?.azure;
+      const voice = azureOverride?.voice || (req.config as any)?.azure?.voice;
+      const lang = azureOverride?.lang || (req.config as any)?.azure?.lang;
       const outputFormat =
+        azureOverride?.outputFormat ??
         (req.config as any)?.azure?.outputFormat ??
         DEFAULT_AZURE_OUTPUT_FORMAT;
 
       if (!voice) {
-        throw new Error("Azure voice not configured");
+        throw new Error("Azure voice not configured. Set voice in config or use [[tts:voice=zh-HK-HiuMaanNeural]] directive");
       }
+
+      // Use timeout from config, directive, or default
+      const timeoutMs = (req.config as any)?.azure?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
       const ssml = buildAzureSSML(req.text, voice, lang);
 
@@ -128,7 +143,7 @@ export function buildAzureSpeechProvider(): SpeechProviderPlugin {
           "X-Microsoft-OutputFormat": outputFormat,
         },
         body: ssml,
-        signal: AbortSignal.timeout((req.config as any)?.azure?.timeoutMs ?? 30000),
+        signal: AbortSignal.timeout(timeoutMs),
       });
 
       if (!response.ok) {
@@ -139,7 +154,7 @@ export function buildAzureSpeechProvider(): SpeechProviderPlugin {
       return {
         audioBuffer: Buffer.from(audioBuffer),
         outputFormat,
-        fileExtension: outputFormat.includes("mp3") ? ".mp3" : ".wav",
+        fileExtension: getFileExtension(outputFormat),
         voiceCompatible: true,
       };
     },

--- a/src/tts/providers/azure.ts
+++ b/src/tts/providers/azure.ts
@@ -27,9 +27,11 @@ export async function listAzureVoices(params: {
   region?: string;
   baseUrl?: string;
 }): Promise<SpeechVoiceOption[]> {
-  const base = normalizeAzureBaseUrl(params.baseUrl);
   const region = params.region || "eastus";
-  const url = `https://${region}.tts.speech.microsoft.com/cognitiveservices/voices/list`;
+  // Use baseUrl if provided, otherwise derive from region
+  const url = params.baseUrl
+    ? `${normalizeAzureBaseUrl(params.baseUrl)}/cognitiveservices/voices/list`
+    : `https://${region}.tts.speech.microsoft.com/cognitiveservices/voices/list`;
 
   const response = await fetch(url, {
     headers: {
@@ -42,8 +44,10 @@ export async function listAzureVoices(params: {
   }
 
   const voices = (await response.json()) as AzureVoiceListEntry[];
+  // Filter deprecated voices BEFORE mapping (Status field is available here)
   return Array.isArray(voices)
     ? voices
+        .filter((voice) => voice.Status !== "Deprecated")
         .map((voice) => ({
           id: voice.ShortName?.trim() ?? "",
           name: voice.DisplayName?.trim() || voice.ShortName?.trim() || undefined,
@@ -51,7 +55,7 @@ export async function listAzureVoices(params: {
           locale: voice.Locale?.trim() || undefined,
           gender: voice.Gender?.trim() || undefined,
         }))
-        .filter((voice) => voice.id.length > 0 && voice.Status !== "Deprecated")
+        .filter((voice) => voice.id.length > 0)
     : [];
 }
 
@@ -74,43 +78,46 @@ export function buildAzureSpeechProvider(): SpeechProviderPlugin {
     listVoices: async (req) => {
       const apiKey =
         req.apiKey ||
-        req.config?.azure?.apiKey ||
+        (req.config as any)?.azure?.apiKey ||
         process.env.AZURE_SPEECH_API_KEY;
       if (!apiKey) {
         throw new Error("Azure Speech API key missing");
       }
       return listAzureVoices({
         apiKey,
-        region: req.config?.azure?.region || process.env.AZURE_SPEECH_REGION,
-        baseUrl: req.config?.azure?.baseUrl,
+        region: (req.config as any)?.azure?.region || process.env.AZURE_SPEECH_REGION,
+        baseUrl: (req.config as any)?.azure?.baseUrl,
       });
     },
     isConfigured: ({ config }) =>
       Boolean(
-        config.azure?.apiKey ||
+        (config as any)?.azure?.apiKey ||
           process.env.AZURE_SPEECH_API_KEY,
       ),
     synthesize: async (req) => {
       const apiKey =
-        req.config.azure?.apiKey || process.env.AZURE_SPEECH_API_KEY;
+        (req.config as any)?.azure?.apiKey || process.env.AZURE_SPEECH_API_KEY;
       if (!apiKey) {
         throw new Error("Azure Speech API key missing");
       }
 
-      const region = req.config?.azure?.region || process.env.AZURE_SPEECH_REGION || "eastus";
-      const baseUrl = normalizeAzureBaseUrl(req.config?.azure?.baseUrl);
-      const voice = req.overrides?.azure?.voice ?? req.config?.azure?.voice;
-      const lang = req.overrides?.azure?.lang ?? req.config?.azure?.lang;
+      const region = (req.config as any)?.azure?.region || process.env.AZURE_SPEECH_REGION || "eastus";
+      const baseUrl = (req.config as any)?.azure?.baseUrl;
+      // Use baseUrl if provided, otherwise derive from region
+      const endpoint = baseUrl
+        ? `${normalizeAzureBaseUrl(baseUrl)}/cognitiveservices/v1`
+        : `https://${region}.tts.speech.microsoft.com/cognitiveservices/v1`;
+
+      const voice = (req.config as any)?.azure?.voice;
+      const lang = (req.config as any)?.azure?.lang;
       const outputFormat =
-        req.overrides?.azure?.outputFormat ??
-        req.config?.azure?.outputFormat ??
+        (req.config as any)?.azure?.outputFormat ??
         DEFAULT_AZURE_OUTPUT_FORMAT;
 
       if (!voice) {
         throw new Error("Azure voice not configured");
       }
 
-      const endpoint = `${baseUrl}/cognitiveservices/v1`;
       const ssml = buildAzureSSML(req.text, voice, lang);
 
       const response = await fetch(endpoint, {
@@ -121,6 +128,7 @@ export function buildAzureSpeechProvider(): SpeechProviderPlugin {
           "X-Microsoft-OutputFormat": outputFormat,
         },
         body: ssml,
+        signal: AbortSignal.timeout((req.config as any)?.azure?.timeoutMs ?? 30000),
       });
 
       if (!response.ok) {

--- a/src/tts/providers/azure.ts
+++ b/src/tts/providers/azure.ts
@@ -86,9 +86,7 @@ export function buildAzureSpeechProvider(): SpeechProviderPlugin {
     aliases: ["azure-tts"],
     listVoices: async (req) => {
       const apiKey =
-        req.apiKey ||
-        (req.config as any)?.azure?.apiKey ||
-        process.env.AZURE_SPEECH_API_KEY;
+        req.apiKey || (req.config as any)?.azure?.apiKey || process.env.AZURE_SPEECH_API_KEY;
       if (!apiKey) {
         throw new Error("Azure Speech API key missing");
       }
@@ -101,16 +99,16 @@ export function buildAzureSpeechProvider(): SpeechProviderPlugin {
     isConfigured: ({ config }) =>
       Boolean(
         ((config as any)?.azure?.apiKey || process.env.AZURE_SPEECH_API_KEY) &&
-        ((config as any)?.azure?.voice || (config as any)?.azure?.lang)
+        ((config as any)?.azure?.voice || (config as any)?.azure?.lang),
       ),
     synthesize: async (req) => {
-      const apiKey =
-        (req.config as any)?.azure?.apiKey || process.env.AZURE_SPEECH_API_KEY;
+      const apiKey = (req.config as any)?.azure?.apiKey || process.env.AZURE_SPEECH_API_KEY;
       if (!apiKey) {
         throw new Error("Azure Speech API key missing");
       }
 
-      const region = (req.config as any)?.azure?.region || process.env.AZURE_SPEECH_REGION || "eastus";
+      const region =
+        (req.config as any)?.azure?.region || process.env.AZURE_SPEECH_REGION || "eastus";
       const baseUrl = (req.config as any)?.azure?.baseUrl;
       // Use baseUrl if provided, otherwise derive from region
       const endpoint = baseUrl
@@ -127,7 +125,9 @@ export function buildAzureSpeechProvider(): SpeechProviderPlugin {
         DEFAULT_AZURE_OUTPUT_FORMAT;
 
       if (!voice) {
-        throw new Error("Azure voice not configured. Set voice in config or use [[tts:voice=zh-HK-HiuMaanNeural]] directive");
+        throw new Error(
+          "Azure voice not configured. Set voice in config or use [[tts:voice=zh-HK-HiuMaanNeural]] directive",
+        );
       }
 
       // Use timeout from config, directive, or default

--- a/src/tts/providers/azure.ts
+++ b/src/tts/providers/azure.ts
@@ -1,0 +1,139 @@
+import type { SpeechProviderPlugin } from "../../plugins/types.js";
+import type { SpeechVoiceOption } from "../provider-types.js";
+
+const DEFAULT_AZURE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+
+type AzureVoiceListEntry = {
+  Name?: string;
+  DisplayName?: string;
+  LocalName?: string;
+  ShortName?: string;
+  Gender?: string;
+  Locale?: string;
+  VoiceType?: string;
+  Status?: string;
+};
+
+function normalizeAzureBaseUrl(baseUrl: string | undefined): string {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return "https://eastus.tts.speech.microsoft.com";
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+export async function listAzureVoices(params: {
+  apiKey: string;
+  region?: string;
+  baseUrl?: string;
+}): Promise<SpeechVoiceOption[]> {
+  const base = normalizeAzureBaseUrl(params.baseUrl);
+  const region = params.region || "eastus";
+  const url = `https://${region}.tts.speech.microsoft.com/cognitiveservices/voices/list`;
+
+  const response = await fetch(url, {
+    headers: {
+      "Ocp-Apim-Subscription-Key": params.apiKey,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Azure voices API error (${response.status})`);
+  }
+
+  const voices = (await response.json()) as AzureVoiceListEntry[];
+  return Array.isArray(voices)
+    ? voices
+        .map((voice) => ({
+          id: voice.ShortName?.trim() ?? "",
+          name: voice.DisplayName?.trim() || voice.ShortName?.trim() || undefined,
+          category: voice.VoiceType?.trim() || undefined,
+          locale: voice.Locale?.trim() || undefined,
+          gender: voice.Gender?.trim() || undefined,
+        }))
+        .filter((voice) => voice.id.length > 0 && voice.Status !== "Deprecated")
+    : [];
+}
+
+function buildAzureSSML(text: string, voice: string, lang?: string): string {
+  const escapedText = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+
+  return `<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='${lang || "en-US"}'><voice name='${voice}'>${escapedText}</voice></speak>`;
+}
+
+export function buildAzureSpeechProvider(): SpeechProviderPlugin {
+  return {
+    id: "azure",
+    label: "Azure Speech",
+    aliases: ["azure-tts"],
+    listVoices: async (req) => {
+      const apiKey =
+        req.apiKey ||
+        req.config?.azure?.apiKey ||
+        process.env.AZURE_SPEECH_API_KEY;
+      if (!apiKey) {
+        throw new Error("Azure Speech API key missing");
+      }
+      return listAzureVoices({
+        apiKey,
+        region: req.config?.azure?.region || process.env.AZURE_SPEECH_REGION,
+        baseUrl: req.config?.azure?.baseUrl,
+      });
+    },
+    isConfigured: ({ config }) =>
+      Boolean(
+        config.azure?.apiKey ||
+          process.env.AZURE_SPEECH_API_KEY,
+      ),
+    synthesize: async (req) => {
+      const apiKey =
+        req.config.azure?.apiKey || process.env.AZURE_SPEECH_API_KEY;
+      if (!apiKey) {
+        throw new Error("Azure Speech API key missing");
+      }
+
+      const region = req.config?.azure?.region || process.env.AZURE_SPEECH_REGION || "eastus";
+      const baseUrl = normalizeAzureBaseUrl(req.config?.azure?.baseUrl);
+      const voice = req.overrides?.azure?.voice ?? req.config?.azure?.voice;
+      const lang = req.overrides?.azure?.lang ?? req.config?.azure?.lang;
+      const outputFormat =
+        req.overrides?.azure?.outputFormat ??
+        req.config?.azure?.outputFormat ??
+        DEFAULT_AZURE_OUTPUT_FORMAT;
+
+      if (!voice) {
+        throw new Error("Azure voice not configured");
+      }
+
+      const endpoint = `${baseUrl}/cognitiveservices/v1`;
+      const ssml = buildAzureSSML(req.text, voice, lang);
+
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Ocp-Apim-Subscription-Key": apiKey,
+          "Content-Type": "application/ssml+xml",
+          "X-Microsoft-OutputFormat": outputFormat,
+        },
+        body: ssml,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Azure TTS failed: ${response.status} ${response.statusText}`);
+      }
+
+      const audioBuffer = await response.arrayBuffer();
+      return {
+        audioBuffer: Buffer.from(audioBuffer),
+        outputFormat,
+        fileExtension: outputFormat.includes("mp3") ? ".mp3" : ".wav",
+        voiceCompatible: true,
+      };
+    },
+  };
+}

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -176,6 +176,20 @@ export function parseTtsDirectives(
               warnings.push(`invalid OpenAI voice "${rawValue}"`);
             }
             break;
+
+          case "azure_voice":
+          case "azurevoice":
+            if (!policy.allowVoice) {
+              break;
+            }
+            // Azure voice names are ShortName format like "zh-HK-HiuMaanNeural"
+            // Basic validation: non-empty string
+            if (rawValue && rawValue.trim().length > 0) {
+              overrides.azure = { ...overrides.azure, voice: rawValue };
+            } else {
+              warnings.push(`invalid Azure voice "${rawValue}"`);
+            }
+            break;
           case "voiceid":
           case "voice_id":
           case "elevenlabs_voice":

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -120,7 +120,7 @@ export type ResolvedTtsConfig = {
     speed?: number;
     instructions?: string;
   };
-  
+
   azure: {
     apiKey?: string;
     region: string;
@@ -130,7 +130,7 @@ export type ResolvedTtsConfig = {
     outputFormat: string;
     timeoutMs?: number;
   };
-edge: {
+  edge: {
     enabled: boolean;
     voice: string;
     lang: string;

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -505,6 +505,9 @@ export function getTtsProvider(config: ResolvedTtsConfig, prefsPath: string): Tt
   if (resolveTtsApiKey(config, "elevenlabs")) {
     return "elevenlabs";
   }
+  if (resolveTtsApiKey(config, "azure")) {
+    return "azure";
+  }
   return "microsoft";
 }
 
@@ -573,10 +576,13 @@ export function resolveTtsApiKey(
   if (normalizedProvider === "openai") {
     return config.openai.apiKey || process.env.OPENAI_API_KEY;
   }
+  if (normalizedProvider === "azure") {
+    return config.azure.apiKey || process.env.AZURE_SPEECH_API_KEY;
+  }
   return undefined;
 }
 
-export const TTS_PROVIDERS = ["openai", "elevenlabs", "microsoft"] as const;
+export const TTS_PROVIDERS = ["openai", "elevenlabs", "microsoft", "azure"] as const;
 
 export function resolveTtsProviderOrder(primary: TtsProvider, cfg?: OpenClawConfig): TtsProvider[] {
   const normalizedPrimary = normalizeSpeechProviderId(primary) ?? primary;

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -195,6 +195,7 @@ export type TtsDirectiveOverrides = {
     lang?: string;
     outputFormat?: string;
   };
+};
 
 export type TtsDirectiveParseResult = {
   cleanedText: string;

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -61,6 +61,7 @@ const DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2";
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
 const DEFAULT_EDGE_LANG = "en-US";
 const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+const DEFAULT_AZURE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
 
 const DEFAULT_ELEVENLABS_VOICE_SETTINGS = {
   stability: 0.5,
@@ -119,7 +120,17 @@ export type ResolvedTtsConfig = {
     speed?: number;
     instructions?: string;
   };
-  edge: {
+  
+  azure: {
+    apiKey?: string;
+    region: string;
+    baseUrl: string;
+    voice: string;
+    lang: string;
+    outputFormat: string;
+    timeoutMs?: number;
+  };
+edge: {
     enabled: boolean;
     voice: string;
     lang: string;
@@ -179,7 +190,11 @@ export type TtsDirectiveOverrides = {
     voice?: string;
     outputFormat?: string;
   };
-};
+  azure?: {
+    voice?: string;
+    lang?: string;
+    outputFormat?: string;
+  };
 
 export type TtsDirectiveParseResult = {
   cleanedText: string;
@@ -325,6 +340,18 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       voice: raw.openai?.voice ?? DEFAULT_OPENAI_VOICE,
       speed: raw.openai?.speed,
       instructions: raw.openai?.instructions?.trim() || undefined,
+    },
+    azure: {
+      apiKey: normalizeResolvedSecretInputString({
+        value: raw.azure?.apiKey,
+        path: "messages.tts.azure.apiKey",
+      }),
+      region: raw.azure?.region?.trim() || process.env.AZURE_SPEECH_REGION || "eastus",
+      baseUrl: raw.azure?.baseUrl?.trim() || "",
+      voice: raw.azure?.voice || "",
+      lang: raw.azure?.lang?.trim() || "en-US",
+      outputFormat: raw.azure?.outputFormat?.trim() || DEFAULT_AZURE_OUTPUT_FORMAT,
+      timeoutMs: raw.azure?.timeoutMs,
     },
     edge: {
       enabled: rawMicrosoft.enabled ?? true,


### PR DESCRIPTION
## Summary

Add Azure Speech TTS provider to OpenClaw with SSML synthesis support.

## Problem
- OpenClaw currently supports Edge TTS, ElevenLabs, and OpenAI TTS
- Azure Speech has 400+ neural voices including Cantonese (zh-HK) which users have requested
- Many users already have Azure accounts and API keys

## What Changed
- Added `src/tts/providers/azure.ts` - Azure TTS provider implementation
- Updated `src/tts/provider-registry.ts` to register Azure provider
- Updated `src/config/types.tts.ts` with Azure config types
- Updated `src/config/zod-schema.core.ts` with Azure validation schema

## Features
- SSML-based synthesis for natural speech
- 400+ neural voices including Cantonese (zh-HK-HiuMaanNeural)
- Config options: apiKey, region, voice, lang, outputFormat
- Environment variables: AZURE_SPEECH_API_KEY, AZURE_SPEECH_REGION
- Provider ID: 'azure' with alias 'azure-tts'

## Config Example
```json
{
  "messages": {
    "tts": {
      "provider": "azure",
      "azure": {
        "apiKey": "your-key",
        "region": "eastus",
        "voice": "zh-HK-HiuMaanNeural",
        "lang": "zh-HK"
      }
    }
  }
}
```

## Human Verification
- Tested Azure TTS synthesis with Cantonese voice (zh-HK-HiuMaanNeural)
- Verified API authentication works with East US region
- Voice output plays correctly in Telegram