### PR TITLE
telegram: add awaited ingress middleware chain before dispatch

### DIFF
--- a/extensions/telegram/src/bot-message.ingress-runtime.test.ts
+++ b/extensions/telegram/src/bot-message.ingress-runtime.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const buildTelegramMessageContext = vi.hoisted(() => vi.fn());
+const dispatchTelegramMessage = vi.hoisted(() => vi.fn());
+const maybeRunTelegramIngressMiddlewares = vi.hoisted(() => vi.fn());
+
+vi.mock("./bot-message-context.js", () => ({
+  buildTelegramMessageContext,
+}));
+
+vi.mock("./bot-message-dispatch.js", () => ({
+  dispatchTelegramMessage,
+}));
+
+vi.mock("./ingress-runtime.js", () => ({
+  maybeRunTelegramIngressMiddlewares,
+}));
+
+import { createTelegramMessageProcessor } from "./bot-message.js";
+
+describe("telegram ingress middleware integration", () => {
+  beforeEach(() => {
+    buildTelegramMessageContext.mockReset();
+    dispatchTelegramMessage.mockReset();
+    maybeRunTelegramIngressMiddlewares.mockReset();
+  });
+
+  it("runs ingress middleware before telegram dispatch when configured", async () => {
+    const order: string[] = [];
+    const context = {
+      route: { agentId: "public", sessionKey: "agent:public:telegram:direct:1" },
+      ctxPayload: { SessionKey: "agent:public:telegram:direct:1" },
+      msg: { from: { id: 1 }, chat: { id: 1, type: "private" } },
+      isGroup: false,
+      chatId: 1,
+    };
+    buildTelegramMessageContext.mockImplementation(async () => context);
+    maybeRunTelegramIngressMiddlewares.mockImplementation(async () => {
+      order.push("ingress");
+      return { middlewareCount: 1, outcomes: [] };
+    });
+    dispatchTelegramMessage.mockImplementation(async () => {
+      order.push("dispatch");
+    });
+
+    const processor = createTelegramMessageProcessor({
+      bot: {} as never,
+      cfg: {} as never,
+      account: {} as never,
+      telegramCfg: { ingressMiddlewares: ["file:///tmp/test.mjs"] } as never,
+      historyLimit: 0,
+      groupHistories: new Map(),
+      dmPolicy: "pairing",
+      allowFrom: [],
+      groupAllowFrom: [],
+      ackReactionScope: "off",
+      logger: { info() {}, warn() {}, error() {} } as never,
+      resolveGroupActivation: () => ({ allowed: true }) as never,
+      resolveGroupRequireMention: () => false,
+      resolveTelegramGroupConfig: () => ({ groupConfig: undefined, topicConfig: undefined }),
+      loadFreshConfig: () => ({}) as never,
+      sendChatActionHandler: { sendChatAction: vi.fn() } as never,
+      runtime: { info() {}, warn() {}, error() {} } as never,
+      replyToMode: "off",
+      streamMode: "off",
+      textLimit: 4000,
+      telegramDeps: { upsertChannelPairingRequest: vi.fn() } as never,
+      opts: { token: "x" },
+    });
+
+    await processor({ message: { chat: { id: 1, type: "private" } } } as never, [], []);
+
+    expect(order).toEqual(["ingress", "dispatch"]);
+    expect(maybeRunTelegramIngressMiddlewares).toHaveBeenCalledTimes(1);
+    expect(dispatchTelegramMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -86,6 +86,8 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     if (!context) {
       return;
     }
+    // Current ingress middlewares are execution-oriented only:
+    // outcomes are collected for diagnostics, but dispatch always continues.
     await maybeRunTelegramIngressMiddlewares({
       context,
       cfg,

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -11,6 +11,7 @@ import {
 import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
 import type { TelegramBotOptions } from "./bot.js";
 import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
+import { maybeRunTelegramIngressMiddlewares } from "./ingress-runtime.js";
 
 /** Dependencies injected once when creating the message processor. */
 type TelegramMessageProcessorDeps = Omit<
@@ -85,6 +86,13 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
     if (!context) {
       return;
     }
+    await maybeRunTelegramIngressMiddlewares({
+      context,
+      cfg,
+      account,
+      telegramCfg,
+      runtime,
+    });
     try {
       await dispatchTelegramMessage({
         context,

--- a/extensions/telegram/src/ingress-runtime.ts
+++ b/extensions/telegram/src/ingress-runtime.ts
@@ -1,6 +1,6 @@
+import { runChannelIngressMiddlewares } from "openclaw/plugin-sdk/channel-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { runChannelIngressMiddlewares } from "../../../src/channels/ingress/runtime.js";
 import type { OpenClawConfig } from "../../../src/config/config.js";
 import type { TelegramAccountConfig } from "../../../src/config/types.telegram.js";
 import { buildTelegramMessageContext } from "./bot-message-context.js";
@@ -63,6 +63,9 @@ export async function maybeRunTelegramIngressMiddlewares(params: {
     return await runTelegramIngressMiddlewares(params);
   } catch (err) {
     params.runtime.error(danger(`ingress-runtime failed: ${String(err)}`));
-    return { middlewareCount: 0, outcomes: [] };
+    return {
+      middlewareCount: params.telegramCfg.ingressMiddlewares?.length ?? 0,
+      outcomes: [],
+    };
   }
 }

--- a/extensions/telegram/src/ingress-runtime.ts
+++ b/extensions/telegram/src/ingress-runtime.ts
@@ -1,0 +1,68 @@
+import { danger } from "openclaw/plugin-sdk/runtime-env";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { runChannelIngressMiddlewares } from "../../../src/channels/ingress/runtime.js";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import type { TelegramAccountConfig } from "../../../src/config/types.telegram.js";
+import { buildTelegramMessageContext } from "./bot-message-context.js";
+import type { BuildTelegramMessageContextParams } from "./bot-message-context.js";
+import { sendMessageTelegram } from "./send.js";
+
+export type TelegramMessageContext = NonNullable<
+  Awaited<ReturnType<typeof buildTelegramMessageContext>>
+>;
+
+export async function runTelegramIngressMiddlewares(params: {
+  context: TelegramMessageContext;
+  cfg: OpenClawConfig;
+  account: BuildTelegramMessageContextParams["account"];
+  telegramCfg: TelegramAccountConfig;
+  runtime: RuntimeEnv;
+}) {
+  const { context, cfg, account, telegramCfg, runtime } = params;
+  const routeAgentId = String(context.route?.agentId ?? "");
+  const sessionKey = String(context.route?.sessionKey ?? context.ctxPayload?.SessionKey ?? "");
+  const senderId = context.msg?.from?.id != null ? String(context.msg.from.id) : "";
+  runtime.log(
+    `ingress-runtime enter agent=${routeAgentId || "-"} session=${sessionKey || "-"} sender=${senderId || "-"} group=${String(Boolean(context.isGroup))}`,
+  );
+  const result = await runChannelIngressMiddlewares({
+    entries: telegramCfg.ingressMiddlewares,
+    args: {
+      context,
+      sendTelegram: async (to: string, text: string) => {
+        await sendMessageTelegram(to, text, { cfg, accountId: account.accountId });
+      },
+      logger: runtime,
+    },
+    logger: runtime,
+  });
+  const notifiedCount = result.outcomes.filter(
+    (entry) =>
+      entry.result &&
+      typeof entry.result === "object" &&
+      "notified" in (entry.result as Record<string, unknown>) &&
+      (entry.result as { notified?: unknown }).notified === true,
+  ).length;
+  runtime.log(
+    `ingress-runtime done middlewares=${String(result.middlewareCount)} notified=${String(notifiedCount)} session=${sessionKey || "-"}`,
+  );
+  return result;
+}
+
+export async function maybeRunTelegramIngressMiddlewares(params: {
+  context: TelegramMessageContext;
+  cfg: OpenClawConfig;
+  account: BuildTelegramMessageContextParams["account"];
+  telegramCfg: TelegramAccountConfig;
+  runtime: RuntimeEnv;
+}) {
+  if (!params.telegramCfg.ingressMiddlewares?.length) {
+    return { middlewareCount: 0, outcomes: [] };
+  }
+  try {
+    return await runTelegramIngressMiddlewares(params);
+  } catch (err) {
+    params.runtime.error(danger(`ingress-runtime failed: ${String(err)}`));
+    return { middlewareCount: 0, outcomes: [] };
+  }
+}

--- a/src/channels/ingress/runtime.test.ts
+++ b/src/channels/ingress/runtime.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { normalizeChannelIngressMiddlewareEntry, runChannelIngressMiddlewares } from "./runtime.js";
+
+describe("channel ingress runtime", () => {
+  it("normalizes string and object entries", () => {
+    expect(normalizeChannelIngressMiddlewareEntry("file:///tmp/a.mjs", 0)).toEqual({
+      name: "middleware-1",
+      module: "file:///tmp/a.mjs",
+      exportName: "runIngressMiddleware",
+    });
+    expect(
+      normalizeChannelIngressMiddlewareEntry(
+        { name: "custom", module: "file:///tmp/b.mjs", exportName: "run" },
+        1,
+      ),
+    ).toEqual({
+      name: "custom",
+      module: "file:///tmp/b.mjs",
+      exportName: "run",
+    });
+  });
+
+  it("runs middleware functions in order and reports outcomes", async () => {
+    const calls: string[] = [];
+    const result = await runChannelIngressMiddlewares({
+      entries: ["unused"],
+      args: { ping: true },
+      resolveFns: async () => [
+        {
+          name: "first",
+          fn: async () => {
+            calls.push("first");
+            return { handled: true, reason: "first" };
+          },
+        },
+        {
+          name: "second",
+          fn: async () => {
+            calls.push("second");
+            return { handled: true, reason: "second" };
+          },
+        },
+      ],
+    });
+
+    expect(calls).toEqual(["first", "second"]);
+    expect(result.middlewareCount).toBe(2);
+    expect(result.outcomes).toHaveLength(2);
+    expect(result.outcomes[1]?.result).toEqual({ handled: true, reason: "second" });
+  });
+});

--- a/src/channels/ingress/runtime.ts
+++ b/src/channels/ingress/runtime.ts
@@ -3,7 +3,7 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 type IngressRuntimeLogger = Pick<RuntimeEnv, "log" | "error">;
 
 const logIngressWarn = (logger: IngressRuntimeLogger | undefined, text: string) => {
-  logger?.error?.(text);
+  logger?.log?.(text);
 };
 
 export type ChannelIngressMiddlewareConfig =

--- a/src/channels/ingress/runtime.ts
+++ b/src/channels/ingress/runtime.ts
@@ -1,0 +1,125 @@
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+
+type IngressRuntimeLogger = Pick<RuntimeEnv, "log" | "error">;
+
+const logIngressWarn = (logger: IngressRuntimeLogger | undefined, text: string) => {
+  logger?.error?.(text);
+};
+
+export type ChannelIngressMiddlewareConfig =
+  | string
+  | {
+      name?: string;
+      module: string;
+      exportName?: string;
+    };
+
+export type ChannelIngressMiddlewareOutcome = {
+  name: string;
+  ok: boolean;
+  durationMs: number;
+  result?: unknown;
+  error?: string;
+};
+
+export type ChannelIngressMiddlewareRunResult = {
+  middlewareCount: number;
+  outcomes: ChannelIngressMiddlewareOutcome[];
+};
+
+const toArray = <T>(value: T[] | undefined): T[] => (Array.isArray(value) ? value : []);
+
+export const normalizeChannelIngressMiddlewareEntry = (
+  entry: ChannelIngressMiddlewareConfig,
+  index: number,
+): { name: string; module: string; exportName: string } | null => {
+  if (typeof entry === "string") {
+    return {
+      name: `middleware-${index + 1}`,
+      module: entry,
+      exportName: "runIngressMiddleware",
+    };
+  }
+  if (entry && typeof entry === "object" && typeof entry.module === "string") {
+    return {
+      name: entry.name?.trim() || `middleware-${index + 1}`,
+      module: entry.module,
+      exportName: entry.exportName?.trim() || "runIngressMiddleware",
+    };
+  }
+  return null;
+};
+
+type ChannelIngressMiddlewareFn = (args: unknown) => unknown;
+
+export async function resolveChannelIngressMiddlewareFunctions(
+  entries: ChannelIngressMiddlewareConfig[] | undefined,
+  logger?: IngressRuntimeLogger,
+): Promise<Array<{ name: string; fn: ChannelIngressMiddlewareFn }>> {
+  const resolved: Array<{ name: string; fn: ChannelIngressMiddlewareFn }> = [];
+  for (const [index, rawEntry] of toArray(entries).entries()) {
+    const entry = normalizeChannelIngressMiddlewareEntry(rawEntry, index);
+    if (!entry) {
+      logIngressWarn(logger, `ingress-runtime skip middleware[${index}] reason=invalid-entry`);
+      continue;
+    }
+    try {
+      const imported = await import(entry.module);
+      const fn = imported?.[entry.exportName];
+      if (typeof fn !== "function") {
+        logIngressWarn(
+          logger,
+          `ingress-runtime skip middleware name=${entry.name} reason=missing-export export=${entry.exportName}`,
+        );
+        continue;
+      }
+      resolved.push({ name: entry.name, fn });
+    } catch (err) {
+      logIngressWarn(
+        logger,
+        `ingress-runtime skip middleware name=${entry.name} reason=import-failed err=${String(err)}`,
+      );
+    }
+  }
+  return resolved;
+}
+
+export async function runChannelIngressMiddlewares<TArgs>(params: {
+  entries: ChannelIngressMiddlewareConfig[] | undefined;
+  args: TArgs;
+  logger?: IngressRuntimeLogger;
+  resolveFns?: typeof resolveChannelIngressMiddlewareFunctions;
+}): Promise<ChannelIngressMiddlewareRunResult> {
+  const resolved = await (params.resolveFns ?? resolveChannelIngressMiddlewareFunctions)(
+    params.entries,
+    params.logger,
+  );
+  const outcomes: ChannelIngressMiddlewareOutcome[] = [];
+  for (const middleware of resolved) {
+    const startedAt = Date.now();
+    try {
+      const result = await middleware.fn(params.args);
+      outcomes.push({
+        name: middleware.name,
+        ok: true,
+        durationMs: Date.now() - startedAt,
+        result,
+      });
+    } catch (err) {
+      outcomes.push({
+        name: middleware.name,
+        ok: false,
+        durationMs: Date.now() - startedAt,
+        error: String(err),
+      });
+      logIngressWarn(
+        params.logger,
+        `ingress-runtime middleware-failed name=${middleware.name} err=${String(err)}`,
+      );
+    }
+  }
+  return {
+    middlewareCount: resolved.length,
+    outcomes,
+  };
+}

--- a/src/config/config.telegram-ingress-middlewares.test.ts
+++ b/src/config/config.telegram-ingress-middlewares.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("telegram ingress middlewares schema", () => {
+  it("accepts string and object middleware entries", () => {
+    const res = OpenClawSchema.safeParse({
+      channels: {
+        telegram: {
+          ingressMiddlewares: [
+            "file:///root/.openclaw/workspace/scripts/deterministic-public-bridge.mjs",
+            {
+              name: "det-bridge",
+              module: "file:///root/.openclaw/workspace/scripts/deterministic-public-bridge.mjs",
+              exportName: "runIngressMiddleware",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+    if (!res.success) {
+      return;
+    }
+
+    expect(res.data.channels?.telegram?.ingressMiddlewares).toEqual([
+      "file:///root/.openclaw/workspace/scripts/deterministic-public-bridge.mjs",
+      {
+        name: "det-bridge",
+        module: "file:///root/.openclaw/workspace/scripts/deterministic-public-bridge.mjs",
+        exportName: "runIngressMiddleware",
+      },
+    ]);
+  });
+});

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -1,3 +1,4 @@
+import type { ChannelIngressMiddlewareConfig } from "../channels/ingress/runtime.js";
 import type {
   BlockStreamingChunkConfig,
   BlockStreamingCoalesceConfig,
@@ -85,16 +86,7 @@ export type TelegramCustomCommand = {
   description: string;
 };
 
-export type TelegramIngressMiddlewareConfig =
-  | string
-  | {
-      /** Optional logical name for diagnostics/logging. */
-      name?: string;
-      /** ESM module specifier or file:// URL. */
-      module: string;
-      /** Export to call. Defaults to runIngressMiddleware. */
-      exportName?: string;
-    };
+export type TelegramIngressMiddlewareConfig = ChannelIngressMiddlewareConfig;
 
 export type TelegramAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -85,6 +85,17 @@ export type TelegramCustomCommand = {
   description: string;
 };
 
+export type TelegramIngressMiddlewareConfig =
+  | string
+  | {
+      /** Optional logical name for diagnostics/logging. */
+      name?: string;
+      /** ESM module specifier or file:// URL. */
+      module: string;
+      /** Export to call. Defaults to runIngressMiddleware. */
+      exportName?: string;
+    };
+
 export type TelegramAccountConfig = {
   /** Optional display name for this account (used in CLI/UI lists). */
   name?: string;
@@ -92,6 +103,8 @@ export type TelegramAccountConfig = {
   capabilities?: TelegramCapabilitiesConfig;
   /** Telegram-native exec approval delivery + approver authorization. */
   execApprovals?: TelegramExecApprovalConfig;
+  /** Awaited ingress middleware chain executed before Telegram model-dispatch. */
+  ingressMiddlewares?: TelegramIngressMiddlewareConfig[];
   /** Markdown formatting overrides (tables). */
   markdown?: MarkdownConfig;
   /** Override native command registration for Telegram (bool or "auto"). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -120,6 +120,17 @@ const TelegramCustomCommandSchema = z
   })
   .strict();
 
+const TelegramIngressMiddlewareSchema = z.union([
+  z.string(),
+  z
+    .object({
+      name: z.string().optional(),
+      module: z.string(),
+      exportName: z.string().optional(),
+    })
+    .strict(),
+]);
+
 const validateTelegramCustomCommands = (
   value: { customCommands?: Array<{ command?: string; description?: string }> },
   ctx: z.RefinementCtx,
@@ -175,6 +186,7 @@ export const TelegramAccountSchemaBase = z
       })
       .strict()
       .optional(),
+    ingressMiddlewares: z.array(TelegramIngressMiddlewareSchema).optional(),
     markdown: MarkdownConfigSchema,
     enabled: z.boolean().optional(),
     commands: ProviderCommandsSchema,

--- a/src/plugin-sdk/channel-runtime.ts
+++ b/src/plugin-sdk/channel-runtime.ts
@@ -12,6 +12,7 @@ export * from "../channels/conversation-label.js";
 export * from "../channels/draft-stream-controls.js";
 export * from "../channels/draft-stream-loop.js";
 export * from "../channels/inbound-debounce-policy.js";
+export * from "../channels/ingress/runtime.js";
 export * from "../channels/location.js";
 export * from "../channels/logging.js";
 export * from "../channels/mention-gating.js";


### PR DESCRIPTION
# PR-ready package: source-level Telegram ingress middleware

## Suggested PR title

`telegram: add awaited ingress middleware chain before message dispatch`

## Problem

Deterministic `public -> private` notifications were initially implemented as a dist-level hotfix against compiled OpenClaw bundles. That solved the operational problem, but left architectural debt:

- logic depended on specific compiled chunks;
- updates could silently break the patch;
- inbound control lived outside a first-class source abstraction;
- Telegram pre-dispatch logic could not be extended cleanly with additional deterministic middleware.

## What this patch does

This patch introduces a source-level awaited ingress middleware layer for Telegram message processing.

### New capabilities

- adds a generic channel ingress runtime:
  - `src/channels/ingress/runtime.ts`
- adds Telegram integration before model dispatch:
  - `extensions/telegram/src/ingress-runtime.ts`
  - `extensions/telegram/src/bot-message.ts`
- adds config support for awaited Telegram ingress middleware entries:
  - `channels.telegram.ingressMiddlewares`
- adds tests for:
  - middleware runtime ordering
  - Telegram integration ordering
  - config schema acceptance

## Files changed

### New files
- `src/channels/ingress/runtime.ts`
- `src/channels/ingress/runtime.test.ts`
- `extensions/telegram/src/ingress-runtime.ts`
- `extensions/telegram/src/bot-message.ingress-runtime.test.ts`
- `src/config/config.telegram-ingress-middlewares.test.ts`

### Updated files
- `extensions/telegram/src/bot-message.ts`
- `src/config/types.telegram.ts`
- `src/config/zod-schema.providers-core.ts`

## Behavioral change

Telegram message flow becomes:

```text
buildTelegramMessageContext(...)
-> maybeRunTelegramIngressMiddlewares(...)
-> dispatchTelegramMessage(...)
```

This creates a source-level awaited pre-dispatch seam for deterministic logic.

## Example config

```json
{
  "channels": {
    "telegram": {
      "ingressMiddlewares": [
        {
          "name": "deterministic-public-private-bridge",
          "module": "file:///root/.openclaw/workspace/scripts/deterministic-public-bridge.mjs",
          "exportName": "runIngressMiddleware"
        }
      ]
    }
  }
}
```

## Suggested commit message

```text
telegram: add awaited ingress middleware chain before dispatch

Add a source-level Telegram ingress middleware layer that runs after
message context construction and before dispatchTelegramMessage().

This creates a first-class awaited pre-dispatch extension point for
 deterministic inbound logic such as public/private bridging, dedupe,
 moderation, and deterministic notifications.

Also adds config support for channels.telegram.ingressMiddlewares and
coverage for runtime ordering, Telegram integration, and schema parsing.
```

## Suggested PR description

### Summary

This PR adds a source-level awaited Telegram ingress middleware chain before normal message dispatch.

### Why

We needed a deterministic pre-model/pre-dispatch extension point for public/private ingress logic. A compiled-bundle hotfix worked operationally, but it was not maintainable. This patch moves the extension seam into source-level code.

### What changed

- introduced generic channel ingress middleware runtime
- wired Telegram message processor to await ingress middleware execution before dispatch
- added config support via `channels.telegram.ingressMiddlewares`
- added targeted tests

### Validation

Targeted validation passed:
- `src/channels/ingress/runtime.test.ts`
- `src/config/config.telegram-ingress-middlewares.test.ts`
- `extensions/telegram/src/bot-message.ingress-runtime.test.ts`

### Notes

This PR introduces the awaited ingress extension seam, but does not by itself force any specific middleware behavior. Existing behavior remains unchanged unless `channels.telegram.ingressMiddlewares` is configured.

## Rollout notes

1. Merge source patch.
2. Build OpenClaw from source.
3. Configure `channels.telegram.ingressMiddlewares` only for the target account/environment.
4. Run focused Telegram smoke tests:
   - owner DM -> main
   - external DM -> public
   - meaningful pending update -> notify
   - trivial update -> no notify
   - security alert -> blocked + notify
5. Remove dist-level hotfix after source deployment is confirmed.

## Known limitations

- This patch introduces the awaited Telegram ingress seam, but not a fully channel-agnostic ingress decision API yet.
- Current runtime middleware contract is execution-oriented, not a full `continue/drop/handled/reroute` decision protocol.
- The live bot still uses runtime hotfix/apply/verify tooling until a source-built deployment replaces it.
- Baseline repository type issues outside this patch still exist in the temp source tree (`qrcode-terminal`, `pdf-extract`, `node-pty`).

## Recommended follow-up PRs

1. Promote ingress middleware from Telegram-focused runtime seam to a core cross-channel ingress decision layer.
2. Define explicit middleware decision results:
   - `continue`
   - `drop`
   - `handled`
   - `reroute`
3. Add structured diagnostics/metrics for ingress middleware outcomes.
4. Replace the live dist-level Telegram hotfix with the source-built implementation.
