### PR TITLE
docs(browser): use wss:// for Browserless CDP URL

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -191,8 +191,9 @@ Notes:
 ## Browserless (hosted remote CDP)
 
 [Browserless](https://browserless.io) is a hosted Chromium service that exposes
-CDP endpoints over HTTPS. You can point an OpenClaw browser profile at a
-Browserless region endpoint and authenticate with your API key.
+remote CDP endpoints. You can point an OpenClaw browser profile at a
+Browserless region endpoint and authenticate with your API key. The example
+below uses Browserless's direct WebSocket endpoint.
 
 Example:
 
@@ -223,10 +224,11 @@ Notes:
 Some hosted browser services expose a **direct WebSocket** endpoint rather than
 the standard HTTP-based CDP discovery (`/json/version`). OpenClaw supports both:
 
-- **HTTP(S) endpoints** (e.g. Browserless) — OpenClaw calls `/json/version` to
+- **HTTP(S) endpoints** — OpenClaw calls `/json/version` to
   discover the WebSocket debugger URL, then connects.
 - **WebSocket endpoints** (`ws://` / `wss://`) — OpenClaw connects directly,
   skipping `/json/version`. Use this for services like
+  [Browserless](https://browserless.io),
   [Browserbase](https://www.browserbase.com) or any provider that hands you a
   WebSocket URL.
 

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -205,7 +205,7 @@ Example:
     remoteCdpHandshakeTimeoutMs: 4000,
     profiles: {
       browserless: {
-        cdpUrl: "https://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
+        cdpUrl: "wss://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
         color: "#00AA00",
       },
     },

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -228,9 +228,16 @@ the standard HTTP-based CDP discovery (`/json/version`). OpenClaw supports both:
   discover the WebSocket debugger URL, then connects.
 - **WebSocket endpoints** (`ws://` / `wss://`) — OpenClaw connects directly,
   skipping `/json/version`. Use this for services like
+  [Browserbase](https://www.browserbase.com), [Browserless](https://browserless.io),
+  or any provider that hands you a WebSocket URL.
+
   [Browserless](https://browserless.io),
   [Browserbase](https://www.browserbase.com) or any provider that hands you a
   WebSocket URL.
+=======
+  [Browserbase](https://www.browserbase.com), [Browserless](https://browserless.io),
+  or any provider that hands you a WebSocket URL.
+>>>>>>> 06838c8 (docs(browser): fix Browserless websocket wording)
 
 ### Browserbase
 

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -230,10 +230,6 @@ the standard HTTP-based CDP discovery (`/json/version`). OpenClaw supports both:
   skipping `/json/version`. Use this for services like
   [Browserbase](https://www.browserbase.com), [Browserless](https://browserless.io),
   or any provider that hands you a WebSocket URL.
-
-  [Browserless](https://browserless.io),
-  [Browserbase](https://www.browserbase.com) or any provider that hands you a
-  WebSocket URL.
 =======
   [Browserbase](https://www.browserbase.com), [Browserless](https://browserless.io),
   or any provider that hands you a WebSocket URL.

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -230,10 +230,6 @@ the standard HTTP-based CDP discovery (`/json/version`). OpenClaw supports both:
   skipping `/json/version`. Use this for services like
   [Browserbase](https://www.browserbase.com), [Browserless](https://browserless.io),
   or any provider that hands you a WebSocket URL.
-=======
-  [Browserbase](https://www.browserbase.com), [Browserless](https://browserless.io),
-  or any provider that hands you a WebSocket URL.
->>>>>>> 06838c8 (docs(browser): fix Browserless websocket wording)
 
 ### Browserbase
 


### PR DESCRIPTION
## Summary
- fix the Browserless CDP example to use the websocket scheme
- keep the change minimal and docs-only

## Testing
- not run (docs-only)

Fixes #44992