### PR TITLE
fix(cron): skip announce delivery for NO_REPLY

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -18,6 +18,8 @@ Tip: run `openclaw cron --help` for the full command surface.
 
 Note: isolated `cron add` jobs default to `--announce` delivery. Use `--no-deliver` to keep
 output internal. `--deliver` remains as a deprecated alias for `--announce`.
+When an announced isolated run replies with exact `NO_REPLY` (after trimming), OpenClaw suppresses
+the outbound delivery.
 
 Note: cron-owned isolated runs expect a plain-text summary and the runner owns
 the final send path. `--no-deliver` keeps the run internal; it does not hand

--- a/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
@@ -97,4 +97,46 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
       });
     });
   });
+
+  it('suppresses exact "NO_REPLY" for plain announce delivery', async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "NO_REPLY" }]);
+
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+    });
+  });
+
+  it('suppresses exact "NO_REPLY" for forum-topic announce delivery', async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "NO_REPLY" }]);
+
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123:topic:42" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -420,7 +420,25 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
-  it("does not mark NO_REPLY output as delivered when no direct send occurs", async () => {
+  it("skips announce when the agent reply is whitespace-padded NO_REPLY", async () => {
+    await withTelegramAnnounceFixture(async ({ home, storePath, deps }) => {
+      mockAgentPayloads([{ text: "  NO_REPLY \n" }]);
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+    });
+  });
+
+  it("skips announce when the agent reply is exact NO_REPLY", async () => {
     await withTelegramAnnounceFixture(async ({ home, storePath, deps }) => {
       mockAgentPayloads([{ text: "NO_REPLY" }]);
       const res = await runTelegramAnnounceTurn({
@@ -432,6 +450,7 @@ describe("runCronIsolatedAgentTurn", () => {
 
       expect(res.status).toBe("ok");
       expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(true);
       expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
       expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
     });
@@ -459,6 +478,7 @@ describe("runCronIsolatedAgentTurn", () => {
 
       expect(res.status).toBe("ok");
       expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(true);
       expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
       expect(callGateway).toHaveBeenCalledTimes(1);
       expect(callGateway).toHaveBeenCalledWith(
@@ -473,7 +493,6 @@ describe("runCronIsolatedAgentTurn", () => {
       );
     });
   });
-
   it("fails when structured direct delivery fails and best-effort is disabled", async () => {
     await expectStructuredTelegramFailure({
       payload: { text: "hello from cron", mediaUrl: "https://example.com/img.png" },

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -90,6 +90,24 @@ export type DispatchCronDeliveryState = {
   deliveryPayloads: ReplyPayload[];
 };
 
+function isDirectSilentReplyOnly(payloads: readonly ReplyPayload[]): boolean {
+  if (payloads.length !== 1) {
+    return false;
+  }
+  const [payload] = payloads;
+  if (!payload || !isSilentReplyText(payload.text, SILENT_REPLY_TOKEN)) {
+    return false;
+  }
+  return !(
+    payload.mediaUrl ||
+    (payload.mediaUrls?.length ?? 0) > 0 ||
+    payload.interactive ||
+    payload.btw ||
+    payload.audioAsVoice === true ||
+    Object.keys(payload.channelData ?? {}).length > 0
+  );
+}
+
 const TRANSIENT_DIRECT_CRON_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /\berrorcode=unavailable\b/i,
   /\bstatus\s*[:=]\s*"?unavailable\b/i,
@@ -430,6 +448,18 @@ export async function dispatchCronDelivery(
       );
       if (payloadsForDelivery.length === 0) {
         return await finishSilentReplyDelivery();
+      }
+      if (isDirectSilentReplyOnly(payloadsForDelivery)) {
+        deliveryAttempted = true;
+        delivered = false;
+        return params.withRunSession({
+          status: "ok",
+          summary,
+          outputText,
+          delivered: false,
+          deliveryAttempted: true,
+          ...params.telemetry,
+        });
       }
       if (params.isAborted()) {
         return params.withRunSession({


### PR DESCRIPTION
## Summary
- treat exact NO_REPLY output as a silent response for cron announce delivery
- skip outbound announce delivery when the isolated run returns NO_REPLY
- document the behavior and add regression coverage

## Testing
- added regression coverage for whitespace-trimmed NO_REPLY handling
- not run in this temp environment because pnpm install/test was blocked by DNS resolution for registry.npmjs.org

Fixes #45810