### PR TITLE
fix(ui): resolve bare model alias to full key in buildModelOptions

### DIFF
--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -576,9 +576,35 @@ export function buildModelOptions(
   current?: string | null,
 ) {
   const options = resolveConfiguredModels(configForm);
-  const hasCurrent = current ? options.some((option) => option.value === current) : false;
-  if (current && !hasCurrent) {
-    options.unshift({ value: current, label: `Current (${current})` });
+
+  // Resolve bare alias (e.g. "k2p5") → full key (e.g. "kimi-coding/k2p5")
+  // so the select value is always a complete provider/key, never a bare alias.
+  const resolvedCurrent = (() => {
+    if (!current) return null;
+    if (options.some((o) => o.value === current)) return current;
+    const cfg = configForm as ConfigSnapshot | null;
+    const models = cfg?.agents?.defaults?.models;
+    if (models && typeof models === "object") {
+      for (const [modelId, modelRaw] of Object.entries(models)) {
+        const alias =
+          modelRaw && typeof modelRaw === "object" && "alias" in modelRaw
+            ? typeof (modelRaw as { alias?: unknown }).alias === "string"
+              ? (modelRaw as { alias?: string }).alias?.trim()
+              : undefined
+            : undefined;
+        if (alias === current) {
+          return modelId.trim();
+        }
+      }
+    }
+    return current;
+  })();
+
+  const hasCurrent = resolvedCurrent
+    ? options.some((option) => option.value === resolvedCurrent)
+    : false;
+  if (resolvedCurrent && !hasCurrent) {
+    options.unshift({ value: resolvedCurrent, label: `Current (${resolvedCurrent})` });
   }
   if (options.length === 0) {
     return html`


### PR DESCRIPTION
When an agent config stores a model alias (e.g., "k2p5") instead of the 
full qualified key (e.g., "kimi-coding/k2p5"), buildModelOptions would 
add the bare alias as an option value. The backend then resolves "k2p5" 
using the default provider, producing an invalid key like "minimax/k2p5".

This fix reverse-matches the alias to the full key before using it as
the select value, ensuring the UI always submits a complete provider/key pair.

Fixes model switching errors like "model not allowed: minimax/k2p5".