### PR TITLE
fix(ios): use existing CLLocationManager for authorizationStatus check

### DIFF
--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -895,7 +895,6 @@ final class GatewayConnectionController {
         if let appModel = self.appModel {
             permissions["location"] = Self.isLocationAuthorized(
                 status: appModel.locationAuthorizationStatus())
-                && appModel.isLocationServicesEnabled
         }
         permissions["screenRecording"] = RPScreenRecorder.shared().isAvailable
 

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -895,7 +895,7 @@ final class GatewayConnectionController {
         if let appModel = self.appModel {
             permissions["location"] = Self.isLocationAuthorized(
                 status: appModel.locationAuthorizationStatus())
-                && CLLocationManager.locationServicesEnabled()
+                && appModel.isLocationServicesEnabled
         }
         permissions["screenRecording"] = RPScreenRecorder.shared().isAvailable
 

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -892,9 +892,10 @@ final class GatewayConnectionController {
         permissions["camera"] = AVCaptureDevice.authorizationStatus(for: .video) == .authorized
         permissions["microphone"] = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
         permissions["speechRecognition"] = SFSpeechRecognizer.authorizationStatus() == .authorized
-        permissions["location"] = Self.isLocationAuthorized(
-            status: CLLocationManager().authorizationStatus)
-            && CLLocationManager.locationServicesEnabled()
+        if let appModel = self.appModel {
+            permissions["location"] = Self.isLocationAuthorized(
+                status: appModel.locationAuthorizationStatus())
+        }
         permissions["screenRecording"] = RPScreenRecorder.shared().isAvailable
 
         let photoStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -895,6 +895,7 @@ final class GatewayConnectionController {
         if let appModel = self.appModel {
             permissions["location"] = Self.isLocationAuthorized(
                 status: appModel.locationAuthorizationStatus())
+                && CLLocationManager.locationServicesEnabled()
         }
         permissions["screenRecording"] = RPScreenRecorder.shared().isAvailable
 

--- a/apps/ios/Sources/Location/LocationService.swift
+++ b/apps/ios/Sources/Location/LocationService.swift
@@ -16,7 +16,6 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
     private var isStreaming = false
     private var significantLocationCallback: (@Sendable (CLLocation) -> Void)?
     private var isMonitoringSignificantChanges = false
-    private(set) var isLocationServicesEnabled = CLLocationManager.locationServicesEnabled()
 
     var locationManager: CLLocationManager {
         self.manager
@@ -135,9 +134,7 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
 
     nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         let status = manager.authorizationStatus
-        let servicesEnabled = CLLocationManager.locationServicesEnabled()
         Task { @MainActor in
-            self.isLocationServicesEnabled = servicesEnabled
             if let cont = self.authContinuation {
                 self.authContinuation = nil
                 cont.resume(returning: status)

--- a/apps/ios/Sources/Location/LocationService.swift
+++ b/apps/ios/Sources/Location/LocationService.swift
@@ -16,6 +16,7 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
     private var isStreaming = false
     private var significantLocationCallback: (@Sendable (CLLocation) -> Void)?
     private var isMonitoringSignificantChanges = false
+    private(set) var isLocationServicesEnabled = CLLocationManager.locationServicesEnabled()
 
     var locationManager: CLLocationManager {
         self.manager
@@ -32,8 +33,6 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
     }
 
     func ensureAuthorization(mode: OpenClawLocationMode) async -> CLAuthorizationStatus {
-        guard CLLocationManager.locationServicesEnabled() else { return .denied }
-
         let status = self.manager.authorizationStatus
         if status == .notDetermined {
             self.manager.requestWhenInUseAuthorization()
@@ -136,7 +135,9 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
 
     nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         let status = manager.authorizationStatus
+        let servicesEnabled = CLLocationManager.locationServicesEnabled()
         Task { @MainActor in
+            self.isLocationServicesEnabled = servicesEnabled
             if let cont = self.authContinuation {
                 self.authContinuation = nil
                 cont.resume(returning: status)

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import OpenClawChatUI
 import OpenClawKit
 import OpenClawProtocol
@@ -512,6 +513,10 @@ final class NodeAppModel {
                 enabled: enabled,
                 phase: enabled ? "enabled" : "disabled")
         }
+    }
+
+    func locationAuthorizationStatus() -> CLAuthorizationStatus {
+        self.locationService.authorizationStatus()
     }
 
     func requestLocationPermissions(mode: OpenClawLocationMode) async -> Bool {

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -519,10 +519,6 @@ final class NodeAppModel {
         self.locationService.authorizationStatus()
     }
 
-    var isLocationServicesEnabled: Bool {
-        self.locationService.isLocationServicesEnabled
-    }
-
     func requestLocationPermissions(mode: OpenClawLocationMode) async -> Bool {
         guard mode != .off else { return true }
         let status = await self.locationService.ensureAuthorization(mode: mode)

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -519,6 +519,10 @@ final class NodeAppModel {
         self.locationService.authorizationStatus()
     }
 
+    var isLocationServicesEnabled: Bool {
+        self.locationService.isLocationServicesEnabled
+    }
+
     func requestLocationPermissions(mode: OpenClawLocationMode) async -> Bool {
         guard mode != .off else { return true }
         let status = await self.locationService.ensureAuthorization(mode: mode)

--- a/apps/ios/Sources/Services/NodeServiceProtocols.swift
+++ b/apps/ios/Sources/Services/NodeServiceProtocols.swift
@@ -25,6 +25,7 @@ protocol ScreenRecordingServicing: Sendable {
 protocol LocationServicing: Sendable {
     func authorizationStatus() -> CLAuthorizationStatus
     func accuracyAuthorization() -> CLAccuracyAuthorization
+    var isLocationServicesEnabled: Bool { get }
     func ensureAuthorization(mode: OpenClawLocationMode) async -> CLAuthorizationStatus
     func currentLocation(
         params: OpenClawLocationGetParams,

--- a/apps/ios/Sources/Services/NodeServiceProtocols.swift
+++ b/apps/ios/Sources/Services/NodeServiceProtocols.swift
@@ -25,7 +25,6 @@ protocol ScreenRecordingServicing: Sendable {
 protocol LocationServicing: Sendable {
     func authorizationStatus() -> CLAuthorizationStatus
     func accuracyAuthorization() -> CLAccuracyAuthorization
-    var isLocationServicesEnabled: Bool { get }
     func ensureAuthorization(mode: OpenClawLocationMode) async -> CLAuthorizationStatus
     func currentLocation(
         params: OpenClawLocationGetParams,


### PR DESCRIPTION
Avoid creating a throwaway `CLLocationManager()` on the main thread in `currentPermissions()`. Route through `NodeAppModel.locationAuthorizationStatus()` which reads from the delegate-managed `LocationService` instance instead. Additionally, remove all `CLLocationManager.locationServicesEnabled()` calls that triggered the same CoreLocation Fault warning — per Apple docs, disabling system-wide Location Services causes `authorizationStatus` to report `.denied`, making the separate check redundant.

## Summary

- **Problem:** `currentPermissions()` in `GatewayConnectionController` created a new `CLLocationManager()` every call just to read `authorizationStatus`, and both `currentPermissions()` and `LocationService.ensureAuthorization()` called `CLLocationManager.locationServicesEnabled()` on the main thread. CoreLocation emits a Fault log warning for all of these, indicating potential UI unresponsiveness.
- **Why it matters:** Fault-level logs indicate main-thread blocking. The throwaway manager also bypassed the delegate-managed state already maintained by `LocationService`.
- **What changed:**
  - Added `NodeAppModel.locationAuthorizationStatus()` that delegates to the existing `LocationService` instance, and updated `currentPermissions()` to call it via `appModel` instead of creating a throwaway `CLLocationManager`.
  - Removed `CLLocationManager.locationServicesEnabled()` from both `currentPermissions()` and `LocationService.ensureAuthorization()`. Per [Apple docs](https://developer.apple.com/documentation/corelocation/cllocationmanager/locationservicesenabled()), when users disable Location Services globally, the delegate receives `authorizationStatus == .denied`, so `isLocationAuthorized()` (which only allows `.authorizedAlways`/`.authorizedWhenInUse`) already handles this case correctly.
- **What did NOT change (scope boundary):** No changes to keepalive, reconnect logic, location permission request flows, or any other CoreLocation handling beyond the permission snapshot and authorization guard.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

None. Eliminates CoreLocation Fault logs and potential main-thread stalls during permission checks. No functional behavior change — location permission reporting remains identical.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: iOS 16+ (simulator or device)
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel: Gateway WebSocket connection

### Steps

1. Launch the app and connect to a gateway.
2. Monitor Console.app / Xcode console for CoreLocation Fault logs.
3. Observe `currentPermissions()` being called during gateway connect.

### Expected

- No CoreLocation Fault log about `authorizationStatus` or `locationServicesEnabled` on the main thread.

### Actual (before fix)

- `This method can cause UI unresponsiveness if invoked on the main thread. Instead, consider waiting for the -locationManagerDidChangeAuthorization: callback and checking authorizationStatus first.` (Type: Fault, Subsystem: com.apple.runtime-issues, Category: CoreLocation)

## Evidence

- [x] Trace/log snippets: CoreLocation Fault log triggered by both `CLLocationManager().authorizationStatus` and `CLLocationManager.locationServicesEnabled()` in `currentPermissions()`.
- [x] Apple documentation confirms `locationServicesEnabled()` is redundant: "When users disable the switch, the system calls your delegate's `locationManager(_:didChangeAuthorization:)` method with a denied authorization status (`CLAuthorizationStatus.denied`)."

## Human Verification (required)

- Verified scenarios: Xcode live diagnostics confirm no compiler errors across all modified files. Apple documentation confirms `authorizationStatus == .denied` when Location Services are globally disabled.
- Edge cases checked: `appModel` being `nil` (weak reference) — the `location` key is simply omitted from the permissions dict, which is safe since the gateway connection is already torn down. Location Services toggled globally off — `authorizationStatus` reports `.denied`, `isLocationAuthorized()` returns `false`.
- What I did **not** verify: Full integration test on a physical device with Location Services toggled on/off during an active gateway session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert all commits on this branch.
- Files/config to restore: `apps/ios/Sources/Gateway/GatewayConnectionController.swift`, `apps/ios/Sources/Model/NodeAppModel.swift`, `apps/ios/Sources/Location/LocationService.swift`
- Known bad symptoms reviewers should watch for: If reverted, the original CoreLocation Fault logs return. No functional breakage expected from revert.

## Risks and Mitigations

- **Risk:** When `appModel` is `nil`, the `location` permission key is omitted from the dict (previously it was always present).
  - **Mitigation:** `appModel` is `nil` only after the controller is being torn down, at which point the permissions dict is not consumed by the gateway. The omission is functionally equivalent to `false`.
- **Risk:** Removing `locationServicesEnabled()` guard from `ensureAuthorization()` could allow authorization requests when Location Services are globally off.
  - **Mitigation:** Per Apple docs, `authorizationStatus` returns `.denied` when Location Services are off, so the `notDetermined` and `authorizedWhenInUse` branches that trigger `requestWhenInUseAuthorization()`/`requestAlwaysAuthorization()` are never reached. The system also silently ignores these requests when services are disabled.