### PR TITLE
fix(feishu): extractPermissionError also recognizes code 99991401

### DIFF
--- a/extensions/feishu/src/bot-sender-name.ts
+++ b/extensions/feishu/src/bot-sender-name.ts
@@ -43,7 +43,12 @@ function extractPermissionError(err: unknown): FeishuPermissionError | null {
     return null;
   }
   const feishuErr = data as { code?: number; msg?: string };
-  if (feishuErr.code !== 99991672) {
+  // Feishu permission/scope error codes: 99991401 (scope not granted) and 99991672 (permission denied)
+  const isPermissionError =
+    feishuErr.code === 99991672 ||
+    feishuErr.code === 99991401 ||
+    (feishuErr.code !== 0 && typeof feishuErr.code === "number" && feishuErr.msg?.toLowerCase().includes("permission"));
+  if (!isPermissionError) {
     return null;
   }
   const msg = feishuErr.msg ?? "";


### PR DESCRIPTION
## Bug

`extractPermissionError()` in `bot-sender-name.ts` only checked for error code `99991672`, silently swallowing other Feishu permission error codes like `99991401`.

This caused `resolveFeishuSenderName()` to return `{}` instead of surfacing permission errors when the Feishu contact API returned `99991401` (scope not granted) or other permission-related error codes.

## Fix

Updated `extractPermissionError()` to also recognize:
- `99991401` (scope not granted) - confirmed by `send.reply-fallback.test.ts:244` and `typing.test.ts:36`
- `99991672` (permission denied) - already supported
- Any non-zero code with 'permission' in the error message - fallback for future codes

## Testing

- `send.reply-fallback.test.ts:244` uses `99991401` as a permission error code
- `typing.test.ts:36,84` use `99991401` as a Feishu API error response code
