### PR TITLE
feat(apple-notes): update skill for memo fork with pipx install and notes api

### DIFF
--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: apple-notes
 description: Manage Apple Notes via the `memo` CLI on macOS (create, view, edit, delete, search, move, and export notes). Use when a user asks OpenClaw to add a note, list notes, search notes, or manage note folders.
-homepage: https://github.com/antoniorodr/memo
+homepage: https://github.com/jacob-bayer/memo
 metadata:
   {
     "openclaw":
@@ -14,7 +14,7 @@ metadata:
             {
               "id": "brew",
               "kind": "brew",
-              "formula": "antoniorodr/memo/memo",
+              "formula": "jacob-bayer/tap/memo",
               "bins": ["memo"],
               "label": "Install memo via Homebrew",
             },
@@ -29,7 +29,7 @@ Use `memo notes` to manage Apple Notes directly from the terminal. Create, view,
 
 Setup
 
-- Install (Homebrew): `brew tap antoniorodr/memo && brew install antoniorodr/memo/memo`
+- Install (Homebrew): `brew tap jacob-bayer/tap && brew install jacob-bayer/tap/memo`
 - Manual (pip): `pip install .` (after cloning the repo)
 - macOS-only; if prompted, grant Automation access to Notes.app.
 
@@ -65,10 +65,25 @@ Export Notes
 - Export to HTML/Markdown: `memo notes -ex`
   - Exports selected note; uses Mistune for markdown processing.
 
+Non-Interactive API (for agents and scripts)
+
+Use `memo notes api <subcommand>` for scripting and agent workflows. All commands are non-interactive and machine-readable.
+
+- List notes: `memo notes api list [--folder FOLDER] [--format tsv|json|lines]`
+- Show note body (Markdown): `memo notes api show <note-id>`
+- Edit note from stdin: `echo "# Updated content" | memo notes api edit <note-id>`
+- Add note from stdin: `echo "# New note" | memo notes api add --folder "Folder Name"`
+- Delete note: `memo notes api delete <note-id>`
+- Move note: `memo notes api move <note-id> <target-folder>`
+- List folders: `memo notes api folders [--format tsv|json]`
+- Search notes: `memo notes api search <query> [--folder FOLDER] [--format tsv|json] [--body]`
+- Remove folder: `memo notes api remove <folder-name> --force`
+- Export notes: `memo notes api export --path /path/to/dir [--markdown]`
+
 Limitations
 
-- Cannot edit notes containing images or attachments.
-- Interactive prompts may require terminal access.
+- Cannot edit notes containing images or attachments via the API.
+- Interactive prompts require terminal access (use `api` subcommands for automation).
 
 Notes
 


### PR DESCRIPTION
## Summary

Updates the `apple-notes` skill to point to the [jacob-bayer/memo](https://github.com/jacob-bayer/memo) fork, which includes:

- A new non-interactive `memo notes api` subcommand designed for agent/script use
- AppleScript injection prevention (escaping user-supplied values before interpolation)

## Background

The upstream author has explicitly declined to add non-interactive / agent-friendly features to memo. When this functionality was proposed in [antoniorodr/memo#30](https://github.com/antoniorodr/memo/pull/30), the response was:

> "There is no way to pass content non-interactively because Memo was not created with AI Agents in mind. I am not interested into making Memo more 'AI friendly' at the moment."

This fork exists to fill that gap for OpenClaw users.

## Changes

### Install method
- **Before:** `brew tap antoniorodr/memo && brew install antoniorodr/memo/memo`
- **After:** `brew tap jacob-bayer/tap && brew install jacob-bayer/tap/memo` via [jacob-bayer/homebrew-tap](https://github.com/jacob-bayer/homebrew-tap)

### New `notes api` subcommand documentation
Documents the machine-friendly API added in the fork:
- `memo notes api list` — list notes (tsv/json/lines output)
- `memo notes api show <id>` — fetch note body as Markdown
- `memo notes api edit <id>` — replace note body from stdin
- `memo notes api add --folder <name>` — create note from stdin
- `memo notes api delete <id>` — delete a note
- `memo notes api move <id> <folder>` — move a note
- `memo notes api folders` — list folders
- `memo notes api search <query>` — search notes
- `memo notes api remove <folder> --force` — delete a folder
- `memo notes api export --path <dir>` — export notes

These enable agent workflows where parameters may originate from untrusted sources — the fork addresses this with AppleScript string escaping.