### PR TITLE
Refresh skill prompts inside sandbox workspaces

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -521,18 +521,20 @@ export async function compactEmbeddedPiSessionDirect(
   let restoreSkillEnv: (() => void) | undefined;
   process.chdir(effectiveWorkspace);
   try {
+    const preferWorkspaceSkillPaths = effectiveWorkspace !== resolvedWorkspace;
     const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
       workspaceDir: effectiveWorkspace,
       config: params.config,
       skillsSnapshot: params.skillsSnapshot,
+      preferWorkspaceEntries: preferWorkspaceSkillPaths,
     });
-    restoreSkillEnv = params.skillsSnapshot
-      ? applySkillEnvOverridesFromSnapshot({
-          snapshot: params.skillsSnapshot,
+    restoreSkillEnv = shouldLoadSkillEntries
+      ? applySkillEnvOverrides({
+          skills: skillEntries ?? [],
           config: params.config,
         })
-      : applySkillEnvOverrides({
-          skills: skillEntries ?? [],
+      : applySkillEnvOverridesFromSnapshot({
+          snapshot: params.skillsSnapshot,
           config: params.config,
         });
     const skillsPrompt = resolveSkillsPromptForRun({
@@ -540,6 +542,7 @@ export async function compactEmbeddedPiSessionDirect(
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
+      preferEntries: preferWorkspaceSkillPaths,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1657,18 +1657,20 @@ export async function runEmbeddedAttempt(
   let restoreSkillEnv: (() => void) | undefined;
   process.chdir(effectiveWorkspace);
   try {
+    const preferWorkspaceSkillPaths = effectiveWorkspace !== resolvedWorkspace;
     const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
       workspaceDir: effectiveWorkspace,
       config: params.config,
       skillsSnapshot: params.skillsSnapshot,
+      preferWorkspaceEntries: preferWorkspaceSkillPaths,
     });
-    restoreSkillEnv = params.skillsSnapshot
-      ? applySkillEnvOverridesFromSnapshot({
-          snapshot: params.skillsSnapshot,
+    restoreSkillEnv = shouldLoadSkillEntries
+      ? applySkillEnvOverrides({
+          skills: skillEntries ?? [],
           config: params.config,
         })
-      : applySkillEnvOverrides({
-          skills: skillEntries ?? [],
+      : applySkillEnvOverridesFromSnapshot({
+          snapshot: params.skillsSnapshot,
           config: params.config,
         });
 
@@ -1677,6 +1679,7 @@ export async function runEmbeddedAttempt(
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
+      preferEntries: preferWorkspaceSkillPaths,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/pi-embedded-runner/skills-runtime.test.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.test.ts
@@ -67,4 +67,25 @@ describe("resolveEmbeddedRunSkillEntries", () => {
     });
     expect(hoisted.loadWorkspaceSkillEntries).not.toHaveBeenCalled();
   });
+
+  it("reloads skill entries when sandbox execution prefers workspace-local skill paths", () => {
+    const snapshot: SkillSnapshot = {
+      prompt: "skills prompt",
+      skills: [{ name: "diffs" }],
+      resolvedSkills: [],
+    };
+
+    const result = resolveEmbeddedRunSkillEntries({
+      workspaceDir: "/tmp/workspace-sandbox",
+      config: {},
+      skillsSnapshot: snapshot,
+      preferWorkspaceEntries: true,
+    });
+
+    expect(result.shouldLoadSkillEntries).toBe(true);
+    expect(hoisted.loadWorkspaceSkillEntries).toHaveBeenCalledTimes(1);
+    expect(hoisted.loadWorkspaceSkillEntries).toHaveBeenCalledWith("/tmp/workspace-sandbox", {
+      config: {},
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -5,11 +5,15 @@ export function resolveEmbeddedRunSkillEntries(params: {
   workspaceDir: string;
   config?: OpenClawConfig;
   skillsSnapshot?: SkillSnapshot;
+  preferWorkspaceEntries?: boolean;
 }): {
   shouldLoadSkillEntries: boolean;
   skillEntries: SkillEntry[];
 } {
-  const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+  const shouldLoadSkillEntries =
+    params.preferWorkspaceEntries ||
+    !params.skillsSnapshot ||
+    !params.skillsSnapshot.resolvedSkills;
   return {
     shouldLoadSkillEntries,
     skillEntries: shouldLoadSkillEntries

--- a/src/agents/skills.resolveskillspromptforrun.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.test.ts
@@ -29,4 +29,27 @@ describe("resolveSkillsPromptForRun", () => {
     expect(prompt).toContain("<available_skills>");
     expect(prompt).toContain("/app/skills/demo-skill/SKILL.md");
   });
+
+  it("prefers workspace-built prompt when sandbox execution overrides snapshot paths", () => {
+    const entry: SkillEntry = {
+      skill: {
+        name: "demo-skill",
+        description: "Demo",
+        filePath: "/sandbox/workspace/skills/demo-skill/SKILL.md",
+        baseDir: "/sandbox/workspace/skills/demo-skill",
+        source: "workspace",
+        disableModelInvocation: false,
+      },
+      frontmatter: {},
+    };
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: { prompt: "SNAPSHOT", skills: [] },
+      entries: [entry],
+      workspaceDir: "/sandbox/workspace",
+      preferEntries: true,
+    });
+
+    expect(prompt).toContain("/sandbox/workspace/skills/demo-skill/SKILL.md");
+    expect(prompt).not.toBe("SNAPSHOT");
+  });
 });

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -696,9 +696,10 @@ export function resolveSkillsPromptForRun(params: {
   entries?: SkillEntry[];
   config?: OpenClawConfig;
   workspaceDir: string;
+  preferEntries?: boolean;
 }): string {
   const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
-  if (snapshotPrompt) {
+  if (snapshotPrompt && !params.preferEntries) {
     return snapshotPrompt;
   }
   if (params.entries && params.entries.length > 0) {


### PR DESCRIPTION
Cherry-picks cc0ef9e8a3 onto a clean branch from origin/main.

Verification:
- pnpm exec vitest run --config vitest.config.ts src/agents/pi-embedded-runner/skills-runtime.test.ts src/agents/skills.resolveskillspromptforrun.test.ts
- Result: 2 test files passed, 6 tests passed

Notes:
- Branch diff is limited to the 6 files from cc0ef9e8a3.
- No conflict resolution was needed.