### PR TITLE
Export Feishu workspace artifact helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,10 @@
       "types": "./dist/plugin-sdk/acp-runtime.d.ts",
       "default": "./dist/plugin-sdk/acp-runtime.js"
     },
+    "./plugin-sdk/feishu": {
+      "types": "./dist/plugin-sdk/feishu.d.ts",
+      "default": "./dist/plugin-sdk/feishu.js"
+    },
     "./plugin-sdk/lazy-runtime": {
       "types": "./dist/plugin-sdk/lazy-runtime.d.ts",
       "default": "./dist/plugin-sdk/lazy-runtime.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -38,6 +38,7 @@
   "process-runtime",
   "windows-spawn",
   "acp-runtime",
+  "feishu",
   "lazy-runtime",
   "testing",
   "account-helpers",

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -78,7 +78,11 @@ export {
   buildRuntimeAccountStatusSnapshot,
   createDefaultChannelRuntimeState,
 } from "./status-helpers.js";
-export { withTempDownloadPath } from "./temp-path.js";
+export {
+  buildAgentWorkspaceArtifactPath,
+  resolveAgentWorkspaceOutputPath,
+  withTempDownloadPath,
+} from "./temp-path.js";
 export {
   buildFeishuConversationId,
   parseFeishuConversationId,

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -34,6 +34,7 @@ import type {
   PluginRuntime as CorePluginRuntime,
 } from "openclaw/plugin-sdk/core";
 import * as directoryRuntimeSdk from "openclaw/plugin-sdk/directory-runtime";
+import * as feishuSdk from "openclaw/plugin-sdk/feishu";
 import * as infraRuntimeSdk from "openclaw/plugin-sdk/infra-runtime";
 import * as lazyRuntimeSdk from "openclaw/plugin-sdk/lazy-runtime";
 import * as matrixRuntimeSharedSdk from "openclaw/plugin-sdk/matrix-runtime-shared";
@@ -97,8 +98,6 @@ describe("plugin-sdk subpath exports", () => {
     expect(pluginSdkSubpaths).not.toContain("bluebubbles");
     expect(pluginSdkSubpaths).not.toContain("compat");
     expect(pluginSdkSubpaths).not.toContain("device-pair");
-    expect(pluginSdkSubpaths).not.toContain("discord");
-    expect(pluginSdkSubpaths).not.toContain("feishu");
     expect(pluginSdkSubpaths).not.toContain("google");
     expect(pluginSdkSubpaths).not.toContain("googlechat");
     expect(pluginSdkSubpaths).not.toContain("imessage");
@@ -238,6 +237,12 @@ describe("plugin-sdk subpath exports", () => {
   it("exports infra runtime helpers from the dedicated subpath", () => {
     expect(typeof infraRuntimeSdk.createRuntimeOutboundDelegates).toBe("function");
     expect(typeof infraRuntimeSdk.resolveOutboundSendDep).toBe("function");
+  });
+
+  it("exports feishu helpers from the dedicated subpath", () => {
+    expect(typeof feishuSdk.buildAgentWorkspaceArtifactPath).toBe("function");
+    expect(typeof feishuSdk.resolveAgentWorkspaceOutputPath).toBe("function");
+    expect(typeof feishuSdk.withTempDownloadPath).toBe("function");
   });
 
   it("exports channel runtime helpers from the dedicated subpath", () => {

--- a/src/plugin-sdk/temp-path.test.ts
+++ b/src/plugin-sdk/temp-path.test.ts
@@ -2,7 +2,26 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
-import { buildRandomTempFilePath, withTempDownloadPath } from "./temp-path.js";
+import {
+  buildAgentWorkspaceArtifactPath,
+  buildRandomTempFilePath,
+  resolveAgentWorkspaceOutputPath,
+  withTempDownloadPath,
+} from "./temp-path.js";
+
+const cfg = {
+  agents: {
+    defaults: {
+      workspace: "/Users/admin/.openclaw/workspace",
+    },
+    list: [
+      {
+        id: "ops",
+        workspace: "/Users/admin/.openclaw/workspace-ops",
+      },
+    ],
+  },
+};
 
 describe("buildRandomTempFilePath", () => {
   it("builds deterministic paths when now/uuid are provided", () => {
@@ -67,5 +86,94 @@ describe("withTempDownloadPath", () => {
     expect(rel === ".." || rel.startsWith(`..${path.sep}`)).toBe(false);
     expect(path.basename(capturedPath)).toBe("evil.bin");
     expect(capturedPath).not.toContain("..");
+  });
+});
+
+describe("buildAgentWorkspaceArtifactPath", () => {
+  it("places artifacts inside the resolved agent workspace", () => {
+    const output = buildAgentWorkspaceArtifactPath({
+      cfg,
+      agentId: "ops",
+      prefix: "feishu-resource",
+      preferredFileName: "weekly-report.xlsx",
+      pathSegments: [".openclaw", "artifacts", "feishu"],
+      now: 123,
+      uuid: "abc",
+    });
+
+    expect(output.workspaceDir).toBe("/Users/admin/.openclaw/workspace-ops");
+    expect(output.absolutePath).toBe(
+      "/Users/admin/.openclaw/workspace-ops/.openclaw/artifacts/feishu/weekly-report-123-abc.xlsx",
+    );
+    expect(output.workspacePath).toBe(".openclaw/artifacts/feishu/weekly-report-123-abc.xlsx");
+  });
+
+  it("sanitizes dot segments in artifact paths so they cannot escape the workspace", () => {
+    const output = buildAgentWorkspaceArtifactPath({
+      cfg,
+      agentId: "ops",
+      prefix: "feishu-resource",
+      pathSegments: ["..", "feishu"],
+      now: 1,
+      uuid: "abc",
+    });
+
+    expect(output.absolutePath).toBe(
+      "/Users/admin/.openclaw/workspace-ops/artifact/feishu/feishu-resource-1-abc",
+    );
+    expect(output.workspacePath).toBe("artifact/feishu/feishu-resource-1-abc");
+  });
+});
+
+describe("resolveAgentWorkspaceOutputPath", () => {
+  it("auto-generates a workspace-local artifact path when output_path is omitted", () => {
+    const output = resolveAgentWorkspaceOutputPath({
+      cfg,
+      agentId: "ops",
+      prefix: "drive-file",
+      preferredFileName: "summary.pdf",
+      pathSegments: [".openclaw", "artifacts", "feishu"],
+      now: 456,
+      uuid: "xyz",
+    });
+
+    expect(output.absolutePath).toBe(
+      "/Users/admin/.openclaw/workspace-ops/.openclaw/artifacts/feishu/summary-456-xyz.pdf",
+    );
+    expect(output.workspacePath).toBe(".openclaw/artifacts/feishu/summary-456-xyz.pdf");
+  });
+
+  it("resolves relative output paths inside the agent workspace", () => {
+    const output = resolveAgentWorkspaceOutputPath({
+      cfg,
+      agentId: "ops",
+      prefix: "drive-file",
+      outputPath: "exports/report.xlsx",
+    });
+
+    expect(output.absolutePath).toBe("/Users/admin/.openclaw/workspace-ops/exports/report.xlsx");
+    expect(output.workspacePath).toBe("exports/report.xlsx");
+  });
+
+  it("rejects relative output paths that escape the agent workspace", () => {
+    expect(() =>
+      resolveAgentWorkspaceOutputPath({
+        cfg,
+        agentId: "ops",
+        prefix: "drive-file",
+        outputPath: "../outside/report.xlsx",
+      }),
+    ).toThrow("output_path must stay within the current workspace");
+  });
+
+  it("rejects absolute output paths outside the agent workspace", () => {
+    expect(() =>
+      resolveAgentWorkspaceOutputPath({
+        cfg,
+        agentId: "ops",
+        prefix: "drive-file",
+        outputPath: "/tmp/outside/report.xlsx",
+      }),
+    ).toThrow("output_path must stay within the current workspace");
   });
 });

--- a/src/plugin-sdk/temp-path.ts
+++ b/src/plugin-sdk/temp-path.ts
@@ -1,6 +1,8 @@
 import crypto from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import path from "node:path";
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 
 function sanitizePrefix(prefix: string): string {
@@ -25,6 +27,18 @@ function sanitizeFileName(fileName: string): string {
   const base = path.basename(fileName).replace(/[^a-zA-Z0-9._-]+/g, "-");
   const normalized = base.replace(/^-+|-+$/g, "");
   return normalized || "download.bin";
+}
+
+function sanitizeWorkspacePathSegment(segment: string): string {
+  const normalized = segment
+    .normalize("NFKC")
+    .replace(/[\\/]+/g, "-")
+    .replace(/\p{Cc}/gu, "")
+    .trim();
+  if (normalized === "." || normalized === "..") {
+    return "artifact";
+  }
+  return normalized || "artifact";
 }
 
 function resolveTempRoot(tmpDir?: string): string {
@@ -57,6 +71,119 @@ export function buildRandomTempFilePath(params: {
       : Date.now();
   const uuid = params.uuid?.trim() || crypto.randomUUID();
   return path.join(resolveTempRoot(params.tmpDir), `${prefix}-${now}-${uuid}${extension}`);
+}
+
+export type WorkspaceArtifactPath = {
+  workspaceDir: string;
+  absolutePath: string;
+  workspacePath?: string;
+};
+
+function toWorkspaceRelativePath(workspaceDir: string, absolutePath: string): string | undefined {
+  const relativePath = path.relative(workspaceDir, absolutePath);
+  if (!relativePath || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return undefined;
+  }
+  return relativePath.split(path.sep).join(path.posix.sep);
+}
+
+function normalizeWorkspaceExtension(params: {
+  extension?: string;
+  preferredFileName?: string;
+}): string {
+  if (params.extension) {
+    return sanitizeExtension(params.extension);
+  }
+  const preferredExt = params.preferredFileName ? path.extname(params.preferredFileName) : "";
+  return sanitizeExtension(preferredExt);
+}
+
+function buildWorkspaceArtifactFileName(params: {
+  prefix: string;
+  extension?: string;
+  preferredFileName?: string;
+  now?: number;
+  uuid?: string;
+}): string {
+  const baseName = params.preferredFileName
+    ? path.basename(params.preferredFileName, path.extname(params.preferredFileName))
+    : params.prefix;
+  const normalizedBase = sanitizeWorkspacePathSegment(baseName);
+  const nowCandidate = params.now;
+  const now =
+    typeof nowCandidate === "number" && Number.isFinite(nowCandidate)
+      ? Math.trunc(nowCandidate)
+      : Date.now();
+  const uuid = params.uuid?.trim() || crypto.randomUUID();
+  return `${normalizedBase}-${now}-${uuid}${normalizeWorkspaceExtension(params)}`;
+}
+
+function normalizeArtifactSegments(segments?: string[]): string[] {
+  const normalized = (segments ?? [".openclaw", "artifacts", "downloads"])
+    .map((segment) => sanitizeWorkspacePathSegment(segment))
+    .filter(Boolean);
+  return normalized.length > 0 ? normalized : [".openclaw", "artifacts", "downloads"];
+}
+
+export function buildAgentWorkspaceArtifactPath(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  prefix: string;
+  extension?: string;
+  preferredFileName?: string;
+  pathSegments?: string[];
+  now?: number;
+  uuid?: string;
+}): WorkspaceArtifactPath {
+  const workspaceDir = path.resolve(resolveAgentWorkspaceDir(params.cfg, params.agentId));
+  const fileName = buildWorkspaceArtifactFileName(params);
+  const absolutePath = path.join(
+    workspaceDir,
+    ...normalizeArtifactSegments(params.pathSegments),
+    fileName,
+  );
+  const workspacePath = toWorkspaceRelativePath(workspaceDir, absolutePath);
+  if (!workspacePath) {
+    throw new Error("artifact path must stay within the current workspace");
+  }
+  return {
+    workspaceDir,
+    absolutePath,
+    workspacePath,
+  };
+}
+
+export function resolveAgentWorkspaceOutputPath(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  outputPath?: string;
+  prefix: string;
+  extension?: string;
+  preferredFileName?: string;
+  pathSegments?: string[];
+  now?: number;
+  uuid?: string;
+}): WorkspaceArtifactPath {
+  if (!params.outputPath?.trim()) {
+    return buildAgentWorkspaceArtifactPath(params);
+  }
+
+  const workspaceDir = path.resolve(resolveAgentWorkspaceDir(params.cfg, params.agentId));
+  const rawOutputPath = params.outputPath.trim();
+  const absolutePath = path.isAbsolute(rawOutputPath)
+    ? rawOutputPath
+    : path.resolve(workspaceDir, rawOutputPath);
+  const workspacePath = toWorkspaceRelativePath(workspaceDir, absolutePath);
+
+  if (!workspacePath) {
+    throw new Error("output_path must stay within the current workspace");
+  }
+
+  return {
+    workspaceDir,
+    absolutePath,
+    workspacePath,
+  };
 }
 
 /** Create a temporary download directory, run the callback, then clean it up best-effort. */


### PR DESCRIPTION
## Summary
- expose a dedicated `openclaw/plugin-sdk/feishu` subpath for workspace-safe Feishu artifact helpers
- export workspace artifact path builders and temp download helpers from the Feishu SDK surface
- harden the helper paths so `..` segments and absolute `output_path` values cannot escape the current workspace

## Verification
- `pnpm exec vitest run src/plugin-sdk/temp-path.test.ts src/plugin-sdk/subpaths.test.ts`
- `pnpm plugin-sdk:check-exports`

## Notes
- this replaces the mixed-content `#51129` branch for the helper portion only
- the prior branch also collected sandbox skill-prompt work; that is being tracked separately in `#51471`