### PR TITLE
fix: use global OAuth refresh lock to prevent cross-agent race (#26322)

### DIFF
--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -27,6 +27,8 @@ Main agent credentials are **not** shared automatically. Never reuse `agentDir`
 across agents (it causes auth/session collisions). If you want to share creds,
 copy `auth-profiles.json` into the other agent's `agentDir`.
 
+> **OAuth refresh coordination:** When multiple agents share the same OAuth profile, token refresh is serialized by a global lock and refreshed credentials are written back to the main agent store. This prevents `refresh_token_reused` race conditions. See [OAuth refresh + expiry](/concepts/oauth#refresh--expiry).
+
 Skills are per-agent via each workspace’s `skills/` folder, with shared skills
 available from `~/.openclaw/skills`. See [Skills: per-agent vs shared](/tools/skills#per-agent-vs-shared-skills).
 

--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -145,9 +145,15 @@ Profiles store an `expires` timestamp.
 At runtime:
 
 - if `expires` is in the future → use the stored access token
-- if expired → refresh (under a file lock) and overwrite the stored credentials
+- if expired → refresh (under a global per-profile lock) and overwrite the stored credentials
 
 The refresh flow is automatic; you generally don't need to manage tokens manually.
+
+### Multi-agent refresh coordination
+
+When multiple agents share the same OAuth profile (same `profileId`), refresh is serialized by a global file lock at `~/.openclaw/locks/oauth-refresh/`. Only one agent performs the HTTP refresh; others wait and adopt the result. After a successful refresh, the refreshed credentials are written back to the main agent store so peer agents benefit without re-refreshing.
+
+If refresh fails with `refresh_token_reused` (the token was already consumed by another process), OpenClaw re-reads the main store and adopts the fresher credentials before triggering failover.
 
 ## Multiple accounts (profiles) + routing
 

--- a/docs/tools/multi-agent-sandbox-tools.md
+++ b/docs/tools/multi-agent-sandbox-tools.md
@@ -19,6 +19,7 @@ Auth is per-agent: each agent reads from its own `agentDir` auth store at
 `~/.openclaw/agents/<agentId>/agent/auth-profiles.json`.
 Credentials are **not** shared between agents. Never reuse `agentDir` across agents.
 If you want to share creds, copy `auth-profiles.json` into the other agent's `agentDir`.
+OAuth token refresh is coordinated across agents via a global lock — see [OAuth refresh](/concepts/oauth#multi-agent-refresh-coordination).
 
 ---
 

--- a/src/agents/auth-profiles.paths.test.ts
+++ b/src/agents/auth-profiles.paths.test.ts
@@ -26,14 +26,23 @@ describe("resolveOAuthRefreshLockPath", () => {
 
     expect(path.dirname(dotSegmentPath)).toBe(refreshLockDir);
     expect(path.dirname(currentDirPath)).toBe(refreshLockDir);
-    expect(path.basename(dotSegmentPath)).toBe("utf8-2e2e");
-    expect(path.basename(currentDirPath)).toBe("utf8-2e");
+    expect(path.basename(dotSegmentPath)).toMatch(/^sha256-[0-9a-f]{64}$/);
+    expect(path.basename(currentDirPath)).toMatch(/^sha256-[0-9a-f]{64}$/);
+    expect(path.basename(dotSegmentPath)).not.toBe(path.basename(currentDirPath));
   });
 
-  it("encodes full utf8 bytes so distinct profile ids stay distinct", () => {
+  it("hashes profile ids so distinct values stay distinct", () => {
     expect(resolveOAuthRefreshLockPath("openai-codex:work/test")).not.toBe(
       resolveOAuthRefreshLockPath("openai-codex_work:test"),
     );
     expect(resolveOAuthRefreshLockPath("«c")).not.toBe(resolveOAuthRefreshLockPath("઼"));
+  });
+
+  it("keeps lock filenames short for long profile ids", () => {
+    const longProfileId = `openai-codex:${"x".repeat(512)}`;
+    const basename = path.basename(resolveOAuthRefreshLockPath(longProfileId));
+
+    expect(basename).toMatch(/^sha256-[0-9a-f]{64}$/);
+    expect(Buffer.byteLength(basename, "utf8")).toBeLessThan(255);
   });
 });

--- a/src/agents/auth-profiles.paths.test.ts
+++ b/src/agents/auth-profiles.paths.test.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { captureEnv } from "../test-utils/env.js";
+import { resolveOAuthRefreshLockPath } from "./auth-profiles/paths.js";
+
+describe("resolveOAuthRefreshLockPath", () => {
+  const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+  let stateDir = "";
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-lock-path-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+  });
+
+  afterEach(async () => {
+    envSnapshot.restore();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("keeps lock paths inside the oauth-refresh directory for dot-segment ids", () => {
+    const refreshLockDir = path.join(stateDir, "locks", "oauth-refresh");
+    const dotSegmentPath = resolveOAuthRefreshLockPath("..");
+    const currentDirPath = resolveOAuthRefreshLockPath(".");
+
+    expect(path.dirname(dotSegmentPath)).toBe(refreshLockDir);
+    expect(path.dirname(currentDirPath)).toBe(refreshLockDir);
+    expect(path.basename(dotSegmentPath)).toBe("utf8-2e2e");
+    expect(path.basename(currentDirPath)).toBe("utf8-2e");
+  });
+
+  it("encodes full utf8 bytes so distinct profile ids stay distinct", () => {
+    expect(resolveOAuthRefreshLockPath("openai-codex:work/test")).not.toBe(
+      resolveOAuthRefreshLockPath("openai-codex_work:test"),
+    );
+    expect(resolveOAuthRefreshLockPath("«c")).not.toBe(resolveOAuthRefreshLockPath("઼"));
+  });
+});

--- a/src/agents/auth-profiles/constants.ts
+++ b/src/agents/auth-profiles/constants.ts
@@ -20,6 +20,17 @@ export const AUTH_STORE_LOCK_OPTIONS = {
   stale: 30_000,
 } as const;
 
+export const OAUTH_REFRESH_LOCK_OPTIONS = {
+  retries: {
+    retries: 10,
+    factor: 2,
+    minTimeout: 100,
+    maxTimeout: 10_000,
+    randomize: true,
+  },
+  stale: 30_000,
+} as const;
+
 export const EXTERNAL_CLI_SYNC_TTL_MS = 15 * 60 * 1000;
 export const EXTERNAL_CLI_NEAR_EXPIRY_MS = 10 * 60 * 1000;
 

--- a/src/agents/auth-profiles/constants.ts
+++ b/src/agents/auth-profiles/constants.ts
@@ -20,6 +20,8 @@ export const AUTH_STORE_LOCK_OPTIONS = {
   stale: 30_000,
 } as const;
 
+// Intentionally separate from AUTH_STORE_LOCK_OPTIONS for independent tuning:
+// this guards the global cross-agent OAuth refresh; the other guards per-store file writes.
 export const OAUTH_REFRESH_LOCK_OPTIONS = {
   retries: {
     retries: 10,

--- a/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
+++ b/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
@@ -80,6 +80,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
     refresh: string;
     expires: number;
     provider?: string;
+    accountId?: string;
   }): AuthProfileStore {
     return {
       version: 1,
@@ -90,6 +91,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
           access: params.access,
           refresh: params.refresh,
           expires: params.expires,
+          accountId: params.accountId,
         },
       },
     };
@@ -165,6 +167,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
         access: "expired-access-token",
         refresh: "expired-refresh-token",
         expires: expiredTime,
+        accountId: "acct-shared",
       }),
     );
 
@@ -176,6 +179,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
         access: "fresh-access-token",
         refresh: "fresh-refresh-token",
         expires: freshTime,
+        accountId: "acct-shared",
       }),
     );
 
@@ -198,6 +202,45 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
     });
   });
 
+  it("does not inherit main agent credentials on provider-only matches", async () => {
+    const profileId = "anthropic:claude-cli";
+    const now = Date.now();
+    const expiredTime = now - 60 * 60 * 1000;
+    const freshTime = now + 60 * 60 * 1000;
+
+    await writeAuthProfilesStore(
+      secondaryAgentDir,
+      createOauthStore({
+        profileId,
+        access: "secondary-expired-access-token",
+        refresh: "secondary-expired-refresh-token",
+        expires: expiredTime,
+      }),
+    );
+
+    await writeAuthProfilesStore(
+      mainAgentDir,
+      createOauthStore({
+        profileId,
+        access: "main-fresh-access-token",
+        refresh: "main-fresh-refresh-token",
+        expires: freshTime,
+      }),
+    );
+
+    await expect(resolveFromSecondaryAgent(profileId)).rejects.toThrow(
+      /OAuth token refresh failed for anthropic/,
+    );
+
+    const updatedSecondaryStore = JSON.parse(
+      await fs.readFile(path.join(secondaryAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(updatedSecondaryStore.profiles[profileId]).toMatchObject({
+      access: "secondary-expired-access-token",
+      expires: expiredTime,
+    });
+  });
+
   it("adopts newer OAuth token from main agent even when secondary token is still valid", async () => {
     const profileId = "anthropic:claude-cli";
     const now = Date.now();
@@ -211,6 +254,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
         access: "secondary-access-token",
         refresh: "secondary-refresh-token",
         expires: secondaryExpiry,
+        accountId: "acct-shared",
       }),
     );
 
@@ -221,6 +265,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
         access: "main-newer-access-token",
         refresh: "main-newer-refresh-token",
         expires: mainExpiry,
+        accountId: "acct-shared",
       }),
     );
 
@@ -249,6 +294,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
         access: "secondary-stale",
         refresh: "secondary-refresh",
         expires: NaN,
+        accountId: "acct-shared",
       }),
     );
 
@@ -259,6 +305,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
         access: "main-fresh-token",
         refresh: "main-refresh",
         expires: mainExpiry,
+        accountId: "acct-shared",
       }),
     );
 

--- a/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
+++ b/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
@@ -81,6 +81,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
     expires: number;
     provider?: string;
     accountId?: string;
+    email?: string;
   }): AuthProfileStore {
     return {
       version: 1,
@@ -92,6 +93,7 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
           refresh: params.refresh,
           expires: params.expires,
           accountId: params.accountId,
+          email: params.email,
         },
       },
     };
@@ -238,6 +240,49 @@ describe("resolveApiKeyForProfile fallback to main agent", () => {
     expect(updatedSecondaryStore.profiles[profileId]).toMatchObject({
       access: "secondary-expired-access-token",
       expires: expiredTime,
+    });
+  });
+
+  it("inherits main agent credentials when only one side has accountId but emails match", async () => {
+    const profileId = "anthropic:claude-cli";
+    const now = Date.now();
+    const expiredTime = now - 60 * 60 * 1000;
+    const freshTime = now + 60 * 60 * 1000;
+
+    await writeAuthProfilesStore(
+      secondaryAgentDir,
+      createOauthStore({
+        profileId,
+        access: "secondary-expired-access-token",
+        refresh: "secondary-expired-refresh-token",
+        expires: expiredTime,
+        email: "shared@example.com",
+      }),
+    );
+
+    await writeAuthProfilesStore(
+      mainAgentDir,
+      createOauthStore({
+        profileId,
+        access: "main-fresh-access-token",
+        refresh: "main-fresh-refresh-token",
+        expires: freshTime,
+        accountId: "acct-shared",
+        email: "shared@example.com",
+      }),
+    );
+
+    const result = await resolveFromSecondaryAgent(profileId);
+
+    expect(result?.apiKey).toBe("main-fresh-access-token");
+
+    const updatedSecondaryStore = JSON.parse(
+      await fs.readFile(path.join(secondaryAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(updatedSecondaryStore.profiles[profileId]).toMatchObject({
+      access: "main-fresh-access-token",
+      expires: freshTime,
+      email: "shared@example.com",
     });
   });
 

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetFileLockStateForTest } from "../../infra/file-lock.js";
 import { captureEnv } from "../../test-utils/env.js";
+import { resolveAuthStorePath } from "./paths.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
@@ -607,6 +608,73 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
       type: "token",
       token: "replacement-token",
     });
+  });
+
+  it("returns freshly refreshed credentials when CAS persistence times out", async () => {
+    const profileId = "openai-codex:default";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+    const authPath = resolveAuthStorePath(agentDir);
+    const authLockPath = `${authPath}.lock`;
+    const { AUTH_STORE_LOCK_OPTIONS: liveAuthStoreLockOptions } = await import("./constants.js");
+    const originalRetries = { ...liveAuthStoreLockOptions.retries };
+
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      agentDir,
+    );
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        ({
+          type: "oauth",
+          provider: "openai-codex",
+          access: "fresh-access-after-timeout",
+          refresh: "fresh-refresh-after-timeout",
+          expires: freshExpiry,
+        }) as never,
+    );
+
+    await fs.writeFile(
+      authLockPath,
+      JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }),
+      "utf8",
+    );
+    Object.assign(liveAuthStoreLockOptions.retries as Record<string, number | boolean>, {
+      retries: 0,
+      factor: 1,
+      minTimeout: 1,
+      maxTimeout: 1,
+      randomize: false,
+    });
+
+    try {
+      clearRuntimeAuthProfileStoreSnapshots();
+      const result = await resolveApiKeyForProfile({
+        store: ensureAuthProfileStore(agentDir),
+        profileId,
+        agentDir,
+      });
+
+      expect(result).toEqual({
+        apiKey: "fresh-access-after-timeout",
+        provider: "openai-codex",
+        email: undefined,
+      });
+
+      const currentStore = JSON.parse(
+        await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+      ) as AuthProfileStore;
+      expect(currentStore.profiles[profileId]).toMatchObject({
+        type: "oauth",
+        access: "cached-access-token",
+        refresh: "refresh-token",
+      });
+    } finally {
+      Object.assign(
+        liveAuthStoreLockOptions.retries as Record<string, number | boolean>,
+        originalRetries,
+      );
+      await fs.rm(authLockPath, { force: true });
+    }
   });
 
   it("re-resolves inherited main-store updates when refresh returns null", async () => {

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -406,6 +406,75 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
     });
   });
 
+  it("refreshes inherited main-store oauth profiles without creating a local clone", async () => {
+    const profileId = "openai-codex:default";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+
+    const subAgentDir = path.join(tempRoot, "agents", "sub-inherited", "agent");
+    await fs.mkdir(subAgentDir, { recursive: true });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "anthropic:default": {
+            type: "api_key",
+            provider: "anthropic",
+            key: "sk-subagent-only",
+          },
+        },
+      },
+      subAgentDir,
+    );
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        accountId: "acct-shared",
+      }),
+      agentDir,
+    );
+
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        ({
+          type: "oauth",
+          provider: "openai-codex",
+          access: "main-refreshed-access",
+          refresh: "main-refreshed-refresh",
+          expires: freshExpiry,
+          accountId: "acct-shared",
+        }) as never,
+    );
+
+    clearRuntimeAuthProfileStoreSnapshots();
+    const result = await resolveApiKeyForProfile({
+      store: ensureAuthProfileStore(subAgentDir),
+      profileId,
+      agentDir: subAgentDir,
+    });
+
+    expect(result?.apiKey).toBe("main-refreshed-access");
+
+    const mainStoreRaw = JSON.parse(
+      await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(mainStoreRaw.profiles[profileId]).toMatchObject({
+      access: "main-refreshed-access",
+      refresh: "main-refreshed-refresh",
+      expires: freshExpiry,
+    });
+
+    const subStoreRaw = JSON.parse(
+      await fs.readFile(path.join(subAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(subStoreRaw.profiles[profileId]).toBeUndefined();
+    expect(subStoreRaw.profiles["anthropic:default"]).toMatchObject({
+      type: "api_key",
+      provider: "anthropic",
+      key: "sk-subagent-only",
+    });
+  });
+
   it("preserves a token re-auth that lands while refresh is in flight", async () => {
     const profileId = "openai-codex:default";
     const freshExpiry = Date.now() + 60 * 60 * 1000;

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -494,7 +494,7 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
     );
     refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
       async () =>
-        await new Promise<{
+        (await new Promise<{
           type: "oauth";
           provider: string;
           access: string;
@@ -502,7 +502,7 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
           expires: number;
         }>((resolve) => {
           releaseRefresh = resolve;
-        }),
+        })) as never,
     );
 
     clearRuntimeAuthProfileStoreSnapshots();
@@ -591,7 +591,7 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
     );
     refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
       async () =>
-        await new Promise<{
+        (await new Promise<{
           type: "oauth";
           provider: string;
           access: string;
@@ -600,7 +600,7 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
           accountId?: string;
         }>((resolve) => {
           releaseRefresh = resolve;
-        }),
+        })) as never,
     );
 
     clearRuntimeAuthProfileStoreSnapshots();
@@ -672,7 +672,7 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
     );
     refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
       async () =>
-        await new Promise<{
+        (await new Promise<{
           type: "oauth";
           provider: string;
           access: string;
@@ -680,7 +680,7 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
           expires: number;
         }>((resolve) => {
           releaseRefresh = resolve;
-        }),
+        })) as never,
     );
 
     clearRuntimeAuthProfileStoreSnapshots();

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -552,6 +552,63 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
     });
   });
 
+  it("re-resolves a token re-auth when refresh throws", async () => {
+    const profileId = "openai-codex:default";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+    let releaseRefreshError: ((error: Error) => void) | undefined;
+
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      agentDir,
+    );
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        await new Promise<never>((_resolve, reject) => {
+          releaseRefreshError = reject;
+        }),
+    );
+
+    clearRuntimeAuthProfileStoreSnapshots();
+    const resolving = resolveApiKeyForProfile({
+      store: ensureAuthProfileStore(agentDir),
+      profileId,
+      agentDir,
+    });
+
+    await vi.waitFor(() =>
+      expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1),
+    );
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: {
+            type: "token",
+            provider: "openai-codex",
+            token: "replacement-token",
+            expires: freshExpiry,
+          },
+        },
+      },
+      agentDir,
+    );
+    releaseRefreshError?.(new Error("invalid_grant"));
+
+    await expect(resolving).resolves.toEqual({
+      apiKey: "replacement-token",
+      provider: "openai-codex",
+      email: undefined,
+    });
+
+    const currentStore = JSON.parse(
+      await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(currentStore.profiles[profileId]).toMatchObject({
+      type: "token",
+      token: "replacement-token",
+    });
+  });
+
   it("re-resolves inherited main-store updates when refresh returns null", async () => {
     const profileId = "openai-codex:default";
     const freshExpiry = Date.now() + 60 * 60 * 1000;

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -552,6 +552,107 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
     });
   });
 
+  it("re-resolves inherited main-store updates when refresh returns null", async () => {
+    const profileId = "openai-codex:default";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+    let releaseRefresh:
+      | ((value: {
+          type: "oauth";
+          provider: string;
+          access: string;
+          refresh: string;
+          expires: number;
+          accountId?: string;
+        }) => void)
+      | undefined;
+
+    const subAgentDir = path.join(tempRoot, "agents", "sub-null-reresolve", "agent");
+    await fs.mkdir(subAgentDir, { recursive: true });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "anthropic:default": {
+            type: "api_key",
+            provider: "anthropic",
+            key: "sk-subagent-only",
+          },
+        },
+      },
+      subAgentDir,
+    );
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        accountId: "acct-shared",
+      }),
+      agentDir,
+    );
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        await new Promise<{
+          type: "oauth";
+          provider: string;
+          access: string;
+          refresh: string;
+          expires: number;
+          accountId?: string;
+        }>((resolve) => {
+          releaseRefresh = resolve;
+        }),
+    );
+
+    clearRuntimeAuthProfileStoreSnapshots();
+    const resolving = resolveApiKeyForProfile({
+      store: ensureAuthProfileStore(subAgentDir),
+      profileId,
+      agentDir: subAgentDir,
+    });
+
+    await vi.waitFor(() =>
+      expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1),
+    );
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: {
+            type: "token",
+            provider: "openai-codex",
+            token: "replacement-token",
+            expires: freshExpiry,
+          },
+        },
+      },
+      agentDir,
+    );
+    releaseRefresh?.({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "stale-refreshed-access",
+      refresh: "stale-refreshed-refresh",
+      expires: freshExpiry,
+      accountId: "acct-shared",
+    });
+
+    await expect(resolving).resolves.toEqual({
+      apiKey: "replacement-token",
+      provider: "openai-codex",
+      email: undefined,
+    });
+
+    const subStoreRaw = JSON.parse(
+      await fs.readFile(path.join(subAgentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(subStoreRaw.profiles[profileId]).toBeUndefined();
+    expect(subStoreRaw.profiles["anthropic:default"]).toMatchObject({
+      type: "api_key",
+      provider: "anthropic",
+      key: "sk-subagent-only",
+    });
+  });
+
   it("does not recreate a profile that was deleted while refresh was in flight", async () => {
     const profileId = "openai-codex:default";
     const freshExpiry = Date.now() + 60 * 60 * 1000;

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -182,4 +182,196 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
       }),
     ).rejects.toThrow(/OAuth token refresh failed for openai-codex/);
   });
+
+  it("recovers from refresh_token_reused by adopting fresher main agent credentials", async () => {
+    const profileId = "openai-codex:default";
+    const now = Date.now();
+    const freshExpiry = now + 60 * 60 * 1000;
+
+    // Sub-agent has expired credentials
+    const subAgentDir = path.join(tempRoot, "agents", "sub-a", "agent");
+    await fs.mkdir(subAgentDir, { recursive: true });
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      subAgentDir,
+    );
+
+    // Main agent has fresh credentials (as if another agent already refreshed and wrote back)
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "fresh-access-from-main",
+            refresh: "fresh-refresh-from-main",
+            expires: freshExpiry,
+          },
+        },
+      },
+      agentDir,
+    );
+
+    // Plugin refresh throws refresh_token_reused
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+      throw new Error(
+        '401 {"error":{"message":"Your refresh token has already been used","type":"invalid_request_error","code":"refresh_token_reused"}}',
+      );
+    });
+
+    clearRuntimeAuthProfileStoreSnapshots();
+    const result = await resolveApiKeyForProfile({
+      store: ensureAuthProfileStore(subAgentDir),
+      profileId,
+      agentDir: subAgentDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.apiKey).toBe("fresh-access-from-main");
+    expect(result?.provider).toBe("openai-codex");
+  });
+
+  it("still throws when refresh_token_reused fires and no fresh creds exist anywhere", async () => {
+    const profileId = "openai-codex:default";
+
+    // Both main and sub-agent have expired credentials
+    const subAgentDir = path.join(tempRoot, "agents", "sub-b", "agent");
+    await fs.mkdir(subAgentDir, { recursive: true });
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      subAgentDir,
+    );
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      agentDir,
+    );
+
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+      throw new Error(
+        '401 {"error":{"message":"Your refresh token has already been used","type":"invalid_request_error","code":"refresh_token_reused"}}',
+      );
+    });
+
+    clearRuntimeAuthProfileStoreSnapshots();
+    await expect(
+      resolveApiKeyForProfile({
+        store: ensureAuthProfileStore(subAgentDir),
+        profileId,
+        agentDir: subAgentDir,
+      }),
+    ).rejects.toThrow(/OAuth token refresh failed for openai-codex/);
+  });
+
+  // Task 5: verifies write-back of refreshed credentials to the main agent store
+  it("writes refreshed credentials back to main agent store", async () => {
+    const profileId = "openai-codex:default";
+    const now = Date.now();
+    const freshExpiry = now + 60 * 60 * 1000;
+
+    // Sub-agent has expired credentials
+    const subAgentDir = path.join(tempRoot, "agents", "sub-wb", "agent");
+    await fs.mkdir(subAgentDir, { recursive: true });
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      subAgentDir,
+    );
+
+    // Main agent also has expired credentials
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      agentDir,
+    );
+
+    // Plugin refresh succeeds with new credentials
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        ({
+          type: "oauth",
+          provider: "openai-codex",
+          access: "newly-refreshed-access",
+          refresh: "newly-refreshed-refresh",
+          expires: freshExpiry,
+        }) as never,
+    );
+
+    clearRuntimeAuthProfileStoreSnapshots();
+    const result = await resolveApiKeyForProfile({
+      store: ensureAuthProfileStore(subAgentDir),
+      profileId,
+      agentDir: subAgentDir,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.apiKey).toBe("newly-refreshed-access");
+
+    // Verify write-back: main agent store should now have the fresh credentials
+    const mainStoreRaw = JSON.parse(
+      await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(mainStoreRaw.profiles[profileId]).toMatchObject({
+      access: "newly-refreshed-access",
+      expires: freshExpiry,
+    });
+  });
+
+  it("serializes concurrent refreshes so only one HTTP call is made", async () => {
+    const profileId = "openai-codex:default";
+    const now = Date.now();
+    const freshExpiry = now + 60 * 60 * 1000;
+
+    const subAgentDir = path.join(tempRoot, "agents", "sub-conc", "agent");
+    await fs.mkdir(subAgentDir, { recursive: true });
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      subAgentDir,
+    );
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      agentDir,
+    );
+
+    // Plugin refresh succeeds but with a small delay to widen the race window
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementation(
+      async () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                type: "oauth",
+                provider: "openai-codex",
+                access: "concurrent-refreshed-access",
+                refresh: "concurrent-refreshed-refresh",
+                expires: freshExpiry,
+              } as never),
+            50,
+          ),
+        ),
+    );
+
+    clearRuntimeAuthProfileStoreSnapshots();
+
+    // Fire two concurrent resolves for the same sub-agent
+    const [result1, result2] = await Promise.all([
+      resolveApiKeyForProfile({
+        store: ensureAuthProfileStore(subAgentDir),
+        profileId,
+        agentDir: subAgentDir,
+      }),
+      resolveApiKeyForProfile({
+        store: ensureAuthProfileStore(subAgentDir),
+        profileId,
+        agentDir: subAgentDir,
+      }),
+    ]);
+
+    // Both should succeed with the same token
+    expect(result1).not.toBeNull();
+    expect(result2).not.toBeNull();
+    expect(result1?.apiKey).toBe("concurrent-refreshed-access");
+    expect(result2?.apiKey).toBe("concurrent-refreshed-access");
+
+    // Only one HTTP refresh should have been made
+    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -196,25 +196,31 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
       subAgentDir,
     );
 
-    // Main agent has fresh credentials (as if another agent already refreshed and wrote back)
+    // Main agent also starts with expired credentials
     saveAuthProfileStore(
-      {
-        version: 1,
-        profiles: {
-          [profileId]: {
-            type: "oauth",
-            provider: "openai-codex",
-            access: "fresh-access-from-main",
-            refresh: "fresh-refresh-from-main",
-            expires: freshExpiry,
-          },
-        },
-      },
+      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
       agentDir,
     );
 
-    // Plugin refresh throws refresh_token_reused
+    // Simulate a race: another process refreshes and writes fresh creds to the
+    // main store right before our refresh attempt. The mock writes fresh creds
+    // then throws refresh_token_reused (the token was already consumed).
     refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(async () => {
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            [profileId]: {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "fresh-access-from-main",
+              refresh: "fresh-refresh-from-main",
+              expires: freshExpiry,
+            },
+          },
+        },
+        agentDir,
+      );
       throw new Error(
         '401 {"error":{"message":"Your refresh token has already been used","type":"invalid_request_error","code":"refresh_token_reused"}}',
       );
@@ -230,6 +236,7 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
     expect(result).not.toBeNull();
     expect(result?.apiKey).toBe("fresh-access-from-main");
     expect(result?.provider).toBe("openai-codex");
+    expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
   });
 
   it("still throws when refresh_token_reused fires and no fresh creds exist anywhere", async () => {

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -22,17 +22,21 @@ const {
   refreshProviderOAuthCredentialWithPluginMock,
   formatProviderAuthProfileApiKeyWithPluginMock,
   buildProviderAuthDoctorHintWithPluginMock,
+  readCodexCliCredentialsCachedMock,
+  readMiniMaxCliCredentialsCachedMock,
 } = vi.hoisted(() => ({
   refreshProviderOAuthCredentialWithPluginMock: vi.fn(
     async (_params?: { context?: unknown }) => undefined,
   ),
   formatProviderAuthProfileApiKeyWithPluginMock: vi.fn(() => undefined),
   buildProviderAuthDoctorHintWithPluginMock: vi.fn(async () => undefined),
+  readCodexCliCredentialsCachedMock: vi.fn(() => null),
+  readMiniMaxCliCredentialsCachedMock: vi.fn(() => null),
 }));
 
 vi.mock("../cli-credentials.js", () => ({
-  readCodexCliCredentialsCached: () => null,
-  readMiniMaxCliCredentialsCached: () => null,
+  readCodexCliCredentialsCached: readCodexCliCredentialsCachedMock,
+  readMiniMaxCliCredentialsCached: readMiniMaxCliCredentialsCachedMock,
   resetCliCredentialCachesForTest: () => undefined,
 }));
 
@@ -65,6 +69,8 @@ function createExpiredOauthStore(params: {
   profileId: string;
   provider: string;
   access?: string;
+  refresh?: string;
+  accountId?: string;
 }): AuthProfileStore {
   return {
     version: 1,
@@ -73,8 +79,9 @@ function createExpiredOauthStore(params: {
         type: "oauth",
         provider: params.provider,
         access: params.access ?? "cached-access-token",
-        refresh: "refresh-token",
+        refresh: params.refresh ?? "refresh-token",
         expires: Date.now() - 60_000,
+        accountId: params.accountId,
       },
     },
   };
@@ -98,6 +105,10 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
     formatProviderAuthProfileApiKeyWithPluginMock.mockReturnValue(undefined);
     buildProviderAuthDoctorHintWithPluginMock.mockReset();
     buildProviderAuthDoctorHintWithPluginMock.mockResolvedValue(undefined);
+    readCodexCliCredentialsCachedMock.mockReset();
+    readCodexCliCredentialsCachedMock.mockReturnValue(null);
+    readMiniMaxCliCredentialsCachedMock.mockReset();
+    readMiniMaxCliCredentialsCachedMock.mockReturnValue(null);
     clearRuntimeAuthProfileStoreSnapshots();
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-refresh-fallback-"));
     agentDir = path.join(tempRoot, "agents", "main", "agent");
@@ -192,13 +203,21 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
     const subAgentDir = path.join(tempRoot, "agents", "sub-a", "agent");
     await fs.mkdir(subAgentDir, { recursive: true });
     saveAuthProfileStore(
-      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        accountId: "acct-shared",
+      }),
       subAgentDir,
     );
 
     // Main agent also starts with expired credentials
     saveAuthProfileStore(
-      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        accountId: "acct-shared",
+      }),
       agentDir,
     );
 
@@ -216,6 +235,7 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
               access: "fresh-access-from-main",
               refresh: "fresh-refresh-from-main",
               expires: freshExpiry,
+              accountId: "acct-shared",
             },
           },
         },
@@ -280,13 +300,21 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
     const subAgentDir = path.join(tempRoot, "agents", "sub-wb", "agent");
     await fs.mkdir(subAgentDir, { recursive: true });
     saveAuthProfileStore(
-      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        accountId: "acct-shared",
+      }),
       subAgentDir,
     );
 
     // Main agent also has expired credentials
     saveAuthProfileStore(
-      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        accountId: "acct-shared",
+      }),
       agentDir,
     );
 
@@ -299,6 +327,7 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
           access: "newly-refreshed-access",
           refresh: "newly-refreshed-refresh",
           expires: freshExpiry,
+          accountId: "acct-shared",
         }) as never,
     );
 
@@ -320,6 +349,201 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
       access: "newly-refreshed-access",
       expires: freshExpiry,
     });
+  });
+
+  it("does not write back refreshed credentials to main on provider-only matches", async () => {
+    const profileId = "openai-codex:default";
+    const now = Date.now();
+    const freshExpiry = now + 60 * 60 * 1000;
+
+    const subAgentDir = path.join(tempRoot, "agents", "sub-isolated", "agent");
+    await fs.mkdir(subAgentDir, { recursive: true });
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        access: "sub-expired-access",
+        refresh: "sub-expired-refresh",
+      }),
+      subAgentDir,
+    );
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+        access: "main-expired-access",
+        refresh: "main-expired-refresh",
+      }),
+      agentDir,
+    );
+
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        ({
+          type: "oauth",
+          provider: "openai-codex",
+          access: "sub-refreshed-access",
+          refresh: "sub-refreshed-refresh",
+          expires: freshExpiry,
+        }) as never,
+    );
+
+    clearRuntimeAuthProfileStoreSnapshots();
+    const result = await resolveApiKeyForProfile({
+      store: ensureAuthProfileStore(subAgentDir),
+      profileId,
+      agentDir: subAgentDir,
+    });
+
+    expect(result?.apiKey).toBe("sub-refreshed-access");
+
+    const mainStoreRaw = JSON.parse(
+      await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(mainStoreRaw.profiles[profileId]).toMatchObject({
+      access: "main-expired-access",
+      refresh: "main-expired-refresh",
+    });
+  });
+
+  it("preserves a token re-auth that lands while refresh is in flight", async () => {
+    const profileId = "openai-codex:default";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+    let releaseRefresh:
+      | ((value: {
+          type: "oauth";
+          provider: string;
+          access: string;
+          refresh: string;
+          expires: number;
+        }) => void)
+      | undefined;
+
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      agentDir,
+    );
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        await new Promise<{
+          type: "oauth";
+          provider: string;
+          access: string;
+          refresh: string;
+          expires: number;
+        }>((resolve) => {
+          releaseRefresh = resolve;
+        }),
+    );
+
+    clearRuntimeAuthProfileStoreSnapshots();
+    const resolving = resolveApiKeyForProfile({
+      store: ensureAuthProfileStore(agentDir),
+      profileId,
+      agentDir,
+    });
+
+    await vi.waitFor(() =>
+      expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1),
+    );
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: {
+            type: "token",
+            provider: "openai-codex",
+            token: "replacement-token",
+            expires: freshExpiry,
+          },
+        },
+      },
+      agentDir,
+    );
+    releaseRefresh?.({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "stale-refreshed-access",
+      refresh: "stale-refreshed-refresh",
+      expires: freshExpiry,
+    });
+
+    await expect(resolving).resolves.toEqual({
+      apiKey: "replacement-token",
+      provider: "openai-codex",
+      email: undefined,
+    });
+
+    const currentStore = JSON.parse(
+      await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(currentStore.profiles[profileId]).toMatchObject({
+      type: "token",
+      token: "replacement-token",
+    });
+  });
+
+  it("does not recreate a profile that was deleted while refresh was in flight", async () => {
+    const profileId = "openai-codex:default";
+    const freshExpiry = Date.now() + 60 * 60 * 1000;
+    let releaseRefresh:
+      | ((value: {
+          type: "oauth";
+          provider: string;
+          access: string;
+          refresh: string;
+          expires: number;
+        }) => void)
+      | undefined;
+
+    saveAuthProfileStore(
+      createExpiredOauthStore({ profileId, provider: "openai-codex" }),
+      agentDir,
+    );
+    refreshProviderOAuthCredentialWithPluginMock.mockImplementationOnce(
+      async () =>
+        await new Promise<{
+          type: "oauth";
+          provider: string;
+          access: string;
+          refresh: string;
+          expires: number;
+        }>((resolve) => {
+          releaseRefresh = resolve;
+        }),
+    );
+
+    clearRuntimeAuthProfileStoreSnapshots();
+    const resolving = resolveApiKeyForProfile({
+      store: ensureAuthProfileStore(agentDir),
+      profileId,
+      agentDir,
+    });
+
+    await vi.waitFor(() =>
+      expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1),
+    );
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {},
+      },
+      agentDir,
+    );
+    releaseRefresh?.({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "stale-refreshed-access",
+      refresh: "stale-refreshed-refresh",
+      expires: freshExpiry,
+    });
+
+    await expect(resolving).resolves.toBeNull();
+
+    const currentStore = JSON.parse(
+      await fs.readFile(path.join(agentDir, "auth-profiles.json"), "utf8"),
+    ) as AuthProfileStore;
+    expect(currentStore.profiles[profileId]).toBeUndefined();
   });
 
   it("serializes concurrent refreshes so only one HTTP call is made", async () => {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -584,7 +584,10 @@ async function tryResolveOAuthProfile(
     agentDir: params.agentDir,
   });
   if (!refreshed) {
-    const refreshedStore = loadAuthProfileStoreForAgent(params.agentDir);
+    const refreshedStore = loadAuthProfileStoreForRuntime(
+      params.agentDir,
+      READ_ONLY_AUTH_STORE_OPTIONS,
+    );
     const current = refreshedStore.profiles[profileId];
     if (current && (current.type !== "oauth" || !areOAuthCredentialsEquivalent(current, cred))) {
       return await resolveApiKeyForProfile({
@@ -740,7 +743,10 @@ export async function resolveApiKeyForProfile(
       agentDir: params.agentDir,
     });
     if (!result) {
-      const refreshedStore = loadAuthProfileStoreForAgent(params.agentDir);
+      const refreshedStore = loadAuthProfileStoreForRuntime(
+        params.agentDir,
+        READ_ONLY_AUTH_STORE_OPTIONS,
+      );
       const current = refreshedStore.profiles[profileId];
       if (
         current &&

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -132,6 +132,12 @@ function isSameOAuthIdentity(a: OAuthCredential, b: OAuthCredential): boolean {
   if (a.provider !== b.provider) {
     return false;
   }
+  // accountId is the strongest identity signal (used by Codex CLI credentials).
+  const aAcct = (a as Record<string, unknown>).accountId;
+  const bAcct = (b as Record<string, unknown>).accountId;
+  if (aAcct && bAcct && aAcct !== bAcct) {
+    return false;
+  }
   if (a.email && b.email && a.email !== b.email) {
     return false;
   }
@@ -222,7 +228,7 @@ function adoptNewerMainOAuthCredential(params: {
     const mainCred = mainStore.profiles[params.profileId];
     if (
       mainCred?.type === "oauth" &&
-      mainCred.provider === params.cred.provider &&
+      isSameOAuthIdentity(params.cred, mainCred) &&
       Number.isFinite(mainCred.expires) &&
       (!Number.isFinite(params.cred.expires) || mainCred.expires > params.cred.expires)
     ) {
@@ -605,8 +611,12 @@ export async function resolveApiKeyForProfile(
       try {
         const mainStore = ensureAuthProfileStore(undefined); // main agent (no agentDir)
         const mainCred = mainStore.profiles[profileId];
-        if (mainCred?.type === "oauth" && Date.now() < mainCred.expires) {
-          // Main agent has fresh credentials - copy them to this agent and use them
+        if (
+          mainCred?.type === "oauth" &&
+          Date.now() < mainCred.expires &&
+          isSameOAuthIdentity(cred, mainCred)
+        ) {
+          // Main agent has fresh credentials for the same identity - copy and use
           refreshedStore.profiles[profileId] = { ...mainCred };
           saveAuthProfileStore(refreshedStore, params.agentDir);
           log.info("inherited fresh OAuth credentials from main agent", {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -158,14 +158,14 @@ function hasPositiveOAuthIdentityMatch(a: OAuthCredential, b: OAuthCredential): 
   // accountId is the strongest identity signal (used by Codex CLI credentials).
   const aAcct = normalizeOAuthIdentityValue(a.accountId);
   const bAcct = normalizeOAuthIdentityValue(b.accountId);
-  if (aAcct || bAcct) {
-    return aAcct !== undefined && aAcct === bAcct;
+  if (aAcct !== undefined && bAcct !== undefined) {
+    return aAcct === bAcct;
   }
 
   const aEmail = normalizeOAuthEmail(a.email);
   const bEmail = normalizeOAuthEmail(b.email);
-  if (aEmail || bEmail) {
-    return aEmail !== undefined && aEmail === bEmail;
+  if (aEmail !== undefined && bEmail !== undefined) {
+    return aEmail === bEmail;
   }
 
   return false;
@@ -176,6 +176,32 @@ function canShareOAuthCredentialAcrossAgents(a: OAuthCredential, b: OAuthCredent
     return false;
   }
   return hasPositiveOAuthIdentityMatch(a, b) || areOAuthCredentialsEquivalent(a, b);
+}
+
+async function resolveChangedProfileAfterRefresh(params: {
+  cfg?: OpenClawConfig;
+  store: AuthProfileStore;
+  profileId: string;
+  agentDir?: string;
+  previousCred: OAuthCredential;
+}): Promise<{ apiKey: string; provider: string; email?: string } | null> {
+  const current = params.store.profiles[params.profileId];
+  if (!current) {
+    return null;
+  }
+  if (current.type === "oauth" && areOAuthCredentialsEquivalent(current, params.previousCred)) {
+    return null;
+  }
+  try {
+    return await resolveApiKeyForProfile({
+      cfg: params.cfg,
+      store: params.store,
+      profileId: params.profileId,
+      agentDir: params.agentDir,
+    });
+  } catch {
+    return null;
+  }
 }
 
 function shouldOverwriteOAuthCredential(
@@ -747,17 +773,15 @@ export async function resolveApiKeyForProfile(
         params.agentDir,
         READ_ONLY_AUTH_STORE_OPTIONS,
       );
-      const current = refreshedStore.profiles[profileId];
-      if (
-        current &&
-        (current.type !== "oauth" || !areOAuthCredentialsEquivalent(current, oauthCred))
-      ) {
-        return await resolveApiKeyForProfile({
-          cfg,
-          store: refreshedStore,
-          profileId,
-          agentDir: params.agentDir,
-        });
+      const reResolved = await resolveChangedProfileAfterRefresh({
+        cfg,
+        store: refreshedStore,
+        profileId,
+        agentDir: params.agentDir,
+        previousCred: oauthCred,
+      });
+      if (reResolved) {
+        return reResolved;
       }
       return null;
     }
@@ -767,14 +791,19 @@ export async function resolveApiKeyForProfile(
       email: oauthCred.email,
     });
   } catch (error) {
-    const refreshedStore = ensureAuthProfileStore(params.agentDir);
-    const refreshed = refreshedStore.profiles[profileId];
-    if (refreshed?.type === "oauth" && Date.now() < refreshed.expires) {
-      return await buildOAuthProfileResult({
-        provider: refreshed.provider,
-        credentials: refreshed,
-        email: refreshed.email ?? cred.email,
-      });
+    const refreshedStore = loadAuthProfileStoreForRuntime(
+      params.agentDir,
+      READ_ONLY_AUTH_STORE_OPTIONS,
+    );
+    const reResolved = await resolveChangedProfileAfterRefresh({
+      cfg,
+      store: refreshedStore,
+      profileId,
+      agentDir: params.agentDir,
+      previousCred: oauthCred,
+    });
+    if (reResolved) {
+      return reResolved;
     }
     const fallbackProfileId = suggestOAuthProfileIdForLegacyDefault({
       cfg,

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -147,7 +147,6 @@ function isSameOAuthIdentity(a: OAuthCredential, b: OAuthCredential): boolean {
 async function performOAuthRefresh(
   cred: OAuthCredential,
 ): Promise<{ apiKey: string; newCredentials: OAuthCredentials } | null> {
-  const { refreshProviderOAuthCredentialWithPlugin } = await loadProviderRuntime();
   const pluginRefreshed = await refreshProviderOAuthCredentialWithPlugin({
     provider: cred.provider,
     context: cred,
@@ -187,8 +186,10 @@ async function writeCredentialToAgentStore(
           existing.type !== "oauth" ||
           !Number.isFinite(existing.expires) ||
           existing.expires < newCred.expires ||
-          existing.access !== newCred.access ||
-          existing.refresh !== newCred.refresh
+          // Token rotation without expiry change: persist when expiry matches
+          // but don't overwrite a strictly newer credential from a concurrent re-auth.
+          (existing.expires === newCred.expires &&
+            (existing.access !== newCred.access || existing.refresh !== newCred.refresh))
         ) {
           store.profiles[profileId] = { ...newCred };
           return true;

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -13,12 +13,17 @@ import {
 } from "../../plugins/provider-runtime.runtime.js";
 import { resolveSecretRefString, type SecretRefResolveCache } from "../../secrets/resolve.js";
 import { refreshChutesTokens } from "../chutes-oauth.js";
-import { AUTH_STORE_LOCK_OPTIONS, log } from "./constants.js";
+import { OAUTH_REFRESH_LOCK_OPTIONS, log } from "./constants.js";
 import { resolveTokenExpiryState } from "./credential-state.js";
 import { formatAuthDoctorHint } from "./doctor.js";
-import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
+import { ensureAuthStoreFile, resolveAuthStorePath, resolveOAuthRefreshLockPath } from "./paths.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
-import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
+import {
+  ensureAuthProfileStore,
+  loadAuthProfileStoreForAgent,
+  saveAuthProfileStore,
+  updateAuthProfileStoreWithLock,
+} from "./store.js";
 import type { AuthProfileStore, OAuthCredential } from "./types.js";
 
 function listOAuthProviderIds(): string[] {
@@ -112,6 +117,88 @@ function extractErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function isRefreshTokenReusedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /refresh_token_reused/i.test(message);
+}
+
+/**
+ * Guard: only allow cross-agent credential operations when both credentials
+ * belong to the same OAuth identity (same provider, and same email if both set).
+ * Prevents overwriting credentials when agents use different accounts under the
+ * same profile name.
+ */
+function isSameOAuthIdentity(a: OAuthCredential, b: OAuthCredential): boolean {
+  if (a.provider !== b.provider) {
+    return false;
+  }
+  if (a.email && b.email && a.email !== b.email) {
+    return false;
+  }
+  return true;
+}
+
+async function performOAuthRefresh(
+  cred: OAuthCredential,
+): Promise<{ apiKey: string; newCredentials: OAuthCredentials } | null> {
+  const { refreshProviderOAuthCredentialWithPlugin } = await loadProviderRuntime();
+  const pluginRefreshed = await refreshProviderOAuthCredentialWithPlugin({
+    provider: cred.provider,
+    context: cred,
+  });
+  if (pluginRefreshed) {
+    return {
+      apiKey: await buildOAuthApiKey(cred.provider, pluginRefreshed),
+      newCredentials: pluginRefreshed,
+    };
+  }
+
+  const oauthCreds: Record<string, OAuthCredentials> = { [cred.provider]: cred };
+  if (String(cred.provider) === "chutes") {
+    const newCredentials = await refreshChutesTokens({ credential: cred });
+    return { apiKey: newCredentials.access, newCredentials };
+  }
+
+  const oauthProvider = resolveOAuthProvider(cred.provider);
+  if (!oauthProvider) {
+    return null;
+  }
+  return await getOAuthApiKey(oauthProvider, oauthCreds);
+}
+
+async function writeCredentialToAgentStore(
+  agentDir: string | undefined,
+  profileId: string,
+  newCred: OAuthCredential,
+): Promise<void> {
+  try {
+    await updateAuthProfileStoreWithLock({
+      agentDir,
+      updater: (store) => {
+        const existing = store.profiles[profileId];
+        if (
+          !existing ||
+          existing.type !== "oauth" ||
+          !Number.isFinite(existing.expires) ||
+          existing.expires < newCred.expires ||
+          existing.access !== newCred.access ||
+          existing.refresh !== newCred.refresh
+        ) {
+          store.profiles[profileId] = { ...newCred };
+          return true;
+        }
+        return false;
+      },
+    });
+  } catch (err) {
+    log.debug("writeCredentialToAgentStore failed", {
+      profileId,
+      agentDir,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
 type ResolveApiKeyForProfileParams = {
   cfg?: OpenClawConfig;
   store: AuthProfileStore;
@@ -158,20 +245,58 @@ function adoptNewerMainOAuthCredential(params: {
   return null;
 }
 
+/**
+ * In-process serialization: callers for the same profileId are chained so only
+ * one enters doRefreshOAuthTokenWithLock at a time. This prevents the re-entrant
+ * file lock (same PID) from allowing concurrent performOAuthRefresh calls.
+ * Keyed by profileId (not agentDir) so shared-profile agents serialize correctly.
+ */
+const refreshQueues = new Map<string, Promise<unknown>>();
+
 async function refreshOAuthTokenWithLock(params: {
+  profileId: string;
+  agentDir?: string;
+}): Promise<{ apiKey: string; newCredentials: OAuthCredentials } | null> {
+  const key = params.profileId;
+  const prev = refreshQueues.get(key) ?? Promise.resolve();
+  let resolve!: () => void;
+  const gate = new Promise<void>((r) => {
+    resolve = r;
+  });
+  refreshQueues.set(key, gate);
+  try {
+    await prev;
+    return await doRefreshOAuthTokenWithLock(params);
+  } finally {
+    resolve();
+    if (refreshQueues.get(key) === gate) {
+      refreshQueues.delete(key);
+    }
+  }
+}
+
+async function doRefreshOAuthTokenWithLock(params: {
   profileId: string;
   agentDir?: string;
 }): Promise<{ apiKey: string; newCredentials: OAuthCredentials } | null> {
   const authPath = resolveAuthStorePath(params.agentDir);
   ensureAuthStoreFile(authPath);
+  const globalLockPath = resolveOAuthRefreshLockPath(params.profileId);
 
-  return await withFileLock(authPath, AUTH_STORE_LOCK_OPTIONS, async () => {
-    const store = ensureAuthProfileStore(params.agentDir);
-    const cred = store.profiles[params.profileId];
+  return await withFileLock(globalLockPath, OAUTH_REFRESH_LOCK_OPTIONS, async () => {
+    // Re-read the agent's own store (fresh disk read, bypasses runtime snapshot cache).
+    const store = loadAuthProfileStoreForAgent(params.agentDir);
+    let cred = store.profiles[params.profileId];
+    // Profile may only exist in main store (inherited via ensureAuthProfileStore merge).
+    if ((!cred || cred.type !== "oauth") && params.agentDir) {
+      const mainStore = loadAuthProfileStoreForAgent(undefined);
+      cred = mainStore.profiles[params.profileId];
+    }
     if (!cred || cred.type !== "oauth") {
       return null;
     }
 
+    // Token may have been refreshed between the caller's expiry check and lock acquisition.
     if (Date.now() < cred.expires) {
       return {
         apiKey: await buildOAuthApiKey(cred.provider, cred),
@@ -179,47 +304,82 @@ async function refreshOAuthTokenWithLock(params: {
       };
     }
 
-    const pluginRefreshed = await refreshProviderOAuthCredentialWithPlugin({
-      provider: cred.provider,
-      context: cred,
-    });
-    if (pluginRefreshed) {
-      return {
-        apiKey: await buildOAuthApiKey(cred.provider, pluginRefreshed),
-        newCredentials: pluginRefreshed,
-      };
+    // Check if another process already refreshed (visible in the main store).
+    // Only adopt if the main credential belongs to the same OAuth identity
+    // (same provider + email) to avoid cross-account overwrites.
+    if (params.agentDir) {
+      const mainStore = loadAuthProfileStoreForAgent(undefined);
+      const mainCred = mainStore.profiles[params.profileId];
+      if (
+        mainCred?.type === "oauth" &&
+        Date.now() < mainCred.expires &&
+        isSameOAuthIdentity(cred, mainCred)
+      ) {
+        await writeCredentialToAgentStore(params.agentDir, params.profileId, mainCred);
+        log.info("adopted fresh OAuth credentials from main store (under global lock)", {
+          profileId: params.profileId,
+          agentDir: params.agentDir,
+          expires: new Date(mainCred.expires).toISOString(),
+        });
+        return {
+          apiKey: await buildOAuthApiKey(mainCred.provider, mainCred),
+          newCredentials: mainCred,
+        };
+      }
     }
 
-    const oauthCreds: Record<string, OAuthCredentials> = { [cred.provider]: cred };
-    const result =
-      String(cred.provider) === "chutes"
-        ? await (async () => {
-            const newCredentials = await refreshChutesTokens({
-              credential: cred,
-            });
-            return { apiKey: newCredentials.access, newCredentials };
-          })()
-        : await (async () => {
-            const oauthProvider = resolveOAuthProvider(cred.provider);
-            if (!oauthProvider) {
-              return null;
-            }
-            if (typeof getOAuthApiKey !== "function") {
-              return null;
-            }
-            return await getOAuthApiKey(oauthProvider, oauthCreds);
-          })();
-    if (!result) {
+    // Attempt actual OAuth refresh.
+    let refreshResult: { apiKey: string; newCredentials: OAuthCredentials } | null;
+    try {
+      refreshResult = await performOAuthRefresh(cred);
+    } catch (refreshError) {
+      // Recovery: if refresh_token_reused, another process may have refreshed
+      // outside the lock (different machine, stale lock, copied credentials).
+      if (isRefreshTokenReusedError(refreshError) && params.agentDir) {
+        const recoveryStore = loadAuthProfileStoreForAgent(undefined);
+        const recoveryCred = recoveryStore.profiles[params.profileId];
+        if (
+          recoveryCred?.type === "oauth" &&
+          Date.now() < recoveryCred.expires &&
+          isSameOAuthIdentity(cred, recoveryCred)
+        ) {
+          await writeCredentialToAgentStore(params.agentDir, params.profileId, recoveryCred);
+          log.info("recovered from refresh_token_reused via main store", {
+            profileId: params.profileId,
+            expires: new Date(recoveryCred.expires).toISOString(),
+          });
+          return {
+            apiKey: await buildOAuthApiKey(recoveryCred.provider, recoveryCred),
+            newCredentials: recoveryCred,
+          };
+        }
+      }
+      throw refreshError;
+    }
+
+    if (!refreshResult) {
       return null;
     }
-    store.profiles[params.profileId] = {
+
+    // Write refreshed token to the agent's own store (under its own file lock).
+    const mergedCred: OAuthCredential = {
       ...cred,
-      ...result.newCredentials,
+      ...refreshResult.newCredentials,
       type: "oauth",
     };
-    saveAuthProfileStore(store, params.agentDir);
+    await writeCredentialToAgentStore(params.agentDir, params.profileId, mergedCred);
 
-    return result;
+    // Write-back to main agent store so other agents benefit — only if
+    // the sub-agent and main agent share the same OAuth identity.
+    if (params.agentDir) {
+      const mainStore = loadAuthProfileStoreForAgent(undefined);
+      const mainCred = mainStore.profiles[params.profileId];
+      if (mainCred?.type === "oauth" && isSameOAuthIdentity(cred, mainCred)) {
+        await writeCredentialToAgentStore(undefined, params.profileId, mergedCred);
+      }
+    }
+
+    return refreshResult;
   });
 }
 

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -290,6 +290,37 @@ type ResolveApiKeyForProfileParams = {
 type SecretDefaults = NonNullable<OpenClawConfig["secrets"]>["defaults"];
 const READ_ONLY_AUTH_STORE_OPTIONS = { readOnly: true, allowKeychainPrompt: false } as const;
 
+function resolveOAuthRefreshWriteTarget(params: {
+  agentDir?: string;
+  profileId: string;
+  currentCred: OAuthCredential;
+}): { agentDir: string | undefined; expectedCurrent: OAuthCredential } {
+  const localStore = loadAuthProfileStoreForAgent(params.agentDir, READ_ONLY_AUTH_STORE_OPTIONS);
+  const localCred = localStore.profiles[params.profileId];
+  if (localCred?.type === "oauth" && areOAuthCredentialsEquivalent(localCred, params.currentCred)) {
+    return {
+      agentDir: params.agentDir,
+      expectedCurrent: localCred,
+    };
+  }
+
+  if (params.agentDir) {
+    const mainStore = loadAuthProfileStoreForAgent(undefined, READ_ONLY_AUTH_STORE_OPTIONS);
+    const mainCred = mainStore.profiles[params.profileId];
+    if (mainCred?.type === "oauth" && areOAuthCredentialsEquivalent(mainCred, params.currentCred)) {
+      return {
+        agentDir: undefined,
+        expectedCurrent: mainCred,
+      };
+    }
+  }
+
+  return {
+    agentDir: params.agentDir,
+    expectedCurrent: params.currentCred,
+  };
+}
+
 async function adoptNewerMainOAuthCredential(params: {
   store: AuthProfileStore;
   profileId: string;
@@ -466,16 +497,24 @@ async function doRefreshOAuthTokenWithLock(params: {
       return null;
     }
 
-    // Write refreshed token to the agent's own store (under its own file lock).
+    const refreshWriteTarget = resolveOAuthRefreshWriteTarget({
+      agentDir: params.agentDir,
+      profileId: params.profileId,
+      currentCred: cred,
+    });
+
+    // Persist the refreshed token back to whichever store currently owns this
+    // OAuth snapshot. Sub-agents can inherit shared profiles from main without
+    // having a local oauth entry to overwrite.
     const mergedCred: OAuthCredential = {
       ...cred,
       ...refreshResult.newCredentials,
       type: "oauth",
     };
     const localWrite = await writeCredentialToAgentStore({
-      agentDir: params.agentDir,
+      agentDir: refreshWriteTarget.agentDir,
       profileId: params.profileId,
-      expectedCurrent: cred,
+      expectedCurrent: refreshWriteTarget.expectedCurrent,
       newCred: mergedCred,
     });
     const effectiveCred = localWrite.current;
@@ -492,6 +531,7 @@ async function doRefreshOAuthTokenWithLock(params: {
       const mainStore = loadAuthProfileStoreForAgent(undefined, READ_ONLY_AUTH_STORE_OPTIONS);
       const mainCred = mainStore.profiles[params.profileId];
       if (
+        refreshWriteTarget.agentDir !== undefined &&
         (localWrite.status === "written" || localWrite.status === "kept_current") &&
         mainCred?.type === "oauth" &&
         canShareOAuthCredentialAcrossAgents(cred, mainCred)

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -545,6 +545,21 @@ async function doRefreshOAuthTokenWithLock(params: {
     });
     const effectiveCred = localWrite.current;
     if (!effectiveCred || Date.now() >= effectiveCred.expires) {
+      if (localWrite.status === "lock_failed") {
+        const refreshedStore = loadAuthProfileStoreForRuntime(
+          params.agentDir,
+          READ_ONLY_AUTH_STORE_OPTIONS,
+        );
+        const current = refreshedStore.profiles[params.profileId];
+        // If the store still resolves to the same stale OAuth snapshot, use the
+        // freshly minted credential for this request rather than failing auth.
+        if (
+          !current ||
+          (current.type === "oauth" && areOAuthCredentialsEquivalent(current, cred))
+        ) {
+          return refreshResult;
+        }
+      }
       if (areOAuthCredentialsEquivalent(mergedCred, cred)) {
         return refreshResult;
       }

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -21,7 +21,7 @@ import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
 import {
   ensureAuthProfileStore,
   loadAuthProfileStoreForAgent,
-  saveAuthProfileStore,
+  loadAuthProfileStoreForRuntime,
   updateAuthProfileStoreWithLock,
 } from "./store.js";
 import type { AuthProfileStore, OAuthCredential } from "./types.js";
@@ -123,25 +123,81 @@ function isRefreshTokenReusedError(error: unknown): boolean {
 }
 
 /**
- * Guard: only allow cross-agent credential operations when both credentials
- * belong to the same OAuth identity (same provider, and same email if both set).
- * Prevents overwriting credentials when agents use different accounts under the
- * same profile name.
+ * Cross-agent credential sharing needs positive identity evidence. Providers
+ * without stable account metadata may reuse the same profile id across distinct
+ * accounts, so provider-only matches are not enough to safely copy tokens.
  */
-function isSameOAuthIdentity(a: OAuthCredential, b: OAuthCredential): boolean {
+function normalizeOAuthIdentityValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeOAuthEmail(value: string | undefined): string | undefined {
+  const normalized = normalizeOAuthIdentityValue(value);
+  return normalized?.toLowerCase();
+}
+
+function areOAuthCredentialsEquivalent(a: OAuthCredential, b: OAuthCredential): boolean {
+  return (
+    a.provider === b.provider &&
+    a.access === b.access &&
+    a.refresh === b.refresh &&
+    Object.is(a.expires, b.expires) &&
+    a.email === b.email &&
+    a.enterpriseUrl === b.enterpriseUrl &&
+    a.projectId === b.projectId &&
+    a.accountId === b.accountId
+  );
+}
+
+function hasPositiveOAuthIdentityMatch(a: OAuthCredential, b: OAuthCredential): boolean {
   if (a.provider !== b.provider) {
     return false;
   }
+
   // accountId is the strongest identity signal (used by Codex CLI credentials).
-  const aAcct = (a as Record<string, unknown>).accountId;
-  const bAcct = (b as Record<string, unknown>).accountId;
-  if (aAcct && bAcct && aAcct !== bAcct) {
+  const aAcct = normalizeOAuthIdentityValue(a.accountId);
+  const bAcct = normalizeOAuthIdentityValue(b.accountId);
+  if (aAcct || bAcct) {
+    return aAcct !== undefined && aAcct === bAcct;
+  }
+
+  const aEmail = normalizeOAuthEmail(a.email);
+  const bEmail = normalizeOAuthEmail(b.email);
+  if (aEmail || bEmail) {
+    return aEmail !== undefined && aEmail === bEmail;
+  }
+
+  return false;
+}
+
+function canShareOAuthCredentialAcrossAgents(a: OAuthCredential, b: OAuthCredential): boolean {
+  if (a.provider !== b.provider) {
     return false;
   }
-  if (a.email && b.email && a.email !== b.email) {
+  return hasPositiveOAuthIdentityMatch(a, b) || areOAuthCredentialsEquivalent(a, b);
+}
+
+function shouldOverwriteOAuthCredential(
+  existing: OAuthCredential,
+  incoming: OAuthCredential,
+): boolean {
+  if (areOAuthCredentialsEquivalent(existing, incoming)) {
     return false;
   }
-  return true;
+  if (!Number.isFinite(existing.expires)) {
+    return true;
+  }
+  if (!Number.isFinite(incoming.expires)) {
+    return false;
+  }
+  if (existing.expires < incoming.expires) {
+    return true;
+  }
+  return (
+    existing.expires === incoming.expires &&
+    (existing.access !== incoming.access || existing.refresh !== incoming.refresh)
+  );
 }
 
 async function performOAuthRefresh(
@@ -171,38 +227,56 @@ async function performOAuthRefresh(
   return await getOAuthApiKey(oauthProvider, oauthCreds);
 }
 
-async function writeCredentialToAgentStore(
-  agentDir: string | undefined,
-  profileId: string,
-  newCred: OAuthCredential,
-): Promise<void> {
+type WriteOAuthCredentialResult =
+  | { status: "written" | "kept_current"; current: OAuthCredential }
+  | { status: "missing" | "conflict" | "lock_failed"; current: null | OAuthCredential };
+
+async function writeCredentialToAgentStore(params: {
+  agentDir: string | undefined;
+  profileId: string;
+  expectedCurrent: OAuthCredential;
+  newCred: OAuthCredential;
+}): Promise<WriteOAuthCredentialResult> {
+  let result: WriteOAuthCredentialResult = { status: "lock_failed", current: null };
   try {
-    await updateAuthProfileStoreWithLock({
-      agentDir,
+    const updatedStore = await updateAuthProfileStoreWithLock({
+      agentDir: params.agentDir,
       updater: (store) => {
-        const existing = store.profiles[profileId];
-        if (
-          !existing ||
-          existing.type !== "oauth" ||
-          !Number.isFinite(existing.expires) ||
-          existing.expires < newCred.expires ||
-          // Token rotation without expiry change: persist when expiry matches
-          // but don't overwrite a strictly newer credential from a concurrent re-auth.
-          (existing.expires === newCred.expires &&
-            (existing.access !== newCred.access || existing.refresh !== newCred.refresh))
-        ) {
-          store.profiles[profileId] = { ...newCred };
+        const existing = store.profiles[params.profileId];
+        if (!existing || existing.type !== "oauth") {
+          result = { status: "missing", current: null };
+          return false;
+        }
+        if (!areOAuthCredentialsEquivalent(existing, params.expectedCurrent)) {
+          result = { status: "conflict", current: existing };
+          return false;
+        }
+        if (!shouldOverwriteOAuthCredential(existing, params.newCred)) {
+          result = { status: "kept_current", current: existing };
+          return false;
+        }
+
+        store.profiles[params.profileId] = { ...params.newCred };
+        const written = store.profiles[params.profileId];
+        if (written.type === "oauth") {
+          result = { status: "written", current: written };
           return true;
         }
+        result = { status: "missing", current: null };
         return false;
       },
     });
+    if (!updatedStore) {
+      return result;
+    }
+    return result;
   } catch (err) {
     log.debug("writeCredentialToAgentStore failed", {
-      profileId,
-      agentDir,
+      profileId: params.profileId,
+      agentDir: params.agentDir,
       error: err instanceof Error ? err.message : String(err),
     });
+    return { status: "lock_failed", current: null };
   }
 }
 
@@ -214,13 +288,14 @@ type ResolveApiKeyForProfileParams = {
 };
 
 type SecretDefaults = NonNullable<OpenClawConfig["secrets"]>["defaults"];
+const READ_ONLY_AUTH_STORE_OPTIONS = { readOnly: true, allowKeychainPrompt: false } as const;
 
-function adoptNewerMainOAuthCredential(params: {
+async function adoptNewerMainOAuthCredential(params: {
   store: AuthProfileStore;
   profileId: string;
   agentDir?: string;
   cred: OAuthCredentials & { type: "oauth"; provider: string; email?: string };
-}): (OAuthCredentials & { type: "oauth"; provider: string; email?: string }) | null {
+}): Promise<(OAuthCredentials & { type: "oauth"; provider: string; email?: string }) | null> {
   if (!params.agentDir) {
     return null;
   }
@@ -229,18 +304,31 @@ function adoptNewerMainOAuthCredential(params: {
     const mainCred = mainStore.profiles[params.profileId];
     if (
       mainCred?.type === "oauth" &&
-      isSameOAuthIdentity(params.cred, mainCred) &&
+      canShareOAuthCredentialAcrossAgents(params.cred, mainCred) &&
       Number.isFinite(mainCred.expires) &&
       (!Number.isFinite(params.cred.expires) || mainCred.expires > params.cred.expires)
     ) {
-      params.store.profiles[params.profileId] = { ...mainCred };
-      saveAuthProfileStore(params.store, params.agentDir);
-      log.info("adopted newer OAuth credentials from main agent", {
-        profileId: params.profileId,
+      const writeResult = await writeCredentialToAgentStore({
         agentDir: params.agentDir,
-        expires: new Date(mainCred.expires).toISOString(),
+        profileId: params.profileId,
+        expectedCurrent: params.cred,
+        newCred: mainCred,
       });
-      return mainCred;
+      const currentCred = writeResult.current;
+      if (
+        currentCred &&
+        canShareOAuthCredentialAcrossAgents(params.cred, currentCred) &&
+        Number.isFinite(currentCred.expires) &&
+        (!Number.isFinite(params.cred.expires) || currentCred.expires > params.cred.expires)
+      ) {
+        params.store.profiles[params.profileId] = { ...currentCred };
+        log.info("adopted newer OAuth credentials from main agent", {
+          profileId: params.profileId,
+          agentDir: params.agentDir,
+          expires: new Date(currentCred.expires).toISOString(),
+        });
+        return currentCred;
+      }
     }
   } catch (err) {
     // Best-effort: don't crash if main agent store is missing or unreadable.
@@ -291,14 +379,11 @@ async function doRefreshOAuthTokenWithLock(params: {
   const globalLockPath = resolveOAuthRefreshLockPath(params.profileId);
 
   return await withFileLock(globalLockPath, OAUTH_REFRESH_LOCK_OPTIONS, async () => {
-    // Re-read the agent's own store (fresh disk read, bypasses runtime snapshot cache).
-    const store = loadAuthProfileStoreForAgent(params.agentDir);
-    let cred = store.profiles[params.profileId];
-    // Profile may only exist in main store (inherited via ensureAuthProfileStore merge).
-    if ((!cred || cred.type !== "oauth") && params.agentDir) {
-      const mainStore = loadAuthProfileStoreForAgent(undefined);
-      cred = mainStore.profiles[params.profileId];
-    }
+    // Refresh holds the global OAuth lock, not the per-store auth lock. Keep
+    // these lookups read-only so external CLI sync can't persist auth store
+    // changes while we're only coordinating refresh.
+    const store = loadAuthProfileStoreForRuntime(params.agentDir, READ_ONLY_AUTH_STORE_OPTIONS);
+    const cred = store.profiles[params.profileId];
     if (!cred || cred.type !== "oauth") {
       return null;
     }
@@ -312,26 +397,32 @@ async function doRefreshOAuthTokenWithLock(params: {
     }
 
     // Check if another process already refreshed (visible in the main store).
-    // Only adopt if the main credential belongs to the same OAuth identity
-    // (same provider + email) to avoid cross-account overwrites.
+    // Only adopt if the main credential is provably the same shared profile.
     if (params.agentDir) {
-      const mainStore = loadAuthProfileStoreForAgent(undefined);
+      const mainStore = loadAuthProfileStoreForAgent(undefined, READ_ONLY_AUTH_STORE_OPTIONS);
       const mainCred = mainStore.profiles[params.profileId];
       if (
         mainCred?.type === "oauth" &&
         Date.now() < mainCred.expires &&
-        isSameOAuthIdentity(cred, mainCred)
+        canShareOAuthCredentialAcrossAgents(cred, mainCred)
       ) {
-        await writeCredentialToAgentStore(params.agentDir, params.profileId, mainCred);
-        log.info("adopted fresh OAuth credentials from main store (under global lock)", {
-          profileId: params.profileId,
+        const adopted = await writeCredentialToAgentStore({
           agentDir: params.agentDir,
-          expires: new Date(mainCred.expires).toISOString(),
+          profileId: params.profileId,
+          expectedCurrent: cred,
+          newCred: mainCred,
         });
-        return {
-          apiKey: await buildOAuthApiKey(mainCred.provider, mainCred),
-          newCredentials: mainCred,
-        };
+        if (adopted.current && Date.now() < adopted.current.expires) {
+          log.info("adopted fresh OAuth credentials from main store (under global lock)", {
+            profileId: params.profileId,
+            agentDir: params.agentDir,
+            expires: new Date(adopted.current.expires).toISOString(),
+          });
+          return {
+            apiKey: await buildOAuthApiKey(adopted.current.provider, adopted.current),
+            newCredentials: adopted.current,
+          };
+        }
       }
     }
 
@@ -343,22 +434,29 @@ async function doRefreshOAuthTokenWithLock(params: {
       // Recovery: if refresh_token_reused, another process may have refreshed
       // outside the lock (different machine, stale lock, copied credentials).
       if (isRefreshTokenReusedError(refreshError) && params.agentDir) {
-        const recoveryStore = loadAuthProfileStoreForAgent(undefined);
+        const recoveryStore = loadAuthProfileStoreForAgent(undefined, READ_ONLY_AUTH_STORE_OPTIONS);
         const recoveryCred = recoveryStore.profiles[params.profileId];
         if (
           recoveryCred?.type === "oauth" &&
           Date.now() < recoveryCred.expires &&
-          isSameOAuthIdentity(cred, recoveryCred)
+          canShareOAuthCredentialAcrossAgents(cred, recoveryCred)
         ) {
-          await writeCredentialToAgentStore(params.agentDir, params.profileId, recoveryCred);
-          log.info("recovered from refresh_token_reused via main store", {
+          const recovered = await writeCredentialToAgentStore({
+            agentDir: params.agentDir,
             profileId: params.profileId,
-            expires: new Date(recoveryCred.expires).toISOString(),
+            expectedCurrent: cred,
+            newCred: recoveryCred,
           });
-          return {
-            apiKey: await buildOAuthApiKey(recoveryCred.provider, recoveryCred),
-            newCredentials: recoveryCred,
-          };
+          if (recovered.current && Date.now() < recovered.current.expires) {
+            log.info("recovered from refresh_token_reused via main store", {
+              profileId: params.profileId,
+              expires: new Date(recovered.current.expires).toISOString(),
+            });
+            return {
+              apiKey: await buildOAuthApiKey(recovered.current.provider, recovered.current),
+              newCredentials: recovered.current,
+            };
+          }
         }
       }
       throw refreshError;
@@ -374,19 +472,43 @@ async function doRefreshOAuthTokenWithLock(params: {
       ...refreshResult.newCredentials,
       type: "oauth",
     };
-    await writeCredentialToAgentStore(params.agentDir, params.profileId, mergedCred);
+    const localWrite = await writeCredentialToAgentStore({
+      agentDir: params.agentDir,
+      profileId: params.profileId,
+      expectedCurrent: cred,
+      newCred: mergedCred,
+    });
+    const effectiveCred = localWrite.current;
+    if (!effectiveCred || Date.now() >= effectiveCred.expires) {
+      if (areOAuthCredentialsEquivalent(mergedCred, cred)) {
+        return refreshResult;
+      }
+      return null;
+    }
 
     // Write-back to main agent store so other agents benefit — only if
     // the sub-agent and main agent share the same OAuth identity.
     if (params.agentDir) {
-      const mainStore = loadAuthProfileStoreForAgent(undefined);
+      const mainStore = loadAuthProfileStoreForAgent(undefined, READ_ONLY_AUTH_STORE_OPTIONS);
       const mainCred = mainStore.profiles[params.profileId];
-      if (mainCred?.type === "oauth" && isSameOAuthIdentity(cred, mainCred)) {
-        await writeCredentialToAgentStore(undefined, params.profileId, mergedCred);
+      if (
+        (localWrite.status === "written" || localWrite.status === "kept_current") &&
+        mainCred?.type === "oauth" &&
+        canShareOAuthCredentialAcrossAgents(cred, mainCred)
+      ) {
+        await writeCredentialToAgentStore({
+          agentDir: undefined,
+          profileId: params.profileId,
+          expectedCurrent: mainCred,
+          newCred: effectiveCred,
+        });
       }
     }
 
-    return refreshResult;
+    return {
+      apiKey: await buildOAuthApiKey(effectiveCred.provider, effectiveCred),
+      newCredentials: effectiveCred,
+    };
   });
 }
 
@@ -422,6 +544,16 @@ async function tryResolveOAuthProfile(
     agentDir: params.agentDir,
   });
   if (!refreshed) {
+    const refreshedStore = loadAuthProfileStoreForAgent(params.agentDir);
+    const current = refreshedStore.profiles[profileId];
+    if (current && (current.type !== "oauth" || !areOAuthCredentialsEquivalent(current, cred))) {
+      return await resolveApiKeyForProfile({
+        cfg,
+        store: refreshedStore,
+        profileId,
+        agentDir: params.agentDir,
+      });
+    }
     return null;
   }
   return buildApiKeyProfileResult({
@@ -547,12 +679,12 @@ export async function resolveApiKeyForProfile(
   }
 
   const oauthCred =
-    adoptNewerMainOAuthCredential({
+    (await adoptNewerMainOAuthCredential({
       store,
       profileId,
       agentDir: params.agentDir,
       cred,
-    }) ?? cred;
+    })) ?? cred;
 
   if (Date.now() < oauthCred.expires) {
     return await buildOAuthProfileResult({
@@ -568,12 +700,25 @@ export async function resolveApiKeyForProfile(
       agentDir: params.agentDir,
     });
     if (!result) {
+      const refreshedStore = loadAuthProfileStoreForAgent(params.agentDir);
+      const current = refreshedStore.profiles[profileId];
+      if (
+        current &&
+        (current.type !== "oauth" || !areOAuthCredentialsEquivalent(current, oauthCred))
+      ) {
+        return await resolveApiKeyForProfile({
+          cfg,
+          store: refreshedStore,
+          profileId,
+          agentDir: params.agentDir,
+        });
+      }
       return null;
     }
     return buildApiKeyProfileResult({
       apiKey: result.apiKey,
-      provider: cred.provider,
-      email: cred.email,
+      provider: oauthCred.provider,
+      email: oauthCred.email,
     });
   } catch (error) {
     const refreshedStore = ensureAuthProfileStore(params.agentDir);
@@ -615,21 +760,26 @@ export async function resolveApiKeyForProfile(
         if (
           mainCred?.type === "oauth" &&
           Date.now() < mainCred.expires &&
-          isSameOAuthIdentity(cred, mainCred)
+          canShareOAuthCredentialAcrossAgents(cred, mainCred)
         ) {
-          // Main agent has fresh credentials for the same identity - copy and use
-          refreshedStore.profiles[profileId] = { ...mainCred };
-          saveAuthProfileStore(refreshedStore, params.agentDir);
-          log.info("inherited fresh OAuth credentials from main agent", {
-            profileId,
+          const inherited = await writeCredentialToAgentStore({
             agentDir: params.agentDir,
-            expires: new Date(mainCred.expires).toISOString(),
+            profileId,
+            expectedCurrent: cred,
+            newCred: mainCred,
           });
-          return await buildOAuthProfileResult({
-            provider: mainCred.provider,
-            credentials: mainCred,
-            email: mainCred.email,
-          });
+          if (inherited.current && Date.now() < inherited.current.expires) {
+            log.info("inherited fresh OAuth credentials from main agent", {
+              profileId,
+              agentDir: params.agentDir,
+              expires: new Date(inherited.current.expires).toISOString(),
+            });
+            return await buildOAuthProfileResult({
+              provider: inherited.current.provider,
+              credentials: inherited.current,
+              email: inherited.current.email,
+            });
+          }
         }
       } catch {
         // keep original error if main agent fallback also fails

--- a/src/agents/auth-profiles/paths.ts
+++ b/src/agents/auth-profiles/paths.ts
@@ -34,6 +34,9 @@ export function ensureAuthStoreFile(pathname: string) {
 }
 
 export function resolveOAuthRefreshLockPath(profileId: string): string {
-  const safeId = profileId.replace(/[^a-zA-Z0-9_.-]/g, "_");
+  const safeId = profileId.replace(
+    /[^a-zA-Z0-9_.-]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).padStart(2, "0")}`,
+  );
   return path.join(resolveStateDir(), "locks", "oauth-refresh", safeId);
 }

--- a/src/agents/auth-profiles/paths.ts
+++ b/src/agents/auth-profiles/paths.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "../../config/paths.js";
@@ -34,9 +35,8 @@ export function ensureAuthStoreFile(pathname: string) {
 }
 
 export function resolveOAuthRefreshLockPath(profileId: string): string {
-  // Encode the full UTF-8 byte sequence so lock ids remain collision-free and
-  // never normalize into "."/".." path segments.
-  const encodedId = Buffer.from(profileId, "utf8").toString("hex");
-  const safeId = `utf8-${encodedId || "00"}`;
+  // Hash the full UTF-8 byte sequence so lock ids stay namespace-safe while
+  // keeping the resulting filename length bounded for long profile ids.
+  const safeId = `sha256-${createHash("sha256").update(profileId, "utf8").digest("hex")}`;
   return path.join(resolveStateDir(), "locks", "oauth-refresh", safeId);
 }

--- a/src/agents/auth-profiles/paths.ts
+++ b/src/agents/auth-profiles/paths.ts
@@ -34,9 +34,9 @@ export function ensureAuthStoreFile(pathname: string) {
 }
 
 export function resolveOAuthRefreshLockPath(profileId: string): string {
-  const safeId = profileId.replace(
-    /[^a-zA-Z0-9_.-]/g,
-    (c) => `%${c.charCodeAt(0).toString(16).padStart(2, "0")}`,
-  );
+  // Encode the full UTF-8 byte sequence so lock ids remain collision-free and
+  // never normalize into "."/".." path segments.
+  const encodedId = Buffer.from(profileId, "utf8").toString("hex");
+  const safeId = `utf8-${encodedId || "00"}`;
   return path.join(resolveStateDir(), "locks", "oauth-refresh", safeId);
 }

--- a/src/agents/auth-profiles/paths.ts
+++ b/src/agents/auth-profiles/paths.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { resolveStateDir } from "../../config/paths.js";
 import { saveJsonFile } from "../../infra/json-file.js";
 import { resolveUserPath } from "../../utils.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
@@ -30,4 +31,9 @@ export function ensureAuthStoreFile(pathname: string) {
     profiles: {},
   };
   saveJsonFile(pathname, payload);
+}
+
+export function resolveOAuthRefreshLockPath(profileId: string): string {
+  const safeId = profileId.replace(/[^a-zA-Z0-9_.-]/g, "_");
+  return path.join(resolveStateDir(), "locks", "oauth-refresh", safeId);
 }

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -441,7 +441,7 @@ export function loadAuthProfileStore(): AuthProfileStore {
   return store;
 }
 
-function loadAuthProfileStoreForAgent(
+export function loadAuthProfileStoreForAgent(
   agentDir?: string,
   options?: LoadAuthProfileStoreOptions,
 ): AuthProfileStore {


### PR DESCRIPTION
## Summary

- Problem: shared OAuth profiles could race refresh, and follow-up review uncovered new corruption and null-return paths once refresh stopped holding the per-store auth lock for the whole network round-trip.
- Why it matters: agents could overwrite newer auth-mode changes, leak OAuth tokens across agent stores, contend on ambiguous lock paths, or fail inherited-profile refreshes even when valid main-store credentials existed.
- What changed: kept the global per-profile refresh lock, but made post-refresh writes compare-and-set against the exact persisted OAuth snapshot; tightened cross-agent identity checks; switched auth-store reads under the global refresh lock to read-only; replaced variable-length UTF-8 hex lock ids with bounded SHA-256 lock ids; fixed inherited main-store profile refresh and merged-store re-resolution paths; returned freshly refreshed credentials for the in-flight request when CAS persistence cannot complete and no newer auth state is visible; added focused regressions for each race.
- What did NOT change (scope boundary): plugin OAuth refresh interfaces, failover/cooldown behavior, non-OAuth auth-store mutation semantics outside these refresh races, or the overall main-agent/shared-profile model.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Auth / tokens

## Linked Issue/PR

- Closes #26322
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the global refresh lock fixed the thundering-herd network race, but the original follow-up write paths still assumed the same local OAuth entry remained authoritative after refresh. That was wrong for delete/re-auth races, inherited main-store profiles, and providers without stable identity metadata. The first lock-path encoder also allowed ambiguous or unsafe filenames.
- Missing detection / guardrail: there was no compare-and-set write against the persisted OAuth snapshot, no strict positive-identity requirement for cross-agent token sharing, no focused inherited-profile retry coverage, and no lock-path tests for distinct ids, dot-segment safety, and bounded filename length.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this PR started as a fix for the shared-profile `refresh_token_reused` race described in #26322. Review then surfaced the post-refresh corruption paths introduced by shortening the lock scope.
- Why this regressed now: refresh is now serialized by a global per-profile lock instead of the per-store auth lock, so stale post-refresh writes had to become conditional instead of relying on old lock ordering.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts`, `src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts`, `src/agents/auth-profiles.paths.test.ts`
- Scenario the test should lock in: delete/type-change during refresh, provider-only identity mismatch, inherited main-store profile refresh/write-back, merged-store re-resolution after a `null` refresh result, current-request success when auth-store CAS persistence times out after refresh, and distinct, dot-safe, bounded-length lock path encoding.
- Why this is the smallest reliable guardrail: these tests exercise the real auth-store merge, refresh, and persistence behavior across main/sub-agent stores without needing live multi-process OAuth.
- Existing test that already covers this (if any): `src/agents/auth-profiles/oauth.test.ts` still covers the baseline OAuth resolution behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- OAuth refresh is serialized per shared profile, avoiding `refresh_token_reused` stampedes.
- In-flight refreshes no longer recreate deleted profiles or overwrite a newer `token` / `api_key` re-auth.
- Cross-agent OAuth adoption/write-back now requires positive identity evidence (`accountId` or matching email) or exact credential equivalence, preserving per-agent account isolation.
- A request that successfully refreshes OAuth can still proceed even if the local CAS write-back times out, as long as no newer auth mode is visible in the merged runtime store.
- Refresh lock filenames are now namespace-safe, bounded in length, and hash-based.
- Sub-agents that inherit OAuth profiles from main now refresh and recover correctly without forcing a local clone of that profile.

## Diagram (if applicable)

```text
Before:
[sub-agent refresh] -> [global/shared race or stale local write] -> [401 / overwrite / null return]

After:
[sub-agent refresh] -> [global per-profile lock] -> [CAS write to owning store + merged re-resolution] -> [usable credentials without clobbering newer auth state]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: token persistence rules are stricter now. Cross-agent sharing only happens with positive identity evidence or exact credential equivalence; persisted writes are compare-and-set against the expected OAuth snapshot; reads under the global refresh lock are read-only; and refresh lock ids now use deterministic SHA-256 filenames that stay dot-safe and bounded in length.

## Repro + Verification

### Environment

- OS: macOS 26.3.1 arm64
- Runtime/container: Bun test wrapper in the repo workspace
- Model/provider: auth-profile OAuth flows (`openai-codex`, `anthropic`)
- Integration/channel (if any): N/A
- Relevant config (redacted): main + sub-agent auth-profile stores, including shared and inherited OAuth profile cases

### Steps

1. Configure shared or inherited OAuth profiles across main and sub-agent auth stores.
2. Trigger refresh while concurrently deleting/re-authing the profile or updating the main-store credential.
3. Observe the stored credential and resolved auth result.

### Expected

- Refresh serializes once per profile.
- Newer auth-mode changes win over stale refresh output.
- Different-account agents do not exchange tokens on provider-only matches.
- Inherited main-store profiles refresh and re-resolve successfully.

### Actual (before fix)

- Refresh could clobber a newer `token` / `api_key` entry or recreate a deleted profile.
- Provider-only identity matches could copy one agent's OAuth tokens into another agent's store.
- Ambiguous lock ids could collide or form unsafe path segments, and long encoded ids could fail with `ENAMETOOLONG`.
- Inherited-profile refreshes could return `null` even after valid main-store updates.
- A successful refresh could still fail the current request if CAS persistence of the new OAuth entry timed out or errored before the refreshed credential became visible in the auth store.

## Evidence

- [x] Failing test/log before + passing after

Focused regressions now cover:
- `refresh_token_reused` recovery against a fresher main-store credential
- no stale overwrite after delete or token re-auth during refresh
- no provider-only cross-agent write-back/adoption
- inherited main-store profile refresh and `null`-retry re-resolution
- current-request success when refreshed OAuth CAS persistence times out
- distinct, bounded, and dot-safe refresh lock paths

## Human Verification (required)

- Verified scenarios: `bun run test -- src/agents/auth-profiles.paths.test.ts src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts src/agents/auth-profiles/oauth.test.ts` (4 files, 40 tests passing), plus `oxlint` and `oxfmt --check` on the touched files.
- Edge cases checked: delete during refresh, token re-auth during refresh, provider-only account mismatch, inherited-profile refresh/write-back, merged-store retry after `null`, auth-store CAS lock timeout after refresh, and lock-path collision/dot-segment safety.
- What you did **not** verify: live multi-process refresh across separate OS processes; repo-wide `pnpm test`, `pnpm check`, and `pnpm build` were not rerun as part of this final update.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: shared-profile refresh still serializes peers behind a single profile lock.
  - Mitigation: the lock is per-profile rather than global, stale-lock handling remains in place, and the main benefit is preventing the refresh-token herd.
- Risk: cross-agent credential sharing could still be dangerous if identity inference were too loose.
  - Mitigation: the current branch requires positive identity evidence or exact credential equivalence, and all persisted writes are compare-and-set guarded against the owning store snapshot.

