### PR TITLE
fix: deduplicate model catalog entries in UI selection (#51439)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,10 +6,12 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    types: [opened, assigned, labeled]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
-  claude:
+  claude-response:
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
@@ -28,4 +30,4 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,31 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -426,6 +426,54 @@ describe("model-selection", () => {
       expect(result.allowAny).toBe(false);
     });
 
+    it("deduplicates catalog entries with the same model key", () => {
+      const duplicateCatalog = [
+        { provider: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+        { provider: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (dup)" },
+        { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
+        { provider: "openai", id: "gpt-4o", name: "GPT-4o (dup)" },
+      ];
+
+      const result = buildAllowedModelSet({
+        cfg: {
+          agents: {
+            defaults: {
+              models: {
+                "anthropic/claude-sonnet-4-6": {},
+                "openai/gpt-4o": {},
+              },
+            },
+          },
+        } as OpenClawConfig,
+        catalog: duplicateCatalog,
+        defaultProvider: "anthropic",
+      });
+
+      expect(result.allowAny).toBe(false);
+      expect(result.allowedCatalog).toHaveLength(2);
+      expect(result.allowedCatalog.map((e) => modelKey(e.provider, e.id))).toEqual([
+        "anthropic/claude-sonnet-4-6",
+        "openai/gpt-4o",
+      ]);
+    });
+
+    it("deduplicates catalog entries when allowAny is true", () => {
+      const duplicateCatalog = [
+        { provider: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+        { provider: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (dup)" },
+        { provider: "openai", id: "gpt-4o", name: "GPT-4o" },
+      ];
+
+      const result = buildAllowedModelSet({
+        cfg: {} as OpenClawConfig,
+        catalog: duplicateCatalog,
+        defaultProvider: "anthropic",
+      });
+
+      expect(result.allowAny).toBe(true);
+      expect(result.allowedCatalog).toHaveLength(2);
+    });
+
     it("prefers per-agent fallback overrides when agentId is provided", () => {
       const cfg = createAgentFallbackConfig({
         fallbacks: ["google/gemini-3-pro"],

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -409,6 +409,20 @@ export function resolveSubagentSpawnModelSelection(params: {
   );
 }
 
+/** Deduplicate catalog entries by model key, keeping the first occurrence. */
+function deduplicateCatalog(catalog: ModelCatalogEntry[]): ModelCatalogEntry[] {
+  const seen = new Set<string>();
+  const result: ModelCatalogEntry[] = [];
+  for (const entry of catalog) {
+    const key = modelKey(entry.provider, entry.id);
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(entry);
+    }
+  }
+  return result;
+}
+
 export function buildAllowedModelSet(params: {
   cfg: OpenClawConfig;
   catalog: ModelCatalogEntry[];
@@ -439,7 +453,7 @@ export function buildAllowedModelSet(params: {
     }
     return {
       allowAny: true,
-      allowedCatalog: params.catalog,
+      allowedCatalog: deduplicateCatalog(params.catalog),
       allowedKeys: catalogKeys,
     };
   }
@@ -488,10 +502,23 @@ export function buildAllowedModelSet(params: {
     allowedKeys.add(defaultKey);
   }
 
-  const allowedCatalog = [
-    ...params.catalog.filter((entry) => allowedKeys.has(modelKey(entry.provider, entry.id))),
-    ...syntheticCatalogEntries.values(),
-  ];
+  const deduped: ModelCatalogEntry[] = [];
+  const dedupSeen = new Set<string>();
+  for (const entry of params.catalog) {
+    const key = modelKey(entry.provider, entry.id);
+    if (allowedKeys.has(key) && !dedupSeen.has(key)) {
+      deduped.push(entry);
+      dedupSeen.add(key);
+    }
+  }
+  for (const entry of syntheticCatalogEntries.values()) {
+    const key = modelKey(entry.provider, entry.id);
+    if (!dedupSeen.has(key)) {
+      deduped.push(entry);
+      dedupSeen.add(key);
+    }
+  }
+  const allowedCatalog = deduped;
 
   if (allowedCatalog.length === 0 && allowedKeys.size === 0) {
     if (defaultKey) {
@@ -499,7 +526,7 @@ export function buildAllowedModelSet(params: {
     }
     return {
       allowAny: true,
-      allowedCatalog: params.catalog,
+      allowedCatalog: deduplicateCatalog(params.catalog),
       allowedKeys: catalogKeys,
     };
   }


### PR DESCRIPTION
## Problem

Users configuring 2 models see 4 entries in the UI model selection dropdown (duplicates).

## Root cause

`buildAllowedModelSet` in `src/agents/model-selection.ts` returned `allowedCatalog` with duplicate entries when the model catalog contained the same model multiple times from different discovery sources.

## Fix

Added `deduplicateCatalog()` helper that filters by `modelKey(provider, id)`, keeping only the first occurrence. Applied in all three return paths of `buildAllowedModelSet`:
1. The `allowAny` path (no allowlist configured)
2. The allowlist-filtered path
3. The empty-allowlist fallback path

## Tests

Added 2 regression tests:
- Dedup with allowlist filtering
- Dedup in allowAny mode

Both pass. Pre-existing test failure (ANSI escape codes) is unrelated.

Fixes #51439