### PR TITLE
docs: add cc-soul to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -18,19 +18,6 @@ openclaw plugins install <npm-spec>
 
 ## Listed plugins
 
-### Codex App Server Bridge
-
-Independent OpenClaw bridge for Codex App Server conversations. Bind a chat to
-a Codex thread, talk to it with plain text, and control it with chat-native
-commands for resume, planning, review, model selection, compaction, and more.
-
-- **npm:** `openclaw-codex-app-server`
-- **repo:** [github.com/pwrdrvr/openclaw-codex-app-server](https://github.com/pwrdrvr/openclaw-codex-app-server)
-
-```bash
-openclaw plugins install openclaw-codex-app-server
-```
-
 ### cc-soul
 
 Give your AI a soul: persistent memory (10K+), 5 auto-switching personality
@@ -42,6 +29,19 @@ features, auto-detects AI backend.
 
 ```bash
 openclaw plugins install @cc-soul/openclaw
+```
+
+### Codex App Server Bridge
+
+Independent OpenClaw bridge for Codex App Server conversations. Bind a chat to
+a Codex thread, talk to it with plain text, and control it with chat-native
+commands for resume, planning, review, model selection, compaction, and more.
+
+- **npm:** `openclaw-codex-app-server`
+- **repo:** [github.com/pwrdrvr/openclaw-codex-app-server](https://github.com/pwrdrvr/openclaw-codex-app-server)
+
+```bash
+openclaw plugins install openclaw-codex-app-server
 ```
 
 ### DingTalk

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -31,6 +31,19 @@ commands for resume, planning, review, model selection, compaction, and more.
 openclaw plugins install openclaw-codex-app-server
 ```
 
+### cc-soul
+
+Give your AI a soul: persistent memory (10K+), 5 auto-switching personality
+faces, emotional awareness, self-evolution, knowledge network. 22 toggleable
+features, auto-detects AI backend.
+
+- **npm:** `@cc-soul/openclaw`
+- **repo:** [github.com/wenroudeyu-collab/cc-soul](https://github.com/wenroudeyu-collab/cc-soul)
+
+```bash
+openclaw plugins install @cc-soul/openclaw
+```
+
 ### DingTalk
 
 Enterprise robot integration using Stream mode. Supports text, images, and


### PR DESCRIPTION
## Summary

Add cc-soul to the community plugins listing.

**cc-soul** is a cognitive architecture plugin that gives OpenClaw AIs persistent memory, personality evolution, emotional awareness, and knowledge networking.

- **npm:** `@cc-soul/openclaw` (v1.0.3, published)
- **GitHub:** https://github.com/wenroudeyu-collab/cc-soul
- **ClawHub:** `cc-soul`
- 30 modules, ~8000 lines of TypeScript
- 22 toggleable features, auto-detects AI backend

### Meets listing requirements
- ✅ Published on npm: `openclaw plugins install @cc-soul/openclaw`
- ✅ Public GitHub repo with README, docs, issue tracker
- ✅ Active maintenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)