### PR TITLE
fix(health): bound gateway health snapshots and normalize legacy cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gateway/health: parallelize per-channel account probes, bound total snapshot time, and normalize legacy cron job ids (numeric/missing) during store migration so admin CLI paths stay responsive under multi-account setups (#51498).
 - Models/Anthropic Vertex: add core `anthropic-vertex` provider support for Claude via Google Vertex AI, including GCP auth/discovery and main run-path routing. (#43356) Thanks @sallyom and @yossiovadia.
 - Commands/btw: add `/btw` side questions for quick tool-less answers about the current session without changing future session context, with dismissible in-session TUI answers and explicit BTW replies on external channels. (#45444) Thanks @ngutman.
 - Gateway/docs: clarify that empty URL input allowlists are treated as unset, document `allowUrl: false` as the deny-all switch, and add regression coverage for the normalization path.

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -73,6 +73,20 @@ export type HealthSummary = {
 };
 
 const DEFAULT_TIMEOUT_MS = 10_000;
+/**
+ * Default wall-clock budget for {@link getHealthSnapshot}. Channel probes used to run
+ * sequentially (N × timeout), which could exceed common CLI/gateway limits (~30s) when many
+ * plugins/accounts are configured (#51498). Parallel probes + this cap keep snapshots bounded.
+ */
+const DEFAULT_HEALTH_SNAPSHOT_BUDGET_MS = 25_000;
+
+function resolveProbeBudgetMs(deadlineMs: number, perProbeCap: number): number {
+  const remaining = deadlineMs - Date.now();
+  if (remaining <= 0) {
+    return 0;
+  }
+  return Math.min(perProbeCap, Math.max(50, remaining));
+}
 
 const debugHealth = (...args: unknown[]) => {
   if (isTruthyEnvValue(process.env.OPENCLAW_DEBUG_HEALTH)) {
@@ -419,6 +433,8 @@ export const formatHealthChannelLines = (
 export async function getHealthSnapshot(params?: {
   timeoutMs?: number;
   probe?: boolean;
+  /** Wall-clock budget for the full snapshot (parallel probes + summaries). */
+  maxSnapshotMs?: number;
 }): Promise<HealthSummary> {
   const timeoutMs = params?.timeoutMs;
   const cfg = loadConfig();
@@ -447,6 +463,8 @@ export async function getHealthSnapshot(params?: {
 
   const start = Date.now();
   const cappedTimeout = timeoutMs === undefined ? DEFAULT_TIMEOUT_MS : Math.max(50, timeoutMs);
+  const maxSnapshotMs = params?.maxSnapshotMs ?? DEFAULT_HEALTH_SNAPSHOT_BUDGET_MS;
+  const deadlineMs = start + Math.max(1000, maxSnapshotMs);
   const doProbe = params?.probe !== false;
   const channels: Record<string, ChannelHealthSummary> = {};
   const channelOrder = listChannelPlugins().map((plugin) => plugin.id);
@@ -484,80 +502,91 @@ export async function getHealthSnapshot(params?: {
       preferredAccountId,
       accountIdsToProbe,
     });
-    const accountSummaries: Record<string, ChannelAccountHealthSummary> = {};
-
-    for (const accountId of accountIdsToProbe) {
-      const { account, enabled, configured, diagnostics } = await resolveHealthAccountContext({
-        plugin,
-        cfg,
-        accountId,
-      });
-      if (diagnostics.length > 0) {
-        debugHealth("account.diagnostics", { channel: plugin.id, accountId, diagnostics });
-      }
-
-      let probe: unknown;
-      let lastProbeAt: number | null = null;
-      if (enabled && configured && doProbe && plugin.status?.probeAccount) {
-        try {
-          probe = await plugin.status.probeAccount({
-            account,
-            timeoutMs: cappedTimeout,
-            cfg,
-          });
-          lastProbeAt = Date.now();
-        } catch (err) {
-          probe = { ok: false, error: formatErrorMessage(err) };
-          lastProbeAt = Date.now();
+    const accountEntries = await Promise.all(
+      accountIdsToProbe.map(async (accountId) => {
+        const { account, enabled, configured, diagnostics } = await resolveHealthAccountContext({
+          plugin,
+          cfg,
+          accountId,
+        });
+        if (diagnostics.length > 0) {
+          debugHealth("account.diagnostics", { channel: plugin.id, accountId, diagnostics });
         }
-      }
 
-      const probeRecord =
-        probe && typeof probe === "object" ? (probe as Record<string, unknown>) : null;
-      const bot =
-        probeRecord && typeof probeRecord.bot === "object"
-          ? (probeRecord.bot as { username?: string | null })
-          : null;
-      if (bot?.username) {
-        debugHealth("probe.bot", { channel: plugin.id, accountId, username: bot.username });
-      }
+        let probe: unknown;
+        let lastProbeAt: number | null = null;
+        const budgetMs = resolveProbeBudgetMs(deadlineMs, cappedTimeout);
+        if (enabled && configured && doProbe && plugin.status?.probeAccount) {
+          if (budgetMs > 0) {
+            try {
+              probe = await plugin.status.probeAccount({
+                account,
+                timeoutMs: budgetMs,
+                cfg,
+              });
+              lastProbeAt = Date.now();
+            } catch (err) {
+              probe = { ok: false, error: formatErrorMessage(err) };
+              lastProbeAt = Date.now();
+            }
+          } else {
+            probe = { ok: false, error: "health snapshot budget exceeded" };
+            lastProbeAt = Date.now();
+          }
+        }
 
-      const snapshot: ChannelAccountSnapshot = {
-        accountId,
-        enabled,
-        configured,
-      };
-      if (probe !== undefined) {
-        snapshot.probe = probe;
-      }
-      if (lastProbeAt) {
-        snapshot.lastProbeAt = lastProbeAt;
-      }
+        const probeRecord =
+          probe && typeof probe === "object" ? (probe as Record<string, unknown>) : null;
+        const bot =
+          probeRecord && typeof probeRecord.bot === "object"
+            ? (probeRecord.bot as { username?: string | null })
+            : null;
+        if (bot?.username) {
+          debugHealth("probe.bot", { channel: plugin.id, accountId, username: bot.username });
+        }
 
-      const summary = plugin.status?.buildChannelSummary
-        ? await plugin.status.buildChannelSummary({
-            account,
-            cfg,
-            defaultAccountId: accountId,
-            snapshot,
-          })
-        : undefined;
-      const record =
-        summary && typeof summary === "object"
-          ? (summary as ChannelAccountHealthSummary)
-          : ({
-              accountId,
-              configured,
-              probe,
-              lastProbeAt,
-            } satisfies ChannelAccountHealthSummary);
-      if (record.configured === undefined) {
-        record.configured = configured;
-      }
-      if (record.lastProbeAt === undefined && lastProbeAt) {
-        record.lastProbeAt = lastProbeAt;
-      }
-      record.accountId = accountId;
+        const snapshot: ChannelAccountSnapshot = {
+          accountId,
+          enabled,
+          configured,
+        };
+        if (probe !== undefined) {
+          snapshot.probe = probe;
+        }
+        if (lastProbeAt) {
+          snapshot.lastProbeAt = lastProbeAt;
+        }
+
+        const summary = plugin.status?.buildChannelSummary
+          ? await plugin.status.buildChannelSummary({
+              account,
+              cfg,
+              defaultAccountId: accountId,
+              snapshot,
+            })
+          : undefined;
+        const record =
+          summary && typeof summary === "object"
+            ? (summary as ChannelAccountHealthSummary)
+            : ({
+                accountId,
+                configured,
+                probe,
+                lastProbeAt,
+              } satisfies ChannelAccountHealthSummary);
+        if (record.configured === undefined) {
+          record.configured = configured;
+        }
+        if (record.lastProbeAt === undefined && lastProbeAt) {
+          record.lastProbeAt = lastProbeAt;
+        }
+        record.accountId = accountId;
+        return { accountId, record };
+      }),
+    );
+
+    const accountSummaries: Record<string, ChannelAccountHealthSummary> = {};
+    for (const { accountId, record } of accountEntries) {
       accountSummaries[accountId] = record;
     }
 

--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -97,6 +97,32 @@ describe("normalizeStoredCronJobs", () => {
     expect(result.issues.legacyPayloadKind).toBeUndefined();
   });
 
+  it("assigns uuid when id is missing and coerces numeric id to string (#51498)", () => {
+    const jobs = [
+      {
+        jobId: null,
+        name: "needs-id",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: { kind: "agentTurn", message: "hi" },
+        state: {},
+      },
+      {
+        id: 42,
+        name: "numeric-id",
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: { kind: "agentTurn", message: "hi" },
+        state: {},
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(typeof jobs[0]?.id).toBe("string");
+    expect(String(jobs[0]?.id).length).toBeGreaterThan(10);
+    expect(jobs[1]?.id).toBe("42");
+  });
+
   it("normalizes whitespace-padded and non-canonical payload kinds", () => {
     const jobs = [
       {

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { normalizeLegacyDeliveryInput } from "./legacy-delivery.js";
 import { parseAbsoluteTimeMs } from "./parse.js";
 import { migrateLegacyCronPayload } from "./payload-migration.js";
@@ -215,6 +216,22 @@ export function normalizeStoredCronJobs(
       delete raw.jobId;
       mutated = true;
       trackIssue("jobId");
+    }
+
+    // Coerce legacy numeric ids and ensure every job has a non-empty string id (#51498).
+    if (typeof raw.id === "number" && Number.isFinite(raw.id)) {
+      raw.id = String(Math.trunc(raw.id));
+      mutated = true;
+      trackIssue("jobId");
+    }
+    const idTrimmed = typeof raw.id === "string" ? raw.id.trim() : "";
+    if (!idTrimmed) {
+      raw.id = randomUUID();
+      mutated = true;
+      trackIssue("jobId");
+    } else if (typeof raw.id !== "string" || raw.id !== idTrimmed) {
+      raw.id = idTrimmed;
+      mutated = true;
     }
 
     if (typeof raw.schedule === "string") {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem**: `openclaw cron list` / `cron status` and `openclaw health --json` could hit gateway timeouts (~30s) while `gateway status` still showed a healthy RPC probe; users with many channel accounts also paid a sequential health snapshot cost (N×probe timeout). Legacy cron rows could have non-string or empty `id` values.
- **Why it matters**: Admins lose the ability to inspect cron and gateway health via CLI despite a running scheduler; multi-account setups amplified health snapshot latency.
- **What changed**: `getHealthSnapshot` now runs per-channel account probes in parallel, applies a default wall-clock budget (`DEFAULT_HEALTH_SNAPSHOT_BUDGET_MS`), and passes a per-probe budget derived from remaining time; `normalizeStoredCronJobs` coerces numeric `id` to string and assigns a UUID when `id` is missing/empty after legacy migration.
- **What did NOT change (scope boundary)**: No change to cron execution semantics, gateway auth, or unrelated channel plugins beyond health snapshot gathering and cron store normalization on load.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #51498
- Related #

## User-visible / Behavior Changes

- `health` RPC / `openclaw health` snapshots complete within a bounded time more reliably on multi-account configs; probes for accounts under one channel run concurrently.
- Legacy cron jobs with numeric or missing `id` are normalized when the store is loaded/saved (may persist a one-time rewrite).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No` — same probes, different scheduling/budget)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: any (fix is Node/TS in gateway + CLI)
- Runtime: OpenClaw gateway + CLI calling `health` / `cron.*` RPCs
- Relevant config: multiple channel accounts or many plugins increases snapshot work; cron store with legacy `id` / `jobId`

### Steps

1. Run `pnpm check` locally on the branch (passes).
2. (Optional) Run gateway and exercise `openclaw health --json` / `openclaw cron list` against a multi-account config.

### Expected

Health snapshot and cron admin RPCs return before client timeout in typical setups; cron store normalizes legacy ids without manual doctor intervention.

### Actual

Local `pnpm check` passed; unit coverage in `health.snapshot.test.ts` / `store-migration.test.ts`.

## Evidence

- [x] Failing pattern addressed: sequential health probes + unbounded total time; missing cron id coercion — covered by code change + tests
- [x] `pnpm check` green locally

## Human Verification (required)

- Verified scenarios: `pnpm check` full suite; targeted tests for health snapshot and cron migration.
- Edge cases checked: parallel account probes preserve per-account error handling; budget exceeded returns structured probe error string.
- What you did **not** verify: End-to-end on the reporter’s exact Linux systemd gateway host.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No` — cron ids are normalized on load; optional persist on next write)

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit.
- Files/config to restore: `src/commands/health.ts`, `src/cron/store-migration.ts`, tests, `CHANGELOG.md`

## Risks and Mitigations

- **Risk**: Parallel probes could increase concurrent outbound requests to providers. **Mitigation**: Same probes as before, only concurrency per channel; overall budget caps total wait.
- **Risk**: UUID assignment for empty ids changes stable ids for broken rows. **Mitigation**: Only when `id` was unusable; improves correctness.
