### PR TITLE
test(config): add regression test for telegram topic agentId (#50574)

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -224,4 +224,22 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts agentId in telegram topic config (#50574)", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          groups: {
+            "-1003806191278": {
+              topics: {
+                "214": { agentId: "test" },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Adds a regression test to ensure agentId is accepted in Telegram topic config.

## Context

- Issue #50574 reported that openclaw doctor rejects agentId in telegram topic config
- The Zod schema TelegramTopicSchema already includes agentId: z.string().optional()
- This test ensures the schema continues to accept agentId and does not regress

## Test

Added test in src/config/config.schema-regressions.test.ts that validates a config with agentId in telegram topics is accepted.

## Related

- #33647 added per-topic agent routing feature
- #35498 fixed similar issue for editMessage/createForumTopic in Telegram actions schema
