### PR TITLE
fix(pairing): propagate non-ENOENT errors in sync allowlist reader

### DIFF
--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -406,7 +406,7 @@ function readAllowFromStateForPathSyncWithExists(
   } catch (err) {
     const code = (err as { code?: string }).code;
     if (code !== "ENOENT") {
-      return { entries: [], exists: false };
+      throw err;
     }
   }
 
@@ -426,7 +426,7 @@ function readAllowFromStateForPathSyncWithExists(
     if (code === "ENOENT") {
       return { entries: [], exists: false };
     }
-    return { entries: [], exists: false };
+    throw err;
   }
   // stat is guaranteed non-null here: resolveAllowFromReadCacheOrMissing returns early when stat is null.
   try {


### PR DESCRIPTION
## Summary

- The sync variant `readAllowFromStateForPathSyncWithExists` silently swallows non-ENOENT file system errors (EACCES, EIO, etc.) by returning empty entries
- The async variant `readAllowFromStateForPathWithExists` correctly rethrows non-ENOENT errors (line 367-368)
- This inconsistency means permission errors, disk I/O errors, etc. are hidden in the sync path, causing the pairing allowlist to silently appear empty

## Root cause

Two error-handling sites in the sync reader diverged from the async version:

1. **`statSync` catch block** (line 408): returns `{ entries: [], exists: false }` on non-ENOENT errors instead of rethrowing
2. **`readFileSync` catch block** (line 429): returns `{ entries: [], exists: false }` on non-ENOENT errors instead of rethrowing

The sync function is called from 4 call sites in the pairing system (lines 500, 570, 588, 590), all of which would silently get empty allowlists on I/O errors.

## Fix

- `statSync` catch: rethrow non-ENOENT errors (matching async behavior)
- `readFileSync` catch: rethrow non-ENOENT errors (matching async behavior)

ENOENT is still treated as "file not found → return empty" in both paths.

## Test plan

- [x] All 43 pairing tests pass (`pnpm test -- src/pairing/`)
- [x] Code inspection confirms sync and async error handling are now consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)