### PR TITLE
fix(process): add windowsHide to spawn in runCommandWithTimeout

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -233,6 +233,7 @@ export async function runCommandWithTimeout(
       stdio,
       cwd,
       env: resolvedEnv,
+      windowsHide: true,
       windowsVerbatimArguments: useCmdWrapper ? true : windowsVerbatimArguments,
       ...(shouldSpawnWithShell({ resolvedCommand, platform: process.platform })
         ? { shell: true }


### PR DESCRIPTION
## Summary

- Problem: On Windows, `runCommandWithTimeout()` spawns child processes without `windowsHide: true`, causing a visible cmd.exe window to flash briefly for every spawned command. This is especially noticeable during gateway startup when `ensureGitRepo()` invokes `git --version` and `git init`.
- Why it matters: The flashing cmd window is a jarring UX issue for Windows users, particularly for applications that embed OpenClaw as an npm package and run it in the background.
- What changed: Added `windowsHide: true` to the `spawn()` options in `runCommandWithTimeout()` (`src/process/exec.ts`).
- What did NOT change (scope boundary): No other spawn call sites were modified. Only the central `runCommandWithTimeout` function was touched. No behavioral changes on non-Windows platforms (`windowsHide` is ignored on macOS/Linux).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Windows cmd window flashing on gateway startup

## User-visible / Behavior Changes

- Windows: No more visible cmd.exe window flash when OpenClaw spawns background commands (git, npm, etc.)
- Non-Windows: No change.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node.js 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Default gateway config

### Steps

1. Install OpenClaw as an npm package on Windows
2. Start the gateway (`openclaw gateway run`)
3. Observe a cmd.exe window briefly flashing during startup (when `ensureGitRepo` runs git commands)

### Expected

- No visible cmd window during gateway startup

### Actual

- A cmd.exe window flashes briefly each time `spawn()` is called without `windowsHide: true`

## Evidence

- [x] Trace/log snippets
- The `windowsHide` option is a [documented Node.js spawn option](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options) specifically designed to prevent this behavior on Windows.

## Human Verification (required)

- Verified scenarios: Gateway startup on Windows 11 — no cmd window flash after the fix.
- Edge cases checked: Confirmed `windowsHide` is ignored on non-Windows platforms (no behavioral change on macOS/Linux).
- What you did **not** verify: Other spawn call sites in the codebase (this PR only addresses `runCommandWithTimeout`; other sites may also benefit from the same fix).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single-line addition of `windowsHide: true` in `src/process/exec.ts`
- Files/config to restore: `src/process/exec.ts`
- Known bad symptoms reviewers should watch for: None expected — `windowsHide` is a no-op on non-Windows

## Risks and Mitigations

`None` — this is a well-documented Node.js API option with no side effects on non-Windows platforms.

---

**AI-assisted PR** (CodeBuddy). Fully tested on Windows 11. I understand what the code does.
