### PR TITLE
Fix/issue 51097 session store memory tests

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -111,3 +111,17 @@ openclaw sessions cleanup --json
 Related:
 
 - Session config: [Configuration reference](/gateway/configuration-reference#session)
+- Session cache limit: [Environment variables](/help/environment#session-store-cache)
+
+## Large session stores
+
+OpenClaw keeps short-lived in-memory session-store caches for `sessions.json`, but those caches now have a size limit. By default, stores larger than `1 MB` (`1000000` bytes) are still read normally, but their in-memory parsed and serialized caches are disabled to reduce memory retention in long-running gateways.
+
+When the limit is exceeded:
+
+- session behavior stays the same
+- no sessions are deleted or reset
+- repeated store reads may be slower because OpenClaw reads and parses from disk again
+- OpenClaw logs a one-time warning for that store path
+
+To override the limit, set `OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES`. Setting it to `0` disables the session object cache entirely. See [Environment variables](/help/environment#session-store-cache).

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -117,6 +117,16 @@ Both resolve from process env at activation time. SecretRef details are document
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `OPENCLAW_LOG_LEVEL` | Override log level for both file and console (e.g. `debug`, `trace`). Takes precedence over `logging.level` and `logging.consoleLevel` in config. Invalid values are ignored with a warning. |
 
+## Session store cache
+
+| Variable                                  | Purpose                                                                                                                                                            |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES` | Maximum `sessions.json` size eligible for the in-memory session-store caches. Defaults to `1000000` bytes (`1 MB`). Set to `0` to disable those caches completely. |
+
+When a session store grows past this limit, OpenClaw stops retaining both the parsed object cache and the serialized in-memory copy for that `sessions.json`. This lowers memory retention for large stores at the cost of extra disk reads on repeated access.
+
+If the limit is exceeded, OpenClaw logs a one-time warning per store path that includes the store path, current size, configured limit, and `OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES`.
+
 ### `OPENCLAW_HOME`
 
 When set, `OPENCLAW_HOME` replaces the system home directory (`$HOME` / `os.homedir()`) for all internal path resolution. This enables full filesystem isolation for headless service accounts.

--- a/scripts/measure-session-store-cache.ts
+++ b/scripts/measure-session-store-cache.ts
@@ -1,0 +1,278 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import {
+  clearSessionStoreCacheForTest,
+  loadSessionStore,
+  saveSessionStore,
+} from "../src/config/sessions.js";
+import type { SessionEntry } from "../src/config/sessions.js";
+import {
+  dropSessionStoreObjectCache,
+  setSerializedSessionStore,
+} from "../src/config/sessions/store-cache.js";
+
+type Mode = "full-cache" | "serialized-retained" | "no-cache";
+
+type ChildResult = {
+  entries: number;
+  mode: Mode;
+  fileSizeBytes: number;
+  firstLoadMs: number;
+  secondLoadMs: number;
+  retainedHeapDeltaKb: number;
+};
+
+type AggregateResult = {
+  entries: number;
+  mode: Mode;
+  fileSizeBytes: number;
+  firstLoadMsMedian: number;
+  secondLoadMsMedian: number;
+  retainedHeapDeltaKbMedian: number;
+};
+
+const ENTRY_COUNTS = [100, 250, 500, 1000, 2000];
+const PAYLOAD_SIZE = 2048;
+const REPEATS = 3;
+const CHILD_MARKER = "__OPENCLAW_SESSION_CACHE_MEASURE__=";
+
+function forceGc() {
+  if (typeof global.gc === "function") {
+    global.gc();
+  }
+}
+
+function createStore(entryCount: number): Record<string, SessionEntry> {
+  const repeated = "x".repeat(PAYLOAD_SIZE);
+  const store: Record<string, SessionEntry> = {};
+  const baseUpdatedAt = Date.now();
+  for (let i = 0; i < entryCount; i += 1) {
+    store[`session:${String(i)}`] = {
+      sessionId: `id-${String(i)}`,
+      updatedAt: baseUpdatedAt + i,
+      displayName: `Measured Session ${String(i)} ${repeated}`,
+    };
+  }
+  return store;
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].toSorted((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[middle - 1] + sorted[middle]) / 2;
+  }
+  return sorted[middle];
+}
+
+function parseArgs(argv: string[]) {
+  const parsed: {
+    child: boolean;
+    entries?: number;
+    mode?: Mode;
+  } = { child: false };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--child") {
+      parsed.child = true;
+      continue;
+    }
+    if (arg === "--entries") {
+      const value = Number.parseInt(argv[i + 1] ?? "", 10);
+      if (Number.isFinite(value) && value > 0) {
+        parsed.entries = value;
+      }
+      i += 1;
+      continue;
+    }
+    if (arg === "--mode") {
+      const value = argv[i + 1];
+      if (value === "full-cache" || value === "serialized-retained" || value === "no-cache") {
+        parsed.mode = value;
+      }
+      i += 1;
+    }
+  }
+
+  return parsed;
+}
+
+async function runChild(params: { entries: number; mode: Mode }) {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-cache-measure-"));
+  const storePath = path.join(rootDir, "sessions.json");
+  const previousTtl = process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+  const previousObjectCacheMaxBytes = process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+
+  try {
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+    await saveSessionStore(storePath, createStore(params.entries));
+    const fileSizeBytes = fs.statSync(storePath).size;
+
+    clearSessionStoreCacheForTest();
+    if (params.mode === "full-cache") {
+      process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES = String(fileSizeBytes + 1024);
+    } else if (params.mode === "serialized-retained") {
+      process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES = String(fileSizeBytes + 1024);
+      setSerializedSessionStore(storePath, fs.readFileSync(storePath, "utf8"));
+    } else if (params.mode === "no-cache") {
+      process.env.OPENCLAW_SESSION_CACHE_TTL_MS = "0";
+      process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES = "0";
+      setSerializedSessionStore(storePath, undefined);
+    }
+
+    forceGc();
+    const beforeHeap = process.memoryUsage().heapUsed;
+
+    const firstLoadMs = (() => {
+      const startedAt = performance.now();
+      const loaded = loadSessionStore(storePath);
+      void Object.keys(loaded).length;
+      return performance.now() - startedAt;
+    })();
+
+    if (params.mode === "serialized-retained") {
+      dropSessionStoreObjectCache(storePath);
+    } else if (params.mode === "no-cache") {
+      dropSessionStoreObjectCache(storePath);
+      setSerializedSessionStore(storePath, undefined);
+    }
+
+    forceGc();
+
+    const secondLoadMs = (() => {
+      const startedAt = performance.now();
+      const loadedAgain = loadSessionStore(storePath);
+      void Object.keys(loadedAgain).length;
+      return performance.now() - startedAt;
+    })();
+
+    if (params.mode === "serialized-retained") {
+      dropSessionStoreObjectCache(storePath);
+    } else if (params.mode === "no-cache") {
+      dropSessionStoreObjectCache(storePath);
+      setSerializedSessionStore(storePath, undefined);
+    }
+
+    forceGc();
+    const afterSecondHeap = process.memoryUsage().heapUsed;
+
+    const result: ChildResult = {
+      entries: params.entries,
+      mode: params.mode,
+      fileSizeBytes,
+      firstLoadMs: Number(firstLoadMs.toFixed(2)),
+      secondLoadMs: Number(secondLoadMs.toFixed(2)),
+      retainedHeapDeltaKb: Math.round((afterSecondHeap - beforeHeap) / 1024),
+    };
+
+    console.log(`${CHILD_MARKER}${JSON.stringify(result)}`);
+  } finally {
+    clearSessionStoreCacheForTest();
+    if (previousTtl === undefined) {
+      delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    } else {
+      process.env.OPENCLAW_SESSION_CACHE_TTL_MS = previousTtl;
+    }
+    if (previousObjectCacheMaxBytes === undefined) {
+      delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+    } else {
+      process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES = previousObjectCacheMaxBytes;
+    }
+    fs.rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+function runOne(entries: number, mode: Mode): ChildResult {
+  const output = execFileSync(
+    process.execPath,
+    [
+      "--expose-gc",
+      "--import",
+      "tsx",
+      path.resolve("scripts/measure-session-store-cache.ts"),
+      "--child",
+      "--entries",
+      String(entries),
+      "--mode",
+      mode,
+    ],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NODE_NO_WARNINGS: "1",
+        PATH: process.env.PATH ?? "",
+      },
+      maxBuffer: 10 * 1024 * 1024,
+    },
+  );
+
+  const line = output.split("\n").find((candidate) => candidate.startsWith(CHILD_MARKER));
+
+  if (!line) {
+    throw new Error(`measurement child did not produce result for ${mode}/${String(entries)}`);
+  }
+
+  return JSON.parse(line.slice(CHILD_MARKER.length)) as ChildResult;
+}
+
+function aggregate(entries: number, mode: Mode): AggregateResult {
+  const samples: ChildResult[] = [];
+  for (let i = 0; i < REPEATS; i += 1) {
+    samples.push(runOne(entries, mode));
+  }
+
+  return {
+    entries,
+    mode,
+    fileSizeBytes: samples[0]?.fileSizeBytes ?? 0,
+    firstLoadMsMedian: Number(median(samples.map((sample) => sample.firstLoadMs)).toFixed(2)),
+    secondLoadMsMedian: Number(median(samples.map((sample) => sample.secondLoadMs)).toFixed(2)),
+    retainedHeapDeltaKbMedian: Math.round(
+      median(samples.map((sample) => sample.retainedHeapDeltaKb)),
+    ),
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.child) {
+    if (!args.entries || !args.mode) {
+      throw new Error("child mode requires --entries and --mode");
+    }
+    await runChild({ entries: args.entries, mode: args.mode });
+    return;
+  }
+
+  const results: AggregateResult[] = [];
+  const modes: Mode[] = ["full-cache", "serialized-retained", "no-cache"];
+
+  for (const entries of ENTRY_COUNTS) {
+    for (const mode of modes) {
+      results.push(aggregate(entries, mode));
+    }
+  }
+
+  console.log("mode\tentries\tfile_kb\tfirst_load_ms\tsecond_load_ms\tretained_heap_delta_kb");
+  for (const result of results) {
+    console.log(
+      [
+        result.mode,
+        String(result.entries),
+        String(Math.round(result.fileSizeBytes / 1024)),
+        result.firstLoadMsMedian.toFixed(2),
+        result.secondLoadMsMedian.toFixed(2),
+        String(result.retainedHeapDeltaKbMedian),
+      ].join("\t"),
+    );
+  }
+}
+
+void main();

--- a/scripts/stress-session-store-rss.ts
+++ b/scripts/stress-session-store-rss.ts
@@ -1,0 +1,231 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import {
+  clearSessionStoreCacheForTest,
+  loadSessionStore,
+  saveSessionStore,
+  updateSessionStore,
+  type SessionEntry,
+} from "../src/config/sessions.js";
+
+type Options = {
+  targetKb: number;
+  cycles: number;
+  sampleEvery: number;
+  payloadSize: number;
+  uniqueTouches: number;
+  cacheTtlMs?: string;
+  reuseLoadedStore: boolean;
+};
+
+type Sample = {
+  cycle: number;
+  rssMb: number;
+  heapUsedMb: number;
+  externalMb: number;
+  storeKb: number;
+  elapsedMs: number;
+};
+
+function parseArgs(argv: string[]): Options {
+  const options: Options = {
+    targetKb: 7600,
+    cycles: 300,
+    sampleEvery: 25,
+    payloadSize: 2048,
+    uniqueTouches: 400,
+    reuseLoadedStore: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === "--target-kb") {
+      const parsed = Number.parseInt(next ?? "", 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        options.targetKb = parsed;
+      }
+      i += 1;
+      continue;
+    }
+    if (arg === "--cycles") {
+      const parsed = Number.parseInt(next ?? "", 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        options.cycles = parsed;
+      }
+      i += 1;
+      continue;
+    }
+    if (arg === "--sample-every") {
+      const parsed = Number.parseInt(next ?? "", 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        options.sampleEvery = parsed;
+      }
+      i += 1;
+      continue;
+    }
+    if (arg === "--payload-size") {
+      const parsed = Number.parseInt(next ?? "", 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        options.payloadSize = parsed;
+      }
+      i += 1;
+      continue;
+    }
+    if (arg === "--unique-touches") {
+      const parsed = Number.parseInt(next ?? "", 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        options.uniqueTouches = parsed;
+      }
+      i += 1;
+      continue;
+    }
+    if (arg === "--cache-ttl-ms") {
+      if (typeof next === "string" && next.length > 0) {
+        options.cacheTtlMs = next;
+      }
+      i += 1;
+      continue;
+    }
+    if (arg === "--reuse-loaded-store") {
+      options.reuseLoadedStore = true;
+    }
+  }
+
+  return options;
+}
+
+function formatMb(bytes: number): number {
+  return Number((bytes / (1024 * 1024)).toFixed(1));
+}
+
+function forceGc() {
+  if (typeof global.gc === "function") {
+    global.gc();
+  }
+}
+
+function createEntry(index: number, payloadSize: number): SessionEntry {
+  const repeated = "x".repeat(payloadSize);
+  return {
+    sessionId: `sess-${String(index)}`,
+    updatedAt: Date.now() + index,
+    displayName: `Stress Session ${String(index)} ${repeated}`,
+    label: `stress-${String(index)}`,
+  };
+}
+
+function buildStoreUntilSize(
+  targetBytes: number,
+  payloadSize: number,
+): Record<string, SessionEntry> {
+  const store: Record<string, SessionEntry> = {};
+  for (let index = 0; ; index += 1) {
+    store[`session:${String(index)}`] = createEntry(index, payloadSize);
+    const serializedSize = Buffer.byteLength(JSON.stringify(store, null, 2), "utf8");
+    if (serializedSize >= targetBytes) {
+      return store;
+    }
+  }
+}
+
+function captureSample(cycle: number, storePath: string, startedAt: number): Sample {
+  const usage = process.memoryUsage();
+  const storeKb = Math.round(fs.statSync(storePath).size / 1024);
+  return {
+    cycle,
+    rssMb: formatMb(usage.rss),
+    heapUsedMb: formatMb(usage.heapUsed),
+    externalMb: formatMb(usage.external),
+    storeKb,
+    elapsedMs: Math.round(performance.now() - startedAt),
+  };
+}
+
+function printSamples(samples: Sample[]) {
+  console.log("cycle\trss_mb\theap_mb\texternal_mb\tstore_kb\telapsed_ms");
+  for (const sample of samples) {
+    console.log(
+      [
+        String(sample.cycle),
+        sample.rssMb.toFixed(1),
+        sample.heapUsedMb.toFixed(1),
+        sample.externalMb.toFixed(1),
+        String(sample.storeKb),
+        String(sample.elapsedMs),
+      ].join("\t"),
+    );
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-store-rss-"));
+  const storePath = path.join(rootDir, "sessions.json");
+  const previousTtl = process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+  const targetBytes = options.targetKb * 1024;
+  const startedAt = performance.now();
+
+  try {
+    if (options.cacheTtlMs === undefined) {
+      delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    } else {
+      process.env.OPENCLAW_SESSION_CACHE_TTL_MS = options.cacheTtlMs;
+    }
+    clearSessionStoreCacheForTest();
+
+    const initialStore = buildStoreUntilSize(targetBytes, options.payloadSize);
+    await saveSessionStore(storePath, initialStore, { skipMaintenance: true });
+
+    const sessionKeys = Object.keys(initialStore);
+    const samples: Sample[] = [];
+
+    forceGc();
+    samples.push(captureSample(0, storePath, startedAt));
+
+    for (let cycle = 1; cycle <= options.cycles; cycle += 1) {
+      const touchedKey =
+        sessionKeys[(cycle - 1) % Math.min(sessionKeys.length, options.uniqueTouches)];
+
+      // Simulate a gateway-like read path before the write path.
+      const store = loadSessionStore(storePath, { skipCache: true });
+      void store[touchedKey]?.updatedAt;
+
+      await updateSessionStore(
+        storePath,
+        (nextStore) => {
+          const current = nextStore[touchedKey];
+          nextStore[touchedKey] = {
+            ...current,
+            updatedAt: Date.now(),
+            lastTo: `target-${String(cycle % 10)}`,
+            label: `stress-cycle-${String(cycle)}`,
+          };
+        },
+        {
+          skipMaintenance: true,
+          ...(options.reuseLoadedStore ? { baseStore: store } : {}),
+        },
+      );
+
+      if (cycle % options.sampleEvery === 0 || cycle === options.cycles) {
+        forceGc();
+        samples.push(captureSample(cycle, storePath, startedAt));
+      }
+    }
+
+    printSamples(samples);
+  } finally {
+    clearSessionStoreCacheForTest();
+    if (previousTtl === undefined) {
+      delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    } else {
+      process.env.OPENCLAW_SESSION_CACHE_TTL_MS = previousTtl;
+    }
+    fs.rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+void main();

--- a/src/auto-reply/reply/abort-cutoff.runtime.ts
+++ b/src/auto-reply/reply/abort-cutoff.runtime.ts
@@ -18,15 +18,19 @@ export async function clearAbortCutoffInSessionRuntime(params: {
   sessionStore[sessionKey] = sessionEntry;
 
   if (storePath) {
-    await updateSessionStore(storePath, (store) => {
-      const existing = store[sessionKey] ?? sessionEntry;
-      if (!existing) {
-        return;
-      }
-      applyAbortCutoffToSessionEntry(existing, undefined);
-      existing.updatedAt = Date.now();
-      store[sessionKey] = existing;
-    });
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        const existing = store[sessionKey] ?? sessionEntry;
+        if (!existing) {
+          return;
+        }
+        applyAbortCutoffToSessionEntry(existing, undefined);
+        existing.updatedAt = Date.now();
+        store[sessionKey] = existing;
+      },
+      { baseStore: sessionStore },
+    );
   }
 
   return true;

--- a/src/auto-reply/reply/abort-cutoff.ts
+++ b/src/auto-reply/reply/abort-cutoff.ts
@@ -48,7 +48,6 @@ export function applyAbortCutoffToSessionEntry(
   entry.abortCutoffMessageSid = cutoff?.messageSid;
   entry.abortCutoffTimestamp = cutoff?.timestamp;
 }
-
 function toNumericMessageSid(value: string | undefined): bigint | undefined {
   const trimmed = normalizeOptionalString(value);
   if (!trimmed || !/^\d+$/.test(trimmed)) {

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -314,21 +314,25 @@ export async function tryFastAbortFromMessage(params: {
           delete store[legacyKey];
         }
       }
-      await updateSessionStore(storePath, (nextStore) => {
-        const nextEntry = nextStore[key] ?? entry;
-        if (!nextEntry) {
-          return;
-        }
-        nextEntry.abortedLastRun = true;
-        applyAbortCutoffToSessionEntry(nextEntry, abortCutoff);
-        nextEntry.updatedAt = Date.now();
-        nextStore[key] = nextEntry;
-        for (const legacyKey of legacyKeys ?? []) {
-          if (legacyKey !== key) {
-            delete nextStore[legacyKey];
+      await updateSessionStore(
+        storePath,
+        (nextStore) => {
+          const nextEntry = nextStore[key] ?? entry;
+          if (!nextEntry) {
+            return;
           }
-        }
-      });
+          nextEntry.abortedLastRun = true;
+          applyAbortCutoffToSessionEntry(nextEntry, abortCutoff);
+          nextEntry.updatedAt = Date.now();
+          nextStore[key] = nextEntry;
+          for (const legacyKey of legacyKeys ?? []) {
+            if (legacyKey !== key) {
+              delete nextStore[legacyKey];
+            }
+          }
+        },
+        { baseStore: store },
+      );
     } else if (abortKey) {
       setAbortMemory(abortKey, true);
     }

--- a/src/auto-reply/reply/agent-runner-session-reset.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.ts
@@ -85,9 +85,13 @@ export async function resetReplyRunSession(params: {
   nextEntry.sessionFile = nextSessionFile;
   params.activeSessionStore[params.sessionKey] = nextEntry;
   try {
-    await deps.updateSessionStore(params.storePath, (store) => {
-      store[params.sessionKey!] = nextEntry;
-    });
+    await deps.updateSessionStore(
+      params.storePath,
+      (store) => {
+        store[params.sessionKey!] = nextEntry;
+      },
+      { baseStore: params.activeSessionStore },
+    );
   } catch (err) {
     deps.error(
       `Failed to persist session reset after ${params.options.failureLabel} (${params.sessionKey}): ${String(err)}`,

--- a/src/auto-reply/reply/commands-session-store.ts
+++ b/src/auto-reply/reply/commands-session-store.ts
@@ -12,9 +12,13 @@ export async function persistSessionEntry(params: CommandParams): Promise<boolea
   params.sessionEntry.updatedAt = Date.now();
   params.sessionStore[params.sessionKey] = params.sessionEntry;
   if (params.storePath) {
-    await updateSessionStore(params.storePath, (store) => {
-      store[params.sessionKey] = params.sessionEntry as SessionEntry;
-    });
+    await updateSessionStore(
+      params.storePath,
+      (store) => {
+        store[params.sessionKey] = params.sessionEntry as SessionEntry;
+      },
+      { baseStore: params.sessionStore },
+    );
   }
   return true;
 }
@@ -37,16 +41,20 @@ export async function persistAbortTargetEntry(params: {
   sessionStore[key] = entry;
 
   if (storePath) {
-    await updateSessionStore(storePath, (store) => {
-      const nextEntry = store[key] ?? entry;
-      if (!nextEntry) {
-        return;
-      }
-      nextEntry.abortedLastRun = true;
-      applyAbortCutoffToSessionEntry(nextEntry, abortCutoff);
-      nextEntry.updatedAt = Date.now();
-      store[key] = nextEntry;
-    });
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        const nextEntry = store[key] ?? entry;
+        if (!nextEntry) {
+          return;
+        }
+        nextEntry.abortedLastRun = true;
+        applyAbortCutoffToSessionEntry(nextEntry, abortCutoff);
+        nextEntry.updatedAt = Date.now();
+        store[key] = nextEntry;
+      },
+      { baseStore: sessionStore },
+    );
   }
 
   return true;

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -437,9 +437,13 @@ export async function handleDirectiveOnly(
     sessionEntry.updatedAt = Date.now();
     sessionStore[sessionKey] = sessionEntry;
     if (storePath) {
-      await updateSessionStore(storePath, (store) => {
-        store[sessionKey] = sessionEntry;
-      });
+      await updateSessionStore(
+        storePath,
+        (store) => {
+          store[sessionKey] = sessionEntry;
+        },
+        { baseStore: sessionStore },
+      );
     }
     if (modelSelection && modelSelectionUpdated && sessionKey) {
       // `/model` should retarget queued/future work without interrupting the

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -255,9 +255,13 @@ export async function persistInlineDirectives(params: {
       sessionEntry.updatedAt = Date.now();
       sessionStore[sessionKey] = sessionEntry;
       if (storePath) {
-        await updateSessionStore(storePath, (store) => {
-          store[sessionKey] = sessionEntry;
-        });
+        await updateSessionStore(
+          storePath,
+          (store) => {
+            store[sessionKey] = sessionEntry;
+          },
+          { baseStore: sessionStore },
+        );
       }
       enqueueModeSwitchEvents({
         enqueueSystemEvent,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -524,9 +524,13 @@ export async function runPreparedReply(
         sessionStore[sessionKey] = sessionEntry;
         if (storePath) {
           const { updateSessionStore } = await loadSessionStoreRuntime();
-          await updateSessionStore(storePath, (store) => {
-            store[sessionKey] = sessionEntry;
-          });
+          await updateSessionStore(
+            storePath,
+            (store) => {
+              store[sessionKey] = sessionEntry;
+            },
+            { baseStore: sessionStore },
+          );
         }
       }
     }

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -392,9 +392,13 @@ export async function createModelSelectionState(params: {
         if (storePath) {
           await (
             await loadSessionStoreRuntime()
-          ).updateSessionStore(storePath, (store) => {
-            store[sessionKey] = sessionEntry;
-          });
+          ).updateSessionStore(
+            storePath,
+            (store) => {
+              store[sessionKey] = sessionEntry;
+            },
+            { baseStore: sessionStore },
+          );
         }
       }
       resetModelOverride = updated;

--- a/src/auto-reply/reply/session-reset-model.test.ts
+++ b/src/auto-reply/reply/session-reset-model.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import { buildModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
-import { applyResetModelOverride } from "./session-reset-model.js";
+
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...original,
+    updateSessionStore: vi.fn(async () => undefined),
+  };
+});
 
 const modelCatalog: ModelCatalogEntry[] = [
   { provider: "minimax", id: "m2.7", name: "M2.7" },
@@ -33,6 +40,7 @@ async function applyResetFixture(params: {
   sessionEntry?: Partial<SessionEntry>;
 }) {
   const fixture = createResetFixture(params.sessionEntry);
+  const { applyResetModelOverride } = await import("./session-reset-model.js");
   await applyResetModelOverride({
     cfg: fixture.cfg,
     resetTriggered: params.resetTriggered,
@@ -51,6 +59,49 @@ async function applyResetFixture(params: {
 }
 
 describe("applyResetModelOverride", () => {
+  let applyResetModelOverride: typeof import("./session-reset-model.js").applyResetModelOverride;
+  let updateSessionStore: typeof import("../../config/sessions.js").updateSessionStore;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ applyResetModelOverride } = await import("./session-reset-model.js"));
+    ({ updateSessionStore } = await import("../../config/sessions.js"));
+  });
+
+  it("does not pass a mutable base store to fire-and-forget persistence", async () => {
+    const cfg = {} as OpenClawConfig;
+    const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: "openai" });
+    const sessionKey = "agent:main:dm:1";
+    const sessionEntry: SessionEntry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    const sessionCtx = { BodyStripped: "minimax summarize" };
+    const ctx = { ChatType: "direct" };
+
+    vi.mocked(updateSessionStore).mockClear();
+
+    await applyResetModelOverride({
+      cfg,
+      resetTriggered: true,
+      bodyStripped: "minimax summarize",
+      sessionCtx,
+      ctx,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath: "/tmp/sessions.json",
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o-mini",
+      aliasIndex,
+      modelCatalog,
+    });
+
+    expect(updateSessionStore).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(updateSessionStore).mock.calls[0]?.[2]).toBeUndefined();
+  });
+
   it("selects a model hint and strips it from the body", async () => {
     const { sessionEntry, sessionCtx } = await applyResetFixture({
       resetTriggered: true,

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -42,9 +42,13 @@ async function persistSessionEntryUpdate(params: {
   if (!params.storePath) {
     return;
   }
-  await updateSessionStore(params.storePath, (store) => {
-    store[params.sessionKey!] = { ...store[params.sessionKey!], ...params.nextEntry };
-  });
+  await updateSessionStore(
+    params.storePath,
+    (store) => {
+      store[params.sessionKey!] = { ...store[params.sessionKey!], ...params.nextEntry };
+    },
+    { baseStore: params.sessionStore },
+  );
 }
 
 function emitCompactionSessionLifecycleHooks(params: {

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -238,6 +238,86 @@ describe("session store lock (Promise chain mutex)", () => {
     expect(store[key]?.modelOverride).toBe("recovered");
   });
 
+  it("does not replay a failed Windows baseStore write on the next update", async () => {
+    const key = "agent:main:base-store-retry";
+    const { storePath } = await makeTmpStore({
+      [key]: { sessionId: "s1", updatedAt: 100, label: "initial", displayName: "before" },
+    });
+
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const baseStore = loadSessionStore(storePath, { skipCache: true });
+    const writeError = Object.assign(new Error("busy"), { code: "EBUSY" });
+    const writeSpy = vi.spyOn(jsonFiles, "writeTextAtomic").mockRejectedValue(writeError);
+
+    await updateSessionStore(
+      storePath,
+      async (store) => {
+        store[key] = {
+          ...store[key],
+          label: "failed-write",
+        };
+      },
+      { skipMaintenance: true, baseStore },
+    );
+
+    writeSpy.mockRestore();
+
+    await updateSessionStore(
+      storePath,
+      async (store) => {
+        store[key] = {
+          ...store[key],
+          displayName: "fresh",
+        };
+      },
+      { skipMaintenance: true, baseStore },
+    );
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[key]?.label).toBe("initial");
+    expect(store[key]?.displayName).toBe("fresh");
+
+    platformSpy.mockRestore();
+  });
+
+  it("does not replay a failed baseStore mutator on the next update", async () => {
+    const key = "agent:main:base-store-throw";
+    const { storePath } = await makeTmpStore({
+      [key]: { sessionId: "s1", updatedAt: 100, label: "initial", displayName: "before" },
+    });
+
+    const baseStore = loadSessionStore(storePath, { skipCache: true });
+
+    await expect(
+      updateSessionStore(
+        storePath,
+        async (store) => {
+          store[key] = {
+            ...store[key],
+            label: "failed-mutation",
+          };
+          throw new Error("boom");
+        },
+        { skipMaintenance: true, baseStore },
+      ),
+    ).rejects.toThrow("boom");
+
+    await updateSessionStore(
+      storePath,
+      async (store) => {
+        store[key] = {
+          ...store[key],
+          displayName: "fresh",
+        };
+      },
+      { skipMaintenance: true, baseStore },
+    );
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[key]?.label).toBe("initial");
+    expect(store[key]?.displayName).toBe("fresh");
+  });
+
   it("clears stale runtime provider when model is patched without provider", () => {
     const merged = mergeSessionEntry(
       {
@@ -300,6 +380,40 @@ describe("session store lock (Promise chain mutex)", () => {
         model: "gpt-5.4",
       };
     });
+
+    const store = loadSessionStore(storePath);
+    expect(store[key]?.acp).toEqual(acp);
+    expect(store[key]?.modelProvider).toBe("openai-codex");
+    expect(store[key]?.model).toBe("gpt-5.4");
+  });
+
+  it("preserves ACP metadata when baseStore reuse starts from a pre-mutated entry", async () => {
+    const key = "agent:codex:acp:binding:discord:default:feedface";
+    const acp = {
+      backend: "acpx",
+      agent: "codex",
+      runtimeSessionName: "codex-discord",
+      mode: "persistent" as const,
+      state: "idle" as const,
+      lastActivityAt: 100,
+    };
+    const { storePath } = await makeTmpStore({
+      [key]: {
+        sessionId: "sess-acp",
+        updatedAt: 100,
+        acp,
+      },
+    });
+
+    const baseStore = loadSessionStore(storePath, { skipCache: true });
+    baseStore[key] = {
+      sessionId: "sess-acp",
+      updatedAt: 200,
+      modelProvider: "openai-codex",
+      model: "gpt-5.4",
+    };
+
+    await updateSessionStore(storePath, () => undefined, { baseStore, skipMaintenance: true });
 
     const store = loadSessionStore(storePath);
     expect(store[key]?.acp).toEqual(acp);

--- a/src/config/sessions/store-cache-limit.ts
+++ b/src/config/sessions/store-cache-limit.ts
@@ -1,0 +1,11 @@
+import { parseStrictNonNegativeInteger } from "../../infra/parse-finite-number.js";
+
+export const DEFAULT_SESSION_OBJECT_CACHE_MAX_BYTES = 1_000_000;
+export const SESSION_OBJECT_CACHE_MAX_BYTES_ENV = "OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES";
+
+export function resolveSessionObjectCacheMaxBytes(
+  envValue = process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES,
+): number {
+  const parsed = parseStrictNonNegativeInteger(envValue);
+  return parsed ?? DEFAULT_SESSION_OBJECT_CACHE_MAX_BYTES;
+}

--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -13,7 +13,12 @@ const DEFAULT_SESSION_STORE_TTL_MS = 45_000; // 45 seconds (between 30-60s)
 const SESSION_STORE_CACHE = createExpiringMapCache<string, SessionStoreCacheEntry>({
   ttlMs: getSessionStoreTtl,
 });
-const SESSION_STORE_SERIALIZED_CACHE = new Map<string, string>();
+type SerializedSessionStoreCacheEntry = {
+  loadedAt: number;
+  serialized: string;
+};
+
+const SESSION_STORE_SERIALIZED_CACHE = new Map<string, SerializedSessionStoreCacheEntry>();
 
 export function getSessionStoreTtl(): number {
   return resolveCacheTtlMs({
@@ -36,16 +41,34 @@ export function invalidateSessionStoreCache(storePath: string): void {
   SESSION_STORE_SERIALIZED_CACHE.delete(storePath);
 }
 
-export function getSerializedSessionStore(storePath: string): string | undefined {
-  return SESSION_STORE_SERIALIZED_CACHE.get(storePath);
+export function getSerializedSessionStore(params: {
+  storePath: string;
+  ttlMs: number;
+}): string | undefined {
+  const cached = SESSION_STORE_SERIALIZED_CACHE.get(params.storePath);
+  if (!cached) {
+    return undefined;
+  }
+  if (params.ttlMs <= 0 || Date.now() - cached.loadedAt > params.ttlMs) {
+    SESSION_STORE_SERIALIZED_CACHE.delete(params.storePath);
+    return undefined;
+  }
+  return cached.serialized;
 }
 
-export function setSerializedSessionStore(storePath: string, serialized?: string): void {
+export function setSerializedSessionStore(
+  storePath: string,
+  serialized?: string,
+  loadedAt = Date.now(),
+): void {
   if (serialized === undefined) {
     SESSION_STORE_SERIALIZED_CACHE.delete(storePath);
     return;
   }
-  SESSION_STORE_SERIALIZED_CACHE.set(storePath, serialized);
+  SESSION_STORE_SERIALIZED_CACHE.set(storePath, {
+    loadedAt,
+    serialized,
+  });
 }
 
 export function dropSessionStoreObjectCache(storePath: string): void {
@@ -75,6 +98,7 @@ export function writeSessionStoreCache(params: {
   sizeBytes?: number;
   serialized?: string;
 }): void {
+  const loadedAt = Date.now();
   SESSION_STORE_CACHE.set(params.storePath, {
     store: structuredClone(params.store),
     mtimeMs: params.mtimeMs,
@@ -82,6 +106,9 @@ export function writeSessionStoreCache(params: {
     serialized: params.serialized,
   });
   if (params.serialized !== undefined) {
-    SESSION_STORE_SERIALIZED_CACHE.set(params.storePath, params.serialized);
+    SESSION_STORE_SERIALIZED_CACHE.set(params.storePath, {
+      loadedAt,
+      serialized: params.serialized,
+    });
   }
 }

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -66,6 +66,22 @@ export function rememberLoadedSessionStoreSnapshot(params: {
   });
 }
 
+export function copyLoadedSessionStoreSnapshot(params: {
+  source: Record<string, SessionEntry> | undefined;
+  target: Record<string, SessionEntry>;
+}): void {
+  const snapshot = getLoadedSessionStoreSnapshot(params.source);
+  if (!snapshot) {
+    forgetLoadedSessionStoreSnapshot(params.target);
+    return;
+  }
+  loadedSessionStoreSnapshots.set(params.target, {
+    serializedFromDisk: snapshot.serializedFromDisk,
+    serializedDigest: snapshot.serializedDigest,
+    acpByKey: new Map(snapshot.acpByKey),
+  });
+}
+
 export function getLoadedSessionStoreSnapshot(
   store: Record<string, SessionEntry> | undefined,
 ): LoadedSessionStoreSnapshot | undefined {

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -1,8 +1,16 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.shared.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
 import {
+  resolveSessionObjectCacheMaxBytes,
+  SESSION_OBJECT_CACHE_MAX_BYTES_ENV,
+} from "./store-cache-limit.js";
+import {
+  dropSessionStoreObjectCache,
+  getSerializedSessionStore,
+  getSessionStoreTtl,
   isSessionStoreCacheEnabled,
   readSessionStoreCache,
   setSerializedSessionStore,
@@ -23,9 +31,125 @@ export type LoadSessionStoreOptions = {
 };
 
 const log = createSubsystemLogger("sessions/store");
+const WARNED_SESSION_OBJECT_CACHE_LIMIT_PATHS = new Set<string>();
+type LoadedSessionStoreSnapshot = {
+  serializedFromDisk?: string;
+  serializedDigest?: string;
+  acpByKey: Map<string, NonNullable<SessionEntry["acp"]>>;
+};
+let loadedSessionStoreSnapshots = new WeakMap<
+  Record<string, SessionEntry>,
+  LoadedSessionStoreSnapshot
+>();
+
+export function clearSessionObjectCacheLimitWarningsForTest(): void {
+  WARNED_SESSION_OBJECT_CACHE_LIMIT_PATHS.clear();
+}
+
+export function clearLoadedSessionStoreSnapshotsForTest(): void {
+  loadedSessionStoreSnapshots = new WeakMap();
+}
+
+export function rememberLoadedSessionStoreSnapshot(params: {
+  store: Record<string, SessionEntry>;
+  serializedFromDisk?: string;
+  retainSerializedFromDisk?: boolean;
+}): void {
+  const retainSerializedFromDisk = params.retainSerializedFromDisk ?? true;
+  loadedSessionStoreSnapshots.set(params.store, {
+    serializedFromDisk: retainSerializedFromDisk ? params.serializedFromDisk : undefined,
+    serializedDigest:
+      !retainSerializedFromDisk && params.serializedFromDisk
+        ? createHash("sha256").update(params.serializedFromDisk).digest("hex")
+        : undefined,
+    acpByKey: collectAcpMetadataSnapshot(params.store),
+  });
+}
+
+export function getLoadedSessionStoreSnapshot(
+  store: Record<string, SessionEntry> | undefined,
+): LoadedSessionStoreSnapshot | undefined {
+  if (!store) {
+    return undefined;
+  }
+  return loadedSessionStoreSnapshots.get(store);
+}
+
+export function forgetLoadedSessionStoreSnapshot(
+  store: Record<string, SessionEntry> | undefined,
+): void {
+  if (!store) {
+    return;
+  }
+  loadedSessionStoreSnapshots.delete(store);
+}
 
 function isSessionStoreRecord(value: unknown): value is Record<string, SessionEntry> {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function collectAcpMetadataSnapshot(
+  store: Record<string, SessionEntry>,
+): Map<string, NonNullable<SessionEntry["acp"]>> {
+  const snapshot = new Map<string, NonNullable<SessionEntry["acp"]>>();
+  for (const [sessionKey, entry] of Object.entries(store)) {
+    if (entry?.acp) {
+      snapshot.set(sessionKey, structuredClone(entry.acp));
+    }
+  }
+  return snapshot;
+}
+
+function warnSessionObjectCacheLimitHit(params: {
+  storePath: string;
+  sizeBytes: number;
+  limitBytes: number;
+}): void {
+  if (WARNED_SESSION_OBJECT_CACHE_LIMIT_PATHS.has(params.storePath)) {
+    return;
+  }
+  WARNED_SESSION_OBJECT_CACHE_LIMIT_PATHS.add(params.storePath);
+  log.warn("session object cache disabled for large store", {
+    storePath: params.storePath,
+    sizeBytes: params.sizeBytes,
+    limitBytes: params.limitBytes,
+    envVar: SESSION_OBJECT_CACHE_MAX_BYTES_ENV,
+  });
+}
+
+export function isSessionStoreObjectCacheEligible(params: {
+  storePath: string;
+  sizeBytes?: number;
+}): boolean {
+  if (!isSessionStoreCacheEnabled()) {
+    return false;
+  }
+  const maxBytes = resolveSessionObjectCacheMaxBytes();
+  if (maxBytes === 0) {
+    dropSessionStoreObjectCache(params.storePath);
+    return false;
+  }
+  if (params.sizeBytes !== undefined && params.sizeBytes > maxBytes) {
+    warnSessionObjectCacheLimitHit({
+      storePath: params.storePath,
+      sizeBytes: params.sizeBytes,
+      limitBytes: maxBytes,
+    });
+    dropSessionStoreObjectCache(params.storePath);
+    return false;
+  }
+  return true;
+}
+
+function shouldRetainSessionStoreSerializedCache(sizeBytes?: number): boolean {
+  if (!isSessionStoreCacheEnabled()) {
+    return false;
+  }
+  const maxBytes = resolveSessionObjectCacheMaxBytes();
+  if (maxBytes === 0) {
+    return false;
+  }
+  return sizeBytes === undefined || sizeBytes <= maxBytes;
 }
 
 function normalizeSessionEntryDelivery(entry: SessionEntry): SessionEntry {
@@ -77,15 +201,29 @@ export function loadSessionStore(
   storePath: string,
   opts: LoadSessionStoreOptions = {},
 ): Record<string, SessionEntry> {
-  if (!opts.skipCache && isSessionStoreCacheEnabled()) {
+  if (!opts.skipCache) {
     const currentFileStat = getFileStatSnapshot(storePath);
-    const cached = readSessionStoreCache({
-      storePath,
-      mtimeMs: currentFileStat?.mtimeMs,
-      sizeBytes: currentFileStat?.sizeBytes,
-    });
-    if (cached) {
-      return cached;
+    if (
+      isSessionStoreObjectCacheEligible({
+        storePath,
+        sizeBytes: currentFileStat?.sizeBytes,
+      })
+    ) {
+      const cached = readSessionStoreCache({
+        storePath,
+        mtimeMs: currentFileStat?.mtimeMs,
+        sizeBytes: currentFileStat?.sizeBytes,
+      });
+      if (cached) {
+        rememberLoadedSessionStoreSnapshot({
+          store: cached,
+          serializedFromDisk: getSerializedSessionStore({
+            storePath,
+            ttlMs: getSessionStoreTtl(),
+          }),
+        });
+        return cached;
+      }
     }
   }
 
@@ -120,7 +258,10 @@ export function loadSessionStore(
     }
   }
 
-  if (serializedFromDisk !== undefined) {
+  if (
+    serializedFromDisk !== undefined &&
+    shouldRetainSessionStoreSerializedCache(fileStat?.sizeBytes)
+  ) {
     setSerializedSessionStore(storePath, serializedFromDisk);
   } else {
     setSerializedSessionStore(storePath, undefined);
@@ -148,7 +289,13 @@ export function loadSessionStore(
     }
   }
 
-  if (!opts.skipCache && isSessionStoreCacheEnabled()) {
+  if (
+    !opts.skipCache &&
+    isSessionStoreObjectCacheEligible({
+      storePath,
+      sizeBytes: fileStat?.sizeBytes,
+    })
+  ) {
     writeSessionStoreCache({
       storePath,
       store,
@@ -156,7 +303,16 @@ export function loadSessionStore(
       sizeBytes: fileStat?.sizeBytes,
       serialized: serializedFromDisk,
     });
+  } else if (!opts.skipCache) {
+    dropSessionStoreObjectCache(storePath);
   }
 
-  return structuredClone(store);
+  const clonedStore = structuredClone(store);
+  const retainSerializedFromDisk = shouldRetainSessionStoreSerializedCache(fileStat?.sizeBytes);
+  rememberLoadedSessionStoreSnapshot({
+    store: clonedStore,
+    serializedFromDisk,
+    retainSerializedFromDisk,
+  });
+  return clonedStore;
 }

--- a/src/config/sessions/store-lock-state.ts
+++ b/src/config/sessions/store-lock-state.ts
@@ -1,4 +1,8 @@
 import { clearSessionStoreCaches } from "./store-cache.js";
+import {
+  clearLoadedSessionStoreSnapshotsForTest,
+  clearSessionObjectCacheLimitWarningsForTest,
+} from "./store-load.js";
 
 export type SessionStoreLockTask = {
   fn: () => Promise<unknown>;
@@ -18,6 +22,8 @@ export const LOCK_QUEUES = new Map<string, SessionStoreLockQueue>();
 
 export function clearSessionStoreCacheForTest(): void {
   clearSessionStoreCaches();
+  clearSessionObjectCacheLimitWarningsForTest();
+  clearLoadedSessionStoreSnapshotsForTest();
   for (const queue of LOCK_QUEUES.values()) {
     for (const task of queue.pending) {
       task.reject(new Error("session store queue cleared for test"));

--- a/src/config/sessions/store.cache.large-store-noop-save.test.ts
+++ b/src/config/sessions/store.cache.large-store-noop-save.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { clearSessionStoreCacheForTest, saveSessionStore, type SessionEntry } from "../sessions.js";
+
+function createLargeSessionStore(): Record<string, SessionEntry> {
+  const repeated = "x".repeat(4096);
+  const now = Date.now();
+  const store: Record<string, SessionEntry> = {};
+  for (let i = 0; i < 320; i += 1) {
+    store[`session:${String(i)}`] = {
+      sessionId: `id-${String(i)}`,
+      updatedAt: now + i,
+      displayName: `Large Session ${String(i)} ${repeated}`,
+    };
+  }
+  return store;
+}
+
+describe("large session-store no-op saves", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+  let testDir = "";
+  let storePath = "";
+
+  beforeAll(() => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "session-cache-large-noop-save-test-"));
+  });
+
+  afterAll(() => {
+    if (fixtureRoot) {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  beforeEach(() => {
+    testDir = path.join(fixtureRoot, `case-${caseId++}`);
+    fs.mkdirSync(testDir, { recursive: true });
+    storePath = path.join(testDir, "sessions.json");
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+  });
+
+  afterEach(() => {
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+  });
+
+  it("does not rewrite unchanged oversized stores", async () => {
+    const store = createLargeSessionStore();
+
+    await saveSessionStore(storePath, store);
+    expect(fs.statSync(storePath).size).toBeGreaterThan(1_000_000);
+
+    const before = fs.statSync(storePath);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    await saveSessionStore(storePath, store);
+
+    const after = fs.statSync(storePath);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+  });
+});

--- a/src/config/sessions/store.cache.large-store.test.ts
+++ b/src/config/sessions/store.cache.large-store.test.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSessionStoreCacheForTest,
+  loadSessionStore,
+  saveSessionStore,
+  type SessionEntry,
+} from "../sessions.js";
+
+const LARGE_STORE_MIN_BYTES = 1_000_000;
+
+function createLargeSessionStore(): Record<string, SessionEntry> {
+  const repeated = "x".repeat(4096);
+  const store: Record<string, SessionEntry> = {};
+  const now = Date.now();
+  for (let i = 0; i < 320; i += 1) {
+    store[`session:${String(i)}`] = {
+      sessionId: `id-${String(i)}`,
+      updatedAt: now + i,
+      displayName: `Large Session ${String(i)} ${repeated}`,
+    };
+  }
+  return store;
+}
+
+describe("Session Store Cache large store baseline", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+  let testDir = "";
+  let storePath = "";
+
+  beforeAll(() => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "session-cache-large-store-test-"));
+  });
+
+  afterAll(() => {
+    if (fixtureRoot) {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  beforeEach(() => {
+    testDir = path.join(fixtureRoot, `case-${caseId++}`);
+    fs.mkdirSync(testDir, { recursive: true });
+    storePath = path.join(testDir, "sessions.json");
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+  });
+
+  afterEach(() => {
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+  });
+
+  it("keeps a >1 MB store in the write-through cache when the limit is raised", async () => {
+    const store = createLargeSessionStore();
+    process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES = String(LARGE_STORE_MIN_BYTES * 2);
+
+    await saveSessionStore(storePath, store);
+
+    const sizeBytes = fs.statSync(storePath).size;
+    expect(sizeBytes).toBeGreaterThan(LARGE_STORE_MIN_BYTES);
+
+    const readSpy = vi.spyOn(fs, "readFileSync");
+
+    const loaded1 = loadSessionStore(storePath);
+    const loaded2 = loadSessionStore(storePath);
+
+    expect(Object.keys(loaded1)).toHaveLength(Object.keys(store).length);
+    expect(Object.keys(loaded2)).toHaveLength(Object.keys(store).length);
+    expect(readSpy).toHaveBeenCalledTimes(0);
+
+    readSpy.mockRestore();
+  });
+
+  it("falls back to disk for the same large store when cache TTL is disabled", async () => {
+    const store = createLargeSessionStore();
+    process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES = String(LARGE_STORE_MIN_BYTES * 2);
+
+    await saveSessionStore(storePath, store);
+
+    const sizeBytes = fs.statSync(storePath).size;
+    expect(sizeBytes).toBeGreaterThan(LARGE_STORE_MIN_BYTES);
+
+    process.env.OPENCLAW_SESSION_CACHE_TTL_MS = "0";
+    clearSessionStoreCacheForTest();
+
+    const readSpy = vi.spyOn(fs, "readFileSync");
+
+    const loaded = loadSessionStore(storePath);
+
+    expect(Object.keys(loaded)).toHaveLength(Object.keys(store).length);
+    expect(readSpy).toHaveBeenCalledTimes(1);
+
+    readSpy.mockRestore();
+  });
+});

--- a/src/config/sessions/store.cache.limit-config.test.ts
+++ b/src/config/sessions/store.cache.limit-config.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SESSION_OBJECT_CACHE_MAX_BYTES,
+  resolveSessionObjectCacheMaxBytes,
+} from "./store-cache-limit.js";
+
+describe("session object cache limit config", () => {
+  it("defaults to 1 MB when the env var is unset", () => {
+    expect(resolveSessionObjectCacheMaxBytes(undefined)).toBe(
+      DEFAULT_SESSION_OBJECT_CACHE_MAX_BYTES,
+    );
+  });
+
+  it("accepts a positive integer override", () => {
+    expect(resolveSessionObjectCacheMaxBytes("2048")).toBe(2048);
+  });
+
+  it("accepts zero to disable the object cache", () => {
+    expect(resolveSessionObjectCacheMaxBytes("0")).toBe(0);
+  });
+
+  it("falls back to the default for invalid values", () => {
+    expect(resolveSessionObjectCacheMaxBytes("-1")).toBe(DEFAULT_SESSION_OBJECT_CACHE_MAX_BYTES);
+    expect(resolveSessionObjectCacheMaxBytes("not-a-number")).toBe(
+      DEFAULT_SESSION_OBJECT_CACHE_MAX_BYTES,
+    );
+  });
+});

--- a/src/config/sessions/store.cache.limit-read.test.ts
+++ b/src/config/sessions/store.cache.limit-read.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSessionStoreCacheForTest,
+  loadSessionStore,
+  saveSessionStore,
+  type SessionEntry,
+} from "../sessions.js";
+
+const LARGE_STORE_LIMIT_BYTES = 1_000_000;
+
+function createSmallSessionStore(): Record<string, SessionEntry> {
+  return {
+    "session:1": {
+      sessionId: "id-1",
+      updatedAt: Date.now(),
+      displayName: "Small Session",
+    },
+  };
+}
+
+function createLargeSessionStore(): Record<string, SessionEntry> {
+  const repeated = "x".repeat(4096);
+  const now = Date.now();
+  const store: Record<string, SessionEntry> = {};
+  for (let i = 0; i < 320; i += 1) {
+    store[`session:${String(i)}`] = {
+      sessionId: `id-${String(i)}`,
+      updatedAt: now + i,
+      displayName: `Large Session ${String(i)} ${repeated}`,
+    };
+  }
+  return store;
+}
+
+describe("session object cache read limit", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+  let testDir = "";
+  let storePath = "";
+
+  beforeAll(() => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "session-cache-limit-read-test-"));
+  });
+
+  afterAll(() => {
+    if (fixtureRoot) {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  beforeEach(() => {
+    testDir = path.join(fixtureRoot, `case-${caseId++}`);
+    fs.mkdirSync(testDir, { recursive: true });
+    storePath = path.join(testDir, "sessions.json");
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+  });
+
+  afterEach(() => {
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+  });
+
+  it("keeps using the object cache for small stores", async () => {
+    await saveSessionStore(storePath, createSmallSessionStore());
+
+    const readSpy = vi.spyOn(fs, "readFileSync");
+
+    loadSessionStore(storePath);
+    loadSessionStore(storePath);
+
+    expect(readSpy).toHaveBeenCalledTimes(0);
+    readSpy.mockRestore();
+  });
+
+  it("skips the object cache for large stores above the default limit", async () => {
+    await saveSessionStore(storePath, createLargeSessionStore());
+
+    expect(fs.statSync(storePath).size).toBeGreaterThan(LARGE_STORE_LIMIT_BYTES);
+
+    const readSpy = vi.spyOn(fs, "readFileSync");
+
+    loadSessionStore(storePath);
+    loadSessionStore(storePath);
+
+    expect(readSpy).toHaveBeenCalledTimes(2);
+    readSpy.mockRestore();
+  });
+
+  it("disables object-cache reads entirely when the limit is set to zero", async () => {
+    process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES = "0";
+    await saveSessionStore(storePath, createSmallSessionStore());
+
+    const readSpy = vi.spyOn(fs, "readFileSync");
+
+    loadSessionStore(storePath);
+    loadSessionStore(storePath);
+
+    expect(readSpy).toHaveBeenCalledTimes(2);
+    readSpy.mockRestore();
+  });
+});

--- a/src/config/sessions/store.cache.limit-warning.test.ts
+++ b/src/config/sessions/store.cache.limit-warning.test.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { warnMock } = vi.hoisted(() => ({
+  warnMock: vi.fn(),
+}));
+
+vi.mock("../../logging/subsystem.js", () => {
+  const makeLogger = () => ({
+    subsystem: "sessions/store",
+    isEnabled: () => true,
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: warnMock,
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: () => makeLogger(),
+  });
+  return { createSubsystemLogger: () => makeLogger() };
+});
+
+import type { SessionEntry } from "../sessions.js";
+
+const LARGE_STORE_LIMIT_BYTES = 1_000_000;
+
+function createSmallSessionStore(): Record<string, SessionEntry> {
+  return {
+    "session:1": {
+      sessionId: "id-1",
+      updatedAt: Date.now(),
+      displayName: "Small Session",
+    },
+  };
+}
+
+function createLargeSessionStore(): Record<string, SessionEntry> {
+  const repeated = "x".repeat(4096);
+  const now = Date.now();
+  const store: Record<string, SessionEntry> = {};
+  for (let i = 0; i < 320; i += 1) {
+    store[`session:${String(i)}`] = {
+      sessionId: `id-${String(i)}`,
+      updatedAt: now + i,
+      displayName: `Large Session ${String(i)} ${repeated}`,
+    };
+  }
+  return store;
+}
+
+describe("session object cache limit warning", () => {
+  let clearSessionStoreCacheForTest: typeof import("../sessions.js").clearSessionStoreCacheForTest;
+  let loadSessionStore: typeof import("../sessions.js").loadSessionStore;
+  let saveSessionStore: typeof import("../sessions.js").saveSessionStore;
+  let fixtureRoot = "";
+  let caseId = 0;
+  let testDir = "";
+  let storePath = "";
+
+  beforeAll(() => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "session-cache-limit-warning-test-"));
+  });
+
+  afterAll(() => {
+    if (fixtureRoot) {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ clearSessionStoreCacheForTest, loadSessionStore, saveSessionStore } =
+      await import("../sessions.js"));
+    warnMock.mockClear();
+    testDir = path.join(fixtureRoot, `case-${caseId++}`);
+    fs.mkdirSync(testDir, { recursive: true });
+    storePath = path.join(testDir, "sessions.json");
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+  });
+
+  afterEach(() => {
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+  });
+
+  it("logs a warning the first time a store exceeds the object cache limit", async () => {
+    await saveSessionStore(storePath, createLargeSessionStore());
+
+    expect(fs.statSync(storePath).size).toBeGreaterThan(LARGE_STORE_LIMIT_BYTES);
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledWith(
+      "session object cache disabled for large store",
+      expect.objectContaining({
+        envVar: "OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES",
+        limitBytes: LARGE_STORE_LIMIT_BYTES,
+        sizeBytes: expect.any(Number),
+        storePath,
+      }),
+    );
+  });
+
+  it("does not spam warnings for repeated oversized accesses to the same store", async () => {
+    await saveSessionStore(storePath, createLargeSessionStore());
+    loadSessionStore(storePath);
+    loadSessionStore(storePath);
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not warn for small stores", async () => {
+    await saveSessionStore(storePath, createSmallSessionStore());
+    loadSessionStore(storePath);
+
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/config/sessions/store.cache.limit-write.test.ts
+++ b/src/config/sessions/store.cache.limit-write.test.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSessionStoreCacheForTest,
+  loadSessionStore,
+  saveSessionStore,
+  type SessionEntry,
+} from "../sessions.js";
+
+const LARGE_STORE_LIMIT_BYTES = 1_000_000;
+
+function createSmallSessionStore(): Record<string, SessionEntry> {
+  return {
+    "session:1": {
+      sessionId: "id-1",
+      updatedAt: Date.now(),
+      displayName: "Small Session",
+    },
+  };
+}
+
+function createLargeSessionStore(): Record<string, SessionEntry> {
+  const repeated = "x".repeat(4096);
+  const now = Date.now();
+  const store: Record<string, SessionEntry> = {};
+  for (let i = 0; i < 320; i += 1) {
+    store[`session:${String(i)}`] = {
+      sessionId: `id-${String(i)}`,
+      updatedAt: now + i,
+      displayName: `Large Session ${String(i)} ${repeated}`,
+    };
+  }
+  return store;
+}
+
+describe("session object cache write limit", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+  let testDir = "";
+  let storePath = "";
+
+  beforeAll(() => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "session-cache-limit-write-test-"));
+  });
+
+  afterAll(() => {
+    if (fixtureRoot) {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  beforeEach(() => {
+    testDir = path.join(fixtureRoot, `case-${caseId++}`);
+    fs.mkdirSync(testDir, { recursive: true });
+    storePath = path.join(testDir, "sessions.json");
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+  });
+
+  afterEach(() => {
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+  });
+
+  it("does not keep an oversized write-through cache entry after save", async () => {
+    await saveSessionStore(storePath, createLargeSessionStore());
+
+    expect(fs.statSync(storePath).size).toBeGreaterThan(LARGE_STORE_LIMIT_BYTES);
+
+    process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES = String(LARGE_STORE_LIMIT_BYTES * 2);
+    const readSpy = vi.spyOn(fs, "readFileSync");
+
+    loadSessionStore(storePath);
+
+    expect(readSpy).toHaveBeenCalledTimes(1);
+    readSpy.mockRestore();
+  });
+
+  it("does not repopulate the object cache after loading an oversized store from disk", async () => {
+    await saveSessionStore(storePath, createLargeSessionStore());
+
+    expect(fs.statSync(storePath).size).toBeGreaterThan(LARGE_STORE_LIMIT_BYTES);
+
+    loadSessionStore(storePath);
+
+    process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES = String(LARGE_STORE_LIMIT_BYTES * 2);
+    const readSpy = vi.spyOn(fs, "readFileSync");
+
+    loadSessionStore(storePath);
+
+    expect(readSpy).toHaveBeenCalledTimes(1);
+    readSpy.mockRestore();
+  });
+
+  it("drops object-cache eligibility immediately when a store grows past the limit", async () => {
+    await saveSessionStore(storePath, createSmallSessionStore());
+    loadSessionStore(storePath);
+
+    await saveSessionStore(storePath, createLargeSessionStore());
+
+    process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES = String(LARGE_STORE_LIMIT_BYTES * 2);
+    const readSpy = vi.spyOn(fs, "readFileSync");
+
+    loadSessionStore(storePath);
+
+    expect(readSpy).toHaveBeenCalledTimes(1);
+    readSpy.mockRestore();
+  });
+
+  it("keeps normal write-through caching for small stores", async () => {
+    process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES = "1024";
+    await saveSessionStore(storePath, createSmallSessionStore());
+
+    const readSpy = vi.spyOn(fs, "readFileSync");
+
+    loadSessionStore(storePath);
+    loadSessionStore(storePath);
+
+    expect(readSpy).toHaveBeenCalledTimes(0);
+    readSpy.mockRestore();
+  });
+});

--- a/src/config/sessions/store.cache.serialized-ttl.test.ts
+++ b/src/config/sessions/store.cache.serialized-ttl.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearSessionStoreCacheForTest, saveSessionStore, type SessionEntry } from "../sessions.js";
+import {
+  clearSessionStoreCaches,
+  getSerializedSessionStore,
+  setSerializedSessionStore,
+} from "./store-cache.js";
+
+describe("session serialized cache ttl", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+
+  beforeAll(() => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "session-cache-serialized-ttl-test-"));
+  });
+
+  afterAll(() => {
+    if (fixtureRoot) {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-21T00:00:00.000Z"));
+    clearSessionStoreCaches();
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+  });
+
+  afterEach(() => {
+    clearSessionStoreCaches();
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+    vi.useRealTimers();
+  });
+
+  it("expires serialized entries after the cache ttl", () => {
+    const storePath = "/tmp/sessions.json";
+
+    setSerializedSessionStore(storePath, '{"session":1}');
+    expect(getSerializedSessionStore({ storePath, ttlMs: 10 })).toBe('{"session":1}');
+
+    vi.advanceTimersByTime(11);
+
+    expect(getSerializedSessionStore({ storePath, ttlMs: 10 })).toBeUndefined();
+  });
+
+  it("treats ttl=0 as disabled for serialized entries", () => {
+    const storePath = "/tmp/sessions.json";
+
+    setSerializedSessionStore(storePath, '{"session":1}');
+
+    expect(getSerializedSessionStore({ storePath, ttlMs: 0 })).toBeUndefined();
+  });
+
+  it("does not retain serialized cache entries for oversized stores", async () => {
+    const repeated = "x".repeat(4096);
+    const store: Record<string, SessionEntry> = {};
+    const now = Date.now();
+    for (let i = 0; i < 320; i += 1) {
+      store[`session:${String(i)}`] = {
+        sessionId: `id-${String(i)}`,
+        updatedAt: now + i,
+        displayName: `Large Session ${String(i)} ${repeated}`,
+      };
+    }
+
+    const testDir = path.join(fixtureRoot, `case-${caseId++}`);
+    fs.mkdirSync(testDir, { recursive: true });
+    const storePath = path.join(testDir, "sessions.json");
+
+    await saveSessionStore(storePath, store);
+
+    expect(fs.statSync(storePath).size).toBeGreaterThan(1_000_000);
+    expect(getSerializedSessionStore({ storePath, ttlMs: 45_000 })).toBeUndefined();
+  });
+});

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -29,6 +29,7 @@ import {
 } from "./store-cache.js";
 import { normalizeStoreSessionKey, resolveSessionStoreEntry } from "./store-entry.js";
 import {
+  copyLoadedSessionStoreSnapshot,
   forgetLoadedSessionStoreSnapshot,
   getLoadedSessionStoreSnapshot,
   isSessionStoreObjectCacheEligible,
@@ -259,6 +260,19 @@ function tryReuseLoadedSessionStoreSnapshot(params: {
     return undefined;
   }
   try {
+    // Reject reuse if the caller-owned store has drifted from the loaded snapshot.
+    const currentBaseStoreSerialized = JSON.stringify(params.baseStore, null, 2);
+    if (snapshot.serializedFromDisk !== undefined) {
+      if (currentBaseStoreSerialized !== snapshot.serializedFromDisk) {
+        return undefined;
+      }
+    } else if (
+      createHash("sha256").update(currentBaseStoreSerialized).digest("hex") !==
+      snapshot.serializedDigest
+    ) {
+      return undefined;
+    }
+
     const serialized = fs.readFileSync(params.storePath, "utf-8");
     if (snapshot.serializedFromDisk !== undefined) {
       if (serialized !== snapshot.serializedFromDisk) {
@@ -272,6 +286,20 @@ function tryReuseLoadedSessionStoreSnapshot(params: {
     return params.baseStore;
   } catch {
     return undefined;
+  }
+}
+
+function syncSessionStoreInPlace(params: {
+  target: Record<string, SessionEntry>;
+  source: Record<string, SessionEntry>;
+}): void {
+  for (const key of Object.keys(params.target)) {
+    if (!(key in params.source)) {
+      delete params.target[key];
+    }
+  }
+  for (const [key, entry] of Object.entries(params.source)) {
+    params.target[key] = structuredClone(entry);
   }
 }
 
@@ -542,7 +570,16 @@ export async function updateSessionStore<T>(
       storePath,
       baseStore: opts?.baseStore,
     });
-    const store = reusedBaseStore ?? loadSessionStore(storePath, { skipCache: true });
+    // Work on a clone so unrelated mutations on a shared baseStore object do not leak into saves.
+    const store = reusedBaseStore
+      ? structuredClone(reusedBaseStore)
+      : loadSessionStore(storePath, { skipCache: true });
+    if (reusedBaseStore) {
+      copyLoadedSessionStoreSnapshot({
+        source: reusedBaseStore,
+        target: store,
+      });
+    }
     const previousAcpByKey =
       getLoadedSnapshotAcpMetadata(reusedBaseStore) ?? collectAcpMetadataSnapshot(store);
     try {
@@ -553,6 +590,16 @@ export async function updateSessionStore<T>(
         allowDropSessionKeys: opts?.allowDropAcpMetaSessionKeys,
       });
       await saveSessionStoreUnlocked(storePath, store, opts);
+      if (reusedBaseStore) {
+        syncSessionStoreInPlace({
+          target: reusedBaseStore,
+          source: store,
+        });
+        copyLoadedSessionStoreSnapshot({
+          source: store,
+          target: reusedBaseStore,
+        });
+      }
       return result;
     } catch (error) {
       forgetLoadedSessionStoreSnapshot(store);

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import {
@@ -17,15 +18,24 @@ import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
+import { resolveSessionObjectCacheMaxBytes } from "./store-cache-limit.js";
 import {
   dropSessionStoreObjectCache,
   getSerializedSessionStore,
+  getSessionStoreTtl,
   isSessionStoreCacheEnabled,
   setSerializedSessionStore,
   writeSessionStoreCache,
 } from "./store-cache.js";
 import { normalizeStoreSessionKey, resolveSessionStoreEntry } from "./store-entry.js";
-import { loadSessionStore, normalizeSessionStore } from "./store-load.js";
+import {
+  forgetLoadedSessionStoreSnapshot,
+  getLoadedSessionStoreSnapshot,
+  isSessionStoreObjectCacheEligible,
+  loadSessionStore,
+  rememberLoadedSessionStoreSnapshot,
+  normalizeSessionStore,
+} from "./store-load.js";
 import {
   clearSessionStoreCacheForTest,
   drainSessionStoreLockQueuesForTest,
@@ -66,6 +76,48 @@ let sessionWriteLockAcquirerForTests: typeof acquireSessionWriteLock | null = nu
 function loadSessionArchiveRuntime() {
   sessionArchiveRuntimePromise ??= import("../../gateway/session-archive.runtime.js");
   return sessionArchiveRuntimePromise;
+}
+
+export function getLoadedSessionStoreSnapshotForTest(
+  store: Record<string, SessionEntry> | undefined,
+): { hasSerializedFromDisk: boolean; hasSerializedDigest: boolean } | undefined {
+  const snapshot = getLoadedSessionStoreSnapshot(store);
+  if (!snapshot) {
+    return undefined;
+  }
+  return {
+    hasSerializedFromDisk: snapshot.serializedFromDisk !== undefined,
+    hasSerializedDigest: snapshot.serializedDigest !== undefined,
+  };
+}
+
+function shouldRetainSessionStoreSerializedCache(sizeBytes?: number): boolean {
+  if (!isSessionStoreCacheEnabled()) {
+    return false;
+  }
+  const maxBytes = resolveSessionObjectCacheMaxBytes();
+  if (maxBytes === 0) {
+    return false;
+  }
+  return sizeBytes === undefined || sizeBytes <= maxBytes;
+}
+
+function isSessionStoreSerializedSnapshotEqual(params: {
+  storePath: string;
+  serialized: string;
+}): boolean {
+  const cached = getSerializedSessionStore({
+    storePath: params.storePath,
+    ttlMs: getSessionStoreTtl(),
+  });
+  if (cached !== undefined) {
+    return cached === params.serialized;
+  }
+  try {
+    return fs.readFileSync(params.storePath, "utf-8") === params.serialized;
+  } catch {
+    return false;
+  }
 }
 
 function removeThreadFromDeliveryContext(context?: DeliveryContext): DeliveryContext | undefined {
@@ -151,14 +203,33 @@ type SaveSessionStoreOptions = {
   maintenanceConfig?: ResolvedSessionMaintenanceConfig;
 };
 
+type UpdateSessionStoreOptions = SaveSessionStoreOptions & {
+  baseStore?: Record<string, SessionEntry>;
+};
+
 function updateSessionStoreWriteCaches(params: {
   storePath: string;
   store: Record<string, SessionEntry>;
   serialized: string;
 }): void {
   const fileStat = getFileStatSnapshot(params.storePath);
-  setSerializedSessionStore(params.storePath, params.serialized);
-  if (!isSessionStoreCacheEnabled()) {
+  const retainSerializedFromDisk = shouldRetainSessionStoreSerializedCache(fileStat?.sizeBytes);
+  if (retainSerializedFromDisk) {
+    setSerializedSessionStore(params.storePath, params.serialized);
+  } else {
+    setSerializedSessionStore(params.storePath, undefined);
+  }
+  if (
+    !isSessionStoreObjectCacheEligible({
+      storePath: params.storePath,
+      sizeBytes: fileStat?.sizeBytes,
+    })
+  ) {
+    rememberLoadedSessionStoreSnapshot({
+      store: params.store,
+      serializedFromDisk: params.serialized,
+      retainSerializedFromDisk,
+    });
     dropSessionStoreObjectCache(params.storePath);
     return;
   }
@@ -169,6 +240,39 @@ function updateSessionStoreWriteCaches(params: {
     sizeBytes: fileStat?.sizeBytes,
     serialized: params.serialized,
   });
+  rememberLoadedSessionStoreSnapshot({
+    store: params.store,
+    serializedFromDisk: params.serialized,
+    retainSerializedFromDisk,
+  });
+}
+
+function tryReuseLoadedSessionStoreSnapshot(params: {
+  storePath: string;
+  baseStore?: Record<string, SessionEntry>;
+}): Record<string, SessionEntry> | undefined {
+  const snapshot = getLoadedSessionStoreSnapshot(params.baseStore);
+  if (
+    !params.baseStore ||
+    (snapshot?.serializedFromDisk === undefined && snapshot?.serializedDigest === undefined)
+  ) {
+    return undefined;
+  }
+  try {
+    const serialized = fs.readFileSync(params.storePath, "utf-8");
+    if (snapshot.serializedFromDisk !== undefined) {
+      if (serialized !== snapshot.serializedFromDisk) {
+        return undefined;
+      }
+      return params.baseStore;
+    }
+    if (createHash("sha256").update(serialized).digest("hex") !== snapshot.serializedDigest) {
+      return undefined;
+    }
+    return params.baseStore;
+  } catch {
+    return undefined;
+  }
 }
 
 function resolveMutableSessionStoreKey(
@@ -195,10 +299,20 @@ function collectAcpMetadataSnapshot(
   const snapshot = new Map<string, NonNullable<SessionEntry["acp"]>>();
   for (const [sessionKey, entry] of Object.entries(store)) {
     if (entry?.acp) {
-      snapshot.set(sessionKey, entry.acp);
+      snapshot.set(sessionKey, structuredClone(entry.acp));
     }
   }
   return snapshot;
+}
+
+function getLoadedSnapshotAcpMetadata(
+  store: Record<string, SessionEntry> | undefined,
+): Map<string, NonNullable<SessionEntry["acp"]>> | undefined {
+  const snapshot = getLoadedSessionStoreSnapshot(store);
+  if (!snapshot) {
+    return undefined;
+  }
+  return new Map(snapshot.acpByKey);
 }
 
 function preserveExistingAcpMetadata(params: {
@@ -351,7 +465,7 @@ async function saveSessionStoreUnlocked(
 
   await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
   const json = JSON.stringify(store, null, 2);
-  if (getSerializedSessionStore(storePath) === json) {
+  if (isSessionStoreSerializedSnapshotEqual({ storePath, serialized: json })) {
     updateSessionStoreWriteCaches({ storePath, store, serialized: json });
     return;
   }
@@ -365,6 +479,7 @@ async function saveSessionStoreUnlocked(
       } catch (err) {
         const code = getErrorCode(err);
         if (code === "ENOENT") {
+          forgetLoadedSessionStoreSnapshot(store);
           return;
         }
         if (i < 4) {
@@ -373,6 +488,7 @@ async function saveSessionStoreUnlocked(
         }
         // Final attempt failed — skip this save. The write lock ensures
         // the next save will retry with fresh data. Log for diagnostics.
+        forgetLoadedSessionStoreSnapshot(store);
         log.warn(`atomic write failed after 5 attempts: ${storePath}`);
       }
     }
@@ -392,13 +508,16 @@ async function saveSessionStoreUnlocked(
       } catch (err2) {
         const code2 = getErrorCode(err2);
         if (code2 === "ENOENT") {
+          forgetLoadedSessionStoreSnapshot(store);
           return;
         }
+        forgetLoadedSessionStoreSnapshot(store);
         throw err2;
       }
       return;
     }
 
+    forgetLoadedSessionStoreSnapshot(store);
     throw err;
   }
 }
@@ -416,20 +535,29 @@ export async function saveSessionStore(
 export async function updateSessionStore<T>(
   storePath: string,
   mutator: (store: Record<string, SessionEntry>) => Promise<T> | T,
-  opts?: SaveSessionStoreOptions,
+  opts?: UpdateSessionStoreOptions,
 ): Promise<T> {
   return await withSessionStoreLock(storePath, async () => {
-    // Always re-read inside the lock to avoid clobbering concurrent writers.
-    const store = loadSessionStore(storePath, { skipCache: true });
-    const previousAcpByKey = collectAcpMetadataSnapshot(store);
-    const result = await mutator(store);
-    preserveExistingAcpMetadata({
-      previousAcpByKey,
-      nextStore: store,
-      allowDropSessionKeys: opts?.allowDropAcpMetaSessionKeys,
+    const reusedBaseStore = tryReuseLoadedSessionStoreSnapshot({
+      storePath,
+      baseStore: opts?.baseStore,
     });
-    await saveSessionStoreUnlocked(storePath, store, opts);
-    return result;
+    const store = reusedBaseStore ?? loadSessionStore(storePath, { skipCache: true });
+    const previousAcpByKey =
+      getLoadedSnapshotAcpMetadata(reusedBaseStore) ?? collectAcpMetadataSnapshot(store);
+    try {
+      const result = await mutator(store);
+      preserveExistingAcpMetadata({
+        previousAcpByKey,
+        nextStore: store,
+        allowDropSessionKeys: opts?.allowDropAcpMetaSessionKeys,
+      });
+      await saveSessionStoreUnlocked(storePath, store, opts);
+      return result;
+    } catch (error) {
+      forgetLoadedSessionStoreSnapshot(store);
+      throw error;
+    }
   });
 }
 

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -260,15 +260,18 @@ function tryReuseLoadedSessionStoreSnapshot(params: {
     return undefined;
   }
   try {
-    // Reject reuse if the caller-owned store has drifted from the loaded snapshot.
     const currentBaseStoreSerialized = JSON.stringify(params.baseStore, null, 2);
-    if (snapshot.serializedFromDisk !== undefined) {
-      if (currentBaseStoreSerialized !== snapshot.serializedFromDisk) {
-        return undefined;
-      }
-    } else if (
+    if (
+      snapshot.serializedFromDisk !== undefined &&
+      currentBaseStoreSerialized !== snapshot.serializedFromDisk &&
+      !isAcpScopedBaseStoreDrift(params.baseStore, snapshot)
+    ) {
+      return undefined;
+    }
+    if (
+      snapshot.serializedDigest !== undefined &&
       createHash("sha256").update(currentBaseStoreSerialized).digest("hex") !==
-      snapshot.serializedDigest
+        snapshot.serializedDigest
     ) {
       return undefined;
     }
@@ -287,6 +290,41 @@ function tryReuseLoadedSessionStoreSnapshot(params: {
   } catch {
     return undefined;
   }
+}
+
+function isAcpScopedBaseStoreDrift(
+  baseStore: Record<string, SessionEntry>,
+  snapshot: {
+    serializedFromDisk?: string;
+    acpByKey: Map<string, NonNullable<SessionEntry["acp"]>>;
+  },
+): boolean {
+  if (snapshot.serializedFromDisk === undefined) {
+    return false;
+  }
+  let parsedSnapshot: Record<string, SessionEntry>;
+  try {
+    const parsed = JSON.parse(snapshot.serializedFromDisk);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return false;
+    }
+    parsedSnapshot = parsed as Record<string, SessionEntry>;
+  } catch {
+    return false;
+  }
+
+  const allKeys = new Set([...Object.keys(parsedSnapshot), ...Object.keys(baseStore)]);
+  for (const key of allKeys) {
+    const before = parsedSnapshot[key];
+    const after = baseStore[key];
+    if (JSON.stringify(before) === JSON.stringify(after)) {
+      continue;
+    }
+    if (!snapshot.acpByKey.has(key)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function syncSessionStoreInPlace(params: {

--- a/src/config/sessions/store.update-base-store.test.ts
+++ b/src/config/sessions/store.update-base-store.test.ts
@@ -1,0 +1,196 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSessionStoreCacheForTest,
+  getLoadedSessionStoreSnapshotForTest,
+  loadSessionStore,
+  saveSessionStore,
+  updateSessionStore,
+  type SessionEntry,
+} from "../sessions.js";
+
+function createStore(): Record<string, SessionEntry> {
+  return {
+    "session:1": {
+      sessionId: "id-1",
+      updatedAt: 1,
+      displayName: "Session 1",
+      label: "initial",
+    },
+    "session:2": {
+      sessionId: "id-2",
+      updatedAt: 2,
+      displayName: "Session 2",
+      label: "stable",
+    },
+  };
+}
+
+function createLargeStore(): Record<string, SessionEntry> {
+  const repeated = "x".repeat(4096);
+  const store: Record<string, SessionEntry> = {};
+  const now = Date.now();
+  for (let i = 0; i < 320; i += 1) {
+    store[`session:${String(i)}`] = {
+      sessionId: `id-${String(i)}`,
+      updatedAt: now + i,
+      displayName: `Large Session ${String(i)} ${repeated}`,
+      label: `initial-${String(i)}`,
+    };
+  }
+  return store;
+}
+
+describe("session store base snapshot reuse", () => {
+  let fixtureRoot = "";
+  let caseId = 0;
+  let testDir = "";
+  let storePath = "";
+
+  beforeAll(() => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "session-store-base-snapshot-test-"));
+  });
+
+  afterAll(() => {
+    if (fixtureRoot) {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  beforeEach(() => {
+    testDir = path.join(fixtureRoot, `case-${caseId++}`);
+    fs.mkdirSync(testDir, { recursive: true });
+    storePath = path.join(testDir, "sessions.json");
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearSessionStoreCacheForTest();
+    delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    delete process.env.OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES;
+  });
+
+  it("reuses an unchanged loaded store snapshot without reparsing the file", async () => {
+    await saveSessionStore(storePath, createStore(), { skipMaintenance: true });
+
+    const baseStore = loadSessionStore(storePath, { skipCache: true });
+    expect(getLoadedSessionStoreSnapshotForTest(baseStore)).toEqual({
+      hasSerializedDigest: false,
+      hasSerializedFromDisk: true,
+    });
+    const parseSpy = vi.spyOn(JSON, "parse");
+    parseSpy.mockClear();
+
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        store["session:1"] = {
+          ...store["session:1"],
+          label: "updated-once",
+        };
+      },
+      { skipMaintenance: true, baseStore },
+    );
+
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        store["session:1"] = {
+          ...store["session:1"],
+          label: "updated-twice",
+        };
+      },
+      { skipMaintenance: true, baseStore },
+    );
+
+    expect(parseSpy).not.toHaveBeenCalled();
+    parseSpy.mockRestore();
+
+    const saved = loadSessionStore(storePath, { skipCache: true });
+    expect(saved["session:1"].label).toBe("updated-twice");
+  });
+
+  it("falls back to reparsing when the on-disk store changed", async () => {
+    await saveSessionStore(storePath, createStore(), { skipMaintenance: true });
+
+    const baseStore = loadSessionStore(storePath, { skipCache: true });
+    const concurrent = loadSessionStore(storePath, { skipCache: true });
+    concurrent["session:2"] = {
+      ...concurrent["session:2"],
+      label: "concurrent-change",
+    };
+    await saveSessionStore(storePath, concurrent, { skipMaintenance: true });
+
+    const parseSpy = vi.spyOn(JSON, "parse");
+    parseSpy.mockClear();
+
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        store["session:1"] = {
+          ...store["session:1"],
+          label: "updated-after-fallback",
+        };
+      },
+      { skipMaintenance: true, baseStore },
+    );
+
+    expect(parseSpy).toHaveBeenCalled();
+    parseSpy.mockRestore();
+
+    const saved = loadSessionStore(storePath, { skipCache: true });
+    expect(saved["session:1"].label).toBe("updated-after-fallback");
+    expect(saved["session:2"].label).toBe("concurrent-change");
+  });
+
+  it("reuses an unchanged oversized loaded store snapshot without reparsing the file", async () => {
+    await saveSessionStore(storePath, createLargeStore(), { skipMaintenance: true });
+
+    expect(fs.statSync(storePath).size).toBeGreaterThan(1_000_000);
+
+    const baseStore = loadSessionStore(storePath, { skipCache: true });
+    expect(getLoadedSessionStoreSnapshotForTest(baseStore)).toEqual({
+      hasSerializedDigest: true,
+      hasSerializedFromDisk: false,
+    });
+    const parseSpy = vi.spyOn(JSON, "parse");
+    parseSpy.mockClear();
+
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        store["session:1"] = {
+          ...store["session:1"],
+          label: "updated-large-once",
+        };
+      },
+      { skipMaintenance: true, baseStore },
+    );
+
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        store["session:1"] = {
+          ...store["session:1"],
+          label: "updated-large-twice",
+        };
+      },
+      { skipMaintenance: true, baseStore },
+    );
+
+    expect(parseSpy).not.toHaveBeenCalled();
+    parseSpy.mockRestore();
+    expect(getLoadedSessionStoreSnapshotForTest(baseStore)).toEqual({
+      hasSerializedDigest: true,
+      hasSerializedFromDisk: false,
+    });
+
+    const saved = loadSessionStore(storePath, { skipCache: true });
+    expect(saved["session:1"].label).toBe("updated-large-twice");
+  });
+});

--- a/src/config/sessions/store.update-base-store.test.ts
+++ b/src/config/sessions/store.update-base-store.test.ts
@@ -193,4 +193,77 @@ describe("session store base snapshot reuse", () => {
     const saved = loadSessionStore(storePath, { skipCache: true });
     expect(saved["session:1"].label).toBe("updated-large-twice");
   });
+
+  it("does not persist unrelated shared base-store mutations while an update is in flight", async () => {
+    await saveSessionStore(storePath, createStore(), { skipMaintenance: true });
+
+    const baseStore = loadSessionStore(storePath, { skipCache: true });
+    let releaseMutator: (() => void) | undefined;
+    let markMutatorStarted: (() => void) | undefined;
+    const mutatorPaused = new Promise<void>((resolve) => {
+      releaseMutator = resolve;
+    });
+    const mutatorStarted = new Promise<void>((resolve) => {
+      markMutatorStarted = resolve;
+    });
+
+    const updatePromise = updateSessionStore(
+      storePath,
+      async (store) => {
+        markMutatorStarted?.();
+        store["session:1"] = {
+          ...store["session:1"],
+          label: "updated-in-mutator",
+        };
+        await mutatorPaused;
+      },
+      { skipMaintenance: true, baseStore },
+    );
+
+    await mutatorStarted;
+    baseStore["session:2"] = {
+      ...baseStore["session:2"],
+      label: "unrelated-out-of-band-change",
+    };
+    releaseMutator?.();
+
+    await updatePromise;
+
+    const saved = loadSessionStore(storePath, { skipCache: true });
+    expect(saved["session:1"].label).toBe("updated-in-mutator");
+    expect(saved["session:2"].label).toBe("stable");
+    expect(baseStore["session:1"].label).toBe("updated-in-mutator");
+    expect(baseStore["session:2"].label).toBe("stable");
+  });
+
+  it("falls back to reparsing when baseStore drifted before the update started", async () => {
+    await saveSessionStore(storePath, createStore(), { skipMaintenance: true });
+
+    const baseStore = loadSessionStore(storePath, { skipCache: true });
+    baseStore["session:2"] = {
+      ...baseStore["session:2"],
+      label: "unrelated-preexisting-change",
+    };
+
+    const parseSpy = vi.spyOn(JSON, "parse");
+    parseSpy.mockClear();
+
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        store["session:1"] = {
+          ...store["session:1"],
+          label: "updated-after-base-drift",
+        };
+      },
+      { skipMaintenance: true, baseStore },
+    );
+
+    expect(parseSpy).toHaveBeenCalled();
+    parseSpy.mockRestore();
+
+    const saved = loadSessionStore(storePath, { skipCache: true });
+    expect(saved["session:1"].label).toBe("updated-after-base-drift");
+    expect(saved["session:2"].label).toBe("stable");
+  });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1275,12 +1275,21 @@ export async function runHeartbeatOnce(opts: {
       const store = loadSessionStore(storePath);
       const current = store[sessionKey];
       if (current) {
-        store[sessionKey] = {
-          ...current,
-          lastHeartbeatText: normalized.text,
-          lastHeartbeatSentAt: startedAt,
-        };
-        await saveSessionStore(storePath, store);
+        await updateSessionStore(
+          storePath,
+          (nextStore) => {
+            const nextCurrent = nextStore[sessionKey];
+            if (!nextCurrent) {
+              return;
+            }
+            nextStore[sessionKey] = {
+              ...nextCurrent,
+              lastHeartbeatText: normalized.text,
+              lastHeartbeatSentAt: startedAt,
+            };
+          },
+          { baseStore: store },
+        );
       }
     }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

  - Problem: large sessions.json stores could drive long-running gateway RSS toward ~1.2–1.3 GB because session metadata stayed on a whole-file read/
    parse/write path, and hot paths often loaded a store and then immediately reparsed it again inside updateSessionStore.
  - Why it matters: cron-heavy and long-lived gateways pay repeated O(n) session-store costs, which increases memory pressure and makes the reported
    #51097 behavior reproducible locally.
  - What changed: added a default OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES guard for oversized in-memory session-store caching, stopped retaining
    oversized serialized snapshots, and taught updateSessionStore to reuse an already-loaded store snapshot when the on-disk file still matches it.
  - What did NOT change (scope boundary): this PR does not replace sessions.json with SQLite/sharding and does not remove the underlying whole-file
    stringify/write design.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #51097
- Related #17971

## User-visible / Behavior Changes

  - Added OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES with a default of 1000000 bytes.
  - When sessions.json exceeds that limit, OpenClaw disables the parsed object cache for that store and logs a one-time warning.
  - Large stores now retain less memory and avoid one redundant whole-store reparse on common update paths.
  - Session semantics, file format, and maintenance defaults did not change.

## Security Impact (required)

  - New permissions/capabilities? (Yes/No) No
  - Secrets/tokens handling changed? (Yes/No) No
  - New/changed network calls? (Yes/No) No
  - Command/tool execution surface changed? (Yes/No) No
  - Data access scope changed? (Yes/No) No
  - If any Yes, explain risk + mitigation: None

## Repro + Verification

### Environment

  - OS: macOS local dev machine
  - Runtime/container: Node 22 + pnpm
  - Model/provider: None
  - Integration/channel (if any): synthetic session-store stress harness; heartbeat persistence path regression-tested
  - Relevant config (redacted): default session config, synthetic ~7.6 MB sessions.json, OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES=1000000,
    OPENCLAW_SESSION_CACHE_TTL_MS unset

### Steps

  1. Generate a synthetic large sessions.json and run repeated session-store read/update cycles with scripts/stress-session-store-rss.ts.
  2. Observe RSS growth on the pre-fix path with the same ~7.6 MB store shape reported in #51097.
  3. Apply the cache-limit + snapshot-reuse fixes and rerun the same stress harness and focused tests.

### Expected

  - Large stores should retain less memory.
  - Hot update paths should avoid a redundant second parse when the caller already loaded the same unchanged store.
  - Focused regression tests should stay green.

### Actual

  - Pre-fix reproduced roughly 1236 MB RSS by cycle 50.
  - Post-fix snapshot-reuse run dropped to roughly 890 MB RSS by cycle 50.
  - Focused session-store and heartbeat tests passed.

## Evidence

Attach at least one:

  - [x] Failing test/log before + passing after
  - [x] Trace/log snippets
  - [ ] Screenshot/recording
  - [x] Perf numbers (if relevant)

  ### Failing test/log before + passing after

  Before:

  scripts/stress-session-store-rss.ts --target-kb 7600 --cycles 50 --sample-every 10

  cycle  rss_mb  heap_mb  external_mb  store_kb  elapsed_ms
  0      668.7   221.3    21.4         7601      15181
  10     877.6   236.3    20.1         7602      15760
  20    1004.7   236.3    20.1         7603      16318
  30    1109.8   236.3    20.1         7604      16873
  40    1214.1   236.3    20.1         7605      17433
  50    1236.6   236.3    20.1         7605      17987

  After:

  scripts/stress-session-store-rss.ts --target-kb 7600 --cycles 50 --sample-every 10 --reuse-loaded-store

  cycle  rss_mb  heap_mb  external_mb  store_kb  elapsed_ms
  0      662.1   221.3    12.6         7601      15115
  10     740.7   236.3    27.5         7602      15561
  20     778.6   236.3    27.5         7603      16001
  30     815.9   236.3    27.5         7604      16430
  40     853.2   236.3    27.5         7605      16862
  50     890.5   236.3    27.5         7605      17297

  Focused regression tests after the fix:

  pnpm test -- src/config/sessions/store.update-base-store.test.ts src/config/sessions/store.cache.large-store.test.ts src/config/sessions/
  store.cache.large-store-noop-save.test.ts src/config/sessions/store.cache.limit-config.test.ts src/config/sessions/store.cache.limit-read.test.ts
  src/config/sessions/store.cache.limit-warning.test.ts src/config/sessions/store.cache.limit-write.test.ts src/config/sessions/
  store.cache.serialized-ttl.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts

  Test Files  9 passed (9)
  Tests       47 passed (47)

  ### Trace/log snippets

  Oversized-store warning showing the cache limit path activates:

  [sessions/store] session object cache disabled for large store

  Relevant code-path evidence:

  - src/config/sessions/store.ts
      - large stores skip parsed object-cache reuse
      - updateSessionStore can reuse a caller-provided loaded snapshot when file contents still match
  - src/auto-reply/reply/session-updates.ts
      - reply/session hot path now passes baseStore
  - src/infra/heartbeat-runner.ts
      - heartbeat dedupe persistence now uses updateSessionStore(..., { baseStore })

  ### Perf numbers

  Reporter-scale synthetic store, ~7.6 MB:

  - Before hot-path snapshot reuse: 1236.6 MB RSS at cycle 50
  - After hot-path snapshot reuse: 890.5 MB RSS at cycle 50

  Delta:

  - RSS reduction at cycle 50: about 346 MB
  - Relative reduction: about 28%

  Validation gates:

  pnpm build   ✅
  pnpm check   ✅
  focused tests ✅


## Human Verification (required)

What you personally verified (not just CI), and how:

  - Verified scenarios:
      - pnpm build
      - pnpm check
      - pnpm test -- src/config/sessions/store.update-base-store.test.ts src/config/sessions/store.cache.large-store.test.ts src/config/sessions/
        store.cache.large-store-noop-save.test.ts src/config/sessions/store.cache.limit-config.test.ts src/config/sessions/store.cache.limit-
        read.test.ts src/config/sessions/store.cache.limit-warning.test.ts src/config/sessions/store.cache.limit-write.test.ts src/config/sessions/
        store.cache.serialized-ttl.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts
      - scripts/stress-session-store-rss.ts before/after on a ~7.6 MB store
  - Edge cases checked:
      - oversized stores stop using parsed object cache
      - oversized serialized snapshots are not retained
      - unchanged oversized stores do not rewrite unnecessarily
      - updateSessionStore reuses the caller snapshot only when the on-disk file still matches
      - fallback reparsing still happens if the file changed underneath the caller
      - heartbeat dedupe persistence still passes focused regression coverage
  - What you did not verify:
      - full pnpm test across the entire repo on this machine
      - production multi-process gateway deployments
      - a clean terminating codex review --base origin/main run; repeated runs stalled without surfacing explicit findings

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

  - Backward compatible? (Yes/No) Yes
  - Config/env changes? (Yes/No) Yes
  - Migration needed? (Yes/No) No
  - If yes, exact upgrade steps:
      - Operators can optionally tune OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES.
      - No data migration is required.

## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly:
      - Revert this PR.
      - As an operational workaround, raise OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES if the new cache limit is too aggressive.
  - Files/config to restore:
      - src/config/sessions/store.ts
      - src/config/sessions/store-cache.ts
      - src/config/sessions/store-cache-limit.ts
      - reply/heartbeat call sites updated to pass baseStore
  - Known bad symptoms reviewers should watch for:
      - session metadata not persisting after in-memory updates
      - stale session data winning over newer on-disk changes
      - unexpected repeated warning logs for oversized stores

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

  - Risk:
      - The optimistic snapshot-reuse path could miss a concurrent on-disk change if the equality check is wrong.
      - Mitigation: reuse only happens while holding the write lock and only when the current file bytes still exactly match the previously loaded
        serialized snapshot; otherwise it falls back to the old reparse path.
  - Risk:
      - The new object-cache size limit could trade memory down for slower repeated reads on large stores.
      - Mitigation: the limit is configurable via env var, logged once per oversized store, and the change preserves session behavior rather than
        pruning data.

## Built with Codex

# Build prompt- 

# Issue 51097 Session Cache Fix Plan

> DO NOT COMMIT THIS FILE.
> Keep this file untracked for the entire implementation.
> It will be needed later when drafting the PR description.

## Goal

Implement a safe first fix for https://github.com/openclaw/openclaw/issues/51097 by size-gating the in-memory session object cache, defaulting the limit to 1 MB, while preserving existing session behavior and validating the change with targeted tests plus all applicable local CI-equivalent gates.

## Scope Assumptions

- The fix is limited to the session object cache, not session pruning, storage format redesign, or maintenance mode changes.
- The expected touched code paths are under `src/config/sessions/`, tests under `src/config/sessions/`, and operator docs under `docs/`.
- For changes under `src/` and `scripts/`, `scripts/ci-changed-scope.mjs` implies `run_node=true` and `run_windows=true`.
- `run_macos=false`, `run_android=false`, and `run_skills_python=false` unless the implementation expands into `apps/macos`, `apps/android`, `apps/shared`, `skills/`, or `.github/workflows/ci.yml`.
- If docs are changed, `check-docs` must also be run locally before push.

## Execution Rules

- Use `AGENTS.md` as the operational guardrail for the entire session.
- Use `CONTRIBUTING.md` as the PR-readiness guardrail for the entire session.
- Keep this plan file untracked and never include it in any commit.
- Keep the resulting work scoped to the concrete fix for issue #51097; do not turn it into a refactor-only or test-only PR.
- Before every code-changing commit:
  - run the step-specific targeted tests
  - run `pnpm build`
  - make the commit with `scripts/committer "<message>" <files...>`
- If a step has no tracked file changes, do not create an empty commit.
- If any baseline gate is red before starting code changes, stop and record the failure locally before proceeding.
- Do not push until the full final verification section is complete.

## Baseline Gate (No Commit By Design)

- [ ] Confirm branch state is clean and synced with the intended working branch.
- [ ] Run dependency sync once:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm install
  ```
- [ ] Record the current branch tip and baseline environment versions:
  ```bash
  git branch --show-current
  git log -1 --oneline --decorate
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH node -v
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm -v
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH bun -v
  ```
- [ ] Run the main repo-wide gate used by the commit hook:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm check
  ```
- [ ] Run the strict build smoke used by CI:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm build:strict-smoke
  ```
- [ ] Run the main build:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm build
  ```
- [ ] Run the exact minimum pre-PR gate required by `CONTRIBUTING.md`:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm build && pnpm check && pnpm test
  ```
- [ ] Run the two Linux unit-test shards locally, one at a time, using the same environment shape as CI:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm canvas:a2ui:bundle
  OPENCLAW_TEST_WORKERS=2 OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB=6144 OPENCLAW_TEST_SHARDS=2 OPENCLAW_TEST_SHARD_INDEX=1 PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test
  OPENCLAW_TEST_WORKERS=2 OPENCLAW_TEST_MAX_OLD_SPACE_SIZE_MB=6144 OPENCLAW_TEST_SHARDS=2 OPENCLAW_TEST_SHARD_INDEX=2 PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test
  ```
- [ ] Run the remaining Linux CI matrix lanes:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test:extensions
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test:channels
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test:contracts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm protocol:check
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm canvas:a2ui:bundle
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH bunx vitest run --config vitest.unit.config.ts
  ```
- [ ] Run the Node 22 compatibility lane locally in a Node 22 shell or toolchain manager session:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm build
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH node scripts/stage-bundled-plugin-runtime-deps.mjs
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH node --import tsx scripts/release-check.ts
  ```
- [ ] Run the `check-additional` gates:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm run lint:plugins:no-extension-imports
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm run lint:web-search-provider-boundaries
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm run lint:extensions:no-src-outside-plugin-sdk
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm run lint:extensions:no-plugin-sdk-internal
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm lint:ui:no-raw-window-open
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test:gateway:watch-regression
  ```
- [ ] Run the `build-smoke` gates:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm build
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH node openclaw.mjs --help
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH node openclaw.mjs status --json --timeout 1
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test:build:singleton
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test:startup:memory
  ```
- [ ] Run the always-on security/workflow gates locally:

  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH python3 -m pip install --upgrade pip pre-commit
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pre-commit run --all-files detect-private-key
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pre-commit run --all-files pnpm-audit-prod
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH python3 - <<'PY'
  from __future__ import annotations
  import pathlib
  import sys

  root = pathlib.Path(".github/workflows")
  bad: list[str] = []
  for path in sorted(root.rglob("*.yml")):
      if b"\t" in path.read_bytes():
          bad.append(str(path))
  for path in sorted(root.rglob("*.yaml")):
      if b"\t" in path.read_bytes():
          bad.append(str(path))
  if bad:
      print("Tabs found in workflow file(s):")
      for path in bad:
          print(f"- {path}")
      sys.exit(1)
  PY
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH python3 scripts/check-composite-action-input-interpolation.py
  ```

- [ ] Run `actionlint` locally if any workflow files might be touched during the work:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH actionlint
  ```
- [ ] Run the install-smoke workflow locally:
  ```bash
  docker build -t openclaw-dockerfile-smoke:local -f Dockerfile .
  docker run --rm --entrypoint sh openclaw-dockerfile-smoke:local -lc 'which openclaw && openclaw --version'
  docker build --build-arg OPENCLAW_EXTENSIONS=matrix -t openclaw-ext-smoke:local -f Dockerfile .
  docker run --rm --entrypoint sh openclaw-ext-smoke:local -lc 'which openclaw && openclaw --version && openclaw plugins list --json >/tmp/plugins.json && test -s /tmp/plugins.json'
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test:install:smoke
  ```
- [ ] Run the Windows CI-equivalent lane on a Windows host or Windows VM because `src/` or `scripts/` changes trigger `run_windows=true`.
- [ ] On Windows, run:
  ```powershell
  pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
  pnpm canvas:a2ui:bundle
  $env:OPENCLAW_TEST_WORKERS="1"
  $env:OPENCLAW_TEST_SHARDS="6"
  $env:OPENCLAW_TEST_SHARD_INDEX="1"; pnpm test
  $env:OPENCLAW_TEST_SHARD_INDEX="2"; pnpm test
  $env:OPENCLAW_TEST_SHARD_INDEX="3"; pnpm test
  $env:OPENCLAW_TEST_SHARD_INDEX="4"; pnpm test
  $env:OPENCLAW_TEST_SHARD_INDEX="5"; pnpm test
  $env:OPENCLAW_TEST_SHARD_INDEX="6"; pnpm test
  ```
- [ ] If docs are changed later, run the docs gate now and again at the end:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm check:docs
  ```

## Step 1: Add Threshold Configuration Helper And Tests

- [ ] Add a new helper in `src/config/sessions/store.ts` or a new `src/config/sessions/` helper file to resolve the object-cache byte limit.
- [ ] Define the initial semantics:
  - default object-cache limit is `1_000_000` bytes
  - a positive integer env override is accepted
  - invalid values fall back to the default
  - `0` disables the object cache entirely
- [ ] Add a new dedicated test file for helper behavior, for example `src/config/sessions/store.cache.limit-config.test.ts`.
- [ ] Verify this step with:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-config.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm build
  ```
- [ ] Commit only the helper and helper-test files with:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH scripts/committer "fix(sessions): add object cache limit config helper" <files...>
  ```

## Step 2: Gate Object-Cache Reads For Oversized Stores

- [ ] Teach `loadSessionStore(...)` to skip serving the in-memory object cache when the current file size is above the configured limit.
- [ ] When a store is above the limit, explicitly drop any existing object cache for that path so the process does not retain stale large cache entries.
- [ ] Add a new dedicated behavior test file, for example `src/config/sessions/store.cache.limit-read.test.ts`.
- [ ] Cover at least these cases:
  - small store remains cached
  - large store is not served from object cache
  - `OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES=0` disables object-cache reads even for small stores
- [ ] Re-run the existing large baseline test to ensure the pre-fix assumption now changes only when the limit is set.
- [ ] Verify this step with:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-config.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-read.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.large-store.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm build
  ```
- [ ] Commit only the files from this step with:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH scripts/committer "fix(sessions): skip object cache reads for large stores" <files...>
  ```

## Step 3: Gate Object-Cache Writes After Load And Save

- [ ] Update cache population paths so oversized stores do not populate the object cache during:
  - load-time cache writes
  - save-time write-through cache updates
- [ ] Keep the serialized cache unchanged in this first implementation.
- [ ] Add or update a dedicated test file, for example `src/config/sessions/store.cache.limit-write.test.ts`.
- [ ] Cover at least these cases:
  - oversized stores do not populate write-through object cache after `saveSessionStore(...)`
  - stores that grow across the limit lose object-cache eligibility immediately
  - small stores still get normal write-through caching
- [ ] Verify this step with:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-config.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-read.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-write.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.large-store.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm build
  ```
- [ ] Commit only the files from this step with:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH scripts/committer "fix(sessions): stop caching oversized session stores" <files...>
  ```

## Step 4: Add A One-Time Operator Warning

- [ ] Add a once-per-store-path warning when the object cache is disabled because a store exceeded the configured limit.
- [ ] Ensure the warning text includes:
  - store path
  - current size
  - configured limit
  - `OPENCLAW_SESSION_OBJECT_CACHE_MAX_BYTES`
- [ ] Ensure the warning is low-noise:
  - warn once per store path per process
  - do not warn on every load or save
- [ ] Add a dedicated warning test file, for example `src/config/sessions/store.cache.limit-warning.test.ts`.
- [ ] Cover at least these cases:
  - first oversized access logs the warning
  - repeated oversized accesses for the same path do not spam
  - small stores do not warn
- [ ] Verify this step with:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-config.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-read.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-write.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-warning.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.large-store.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm build
  ```
- [ ] Commit only the files from this step with:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH scripts/committer "fix(sessions): warn when object cache limit is hit" <files...>
  ```

## Step 5: Document The New Limit And Operator Override

- [ ] Update the operator/environment documentation in `docs/help/environment.md`.
- [ ] Update the session CLI/operator documentation in `docs/cli/sessions.md`.
- [ ] Document:
  - the env var name
  - the default value (`1 MB`)
  - what happens when the limit is exceeded
  - that exceeding the limit changes memory/performance tradeoffs, not session semantics
- [ ] Keep internal links Mintlify-safe and root-relative.
- [ ] Verify this step with:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm check:docs
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm build
  ```
- [ ] Commit only the docs files from this step with:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH scripts/committer "docs(sessions): document object cache size limit" <files...>
  ```

## Step 6: Re-run The Session Measurements Against The Fix

- [ ] Re-run the targeted measurement harness with the default limit:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH node --import tsx scripts/measure-session-store-cache.ts
  ```
- [ ] Re-run the RSS stress harness with the default limit:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH node --expose-gc --import tsx scripts/stress-session-store-rss.ts --target-kb 7600 --cycles 50 --sample-every 10
  ```
- [ ] Confirm the post-fix measurements show lower RSS growth or at least materially lower retained object-cache memory for oversized stores.
- [ ] If the measurements suggest the default needs adjustment, stop and make that change in a separate follow-up commit rather than folding it into an unreviewable mixed step.

## Final PR-Readiness Gate (No Commit By Design)

- [ ] Re-run the canonical `CONTRIBUTING.md` pre-PR gate exactly:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm build && pnpm check && pnpm test
  ```
- [ ] Re-run all targeted session-cache tests for the touched files:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-config.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-read.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-write.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.limit-warning.test.ts
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm test -- src/config/sessions/store.cache.large-store.test.ts
  ```
- [ ] If docs changed, re-run:
  ```bash
  PATH=/usr/local/bin:/opt/homebrew/bin:$PATH pnpm check:docs
  ```
- [ ] Run the Codex review required by `CONTRIBUTING.md` before opening or updating the PR:
  ```bash
  codex review --base origin/main
  ```
- [ ] Confirm every bot/Codex review conversation introduced by the PR is addressed or explicitly responded to before requesting review.
- [ ] Confirm this plan file is still untracked:
  ```bash
  git status --short ISSUE_51097_FIX_PLAN.md
  ```

## Final Verification Gate Before Push (No Commit By Design)

- [ ] Re-run every baseline gate from the `Baseline Gate` section after the final code commit.
- [ ] Re-run docs checks if any docs changed.
- [ ] Re-run Windows shard coverage on a Windows host or Windows VM because the touched paths still imply `run_windows=true`.
- [ ] Confirm `git status --short` is clean before pushing.
- [ ] Confirm commit history is one logical commit per step plus any intentional merge-from-main commit.
- [ ] Push only after every applicable local CI-equivalent lane is green.

## Suggested Commit Sequence

- [ ] `fix(sessions): add object cache limit config helper`
- [ ] `fix(sessions): skip object cache reads for large stores`
- [ ] `fix(sessions): stop caching oversized session stores`
- [ ] `fix(sessions): warn when object cache limit is hit`
- [ ] `docs(sessions): document object cache size limit`

## Final Deliverables Checklist

- [ ] New configurable object-cache limit with default `1 MB`
- [ ] Targeted tests for config, read gating, write gating, and warnings
- [ ] Existing large-store baseline test still meaningful
- [ ] Updated operator/docs guidance
- [ ] Full applicable local CI-equivalent coverage completed before push
- [ ] This plan file remains uncommitted for later PR description drafting

