### PR TITLE
fix: classify openrouter json 404 model errors

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -19,6 +19,8 @@ const GEMINI_RESOURCE_EXHAUSTED_MESSAGE =
   "RESOURCE_EXHAUSTED: Resource has been exhausted (e.g. check quota).";
 // OpenRouter 402 billing example: https://openrouter.ai/docs/api-reference/errors
 const OPENROUTER_CREDITS_MESSAGE = "Payment Required: insufficient credits";
+const OPENROUTER_MODEL_NOT_FOUND_PAYLOAD =
+  '{"error":{"message":"Healer Alpha was a stealth model revealed on March 18th as an early testing version of MiMo-V2-Omni. Find it here: https://openrouter.ai/xiaomi/mimo-v2-omni","code":404},"user_id":"user_33GTyP8uDSYYbaeBO48AGHXyuMC"}';
 const TOGETHER_MONTHLY_SPEND_CAP_MESSAGE =
   "The account associated with this API key has reached its maximum allowed monthly spending limit.";
 // Issue-backed Anthropic/OpenAI-compatible insufficient_quota payload under HTTP 400:
@@ -191,6 +193,14 @@ describe("failover-error", () => {
     expect(
       resolveFailoverReasonFromError({
         message: "404 No endpoints found for deepseek/deepseek-r1:free.",
+      }),
+    ).toBe("model_not_found");
+  });
+
+  it("classifies JSON-wrapped OpenRouter stealth-model 404s as model_not_found", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message: OPENROUTER_MODEL_NOT_FOUND_PAYLOAD,
       }),
     ).toBe("model_not_found");
   });
@@ -567,6 +577,16 @@ describe("failover-error", () => {
     expect(err?.status).toBe(402);
     expect(err?.provider).toBe("anthropic");
     expect(err?.model).toBe("claude-opus-4-6");
+  });
+
+  it("coerces JSON-wrapped OpenRouter stealth-model 404s into FailoverError", () => {
+    const err = coerceToFailoverError(OPENROUTER_MODEL_NOT_FOUND_PAYLOAD, {
+      provider: "openrouter",
+      model: "openrouter/healer-alpha",
+    });
+
+    expect(err?.reason).toBe("model_not_found");
+    expect(err?.status).toBe(404);
   });
 
   it("maps overloaded to a 503 fallback status", () => {

--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -6,10 +6,14 @@ import {
 
 describe("live model error helpers", () => {
   it("detects generic model-not-found messages", () => {
+    const openRouterJson404Payload =
+      '{"error":{"message":"Healer Alpha was a stealth model revealed on March 18th as an early testing version of MiMo-V2-Omni. Find it here: https://openrouter.ai/xiaomi/mimo-v2-omni","code":404},"user_id":"user_33GTyP8uDSYYbaeBO48AGHXyuMC"}';
+
     expect(isModelNotFoundErrorMessage("Model not found: openai/gpt-6")).toBe(true);
     expect(isModelNotFoundErrorMessage("model_not_found")).toBe(true);
     expect(isModelNotFoundErrorMessage("The model gpt-foo does not exist.")).toBe(true);
     expect(isModelNotFoundErrorMessage('{"code":404,"message":"model not found"}')).toBe(true);
+    expect(isModelNotFoundErrorMessage(openRouterJson404Payload)).toBe(true);
     expect(isModelNotFoundErrorMessage("model: MiniMax-M2.7-highspeed not found")).toBe(true);
     expect(
       isModelNotFoundErrorMessage("404 No endpoints found for deepseek/deepseek-r1:free."),
@@ -32,6 +36,9 @@ describe("live model error helpers", () => {
     expect(
       isModelNotFoundErrorMessage("The deployment does not exist or you do not have access."),
     ).toBe(false);
+    expect(isModelNotFoundErrorMessage('{"error":{"message":"Resource missing","code":404}}')).toBe(
+      false,
+    );
     expect(isModelNotFoundErrorMessage("request ended without sending any chunks")).toBe(false);
   });
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -22,6 +22,8 @@ vi.mock("../plugins/provider-runtime.js", () => ({
 }));
 
 const makeCfg = makeModelFallbackCfg;
+const OPENROUTER_MODEL_NOT_FOUND_PAYLOAD =
+  '{"error":{"message":"Healer Alpha was a stealth model revealed on March 18th as an early testing version of MiMo-V2-Omni. Find it here: https://openrouter.ai/xiaomi/mimo-v2-omni","code":404},"user_id":"user_33GTyP8uDSYYbaeBO48AGHXyuMC"}';
 
 function makeFallbacksOnlyCfg(): OpenClawConfig {
   return {
@@ -567,6 +569,26 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(2);
     expect(run.mock.calls[1]?.[0]).toBe("anthropic");
     expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("falls back on JSON-wrapped OpenRouter stealth-model 404s", async () => {
+    const cfg = makeCfg();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error(OPENROUTER_MODEL_NOT_FOUND_PAYLOAD))
+      .mockResolvedValueOnce("ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openrouter",
+      model: "openrouter/healer-alpha",
+      run,
+    });
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("openai");
+    expect(run.mock.calls[1]?.[1]).toBe("gpt-4.1-mini");
   });
 
   it("warns when falling back due to model_not_found", async () => {


### PR DESCRIPTION
## Summary

- Problem: OpenRouter can return a JSON-wrapped HTTP 404 payload for unavailable models, and we want a stable regression guard that proves fallback still treats that payload as `model_not_found`.
- Why it matters: this exact payload is easy to regress during future matcher/refactor work, and a regression would stop model selection on a dead OpenRouter candidate instead of continuing through the configured fallback chain.
- What changed: rewrote the stale branch on top of current `main` and kept only regression coverage for the exact payload in the shared matcher, failover classifier, and fallback loop.
- What did NOT change (scope boundary): no production behavior changes in this branch; current `main` already handles the payload correctly.

## Change Type (select all)

- [x] Bug fix
- [x] Tests / regression coverage

## Scope (select all touched areas)

- [x] Agents / fallback
- [x] Tests

## Linked Issue/PR

- Closes #51571

## User-visible / Behavior Changes

- No new runtime behavior in this branch; it locks in existing current-main behavior with regression tests.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: None.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local workspace
- Model/provider: OpenRouter
- Integration/channel (if any): model fallback path
- Relevant config (redacted): `model: "openrouter/healer-alpha"`

### Steps

1. Construct the JSON 404 payload from #51571.
2. Run the shared model-not-found matcher on current `main`.
3. Run the failover classifier and fallback loop against the same payload.

### Expected

- The payload is recognized as `model_not_found` and fallback continues.

### Actual

- Current `main` already behaves correctly; this PR preserves that behavior with regression coverage.

## Evidence

- [x] Targeted runtime probe on current `main`
- [x] Regression tests added and passing locally
- [ ] Live production rollout behavior

## Human Verification (required)

- Verified scenarios: `node_modules/.bin/vitest run src/agents/live-model-errors.test.ts src/agents/failover-error.test.ts src/agents/model-fallback.test.ts`
- Edge cases checked: the exact OpenRouter stealth-model JSON 404 payload is recognized; a generic JSON 404 payload is not over-classified in the shared matcher.
- What you did **not** verify: full repo CI is currently noisy on unrelated current-main checks.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: None.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit
- Files/config to restore: `src/agents/live-model-errors.test.ts`, `src/agents/failover-error.test.ts`, `src/agents/model-fallback.test.ts`
- Known bad symptoms reviewers should watch for: future matcher changes stop recognizing the JSON payload or start over-classifying generic JSON 404 payloads.

## Risks and Mitigations

- Risk: the branch no longer matches the original stale implementation diff.
  - Mitigation: the branch was intentionally rebuilt on current `main` after verifying the underlying runtime behavior already landed upstream.
