### PR TITLE
fix(completion): add compinit guard to zsh completion output

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -382,7 +382,7 @@ function generateZshCompletion(program: Command): string {
 # Ensure zsh completion system is initialized.
 # When sourced via \`source <(openclaw completion --shell zsh)\`,
 # compdef may not be available unless compinit has been called first.
-if (( ! \$+functions[compdef] )); then
+if (( ! $+functions[compdef] )); then
   autoload -Uz compinit
   compinit -C
 fi

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -379,6 +379,14 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
 function generateZshCompletion(program: Command): string {
   const rootCmd = program.name();
   const script = `
+# Ensure zsh completion system is initialized.
+# When sourced via \`source <(openclaw completion --shell zsh)\`,
+# compdef may not be available unless compinit has been called first.
+if (( ! \$+functions[compdef] )); then
+  autoload -Uz compinit
+  compinit -C
+fi
+
 #compdef ${rootCmd}
 
 _${rootCmd}_root_completion() {


### PR DESCRIPTION
Fixes #14289

When users `source <(openclaw completion --shell zsh)` in their `.zshrc` before `compinit` has been called, zsh errors with `command not found: compdef`.

### Fix

Add a defensive guard at the top of the generated zsh completion script that checks if `compdef` is available and only initializes the completion system when needed:

```zsh
if (( ! $+functions[compdef] )); then
  autoload -Uz compinit
  compinit -C
fi
```

- Uses `$+functions[compdef]` — idiomatic zsh check for function existence
- Only loads `compinit` if not already initialized (no double-init for users who already call `compinit`)
- `-C` flag skips security check for faster startup

### Test

```
pnpm test -- src/cli/completion-cli.test.ts
✓ src/cli/completion-cli.test.ts (3 tests) 3ms
Test Files  1 passed (1)
Tests       3 passed (3)
```