### PR TITLE
feat(cron): add --thread-id flag to cron create/edit for Telegram forum topics

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -279,7 +279,7 @@ export function registerCronAddCommand(cron: Command) {
                     if (threadId && !/^\d+$/.test(threadId)) {
                       throw new Error("--thread-id must be a numeric value");
                     }
-                    const to = toRaw.replace(/:topic:\d+$/, "");
+                    const to = threadId ? toRaw.replace(/:topic:\d+$/, "") : toRaw;
                     if (to && threadId) {
                       return `${to}:topic:${threadId}`;
                     }

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -279,7 +279,8 @@ export function registerCronAddCommand(cron: Command) {
                     if (threadId && !/^\d+$/.test(threadId)) {
                       throw new Error("--thread-id must be a numeric value");
                     }
-                    const channel = typeof opts.channel === "string" ? opts.channel.trim().toLowerCase() : "";
+                    const channel =
+                      typeof opts.channel === "string" ? opts.channel.trim().toLowerCase() : "";
                     if (threadId && channel && channel !== "telegram") {
                       throw new Error("--thread-id is only supported for Telegram channels");
                     }

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -281,7 +281,7 @@ export function registerCronAddCommand(cron: Command) {
                     }
                     const channel =
                       typeof opts.channel === "string" ? opts.channel.trim().toLowerCase() : "";
-                    if (threadId && channel && channel !== "telegram") {
+                    if (threadId && channel && channel !== "telegram" && channel !== "last") {
                       throw new Error("--thread-id is only supported for Telegram channels");
                     }
                     const to = threadId ? toRaw.replace(/:(?:topic:)?\d+$/, "") : toRaw;

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -281,8 +281,8 @@ export function registerCronAddCommand(cron: Command) {
                     }
                     const channel =
                       typeof opts.channel === "string" ? opts.channel.trim().toLowerCase() : "";
-                    if (threadId && channel && channel !== "telegram" && channel !== "last") {
-                      throw new Error("--thread-id is only supported for Telegram channels");
+                    if (threadId && channel !== "telegram") {
+                      throw new Error("--thread-id requires --channel telegram");
                     }
                     const to = threadId ? toRaw.replace(/:(?:topic:)?\d+$/, "") : toRaw;
                     if (to && threadId) {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -279,7 +279,7 @@ export function registerCronAddCommand(cron: Command) {
                     if (threadId && !/^\d+$/.test(threadId)) {
                       throw new Error("--thread-id must be a numeric value");
                     }
-                    const to = threadId ? toRaw.replace(/:topic:\d+$/, "") : toRaw;
+                    const to = threadId ? toRaw.replace(/:(?:topic:)?\d+$/, "") : toRaw;
                     if (to && threadId) {
                       return `${to}:topic:${threadId}`;
                     }

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -96,6 +96,7 @@ export function registerCronAddCommand(cron: Command) {
         "--to <dest>",
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
       )
+      .option("--thread-id <id>", "Thread id (Telegram forum topic)")
       .option("--account <id>", "Channel account id for delivery (multi-account setups)")
       .option("--best-effort-deliver", "Do not fail the job if delivery fails", false)
       .option("--json", "Output JSON", false)
@@ -272,7 +273,14 @@ export function registerCronAddCommand(cron: Command) {
                     typeof opts.channel === "string" && opts.channel.trim()
                       ? opts.channel.trim()
                       : undefined,
-                  to: typeof opts.to === "string" && opts.to.trim() ? opts.to.trim() : undefined,
+                  to: (() => {
+                    const to = typeof opts.to === "string" ? opts.to.trim() : "";
+                    const threadId = typeof opts.threadId === "string" ? opts.threadId.trim() : "";
+                    if (to && threadId) {
+                      return `${to}:topic:${threadId}`;
+                    }
+                    return to || undefined;
+                  })(),
                   accountId,
                   bestEffort: opts.bestEffortDeliver ? true : undefined,
                 }

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -96,7 +96,7 @@ export function registerCronAddCommand(cron: Command) {
         "--to <dest>",
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
       )
-      .option("--thread-id <id>", "Thread id (Telegram forum topic)")
+      .option("--thread-id <id>", "Thread id (Telegram forum topic, must be a number)")
       .option("--account <id>", "Channel account id for delivery (multi-account setups)")
       .option("--best-effort-deliver", "Do not fail the job if delivery fails", false)
       .option("--json", "Output JSON", false)
@@ -274,8 +274,12 @@ export function registerCronAddCommand(cron: Command) {
                       ? opts.channel.trim()
                       : undefined,
                   to: (() => {
-                    const to = typeof opts.to === "string" ? opts.to.trim() : "";
+                    const toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
                     const threadId = typeof opts.threadId === "string" ? opts.threadId.trim() : "";
+                    if (threadId && !/^\d+$/.test(threadId)) {
+                      throw new Error("--thread-id must be a numeric value");
+                    }
+                    const to = toRaw.replace(/:topic:\d+$/, "");
                     if (to && threadId) {
                       return `${to}:topic:${threadId}`;
                     }

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -279,7 +279,7 @@ export function registerCronAddCommand(cron: Command) {
                     if (threadId && !/^\d+$/.test(threadId)) {
                       throw new Error("--thread-id must be a numeric value");
                     }
-                    const channel = typeof opts.channel === "string" ? opts.channel.trim() : "";
+                    const channel = typeof opts.channel === "string" ? opts.channel.trim().toLowerCase() : "";
                     if (threadId && channel && channel !== "telegram") {
                       throw new Error("--thread-id is only supported for Telegram channels");
                     }

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -279,6 +279,10 @@ export function registerCronAddCommand(cron: Command) {
                     if (threadId && !/^\d+$/.test(threadId)) {
                       throw new Error("--thread-id must be a numeric value");
                     }
+                    const channel = typeof opts.channel === "string" ? opts.channel.trim() : "";
+                    if (threadId && channel && channel !== "telegram") {
+                      throw new Error("--thread-id is only supported for Telegram channels");
+                    }
                     const to = threadId ? toRaw.replace(/:(?:topic:)?\d+$/, "") : toRaw;
                     if (to && threadId) {
                       return `${to}:topic:${threadId}`;

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -283,6 +283,9 @@ export function registerCronAddCommand(cron: Command) {
                     if (to && threadId) {
                       return `${to}:topic:${threadId}`;
                     }
+                    if (threadId && !to) {
+                      throw new Error("--thread-id requires --to");
+                    }
                     return to || undefined;
                   })(),
                   accountId,

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -65,6 +65,7 @@ export function registerCronEditCommand(cron: Command) {
         "--to <dest>",
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
       )
+      .option("--thread-id <id>", "Thread id (Telegram forum topic)")
       .option("--account <id>", "Channel account id for delivery (multi-account setups)")
       .option("--best-effort-deliver", "Do not fail job if delivery fails")
       .option("--no-best-effort-deliver", "Fail job when delivery fails")
@@ -219,6 +220,7 @@ export function registerCronEditCommand(cron: Command) {
           const hasDeliveryModeFlag = opts.announce || typeof opts.deliver === "boolean";
           const hasDeliveryTarget = typeof opts.channel === "string" || typeof opts.to === "string";
           const hasDeliveryAccount = typeof opts.account === "string";
+          const hasThreadId = typeof opts.threadId === "string";
           const hasBestEffort = typeof opts.bestEffortDeliver === "boolean";
           const hasAgentTurnPatch =
             typeof opts.message === "string" ||
@@ -253,7 +255,13 @@ export function registerCronEditCommand(cron: Command) {
             patch.payload = payload;
           }
 
-          if (hasDeliveryModeFlag || hasDeliveryTarget || hasDeliveryAccount || hasBestEffort) {
+          if (
+            hasDeliveryModeFlag ||
+            hasDeliveryTarget ||
+            hasDeliveryAccount ||
+            hasThreadId ||
+            hasBestEffort
+          ) {
             const delivery: Record<string, unknown> = {};
             if (hasDeliveryModeFlag) {
               delivery.mode = opts.announce || opts.deliver === true ? "announce" : "none";
@@ -265,9 +273,14 @@ export function registerCronEditCommand(cron: Command) {
               const channel = opts.channel.trim();
               delivery.channel = channel ? channel : undefined;
             }
-            if (typeof opts.to === "string") {
-              const to = opts.to.trim();
-              delivery.to = to ? to : undefined;
+            if (typeof opts.to === "string" || typeof opts.threadId === "string") {
+              const to = typeof opts.to === "string" ? opts.to.trim() : "";
+              const threadId = typeof opts.threadId === "string" ? opts.threadId.trim() : "";
+              if (to && threadId) {
+                delivery.to = `${to}:topic:${threadId}`;
+              } else if (to) {
+                delivery.to = to || undefined;
+              }
             }
             if (typeof opts.account === "string") {
               const account = opts.account.trim();

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -280,7 +280,7 @@ export function registerCronEditCommand(cron: Command) {
               if (threadId && !/^\d+$/.test(threadId)) {
                 throw new Error("--thread-id must be a numeric value");
               }
-              const to = threadId ? toRaw.replace(/:topic:\d+$/, "") : toRaw;
+              const to = threadId ? toRaw.replace(/:(?:topic:)?\d+$/, "") : toRaw;
               if (to && threadId) {
                 delivery.to = `${to}:topic:${threadId}`;
               } else if (to) {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -302,8 +302,7 @@ export function registerCronEditCommand(cron: Command) {
                   if (existingMode === "webhook") {
                     throw new Error("--thread-id is not supported for webhook delivery jobs");
                   }
-                  const ec = existingChannel.toLowerCase();
-                  if (existingChannel && ec !== "telegram") {
+                  if (existingChannel.toLowerCase() !== "telegram") {
                     throw new Error("--thread-id requires --channel telegram");
                   }
                 }

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -280,7 +280,7 @@ export function registerCronEditCommand(cron: Command) {
               if (threadId && !/^\d+$/.test(threadId)) {
                 throw new Error("--thread-id must be a numeric value");
               }
-              const to = toRaw.replace(/:topic:\d+$/, "");
+              const to = threadId ? toRaw.replace(/:topic:\d+$/, "") : toRaw;
               if (to && threadId) {
                 delivery.to = `${to}:topic:${threadId}`;
               } else if (to) {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -299,12 +299,15 @@ export function registerCronEditCommand(cron: Command) {
                 }
                 const existingChannel =
                   (existing?.delivery as Record<string, string> | undefined)?.channel ?? "";
-                if (
-                  typeof opts.channel !== "string" &&
-                  existingChannel &&
-                  existingChannel.toLowerCase() !== "telegram"
-                ) {
-                  throw new Error("--thread-id is only supported for Telegram channels");
+                const existingMode =
+                  (existing?.delivery as Record<string, string> | undefined)?.mode ?? "";
+                if (typeof opts.channel !== "string") {
+                  if (existingMode === "webhook") {
+                    throw new Error("--thread-id is not supported for webhook delivery jobs");
+                  }
+                  if (existingChannel && existingChannel.toLowerCase() !== "telegram") {
+                    throw new Error("--thread-id is only supported for Telegram channels");
+                  }
                 }
                 if (!toRaw) {
                   toRaw = (existing?.delivery as Record<string, string> | undefined)?.to ?? "";

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -279,7 +279,12 @@ export function registerCronEditCommand(cron: Command) {
               if (threadId && !/^\d+$/.test(threadId)) {
                 throw new Error("--thread-id must be a numeric value");
               }
-              if (threadId && typeof opts.channel === "string" && opts.channel.trim() && opts.channel.trim().toLowerCase() !== "telegram") {
+              if (
+                threadId &&
+                typeof opts.channel === "string" &&
+                opts.channel.trim() &&
+                opts.channel.trim().toLowerCase() !== "telegram"
+              ) {
                 throw new Error("--thread-id is only supported for Telegram channels");
               }
               let toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
@@ -292,8 +297,13 @@ export function registerCronEditCommand(cron: Command) {
                 if (!existing) {
                   throw new Error(`Cron job ${id} not found`);
                 }
-                const existingChannel = (existing?.delivery as Record<string, string> | undefined)?.channel ?? "";
-                if (existingChannel && existingChannel.toLowerCase() !== "telegram") {
+                const existingChannel =
+                  (existing?.delivery as Record<string, string> | undefined)?.channel ?? "";
+                if (
+                  typeof opts.channel !== "string" &&
+                  existingChannel &&
+                  existingChannel.toLowerCase() !== "telegram"
+                ) {
                   throw new Error("--thread-id is only supported for Telegram channels");
                 }
                 if (!toRaw) {
@@ -306,7 +316,9 @@ export function registerCronEditCommand(cron: Command) {
               } else if (to) {
                 delivery.to = to;
               } else if (threadId) {
-                throw new Error("--thread-id requires a delivery target (use --to or ensure the job has one)");
+                throw new Error(
+                  "--thread-id requires a delivery target (use --to or ensure the job has one)",
+                );
               } else if (typeof opts.to === "string") {
                 delivery.to = undefined;
               }

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -279,11 +279,13 @@ export function registerCronEditCommand(cron: Command) {
               if (threadId && !/^\d+$/.test(threadId)) {
                 throw new Error("--thread-id must be a numeric value");
               }
+              const explicitChannel =
+                typeof opts.channel === "string" ? opts.channel.trim().toLowerCase() : "";
               if (
                 threadId &&
-                typeof opts.channel === "string" &&
-                opts.channel.trim() &&
-                opts.channel.trim().toLowerCase() !== "telegram"
+                explicitChannel &&
+                explicitChannel !== "telegram" &&
+                explicitChannel !== "last"
               ) {
                 throw new Error("--thread-id is only supported for Telegram channels");
               }
@@ -305,7 +307,8 @@ export function registerCronEditCommand(cron: Command) {
                   if (existingMode === "webhook") {
                     throw new Error("--thread-id is not supported for webhook delivery jobs");
                   }
-                  if (existingChannel && existingChannel.toLowerCase() !== "telegram") {
+                  const ec = existingChannel.toLowerCase();
+                  if (existingChannel && ec !== "telegram" && ec !== "last") {
                     throw new Error("--thread-id is only supported for Telegram channels");
                   }
                 }

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -281,13 +281,8 @@ export function registerCronEditCommand(cron: Command) {
               }
               const explicitChannel =
                 typeof opts.channel === "string" ? opts.channel.trim().toLowerCase() : "";
-              if (
-                threadId &&
-                explicitChannel &&
-                explicitChannel !== "telegram" &&
-                explicitChannel !== "last"
-              ) {
-                throw new Error("--thread-id is only supported for Telegram channels");
+              if (threadId && explicitChannel && explicitChannel !== "telegram") {
+                throw new Error("--thread-id requires --channel telegram");
               }
               let toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
               // When --thread-id needs existing job context (no --to or no --channel), fetch it
@@ -308,8 +303,8 @@ export function registerCronEditCommand(cron: Command) {
                     throw new Error("--thread-id is not supported for webhook delivery jobs");
                   }
                   const ec = existingChannel.toLowerCase();
-                  if (existingChannel && ec !== "telegram" && ec !== "last") {
-                    throw new Error("--thread-id is only supported for Telegram channels");
+                  if (existingChannel && ec !== "telegram") {
+                    throw new Error("--thread-id requires --channel telegram");
                   }
                 }
                 if (!toRaw) {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -65,7 +65,7 @@ export function registerCronEditCommand(cron: Command) {
         "--to <dest>",
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
       )
-      .option("--thread-id <id>", "Thread id (Telegram forum topic)")
+      .option("--thread-id <id>", "Thread id (Telegram forum topic, must be a number)")
       .option("--account <id>", "Channel account id for delivery (multi-account setups)")
       .option("--best-effort-deliver", "Do not fail job if delivery fails")
       .option("--no-best-effort-deliver", "Fail job when delivery fails")
@@ -231,6 +231,7 @@ export function registerCronEditCommand(cron: Command) {
             hasDeliveryModeFlag ||
             hasDeliveryTarget ||
             hasDeliveryAccount ||
+            hasThreadId ||
             hasBestEffort;
           if (hasSystemEventPatch && hasAgentTurnPatch) {
             throw new Error("Choose at most one payload change");
@@ -274,12 +275,16 @@ export function registerCronEditCommand(cron: Command) {
               delivery.channel = channel ? channel : undefined;
             }
             if (typeof opts.to === "string" || typeof opts.threadId === "string") {
-              const to = typeof opts.to === "string" ? opts.to.trim() : "";
+              const toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
               const threadId = typeof opts.threadId === "string" ? opts.threadId.trim() : "";
+              if (threadId && !/^\d+$/.test(threadId)) {
+                throw new Error("--thread-id must be a numeric value");
+              }
+              const to = toRaw.replace(/:topic:\d+$/, "");
               if (to && threadId) {
                 delivery.to = `${to}:topic:${threadId}`;
               } else if (to) {
-                delivery.to = to || undefined;
+                delivery.to = to;
               }
             }
             if (typeof opts.account === "string") {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -275,10 +275,18 @@ export function registerCronEditCommand(cron: Command) {
               delivery.channel = channel ? channel : undefined;
             }
             if (typeof opts.to === "string" || typeof opts.threadId === "string") {
-              const toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
               const threadId = typeof opts.threadId === "string" ? opts.threadId.trim() : "";
               if (threadId && !/^\d+$/.test(threadId)) {
                 throw new Error("--thread-id must be a numeric value");
+              }
+              let toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
+              // When --thread-id is provided without --to, fetch existing job's delivery target
+              if (threadId && !toRaw) {
+                const listed = (await callGatewayFromCli("cron.list", opts, {
+                  includeDisabled: true,
+                })) as { jobs?: CronJob[] } | null;
+                const existing = (listed?.jobs ?? []).find((job) => job.id === id);
+                toRaw = (existing?.delivery as Record<string, string> | undefined)?.to ?? "";
               }
               const to = threadId ? toRaw.replace(/:(?:topic:)?\d+$/, "") : toRaw;
               if (to && threadId) {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -279,6 +279,9 @@ export function registerCronEditCommand(cron: Command) {
               if (threadId && !/^\d+$/.test(threadId)) {
                 throw new Error("--thread-id must be a numeric value");
               }
+              if (threadId && typeof opts.channel === "string" && opts.channel.trim() && opts.channel.trim() !== "telegram") {
+                throw new Error("--thread-id is only supported for Telegram channels");
+              }
               let toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
               // When --thread-id is provided without --to, fetch existing job's delivery target
               if (threadId && !toRaw) {
@@ -286,6 +289,9 @@ export function registerCronEditCommand(cron: Command) {
                   includeDisabled: true,
                 })) as { jobs?: CronJob[] } | null;
                 const existing = (listed?.jobs ?? []).find((job) => job.id === id);
+                if (!existing) {
+                  throw new Error(`Cron job ${id} not found`);
+                }
                 toRaw = (existing?.delivery as Record<string, string> | undefined)?.to ?? "";
               }
               const to = threadId ? toRaw.replace(/:(?:topic:)?\d+$/, "") : toRaw;

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -279,7 +279,7 @@ export function registerCronEditCommand(cron: Command) {
               if (threadId && !/^\d+$/.test(threadId)) {
                 throw new Error("--thread-id must be a numeric value");
               }
-              if (threadId && typeof opts.channel === "string" && opts.channel.trim() && opts.channel.trim() !== "telegram") {
+              if (threadId && typeof opts.channel === "string" && opts.channel.trim() && opts.channel.trim().toLowerCase() !== "telegram") {
                 throw new Error("--thread-id is only supported for Telegram channels");
               }
               let toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
@@ -291,6 +291,10 @@ export function registerCronEditCommand(cron: Command) {
                 const existing = (listed?.jobs ?? []).find((job) => job.id === id);
                 if (!existing) {
                   throw new Error(`Cron job ${id} not found`);
+                }
+                const existingChannel = (existing?.delivery as Record<string, string> | undefined)?.channel ?? "";
+                if (existingChannel && existingChannel.toLowerCase() !== "telegram") {
+                  throw new Error("--thread-id is only supported for Telegram channels");
                 }
                 toRaw = (existing?.delivery as Record<string, string> | undefined)?.to ?? "";
               }

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -293,6 +293,10 @@ export function registerCronEditCommand(cron: Command) {
                 delivery.to = `${to}:topic:${threadId}`;
               } else if (to) {
                 delivery.to = to;
+              } else if (threadId) {
+                throw new Error("--thread-id requires a delivery target (use --to or ensure the job has one)");
+              } else if (typeof opts.to === "string") {
+                delivery.to = undefined;
               }
             }
             if (typeof opts.account === "string") {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -283,8 +283,8 @@ export function registerCronEditCommand(cron: Command) {
                 throw new Error("--thread-id is only supported for Telegram channels");
               }
               let toRaw = typeof opts.to === "string" ? opts.to.trim() : "";
-              // When --thread-id is provided without --to, fetch existing job's delivery target
-              if (threadId && !toRaw) {
+              // When --thread-id needs existing job context (no --to or no --channel), fetch it
+              if (threadId && (!toRaw || typeof opts.channel !== "string")) {
                 const listed = (await callGatewayFromCli("cron.list", opts, {
                   includeDisabled: true,
                 })) as { jobs?: CronJob[] } | null;
@@ -296,7 +296,9 @@ export function registerCronEditCommand(cron: Command) {
                 if (existingChannel && existingChannel.toLowerCase() !== "telegram") {
                   throw new Error("--thread-id is only supported for Telegram channels");
                 }
-                toRaw = (existing?.delivery as Record<string, string> | undefined)?.to ?? "";
+                if (!toRaw) {
+                  toRaw = (existing?.delivery as Record<string, string> | undefined)?.to ?? "";
+                }
               }
               const to = threadId ? toRaw.replace(/:(?:topic:)?\d+$/, "") : toRaw;
               if (to && threadId) {


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw cron create` and `cron edit` have no way to specify a Telegram forum topic (thread id) for delivery. `message send` already supports `--thread-id`, but cron commands do not.
- **Why it matters:** Users with Telegram forum groups cannot target specific topics for cron job delivery. Messages either land in General or require manually encoding `:topic:` into the `--to` flag, which is undiscoverable.
- **What changed:** Added `--thread-id <id>` flag to both `cron create` and `cron edit`. The flag merges the thread id into the `--to` delivery target using the existing `:topic:` format that the delivery dispatch layer already supports.
- **What did NOT change:** No changes to the delivery dispatch layer, types, RPC schema, or agent tool path. This is a CLI-only change.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50982

## User-visible / Behavior Changes

- New `--thread-id <id>` flag on `openclaw cron create` and `openclaw cron edit`
- When provided with `--to`, the thread id is appended as `:topic:<id>` (e.g. `--to "-1001234567890" --thread-id 48` produces delivery target `-1001234567890:topic:48`)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.20.0
- Model/provider: openai-codex/gpt-5.1-codex-mini
- Integration/channel: Telegram (forum group with topics)

### Steps

1. `openclaw cron create --name "test" --at "+5m" --message "hello" --channel telegram --to "-100XXXXXXXXXX" --thread-id 48 --account research --agent research --announce`
2. Wait for cron job to fire
3. Check Telegram forum group

### Expected

- Message appears in topic 48

### Actual (before fix)

- No `--thread-id` flag available; users must manually encode `:topic:48` into `--to`

### Actual (after fix)

- `--thread-id 48` merges into `--to` as `:topic:48`, message delivered to correct topic

## Evidence

- [x] Tested locally: created cron job with `--thread-id 48`, message delivered to Telegram topic 48
- [x] Tested `cron edit --thread-id 48`: delivery target updated correctly to include `:topic:48`
- [x] Existing test suite: 7794 passed, 1 failed (pre-existing locale issue in `ui.presenter-next-run.test.ts`, unrelated)

## Human Verification (required)

- Verified scenarios: `cron create --thread-id`, `cron edit --thread-id`, delivery to Telegram forum topic
- Edge cases checked: `--thread-id` without `--to` (no-op), `--to` without `--thread-id` (unchanged behavior)
- What I did **not** verify: Discord threads, agent tool path (out of scope for this PR)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; `--thread-id` flag simply disappears
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: None

## Risks and Mitigations

- Risk: `--thread-id` without `--to` is silently ignored
  - Mitigation: Consistent with how `--account` behaves without `--channel`; could add validation in a follow-up

## AI Disclosure

- [x] AI-assisted (Kiro CLI)
- [x] Fully tested locally against live Telegram forum group
- [x] I understand what the code does

## Follow-up

@astroclaw's suggestion to show thread id in `cron list` output is a great idea. I kept this PR focused on the flag itself, but I'm happy to add that in a follow-up PR if it would be helpful.