### PR TITLE
fix(telegram): match grammY HttpError in retry regex

### DIFF
--- a/src/infra/retry-policy.test.ts
+++ b/src/infra/retry-policy.test.ts
@@ -66,6 +66,23 @@ describe("createTelegramRetryRunner", () => {
         expectedValue: "ok",
       },
       {
+        name: "retries grammY HttpError wrapping network failures via regex",
+        runnerOptions: {
+          retry: { ...ZERO_DELAY_RETRY, attempts: 2 },
+        },
+        fnSteps: [
+          {
+            type: "reject" as const,
+            value: Object.assign(new Error("Network request for 'sendMessage' failed!"), {
+              name: "HttpError",
+            }),
+          },
+          { type: "resolve" as const, value: "ok" },
+        ],
+        expectedCalls: 2,
+        expectedValue: "ok",
+      },
+      {
         name: "does not retry unrelated errors when neither predicate nor regex match",
         runnerOptions: {
           retry: { ...ZERO_DELAY_RETRY, attempts: 2 },

--- a/src/infra/retry-policy.ts
+++ b/src/infra/retry-policy.ts
@@ -11,7 +11,8 @@ export const TELEGRAM_RETRY_DEFAULTS = {
   jitter: 0.1,
 };
 
-const TELEGRAM_RETRY_RE = /429|timeout|connect|reset|closed|unavailable|temporarily/i;
+const TELEGRAM_RETRY_RE =
+  /429|timeout|connect|reset|closed|unavailable|temporarily|network request/i;
 const log = createSubsystemLogger("retry-policy");
 
 function resolveTelegramShouldRetry(params: {


### PR DESCRIPTION
## Summary

- Add `network request` to `TELEGRAM_RETRY_RE` so grammY `HttpError` messages trigger the retry path
- Add test case covering the grammY HttpError message format

## Root Cause

grammY wraps underlying network errors in `HttpError` with the message:

```
Network request for 'sendMessage' failed!
```

This string contains none of the existing `TELEGRAM_RETRY_RE` keywords (`429|timeout|connect|reset|closed|unavailable|temporarily`), so `shouldRetry` returns `false` and retries never fire — even though the underlying cause is a transient network failure (ECONNRESET, UND_ERR_CONNECT_TIMEOUT, etc.).

## Fix

Add `network request` to the regex. This matches grammY's `HttpError` message format at the top level without needing to traverse `.cause`, keeping the change minimal and backwards-compatible.

The `strictShouldRetry` guard for non-idempotent operations (e.g. `sendMessage`) is unaffected — the regex fallback is only OR'd in for idempotent paths like `sendChatAction`, `setReaction`, and `deleteMessage`.

## Test Plan

- [x] Added test: `retries grammY HttpError wrapping network failures via regex`
- [x] All 7 existing + new tests pass
- [x] Verified `strictShouldRetry: true` still suppresses the regex fallback

Closes #51525