### PR TITLE
fix(gateway): initialize nested command lane concurrency

### DIFF
--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -7,4 +7,5 @@ export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) 
   setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
+  setCommandLaneConcurrency(CommandLane.Nested, resolveAgentMaxConcurrent(cfg));
 }

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -151,6 +151,7 @@ export function createGatewayReloadHandlers(params: {
     setCommandLaneConcurrency(CommandLane.Cron, nextConfig.cron?.maxConcurrentRuns ?? 1);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
+    setCommandLaneConcurrency(CommandLane.Nested, resolveAgentMaxConcurrent(nextConfig));
 
     if (plan.hotReasons.length > 0) {
       params.logReload.info(`config hot reload applied (${plan.hotReasons.join(", ")})`);


### PR DESCRIPTION
## Summary

Initialize the nested command lane (`CommandLane.Nested`) with `resolveAgentMaxConcurrent(cfg)` in both gateway startup and config hot-reload paths.

## Problem

The nested command lane used by `sessions_send` (agent-to-agent messaging) was never initialized with `setCommandLaneConcurrency`, causing it to default to `maxConcurrent: 1`. This serialized all inter-agent communication — even when sending messages to multiple agents simultaneously with `timeoutSeconds: 0`, agent runs would execute sequentially with ~30 second gaps between them.

## Fix

Add one line in each of two locations:
- `src/gateway/server-lanes.ts` — gateway startup initialization
- `src/gateway/server-reload-handlers.ts` — config hot-reload handler

Both use `resolveAgentMaxConcurrent(cfg)` to match the main lane's concurrency.

## Tests

Command-queue tests pass (17/17). No dedicated test files exist for server-lanes or server-reload-handlers.

Fixes #45165