### PR TITLE
fix(errors): detect OpenRouter JSON 404 payloads as model-not-found

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -771,6 +771,13 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
     return true;
   }
 
+  // OpenRouter (and similar) returns {"error":{"code":404,"message":"..."}} where the message
+  // may not contain "not found" text (e.g., model redirect notices). Treat a JSON-style
+  // "code": 404 as model-not-found when paired with an error envelope.
+  if (/"code"\s*:\s*404\b/.test(raw) && /"error"/.test(raw)) {
+    return true;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
## Summary

Add detection for JSON-wrapped 404 error payloads in `isModelNotFoundErrorMessage` so that model fallback continues to the next candidate.

## Problem

OpenRouter returns HTTP 404 with a JSON body like:
```json
{"error":{"message":"Healer Alpha was a stealth model...","code":404}}
```

The existing check required both `404` AND `not found` text in the error message. OpenRouter's payload uses a descriptive message (e.g., model redirect notice) instead of "not found", so the fallback classifier missed it.

## Fix

Add a check for `"code": 404` paired with `"error"` envelope in `isModelNotFoundErrorMessage`. This catches JSON-formatted 404 responses from OpenRouter and similar providers where the message body doesn't contain explicit "not found" text.

Fixes #51571