### PR TITLE
fix(errors): exclude Jinja template errors from context overflow detection

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -83,6 +83,11 @@ function hasRateLimitTpmHint(raw: string): boolean {
   return /\btpm\b/i.test(lower) || lower.includes("tokens per minute");
 }
 
+/** Jinja template rendering errors are provider-side prompt formatting failures, not context overflow. */
+function isJinjaTemplateError(errorMessage: string): boolean {
+  return /jinja.?template/i.test(errorMessage) && /render|error/i.test(errorMessage);
+}
+
 export function isContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {
     return false;
@@ -95,6 +100,11 @@ export function isContextOverflowError(errorMessage?: string): boolean {
   }
 
   if (isReasoningConstraintErrorMessage(errorMessage)) {
+    return false;
+  }
+
+  // Jinja template errors from LM Studio / Qwen are prompt formatting failures, not overflow.
+  if (isJinjaTemplateError(errorMessage)) {
     return false;
   }
 
@@ -148,6 +158,11 @@ export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   }
 
   if (isReasoningConstraintErrorMessage(errorMessage)) {
+    return false;
+  }
+
+  // Jinja template errors from LM Studio / Qwen are prompt formatting failures, not overflow.
+  if (isJinjaTemplateError(errorMessage)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary

Add `isJinjaTemplateError` guard in both `isContextOverflowError` and `isLikelyContextOverflowError` to prevent Jinja template errors from being misclassified as context window overflow.

## Problem

LM Studio with Qwen models returns errors like:
```
Error rendering prompt with jinja template: "No user query found in messages."
```

This is a prompt **formatting** failure (the model's Jinja template expects a specific message structure), not a context window overflow. When misclassified, OpenClaw enters the auto-compaction loop that immediately fails (no messages to compact), giving users a misleading "Context overflow" error and blocking all responses.

## Fix

Add `isJinjaTemplateError` helper that matches `jinja template` + `render|error` patterns, and call it early in both overflow detection functions. This follows the existing pattern of excluding rate limit, billing, and reasoning errors from overflow detection.

Fixes #32936