### PR TITLE
feat: expose nested lane maxConcurrent as config option

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -2906,6 +2906,26 @@
       "hasChildren": false
     },
     {
+      "path": "agents.defaults.nested",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "agents.defaults.nested.maxConcurrent",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "agents.defaults.pdfMaxBytesMb",
       "kind": "core",
       "type": "number",

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5563}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5565}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -241,6 +241,8 @@
 {"recordType":"path","path":"agents.defaults.models.*.params","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"agents.defaults.models.*.params.*","kind":"core","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"agents.defaults.models.*.streaming","kind":"core","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"agents.defaults.nested","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"agents.defaults.nested.maxConcurrent","kind":"core","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"agents.defaults.pdfMaxBytesMb","kind":"core","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":["performance"],"label":"PDF Max Size (MB)","help":"Maximum PDF file size in megabytes for the PDF tool (default: 10).","hasChildren":false}
 {"recordType":"path","path":"agents.defaults.pdfMaxPages","kind":"core","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":["performance"],"label":"PDF Max Pages","help":"Maximum number of PDF pages to process for the PDF tool (default: 20).","hasChildren":false}
 {"recordType":"path","path":"agents.defaults.pdfModel","kind":"core","type":["object","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}

--- a/src/config/agent-limits.ts
+++ b/src/config/agent-limits.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "./types.js";
 
 export const DEFAULT_AGENT_MAX_CONCURRENT = 4;
 export const DEFAULT_SUBAGENT_MAX_CONCURRENT = 8;
+export const DEFAULT_NESTED_MAX_CONCURRENT = 4;
 // Keep depth-1 subagents as leaves unless config explicitly opts into nesting.
 export const DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH = 1;
 
@@ -19,4 +20,12 @@ export function resolveSubagentMaxConcurrent(cfg?: OpenClawConfig): number {
     return Math.max(1, Math.floor(raw));
   }
   return DEFAULT_SUBAGENT_MAX_CONCURRENT;
+}
+
+export function resolveNestedMaxConcurrent(cfg?: OpenClawConfig): number {
+  const raw = cfg?.agents?.defaults?.nested?.maxConcurrent;
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return Math.max(1, Math.floor(raw));
+  }
+  return DEFAULT_NESTED_MAX_CONCURRENT;
 }

--- a/src/config/config.agent-concurrency-defaults.test.ts
+++ b/src/config/config.agent-concurrency-defaults.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_AGENT_MAX_CONCURRENT,
+  DEFAULT_NESTED_MAX_CONCURRENT,
   DEFAULT_SUBAGENT_MAX_CONCURRENT,
   resolveAgentMaxConcurrent,
+  resolveNestedMaxConcurrent,
   resolveSubagentMaxConcurrent,
 } from "./agent-limits.js";
 import { loadConfig } from "./config.js";
@@ -13,6 +15,7 @@ describe("agent concurrency defaults", () => {
   it("resolves defaults when unset", () => {
     expect(resolveAgentMaxConcurrent({})).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
     expect(resolveSubagentMaxConcurrent({})).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
+    expect(resolveNestedMaxConcurrent({})).toBe(DEFAULT_NESTED_MAX_CONCURRENT);
   });
 
   it("clamps invalid values to at least 1", () => {
@@ -21,11 +24,24 @@ describe("agent concurrency defaults", () => {
         defaults: {
           maxConcurrent: 0,
           subagents: { maxConcurrent: -3 },
+          nested: { maxConcurrent: -1 },
         },
       },
     };
     expect(resolveAgentMaxConcurrent(cfg)).toBe(1);
     expect(resolveSubagentMaxConcurrent(cfg)).toBe(1);
+    expect(resolveNestedMaxConcurrent(cfg)).toBe(1);
+  });
+
+  it("reads nested maxConcurrent from config", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          nested: { maxConcurrent: 8 },
+        },
+      },
+    };
+    expect(resolveNestedMaxConcurrent(cfg)).toBe(8);
   });
 
   it("accepts subagent spawn depth and per-agent child limits", () => {
@@ -52,6 +68,7 @@ describe("agent concurrency defaults", () => {
 
       expect(cfg.agents?.defaults?.maxConcurrent).toBe(DEFAULT_AGENT_MAX_CONCURRENT);
       expect(cfg.agents?.defaults?.subagents?.maxConcurrent).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
+      expect(cfg.agents?.defaults?.nested?.maxConcurrent).toBe(DEFAULT_NESTED_MAX_CONCURRENT);
     });
   });
 });

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,6 +1,10 @@
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import { normalizeProviderId, parseModelRef } from "../agents/model-selection.js";
-import { DEFAULT_AGENT_MAX_CONCURRENT, DEFAULT_SUBAGENT_MAX_CONCURRENT } from "./agent-limits.js";
+import {
+  DEFAULT_AGENT_MAX_CONCURRENT,
+  DEFAULT_NESTED_MAX_CONCURRENT,
+  DEFAULT_SUBAGENT_MAX_CONCURRENT,
+} from "./agent-limits.js";
 import { resolveAgentModelPrimaryValue } from "./model-input.js";
 import {
   DEFAULT_TALK_PROVIDER,
@@ -354,7 +358,10 @@ export function applyAgentDefaults(cfg: OpenClawConfig): OpenClawConfig {
   const hasSubMax =
     typeof defaults?.subagents?.maxConcurrent === "number" &&
     Number.isFinite(defaults.subagents.maxConcurrent);
-  if (hasMax && hasSubMax) {
+  const hasNestedMax =
+    typeof defaults?.nested?.maxConcurrent === "number" &&
+    Number.isFinite(defaults.nested.maxConcurrent);
+  if (hasMax && hasSubMax && hasNestedMax) {
     return cfg;
   }
 
@@ -371,6 +378,12 @@ export function applyAgentDefaults(cfg: OpenClawConfig): OpenClawConfig {
     mutated = true;
   }
 
+  const nextNested = defaults?.nested ? { ...defaults.nested } : {};
+  if (!hasNestedMax) {
+    nextNested.maxConcurrent = DEFAULT_NESTED_MAX_CONCURRENT;
+    mutated = true;
+  }
+
   if (!mutated) {
     return cfg;
   }
@@ -382,6 +395,7 @@ export function applyAgentDefaults(cfg: OpenClawConfig): OpenClawConfig {
       defaults: {
         ...nextDefaults,
         subagents: nextSubagents,
+        nested: nextNested,
       },
     },
   };

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -272,6 +272,11 @@ export type AgentDefaultsConfig = {
   };
   /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
   maxConcurrent?: number;
+  /** Nested session defaults (sessions_send and similar nested invocations). */
+  nested?: {
+    /** Max concurrent nested runs (global lane: "nested"). Default: 4. */
+    maxConcurrent?: number;
+  };
   /** Sub-agent defaults (spawned via sessions_spawn). */
   subagents?: {
     /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 1. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -168,6 +168,7 @@ export const AgentDefaultsSchema = z
       .object({
         maxConcurrent: z.number().int().positive().optional(),
       })
+      .strict()
       .optional(),
     subagents: z
       .object({

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -164,6 +164,11 @@ export const AgentDefaultsSchema = z
     typingMode: TypingModeSchema.optional(),
     heartbeat: HeartbeatSchema,
     maxConcurrent: z.number().int().positive().optional(),
+    nested: z
+      .object({
+        maxConcurrent: z.number().int().positive().optional(),
+      })
+      .optional(),
     subagents: z
       .object({
         maxConcurrent: z.number().int().positive().optional(),

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -1,4 +1,8 @@
-import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
+import {
+  resolveAgentMaxConcurrent,
+  resolveNestedMaxConcurrent,
+  resolveSubagentMaxConcurrent,
+} from "../config/agent-limits.js";
 import type { loadConfig } from "../config/config.js";
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
@@ -7,4 +11,5 @@ export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) 
   setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
+  setCommandLaneConcurrency(CommandLane.Nested, resolveNestedMaxConcurrent(cfg));
 }

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,7 +1,11 @@
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CliDeps } from "../cli/deps.js";
-import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
+import {
+  resolveAgentMaxConcurrent,
+  resolveNestedMaxConcurrent,
+  resolveSubagentMaxConcurrent,
+} from "../config/agent-limits.js";
 import { isRestartEnabled } from "../config/commands.js";
 import type { loadConfig } from "../config/config.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
@@ -151,6 +155,7 @@ export function createGatewayReloadHandlers(params: {
     setCommandLaneConcurrency(CommandLane.Cron, nextConfig.cron?.maxConcurrentRuns ?? 1);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
+    setCommandLaneConcurrency(CommandLane.Nested, resolveNestedMaxConcurrent(nextConfig));
 
     if (plan.hotReasons.length > 0) {
       params.logReload.info(`config hot reload applied (${plan.hotReasons.join(", ")})`);


### PR DESCRIPTION
## Summary

The `CommandLane.Nested` lane (used by `sessions_send` and similar nested invocations) was **hardcoded to `maxConcurrent: 1`** at gateway startup. This forced all nested session calls to run serially, causing severe bottlenecks in multi-agent architectures.

### The Problem

When an orchestrator agent broadcasts to multiple sub-agents via `sessions_send`, each call queues behind the previous one. With `maxConcurrent: 1`:

- Sending to 3 agents takes **3× the time** (serial queue)
- `sessions_send` timeout starts from **call time**, not **delivery time** — so queue wait eats into the timeout budget
- Agents later in the queue reliably hit timeout even when they respond quickly

**Real-world impact**: A cron job sending `sessions_send` to 2 agents with 60s timeout would fail because:
1. Agent A queues, waits ~30s, executes
2. Agent B queues behind A, starts at T+30s, only has 30s left of the original 60s timeout
3. Agent B times out even though it responds in 5 seconds

This issue was reported in #14214 but marked stale without resolution.

### The Fix

Adds a new config key `agents.defaults.nested.maxConcurrent` (default: **4**) so users can tune nested lane parallelism, consistent with how `agents.defaults.maxConcurrent` and `agents.defaults.subagents.maxConcurrent` already work.

The new setting is applied both at gateway startup and on hot-reload.

### Config example

```yaml
agents:
  defaults:
    nested:
      maxConcurrent: 8   # default 4
```

## Files changed

| File | What |
|------|------|
| `src/config/agent-limits.ts` | `DEFAULT_NESTED_MAX_CONCURRENT`, `resolveNestedMaxConcurrent()` |
| `src/config/types.agent-defaults.ts` | `nested?: { maxConcurrent?: number }` on `AgentDefaultsConfig` |
| `src/config/zod-schema.agent-defaults.ts` | Zod schema for the new key |
| `src/config/defaults.ts` | Inject default in `applyAgentDefaults()` |
| `src/gateway/server-lanes.ts` | Set nested lane at startup |
| `src/gateway/server-reload-handlers.ts` | Set nested lane on hot-reload |
| `src/config/config.agent-concurrency-defaults.test.ts` | Tests for defaults, clamping, config read |

## Test plan

- ✅ All pre-commit checks pass (tsgo, oxlint, oxfmt, boundary lints)
- ✅ `pnpm test` passes (unit tests for `resolveNestedMaxConcurrent`)
- ✅ Gateway starts with default nested concurrency = 4
- ✅ Setting `agents.defaults.nested.maxConcurrent: 8` in config is respected
- ✅ Hot-reload picks up nested concurrency changes without restart

## Related

- Fixes #14214

---

🤖 Generated with Claude Code
