### PR TITLE
fix(outbound): strip inbound metadata in normalizeReplyPayloadsForDelivery

### DIFF
--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -72,6 +72,36 @@ describe("normalizeReplyPayloadsForDelivery", () => {
       },
     ]);
   });
+
+  it("strips inbound metadata from payload text", () => {
+    expect(
+      normalizeReplyPayloadsForDelivery([
+        {
+          text: `Conversation info (untrusted metadata):
+\`\`\`json
+{"channel":"discord"}
+\`\`\`
+
+Sender (untrusted metadata):
+\`\`\`json
+{"displayName":"Alice"}
+\`\`\`
+
+Hello there`,
+        },
+      ]),
+    ).toEqual([
+      {
+        text: "Hello there",
+        mediaUrls: undefined,
+        mediaUrl: undefined,
+        replyToId: undefined,
+        replyToCurrent: false,
+        replyToTag: false,
+        audioAsVoice: false,
+      },
+    ]);
+  });
 });
 
 describe("normalizeOutboundPayloadsForJson", () => {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -1,5 +1,6 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
+import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 import {
   formatBtwTextForExternalDelivery,
   isRenderablePayload,
@@ -70,10 +71,12 @@ export function normalizeReplyPayloadsForDelivery(
     const next: ReplyPayload = {
       ...payload,
       text:
-        formatBtwTextForExternalDelivery({
-          ...payload,
-          text: parsed.text ?? "",
-        }) ?? "",
+        stripInboundMetadata(
+          formatBtwTextForExternalDelivery({
+            ...payload,
+            text: parsed.text ?? "",
+          }) ?? "",
+        ),
       mediaUrls: mergedMedia.length ? mergedMedia : undefined,
       mediaUrl: resolvedMediaUrl,
       replyToId: payload.replyToId ?? parsed.replyToId,


### PR DESCRIPTION
## Summary

- Apply `stripInboundMetadata()` to outbound payload text in `normalizeReplyPayloadsForDelivery()`, preventing AI-facing metadata blocks from leaking into user-visible messages
- The inbound metadata (Conversation info, Sender info, reply context, etc.) injected by `buildInboundUserContextPrefix` was not being stripped in the outbound delivery pipeline
- Add regression test verifying metadata-prefixed payload text is normalized to user-visible content only

Fixes #39847
Related: #41355

## Details

`normalizeReplyPayloadsForDelivery()` processes reply payloads through `formatBtwTextForExternalDelivery` but did not call `stripInboundMetadata()`. This meant that on delivery paths where the text still contained raw inbound metadata blocks, those blocks would appear in the user-facing message.

The fix wraps the existing `formatBtwTextForExternalDelivery(...)` result with `stripInboundMetadata(...)` — a single-line change at the source level that covers all delivery paths (Discord, compact mode, Pi-embedded, etc.) without needing per-adapter patches.

## Test plan

- [ ] `pnpm test -- src/infra/outbound/payloads.test.ts` — new test verifies metadata stripping
- [ ] Existing payload normalization tests still pass
- [ ] Manual: send a message via Discord thread and confirm no metadata prefix in delivered reply

🤖 Generated with [Claude Code](https://claude.com/claude-code) + [Codex](https://openai.com/codex)