### PR TITLE
docs: add missing README for synology-chat extension

### DIFF
--- a/extensions/synology-chat/README.md
+++ b/extensions/synology-chat/README.md
@@ -1,0 +1,21 @@
+# Synology Chat (OpenClaw plugin)
+
+Synology Chat channel plugin for OpenClaw. Connect your Synology NAS Chat to OpenClaw with full agent capabilities via webhooks.
+
+## Setup
+
+```bash
+openclaw channel add synology-chat
+```
+
+Full setup instructions: https://docs.openclaw.ai/channels/synology-chat
+
+## Features
+
+- Incoming and outgoing webhook integration
+- Full agent capabilities through Synology Chat
+- Works with any Synology NAS running Chat
+
+## Dependencies
+
+- `zod` - Runtime schema validation


### PR DESCRIPTION
Add README.md for the synology-chat extension which was the only channel extension without one. Includes setup, features, and dependencies.