### PR TITLE
fix(agents): avoid stale CLI session resume after /new

### DIFF
--- a/src/agents/agent-command.new-session-cli.test.ts
+++ b/src/agents/agent-command.new-session-cli.test.ts
@@ -340,6 +340,7 @@ function createSessionResolution(params?: {
   cliSessionIds?: Record<string, string>;
   claudeCliSessionId?: string;
   systemPromptReport?: TestSessionEntry["systemPromptReport"];
+  skillsSnapshot?: TestSessionEntry["skillsSnapshot"];
 }): {
   sessionId: string;
   sessionKey: string;
@@ -361,6 +362,7 @@ function createSessionResolution(params?: {
     cliSessionIds,
     claudeCliSessionId: params?.claudeCliSessionId,
     systemPromptReport: params?.systemPromptReport,
+    skillsSnapshot: params?.skillsSnapshot,
   };
   hoisted.sessionStore[sessionKey] = sessionEntry;
   return {
@@ -477,6 +479,31 @@ describe("agentCommand CLI session rollover", () => {
       sessionId: "session-new",
     });
     expect(hoisted.sessionStore[sessionResolution.sessionKey]?.cliSessionIds).toBeUndefined();
+  });
+
+  it("drops stale skills snapshots when the first post-reset turn fails before startup", async () => {
+    const sessionResolution = createSessionResolution({
+      isNewSession: true,
+      skillsSnapshot: {
+        prompt: "stale snapshot",
+        skills: [{ id: "old-skill" }],
+      },
+    });
+    hoisted.resolveSessionMock.mockReturnValue(sessionResolution);
+    hoisted.sendPolicy = "deny";
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        agentId: "main",
+        deliver: true,
+      }),
+    ).rejects.toThrow("send blocked by session policy");
+
+    expect(hoisted.sessionStore[sessionResolution.sessionKey]).toMatchObject({
+      sessionId: "session-new",
+    });
+    expect(hoisted.sessionStore[sessionResolution.sessionKey]?.skillsSnapshot).toBeUndefined();
   });
 
   it("resets stale bootstrap warning state for the first turn in a new CLI session", async () => {

--- a/src/agents/agent-command.new-session-cli.test.ts
+++ b/src/agents/agent-command.new-session-cli.test.ts
@@ -1,0 +1,524 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type TestSessionEntry = {
+  sessionId: string;
+  updatedAt: number;
+  cliSessionIds?: Record<string, string>;
+  claudeCliSessionId?: string;
+  systemPromptReport?: {
+    bootstrapTruncation?: {
+      warningMode?: "off" | "once" | "always";
+      warningSignaturesSeen?: string[];
+      promptWarningSignature?: string;
+    };
+  };
+  skillsSnapshot?: { prompt: string; skills: unknown[] };
+};
+
+const hoisted = vi.hoisted(() => ({
+  config: {
+    session: {
+      mainKey: "main",
+      scope: "per-sender",
+    },
+    agents: {
+      defaults: {},
+      list: [{ id: "main" }],
+    },
+  } as Record<string, unknown>,
+  sessionStore: {} as Record<string, TestSessionEntry>,
+  resolveSessionMock: vi.fn(),
+  runCliAgentMock: vi.fn(),
+  updateSessionStoreMock: vi.fn(),
+  updateSessionStoreAfterAgentRunMock: vi.fn(),
+  deliverAgentCommandResultMock: vi.fn(),
+  resolveBootstrapWarningSignaturesSeenMock: vi.fn(),
+  sendPolicy: "allow" as "allow" | "deny",
+}));
+
+vi.mock("../acp/control-plane/manager.js", () => ({
+  getAcpSessionManager: () => ({
+    resolveSession: () => null,
+  }),
+}));
+
+vi.mock("../acp/policy.js", () => ({
+  resolveAcpAgentPolicyError: () => null,
+  resolveAcpDispatchPolicyError: () => null,
+}));
+
+vi.mock("../acp/runtime/errors.js", () => ({
+  toAcpRuntimeError: ({ error }: { error: unknown }) => error,
+}));
+
+vi.mock("../acp/runtime/session-identifiers.js", () => ({
+  resolveAcpSessionCwd: () => undefined,
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    warn: vi.fn(),
+  }),
+}));
+
+vi.mock("../auto-reply/reply/normalize-reply.js", () => ({
+  normalizeReplyPayload: ({ text }: { text?: string }) => (text ? { type: "text", text } : null),
+}));
+
+vi.mock("../auto-reply/thinking.js", () => ({
+  formatThinkingLevels: () => "low, medium, high",
+  formatXHighModelHint: () => "supported models",
+  normalizeThinkLevel: (value: string | undefined) => value,
+  normalizeVerboseLevel: (value: string | undefined) => value,
+  supportsXHighThinking: () => true,
+}));
+
+vi.mock("../auto-reply/tokens.js", () => ({
+  isSilentReplyPrefixText: () => false,
+  isSilentReplyText: () => false,
+  SILENT_REPLY_TOKEN: "<silent>",
+}));
+
+vi.mock("../cli/command-format.js", () => ({
+  formatCliCommand: (value: string) => value,
+}));
+
+vi.mock("../cli/command-secret-gateway.js", () => ({
+  resolveCommandSecretRefsViaGateway: async ({ config }: { config: Record<string, unknown> }) => ({
+    resolvedConfig: config,
+    diagnostics: [] as string[],
+  }),
+}));
+
+vi.mock("../cli/command-secret-targets.js", () => ({
+  getAgentRuntimeCommandSecretTargetIds: () => [],
+}));
+
+vi.mock("../cli/deps.js", () => ({
+  createDefaultDeps: () => ({}),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => hoisted.config,
+  readConfigFileSnapshotForWrite: async () => ({
+    snapshot: {
+      valid: false,
+      resolved: hoisted.config,
+    },
+  }),
+  setRuntimeConfigSnapshot: () => {},
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  mergeSessionEntry: (
+    existing: TestSessionEntry | undefined,
+    patch: Partial<TestSessionEntry>,
+  ): TestSessionEntry =>
+    ({
+      ...existing,
+      ...patch,
+    }) as TestSessionEntry,
+  resolveAgentIdFromSessionKey: () => "main",
+  updateSessionStore: async (
+    storePath: string,
+    updater: (store: Record<string, TestSessionEntry>) => TestSessionEntry,
+  ) => await hoisted.updateSessionStoreMock(storePath, updater),
+}));
+
+vi.mock("../config/sessions/transcript.js", () => ({
+  resolveSessionTranscriptFile: async ({ sessionEntry }: { sessionEntry?: TestSessionEntry }) => ({
+    sessionFile: "/tmp/session.jsonl",
+    sessionEntry,
+  }),
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  clearAgentRunContext: () => {},
+  emitAgentEvent: () => {},
+  registerAgentRunContext: () => {},
+}));
+
+vi.mock("../infra/outbound/session-context.js", () => ({
+  buildOutboundSessionContext: () => ({}),
+}));
+
+vi.mock("../infra/skills-remote.js", () => ({
+  getRemoteSkillEligibility: () => ({}),
+}));
+
+vi.mock("../routing/session-key.js", () => ({
+  normalizeAgentId: (value: string) => value.trim().toLowerCase(),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {
+    log: () => {},
+  },
+}));
+
+vi.mock("../sessions/level-overrides.js", () => ({
+  applyVerboseOverride: () => {},
+}));
+
+vi.mock("../sessions/model-overrides.js", () => ({
+  applyModelOverrideToSessionEntry: () => ({ updated: false }),
+}));
+
+vi.mock("../sessions/send-policy.js", () => ({
+  resolveSendPolicy: () => hoisted.sendPolicy,
+}));
+
+vi.mock("../sessions/transcript-events.js", () => ({
+  emitSessionTranscriptUpdate: () => {},
+}));
+
+vi.mock("../terminal/ansi.js", () => ({
+  sanitizeForLog: (value: unknown) => String(value),
+}));
+
+vi.mock("../utils/message-channel.js", () => ({
+  resolveMessageChannel: () => "cli",
+}));
+
+vi.mock("./agent-scope.js", () => ({
+  listAgentIds: () => ["main"],
+  resolveAgentDir: () => "/tmp/agent",
+  resolveEffectiveModelFallbacks: () => undefined,
+  resolveSessionAgentId: () => "main",
+  resolveAgentSkillsFilter: () => undefined,
+  resolveAgentWorkspaceDir: () => "/tmp/workspace",
+}));
+
+vi.mock("./auth-profiles.js", () => ({
+  ensureAuthProfileStore: () => ({ profiles: {} }),
+}));
+
+vi.mock("./auth-profiles/session-override.js", () => ({
+  clearSessionAuthProfileOverride: async () => {},
+}));
+
+vi.mock("./bootstrap-budget.js", () => ({
+  resolveBootstrapWarningSignaturesSeen: (report?: TestSessionEntry["systemPromptReport"]) =>
+    hoisted.resolveBootstrapWarningSignaturesSeenMock(report),
+}));
+
+vi.mock("./cli-runner.js", () => ({
+  runCliAgent: (params: Record<string, unknown>) => hoisted.runCliAgentMock(params),
+}));
+
+vi.mock("./command/delivery.js", () => ({
+  deliverAgentCommandResult: (params: Record<string, unknown>) =>
+    hoisted.deliverAgentCommandResultMock(params),
+}));
+
+vi.mock("./command/run-context.js", () => ({
+  resolveAgentRunContext: () => ({
+    messageChannel: "cli",
+  }),
+}));
+
+vi.mock("./command/session-store.js", () => ({
+  updateSessionStoreAfterAgentRun: (params: Record<string, unknown>) =>
+    hoisted.updateSessionStoreAfterAgentRunMock(params),
+}));
+
+vi.mock("./command/session.js", () => ({
+  resolveSession: (params: Record<string, unknown>) => hoisted.resolveSessionMock(params),
+}));
+
+vi.mock("./defaults.js", () => ({
+  DEFAULT_MODEL: "gpt-5.2-codex",
+  DEFAULT_PROVIDER: "codex-cli",
+}));
+
+vi.mock("./failover-error.js", () => ({
+  FailoverError: class FailoverError extends Error {
+    reason?: string;
+  },
+}));
+
+vi.mock("./internal-events.js", () => ({
+  formatAgentInternalEventsForPrompt: () => "",
+}));
+
+vi.mock("./lanes.js", () => ({
+  AGENT_LANE_SUBAGENT: "subagent",
+}));
+
+vi.mock("./model-catalog.js", () => ({
+  loadModelCatalog: async () => [],
+}));
+
+vi.mock("./model-fallback.js", () => ({
+  runWithModelFallback: async ({
+    provider,
+    model,
+    run,
+  }: {
+    provider: string;
+    model: string;
+    run: (
+      providerOverride: string,
+      modelOverride: string,
+      runOptions?: Record<string, unknown>,
+    ) => Promise<unknown>;
+  }) => ({
+    provider,
+    model,
+    result: await run(provider, model, {}),
+  }),
+}));
+
+vi.mock("./model-selection.js", () => ({
+  buildAllowedModelSet: () => ({
+    allowedKeys: new Set<string>(),
+    allowedCatalog: [],
+    allowAny: false,
+  }),
+  isCliProvider: (provider: string) => provider.trim().toLowerCase().endsWith("-cli"),
+  modelKey: (provider: string, model: string) => `${provider}/${model}`,
+  normalizeModelRef: (provider: string, model: string) => ({ provider, model }),
+  normalizeProviderId: (provider: string) => provider.trim().toLowerCase(),
+  parseModelRef: (raw: string, defaultProvider: string) => {
+    const trimmed = raw.trim();
+    const slash = trimmed.indexOf("/");
+    if (slash === -1) {
+      return { provider: defaultProvider, model: trimmed };
+    }
+    return {
+      provider: trimmed.slice(0, slash),
+      model: trimmed.slice(slash + 1),
+    };
+  },
+  resolveConfiguredModelRef: () => ({
+    provider: "codex-cli",
+    model: "gpt-5.2-codex",
+  }),
+  resolveDefaultModelForAgent: () => ({
+    provider: "codex-cli",
+    model: "gpt-5.2-codex",
+  }),
+  resolveThinkingDefault: () => "low",
+}));
+
+vi.mock("./pi-embedded-runner/session-manager-init.js", () => ({
+  prepareSessionManagerForRun: async () => {},
+}));
+
+vi.mock("./pi-embedded.js", () => ({
+  runEmbeddedPiAgent: vi.fn(),
+}));
+
+vi.mock("./skills.js", () => ({
+  buildWorkspaceSkillSnapshot: () => ({
+    prompt: "",
+    skills: [],
+  }),
+}));
+
+vi.mock("./skills/refresh.js", () => ({
+  getSkillsSnapshotVersion: () => 1,
+}));
+
+vi.mock("./spawned-context.js", () => ({
+  normalizeSpawnedRunMetadata: (value: Record<string, unknown>) => value,
+}));
+
+vi.mock("./timeout.js", () => ({
+  resolveAgentTimeoutMs: () => 1_000,
+}));
+
+vi.mock("./workspace.js", () => ({
+  ensureAgentWorkspace: async ({ dir }: { dir: string }) => ({ dir }),
+}));
+
+import { agentCommand } from "./agent-command.js";
+
+function createSessionResolution(params?: {
+  isNewSession?: boolean;
+  cliSessionId?: string;
+  cliSessionIds?: Record<string, string>;
+  claudeCliSessionId?: string;
+  systemPromptReport?: TestSessionEntry["systemPromptReport"];
+}): {
+  sessionId: string;
+  sessionKey: string;
+  sessionEntry: TestSessionEntry;
+  sessionStore: Record<string, TestSessionEntry>;
+  storePath: string;
+  isNewSession: boolean;
+  persistedThinking: undefined;
+  persistedVerbose: undefined;
+} {
+  const sessionKey = "agent:main:main";
+  const cliSessionId = params?.cliSessionId ?? "thread-stale";
+  const cliSessionIds = params?.cliSessionIds ?? {
+    "codex-cli": cliSessionId,
+  };
+  const sessionEntry: TestSessionEntry = {
+    sessionId: "session-old",
+    updatedAt: 1,
+    cliSessionIds,
+    claudeCliSessionId: params?.claudeCliSessionId,
+    systemPromptReport: params?.systemPromptReport,
+  };
+  hoisted.sessionStore[sessionKey] = sessionEntry;
+  return {
+    sessionId: "session-new",
+    sessionKey,
+    sessionEntry,
+    sessionStore: hoisted.sessionStore,
+    storePath: "/tmp/sessions.json",
+    isNewSession: params?.isNewSession ?? true,
+    persistedThinking: undefined,
+    persistedVerbose: undefined,
+  };
+}
+
+describe("agentCommand CLI session rollover", () => {
+  beforeEach(() => {
+    hoisted.sessionStore = {};
+    hoisted.resolveSessionMock.mockReset();
+    hoisted.runCliAgentMock.mockReset().mockResolvedValue({
+      payloads: [{ type: "text", text: "ok" }],
+      meta: {
+        agentMeta: {
+          sessionId: "thread-fresh",
+          provider: "codex-cli",
+          model: "gpt-5.2-codex",
+        },
+      },
+    });
+    hoisted.updateSessionStoreMock
+      .mockReset()
+      .mockImplementation(
+        async (
+          _storePath: string,
+          updater: (store: Record<string, TestSessionEntry>) => TestSessionEntry,
+        ) => updater(hoisted.sessionStore),
+      );
+    hoisted.updateSessionStoreAfterAgentRunMock.mockReset().mockResolvedValue(undefined);
+    hoisted.deliverAgentCommandResultMock
+      .mockReset()
+      .mockImplementation(async ({ result }: { result: unknown }) => result);
+    hoisted.resolveBootstrapWarningSignaturesSeenMock.mockReset().mockImplementation((report) => {
+      const seen = report?.bootstrapTruncation?.warningSignaturesSeen;
+      return Array.isArray(seen) ? seen : [];
+    });
+    hoisted.sendPolicy = "allow";
+  });
+
+  it("does not resume stale CLI backend sessions after a new session rollover", async () => {
+    hoisted.resolveSessionMock.mockReturnValue(createSessionResolution({ isNewSession: true }));
+
+    await agentCommand({
+      message: "hello",
+      agentId: "main",
+    });
+
+    expect(hoisted.runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.runCliAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      sessionId: "session-new",
+      cliSessionId: undefined,
+      provider: "codex-cli",
+      model: "gpt-5.2-codex",
+    });
+  });
+
+  it("clears stale CLI backend ids when a new session starts on a different CLI provider", async () => {
+    const sessionResolution = createSessionResolution({
+      isNewSession: true,
+      cliSessionIds: {
+        "claude-cli": "thread-stale-claude",
+        "codex-cli": "thread-stale-codex",
+      },
+      claudeCliSessionId: "thread-stale-claude",
+    });
+    hoisted.resolveSessionMock.mockReturnValue(sessionResolution);
+
+    await agentCommand({
+      message: "hello",
+      agentId: "main",
+      provider: "claude-cli",
+    });
+
+    expect(hoisted.runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.runCliAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      sessionId: "session-new",
+      cliSessionId: undefined,
+      provider: "claude-cli",
+    });
+    expect(hoisted.sessionStore[sessionResolution.sessionKey]).toMatchObject({
+      sessionId: "session-new",
+    });
+    expect(hoisted.sessionStore[sessionResolution.sessionKey]?.cliSessionIds).toBeUndefined();
+    expect(hoisted.sessionStore[sessionResolution.sessionKey]?.claudeCliSessionId).toBeUndefined();
+  });
+
+  it("keeps the new outer session id when the first post-reset turn fails early", async () => {
+    const sessionResolution = createSessionResolution({
+      isNewSession: true,
+      cliSessionIds: {
+        "codex-cli": "thread-stale-codex",
+      },
+    });
+    hoisted.resolveSessionMock.mockReturnValue(sessionResolution);
+    hoisted.sendPolicy = "deny";
+
+    await expect(
+      agentCommand({
+        message: "hello",
+        agentId: "main",
+        deliver: true,
+      }),
+    ).rejects.toThrow("send blocked by session policy");
+
+    expect(hoisted.sessionStore[sessionResolution.sessionKey]).toMatchObject({
+      sessionId: "session-new",
+    });
+    expect(hoisted.sessionStore[sessionResolution.sessionKey]?.cliSessionIds).toBeUndefined();
+  });
+
+  it("resets stale bootstrap warning state for the first turn in a new CLI session", async () => {
+    const sessionResolution = createSessionResolution({
+      isNewSession: true,
+      systemPromptReport: {
+        bootstrapTruncation: {
+          warningMode: "once",
+          warningSignaturesSeen: ["stale-bootstrap-warning"],
+          promptWarningSignature: "stale-bootstrap-warning",
+        },
+      },
+    });
+    hoisted.resolveSessionMock.mockReturnValue(sessionResolution);
+
+    await agentCommand({
+      message: "hello",
+      agentId: "main",
+    });
+
+    expect(hoisted.resolveBootstrapWarningSignaturesSeenMock).toHaveBeenCalledWith(undefined);
+    expect(hoisted.runCliAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      bootstrapPromptWarningSignaturesSeen: [],
+      bootstrapPromptWarningSignature: undefined,
+    });
+    expect(hoisted.sessionStore[sessionResolution.sessionKey]?.systemPromptReport).toBeUndefined();
+  });
+
+  it("keeps resuming the stored CLI backend session for fresh sessions", async () => {
+    hoisted.resolveSessionMock.mockReturnValue(createSessionResolution({ isNewSession: false }));
+
+    await agentCommand({
+      message: "hello",
+      agentId: "main",
+    });
+
+    expect(hoisted.runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.runCliAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      sessionId: "session-new",
+      cliSessionId: "thread-stale",
+      provider: "codex-cli",
+      model: "gpt-5.2-codex",
+    });
+  });
+});

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -103,7 +103,7 @@ type PersistSessionEntryParams = {
   entry: SessionEntry;
 };
 
-type OverrideFieldClearedByDelete =
+type SessionFieldClearedByDelete =
   | "providerOverride"
   | "modelOverride"
   | "authProfileOverride"
@@ -113,10 +113,11 @@ type OverrideFieldClearedByDelete =
   | "fallbackNoticeActiveModel"
   | "fallbackNoticeReason"
   | "systemPromptReport"
+  | "skillsSnapshot"
   | "cliSessionIds"
   | "claudeCliSessionId";
 
-const OVERRIDE_FIELDS_CLEARED_BY_DELETE: OverrideFieldClearedByDelete[] = [
+const SESSION_FIELDS_CLEARED_BY_DELETE: SessionFieldClearedByDelete[] = [
   "providerOverride",
   "modelOverride",
   "authProfileOverride",
@@ -126,6 +127,7 @@ const OVERRIDE_FIELDS_CLEARED_BY_DELETE: OverrideFieldClearedByDelete[] = [
   "fallbackNoticeActiveModel",
   "fallbackNoticeReason",
   "systemPromptReport",
+  "skillsSnapshot",
   "cliSessionIds",
   "claudeCliSessionId",
 ];
@@ -163,8 +165,8 @@ function normalizeExplicitOverrideInput(raw: string, kind: "provider" | "model")
 async function persistSessionEntry(params: PersistSessionEntryParams): Promise<void> {
   const persisted = await updateSessionStore(params.storePath, (store) => {
     const merged = mergeSessionEntry(store[params.sessionKey], params.entry);
-    // Preserve explicit `delete` clears done by session override helpers.
-    for (const field of OVERRIDE_FIELDS_CLEARED_BY_DELETE) {
+    // Preserve explicit `delete` clears done by session rollover/override helpers.
+    for (const field of SESSION_FIELDS_CLEARED_BY_DELETE) {
       if (!Object.hasOwn(params.entry, field)) {
         Reflect.deleteProperty(merged, field);
       }
@@ -752,10 +754,14 @@ async function agentCommandInternal(
       const next = { ...sessionEntry };
       const clearedCliState = clearAllCliSessionIds(next);
       const hadSystemPromptReport = Object.hasOwn(next, "systemPromptReport");
+      const hadSkillsSnapshot = Object.hasOwn(next, "skillsSnapshot");
       if (hadSystemPromptReport) {
         delete next.systemPromptReport;
       }
-      if (clearedCliState || hadSystemPromptReport) {
+      if (hadSkillsSnapshot) {
+        delete next.skillsSnapshot;
+      }
+      if (clearedCliState || hadSystemPromptReport || hadSkillsSnapshot) {
         next.sessionId = sessionId;
         next.updatedAt = Date.now();
         await persistSessionEntry({

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -65,7 +65,7 @@ import { ensureAuthProfileStore } from "./auth-profiles.js";
 import { clearSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
 import { resolveBootstrapWarningSignaturesSeen } from "./bootstrap-budget.js";
 import { runCliAgent } from "./cli-runner.js";
-import { getCliSessionId, setCliSessionId } from "./cli-session.js";
+import { clearAllCliSessionIds, getCliSessionId, setCliSessionId } from "./cli-session.js";
 import { deliverAgentCommandResult } from "./command/delivery.js";
 import { resolveAgentRunContext } from "./command/run-context.js";
 import { updateSessionStoreAfterAgentRun } from "./command/session-store.js";
@@ -112,6 +112,8 @@ type OverrideFieldClearedByDelete =
   | "fallbackNoticeSelectedModel"
   | "fallbackNoticeActiveModel"
   | "fallbackNoticeReason"
+  | "systemPromptReport"
+  | "cliSessionIds"
   | "claudeCliSessionId";
 
 const OVERRIDE_FIELDS_CLEARED_BY_DELETE: OverrideFieldClearedByDelete[] = [
@@ -123,6 +125,8 @@ const OVERRIDE_FIELDS_CLEARED_BY_DELETE: OverrideFieldClearedByDelete[] = [
   "fallbackNoticeSelectedModel",
   "fallbackNoticeActiveModel",
   "fallbackNoticeReason",
+  "systemPromptReport",
+  "cliSessionIds",
   "claudeCliSessionId",
 ];
 
@@ -354,6 +358,7 @@ function runAgentAttempt(params: {
   modelOverride: string;
   cfg: ReturnType<typeof loadConfig>;
   sessionEntry: SessionEntry | undefined;
+  isNewSession: boolean;
   sessionId: string;
   sessionKey: string | undefined;
   sessionAgentId: string;
@@ -387,7 +392,10 @@ function runAgentAttempt(params: {
   const bootstrapPromptWarningSignature =
     bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
   if (isCliProvider(params.providerOverride, params.cfg)) {
-    const cliSessionId = getCliSessionId(params.sessionEntry, params.providerOverride);
+    // `/new` and `/reset` must not resume a stale backend CLI thread from the prior session.
+    const cliSessionId = params.isNewSession
+      ? undefined
+      : getCliSessionId(params.sessionEntry, params.providerOverride);
     const runCliWithSession = (nextCliSessionId: string | undefined) =>
       runCliAgent({
         sessionId: params.sessionId,
@@ -740,6 +748,26 @@ async function agentCommandInternal(
   let sessionEntry = prepared.sessionEntry;
 
   try {
+    if (isNewSession && sessionStore && sessionKey && sessionEntry) {
+      const next = { ...sessionEntry };
+      const clearedCliState = clearAllCliSessionIds(next);
+      const hadSystemPromptReport = Object.hasOwn(next, "systemPromptReport");
+      if (hadSystemPromptReport) {
+        delete next.systemPromptReport;
+      }
+      if (clearedCliState || hadSystemPromptReport) {
+        next.sessionId = sessionId;
+        next.updatedAt = Date.now();
+        await persistSessionEntry({
+          sessionStore,
+          sessionKey,
+          storePath,
+          entry: next,
+        });
+        sessionEntry = next;
+      }
+    }
+
     if (opts.deliver === true) {
       const sendPolicy = resolveSendPolicy({
         cfg,
@@ -1185,6 +1213,7 @@ async function agentCommandInternal(
             modelOverride,
             cfg,
             sessionEntry,
+            isNewSession,
             sessionId,
             sessionKey,
             sessionAgentId,

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -35,3 +35,16 @@ export function setCliSessionId(entry: SessionEntry, provider: string, sessionId
     entry.claudeCliSessionId = trimmed;
   }
 }
+
+export function clearAllCliSessionIds(entry: SessionEntry): boolean {
+  let changed = false;
+  if (Object.hasOwn(entry, "cliSessionIds")) {
+    delete entry.cliSessionIds;
+    changed = true;
+  }
+  if (Object.hasOwn(entry, "claudeCliSessionId")) {
+    delete entry.claudeCliSessionId;
+    changed = true;
+  }
+  return changed;
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `/new` and `/reset` can still reuse a stale backend CLI session id from the previous outer session, because `resolveSession()` marks the run as new but `runAgentAttempt()` still reads `cliSessionIds` from the old `sessionEntry`.
- Why it matters: CLI-backed providers can silently continue the previous backend thread, which also suppresses first-session startup/system prompt behavior such as re-sending bootstrap instructions.
- What changed: skip stored CLI session ids when `isNewSession` is true, add focused regression coverage for stale-vs-fresh session behavior, and document the user-visible fix in the changelog.
- What did NOT change (scope boundary): this does not change non-CLI providers or add any new startup/bootstrap mechanism; it only stops `/new`/`/reset` from resuming a stale CLI backend thread.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #49101

## User-visible / Behavior Changes

- CLI-backed agent sessions started via `/new` or `/reset` now start a fresh backend CLI thread instead of resuming the previous session's stored CLI id.
- Backends that only send startup/system prompts on the first CLI session can now re-run that startup behavior after `/new` or `/reset`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `No`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `No`
- Data access scope changed? (`Yes/No`) `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: minimal partial checkout, no local dependencies installed
- Model/provider: code-path verification for CLI-backed providers (`codex-cli`, legacy `claude-cli` storage path)
- Integration/channel (if any): N/A
- Relevant config (redacted): persisted session entry containing stale `cliSessionIds` from a prior session

### Steps

1. Trace `resolveSession()` in `src/agents/command/session.ts` and observe that a rollover run returns `isNewSession = true` while still handing back the previous `sessionEntry`.
2. Trace the CLI path in `src/agents/agent-command.ts` and observe that it reads `getCliSessionId(params.sessionEntry, params.providerOverride)` even for that new outer session.
3. Trace `resolveSessionIdToSend()` / `resolveSystemPromptUsage()` in `src/agents/cli-runner/helpers.ts` and observe that reusing the stale CLI session id makes the backend treat the run as a resumed session instead of a new one.

### Expected

- `/new` and `/reset` should not reuse the previous session's stored backend CLI thread id.
- CLI backends should treat the first turn after reset as a new CLI session and re-run first-session prompt behavior when configured.

### Actual

- Before this patch, a rollover run could still resume the previous backend CLI thread through `cliSessionIds` / `claudeCliSessionId`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: traced the rollover -> CLI run path on current `main`, confirmed the stale-session reuse bug, and added a regression test that asserts new sessions pass `cliSessionId: undefined` while fresh sessions still reuse the stored id.
- Edge cases checked: the regression test covers both normalized `cliSessionIds` storage and the normal fresh-session resume path; the runtime fix also covers legacy `claudeCliSessionId` because it skips all stored CLI ids on `isNewSession`.
- What you did **not** verify: I did not run Vitest or build locally because this minimal checkout intentionally has no `node_modules`, and I avoided installing dependencies to keep disk and memory use low.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `No`
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the `isNewSession` guard in `src/agents/agent-command.ts`
- Files/config to restore: `src/agents/agent-command.ts`, `src/agents/agent-command.new-session-cli.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: if reverted or broken, `/new` and `/reset` on CLI-backed providers may continue the previous backend thread instead of re-running first-session startup behavior

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: this fixes only the CLI-backed stale-session reuse path and may not explain every startup-state issue reported under other provider stacks.
  - Mitigation: keep the patch narrowly scoped, state the boundary explicitly, and only touch the implicated CLI session handoff path.