### PR TITLE
docs: remove trailing whitespace from documentation files

### DIFF
--- a/docs/channels/broadcast-groups.md
+++ b/docs/channels/broadcast-groups.md
@@ -9,7 +9,7 @@ title: "Broadcast Groups"
 
 # Broadcast Groups
 
-**Status:** Experimental  
+**Status:** Experimental
 **Version:** Added in 2026.1.9
 
 ## Overview
@@ -219,7 +219,7 @@ Design each agent with a single, clear responsibility:
 }
 ```
 
-✅ **Good:** Each agent has one job  
+✅ **Good:** Each agent has one job
 ❌ **Bad:** One generic "dev-helper" agent
 
 ### 2. Use Descriptive Names
@@ -372,7 +372,7 @@ tail -f ~/.openclaw/logs/gateway.log | grep broadcast
 }
 ```
 
-**User sends:** Code snippet  
+**User sends:** Code snippet
 **Responses:**
 
 - code-formatter: "Fixed indentation and added type hints"

--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -38,7 +38,7 @@ The Gateway can be accessed via:
 - SSH port forwarding from your laptop
 - Direct port exposure if you manage firewalling and tokens yourself
 
-This guide assumes Ubuntu or Debian on Hetzner.  
+This guide assumes Ubuntu or Debian on Hetzner.
 If you are on another Linux VPS, map packages accordingly.
 For the generic Docker flow, see [Docker](/install/docker).
 

--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -30,7 +30,7 @@ Perfect for:
 | **Pi 3B+**      | 1GB     | ⚠️ Slow  | Works but sluggish                 |
 | **Pi Zero 2 W** | 512MB   | ❌       | Not recommended                    |
 
-**Minimum specs:** 1GB RAM, 1 core, 500MB disk  
+**Minimum specs:** 1GB RAM, 1 core, 500MB disk
 **Recommended:** 2GB+ RAM, 64-bit OS, 16GB+ SD card (or USB SSD)
 
 ## What you need

--- a/docs/providers/deepgram.md
+++ b/docs/providers/deepgram.md
@@ -15,7 +15,7 @@ When enabled, OpenClaw uploads the audio file to Deepgram and injects the transc
 into the reply pipeline (`{{Transcript}}` + `[Audio]` block). This is **not streaming**;
 it uses the pre-recorded transcription endpoint.
 
-Website: [https://deepgram.com](https://deepgram.com)  
+Website: [https://deepgram.com](https://deepgram.com)
 Docs: [https://developers.deepgram.com](https://developers.deepgram.com)
 
 ## Quick start

--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -235,16 +235,16 @@ A scheduled prompt generates a single "scene" image each morning (weather, tasks
 
 <Card title="Padel Court Booking" icon="calendar-check" href="https://github.com/joshp123/padel-cli">
   **@joshp123** • `automation` `booking` `cli`
-  
-  Playtomic availability checker + booking CLI. Never miss an open court again.
-  
+
+Playtomic availability checker + booking CLI. Never miss an open court again.
+
   <img src="/assets/showcase/padel-screenshot.jpg" alt="padel-cli screenshot" />
 </Card>
 
 <Card title="Accounting Intake" icon="file-invoice-dollar">
   **Community** • `automation` `email` `pdf`
-  
-  Collects PDFs from email, preps documents for tax consultant. Monthly accounting on autopilot.
+
+Collects PDFs from email, preps documents for tax consultant. Monthly accounting on autopilot.
 </Card>
 
 <Card title="Couch Potato Dev Mode" icon="couch" href="https://davekiss.com">
@@ -291,28 +291,28 @@ Watches company Slack channel, responds helpfully, and forwards notifications to
 
 <Card title="xuezh Chinese Learning" icon="language" href="https://github.com/joshp123/xuezh">
   **@joshp123** • `learning` `voice` `skill`
-  
-  Chinese learning engine with pronunciation feedback and study flows via OpenClaw.
-  
+
+Chinese learning engine with pronunciation feedback and study flows via OpenClaw.
+
   <img src="/assets/showcase/xuezh-pronunciation.jpeg" alt="xuezh pronunciation feedback" />
 </Card>
 
 <Card title="WhatsApp Memory Vault" icon="vault">
   **Community** • `memory` `transcription` `indexing`
-  
-  Ingests full WhatsApp exports, transcribes 1k+ voice notes, cross-checks with git logs, outputs linked markdown reports.
+
+Ingests full WhatsApp exports, transcribes 1k+ voice notes, cross-checks with git logs, outputs linked markdown reports.
 </Card>
 
 <Card title="Karakeep Semantic Search" icon="magnifying-glass" href="https://github.com/jamesbrooksco/karakeep-semantic-search">
   **@jamesbrooksco** • `search` `vector` `bookmarks`
-  
-  Adds vector search to Karakeep bookmarks using Qdrant + OpenAI/Ollama embeddings.
+
+Adds vector search to Karakeep bookmarks using Qdrant + OpenAI/Ollama embeddings.
 </Card>
 
 <Card title="Inside-Out-2 Memory" icon="brain">
   **Community** • `memory` `beliefs` `self-model`
-  
-  Separate memory manager that turns session files into memories → beliefs → evolving self model.
+
+Separate memory manager that turns session files into memories → beliefs → evolving self model.
 </Card>
 
 </CardGroup>
@@ -323,8 +323,8 @@ Watches company Slack channel, responds helpfully, and forwards notifications to
 
 <Card title="Clawdia Phone Bridge" icon="phone" href="https://github.com/alejandroOPI/clawdia-bridge">
   **@alejandroOPI** • `voice` `vapi` `bridge`
-  
-  Vapi voice assistant ↔ OpenClaw HTTP bridge. Near real-time phone calls with your agent.
+
+Vapi voice assistant ↔ OpenClaw HTTP bridge. Near real-time phone calls with your agent.
 </Card>
 
 <Card title="OpenRouter Transcription" icon="microphone" href="https://clawhub.com/obviyus/openrouter-transcribe">
@@ -341,26 +341,26 @@ Multi-lingual audio transcription via OpenRouter (Gemini, etc). Available on Cla
 
 <Card title="Home Assistant Add-on" icon="home" href="https://github.com/ngutman/openclaw-ha-addon">
   **@ngutman** • `homeassistant` `docker` `raspberry-pi`
-  
-  OpenClaw gateway running on Home Assistant OS with SSH tunnel support and persistent state.
+
+OpenClaw gateway running on Home Assistant OS with SSH tunnel support and persistent state.
 </Card>
 
 <Card title="Home Assistant Skill" icon="toggle-on" href="https://clawhub.com/skills/homeassistant">
   **ClawHub** • `homeassistant` `skill` `automation`
-  
-  Control and automate Home Assistant devices via natural language.
+
+Control and automate Home Assistant devices via natural language.
 </Card>
 
 <Card title="Nix Packaging" icon="snowflake" href="https://github.com/openclaw/nix-openclaw">
   **@openclaw** • `nix` `packaging` `deployment`
-  
-  Batteries-included nixified OpenClaw configuration for reproducible deployments.
+
+Batteries-included nixified OpenClaw configuration for reproducible deployments.
 </Card>
 
 <Card title="CalDAV Calendar" icon="calendar" href="https://clawhub.com/skills/caldav-calendar">
   **ClawHub** • `calendar` `caldav` `skill`
-  
-  Calendar skill using khal/vdirsyncer. Self-hosted calendar integration.
+
+Calendar skill using khal/vdirsyncer. Self-hosted calendar integration.
 </Card>
 
 </CardGroup>
@@ -371,17 +371,17 @@ Multi-lingual audio transcription via OpenRouter (Gemini, etc). Available on Cla
 
 <Card title="GoHome Automation" icon="house-signal" href="https://github.com/joshp123/gohome">
   **@joshp123** • `home` `nix` `grafana`
-  
-  Nix-native home automation with OpenClaw as the interface, plus beautiful Grafana dashboards.
-  
+
+Nix-native home automation with OpenClaw as the interface, plus beautiful Grafana dashboards.
+
   <img src="/assets/showcase/gohome-grafana.png" alt="GoHome Grafana dashboard" />
 </Card>
 
 <Card title="Roborock Vacuum" icon="robot" href="https://github.com/joshp123/gohome/tree/main/plugins/roborock">
   **@joshp123** • `vacuum` `iot` `plugin`
-  
-  Control your Roborock robot vacuum through natural conversation.
-  
+
+Control your Roborock robot vacuum through natural conversation.
+
   <img src="/assets/showcase/roborock-screenshot.jpg" alt="Roborock status" />
 </Card>
 
@@ -393,8 +393,8 @@ Multi-lingual audio transcription via OpenRouter (Gemini, etc). Available on Cla
 
 <Card title="StarSwap Marketplace" icon="star" href="https://star-swap.com/">
   **Community** • `marketplace` `astronomy` `webapp`
-  
-  Full astronomy gear marketplace. Built with/around the OpenClaw ecosystem.
+
+Full astronomy gear marketplace. Built with/around the OpenClaw ecosystem.
 </Card>
 
 </CardGroup>


### PR DESCRIPTION
Remove trailing whitespace from 5 documentation files for cleaner formatting.