### PR TITLE
feishu: download media for group history and quoted messages

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -28,6 +28,7 @@ import {
   parseMergeForwardContent,
   parseMessageContent,
   resolveFeishuGroupSession,
+  parseMediaKeys,
   resolveFeishuMediaList,
   toMessageResourceType,
 } from "./bot-content.js";
@@ -425,13 +426,42 @@ export async function handleFeishuMessage(params: {
       // agent sessions — buffering here would cause duplicate replay when this account
       // later becomes active via buildPendingHistoryContextFromMap.
       if (!broadcastAgents && chatHistories && groupHistoryKey) {
+        // Download media for file/image messages even when bot isn't mentioned
+        // so that downloaded file paths are included in the history context.
+        let historyBody = `${ctx.senderName ?? ctx.senderOpenId}: ${ctx.content}`;
+        const historyMediaTypes = ["image", "file", "audio", "video", "sticker"];
+        if (historyMediaTypes.includes(event.message.message_type)) {
+          try {
+            const mediaMaxBytes = (feishuCfg?.mediaMaxMb ?? 30) * 1024 * 1024;
+            const mediaList = await resolveFeishuMediaList({
+              cfg,
+              messageId: ctx.messageId,
+              messageType: event.message.message_type,
+              content: event.message.content,
+              maxBytes: mediaMaxBytes,
+              log,
+              accountId: account.accountId,
+            });
+            if (mediaList.length > 0) {
+              const mediaPaths = mediaList.map((m) => m.path).join(", ");
+              const mediaKeys = parseMediaKeys(event.message.content, event.message.message_type);
+              const fileName = mediaKeys.fileName || "attachment";
+              historyBody = `${ctx.senderName ?? ctx.senderOpenId}: ${ctx.content} [File saved: ${fileName} → ${mediaPaths}]`;
+            }
+          } catch (err) {
+            log(
+              `feishu[${account.accountId}]: failed to download media for history entry: ${String(err)}`,
+            );
+          }
+        }
+
         recordPendingHistoryEntryIfEnabled({
           historyMap: chatHistories,
           historyKey: groupHistoryKey,
           limit: historyLimit,
           entry: {
             sender: ctx.senderOpenId,
-            body: `${ctx.senderName ?? ctx.senderOpenId}: ${ctx.content}`,
+            body: historyBody,
             timestamp: Date.now(),
             messageId: ctx.messageId,
           },
@@ -682,9 +712,43 @@ export async function handleFeishuMessage(params: {
           accountId: account.accountId,
         });
         if (quotedMessageInfo) {
-          quotedContent = quotedMessageInfo.content;
+          // If the quoted message contains media, download and attach it
+          const quotedMediaTypes = ["image", "file", "audio", "video", "sticker", "post"];
+          if (quotedMediaTypes.includes(quotedMessageInfo.contentType)) {
+            const quotedMediaList = await resolveFeishuMediaList({
+              cfg,
+              messageId: quotedMessageInfo.messageId,
+              messageType: quotedMessageInfo.contentType,
+              content: quotedMessageInfo.content,
+              maxBytes: mediaMaxBytes,
+              log,
+              accountId: account.accountId,
+            });
+            if (quotedMediaList.length > 0) {
+              const existingPaths = mediaPayload.MediaPaths ?? [];
+              const existingTypes = mediaPayload.MediaTypes ?? [];
+              for (const qm of quotedMediaList) {
+                existingPaths.push(qm.path);
+                if (qm.contentType) existingTypes.push(qm.contentType);
+              }
+              if (!mediaPayload.MediaPath) {
+                mediaPayload.MediaPath = quotedMediaList[0].path;
+                mediaPayload.MediaType = quotedMediaList[0].contentType;
+                mediaPayload.MediaUrl = quotedMediaList[0].path;
+              }
+              mediaPayload.MediaPaths = existingPaths;
+              mediaPayload.MediaUrls = existingPaths;
+              mediaPayload.MediaTypes = existingTypes.length > 0 ? existingTypes : undefined;
+              log(
+                `feishu[${account.accountId}]: resolved ${quotedMediaList.length} media from quoted message`,
+              );
+            }
+            quotedContent = `<media:${quotedMessageInfo.contentType}>`;
+          } else {
+            quotedContent = quotedMessageInfo.content;
+          }
           log(
-            `feishu[${account.accountId}]: fetched quoted message: ${quotedContent?.slice(0, 100)}`,
+            `feishu[${account.accountId}]: fetched quoted message (${quotedMessageInfo.contentType}): ${(quotedContent ?? "").slice(0, 100)}`,
           );
         }
       } catch (err) {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -713,13 +713,13 @@ export async function handleFeishuMessage(params: {
         });
         if (quotedMessageInfo) {
           // If the quoted message contains media, download and attach it
-          const quotedMediaTypes = ["image", "file", "audio", "video", "sticker", "post"];
+          const quotedMediaTypes = ["image", "file", "audio", "video", "sticker"];
           if (quotedMediaTypes.includes(quotedMessageInfo.contentType)) {
             const quotedMediaList = await resolveFeishuMediaList({
               cfg,
               messageId: quotedMessageInfo.messageId,
               messageType: quotedMessageInfo.contentType,
-              content: quotedMessageInfo.content,
+              content: quotedMessageInfo.rawContent ?? quotedMessageInfo.content,
               maxBytes: mediaMaxBytes,
               log,
               accountId: account.accountId,
@@ -743,7 +743,10 @@ export async function handleFeishuMessage(params: {
                 `feishu[${account.accountId}]: resolved ${quotedMediaList.length} media from quoted message`,
               );
             }
-            quotedContent = `<media:${quotedMessageInfo.contentType}>`;
+            quotedContent =
+              quotedMediaList.length > 0
+                ? `<media:${quotedMessageInfo.contentType}>`
+                : quotedMessageInfo.content;
           } else {
             quotedContent = quotedMessageInfo.content;
           }

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -270,6 +270,7 @@ function parseFeishuMessageItem(
     senderOpenId: item.sender?.id_type === "open_id" ? item.sender?.id : undefined,
     senderType: item.sender?.sender_type,
     content: parseFeishuMessageContent(rawContent, msgType),
+    rawContent,
     contentType: msgType,
     createTime: item.create_time ? parseInt(String(item.create_time), 10) : undefined,
     threadId: item.thread_id || undefined,

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -70,6 +70,8 @@ export type FeishuMessageInfo = {
   senderOpenId?: string;
   senderType?: string;
   content: string;
+  /** Raw body.content JSON from the Feishu API (before normalization). */
+  rawContent?: string;
   contentType: string;
   createTime?: number;
   /** Feishu thread ID (omt_xxx) — present when the message belongs to a topic thread. */

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -25,6 +25,10 @@ import type {
 import { logVerbose } from "../globals.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { stripMarkdown } from "../line/markdown-to-line.js";
+import {
+  OPENAI_DEFAULT_TTS_MODEL as DEFAULT_OPENAI_MODEL,
+  OPENAI_DEFAULT_TTS_VOICE as DEFAULT_OPENAI_VOICE,
+} from "../providers/openai-defaults.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import {
   getSpeechProvider,
@@ -32,10 +36,6 @@ import {
   normalizeSpeechProviderId,
 } from "./provider-registry.js";
 import type { SpeechVoiceOption } from "./provider-types.js";
-import {
-  OPENAI_DEFAULT_TTS_MODEL as DEFAULT_OPENAI_MODEL,
-  OPENAI_DEFAULT_TTS_VOICE as DEFAULT_OPENAI_VOICE,
-} from "../providers/openai-defaults.js";
 import {
   DEFAULT_OPENAI_BASE_URL,
   isValidOpenAIModel,


### PR DESCRIPTION
## Summary

- **Media in group history**: When media messages (image, file, audio, video, sticker) are sent in a group chat without @-mentioning the bot, download the media and include file paths in the pending history entry. This gives the bot context about shared files when it's later mentioned.
- **Quoted message media**: When a user replies to a media message while mentioning the bot, download the quoted message's attachments and merge them into the media payload sent to the agent. Previously, replying to an image/file with "@bot analyze this" would not include the quoted media.

### Motivation

In group chats on Lark international, users frequently share files and images without mentioning the bot, then later ask the bot about them. Without this change, the bot has no record of those files. Similarly, when a user quotes/replies to a file message to ask the bot about it, the bot couldn't access the quoted file's content.

## Test plan

- [ ] Send a file in a group without mentioning bot, then mention bot and ask about the file — verify bot has context from history
- [ ] Send an image in a group without mentioning bot — verify media is downloaded and path appears in history entry
- [ ] Reply to a file message with "@bot analyze this" — verify the quoted file is downloaded and included in media payload
- [ ] Reply to a text message with "@bot" — verify existing behavior unchanged (text quoted content, no extra media)
- [ ] Verify non-media messages in group still record plain text history as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)