### PR TITLE
fix(media): strip sensitive headers on cross-origin download redirects

### DIFF
--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -175,6 +175,43 @@ function looksLikeUrl(src: string) {
 }
 
 /**
+ * Headers that are safe to forward on cross-origin redirects.
+ * Sensitive headers like Authorization and Cookie must be stripped when the
+ * redirect target differs in origin from the original request.
+ */
+const CROSS_ORIGIN_SAFE_HEADERS = new Set([
+  "accept",
+  "accept-encoding",
+  "accept-language",
+  "cache-control",
+  "user-agent",
+]);
+
+/**
+ * Strip sensitive headers when a redirect crosses origins (different scheme,
+ * host, or port). Only headers known to be safe are retained.
+ */
+function retainSafeHeadersOnCrossOriginRedirect(
+  originalUrl: URL,
+  redirectUrl: URL,
+  headers?: Record<string, string>,
+): Record<string, string> | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  if (originalUrl.origin === redirectUrl.origin) {
+    return headers;
+  }
+  const safe: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (CROSS_ORIGIN_SAFE_HEADERS.has(key.toLowerCase())) {
+      safe[key] = value;
+    }
+  }
+  return Object.keys(safe).length > 0 ? safe : undefined;
+}
+
+/**
  * Download media to disk while capturing the first few KB for mime sniffing.
  */
 async function downloadToFile(
@@ -203,11 +240,21 @@ async function downloadToFile(
           if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
             const location = res.headers.location;
             if (!location || maxRedirects <= 0) {
+              res.resume(); // drain the response body before rejecting
               reject(new Error(`Redirect loop or missing Location header`));
               return;
             }
-            const redirectUrl = new URL(location, url).href;
-            resolve(downloadToFile(redirectUrl, dest, headers, maxRedirects - 1));
+            const redirectParsedUrl = new URL(location, url);
+            const redirectUrl = redirectParsedUrl.href;
+            // Strip sensitive headers (Authorization, Cookie, etc.) on
+            // cross-origin redirects to prevent credential leakage.
+            const redirectHeaders = retainSafeHeadersOnCrossOriginRedirect(
+              parsedUrl,
+              redirectParsedUrl,
+              headers,
+            );
+            res.resume(); // drain the redirect response body
+            resolve(downloadToFile(redirectUrl, dest, redirectHeaders, maxRedirects - 1));
             return;
           }
           if (!res.statusCode || res.statusCode >= 400) {


### PR DESCRIPTION
## Problem

The `downloadToFile` function in the media store follows HTTP redirects but forwards all request headers to the redirect target unchanged. When a media URL redirects to a different origin (common with CDN-backed storage that redirects to signed URLs on a different domain), sensitive headers like `Authorization` and `Cookie` are leaked to the third-party server.

## Fix

Apply the same cross-origin header-stripping pattern already used in `fetch-guard.ts`:

- When a redirect crosses origins (different scheme, host, or port), only retain a safe set of headers: `accept`, `accept-encoding`, `accept-language`, `cache-control`, `user-agent`
- Sensitive headers (`Authorization`, `Cookie`, custom auth headers, etc.) are dropped
- Same-origin redirects continue forwarding all headers unchanged

Additionally, the redirect response body is now properly drained via `res.resume()` before following the redirect, preventing socket resource leaks.

## Context

The guarded fetch layer (`fetchWithSsrFGuard`) already implements this via `retainSafeHeadersForCrossOriginRedirect`, but the media store uses Node.js `http.request` directly with its own redirect-following logic and lacked this protection.