### PR TITLE
fix(session): sanitize orphaned tool_result API errors before posting to channels

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -70,6 +70,24 @@ describe("formatAssistantErrorText", () => {
     expect(result).toContain("Session history looks corrupted");
     expect(result).toContain("/new");
   });
+  it("returns a safe message for orphaned tool_result errors without leaking raw API details", () => {
+    const msg = makeAssistantError(
+      "messages.144.content.1: unexpected tool_use_id found in tool_result blocks: toolu_01HjX9c7NLJaBLDzyBasSkKw. Each tool_result block must have a corresponding tool_use block in the previous message.",
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toBe("⚠️ Session context error. Use /new to start a fresh session.");
+    expect(result).not.toContain("tool_use_id");
+    expect(result).not.toContain("messages.144");
+    expect(result).not.toContain("toolu_");
+  });
+  it("returns a safe message for JSON-wrapped orphaned tool_result errors", () => {
+    const msg = makeAssistantError(
+      '{"type":"error","error":{"type":"invalid_request_error","message":"messages.12.content.0: unexpected tool_use_id found in tool_result blocks: toolu_abc123"}}',
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toBe("⚠️ Session context error. Use /new to start a fresh session.");
+    expect(result).not.toContain("toolu_abc123");
+  });
   it("handles JSON-wrapped role errors", () => {
     const msg = makeAssistantError('{"error":{"message":"400 Incorrect role information"}}');
     const result = formatAssistantErrorText(msg);

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -30,6 +30,7 @@ export {
   isCloudCodeAssistFormatError,
   isCompactionFailureError,
   isContextOverflowError,
+  isOrphanedToolResultError,
   isLikelyContextOverflowError,
   isFailoverAssistantError,
   isFailoverErrorMessage,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -607,6 +607,10 @@ export function formatAssistantErrorText(
     );
   }
 
+  if (isOrphanedToolResultError(raw)) {
+    return "⚠️ Session context error. Use /new to start a fresh session.";
+  }
+
   const invalidRequest = raw.match(/"type":"invalid_request_error".*?"message":"([^"]+)"/);
   if (invalidRequest?.[1]) {
     return `LLM request rejected: ${invalidRequest[1]}`;
@@ -660,6 +664,10 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
         "Message ordering conflict - please try again. " +
         "If this persists, use /new to start a fresh session."
       );
+    }
+
+    if (isOrphanedToolResultError(trimmed)) {
+      return "⚠️ Session context error. Use /new to start a fresh session.";
     }
 
     if (shouldRewriteContextOverflowText(trimmed)) {
@@ -721,6 +729,16 @@ export function isMissingToolCallInputError(raw: string): boolean {
     return false;
   }
   return TOOL_CALL_INPUT_MISSING_RE.test(raw) || TOOL_CALL_INPUT_PATH_RE.test(raw);
+}
+
+const ORPHANED_TOOL_RESULT_RE =
+  /unexpected tool_use_id found in tool_result|tool_result.*must have a corresponding tool_use/i;
+
+export function isOrphanedToolResultError(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  return ORPHANED_TOOL_RESULT_RE.test(raw);
 }
 
 export function isBillingAssistantError(msg: AssistantMessage | undefined): boolean {

--- a/src/agents/pi-embedded-helpers/orphaned-tool-result-error.test.ts
+++ b/src/agents/pi-embedded-helpers/orphaned-tool-result-error.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { isOrphanedToolResultError } from "./errors.js";
+
+describe("isOrphanedToolResultError", () => {
+  it("detects the Anthropic 'unexpected tool_use_id found in tool_result' error", () => {
+    expect(
+      isOrphanedToolResultError(
+        "messages.144.content.1: unexpected tool_use_id found in tool_result blocks: toolu_01HjX9c7NLJaBLDzyBasSkKw. Each tool_result block must have a corresponding tool_use block in the previous message.",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects a JSON-wrapped variant", () => {
+    expect(
+      isOrphanedToolResultError(
+        '{"type":"error","error":{"type":"invalid_request_error","message":"messages.12.content.0: unexpected tool_use_id found in tool_result blocks: toolu_abc123"}}',
+      ),
+    ).toBe(true);
+  });
+
+  it("detects the 'tool_result must have a corresponding tool_use' variant", () => {
+    expect(
+      isOrphanedToolResultError(
+        "tool_result block must have a corresponding tool_use block in the previous message",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isOrphanedToolResultError("")).toBe(false);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isOrphanedToolResultError("rate limit exceeded")).toBe(false);
+  });
+
+  it("returns false for generic tool errors", () => {
+    expect(isOrphanedToolResultError("unknown tool: my_tool")).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -12,6 +12,7 @@ import {
   isContextOverflowError,
   isBillingErrorMessage,
   isLikelyContextOverflowError,
+  isOrphanedToolResultError,
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
@@ -561,6 +562,7 @@ export async function runAgentTurnWithFallback(params: {
       const isContextOverflow = !isBilling && isLikelyContextOverflowError(message);
       const isCompactionFailure = !isBilling && isCompactionFailureError(message);
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
+      const isOrphanedToolResult = isOrphanedToolResultError(message);
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
       const isTransientHttp = isTransientHttpError(message);
 
@@ -587,6 +589,16 @@ export async function runAgentTurnWithFallback(params: {
             },
           };
         }
+      }
+
+      if (isOrphanedToolResult) {
+        defaultRuntime.error(`Orphaned tool_result in session transcript: ${message}`);
+        return {
+          kind: "final",
+          payload: {
+            text: "⚠️ Session context error. Use /new to start a fresh session.",
+          },
+        };
       }
 
       // Auto-recover from Gemini session corruption by resetting the session


### PR DESCRIPTION
## Summary

When a session transcript becomes corrupted with an orphaned `tool_result` block (no matching `tool_use`), the raw Anthropic API error was delivered directly to the chat surface on every subsequent message ÔÇö effectively spamming public channels like Telegram groups or Discord.

**Example of what was leaking:**
```
LLM request rejected: messages.144.content.1: unexpected tool_use_id found in
tool_result blocks: toolu_01HjX9c7NLJaBLDzyBasSkKw. Each tool_result block must
have a corresponding tool_use block in the previous message.
```

This raw API error exposes internal message indices, tool_use IDs, and model implementation details users should not see.

## Details

Added `isOrphanedToolResultError()` to the error classification module in `errors.ts`. When this error is detected in `agent-runner-execution.ts`, the channel receives a safe actionable message instead:

```
ÔÜá´©Å Session context error detected. Use /new to start a fresh session.
```

The original error is still logged internally ÔÇö it is only redacted from the outbound channel payload.

## Related Issues

Fixes #11038

## How to Validate

1. Create a corrupted session transcript with an orphaned tool_result block
2. Send a message to that session via Telegram/Discord
3. Confirm the channel receives the generic safe message, not the raw API error
4. Confirm internal logs (`openclaw logs --follow`) still show the full error

Run unit tests: `pnpm test -- --testPathPattern="pi-embedded-helpers|orphaned-tool-result"`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run

---
## AI-Assisted Disclosure

- [x] This PR was built with Claude Code (Anthropic)
- [x] Fully tested locally — tests pass, oxfmt formatting verified
- [x] Author reviewed and understands all changes
- [x] Codex review not available locally (not installed)
