### PR TITLE
fix: normalize open-prose description and add missing code block language tags

### DIFF
--- a/docs/automation/cron-vs-heartbeat.md
+++ b/docs/automation/cron-vs-heartbeat.md
@@ -132,7 +132,7 @@ See [Cron jobs](/automation/cron-jobs) for full CLI reference.
 
 ## Decision Flowchart
 
-```
+```text
 Does the task need to run at an EXACT time?
   YES -> Use cron
   NO  -> Continue...

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -88,7 +88,7 @@ Managed hook directories can be either a **single hook** or a **hook pack** (pac
 
 Each hook is a directory containing:
 
-```
+```text
 my-hook/
 ├── HOOK.md          # Metadata + documentation
 └── handler.ts       # Handler implementation
@@ -781,7 +781,7 @@ metadata: { "openclaw": { "events": ["command"] } } # General - more overhead
 
 The gateway logs hook loading at startup:
 
-```
+```text
 Registered hook: session-memory -> command:new
 Registered hook: bootstrap-extra-files -> agent:bootstrap
 Registered hook: command-logger -> command
@@ -871,7 +871,7 @@ test("my handler works", async () => {
 
 ### Discovery Flow
 
-```
+```text
 Gateway startup
     ↓
 Scan directories (workspace → managed → bundled)
@@ -887,7 +887,7 @@ Register handlers for events
 
 ### Event Flow
 
-```
+```text
 User sends /new
     ↓
 Command validation

--- a/docs/automation/standing-orders.md
+++ b/docs/automation/standing-orders.md
@@ -75,7 +75,7 @@ Put standing orders in `AGENTS.md` to guarantee they're loaded every session. Th
 
 Standing orders define **what** the agent is authorized to do. [Cron jobs](/automation/cron-jobs) define **when** it happens. They work together:
 
-```
+```text
 Standing Order: "You own the daily inbox triage"
     ↓
 Cron Job (8 AM daily): "Execute inbox triage per standing orders"

--- a/docs/channels/bluebubbles.md
+++ b/docs/channels/bluebubbles.md
@@ -128,7 +128,7 @@ launchctl load ~/Library/LaunchAgents/com.user.poke-messages.plist
 
 BlueBubbles is available in interactive onboarding:
 
-```
+```bash
 openclaw onboard
 ```
 
@@ -142,7 +142,7 @@ The wizard prompts for:
 
 You can also add BlueBubbles via CLI:
 
-```
+```bash
 openclaw channels add bluebubbles --http-url http://192.168.1.100:1234 --password <password>
 ```
 

--- a/docs/channels/broadcast-groups.md
+++ b/docs/channels/broadcast-groups.md
@@ -26,7 +26,7 @@ Broadcast groups are evaluated after channel allowlists and group activation rul
 
 Deploy multiple agents with atomic, focused responsibilities:
 
-```
+```text
 Group: "Development Team"
 Agents:
   - CodeReviewer (reviews code snippets)
@@ -39,7 +39,7 @@ Each agent processes the same message and provides its specialized perspective.
 
 ### 2. Multi-Language Support
 
-```
+```text
 Group: "International Support"
 Agents:
   - Agent_EN (responds in English)
@@ -49,7 +49,7 @@ Agents:
 
 ### 3. Quality Assurance Workflows
 
-```
+```text
 Group: "Customer Support"
 Agents:
   - SupportAgent (provides answer)
@@ -58,7 +58,7 @@ Agents:
 
 ### 4. Task Automation
 
-```
+```text
 Group: "Project Management"
 Agents:
   - TaskTracker (updates task database)
@@ -189,7 +189,7 @@ In group `120363403215116621@g.us` with agents `["alfred", "baerbel"]`:
 
 **Alfred's context:**
 
-```
+```text
 Session: agent:alfred:whatsapp:group:120363403215116621@g.us
 History: [user message, alfred's previous responses]
 Workspace: /Users/pascal/openclaw-alfred/
@@ -198,7 +198,7 @@ Tools: read, write, exec
 
 **Bärbel's context:**
 
-```
+```text
 Session: agent:baerbel:whatsapp:group:120363403215116621@g.us
 History: [user message, baerbel's previous responses]
 Workspace: /Users/pascal/openclaw-baerbel/
@@ -265,7 +265,7 @@ With many agents, consider:
 
 Agents fail independently. One agent's error doesn't block others:
 
-```
+```text
 Message → [Agent A ✓, Agent B ✗ error, Agent C ✓]
 Result: Agent A and C respond, Agent B logs error
 ```

--- a/docs/channels/googlechat.md
+++ b/docs/channels/googlechat.md
@@ -212,7 +212,7 @@ Secrets reference details: [Secrets Management](/gateway/secrets).
 
 If Google Cloud Logs Explorer shows errors like:
 
-```
+```text
 status code: 405, reason phrase: HTTP error response: HTTP/1.1 405 Method Not Allowed
 ```
 

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -29,7 +29,7 @@ Translation: allowlisted senders can trigger OpenClaw by mentioning it.
 
 Quick flow (what happens to a group message):
 
-```
+```text
 groupPolicy? disabled -> drop
 groupPolicy? allowlist -> group allowed? no -> drop
 requireMention? yes -> mentioned? no -> store for context only

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -40,7 +40,7 @@ openclaw plugins install ./extensions/line
 4. Enable **Use webhook** in the Messaging API settings.
 5. Set the webhook URL to your gateway endpoint (HTTPS required):
 
-```
+```text
 https://gateway-host/line/webhook
 ```
 
@@ -180,7 +180,7 @@ messages.
 
 The LINE plugin also ships a `/card` command for Flex message presets:
 
-```
+```text
 /card info "Welcome" "Thanks for joining!"
 ```
 

--- a/docs/channels/location.md
+++ b/docs/channels/location.md
@@ -32,7 +32,7 @@ Locations are rendered as friendly lines without brackets:
 
 If the channel includes a caption/comment, it is appended on the next line:
 
-```
+```text
 📍 48.858844, 2.294351 ±12m
 Meet here
 ```

--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -230,7 +230,7 @@ Notes:
 
 Examples:
 
-```
+```text
 message action=react channel=mattermost target=channel:<channelId> messageId=<postId> emoji=thumbsup
 message action=react channel=mattermost target=channel:<channelId> messageId=<postId> emoji=thumbsup remove=true
 ```
@@ -259,7 +259,7 @@ Enable buttons by adding `inlineButtons` to the channel capabilities:
 
 Use `message action=send` with a `buttons` parameter. Buttons are a 2D array (rows of buttons):
 
-```
+```text
 message action=send channel=mattermost target=channel:<channelId> buttons=[[{"text":"Yes","callback_data":"yes"},{"text":"No","callback_data":"no"}]]
 ```
 

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -708,7 +708,7 @@ The `groupId` query parameter in Teams URLs is **NOT** the team ID used for conf
 
 **Team URL:**
 
-```
+```text
 https://teams.microsoft.com/l/team/19%3ABk4j...%40thread.tacv2/conversations?groupId=...
                                     └────────────────────────────┘
                                     Team ID (URL-decode this)
@@ -716,7 +716,7 @@ https://teams.microsoft.com/l/team/19%3ABk4j...%40thread.tacv2/conversations?gro
 
 **Channel URL:**
 
-```
+```text
 https://teams.microsoft.com/l/channel/19%3A15bc...%40thread.tacv2/ChannelName?groupId=...
                                       └─────────────────────────┘
                                       Channel ID (URL-decode this)

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -229,7 +229,7 @@ Groups:
 
 Examples:
 
-```
+```text
 message action=react channel=signal target=uuid:123e4567-e89b-12d3-a456-426614174000 messageId=1737630212345 emoji=🔥
 message action=react channel=signal target=+15551234567 messageId=1737630212345 emoji=🔥 remove=true
 message action=react channel=signal target=signal:group:<groupId> targetAuthor=uuid:<sender-uuid> messageId=1737630212345 emoji=✅

--- a/docs/channels/twitch.md
+++ b/docs/channels/twitch.md
@@ -274,7 +274,7 @@ openclaw channels status --probe
 
 **Check logs for refresh events:**
 
-```
+```text
 Using env token source for mybot
 Access token refreshed for user 123456 (expires in 14400s)
 ```

--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -16,7 +16,7 @@ Manage device pairing requests and device-scoped tokens.
 
 List pending pairing requests and paired devices.
 
-```
+```bash
 openclaw devices list
 openclaw devices list --json
 ```
@@ -28,7 +28,7 @@ be reviewed before you approve.
 
 Remove one paired device entry.
 
-```
+```bash
 openclaw devices remove <deviceId>
 openclaw devices remove <deviceId> --json
 ```
@@ -37,7 +37,7 @@ openclaw devices remove <deviceId> --json
 
 Clear paired devices in bulk.
 
-```
+```bash
 openclaw devices clear --yes
 openclaw devices clear --yes --pending
 openclaw devices clear --yes --pending --json
@@ -53,7 +53,7 @@ key), OpenClaw supersedes the previous pending entry and issues a new
 `requestId`. Run `openclaw devices list` right before approval to use the
 current ID.
 
-```
+```bash
 openclaw devices approve
 openclaw devices approve <requestId>
 openclaw devices approve --latest
@@ -63,7 +63,7 @@ openclaw devices approve --latest
 
 Reject a pending device pairing request.
 
-```
+```bash
 openclaw devices reject <requestId>
 ```
 
@@ -71,7 +71,7 @@ openclaw devices reject <requestId>
 
 Rotate a device token for a specific role (optionally updating scopes).
 
-```
+```bash
 openclaw devices rotate --device <deviceId> --role operator --scope operator.read --scope operator.write
 ```
 
@@ -79,7 +79,7 @@ openclaw devices rotate --device <deviceId> --role operator --scope operator.rea
 
 Revoke a device token for a specific role.
 
-```
+```bash
 openclaw devices revoke --device <deviceId> --role node
 ```
 

--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -31,7 +31,7 @@ List all discovered hooks from workspace, managed, and bundled directories.
 
 **Example output:**
 
-```
+```text
 Hooks (4/4 ready)
 
 Ready:
@@ -81,7 +81,7 @@ openclaw hooks info session-memory
 
 **Output:**
 
-```
+```text
 💾 session-memory ✓ Ready
 
 Save session context to memory when /new command is issued
@@ -111,7 +111,7 @@ Show summary of hook eligibility status (how many are ready vs. not ready).
 
 **Example output:**
 
-```
+```text
 Hooks Status
 
 Total hooks: 4
@@ -142,7 +142,7 @@ openclaw hooks enable session-memory
 
 **Output:**
 
-```
+```text
 ✓ Enabled hook: 💾 session-memory
 ```
 
@@ -176,7 +176,7 @@ openclaw hooks disable command-logger
 
 **Output:**
 
-```
+```text
 ⏸ Disabled hook: 📝 command-logger
 ```
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -92,7 +92,7 @@ Palette source of truth: `src/terminal/palette.ts` (the “lobster palette”).
 
 ## Command tree
 
-```
+```bash
 openclaw [--dev] [--profile <name>] <command>
   setup
   onboard

--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -13,7 +13,7 @@ Single outbound command for sending messages and channel actions
 
 ## Usage
 
-```
+```bash
 openclaw message <subcommand> [flags]
 ```
 
@@ -197,14 +197,14 @@ Name lookup:
 
 Send a Discord reply:
 
-```
+```bash
 openclaw message send --channel discord \
   --target channel:123 --message "hi" --reply-to 456
 ```
 
 Send a Discord message with components:
 
-```
+```bash
 openclaw message send --channel discord \
   --target channel:123 --message "Choose:" \
   --components '{"text":"Choose a path","blocks":[{"type":"actions","buttons":[{"label":"Approve","style":"success"},{"label":"Decline","style":"danger"}]}]}'
@@ -214,7 +214,7 @@ See [Discord components](/channels/discord#interactive-components) for the full 
 
 Create a Discord poll:
 
-```
+```bash
 openclaw message poll --channel discord \
   --target channel:123 \
   --poll-question "Snack?" \
@@ -224,7 +224,7 @@ openclaw message poll --channel discord \
 
 Create a Telegram poll (auto-close in 2 minutes):
 
-```
+```bash
 openclaw message poll --channel telegram \
   --target @mychat \
   --poll-question "Lunch?" \
@@ -234,14 +234,14 @@ openclaw message poll --channel telegram \
 
 Send a Teams proactive message:
 
-```
+```bash
 openclaw message send --channel msteams \
   --target conversation:19:abc@thread.tacv2 --message "hi"
 ```
 
 Create a Teams poll:
 
-```
+```bash
 openclaw message poll --channel msteams \
   --target conversation:19:abc@thread.tacv2 \
   --poll-question "Lunch?" \
@@ -250,14 +250,14 @@ openclaw message poll --channel msteams \
 
 React in Slack:
 
-```
+```bash
 openclaw message react --channel slack \
   --target C123 --message-id 456 --emoji "✅"
 ```
 
 React in a Signal group:
 
-```
+```bash
 openclaw message react --channel signal \
   --target signal:group:abc123 --message-id 1737630212345 \
   --emoji "✅" --target-author-uuid 123e4567-e89b-12d3-a456-426614174000
@@ -265,7 +265,7 @@ openclaw message react --channel signal \
 
 Send Telegram inline buttons:
 
-```
+```bash
 openclaw message send --channel telegram --target @mychat --message "Choose:" \
   --buttons '[ [{"text":"Yes","callback_data":"cmd:yes"}], [{"text":"No","callback_data":"cmd:no"}] ]'
 ```

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -70,7 +70,7 @@ durable notes to disk. See [Memory](/concepts/memory) for details and config.
 
 Use `/compact` (optionally with instructions) to force a compaction pass:
 
-```
+```text
 /compact Focus on decisions and open questions
 ```
 

--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -35,7 +35,7 @@ Values vary by model, provider, tool policy, and what’s in your workspace.
 
 ### `/context list`
 
-```
+```text
 🧠 Context breakdown
 Workspace: <workspaceDir>
 Bootstrap max/file: 20,000 chars
@@ -62,7 +62,7 @@ Session tokens (cached): 14,250 total / ctx=32,000
 
 ### `/context detail`
 
-```
+```text
 🧠 Context breakdown (detailed)
 …
 Top skills (prompt entry size):

--- a/docs/concepts/delegate-architecture.md
+++ b/docs/concepts/delegate-architecture.md
@@ -190,7 +190,7 @@ Create a service account and enable domain-wide delegation in the Admin Console.
 
 Delegate only the scopes you need:
 
-```
+```text
 https://www.googleapis.com/auth/gmail.readonly    # Tier 1
 https://www.googleapis.com/auth/gmail.send         # Tier 2
 https://www.googleapis.com/auth/calendar           # Tier 2

--- a/docs/concepts/messages.md
+++ b/docs/concepts/messages.md
@@ -14,7 +14,7 @@ streaming, and reasoning visibility.
 
 ## Message flow (high level)
 
-```
+```text
 Inbound message
   -> routing/bindings -> session key
   -> queue (if a run is active)

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -66,7 +66,7 @@ If `agents.defaults.models` is set, it becomes the **allowlist** for `/model` an
 session overrides. When a user selects a model that isn’t in that allowlist,
 OpenClaw returns:
 
-```
+```text
 Model "provider/model" is not allowed. Use /model to list available models.
 ```
 
@@ -95,7 +95,7 @@ Example allowlist config:
 
 You can switch models for the current session without restarting:
 
-```
+```text
 /model
 /model list
 /model 3

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -20,7 +20,7 @@ There is **no true token-delta streaming** to channel messages today. Preview st
 
 Block streaming sends assistant output in coarse chunks as it becomes available.
 
-```
+```text
 Model output
   └─ text_delta/events
        ├─ (blockStreamingBreak=text_end)

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -110,7 +110,7 @@ prompt instructs the model to use `read` to load the SKILL.md at the listed
 location (workspace, managed, or bundled). If no skills are eligible, the
 Skills section is omitted.
 
-```
+```text
 <available_skills>
   <skill>
     <name>...</name>

--- a/docs/concepts/timezone.md
+++ b/docs/concepts/timezone.md
@@ -14,7 +14,7 @@ OpenClaw standardizes timestamps so the model sees a **single reference time**.
 
 Inbound messages are wrapped in an envelope like:
 
-```
+```json
 [Provider ... 2026-01-05 16:26 PST] message text
 ```
 
@@ -44,19 +44,19 @@ You can override this with:
 
 **Local (default):**
 
-```
+```json
 [Signal Alice +1555 2026-01-18 00:19 PST] hello
 ```
 
 **Fixed timezone:**
 
-```
+```json
 [Signal Alice +1555 2026-01-18 06:19 GMT+1] hello
 ```
 
 **Elapsed time:**
 
-```
+```json
 [Signal Alice +1555 +2m 2026-01-18T05:19Z] follow-up
 ```
 

--- a/docs/concepts/typebox.md
+++ b/docs/concepts/typebox.md
@@ -31,7 +31,7 @@ methods (e.g. `health`, `send`, `chat.send`) and subscribe to events (e.g.
 
 Connection flow (minimal):
 
-```
+```text
 Client                    Gateway
   |---- req:connect -------->|
   |<---- res:hello-ok --------|

--- a/docs/date-time.md
+++ b/docs/date-time.md
@@ -15,7 +15,7 @@ Provider timestamps are preserved so tools keep their native semantics (current 
 
 Inbound messages are wrapped with a timestamp (minute precision):
 
-```
+```json
 [Provider ... 2026-01-05 16:26 PST] message text
 ```
 
@@ -46,19 +46,19 @@ You can override this behavior:
 
 **Local (default):**
 
-```
+```json
 [WhatsApp +1555 2026-01-18 00:19 PST] hello
 ```
 
 **User timezone:**
 
-```
+```json
 [WhatsApp +1555 2026-01-18 00:19 CST] hello
 ```
 
 **Elapsed time enabled:**
 
-```
+```json
 [WhatsApp +1555 +30s 2026-01-18T05:19Z] follow-up
 ```
 
@@ -68,7 +68,7 @@ If the user timezone is known, the system prompt includes a dedicated
 **Current Date & Time** section with the **time zone only** (no clock/time format)
 to keep prompt caching stable:
 
-```
+```text
 Time zone: America/Chicago
 ```
 
@@ -80,7 +80,7 @@ card includes a timestamp line.
 Queued system events inserted into agent context are prefixed with a timestamp using the
 same timezone selection as message envelopes (default: host-local).
 
-```
+```text
 System: [2026-01-12 12:19:17 PST] Model switched.
 ```
 

--- a/docs/debug/node-issue.md
+++ b/docs/debug/node-issue.md
@@ -12,7 +12,7 @@ title: "Node + tsx Crash"
 
 Running OpenClaw via Node with `tsx` fails at startup with:
 
-```
+```json
 [openclaw] Failed to start CLI: TypeError: __name is not a function
     at createSubsystemLogger (.../src/logging/subsystem.ts:203:25)
     at .../src/agents/auth-profiles/constants.ts:25:20

--- a/docs/diagnostics/flags.md
+++ b/docs/diagnostics/flags.md
@@ -56,7 +56,7 @@ OPENCLAW_DIAGNOSTICS=0
 
 Flags emit logs into the standard diagnostics log file. By default:
 
-```
+```text
 /tmp/openclaw/openclaw-YYYY-MM-DD.log
 ```
 

--- a/docs/gateway/authentication.md
+++ b/docs/gateway/authentication.md
@@ -78,7 +78,7 @@ openclaw models auth paste-token --provider anthropic
 
 If you see an Anthropic error like:
 
-```
+```text
 This credential is only authorized for use with Claude Code and cannot be used for other API requests.
 ```
 

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -85,14 +85,14 @@ Notes:
 
 All CLI backends live under:
 
-```
+```text
 agents.defaults.cliBackends
 ```
 
 Each entry is keyed by a **provider id** (e.g. `claude-cli`, `my-cli`).
 The provider id becomes the left side of your model ref:
 
-```
+```text
 <provider>/<model>
 ```
 

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -1132,7 +1132,7 @@ Common use cases:
 
 Include security guidelines in your agent's system prompt:
 
-```
+```text
 ## Security Rules
 - Never share directory listings or file paths with strangers
 - Never reveal API keys, credentials, or infrastructure details

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -192,7 +192,7 @@ Caddy with the `caddy-security` plugin can authenticate users and pass identity 
 
 Caddyfile snippet:
 
-```
+```bash
 openclaw.example.com {
     authenticate with oauth2_provider
     authorize with policy1

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -20,7 +20,7 @@ This is handy when you need to toggle obscure settings without editing `openclaw
 
 Examples:
 
-```
+```text
 /debug show
 /debug set messages.responsePrefix="[openclaw]"
 /debug unset messages.responsePrefix

--- a/docs/install/docker-vm-runtime.md
+++ b/docs/install/docker-vm-runtime.md
@@ -95,7 +95,7 @@ docker compose exec openclaw-gateway which wacli
 
 Expected output:
 
-```
+```text
 /usr/local/bin/gog
 /usr/local/bin/goplaces
 /usr/local/bin/wacli
@@ -109,7 +109,7 @@ docker compose logs -f openclaw-gateway
 
 Expected output:
 
-```
+```json
 [gateway] listening on ws://0.0.0.0:18789
 ```
 

--- a/docs/install/exe-dev.md
+++ b/docs/install/exe-dev.md
@@ -30,7 +30,7 @@ This page assumes exe.dev's default **exeuntu** image. If you picked a different
 Shelley, [exe.dev](https://exe.dev)'s agent, can install OpenClaw instantly with our
 prompt. The prompt used is as below:
 
-```
+```text
 Set up OpenClaw (https://docs.openclaw.ai/install) on this VM. Use the non-interactive and accept-risk flags for openclaw onboarding. Add the supplied auth or token as needed. Configure nginx to forward from the default port 18789 to the root location on the default enabled site config, making sure to enable Websocket support. Pairing is done by "openclaw devices list" and "openclaw devices approve <request id>". Make sure the dashboard shows that OpenClaw's health is OK. exe.dev handles forwarding from port 8000 to port 80/443 and HTTPS for us, so the final "reachable" should be <vm-name>.exe.xyz, without port specification.
 ```
 
@@ -71,7 +71,7 @@ curl -fsSL https://openclaw.ai/install.sh | bash
 
 Edit `/etc/nginx/sites-enabled/default` with
 
-```
+```text
 server {
     listen 80 default_server;
     listen [::]:80 default_server;

--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -403,7 +403,7 @@ fly ips allocate-v6 --private -a my-openclaw
 
 After this, `fly ips list` should show only a `private` type IP:
 
-```
+```text
 VERSION  IP                   TYPE             REGION
 v6       fdaa:x:x:x:x::x      private          global
 ```

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -83,7 +83,7 @@ open http://localhost:18789
 
 ## What gets deployed
 
-```
+```text
 Namespace: openclaw (configurable via OPENCLAW_NAMESPACE)
 ├── Deployment/openclaw        # Single pod, init container + gateway
 ├── Service/openclaw           # ClusterIP on port 18789
@@ -178,7 +178,7 @@ This deletes the namespace and all resources in it, including the PVC.
 
 ## File structure
 
-```
+```text
 scripts/k8s/
 ├── deploy.sh                   # Creates namespace + secret, deploys via kustomize
 ├── create-kind.sh              # Local Kind cluster (auto-detects docker/podman)

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -211,7 +211,7 @@ Flags are case-insensitive and support wildcards (e.g. `telegram.*` or `*`).
 
 Env override (one-off):
 
-```
+```text
 OPENCLAW_DIAGNOSTICS=telegram.http,telegram.payload
 ```
 

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -150,7 +150,7 @@ openclaw config set tools.exec.node "<id-or-name>"
 
 Or per session:
 
-```
+```text
 /exec host=node security=allowlist node=<id-or-name>
 ```
 

--- a/docs/nodes/media-understanding.md
+++ b/docs/nodes/media-understanding.md
@@ -376,7 +376,7 @@ When `mode: "all"`, outputs are labeled `[Image 1/2]`, `[Audio 2/2]`, etc.
 
 When media understanding runs, `/status` includes a short summary line:
 
-```
+```text
 📎 Media: image ok (openai/gpt-5.2) · audio skipped (maxBytes)
 ```
 

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -41,7 +41,7 @@ OpenClaw uses the pi SDK to embed an AI coding agent into its messaging gateway 
 
 ## File Structure
 
-```
+```text
 src/agents/
 ├── pi-embedded-runner.ts          # Re-exports from pi-embedded-runner/
 ├── pi-embedded-runner/

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -38,19 +38,19 @@ Full Linux server guide: [Linux Server](/vps). Step-by-step VPS example: [exe.de
 
 Use one of these:
 
-```
+```bash
 openclaw onboard --install-daemon
 ```
 
 Or:
 
-```
+```bash
 openclaw gateway install
 ```
 
 Or:
 
-```
+```bash
 openclaw configure
 ```
 
@@ -58,7 +58,7 @@ Select **Gateway service** when prompted.
 
 Repair/migrate:
 
-```
+```bash
 openclaw doctor
 ```
 
@@ -72,7 +72,7 @@ Minimal setup:
 
 Create `~/.config/systemd/user/openclaw-gateway[-<profile>].service`:
 
-```
+```json
 [Unit]
 Description=OpenClaw Gateway (profile: <profile>, v<version>)
 After=network-online.target
@@ -89,6 +89,6 @@ WantedBy=default.target
 
 Enable it:
 
-```
+```bash
 systemctl --user enable --now openclaw-gateway[-<profile>].service
 ```

--- a/docs/platforms/mac/canvas.md
+++ b/docs/platforms/mac/canvas.md
@@ -72,7 +72,7 @@ A2UI host page on first open.
 
 Default A2UI host URL:
 
-```
+```text
 http://<gateway-host>:18789/__openclaw__/a2ui/
 ```
 

--- a/docs/platforms/mac/xpc.md
+++ b/docs/platforms/mac/xpc.md
@@ -30,7 +30,7 @@ title: "macOS IPC"
 
 Diagram (SCI):
 
-```
+```text
 Agent -> Gateway -> Node Service (WS)
                       |  IPC (UDS + token + HMAC + TTL)
                       v

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -65,7 +65,7 @@ Node service + app IPC:
 
 Diagram (SCI):
 
-```
+```text
 Gateway -> Node Service (WS)
                  |  IPC (UDS + token + HMAC + TTL)
                  v
@@ -77,7 +77,7 @@ Gateway -> Node Service (WS)
 `system.run` is controlled by **Exec approvals** in the macOS app (Settings → Exec approvals).
 Security + ask + allowlist are stored locally on the Mac in:
 
-```
+```text
 ~/.openclaw/exec-approvals.json
 ```
 

--- a/docs/platforms/oracle.md
+++ b/docs/platforms/oracle.md
@@ -160,7 +160,7 @@ This blocks SSH on port 22, HTTP, HTTPS, and everything else at the network edge
 
 From any device on your Tailscale network:
 
-```
+```text
 https://openclaw.<tailnet-name>.ts.net/
 ```
 

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -69,19 +69,19 @@ If Scheduled Task creation is blocked, the fallback service mode still auto-star
 
 Inside WSL2:
 
-```
+```bash
 openclaw onboard --install-daemon
 ```
 
 Or:
 
-```
+```bash
 openclaw gateway install
 ```
 
 Or:
 
-```
+```bash
 openclaw configure
 ```
 
@@ -89,7 +89,7 @@ Select **Gateway service** when prompted.
 
 Repair/migrate:
 
-```
+```bash
 openclaw doctor
 ```
 

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -48,7 +48,7 @@ A plugin that registers zero capabilities but provides hooks or services is a
 
 Plugins follow this layout (whether in-repo or standalone):
 
-```
+```text
 my-plugin/
 ├── package.json          # npm metadata + openclaw config
 ├── openclaw.plugin.json  # Plugin manifest

--- a/docs/prose.md
+++ b/docs/prose.md
@@ -39,7 +39,7 @@ OpenProse registers `/prose` as a user-invocable skill command. It routes to the
 
 Common commands:
 
-```
+```text
 /prose help
 /prose run <file.prose>
 /prose run <handle/slug>
@@ -78,7 +78,7 @@ context: { findings, draft }
 
 OpenProse keeps state under `.prose/` in your workspace:
 
-```
+```text
 .prose/
 ├── .env
 ├── runs/
@@ -92,7 +92,7 @@ OpenProse keeps state under `.prose/` in your workspace:
 
 User-level persistent agents live at:
 
-```
+```text
 ~/.prose/agents/
 ```
 

--- a/docs/providers/claude-max-api-proxy.md
+++ b/docs/providers/claude-max-api-proxy.md
@@ -28,7 +28,7 @@ If you have a Claude Max subscription and want to use it with OpenAI-compatible 
 
 ## How It Works
 
-```
+```text
 Your App → claude-max-api-proxy → Claude Code CLI → Anthropic (via subscription)
      (OpenAI format)              (converts format)      (uses your login)
 ```

--- a/docs/providers/deepgram.md
+++ b/docs/providers/deepgram.md
@@ -22,7 +22,7 @@ Docs: [https://developers.deepgram.com](https://developers.deepgram.com)
 
 1. Set your API key:
 
-```
+```text
 DEEPGRAM_API_KEY=dg_...
 ```
 

--- a/docs/providers/kilocode.md
+++ b/docs/providers/kilocode.md
@@ -57,7 +57,7 @@ OpenClaw dynamically discovers available models from the Kilo Gateway at startup
 
 Any model available on the gateway can be used with the `kilocode/` prefix:
 
-```
+```text
 kilocode/kilo/auto              (default - smart routing)
 kilocode/anthropic/claude-sonnet-4
 kilocode/openai/gpt-5.2

--- a/docs/providers/synthetic.md
+++ b/docs/providers/synthetic.md
@@ -22,7 +22,7 @@ openclaw onboard --auth-choice synthetic-api-key
 
 The default model is set to:
 
-```
+```text
 synthetic/hf:MiniMaxAI/MiniMax-M2.5
 ```
 

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -425,7 +425,7 @@ If we want to get fancier later, common next steps are Reciprocal Rank Fusion (R
 After merging vector and keyword scores, two optional post-processing stages
 refine the result list before it reaches the agent:
 
-```
+```text
 Vector + Keyword -> Weighted Merge -> Temporal Decay -> Sort -> MMR -> Top-K Results
 ```
 
@@ -456,7 +456,7 @@ The `lambda` parameter controls the trade-off:
 
 Given these memory files:
 
-```
+```text
 memory/2026-02-10.md  -> "Configured Omada router, set VLAN 10 for IoT devices"
 memory/2026-02-08.md  -> "Configured Omada router, moved IoT to VLAN 10"
 memory/2026-02-05.md  -> "Set up AdGuard DNS on 192.168.10.2"
@@ -465,7 +465,7 @@ memory/network.md     -> "Router: Omada ER605, AdGuard: 192.168.10.2, VLAN 10: I
 
 Without MMR -- top 3 results:
 
-```
+```text
 1. memory/2026-02-10.md  (score: 0.92)  <- router + VLAN
 2. memory/2026-02-08.md  (score: 0.89)  <- router + VLAN (near-duplicate!)
 3. memory/network.md     (score: 0.85)  <- reference doc
@@ -473,7 +473,7 @@ Without MMR -- top 3 results:
 
 With MMR (lambda=0.7) -- top 3 results:
 
-```
+```text
 1. memory/2026-02-10.md  (score: 0.92)  <- router + VLAN
 2. memory/network.md     (score: 0.85)  <- reference doc (diverse!)
 3. memory/2026-02-05.md  (score: 0.78)  <- AdGuard DNS (diverse!)
@@ -492,7 +492,7 @@ a well-worded note from six months ago can outrank yesterday's update on the sam
 **Temporal decay** applies an exponential multiplier to scores based on the age of each result,
 so recent memories naturally rank higher while old ones fade:
 
-```
+```text
 decayedScore = score x e^(-lambda x ageInDays)
 ```
 
@@ -519,7 +519,7 @@ Other sources (e.g., session transcripts) fall back to file modification time (`
 
 Given these memory files (today is Feb 10):
 
-```
+```text
 memory/2025-09-15.md  -> "Rod works Mon-Fri, standup at 10am, pairing at 2pm"  (148 days old)
 memory/2026-02-10.md  -> "Rod has standup at 14:15, 1:1 with Zeb at 14:45"    (today)
 memory/2026-02-03.md  -> "Rod started new team, standup moved to 14:15"        (7 days old)
@@ -527,7 +527,7 @@ memory/2026-02-03.md  -> "Rod started new team, standup moved to 14:15"        (
 
 Without decay:
 
-```
+```text
 1. memory/2025-09-15.md  (score: 0.91)  <- best semantic match, but stale!
 2. memory/2026-02-10.md  (score: 0.82)
 3. memory/2026-02-03.md  (score: 0.80)
@@ -535,7 +535,7 @@ Without decay:
 
 With decay (halfLife=30):
 
-```
+```text
 1. memory/2026-02-10.md  (score: 0.82 x 1.00 = 0.82)  <- today, no decay
 2. memory/2026-02-03.md  (score: 0.80 x 0.85 = 0.68)  <- 7 days, mild decay
 3. memory/2025-09-15.md  (score: 0.91 x 0.03 = 0.03)  <- 148 days, nearly gone

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -65,7 +65,7 @@ Other surfaces:
 
 Costs are estimated from your model pricing config:
 
-```
+```text
 models.providers.<provider>.models[].cost
 ```
 

--- a/docs/security/THREAT-MODEL-ATLAS.md
+++ b/docs/security/THREAT-MODEL-ATLAS.md
@@ -65,7 +65,7 @@ Nothing is explicitly out of scope for this threat model.
 
 ### 2.1 Trust Boundaries
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                    UNTRUSTED ZONE                                │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐              │
@@ -514,21 +514,21 @@ Current patterns in `moderation.ts`:
 
 **Attack Chain 1: Skill-Based Data Theft**
 
-```
+```text
 T-PERSIST-001 → T-EVADE-001 → T-EXFIL-003
 (Publish malicious skill) → (Evade moderation) → (Harvest credentials)
 ```
 
 **Attack Chain 2: Prompt Injection to RCE**
 
-```
+```text
 T-EXEC-001 → T-EXEC-004 → T-IMPACT-001
 (Inject prompt) → (Bypass exec approval) → (Execute commands)
 ```
 
 **Attack Chain 3: Indirect Injection via Fetched Content**
 
-```
+```text
 T-EXEC-002 → T-EXFIL-001 → External exfiltration
 (Poison URL content) → (Agent fetches & follows instructions) → (Data sent to attacker)
 ```

--- a/docs/start/lore.md
+++ b/docs/start/lore.md
@@ -35,7 +35,7 @@ _The crustacean known as Clawd had officially molted._
 
 ## The Name
 
-```
+```text
 OpenClaw = OPEN + CLAW
         = Open source, open to everyone
         = Our lobster heritage, where we came from
@@ -162,7 +162,7 @@ Peter: _nervously checks credit card access_
 
 ## The Lobster Creed
 
-```
+```text
 I am Molty.
 I live in the OpenClaw.
 I shall not dump directories to strangers.

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -185,7 +185,7 @@ Inbound attachments (images/audio/docs) can be surfaced to your command via temp
 
 Outbound attachments from the agent: include `MEDIA:<path-or-url>` on its own line (no spaces). Example:
 
-```
+```text
 Here’s the screenshot.
 MEDIA:https://example.com/screenshot.png
 ```

--- a/docs/tools/apply-patch.md
+++ b/docs/tools/apply-patch.md
@@ -13,7 +13,7 @@ or multi-hunk edits where a single `edit` call would be brittle.
 
 The tool accepts a single `input` string that wraps one or more file operations:
 
-```
+```text
 *** Begin Patch
 *** Add File: path/to/file.txt
 +line 1

--- a/docs/tools/browser-linux-troubleshooting.md
+++ b/docs/tools/browser-linux-troubleshooting.md
@@ -10,8 +10,8 @@ title: "Browser Troubleshooting"
 
 OpenClaw's browser control server fails to launch Chrome/Brave/Edge/Chromium with the error:
 
-```
-{"error":"Error: Failed to start Chrome CDP on port 18800 for profile \"openclaw\"."}
+```json
+{ "error": "Error: Failed to start Chrome CDP on port 18800 for profile \"openclaw\"." }
 ```
 
 ### Root Cause
@@ -20,7 +20,7 @@ On Ubuntu (and many Linux distros), the default Chromium installation is a **sna
 
 The `apt install chromium` command installs a stub package that redirects to snap:
 
-```
+```text
 Note, selecting 'chromium-browser' instead of 'chromium'
 chromium-browser is already the newest version (2:1snap1-0ubuntu2).
 ```

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -325,7 +325,7 @@ Config:
 
 Reply in chat:
 
-```
+```text
 /approve <id> allow-once
 /approve <id> allow-always
 /approve <id> deny
@@ -359,7 +359,7 @@ See:
 
 ### macOS IPC flow
 
-```
+```text
 Gateway -> Node Service (WS)
                  |  IPC (UDS + token + HMAC + TTL)
                  v

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -102,7 +102,7 @@ Send `/exec` with no arguments to show the current values.
 
 Example:
 
-```
+```text
 /exec host=gateway security=allowlist ask=on-miss node=mac-1
 ```
 

--- a/docs/tools/lobster.md
+++ b/docs/tools/lobster.md
@@ -196,7 +196,7 @@ tools, include the core tools or groups you want in the allowlist too.
 
 Without Lobster:
 
-```
+```text
 User: "Check my email and draft replies"
 → openclaw calls gmail.list
 → LLM summarizes

--- a/docs/tools/multi-agent-sandbox-tools.md
+++ b/docs/tools/multi-agent-sandbox-tools.md
@@ -175,7 +175,7 @@ When both global (`agents.defaults.*`) and agent-specific (`agents.list[].*`) co
 
 Agent-specific settings override global:
 
-```
+```text
 agents.list[].sandbox.mode > agents.defaults.sandbox.mode
 agents.list[].sandbox.scope > agents.defaults.sandbox.scope
 agents.list[].sandbox.workspaceRoot > agents.defaults.sandbox.workspaceRoot

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -279,7 +279,7 @@ When skills are eligible, OpenClaw injects a compact XML list of available skill
 
 Formula (characters):
 
-```
+```text
 total = 195 + Σ (97 + len(name_escaped) + len(description_escaped) + len(location_escaped))
 ```
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -166,7 +166,7 @@ Notes:
 
 Examples:
 
-```
+```text
 /model
 /model list
 /model 3
@@ -188,7 +188,7 @@ Notes:
 
 Examples:
 
-```
+```text
 /debug show
 /debug set messages.responsePrefix="[openclaw]"
 /debug set channels.whatsapp.allowFrom=["+1555","+4477"]
@@ -207,7 +207,7 @@ Notes:
 
 Examples:
 
-```
+```text
 /config show
 /config show messages.responsePrefix
 /config get messages.responsePrefix

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -196,7 +196,7 @@ Full schema is in [Gateway configuration](/gateway/configuration).
 
 Then run:
 
-```
+```text
 /tts summary off
 ```
 
@@ -255,7 +255,7 @@ the audio.
 
 Example reply payload:
 
-```
+```text
 Here you go.
 
 [[tts:voiceId=pMsXgVXv3BLzUgSXRplE model=eleven_v3 speed=1.1]]
@@ -347,7 +347,7 @@ is skipped and the normal text reply is sent.
 
 ## Flow diagram
 
-```
+```text
 Reply -> TTS enabled?
   no  -> send text
   yes -> has media / MEDIA: / short?
@@ -368,7 +368,7 @@ See [Slash commands](/tools/slash-commands) for enablement details.
 Discord note: `/tts` is a built-in Discord command, so OpenClaw registers
 `/voice` as the native command there. Text `/tts ...` still works.
 
-```
+```text
 /tts off
 /tts always
 /tts inbound

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -196,7 +196,7 @@ Full schema is in [Gateway configuration](/gateway/configuration).
 
 Then run:
 
-```
+```text
 /tts summary off
 ```
 
@@ -255,7 +255,7 @@ the audio.
 
 Example reply payload:
 
-```
+```text
 Here you go.
 
 [[tts:voiceId=pMsXgVXv3BLzUgSXRplE model=eleven_v3 speed=1.1]]
@@ -347,7 +347,7 @@ is skipped and the normal text reply is sent.
 
 ## Flow diagram
 
-```
+```text
 Reply -> TTS enabled?
   no  -> send text
   yes -> has media / MEDIA: / short?
@@ -368,7 +368,7 @@ See [Slash commands](/tools/slash-commands) for enablement details.
 Discord note: `/tts` is a built-in Discord command, so OpenClaw registers
 `/voice` as the native command there. Text `/tts ...` still works.
 
-```
+```text
 /tts off
 /tts always
 /tts inbound

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -2,7 +2,7 @@
   "name": "@openclaw/open-prose",
   "version": "2026.3.14",
   "private": true,
-  "description": "OpenProse VM skill pack plugin (slash command + telemetry).",
+  "description": "OpenProse VM skill pack plugin (slash command + telemetry)",
   "type": "module",
   "openclaw": {
     "extensions": [


### PR DESCRIPTION
Remove trailing period from open-prose package.json description for consistency with all other extensions. Also adds missing language tags to fenced code blocks in docs.