### PR TITLE
feat(browser): support cdpPort for existing-session profile targeting

### DIFF
--- a/PR-PLAN.md
+++ b/PR-PLAN.md
@@ -1,0 +1,161 @@
+# PR Plan: Chrome Profile Targeting for existing-session
+
+## Issue
+
+GitHub Issue #49241: When using `driver: "existing-session"`, OpenClaw connects via Chrome MCP's `--autoConnect` flag which grabs the first Chrome instance it discovers. If a user has multiple Chrome profile windows open (personal + work), the agent attaches to whichever one MCP finds first — there's no way to specify which profile to target.
+
+## Root Cause Analysis
+
+### 1. `resolveProfile()` discards cdpPort for existing-session profiles
+
+In `src/browser/config.ts`, line ~235:
+
+```typescript
+if (driver === "existing-session") {
+  return {
+    cdpPort: 0, // HARDCODED — ignores profile.cdpPort from config
+    cdpUrl: "", // HARDCODED — ignores profile.cdpUrl from config
+    cdpHost: "",
+    cdpIsLoopback: true,
+    userDataDir: resolveUserPath(profile.userDataDir?.trim() || "") || undefined,
+    color: profile.color,
+    driver,
+    attachOnly: true,
+  };
+}
+```
+
+Even if the user sets `cdpPort: 9222` in their profile config, it gets thrown away.
+
+### 2. Chrome MCP is always launched with `--autoConnect` (no port targeting)
+
+In `src/browser/chrome-mcp.ts`:
+
+```typescript
+const DEFAULT_CHROME_MCP_ARGS = [
+  "-y",
+  "chrome-devtools-mcp@latest",
+  "--autoConnect",
+  "--experimentalStructuredContent",
+  "--experimental-page-id-routing",
+];
+```
+
+And `buildChromeMcpArgs()` only optionally adds `--userDataDir`:
+
+```typescript
+export function buildChromeMcpArgs(userDataDir?: string): string[] {
+  const normalizedUserDataDir = normalizeChromeMcpUserDataDir(userDataDir);
+  return normalizedUserDataDir
+    ? [...DEFAULT_CHROME_MCP_ARGS, "--userDataDir", normalizedUserDataDir]
+    : [...DEFAULT_CHROME_MCP_ARGS];
+}
+```
+
+No support for `--port` to target a specific Chrome debug port.
+
+### 3. The data flow never passes cdpPort to MCP
+
+The entire chain: `config → resolveProfile → server-context → chrome-mcp` never threads a CDP port for existing-session profiles because `resolveProfile()` zeros it out at step 1.
+
+## Solution
+
+### Approach: CDP Port-Based Targeting
+
+The cleanest approach: let users launch each Chrome profile with a different `--remote-debugging-port` and configure OpenClaw to connect to the specific port.
+
+**Why this approach:**
+
+- `chrome-devtools-mcp` already supports `--port <number>` to target a specific CDP port instead of auto-discovering
+- Doesn't require scraping Chrome internals or checking logged-in Google accounts
+- Users already know how to launch Chrome with `--remote-debugging-port=XXXX`
+- Each profile window gets a unique port = deterministic targeting
+- Works on all platforms (macOS, Windows, Linux)
+
+**User experience after fix:**
+
+```json
+{
+  "browser": {
+    "profiles": {
+      "personal": {
+        "driver": "existing-session",
+        "cdpPort": 9222,
+        "color": "#00AA00"
+      },
+      "work": {
+        "driver": "existing-session",
+        "cdpPort": 9223,
+        "color": "#FF0000"
+      }
+    }
+  }
+}
+```
+
+User launches Chrome profiles:
+
+```bash
+# Personal profile
+open -na "Google Chrome" --args --profile-directory="Profile 1" --remote-debugging-port=9222
+
+# Work profile
+open -na "Google Chrome" --args --profile-directory="Profile 3" --remote-debugging-port=9223
+```
+
+## Files to Modify
+
+### 1. `src/browser/config.ts` — `resolveProfile()`
+
+**What:** Stop discarding `cdpPort` for existing-session profiles. Pass it through to `ResolvedBrowserProfile`.
+**How:** When `driver === "existing-session"` and `profile.cdpPort` is set, include it in the return value instead of hardcoding 0.
+
+### 2. `src/browser/chrome-mcp.ts` — `buildChromeMcpArgs()` + `createRealSession()`
+
+**What:** Thread `cdpPort` through to MCP args. When a port is specified, pass `--port <number>` to `chrome-devtools-mcp` so it connects to that specific debug port instead of auto-discovering.
+**How:**
+
+- Update `buildChromeMcpArgs()` signature to accept `cdpPort?: number`
+- When `cdpPort` is provided and > 0, add `--port`, `<cdpPort>` to the args array
+- Update `createRealSession()` to accept and forward `cdpPort`
+- Update `getSession()` and `callTool()` to thread `cdpPort` through
+- Update cache key to include cdpPort (so different ports get different sessions)
+
+### 3. `src/browser/chrome-mcp.ts` — All exported functions
+
+**What:** Add `cdpPort?: number` parameter to all exported functions that call `callTool()`.
+**How:** Each function like `listChromeMcpPages`, `openChromeMcpTab`, `takeChromeMcpSnapshot`, etc. needs to accept and forward `cdpPort`.
+
+### 4. Call sites that pass profile data to chrome-mcp functions
+
+**What:** Thread `cdpPort` from `ResolvedBrowserProfile` to chrome-mcp function calls.
+**How:** Search for all call sites of chrome-mcp functions and pass `profile.cdpPort` where available.
+
+### 5. `src/config/types.browser.ts` — Documentation
+
+**What:** Update JSDoc on `cdpPort` in `BrowserProfileConfig` to clarify it works with existing-session too.
+
+### 6. Tests
+
+- Update existing tests in `src/browser/config.test.ts` for the new resolveProfile behavior
+- Update existing tests in `src/browser/server-context.existing-session.test.ts`
+- Add a test in chrome-mcp tests for `buildChromeMcpArgs` with cdpPort
+
+## What NOT to Change
+
+- Don't change the default behavior (no cdpPort = autoConnect as before)
+- Don't add new config fields — `cdpPort` already exists in BrowserProfileConfig
+- Don't change how `userDataDir` works — it's orthogonal
+- Don't change the extension or openclaw driver flows
+
+## Testing Strategy
+
+1. Unit tests for `resolveProfile()` with existing-session + cdpPort
+2. Unit tests for `buildChromeMcpArgs()` with cdpPort parameter
+3. Verify existing tests still pass (no regressions)
+4. Manual test: launch 2 Chrome profiles with different ports, connect to each
+
+## Backward Compatibility
+
+- Fully backward compatible: existing configs without `cdpPort` on existing-session profiles work exactly as before (autoConnect)
+- Only behavior change: when `cdpPort` IS specified, it's now respected instead of silently discarded

--- a/src/browser/chrome-mcp.test.ts
+++ b/src/browser/chrome-mcp.test.ts
@@ -116,6 +116,49 @@ describe("chrome MCP page parsing", () => {
     ]);
   });
 
+  it("adds --port when cdpPort is specified for targeting a specific Chrome debug port", () => {
+    expect(buildChromeMcpArgs(undefined, 9222)).toEqual([
+      "-y",
+      "chrome-devtools-mcp@latest",
+      "--autoConnect",
+      "--experimentalStructuredContent",
+      "--experimental-page-id-routing",
+      "--port",
+      "9222",
+    ]);
+  });
+
+  it("adds both --userDataDir and --port when both are specified", () => {
+    expect(buildChromeMcpArgs("/tmp/brave-profile", 9223)).toEqual([
+      "-y",
+      "chrome-devtools-mcp@latest",
+      "--autoConnect",
+      "--experimentalStructuredContent",
+      "--experimental-page-id-routing",
+      "--userDataDir",
+      "/tmp/brave-profile",
+      "--port",
+      "9223",
+    ]);
+  });
+
+  it("does not add --port when cdpPort is 0 or negative", () => {
+    expect(buildChromeMcpArgs(undefined, 0)).toEqual([
+      "-y",
+      "chrome-devtools-mcp@latest",
+      "--autoConnect",
+      "--experimentalStructuredContent",
+      "--experimental-page-id-routing",
+    ]);
+    expect(buildChromeMcpArgs(undefined, -1)).toEqual([
+      "-y",
+      "chrome-devtools-mcp@latest",
+      "--autoConnect",
+      "--experimentalStructuredContent",
+      "--experimental-page-id-routing",
+    ]);
+  });
+
   it("parses new_page text responses and returns the created tab", async () => {
     const factory: ChromeMcpSessionFactory = async () => createFakeSession();
     setChromeMcpSessionFactoryForTest(factory);

--- a/src/browser/chrome-mcp.test.ts
+++ b/src/browser/chrome-mcp.test.ts
@@ -333,6 +333,30 @@ describe("chrome MCP page parsing", () => {
     expect(closeMocks[1]).not.toHaveBeenCalled();
   });
 
+  it("creates a fresh session when cdpPort changes for the same profile", async () => {
+    const closeMocks: Array<ReturnType<typeof vi.fn>> = [];
+    const factoryCalls: Array<{ profileName: string; userDataDir?: string; cdpPort?: number }> = [];
+    const factory: ChromeMcpSessionFactory = async (profileName, userDataDir, cdpPort) => {
+      factoryCalls.push({ profileName, userDataDir, cdpPort });
+      const session = createFakeSession();
+      const closeMock = vi.fn().mockResolvedValue(undefined);
+      session.client.close = closeMock as typeof session.client.close;
+      closeMocks.push(closeMock);
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    await listChromeMcpTabs("chrome-live", undefined, 9222);
+    await listChromeMcpTabs("chrome-live", undefined, 9223);
+
+    expect(factoryCalls).toEqual([
+      { profileName: "chrome-live", userDataDir: undefined, cdpPort: 9222 },
+      { profileName: "chrome-live", userDataDir: undefined, cdpPort: 9223 },
+    ]);
+    expect(closeMocks[0]).toHaveBeenCalledTimes(1);
+    expect(closeMocks[1]).not.toHaveBeenCalled();
+  });
+
   it("clears failed pending sessions so the next call can retry", async () => {
     let factoryCalls = 0;
     const factory: ChromeMcpSessionFactory = async () => {

--- a/src/browser/chrome-mcp.ts
+++ b/src/browser/chrome-mcp.ts
@@ -29,6 +29,7 @@ type ChromeMcpSession = {
 type ChromeMcpSessionFactory = (
   profileName: string,
   userDataDir?: string,
+  cdpPort?: number,
 ) => Promise<ChromeMcpSession>;
 
 const DEFAULT_CHROME_MCP_COMMAND = "npx";
@@ -260,12 +261,16 @@ async function createRealSession(
       }
     } catch (err) {
       await client.close().catch(() => {});
-      const targetLabel = userDataDir
-        ? `the configured Chromium user data dir (${userDataDir})`
-        : "Google Chrome's default profile";
+      const targetLabel =
+        cdpPort && cdpPort > 0
+          ? `Chrome running on debug port ${cdpPort}`
+          : userDataDir
+            ? `the configured Chromium user data dir (${userDataDir})`
+            : "Google Chrome's default profile";
       throw new BrowserProfileUnavailableError(
         `Chrome MCP existing-session attach failed for profile "${profileName}". ` +
-          `Make sure ${targetLabel} is running locally with remote debugging enabled. ` +
+          `Make sure ${targetLabel} is running locally with remote debugging enabled` +
+          `${cdpPort && cdpPort > 0 ? ` (--remote-debugging-port=${cdpPort})` : ""}. ` +
           `Details: ${String(err)}`,
       );
     }

--- a/src/browser/chrome-mcp.ts
+++ b/src/browser/chrome-mcp.ts
@@ -176,8 +176,16 @@ function normalizeChromeMcpUserDataDir(userDataDir?: string): string | undefined
   return trimmed ? trimmed : undefined;
 }
 
-function buildChromeMcpSessionCacheKey(profileName: string, userDataDir?: string): string {
-  return JSON.stringify([profileName, normalizeChromeMcpUserDataDir(userDataDir) ?? ""]);
+function buildChromeMcpSessionCacheKey(
+  profileName: string,
+  userDataDir?: string,
+  cdpPort?: number,
+): string {
+  return JSON.stringify([
+    profileName,
+    normalizeChromeMcpUserDataDir(userDataDir) ?? "",
+    typeof cdpPort === "number" && cdpPort > 0 ? cdpPort : 0,
+  ]);
 }
 
 function cacheKeyMatchesProfileName(cacheKey: string, profileName: string): boolean {
@@ -213,20 +221,26 @@ async function closeChromeMcpSessionsForProfile(
   return closed;
 }
 
-export function buildChromeMcpArgs(userDataDir?: string): string[] {
+export function buildChromeMcpArgs(userDataDir?: string, cdpPort?: number): string[] {
   const normalizedUserDataDir = normalizeChromeMcpUserDataDir(userDataDir);
-  return normalizedUserDataDir
-    ? [...DEFAULT_CHROME_MCP_ARGS, "--userDataDir", normalizedUserDataDir]
-    : [...DEFAULT_CHROME_MCP_ARGS];
+  const args = [...DEFAULT_CHROME_MCP_ARGS];
+  if (normalizedUserDataDir) {
+    args.push("--userDataDir", normalizedUserDataDir);
+  }
+  if (typeof cdpPort === "number" && cdpPort > 0) {
+    args.push("--port", String(cdpPort));
+  }
+  return args;
 }
 
 async function createRealSession(
   profileName: string,
   userDataDir?: string,
+  cdpPort?: number,
 ): Promise<ChromeMcpSession> {
   const transport = new StdioClientTransport({
     command: DEFAULT_CHROME_MCP_COMMAND,
-    args: buildChromeMcpArgs(userDataDir),
+    args: buildChromeMcpArgs(userDataDir, cdpPort),
     stderr: "pipe",
   });
   const client = new Client(
@@ -264,8 +278,12 @@ async function createRealSession(
   };
 }
 
-async function getSession(profileName: string, userDataDir?: string): Promise<ChromeMcpSession> {
-  const cacheKey = buildChromeMcpSessionCacheKey(profileName, userDataDir);
+async function getSession(
+  profileName: string,
+  userDataDir?: string,
+  cdpPort?: number,
+): Promise<ChromeMcpSession> {
+  const cacheKey = buildChromeMcpSessionCacheKey(profileName, userDataDir, cdpPort);
   await closeChromeMcpSessionsForProfile(profileName, cacheKey);
 
   let session = sessions.get(cacheKey);
@@ -277,7 +295,11 @@ async function getSession(profileName: string, userDataDir?: string): Promise<Ch
     let pending = pendingSessions.get(cacheKey);
     if (!pending) {
       pending = (async () => {
-        const created = await (sessionFactory ?? createRealSession)(profileName, userDataDir);
+        const created = await (sessionFactory ?? createRealSession)(
+          profileName,
+          userDataDir,
+          cdpPort,
+        );
         if (pendingSessions.get(cacheKey) === pending) {
           sessions.set(cacheKey, created);
         } else {
@@ -312,9 +334,10 @@ async function callTool(
   userDataDir: string | undefined,
   name: string,
   args: Record<string, unknown> = {},
+  cdpPort?: number,
 ): Promise<ChromeMcpToolResult> {
-  const cacheKey = buildChromeMcpSessionCacheKey(profileName, userDataDir);
-  const session = await getSession(profileName, userDataDir);
+  const cacheKey = buildChromeMcpSessionCacheKey(profileName, userDataDir, cdpPort);
+  const session = await getSession(profileName, userDataDir, cdpPort);
   let result: ChromeMcpToolResult;
   try {
     result = (await session.client.callTool({
@@ -349,8 +372,9 @@ async function findPageById(
   profileName: string,
   pageId: number,
   userDataDir?: string,
+  cdpPort?: number,
 ): Promise<ChromeMcpStructuredPage> {
-  const pages = await listChromeMcpPages(profileName, userDataDir);
+  const pages = await listChromeMcpPages(profileName, userDataDir, cdpPort);
   const page = pages.find((entry) => entry.id === pageId);
   if (!page) {
     throw new BrowserTabNotFoundError();
@@ -361,8 +385,9 @@ async function findPageById(
 export async function ensureChromeMcpAvailable(
   profileName: string,
   userDataDir?: string,
+  cdpPort?: number,
 ): Promise<void> {
-  await getSession(profileName, userDataDir);
+  await getSession(profileName, userDataDir, cdpPort);
 }
 
 export function getChromeMcpPid(profileName: string): number | null {
@@ -388,24 +413,27 @@ export async function stopAllChromeMcpSessions(): Promise<void> {
 export async function listChromeMcpPages(
   profileName: string,
   userDataDir?: string,
+  cdpPort?: number,
 ): Promise<ChromeMcpStructuredPage[]> {
-  const result = await callTool(profileName, userDataDir, "list_pages");
+  const result = await callTool(profileName, userDataDir, "list_pages", {}, cdpPort);
   return extractStructuredPages(result);
 }
 
 export async function listChromeMcpTabs(
   profileName: string,
   userDataDir?: string,
+  cdpPort?: number,
 ): Promise<BrowserTab[]> {
-  return toBrowserTabs(await listChromeMcpPages(profileName, userDataDir));
+  return toBrowserTabs(await listChromeMcpPages(profileName, userDataDir, cdpPort));
 }
 
 export async function openChromeMcpTab(
   profileName: string,
   url: string,
   userDataDir?: string,
+  cdpPort?: number,
 ): Promise<BrowserTab> {
-  const result = await callTool(profileName, userDataDir, "new_page", { url });
+  const result = await callTool(profileName, userDataDir, "new_page", { url }, cdpPort);
   const pages = extractStructuredPages(result);
   const chosen = pages.find((page) => page.selected) ?? pages.at(-1);
   if (!chosen) {
@@ -423,38 +451,60 @@ export async function focusChromeMcpTab(
   profileName: string,
   targetId: string,
   userDataDir?: string,
+  cdpPort?: number,
 ): Promise<void> {
-  await callTool(profileName, userDataDir, "select_page", {
-    pageId: parsePageId(targetId),
-    bringToFront: true,
-  });
+  await callTool(
+    profileName,
+    userDataDir,
+    "select_page",
+    {
+      pageId: parsePageId(targetId),
+      bringToFront: true,
+    },
+    cdpPort,
+  );
 }
 
 export async function closeChromeMcpTab(
   profileName: string,
   targetId: string,
   userDataDir?: string,
+  cdpPort?: number,
 ): Promise<void> {
-  await callTool(profileName, userDataDir, "close_page", { pageId: parsePageId(targetId) });
+  await callTool(
+    profileName,
+    userDataDir,
+    "close_page",
+    { pageId: parsePageId(targetId) },
+    cdpPort,
+  );
 }
 
 export async function navigateChromeMcpPage(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   url: string;
   timeoutMs?: number;
 }): Promise<{ url: string }> {
-  await callTool(params.profileName, params.userDataDir, "navigate_page", {
-    pageId: parsePageId(params.targetId),
-    type: "url",
-    url: params.url,
-    ...(typeof params.timeoutMs === "number" ? { timeout: params.timeoutMs } : {}),
-  });
+  await callTool(
+    params.profileName,
+    params.userDataDir,
+    "navigate_page",
+    {
+      pageId: parsePageId(params.targetId),
+      type: "url",
+      url: params.url,
+      ...(typeof params.timeoutMs === "number" ? { timeout: params.timeoutMs } : {}),
+    },
+    params.cdpPort,
+  );
   const page = await findPageById(
     params.profileName,
     parsePageId(params.targetId),
     params.userDataDir,
+    params.cdpPort,
   );
   return { url: page.url ?? params.url };
 }
@@ -462,30 +512,44 @@ export async function navigateChromeMcpPage(params: {
 export async function takeChromeMcpSnapshot(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
 }): Promise<ChromeMcpSnapshotNode> {
-  const result = await callTool(params.profileName, params.userDataDir, "take_snapshot", {
-    pageId: parsePageId(params.targetId),
-  });
+  const result = await callTool(
+    params.profileName,
+    params.userDataDir,
+    "take_snapshot",
+    {
+      pageId: parsePageId(params.targetId),
+    },
+    params.cdpPort,
+  );
   return extractSnapshot(result);
 }
 
 export async function takeChromeMcpScreenshot(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   uid?: string;
   fullPage?: boolean;
   format?: "png" | "jpeg";
 }): Promise<Buffer> {
   return await withTempFile(async (filePath) => {
-    await callTool(params.profileName, params.userDataDir, "take_screenshot", {
-      pageId: parsePageId(params.targetId),
-      filePath,
-      format: params.format ?? "png",
-      ...(params.uid ? { uid: params.uid } : {}),
-      ...(params.fullPage ? { fullPage: true } : {}),
-    });
+    await callTool(
+      params.profileName,
+      params.userDataDir,
+      "take_screenshot",
+      {
+        pageId: parsePageId(params.targetId),
+        filePath,
+        format: params.format ?? "png",
+        ...(params.uid ? { uid: params.uid } : {}),
+        ...(params.fullPage ? { fullPage: true } : {}),
+      },
+      params.cdpPort,
+    );
     return await fs.readFile(filePath);
   });
 }
@@ -493,150 +557,227 @@ export async function takeChromeMcpScreenshot(params: {
 export async function clickChromeMcpElement(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   uid: string;
   doubleClick?: boolean;
 }): Promise<void> {
-  await callTool(params.profileName, params.userDataDir, "click", {
-    pageId: parsePageId(params.targetId),
-    uid: params.uid,
-    ...(params.doubleClick ? { dblClick: true } : {}),
-  });
+  await callTool(
+    params.profileName,
+    params.userDataDir,
+    "click",
+    {
+      pageId: parsePageId(params.targetId),
+      uid: params.uid,
+      ...(params.doubleClick ? { dblClick: true } : {}),
+    },
+    params.cdpPort,
+  );
 }
 
 export async function fillChromeMcpElement(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   uid: string;
   value: string;
 }): Promise<void> {
-  await callTool(params.profileName, params.userDataDir, "fill", {
-    pageId: parsePageId(params.targetId),
-    uid: params.uid,
-    value: params.value,
-  });
+  await callTool(
+    params.profileName,
+    params.userDataDir,
+    "fill",
+    {
+      pageId: parsePageId(params.targetId),
+      uid: params.uid,
+      value: params.value,
+    },
+    params.cdpPort,
+  );
 }
 
 export async function fillChromeMcpForm(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   elements: Array<{ uid: string; value: string }>;
 }): Promise<void> {
-  await callTool(params.profileName, params.userDataDir, "fill_form", {
-    pageId: parsePageId(params.targetId),
-    elements: params.elements,
-  });
+  await callTool(
+    params.profileName,
+    params.userDataDir,
+    "fill_form",
+    {
+      pageId: parsePageId(params.targetId),
+      elements: params.elements,
+    },
+    params.cdpPort,
+  );
 }
 
 export async function hoverChromeMcpElement(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   uid: string;
 }): Promise<void> {
-  await callTool(params.profileName, params.userDataDir, "hover", {
-    pageId: parsePageId(params.targetId),
-    uid: params.uid,
-  });
+  await callTool(
+    params.profileName,
+    params.userDataDir,
+    "hover",
+    {
+      pageId: parsePageId(params.targetId),
+      uid: params.uid,
+    },
+    params.cdpPort,
+  );
 }
 
 export async function dragChromeMcpElement(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   fromUid: string;
   toUid: string;
 }): Promise<void> {
-  await callTool(params.profileName, params.userDataDir, "drag", {
-    pageId: parsePageId(params.targetId),
-    from_uid: params.fromUid,
-    to_uid: params.toUid,
-  });
+  await callTool(
+    params.profileName,
+    params.userDataDir,
+    "drag",
+    {
+      pageId: parsePageId(params.targetId),
+      from_uid: params.fromUid,
+      to_uid: params.toUid,
+    },
+    params.cdpPort,
+  );
 }
 
 export async function uploadChromeMcpFile(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   uid: string;
   filePath: string;
 }): Promise<void> {
-  await callTool(params.profileName, params.userDataDir, "upload_file", {
-    pageId: parsePageId(params.targetId),
-    uid: params.uid,
-    filePath: params.filePath,
-  });
+  await callTool(
+    params.profileName,
+    params.userDataDir,
+    "upload_file",
+    {
+      pageId: parsePageId(params.targetId),
+      uid: params.uid,
+      filePath: params.filePath,
+    },
+    params.cdpPort,
+  );
 }
 
 export async function pressChromeMcpKey(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   key: string;
 }): Promise<void> {
-  await callTool(params.profileName, params.userDataDir, "press_key", {
-    pageId: parsePageId(params.targetId),
-    key: params.key,
-  });
+  await callTool(
+    params.profileName,
+    params.userDataDir,
+    "press_key",
+    {
+      pageId: parsePageId(params.targetId),
+      key: params.key,
+    },
+    params.cdpPort,
+  );
 }
 
 export async function resizeChromeMcpPage(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   width: number;
   height: number;
 }): Promise<void> {
-  await callTool(params.profileName, params.userDataDir, "resize_page", {
-    pageId: parsePageId(params.targetId),
-    width: params.width,
-    height: params.height,
-  });
+  await callTool(
+    params.profileName,
+    params.userDataDir,
+    "resize_page",
+    {
+      pageId: parsePageId(params.targetId),
+      width: params.width,
+      height: params.height,
+    },
+    params.cdpPort,
+  );
 }
 
 export async function handleChromeMcpDialog(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   action: "accept" | "dismiss";
   promptText?: string;
 }): Promise<void> {
-  await callTool(params.profileName, params.userDataDir, "handle_dialog", {
-    pageId: parsePageId(params.targetId),
-    action: params.action,
-    ...(params.promptText ? { promptText: params.promptText } : {}),
-  });
+  await callTool(
+    params.profileName,
+    params.userDataDir,
+    "handle_dialog",
+    {
+      pageId: parsePageId(params.targetId),
+      action: params.action,
+      ...(params.promptText ? { promptText: params.promptText } : {}),
+    },
+    params.cdpPort,
+  );
 }
 
 export async function evaluateChromeMcpScript(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   fn: string;
   args?: string[];
 }): Promise<unknown> {
-  const result = await callTool(params.profileName, params.userDataDir, "evaluate_script", {
-    pageId: parsePageId(params.targetId),
-    function: params.fn,
-    ...(params.args?.length ? { args: params.args } : {}),
-  });
+  const result = await callTool(
+    params.profileName,
+    params.userDataDir,
+    "evaluate_script",
+    {
+      pageId: parsePageId(params.targetId),
+      function: params.fn,
+      ...(params.args?.length ? { args: params.args } : {}),
+    },
+    params.cdpPort,
+  );
   return extractJsonMessage(result);
 }
 
 export async function waitForChromeMcpText(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   text: string[];
   timeoutMs?: number;
 }): Promise<void> {
-  await callTool(params.profileName, params.userDataDir, "wait_for", {
-    pageId: parsePageId(params.targetId),
-    text: params.text,
-    ...(typeof params.timeoutMs === "number" ? { timeout: params.timeoutMs } : {}),
-  });
+  await callTool(
+    params.profileName,
+    params.userDataDir,
+    "wait_for",
+    {
+      pageId: parsePageId(params.targetId),
+      text: params.text,
+      ...(typeof params.timeoutMs === "number" ? { timeout: params.timeoutMs } : {}),
+    },
+    params.cdpPort,
+  );
 }
 
 export function setChromeMcpSessionFactoryForTest(factory: ChromeMcpSessionFactory | null): void {

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -281,6 +281,36 @@ describe("browser config", () => {
     expect(profile?.color).toBe("#00AA00");
   });
 
+  it("resolves existing-session profiles with explicit cdpPort for targeting specific Chrome debug port", () => {
+    const resolved = resolveBrowserConfig({
+      profiles: {
+        personal: {
+          driver: "existing-session",
+          cdpPort: 9222,
+          color: "#00AA00",
+        },
+        work: {
+          driver: "existing-session",
+          cdpPort: 9223,
+          color: "#FF0000",
+        },
+      },
+    });
+    const personal = resolveProfile(resolved, "personal");
+    expect(personal).not.toBeNull();
+    expect(personal?.driver).toBe("existing-session");
+    expect(personal?.cdpPort).toBe(9222);
+    expect(personal?.cdpUrl).toBe("");
+    expect(personal?.color).toBe("#00AA00");
+
+    const work = resolveProfile(resolved, "work");
+    expect(work).not.toBeNull();
+    expect(work?.driver).toBe("existing-session");
+    expect(work?.cdpPort).toBe(9223);
+    expect(work?.cdpUrl).toBe("");
+    expect(work?.color).toBe("#FF0000");
+  });
+
   it("expands tilde-prefixed userDataDir for existing-session profiles", () => {
     const resolved = resolveBrowserConfig({
       profiles: {

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -323,10 +323,14 @@ export function resolveProfile(
   const driver = profile.driver === "existing-session" ? "existing-session" : "openclaw";
 
   if (driver === "existing-session") {
-    // existing-session uses Chrome MCP auto-connect; no CDP port/URL needed
+    // existing-session uses Chrome MCP. When cdpPort is specified, it targets
+    // a specific Chrome instance launched with --remote-debugging-port=<port>.
+    // Without cdpPort, Chrome MCP auto-discovers any running Chrome.
+    const explicitCdpPort =
+      typeof profile.cdpPort === "number" && profile.cdpPort > 0 ? profile.cdpPort : 0;
     return {
       name: profileName,
-      cdpPort: 0,
+      cdpPort: explicitCdpPort,
       cdpUrl: "",
       cdpHost: "",
       cdpIsLoopback: true,

--- a/src/browser/routes/agent.act.hooks.ts
+++ b/src/browser/routes/agent.act.hooks.ts
@@ -66,6 +66,7 @@ export function registerBrowserAgentActHookRoutes(
           await uploadChromeMcpFile({
             profileName: profileCtx.profile.name,
             userDataDir: profileCtx.profile.userDataDir,
+            cdpPort: profileCtx.profile.cdpPort,
             targetId: tab.targetId,
             uid,
             filePath: resolvedPaths[0] ?? "",
@@ -136,6 +137,7 @@ export function registerBrowserAgentActHookRoutes(
           await evaluateChromeMcpScript({
             profileName: profileCtx.profile.name,
             userDataDir: profileCtx.profile.userDataDir,
+            cdpPort: profileCtx.profile.cdpPort,
             targetId: tab.targetId,
             fn: `() => {
               const state = (window.__openclawDialogHook ??= {});

--- a/src/browser/routes/agent.act.ts
+++ b/src/browser/routes/agent.act.ts
@@ -79,6 +79,7 @@ function buildExistingSessionWaitPredicate(params: {
 async function waitForExistingSessionCondition(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   timeMs?: number;
   text?: string;
@@ -105,6 +106,7 @@ async function waitForExistingSessionCondition(params: {
         await evaluateChromeMcpScript({
           profileName: params.profileName,
           userDataDir: params.userDataDir,
+          cdpPort: params.cdpPort,
           targetId: params.targetId,
           fn: `async () => ${predicate}`,
         }),
@@ -114,6 +116,7 @@ async function waitForExistingSessionCondition(params: {
       const currentUrl = await evaluateChromeMcpScript({
         profileName: params.profileName,
         userDataDir: params.userDataDir,
+        cdpPort: params.cdpPort,
         targetId: params.targetId,
         fn: "() => window.location.href",
       });
@@ -524,6 +527,7 @@ export function registerBrowserAgentActRoutes(
               await clickChromeMcpElement({
                 profileName,
                 userDataDir: profileCtx.profile.userDataDir,
+                cdpPort: profileCtx.profile.cdpPort,
                 targetId: tab.targetId,
                 uid: ref!,
                 doubleClick,
@@ -591,6 +595,7 @@ export function registerBrowserAgentActRoutes(
               await fillChromeMcpElement({
                 profileName,
                 userDataDir: profileCtx.profile.userDataDir,
+                cdpPort: profileCtx.profile.cdpPort,
                 targetId: tab.targetId,
                 uid: ref!,
                 value: text,
@@ -599,6 +604,7 @@ export function registerBrowserAgentActRoutes(
                 await pressChromeMcpKey({
                   profileName,
                   userDataDir: profileCtx.profile.userDataDir,
+                  cdpPort: profileCtx.profile.cdpPort,
                   targetId: tab.targetId,
                   key: "Enter",
                 });
@@ -641,6 +647,7 @@ export function registerBrowserAgentActRoutes(
               await pressChromeMcpKey({
                 profileName,
                 userDataDir: profileCtx.profile.userDataDir,
+                cdpPort: profileCtx.profile.cdpPort,
                 targetId: tab.targetId,
                 key,
               });
@@ -683,6 +690,7 @@ export function registerBrowserAgentActRoutes(
               await hoverChromeMcpElement({
                 profileName,
                 userDataDir: profileCtx.profile.userDataDir,
+                cdpPort: profileCtx.profile.cdpPort,
                 targetId: tab.targetId,
                 uid: ref!,
               });
@@ -726,6 +734,7 @@ export function registerBrowserAgentActRoutes(
               await evaluateChromeMcpScript({
                 profileName,
                 userDataDir: profileCtx.profile.userDataDir,
+                cdpPort: profileCtx.profile.cdpPort,
                 targetId: tab.targetId,
                 fn: `(el) => { el.scrollIntoView({ block: "center", inline: "center" }); return true; }`,
                 args: [ref!],
@@ -782,6 +791,7 @@ export function registerBrowserAgentActRoutes(
               await dragChromeMcpElement({
                 profileName,
                 userDataDir: profileCtx.profile.userDataDir,
+                cdpPort: profileCtx.profile.cdpPort,
                 targetId: tab.targetId,
                 fromUid: startRef!,
                 toUid: endRef!,
@@ -836,6 +846,7 @@ export function registerBrowserAgentActRoutes(
               await fillChromeMcpElement({
                 profileName,
                 userDataDir: profileCtx.profile.userDataDir,
+                cdpPort: profileCtx.profile.cdpPort,
                 targetId: tab.targetId,
                 uid: ref!,
                 value: values[0] ?? "",
@@ -881,6 +892,7 @@ export function registerBrowserAgentActRoutes(
               await fillChromeMcpForm({
                 profileName,
                 userDataDir: profileCtx.profile.userDataDir,
+                cdpPort: profileCtx.profile.cdpPort,
                 targetId: tab.targetId,
                 elements: fields.map((field) => ({
                   uid: field.ref,
@@ -911,6 +923,7 @@ export function registerBrowserAgentActRoutes(
               await resizeChromeMcpPage({
                 profileName,
                 userDataDir: profileCtx.profile.userDataDir,
+                cdpPort: profileCtx.profile.cdpPort,
                 targetId: tab.targetId,
                 width,
                 height,
@@ -973,6 +986,7 @@ export function registerBrowserAgentActRoutes(
               await waitForExistingSessionCondition({
                 profileName,
                 userDataDir: profileCtx.profile.userDataDir,
+                cdpPort: profileCtx.profile.cdpPort,
                 targetId: tab.targetId,
                 timeMs,
                 text,
@@ -1024,6 +1038,7 @@ export function registerBrowserAgentActRoutes(
               const result = await evaluateChromeMcpScript({
                 profileName,
                 userDataDir: profileCtx.profile.userDataDir,
+                cdpPort: profileCtx.profile.cdpPort,
                 targetId: tab.targetId,
                 fn,
                 args: ref ? [ref] : undefined,
@@ -1059,7 +1074,12 @@ export function registerBrowserAgentActRoutes(
           }
           case "close": {
             if (isExistingSession) {
-              await closeChromeMcpTab(profileName, tab.targetId, profileCtx.profile.userDataDir);
+              await closeChromeMcpTab(
+                profileName,
+                tab.targetId,
+                profileCtx.profile.userDataDir,
+                profileCtx.profile.cdpPort,
+              );
               return res.json({ ok: true, targetId: tab.targetId });
             }
             const pw = await requirePwAi(res, `act:${kind}`);
@@ -1175,6 +1195,7 @@ export function registerBrowserAgentActRoutes(
           await evaluateChromeMcpScript({
             profileName: profileCtx.profile.name,
             userDataDir: profileCtx.profile.userDataDir,
+            cdpPort: profileCtx.profile.cdpPort,
             targetId: tab.targetId,
             args: [ref],
             fn: `(el) => {

--- a/src/browser/routes/agent.snapshot.ts
+++ b/src/browser/routes/agent.snapshot.ts
@@ -45,11 +45,13 @@ const CHROME_MCP_OVERLAY_ATTR = "data-openclaw-mcp-overlay";
 async function clearChromeMcpOverlay(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
 }): Promise<void> {
   await evaluateChromeMcpScript({
     profileName: params.profileName,
     userDataDir: params.userDataDir,
+    cdpPort: params.cdpPort,
     targetId: params.targetId,
     fn: `() => {
       document.querySelectorAll("[${CHROME_MCP_OVERLAY_ATTR}]").forEach((node) => node.remove());
@@ -61,6 +63,7 @@ async function clearChromeMcpOverlay(params: {
 async function renderChromeMcpLabels(params: {
   profileName: string;
   userDataDir?: string;
+  cdpPort?: number;
   targetId: string;
   refs: string[];
 }): Promise<{ labels: number; skipped: number }> {
@@ -68,6 +71,7 @@ async function renderChromeMcpLabels(params: {
   const result = await evaluateChromeMcpScript({
     profileName: params.profileName,
     userDataDir: params.userDataDir,
+    cdpPort: params.cdpPort,
     targetId: params.targetId,
     args: params.refs,
     fn: `(...elements) => {
@@ -236,6 +240,7 @@ export function registerBrowserAgentSnapshotRoutes(
           const result = await navigateChromeMcpPage({
             profileName: profileCtx.profile.name,
             userDataDir: profileCtx.profile.userDataDir,
+            cdpPort: profileCtx.profile.cdpPort,
             targetId: tab.targetId,
             url,
           });
@@ -328,6 +333,7 @@ export function registerBrowserAgentSnapshotRoutes(
           const buffer = await takeChromeMcpScreenshot({
             profileName: profileCtx.profile.name,
             userDataDir: profileCtx.profile.userDataDir,
+            cdpPort: profileCtx.profile.cdpPort,
             targetId: tab.targetId,
             uid: ref,
             fullPage,
@@ -413,6 +419,7 @@ export function registerBrowserAgentSnapshotRoutes(
         const snapshot = await takeChromeMcpSnapshot({
           profileName: profileCtx.profile.name,
           userDataDir: profileCtx.profile.userDataDir,
+          cdpPort: profileCtx.profile.cdpPort,
           targetId: tab.targetId,
         });
         if (plan.format === "aria") {
@@ -438,6 +445,7 @@ export function registerBrowserAgentSnapshotRoutes(
           const labelResult = await renderChromeMcpLabels({
             profileName: profileCtx.profile.name,
             userDataDir: profileCtx.profile.userDataDir,
+            cdpPort: profileCtx.profile.cdpPort,
             targetId: tab.targetId,
             refs,
           });
@@ -445,6 +453,7 @@ export function registerBrowserAgentSnapshotRoutes(
             const labeled = await takeChromeMcpScreenshot({
               profileName: profileCtx.profile.name,
               userDataDir: profileCtx.profile.userDataDir,
+              cdpPort: profileCtx.profile.cdpPort,
               targetId: tab.targetId,
               format: "png",
             });
@@ -475,6 +484,7 @@ export function registerBrowserAgentSnapshotRoutes(
             await clearChromeMcpOverlay({
               profileName: profileCtx.profile.name,
               userDataDir: profileCtx.profile.userDataDir,
+              cdpPort: profileCtx.profile.cdpPort,
               targetId: tab.targetId,
             });
           }

--- a/src/browser/server-context.availability.ts
+++ b/src/browser/server-context.availability.ts
@@ -64,7 +64,7 @@ export function createProfileAvailability({
   const isReachable = async (timeoutMs?: number) => {
     if (capabilities.usesChromeMcp) {
       // listChromeMcpTabs creates the session if needed — no separate ensureChromeMcpAvailable call required
-      await listChromeMcpTabs(profile.name, profile.userDataDir);
+      await listChromeMcpTabs(profile.name, profile.userDataDir, profile.cdpPort);
       return true;
     }
     const { httpTimeoutMs, wsTimeoutMs } = resolveTimeouts(timeoutMs);
@@ -159,7 +159,7 @@ export function createProfileAvailability({
           `Browser user data directory not found for profile "${profile.name}": ${profile.userDataDir}`,
         );
       }
-      await ensureChromeMcpAvailable(profile.name, profile.userDataDir);
+      await ensureChromeMcpAvailable(profile.name, profile.userDataDir, profile.cdpPort);
       return;
     }
     const current = state();

--- a/src/browser/server-context.existing-session.test.ts
+++ b/src/browser/server-context.existing-session.test.ts
@@ -99,17 +99,24 @@ describe("browser server-context existing-session profile", () => {
     expect(chromeMcp.ensureChromeMcpAvailable).toHaveBeenCalledWith(
       "chrome-live",
       "/tmp/brave-profile",
+      18801,
     );
-    expect(chromeMcp.listChromeMcpTabs).toHaveBeenCalledWith("chrome-live", "/tmp/brave-profile");
+    expect(chromeMcp.listChromeMcpTabs).toHaveBeenCalledWith(
+      "chrome-live",
+      "/tmp/brave-profile",
+      18801,
+    );
     expect(chromeMcp.openChromeMcpTab).toHaveBeenCalledWith(
       "chrome-live",
       "https://openclaw.ai",
       "/tmp/brave-profile",
+      18801,
     );
     expect(chromeMcp.focusChromeMcpTab).toHaveBeenCalledWith(
       "chrome-live",
       "7",
       "/tmp/brave-profile",
+      18801,
     );
     expect(chromeMcp.closeChromeMcpSession).toHaveBeenCalledWith("chrome-live");
   });

--- a/src/browser/server-context.selection.ts
+++ b/src/browser/server-context.selection.ts
@@ -94,7 +94,7 @@ export function createProfileSelectionOps({
     const resolvedTargetId = await resolveTargetIdOrThrow(targetId);
 
     if (capabilities.usesChromeMcp) {
-      await focusChromeMcpTab(profile.name, resolvedTargetId, profile.userDataDir);
+      await focusChromeMcpTab(profile.name, resolvedTargetId, profile.userDataDir, profile.cdpPort);
       const profileState = getProfileState();
       profileState.lastTargetId = resolvedTargetId;
       return;
@@ -124,7 +124,7 @@ export function createProfileSelectionOps({
     const resolvedTargetId = await resolveTargetIdOrThrow(targetId);
 
     if (capabilities.usesChromeMcp) {
-      await closeChromeMcpTab(profile.name, resolvedTargetId, profile.userDataDir);
+      await closeChromeMcpTab(profile.name, resolvedTargetId, profile.userDataDir, profile.cdpPort);
       return;
     }
 

--- a/src/browser/server-context.tab-ops.ts
+++ b/src/browser/server-context.tab-ops.ts
@@ -67,7 +67,7 @@ export function createProfileTabOps({
 
   const listTabs = async (): Promise<BrowserTab[]> => {
     if (capabilities.usesChromeMcp) {
-      return await listChromeMcpTabs(profile.name, profile.userDataDir);
+      return await listChromeMcpTabs(profile.name, profile.userDataDir, profile.cdpPort);
     }
 
     if (capabilities.usesPersistentPlaywright) {
@@ -141,7 +141,7 @@ export function createProfileTabOps({
 
     if (capabilities.usesChromeMcp) {
       await assertBrowserNavigationAllowed({ url, ...ssrfPolicyOpts });
-      const page = await openChromeMcpTab(profile.name, url, profile.userDataDir);
+      const page = await openChromeMcpTab(profile.name, url, profile.userDataDir, profile.cdpPort);
       const profileState = getProfileState();
       profileState.lastTargetId = page.targetId;
       await assertBrowserNavigationResultAllowed({ url: page.url, ...ssrfPolicyOpts });

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -1,5 +1,12 @@
 export type BrowserProfileConfig = {
-  /** CDP port for this profile. Allocated once at creation, persisted permanently. */
+  /**
+   * CDP port for this profile.
+   * For `openclaw` driver: allocated once at creation, persisted permanently.
+   * For `existing-session` driver: targets a specific Chrome instance launched with
+   * `--remote-debugging-port=<port>`. When set, OpenClaw connects to that specific
+   * port instead of auto-discovering any running Chrome. This enables targeting a
+   * specific Chrome profile when multiple profile windows are open.
+   */
   cdpPort?: number;
   /** CDP URL for this profile (use for remote Chrome). */
   cdpUrl?: string;


### PR DESCRIPTION
## Summary

When multiple Chrome profile windows are open, OpenClaw's `existing-session` driver connects to whichever profile Chrome MCP auto-discovers first. This makes it impossible to target a specific Chrome profile.

This PR adds support for explicit `cdpPort` configuration on `existing-session` profiles. When `cdpPort` is set, `chrome-devtools-mcp` is launched with `--port <N>` to connect to that specific Chrome debug port instead of auto-discovering.

## Usage

Launch each Chrome profile with a different debug port:

```bash
# Personal profile (port 9222)
open -na 'Google Chrome' --args --profile-directory='Profile 1' --remote-debugging-port=9222

# Work profile (port 9223)
open -na 'Google Chrome' --args --profile-directory='Profile 3' --remote-debugging-port=9223
```

Configure OpenClaw to target specific ports:

```json
{
  "browser": {
    "profiles": {
      "personal": {
        "driver": "existing-session",
        "cdpPort": 9222,
        "color": "#00AA00"
      },
      "work": {
        "driver": "existing-session",
        "cdpPort": 9223,
        "color": "#FF0000"
      }
    }
  }
}
```

## Changes

| File | Change |
|------|--------|
| `config.ts` | Stop discarding `cdpPort` for `existing-session` profiles |
| `chrome-mcp.ts` | Thread `cdpPort` through session creation/tool calls; add `--port` flag to MCP args |
| `agent.act.ts`, `agent.snapshot.ts`, etc. | Forward `profile.cdpPort` alongside `userDataDir` in all chrome-mcp calls |
| `types.browser.ts` | Document `cdpPort` usage for `existing-session` profiles |
| Tests | Add coverage for `cdpPort` in `resolveProfile` and `buildChromeMcpArgs` |

## Root Cause

1. `resolveProfile()` hardcoded `cdpPort: 0` for `existing-session` profiles — even when configured
2. `buildChromeMcpArgs()` never passed `--port` to target a specific debug port
3. The entire data flow from config → chrome-mcp never threaded a CDP port for existing-session profiles

## Backward Compatibility

Fully backward compatible. Existing configs without `cdpPort` continue to use Chrome MCP auto-connect as before.

Fixes #49241