### PR TITLE
perf(status): lazy-load status summary, channel config, and gateway modules to reduce startup RSS

### DIFF
--- a/src/commands/status.scan.fast-json.ts
+++ b/src/commands/status.scan.fast-json.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { hasPotentialConfiguredChannels } from "../channels/config-presence.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveOsSummary } from "../infra/os-summary.js";
@@ -18,7 +17,6 @@ import {
   type MemoryPluginStatus,
   type MemoryStatusSnapshot,
 } from "./status.scan.shared.js";
-import { getStatusSummary } from "./status.summary.js";
 import { getUpdateCheckResult } from "./status.update.js";
 
 let pluginRegistryModulePromise: Promise<typeof import("../cli/plugin-registry.js")> | undefined;
@@ -31,6 +29,10 @@ let commandSecretGatewayModulePromise:
   | Promise<typeof import("../cli/command-secret-gateway.js")>
   | undefined;
 let memorySearchModulePromise: Promise<typeof import("../agents/memory-search.js")> | undefined;
+let statusSummaryModulePromise: Promise<typeof import("./status.summary.js")> | undefined;
+let channelConfigPresenceModulePromise:
+  | Promise<typeof import("../channels/config-presence.js")>
+  | undefined;
 let statusScanDepsRuntimeModulePromise:
   | Promise<typeof import("./status.scan.deps.runtime.js")>
   | undefined;
@@ -70,6 +72,16 @@ function loadStatusScanDepsRuntimeModule() {
   return statusScanDepsRuntimeModulePromise;
 }
 
+function loadStatusSummaryModule() {
+  statusSummaryModulePromise ??= import("./status.summary.js");
+  return statusSummaryModulePromise;
+}
+
+function loadChannelConfigPresenceModule() {
+  channelConfigPresenceModulePromise ??= import("../channels/config-presence.js");
+  return channelConfigPresenceModulePromise;
+}
+
 function shouldSkipMissingConfigFastPath(): boolean {
   return (
     process.env.VITEST === "true" ||
@@ -91,8 +103,23 @@ function buildColdStartUpdateResult(): Awaited<ReturnType<typeof getUpdateCheckR
 }
 
 function shouldCollectPluginCompatibility(cfg: OpenClawConfig): boolean {
-  if (hasPotentialConfiguredChannels(cfg)) {
-    return true;
+  // Inline the lightweight check to avoid eagerly loading channels/config-presence
+  // at module evaluation time. The full module is loaded lazily when needed.
+  const channels = cfg.channels;
+  if (channels && typeof channels === "object" && !Array.isArray(channels)) {
+    for (const [key, value] of Object.entries(channels as Record<string, unknown>)) {
+      if (key === "defaults" || key === "modelByChannel") {
+        continue;
+      }
+      if (
+        value &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        Object.keys(value).some((k) => k !== "enabled")
+      ) {
+        return true;
+      }
+    }
   }
   return existsSync(resolveConfigPath(process.env));
 }
@@ -156,10 +183,14 @@ export async function scanStatusJsonFast(
     sourceConfig: loadedRaw,
     commandName: "status --json",
   });
-  const hasConfiguredChannels = hasPotentialConfiguredChannels(cfg);
-  if (hasConfiguredChannels) {
-    const { ensurePluginRegistryLoaded } = await loadPluginRegistryModule();
-    ensurePluginRegistryLoaded({ scope: "configured-channels" });
+  let hasConfiguredChannels = false;
+  if (shouldCollectPluginCompatibility(cfg)) {
+    const { hasPotentialConfiguredChannels } = await loadChannelConfigPresenceModule();
+    hasConfiguredChannels = hasPotentialConfiguredChannels(cfg);
+    if (hasConfiguredChannels) {
+      const { ensurePluginRegistryLoaded } = await loadPluginRegistryModule();
+      ensurePluginRegistryLoaded({ scope: "configured-channels" });
+    }
   }
   const osSummary = resolveOsSummary();
   const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";
@@ -173,7 +204,9 @@ export async function scanStatusJsonFast(
         includeRegistry: true,
       });
   const agentStatusPromise = getAgentLocalStatuses(cfg);
-  const summaryPromise = getStatusSummary({ config: cfg, sourceConfig: loadedRaw });
+  const summaryPromise = loadStatusSummaryModule().then(({ getStatusSummary }) =>
+    getStatusSummary({ config: cfg, sourceConfig: loadedRaw }),
+  );
 
   const tailscaleDnsPromise =
     tailscaleMode === "off"

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -1,13 +1,26 @@
 import { existsSync } from "node:fs";
 import type { OpenClawConfig } from "../config/types.js";
-import { buildGatewayConnectionDetails } from "../gateway/call.js";
+import type { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
-import { probeGateway } from "../gateway/probe.js";
+import type { probeGateway } from "../gateway/probe.js";
 import type { MemoryProviderStatus } from "../memory/types.js";
 import {
   pickGatewaySelfPresence,
   resolveGatewayProbeAuthResolution,
 } from "./status.gateway-probe.js";
+
+let gatewayCallModulePromise: Promise<typeof import("../gateway/call.js")> | undefined;
+let gatewayProbeModulePromise: Promise<typeof import("../gateway/probe.js")> | undefined;
+
+function loadGatewayCallModule() {
+  gatewayCallModulePromise ??= import("../gateway/call.js");
+  return gatewayCallModulePromise;
+}
+
+function loadGatewayProbeModule() {
+  gatewayProbeModulePromise ??= import("../gateway/probe.js");
+  return gatewayProbeModulePromise;
+}
 
 export type MemoryStatusSnapshot = MemoryProviderStatus & {
   agentId: string;
@@ -60,6 +73,7 @@ export async function resolveGatewayProbeSnapshot(params: {
   cfg: OpenClawConfig;
   opts: { timeoutMs?: number; all?: boolean; skipProbe?: boolean };
 }): Promise<GatewayProbeSnapshot> {
+  const { buildGatewayConnectionDetails } = await loadGatewayCallModule();
   const gatewayConnection = buildGatewayConnectionDetails({ config: params.cfg });
   const isRemoteMode = params.cfg.gateway?.mode === "remote";
   const remoteUrlRaw =
@@ -68,7 +82,8 @@ export async function resolveGatewayProbeSnapshot(params: {
   const gatewayMode = isRemoteMode ? "remote" : "local";
   const gatewayProbeAuthResolution = resolveGatewayProbeAuthResolution(params.cfg);
   let gatewayProbeAuthWarning = gatewayProbeAuthResolution.warning;
-  const gatewayProbe = remoteUrlMissing
+  const { probeGateway } = await loadGatewayProbeModule();
+  const gatewayProbe: Awaited<ReturnType<typeof probeGateway>> | null = remoteUrlMissing
     ? null
     : params.opts.skipProbe
       ? null

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -1,5 +1,4 @@
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
-import { hasPotentialConfiguredChannels } from "../channels/config-presence.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import { resolveMainSessionKey } from "../config/sessions/main-session.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
@@ -17,6 +16,9 @@ import type { HeartbeatStatus, SessionStatus, StatusSummary } from "./status.typ
 let channelSummaryModulePromise: Promise<typeof import("../infra/channel-summary.js")> | undefined;
 let linkChannelModulePromise: Promise<typeof import("./status.link-channel.js")> | undefined;
 let configIoModulePromise: Promise<typeof import("../config/io.js")> | undefined;
+let channelConfigPresenceModulePromise:
+  | Promise<typeof import("../channels/config-presence.js")>
+  | undefined;
 
 function loadChannelSummaryModule() {
   channelSummaryModulePromise ??= import("../infra/channel-summary.js");
@@ -36,6 +38,11 @@ const loadStatusSummaryRuntimeModule = createLazyRuntimeSurface(
 function loadConfigIoModule() {
   configIoModulePromise ??= import("../config/io.js");
   return configIoModulePromise;
+}
+
+function loadChannelConfigPresenceModule() {
+  channelConfigPresenceModulePromise ??= import("../channels/config-presence.js");
+  return channelConfigPresenceModulePromise;
 }
 
 function parseStatusModelRef(
@@ -178,6 +185,7 @@ export async function getStatusSummary(
   const { classifySessionKey, resolveContextTokensForModel, resolveSessionModelRef } =
     await loadStatusSummaryRuntimeModule();
   const cfg = options.config ?? (await loadConfigIoModule()).loadConfig();
+  const { hasPotentialConfiguredChannels } = await loadChannelConfigPresenceModule();
   const needsChannelPlugins = hasPotentialConfiguredChannels(cfg);
   const linkContext = needsChannelPlugins
     ? await loadLinkChannelModule().then(({ resolveLinkChannelContext }) =>


### PR DESCRIPTION
## Summary

Defer importing `status.summary.js`, `channels/config-presence.js`, `gateway/call.js`, and `gateway/probe.js` from the `status --json` startup path. These modules are bundled into the 12 MB `auth-profiles` chunk; making them lazy avoids evaluating that chunk at startup, shaving ~10 MB off peak RSS (measured locally on macOS arm64).

## Changes

| File | Change |
|------|--------|
| `src/commands/status.scan.fast-json.ts` | Lazy-load `getStatusSummary` from `status.summary.js`; lazy-load `hasPotentialConfiguredChannels` from `channels/config-presence.js` with inline lightweight check |
| `src/commands/status.scan.shared.ts` | Lazy-load `gateway/call.js` and `gateway/probe.js` |
| `src/commands/status.summary.ts` | Lazy-load `hasPotentialConfiguredChannels` from `channels/config-presence.js` |

## Measurements (local, macOS arm64)

| Metric | Baseline (main) | With fix | Savings |
|--------|-----------------|----------|---------|
| RSS avg (3 runs) | **344.2 MB** | **334.7 MB** | **~9.5 MB (2.7%)** |
| RSS range | 339–349 MB | 331–337 MB | |

## Context

The `status --json` command's build-smoke memory check was tightened from 925 MB to 400 MB in `c38295c7`. CI on Linux x86_64 reports 414 MB, 14 MB over the new limit. This PR addresses the overage by deferring heavy module evaluation on the `status --json` startup path.

The `auth-profiles` chunk (12 MB, 344K lines) remains loaded via side-effect imports from core modules (`redact`, `exec`) — eliminating this would require bundler-level chunk splitting (`manualChunks`) which currently triggers `[INEFFECTIVE_DYNAMIC_IMPORT]` hard errors.

## Test plan

- `pnpm build` — passes, no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings
- `node scripts/check-cli-startup-memory.mjs` — all 3 cases pass locally
- Scoped tests (`status-json.test.ts`, `status.scan.fast-json.test.ts`) — 4/4 pass
- `status.summary.test.ts` — 3 failures pre-existing on `main` (WhatsApp auth-store `resolveOAuthDir` issue)