### PR TITLE
fix(plugins): correct systemPrompt priority inversion in hook merging

### DIFF
--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -173,7 +173,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     acc: PluginHookBeforePromptBuildResult | undefined,
     next: PluginHookBeforePromptBuildResult,
   ): PluginHookBeforePromptBuildResult => ({
-    systemPrompt: next.systemPrompt ?? acc?.systemPrompt,
+    // Keep the first defined override so higher-priority hooks win.
+    systemPrompt: acc?.systemPrompt ?? next.systemPrompt,
     prependContext: concatOptionalTextSegments({
       left: acc?.prependContext,
       right: next.prependContext,


### PR DESCRIPTION
## Summary

- `mergeBeforePromptBuild` uses `next.systemPrompt ?? acc?.systemPrompt`, giving **lower-priority** hooks precedence over higher-priority ones
- `mergeBeforeModelResolve` (same file, line 167-168) correctly uses `acc?.modelOverride ?? next.modelOverride` with the explicit comment "Keep the first defined override so higher-priority hooks win"
- Both `systemPrompt` and `modelOverride` are override semantics, so they should follow the same priority rule

## Root cause

Hooks are sorted by `priority` descending (line 145), so higher-priority hooks run first and their results accumulate into `acc`. The merge function receives `(acc, next)` where `acc` = higher-priority accumulated result and `next` = current lower-priority hook result.

For override fields, the pattern should be `acc ?? next` (first defined wins = higher priority wins). The `systemPrompt` field incorrectly used `next ?? acc` (last defined wins = lower priority wins).

The concat fields (`prependContext`, `prependSystemContext`, `appendSystemContext`) in the same merge function are not affected — they correctly concatenate with `left: acc, right: next`.

## Fix

Change `next.systemPrompt ?? acc?.systemPrompt` to `acc?.systemPrompt ?? next.systemPrompt`, matching the established pattern from `mergeBeforeModelResolve`.

## Test plan

- [x] 318 plugin tests pass (45 test files); failures are pre-existing dependency issues
- [x] Code inspection confirms the fix aligns with the documented priority rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)