### PR TITLE
fix: vLLM token usage not recorded in session files (#47639)

### DIFF
--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -492,7 +492,8 @@ export function buildAssistantMessageFromResponse(
     stopReason,
     usage: buildUsageWithNoCost({
       input: response.usage?.input_tokens ?? 0,
-      output: response.usage?.output_tokens ?? 0,
+      // vLLM uses completion_tokens, not output_tokens
+      output: response.usage?.output_tokens ?? response.usage?.completion_tokens ?? 0,
       totalTokens: response.usage?.total_tokens ?? 0,
     }),
   });

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -181,6 +181,12 @@ export function deriveSessionTotalTokens(params: {
       });
 
   if (!(typeof promptTokens === "number") || !Number.isFinite(promptTokens) || promptTokens <= 0) {
+    // No valid prompt token count. If the API reported a total (e.g. vLLM's total_tokens),
+    // use it as a fallback — it includes prompt tokens and is meaningful for context display.
+    const reportedTotal = asFiniteNumber(usage?.total);
+    if (reportedTotal !== undefined && reportedTotal > 0) {
+      return reportedTotal;
+    }
     return undefined;
   }
 


### PR DESCRIPTION
Fixes openclaw/openclaw#47639: vLLM token usage not recorded in session files, dashboard shows n/a.

Bug 1: openai-ws-stream.ts mapped output from output_tokens, but vLLM uses completion_tokens. Added completion_tokens as fallback.

Bug 2: deriveSessionTotalTokens had no fallback to usage.total. When promptTokens is invalid but usage.total is available, now falls back to usage.total.

With this fix, vLLM responses with usage {prompt_tokens:11, completion_tokens:443, total_tokens:454} will correctly record totalTokens=454 in session files.