### PR TITLE
[codex] improve web chat session management

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildUniqueChatSessionIdentity,
   isCronSessionKey,
   parseSessionKey,
+  resolveSessionOptionGroups,
   resolveSessionDisplayName,
 } from "./app-render.helpers.ts";
 import type { SessionsListResult } from "./types.ts";
@@ -11,6 +13,42 @@ type SessionRow = SessionsListResult["sessions"][number];
 function row(overrides: Partial<SessionRow> & { key: string }): SessionRow {
   return { kind: "direct", updatedAt: 0, ...overrides };
 }
+
+describe("buildUniqueChatSessionIdentity", () => {
+  it("builds a new agent-scoped session key from the requested label", () => {
+    expect(
+      buildUniqueChatSessionIdentity({
+        agentId: "main",
+        requestedLabel: "Project Alpha",
+        sessions: { sessions: [] },
+      }),
+    ).toEqual({
+      key: "agent:main:project-alpha",
+      label: "Project Alpha",
+    });
+  });
+
+  it("adds a numeric suffix when the key or label already exists", () => {
+    const sessions: SessionsListResult = {
+      sessions: [
+        row({
+          key: "agent:main:project-alpha",
+          label: "Project Alpha",
+        }),
+      ],
+    };
+    expect(
+      buildUniqueChatSessionIdentity({
+        agentId: "main",
+        requestedLabel: "Project Alpha",
+        sessions,
+      }),
+    ).toEqual({
+      key: "agent:main:project-alpha-2",
+      label: "Project Alpha 2",
+    });
+  });
+});
 
 /* ================================================================
  *  parseSessionKey – low-level key → type / fallback mapping
@@ -282,5 +320,54 @@ describe("isCronSessionKey", () => {
     expect(isCronSessionKey("main")).toBe(false);
     expect(isCronSessionKey("discord:group:eng")).toBe(false);
     expect(isCronSessionKey("agent:main:slack:cron:job:run:uuid")).toBe(false);
+  });
+});
+
+describe("resolveSessionOptionGroups", () => {
+  it("sorts sessions by most recent updatedAt first within the same agent group", () => {
+    const groups = resolveSessionOptionGroups(
+      {
+        sessionsHideCron: true,
+        agentsList: { agents: [{ id: "main", name: "Main" }] },
+      } as never,
+      "agent:main:older",
+      {
+        sessions: [
+          row({ key: "agent:main:older", updatedAt: 100 }),
+          row({ key: "agent:main:newer", updatedAt: 200 }),
+          row({ key: "agent:main:newest", updatedAt: 300 }),
+        ],
+      },
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.options.map((entry) => entry.key)).toEqual([
+      "agent:main:newest",
+      "agent:main:newer",
+      "agent:main:older",
+    ]);
+  });
+
+  it("sorts agent groups by their most recently used session", () => {
+    const groups = resolveSessionOptionGroups(
+      {
+        sessionsHideCron: true,
+        agentsList: {
+          agents: [
+            { id: "main", name: "Main" },
+            { id: "ops", name: "Ops" },
+          ],
+        },
+      } as never,
+      "agent:main:chat-a",
+      {
+        sessions: [
+          row({ key: "agent:main:chat-a", updatedAt: 100 }),
+          row({ key: "agent:ops:chat-b", updatedAt: 500 }),
+        ],
+      },
+    );
+
+    expect(groups.map((entry) => entry.id)).toEqual(["agent:ops", "agent:main"]);
   });
 });

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,6 +1,8 @@
 import { html, nothing } from "lit";
+import { live } from "lit/directives/live.js";
 import { repeat } from "lit/directives/repeat.js";
 import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
+import { buildAgentMainSessionKey } from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { refreshChat } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
@@ -76,13 +78,6 @@ export function renderTab(state: AppViewState, tab: Tab, opts?: { collapsed?: bo
           return;
         }
         event.preventDefault();
-        if (tab === "chat") {
-          const mainSessionKey = resolveSidebarChatSessionKey(state);
-          if (state.sessionKey !== mainSessionKey) {
-            resetChatStateForSessionSwitch(state, mainSessionKey);
-            void state.loadAssistantIdentity();
-          }
-        }
         state.setTab(tab);
       }}
       title=${titleForTab(tab)}
@@ -140,7 +135,7 @@ export function renderChatSessionSelect(state: AppViewState) {
     <div class="chat-controls__session-row">
       <label class="field chat-controls__session">
         <select
-          .value=${state.sessionKey}
+          .value=${live(state.sessionKey)}
           ?disabled=${!state.connected || sessionGroups.length === 0}
           @change=${(e: Event) => {
             const next = (e.target as HTMLSelectElement).value;
@@ -159,7 +154,11 @@ export function renderChatSessionSelect(state: AppViewState) {
                   group.options,
                   (entry) => entry.key,
                   (entry) =>
-                    html`<option value=${entry.key} title=${entry.title}>
+                    html`<option
+                      value=${entry.key}
+                      title=${entry.title}
+                      ?selected=${entry.key === state.sessionKey}
+                    >
                       ${entry.label}
                     </option>`,
                 )}
@@ -410,7 +409,7 @@ export function renderChatMobileToggle(state: AppViewState) {
         <div class="chat-controls">
           <label class="field chat-controls__session">
             <select
-              .value=${state.sessionKey}
+              .value=${live(state.sessionKey)}
               @change=${(e: Event) => {
                 const next = (e.target as HTMLSelectElement).value;
                 switchChatSession(state, next);
@@ -421,7 +420,11 @@ export function renderChatMobileToggle(state: AppViewState) {
                   <optgroup label=${group.label}>
                     ${group.options.map(
                       (opt) => html`
-                        <option value=${opt.key} title=${opt.title}>
+                        <option
+                          value=${opt.key}
+                          title=${opt.title}
+                          ?selected=${opt.key === state.sessionKey}
+                        >
                           ${opt.label}
                         </option>
                       `,
@@ -510,6 +513,88 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   );
   void loadChatHistory(state as unknown as ChatState);
   void refreshSessionOptions(state);
+}
+
+function slugifySessionLabel(value: string): string {
+  const trimmed = value.trim().toLowerCase();
+  const slug = trimmed
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  return slug || "session";
+}
+
+function buildSessionNameSuggestion(): string {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  const hour = String(now.getHours()).padStart(2, "0");
+  const minute = String(now.getMinutes()).padStart(2, "0");
+  return `chat-${month}${day}-${hour}${minute}`;
+}
+
+function normalizeSessionLabelValue(value: string | undefined | null): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+export function buildUniqueChatSessionIdentity(params: {
+  agentId: string;
+  requestedLabel: string;
+  sessions: SessionsListResult | null;
+}): { key: string; label: string } {
+  const requestedLabel = params.requestedLabel.trim() || buildSessionNameSuggestion();
+  const rows = params.sessions?.sessions ?? [];
+  const takenKeys = new Set(rows.map((row) => row.key.trim().toLowerCase()));
+  const takenLabels = new Set(
+    rows.flatMap((row) =>
+      [row.label, row.displayName].map((value) => normalizeSessionLabelValue(value)).filter(Boolean),
+    ),
+  );
+  const baseSlug = slugifySessionLabel(requestedLabel);
+  let attempt = 0;
+  while (attempt < 500) {
+    const suffix = attempt === 0 ? "" : `-${attempt + 1}`;
+    const label = attempt === 0 ? requestedLabel : `${requestedLabel} ${attempt + 1}`;
+    const key = buildAgentMainSessionKey({
+      agentId: params.agentId,
+      mainKey: `${baseSlug}${suffix}`,
+    });
+    if (!takenKeys.has(key.toLowerCase()) && !takenLabels.has(label.toLowerCase())) {
+      return { key, label };
+    }
+    attempt += 1;
+  }
+  const fallbackKey = buildAgentMainSessionKey({
+    agentId: params.agentId,
+    mainKey: `${baseSlug}-${Date.now()}`,
+  });
+  return { key: fallbackKey, label: `${requestedLabel} ${Date.now()}` };
+}
+
+export async function createAndSwitchChatSession(state: AppViewState): Promise<void> {
+  if (!state.client || !state.connected) {
+    return;
+  }
+  const activeRow = resolveActiveSessionRow(state);
+  const promptDefault = activeRow?.label?.trim() || buildSessionNameSuggestion();
+  const requestedLabel = window.prompt("Name the new session", promptDefault);
+  if (requestedLabel === null) {
+    return;
+  }
+  const agentId = parseAgentSessionKey(state.sessionKey)?.agentId ?? "main";
+  const { key, label } = buildUniqueChatSessionIdentity({
+    agentId,
+    requestedLabel,
+    sessions: state.sessionsResult,
+  });
+  try {
+    await state.client.request("sessions.patch", { key, label });
+    switchChatSession(state, key);
+  } catch (err) {
+    state.lastError = String(err);
+    return;
+  }
 }
 
 async function refreshSessionOptions(state: AppViewState) {
@@ -777,6 +862,7 @@ type SessionOptionEntry = {
   label: string;
   scopeLabel: string;
   title: string;
+  updatedAt: number;
 };
 
 type SessionOptionGroup = {
@@ -833,6 +919,7 @@ export function resolveSessionOptionGroups(
       label,
       scopeLabel,
       title: key,
+      updatedAt: resolveSessionUpdatedAt(row),
     });
   };
 
@@ -848,6 +935,12 @@ export function resolveSessionOptionGroups(
   addOption(sessionKey);
 
   for (const group of groups.values()) {
+    group.options.sort((a, b) => {
+      if (b.updatedAt !== a.updatedAt) {
+        return b.updatedAt - a.updatedAt;
+      }
+      return a.label.localeCompare(b.label);
+    });
     const counts = new Map<string, number>();
     for (const option of group.options) {
       counts.set(option.label, (counts.get(option.label) ?? 0) + 1);
@@ -859,7 +952,14 @@ export function resolveSessionOptionGroups(
     }
   }
 
-  return Array.from(groups.values());
+  return Array.from(groups.values()).sort((a, b) => {
+    const aLatest = a.options[0]?.updatedAt ?? 0;
+    const bLatest = b.options[0]?.updatedAt ?? 0;
+    if (bLatest !== aLatest) {
+      return bLatest - aLatest;
+    }
+    return a.label.localeCompare(b.label);
+  });
 }
 
 /** Count sessions with a cron: key that would be hidden when hideCron=true. */
@@ -897,6 +997,10 @@ function resolveSessionScopedOptionLabel(
   }
 
   return base;
+}
+
+function resolveSessionUpdatedAt(row?: SessionsListResult["sessions"][number]): number {
+  return typeof row?.updatedAt === "number" ? row.updatedAt : 0;
 }
 
 type ThemeOption = { id: ThemeName; label: string; icon: string };

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -8,6 +8,7 @@ import { getSafeLocalStorage } from "../local-storage.ts";
 import { refreshChatAvatar } from "./app-chat.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
 import {
+  createAndSwitchChatSession,
   renderChatControls,
   renderChatMobileToggle,
   renderChatSessionSelect,
@@ -1406,7 +1407,7 @@ export function renderApp(state: AppViewState) {
                 canAbort: Boolean(state.chatRunId),
                 onAbort: () => void state.handleAbortChat(),
                 onQueueRemove: (id) => state.removeQueuedMessage(id),
-                onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
+                onNewSession: () => void createAndSwitchChatSession(state),
                 onClearHistory: async () => {
                   if (!state.client || !state.connected) {
                     return;


### PR DESCRIPTION
## Summary
This updates the web chat session flow so "New session" creates a real independent chat session instead of sending `/new` into the current one.

It also improves the session selector UX by sorting sessions by recency and fixing selector desync when navigating away from chat and back.

## Problem
In the current web chat UI, the New session action behaves like a reset of the current chat rather than creating a separate switchable session. That makes it easy to lose the feeling of independent conversations and does not match user expectations for session-based chat navigation.

While iterating on that flow, there was also a selector-state bug: navigating from Chat to another page like Usage and back could leave the visible session picker briefly out of sync with the actual chat content.

## Changes
- replace the `/new` send shortcut with a `createAndSwitchChatSession` flow
- prompt for a session name and generate a unique agent-scoped session key
- create the session via `sessions.patch` and switch directly to it
- sort session options by most recent `updatedAt` within each agent group
- sort session groups by their most recently used session
- stop forcing chat navigation back through the sidebar reset path
- use `live(...)` plus explicit selected state on both desktop and mobile session selectors so the visible control stays aligned with the active session
- add tests for unique session key generation and recent-first ordering

## Validation
- `vitest run src/ui/app-render.helpers.node.test.ts --config vitest.node.config.ts`
- `vite build`
- manually verified in the browser that:
  - New session creates a distinct switchable session
  - switching to Usage and back keeps the same active chat session
  - the session selector no longer flashes the wrong session label on return to Chat
