### PR TITLE
fix(agent-events): delete seqByRun entry in clearAgentRunContext

### DIFF
--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -25,6 +25,27 @@ describe("agent-events sequencing", () => {
     expect(getAgentRunContext("run-1")).toBeUndefined();
   });
 
+  test("clearAgentRunContext also removes seqByRun entry", async () => {
+    resetAgentRunContextForTest();
+    registerAgentRunContext("run-seq", { sessionKey: "main" });
+    emitAgentEvent({ runId: "run-seq", stream: "lifecycle", data: {} });
+    emitAgentEvent({ runId: "run-seq", stream: "lifecycle", data: {} });
+
+    clearAgentRunContext("run-seq");
+
+    // After clearing, the next event for the same runId should restart from seq 1
+    const seqs: number[] = [];
+    const stop = onAgentEvent((evt) => {
+      if (evt.runId === "run-seq") {
+        seqs.push(evt.seq);
+      }
+    });
+    emitAgentEvent({ runId: "run-seq", stream: "lifecycle", data: {} });
+    stop();
+
+    expect(seqs).toEqual([1]);
+  });
+
   test("maintains monotonic seq per runId", async () => {
     const seen: Record<string, number[]> = {};
     const stop = onAgentEvent((evt) => {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -63,6 +63,7 @@ export function getAgentRunContext(runId: string) {
 
 export function clearAgentRunContext(runId: string) {
   state.runContextById.delete(runId);
+  state.seqByRun.delete(runId);
 }
 
 export function resetAgentRunContextForTest() {


### PR DESCRIPTION
## Problem

The `seqByRun` Map in `src/infra/agent-events.ts` stores one entry per `runId` for monotonic event sequencing, but `clearAgentRunContext()` only cleaned up `runContextById` — the `seqByRun` entry was never deleted. Over time this Map grows by hundreds of entries per day and is never pruned, contributing to heap growth on long-running gateways.

## Fix

Add `state.seqByRun.delete(runId)` in `clearAgentRunContext()` alongside the existing `runContextById` cleanup.

## Test

Added a regression test verifying that sequence numbers restart from 1 after `clearAgentRunContext()` is called for a given runId.

All 9 tests pass:
```
✓ agent-events sequencing > stores and clears run context
✓ agent-events sequencing > clearAgentRunContext also removes seqByRun entry  (new)
✓ agent-events sequencing > maintains monotonic seq per runId
...
```

Closes #51819