### PR TITLE
fix(ui): resolve model alias in qualified refs for Control UI model picker

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -586,6 +586,32 @@ describe("model-selection", () => {
       });
       expect(resolved?.alias).toBe("kimi");
     });
+
+    it("resolves alias in model part of qualified ref (Control UI picker bug #51608)", () => {
+      const index = {
+        byAlias: new Map([
+          [
+            "bailian",
+            {
+              alias: "bailian",
+              ref: { provider: "custom-dashscope-aliyuncs-com", model: "qwen3.5-flash" },
+            },
+          ],
+        ]),
+        byKey: new Map(),
+      };
+
+      const resolved = resolveModelRefFromString({
+        raw: "custom-dashscope-aliyuncs-com/bailian",
+        defaultProvider: "minimax-cn",
+        aliasIndex: index,
+      });
+      expect(resolved?.ref).toEqual({
+        provider: "custom-dashscope-aliyuncs-com",
+        model: "qwen3.5-flash",
+      });
+      expect(resolved?.alias).toBe("bailian");
+    });
   });
 
   describe("resolveConfiguredModelRef", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -268,6 +268,16 @@ export function resolveModelRefFromString(params: {
   if (!parsed) {
     return null;
   }
+  if (params.aliasIndex) {
+    const modelAliasKey = normalizeAliasKey(parsed.model);
+    const modelAliasMatch = params.aliasIndex.byAlias.get(modelAliasKey);
+    if (modelAliasMatch) {
+      return {
+        ref: { provider: parsed.provider, model: modelAliasMatch.ref.model },
+        alias: modelAliasMatch.alias,
+      };
+    }
+  }
   return { ref: parsed };
 }
 


### PR DESCRIPTION
## Summary

Fixes #51824 and #51608 - Control UI model picker incorrectly maps models to the wrong provider prefix.

When selecting a bailian model (e.g., `bailian/qwen3.5-plus`) from the Control UI model dropdown, the UI incorrectly sends the model ID to the backend as `qwen-portal/qwen3.5-plus` instead of `bailian/qwen3.5-plus`.

## Changes

- Added logic in `resolveModelRefFromString` to check if the model part (after `/`) is an alias in the alias index
- If an alias match is found, resolve to the correct model ID while preserving the provider prefix
- Added test case for this specific scenario

## Testing

- Added unit test in `src/agents/model-selection.test.ts`
- Test verifies that `custom-dashscope-aliyuncs-com/bailian` correctly resolves to `custom-dashscope-aliyuncs-com/qwen3.5-flash` with alias `bailian`

## Impact

- Minimal change
- Only affects Control UI model picker behavior
- No breaking changes