### PR TITLE
fix(webhooks): allow BlueBubbles in hook mapping channels

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1266,7 +1266,7 @@ export const FIELD_HELP: Record<string, string> = {
   "hooks.mappings[].allowUnsafeExternalContent":
     "When true, mapping content may include less-sanitized external payload data in generated messages. Keep false by default and enable only for trusted sources with reviewed transform logic.",
   "hooks.mappings[].channel":
-    'Delivery channel override for mapping outputs (for example "last", "telegram", "discord", "slack", "signal", "imessage", or "msteams"). Keep channel overrides explicit to avoid accidental cross-channel sends.',
+    'Delivery channel override for mapping outputs (for example "last", "telegram", "discord", "slack", "signal", "imessage", "bluebubbles", or "msteams"). Keep channel overrides explicit to avoid accidental cross-channel sends.',
   "hooks.mappings[].to":
     "Destination identifier inside the selected channel when mapping replies should route to a fixed target. Verify provider-specific destination formats before enabling production mappings.",
   "hooks.mappings[].model":

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -32,6 +32,7 @@ export type HookMappingConfig = {
     | "slack"
     | "signal"
     | "imessage"
+    | "bluebubbles"
     | "msteams";
   to?: string;
   /** Override model for this hook (provider/model or alias). */

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -59,6 +59,7 @@ export const HookMappingSchema = z
         z.literal("slack"),
         z.literal("signal"),
         z.literal("imessage"),
+        z.literal("bluebubbles"),
         z.literal("msteams"),
       ])
       .optional(),


### PR DESCRIPTION
## Summary

- Gmail pub/sub is broken for non-hardcoded channels.
- This PR adds `bluebubbles` channel (preferred?) alternative for `imessage`.
- Intentionally smaller version on #50570 for maintainer experience (<3).

Problem:
- Why it matters: Gmail pub/sub is a webhook example in docs, and does not work with preferred iMessages middleware.
- What changed: Add `bluebubbles` to enum.
- What did NOT change (scope boundary): Non-hardcoded channels still won't work.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes:
#17155 
- Related:
#50570
#25775

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15 (Sequoia) Darwin 25.2.0 arm64
- Runtime/container: OpenClaw 2026.2.14 (c1feda1), Node v22.22.0, gateway via LaunchAgent
- Model/provider: N/A (config validation layer)
- Integration/channel: BlueBubbles (iMessage plugin), Gmail Pub/Sub webhook hook
- Relevant config (redacted):
```json
{
 "plugins": {
 "entries": {
 "imessage": { "enabled": false },
 "bluebubbles": { "enabled": true }
 }
 },
 "hooks": {
 "mappings": [
 {
 "path": "/hooks/gmail",
 "channel": "bluebubbles",
 "deliver": true,
 "to": "+1**"
 }
 ]
 }
}
```
### Steps

1. Configure Gmail Pub/Sub webhook with hooks.mappings[].channel: "bluebubbles" to deliver email summaries via iMessage.
2. Apply config via config.patch or config.apply.
3. Config validation rejects with invalid config — bluebubbles is not in the hardcoded Zod literal union (whatsapp | telegram | discord | irc | slack | signal | imessage | msteams | last).

### Expected

- Config accepts bluebubbles as a valid channel since the plugin is enabled and registered.

### Actual
- channel: "bluebubbles" — rejected by config schema (Zod static enum)
- channel: "imessage" — passes config schema but rejected at runtime dispatch: channel must be last|telegram|slack|bluebubbles
- channel omitted (defaults to "last") — silently fails for webhook-spawned isolated sessions with ANNOUNCE_SKIP (no prior channel context to fall back to)
- No valid value exists that passes both validation layers.

## Evidence

Attach at least one:

- [x] Log snippets

Gateway log on runtime dispatch after setting channel: "imessage" to bypass config validation:
```
[bluebubbles] webhook rejected: unable to parse message payload
config.patch attempt with channel: "bluebubbles":
invalid config

Writing channel: "bluebubbles" directly to openclaw.json` bypassing validation caused a gateway crash loop — config watcher reloaded and crashed repeatedly. Required rescue gateway to restore config from git.
```
## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: OpenClaw happily adds "bad" channels to webhook mappings, requiring me to fix manually in `openclaw.json`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit; manually add known-good channels (`last` seems universally safe).

## Risks and Mitigations

Change is harmless, if brittle.

## Vibe coded disclaimer

Vibe coded with Codex/GPT-5.4.

Prompt Requests:

> In the same of https://github.com/openclaw/openclaw/pull/50570 let's make a much simpler, smaller PR, where we just add `bluebubbles` (or whatever it should be) as a channel. The goal is to get us unblocked, and make a smaller PR that is easier for maintainers to approve.

And in response to a narrow regression test:

> Is that regression test needed? Can it be supersede by existing test `"accepts known plugin ids and valid channel/heartbeat enums"`?
> Is the regression test all that valuable? It seems like a special snowflake for just our channel, in which the maintainers didn't think or care to add coverage for all the other channels. I just want this PR to fit in without being opinionated.