### PR TITLE
fix(cron): include subagent and ACP sessions in retention sweep

### DIFF
--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -228,6 +228,77 @@ describe("sweepCronRunSessions", () => {
     expect(r2.swept).toBe(false);
   });
 
+  it("prunes completed subagent sessions past retention", async () => {
+    const now = Date.now();
+    const store: Record<string, { sessionId: string; updatedAt: number; endedAt?: number }> = {
+      "agent:main:subagent:completed-old": {
+        sessionId: "sub-old",
+        updatedAt: now - 30 * 3_600_000,
+        endedAt: now - 26 * 3_600_000, // completed 26h ago — expired
+      },
+      "agent:main:subagent:completed-recent": {
+        sessionId: "sub-recent",
+        updatedAt: now - 2 * 3_600_000,
+        endedAt: now - 1 * 3_600_000, // completed 1h ago — not expired
+      },
+      "agent:main:subagent:still-running": {
+        sessionId: "sub-running",
+        updatedAt: now - 30 * 3_600_000, // old but no endedAt — still running
+      },
+      "agent:main:telegram:dm:123": {
+        sessionId: "regular-session",
+        updatedAt: now - 100 * 3_600_000, // old but not ephemeral
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.swept).toBe(true);
+    expect(result.pruned).toBe(1);
+
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(updated["agent:main:subagent:completed-old"]).toBeUndefined();
+    expect(updated["agent:main:subagent:completed-recent"]).toBeDefined();
+    expect(updated["agent:main:subagent:still-running"]).toBeDefined();
+    expect(updated["agent:main:telegram:dm:123"]).toBeDefined();
+  });
+
+  it("prunes completed ACP sessions past retention", async () => {
+    const now = Date.now();
+    const store: Record<string, { sessionId: string; updatedAt: number; endedAt?: number }> = {
+      "agent:main:acp:old-task": {
+        sessionId: "acp-old",
+        updatedAt: now - 30 * 3_600_000,
+        endedAt: now - 26 * 3_600_000,
+      },
+      "agent:main:acp:running-task": {
+        sessionId: "acp-running",
+        updatedAt: now - 30 * 3_600_000,
+        // no endedAt — still running
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.pruned).toBe(1);
+
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(updated["agent:main:acp:old-task"]).toBeUndefined();
+    expect(updated["agent:main:acp:running-task"]).toBeDefined();
+  });
+
   it("throttles per store path", async () => {
     const now = Date.now();
     const otherPath = path.join(tmpDir, "sessions-other.json");

--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -292,6 +292,7 @@ describe("sweepCronRunSessions", () => {
       force: true,
     });
 
+    expect(result.swept).toBe(true);
     expect(result.pruned).toBe(1);
 
     const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -99,7 +99,7 @@ export async function sweepCronRunSessions(params: {
         }
         // For subagent/ACP sessions, only prune completed sessions (endedAt set).
         // Running sessions (no endedAt) are skipped to avoid killing active work.
-        if (!isCronRun && !entry.endedAt) {
+        if (!isCronRun && entry.endedAt == null) {
           continue;
         }
         const ageRef = isCronRun ? (entry.updatedAt ?? 0) : (entry.endedAt ?? entry.updatedAt ?? 0);
@@ -150,7 +150,7 @@ export async function sweepCronRunSessions(params: {
   if (pruned > 0) {
     params.log.info(
       { pruned, retentionMs },
-      `cron-reaper: pruned ${pruned} expired cron run session(s)`,
+      `cron-reaper: pruned ${pruned} expired ephemeral session(s)`,
     );
   }
 

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -14,7 +14,11 @@ import {
 } from "../config/sessions.js";
 import type { CronConfig } from "../config/types.cron.js";
 import { cleanupArchivedSessionTranscripts } from "../gateway/session-utils.fs.js";
-import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import {
+  isCronRunSessionKey,
+  isSubagentSessionKey,
+  isAcpSessionKey,
+} from "../sessions/session-key-utils.js";
 import type { Logger } from "./service/state.js";
 
 const DEFAULT_RETENTION_MS = 24 * 3_600_000; // 24 hours
@@ -84,15 +88,22 @@ export async function sweepCronRunSessions(params: {
     await updateSessionStore(storePath, (store) => {
       const cutoff = now - retentionMs;
       for (const key of Object.keys(store)) {
-        if (!isCronRunSessionKey(key)) {
+        const isCronRun = isCronRunSessionKey(key);
+        const isEphemeral = isCronRun || isSubagentSessionKey(key) || isAcpSessionKey(key);
+        if (!isEphemeral) {
           continue;
         }
         const entry = store[key];
         if (!entry) {
           continue;
         }
-        const updatedAt = entry.updatedAt ?? 0;
-        if (updatedAt < cutoff) {
+        // For subagent/ACP sessions, only prune completed sessions (endedAt set).
+        // Running sessions (no endedAt) are skipped to avoid killing active work.
+        if (!isCronRun && !entry.endedAt) {
+          continue;
+        }
+        const ageRef = isCronRun ? (entry.updatedAt ?? 0) : (entry.endedAt ?? entry.updatedAt ?? 0);
+        if (ageRef < cutoff) {
           if (!prunedSessions.has(entry.sessionId) || entry.sessionFile) {
             prunedSessions.set(entry.sessionId, entry.sessionFile);
           }


### PR DESCRIPTION
## Summary

`sessionRetention` only pruned cron run sessions. Subagent and ACP sessions accumulated indefinitely in `sessions.json`, causing RSS growth after repeated spawns.

## Root cause

`sweepCronRunSessions()` in `src/cron/session-reaper.ts` had a hard guard:

```ts
if (!isCronRunSessionKey(key)) continue;
```

`isSubagentSessionKey()` and `isAcpSessionKey()` already exist in `session-key-utils.ts` but were never used in the reaper. Both session types have `endedAt` set after completion, suitable for age-based pruning.

## Fix

- Expand the ephemeral-session check to include subagent and ACP keys
- For subagent/ACP: only prune if `endedAt` is set and past the retention cutoff (running sessions — no `endedAt` — are never touched)
- Cron session logic unchanged (still uses `updatedAt`)

## Files changed

- `src/cron/session-reaper.ts` — expand sweep guard + use `endedAt` for subagent/ACP age ref
- `src/cron/session-reaper.test.ts` — add tests for completed subagent pruning and running subagent preservation

Closes #51767

---

- [x] I have read the contributing guidelines
- [x] I have tested my changes locally
- [x] I have added tests where applicable