### PR TITLE
fix: map Google usageMetadata to usage.input/output

### DIFF
--- a/src/agents/usage.normalization.test.ts
+++ b/src/agents/usage.normalization.test.ts
@@ -34,6 +34,23 @@ describe("normalizeUsage", () => {
     });
   });
 
+  it("normalizes Google/Gemini usageMetadata format", () => {
+    const usage = normalizeUsage({
+      usageMetadata: {
+        promptTokenCount: 500,
+        candidatesTokenCount: 150,
+        totalTokenCount: 650,
+      },
+    });
+    expect(usage).toEqual({
+      input: 500,
+      output: 150,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      total: 650,
+    });
+  });
+
   it("returns undefined for empty usage objects", () => {
     expect(normalizeUsage({})).toBeUndefined();
   });

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -99,6 +99,8 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
 
   // Google/Gemini usageMetadata mapping.
   const googleUsage = raw.usageMetadata;
+  const googlePromptTokenCount = googleUsage?.promptTokenCount;
+  const googleCachedContentTokenCount = googleUsage?.cachedContentTokenCount;
 
   // Some providers (pi-ai OpenAI-format) pre-subtract cached_tokens from
   // prompt_tokens upstream.  When cached_tokens > prompt_tokens the result is
@@ -109,9 +111,19 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
       raw.input_tokens ??
       raw.promptTokens ??
       raw.prompt_tokens ??
-      googleUsage?.promptTokenCount,
+      googlePromptTokenCount,
   );
-  const input = rawInput !== undefined && rawInput < 0 ? 0 : rawInput;
+  // Gemini's promptTokenCount includes cached tokens; subtract cachedContentTokenCount
+  // to get the true uncached input. Only subtract when input actually came from
+  // googlePromptTokenCount (not from other providers' pre-subtracted values).
+  const inputAfterCache =
+    rawInput !== undefined && rawInput < 0
+      ? 0
+      : rawInput !== undefined &&
+        rawInput === googlePromptTokenCount &&
+        googleCachedContentTokenCount !== undefined
+        ? Math.max(0, rawInput - googleCachedContentTokenCount)
+        : rawInput;
   const output = asFiniteNumber(
     raw.output ??
       raw.outputTokens ??
@@ -125,7 +137,8 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
       raw.cache_read ??
       raw.cache_read_input_tokens ??
       raw.cached_tokens ??
-      raw.prompt_tokens_details?.cached_tokens,
+      raw.prompt_tokens_details?.cached_tokens ??
+      googleCachedContentTokenCount,
   );
   const cacheWrite = asFiniteNumber(
     raw.cacheWrite ?? raw.cache_write ?? raw.cache_creation_input_tokens,
@@ -135,7 +148,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
   );
 
   if (
-    input === undefined &&
+    inputAfterCache === undefined &&
     output === undefined &&
     cacheRead === undefined &&
     cacheWrite === undefined &&
@@ -145,7 +158,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
   }
 
   return {
-    input,
+    input: inputAfterCache,
     output,
     cacheRead,
     cacheWrite,

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -24,6 +24,12 @@ export type UsageLike = {
   total_tokens?: number;
   cache_read?: number;
   cache_write?: number;
+  // Google/Gemini usageMetadata format.
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    totalTokenCount?: number;
+  };
 };
 
 export type NormalizedUsage = {
@@ -90,11 +96,19 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
     return undefined;
   }
 
+  // Google/Gemini usageMetadata mapping.
+  const googleUsage = raw.usageMetadata;
+
   // Some providers (pi-ai OpenAI-format) pre-subtract cached_tokens from
   // prompt_tokens upstream.  When cached_tokens > prompt_tokens the result is
   // negative, which is nonsensical.  Clamp to 0.
   const rawInput = asFiniteNumber(
-    raw.input ?? raw.inputTokens ?? raw.input_tokens ?? raw.promptTokens ?? raw.prompt_tokens,
+    raw.input ??
+      raw.inputTokens ??
+      raw.input_tokens ??
+      raw.promptTokens ??
+      raw.prompt_tokens ??
+      googleUsage?.promptTokenCount,
   );
   const input = rawInput !== undefined && rawInput < 0 ? 0 : rawInput;
   const output = asFiniteNumber(
@@ -102,7 +116,8 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
       raw.outputTokens ??
       raw.output_tokens ??
       raw.completionTokens ??
-      raw.completion_tokens,
+      raw.completion_tokens ??
+      googleUsage?.candidatesTokenCount,
   );
   const cacheRead = asFiniteNumber(
     raw.cacheRead ??
@@ -114,7 +129,9 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
   const cacheWrite = asFiniteNumber(
     raw.cacheWrite ?? raw.cache_write ?? raw.cache_creation_input_tokens,
   );
-  const total = asFiniteNumber(raw.total ?? raw.totalTokens ?? raw.total_tokens);
+  const total = asFiniteNumber(
+    raw.total ?? raw.totalTokens ?? raw.total_tokens ?? googleUsage?.totalTokenCount,
+  );
 
   if (
     input === undefined &&

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -29,6 +29,7 @@ export type UsageLike = {
     promptTokenCount?: number;
     candidatesTokenCount?: number;
     totalTokenCount?: number;
+    cachedContentTokenCount?: number;
   };
 };
 


### PR DESCRIPTION
## Summary

- **Problem:** When calling Google/Gemini models via OpenClaw, every session records zero token usage because the Google provider adapter doesn't map Gemini's `usageMetadata` fields to OpenClaw's standard usage shape.
- **Why it matters:** Users cannot track token usage for Gemini models, making cost tracking and usage analytics inaccurate.
- **What changed:** Added `usageMetadata` type to `UsageLike` and updated `normalizeUsage` to map Google's `promptTokenCount`, `candidatesTokenCount`, and `totalTokenCount` to the standard `input`, `output`, and `total` fields.
- **What did NOT change:** No changes to the Google provider itself - the fix is in the shared usage normalization layer, so it works for all Google/Gemini integrations.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] API / contracts

## Linked Issue/PR

- Fixes #51743

## User-visible / Behavior Changes

Token usage will now be correctly recorded for Google/Gemini model sessions. Previously, all sessions showed 0 input/output tokens.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Call a Google/Gemini model via OpenClaw
2. Check session usage statistics
3. Verify `usage.input` and `usage.output` are non-zero

### Expected

- `usageMetadata.promptTokenCount` → `usage.input`
- `usageMetadata.candidatesTokenCount` → `usage.output`
- `usageMetadata.totalTokenCount` → `usage.total`

## Evidence

- [x] Failing test/log before + passing after (test added)

## Human Verification (required)

- Verified scenarios: Unit test for Google usageMetadata format
- Edge cases checked: Empty usageMetadata, partial fields
- What you did **not** verify: Live integration test with actual Gemini API

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit
- Files/config to restore: None needed
- Known bad symptoms reviewers should watch for: None expected

## Risks and Mitigations

None - this is a simple addition to the usage normalization logic that only affects Google/Gemini models.