### PR TITLE
fix(discord): gracefully handle large attachment fetch failures

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -9,6 +9,11 @@ import {
   createThreadBindingManager,
 } from "./thread-bindings.js";
 
+const messageUtilsMocks = vi.hoisted(() => ({
+  resolveMediaList: vi.fn(async () => []),
+  resolveForwardedMediaList: vi.fn(async () => []),
+}));
+
 const sendMocks = vi.hoisted(() => ({
   reactMessageDiscord: vi.fn(async () => {}),
   removeReactionDiscord: vi.fn(async () => {}),
@@ -126,6 +131,15 @@ vi.mock("../../../../src/config/sessions.js", () => ({
   resolveStorePath: configSessionsMocks.resolveStorePath,
 }));
 
+vi.mock("./message-utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./message-utils.js")>();
+  return {
+    ...actual,
+    resolveMediaList: messageUtilsMocks.resolveMediaList,
+    resolveForwardedMediaList: messageUtilsMocks.resolveForwardedMediaList,
+  };
+});
+
 const { processDiscordMessage } = await import("./message-handler.process.js");
 
 const createBaseContext = createBaseDiscordMessageContext;
@@ -165,6 +179,8 @@ beforeEach(() => {
   recordInboundSession.mockClear();
   readSessionUpdatedAt.mockClear();
   resolveStorePath.mockClear();
+  messageUtilsMocks.resolveMediaList.mockReset().mockResolvedValue([]);
+  messageUtilsMocks.resolveForwardedMediaList.mockReset().mockResolvedValue([]);
   dispatchInboundMessage.mockResolvedValue(createNoQueuedDispatchResult());
   recordInboundSession.mockResolvedValue(undefined);
   readSessionUpdatedAt.mockReturnValue(undefined);
@@ -673,5 +689,25 @@ describe("processDiscordMessage draft streaming", () => {
     await runInPartialStreamMode();
 
     expect(draftStream.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("processDiscordMessage attachment fetch resilience", () => {
+  it("continues processing when resolveMediaList throws", async () => {
+    messageUtilsMocks.resolveMediaList.mockRejectedValueOnce(new Error("HTTP 404 Not Found"));
+    const ctx = await createBaseContext();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+    expect(dispatchInboundMessage).toHaveBeenCalled();
+  });
+
+  it("continues processing when resolveForwardedMediaList throws", async () => {
+    messageUtilsMocks.resolveForwardedMediaList.mockRejectedValueOnce(
+      new Error("HTTP 404 Not Found"),
+    );
+    const ctx = await createBaseContext();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+    expect(dispatchInboundMessage).toHaveBeenCalled();
   });
 });

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -121,20 +121,34 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   }
 
   const ssrfPolicy = cfg.browser?.ssrfPolicy;
-  const mediaList = await resolveMediaList(message, mediaMaxBytes, discordRestFetch, ssrfPolicy);
+  const mediaList: Awaited<ReturnType<typeof resolveMediaList>> = [];
+  try {
+    const resolved = await resolveMediaList(message, mediaMaxBytes, discordRestFetch, ssrfPolicy);
+    mediaList.push(...resolved);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : "unknown error";
+    logVerbose(`discord: failed to resolve attachments for message ${message.id}: ${reason}`);
+  }
   if (isProcessAborted(abortSignal)) {
     return;
   }
-  const forwardedMediaList = await resolveForwardedMediaList(
-    message,
-    mediaMaxBytes,
-    discordRestFetch,
-    ssrfPolicy,
-  );
+  try {
+    const forwardedMediaList = await resolveForwardedMediaList(
+      message,
+      mediaMaxBytes,
+      discordRestFetch,
+      ssrfPolicy,
+    );
+    mediaList.push(...forwardedMediaList);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : "unknown error";
+    logVerbose(
+      `discord: failed to resolve forwarded attachments for message ${message.id}: ${reason}`,
+    );
+  }
   if (isProcessAborted(abortSignal)) {
     return;
   }
-  mediaList.push(...forwardedMediaList);
   const text = messageText;
   if (!text) {
     logVerbose("discord: drop message " + message.id + " (empty content)");


### PR DESCRIPTION
## Summary

When a Discord Nitro user uploads a large file (e.g., a ~32MB PDF), OpenClaw's message listener crashes and stops receiving inbound messages in that channel. The root cause is an unhandled fetch failure when the Discord CDN returns HTTP 404 for Nitro-sized attachments.

## Details

Wrapped `resolveMediaList()` and `resolveForwardedMediaList()` calls in `message-handler.process.ts` with individual try/catch blocks. On failure:
- A warning is logged with the message ID and error reason
- Processing continues with whatever media was already resolved
- The message listener does NOT crash ÔÇö the channel keeps receiving messages

## Related Issues

Fixes #47649

## How to Validate

1. Upload a large file (>8MB) via Discord Nitro to a channel monitored by OpenClaw
2. Confirm the bot continues responding to subsequent messages in the same channel
3. Check logs ÔÇö warning shows the failed attachment, processing continues

Run unit tests: `pnpm test -- --testPathPattern=message-handler.process`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run

---
## AI-Assisted Disclosure

- [x] This PR was built with Claude Code (Anthropic)
- [x] Fully tested locally — tests pass, oxfmt formatting verified
- [x] Author reviewed and understands all changes
- [x] Codex review not available locally (not installed)
