### PR TITLE
normalize image/apng to image/png in attachment parsing

### DIFF
--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -137,6 +137,21 @@ describe("parseMessageWithAttachments", () => {
     expect(parsed.images[0]?.data).toBe(PNG_1x1);
     expect(logs.some((l) => /non-image/i.test(l))).toBe(true);
   });
+
+  it("normalizes image/apng to image/png", async () => {
+    // Minimal APNG (PNG with acTL chunk) that file-type detects as image/apng.
+    // Our normalization should map it to image/png for Claude API compatibility.
+    const APNG_1x1 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACGFjVEwAAAABAAAAALQVc9o" +
+      "AAAAMSURBVAjXY2BgYAAAAAQAAQb2F4+uAAAAAElFTkSuQmCC";
+
+    const { parsed } = await parseWithWarnings("apng test", [
+      { type: "image", mimeType: "image/jpeg", fileName: "anim.png", content: APNG_1x1 },
+    ]);
+
+    expect(parsed.images).toHaveLength(1);
+    expect(parsed.images[0]?.mimeType).toBe("image/png");
+  });
 });
 
 describe("shared attachment validation", () => {

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -134,10 +134,15 @@ export async function parseMessageWithAttachments(
       );
     }
 
+    // Normalize image/apng to image/png: APNG is a valid PNG superset,
+    // but Claude API rejects image/apng (only accepts jpeg/png/gif/webp).
+    const effectiveMime =
+      (sniffedMime === "image/apng" ? "image/png" : sniffedMime) ?? providedMime ?? mime;
+
     images.push({
       type: "image",
       data: b64,
-      mimeType: sniffedMime ?? providedMime ?? mime,
+      mimeType: effectiveMime,
     });
   }
 


### PR DESCRIPTION
## Problem

`file-type` (v21.3.3) detects certain PNG files as `image/apng` (Animated PNG). The `parseMessageWithAttachments()` function in `chat-attachments.ts` passes the sniffed MIME directly to the Claude API, which only accepts `image/jpeg`, `image/png`, `image/gif`, or `image/webp`. This causes HTTP 400 ValidationException and silently drops images.

Particularly affects PNG files exported from mobile apps (e.g., WeChat) that contain APNG-compatible chunks.

## Root Cause

`sniffMimeFromBase64()` calls `file-type`'s `fileTypeFromBuffer()`, which returns `{ext: 'apng', mime: 'image/apng'}` for PNGs with an `acTL` animation control chunk. The sniffed MIME takes priority over the provided MIME per existing logic, so `image/apng` reaches the API unchanged.

## Fix

Normalize `image/apng` to `image/png` after sniffing, before passing to the API. APNG is a strict superset of PNG, so this is semantically correct and safe for all providers.

**2 files changed, 21 insertions(+), 1 deletion(-)**

Fixes #51881