### PR TITLE
fix(text): recover content after unclosed reasoning tag in strict mode

### DIFF
--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -207,6 +207,51 @@ describe("stripReasoningTagsFromText", () => {
     });
   });
 
+  describe("strict-mode unclosed-tag fallback", () => {
+    it("recovers content after an unclosed opening tag that drops all text", () => {
+      const cases = [
+        {
+          name: "unclosed think tag wrapping entire response",
+          input: "<think>This is the full response text",
+          expected: "This is the full response text",
+        },
+        {
+          name: "unclosed thinking tag wrapping entire response",
+          input: "<thinking>Full response here",
+          expected: "Full response here",
+        },
+      ] as const;
+      for (const { name, input, expected } of cases) {
+        expect(stripReasoningTagsFromText(input, { mode: "strict" }), name).toBe(expected);
+      }
+    });
+
+    it("does not fall back for properly closed think tags (strict-mode contract)", () => {
+      // Closed tags: strict mode correctly strips content — not a bug.
+      expect(stripReasoningTagsFromText("<think>reasoning</think>", { mode: "strict" })).toBe("");
+      expect(
+        stripReasoningTagsFromText("<think>a</think><think>b</think>", { mode: "strict" }),
+      ).toBe("");
+    });
+
+    it("does not fall back when there is visible text outside tags", () => {
+      const input = "Before <think>hidden</think>";
+      expect(stripReasoningTagsFromText(input, { mode: "strict" })).toBe("Before");
+    });
+
+    it("does not fall back when unclosed tag has visible text before it", () => {
+      const input = "Visible <think>unclosed content";
+      expect(stripReasoningTagsFromText(input, { mode: "strict" })).toBe("Visible");
+    });
+
+    it("preserves code-block tags during fallback", () => {
+      const input = "<think>Use `<think>` in your response";
+      expect(stripReasoningTagsFromText(input, { mode: "strict" })).toBe(
+        "Use `<think>` in your response",
+      );
+    });
+  });
+
   describe("trim options", () => {
     it("applies configured trim strategies", () => {
       const cases = [

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -250,6 +250,14 @@ describe("stripReasoningTagsFromText", () => {
         "Use `<think>` in your response",
       );
     });
+
+    it("recovers only content after the last tag when multiple unclosed tags appear", () => {
+      // With `<think>A<think>B`, lastIndex advances past the second <think>,
+      // so only "B" is recovered. "A" between the two tags is lost. Acceptable
+      // for the target scenario (single unclosed tag wrapping the entire response).
+      const input = "<think>Part A<think>Part B";
+      expect(stripReasoningTagsFromText(input, { mode: "strict" })).toBe("Part B");
+    });
   });
 
   describe("trim options", () => {

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -192,7 +192,7 @@ describe("stripReasoningTagsFromText", () => {
     it("applies strict and preserve modes to unclosed tags", () => {
       const input = "Before <think>unclosed content after";
       const cases = [
-        { mode: "strict" as const, expected: "Before" },
+        { mode: "strict" as const, expected: "Before unclosed content after" },
         { mode: "preserve" as const, expected: "Before unclosed content after" },
       ];
       for (const { mode, expected } of cases) {
@@ -207,8 +207,8 @@ describe("stripReasoningTagsFromText", () => {
     });
   });
 
-  describe("strict-mode unclosed-tag fallback", () => {
-    it("recovers content after an unclosed opening tag that drops all text", () => {
+  describe("unclosed-tag fix (trailing text preservation)", () => {
+    it("preserves text after unclosed opening tags", () => {
       const cases = [
         {
           name: "unclosed think tag wrapping entire response",
@@ -220,31 +220,24 @@ describe("stripReasoningTagsFromText", () => {
           input: "<thinking>Full response here",
           expected: "Full response here",
         },
+        {
+          name: "visible text before unclosed tag — both preserved",
+          input: "Visible <think>unclosed content",
+          expected: "Visible unclosed content",
+        },
       ] as const;
       for (const { name, input, expected } of cases) {
         expect(stripReasoningTagsFromText(input, { mode: "strict" }), name).toBe(expected);
       }
     });
 
-    it("does not fall back for properly closed think tags (strict-mode contract)", () => {
-      // Closed tags: strict mode correctly strips content — not a bug.
-      expect(stripReasoningTagsFromText("<think>reasoning</think>", { mode: "strict" })).toBe("");
-      expect(
-        stripReasoningTagsFromText("<think>a</think><think>b</think>", { mode: "strict" }),
-      ).toBe("");
+    it("still strips closed blocks normally", () => {
+      expect(stripReasoningTagsFromText("Before <think>hidden</think>", { mode: "strict" })).toBe(
+        "Before",
+      );
     });
 
-    it("does not fall back when there is visible text outside tags", () => {
-      const input = "Before <think>hidden</think>";
-      expect(stripReasoningTagsFromText(input, { mode: "strict" })).toBe("Before");
-    });
-
-    it("does not fall back when unclosed tag has visible text before it", () => {
-      const input = "Visible <think>unclosed content";
-      expect(stripReasoningTagsFromText(input, { mode: "strict" })).toBe("Visible");
-    });
-
-    it("preserves code-block tags during fallback", () => {
+    it("preserves code-block tags in trailing text", () => {
       const input = "<think>Use `<think>` in your response";
       expect(stripReasoningTagsFromText(input, { mode: "strict" })).toBe(
         "Use `<think>` in your response",
@@ -252,11 +245,44 @@ describe("stripReasoningTagsFromText", () => {
     });
 
     it("recovers only content after the last tag when multiple unclosed tags appear", () => {
-      // With `<think>A<think>B`, lastIndex advances past the second <think>,
-      // so only "B" is recovered. "A" between the two tags is lost. Acceptable
-      // for the target scenario (single unclosed tag wrapping the entire response).
       const input = "<think>Part A<think>Part B";
       expect(stripReasoningTagsFromText(input, { mode: "strict" })).toBe("Part B");
+    });
+  });
+
+  describe("empty-result safety net (closed-tag fallback)", () => {
+    it("recovers content when closed tags wrap entire response", () => {
+      // Model error: entire response inside <think>. Empty delivery is worse
+      // than showing the content, so fall back to tag-only removal.
+      const cases = [
+        {
+          name: "single closed think block",
+          input: "<think>This is the full response text</think>",
+          expected: "This is the full response text",
+        },
+        {
+          name: "single closed thinking block",
+          input: "<thinking>Full response here</thinking>",
+          expected: "Full response here",
+        },
+        {
+          name: "multiple closed blocks",
+          input: "<think>block one</think><think>block two</think>",
+          expected: "block oneblock two",
+        },
+      ] as const;
+      for (const { name, input, expected } of cases) {
+        expect(stripReasoningTagsFromText(input, { mode: "strict" }), name).toBe(expected);
+      }
+    });
+
+    it("does not trigger when there is visible text outside tags", () => {
+      expect(stripReasoningTagsFromText("Before <think>hidden</think>", { mode: "strict" })).toBe(
+        "Before",
+      );
+      expect(
+        stripReasoningTagsFromText("A <think>x</think> B <think>y</think> C", { mode: "strict" }),
+      ).toBe("A  B  C");
     });
   });
 

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -30,7 +30,7 @@ export function stripReasoningTagsFromText(
     return text;
   }
 
-  const mode = options?.mode ?? "strict";
+  const _mode = options?.mode ?? "strict";
   const trimMode = options?.trim ?? "both";
 
   let cleaned = text;
@@ -84,27 +84,26 @@ export function stripReasoningTagsFromText(
     lastIndex = idx + match[0].length;
   }
 
-  if (!inThinking || mode === "preserve") {
-    result += cleaned.slice(lastIndex);
-  }
+  // Always include text after the last matched tag. Previously, strict mode
+  // discarded trailing text when an unclosed opening tag was active
+  // (inThinking=true), silently dropping entire responses when models wrap
+  // output in unclosed <think> tags (observed with Gemini Flash, Qwen 3.5).
+  // Closed <think>…</think> blocks are unaffected — their content is already
+  // excluded by the main loop above.
+  result += cleaned.slice(lastIndex);
 
   const trimmed = applyTrim(result, trimMode);
 
-  // When an unclosed opening tag at EOF causes strict mode to drop all
-  // remaining content, the user receives nothing — a silent response drop.
-  // Recover by including the text after the last matched tag (the same content
-  // preserve mode would keep). Only fires for genuinely unclosed tags; properly
-  // closed <think>…</think> blocks are still stripped per strict-mode contract.
-  // Observed with Gemini Flash wrapping entire responses in unclosed <think>.
-  //
-  // Limitation: when multiple unclosed opening tags appear (e.g.
-  // `<think>A<think>B`), only content after the last matched tag is recovered
-  // ("B"). Content between earlier tags ("A") is lost. This is acceptable for
-  // the target scenario (single unclosed tag wrapping the entire response).
-  if (mode === "strict" && inThinking && !trimmed && text.trim()) {
-    const fallbackResult = applyTrim(cleaned.slice(lastIndex), trimMode);
-    if (fallbackResult) {
-      return fallbackResult;
+  // Safety net: if the result is still empty after the above fix (e.g. the
+  // model wrapped the entire response in properly closed <think> tags), fall
+  // back to tag-only removal. An empty delivery is always a worse outcome
+  // than showing the content — the model made an error by tagging its entire
+  // response as reasoning, but the user should still see something.
+  if (!trimmed && text.trim()) {
+    THINKING_TAG_RE.lastIndex = 0;
+    const fallback = applyTrim(cleaned.replace(THINKING_TAG_RE, ""), trimMode);
+    if (fallback) {
+      return fallback;
     }
   }
 

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -88,5 +88,24 @@ export function stripReasoningTagsFromText(
     result += cleaned.slice(lastIndex);
   }
 
-  return applyTrim(result, trimMode);
+  const trimmed = applyTrim(result, trimMode);
+
+  // When an unclosed opening tag at EOF causes strict mode to drop all
+  // remaining content, the user receives nothing — a silent response drop.
+  // Recover by including the text after the last matched tag (the same content
+  // preserve mode would keep). Only fires for genuinely unclosed tags; properly
+  // closed <think>…</think> blocks are still stripped per strict-mode contract.
+  // Observed with Gemini Flash wrapping entire responses in unclosed <think>.
+  if (mode === "strict" && inThinking && !trimmed && text.trim()) {
+    result += cleaned.slice(lastIndex);
+    const fallbackResult = applyTrim(result, trimMode);
+    if (fallbackResult) {
+      console.warn(
+        `[reasoning-tags] strict-mode empty-result fallback activated. Input length=${text.length}, recovered length=${fallbackResult.length}`,
+      );
+      return fallbackResult;
+    }
+  }
+
+  return trimmed;
 }

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -96,13 +96,14 @@ export function stripReasoningTagsFromText(
   // preserve mode would keep). Only fires for genuinely unclosed tags; properly
   // closed <think>…</think> blocks are still stripped per strict-mode contract.
   // Observed with Gemini Flash wrapping entire responses in unclosed <think>.
+  //
+  // Limitation: when multiple unclosed opening tags appear (e.g.
+  // `<think>A<think>B`), only content after the last matched tag is recovered
+  // ("B"). Content between earlier tags ("A") is lost. This is acceptable for
+  // the target scenario (single unclosed tag wrapping the entire response).
   if (mode === "strict" && inThinking && !trimmed && text.trim()) {
-    result += cleaned.slice(lastIndex);
-    const fallbackResult = applyTrim(result, trimMode);
+    const fallbackResult = applyTrim(cleaned.slice(lastIndex), trimMode);
     if (fallbackResult) {
-      console.warn(
-        `[reasoning-tags] strict-mode empty-result fallback activated. Input length=${text.length}, recovered length=${fallbackResult.length}`,
-      );
       return fallbackResult;
     }
   }


### PR DESCRIPTION
## Summary

**Problem:** When a model wraps its entire response in an unclosed `<think>` tag (e.g. `<think>Here is my answer`), `stripReasoningTagsFromText()` in strict mode drops all content after the unclosed tag. The user receives an empty response -- no error, no partial content, just silence. Observed with Gemini Flash and Qwen 3.5 (reported in #37696 by @druide67).

**Why it matters:** This affects all channels (Telegram, Discord, Slack, Signal, etc.) since `stripReasoningTagsFromText` is the shared text sanitizer in the SDK pipeline. The agent produces a valid response (visible in session transcripts), but the delivery pipeline silently drops it.

**What changed -- two-layer fix:**

1. **Trailing text preservation** (adopts @druide67's proposal from #37696): remove the \`!inThinking\` guard so text after unclosed opening tags is always included. This directly fixes the reported bug. Closed \`<think>...</think>\` blocks are unaffected -- their content is already excluded by the main parsing loop.

2. **Empty-result safety net**: if the result is still empty after layer 1 (e.g. model wrapped the entire response in properly closed \`<think>\` tags), fall back to tag-only removal. An empty delivery is always a worse outcome than showing the content.

**What did NOT change:** Code-block preservation is unaffected. Preserve mode is unchanged. Properly closed blocks with visible text outside them are still stripped normally.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway
- [x] Integrations

## Linked Issue/PR

Closes #37696

Complementary to #40777 (delivery pipeline level fix in \`sanitizeUserFacingText\`; this fix is at the source function).

## User-visible / Behavior Changes

- Responses wrapped in unclosed \`<think>\` tags are now delivered instead of silently dropped
- Responses wrapped in closed \`<think>...</think>\` tags (entire response) are now delivered as a last resort instead of returning empty

## Security Impact

- Does this change handle user input? **Yes** -- model output processed by the shared text sanitizer.
- Does this change affect authentication/authorization? **No**
- Does this change expose new APIs or endpoints? **No**
- Does this change modify security-sensitive paths? **No**
- Does this change affect data privacy? **No**

**Risk assessment:** Layer 1 (trailing text) is a straightforward fix with no security implications -- unclosed tags are a model error, not intentional reasoning. Layer 2 (safety net) trades strict-mode purity for user experience: when the only alternative is delivering nothing, showing content is always better.

## Repro + Verification

**Environment:** Any channel using strict-mode reasoning tag stripping.

**Steps:**
1. Model emits: \`<think>Here is my answer to your question\`
2. \`stripReasoningTagsFromText(text, { mode: "strict" })\` is called

**Expected (after fix):** \`"Here is my answer to your question"\`
**Actual (before fix):** \`""\`

## Evidence

Tests: 20/20 pass (10 new tests covering both layers).

Layer 1 (trailing text preservation):
- Unclosed think/thinking tags -- content recovered
- Visible text before unclosed tag -- both preserved
- Code-block tags in trailing text -- preserved
- Multiple unclosed tags -- content after last tag recovered

Layer 2 (empty-result safety net):
- Closed tags wrapping entire response -- content recovered
- Multiple closed blocks -- all content recovered
- Visible text outside tags -- normal stripping, no fallback

Lint: 0 errors. Format: all correct.

## Human Verification

- [x] Verified unclosed tag recovery
- [x] Verified closed-tag safety net
- [x] Verified code-block preservation
- [x] Verified no regression on normal closed-block stripping
- [ ] Not tested with live model output (non-deterministic)

## Compatibility / Migration

No breaking changes. The \`mode\` option is preserved for API compatibility but no longer affects behavior (strict and preserve now produce the same result for unclosed tags).

## Failure Recovery

**Revert:** \`git revert <commit>\` -- single commit, no migration needed.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Layer 2 recovers content that strict mode would strip | Only fires when the alternative is empty delivery. Properly closed blocks with visible text outside them are still stripped normally. |
| Code-block tags stripped in safety net | Safety net uses regex replace (not code-region aware), but only fires when result is already empty -- no code-block content to lose. |
| Telegram lane duplication | Pre-existing interaction; delivering duplicated content is strictly better than delivering nothing. |