### PR TITLE
fix: normalize OpenClawBrain plugin install identity

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -196,6 +196,42 @@ describe("discoverOpenClawPlugins", () => {
     expect(ids).toContain("voice-call");
   });
 
+  it("normalizes scoped package aliases before falling back to unscoped names", async () => {
+    const stateDir = makeTempDir();
+    const globalExt = path.join(stateDir, "extensions", "openclawbrain-pack");
+    mkdirSafe(path.join(globalExt, "src"));
+
+    writePluginPackageManifest({
+      packageDir: globalExt,
+      packageName: "@openclawbrain/openclaw",
+      extensions: ["./src/index.ts"],
+    });
+    fs.writeFileSync(
+      path.join(globalExt, "src", "index.ts"),
+      "export default function () {}",
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(globalExt, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "openclawbrain",
+          name: "OpenClawBrain",
+          version: "0.4.0",
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const { candidates } = await discoverWithStateDir(stateDir, {});
+
+    const ids = candidates.map((c) => c.idHint);
+    expect(ids).toContain("openclawbrain");
+    expect(ids).not.toContain("openclaw");
+  });
+
   it("strips provider suffixes from package-derived ids", async () => {
     const stateDir = makeTempDir();
     const globalExt = path.join(stateDir, "extensions", "ollama-provider-pack");

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -17,6 +17,7 @@ import type { PluginBundleFormat, PluginDiagnostic, PluginFormat, PluginOrigin }
 const EXTENSION_EXTS = new Set([".ts", ".js", ".mts", ".cts", ".mjs", ".cjs"]);
 
 const CANONICAL_PACKAGE_ID_ALIASES: Record<string, string> = {
+  "@openclawbrain/openclaw": "openclawbrain",
   "elevenlabs-speech": "elevenlabs",
   "microsoft-speech": "microsoft",
   "ollama-provider": "ollama",
@@ -345,7 +346,10 @@ function deriveIdHint(params: {
   const unscoped = rawPackageName.includes("/")
     ? (rawPackageName.split("/").pop() ?? rawPackageName)
     : rawPackageName;
-  const canonicalPackageId = CANONICAL_PACKAGE_ID_ALIASES[unscoped] ?? unscoped;
+  const canonicalPackageId =
+    CANONICAL_PACKAGE_ID_ALIASES[rawPackageName] ??
+    CANONICAL_PACKAGE_ID_ALIASES[unscoped] ??
+    unscoped;
   const normalizedPackageId =
     canonicalPackageId.endsWith("-provider") && canonicalPackageId.length > "-provider".length
       ? canonicalPackageId.slice(0, -"-provider".length)

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -221,12 +221,20 @@ async function installFromDirWithWarnings(params: { pluginDir: string; extension
   return { result, warnings };
 }
 
-function setupManifestInstallFixture(params: { manifestId: string }) {
+function setupManifestInstallFixture(params: { manifestId: string; packageName?: string }) {
   const caseDir = makeTempDir();
   const stateDir = path.join(caseDir, "state");
   const pluginDir = path.join(caseDir, "plugin-src");
   fs.mkdirSync(stateDir, { recursive: true });
   fs.cpSync(manifestInstallTemplateDir, pluginDir, { recursive: true });
+  if (params.packageName) {
+    const packageJsonPath = path.join(pluginDir, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as {
+      name?: string;
+    };
+    packageJson.name = params.packageName;
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), "utf-8");
+  }
   fs.writeFileSync(
     path.join(pluginDir, "openclaw.plugin.json"),
     JSON.stringify({
@@ -822,6 +830,25 @@ describe("installPluginFromDir", () => {
     });
 
     expectInstalledWithPluginId(res, extensionsDir, "@team/memory-cognee");
+  });
+
+  it("suppresses manifest/package mismatch chatter for known canonical aliases", async () => {
+    const { pluginDir, extensionsDir } = setupManifestInstallFixture({
+      manifestId: "openclawbrain",
+      packageName: "@openclawbrain/openclaw",
+    });
+
+    const infoMessages: string[] = [];
+    const res = await installPluginFromDir({
+      dirPath: pluginDir,
+      extensionsDir,
+      logger: { info: (msg: string) => infoMessages.push(msg), warn: () => {} },
+    });
+
+    expectInstalledWithPluginId(res, extensionsDir, "openclawbrain");
+    expect(infoMessages.some((msg) => msg.includes('Plugin manifest id "openclawbrain"'))).toBe(
+      false,
+    );
   });
 
   it("preserves scoped package names when no plugin manifest id is present", async () => {

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -58,6 +58,10 @@ export const PLUGIN_INSTALL_ERROR_CODE = {
   PLUGIN_ID_MISMATCH: "plugin_id_mismatch",
 } as const;
 
+const KNOWN_MANIFEST_PACKAGE_ID_EQUIVALENTS: Record<string, string> = {
+  "@openclawbrain/openclaw": "openclawbrain",
+};
+
 export type PluginInstallErrorCode =
   (typeof PLUGIN_INSTALL_ERROR_CODE)[keyof typeof PLUGIN_INSTALL_ERROR_CODE];
 
@@ -124,6 +128,13 @@ function validatePluginId(pluginId: string): string | null {
     return "invalid plugin name: scoped ids must use @scope/name format";
   }
   return null;
+}
+
+function isKnownManifestPackageIdEquivalent(params: {
+  manifestPluginId: string;
+  npmPluginId: string;
+}): boolean {
+  return KNOWN_MANIFEST_PACKAGE_ID_EQUIVALENTS[params.npmPluginId] === params.manifestPluginId;
 }
 
 function matchesExpectedPluginId(params: {
@@ -519,7 +530,11 @@ async function installPluginFromPackageDir(
     };
   }
 
-  if (manifestPluginId && manifestPluginId !== npmPluginId) {
+  if (
+    manifestPluginId &&
+    manifestPluginId !== npmPluginId &&
+    !isKnownManifestPackageIdEquivalent({ manifestPluginId, npmPluginId })
+  ) {
     logger.info?.(
       `Plugin manifest id "${manifestPluginId}" differs from npm package name "${npmPluginId}"; using manifest id as the config key.`,
     );


### PR DESCRIPTION
## Summary
- normalize `@openclawbrain/openclaw` to canonical plugin id `openclawbrain` during discovery
- suppress the old manifest/package mismatch chatter for this known canonical alias during plugin install
- add regression coverage for both discovery and install paths

## Verification
- `npx vitest run src/plugins/discovery.test.ts src/plugins/install.test.ts`

## Why
The split-package OpenClawBrain flow now proves clean reinstall/upgrade behavior on the live host, but older OpenClaw host builds still emit the legacy `openclaw` vs `openclawbrain` warning. This patch makes the host-side identity handling canonical.
