### PR TITLE
[codex] fix telegram polling liveness health monitor

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -4,6 +4,7 @@ import {
 } from "openclaw/plugin-sdk/allowlist-config-edit";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import { createAllowlistProviderRouteAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
+import { createAccountStatusSink } from "openclaw/plugin-sdk/channel-runtime";
 import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import { createChatChannelPlugin } from "openclaw/plugin-sdk/core";
 import { createChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
@@ -547,6 +548,10 @@ export const telegramPlugin = createChatChannelPlugin({
           }
         }
         ctx.log?.info(`[${account.accountId}] starting provider${telegramBotLabel}`);
+        const setStatus = createAccountStatusSink({
+          accountId: account.accountId,
+          setStatus: ctx.setStatus,
+        });
         return monitorTelegramProvider({
           token,
           accountId: account.accountId,
@@ -560,6 +565,7 @@ export const telegramPlugin = createChatChannelPlugin({
           webhookHost: account.config.webhookHost,
           webhookPort: account.config.webhookPort,
           webhookCertPath: account.config.webhookCertPath,
+          setStatus,
         });
       },
       logoutAccount: async ({ accountId, cfg }) => {

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -1,4 +1,5 @@
 import type { RunOptions } from "@grammyjs/runner";
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-runtime";
 import { resolveAgentMaxConcurrent } from "openclaw/plugin-sdk/config-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
@@ -33,6 +34,7 @@ export type MonitorTelegramOpts = {
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
   webhookCertPath?: string;
+  setStatus?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
 };
 
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
@@ -202,6 +204,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       log,
       telegramTransport,
       createTelegramTransport: createTelegramTransportForPolling,
+      setStatus: opts.setStatus,
     });
     await pollingSession.runUntilAbort();
   } finally {

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -3,6 +3,7 @@ import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-runtime
 import { resolveAgentMaxConcurrent } from "openclaw/plugin-sdk/config-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
+import { createConnectedChannelStatusPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/infra-runtime";
 import { waitForAbortSignal } from "openclaw/plugin-sdk/runtime-env";
 import { registerUnhandledRejectionHandler } from "openclaw/plugin-sdk/runtime-env";
@@ -165,6 +166,10 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     };
 
     if (opts.useWebhook) {
+      opts.setStatus?.({
+        ...createConnectedChannelStatusPatch(),
+        mode: "webhook",
+      });
       await startTelegramWebhook({
         token,
         accountId: account.accountId,

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -540,7 +540,7 @@ describe("TelegramPollingSession", () => {
       setStatus.mock.calls.filter(
         ([patch]) => (patch as { connected?: boolean }).connected === false,
       ),
-    ).toHaveLength(3);
+    ).toHaveLength(2);
   });
 
   it("marks polling mode before the first successful getUpdates response", async () => {
@@ -590,5 +590,57 @@ describe("TelegramPollingSession", () => {
         mode: "polling",
       }),
     );
+  });
+
+  it("publishes polling mode before recoverable setup retries", async () => {
+    const abort = new AbortController();
+    const setupError = new Error("recoverable setup error");
+    const setStatus = vi.fn();
+
+    createTelegramBotMock
+      .mockImplementationOnce(() => {
+        throw setupError;
+      })
+      .mockReturnValue({
+        api: {
+          deleteWebhook: vi.fn(async () => true),
+          getUpdates: vi.fn(async () => []),
+          config: { use: vi.fn() },
+        },
+        stop: vi.fn(async () => undefined),
+      });
+
+    runMock.mockImplementation(() => ({
+      task: async () => {
+        abort.abort();
+      },
+      stop: vi.fn(async () => undefined),
+      isRunning: () => false,
+    }));
+
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log: () => undefined,
+      setStatus,
+      telegramTransport: undefined,
+    });
+
+    await session.runUntilAbort();
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connected: false,
+        mode: "polling",
+      }),
+    );
+    expect(createTelegramBotMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -454,4 +454,86 @@ describe("TelegramPollingSession", () => {
     );
     expect(setStatus).toHaveBeenLastCalledWith({ connected: false });
   });
+
+  it("keeps channel marked connected while recoverable poll retries back off", async () => {
+    const abort = new AbortController();
+    const recoverableError = new Error("recoverable polling error");
+    const runnerStop = vi.fn(async () => undefined);
+    const setStatus = vi.fn();
+    const apiConfigUse = vi.fn();
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        getUpdates: vi.fn(async () => []),
+        config: {
+          use: apiConfigUse,
+        },
+      },
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValue(bot);
+
+    let firstCycle = true;
+    runMock.mockImplementation(() => {
+      if (firstCycle) {
+        firstCycle = false;
+        return {
+          task: async () => {
+            const middleware = apiConfigUse.mock.calls[0]?.[0] as
+              | ((
+                  prev: (
+                    method: string,
+                    payload: unknown,
+                    signal: AbortSignal | undefined,
+                  ) => Promise<unknown>,
+                  method: string,
+                  payload: unknown,
+                  signal: AbortSignal | undefined,
+                ) => Promise<unknown>)
+              | undefined;
+            await middleware?.(async () => [], "getUpdates", {}, undefined);
+            throw recoverableError;
+          },
+          stop: runnerStop,
+          isRunning: () => false,
+        };
+      }
+      return {
+        task: async () => {
+          abort.abort();
+        },
+        stop: runnerStop,
+        isRunning: () => false,
+      };
+    });
+
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log: () => undefined,
+      setStatus,
+      telegramTransport: undefined,
+    });
+
+    await session.runUntilAbort();
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connected: true,
+        mode: "polling",
+      }),
+    );
+    expect(
+      setStatus.mock.calls.filter(
+        ([patch]) => (patch as { connected?: boolean }).connected === false,
+      ),
+    ).toHaveLength(1);
+  });
 });

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -449,6 +449,7 @@ describe("TelegramPollingSession", () => {
     expect(setStatus).toHaveBeenCalledWith(
       expect.objectContaining({
         connected: true,
+        mode: "polling",
       }),
     );
     expect(setStatus).toHaveBeenLastCalledWith({ connected: false });

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -389,4 +389,68 @@ describe("TelegramPollingSession", () => {
     expectTelegramBotTransportSequence(transport1, transport1);
     expect(createTelegramTransport).not.toHaveBeenCalled();
   });
+
+
+  it("publishes channel liveness on successful polls and clears it on stop", async () => {
+    const abort = new AbortController();
+    const runnerStop = vi.fn(async () => undefined);
+    const setStatus = vi.fn();
+    const apiConfigUse = vi.fn();
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        getUpdates: vi.fn(async () => []),
+        config: {
+          use: apiConfigUse,
+        },
+      },
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValue(bot);
+
+    runMock.mockImplementation(() => ({
+      task: async () => {
+        const middleware = apiConfigUse.mock.calls[0]?.[0] as
+          | ((
+              prev: (
+                method: string,
+                payload: unknown,
+                signal: AbortSignal | undefined,
+              ) => Promise<unknown>,
+              method: string,
+              payload: unknown,
+              signal: AbortSignal | undefined,
+            ) => Promise<unknown>)
+          | undefined;
+        await middleware?.(async () => [], "getUpdates", {}, undefined);
+        abort.abort();
+      },
+      stop: runnerStop,
+      isRunning: () => false,
+    }));
+
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log: () => undefined,
+      setStatus,
+      telegramTransport: undefined,
+    });
+
+    await session.runUntilAbort();
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connected: true,
+      }),
+    );
+    expect(setStatus).toHaveBeenLastCalledWith({ connected: false });
+  });
 });

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -448,6 +448,12 @@ describe("TelegramPollingSession", () => {
 
     expect(setStatus).toHaveBeenCalledWith(
       expect.objectContaining({
+        connected: false,
+        mode: "polling",
+      }),
+    );
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
         connected: true,
         mode: "polling",
       }),
@@ -534,6 +540,55 @@ describe("TelegramPollingSession", () => {
       setStatus.mock.calls.filter(
         ([patch]) => (patch as { connected?: boolean }).connected === false,
       ),
-    ).toHaveLength(1);
+    ).toHaveLength(3);
+  });
+
+  it("marks polling mode before the first successful getUpdates response", async () => {
+    const abort = new AbortController();
+    const runnerStop = vi.fn(async () => undefined);
+    const setStatus = vi.fn();
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        getUpdates: vi.fn(async () => []),
+        config: {
+          use: vi.fn(),
+        },
+      },
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValue(bot);
+
+    runMock.mockImplementation(() => ({
+      task: async () => {
+        abort.abort();
+      },
+      stop: runnerStop,
+      isRunning: () => false,
+    }));
+
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log: () => undefined,
+      setStatus,
+      telegramTransport: undefined,
+    });
+
+    await session.runUntilAbort();
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connected: false,
+        mode: "polling",
+      }),
+    );
   });
 });

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -540,7 +540,14 @@ describe("TelegramPollingSession", () => {
       setStatus.mock.calls.filter(
         ([patch]) => (patch as { connected?: boolean }).connected === false,
       ),
-    ).toHaveLength(2);
+    ).toHaveLength(3);
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connected: false,
+        mode: "polling",
+        lastEventAt: null,
+      }),
+    );
   });
 
   it("marks polling mode before the first successful getUpdates response", async () => {
@@ -639,8 +646,94 @@ describe("TelegramPollingSession", () => {
       expect.objectContaining({
         connected: false,
         mode: "polling",
+        lastConnectedAt: null,
+        lastEventAt: null,
       }),
     );
     expect(createTelegramBotMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears stale connected liveness before polling restarts after a successful poll", async () => {
+    const abort = new AbortController();
+    const recoverableError = new Error("recoverable polling error");
+    const setStatus = vi.fn();
+    const runnerStop = vi.fn(async () => undefined);
+    const apiConfigUse = vi.fn();
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        getUpdates: vi.fn(async () => []),
+        config: {
+          use: apiConfigUse,
+        },
+      },
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValue(bot);
+
+    let firstCycle = true;
+    runMock.mockImplementation(() => {
+      if (firstCycle) {
+        firstCycle = false;
+        return {
+          task: async () => {
+            const middleware = apiConfigUse.mock.calls[0]?.[0] as
+              | ((
+                  prev: (
+                    method: string,
+                    payload: unknown,
+                    signal: AbortSignal | undefined,
+                  ) => Promise<unknown>,
+                  method: string,
+                  payload: unknown,
+                  signal: AbortSignal | undefined,
+                ) => Promise<unknown>)
+              | undefined;
+            await middleware?.(async () => [], "getUpdates", {}, undefined);
+            throw recoverableError;
+          },
+          stop: runnerStop,
+          isRunning: () => false,
+        };
+      }
+      return {
+        task: async () => {
+          abort.abort();
+        },
+        stop: runnerStop,
+        isRunning: () => false,
+      };
+    });
+
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log: () => undefined,
+      setStatus,
+      telegramTransport: undefined,
+    });
+
+    await session.runUntilAbort();
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connected: true,
+        mode: "polling",
+      }),
+    );
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connected: false,
+        mode: "polling",
+        lastEventAt: null,
+      }),
+    );
   });
 });

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -236,7 +236,10 @@ export class TelegramPollingSession {
         lastGetUpdatesFinishedAt = finishedAt;
         lastGetUpdatesDurationMs = finishedAt - startedAt;
         lastGetUpdatesOutcome = Array.isArray(result) ? `ok:${result.length}` : "ok";
-        this.opts.setStatus?.(createConnectedChannelStatusPatch(finishedAt));
+        this.opts.setStatus?.({
+          ...createConnectedChannelStatusPatch(finishedAt),
+          mode: "polling",
+        });
         return result;
       } catch (err) {
         const finishedAt = Date.now();
@@ -353,7 +356,6 @@ export class TelegramPollingSession {
       );
       return shouldRestart ? "continue" : "exit";
     } catch (err) {
-      this.opts.setStatus?.({ connected: false });
       this.#forceRestarted = false;
       if (this.opts.abortSignal?.aborted) {
         throw err;

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -62,6 +62,7 @@ export class TelegramPollingSession {
   #restartAttempts = 0;
   #webhookCleared = false;
   #forceRestarted = false;
+  #hasSeenSuccessfulPoll = false;
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
   #transportState: TelegramPollingTransportState;
@@ -92,6 +93,10 @@ export class TelegramPollingSession {
 
   async runUntilAbort(): Promise<void> {
     while (!this.opts.abortSignal?.aborted) {
+      this.opts.setStatus?.({
+        mode: "polling",
+        ...(this.#hasSeenSuccessfulPoll ? {} : { connected: false }),
+      });
       const bot = await this.#createPollingBot();
       if (!bot) {
         continue;
@@ -201,10 +206,6 @@ export class TelegramPollingSession {
   }
 
   async #runPollingCycle(bot: TelegramBot): Promise<"continue" | "exit"> {
-    this.opts.setStatus?.({
-      mode: "polling",
-      connected: false,
-    });
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
@@ -240,6 +241,7 @@ export class TelegramPollingSession {
         lastGetUpdatesFinishedAt = finishedAt;
         lastGetUpdatesDurationMs = finishedAt - startedAt;
         lastGetUpdatesOutcome = Array.isArray(result) ? `ok:${result.length}` : "ok";
+        this.#hasSeenSuccessfulPoll = true;
         this.opts.setStatus?.({
           ...createConnectedChannelStatusPatch(finishedAt),
           mode: "polling",

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -1,4 +1,6 @@
 import { type RunOptions, run } from "@grammyjs/runner";
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-runtime";
+import { createConnectedChannelStatusPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { computeBackoff, sleepWithAbort } from "openclaw/plugin-sdk/infra-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/infra-runtime";
 import { formatDurationPrecise } from "openclaw/plugin-sdk/infra-runtime";
@@ -49,6 +51,7 @@ type TelegramPollingSessionOpts = {
   getLastUpdateId: () => number | null;
   persistUpdateId: (updateId: number) => Promise<void>;
   log: (line: string) => void;
+  setStatus?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
   /** Pre-resolved Telegram transport to reuse across bot instances */
   telegramTransport?: TelegramTransport;
   /** Rebuild Telegram transport after stall/network recovery when marked dirty. */
@@ -233,6 +236,7 @@ export class TelegramPollingSession {
         lastGetUpdatesFinishedAt = finishedAt;
         lastGetUpdatesDurationMs = finishedAt - startedAt;
         lastGetUpdatesOutcome = Array.isArray(result) ? `ok:${result.length}` : "ok";
+        this.opts.setStatus?.(createConnectedChannelStatusPatch(finishedAt));
         return result;
       } catch (err) {
         const finishedAt = Date.now();
@@ -349,6 +353,7 @@ export class TelegramPollingSession {
       );
       return shouldRestart ? "continue" : "exit";
     } catch (err) {
+      this.opts.setStatus?.({ connected: false });
       this.#forceRestarted = false;
       if (this.opts.abortSignal?.aborted) {
         throw err;
@@ -374,6 +379,7 @@ export class TelegramPollingSession {
       );
       return shouldRestart ? "continue" : "exit";
     } finally {
+      this.opts.setStatus?.({ connected: false });
       clearInterval(watchdog);
       if (forceCycleTimer) {
         clearTimeout(forceCycleTimer);

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -201,6 +201,10 @@ export class TelegramPollingSession {
   }
 
   async #runPollingCycle(bot: TelegramBot): Promise<"continue" | "exit"> {
+    this.opts.setStatus?.({
+      mode: "polling",
+      connected: false,
+    });
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -265,6 +265,7 @@ export class TelegramPollingSession {
     }
     let stopPromise: Promise<void> | undefined;
     let stalledRestart = false;
+    let shouldClearConnected = true;
     let forceCycleTimer: ReturnType<typeof setTimeout> | undefined;
     let forceCycleResolve: (() => void) | undefined;
     const forceCyclePromise = new Promise<void>((resolve) => {
@@ -354,6 +355,7 @@ export class TelegramPollingSession {
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram polling runner stopped (${reason}); restarting in ${delay}.`,
       );
+      shouldClearConnected = !shouldRestart;
       return shouldRestart ? "continue" : "exit";
     } catch (err) {
       this.#forceRestarted = false;
@@ -379,9 +381,12 @@ export class TelegramPollingSession {
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram ${reason}: ${errMsg}; retrying in ${delay}.`,
       );
+      shouldClearConnected = !shouldRestart;
       return shouldRestart ? "continue" : "exit";
     } finally {
-      this.opts.setStatus?.({ connected: false });
+      if (shouldClearConnected) {
+        this.opts.setStatus?.({ connected: false });
+      }
       clearInterval(watchdog);
       if (forceCycleTimer) {
         clearTimeout(forceCycleTimer);

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -95,7 +95,9 @@ export class TelegramPollingSession {
     while (!this.opts.abortSignal?.aborted) {
       this.opts.setStatus?.({
         mode: "polling",
-        ...(this.#hasSeenSuccessfulPoll ? {} : { connected: false }),
+        connected: false,
+        lastEventAt: null,
+        ...(this.#hasSeenSuccessfulPoll ? {} : { lastConnectedAt: null }),
       });
       const bot = await this.#createPollingBot();
       if (!bot) {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -145,6 +145,7 @@ describe("evaluateChannelHealth", () => {
         configured: true,
         lastStartAt: 0,
         lastEventAt: 0,
+        mode: "polling",
       },
       {
         channelId: "telegram",
@@ -154,6 +155,26 @@ describe("evaluateChannelHealth", () => {
       },
     );
     expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
+  });
+
+  it("skips stale-socket detection for telegram accounts without explicit polling mode", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: 0,
+      },
+      {
+        channelId: "telegram",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
 
   it("skips stale-socket detection for channels in webhook mode", () => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -177,13 +177,35 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
 
-  it("treats telegram polling accounts without a first successful poll as disconnected", () => {
+  it("treats telegram polling accounts without a first successful poll as stale-socket", () => {
     const evaluation = evaluateChannelHealth(
       {
         running: true,
         enabled: true,
         configured: true,
         lastStartAt: 0,
+        lastEventAt: null,
+        mode: "polling",
+      },
+      {
+        channelId: "telegram",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
+  });
+
+  it("treats previously connected telegram polling accounts that drop offline as disconnected", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: false,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastConnectedAt: 50_000,
         lastEventAt: null,
         mode: "polling",
       },

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -177,6 +177,26 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
 
+  it("treats telegram polling accounts without a first successful poll as disconnected", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: null,
+        mode: "polling",
+      },
+      {
+        channelId: "telegram",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "disconnected" });
+  });
+
   it("skips stale-socket detection for channels in webhook mode", () => {
     const evaluation = evaluateDiscordHealth({
       running: true,

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -136,7 +136,7 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
   });
 
-  it("skips stale-socket detection for telegram long-polling channels", () => {
+  it("treats telegram polling channels with stale event liveness as unhealthy", () => {
     const evaluation = evaluateChannelHealth(
       {
         running: true,
@@ -144,7 +144,7 @@ describe("evaluateChannelHealth", () => {
         enabled: true,
         configured: true,
         lastStartAt: 0,
-        lastEventAt: null,
+        lastEventAt: 0,
       },
       {
         channelId: "telegram",
@@ -153,7 +153,7 @@ describe("evaluateChannelHealth", () => {
         staleEventThresholdMs: 30_000,
       },
     );
-    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+    expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
   });
 
   it("skips stale-socket detection for channels in webhook mode", () => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -177,6 +177,27 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
 
+  it("ignores malformed non-string mode patches during health evaluation", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: 0,
+        mode: { polling: true } as unknown as string,
+      },
+      {
+        channelId: "telegram",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
   it("treats telegram polling accounts without a first successful poll as stale-socket", () => {
     const evaluation = evaluateChannelHealth(
       {

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -103,6 +103,14 @@ export function evaluateChannelHealth(
       return { healthy: true, reason: "startup-connect-grace" };
     }
   }
+  const normalizedMode = snapshot.mode?.trim().toLowerCase();
+  if (
+    policy.channelId === "telegram" &&
+    normalizedMode === "polling" &&
+    snapshot.connected !== true
+  ) {
+    return { healthy: false, reason: "disconnected" };
+  }
   if (snapshot.connected === false) {
     return { healthy: false, reason: "disconnected" };
   }
@@ -110,7 +118,6 @@ export function evaluateChannelHealth(
     typeof snapshot.lastEventAt === "number" && Number.isFinite(snapshot.lastEventAt)
       ? snapshot.lastEventAt
       : null;
-  const normalizedMode = snapshot.mode?.trim().toLowerCase();
   const shouldCheckStaleSocket =
     snapshot.connected === true &&
     lastEventAt != null &&

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -106,18 +106,28 @@ export function evaluateChannelHealth(
   if (snapshot.connected === false) {
     return { healthy: false, reason: "disconnected" };
   }
-  // Skip stale-socket check for channels explicitly operating in webhook mode.
-  // Polling channels, including Telegram, can publish synthetic event activity
-  // from successful poll cycles so the monitor can detect wedged listeners.
-  if (snapshot.mode !== "webhook" && snapshot.connected === true && snapshot.lastEventAt != null) {
-    if (lastStartAt != null && snapshot.lastEventAt < lastStartAt) {
+  const lastEventAt =
+    typeof snapshot.lastEventAt === "number" && Number.isFinite(snapshot.lastEventAt)
+      ? snapshot.lastEventAt
+      : null;
+  const normalizedMode = snapshot.mode?.trim().toLowerCase();
+  const shouldCheckStaleSocket =
+    snapshot.connected === true &&
+    lastEventAt != null &&
+    (policy.channelId === "telegram" ? normalizedMode === "polling" : normalizedMode !== "webhook");
+  // Telegram should only opt into stale-socket checks when the runtime
+  // explicitly reports polling mode. Webhook accounts can inherit stale polling
+  // timestamps during restarts, so treating "mode missing" as polling would
+  // cause healthy webhook listeners to be restarted.
+  if (shouldCheckStaleSocket) {
+    if (lastStartAt != null && lastEventAt < lastStartAt) {
       const lifecycleEventGap = Math.max(0, policy.now - lastStartAt);
       if (lifecycleEventGap <= policy.staleEventThresholdMs) {
         return { healthy: true, reason: "healthy" };
       }
       return { healthy: false, reason: "stale-socket" };
     }
-    const eventAge = policy.now - snapshot.lastEventAt;
+    const eventAge = policy.now - lastEventAt;
     if (eventAge > policy.staleEventThresholdMs) {
       return { healthy: false, reason: "stale-socket" };
     }

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -9,6 +9,7 @@ export type ChannelHealthSnapshot = {
   busy?: boolean;
   activeRuns?: number;
   lastRunActivityAt?: number | null;
+  lastConnectedAt?: number | null;
   lastEventAt?: number | null;
   lastStartAt?: number | null;
   reconnectAttempts?: number;
@@ -77,6 +78,10 @@ export function evaluateChannelHealth(
     typeof snapshot.lastRunActivityAt === "number" && Number.isFinite(snapshot.lastRunActivityAt)
       ? snapshot.lastRunActivityAt
       : null;
+  const lastConnectedAt =
+    typeof snapshot.lastConnectedAt === "number" && Number.isFinite(snapshot.lastConnectedAt)
+      ? snapshot.lastConnectedAt
+      : null;
   const busyStateInitializedForLifecycle =
     lastStartAt == null || (lastRunActivityAt != null && lastRunActivityAt >= lastStartAt);
 
@@ -109,7 +114,7 @@ export function evaluateChannelHealth(
     normalizedMode === "polling" &&
     snapshot.connected !== true
   ) {
-    return { healthy: false, reason: "disconnected" };
+    return { healthy: false, reason: lastConnectedAt == null ? "stale-socket" : "disconnected" };
   }
   if (snapshot.connected === false) {
     return { healthy: false, reason: "disconnected" };

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -108,7 +108,8 @@ export function evaluateChannelHealth(
       return { healthy: true, reason: "startup-connect-grace" };
     }
   }
-  const normalizedMode = snapshot.mode?.trim().toLowerCase();
+  const normalizedMode =
+    typeof snapshot.mode === "string" ? snapshot.mode.trim().toLowerCase() : undefined;
   if (
     policy.channelId === "telegram" &&
     normalizedMode === "polling" &&

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -106,16 +106,10 @@ export function evaluateChannelHealth(
   if (snapshot.connected === false) {
     return { healthy: false, reason: "disconnected" };
   }
-  // Skip stale-socket check for Telegram (long-polling mode) and any channel
-  // explicitly operating in webhook mode. In these cases, there is no persistent
-  // outgoing socket that can go half-dead, so the lack of incoming events
-  // does not necessarily indicate a connection failure.
-  if (
-    policy.channelId !== "telegram" &&
-    snapshot.mode !== "webhook" &&
-    snapshot.connected === true &&
-    snapshot.lastEventAt != null
-  ) {
+  // Skip stale-socket check for channels explicitly operating in webhook mode.
+  // Polling channels, including Telegram, can publish synthetic event activity
+  // from successful poll cycles so the monitor can detect wedged listeners.
+  if (snapshot.mode !== "webhook" && snapshot.connected === true && snapshot.lastEventAt != null) {
     if (lastStartAt != null && snapshot.lastEventAt < lastStartAt) {
       const lifecycleEventGap = Math.max(0, policy.now - lastStartAt);
       if (lifecycleEventGap <= policy.staleEventThresholdMs) {

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -127,7 +127,9 @@ export function evaluateChannelHealth(
   const shouldCheckStaleSocket =
     snapshot.connected === true &&
     lastEventAt != null &&
-    (policy.channelId === "telegram" ? normalizedMode === "polling" : normalizedMode !== "webhook");
+    (policy.channelId === "telegram"
+      ? typeof snapshot.mode === "string" && normalizedMode === "polling"
+      : normalizedMode !== "webhook");
   // Telegram should only opt into stale-socket checks when the runtime
   // explicitly reports polling mode. Webhook accounts can inherit stale polling
   // timestamps during restarts, so treating "mode missing" as polling would


### PR DESCRIPTION
This fixes a Telegram-specific failure mode where the provider could stop processing new inbound messages even though the gateway still showed the channel as running.

In the failing case, Telegram polling was interrupted by a `getUpdates` conflict or another poll-loop failure. The provider retried internally, but it never published channel liveness into the gateway runtime snapshot. At the same time, the gateway health monitor intentionally skipped stale-event checks for Telegram. The result was that a wedged or preempted Telegram poller could remain marked as running indefinitely, so new Telegram DMs would stop reaching agent session creation without triggering automatic recovery.

The fix does two things. First, the Telegram polling session now reports successful `getUpdates` activity back into the channel runtime snapshot by publishing connected and event-liveness state on successful poll cycles, and it clears the connected flag when the polling cycle exits or fails. Second, the gateway health policy now treats Telegram polling the same way as other non-webhook channels when event-liveness data is present, so a stalled Telegram poller can be restarted automatically instead of remaining falsely healthy forever.

I also threaded the Telegram gateway `setStatus` sink through the provider startup path so the polling monitor can update the runtime snapshot directly, and I added regression coverage for the polling-session liveness behavior and the health-policy evaluation.

Validation was done with:

- `pnpm vitest run --config vitest.config.ts extensions/telegram/src/polling-session.test.ts src/gateway/channel-health-policy.test.ts`

This is related to the recent Telegram incident work but addresses a separate root cause from the earlier session-reset/followup fix.

## Contribution Notes
- AI-assisted: yes (`Codex`)
- Testing degree: lightly tested
- Review thread handling: addressed and resolved where applicable before re-requesting review
