### PR TITLE
fix(ui): resolve channel config forms via account path

### DIFF
--- a/test/ui/channel-config-extras.test.ts
+++ b/test/ui/channel-config-extras.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveChannelAccountConfigValue,
+  resolveChannelConfigValue,
+} from "../../ui/src/ui/views/channel-config-extras.ts";
+
+describe("channel config value resolution", () => {
+  it("prefers account-scoped channel config when accountId is provided", () => {
+    const config = {
+      channels: {
+        discord: {
+          enabled: true,
+          accounts: {
+            "discord-main": {
+              token: "account-token",
+              dmPolicy: "allow",
+            },
+          },
+        },
+      },
+    } satisfies Record<string, unknown>;
+
+    expect(resolveChannelAccountConfigValue(config, "discord", "discord-main")).toEqual({
+      token: "account-token",
+      dmPolicy: "allow",
+    });
+    expect(resolveChannelConfigValue(config, "discord", "discord-main")).toEqual({
+      token: "account-token",
+      dmPolicy: "allow",
+    });
+  });
+
+  it("falls back to channel root config when the requested account is missing", () => {
+    const config = {
+      channels: {
+        discord: {
+          enabled: true,
+          dmPolicy: "mentions",
+          accounts: {
+            default: {
+              token: "default-token",
+            },
+          },
+        },
+      },
+    } satisfies Record<string, unknown>;
+
+    expect(resolveChannelAccountConfigValue(config, "discord", "discord-main")).toBeNull();
+    expect(resolveChannelConfigValue(config, "discord", "discord-main")).toEqual({
+      enabled: true,
+      dmPolicy: "mentions",
+      accounts: {
+        default: {
+          token: "default-token",
+        },
+      },
+    });
+  });
+});

--- a/ui/src/ui/views/channel-config-extras.ts
+++ b/ui/src/ui/views/channel-config-extras.ts
@@ -1,4 +1,4 @@
-export function resolveChannelConfigValue(
+function resolveChannelRootValue(
   configForm: Record<string, unknown> | null | undefined,
   channelId: string,
 ): Record<string, unknown> | null {
@@ -15,6 +15,34 @@ export function resolveChannelConfigValue(
     return fallback as Record<string, unknown>;
   }
   return null;
+}
+
+export function resolveChannelAccountConfigValue(
+  configForm: Record<string, unknown> | null | undefined,
+  channelId: string,
+  accountId: string | null | undefined,
+): Record<string, unknown> | null {
+  const channel = resolveChannelRootValue(configForm, channelId);
+  if (!channel || !accountId?.trim()) {
+    return null;
+  }
+  const accounts = channel.accounts;
+  if (!accounts || typeof accounts !== "object") {
+    return null;
+  }
+  const account = (accounts as Record<string, unknown>)[accountId];
+  return account && typeof account === "object" ? (account as Record<string, unknown>) : null;
+}
+
+export function resolveChannelConfigValue(
+  configForm: Record<string, unknown> | null | undefined,
+  channelId: string,
+  accountId?: string | null,
+): Record<string, unknown> | null {
+  return (
+    resolveChannelAccountConfigValue(configForm, channelId, accountId) ??
+    resolveChannelRootValue(configForm, channelId)
+  );
 }
 
 export function formatChannelExtraValue(raw: unknown): string {

--- a/ui/src/ui/views/channels.config.ts
+++ b/ui/src/ui/views/channels.config.ts
@@ -6,6 +6,7 @@ import { analyzeConfigSchema, renderNode, schemaType, type JsonSchema } from "./
 
 type ChannelConfigFormProps = {
   channelId: string;
+  accountId?: string | null;
   configValue: Record<string, unknown> | null;
   schema: unknown;
   uiHints: ConfigUiHints;
@@ -49,11 +50,18 @@ function resolveSchemaNode(
   return current;
 }
 
+function resolveScopedChannelPath(channelId: string, accountId?: string | null): Array<string> {
+  return accountId?.trim()
+    ? ["channels", channelId, "accounts", accountId]
+    : ["channels", channelId];
+}
+
 function resolveChannelValue(
   config: Record<string, unknown>,
   channelId: string,
+  accountId?: string | null,
 ): Record<string, unknown> {
-  return resolveChannelConfigValue(config, channelId) ?? {};
+  return resolveChannelConfigValue(config, channelId, accountId) ?? {};
 }
 
 const EXTRA_CHANNEL_FIELDS = ["groupPolicy", "streamMode", "dmPolicy"] as const;
@@ -90,20 +98,21 @@ export function renderChannelConfigForm(props: ChannelConfigFormProps) {
       <div class="callout danger">Schema unavailable. Use Raw.</div>
     `;
   }
-  const node = resolveSchemaNode(normalized, ["channels", props.channelId]);
+  const scopedPath = resolveScopedChannelPath(props.channelId, props.accountId);
+  const node = resolveSchemaNode(normalized, scopedPath);
   if (!node) {
     return html`
       <div class="callout danger">Channel config schema unavailable.</div>
     `;
   }
   const configValue = props.configValue ?? {};
-  const value = resolveChannelValue(configValue, props.channelId);
+  const value = resolveChannelValue(configValue, props.channelId, props.accountId);
   return html`
     <div class="config-form">
       ${renderNode({
         schema: node,
         value,
-        path: ["channels", props.channelId],
+        path: scopedPath,
         hints: props.uiHints,
         unsupported: new Set(analysis.unsupportedPaths),
         disabled: props.disabled,
@@ -115,9 +124,20 @@ export function renderChannelConfigForm(props: ChannelConfigFormProps) {
   `;
 }
 
+function resolvePreferredChannelAccountId(channelId: string, props: ChannelsProps): string | null {
+  const defaultAccountId = props.snapshot?.channelDefaultAccountId?.[channelId];
+  if (defaultAccountId?.trim()) {
+    return defaultAccountId;
+  }
+  const accounts = props.snapshot?.channelAccounts?.[channelId] ?? [];
+  const configured = accounts.find((account) => account.configured && account.accountId?.trim());
+  return configured?.accountId?.trim() || accounts[0]?.accountId?.trim() || null;
+}
+
 export function renderChannelConfigSection(params: { channelId: string; props: ChannelsProps }) {
   const { channelId, props } = params;
   const disabled = props.configSaving || props.configSchemaLoading;
+  const accountId = resolvePreferredChannelAccountId(channelId, props);
   return html`
     <div style="margin-top: 16px;">
       ${
@@ -127,6 +147,7 @@ export function renderChannelConfigSection(params: { channelId: string; props: C
             `
           : renderChannelConfigForm({
               channelId,
+              accountId,
               configValue: props.configForm,
               schema: props.configSchema,
               uiHints: props.configUiHints,


### PR DESCRIPTION
Fixes #51335.

## Summary
- resolve channel config forms against `channels.<provider>.accounts.<accountId>` when a default/configured account is available
- fall back to the channel root config when no scoped account config exists
- add a focused regression test for account-scoped channel config resolution

## Validation
- added `test/ui/channel-config-extras.test.ts`
- local smoke check: `node --input-type=module` import/assert against `resolveChannelConfigValue()` passed
- `pnpm test -- --run test/ui/channel-config-extras.test.ts` still hangs in this checkout, so full vitest confirmation is still pending
