### PR TITLE
fix(agent): bestEffortDeliver skips channel resolution in webchat-only setups (#51936)

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -685,6 +685,43 @@ describe("gateway agent handler", () => {
     expect(callArgs.bestEffortDeliver).toBe(false);
   });
 
+  it("does not fail when bestEffortDeliver=true and no external channels are configured (#51936)", async () => {
+    // In webchat-only setups, exec approval followups pass deliver=true + bestEffortDeliver=true
+    // but no external channel (telegram/discord/etc) is configured. The agent handler should
+    // downgrade gracefully instead of throwing "Channel is required".
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+    const respond = vi.fn();
+
+    await invokeAgent(
+      {
+        message: "exec approval result",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        bestEffortDeliver: true,
+        idempotencyKey: "test-webchat-only-approval",
+      },
+      { reqId: "webchat-only-1", respond },
+    );
+
+    // Should accept (not reject) — the agent run proceeds without external delivery
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const acceptedCall = respond.mock.calls.find(
+      (call: unknown[]) =>
+        call[0] === true && (call[1] as Record<string, unknown>)?.status === "accepted",
+    );
+    expect(acceptedCall).toBeDefined();
+    // Should NOT have been rejected with INVALID_REQUEST
+    const rejectedCall = respond.mock.calls.find(
+      (call: unknown[]) =>
+        call[0] === false &&
+        typeof (call[2] as Record<string, unknown>)?.message === "string" &&
+        ((call[2] as Record<string, unknown>).message as string).includes("Channel is required"),
+    );
+    expect(rejectedCall).toBeUndefined();
+  });
+
   it("rejects public spawned-run metadata fields", async () => {
     primeMainAgentRun();
     mocks.agentCommand.mockClear();

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -624,8 +624,14 @@ export const agentHandlers: GatewayRequestHandlers = {
           resolvedAccountId,
         };
       } catch (err) {
-        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
-        return;
+        if (bestEffortDeliver) {
+          // Best-effort delivery: if no external channel is available (e.g. webchat-only),
+          // downgrade to in-session response instead of failing the entire request.
+          // The agent response will still be written to the session and visible in webchat.
+        } else {
+          respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
+          return;
+        }
       }
     }
 
@@ -643,15 +649,20 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
 
     if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          "delivery channel is required: pass --channel/--reply-channel or use a main session with a previous channel",
-        ),
-      );
-      return;
+      if (bestEffortDeliver) {
+        // Best-effort delivery with no deliverable channel: proceed without delivery.
+        // The response is still written to the session and visible in webchat/control-ui.
+      } else {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "delivery channel is required: pass --channel/--reply-channel or use a main session with a previous channel",
+          ),
+        );
+        return;
+      }
     }
 
     const normalizedTurnSource = normalizeMessageChannel(turnSourceChannel);

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -628,6 +628,10 @@ export const agentHandlers: GatewayRequestHandlers = {
           // Best-effort delivery: if no external channel is available (e.g. webchat-only),
           // downgrade to in-session response instead of failing the entire request.
           // The agent response will still be written to the session and visible in webchat.
+          context.logGateway.info(
+            "bestEffortDeliver: channel resolution failed, proceeding without delivery",
+            { err: String(err) },
+          );
         } else {
           respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
           return;
@@ -652,6 +656,9 @@ export const agentHandlers: GatewayRequestHandlers = {
       if (bestEffortDeliver) {
         // Best-effort delivery with no deliverable channel: proceed without delivery.
         // The response is still written to the session and visible in webchat/control-ui.
+        context.logGateway.info(
+          "bestEffortDeliver: no deliverable channel available, skipping delivery",
+        );
       } else {
         respond(
           false,


### PR DESCRIPTION
## Problem

In webchat/control-ui-only setups (no Telegram, Discord, Slack, etc.), exec approval followups fail with:

```
INVALID_REQUEST: Channel is required (no configured channels detected)
```

The agent handler tries to resolve an external delivery channel when `deliver=true`, even when `bestEffortDeliver=true`. Since webchat is an internal channel (not a "deliverable" channel), channel resolution throws when no external channels are configured.

## Fix

When `bestEffortDeliver=true` and channel resolution fails, downgrade gracefully instead of erroring. The agent run proceeds without external delivery — the response is still written to the session and visible in webchat/control-ui.

Two guards in the agent handler are updated:
1. The `resolveMessageChannelSelection` try/catch now catches the error when `bestEffortDeliver` is true
2. The fallback check for `INTERNAL_MESSAGE_CHANNEL` also skips the error when `bestEffortDeliver` is true

External channel flows (Telegram, Discord, etc.) are completely unaffected — the guards only change behavior when `bestEffortDeliver=true` and no deliverable channel exists.

## Test

Added regression test: "does not fail when bestEffortDeliver=true and no external channels are configured (#51936)"

Verifies the agent handler accepts the request (returns `accepted`) and does not reject with `Channel is required`.

```
pnpm vitest run src/gateway/server-methods/agent.test.ts
# 20 tests passing
```

Fixes #51936