### PR TITLE
feat: add config option to disable tool-result context guard compaction to speed up local LLM calls with prompt caching [AI-assisted]

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2167,6 +2167,7 @@ export async function runEmbeddedAttempt(
             params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
           ),
         ),
+        compaction: params.config?.agents?.defaults?.toolResultContextGuard?.compaction,
       });
       const cacheTrace = createCacheTrace({
         cfg: params.config,

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -161,8 +161,9 @@ function enforceToolResultContextBudgetInPlace(params: {
   messages: AgentMessage[];
   contextBudgetChars: number;
   maxSingleToolResultChars: number;
+  compaction: boolean;
 }): void {
-  const { messages, contextBudgetChars, maxSingleToolResultChars } = params;
+  const { messages, contextBudgetChars, maxSingleToolResultChars, compaction } = params;
   const estimateCache = createMessageCharEstimateCache();
 
   // Ensure each tool result has an upper bound before considering total context usage.
@@ -172,6 +173,10 @@ function enforceToolResultContextBudgetInPlace(params: {
     }
     const truncated = truncateToolResultToChars(message, maxSingleToolResultChars, estimateCache);
     applyMessageMutationInPlace(message, truncated, estimateCache);
+  }
+
+  if (!compaction) {
+    return;
   }
 
   let currentChars = estimateContextChars(messages, estimateCache);
@@ -190,7 +195,10 @@ function enforceToolResultContextBudgetInPlace(params: {
 export function installToolResultContextGuard(params: {
   agent: GuardableAgent;
   contextWindowTokens: number;
+  /** Disable compaction of old tool results to preserve prompt cache stability (default: true). */
+  compaction?: boolean;
 }): () => void {
+  const compactionEnabled = params.compaction !== false;
   const contextWindowTokens = Math.max(1, Math.floor(params.contextWindowTokens));
   const contextBudgetChars = Math.max(
     1_024,
@@ -222,18 +230,22 @@ export function installToolResultContextGuard(params: {
       messages: contextMessages,
       contextBudgetChars,
       maxSingleToolResultChars,
+      compaction: compactionEnabled,
     });
 
     // After tool-result compaction, check if context still exceeds the high-water mark.
     // If it does, non-tool-result content dominates and only full LLM-based session
     // compaction can reduce context size. Throwing a context overflow error triggers
     // the existing overflow recovery cascade in run.ts.
-    const postEnforcementChars = estimateContextChars(
-      contextMessages,
-      createMessageCharEstimateCache(),
-    );
-    if (postEnforcementChars > preemptiveOverflowChars) {
-      throw new Error(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
+    // Skip when compaction is disabled — let the overflow recovery cascade handle it.
+    if (compactionEnabled) {
+      const postEnforcementChars = estimateContextChars(
+        contextMessages,
+        createMessageCharEstimateCache(),
+      );
+      if (postEnforcementChars > preemptiveOverflowChars) {
+        throw new Error(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
+      }
     }
 
     return contextMessages;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -173,6 +173,15 @@ export type AgentDefaultsConfig = {
   contextPruning?: AgentContextPruningConfig;
   /** Compaction tuning and pre-compaction memory flush behavior. */
   compaction?: AgentCompactionConfig;
+  /** Tool-result context guard controls. */
+  toolResultContextGuard?: {
+    /**
+     * Whether to compact (replace) old tool results when context exceeds budget.
+     * Disable this to preserve prompt cache stability across turns (default: true).
+     * Individual oversized results are still truncated on first use.
+     */
+    compaction?: boolean;
+  };
   /** Embedded Pi runner hardening and compatibility controls. */
   embeddedPi?: {
     /**

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -129,6 +129,12 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    toolResultContextGuard: z
+      .object({
+        compaction: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     embeddedPi: z
       .object({
         projectSettingsPolicy: z


### PR DESCRIPTION
## Summary
- Problem: When running a local LLM (e.g. via llama.cpp on Apple Silicon), the tool-result context guard compacts old tool results as context grows. This modifies the message history mid-session, which
  invalidates the prompt cache and forces a full re-prefill on every affected turn — killing the performance benefit of KV cache on local hardware.                                                               
  - Why it matters: Local model users on memory-constrained or high-latency setups (e.g. M3 Ultra running a large model) pay a significant cost for cache invalidation. Per-result truncation (the size safety
  net) still fires, so context can't blow up.                                                                                                                                                                     
  - What changed: Added agents.defaults.toolResultContextGuard.compaction boolean config option (default true). Set to false to skip compaction of old tool results while keeping per-result size truncation
  active.                                                                                                                                                                                                         
  - What did NOT change: Default behavior is unchanged. Per-result truncation always runs regardless of this setting. No changes to the compaction safeguard or any other agent subsystem.

## Change Type (select all)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

New optional config key `agents.defaults.toolResultContextGuard.compaction` (boolean, default true).
Users can set it to false to disable compaction of accumulated tool results, preserving prompt cache stability across turns. Individual oversized tool results are still truncated on first use.

Example config:
```json
{
  "agents": {
    "defaults": {
      "toolResultContextGuard": {
        "compaction": false
      }
    }
  }
}
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon - M3 Ultra)
- Runtime/container: Node v24.14.0
- Model/provider: `GLM-4.7-Flash-Q8_0.gguf` running via `llama.cpp` with prompt caching enabled and 128k context size
- Integration/channel (if any): Telegram
- Relevant config (redacted): `agents.defaults.toolResultContextGuard.compaction: false`

### Steps

1. Run a local LLM with 128k context size
2. Run a large coding task that has many tool outputs
3. Observe that tool calls are redacted as we get to ~70k tokens context and prompt cache is invalidated (early tool calls are compacted resulting in the invalidation)

### Expected

- Tool calls should have the option to not be compacted since it's a huge performance hit on locally running models

### Actual

- Prompt invalidation occurs after certain number of turns since no option to turn it off exists

## Evidence
<img width="2532" height="388" alt="image" src="https://github.com/user-attachments/assets/40b4c94a-86d1-4c2b-82d5-209f128dcc9b" />
Above is an example of the tool compaction causing prompt cache invalidation. We see above that the third latest run (third from the bottom) has `83830` token prompt, and the 6th latest run (6th from the bottom) has a prompt of `83616` tokens. This decrease in tokens despite the run being after is due to tool result compaction showed here:

#### Prompt diff:
<img width="2293" height="557" alt="image" src="https://github.com/user-attachments/assets/3e01118a-9150-4d40-b605-fcd434773d5a" />

This compaction occured on line `410` of a `~5500` line prompt, despite most of the prompt being the exact same. This causes the prompt cache to be invalidated after line `410`. We can see in the first screenshot that this results in a near **5 minute** prompt reprocessing window in my case (will vary based on what model a user is running and what hardware they are using). We see this happen about every 5 or so turns.

After adding this config key and logic, this is the result:
<img width="1409" height="2300" alt="image" src="https://github.com/user-attachments/assets/7c0a5717-bd20-404e-9e53-16929b4d4b78" />
We can see that we no longer get those 5 minute prompt cache invalidation halts. In addition, when context does fill up and compaction occurs (Look at the top of the screenshot at the 3rd column from the right. It shows tokens in to the LLM), it's still far less time than our prompt cache invalidation took because pre-fill on the newly compacted context is way faster since it's a smaller amount of tokens.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Local model session with multiple tool calls: prompt cache remains stable with `compaction: false` default behavior (`compaction: true`) unchanged
  - Edge cases checked: Per-result truncation still fires when a single result exceeds `maxSingleToolResultChars` setting has no effect on the compaction safeguard path
- What you did **not** verify:
idk

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`: opt-in flag, default is true which mimics existing behavior
- Config/env changes? `Yes`: new optional key `agents.defaults.toolResultContextGuard.compaction`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `compaction: false` from config
- Files/config to restore: `src/agents/pi-embedded-runner/tool-result-context-guard.ts`, `src/config/types.agent-defaults.ts`, `src/config/zod-schema.agent-defaults.ts`
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: None
