### PR TITLE
fix(agents): gate exec approval followup delivery on external channel target availability

### DIFF
--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -40,18 +40,22 @@ export async function sendExecApprovalFollowup(
       ? String(params.turnSourceThreadId)
       : undefined;
 
+  const hasDeliveryTarget = Boolean(channel && to);
+
   await callGatewayTool(
     "agent",
     { timeoutMs: 60_000 },
     {
       sessionKey,
       message: buildExecApprovalFollowupPrompt(resultText),
-      deliver: true,
-      bestEffortDeliver: true,
-      channel: channel && to ? channel : undefined,
-      to: channel && to ? to : undefined,
-      accountId: channel && to ? params.turnSourceAccountId?.trim() || undefined : undefined,
-      threadId: channel && to ? threadId : undefined,
+      deliver: hasDeliveryTarget,
+      bestEffortDeliver: hasDeliveryTarget,
+      channel: hasDeliveryTarget ? channel : undefined,
+      to: hasDeliveryTarget ? to : undefined,
+      accountId: hasDeliveryTarget
+        ? params.turnSourceAccountId?.trim() || undefined
+        : undefined,
+      threadId: hasDeliveryTarget ? threadId : undefined,
       idempotencyKey: `exec-approval-followup:${params.approvalId}`,
     },
     { expectFinal: true },


### PR DESCRIPTION
sendExecApprovalFollowup() always set deliver: true and bestEffortDeliver: true
regardless of whether an external delivery target existed. In webchat-only
sessions, channel is set to 'webchat' but to is undefined, causing the gateway
to attempt external channel resolution via resolveMessageChannelSelection()
which throws 'Channel is required (no configured channels detected)'.

Introduce hasDeliveryTarget = Boolean(channel && to) and gate deliver and
bestEffortDeliver on this flag. Webchat-only sessions keep the followup in
session context without requiring an external channel.

Fixes #51936

## Summary

- **Problem:** `sendExecApprovalFollowup()` unconditionally set `deliver: true` and `bestEffortDeliver: true`, even when no external delivery target (`channel` + `to`) was present. In webchat-only setups, `to` is `undefined`, triggering a channel resolution failure in the gateway.
- **Why it matters:** Every approved exec command failed in the followup step in webchat/control-ui-only setups, making the approval feature unusable end-to-end even after the approval itself succeeded.
- **What changed:** `hasDeliveryTarget = Boolean(channel && to)` now gates `deliver` and `bestEffortDeliver` in `bash-tools.exec-approval-followup.ts`.
- **What did NOT change:** External channel delivery (Discord, Telegram, Slack, etc.) is fully preserved — `deliver` and `bestEffortDeliver` remain `true` when a real delivery target exists.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #51936

## User-visible / Behavior Changes

Exec approval followup no longer fails with "Channel is required" in webchat-only setups. The approved command executes and the result is delivered in the session as expected.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

The change only affects whether the followup message attempts external delivery. The approval decision and command execution are unaffected.

## Repro + Verification

### Environment
- OS: Windows 11
- Runtime/container: Docker (docker compose)
- Model/provider: Anthropic (claude-sonnet)
- Integration/channel: webchat / control-ui only (no Discord, Telegram, etc.)
- Relevant config: plain HTTP, no external channels configured

### Steps
1. Start OpenClaw via `docker compose up` on plain HTTP
2. Open control-ui in browser
3. Send a message that triggers an exec approval request
4. Approve the request in the control-ui popup

### Expected
- Command executes after approval
- Result appears in the chat session

### Actual (before fix)
- Gateway threw `Channel is required (no configured channels detected)` after approval
- Command never executed

## Evidence

- [x] Trace/log snippets

Before fix:
```
CHANNEL SELECTION FAILED — Channel is required (no configured channels detected)
```

After fix:
```
[exec-followup] hasDeliveryTarget: false, channel: 'webchat', to: undefined
[agent] wantsDelivery computed { wantsDelivery: false }
→ agent ✓
```

## Human Verification

- Verified scenarios: full exec approval flow in webchat-only Docker setup on Windows 11, allow-once confirmed working end-to-end
- Edge cases checked: external channel delivery (Discord config present) unaffected — `deliver` remains `true` when `to` is set
- What I did not verify: Telegram/Slack followup delivery, macOS native app

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert: revert `hasDeliveryTarget` guard in `src/agents/bash-tools.exec-approval-followup.ts`
- Files/config to restore: `src/agents/bash-tools.exec-approval-followup.ts`
- Known bad symptoms: "Channel is required" error after exec approval in webchat-only setups

## Risks and Mitigations

- Risk: External channel followup delivery silently skipped if `to` is unexpectedly undefined in a non-webchat session
  - Mitigation: `to` is only undefined when no external target was ever set for the session. Sessions with an active external channel always have `to` populated from the session routing context.