### PR TITLE
fix(exec): skip outbound deliver for webchat-only exec approval follow-ups (#51936)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ Docs: https://docs.openclaw.ai
 - Voice Call: enforce spoken-output contract and fix stream TTS silence regression (#51500) Thanks @joshavant.
 - xAI/models: rename the bundled Grok 4.20 catalog entries to the GA IDs and normalize saved deprecated beta IDs at runtime so existing configs and sessions keep resolving. (#50772) thanks @Jaaneek
 - Plugins/Matrix TTS: send auto-TTS replies as native Matrix voice bubbles instead of generic audio attachments. (#37080) thanks @Matthew19990919.
+- Exec/WebChat: run exec-approval completion follow-ups with `deliver=false` when the turn source is not an outbound message channel (for example WebChat-only setups), avoiding gateway agent RPC errors that required an external delivery target. (#51936)
 
 ### Fixes
 

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./tools/gateway.js", () => ({
+  callGatewayTool: vi.fn(),
+}));
+
+import { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
+import { callGatewayTool } from "./tools/gateway.js";
+
+describe("sendExecApprovalFollowup", () => {
+  afterEach(() => {
+    vi.mocked(callGatewayTool).mockReset();
+  });
+
+  it("does not request outbound deliver for webchat-only turn source", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({ status: "ok" });
+
+    await sendExecApprovalFollowup({
+      approvalId: "a1",
+      sessionKey: "agent:main:main",
+      turnSourceChannel: "webchat",
+      turnSourceTo: "session-1",
+      resultText: "done",
+    });
+
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "agent",
+      { timeoutMs: 60_000 },
+      expect.objectContaining({
+        deliver: false,
+        channel: undefined,
+        to: undefined,
+      }),
+      { expectFinal: true },
+    );
+  });
+
+  it("does not request outbound deliver when turn source channel is missing", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({ status: "ok" });
+
+    await sendExecApprovalFollowup({
+      approvalId: "a2",
+      sessionKey: "agent:main:main",
+      resultText: "done",
+    });
+
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "agent",
+      { timeoutMs: 60_000 },
+      expect.objectContaining({ deliver: false }),
+      { expectFinal: true },
+    );
+  });
+
+  it("requests outbound deliver when turn source is a deliverable channel with a target", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValue({ status: "ok" });
+
+    await sendExecApprovalFollowup({
+      approvalId: "a3",
+      sessionKey: "agent:main:main",
+      turnSourceChannel: "telegram",
+      turnSourceTo: "+15551234567",
+      turnSourceAccountId: "default",
+      turnSourceThreadId: "99",
+      resultText: "done",
+    });
+
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "agent",
+      { timeoutMs: 60_000 },
+      expect.objectContaining({
+        deliver: true,
+        channel: "telegram",
+        to: "+15551234567",
+        accountId: "default",
+        threadId: "99",
+      }),
+      { expectFinal: true },
+    );
+  });
+});

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -1,3 +1,4 @@
+import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 type ExecApprovalFollowupParams = {
@@ -33,8 +34,15 @@ export async function sendExecApprovalFollowup(
     return false;
   }
 
-  const channel = params.turnSourceChannel?.trim();
+  const channelRaw = params.turnSourceChannel?.trim();
   const to = params.turnSourceTo?.trim();
+  const normalizedChannel = channelRaw ? normalizeMessageChannel(channelRaw) : undefined;
+  // WebChat and other internal surfaces are not outbound-deliverable; forcing deliver=true
+  // makes the gateway agent RPC fail when no external message channel is configured (#51936).
+  const hasOutboundDeliverTarget =
+    Boolean(channelRaw && to) &&
+    normalizedChannel != null &&
+    isDeliverableMessageChannel(normalizedChannel);
   const threadId =
     params.turnSourceThreadId != null && params.turnSourceThreadId !== ""
       ? String(params.turnSourceThreadId)
@@ -46,12 +54,14 @@ export async function sendExecApprovalFollowup(
     {
       sessionKey,
       message: buildExecApprovalFollowupPrompt(resultText),
-      deliver: true,
+      deliver: hasOutboundDeliverTarget,
       bestEffortDeliver: true,
-      channel: channel && to ? channel : undefined,
-      to: channel && to ? to : undefined,
-      accountId: channel && to ? params.turnSourceAccountId?.trim() || undefined : undefined,
-      threadId: channel && to ? threadId : undefined,
+      channel: hasOutboundDeliverTarget ? normalizedChannel : undefined,
+      to: hasOutboundDeliverTarget ? to : undefined,
+      accountId: hasOutboundDeliverTarget
+        ? params.turnSourceAccountId?.trim() || undefined
+        : undefined,
+      threadId: hasOutboundDeliverTarget ? threadId : undefined,
       idempotencyKey: `exec-approval-followup:${params.approvalId}`,
     },
     { expectFinal: true },

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -437,7 +437,7 @@ describe("exec approvals", () => {
     expect(agentCalls[0]).toEqual(
       expect.objectContaining({
         sessionKey: "agent:main:main",
-        deliver: true,
+        deliver: false,
         idempotencyKey: expect.stringContaining("exec-approval-followup:"),
       }),
     );


### PR DESCRIPTION
## Summary
See commit message on branch `fix/51936-exec-approval-followup-webchat`.

## Test plan
- [ ] CI / targeted tests as noted in commit

Fixes #51936

Made with [Cursor](https://cursor.com)