### PR TITLE
Security: avoid pipe-to-shell false positive on logical OR (||) (#51908) (#51908)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ Docs: https://docs.openclaw.ai
 - Voice Call: enforce spoken-output contract and fix stream TTS silence regression (#51500) Thanks @joshavant.
 - xAI/models: rename the bundled Grok 4.20 catalog entries to the GA IDs and normalize saved deprecated beta IDs at runtime so existing configs and sessions keep resolving. (#50772) thanks @Jaaneek
 - Plugins/Matrix TTS: send auto-TTS replies as native Matrix voice bubbles instead of generic audio attachments. (#37080) thanks @Matthew19990919.
+- Security/exec obfuscation: pipe-to-shell detection no longer treats `||` (logical OR) as a pipe. (#51908)
 
 ### Fixes
 

--- a/src/infra/exec-obfuscation-detect.test.ts
+++ b/src/infra/exec-obfuscation-detect.test.ts
@@ -55,6 +55,11 @@ describe("detectCommandObfuscation", () => {
       expect(result.detected).toBe(true);
       expect(result.matchedPatterns).toContain("pipe-to-shell");
     });
+
+    it("does NOT flag logical OR followed by a shell token", () => {
+      const result = detectCommandObfuscation("false || sh -c 'echo hi'");
+      expect(result.matchedPatterns).not.toContain("pipe-to-shell");
+    });
   });
 
   describe("escape sequence obfuscation", () => {

--- a/src/infra/exec-obfuscation-detect.ts
+++ b/src/infra/exec-obfuscation-detect.ts
@@ -118,7 +118,8 @@ const OBFUSCATION_PATTERNS: ObfuscationPattern[] = [
   {
     id: "pipe-to-shell",
     description: "Content piped directly to shell interpreter",
-    regex: /\|\s*(?:sh|bash|zsh|dash|ksh|fish)\b(?:\s+[^|;\n\r]+)?\s*$/im,
+    // Exclude `||` (logical OR) — the `|` in OR must not look like a pipe (#51908).
+    regex: /(?<!\|)\|\s*(?:sh|bash|zsh|dash|ksh|fish)\b(?:\s+[^|;\n\r]+)?\s*$/im,
   },
   {
     id: "command-substitution-decode-exec",


### PR DESCRIPTION
## Summary
See commit message on branch `fix/51908-exec-obfuscation-pipe-or`.

## Test plan
- [ ] CI / targeted tests as noted in commit

Fixes #51908

Made with [Cursor](https://cursor.com)