### PR TITLE
Gateway: default WebSocket client scopes to admin + read (#51887) (#51887)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/client: default operator WebSocket scopes to `operator.admin` and `operator.read` when callers omit explicit scopes. (#51887)
 - Agents/default timeout: raise the shared default agent timeout from `600s` to `48h` so long-running ACP and agent sessions do not fail unless you configure a shorter limit.
 - Gateway/Linux: auto-detect nvm-managed Node TLS CA bundle needs before CLI startup and refresh installed services that are missing `NODE_EXTRA_CA_CERTS`. (#51146) Thanks @GodsBoy.
 - CLI/config: make `config set --strict-json` enforce real JSON, prefer `JSON.parse` with JSON5 fallback for machine-written cron/subagent stores, and relabel raw config surfaces as `JSON/JSON5` to match actual compatibility. Related: #48415, #43127, #14529, #21332. Thanks @adhitShet and @vincentkoc.

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -22,6 +22,7 @@ import {
 } from "../utils/message-channel.js";
 import { VERSION } from "../version.js";
 import { buildDeviceAuthPayloadV3 } from "./device-auth.js";
+import { ADMIN_SCOPE, READ_SCOPE } from "./method-scopes.js";
 import { isLoopbackHost, isSecureWebSocketUrl } from "./net.js";
 import {
   ConnectErrorDetailCodes,
@@ -413,7 +414,7 @@ export class GatewayClient {
           }
         : undefined;
     const signedAtMs = Date.now();
-    const scopes = this.opts.scopes ?? ["operator.admin"];
+    const scopes = this.opts.scopes ?? [ADMIN_SCOPE, READ_SCOPE];
     const platform = this.opts.platform ?? process.platform;
     const device = (() => {
       if (!this.opts.deviceIdentity) {


### PR DESCRIPTION
## Summary
See commit message on branch `fix/51887-gateway-client-default-scopes`.

## Test plan
- [ ] CI / targeted tests as noted in commit

Fixes #51887

Made with [Cursor](https://cursor.com)