### PR TITLE
Media: treat sniffed image/apng as image/png (#51881) (#51881)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Media/mime: normalize buffer-detected `image/apng` to `image/png` for vision and attachment handling. (#51881)
 - Agents/default timeout: raise the shared default agent timeout from `600s` to `48h` so long-running ACP and agent sessions do not fail unless you configure a shorter limit.
 - Gateway/Linux: auto-detect nvm-managed Node TLS CA bundle needs before CLI startup and refresh installed services that are missing `NODE_EXTRA_CA_CERTS`. (#51146) Thanks @GodsBoy.
 - CLI/config: make `config set --strict-json` enforce real JSON, prefer `JSON.parse` with JSON5 fallback for machine-written cron/subagent stores, and relabel raw config surfaces as `JSON/JSON5` to match actual compatibility. Related: #48415, #43127, #14529, #21332. Thanks @adhitShet and @vincentkoc.

--- a/src/media/mime-apng-normalize.test.ts
+++ b/src/media/mime-apng-normalize.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("file-type", () => ({
+  fileTypeFromBuffer: vi.fn().mockResolvedValue({
+    mime: "image/apng",
+    ext: "apng",
+  }),
+}));
+
+describe("mime buffer sniff apng normalization", () => {
+  it("maps image/apng from file-type to image/png", async () => {
+    const { detectMime } = await import("./mime.js");
+    const mime = await detectMime({ buffer: Buffer.from("any") });
+    expect(mime).toBe("image/png");
+  });
+});

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -71,7 +71,12 @@ async function sniffMime(buffer?: Buffer): Promise<string | undefined> {
   }
   try {
     const type = await fileTypeFromBuffer(buffer);
-    return type?.mime ?? undefined;
+    const mime = type?.mime ?? undefined;
+    // file-type reports animated PNG as image/apng; treat as PNG for downstream vision/API paths (#51881).
+    if (mime === "image/apng") {
+      return "image/png";
+    }
+    return mime;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary
See commit message on branch `fix/51881-mime-apng-as-png`.

## Test plan
- [ ] CI / targeted tests as noted in commit

Fixes #51881

Made with [Cursor](https://cursor.com)