### PR TITLE
iMessage: send reply_to_guid in RPC when replyToId is set (#51892) (#51892)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iMessage: pass sanitized `reply_to_guid` in the send RPC when replying so the CLI helper can thread without relying on the inline reply tag alone. (#51892)
 - Agents/default timeout: raise the shared default agent timeout from `600s` to `48h` so long-running ACP and agent sessions do not fail unless you configure a shorter limit.
 - Gateway/Linux: auto-detect nvm-managed Node TLS CA bundle needs before CLI startup and refresh installed services that are missing `NODE_EXTRA_CA_CERTS`. (#51146) Thanks @GodsBoy.
 - CLI/config: make `config set --strict-json` enforce real JSON, prefer `JSON.parse` with JSON5 fallback for machine-written cron/subagent stores, and relabel raw config surfaces as `JSON/JSON5` to match actual compatibility. Related: #48415, #43127, #14529, #21332. Thanks @adhitShet and @vincentkoc.

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -96,6 +96,7 @@ describe("sendMessageIMessage", () => {
     });
     const params = getSentParams();
     expect(params.text).toBe("[[reply_to:abc-123]] hello\nworld");
+    expect(params.reply_to_guid).toBe("abc-123");
   });
 
   it("rewrites an existing leading reply tag to keep the requested id first", async () => {
@@ -120,6 +121,7 @@ describe("sendMessageIMessage", () => {
     });
     const params = getSentParams();
     expect(params.text).toBe("hello");
+    expect(params.reply_to_guid).toBeUndefined();
   });
 
   it("normalizes string message_id values from rpc result", async () => {

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -168,6 +168,11 @@ export async function sendMessageIMessage(
     params.to = target.to;
   }
 
+  const replyGuid = sanitizeReplyToId(opts.replyToId);
+  if (replyGuid) {
+    params.reply_to_guid = replyGuid;
+  }
+
   const client =
     opts.client ??
     (opts.createClient


### PR DESCRIPTION
## Summary
See commit message on branch `fix/51892-imessage-reply-to-guid-rpc`.

## Test plan
- [ ] CI / targeted tests as noted in commit

Fixes #51892

Made with [Cursor](https://cursor.com)