### PR TITLE
fix(openrouter): enable context caching for DeepSeek and other models via OpenRouter

### DIFF
--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -24,6 +24,7 @@ const OPENROUTER_CACHE_TTL_MODEL_PREFIXES = [
   "moonshot/",
   "moonshotai/",
   "zai/",
+  "deepseek/",
 ] as const;
 
 function buildDynamicOpenRouterModel(

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
@@ -2,7 +2,7 @@ import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model } from "@mariozechner/pi-ai";
 import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { createOpenRouterWrapper } from "./proxy-stream-wrappers.js";
+import { createOpenRouterSystemCacheWrapper, createOpenRouterWrapper } from "./proxy-stream-wrappers.js";
 
 describe("proxy stream wrappers", () => {
   it("adds OpenRouter attribution headers to stream options", () => {
@@ -34,5 +34,105 @@ describe("proxy stream wrappers", () => {
         },
       },
     ]);
+  });
+
+  it("adds cache_control to system message for OpenRouter Anthropic models", () => {
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createOpenRouterSystemCacheWrapper(baseStreamFn);
+    const model = {
+      api: "openai-completions",
+      provider: "openrouter",
+      id: "anthropic/claude-sonnet-4",
+    } as Model<"openai-completions">;
+
+    wrapped(model, { messages: [] }, {
+      onPayload: (payload) => {
+        const systemMsg = (payload as { messages: Array<{ role: string; content: unknown }> })
+          .messages[0];
+        expect(systemMsg.content).toEqual([
+          {
+            type: "text",
+            text: "You are a helpful assistant.",
+            cache_control: { type: "ephemeral" },
+          },
+        ]);
+      },
+    });
+  });
+
+  it("adds cache_control to system message for OpenRouter DeepSeek models", () => {
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createOpenRouterSystemCacheWrapper(baseStreamFn);
+    const model = {
+      api: "openai-completions",
+      provider: "openrouter",
+      id: "deepseek/deepseek-v3.2",
+    } as Model<"openai-completions">;
+
+    wrapped(model, { messages: [] }, {
+      onPayload: (payload) => {
+        const systemMsg = (payload as { messages: Array<{ role: string; content: unknown }> })
+          .messages[0];
+        expect(systemMsg.content).toEqual([
+          {
+            type: "text",
+            text: "You are a helpful assistant.",
+            cache_control: { type: "ephemeral" },
+          },
+        ]);
+      },
+    });
+  });
+
+  it("passes through without modification for non-cacheable OpenRouter models", () => {
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createOpenRouterSystemCacheWrapper(baseStreamFn);
+    const model = {
+      api: "openai-completions",
+      provider: "openrouter",
+      id: "openai/gpt-4",
+    } as Model<"openai-completions">;
+
+    wrapped(model, { messages: [] }, {
+      onPayload: (payload) => {
+        const systemMsg = (payload as { messages: Array<{ role: string; content: unknown }> })
+          .messages[0];
+        if (typeof systemMsg.content === "string") {
+          expect(systemMsg.content).toBe("You are a helpful assistant.");
+        }
+      },
+    });
+  });
+
+  it("passes through without modification for non-OpenRouter providers", () => {
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createOpenRouterSystemCacheWrapper(baseStreamFn);
+    const model = {
+      api: "anthropic-messages",
+      provider: "anthropic",
+      id: "claude-sonnet-4-20250514",
+    } as Model<"anthropic-messages">;
+
+    wrapped(model, { messages: [] }, {
+      onPayload: (payload) => {
+        const systemMsg = (payload as { messages: Array<{ role: string; content: unknown }> })
+          .messages[0];
+        if (typeof systemMsg.content === "string") {
+          expect(systemMsg.content).toBe("You are a helpful assistant.");
+        }
+      },
+    });
   });
 });

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
@@ -37,7 +37,12 @@ describe("proxy stream wrappers", () => {
   });
 
   it("adds cache_control to system message for OpenRouter Anthropic models", () => {
+    let capturedPayload: unknown;
     const baseStreamFn: StreamFn = (_model, _context, options) => {
+      // Simulate the transport calling onPayload with the outgoing payload
+      options?.onPayload?.({
+        messages: [{ role: "system", content: "You are a helpful assistant." }],
+      });
       return createAssistantMessageEventStream();
     };
 
@@ -50,21 +55,27 @@ describe("proxy stream wrappers", () => {
 
     wrapped(model, { messages: [] }, {
       onPayload: (payload) => {
-        const systemMsg = (payload as { messages: Array<{ role: string; content: unknown }> })
-          .messages[0];
-        expect(systemMsg.content).toEqual([
-          {
-            type: "text",
-            text: "You are a helpful assistant.",
-            cache_control: { type: "ephemeral" },
-          },
-        ]);
+        capturedPayload = payload;
       },
     });
+
+    const systemMsg = (capturedPayload as { messages: Array<{ role: string; content: unknown }> })
+      .messages[0];
+    expect(systemMsg.content).toEqual([
+      {
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
   });
 
   it("adds cache_control to system message for OpenRouter DeepSeek models", () => {
+    let capturedPayload: unknown;
     const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.({
+        messages: [{ role: "system", content: "You are a helpful assistant." }],
+      });
       return createAssistantMessageEventStream();
     };
 
@@ -77,21 +88,27 @@ describe("proxy stream wrappers", () => {
 
     wrapped(model, { messages: [] }, {
       onPayload: (payload) => {
-        const systemMsg = (payload as { messages: Array<{ role: string; content: unknown }> })
-          .messages[0];
-        expect(systemMsg.content).toEqual([
-          {
-            type: "text",
-            text: "You are a helpful assistant.",
-            cache_control: { type: "ephemeral" },
-          },
-        ]);
+        capturedPayload = payload;
       },
     });
+
+    const systemMsg = (capturedPayload as { messages: Array<{ role: string; content: unknown }> })
+      .messages[0];
+    expect(systemMsg.content).toEqual([
+      {
+        type: "text",
+        text: "You are a helpful assistant.",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
   });
 
   it("passes through without modification for non-cacheable OpenRouter models", () => {
+    let capturedPayload: unknown;
     const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.({
+        messages: [{ role: "system", content: "You are a helpful assistant." }],
+      });
       return createAssistantMessageEventStream();
     };
 
@@ -104,17 +121,22 @@ describe("proxy stream wrappers", () => {
 
     wrapped(model, { messages: [] }, {
       onPayload: (payload) => {
-        const systemMsg = (payload as { messages: Array<{ role: string; content: unknown }> })
-          .messages[0];
-        if (typeof systemMsg.content === "string") {
-          expect(systemMsg.content).toBe("You are a helpful assistant.");
-        }
+        capturedPayload = payload;
       },
     });
+
+    // Non-cacheable models should pass through unmodified — content stays as string
+    const systemMsg = (capturedPayload as { messages: Array<{ role: string; content: unknown }> })
+      .messages[0];
+    expect(systemMsg.content).toBe("You are a helpful assistant.");
   });
 
   it("passes through without modification for non-OpenRouter providers", () => {
+    let capturedPayload: unknown;
     const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.({
+        messages: [{ role: "system", content: "You are a helpful assistant." }],
+      });
       return createAssistantMessageEventStream();
     };
 
@@ -127,12 +149,13 @@ describe("proxy stream wrappers", () => {
 
     wrapped(model, { messages: [] }, {
       onPayload: (payload) => {
-        const systemMsg = (payload as { messages: Array<{ role: string; content: unknown }> })
-          .messages[0];
-        if (typeof systemMsg.content === "string") {
-          expect(systemMsg.content).toBe("You are a helpful assistant.");
-        }
+        capturedPayload = payload;
       },
     });
+
+    // Non-OpenRouter providers should pass through unmodified
+    const systemMsg = (capturedPayload as { messages: Array<{ role: string; content: unknown }> })
+      .messages[0];
+    expect(systemMsg.content).toBe("You are a helpful assistant.");
   });
 });

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -15,6 +15,20 @@ function isOpenRouterAnthropicModel(provider: string, modelId: string): boolean 
   return provider.toLowerCase() === "openrouter" && modelId.toLowerCase().startsWith("anthropic/");
 }
 
+function isOpenRouterCacheableModel(provider: string, modelId: string): boolean {
+  if (provider.toLowerCase() !== "openrouter") {
+    return false;
+  }
+  const normalized = modelId.toLowerCase();
+  return (
+    normalized.startsWith("anthropic/") ||
+    normalized.startsWith("deepseek/") ||
+    normalized.startsWith("moonshot/") ||
+    normalized.startsWith("moonshotai/") ||
+    normalized.startsWith("zai/")
+  );
+}
+
 function mapThinkingLevelToOpenRouterReasoningEffort(
   thinkingLevel: ThinkLevel,
 ): "none" | "minimal" | "low" | "medium" | "high" | "xhigh" {
@@ -61,7 +75,7 @@ export function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | unde
     if (
       typeof model.provider !== "string" ||
       typeof model.id !== "string" ||
-      !isOpenRouterAnthropicModel(model.provider, model.id)
+      !isOpenRouterCacheableModel(model.provider, model.id)
     ) {
       return underlying(model, context, options);
     }

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -11,10 +11,6 @@ function resolveKilocodeAppHeaders(): Record<string, string> {
   return { [KILOCODE_FEATURE_HEADER]: feature };
 }
 
-function isOpenRouterAnthropicModel(provider: string, modelId: string): boolean {
-  return provider.toLowerCase() === "openrouter" && modelId.toLowerCase().startsWith("anthropic/");
-}
-
 function isOpenRouterCacheableModel(provider: string, modelId: string): boolean {
   if (provider.toLowerCase() !== "openrouter") {
     return false;


### PR DESCRIPTION
## Problem

OpenRouter's system cache wrapper only added cache_control tags for Anthropic models. DeepSeek, Moonshot, MoonshotAI, and Zai models via OpenRouter had no prompt caching at all.

User impact: ~100% cache miss rate -- consecutive identical requests sent full context every time (#51873).

## Root Cause

Two places needed the same fix:

1. extensions/openrouter/index.ts -- OPENROUTER_CACHE_TTL_MODEL_PREFIXES only included anthropic/, moonshot/, moonshotai/, zai/ -- missing deepseek/

2. src/agents/pi-embedded-runner/proxy-stream-wrappers.ts -- createOpenRouterSystemCacheWrapper checked isOpenRouterAnthropicModel(), skipping all non-Anthropic OpenRouter models

## Changes

- Added deepseek/ to OPENROUTER_CACHE_TTL_MODEL_PREFIXES
- Created isOpenRouterCacheableModel() replacing isOpenRouterAnthropicModel() in the cache wrapper, covering: Anthropic, DeepSeek, Moonshot, MoonshotAI, Zai
- Added 4 unit tests for cache_control injection

## Testing

proxy-stream-wrappers.test.ts -- 4 new tests verifying cache_control injection for Anthropic/DeepSeek models and passthrough for non-cacheable/non-OpenRouter providers.

Fixes #51873
