### PR TITLE
fix(plugin-sdk): add compat to exported subpaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
       "types": "./dist/plugin-sdk/index.d.ts",
       "default": "./dist/plugin-sdk/index.js"
     },
+    "./plugin-sdk/compat": {
+      "types": "./dist/plugin-sdk/compat.d.ts",
+      "default": "./dist/plugin-sdk/compat.js"
+    },
     "./plugin-sdk/core": {
       "types": "./dist/plugin-sdk/core.d.ts",
       "default": "./dist/plugin-sdk/core.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -1,5 +1,6 @@
 [
   "index",
+  "compat",
   "core",
   "ollama-setup",
   "provider-setup",


### PR DESCRIPTION
## Summary

- `src/plugin-sdk/compat.ts` exists and is built to `dist/plugin-sdk/compat.js`, but `compat` was missing from `scripts/lib/plugin-sdk-entrypoints.json`
- This caused `./plugin-sdk/compat` to be absent from the `exports` map in `package.json`
- Plugins that import `openclaw/plugin-sdk/compat` (e.g. `dingtalk-connector` ≥ 0.8.1) fail at load time with: `Cannot find module '.../dist/plugin-sdk/root-alias.cjs/compat'`

The jiti alias resolver in `root-alias.cjs` builds its alias map by reading the `exports` field, so any subpath not listed there is invisible to plugins loaded at runtime.

## Fix

Added `"compat"` to `scripts/lib/plugin-sdk-entrypoints.json` and ran `pnpm plugin-sdk:sync-exports` to regenerate the exports entry in `package.json`.

## Test plan

- [ ] `pnpm check` passes (all lint/format/type/export-sync checks green)
- [ ] `dingtalk-connector` ≥ 0.8.1 loads successfully after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)