### PR TITLE
Message: ignore empty poll* fields for non-poll actions (#51830)

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -18,7 +18,11 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../gateway/protocol/client-info.js";
 import { getToolResult, runMessageAction } from "../../infra/outbound/message-action-runner.js";
-import { POLL_CREATION_PARAM_DEFS, SHARED_POLL_CREATION_PARAM_NAMES } from "../../poll-params.js";
+import {
+  POLL_CREATION_PARAM_DEFS,
+  SHARED_POLL_CREATION_PARAM_NAMES,
+  stripInertPollCreationParams,
+} from "../../poll-params.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
 import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
@@ -681,6 +685,9 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       const action = readStringParam(params, "action", {
         required: true,
       }) as ChannelMessageActionName;
+      if (action !== "poll") {
+        stripInertPollCreationParams(params);
+      }
       let cfg = options?.config;
       if (!cfg) {
         const loadedRaw = loadConfig();

--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -252,6 +252,19 @@ describe("runMessageAction context isolation", () => {
       },
       toolContext: { currentChannelId: "C12345678" },
     },
+    {
+      name: "allows send when wrapper injects inert poll defaults (empty question, zero duration)",
+      cfg: slackConfig,
+      actionParams: {
+        channel: "slack",
+        target: "#C12345678",
+        message: "hi",
+        pollQuestion: "",
+        pollOption: [],
+        pollDurationHours: 0,
+      },
+      toolContext: { currentChannelId: "C12345678" },
+    },
   ])("$name", async ({ cfg, actionParams, toolContext }) => {
     const result = await runDrySend({
       cfg,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -16,7 +16,7 @@ import type {
 import type { OpenClawConfig } from "../../config/config.js";
 import { hasInteractiveReplyBlocks, hasReplyPayloadContent } from "../../interactive/payload.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
-import { hasPollCreationParams } from "../../poll-params.js";
+import { hasPollCreationParams, stripInertPollCreationParams } from "../../poll-params.js";
 import { resolvePollMaxSelections } from "../../polls.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -716,6 +716,9 @@ export async function runMessageAction(
 ): Promise<MessageActionRunResult> {
   const cfg = input.cfg;
   let params = { ...input.params };
+  if (input.action !== "poll") {
+    stripInertPollCreationParams(params);
+  }
   const resolvedAgentId =
     input.agentId ??
     (input.sessionKey

--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -60,6 +60,8 @@ describe("poll params", () => {
       pollDurationHours: 0,
       pollDurationSeconds: "0",
       pollMulti: false,
+      pollAnonymous: "false",
+      pollPublic: "FALSE",
     };
     stripInertPollCreationParams(cleared);
     expect(cleared).toEqual({});

--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { hasPollCreationParams, resolveTelegramPollVisibility } from "./poll-params.js";
+import {
+  hasPollCreationParams,
+  resolveTelegramPollVisibility,
+  stripInertPollCreationParams,
+} from "./poll-params.js";
 
 describe("poll params", () => {
   it("does not treat explicit false booleans as poll creation params", () => {
@@ -47,6 +51,30 @@ describe("poll params", () => {
     expect(hasPollCreationParams({ poll_option: ["Pizza", "Sushi"] })).toBe(true);
     expect(hasPollCreationParams({ poll_duration_seconds: "60" })).toBe(true);
     expect(hasPollCreationParams({ poll_public: "true" })).toBe(true);
+  });
+
+  it("stripInertPollCreationParams removes empty defaults without affecting real poll intent", () => {
+    const cleared: Record<string, unknown> = {
+      pollQuestion: "",
+      pollOption: [],
+      pollDurationHours: 0,
+      pollDurationSeconds: "0",
+      pollMulti: false,
+    };
+    stripInertPollCreationParams(cleared);
+    expect(cleared).toEqual({});
+
+    const intact: Record<string, unknown> = {
+      pollQuestion: "Snack?",
+      pollOption: ["A", "B"],
+      pollDurationSeconds: 60,
+    };
+    stripInertPollCreationParams(intact);
+    expect(intact).toEqual({
+      pollQuestion: "Snack?",
+      pollOption: ["A", "B"],
+      pollDurationSeconds: 60,
+    });
   });
 
   it("resolves telegram poll visibility flags", () => {

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -1,4 +1,4 @@
-import { readSnakeCaseParamRaw } from "./param-key.js";
+import { readSnakeCaseParamRaw, toSnakeCaseKey } from "./param-key.js";
 
 export type PollCreationParamKind = "string" | "stringArray" | "number" | "boolean";
 
@@ -48,6 +48,53 @@ export function resolveTelegramPollVisibility(params: {
     throw new Error("pollAnonymous and pollPublic are mutually exclusive");
   }
   return params.pollAnonymous ? true : params.pollPublic ? false : undefined;
+}
+
+/**
+ * Removes poll-creation fields that are empty defaults (often injected by tool wrappers)
+ * so non-poll actions are not rejected by `hasPollCreationParams` guards.
+ */
+export function stripInertPollCreationParams(params: Record<string, unknown>): void {
+  for (const key of POLL_CREATION_PARAM_NAMES) {
+    const def = POLL_CREATION_PARAM_DEFS[key];
+    if (!def) {
+      continue;
+    }
+    const raw = readPollParamRaw(params, key);
+    const snakeKey = toSnakeCaseKey(key);
+    let remove = false;
+
+    if (def.kind === "string") {
+      remove = typeof raw === "string" && raw.trim().length === 0;
+    } else if (def.kind === "stringArray") {
+      if (raw === undefined) {
+        continue;
+      }
+      if (Array.isArray(raw)) {
+        remove = !raw.some((entry) => typeof entry === "string" && entry.trim().length > 0);
+      } else if (typeof raw === "string") {
+        remove = raw.trim().length === 0;
+      }
+    } else if (def.kind === "number") {
+      if (typeof raw === "number" && Number.isFinite(raw)) {
+        remove = raw === 0;
+      } else if (typeof raw === "string") {
+        const trimmed = raw.trim();
+        if (trimmed.length > 0 && Number.isFinite(Number(trimmed))) {
+          remove = Number(trimmed) === 0;
+        }
+      }
+    } else if (def.kind === "boolean") {
+      remove = raw === false;
+    }
+
+    if (remove) {
+      delete params[key];
+      if (snakeKey !== key) {
+        delete params[snakeKey];
+      }
+    }
+  }
 }
 
 export function hasPollCreationParams(params: Record<string, unknown>): boolean {

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -85,7 +85,7 @@ export function stripInertPollCreationParams(params: Record<string, unknown>): v
         }
       }
     } else if (def.kind === "boolean") {
-      remove = raw === false;
+      remove = raw === false || (typeof raw === "string" && raw.trim().toLowerCase() === "false");
     }
 
     if (remove) {


### PR DESCRIPTION
## Summary
Strip empty/default poll creation fields (empty question, empty options, zero durations, false flags) before `hasPollCreationParams` runs, so `action: send` and file sends are not rejected when wrappers auto-fill the unified message schema.

## Test plan
- `pnpm test -- src/poll-params.test.ts src/infra/outbound/message-action-runner.context.test.ts`

Fixes #51830

Made with [Cursor](https://cursor.com)