### PR TITLE
fix(agents): add supportsPromptCache compat opt-in for third-party OpenAI proxies

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2370,4 +2370,46 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.prompt_cache_key).toBe("session-default");
     expect(payload.prompt_cache_retention).toBe("24h");
   });
+
+  it("keeps prompt cache fields for non-OpenAI proxy with supportsPromptCache compat", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "custom-proxy",
+      applyModelId: "gpt-5.4",
+      model: {
+        api: "openai-responses",
+        provider: "custom-proxy",
+        id: "gpt-5.4",
+        baseUrl: "https://my-proxy.example.com/v1",
+        compat: { supportsPromptCache: true },
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        prompt_cache_key: "session-proxy",
+        prompt_cache_retention: "24h",
+      },
+    });
+    expect(payload.prompt_cache_key).toBe("session-proxy");
+    expect(payload.prompt_cache_retention).toBe("24h");
+  });
+
+  it("strips prompt cache fields for non-OpenAI proxy without supportsPromptCache compat", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "custom-proxy",
+      applyModelId: "gpt-5.4",
+      model: {
+        api: "openai-responses",
+        provider: "custom-proxy",
+        id: "gpt-5.4",
+        baseUrl: "https://my-proxy.example.com/v1",
+        compat: { supportsPromptCache: false },
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        prompt_cache_key: "session-proxy",
+        prompt_cache_retention: "24h",
+      },
+    });
+    expect(payload).not.toHaveProperty("prompt_cache_key");
+    expect(payload).not.toHaveProperty("prompt_cache_retention");
+  });
 });

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -158,6 +158,10 @@ function shouldStripResponsesPromptCache(model: { api?: unknown; baseUrl?: unkno
   if (typeof model.api !== "string" || !OPENAI_RESPONSES_APIS.has(model.api)) {
     return false;
   }
+  // Cast needed: Model<Api>.compat is OpenAICompletionsCompat | OpenAIResponsesCompat,
+  // which is not structurally assignable to { supportsPromptCache?: boolean } because
+  // OpenAICompletionsCompat has extra properties. Once pi-ai adds supportsPromptCache
+  // to its compat types, this cast can be removed.
   const compat = (model as { compat?: { supportsPromptCache?: boolean } }).compat;
   if (compat?.supportsPromptCache === true) {
     return false;

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -158,6 +158,10 @@ function shouldStripResponsesPromptCache(model: { api?: unknown; baseUrl?: unkno
   if (typeof model.api !== "string" || !OPENAI_RESPONSES_APIS.has(model.api)) {
     return false;
   }
+  const compat = (model as { compat?: { supportsPromptCache?: boolean } }).compat;
+  if (compat?.supportsPromptCache === true) {
+    return false;
+  }
   // Missing baseUrl means pi-ai will use the default OpenAI endpoint, so keep
   // prompt cache fields for that direct path.
   if (typeof model.baseUrl !== "string" || !model.baseUrl.trim()) {

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -39,6 +39,7 @@ export type ModelCompatConfig = SupportedOpenAICompatFields & {
   toolCallArgumentsEncoding?: "html-entities";
   requiresMistralToolIds?: boolean;
   requiresOpenAiAnthropicToolPayload?: boolean;
+  supportsPromptCache?: boolean;
 };
 
 export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token";

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -208,6 +208,7 @@ export const ModelCompatSchema = z
     toolCallArgumentsEncoding: z.literal("html-entities").optional(),
     requiresMistralToolIds: z.boolean().optional(),
     requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
+    supportsPromptCache: z.boolean().optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

PR #49877 introduced `shouldStripResponsesPromptCache()` to strip `prompt_cache_key` and `prompt_cache_retention` from Responses API payloads when the `baseUrl` is not a direct OpenAI or Azure endpoint. This correctly prevents 400 errors from endpoints that do not support these fields.

However, many users run OpenAI-compatible proxies (rate-limit aggregators, cost-tracking proxies, regional relay endpoints) that forward requests to real OpenAI APIs and fully support prompt caching. For these setups, the cache parameters are silently stripped, resulting in 0% cache hit rates and significantly higher costs.

### Changes

- Add `supportsPromptCache` to `ModelCompatConfig` type and Zod schema
- Check `compat.supportsPromptCache === true` in `shouldStripResponsesPromptCache()` before stripping
- Add 2 test cases verifying the opt-in behavior (keeps fields when true, strips when false)

### Configuration Example

```json
{
  "models": {
    "providers": {
      "my-proxy": {
        "baseUrl": "https://my-proxy.example.com/v1",
        "api": "openai-responses",
        "models": [{
          "id": "gpt-5.4",
          "compat": { "supportsPromptCache": true }
        }]
      }
    }
  }
}
```

Refs #48155