### PR TITLE
docs: add Google Chat Pub/Sub to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -43,6 +43,19 @@ file messages via any DingTalk client.
 openclaw plugins install @largezhou/ddingtalk
 ```
 
+### Google Chat Pub/Sub
+
+Listen to Google Chat spaces via Workspace Events API + Cloud Pub/Sub — no
+@mention required. Multi-agent routing with keyword and alwaysListen support,
+thread-first replies, and per-thread session isolation.
+
+- **npm:** `@teyou/openclaw-googlechatpubsub`
+- **repo:** [github.com/teyou/openclaw-googlechatpubsub-plugin](https://github.com/teyou/openclaw-googlechatpubsub-plugin)
+
+```bash
+openclaw plugins install @teyou/openclaw-googlechatpubsub
+```
+
 ### Lossless Claw (LCM)
 
 Lossless Context Management plugin for OpenClaw. DAG-based conversation

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -46,7 +46,7 @@ openclaw plugins install @largezhou/ddingtalk
 ### Google Chat Pub/Sub
 
 Listen to Google Chat spaces via Workspace Events API + Cloud Pub/Sub — no
-@mention required. Multi-agent routing with keyword and alwaysListen support,
+`@mention` required. Multi-agent routing with keyword and alwaysListen support,
 thread-first replies, and per-thread session isolation.
 
 - **npm:** `@teyou/openclaw-googlechatpubsub`


### PR DESCRIPTION
Adds `@teyou/openclaw-googlechatpubsub` — a channel plugin that enables passive Google Chat listening via Workspace Events API + Cloud Pub/Sub, without requiring @mentions.

- **npm:** [`@teyou/openclaw-googlechatpubsub`](https://www.npmjs.com/package/@teyou/openclaw-googlechatpubsub)
- **Repo:** [teyou/openclaw-googlechatpubsub-plugin](https://github.com/teyou/openclaw-googlechatpubsub-plugin)
- **Visual setup guide:** [teyou.github.io/openclaw-googlechatpubsub-plugin](https://teyou.github.io/openclaw-googlechatpubsub-plugin/)

### Quality bar checklist

| Requirement | Status |
|---|---|
| Published on npm | ✅ [`@teyou/openclaw-googlechatpubsub@0.1.0`](https://www.npmjs.com/package/@teyou/openclaw-googlechatpubsub) |
| Public GitHub repo | ✅ [teyou/openclaw-googlechatpubsub-plugin](https://github.com/teyou/openclaw-googlechatpubsub-plugin) |
| Setup and usage docs | ✅ [Visual guide with screenshots](https://teyou.github.io/openclaw-googlechatpubsub-plugin/) |
| Active maintenance | ✅ Alpha, actively used in production |
