### PR TITLE
fix(ui): preserve history image attachments after chat reload

### DIFF
--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -23,37 +23,106 @@ type ImageBlock = {
   alt?: string;
 };
 
+function normalizeImageDataUrl(data: string, mimeType?: string): string | null {
+  const trimmed = data.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.startsWith("data:")) {
+    return trimmed;
+  }
+  const normalizedMimeType = mimeType?.trim() || "image/png";
+  return `data:${normalizedMimeType};base64,${trimmed}`;
+}
+
+function extractImageUrlFromContentBlock(block: Record<string, unknown>): ImageBlock | null {
+  if (block.type === "image") {
+    const source = block.source as Record<string, unknown> | undefined;
+    if (source?.type === "base64" && typeof source.data === "string") {
+      const url = normalizeImageDataUrl(
+        source.data,
+        typeof source.media_type === "string" ? source.media_type : undefined,
+      );
+      return url ? { url } : null;
+    }
+    if (typeof block.url === "string" && block.url.trim()) {
+      return { url: block.url.trim() };
+    }
+    return null;
+  }
+
+  if (block.type === "image_url") {
+    const imageUrl = block.image_url;
+    if (typeof imageUrl === "string" && imageUrl.trim()) {
+      return { url: imageUrl.trim() };
+    }
+    if (
+      imageUrl &&
+      typeof imageUrl === "object" &&
+      typeof (imageUrl as { url?: unknown }).url === "string" &&
+      (imageUrl as { url: string }).url.trim()
+    ) {
+      return { url: (imageUrl as { url: string }).url.trim() };
+    }
+  }
+
+  return null;
+}
+
+function extractImageUrlFromAttachment(attachment: Record<string, unknown>): ImageBlock | null {
+  const mimeType = typeof attachment.mimeType === "string" ? attachment.mimeType.trim() : undefined;
+  if (mimeType && !mimeType.toLowerCase().startsWith("image/")) {
+    return null;
+  }
+  if (typeof attachment.url === "string" && attachment.url.trim()) {
+    return {
+      url: attachment.url.trim(),
+      alt: typeof attachment.fileName === "string" ? attachment.fileName : undefined,
+    };
+  }
+  if (typeof attachment.content !== "string") {
+    return null;
+  }
+  const url = normalizeImageDataUrl(attachment.content, mimeType);
+  if (!url) {
+    return null;
+  }
+  return {
+    url,
+    alt: typeof attachment.fileName === "string" ? attachment.fileName : undefined,
+  };
+}
+
 function extractImages(message: unknown): ImageBlock[] {
   const m = message as Record<string, unknown>;
   const content = m.content;
   const images: ImageBlock[] = [];
+  const seenUrls = new Set<string>();
+
+  const pushImage = (image: ImageBlock | null) => {
+    if (!image || seenUrls.has(image.url)) {
+      return;
+    }
+    seenUrls.add(image.url);
+    images.push(image);
+  };
 
   if (Array.isArray(content)) {
     for (const block of content) {
       if (typeof block !== "object" || block === null) {
         continue;
       }
-      const b = block as Record<string, unknown>;
+      pushImage(extractImageUrlFromContentBlock(block as Record<string, unknown>));
+    }
+  }
 
-      if (b.type === "image") {
-        // Handle source object format (from sendChatMessage)
-        const source = b.source as Record<string, unknown> | undefined;
-        if (source?.type === "base64" && typeof source.data === "string") {
-          const data = source.data;
-          const mediaType = (source.media_type as string) || "image/png";
-          // If data is already a data URL, use it directly
-          const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
-          images.push({ url });
-        } else if (typeof b.url === "string") {
-          images.push({ url: b.url });
-        }
-      } else if (b.type === "image_url") {
-        // OpenAI format
-        const imageUrl = b.image_url as Record<string, unknown> | undefined;
-        if (typeof imageUrl?.url === "string") {
-          images.push({ url: imageUrl.url });
-        }
+  const attachments = m.attachments;
+  if (Array.isArray(attachments)) {
+    for (const attachment of attachments) {
+      if (typeof attachment !== "object" || attachment === null) {
+        continue;
       }
+      pushImage(extractImageUrlFromAttachment(attachment as Record<string, unknown>));
     }
   }
 

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -70,8 +70,14 @@ function extractImageUrlFromContentBlock(block: Record<string, unknown>): ImageB
 }
 
 function extractImageUrlFromAttachment(attachment: Record<string, unknown>): ImageBlock | null {
+  const attachmentType =
+    typeof attachment.type === "string" ? attachment.type.trim().toLowerCase() : undefined;
   const mimeType = typeof attachment.mimeType === "string" ? attachment.mimeType.trim() : undefined;
-  if (mimeType && !mimeType.toLowerCase().startsWith("image/")) {
+  if (mimeType) {
+    if (!mimeType.toLowerCase().startsWith("image/")) {
+      return null;
+    }
+  } else if (attachmentType !== "image") {
     return null;
   }
   if (typeof attachment.url === "string" && attachment.url.trim()) {

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -23,6 +23,9 @@ type ImageBlock = {
   alt?: string;
 };
 
+const MEDIA_FILENAME_WITH_UUID_RE =
+  /^(.+)---[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}(\.[^./\\]+)?$/i;
+
 function normalizeImageDataUrl(data: string, mimeType?: string): string | null {
   const trimmed = data.trim();
   if (!trimmed) {
@@ -69,6 +72,46 @@ function extractImageUrlFromContentBlock(block: Record<string, unknown>): ImageB
   return null;
 }
 
+function extractMediaPathBasename(mediaPath: string): string {
+  const trimmed = mediaPath.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const withoutQuery = trimmed.split(/[?#]/, 1)[0] ?? "";
+  const segments = withoutQuery.split(/[/\\]/);
+  return segments.at(-1)?.trim() ?? "";
+}
+
+function extractMediaPathAlt(mediaPath: string): string | undefined {
+  const basename = extractMediaPathBasename(mediaPath);
+  if (!basename) {
+    return undefined;
+  }
+  const match = basename.match(MEDIA_FILENAME_WITH_UUID_RE);
+  if (!match?.[1]) {
+    return basename;
+  }
+  return `${match[1]}${match[2] ?? ""}`;
+}
+
+function resolveHistoryMediaUrl(mediaPath: string): string | null {
+  const trimmed = mediaPath.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (
+    /^https?:\/\//i.test(trimmed) ||
+    /^blob:/i.test(trimmed) ||
+    /^data:image\//i.test(trimmed) ||
+    trimmed.startsWith("/media/") ||
+    trimmed.startsWith("media/")
+  ) {
+    return trimmed;
+  }
+  const mediaId = extractMediaPathBasename(trimmed);
+  return mediaId ? `media/${mediaId}` : null;
+}
+
 function extractImageUrlFromAttachment(attachment: Record<string, unknown>): ImageBlock | null {
   const attachmentType =
     typeof attachment.type === "string" ? attachment.type.trim().toLowerCase() : undefined;
@@ -97,6 +140,47 @@ function extractImageUrlFromAttachment(attachment: Record<string, unknown>): Ima
     url,
     alt: typeof attachment.fileName === "string" ? attachment.fileName : undefined,
   };
+}
+
+function extractImageUrlsFromMediaPaths(message: Record<string, unknown>): ImageBlock[] {
+  const rawPaths = Array.isArray(message.MediaPaths)
+    ? message.MediaPaths
+    : typeof message.MediaPath === "string"
+      ? [message.MediaPath]
+      : [];
+  if (rawPaths.length === 0) {
+    return [];
+  }
+
+  const mediaPaths = rawPaths.filter((value): value is string => typeof value === "string");
+  if (mediaPaths.length === 0) {
+    return [];
+  }
+
+  const rawTypes =
+    Array.isArray(message.MediaTypes) && message.MediaTypes.length === mediaPaths.length
+      ? message.MediaTypes
+      : mediaPaths.length === 1 && typeof message.MediaType === "string"
+        ? [message.MediaType]
+        : [];
+
+  const imageTypes = rawTypes
+    .map((value) => (typeof value === "string" ? value.trim() : ""))
+    .filter((value) => value.length > 0);
+  if (imageTypes.length !== mediaPaths.length) {
+    return [];
+  }
+
+  return mediaPaths.flatMap((mediaPath, index) => {
+    if (!imageTypes[index]?.toLowerCase().startsWith("image/")) {
+      return [];
+    }
+    const url = resolveHistoryMediaUrl(mediaPath);
+    if (!url) {
+      return [];
+    }
+    return [{ url, alt: extractMediaPathAlt(mediaPath) }];
+  });
 }
 
 function extractImages(message: unknown): ImageBlock[] {
@@ -130,6 +214,10 @@ function extractImages(message: unknown): ImageBlock[] {
       }
       pushImage(extractImageUrlFromAttachment(attachment as Record<string, unknown>));
     }
+  }
+
+  for (const image of extractImageUrlsFromMediaPaths(m)) {
+    pushImage(image);
   }
 
   return images;

--- a/ui/src/ui/views/chat-image-open.browser.test.ts
+++ b/ui/src/ui/views/chat-image-open.browser.test.ts
@@ -15,7 +15,45 @@ function renderAssistantImage(url: string) {
   };
 }
 
+function renderUserHistoryAttachment(base64: string) {
+  return {
+    role: "user",
+    content: [{ type: "text", text: "see image" }],
+    attachments: [
+      {
+        type: "image",
+        mimeType: "image/png",
+        fileName: "dot.png",
+        content: base64,
+      },
+    ],
+    timestamp: Date.now(),
+  };
+}
+
 describe("chat image open safety", () => {
+  it("keeps history-backed image attachments visible after the assistant reply lands", async () => {
+    const app = mountApp("/chat");
+    await app.updateComplete;
+
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+    app.chatMessages = [
+      renderUserHistoryAttachment(pngBase64),
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+        timestamp: Date.now() + 1,
+      },
+    ];
+    await app.updateComplete;
+
+    const image = app.querySelector<HTMLImageElement>(".chat-group.user .chat-message-image");
+    expect(image).not.toBeNull();
+    expect(image?.getAttribute("src")).toBe(`data:image/png;base64,${pngBase64}`);
+    expect(image?.getAttribute("alt")).toBe("dot.png");
+  });
+
   it("opens safe image URLs in a hardened new tab", async () => {
     const app = mountApp("/chat");
     await app.updateComplete;

--- a/ui/src/ui/views/chat-image-open.browser.test.ts
+++ b/ui/src/ui/views/chat-image-open.browser.test.ts
@@ -15,18 +15,14 @@ function renderAssistantImage(url: string) {
   };
 }
 
-function renderUserHistoryAttachment(base64: string) {
+function renderUserHistoryImage() {
   return {
     role: "user",
     content: [{ type: "text", text: "see image" }],
-    attachments: [
-      {
-        type: "image",
-        mimeType: "image/png",
-        fileName: "dot.png",
-        content: base64,
-      },
-    ],
+    MediaPath: "/tmp/chat-send-image-a.png",
+    MediaPaths: ["/tmp/chat-send-image-a.png"],
+    MediaType: "image/png",
+    MediaTypes: ["image/png"],
     timestamp: Date.now(),
   };
 }
@@ -36,10 +32,8 @@ describe("chat image open safety", () => {
     const app = mountApp("/chat");
     await app.updateComplete;
 
-    const pngBase64 =
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
     app.chatMessages = [
-      renderUserHistoryAttachment(pngBase64),
+      renderUserHistoryImage(),
       {
         role: "assistant",
         content: [{ type: "text", text: "done" }],
@@ -50,8 +44,8 @@ describe("chat image open safety", () => {
 
     const image = app.querySelector<HTMLImageElement>(".chat-group.user .chat-message-image");
     expect(image).not.toBeNull();
-    expect(image?.getAttribute("src")).toBe(`data:image/png;base64,${pngBase64}`);
-    expect(image?.getAttribute("alt")).toBe("dot.png");
+    expect(image?.getAttribute("src")).toBe("media/chat-send-image-a.png");
+    expect(image?.getAttribute("alt")).toBe("chat-send-image-a.png");
   });
 
   it("opens safe image URLs in a hardened new tab", async () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -693,10 +693,8 @@ describe("chat view", () => {
     expect(senderLabels).not.toContain("You");
   });
 
-  it("renders history attachments inline for user messages after chat reload", () => {
+  it("renders persisted history media paths inline for user messages after chat reload", () => {
     const container = document.createElement("div");
-    const pngBase64 =
-      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
     render(
       renderChat(
         createProps({
@@ -704,14 +702,10 @@ describe("chat view", () => {
             {
               role: "user",
               content: [{ type: "text", text: "see image" }],
-              attachments: [
-                {
-                  type: "image",
-                  mimeType: "image/png",
-                  fileName: "dot.png",
-                  content: pngBase64,
-                },
-              ],
+              MediaPath: "/tmp/chat-send-image-a.png",
+              MediaPaths: ["/tmp/chat-send-image-a.png"],
+              MediaType: "image/png",
+              MediaTypes: ["image/png"],
               timestamp: 1000,
             },
             {
@@ -727,8 +721,8 @@ describe("chat view", () => {
 
     const image = container.querySelector<HTMLImageElement>(".chat-group.user .chat-message-image");
     expect(image).not.toBeNull();
-    expect(image?.getAttribute("src")).toBe(`data:image/png;base64,${pngBase64}`);
-    expect(image?.getAttribute("alt")).toBe("dot.png");
+    expect(image?.getAttribute("src")).toBe("media/chat-send-image-a.png");
+    expect(image?.getAttribute("alt")).toBe("chat-send-image-a.png");
   });
 
   it("renders image-typed history attachments even when mimeType is missing", () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -731,6 +731,66 @@ describe("chat view", () => {
     expect(image?.getAttribute("alt")).toBe("dot.png");
   });
 
+  it("renders image-typed history attachments even when mimeType is missing", () => {
+    const container = document.createElement("div");
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+    render(
+      renderChat(
+        createProps({
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "see image" }],
+              attachments: [
+                {
+                  type: "image",
+                  fileName: "dot.png",
+                  content: pngBase64,
+                },
+              ],
+              timestamp: 1000,
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const image = container.querySelector<HTMLImageElement>(".chat-group.user .chat-message-image");
+    expect(image).not.toBeNull();
+    expect(image?.getAttribute("src")).toBe(`data:image/png;base64,${pngBase64}`);
+    expect(image?.getAttribute("alt")).toBe("dot.png");
+  });
+
+  it("does not render non-image history attachments when mimeType is missing", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "see file" }],
+              attachments: [
+                {
+                  type: "file",
+                  fileName: "notes.txt",
+                  url: "https://example.com/notes.txt",
+                },
+              ],
+              timestamp: 1000,
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const image = container.querySelector(".chat-group.user .chat-message-image");
+    expect(image).toBeNull();
+  });
+
   it("keeps consecutive user messages from different senders in separate groups", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -693,6 +693,44 @@ describe("chat view", () => {
     expect(senderLabels).not.toContain("You");
   });
 
+  it("renders history attachments inline for user messages after chat reload", () => {
+    const container = document.createElement("div");
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+    render(
+      renderChat(
+        createProps({
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "see image" }],
+              attachments: [
+                {
+                  type: "image",
+                  mimeType: "image/png",
+                  fileName: "dot.png",
+                  content: pngBase64,
+                },
+              ],
+              timestamp: 1000,
+            },
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "got it" }],
+              timestamp: 1001,
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const image = container.querySelector<HTMLImageElement>(".chat-group.user .chat-message-image");
+    expect(image).not.toBeNull();
+    expect(image?.getAttribute("src")).toBe(`data:image/png;base64,${pngBase64}`);
+    expect(image?.getAttribute("alt")).toBe("dot.png");
+  });
+
   it("keeps consecutive user messages from different senders in separate groups", () => {
     const container = document.createElement("div");
     render(


### PR DESCRIPTION
Fixes #45807

AI-assisted: yes

## Summary
History-backed user messages can carry images in top-level `attachments`, but the chat renderer only extracted images from `content` blocks. That made uploaded images disappear after the assistant reply landed and the UI reloaded chat history.

This change teaches the renderer to read top-level image attachments as well, preserves attachment filenames as image alt text, and deduplicates rendered images by URL.

Resubmitting this PR after reducing my active PR queue below the repo limit.

## Testing
- `npm exec --yes pnpm@10.23.0 -- test -- ui/src/ui/views/chat.test.ts`
- `npm exec --yes pnpm@10.23.0 -- vitest run --config vitest.config.ts --project browser src/ui/views/chat-image-open.browser.test.ts` (run from `ui/`)
- `npm exec --yes pnpm@10.23.0 -- exec oxfmt --check ui/src/ui/chat/grouped-render.ts ui/src/ui/views/chat.test.ts ui/src/ui/views/chat-image-open.browser.test.ts`
- `npm exec --yes pnpm@10.23.0 -- exec oxlint ui/src/ui/chat/grouped-render.ts ui/src/ui/views/chat.test.ts ui/src/ui/views/chat-image-open.browser.test.ts`
- `/Users/jamesavery/.openclaw/openclaw-pr-check.sh`
  - `build` reached unrelated baseline extension dependency/type failures outside this change
  - `check` reached the same unrelated baseline failures in untouched extension files

The browser regression covers the real UI path where a user image attachment should remain visible after the assistant reply appears.