### PR TITLE
CLI: route JSON preaction logs to stderr

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -10,7 +10,9 @@ const setVerboseMock = vi.fn();
 const emitCliBannerMock = vi.fn();
 const ensureConfigReadyMock = vi.fn(async () => {});
 const ensurePluginRegistryLoadedMock = vi.fn();
-const routeLogsToStderrMock = vi.fn();
+const routeLogsToStderrMock = vi.fn(() => {
+  loggingState.forceConsoleToStderr = true;
+});
 
 const runtimeMock = {
   log: vi.fn(),
@@ -83,6 +85,7 @@ beforeEach(() => {
   loggingState.forceConsoleToStderr = false;
   delete process.env.NODE_NO_WARNINGS;
   delete process.env.OPENCLAW_HIDE_BANNER;
+  loggingState.forceConsoleToStderr = false;
 });
 
 afterEach(() => {
@@ -108,6 +111,7 @@ afterEach(() => {
   } else {
     process.env.OPENCLAW_HIDE_BANNER = originalHideBanner;
   }
+  loggingState.forceConsoleToStderr = false;
 });
 
 describe("registerPreActionHooks", () => {
@@ -349,6 +353,7 @@ describe("registerPreActionHooks", () => {
       processArgv: ["node", "openclaw", "status", "--json"],
     });
 
+    expect(loggingState.forceConsoleToStderr).toBe(true);
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["status"],
@@ -357,11 +362,13 @@ describe("registerPreActionHooks", () => {
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
+    loggingState.forceConsoleToStderr = false;
     await runPreAction({
       parseArgv: ["update", "status", "--json"],
       processArgv: ["node", "openclaw", "update", "status", "--json"],
     });
 
+    expect(loggingState.forceConsoleToStderr).toBe(true);
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["update", "status"],
@@ -370,11 +377,13 @@ describe("registerPreActionHooks", () => {
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
+    loggingState.forceConsoleToStderr = false;
     await runPreAction({
       parseArgv: ["config", "set", "gateway.auth.mode", "{bad", "--json"],
       processArgv: ["node", "openclaw", "config", "set", "gateway.auth.mode", "{bad", "--json"],
     });
 
+    expect(loggingState.forceConsoleToStderr).toBe(false);
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
       commandPath: ["config", "set"],
@@ -443,6 +452,7 @@ describe("registerPreActionHooks", () => {
       processArgv: ["node", "openclaw", "backup", "create", "--json"],
     });
 
+    expect(loggingState.forceConsoleToStderr).toBe(true);
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
   });
 
@@ -459,8 +469,8 @@ describe("registerPreActionHooks", () => {
 
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalled();
     expect(stderrDuringPluginLoad).toBe(true);
-    // Flag must be restored after plugin loading completes
-    expect(loggingState.forceConsoleToStderr).toBe(false);
+    // JSON mode keeps stderr routing enabled for the rest of the command.
+    expect(loggingState.forceConsoleToStderr).toBe(true);
   });
 
   it("does not route logs to stderr during plugin loading without --json", async () => {


### PR DESCRIPTION
## Summary

- Problem: CLI commands with `--json` could still print plugin/bootstrap logs to stdout before the JSON payload.
- Why it matters: this breaks machine-readable stdout contracts for commands like `openclaw agents list --json | jq ...`.
- What changed: the CLI `preAction` hook now routes logs to stderr for real JSON-output commands before config guard or plugin loading runs, and the regression test covers both enabled and excluded `--json` paths.
- What did NOT change (scope boundary): no log levels changed, no command payload shapes changed, and parse-only `--json` aliases such as `config set --json` remain untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52032
- Related #37323

## User-visible / Behavior Changes

CLI commands that support real `--json` output now keep stdout reserved for JSON by routing preAction/plugin/bootstrap logs to stderr.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.4
- Runtime/container: local zsh shell
- Model/provider: N/A
- Integration/channel (if any): CLI `preAction`
- Relevant config (redacted): `--json` commands that can load plugins during startup

### Steps

1. Run a CLI command with real JSON output and plugin/bootstrap startup, such as `openclaw agents list --json`.
2. Pipe stdout to a JSON parser.
3. Confirm startup logs no longer corrupt stdout.

### Expected

- Stdout remains valid JSON for real `--json` output commands.

### Actual

- Before: plugin/bootstrap logs could print to stdout before the JSON payload.
- After: those logs are redirected to stderr before config guard/plugin loading, preserving JSON stdout.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- src/cli/program/preaction.test.ts` passes and now asserts `status --json`, `update status --json`, and `backup create --json` flip stderr routing, while `config set --json` does not.
- Edge cases checked: JSON routing is applied before config-guard bypass, so bypassed JSON commands still preserve stdout.
- What you did **not** verify: I did not reproduce a plugin-loaded end-to-end CLI run in this terminal; `pnpm build` also fails on current `upstream/main` due to unrelated untouched memory export errors in `src/memory/embeddings-openai.ts` and `src/memory/manager-sync-ops.ts`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `f902d4989`
- Files/config to restore: `src/cli/program/preaction.ts`, `src/cli/program/preaction.test.ts`
- Known bad symptoms reviewers should watch for: unexpected stderr routing on commands that only use `--json` as an input-parsing mode

## Risks and Mitigations

- Risk: a parse-only `--json` command could accidentally be treated as JSON output and change stderr behavior.
  - Mitigation: the change keeps the existing `isJsonOutputMode(...)` gate and regression coverage for `config set --json`.
