### PR TITLE
fix(plugins): add "discovery" registrationMode for non-activating loads

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1097,6 +1097,60 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
     );
   });
 
+  it("uses 'discovery' registrationMode for non-activating loads", () => {
+    const plugin = writePlugin({
+      id: "discovery-mode-test",
+      body: `module.exports = {
+        id: "discovery-mode-test",
+        register(api) {
+          globalThis.__discoveryModeTest = (globalThis.__discoveryModeTest || []);
+          globalThis.__discoveryModeTest.push(api.registrationMode);
+          api.registerTool({
+            name: "discovery_tool",
+            description: "test",
+            parameters: {},
+            execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+          });
+        }
+      };`,
+    });
+
+    // Non-activating load: registrationMode should be "discovery"
+    const snapshotRegistry = loadOpenClawPlugins({
+      activate: false,
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["discovery-mode-test"],
+        },
+      },
+    });
+
+    expect((globalThis as Record<string, unknown>).__discoveryModeTest).toEqual(["discovery"]);
+    // Registration methods should still work in discovery mode
+    expect(snapshotRegistry.tools.find((t) => t.names.includes("discovery_tool"))).toBeTruthy();
+
+    // Activating load: registrationMode should be "full"
+    loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["discovery-mode-test"],
+        },
+      },
+    });
+
+    expect((globalThis as Record<string, unknown>).__discoveryModeTest).toEqual([
+      "discovery",
+      "full",
+    ]);
+
+    // Cleanup
+    delete (globalThis as Record<string, unknown>).__discoveryModeTest;
+  });
+
   it("re-initializes global hook runner when serving registry from cache", () => {
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -964,7 +964,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           preferSetupRuntimeForChannelPlugins,
         })
         ? "setup-runtime"
-        : "full"
+        : shouldActivate
+          ? "full"
+          : "discovery"
       : includeSetupOnlyChannelPlugins && !validateOnly && manifestRecord.channels.length > 0
         ? "setup-only"
         : null;
@@ -1044,7 +1046,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     // Fast-path bundled memory plugins that are guaranteed disabled by slot policy.
     // This avoids opening/importing heavy memory plugin modules that will never register.
     if (
-      registrationMode === "full" &&
+      (registrationMode === "full" || registrationMode === "discovery") &&
       candidate.origin === "bundled" &&
       manifestRecord.kind === "memory"
     ) {
@@ -1162,7 +1164,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       memorySlotMatched = true;
     }
 
-    if (registrationMode === "full") {
+    if (registrationMode === "full" || registrationMode === "discovery") {
       const memoryDecision = resolveMemorySlotDecision({
         id: record.id,
         kind: record.kind,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -883,6 +883,10 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     },
   ): OpenClawPluginApi => {
     const registrationMode = params.registrationMode ?? "full";
+    // "full" and "discovery" both allow capability registration; "discovery" signals
+    // that the registry will not be globally activated, so plugins should skip
+    // expensive side effects (DB connections, background workers, etc.).
+    const canRegister = registrationMode === "full" || registrationMode === "discovery";
     return {
       id: record.id,
       name: record.name,
@@ -895,68 +899,54 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       pluginConfig: params.pluginConfig,
       runtime: resolvePluginRuntime(record.id),
       logger: normalizeLogger(registryParams.logger),
-      registerTool:
-        registrationMode === "full" ? (tool, opts) => registerTool(record, tool, opts) : () => {},
-      registerHook:
-        registrationMode === "full"
-          ? (events, handler, opts) => registerHook(record, events, handler, opts, params.config)
-          : () => {},
-      registerHttpRoute:
-        registrationMode === "full" ? (params) => registerHttpRoute(record, params) : () => {},
+      registerTool: canRegister ? (tool, opts) => registerTool(record, tool, opts) : () => {},
+      registerHook: canRegister
+        ? (events, handler, opts) => registerHook(record, events, handler, opts, params.config)
+        : () => {},
+      registerHttpRoute: canRegister ? (params) => registerHttpRoute(record, params) : () => {},
       registerChannel: (registration) => registerChannel(record, registration, registrationMode),
-      registerProvider:
-        registrationMode === "full" ? (provider) => registerProvider(record, provider) : () => {},
-      registerSpeechProvider:
-        registrationMode === "full"
-          ? (provider) => registerSpeechProvider(record, provider)
-          : () => {},
-      registerMediaUnderstandingProvider:
-        registrationMode === "full"
-          ? (provider) => registerMediaUnderstandingProvider(record, provider)
-          : () => {},
-      registerImageGenerationProvider:
-        registrationMode === "full"
-          ? (provider) => registerImageGenerationProvider(record, provider)
-          : () => {},
-      registerWebSearchProvider:
-        registrationMode === "full"
-          ? (provider) => registerWebSearchProvider(record, provider)
-          : () => {},
-      registerGatewayMethod:
-        registrationMode === "full"
-          ? (method, handler) => registerGatewayMethod(record, method, handler)
-          : () => {},
-      registerCli:
-        registrationMode === "full"
-          ? (registrar, opts) => registerCli(record, registrar, opts)
-          : () => {},
-      registerService:
-        registrationMode === "full" ? (service) => registerService(record, service) : () => {},
-      registerInteractiveHandler:
-        registrationMode === "full"
-          ? (registration) => {
-              const result = registerPluginInteractiveHandler(record.id, registration, {
-                pluginName: record.name,
-                pluginRoot: record.rootDir,
+      registerProvider: canRegister ? (provider) => registerProvider(record, provider) : () => {},
+      registerSpeechProvider: canRegister
+        ? (provider) => registerSpeechProvider(record, provider)
+        : () => {},
+      registerMediaUnderstandingProvider: canRegister
+        ? (provider) => registerMediaUnderstandingProvider(record, provider)
+        : () => {},
+      registerImageGenerationProvider: canRegister
+        ? (provider) => registerImageGenerationProvider(record, provider)
+        : () => {},
+      registerWebSearchProvider: canRegister
+        ? (provider) => registerWebSearchProvider(record, provider)
+        : () => {},
+      registerGatewayMethod: canRegister
+        ? (method, handler) => registerGatewayMethod(record, method, handler)
+        : () => {},
+      registerCli: canRegister
+        ? (registrar, opts) => registerCli(record, registrar, opts)
+        : () => {},
+      registerService: canRegister ? (service) => registerService(record, service) : () => {},
+      registerInteractiveHandler: canRegister
+        ? (registration) => {
+            const result = registerPluginInteractiveHandler(record.id, registration, {
+              pluginName: record.name,
+              pluginRoot: record.rootDir,
+            });
+            if (!result.ok) {
+              pushDiagnostic({
+                level: "warn",
+                pluginId: record.id,
+                source: record.source,
+                message: result.error ?? "interactive handler registration failed",
               });
-              if (!result.ok) {
-                pushDiagnostic({
-                  level: "warn",
-                  pluginId: record.id,
-                  source: record.source,
-                  message: result.error ?? "interactive handler registration failed",
-                });
-              }
             }
-          : () => {},
-      onConversationBindingResolved:
-        registrationMode === "full"
-          ? (handler) => registerConversationBindingResolvedHandler(record, handler)
-          : () => {},
-      registerCommand:
-        registrationMode === "full" ? (command) => registerCommand(record, command) : () => {},
+          }
+        : () => {},
+      onConversationBindingResolved: canRegister
+        ? (handler) => registerConversationBindingResolvedHandler(record, handler)
+        : () => {},
+      registerCommand: canRegister ? (command) => registerCommand(record, command) : () => {},
       registerContextEngine: (id, factory) => {
-        if (registrationMode !== "full") {
+        if (!canRegister) {
           return;
         }
         if (id === defaultSlotIdForKey("contextEngine")) {
@@ -981,7 +971,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         }
       },
       registerMemoryPromptSection: (builder) => {
-        if (registrationMode !== "full") {
+        if (!canRegister) {
           return;
         }
         if (record.kind !== "memory") {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1287,7 +1287,7 @@ export type OpenClawPluginModule =
   | OpenClawPluginDefinition
   | ((api: OpenClawPluginApi) => void | Promise<void>);
 
-export type PluginRegistrationMode = "full" | "setup-only" | "setup-runtime";
+export type PluginRegistrationMode = "full" | "discovery" | "setup-only" | "setup-runtime";
 
 export type OpenClawPluginApi = {
   id: string;


### PR DESCRIPTION
## Summary

- **Problem:** Enabled plugins loaded with `activate: false` receive `registrationMode: "full"`, giving them no signal that the registry will not be globally activated. Plugins cannot distinguish runtime activation from capability introspection, so expensive side effects (DB connections, background workers) run on every non-activating load.
- **Why it matters:** In agent sub-agent scenarios, snapshot loads happen on every turn. With multiple plugins, redundant `register()` side effects compound to 100+ seconds of overhead per query.
- **What changed:** Added `"discovery"` as a new `PluginRegistrationMode`. Non-activating loads for enabled plugins now use `"discovery"` instead of `"full"`. All registration methods (registerTool, registerProvider, etc.) remain active in discovery mode, so provider/web-search discovery is unaffected. Plugins can check `api.registrationMode` and skip side effects when not `"full"`.
- **What did NOT change:** Activating loads still use `"full"`. Setup modes (`"setup-only"`, `"setup-runtime"`) are unchanged. Memory-slot filtering applies to both `"full"` and `"discovery"` modes.

## Change Type (select all)

- [x] Bug fix
- [x] Performance improvement

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Plugin SDK / extension API

## Linked Issue/PR

- Closes #52031
- Companion docs PR: (docs/plugin-registration-mode-guide — submitted separately)

## User-visible / Behavior Changes

- `api.registrationMode` is `"discovery"` (instead of `"full"`) during non-activating plugin loads
- Plugins that check `api.registrationMode !== "full"` can now skip side effects in non-activating loads
- No behavioral change for plugins that do not check `registrationMode`

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No — registration methods remain active in discovery mode
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15.4
- Runtime: Node 22, pnpm dev

### Steps

1. Create a plugin with side effects in `register()` (e.g., writing to globalThis)
2. Load with `activate: false, cache: false`
3. Check `api.registrationMode` — should be `"discovery"`
4. Verify registration methods (registerTool, registerProvider) still work
5. Load with default options (activate: true) — should be `"full"`

### Expected

- Non-activating loads: `registrationMode === "discovery"`, all methods work
- Activating loads: `registrationMode === "full"`, all methods work

### Actual

Before this change: both cases used `"full"`, no way to distinguish

## Evidence

- [x] Test: `loader.test.ts` — "uses 'discovery' registrationMode for non-activating loads"
- [x] `pnpm build` passes
- [x] `pnpm check` passes
- [x] `pnpm test -- src/plugins/loader.test.ts` — 57/57 passed
- [x] Codex review completed — P2 memory-slot issue identified and fixed

## Human Verification (required)

- Verified scenarios: non-activating load gets "discovery", activating load gets "full", registration methods work in both
- Edge cases checked: memory-slot filtering preserved for discovery mode, onlyPluginIds bypass
- What you did **not** verify: full E2E with provider wizard / model picker (covered by existing tests)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — plugins that do not check registrationMode are unaffected
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the single commit
- Files/config to restore: `src/plugins/types.ts`, `src/plugins/loader.ts`, `src/plugins/registry.ts`
- Known bad symptoms reviewers should watch for: provider/web-search plugins missing from discovery results, memory plugins loading unexpectedly

## Risks and Mitigations

- **Risk:** Plugins that guard `registrationMode !== "full"` will now skip side effects in discovery loads, which changes behavior for non-activating callers
- **Mitigation:** This is the intended behavior — discovery loads should be lightweight. Registration methods still work, so capability introspection is unaffected.