### PR TITLE
fix: route logs to stderr in --json output mode

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -5,6 +5,7 @@ const setVerboseMock = vi.fn();
 const emitCliBannerMock = vi.fn();
 const ensureConfigReadyMock = vi.fn(async () => {});
 const ensurePluginRegistryLoadedMock = vi.fn();
+const routeLogsToStderrMock = vi.fn();
 
 const runtimeMock = {
   log: vi.fn(),
@@ -26,6 +27,10 @@ vi.mock("../banner.js", () => ({
 
 vi.mock("../cli-name.js", () => ({
   resolveCliName: () => "openclaw",
+}));
+
+vi.mock("../../logging/console.js", () => ({
+  routeLogsToStderr: routeLogsToStderrMock,
 }));
 
 vi.mock("./config-guard.js", () => ({
@@ -279,6 +284,33 @@ describe("registerPreActionHooks", () => {
     });
 
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+  });
+
+  it("calls routeLogsToStderr for --json output commands", async () => {
+    await runPreAction({
+      parseArgv: ["agents"],
+      processArgv: ["node", "openclaw", "agents", "--json"],
+    });
+
+    expect(routeLogsToStderrMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call routeLogsToStderr for non-json commands", async () => {
+    await runPreAction({
+      parseArgv: ["agents"],
+      processArgv: ["node", "openclaw", "agents"],
+    });
+
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
+  });
+
+  it("does not call routeLogsToStderr for config set --json (parse-only)", async () => {
+    await runPreAction({
+      parseArgv: ["config", "set", "gateway.auth.mode", "{bad", "--json"],
+      processArgv: ["node", "openclaw", "config", "set", "gateway.auth.mode", "{bad", "--json"],
+    });
+
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
   });
 
   beforeAll(() => {

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { setVerbose } from "../../globals.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
+import { routeLogsToStderr } from "../../logging/console.js";
 import type { LogLevel } from "../../logging/levels.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
@@ -144,6 +145,9 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       return;
     }
     const suppressDoctorStdout = isJsonOutputMode(commandPath, argv);
+    if (suppressDoctorStdout) {
+      routeLogsToStderr();
+    }
     const { ensureConfigReady } = await loadConfigGuardModule();
     await ensureConfigReady({
       runtime: defaultRuntime,

--- a/src/cli/route.test.ts
+++ b/src/cli/route.test.ts
@@ -5,6 +5,11 @@ const ensureConfigReadyMock = vi.hoisted(() => vi.fn(async () => {}));
 const ensurePluginRegistryLoadedMock = vi.hoisted(() => vi.fn());
 const findRoutedCommandMock = vi.hoisted(() => vi.fn());
 const runRouteMock = vi.hoisted(() => vi.fn(async () => true));
+const routeLogsToStderrMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../logging/console.js", () => ({
+  routeLogsToStderr: routeLogsToStderrMock,
+}));
 
 vi.mock("./banner.js", () => ({
   emitCliBanner: emitCliBannerMock,
@@ -83,5 +88,17 @@ describe("tryRouteCli", () => {
       commandPath: ["status"],
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "channels" });
+  });
+
+  it("calls routeLogsToStderr for routed --json commands", async () => {
+    await expect(tryRouteCli(["node", "openclaw", "status", "--json"])).resolves.toBe(true);
+
+    expect(routeLogsToStderrMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call routeLogsToStderr for routed non-json commands", async () => {
+    await expect(tryRouteCli(["node", "openclaw", "status"])).resolves.toBe(true);
+
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -1,4 +1,5 @@
 import { isTruthyEnvValue } from "../infra/env.js";
+import { routeLogsToStderr } from "../logging/console.js";
 import { defaultRuntime } from "../runtime.js";
 import { VERSION } from "../version.js";
 import { getCommandPathWithRootOptions, hasFlag, hasHelpOrVersion } from "./argv.js";
@@ -11,6 +12,9 @@ async function prepareRoutedCommand(params: {
   loadPlugins?: boolean | ((argv: string[]) => boolean);
 }) {
   const suppressDoctorStdout = hasFlag(params.argv, "--json");
+  if (suppressDoctorStdout) {
+    routeLogsToStderr();
+  }
   emitCliBanner(VERSION, { argv: params.argv });
   const { ensureConfigReady } = await import("./program/config-guard.js");
   await ensureConfigReady({


### PR DESCRIPTION
Fixes #52032

## Summary

- Call `routeLogsToStderr()` in both CLI execution paths (fast-path routes and Commander preAction hook) when `--json` is detected, so all log output goes to stderr and stdout stays clean for JSON parsing.

## Root Cause

The CLI has two execution paths that both need the fix:
1. **Fast-path** (`src/cli/route.ts`): `prepareRoutedCommand()` detected `--json` but only used it for `suppressDoctorStdout`, never called `routeLogsToStderr()`.
2. **Commander path** (`src/cli/program/preaction.ts`): Same issue — detected `--json` via `isJsonOutputMode()` but didn't call `routeLogsToStderr()`.

The existing `routeLogsToStderr()` function (already used in `completion-cli.ts` for the same reason) simply sets `loggingState.forceConsoleToStderr = true`, which the subsystem logger's `writeConsoleLine()` checks to route output to stderr.

## Changes

- `src/cli/route.ts`: call `routeLogsToStderr()` in `prepareRoutedCommand()` when `--json` flag is present
- `src/cli/program/preaction.ts`: call `routeLogsToStderr()` in the preAction hook when `isJsonOutputMode()` returns true
- Added tests in `src/cli/route.test.ts` and `src/cli/program/preaction.test.ts`

## Test plan

- [x] `pnpm test -- src/cli/route.test.ts src/cli/program/preaction.test.ts` — 15/15 pass
- [x] `pnpm check` — all pass

> This PR was developed with AI assistance (Claude Code).