### PR TITLE
docs(plugins): document registrationMode and multiple register() calls

### DIFF
--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -344,6 +344,59 @@ Tips:
 - Use `optional: true` for tools that trigger side effects or require extra binaries
 - Users can enable all tools from a plugin by adding the plugin id to `tools.allow`
 
+## Registration modes
+
+OpenClaw may call your plugin's `register()` function in different
+**registration modes**. The mode tells you _why_ your plugin is being loaded
+and controls which API methods are active:
+
+| Mode              | When                                          | API behavior                                        |
+| ----------------- | --------------------------------------------- | --------------------------------------------------- |
+| `"full"`          | Normal runtime activation                     | All methods work                                    |
+| `"setup-only"`    | Channel setup UI (plugin disabled)            | Only `registerChannel` works; all others are no-ops |
+| `"setup-runtime"` | Startup for unconfigured or deferred channels | Only `registerChannel` works; all others are no-ops |
+
+Your plugin receives the current mode via `api.registrationMode`.
+
+### Why this matters
+
+`register()` may be called **multiple times** during the lifecycle of a
+gateway process — for example, once for full activation and again for snapshot
+inspection. If your plugin performs expensive initialization (opening database
+connections, spawning processes, allocating large buffers), those side effects
+run on every call.
+
+### Best practice
+
+Check `api.registrationMode` at the top of `register()` and return early when
+the mode does not require your plugin's work:
+
+```typescript
+export default definePluginEntry({
+  id: "my-plugin",
+  name: "My Plugin",
+  register(api) {
+    // Skip side effects for non-full registration modes
+    if (api.registrationMode !== "full") {
+      return;
+    }
+
+    // Expensive initialization only runs during full activation
+    api.registerTool({
+      /* ... */
+    });
+    initializeDatabaseConnection();
+  },
+});
+```
+
+<Info>
+  Channel plugins using `defineChannelPluginEntry` from `plugin-sdk/core`
+  already handle this automatically — the helper separates channel setup
+  (runs in all modes) from full registration (runs only in `"full"` mode).
+  You only need manual checks when using `definePluginEntry` directly.
+</Info>
+
 ## Lint enforcement (in-repo plugins)
 
 Three scripts enforce SDK boundaries for plugins in the OpenClaw repository:


### PR DESCRIPTION
## Summary

- **Problem:** The plugin authoring guide does not mention that `register()` may be called in multiple registration modes or multiple times during a gateway process lifecycle. Plugin authors with expensive side effects in `register()` have no guidance on how to avoid redundant work.
- **Why it matters:** Without documentation, every plugin author independently discovers the performance trap and implements ad-hoc workarounds.
- **What changed:** Added a "Registration modes" section to `docs/plugins/building-plugins.md` explaining the three modes (`full`, `setup-only`, `setup-runtime`), why `register()` may be called multiple times, and the recommended guard pattern.
- **What did NOT change:** No code changes. No changes to existing documentation sections.

## Change Type (select all)

- [x] Documentation

## Scope (select all touched areas)

- [x] Docs

## Linked Issue/PR

- Ref #52031
- Companion framework PR: #52062

## User-visible / Behavior Changes

None (documentation only)

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- N/A (docs only)

### Steps

1. Read `docs/plugins/building-plugins.md`
2. Verify the new "Registration modes" section is accurate and clear

### Expected

- Section explains modes, multiple calls, and guard pattern

### Actual

- N/A (new content)

## Evidence

- [x] Codex review completed — P3 issues (hook example, setup-runtime description) fixed

## Human Verification (required)

- Verified scenarios: mode descriptions match loader.ts behavior, guard pattern matches defineChannelPluginEntry
- Edge cases checked: setup-runtime applies to both unconfigured and deferred channels (corrected per Codex review)
- What you did **not** verify: Mintlify rendering

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- N/A (docs only)

## Risks and Mitigations

None