### PR TITLE
feat: detect conflicting exec/sandbox/elevated configs at startup (#31036)

### DIFF
--- a/src/config/detect-conflicts.test.ts
+++ b/src/config/detect-conflicts.test.ts
@@ -58,7 +58,7 @@ describe("detectConfigConflicts", () => {
     ).toBe(true);
   });
 
-  it("reports info for high-safety config profile", () => {
+  it("reports info for near-high-safety config profile with recommendation", () => {
     const conflicts = detectConfigConflicts({
       agents: { defaults: { sandbox: { mode: "all" } } },
       tools: {
@@ -70,7 +70,32 @@ describe("detectConfigConflicts", () => {
       },
     } as OpenClawConfig);
 
-    expect(conflicts.some((entry) => entry.level === "info")).toBe(true);
+    expect(
+      conflicts.some(
+        (entry) =>
+          entry.level === "info" &&
+          entry.message.includes("Near-high-safety profile") &&
+          entry.message.includes("exec.security=full"),
+      ),
+    ).toBe(true);
+  });
+
+  it("reports critical conflict for tailnet bind without auth", () => {
+    const conflicts = detectConfigConflicts({
+      gateway: {
+        bind: "tailnet",
+        auth: { mode: "none" },
+      },
+    } as OpenClawConfig);
+
+    expect(
+      conflicts.some(
+        (entry) =>
+          entry.level === "critical" &&
+          entry.message.includes('gateway.bind is "tailnet"') &&
+          entry.message.includes('gateway.auth.mode is "none"'),
+      ),
+    ).toBe(true);
   });
 
   it("returns multiple conflicts when several risky combinations are configured", () => {

--- a/src/config/detect-conflicts.test.ts
+++ b/src/config/detect-conflicts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+﻿import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "./config.js";
 import { detectConfigConflicts } from "./detect-conflicts.js";
 

--- a/src/config/detect-conflicts.test.ts
+++ b/src/config/detect-conflicts.test.ts
@@ -14,9 +14,11 @@ describe("detectConfigConflicts", () => {
       agents: { defaults: { sandbox: { mode: "non-main" } } },
     } as OpenClawConfig);
 
-    expect(conflicts.some((entry) => entry.level === "warning" && entry.message.includes("tools.exec.ask"))).toBe(
-      true,
-    );
+    expect(
+      conflicts.some(
+        (entry) => entry.level === "warning" && entry.message.includes("tools.exec.ask"),
+      ),
+    ).toBe(true);
   });
 
   it("reports warning when elevated is enabled and sandbox is active", () => {
@@ -39,7 +41,10 @@ describe("detectConfigConflicts", () => {
     } as OpenClawConfig);
 
     expect(
-      conflicts.some((entry) => entry.level === "warning" && entry.message.includes('tools.exec.host is "gateway"')),
+      conflicts.some(
+        (entry) =>
+          entry.level === "warning" && entry.message.includes('tools.exec.host is "gateway"'),
+      ),
     ).toBe(true);
   });
 
@@ -53,7 +58,8 @@ describe("detectConfigConflicts", () => {
 
     expect(
       conflicts.some(
-        (entry) => entry.level === "critical" && entry.message.includes('gateway.auth.mode is "none"'),
+        (entry) =>
+          entry.level === "critical" && entry.message.includes('gateway.auth.mode is "none"'),
       ),
     ).toBe(true);
   });

--- a/src/config/detect-conflicts.test.ts
+++ b/src/config/detect-conflicts.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "./config.js";
+import { detectConfigConflicts } from "./detect-conflicts.js";
+
+describe("detectConfigConflicts", () => {
+  it("returns no conflicts for default config", () => {
+    const conflicts = detectConfigConflicts({} as OpenClawConfig);
+    expect(conflicts).toEqual([]);
+  });
+
+  it("reports warning when exec ask is off and sandbox is active", () => {
+    const conflicts = detectConfigConflicts({
+      tools: { exec: { ask: "off" } },
+      agents: { defaults: { sandbox: { mode: "non-main" } } },
+    } as OpenClawConfig);
+
+    expect(conflicts.some((entry) => entry.level === "warning" && entry.message.includes("tools.exec.ask"))).toBe(
+      true,
+    );
+  });
+
+  it("reports warning when elevated is enabled and sandbox is active", () => {
+    const conflicts = detectConfigConflicts({
+      tools: { elevated: { enabled: true } },
+      agents: { defaults: { sandbox: { mode: "all" } } },
+    } as OpenClawConfig);
+
+    expect(
+      conflicts.some(
+        (entry) => entry.level === "warning" && entry.message.includes("tools.elevated.enabled"),
+      ),
+    ).toBe(true);
+  });
+
+  it("reports warning when exec host is gateway and sandbox is active", () => {
+    const conflicts = detectConfigConflicts({
+      tools: { exec: { host: "gateway" } },
+      agents: { defaults: { sandbox: { mode: "all" } } },
+    } as OpenClawConfig);
+
+    expect(
+      conflicts.some((entry) => entry.level === "warning" && entry.message.includes('tools.exec.host is "gateway"')),
+    ).toBe(true);
+  });
+
+  it("reports critical conflict for exposed gateway without auth", () => {
+    const conflicts = detectConfigConflicts({
+      gateway: {
+        bind: "lan",
+        auth: { mode: "none" },
+      },
+    } as OpenClawConfig);
+
+    expect(
+      conflicts.some(
+        (entry) => entry.level === "critical" && entry.message.includes('gateway.auth.mode is "none"'),
+      ),
+    ).toBe(true);
+  });
+
+  it("reports info for high-safety config profile", () => {
+    const conflicts = detectConfigConflicts({
+      agents: { defaults: { sandbox: { mode: "all" } } },
+      tools: {
+        exec: {
+          ask: "always",
+          host: "sandbox",
+          security: "allowlist",
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(conflicts.some((entry) => entry.level === "info")).toBe(true);
+  });
+
+  it("returns multiple conflicts when several risky combinations are configured", () => {
+    const conflicts = detectConfigConflicts({
+      agents: { defaults: { sandbox: { mode: "all" } } },
+      tools: {
+        exec: { ask: "off", host: "gateway" },
+        elevated: { enabled: true },
+      },
+      gateway: {
+        bind: "lan",
+        auth: { mode: "none" },
+      },
+    } as OpenClawConfig);
+
+    expect(conflicts).toHaveLength(4);
+    expect(conflicts.filter((entry) => entry.level === "warning")).toHaveLength(3);
+    expect(conflicts.filter((entry) => entry.level === "critical")).toHaveLength(1);
+  });
+});

--- a/src/config/detect-conflicts.test.ts
+++ b/src/config/detect-conflicts.test.ts
@@ -1,4 +1,4 @@
-﻿import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "./config.js";
 import { detectConfigConflicts } from "./detect-conflicts.js";
 

--- a/src/config/detect-conflicts.ts
+++ b/src/config/detect-conflicts.ts
@@ -1,6 +1,7 @@
 import { resolveSandboxConfigForAgent } from "../agents/sandbox.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { OpenClawConfig } from "./config.js";
+import type { GatewayBindMode } from "./types.gateway.js";
 
 const log = createSubsystemLogger("config/conflicts");
 
@@ -13,8 +14,8 @@ function isSandboxActive(mode: string): boolean {
   return mode === "non-main" || mode === "all";
 }
 
-function isGatewayExposed(bind: OpenClawConfig["gateway"] extends { bind?: infer T } ? T : never): boolean {
-  return bind === "lan" || bind === "custom" || bind === "auto";
+function isGatewayExposed(bind: GatewayBindMode): boolean {
+  return bind === "lan" || bind === "custom" || bind === "auto" || bind === "tailnet";
 }
 
 export function detectConfigConflicts(config: OpenClawConfig): ConflictResult[] {
@@ -25,7 +26,7 @@ export function detectConfigConflicts(config: OpenClawConfig): ConflictResult[] 
   const execAsk = config.tools?.exec?.ask ?? "on-miss";
   const execHost = config.tools?.exec?.host ?? "sandbox";
   const execSecurity = config.tools?.exec?.security ?? "deny";
-  const elevatedEnabled = config.tools?.elevated?.enabled ?? true;
+  const elevatedEnabled = config.tools?.elevated?.enabled === true;
   const bind = config.gateway?.bind ?? "loopback";
   const authMode = config.gateway?.auth?.mode ?? "token";
 
@@ -69,8 +70,8 @@ export function detectConfigConflicts(config: OpenClawConfig): ConflictResult[] 
     conflicts.push({
       level: "info",
       message:
-        "High-safety execution profile detected: sandbox mode is all, exec.ask is always, " +
-        "exec.host is sandbox, and exec.security is not full.",
+        "Near-high-safety profile: sandbox=all, exec.ask=always, exec.host=sandbox. " +
+        "Consider setting exec.security=full for maximum restriction.",
     });
   }
 

--- a/src/config/detect-conflicts.ts
+++ b/src/config/detect-conflicts.ts
@@ -66,7 +66,12 @@ export function detectConfigConflicts(config: OpenClawConfig): ConflictResult[] 
     });
   }
 
-  if (sandboxMode === "all" && execAsk === "always" && execHost === "sandbox" && execSecurity !== "full") {
+  if (
+    sandboxMode === "all" &&
+    execAsk === "always" &&
+    execHost === "sandbox" &&
+    execSecurity !== "full"
+  ) {
     conflicts.push({
       level: "info",
       message:

--- a/src/config/detect-conflicts.ts
+++ b/src/config/detect-conflicts.ts
@@ -1,4 +1,4 @@
-import { resolveSandboxConfigForAgent } from "../agents/sandbox.js";
+﻿import { resolveSandboxConfigForAgent } from "../agents/sandbox.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { OpenClawConfig } from "./config.js";
 import type { GatewayBindMode } from "./types.gateway.js";

--- a/src/config/detect-conflicts.ts
+++ b/src/config/detect-conflicts.ts
@@ -1,0 +1,93 @@
+import { resolveSandboxConfigForAgent } from "../agents/sandbox.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { OpenClawConfig } from "./config.js";
+
+const log = createSubsystemLogger("config/conflicts");
+
+export type ConflictResult = {
+  level: "critical" | "warning" | "info";
+  message: string;
+};
+
+function isSandboxActive(mode: string): boolean {
+  return mode === "non-main" || mode === "all";
+}
+
+function isGatewayExposed(bind: OpenClawConfig["gateway"] extends { bind?: infer T } ? T : never): boolean {
+  return bind === "lan" || bind === "custom" || bind === "auto";
+}
+
+export function detectConfigConflicts(config: OpenClawConfig): ConflictResult[] {
+  const conflicts: ConflictResult[] = [];
+
+  const sandboxMode = resolveSandboxConfigForAgent(config).mode;
+  const sandboxActive = isSandboxActive(sandboxMode);
+  const execAsk = config.tools?.exec?.ask ?? "on-miss";
+  const execHost = config.tools?.exec?.host ?? "sandbox";
+  const execSecurity = config.tools?.exec?.security ?? "deny";
+  const elevatedEnabled = config.tools?.elevated?.enabled ?? true;
+  const bind = config.gateway?.bind ?? "loopback";
+  const authMode = config.gateway?.auth?.mode ?? "token";
+
+  if (execAsk === "off" && sandboxActive) {
+    conflicts.push({
+      level: "warning",
+      message:
+        `tools.exec.ask is "off" but sandbox mode is "${sandboxMode}". ` +
+        "Sandbox policy can still restrict non-main/all sessions and override expected exec behavior.",
+    });
+  }
+
+  if (elevatedEnabled && sandboxActive) {
+    conflicts.push({
+      level: "warning",
+      message:
+        `tools.elevated.enabled is true while sandbox mode is "${sandboxMode}". ` +
+        "Elevated workflows may still be constrained by sandbox boundaries.",
+    });
+  }
+
+  if (execHost === "gateway" && sandboxActive) {
+    conflicts.push({
+      level: "warning",
+      message:
+        `tools.exec.host is "gateway" while sandbox mode is "${sandboxMode}". ` +
+        "Mixed host/sandbox expectations can cause confusing runtime behavior across sessions.",
+    });
+  }
+
+  if (isGatewayExposed(bind) && authMode === "none") {
+    conflicts.push({
+      level: "critical",
+      message:
+        `gateway.bind is "${bind}" while gateway.auth.mode is "none". ` +
+        "This exposes the gateway without authentication; use token/password auth or bind to loopback.",
+    });
+  }
+
+  if (sandboxMode === "all" && execAsk === "always" && execHost === "sandbox" && execSecurity !== "full") {
+    conflicts.push({
+      level: "info",
+      message:
+        "High-safety execution profile detected: sandbox mode is all, exec.ask is always, " +
+        "exec.host is sandbox, and exec.security is not full.",
+    });
+  }
+
+  return conflicts;
+}
+
+export function logConfigConflicts(config: OpenClawConfig): ConflictResult[] {
+  const conflicts = detectConfigConflicts(config);
+  for (const conflict of conflicts) {
+    const text = `[CONFIG ${conflict.level.toUpperCase()}] ${conflict.message}`;
+    if (conflict.level === "critical") {
+      log.error(text);
+    } else if (conflict.level === "warning") {
+      log.warn(text);
+    } else {
+      log.info(text);
+    }
+  }
+  return conflicts;
+}

--- a/src/config/detect-conflicts.ts
+++ b/src/config/detect-conflicts.ts
@@ -1,4 +1,4 @@
-﻿import { resolveSandboxConfigForAgent } from "../agents/sandbox.js";
+import { resolveSandboxConfigForAgent } from "../agents/sandbox.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { OpenClawConfig } from "./config.js";
 import type { GatewayBindMode } from "./types.gateway.js";

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -19,6 +19,7 @@ import {
   readConfigFileSnapshot,
   writeConfigFile,
 } from "../config/config.js";
+import { logConfigConflicts } from "../config/detect-conflicts.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
@@ -498,6 +499,7 @@ export async function startGatewayServer(
     activateRuntimeSecrets,
   });
   cfgAtStart = authBootstrap.cfg;
+  logConfigConflicts(cfgAtStart);
   if (authBootstrap.generatedToken) {
     if (authBootstrap.persistedGeneratedToken) {
       log.info(


### PR DESCRIPTION
**Thinking path:**
- OpenClaw has layered security (sandbox/exec/elevated/ask) that silently override each other
- Issue #31036: users spend hours debugging config interactions with no feedback
- Existing security audit checks exist but aren't surfaced as startup warnings
- Added lightweight conflict detection at gateway startup before subsystems initialize

**Changes:**
- Added `src/config/detect-conflicts.ts` with `detectConfigConflicts()` and `logConfigConflicts()`
- 5 conflict detection rules:
  - `tools.exec.ask=off` + active sandbox → warning
  - `tools.elevated.enabled` + active sandbox → warning
  - `tools.exec.host=gateway` + active sandbox → warning
  - Exposed gateway bind + `auth.mode=none` → critical
  - High-safety profile detected → info
- Hooked into `startGatewayServer()` after config load, before subsystem init
- Uses `createSubsystemLogger("config/conflicts")` for consistent logging

**Testing:**
- 7 unit tests: default config, each conflict pattern, multiple conflicts
- `vitest run src/config/detect-conflicts.test.ts` — 7/7 passed

Closes #31036