### PR TITLE
fix: extend loopDetection to cover exec tool calls (#34574)

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+﻿import { describe, expect, it } from "vitest";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import {

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -249,6 +249,17 @@ describe("tool-loop-detection", () => {
   });
 
   describe("detectToolCallLoop", () => {
+    const execThresholdConfig: ToolLoopDetectionConfig = {
+      enabled: true,
+      warningThreshold: 3,
+      criticalThreshold: 6,
+      detectors: {
+        genericRepeat: true,
+        knownPollNoProgress: true,
+        pingPong: true,
+      },
+    };
+
     it("is disabled by default", () => {
       const state = createState();
 
@@ -274,6 +285,98 @@ describe("tool-loop-detection", () => {
         enabledLoopDetectionConfig,
       );
       expect(result.stuck).toBe(false);
+    });
+
+    it("warns for repeated exec calls at repeat threshold", () => {
+      const result = detectLoopAfterRepeatedCalls({
+        toolName: "exec",
+        toolParams: { command: "ls /tmp" },
+        result: {
+          content: [{ type: "text", text: "file-a\nfile-b" }],
+          details: { status: "completed", exitCode: 0 },
+        },
+        count: 3,
+        config: execThresholdConfig,
+      });
+
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.level).toBe("warning");
+        expect(result.detector).toBe("generic_repeat");
+      }
+    });
+
+    it("does not warn for different exec commands", () => {
+      const state = createState();
+      recordSuccessfulCall(
+        state,
+        "exec",
+        { command: "ls" },
+        { content: [{ type: "text", text: "a" }], details: { status: "completed", exitCode: 0 } },
+        1,
+      );
+      recordSuccessfulCall(
+        state,
+        "exec",
+        { command: "pwd" },
+        {
+          content: [{ type: "text", text: "/workspace" }],
+          details: { status: "completed", exitCode: 0 },
+        },
+        2,
+      );
+      recordSuccessfulCall(
+        state,
+        "exec",
+        { command: "whoami" },
+        {
+          content: [{ type: "text", text: "openclaw" }],
+          details: { status: "completed", exitCode: 0 },
+        },
+        3,
+      );
+
+      const result = detectToolCallLoop(
+        state,
+        "exec",
+        { command: "date" },
+        execThresholdConfig,
+      );
+      expect(result.stuck).toBe(false);
+    });
+
+    it("does not warn for exec calls below threshold", () => {
+      const result = detectLoopAfterRepeatedCalls({
+        toolName: "exec",
+        toolParams: { command: "ls" },
+        result: {
+          content: [{ type: "text", text: "a\nb" }],
+          details: { status: "completed", exitCode: 0 },
+        },
+        count: 2,
+        config: execThresholdConfig,
+      });
+
+      expect(result.stuck).toBe(false);
+    });
+
+    it("keeps non-exec generic loop detection behavior unchanged", () => {
+      const result = detectLoopAfterRepeatedCalls({
+        toolName: "read",
+        toolParams: { path: "a.txt" },
+        result: {
+          content: [{ type: "text", text: "same file data" }],
+          details: { ok: true },
+        },
+        count: 4,
+        config: execThresholdConfig,
+      });
+
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.level).toBe("warning");
+        expect(result.detector).toBe("generic_repeat");
+      }
     });
 
     it("warns on generic repeated tool+args calls", () => {

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -355,12 +355,7 @@ describe("tool-loop-detection", () => {
         3,
       );
 
-      const result = detectToolCallLoop(
-        state,
-        "exec",
-        { command: "date" },
-        execThresholdConfig,
-      );
+      const result = detectToolCallLoop(state, "exec", { command: "date" }, execThresholdConfig);
       expect(result.stuck).toBe(false);
     });
 

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -306,6 +306,25 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("escalates exec to critical at criticalThreshold", () => {
+      const result = detectLoopAfterRepeatedCalls({
+        toolName: "exec",
+        toolParams: { command: "ls /tmp" },
+        result: {
+          content: [{ type: "text", text: "file-a\nfile-b" }],
+          details: { status: "completed", exitCode: 0 },
+        },
+        count: 6,
+        config: execThresholdConfig,
+      });
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.level).toBe("critical");
+        expect(result.detector).toBe("generic_repeat");
+        expect(result.message).toContain("CRITICAL");
+      }
+    });
+
     it("does not warn for different exec commands", () => {
       const state = createState();
       recordSuccessfulCall(

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+﻿import { createHash } from "node:crypto";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -470,10 +470,29 @@ export function detectToolCallLoop(
     };
   }
 
-  // Generic detector: warn-only for repeated identical calls.
+  // Generic detector: warn on repeated identical calls for all tools.
+  // Exec is higher risk, so it escalates to critical at the configured critical threshold.
   const recentCount = history.filter(
     (h) => h.toolName === toolName && h.argsHash === currentHash,
   ).length;
+  const isExecTool = toolName === "exec";
+
+  if (
+    !knownPollTool &&
+    isExecTool &&
+    resolvedConfig.detectors.genericRepeat &&
+    recentCount >= resolvedConfig.criticalThreshold
+  ) {
+    log.error(`Critical exec loop detected: ${toolName} called ${recentCount} times identically`);
+    return {
+      stuck: true,
+      level: "critical",
+      detector: "generic_repeat",
+      count: recentCount,
+      message: `CRITICAL: You have called ${toolName} ${recentCount} times with identical arguments. Session execution blocked to prevent runaway command loops.`,
+      warningKey: `generic:${toolName}:${currentHash}`,
+    };
+  }
 
   if (
     !knownPollTool &&


### PR DESCRIPTION
**What:** loopDetection did not escalate to critical for repeated exec calls. 121 identical shell commands = zero critical alerts.

**Why:** exec is the most dangerous tool type. The generic repeat detector was warn-only for non-poll tools, so criticalThreshold never triggered for exec.

**Changes:**
- Added escalation path for exec tool in loop detection: repeated identical exec calls now trigger critical at criticalThreshold (same as other dangerous patterns)
- Default thresholds unchanged (warningThreshold: 3, criticalThreshold: 6)
- No change to enabled/disabled defaults
- 4 new tests: repeated exec alert, different commands no alert, below threshold no alert, existing non-exec unchanged

**Testing:**
- `vitest run src/agents/tool-loop-detection.test.ts` — all passed
- Existing loop detection behavior unchanged for non-exec tools

Closes #34574
