### PR TITLE
fix(acp): await finishPrompt on error state to prevent hanging prompts

### DIFF
--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -826,7 +826,7 @@ export class AcpGatewayAgent implements Agent {
       // do not treat transient backend errors (timeouts, rate-limits) as deliberate
       // refusals.  TODO: when ChatEventSchema gains a structured errorKind field
       // (e.g. "refusal" | "timeout" | "rate_limit"), use it to distinguish here.
-      void this.finishPrompt(pending.sessionId, pending, "end_turn");
+      await this.finishPrompt(pending.sessionId, pending, "end_turn");
     }
   }
 


### PR DESCRIPTION
## Summary

- In `AcpTranslator.handleChatEvent`, the "error" state code path calls `void this.finishPrompt(...)` instead of `await this.finishPrompt(...)`
- The "final" (line 817) and "aborted" (line 821) paths both correctly `await` the same function
- Only the "error" path (line 829) was missing the `await`

## Root cause

`finishPrompt` is an async method that:
1. Deletes the pending prompt from the map
2. Clears the active run
3. `await`s `getSessionSnapshot()` — **can throw**
4. `await`s `sendSessionSnapshotUpdate()` — wrapped in try/catch
5. Calls `pending.resolve({ stopReason })` — **signals completion to the client**

Using `void` instead of `await` means:
- If step 3 throws, the rejection is unhandled (no caller catches it)
- Step 5 never runs, so the client's prompt request **hangs indefinitely**

## Fix

Replace `void this.finishPrompt(...)` with `await this.finishPrompt(...)`, matching the "final" and "aborted" code paths.

## Test plan

- [x] All 183 ACP tests pass (`pnpm test -- src/acp/` — 21 test files)
- [x] Code inspection confirms all three `finishPrompt` call sites now consistently use `await`

🤖 Generated with [Claude Code](https://claude.com/claude-code)