### PR TITLE
fix(agents): enforce visibility guard after sessionId resolution in session_status

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -372,7 +372,7 @@ export function createSessionStatusTool(opts?: {
         throw new Error(`Unknown ${kind}: ${requestedKeyRaw}`);
       }
 
-      if (visibilityGuard && !requestedKeyRaw.startsWith("agent:")) {
+      if (visibilityGuard && !isExplicitAgentKey) {
         const access = visibilityGuard.check(
           normalizeVisibilityTargetSessionKey(resolved.key, agentId),
         );


### PR DESCRIPTION
## Summary

- When `session_status` receives a sessionId (not an explicit `agent:...` key), the sessionId resolution block (lines 328-357) rewrites `requestedKeyRaw` to an explicit agent key
- The visibility guard check at line 375 tested `!requestedKeyRaw.startsWith("agent:")`, which becomes `false` after resolution — **skipping the visibility check entirely**
- A sandboxed agent could bypass visibility restrictions by providing a sessionId instead of an explicit session key

## Root cause

The visibility guard has two check sites:
1. **Line 281-286**: Runs when the **original input** is an explicit `agent:...` key
2. **Line 375-382**: Runs when the input is NOT an explicit agent key (e.g., a sessionId or alias)

After sessionId resolution at line 340, `requestedKeyRaw` is overwritten to an explicit agent key. The condition at line 375 re-evaluates the now-mutated `requestedKeyRaw` and concludes it starts with `"agent:"`, so it skips the visibility check — even though check #1 also never ran (since the original input was not an explicit key).

## Fix

Replace `!requestedKeyRaw.startsWith("agent:")` with `!isExplicitAgentKey`, which was captured at line 306 **before** sessionId resolution and reflects whether the original input was an explicit agent key.

- Original input = explicit agent key → `isExplicitAgentKey = true` → skip (already checked at line 281)
- Original input = sessionId → `isExplicitAgentKey = false` → run visibility check

## Test plan

- [x] 26 session access/resolution tests pass
- [x] Code inspection confirms both visibility guard check sites now cover all input types without gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)