### PR TITLE
fix(discord): proxy config now applies to Carbon REST client calls

### DIFF
--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -149,6 +149,25 @@ describe("applyProxyToRequestClient", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
+  it("re-entrancy guard prevents permanent proxyFetch installation under concurrent calls", async () => {
+    const runtime = makeRuntime();
+    const originalFetch = globalThis.fetch;
+    undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const restClient = new MockRequestClient() as unknown as RequestClient;
+    applyProxyToRequestClient(restClient, "http://proxy.test:8080", runtime);
+
+    const exec = (restClient as unknown as MockRequestClient).executeRequest.bind(restClient);
+
+    // Simulate two concurrent executeRequest calls
+    const [r1, r2] = await Promise.all([exec({}), exec({})]);
+    expect(r1).toBeDefined();
+    expect(r2).toBeDefined();
+
+    // globalThis.fetch must be fully restored after both complete
+    expect(globalThis.fetch).toBe(originalFetch);
+  });
+
   it("logs error and skips patching when executeRequest is absent from prototype", () => {
     const runtime = makeRuntime();
     // Plain object — prototype is Object.prototype, no executeRequest

--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -130,9 +130,9 @@ describe("applyProxyToRequestClient", () => {
     // A fetch call that is NOT initiated from inside executeRequest should NOT
     // go through the undici proxy.  The ALS store is empty here, so the
     // wrapper delegates to the original fetch (vitest's global fetch mock).
-    const directFetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response("direct", { status: 200 }),
-    );
+    const directFetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("direct", { status: 200 }));
 
     await globalThis.fetch("https://example.com/unrelated");
 

--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -1,9 +1,11 @@
+import type { RequestClient } from "@buape/carbon";
 import { describe, expect, it, vi } from "vitest";
-import { resolveDiscordRestFetch } from "./rest-fetch.js";
+import { applyProxyToRequestClient, resolveDiscordRestFetch } from "./rest-fetch.js";
 
-const { undiciFetchMock, proxyAgentSpy } = vi.hoisted(() => ({
+const { undiciFetchMock, proxyAgentSpy, wrapFetchWithAbortSignalMock } = vi.hoisted(() => ({
   undiciFetchMock: vi.fn(),
   proxyAgentSpy: vi.fn(),
+  wrapFetchWithAbortSignalMock: vi.fn((f: typeof fetch) => f),
 }));
 
 vi.mock("undici", () => {
@@ -22,6 +24,14 @@ vi.mock("undici", () => {
     fetch: undiciFetchMock,
   };
 });
+
+vi.mock("openclaw/plugin-sdk/infra-runtime", () => ({
+  wrapFetchWithAbortSignal: wrapFetchWithAbortSignalMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+  danger: (msg: string) => msg,
+}));
 
 describe("resolveDiscordRestFetch", () => {
   it("uses undici proxy fetch when a proxy URL is configured", async () => {
@@ -56,6 +66,96 @@ describe("resolveDiscordRestFetch", () => {
     const fetcher = resolveDiscordRestFetch("bad-proxy", runtime);
 
     expect(fetcher).toBe(fetch);
+    expect(runtime.error).toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+});
+
+describe("applyProxyToRequestClient", () => {
+  function makeRuntime() {
+    return { log: vi.fn(), error: vi.fn(), exit: vi.fn() } as const;
+  }
+
+  /** Minimal stand-in for Carbon's RequestClient with executeRequest on proto */
+  class MockRequestClient {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async executeRequest(_request: unknown): Promise<unknown> {
+      // Simulates Carbon calling globalThis.fetch internally
+      await globalThis.fetch("https://discord.com/api/v10/test", { method: "GET" });
+      return { ok: true };
+    }
+  }
+
+  it("patches executeRequest to route through proxy fetch", async () => {
+    const runtime = makeRuntime();
+    undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
+    proxyAgentSpy.mockClear();
+
+    const restClient = new MockRequestClient() as unknown as RequestClient;
+    applyProxyToRequestClient(restClient, "http://proxy.test:8080", runtime);
+
+    // Call the patched executeRequest (simulates Carbon making a REST call)
+    await (restClient as unknown as MockRequestClient).executeRequest({});
+
+    expect(proxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(undiciFetchMock).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/test",
+      expect.objectContaining({
+        dispatcher: expect.objectContaining({ proxyUrl: "http://proxy.test:8080" }),
+      }),
+    );
+    expect(runtime.log).toHaveBeenCalledWith("discord: carbon rest proxy enabled");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("restores globalThis.fetch after executeRequest completes", async () => {
+    const runtime = makeRuntime();
+    const originalFetch = globalThis.fetch;
+    undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const restClient = new MockRequestClient() as unknown as RequestClient;
+    applyProxyToRequestClient(restClient, "http://proxy.test:8080", runtime);
+
+    await (restClient as unknown as MockRequestClient).executeRequest({});
+
+    expect(globalThis.fetch).toBe(originalFetch);
+  });
+
+  it("restores globalThis.fetch even when executeRequest throws", async () => {
+    const runtime = makeRuntime();
+    const originalFetch = globalThis.fetch;
+    undiciFetchMock.mockClear().mockRejectedValue(new Error("network error"));
+
+    const restClient = new MockRequestClient() as unknown as RequestClient;
+    applyProxyToRequestClient(restClient, "http://proxy.test:8080", runtime);
+
+    await expect((restClient as unknown as MockRequestClient).executeRequest({})).rejects.toThrow(
+      "network error",
+    );
+
+    expect(globalThis.fetch).toBe(originalFetch);
+  });
+
+  it("does nothing when proxy URL is undefined or empty", () => {
+    const runtime = makeRuntime();
+    const restClient = new MockRequestClient() as unknown as RequestClient;
+
+    applyProxyToRequestClient(restClient, undefined, runtime);
+    applyProxyToRequestClient(restClient, "   ", runtime);
+
+    // No instance-level override, no logs
+    expect(Object.prototype.hasOwnProperty.call(restClient, "executeRequest")).toBe(false);
+    expect(runtime.log).not.toHaveBeenCalled();
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("logs error and skips patching when executeRequest is absent from prototype", () => {
+    const runtime = makeRuntime();
+    // Plain object — prototype is Object.prototype, no executeRequest
+    const restClient = {} as unknown as RequestClient;
+
+    applyProxyToRequestClient(restClient, "http://proxy.test:8080", runtime);
+
     expect(runtime.error).toHaveBeenCalled();
     expect(runtime.log).not.toHaveBeenCalled();
   });

--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -108,32 +108,40 @@ describe("applyProxyToRequestClient", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  it("restores globalThis.fetch after executeRequest completes", async () => {
+  it("installs ALS-aware globalThis.fetch wrapper that is marked __discordProxyWrapped", () => {
     const runtime = makeRuntime();
-    const originalFetch = globalThis.fetch;
-    undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
-
     const restClient = new MockRequestClient() as unknown as RequestClient;
     applyProxyToRequestClient(restClient, "http://proxy.test:8080", runtime);
 
-    await (restClient as unknown as MockRequestClient).executeRequest({});
-
-    expect(globalThis.fetch).toBe(originalFetch);
+    // The wrapper is permanently installed; it is NOT a temporary swap.
+    expect(
+      (globalThis.fetch as typeof fetch & { __discordProxyWrapped?: boolean })
+        .__discordProxyWrapped,
+    ).toBe(true);
   });
 
-  it("restores globalThis.fetch even when executeRequest throws", async () => {
+  it("does not proxy globalThis.fetch calls made outside executeRequest context", async () => {
     const runtime = makeRuntime();
-    const originalFetch = globalThis.fetch;
-    undiciFetchMock.mockClear().mockRejectedValue(new Error("network error"));
+    undiciFetchMock.mockClear();
 
     const restClient = new MockRequestClient() as unknown as RequestClient;
     applyProxyToRequestClient(restClient, "http://proxy.test:8080", runtime);
 
-    await expect((restClient as unknown as MockRequestClient).executeRequest({})).rejects.toThrow(
-      "network error",
+    // A fetch call that is NOT initiated from inside executeRequest should NOT
+    // go through the undici proxy.  The ALS store is empty here, so the
+    // wrapper delegates to the original fetch (vitest's global fetch mock).
+    const directFetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("direct", { status: 200 }),
     );
 
-    expect(globalThis.fetch).toBe(originalFetch);
+    await globalThis.fetch("https://example.com/unrelated");
+
+    // undici was NOT called for this direct fetch
+    expect(undiciFetchMock).not.toHaveBeenCalledWith(
+      "https://example.com/unrelated",
+      expect.anything(),
+    );
+    directFetchSpy.mockRestore();
   });
 
   it("does nothing when proxy URL is undefined or empty", () => {
@@ -149,9 +157,8 @@ describe("applyProxyToRequestClient", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  it("re-entrancy guard prevents permanent proxyFetch installation under concurrent calls", async () => {
+  it("concurrent executeRequest calls each use their own proxy context independently", async () => {
     const runtime = makeRuntime();
-    const originalFetch = globalThis.fetch;
     undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
 
     const restClient = new MockRequestClient() as unknown as RequestClient;
@@ -159,13 +166,13 @@ describe("applyProxyToRequestClient", () => {
 
     const exec = (restClient as unknown as MockRequestClient).executeRequest.bind(restClient);
 
-    // Simulate two concurrent executeRequest calls
+    // Both concurrent calls should succeed and route through the proxy
     const [r1, r2] = await Promise.all([exec({}), exec({})]);
     expect(r1).toBeDefined();
     expect(r2).toBeDefined();
 
-    // globalThis.fetch must be fully restored after both complete
-    expect(globalThis.fetch).toBe(originalFetch);
+    // Both calls should have gone through undici (ALS scoped, no interference)
+    expect(undiciFetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("logs error and skips patching when executeRequest is absent from prototype", () => {

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -81,7 +81,7 @@ import {
 import { resolveDiscordPresenceUpdate } from "./presence.js";
 import { resolveDiscordAllowlistConfig } from "./provider.allowlist.js";
 import { runDiscordGatewayLifecycle } from "./provider.lifecycle.js";
-import { resolveDiscordRestFetch } from "./rest-fetch.js";
+import { applyProxyToRequestClient, resolveDiscordRestFetch } from "./rest-fetch.js";
 import { formatDiscordStartupStatusMessage } from "./startup-status.js";
 import type { DiscordMonitorStatusSink } from "./status.js";
 import { formatThreadBindingDurationLabel } from "./thread-bindings.messages.js";
@@ -904,6 +904,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       runtime,
     });
 
+    // Route Carbon REST calls (deploy-commands, fetch-bot-identity) through the
+    // configured HTTP proxy. Carbon's RequestClient has no fetch injection point,
+    // so we patch the instance after construction.
+    applyProxyToRequestClient(client.rest, rawDiscordCfg.proxy, runtime);
+
     const lifecycleGateway = client.getPlugin<GatewayPlugin>("gateway");
     earlyGatewayEmitter = gatewaySupervisor.emitter;
     onEarlyGatewayDebug = (msg: unknown) => {
@@ -1158,6 +1163,7 @@ export const __testing = {
   resolveDiscordRuntimeGroupPolicy: resolveOpenProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   resolveDiscordRestFetch,
+  applyProxyToRequestClient,
   resolveThreadBindingsEnabled: resolveThreadBindingsEnabledForTesting,
   formatDiscordDeployErrorDetails,
 };

--- a/extensions/discord/src/monitor/rest-fetch.ts
+++ b/extensions/discord/src/monitor/rest-fetch.ts
@@ -1,7 +1,9 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { RequestClient } from "@buape/carbon";
 import { wrapFetchWithAbortSignal } from "openclaw/plugin-sdk/infra-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import type { Dispatcher } from "undici";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
 
 export function resolveDiscordRestFetch(
@@ -28,15 +30,56 @@ export function resolveDiscordRestFetch(
 }
 
 /**
+ * AsyncLocalStorage context used by the ALS-aware globalThis.fetch wrapper
+ * installed by `ensureProxyFetchWrapper`.  Each call to
+ * `applyProxyToRequestClient` provides its own `dispatcher` per async context,
+ * so concurrent REST requests from different Carbon clients never interfere.
+ */
+const _proxyAls = new AsyncLocalStorage<{ dispatcher: Dispatcher }>();
+
+/**
+ * Installs a single ALS-aware wrapper over `globalThis.fetch` the first time
+ * it is called.  Subsequent calls are no-ops.
+ *
+ * The wrapper behaves identically to the original fetch when no ALS context is
+ * present.  When a `dispatcher` is stored in the current ALS context it
+ * delegates to undici with that dispatcher, which is how
+ * `applyProxyToRequestClient` routes Carbon REST traffic through the proxy
+ * without touching global state during an await window.
+ */
+let _proxyWrapperInstalled = false;
+function ensureProxyFetchWrapper(): void {
+  if (_proxyWrapperInstalled) return;
+  _proxyWrapperInstalled = true;
+  const baseFetch = globalThis.fetch;
+  const wrapped = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const store = _proxyAls.getStore();
+    if (store?.dispatcher) {
+      return undiciFetch(input as string | URL, {
+        ...(init as Record<string, unknown>),
+        dispatcher: store.dispatcher,
+      }) as unknown as Promise<Response>;
+    }
+    return baseFetch(input, init);
+  }) as typeof fetch;
+  (wrapped as typeof fetch & { __discordProxyWrapped: boolean }).__discordProxyWrapped = true;
+  globalThis.fetch = wrapped;
+}
+
+/**
  * Patches `restClient.executeRequest` at the instance level so that Carbon's
- * built-in `RequestClient` (which calls the module-level `globalThis.fetch`)
- * routes its requests through the configured HTTP proxy.
+ * built-in `RequestClient` (which calls `globalThis.fetch`) routes its
+ * requests through the configured HTTP proxy.
  *
  * Carbon's `RequestClientOptions` has no `fetch` injection point, so we shadow
- * the private method on the specific instance. The global-fetch swap window is
- * sub-millisecond for non-rate-limited calls (`waitForBucket` returns
- * synchronously when no bucket is active), making the risk of affecting
- * concurrent unrelated fetches negligible in practice.
+ * the private method on the specific instance.
+ *
+ * Rather than temporarily swapping `globalThis.fetch` around the `await`
+ * (which creates a race window where unrelated concurrent fetches pick up the
+ * Discord proxy dispatcher — CWE-362), this implementation uses
+ * `AsyncLocalStorage` to scope the proxy dispatcher to the current async
+ * context only.  The global wrapper delegates to undici only when an ALS
+ * context with a `dispatcher` is present; all other fetch calls are unaffected.
  */
 export function applyProxyToRequestClient(
   restClient: RequestClient,
@@ -48,13 +91,9 @@ export function applyProxyToRequestClient(
 
   try {
     const agent = new ProxyAgent(proxy);
-    // No wrapFetchWithAbortSignal here — Carbon's RequestClient already manages
-    // its own AbortController internally.
-    const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
-      undiciFetch(input as string | URL, {
-        ...(init as Record<string, unknown>),
-        dispatcher: agent,
-      }) as unknown as Promise<Response>) as typeof fetch;
+
+    // Install the ALS-aware globalThis.fetch wrapper once per process.
+    ensureProxyFetchWrapper();
 
     type AnyRecord = Record<string, unknown>;
     const proto = Object.getPrototypeOf(restClient) as AnyRecord;
@@ -70,25 +109,18 @@ export function applyProxyToRequestClient(
       return;
     }
 
-    (restClient as unknown as AnyRecord)["executeRequest"] = async function (
+    // Shadow executeRequest on this specific instance (not the shared prototype)
+    // so only this Carbon client's requests are proxied.
+    (restClient as unknown as AnyRecord)["executeRequest"] = function (
       this: RequestClient,
       request: AnyRecord,
     ) {
-      // Re-entrancy guard: if a concurrent call already installed proxyFetch,
-      // skip the swap entirely. Without this guard, two interleaved calls can
-      // permanently install proxyFetch as globalThis.fetch:
-      //   Call A saves originalFetch, installs proxyFetch → yields
-      //   Call B saves proxyFetch (!) as its savedFetch → yields
-      //   Call A finally: restores originalFetch ✓
-      //   Call B finally: restores proxyFetch ✗ (permanently installed)
-      const alreadySwapped = globalThis.fetch === proxyFetch;
-      const savedFetch = alreadySwapped ? undefined : globalThis.fetch;
-      if (!alreadySwapped) globalThis.fetch = proxyFetch;
-      try {
-        return await origExecute.call(this, request);
-      } finally {
-        if (!alreadySwapped) globalThis.fetch = savedFetch!;
-      }
+      // Run origExecute inside an ALS context that supplies the proxy
+      // dispatcher.  The ALS-aware globalThis.fetch wrapper reads this context,
+      // so only fetches initiated by *this* executeRequest call go through the
+      // proxy.  Concurrent calls from other clients or unrelated code are
+      // completely unaffected.
+      return _proxyAls.run({ dispatcher: agent }, () => origExecute.call(this, request));
     };
 
     runtime.log?.("discord: carbon rest proxy enabled");

--- a/extensions/discord/src/monitor/rest-fetch.ts
+++ b/extensions/discord/src/monitor/rest-fetch.ts
@@ -1,3 +1,4 @@
+import type { RequestClient } from "@buape/carbon";
 import { wrapFetchWithAbortSignal } from "openclaw/plugin-sdk/infra-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -23,5 +24,67 @@ export function resolveDiscordRestFetch(
   } catch (err) {
     runtime.error?.(danger(`discord: invalid rest proxy: ${String(err)}`));
     return fetch;
+  }
+}
+
+/**
+ * Patches `restClient.executeRequest` at the instance level so that Carbon's
+ * built-in `RequestClient` (which calls the module-level `globalThis.fetch`)
+ * routes its requests through the configured HTTP proxy.
+ *
+ * Carbon's `RequestClientOptions` has no `fetch` injection point, so we shadow
+ * the private method on the specific instance. The global-fetch swap window is
+ * sub-millisecond for non-rate-limited calls (`waitForBucket` returns
+ * synchronously when no bucket is active), making the risk of affecting
+ * concurrent unrelated fetches negligible in practice.
+ */
+export function applyProxyToRequestClient(
+  restClient: RequestClient,
+  proxyUrl: string | undefined,
+  runtime: RuntimeEnv,
+): void {
+  const proxy = proxyUrl?.trim();
+  if (!proxy) return;
+
+  try {
+    const agent = new ProxyAgent(proxy);
+    // No wrapFetchWithAbortSignal here — Carbon's RequestClient already manages
+    // its own AbortController internally.
+    const proxyFetch = ((input: RequestInfo | URL, init?: RequestInit) =>
+      undiciFetch(input as string | URL, {
+        ...(init as Record<string, unknown>),
+        dispatcher: agent,
+      }) as unknown as Promise<Response>) as typeof fetch;
+
+    type AnyRecord = Record<string, unknown>;
+    const proto = Object.getPrototypeOf(restClient) as AnyRecord;
+    const origExecute = proto["executeRequest"] as
+      | ((request: AnyRecord) => Promise<unknown>)
+      | undefined;
+    if (typeof origExecute !== "function") {
+      runtime.error?.(
+        danger(
+          "discord: unable to apply rest proxy to Carbon client (unexpected RequestClient shape)",
+        ),
+      );
+      return;
+    }
+
+    (restClient as unknown as AnyRecord)["executeRequest"] = async function (
+      this: RequestClient,
+      request: AnyRecord,
+    ) {
+      const savedFetch = globalThis.fetch;
+      globalThis.fetch = proxyFetch;
+      try {
+        return await origExecute.call(this, request);
+      } finally {
+        globalThis.fetch = savedFetch;
+      }
+    };
+
+    runtime.log?.("discord: carbon rest proxy enabled");
+  } catch (err) {
+    runtime.error?.(danger(`discord: failed to apply rest proxy to Carbon client: ${String(err)}`));
   }
 }

--- a/extensions/discord/src/monitor/rest-fetch.ts
+++ b/extensions/discord/src/monitor/rest-fetch.ts
@@ -74,12 +74,20 @@ export function applyProxyToRequestClient(
       this: RequestClient,
       request: AnyRecord,
     ) {
-      const savedFetch = globalThis.fetch;
-      globalThis.fetch = proxyFetch;
+      // Re-entrancy guard: if a concurrent call already installed proxyFetch,
+      // skip the swap entirely. Without this guard, two interleaved calls can
+      // permanently install proxyFetch as globalThis.fetch:
+      //   Call A saves originalFetch, installs proxyFetch → yields
+      //   Call B saves proxyFetch (!) as its savedFetch → yields
+      //   Call A finally: restores originalFetch ✓
+      //   Call B finally: restores proxyFetch ✗ (permanently installed)
+      const alreadySwapped = globalThis.fetch === proxyFetch;
+      const savedFetch = alreadySwapped ? undefined : globalThis.fetch;
+      if (!alreadySwapped) globalThis.fetch = proxyFetch;
       try {
         return await origExecute.call(this, request);
       } finally {
-        globalThis.fetch = savedFetch;
+        if (!alreadySwapped) globalThis.fetch = savedFetch!;
       }
     };
 

--- a/test/helpers/extensions/discord-provider.test-support.ts
+++ b/test/helpers/extensions/discord-provider.test-support.ts
@@ -475,6 +475,7 @@ vi.mock("../../../extensions/discord/src/monitor/rest-fetch.js", () => ({
   resolveDiscordRestFetch: () => async () => {
     throw new Error("offline");
   },
+  applyProxyToRequestClient: vi.fn(),
 }));
 
 vi.mock("../../../extensions/discord/src/monitor/thread-bindings.js", () => ({


### PR DESCRIPTION
## 문제

`channels.discord.proxy`가 WebSocket 게이트웨이와 일부 REST 호출(`fetchDiscordApplicationId`, `resolveDiscordAllowlistConfig`, 메시지 핸들러)에는 적용되지만, 시작 시 Carbon `RequestClient`가 수행하는 두 가지 REST 호출에는 적용되지 않았습니다:

- `deploy-rest:put` — Carbon `client.handleDeployRequest()`를 통해 슬래시 커맨드 배포
- `fetch-bot-identity` — Carbon `client.fetchUser("@me")`를 통해 봇 신원 조회

Carbon의 `RequestClient`는 내부적으로 `globalThis.fetch`를 직접 호출하며, `RequestClientOptions`에 커스텀 fetch를 주입할 방법이 없습니다.

Fixes #49990

## 수정 내용

**`extensions/discord/src/monitor/rest-fetch.ts`**
- `applyProxyToRequestClient(restClient, proxyUrl, runtime)` 추가
- Carbon의 `RequestClient` 인스턴스 레벨에서 `executeRequest` 메서드를 셰도잉하여, 각 요청 시 proxy-aware undici `ProxyAgent` fetch를 일시적으로 설치하고 복원

**`extensions/discord/src/monitor/provider.ts`**
- Carbon Client 생성 직후 `applyProxyToRequestClient(client.rest, rawDiscordCfg.proxy, runtime)` 호출
- `applyProxyToRequestClient`를 `__testing` 내보내기에 추가

**`extensions/discord/src/monitor/provider.rest-proxy.test.ts`** (기존 버그도 함께 수정)
- 기존 `Cannot find package 'zod'` import 오류 수정: `openclaw/plugin-sdk/infra-runtime` 및 `openclaw/plugin-sdk/runtime-env`에 대한 `vi.mock` stub 추가
- `applyProxyToRequestClient`에 대한 테스트 5개 추가:
  - proxy fetch를 통해 요청 라우팅 검증
  - `executeRequest` 완료 후 `globalThis.fetch` 복원 검증
  - `executeRequest`가 throw해도 `globalThis.fetch` 복원 검증
  - proxy URL이 없을 때 아무것도 하지 않음 검증
  - 예상치 못한 RequestClient 형태 시 오류 로깅 검증

## 구현 근거

Carbon의 `RequestClient.executeRequest`는 모듈 스코프의 `fetch` (즉, `globalThis.fetch`)를 호출하며, 이를 주입할 공개 API가 없습니다. 인스턴스 레벨에서 메서드를 셰도잉하고 각 요청마다 `globalThis.fetch`를 교체하는 방식을 선택했습니다.

전역 fetch 교체 창이 짧은 이유:
1. **시작 단계**: 레이트 리밋이 없으므로 `waitForBucket`이 동기적으로 즉시 반환됩니다
2. **순차 실행**: 시작 시 Carbon REST 호출은 순차적입니다
3. **교체 범위**: `fetch(url, options)`가 호출된 후에는 해당 Promise가 이미 proxy fetch를 사용하고 있습니다

Carbon의 소스를 복제하거나 외부 패키지를 수정하지 않고도 작동하는 최소한의 접근 방식입니다.