### PR TITLE
plugins: fix SDK alias package-root fallback

### DIFF
--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -37,6 +37,7 @@ import type {
   ChannelThreadingToolContext,
 } from "../channels/plugins/types.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
+import { resolvePluginSdkAliasFile } from "../plugins/sdk-alias.js";
 import type { OpenClawPluginApi } from "../plugins/types.js";
 import type {
   ChannelMessageActionContext as SharedChannelMessageActionContext,
@@ -58,8 +59,30 @@ const representativeRuntimeSmokeSubpaths = [
   "webhook-ingress",
 ] as const;
 
+function resolveImportablePluginSdkSubpath(specifier: string): string {
+  let resolved: string | null = null;
+  try {
+    resolved = requireFromHere.resolve(specifier);
+  } catch {
+    resolved = null;
+  }
+  if (resolved && existsSync(resolved)) {
+    return resolved;
+  }
+  const subpath = specifier.replace(/^openclaw\/plugin-sdk\//, "");
+  return (
+    resolvePluginSdkAliasFile({
+      srcFile: `${subpath}.ts`,
+      distFile: `${subpath}.js`,
+      modulePath: fileURLToPath(import.meta.url),
+    }) ??
+    resolved ??
+    specifier
+  );
+}
+
 const importResolvedPluginSdkSubpath = async (specifier: string) =>
-  import(pathToFileURL(requireFromHere.resolve(specifier)).href);
+  import(pathToFileURL(resolveImportablePluginSdkSubpath(specifier)).href);
 
 function readPluginSdkSource(subpath: string): string {
   const file = resolve(PLUGIN_SDK_DIR, `${subpath}.ts`);

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -61,6 +61,20 @@ function withCwd<T>(cwd: string, run: () => T): T {
   }
 }
 
+function withArgv1<T>(argv1: string | undefined, run: () => T): T {
+  const previousArgv = [...process.argv];
+  if (argv1 === undefined) {
+    process.argv.splice(1, 1);
+  } else {
+    process.argv[1] = argv1;
+  }
+  try {
+    return run();
+  } finally {
+    process.argv.splice(0, process.argv.length, ...previousArgv);
+  }
+}
+
 function createPluginSdkAliasFixture(params?: {
   srcFile?: string;
   distFile?: string;
@@ -458,6 +472,30 @@ describe("plugin sdk alias helpers", () => {
       fs.realpathSync(distRootAlias),
     );
     expect(fs.realpathSync(distAliases["openclaw/plugin-sdk/channel-runtime"] ?? "")).toBe(
+      fs.realpathSync(path.join(fixture.root, "dist", "plugin-sdk", "channel-runtime.js")),
+    );
+  });
+
+  it("builds plugin-sdk aliases via argv1 fallback when cwd is outside the package root", () => {
+    const fixture = createPluginSdkAliasFixture({
+      srcFile: "channel-runtime.ts",
+      distFile: "channel-runtime.js",
+      packageExports: {
+        "./plugin-sdk/channel-runtime": { default: "./dist/plugin-sdk/channel-runtime.js" },
+      },
+    });
+    const unrelatedCwd = makeTempDir();
+    const distPluginEntry = path.join(fixture.root, "dist", "extensions", "demo", "index.js");
+    fs.mkdirSync(path.dirname(distPluginEntry), { recursive: true });
+    fs.writeFileSync(distPluginEntry, 'export const plugin = "demo";\n', "utf-8");
+
+    const aliases = withCwd(unrelatedCwd, () =>
+      withArgv1(path.join(fixture.root, "openclaw.mjs"), () =>
+        withEnv({ NODE_ENV: undefined }, () => buildPluginLoaderAliasMap(distPluginEntry)),
+      ),
+    );
+
+    expect(fs.realpathSync(aliases["openclaw/plugin-sdk/channel-runtime"] ?? "")).toBe(
       fs.realpathSync(path.join(fixture.root, "dist", "plugin-sdk", "channel-runtime.js")),
     );
   });

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -17,6 +17,16 @@ type PluginSdkPackageJson = {
   bin?: string | Record<string, unknown>;
 };
 
+function isImplicitOpenClawEntrypointHint(argv1?: string): boolean {
+  const normalized = String(argv1 ?? "").replace(/\\/g, "/");
+  return (
+    normalized.endsWith("/openclaw") ||
+    normalized.endsWith("/openclaw.mjs") ||
+    normalized.endsWith("/dist/index.js") ||
+    normalized.endsWith("/dist/index.mjs")
+  );
+}
+
 function resolveLoaderModulePath(params: LoaderModuleResolveParams = {}): string {
   return params.modulePath ?? fileURLToPath(params.moduleUrl ?? import.meta.url);
 }
@@ -111,14 +121,14 @@ function resolveLoaderPluginSdkPackageRoot(
 ): string | null {
   const cwd = params.cwd ?? path.dirname(params.modulePath);
   const fromCwd = resolveOpenClawPackageRootSync({ cwd });
-  const fromExplicitHints =
-    params.argv1 || params.moduleUrl
-      ? resolveOpenClawPackageRootSync({
-          cwd,
-          ...(params.argv1 ? { argv1: params.argv1 } : {}),
-          ...(params.moduleUrl ? { moduleUrl: params.moduleUrl } : {}),
-        })
-      : null;
+  const argv1 =
+    params.argv1 ?? (isImplicitOpenClawEntrypointHint(process.argv[1]) ? process.argv[1] : null);
+  const moduleUrl = params.moduleUrl;
+  const fromExplicitHints = resolveOpenClawPackageRootSync({
+    cwd,
+    ...(argv1 ? { argv1 } : {}),
+    ...(moduleUrl ? { moduleUrl } : {}),
+  });
   return (
     fromCwd ??
     fromExplicitHints ??


### PR DESCRIPTION
## Summary

- Problem: external plugin SDK aliases can fail to resolve when OpenClaw starts from a working directory outside the package root, such as a launchd-managed gateway with `cwd=/`.
- Why it matters: external plugins that import `openclaw/plugin-sdk/*` can fail at runtime with `Cannot find module 'openclaw/plugin-sdk/core'` even though the SDK is present.
- What changed: constrain the implicit package-root fallback to real OpenClaw entrypoint hints (`openclaw`, `openclaw.mjs`, `dist/index.js`, `dist/index.mjs`) and add a regression test that covers alias construction when `cwd` is outside the package root.
- What did NOT change (scope boundary): plugin packaging, plugin install layout, and the exported plugin SDK surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

External plugins that import `openclaw/plugin-sdk/*` now keep loading when OpenClaw is launched from a non-package-root working directory, including `cwd=/` service launches.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 24.14.0
- Model/provider: N/A
- Integration/channel (if any): external plugins `clawpool`, `clawpool-admin`
- Relevant config (redacted): `plugins.load.paths` pointed at external plugin directories; `plugins.allow` enabled those plugin ids

### Steps

1. Build OpenClaw and install/use external plugins that import `openclaw/plugin-sdk/core`.
2. Launch OpenClaw from a working directory outside the package root, for example `cd / && openclaw plugins list --enabled --verbose --json`, or start the macOS gateway via launchd where the process `cwd` becomes `/`.
3. Observe plugin load behavior.

### Expected

- External plugins load successfully and `openclaw/plugin-sdk/*` resolves to the local OpenClaw SDK files.

### Actual

- Plugin loading can fail with `Cannot find module 'openclaw/plugin-sdk/core'` even though the SDK files exist in the built package.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- src/plugins/sdk-alias.test.ts`; `pnpm build`; reproducing failure from `cwd=/`; verifying `cd / && openclaw plugins list --enabled --verbose --json` succeeds after the fix; verifying `cd / && openclaw plugins doctor` reports no plugin issues; restarting the local gateway and checking that the clawpool plugins load without the prior SDK-module error.
- Edge cases checked: non-OpenClaw cwd fallback remains rejected by the existing `does not resolve ... when package root is not an OpenClaw root` test.
- What you did **not** verify: other service managers beyond the local macOS launchd case.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit and rebuild OpenClaw.
- Files/config to restore: `src/plugins/sdk-alias.ts`, `src/plugins/sdk-alias.test.ts`
- Known bad symptoms reviewers should watch for: external plugins no longer resolving `openclaw/plugin-sdk/*` from service-managed or non-package-root launches.

## Risks and Mitigations

- Risk: the new implicit `argv1` fallback could incorrectly treat unrelated entrypoints as OpenClaw roots.
  - Mitigation: the fallback is now limited to a small allowlist of OpenClaw-specific entrypoint shapes, and the existing negative test still guards against arbitrary cwd-based resolution.
