### PR TITLE
fix(gateway): recognize control-ui and webchat clients as valid exec …

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -71,6 +71,7 @@ import {
 } from "../secrets/runtime.js";
 import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import { isWebchatClient } from "../utils/message-channel.js";
 import { runSetupWizard } from "../wizard/setup.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
@@ -82,7 +83,6 @@ import {
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { GATEWAY_CLIENT_IDS } from "./protocol/client-info.js";
-import { isWebchatClient } from "../utils/message-channel.js";
 import { startGatewayModelPricingRefresh } from "./model-pricing-cache.js";
 import { NodeRegistry } from "./node-registry.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,4 +1,4 @@
-import path from "node:path";
+﻿import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
@@ -83,8 +83,8 @@ import {
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { startGatewayModelPricingRefresh } from "./model-pricing-cache.js";
-import { GATEWAY_CLIENT_IDS } from "./protocol/client-info.js";
 import { NodeRegistry } from "./node-registry.js";
+import { GATEWAY_CLIENT_IDS } from "./protocol/client-info.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";
 import {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -82,8 +82,8 @@ import {
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
-import { GATEWAY_CLIENT_IDS } from "./protocol/client-info.js";
 import { startGatewayModelPricingRefresh } from "./model-pricing-cache.js";
+import { GATEWAY_CLIENT_IDS } from "./protocol/client-info.js";
 import { NodeRegistry } from "./node-registry.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -81,7 +81,9 @@ import {
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
+import { GATEWAY_CLIENT_IDS } from "./protocol/client-info.js";
 import { startGatewayModelPricingRefresh } from "./model-pricing-cache.js";
+import { isWebchatClient } from "../utils/message-channel.js";
 import { NodeRegistry } from "./node-registry.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";
@@ -1084,6 +1086,18 @@ export async function startGatewayServer(
     hasConnectedMobileNode: hasMobileNodeConnected,
     hasExecApprovalClients: () => {
       for (const gatewayClient of clients) {
+        // Plain HTTP (non-secure context): crypto.subtle is unavailable in the browser,
+        // so the control-ui cannot establish device identity. clearUnboundScopes() in
+        // ws-connection/message-handler.ts strips all scopes on connect, making the
+        // scope-based check below always return false even when control-ui is connected
+        // and actively displaying the approval popup. Recognize control-ui and webchat
+        // clients by their client identity instead.
+        if (
+          gatewayClient.connect.clientId === GATEWAY_CLIENT_IDS.CONTROL_UI ||
+          isWebchatClient(gatewayClient.connect)
+        ) {
+          return true;
+        }
         const scopes = Array.isArray(gatewayClient.connect.scopes)
           ? gatewayClient.connect.scopes
           : [];

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -82,8 +82,8 @@ import {
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { GATEWAY_CLIENT_IDS } from "./protocol/client-info.js";
-import { startGatewayModelPricingRefresh } from "./model-pricing-cache.js";
 import { isWebchatClient } from "../utils/message-channel.js";
+import { startGatewayModelPricingRefresh } from "./model-pricing-cache.js";
 import { NodeRegistry } from "./node-registry.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";
@@ -1093,8 +1093,8 @@ export async function startGatewayServer(
         // and actively displaying the approval popup. Recognize control-ui and webchat
         // clients by their client identity instead.
         if (
-          gatewayClient.connect.clientId === GATEWAY_CLIENT_IDS.CONTROL_UI ||
-          isWebchatClient(gatewayClient.connect)
+          gatewayClient.connect.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI ||
+          isWebchatClient(gatewayClient.connect.client)
         ) {
           return true;
         }


### PR DESCRIPTION
approval resolvers over plain HTTP

In plain HTTP (non-secure context) setups, hasExecApprovalClients() always returned false for connected control-ui clients because crypto.subtle is unavailable, preventing device identity and causing clearUnboundScopes() to strip all scopes during handshake.

Extend hasExecApprovalClients() to additionally recognize GATEWAY_CLIENT_IDS.CONTROL_UI and webchat clients as valid approval resolvers regardless of scopes.

Fixes #51932

## Summary

- **Problem:** In plain HTTP setups, `crypto.subtle` is unavailable in the browser, so control-ui cannot establish device identity. `clearUnboundScopes()` strips all scopes on connect, causing `hasExecApprovalClients()` to return `false` even when control-ui is actively connected and displaying the approval popup.
- **Why it matters:** Exec approval requests expired immediately with `no-approval-route` — the feature was completely broken over plain HTTP (e.g. Docker on Windows without TLS).
- **What changed:** `hasExecApprovalClients()` in `server.impl.ts` now additionally checks for `GATEWAY_CLIENT_IDS.CONTROL_UI` and webchat clients as a fallback when scope-based detection fails.
- **What did NOT change:** Scope-based approval client detection (Discord, Telegram, etc.) is fully preserved and unaffected.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #51932

## User-visible / Behavior Changes

Exec approval now works correctly when OpenClaw is accessed over plain HTTP (e.g. Docker on Windows without TLS configured).

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

The change only affects approval client *detection*, not approval *authorization*. A client recognized by this path still goes through the full approval flow — the user must still explicitly approve in the UI.

## Repro + Verification

### Environment
- OS: Windows 11
- Runtime/container: Docker (docker compose)
- Model/provider: Anthropic (claude-sonnet)
- Integration/channel: webchat / control-ui
- Relevant config: plain HTTP (no TLS), `openclaw.json` with HAL agent

### Steps
1. Start OpenClaw via `docker compose up` on plain HTTP
2. Open control-ui in browser
3. Send a message that triggers an exec approval request

### Expected
- Approval popup appears in control-ui
- Approving allows the command to execute

### Actual (before fix)
- Approval expired immediately with `no-approval-route`
- Command never executed

## Evidence

- [x] Trace/log snippets

Before fix:
exec.approval.request — expires immediately: no-approval-route

After fix:
[DEBUG] hasExecApprovalClients: true via scopes client=openclaw-control-ui
exec.approval.request — waiting for decision
exec.approval.resolve ... ok=true
exec.approval.waitDecision ... decision="allow-once"

## Human Verification

- Verified scenarios: exec approval over plain HTTP in Docker on Windows 11, allow-once and allow-session both confirmed working
- Edge cases checked: scope-based clients (Discord) unaffected; HTTPS setup unaffected
- What I did not verify: macOS native app, Linux daemon mode

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert: revert `hasExecApprovalClients()` in `src/gateway/server.impl.ts` to scope-only check
- Files/config to restore: `src/gateway/server.impl.ts`
- Known bad symptoms: exec approval hangs or expires immediately over plain HTTP

## Risks and Mitigations

- Risk: A non-authenticated plain HTTP client could be recognized as an approval resolver
  - Mitigation: The client still undergoes the full WebSocket connection and gateway authentication flow. Recognition as an approval resolver does not bypass the approval decision itself — the user must still explicitly approve in the UI.