### PR TITLE
fix(memory): apply env proxy guard to withRemoteHttpResponse

### DIFF
--- a/packages/memory-host-sdk/src/host/remote-http.ts
+++ b/packages/memory-host-sdk/src/host/remote-http.ts
@@ -1,4 +1,8 @@
-import { fetchWithSsrFGuard } from "../../../../src/infra/net/fetch-guard.js";
+import {
+  fetchWithSsrFGuard,
+  withTrustedEnvProxyGuardedFetchMode,
+} from "../../../../src/infra/net/fetch-guard.js";
+import { hasProxyEnvConfigured } from "../../../../src/infra/net/proxy-env.js";
 import type { SsrFPolicy } from "../../../../src/infra/net/ssrf.js";
 
 export function buildRemoteBaseUrlPolicy(baseUrl: string): SsrFPolicy | undefined {
@@ -26,12 +30,15 @@ export async function withRemoteHttpResponse<T>(params: {
   auditContext?: string;
   onResponse: (response: Response) => Promise<T>;
 }): Promise<T> {
-  const { response, release } = await fetchWithSsrFGuard({
+  const baseOptions = {
     url: params.url,
     init: params.init,
     policy: params.ssrfPolicy,
     auditContext: params.auditContext ?? "memory-remote",
-  });
+  };
+  const { response, release } = await fetchWithSsrFGuard(
+    hasProxyEnvConfigured() ? withTrustedEnvProxyGuardedFetchMode(baseOptions) : baseOptions,
+  );
   try {
     return await params.onResponse(response);
   } finally {


### PR DESCRIPTION
## Summary

- Problem: `withRemoteHttpResponse()` calls `fetchWithSsrFGuard()` without setting a mode, defaulting to `STRICT`. In strict mode, local DNS pre-resolution via `dns.lookup()` runs before the HTTP request, which fails with `getaddrinfo ENOTFOUND` in proxy environments where DNS must go through the proxy.
- Why it matters: Memory embeddings are completely unusable for users behind HTTP proxies (Clash TUN fake-IP, corporate proxies with DNS-over-proxy), even though all other proxy-aware code paths work correctly on the same machine.
- What changed: `withRemoteHttpResponse()` now checks `hasProxyEnvConfigured()` and, when true, wraps fetch options with `withTrustedEnvProxyGuardedFetchMode()` so `fetchWithSsrFGuard()` uses `EnvHttpProxyAgent` instead of pinned DNS.
- What did NOT change: Non-proxy environments still get the default strict SSRF guard behavior. No changes to `fetchWithSsrFGuard()` itself, SSRF policy, or any other code path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52162

## User-visible / Behavior Changes

`openclaw memory status --deep` and `openclaw memory search` now work correctly when environment proxy variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`) are configured and local DNS cannot resolve the embedding provider hostname.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — same `fetchWithSsrFGuard` is used, only the mode changes from `STRICT` to `TRUSTED_ENV_PROXY` when env proxy is detected, which is the same pattern already used by `fetchWithWebToolsNetworkGuard` in `src/agents/tools/web-guarded-fetch.ts`.
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 11 Pro 10.0.22631
- Runtime: Node.js via npm global install
- Model/provider: openai/text-embedding-3-small (remote OpenAI-compatible endpoint)
- Relevant config: `HTTPS_PROXY=http://127.0.0.1:7890` (Clash TUN with fake-IP mode)

### Steps

1. Configure `HTTPS_PROXY` env var pointing to an HTTP proxy
2. Use a proxy setup where local DNS cannot resolve the embedding provider hostname (e.g. Clash TUN fake-IP)
3. Run `openclaw memory status --deep --agent main`

### Expected

Embeddings status shows as available

### Actual (before fix)

`getaddrinfo ENOTFOUND <hostname>` — Embeddings: unavailable

## Evidence

- [x] Trace/log snippets — see issue #52162 for full reproduction logs
- [x] Failing test/log before + passing after — existing unit tests pass (`post-json.test.ts`, `embeddings-remote-fetch.test.ts`); TypeScript type check passes

## Human Verification (required)

- Verified scenarios: Code review confirmed the fix follows the exact same pattern as `fetchWithWebToolsNetworkGuard` in `src/agents/tools/web-guarded-fetch.ts` (line 46-48). Unit tests and type check pass.
- Edge cases checked: When no proxy env is configured, `hasProxyEnvConfigured()` returns false and behavior is unchanged (default strict mode).
- What you did **not** verify: End-to-end test in a Clash TUN environment (do not have the setup in CI). Manual verification by the reporter would be appreciated.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to revert: Revert the single commit; `withRemoteHttpResponse()` goes back to calling `fetchWithSsrFGuard()` without a mode.
- Known bad symptoms: If `TRUSTED_ENV_PROXY` mode somehow causes issues, embedding requests may fail differently (proxy errors instead of DNS errors). Reverting restores previous behavior.

## Risks and Mitigations

- Risk: In `TRUSTED_ENV_PROXY` mode, SSRF DNS pinning is bypassed for the embedding endpoint when a proxy is configured, relying on the proxy for network-level access control.
  - Mitigation: This is the same trade-off already accepted for web tool fetches (`web-guarded-fetch.ts`). The SSRF `policy` (allowed hostnames from `buildRemoteBaseUrlPolicy`) is still validated by `resolvePinnedHostnameWithPolicy` before the mode branch. The proxy itself provides the network boundary.

---

*This PR was prepared with AI assistance (Claude Code). The change was code-reviewed and the pattern was verified against the existing proxy-aware code path in `web-guarded-fetch.ts`.*