### PR TITLE
fix(skills): normalize backslashes in compacted skill paths on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: restore info-level gateway logs for embedded compaction start, completion, and incomplete outcomes. (#71961) Thanks @rubencu.
 - Telegram: build reply-aware inbound turns through the shared channel context path so agents see the current reply target inline with the current message.
 - Telegram: recover legacy message cache files that mixed JSON-array and line-delimited entries so restarted gateways preserve reply-window context. (#80567)
+- Skills/Windows: normalize compacted skill prompt locations to forward slashes after home-prefix compaction so Windows skill paths remain readable by model file tools. (#52200) Thanks @chienchandler.
 - Memory: skip managed dreaming cron reconciliation warnings for ordinary cron and heartbeat hook contexts that cannot manage Gateway cron. (#77027) Thanks @rubencu.
 - Cron: treat Codex app-server turn acceptance, CLI process spawn, and tool starts as execution milestones, preventing isolated runs from tripping the early startup watchdog after work has begun.
 - Yuanbao: bump `openclaw-plugin-yuanbao` to 2.13.1 to support `sourceReplyDeliveryMode: "automatic"` for group chat. (#79814) Thanks @loongfay.

--- a/src/agents/skills.compact-skill-paths.test.ts
+++ b/src/agents/skills.compact-skill-paths.test.ts
@@ -2,7 +2,10 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createCanonicalFixtureSkill } from "./skills.test-helpers.js";
-import { buildWorkspaceSkillsPrompt } from "./skills/workspace.js";
+import {
+  __testing as workspaceSkillsTesting,
+  buildWorkspaceSkillsPrompt,
+} from "./skills/workspace.js";
 
 describe("compactSkillPaths", () => {
   function buildPromptForFixtureSkill(params: {
@@ -49,6 +52,32 @@ describe("compactSkillPaths", () => {
     expect(prompt).toContain("~/");
     expect(prompt).toContain("test-skill");
     expect(prompt).toContain("A test skill for path compaction");
+  });
+
+  it("normalizes compacted Windows skill locations to forward slashes", () => {
+    const home = "C:\\Users\\alice";
+    const skillPath = path.win32.join(home, ".openclaw-test-skills", "win-skill", "SKILL.md");
+
+    const compactedPath = workspaceSkillsTesting.compactHomePath(skillPath, [home]);
+
+    expect(compactedPath).toBe("~/.openclaw-test-skills/win-skill/SKILL.md");
+  });
+
+  it("preserves POSIX literal backslashes after home compaction", () => {
+    const home = os.homedir();
+    const skillDir = path.join(home, ".openclaw-test-skills\\literal-skill");
+
+    const prompt = buildPromptForFixtureSkill({
+      workspaceRoot: home,
+      skillDir,
+      name: "literal-skill",
+      description: "POSIX literal backslash skill",
+    });
+
+    const locationMatch = prompt.match(/<location>([^<]+)<\/location>/);
+    expect(locationMatch).not.toBeNull();
+    expect(locationMatch![1]).toContain("~/");
+    expect(locationMatch![1]).toContain("\\literal-skill");
   });
 
   it("preserves paths outside home directory", () => {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -77,12 +77,25 @@ function compactSkillPaths(skills: Skill[]): Skill[] {
 
 function compactHomePath(filePath: string, homes: readonly string[]): string {
   for (const home of homes) {
-    const prefix = home.endsWith(path.sep) ? home : home + path.sep;
-    if (filePath.startsWith(prefix)) {
-      return "~/" + filePath.slice(prefix.length);
+    for (const prefix of compactHomePrefixesForHome(home)) {
+      if (filePath.startsWith(prefix)) {
+        return "~/" + normalizeCompactedSkillPath(filePath.slice(prefix.length), prefix);
+      }
     }
   }
   return filePath;
+}
+
+function compactHomePrefixesForHome(home: string): string[] {
+  const prefixes = [home.endsWith(path.sep) ? home : home + path.sep];
+  if (home.includes("\\") && !home.endsWith("\\")) {
+    prefixes.push(home + "\\");
+  }
+  return prefixes;
+}
+
+function normalizeCompactedSkillPath(filePath: string, matchedHomePrefix: string): string {
+  return matchedHomePrefix.includes("\\") ? filePath.replace(/\\/g, "/") : filePath;
 }
 
 function compactPathForConsoleMessage(filePath: string): string {
@@ -951,6 +964,10 @@ export function buildWorkspaceSkillsPrompt(
 ): string {
   return resolveWorkspaceSkillPromptState(workspaceDir, opts).prompt;
 }
+
+export const __testing = {
+  compactHomePath,
+};
 
 type WorkspaceSkillBuildOptions = {
   config?: OpenClawConfig;

--- a/src/plugins/provider-validation.test.ts
+++ b/src/plugins/provider-validation.test.ts
@@ -129,7 +129,7 @@ describe("normalizeRegisteredProvider", () => {
           },
         },
       }),
-      expectedProvider: {
+      expectedProvider: makeProvider({
         id: "demo",
         label: "Demo Provider",
         aliases: ["alias-one"],
@@ -160,7 +160,7 @@ describe("normalizeRegisteredProvider", () => {
             label: "Demo models",
           },
         },
-      },
+      }),
       expectedDiagnostics: [
         {
           level: "error",


### PR DESCRIPTION
## What

On Windows, `compactSkillPaths()` can produce hybrid prompt locations like `~/AppData\Roaming\npm\...\SKILL.md`: the home prefix is replaced with `~/`, but the remaining Windows path segments can keep backslashes. Models can then fail to resolve the skill file path.

Fixes #52022

## How

Normalize the compacted suffix only when the matched home prefix is Windows-style. That keeps Windows `~/.../SKILL.md` prompt locations readable while preserving POSIX filenames that contain literal backslash characters.

## Testing

- Original author tested on Windows 11.
- Maintainer verification:
  - `pnpm vitest run src/plugins/provider-validation.test.ts src/agents/skills.compact-skill-paths.test.ts`
  - `pnpm check:test-types`
  - `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/skills/workspace.ts src/agents/skills.compact-skill-paths.test.ts src/plugins/provider-validation.test.ts`
  - `git diff --check`

---
AI-assisted (Claude Code), reviewed and tested by author.

## Real behavior proof

- **Behavior or issue addressed:** Compacted skill prompt locations for home-relative Windows-style skill paths should use forward slashes after `~/`, without rewriting POSIX skill paths that intentionally contain a literal backslash.
- **Real environment tested:** Maintainer OpenClaw checkout running the real compact-path helper and prompt builder with both a Windows-style home-relative skill path and a POSIX literal-backslash skill path.
- **Exact steps or command run after this patch:** `node --import tsx --input-type=module` with `__testing.compactHomePath(...)` for the Windows-style path and `buildWorkspaceSkillsPrompt(...)` for the POSIX literal-backslash prompt location.
- **Evidence after fix:** Copied terminal output from the real code path after the patch:

```text
windowsCompacted=~/.openclaw-test-skills/win-skill/SKILL.md
windowsContainsBackslash=false
posixLocation=~/.openclaw-test-skills\literal-skill/SKILL.md
posixLiteralBackslashPreserved=true
```

- **Observed result after fix:** Windows-style compacted skill paths are normalized to forward slashes for model-facing locations, while POSIX literal-backslash paths stay unchanged.
- **What was not tested:** A fresh live Windows GUI/session run by the maintainer; the external author reported Windows 11 testing in the original PR body.
