### PR TITLE
docs: clarify plugin hook systems: api.registerHook vs api.on

### DIFF
--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -248,38 +248,59 @@ Plugins can register two types of hooks:
 
 ### Internal Hooks (command and gateway events)
 
-Use `api.registerHook()` for command and gateway events:
+Use `api.registerHook()` for command and gateway events. Requires `hooks.internal.enabled: true`
+in your config, and a `name` option to identify the hook:
 
 ```typescript
-export default function register(api) {
-  api.registerHook("command:new", async () => {
-    // Triggered when user issues /new command
-    api.logger.info("New session started");
-  });
-}
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "my-plugin",
+  name: "My Plugin",
+  register(api) {
+    api.registerHook("command:new", async () => {
+      // Triggered when user issues /new command
+      api.logger.info("New session started");
+    }, { name: "my-plugin.command-new" });
+  },
+});
 ```
 
 Common internal hook events: `command:new`, `command:reset`, `command:stop`, `gateway:startup`
 
+Config prerequisite:
+
+```json5
+{
+  hooks: { internal: { enabled: true } },
+}
+```
+
 ### Plugin Lifecycle Hooks (agent and tool events)
 
-Use `api.on()` for agent lifecycle and tool execution events:
+Use `api.on()` for agent lifecycle and tool execution events. No extra config required:
 
 ```typescript
-export default function register(api) {
-  // Tool execution hook
-  api.on("after_tool_call", async (event, ctx) => {
-    api.logger.info(`Tool called: ${event.toolName}`);
-    api.logger.info(`Duration: ${event.durationMs}ms`);
-  });
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 
-  // Prompt injection hook
-  api.on("before_prompt_build", async (event, ctx) => {
-    return {
-      prependContext: "Additional context for this turn",
-    };
-  });
-}
+export default definePluginEntry({
+  id: "my-plugin",
+  name: "My Plugin",
+  register(api) {
+    // Tool execution hook
+    api.on("after_tool_call", async (event, ctx) => {
+      api.logger.info(`Tool called: ${event.toolName}`);
+      api.logger.info(`Duration: ${event.durationMs}ms`);
+    });
+
+    // Prompt injection hook
+    api.on("before_prompt_build", async (event, ctx) => {
+      return {
+        prependContext: "Additional context for this turn",
+      };
+    });
+  },
+});
 ```
 
 Common lifecycle hooks:
@@ -296,7 +317,7 @@ See [Plugin Internals](/plugins/architecture#provider-runtime-hooks) for the com
 
 ```typescript
 // ❌ Wrong: using registerHook for lifecycle events
-api.registerHook("after_tool_call", handler);
+api.registerHook("after_tool_call", handler, { name: "my-plugin.after-tool" });
 
 // ✅ Correct: use api.on() for lifecycle events
 api.on("after_tool_call", async (event, ctx) => {

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -231,7 +231,8 @@ Common registration methods:
 | `registerProvider`                   | Model provider (LLM) |
 | `registerChannel`                    | Chat channel         |
 | `registerTool`                       | Agent tool           |
-| `registerHook` / `on(...)`           | Lifecycle hooks      |
+| `registerHook`                       | Command / gateway hooks|
+| `on(...)`                            | Agent lifecycle hooks|
 | `registerSpeechProvider`             | Text-to-speech / STT |
 | `registerMediaUnderstandingProvider` | Image/audio analysis |
 | `registerImageGenerationProvider`    | Image generation     |

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -318,8 +318,6 @@ Common lifecycle hooks:
 - `before_compaction` / `after_compaction` — memory compaction
 - `gateway_start` / `gateway_stop` — gateway startup and shutdown
 
-See [Plugin Internals](/plugins/architecture#provider-runtime-hooks) for the complete hook list.
-
 ### Common mistake
 
 ```typescript

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -310,6 +310,7 @@ Common lifecycle hooks:
 - `message_received` / `message_sent` — message events
 - `session_start` / `session_end` — session lifecycle
 - `before_compaction` / `after_compaction` — memory compaction
+- `gateway_start` / `gateway_stop` — gateway startup and shutdown
 
 See [Plugin Internals](/plugins/architecture#provider-runtime-hooks) for the complete hook list.
 

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -248,8 +248,8 @@ Plugins can register two types of hooks:
 
 ### Internal Hooks (command and gateway events)
 
-Use `api.registerHook()` for command and gateway events. Requires `hooks.internal.enabled: true`
-in your config, and a `name` option to identify the hook:
+Use `api.registerHook()` for command, gateway, message, and agent events.
+Requires `hooks.internal.enabled: true` in your config, and a `name` option to identify the hook:
 
 ```typescript
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
@@ -258,15 +258,20 @@ export default definePluginEntry({
   id: "my-plugin",
   name: "My Plugin",
   register(api) {
-    api.registerHook("command:new", async () => {
-      // Triggered when user issues /new command
-      api.logger.info("New session started");
-    }, { name: "my-plugin.command-new" });
+    api.registerHook(
+      "command:new",
+      async () => {
+        // Triggered when user issues /new command
+        api.logger.info("New session started");
+      },
+      { name: "my-plugin.command-new" },
+    );
   },
 });
 ```
 
-Common internal hook events: `command:new`, `command:reset`, `command:stop`, `gateway:startup`
+Common internal hook events: `command:new`, `command:reset`, `command:stop`,
+`message:received`, `message:sent`, `agent:bootstrap`, `gateway:startup`
 
 Config prerequisite:
 
@@ -278,7 +283,7 @@ Config prerequisite:
 
 ### Plugin Lifecycle Hooks (agent and tool events)
 
-Use `api.on()` for agent lifecycle and tool execution events. No extra config required:
+Use `api.on()` for typed agent lifecycle and tool execution events:
 
 ```typescript
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
@@ -294,6 +299,7 @@ export default definePluginEntry({
     });
 
     // Prompt injection hook
+    // Note: requires plugins.entries.<id>.hooks.allowPromptInjection to be true (default)
     api.on("before_prompt_build", async (event, ctx) => {
       return {
         prependContext: "Additional context for this turn",

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -241,6 +241,71 @@ Common registration methods:
 | `registerContextEngine`              | Context engine       |
 | `registerService`                    | Background service   |
 
+## Hook systems
+
+Plugins can register two types of hooks:
+
+### Internal Hooks (command and gateway events)
+
+Use `api.registerHook()` for command and gateway events:
+
+```typescript
+export default function register(api) {
+  api.registerHook("command:new", async () => {
+    // Triggered when user issues /new command
+    api.logger.info("New session started");
+  });
+}
+```
+
+Common internal hook events: `command:new`, `command:reset`, `command:stop`, `gateway:startup`
+
+### Plugin Lifecycle Hooks (agent and tool events)
+
+Use `api.on()` for agent lifecycle and tool execution events:
+
+```typescript
+export default function register(api) {
+  // Tool execution hook
+  api.on("after_tool_call", async (event, ctx) => {
+    api.logger.info(`Tool called: ${event.toolName}`);
+    api.logger.info(`Duration: ${event.durationMs}ms`);
+  });
+
+  // Prompt injection hook
+  api.on("before_prompt_build", async (event, ctx) => {
+    return {
+      prependContext: "Additional context for this turn",
+    };
+  });
+}
+```
+
+Common lifecycle hooks:
+
+- `before_tool_call` / `after_tool_call` — tool execution
+- `before_prompt_build` — inject context before agent runs
+- `message_received` / `message_sent` — message events
+- `session_start` / `session_end` — session lifecycle
+- `before_compaction` / `after_compaction` — memory compaction
+
+See [Plugin Internals](/plugins/architecture#provider-runtime-hooks) for the complete hook list.
+
+### Common mistake
+
+```typescript
+// ❌ Wrong: using registerHook for lifecycle events
+api.registerHook("after_tool_call", handler);
+
+// ✅ Correct: use api.on() for lifecycle events
+api.on("after_tool_call", async (event, ctx) => {
+  // event contains tool execution details
+  // ctx contains agent/session context
+});
+```
+
+**Important**: Lifecycle hooks like `before_tool_call`, `after_tool_call`, and `before_prompt_build` must use `api.on()`, not `api.registerHook()`.
+
 ## Related
 
 - [Building Plugins](/plugins/building-plugins) — create your own plugin

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -226,21 +226,21 @@ export default definePluginEntry({
 
 Common registration methods:
 
-| Method                               | What it registers    |
-| ------------------------------------ | -------------------- |
-| `registerProvider`                   | Model provider (LLM) |
-| `registerChannel`                    | Chat channel         |
-| `registerTool`                       | Agent tool           |
-| `registerHook`                       | Command / gateway hooks|
-| `on(...)`                            | Agent lifecycle hooks|
-| `registerSpeechProvider`             | Text-to-speech / STT |
-| `registerMediaUnderstandingProvider` | Image/audio analysis |
-| `registerImageGenerationProvider`    | Image generation     |
-| `registerWebSearchProvider`          | Web search           |
-| `registerHttpRoute`                  | HTTP endpoint        |
-| `registerCommand` / `registerCli`    | CLI commands         |
-| `registerContextEngine`              | Context engine       |
-| `registerService`                    | Background service   |
+| Method                               | What it registers       |
+| ------------------------------------ | ----------------------- |
+| `registerProvider`                   | Model provider (LLM)    |
+| `registerChannel`                    | Chat channel            |
+| `registerTool`                       | Agent tool              |
+| `registerHook`                       | Command / gateway hooks |
+| `on(...)`                            | Agent lifecycle hooks   |
+| `registerSpeechProvider`             | Text-to-speech / STT    |
+| `registerMediaUnderstandingProvider` | Image/audio analysis    |
+| `registerImageGenerationProvider`    | Image generation        |
+| `registerWebSearchProvider`          | Web search              |
+| `registerHttpRoute`                  | HTTP endpoint           |
+| `registerCommand` / `registerCli`    | CLI commands            |
+| `registerContextEngine`              | Context engine          |
+| `registerService`                    | Background service      |
 
 ## Hook systems
 


### PR DESCRIPTION
## Summary

Clarifies the distinction between two plugin hook registration methods that previously caused confusion.

## Changes

- Added "Hook systems" section to plugin documentation
- Explained difference between `api.registerHook()` and `api.on()`
- Provided practical examples for both hook types
- Added a "Common mistakes" section

## Motivation

While developing a plugin I initially confused these two APIs.
This clarification may help other plugin authors.

Lifecycle hooks such as `after_tool_call` must use `api.on()`, which may not be obvious from the current documentation.

## Notes

No functional changes.  
Documentation only.