### PR TITLE
fix(launchd): re-bootstrap LaunchAgent when kickstart failure leaves service unloaded

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -20,6 +20,7 @@ const state = vi.hoisted(() => ({
   bootstrapError: "",
   kickstartError: "",
   kickstartFailuresRemaining: 0,
+  printNotLoadedRemaining: 0,
   dirs: new Set<string>(),
   dirModes: new Map<string, number>(),
   files: new Map<string, string>(),
@@ -72,6 +73,10 @@ vi.mock("./exec-file.js", () => ({
       return { stdout: state.listOutput, stderr: "", code: 0 };
     }
     if (call[0] === "print") {
+      if (state.printNotLoadedRemaining > 0) {
+        state.printNotLoadedRemaining -= 1;
+        return { stdout: "", stderr: "Could not find service", code: 113 };
+      }
       return { stdout: state.printOutput, stderr: "", code: 0 };
     }
     if (call[0] === "bootstrap" && state.bootstrapError) {
@@ -154,6 +159,7 @@ beforeEach(() => {
   state.bootstrapError = "";
   state.kickstartError = "";
   state.kickstartFailuresRemaining = 0;
+  state.printNotLoadedRemaining = 0;
   state.dirs.clear();
   state.dirModes.clear();
   state.files.clear();
@@ -414,6 +420,46 @@ describe("launchd install", () => {
       }),
     ).rejects.toThrow("launchctl kickstart failed: Input/output error");
 
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
+    expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
+  });
+
+  it("re-bootstraps when kickstart failure leaves the service unloaded (#52208)", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.kickstartError = "Input/output error";
+    state.kickstartFailuresRemaining = 1;
+    // After kickstart fails, launchd may remove the service. Simulate print
+    // returning "not loaded" for the ensureLaunchAgentLoadedAfterFailure probe,
+    // then succeeding after re-bootstrap.
+    state.printNotLoadedRemaining = 1;
+
+    await expect(
+      restartLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+      }),
+    ).rejects.toThrow("launchctl kickstart failed: Input/output error");
+
+    // The fix should have detected the unloaded state and re-bootstrapped.
+    expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(true);
+    expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(true);
+  });
+
+  it("skips re-bootstrap when kickstart fails but service is still loaded (#52208)", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.kickstartError = "Input/output error";
+    state.kickstartFailuresRemaining = 1;
+    // print succeeds → service is still loaded, no re-bootstrap needed
+    state.printNotLoadedRemaining = 0;
+
+    await expect(
+      restartLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+      }),
+    ).rejects.toThrow("launchctl kickstart failed: Input/output error");
+
+    // Should NOT have called enable/bootstrap since service is still loaded.
     expect(state.launchctlCalls.some((call) => call[0] === "enable")).toBe(false);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
   });

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -527,6 +527,37 @@ export async function installLaunchAgent({
   return { plistPath };
 }
 
+/**
+ * Attempt to ensure the LaunchAgent remains loaded after a failed kickstart.
+ *
+ * A failed `launchctl kickstart -k` can cause launchd to mark the service
+ * inactive and remove it (#52208). If that happens, re-bootstrap so the
+ * service stays managed even though the restart itself failed.
+ */
+async function ensureLaunchAgentLoadedAfterFailure(params: {
+  domain: string;
+  serviceTarget: string;
+  plistPath: string;
+}): Promise<void> {
+  const probe = await execLaunchctl(["print", params.serviceTarget]);
+  if (probe.code === 0) {
+    // Service is still loaded — nothing to repair.
+    return;
+  }
+  // Service was removed/unloaded. Try to re-bootstrap it so it stays managed.
+  try {
+    await bootstrapLaunchAgentOrThrow({
+      domain: params.domain,
+      serviceTarget: params.serviceTarget,
+      plistPath: params.plistPath,
+      actionHint: "openclaw gateway start",
+    });
+  } catch {
+    // Best-effort: if re-bootstrap also fails we still throw the original
+    // kickstart error below, but at least we tried.
+  }
+}
+
 export async function restartLaunchAgent({
   stdout,
   env,
@@ -565,6 +596,10 @@ export async function restartLaunchAgent({
   }
 
   if (!isLaunchctlNotLoaded(start)) {
+    // kickstart failed for a reason other than "not loaded". A failed kickstart
+    // can cause launchd to mark the service inactive and remove it (#52208).
+    // Re-bootstrap the service so it remains managed before propagating the error.
+    await ensureLaunchAgentLoadedAfterFailure({ domain, serviceTarget, plistPath });
     throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
   }
 
@@ -578,6 +613,9 @@ export async function restartLaunchAgent({
 
   const retry = await execLaunchctl(["kickstart", "-k", serviceTarget]);
   if (retry.code !== 0) {
+    // Retry kickstart also failed after bootstrap. Ensure the service stays
+    // loaded even though the restart itself could not complete (#52208).
+    await ensureLaunchAgentLoadedAfterFailure({ domain, serviceTarget, plistPath });
     throw new Error(`launchctl kickstart failed: ${retry.stderr || retry.stdout}`.trim());
   }
   writeLaunchAgentActionLine(stdout, "Restarted LaunchAgent", serviceTarget);


### PR DESCRIPTION
## Summary

Fixes #52208

When `launchctl kickstart -k` fails during `openclaw gateway start` on macOS, launchd can mark the service as inactive and remove it. Previously, the error was thrown without checking whether the service was still loaded, leaving the LaunchAgent in an unmanaged state with no automatic recovery — the gateway stayed down until manual intervention.

## Changes

### `src/daemon/launchd.ts`
- Added `ensureLaunchAgentLoadedAfterFailure()` helper that probes the service with `launchctl print` after a kickstart failure, and attempts to re-bootstrap if the service was removed/unloaded
- Applied this guard in both error paths of `restartLaunchAgent()`:
  1. When kickstart fails with a non-"not loaded" error (the primary bug path)
  2. When the retry kickstart after bootstrap also fails

### `src/daemon/launchd.test.ts`
- Added test: "re-bootstraps when kickstart failure leaves the service unloaded (#52208)" — verifies that `enable` + `bootstrap` are called when `launchctl print` shows the service was removed after a failed kickstart
- Added test: "skips re-bootstrap when kickstart fails but service is still loaded (#52208)" — verifies no unnecessary re-bootstrap when the service remains loaded despite the kickstart failure
- Added `printNotLoadedRemaining` mock state to simulate launchd removing the service

## Behavior

| Scenario | Before | After |
|---|---|---|
| kickstart fails, service removed by launchd | Service left unloaded, gateway down until manual fix | Re-bootstraps service, then throws error (service stays managed) |
| kickstart fails, service still loaded | Throws error (correct) | Throws error, no unnecessary re-bootstrap (correct) |
| Re-bootstrap also fails | N/A | Best-effort: still throws original kickstart error |

All 27 tests pass.