### PR TITLE
fix: session_status reports effective channel model override instead of default

### DIFF
--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -438,8 +438,39 @@ export function buildStatusMessage(args: StatusArgs): string {
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const selectedProvider = entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
-  const selectedModel = entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
+  let selectedProvider = entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
+  let selectedModel = entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
+
+  // When no per-session override exists, apply channel model overrides so
+  // session_status reports the effective model instead of the agent default.
+  let channelModelApplied = false;
+  if (args.config && entry && !entry.providerOverride?.trim() && !entry.modelOverride?.trim()) {
+    const channelOverride = resolveChannelModelOverride({
+      cfg: args.config,
+      channel: entry.channel ?? entry.origin?.provider,
+      groupId: entry.groupId,
+      groupChannel: entry.groupChannel,
+      groupSubject: entry.subject,
+      parentSessionKey: args.parentSessionKey,
+    });
+    if (channelOverride) {
+      const aliasIndex = buildModelAliasIndex({
+        cfg: args.config,
+        defaultProvider: DEFAULT_PROVIDER,
+      });
+      const resolvedOverride = resolveModelRefFromString({
+        raw: channelOverride.model,
+        defaultProvider: DEFAULT_PROVIDER,
+        aliasIndex,
+      });
+      if (resolvedOverride) {
+        selectedProvider = resolvedOverride.ref.provider;
+        selectedModel = resolvedOverride.ref.model;
+        channelModelApplied = true;
+      }
+    }
+  }
+
   const modelRefs = resolveSelectedAndActiveModel({
     selectedProvider,
     selectedModel,
@@ -612,44 +643,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   const costLabel = showCost && hasUsage ? formatUsd(cost) : undefined;
 
   const selectedAuthLabel = selectedAuthLabelValue ? ` · 🔑 ${selectedAuthLabelValue}` : "";
-  const channelModelNote = (() => {
-    if (!args.config || !entry) {
-      return undefined;
-    }
-    if (entry.modelOverride?.trim() || entry.providerOverride?.trim()) {
-      return undefined;
-    }
-    const channelOverride = resolveChannelModelOverride({
-      cfg: args.config,
-      channel: entry.channel ?? entry.origin?.provider,
-      groupId: entry.groupId,
-      groupChannel: entry.groupChannel,
-      groupSubject: entry.subject,
-      parentSessionKey: args.parentSessionKey,
-    });
-    if (!channelOverride) {
-      return undefined;
-    }
-    const aliasIndex = buildModelAliasIndex({
-      cfg: args.config,
-      defaultProvider: DEFAULT_PROVIDER,
-    });
-    const resolvedOverride = resolveModelRefFromString({
-      raw: channelOverride.model,
-      defaultProvider: DEFAULT_PROVIDER,
-      aliasIndex,
-    });
-    if (!resolvedOverride) {
-      return undefined;
-    }
-    if (
-      resolvedOverride.ref.provider !== selectedProvider ||
-      resolvedOverride.ref.model !== selectedModel
-    ) {
-      return undefined;
-    }
-    return "channel override";
-  })();
+  const channelModelNote = channelModelApplied ? "channel override" : undefined;
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
   const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`;
   const showFallbackAuth = activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;


### PR DESCRIPTION
## Summary

When `channels.modelByChannel` is configured for a channel (e.g. IRC `#dev` → `openai-codex/gpt-5.4`), `session_status` now correctly reports the effective channel-overridden model instead of the default agent model.

## Problem

`buildStatusMessage` resolved the selected model from:
1. `sessionEntry.providerOverride` / `modelOverride` (per-session overrides)
2. The agent default model

It completely ignored `channels.modelByChannel` overrides when computing the displayed model. The channel override was only used to append a "channel override" annotation note — but the `🧠 Model:` line still showed the default agent model.

This meant that for an IRC channel configured with `openai-codex/gpt-5.4`, the actual model routing was correct (transcript/API calls used the right model), but `session_status` reported the default `anthropic/claude-sonnet-4-6`.

## Fix

Moved the channel model override resolution to happen **before** the selected model is used to build model refs and the status card. When no per-session override exists, the channel model override is now applied to `selectedProvider`/`selectedModel`, so the status card reflects the actual effective model.

Also simplified the `channelModelNote` computation — replaced the redundant IIFE (which re-resolved the channel override) with a simple boolean flag since the override is already resolved earlier.

## Changes

- `src/auto-reply/status.ts`: Resolve channel model override early and apply to `selectedProvider`/`selectedModel` when no per-session override exists

Fixes #52189