### PR TITLE
fix(failover): classify HTTP 500 billing errors as billing, not timeout

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -860,4 +860,19 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
   });
+  it("classifies HTTP 500 with billing message as billing, not timeout (#52185)", () => {
+    // MiniMax returns HTTP 500 with "insufficient balance" (code 1008)
+    expect(classifyFailoverReason("500 insufficient balance")).toBe("billing");
+    expect(
+      classifyFailoverReason('500 {"error":{"code":1008,"message":"insufficient balance"}}'),
+    ).toBe("billing");
+    // HTTP status variant
+    expect(classifyFailoverReasonFromHttpStatus(500, "insufficient balance")).toBe("billing");
+    expect(
+      classifyFailoverReasonFromHttpStatus(500, '{"code":1008,"message":"insufficient balance"}'),
+    ).toBe("billing");
+    // Plain 500 without billing signal stays timeout
+    expect(classifyFailoverReasonFromHttpStatus(500, "internal server error")).toBe("timeout");
+    expect(classifyFailoverReason("500 internal server error")).toBe("timeout");
+  });
 });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -874,5 +874,10 @@ describe("classifyFailoverReason", () => {
     // Plain 500 without billing signal stays timeout
     expect(classifyFailoverReasonFromHttpStatus(500, "internal server error")).toBe("timeout");
     expect(classifyFailoverReason("500 internal server error")).toBe("timeout");
+    // HTTP 500 with overload signal preserves overloaded classification
+    expect(classifyFailoverReasonFromHttpStatus(500, "The model is overloaded")).toBe("overloaded");
+    expect(
+      classifyFailoverReasonFromHttpStatus(500, "service unavailable due to capacity limits"),
+    ).toBe("overloaded");
   });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -439,6 +439,14 @@ export function classifyFailoverReasonFromHttpStatus(
   if (status === 408) {
     return "timeout";
   }
+  if (status === 500) {
+    // Some providers (e.g. MiniMax) return billing/balance errors under HTTP 500;
+    // check the message before falling through to default handling.
+    if (message && isBillingErrorMessage(message)) {
+      return "billing";
+    }
+    return "timeout";
+  }
   if (status === 503) {
     if (message && isOverloadedErrorMessage(message)) {
       return "overloaded";
@@ -886,6 +894,11 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
     const status = extractLeadingHttpStatus(raw.trim());
     if (status?.code === 529) {
       return "overloaded";
+    }
+    // Some providers (e.g. MiniMax) return billing/balance errors under HTTP 500;
+    // do not let the transient-5xx fallback mask an explicit billing signal.
+    if (isBillingErrorMessage(raw)) {
+      return "billing";
     }
     // Treat remaining transient 5xx provider failures as retryable transport issues.
     return "timeout";

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -445,6 +445,9 @@ export function classifyFailoverReasonFromHttpStatus(
     if (message && isBillingErrorMessage(message)) {
       return "billing";
     }
+    if (message && isOverloadedErrorMessage(message)) {
+      return "overloaded";
+    }
     return "timeout";
   }
   if (status === 503) {


### PR DESCRIPTION
## Summary
- Providers like MiniMax return HTTP 500 with `insufficient balance` (code 1008) for billing exhaustion. Previously these were misclassified as `timeout` because the transient-5xx check ran before the billing pattern matcher, causing 4x retries against the same exhausted account instead of triggering the configured fallback model.
- Root cause: `isTransientHttpError()` matches 500-class status codes and returns `"timeout"` before `isBillingErrorMessage()` ever runs. Same gap exists in `classifyFailoverReasonFromHttpStatus()` which had no explicit HTTP 500 handler.

Fixes #52185

## Test plan
- [x] `pnpm test -- src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts` — 72/72 pass
- [x] `500 insufficient balance` → classified as `billing`
- [x] `500 {"error":{"code":1008,"message":"insufficient balance"}}` → `billing`
- [x] `classifyFailoverReasonFromHttpStatus(500, "insufficient balance")` → `billing`
- [x] Plain `500 internal server error` still classified as `timeout` (no regression)
- [x] `pnpm check` passes (format, lint, typecheck)