### PR TITLE
plugin-sdk: expose native command + skill listing helpers for channel plugins

### DIFF
--- a/src/plugin-sdk/index.test.ts
+++ b/src/plugin-sdk/index.test.ts
@@ -43,6 +43,15 @@ async function collectRuntimeExports(filePath: string, seen = new Set<string>())
 }
 
 describe("plugin-sdk exports", () => {
+  it("exposes native command listing helpers for plugins", async () => {
+    const runtimeExports = await collectRuntimeExports(path.join(import.meta.dirname, "index.ts"));
+    expect(runtimeExports.has("listNativeCommandSpecs")).toBe(true);
+    expect(runtimeExports.has("listNativeCommandSpecsForConfig")).toBe(true);
+    expect(runtimeExports.has("listSkillCommandsForAgents")).toBe(true);
+    expect(runtimeExports.has("listSkillCommandsForWorkspace")).toBe(true);
+    expect(runtimeExports.has("getPluginCommandSpecs")).toBe(true);
+  });
+
   it("does not expose runtime modules", async () => {
     const runtimeExports = await collectRuntimeExports(path.join(import.meta.dirname, "index.ts"));
     const forbidden = [
@@ -94,6 +103,11 @@ describe("plugin-sdk exports", () => {
       "buildOpenAIImageGenerationProvider",
       "delegateCompactionToRuntime",
       "emptyPluginConfigSchema",
+      "getPluginCommandSpecs",
+      "listNativeCommandSpecs",
+      "listNativeCommandSpecsForConfig",
+      "listSkillCommandsForAgents",
+      "listSkillCommandsForWorkspace",
       "onDiagnosticEvent",
       "registerContextEngine",
     ]);

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -60,9 +60,17 @@ export type { OpenClawConfig as ClawdbotConfig } from "../config/config.js";
 export * from "./image-generation.js";
 export type { SecretInput, SecretRef } from "../config/types.secrets.js";
 export type { RuntimeEnv } from "../runtime.js";
+export type { WizardPrompter } from "../wizard/prompts.js";
+export type { NativeCommandSpec } from "../auto-reply/commands-registry.js";
+export { listNativeCommandSpecs, listNativeCommandSpecsForConfig } from "./native-command-specs.js";
+export type { SkillCommandSpec } from "../agents/skills.js";
+export {
+  listSkillCommandsForAgents,
+  listSkillCommandsForWorkspace,
+} from "../auto-reply/skill-commands.js";
+export { getPluginCommandSpecs } from "../plugins/commands.js";
 export type { HookEntry } from "../hooks/types.js";
 export type { ReplyPayload } from "../auto-reply/types.js";
-export type { WizardPrompter } from "../wizard/prompts.js";
 export type { ContextEngineFactory } from "../context-engine/registry.js";
 export type { DiagnosticEventPayload } from "../infra/diagnostic-events.js";
 export type {

--- a/src/plugin-sdk/native-command-specs.ts
+++ b/src/plugin-sdk/native-command-specs.ts
@@ -1,0 +1,120 @@
+import type { SkillCommandSpec } from "../agents/skills.js";
+import type {
+  ChatCommandDefinition,
+  NativeCommandSpec,
+} from "../auto-reply/commands-registry.types.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { getChatCommands } from "../auto-reply/commands-registry.data.js";
+import { isCommandFlagEnabled } from "../config/commands.js";
+
+function buildSkillCommandDefinitions(skillCommands?: SkillCommandSpec[]): ChatCommandDefinition[] {
+  if (!skillCommands || skillCommands.length === 0) {
+    return [];
+  }
+  return skillCommands.map((spec) => ({
+    key: `skill:${spec.skillName}`,
+    nativeName: spec.name,
+    description: spec.description,
+    textAliases: [`/${spec.name}`],
+    acceptsArgs: true,
+    argsParsing: "none",
+    scope: "both",
+  }));
+}
+
+function listChatCommands(params?: {
+  skillCommands?: SkillCommandSpec[];
+}): ChatCommandDefinition[] {
+  const commands = getChatCommands();
+  if (!params?.skillCommands?.length) {
+    return [...commands];
+  }
+  return [...commands, ...buildSkillCommandDefinitions(params.skillCommands)];
+}
+
+function isCommandEnabled(cfg: OpenClawConfig, commandKey: string): boolean {
+  if (commandKey === "config") {
+    return isCommandFlagEnabled(cfg, "config");
+  }
+  if (commandKey === "mcp") {
+    return isCommandFlagEnabled(cfg, "mcp");
+  }
+  if (commandKey === "plugins") {
+    return isCommandFlagEnabled(cfg, "plugins");
+  }
+  if (commandKey === "debug") {
+    return isCommandFlagEnabled(cfg, "debug");
+  }
+  if (commandKey === "bash") {
+    return isCommandFlagEnabled(cfg, "bash");
+  }
+  return true;
+}
+
+function listChatCommandsForConfig(
+  cfg: OpenClawConfig,
+  params?: { skillCommands?: SkillCommandSpec[] },
+): ChatCommandDefinition[] {
+  const base = getChatCommands().filter((command) => isCommandEnabled(cfg, command.key));
+  if (!params?.skillCommands?.length) {
+    return base;
+  }
+  return [...base, ...buildSkillCommandDefinitions(params.skillCommands)];
+}
+
+const NATIVE_NAME_OVERRIDES: Record<string, Record<string, string>> = {
+  discord: {
+    tts: "voice",
+  },
+  slack: {
+    status: "agentstatus",
+  },
+};
+
+function resolveNativeName(command: ChatCommandDefinition, provider?: string): string | undefined {
+  if (!command.nativeName) {
+    return undefined;
+  }
+  if (provider) {
+    const override = NATIVE_NAME_OVERRIDES[provider]?.[command.key];
+    if (override) {
+      return override;
+    }
+  }
+  return command.nativeName;
+}
+
+function toNativeCommandSpec(command: ChatCommandDefinition, provider?: string): NativeCommandSpec {
+  return {
+    name: resolveNativeName(command, provider) ?? command.key,
+    description: command.description,
+    acceptsArgs: Boolean(command.acceptsArgs),
+    args: command.args,
+  };
+}
+
+function listNativeSpecsFromCommands(
+  commands: ChatCommandDefinition[],
+  provider?: string,
+): NativeCommandSpec[] {
+  return commands
+    .filter((command) => command.scope !== "text" && command.nativeName)
+    .map((command) => toNativeCommandSpec(command, provider));
+}
+
+export function listNativeCommandSpecs(params?: {
+  skillCommands?: SkillCommandSpec[];
+  provider?: string;
+}): NativeCommandSpec[] {
+  return listNativeSpecsFromCommands(
+    listChatCommands({ skillCommands: params?.skillCommands }),
+    params?.provider,
+  );
+}
+
+export function listNativeCommandSpecsForConfig(
+  cfg: OpenClawConfig,
+  params?: { skillCommands?: SkillCommandSpec[]; provider?: string },
+): NativeCommandSpec[] {
+  return listNativeSpecsFromCommands(listChatCommandsForConfig(cfg, params), params?.provider);
+}


### PR DESCRIPTION
## Summary
- export native command listing helpers from openclaw/plugin-sdk
- export skill command listing helpers from openclaw/plugin-sdk
- export plugin command specs helper from openclaw/plugin-sdk
- add plugin-sdk export test coverage for the new helpers

## Why
Inline channel plugin needs the same command source used by native providers (Telegram/Slack/Discord) so startup native command sync can match core behavior, including skill and plugin command registration.

## Exposed API
- listNativeCommandSpecs
- listNativeCommandSpecsForConfig
- listSkillCommandsForAgents
- listSkillCommandsForWorkspace
- getPluginCommandSpecs

## Validation
- pnpm vitest run src/plugin-sdk/index.test.ts src/auto-reply/commands-registry.test.ts src/auto-reply/skill-commands.test.ts