### PR TITLE
fix(ui): make ui:build work on Windows

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -61,6 +61,16 @@ export function shouldUseShellForCommand(cmd, platform = process.platform) {
   return WINDOWS_SHELL_EXTENSIONS.has(extension);
 }
 
+export function quoteWindowsShellCommand(cmd, platform = process.platform) {
+  if (!shouldUseShellForCommand(cmd, platform) || !/\s/.test(cmd)) {
+    return cmd;
+  }
+  if (cmd.startsWith('"') && cmd.endsWith('"')) {
+    return cmd;
+  }
+  return `"${cmd}"`;
+}
+
 export function assertSafeWindowsShellArgs(args, platform = process.platform) {
   if (platform !== "win32") {
     return;
@@ -91,8 +101,9 @@ function createSpawnOptions(cmd, args, envOverride) {
 
 function run(cmd, args) {
   let child;
+  const actualCmd = quoteWindowsShellCommand(cmd);
   try {
-    child = spawn(cmd, args, createSpawnOptions(cmd, args));
+    child = spawn(actualCmd, args, createSpawnOptions(cmd, args));
   } catch (err) {
     console.error(`Failed to launch ${cmd}:`, err);
     process.exit(1);
@@ -112,8 +123,9 @@ function run(cmd, args) {
 
 function runSync(cmd, args, envOverride) {
   let result;
+  const actualCmd = quoteWindowsShellCommand(cmd);
   try {
-    result = spawnSync(cmd, args, createSpawnOptions(cmd, args, envOverride));
+    result = spawnSync(actualCmd, args, createSpawnOptions(cmd, args, envOverride));
   } catch (err) {
     console.error(`Failed to launch ${cmd}:`, err);
     process.exit(1);
@@ -184,10 +196,7 @@ export function main(argv = process.argv.slice(2)) {
   }
 
   if (!depsInstalled(action === "test" ? "test" : "build")) {
-    const installEnv =
-      action === "build" ? { ...process.env, NODE_ENV: "production" } : process.env;
-    const installArgs = action === "build" ? ["install", "--prod"] : ["install"];
-    runSync(runner.cmd, installArgs, installEnv);
+    runSync(runner.cmd, ["install"]);
   }
 
   run(runner.cmd, ["run", script, ...rest]);

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { assertSafeWindowsShellArgs, shouldUseShellForCommand } from "../../scripts/ui.js";
+import {
+  assertSafeWindowsShellArgs,
+  quoteWindowsShellCommand,
+  shouldUseShellForCommand,
+} from "../../scripts/ui.js";
 
 describe("scripts/ui windows spawn behavior", () => {
   it("enables shell for Windows command launchers that require cmd.exe", () => {
@@ -12,6 +16,16 @@ describe("scripts/ui windows spawn behavior", () => {
   it("does not enable shell for non-shell launchers", () => {
     expect(shouldUseShellForCommand("C:\\Program Files\\nodejs\\node.exe", "win32")).toBe(false);
     expect(shouldUseShellForCommand("/usr/local/bin/pnpm", "linux")).toBe(false);
+  });
+
+  it("quotes Windows shell launcher paths that contain spaces", () => {
+    expect(quoteWindowsShellCommand("C:\\Program Files\\pnpm\\pnpm.cmd", "win32")).toBe(
+      '"C:\\Program Files\\pnpm\\pnpm.cmd"',
+    );
+    expect(quoteWindowsShellCommand("C:\\tools\\pnpm.cmd", "win32")).toBe("C:\\tools\\pnpm.cmd");
+    expect(quoteWindowsShellCommand("C:\\Program Files\\nodejs\\node.exe", "win32")).toBe(
+      "C:\\Program Files\\nodejs\\node.exe",
+    );
   });
 
   it("allows safe forwarded args when shell mode is required on Windows", () => {


### PR DESCRIPTION
## Summary

- Problem: `pnpm ui:build` can fail on Windows when the resolved `pnpm.cmd` path contains spaces, because `scripts/ui.js` launches shell-backed commands without quoting the executable path.
- Additional issue found while reproducing on a clean checkout: the build auto-install path used `pnpm install --prod`, which skips `vite` and leaves the UI build unable to start.
- What changed: quote Windows shell launcher paths before `spawn`/`spawnSync`, and make the build auto-install path install the full UI dependency set instead of production-only deps.
- Scope boundary: no UI app code changed; this only touches the build wrapper script and its tests.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52282

## User-visible / Behavior Changes

On Windows, `pnpm ui:build` now works when the package manager lives under a path with spaces (for example `C:\Program Files\...`). On clean checkouts, the command also installs the build-time UI dependencies it needs before invoking Vite.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node v20.19.0 / pnpm v10.32.1
- Relevant command: `pnpm ui:build`

### Expected

- `pnpm ui:build` should launch the resolved package-manager command correctly on Windows.
- The command should be able to install the UI dependencies required for the build and complete successfully.

### Actual before fix

- On affected Windows setups, shell-backed launchers under paths with spaces fail before running: `'D:\Program' is not recognized ...`
- On a clean checkout in my local reproduction, the same code path also installed with `--prod`, so `vite build` failed because `vite` was absent.

## Evidence

- [x] Failing repro before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers

Commands run:

- `pnpm exec vitest run --config vitest.config.ts test/scripts/ui.test.ts`
- `pnpm ui:build`

Observed after fix:

- `test/scripts/ui.test.ts`: `1 passed`, `6 passed` tests
- `pnpm ui:build`: completed successfully and emitted `dist/control-ui/*`

## Human Verification

What I personally verified:

- The Windows shell launcher path is now quoted when needed.
- `pnpm ui:build` succeeds locally on a fresh worktree after the script changes.
- Non-shell launchers remain unquoted.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert this change quickly: revert this commit
- Known bad symptoms reviewers should watch for: none beyond the previous `ui:build` failures returning

## Risks and Mitigations

- Risk: quoting shell launchers on Windows could affect commands that were already quoted.
  - Mitigation: the helper preserves already-quoted commands and only touches shell-backed launchers with whitespace in the path.
- Risk: installing full deps for `build` may do more work than the previous production-only install.
  - Mitigation: this is only used when UI deps are missing, and the build already requires `vite`/other dev-time tooling to succeed.