### PR TITLE
fix(tts): add inbound and tagged modes to /tts help output

### DIFF
--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -48,7 +48,10 @@ function ttsUsage(): ReplyPayload {
       `🔊 **TTS (Text-to-Speech) Help**\n\n` +
       `**Commands:**\n` +
       `• /tts on — Enable automatic TTS for replies\n` +
+      `• /tts always — Enable automatic TTS for replies (alias for on)\n` +
       `• /tts off — Disable TTS\n` +
+      `• /tts inbound — Only reply with audio when you send a voice note\n` +
+      `• /tts tagged — Only reply with audio when reply includes [[tts]] tags\n` +
       `• /tts status — Show current settings\n` +
       `• /tts provider [name] — View/change provider\n` +
       `• /tts limit [number] — View/change text limit\n` +


### PR DESCRIPTION
## Problem

`/tts inbound` and `/tts tagged` are documented in `docs/tts.md` and listed in the slash-commands reference, but are missing from the in-app `/tts help` text.

Users who type `/tts help` see only `on`, `off`, `status`, `provider`, `limit`, `summary`, and `audio` — with no indication that `inbound` or `tagged` modes exist.

## Fix

Added `inbound` and `tagged` to the `ttsUsage()` Commands section with plain-English descriptions:

- `/tts inbound` — Only reply with audio when you send a voice note  
- `/tts tagged` — Only reply with audio when reply includes `[[tts]]` tags

Also surfaced the `always` alias for `on` for completeness.

## Why this matters

`inbound` mode is particularly useful — it makes TTS feel natural by mirroring the user's input format (voice in → voice out, text in → text out). But there's no way to discover it without reading external docs.