### PR TITLE
feat: auto-cleanup stale session lock files on gateway startup

### DIFF
--- a/src/agents/session-lock-startup-cleanup.test.ts
+++ b/src/agents/session-lock-startup-cleanup.test.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the config module before importing the module under test
+vi.mock("../config/paths.js", () => ({
+  resolveStateDir: vi.fn(),
+}));
+
+import { resolveStateDir } from "../config/paths.js";
+import { __testing } from "./session-lock-startup-cleanup.js";
+
+const { cleanAllAgentSessionLocks } = __testing;
+
+describe("session-lock-startup-cleanup", () => {
+  let tmpDir: string;
+  let agentsDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-startup-"));
+    agentsDir = path.join(tmpDir, "agents");
+    await fs.mkdir(agentsDir, { recursive: true });
+
+    // Configure mock to use our temp directory
+    vi.mocked(resolveStateDir).mockReturnValue(tmpDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("cleans stale locks from multiple agent sessions directories", async () => {
+    const nowMs = Date.now();
+
+    // Create two agents with sessions directories
+    const agent1Sessions = path.join(agentsDir, "main", "sessions");
+    const agent2Sessions = path.join(agentsDir, "test-agent", "sessions");
+    await fs.mkdir(agent1Sessions, { recursive: true });
+    await fs.mkdir(agent2Sessions, { recursive: true });
+
+    // Create stale lock (dead PID) in agent1
+    const staleLock1 = path.join(agent1Sessions, "session-a.jsonl.lock");
+    await fs.writeFile(
+      staleLock1,
+      JSON.stringify({
+        pid: 999_999, // Non-existent PID
+        createdAt: new Date(nowMs - 120_000).toISOString(),
+      }),
+      "utf8",
+    );
+
+    // Create stale lock (old timestamp) in agent2
+    const staleLock2 = path.join(agent2Sessions, "session-b.jsonl.lock");
+    await fs.writeFile(
+      staleLock2,
+      JSON.stringify({
+        pid: process.pid, // Alive but too old
+        createdAt: new Date(nowMs - 120_000).toISOString(),
+      }),
+      "utf8",
+    );
+
+    // Create fresh lock (should NOT be removed)
+    const freshLock = path.join(agent1Sessions, "session-c.jsonl.lock");
+    await fs.writeFile(
+      freshLock,
+      JSON.stringify({
+        pid: process.pid,
+        createdAt: new Date(nowMs - 1_000).toISOString(),
+      }),
+      "utf8",
+    );
+
+    const result = await cleanAllAgentSessionLocks({
+      staleMs: 30_000,
+    });
+
+    expect(result.totalCleaned).toBe(2);
+    expect(result.agentsCleaned.toSorted()).toEqual(["main", "test-agent"]);
+
+    // Verify stale locks are removed
+    await expect(fs.access(staleLock1)).rejects.toThrow();
+    await expect(fs.access(staleLock2)).rejects.toThrow();
+
+    // Verify fresh lock is preserved
+    await expect(fs.access(freshLock)).resolves.toBeUndefined();
+  });
+
+  it("handles missing agents directory gracefully", async () => {
+    // Remove the agents directory
+    await fs.rm(agentsDir, { recursive: true, force: true });
+
+    const result = await cleanAllAgentSessionLocks({ staleMs: 30_000 });
+
+    expect(result.totalCleaned).toBe(0);
+    expect(result.agentsCleaned).toEqual([]);
+  });
+
+  it("handles agents without sessions directory", async () => {
+    // Create agent directory without sessions subdirectory
+    const agentDir = path.join(agentsDir, "no-sessions-agent");
+    await fs.mkdir(agentDir, { recursive: true });
+
+    const result = await cleanAllAgentSessionLocks({ staleMs: 30_000 });
+
+    expect(result.totalCleaned).toBe(0);
+    expect(result.agentsCleaned).toEqual([]);
+  });
+
+  it("skips non-directory entries in agents folder", async () => {
+    // Create a file instead of a directory
+    await fs.writeFile(path.join(agentsDir, "not-an-agent.txt"), "test");
+
+    const result = await cleanAllAgentSessionLocks({ staleMs: 30_000 });
+
+    expect(result.totalCleaned).toBe(0);
+    expect(result.agentsCleaned).toEqual([]);
+  });
+});

--- a/src/agents/session-lock-startup-cleanup.ts
+++ b/src/agents/session-lock-startup-cleanup.ts
@@ -1,0 +1,114 @@
+/**
+ * Startup cleanup for stale session lock files.
+ *
+ * After a gateway restart (especially SIGUSR1), lock files from the old process
+ * become stale — they reference dead PIDs. This module scans for and removes
+ * such stale locks on gateway startup.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/52289
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { cleanStaleLockFiles } from "./session-write-lock.js";
+
+const log = createSubsystemLogger("session-lock-startup-cleanup");
+
+/** Delay before cleanup to let the gateway finish bootstrapping. */
+const DEFAULT_CLEANUP_DELAY_MS = 2_000;
+
+/** Default threshold for considering a lock stale (30 minutes). */
+const DEFAULT_STALE_MS = 30 * 60 * 1000;
+
+/**
+ * Scan all agent sessions directories and clean stale lock files.
+ */
+async function cleanAllAgentSessionLocks(params: {
+  staleMs?: number;
+  log?: { warn?: (msg: string) => void; info?: (msg: string) => void };
+}): Promise<{ totalCleaned: number; agentsCleaned: string[] }> {
+  const stateDir = resolveStateDir();
+  const agentsDir = path.join(stateDir, "agents");
+  const staleMs = params.staleMs ?? DEFAULT_STALE_MS;
+
+  let entries: Awaited<ReturnType<typeof fs.readdir>> = [];
+  try {
+    entries = await fs.readdir(agentsDir, { withFileTypes: true });
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ENOENT") {
+      return { totalCleaned: 0, agentsCleaned: [] };
+    }
+    throw err;
+  }
+
+  let totalCleaned = 0;
+  const agentsCleaned: string[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const agentId = entry.name;
+    const sessionsDir = path.join(agentsDir, agentId, "sessions");
+
+    try {
+      const result = await cleanStaleLockFiles({
+        sessionsDir,
+        staleMs,
+        removeStale: true,
+        log: params.log,
+      });
+
+      if (result.cleaned.length > 0) {
+        totalCleaned += result.cleaned.length;
+        agentsCleaned.push(agentId);
+      }
+    } catch (err) {
+      // Skip agents whose sessions directory doesn't exist or is inaccessible
+      const code = (err as { code?: string }).code;
+      if (code !== "ENOENT" && code !== "EACCES") {
+        log.warn(`failed to clean locks for agent ${String(agentId)}: ${String(err)}`);
+      }
+    }
+  }
+
+  return { totalCleaned, agentsCleaned };
+}
+
+/**
+ * Schedule stale lock cleanup after gateway startup.
+ * Runs after a short delay to avoid interfering with critical startup tasks.
+ */
+export function scheduleStartupLockCleanup(params?: { delayMs?: number; staleMs?: number }): void {
+  const delayMs = params?.delayMs ?? DEFAULT_CLEANUP_DELAY_MS;
+  const staleMs = params?.staleMs ?? DEFAULT_STALE_MS;
+
+  setTimeout(() => {
+    void cleanAllAgentSessionLocks({
+      staleMs,
+      log: {
+        warn: (msg) => log.warn(msg),
+        info: (msg) => log.info(msg),
+      },
+    })
+      .then((result) => {
+        if (result.totalCleaned > 0) {
+          log.info(
+            `startup cleanup: removed ${result.totalCleaned} stale lock file(s) ` +
+              `from ${result.agentsCleaned.length} agent(s)`,
+          );
+        }
+      })
+      .catch((err) => {
+        log.warn(`startup lock cleanup failed: ${String(err)}`);
+      });
+  }, delayMs).unref?.();
+}
+
+export const __testing = {
+  cleanAllAgentSessionLocks,
+};

--- a/src/agents/session-lock-startup-cleanup.ts
+++ b/src/agents/session-lock-startup-cleanup.ts
@@ -68,7 +68,8 @@ async function cleanAllAgentSessionLocks(params: {
         agentsCleaned.push(agentId);
       }
     } catch (err) {
-      // Skip agents whose sessions directory doesn't exist or is inaccessible
+      // cleanStaleLockFiles handles ENOENT internally; this catch covers
+      // EACCES and any other unexpected errors to avoid killing the whole sweep.
       const code = (err as { code?: string }).code;
       if (code !== "ENOENT" && code !== "EACCES") {
         log.warn(`failed to clean locks for agent ${String(agentId)}: ${String(err)}`);

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -798,6 +798,18 @@ function restoreSubagentRunsOnce() {
         // Ignore import failures — orphan recovery is best-effort.
       },
     );
+
+    // Clean up stale session lock files from previous gateway instances.
+    // These accumulate after SIGUSR1 restarts and can trigger false alarms
+    // in `openclaw doctor`. Dynamic import for minimal startup overhead. (#52289)
+    void import("./session-lock-startup-cleanup.js").then(
+      ({ scheduleStartupLockCleanup }) => {
+        scheduleStartupLockCleanup();
+      },
+      () => {
+        // Ignore import failures — lock cleanup is best-effort.
+      },
+    );
   } catch {
     // ignore restore failures
   }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -764,6 +764,19 @@ function restoreSubagentRunsOnce() {
   }
   restoreAttempted = true;
   try {
+    // Clean up stale session lock files from previous gateway instances.
+    // This must run unconditionally (before early returns) because stale locks
+    // accumulate after SIGUSR1 restarts regardless of subagent state.
+    // Dynamic import for minimal startup overhead. (#52289)
+    void import("./session-lock-startup-cleanup.js").then(
+      ({ scheduleStartupLockCleanup }) => {
+        scheduleStartupLockCleanup();
+      },
+      () => {
+        // Ignore import failures — lock cleanup is best-effort.
+      },
+    );
+
     const restoredCount = restoreSubagentRunsFromDisk({
       runs: subagentRuns,
       mergeOnly: true,
@@ -796,18 +809,6 @@ function restoreSubagentRunsOnce() {
       },
       () => {
         // Ignore import failures — orphan recovery is best-effort.
-      },
-    );
-
-    // Clean up stale session lock files from previous gateway instances.
-    // These accumulate after SIGUSR1 restarts and can trigger false alarms
-    // in `openclaw doctor`. Dynamic import for minimal startup overhead. (#52289)
-    void import("./session-lock-startup-cleanup.js").then(
-      ({ scheduleStartupLockCleanup }) => {
-        scheduleStartupLockCleanup();
-      },
-      () => {
-        // Ignore import failures — lock cleanup is best-effort.
       },
     );
   } catch {


### PR DESCRIPTION
## Summary

After SIGUSR1 gateway restarts, session lock files from the previous process become stale — they reference dead PIDs. This accumulates over time and triggers false alarms in `openclaw doctor`.

## Changes

This PR adds automatic cleanup on gateway startup:

- **New module**: `src/agents/session-lock-startup-cleanup.ts`
  - `cleanAllAgentSessionLocks()`: scans all agent sessions directories
  - `scheduleStartupLockCleanup()`: schedules cleanup after a 2s delay
- **Integration**: called from `subagent-registry.ts` during gateway bootstrap
- Uses the existing `cleanStaleLockFiles()` from `session-write-lock.ts`

The cleanup runs with a short delay to avoid interfering with critical startup tasks, and failures are logged but do not block the gateway.

## Testing

- Added unit tests in `session-lock-startup-cleanup.test.ts`
- Tests cover: multiple agents, missing directories, non-directory entries

## Fixes

Fixes #52289