### PR TITLE
feat: support OpenAI built-in web search tools via extra params

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2370,4 +2370,42 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.prompt_cache_key).toBe("session-default");
     expect(payload.prompt_cache_retention).toBe("24h");
   });
+
+  it("injects OpenAI built-in web search tools for openai-responses payloads", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "qaq",
+      applyModelId: "gpt-5.4",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "qaq/gpt-5.4": {
+                params: {
+                  openaiWebSearch: true,
+                  openaiWebSearchToolType: "web_search",
+                  openaiWebSearchRequired: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      model: {
+        api: "openai-responses",
+        provider: "qaq",
+        id: "gpt-5.4",
+        baseUrl: "https://example-proxy.invalid/v1",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        tools: [{ type: "function", name: "ping", parameters: {} }],
+      },
+    });
+
+    expect(payload.tools).toEqual([
+      { type: "function", name: "ping", parameters: {} },
+      { type: "web_search" },
+    ]);
+    expect(payload.tool_choice).toBe("required");
+  });
 });

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2408,4 +2408,36 @@ describe("applyExtraParamsToAgent", () => {
     ]);
     expect(payload.tool_choice).toBe("required");
   });
+
+  it("deduplicates OpenAI built-in tools when multiple config paths resolve the same type", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "qaq",
+      applyModelId: "gpt-5.4",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "qaq/gpt-5.4": {
+                params: {
+                  openaiWebSearch: true,
+                  openaiWebSearchToolType: "web_search",
+                  openaiBuiltInTools: [{ type: "web_search" }],
+                },
+              },
+            },
+          },
+        },
+      },
+      model: {
+        api: "openai-responses",
+        provider: "qaq",
+        id: "gpt-5.4",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+      },
+    });
+
+    expect(payload.tools).toEqual([{ type: "web_search" }]);
+  });
 });

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2440,4 +2440,93 @@ describe("applyExtraParamsToAgent", () => {
 
     expect(payload.tools).toEqual([{ type: "web_search" }]);
   });
+
+  it("lets snake_case false disable a global camelCase web search flag", () => {
+    const merged = resolveExtraParams({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "qaq/gpt-5.4": {
+                params: {
+                  openaiWebSearch: true,
+                  openaiWebSearchToolType: "web_search_preview",
+                },
+              },
+            },
+          },
+          list: [
+            {
+              id: "agent-1",
+              params: {
+                openai_web_search: false,
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      provider: "qaq",
+      modelId: "gpt-5.4",
+      agentId: "agent-1",
+    });
+
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "qaq",
+      applyModelId: "gpt-5.4",
+      extraParamsOverride: merged,
+      model: {
+        api: "openai-responses",
+        provider: "qaq",
+        id: "gpt-5.4",
+      } as unknown as Model<"openai-responses">,
+      payload: { store: false },
+    });
+
+    expect(payload.tools).toBeUndefined();
+  });
+
+  it("lets snake_case tool type override a camelCase global tool type", () => {
+    const merged = resolveExtraParams({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "qaq/gpt-5.4": {
+                params: {
+                  openaiWebSearch: true,
+                  openaiWebSearchToolType: "web_search_preview",
+                },
+              },
+            },
+          },
+          list: [
+            {
+              id: "agent-1",
+              params: {
+                openai_web_search: true,
+                openai_web_search_tool_type: "web_search",
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      provider: "qaq",
+      modelId: "gpt-5.4",
+      agentId: "agent-1",
+    });
+
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "qaq",
+      applyModelId: "gpt-5.4",
+      extraParamsOverride: merged,
+      model: {
+        api: "openai-responses",
+        provider: "qaq",
+        id: "gpt-5.4",
+      } as unknown as Model<"openai-responses">,
+      payload: { store: false },
+    });
+
+    expect(payload.tools).toEqual([{ type: "web_search" }]);
+  });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -74,7 +74,9 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
   openaiWsWarmup?: boolean;
 };
 
-function resolveOpenAIBuiltInTools(extraParams: Record<string, unknown> | undefined): Array<Record<string, unknown>> {
+function resolveOpenAIBuiltInTools(
+  extraParams: Record<string, unknown> | undefined,
+): Array<Record<string, unknown>> {
   if (!extraParams) {
     return [];
   }
@@ -102,7 +104,22 @@ function resolveOpenAIBuiltInTools(extraParams: Record<string, unknown> | undefi
     }
   }
 
-  return configured;
+  const deduped: Array<Record<string, unknown>> = [];
+  const seenTypes = new Set<string>();
+  for (const entry of configured) {
+    const type = typeof entry.type === "string" ? entry.type : "";
+    if (!type) {
+      deduped.push(entry);
+      continue;
+    }
+    if (seenTypes.has(type)) {
+      continue;
+    }
+    seenTypes.add(type);
+    deduped.push(entry);
+  }
+
+  return deduped;
 }
 
 function createStreamFnWithExtraParams(
@@ -137,8 +154,10 @@ function createStreamFnWithExtraParams(
   }
   const openaiBuiltInTools = resolveOpenAIBuiltInTools(extraParams);
   const openaiWebSearchRequired =
-    extraParams.openaiWebSearchRequired === true ||
-    extraParams.openai_web_search_required === true;
+    extraParams.openaiWebSearchRequired === true || extraParams.openai_web_search_required === true;
+  if (openaiWebSearchRequired && openaiBuiltInTools.length === 0) {
+    log.warn("ignoring openaiWebSearchRequired because no OpenAI built-in tools were configured");
+  }
 
   if (Object.keys(streamParams).length === 0 && openaiBuiltInTools.length === 0) {
     return undefined;

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -74,6 +74,37 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
   openaiWsWarmup?: boolean;
 };
 
+function resolveOpenAIBuiltInTools(extraParams: Record<string, unknown> | undefined): Array<Record<string, unknown>> {
+  if (!extraParams) {
+    return [];
+  }
+
+  const configured: Array<Record<string, unknown>> = [];
+  const webSearchEnabled =
+    extraParams.openaiWebSearch === true || extraParams.openai_web_search === true;
+  if (webSearchEnabled) {
+    const rawToolType =
+      typeof extraParams.openaiWebSearchToolType === "string"
+        ? extraParams.openaiWebSearchToolType
+        : typeof extraParams.openai_web_search_tool_type === "string"
+          ? extraParams.openai_web_search_tool_type
+          : undefined;
+    const toolType = rawToolType?.trim() || "web_search_preview";
+    configured.push({ type: toolType });
+  }
+
+  const rawBuiltInTools = extraParams.openaiBuiltInTools ?? extraParams.openai_built_in_tools;
+  if (Array.isArray(rawBuiltInTools)) {
+    for (const entry of rawBuiltInTools) {
+      if (entry && typeof entry === "object") {
+        configured.push(entry as Record<string, unknown>);
+      }
+    }
+  }
+
+  return configured;
+}
+
 function createStreamFnWithExtraParams(
   baseStreamFn: StreamFn | undefined,
   extraParams: Record<string, unknown> | undefined,
@@ -104,19 +135,48 @@ function createStreamFnWithExtraParams(
   if (cacheRetention) {
     streamParams.cacheRetention = cacheRetention;
   }
+  const openaiBuiltInTools = resolveOpenAIBuiltInTools(extraParams);
+  const openaiWebSearchRequired =
+    extraParams.openaiWebSearchRequired === true ||
+    extraParams.openai_web_search_required === true;
 
-  if (Object.keys(streamParams).length === 0) {
+  if (Object.keys(streamParams).length === 0 && openaiBuiltInTools.length === 0) {
     return undefined;
   }
 
   log.debug(`creating streamFn wrapper with params: ${JSON.stringify(streamParams)}`);
+  if (openaiBuiltInTools.length > 0) {
+    log.debug(`OpenAI built-in tools enabled: ${JSON.stringify(openaiBuiltInTools)}`);
+  }
 
   const underlying = baseStreamFn ?? streamSimple;
   const wrappedStreamFn: StreamFn = (model, context, options) => {
-    return underlying(model, context, {
+    const nextOptions: SimpleStreamOptions = {
       ...streamParams,
       ...options,
-    });
+    };
+
+    if (
+      openaiBuiltInTools.length > 0 &&
+      (model.api === "openai-responses" || model.api === "openai-codex-responses")
+    ) {
+      const originalOnPayload = options?.onPayload;
+      nextOptions.onPayload = (payload) => {
+        if (payload && typeof payload === "object") {
+          const payloadRecord = payload as Record<string, unknown>;
+          const existingTools = Array.isArray(payloadRecord.tools)
+            ? (payloadRecord.tools as Array<Record<string, unknown>>)
+            : [];
+          payloadRecord.tools = [...existingTools, ...openaiBuiltInTools];
+          if (openaiWebSearchRequired) {
+            payloadRecord.tool_choice = "required";
+          }
+        }
+        return originalOnPayload?.(payload, model);
+      };
+    }
+
+    return underlying(model, context, nextOptions);
   };
 
   return wrappedStreamFn;

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -122,6 +122,35 @@ function resolveOpenAIBuiltInTools(
   return deduped;
 }
 
+function filterConflictingOpenClawTools(
+  existingTools: Array<Record<string, unknown>>,
+  builtInTools: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+  const builtInTypes = new Set(
+    builtInTools
+      .map((tool) => (typeof tool.type === "string" ? tool.type : ""))
+      .filter((type) => type.length > 0),
+  );
+
+  if (builtInTypes.size === 0) {
+    return existingTools;
+  }
+
+  return existingTools.filter((tool) => {
+    const toolType = typeof tool.type === "string" ? tool.type : "";
+    if (toolType && builtInTypes.has(toolType)) {
+      return false;
+    }
+
+    const toolName = typeof tool.name === "string" ? tool.name : "";
+    if (toolName && builtInTypes.has(toolName)) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
 function createStreamFnWithExtraParams(
   baseStreamFn: StreamFn | undefined,
   extraParams: Record<string, unknown> | undefined,
@@ -186,7 +215,11 @@ function createStreamFnWithExtraParams(
           const existingTools = Array.isArray(payloadRecord.tools)
             ? (payloadRecord.tools as Array<Record<string, unknown>>)
             : [];
-          payloadRecord.tools = [...existingTools, ...openaiBuiltInTools];
+          const filteredExistingTools = filterConflictingOpenClawTools(
+            existingTools,
+            openaiBuiltInTools,
+          );
+          payloadRecord.tools = [...filteredExistingTools, ...openaiBuiltInTools];
           if (openaiWebSearchRequired) {
             payloadRecord.tool_choice = "required";
           }

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -66,6 +66,36 @@ export function resolveExtraParams(params: {
     delete merged.parallelToolCalls;
   }
 
+  const resolvedOpenaiWebSearch = resolveAliasedParamValue(
+    [globalParams, agentParams],
+    "openai_web_search",
+    "openaiWebSearch",
+  );
+  if (resolvedOpenaiWebSearch !== undefined) {
+    merged.openai_web_search = resolvedOpenaiWebSearch;
+    delete merged.openaiWebSearch;
+  }
+
+  const resolvedOpenaiWebSearchRequired = resolveAliasedParamValue(
+    [globalParams, agentParams],
+    "openai_web_search_required",
+    "openaiWebSearchRequired",
+  );
+  if (resolvedOpenaiWebSearchRequired !== undefined) {
+    merged.openai_web_search_required = resolvedOpenaiWebSearchRequired;
+    delete merged.openaiWebSearchRequired;
+  }
+
+  const resolvedOpenaiWebSearchToolType = resolveAliasedParamValue(
+    [globalParams, agentParams],
+    "openai_web_search_tool_type",
+    "openaiWebSearchToolType",
+  );
+  if (resolvedOpenaiWebSearchToolType !== undefined) {
+    merged.openai_web_search_tool_type = resolvedOpenaiWebSearchToolType;
+    delete merged.openaiWebSearchToolType;
+  }
+
   return merged;
 }
 
@@ -82,16 +112,10 @@ function resolveOpenAIBuiltInTools(
   }
 
   const configured: Array<Record<string, unknown>> = [];
-  const webSearchEnabled =
-    extraParams.openaiWebSearch === true || extraParams.openai_web_search === true;
+  const webSearchEnabled = extraParams.openai_web_search === true;
   if (webSearchEnabled) {
-    const rawToolType =
-      typeof extraParams.openaiWebSearchToolType === "string"
-        ? extraParams.openaiWebSearchToolType
-        : typeof extraParams.openai_web_search_tool_type === "string"
-          ? extraParams.openai_web_search_tool_type
-          : undefined;
-    const toolType = rawToolType?.trim() || "web_search_preview";
+    const rawToolType = extraParams.openai_web_search_tool_type;
+    const toolType = typeof rawToolType === "string" ? rawToolType.trim() || "web_search_preview" : "web_search_preview";
     configured.push({ type: toolType });
   }
 
@@ -182,8 +206,12 @@ function createStreamFnWithExtraParams(
     streamParams.cacheRetention = cacheRetention;
   }
   const openaiBuiltInTools = resolveOpenAIBuiltInTools(extraParams);
-  const openaiWebSearchRequired =
-    extraParams.openaiWebSearchRequired === true || extraParams.openai_web_search_required === true;
+  const rawOpenaiWebSearchRequired = resolveAliasedParamValue(
+    [extraParams],
+    "openai_web_search_required",
+    "openaiWebSearchRequired",
+  );
+  const openaiWebSearchRequired = rawOpenaiWebSearchRequired === true;
   if (openaiWebSearchRequired && openaiBuiltInTools.length === 0) {
     log.warn("ignoring openaiWebSearchRequired because no OpenAI built-in tools were configured");
   }


### PR DESCRIPTION
## Summary
- add extra-param support for injecting OpenAI built-in tools into `openai-responses` / `openai-codex-responses` payloads
- support a simple `openaiWebSearch` + `openaiWebSearchToolType` + `openaiWebSearchRequired` config path for OpenAI-compatible providers that expose native web search
- add a focused regression test covering injection of `{ type: "web_search" }` and `tool_choice: "required"`

## Why
OpenClaw currently exposes `web_search` as a separate built-in tool, but some OpenAI-compatible Responses endpoints also support native search tools. This patch makes it possible to opt into those built-in tools through model extra params without changing the existing `web_search` provider stack.

## Notes
- verified live against an OpenAI-compatible `/responses` endpoint that accepts `{ type: "web_search" }`
- targeted test passed locally:
  - `corepack pnpm exec vitest run src/agents/pi-embedded-runner-extraparams.test.ts -t "injects OpenAI built-in web search tools for openai-responses payloads"`
- a full-file vitest run in my Windows/Node 24 environment still hits unrelated pre-existing failures in this test file, so validation was kept scoped to the new case
