### PR TITLE
feat: Onboarding add Community Channel Catalog

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -123,6 +123,50 @@ We welcome community plugins that are useful, documented, and safe to operate.
   </Step>
 </Steps>
 
+## Built-in onboarding catalog for community channels
+
+OpenClaw also maintains a small built-in catalog for first-run onboarding of
+community-maintained channel plugins.
+
+This catalog is intentionally conservative:
+
+- It is for community **channel** plugins only.
+- It is not a marketplace, ranking system, or remote registry.
+- It only fills discovery gaps during first-run setup when no higher-priority
+  plugin source already provides that channel.
+
+The current source of truth lives in:
+
+```text
+src/channels/plugins/community-channel-catalog.json
+```
+
+DingTalk is the first example entry in that file, but the mechanism is generic.
+Future community channel plugins should follow the same path.
+
+### How to add a new community channel
+
+1. Publish the plugin to npm so `openclaw plugins install <npm-spec>` works.
+2. Keep the source in a public repository with setup and troubleshooting docs.
+3. Expose valid `openclaw.channel` and `openclaw.install` metadata in the plugin package.
+4. Point `docsPath` to plugin-owned docs, not to a page that must live in the
+   main OpenClaw docs repo.
+5. Add one manifest-shaped entry to `src/channels/plugins/community-channel-catalog.json`.
+6. Keep the entry minimal and reviewable: package name, channel metadata, and install metadata only.
+
+### Review bar for built-in onboarding entries
+
+| Requirement              | Why                                                                               |
+| ------------------------ | --------------------------------------------------------------------------------- |
+| Public npm package       | The onboarding flow installs from npm on demand                                   |
+| Public repository        | Maintainers and users need a reviewable source of truth                           |
+| Valid plugin metadata    | The existing channel catalog parser must be able to load it without special cases |
+| Plugin-owned docs        | Community plugin docs should not depend on pages in the main OpenClaw docs repo   |
+| Conservative maintenance | Built-in onboarding discovery should stay curated and low-risk                    |
+
+If a plugin does not meet that bar, it can still be documented on this page as a
+community plugin without being added to the built-in onboarding catalog.
+
 ## Quality bar
 
 | Requirement          | Why                                           |

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -8,6 +8,7 @@ import type { OpenClawPackageManifest } from "../../plugins/manifest.js";
 import type { PackageManifest as PluginPackageManifest } from "../../plugins/manifest.js";
 import type { PluginOrigin } from "../../plugins/types.js";
 import { isRecord, resolveConfigDir, resolveUserPath } from "../../utils.js";
+import COMMUNITY_CHANNEL_CATALOG_JSON from "./community-channel-catalog.json" with { type: "json" };
 import type { ChannelMeta } from "./types.js";
 
 export type ChannelUiMetaEntry = {
@@ -305,6 +306,16 @@ function loadBundledMetadataCatalogEntries(options: CatalogOptions): ChannelPlug
   return entries;
 }
 
+function loadBuiltInCommunityCatalogEntries(): ChannelPluginCatalogEntry[] {
+  try {
+    return parseCatalogEntries(COMMUNITY_CHANNEL_CATALOG_JSON)
+      .map((entry) => buildExternalCatalogEntry(entry))
+      .filter((entry): entry is ChannelPluginCatalogEntry => Boolean(entry));
+  } catch {
+    return [];
+  }
+}
+
 export function buildChannelUiCatalog(
   plugins: Array<{ id: string; meta: ChannelMeta }>,
 ): ChannelUiCatalog {
@@ -359,6 +370,15 @@ export function listChannelPluginCatalogEntries(
     const existing = resolved.get(entry.id);
     if (!existing || priority < existing.priority) {
       resolved.set(entry.id, { entry, priority });
+    }
+  }
+
+  // The official built-in community catalog powers first-run onboarding
+  // discovery without overriding installed, workspace, config, or bundled
+  // plugin metadata when those higher-priority sources already exist.
+  for (const entry of loadBuiltInCommunityCatalogEntries()) {
+    if (!resolved.has(entry.id)) {
+      resolved.set(entry.id, { entry, priority: 99 });
     }
   }
 

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -373,19 +373,19 @@ export function listChannelPluginCatalogEntries(
     }
   }
 
-  // The official built-in community catalog powers first-run onboarding
-  // discovery without overriding installed, workspace, config, or bundled
-  // plugin metadata when those higher-priority sources already exist.
-  for (const entry of loadBuiltInCommunityCatalogEntries()) {
+  const externalEntries = loadExternalCatalogEntries(options)
+    .map((entry) => buildExternalCatalogEntry(entry))
+    .filter((entry): entry is ChannelPluginCatalogEntry => Boolean(entry));
+  for (const entry of externalEntries) {
     if (!resolved.has(entry.id)) {
       resolved.set(entry.id, { entry, priority: 99 });
     }
   }
 
-  const externalEntries = loadExternalCatalogEntries(options)
-    .map((entry) => buildExternalCatalogEntry(entry))
-    .filter((entry): entry is ChannelPluginCatalogEntry => Boolean(entry));
-  for (const entry of externalEntries) {
+  // The official built-in community catalog powers first-run onboarding
+  // discovery without overriding installed, workspace, config, bundled,
+  // or user-configured external catalog entries.
+  for (const entry of loadBuiltInCommunityCatalogEntries()) {
     if (!resolved.has(entry.id)) {
       resolved.set(entry.id, { entry, priority: 99 });
     }

--- a/src/channels/plugins/community-channel-catalog.json
+++ b/src/channels/plugins/community-channel-catalog.json
@@ -1,0 +1,23 @@
+{
+  "entries": [
+    {
+      "name": "@soimy/dingtalk",
+      "openclaw": {
+        "channel": {
+          "id": "dingtalk",
+          "label": "DingTalk",
+          "selectionLabel": "DingTalk (钉钉)",
+          "docsPath": "https://github.com/soimy/openclaw-channel-dingtalk",
+          "docsLabel": "plugin docs",
+          "blurb": "钉钉企业内部机器人，使用 Stream 模式，无需公网 IP。",
+          "order": 70,
+          "aliases": ["dd", "ding"]
+        },
+        "install": {
+          "npmSpec": "@soimy/dingtalk",
+          "defaultChoice": "npm"
+        }
+      }
+    }
+  ]
+}

--- a/src/channels/plugins/plugins-core.test.ts
+++ b/src/channels/plugins/plugins-core.test.ts
@@ -267,6 +267,49 @@ describe("channel plugin catalog", () => {
     });
   });
 
+  it("keeps external catalog entries ahead of the built-in community catalog", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-catalog-override-"));
+    const catalogPath = path.join(dir, "catalog.json");
+    fs.writeFileSync(
+      catalogPath,
+      JSON.stringify({
+        entries: [
+          {
+            name: "@vendor/dingtalk-external",
+            openclaw: {
+              channel: {
+                id: "dingtalk",
+                label: "DingTalk External",
+                selectionLabel: "DingTalk External",
+                docsPath: "https://example.com/dingtalk",
+                blurb: "External catalog override",
+              },
+              install: {
+                npmSpec: "@vendor/dingtalk-external",
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    const entry = getChannelPluginCatalogEntry("dingtalk", {
+      catalogPaths: [catalogPath],
+    });
+
+    expect(entry).toMatchObject({
+      id: "dingtalk",
+      meta: {
+        label: "DingTalk External",
+        selectionLabel: "DingTalk External",
+        docsPath: "https://example.com/dingtalk",
+      },
+      install: {
+        npmSpec: "@vendor/dingtalk-external",
+      },
+    });
+  });
+
   it("uses the provided env for external catalog path resolution", () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-catalog-home-"));
     const catalogPath = path.join(home, "catalog.json");

--- a/src/channels/plugins/plugins-core.test.ts
+++ b/src/channels/plugins/plugins-core.test.ts
@@ -122,6 +122,13 @@ describe("channel plugin catalog", () => {
     expect(entry?.meta.aliases).toContain("teams");
   });
 
+  it("includes the built-in community DingTalk catalog entry", () => {
+    const entry = getChannelPluginCatalogEntry("dingtalk");
+    expect(entry?.install.npmSpec).toBe("@soimy/dingtalk");
+    expect(entry?.meta.selectionLabel).toBe("DingTalk (钉钉)");
+    expect(entry?.meta.docsPath).toBe("https://github.com/soimy/openclaw-channel-dingtalk");
+  });
+
   it("lists plugin catalog entries", () => {
     const ids = listChannelPluginCatalogEntries().map((entry) => entry.id);
     expect(ids).toContain("msteams");
@@ -202,6 +209,62 @@ describe("channel plugin catalog", () => {
     }).find((item) => item.id === "demo-channel");
 
     expect(entry?.pluginId).toBe("@vendor/demo-runtime");
+  });
+
+  it("keeps discovered plugins ahead of the built-in community catalog", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-catalog-state-"));
+    const pluginDir = path.join(stateDir, "extensions", "dingtalk-plugin");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@vendor/dingtalk-custom",
+        openclaw: {
+          extensions: ["./index.js"],
+          channel: {
+            id: "dingtalk",
+            label: "DingTalk Custom",
+            selectionLabel: "DingTalk Custom",
+            docsPath: "/channels/dingtalk-custom",
+            blurb: "Custom discovered DingTalk entry",
+          },
+          install: {
+            npmSpec: "@vendor/dingtalk-custom",
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "@vendor/dingtalk-runtime",
+        channels: ["dingtalk"],
+        configSchema: {},
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "module.exports = {}", "utf-8");
+
+    const entry = listChannelPluginCatalogEntries({
+      env: {
+        ...process.env,
+        OPENCLAW_STATE_DIR: stateDir,
+        CLAWDBOT_STATE_DIR: undefined,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: "/nonexistent/bundled/plugins",
+        OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE: "1",
+      },
+    }).find((item) => item.id === "dingtalk");
+
+    expect(entry).toMatchObject({
+      id: "dingtalk",
+      pluginId: "@vendor/dingtalk-runtime",
+      meta: {
+        label: "DingTalk Custom",
+        selectionLabel: "DingTalk Custom",
+      },
+      install: {
+        npmSpec: "@vendor/dingtalk-custom",
+      },
+    });
   });
 
   it("uses the provided env for external catalog path resolution", () => {

--- a/src/commands/onboard-channels.e2e.test.ts
+++ b/src/commands/onboard-channels.e2e.test.ts
@@ -329,6 +329,37 @@ describe("setupChannels", () => {
     expect(multiselect).not.toHaveBeenCalled();
   });
 
+  it("shows DingTalk as an installable QuickStart channel from the built-in catalog", async () => {
+    const select = vi.fn(async ({ message, options }: { message: string; options: unknown[] }) => {
+      if (message === "Select channel (QuickStart)") {
+        const entries = options as Array<{ value: string; label: string; hint?: string }>;
+        const dingtalk = entries.find((entry) => entry.value === "dingtalk");
+        expect(dingtalk).toMatchObject({
+          value: "dingtalk",
+          label: "DingTalk (钉钉)",
+          hint: "plugin · install",
+        });
+        return "__skip__";
+      }
+      return "__done__";
+    });
+    const { multiselect, text } = createUnexpectedPromptGuards();
+    const prompter = createPrompter({
+      select: select as unknown as WizardPrompter["select"],
+      multiselect,
+      text,
+    });
+
+    await runSetupChannels({} as OpenClawConfig, prompter, {
+      quickstartDefaults: true,
+    });
+
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Select channel (QuickStart)" }),
+    );
+    expect(multiselect).not.toHaveBeenCalled();
+  });
+
   it("continues Telegram setup when the plugin registry is empty", async () => {
     // Simulate missing registry entries (the scenario reported in #25545).
     setActivePluginRegistry(createEmptyPluginRegistry());


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: first-run `openclaw onboard` could only surface bundled or already discovered channels, so community channel plugins stayed invisible unless users found and installed them separately first.
- Why it matters: this makes community channel onboarding harder for new users and hides valid plugin install paths behind extra discovery steps.
- What changed: added a small built-in community channel catalog source, merged it into channel discovery at low priority, covered it with catalog/onboarding tests, and documented how future community channel plugins can be added.
- What did NOT change (scope boundary): no remote registry fetch, no marketplace dependency, no ranking/search UI, and no main-repo docs page for the example DingTalk plugin.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `openclaw onboard` and related setup flows can now show curated installable community channel plugins even when they are not already installed locally.
- Community catalog entries remain lower priority than discovered, configured, bundled, and otherwise already-resolved plugin sources.
- The built-in community catalog is documented as a generic maintainer mechanism for future community channel plugins, with DingTalk as the first example entry.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): channel onboarding / community plugin catalog
- Relevant config (redacted): default local dev config, plus temp test state during automated tests

### Steps

1. Start from a clean OpenClaw install without the community channel plugin already installed.
2. Run `openclaw onboard` or resolve channel setup entries in the onboarding flow.
3. Confirm the curated community channel appears as an installable channel entry and still loses to a discovered plugin with the same channel id.

### Expected

- Curated community channel entries appear as installable onboarding choices.
- Installed, discovered, and configured plugin metadata keeps winning over the built-in community catalog.

### Actual

- Added a built-in community channel catalog that makes the example DingTalk plugin discoverable in onboarding without overriding higher-priority plugin sources.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran targeted catalog and onboarding tests, full `pnpm build`, full `pnpm test`, and docs lint for the maintainer documentation update.
- Edge cases checked: built-in community entry is present when the plugin is absent; discovered plugin metadata for the same channel id still wins; onboarding marks the entry as `plugin · install`.
- What you did **not** verify: an interactive manual CLI walkthrough against a fresh temp config and a real npm installation during onboarding.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR, or remove the affected entry from `src/channels/plugins/community-channel-catalog.json`.
- Files/config to restore: `src/channels/plugins/community-channel-catalog.json`, `src/channels/plugins/catalog.ts`, and related tests/docs in this PR.
- Known bad symptoms reviewers should watch for: community entries overriding installed/discovered plugins, or onboarding failing to mark curated entries as installable.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: a curated community catalog entry could drift from the plugin's published metadata or docs location.
  - Mitigation: kept the manifest shape identical to existing external catalog entries, documented the maintainer review bar, and pointed community entries at plugin-owned docs instead of main-repo docs pages.
