### PR TITLE
fix(usage): improve MiniMax coding-plan usage parsing for model_remains array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - Node exec approvals: keep node-host `system.run` approvals bound to the prepared execution plan, so script-drift revalidation still runs after agent-side approval forwarding.
 - Models/MiniMax: honor `MINIMAX_API_HOST` for implicit bundled MiniMax provider catalogs so China-hosted API-key setups pick `api.minimaxi.com/anthropic` without manual provider config. (#34524) Thanks @caiqinghua.
 - Usage/MiniMax: invert remaining-style `usage_percent` fields when MiniMax reports only remaining percentage data, so usage bars stop showing nearly-full remaining quota as nearly-exhausted usage. (#60254) Thanks @jwchmodx.
+- Usage/MiniMax: prefer the chat-model `model_remains` entry and derive Coding Plan window labels from MiniMax interval timestamps so MiniMax usage snapshots stop picking zero-budget media rows and misreporting 4h windows as `5h`. (#52349) Thanks @IVY-AI-gif.
 - MiniMax: advertise image input on bundled `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` model definitions so image-capable flows can route through the M2.7 family correctly. (#54843) Thanks @MerlinMiao88888888.
 - Agents/exec approvals: let `exec-approvals.json` agent security override stricter gateway tool defaults so approved subagents can use `security: "full"` without falling back to allowlist enforcement again. (#60310) Thanks @lml2468.
 - Tasks/maintenance: mark stale cron runs and CLI tasks backed only by long-lived chat sessions as lost again so task cleanup does not keep dead work alive indefinitely. (#60310) Thanks @lml2468.

--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -157,6 +157,65 @@ describe("fetchMinimaxUsage", () => {
         windows: [{ label: "2h", usedPercent: 40, resetAt: 1_700_000_100_000 }],
       },
     },
+    {
+      name: "prefers chat model entries from model_remains and derives window labels from timestamps",
+      payload: {
+        data: {
+          model_remains: [
+            {
+              model_name: "speech-hd",
+              current_interval_total_count: 0,
+              current_interval_usage_count: 0,
+              start_time: 1_774_180_800_000,
+              end_time: 1_774_195_200_000,
+            },
+            {
+              model_name: "MiniMax-M*",
+              current_interval_total_count: 600,
+              current_interval_usage_count: 595,
+              start_time: 1_774_180_800_000,
+              end_time: 1_774_195_200_000,
+            },
+            {
+              model_name: "image-01",
+              current_interval_total_count: 0,
+              current_interval_usage_count: 0,
+              start_time: 1_774_180_800_000,
+              end_time: 1_774_195_200_000,
+            },
+          ],
+        },
+      },
+      expected: {
+        plan: "Coding Plan · MiniMax-M*",
+        windows: [{ label: "4h", usedPercent: 0.8333333333333334, resetAt: 1_774_195_200_000 }],
+      },
+    },
+    {
+      name: "falls back to the first non-zero model_remains record when no MiniMax chat entry exists",
+      payload: {
+        data: {
+          model_remains: [
+            {
+              model_name: "speech-hd",
+              current_interval_total_count: 0,
+              current_interval_usage_count: 0,
+            },
+            {
+              model_name: "video-01",
+              current_interval_total_count: 200,
+              current_interval_usage_count: 150,
+              start_time: 1_774_180_800_000,
+              end_time: 1_774_195_200_000,
+            },
+          ],
+        },
+      },
+      expected: {
+        plan: "Coding Plan · video-01",
+        windows: [{ label: "4h", usedPercent: 25, resetAt: 1_774_195_200_000 }],
+      },
+    },
   ])("$name", async ({ payload, expected }) => {
     await expectMinimaxUsageResult({ payload, expected });
   });

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -270,7 +270,7 @@ function collectUsageCandidates(root: Record<string, unknown>): Record<string, u
 function deriveWindowLabelFromTimestamps(record: Record<string, unknown>): string | undefined {
   const startTime = parseEpoch(record.start_time ?? record.startTime);
   const endTime = parseEpoch(record.end_time ?? record.endTime);
-  if (startTime && endTime && endTime > startTime) {
+  if (startTime !== undefined && endTime !== undefined && endTime > startTime) {
     const durationHours = (endTime - startTime) / 3_600_000;
     if (durationHours >= 1 && Number.isFinite(durationHours)) {
       const rounded = Math.round(durationHours);
@@ -336,15 +336,10 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
   return null;
 }
 
-/**
- * When the API returns a `model_remains` array, prefer the entry whose
- * `model_name` matches a chat/text model (e.g. "MiniMax-M*") and that has
- * a non-zero `current_interval_total_count`.  Models with total_count === 0
- * (speech, video, image) are not relevant to the coding-plan budget.
- */
-function pickChatModelRemains(
-  modelRemains: unknown[],
-): Record<string, unknown> | undefined {
+// Prefer the entry whose model_name matches a chat/text model (e.g. "MiniMax-M*")
+// and that has a non-zero current_interval_total_count.  Models with total_count === 0
+// (speech, video, image) are not relevant to the coding-plan budget.
+function pickChatModelRemains(modelRemains: unknown[]): Record<string, unknown> | undefined {
   const records = modelRemains.filter(isRecord);
   if (records.length === 0) {
     return undefined;
@@ -354,7 +349,7 @@ function pickChatModelRemains(
     const name = typeof r.model_name === "string" ? r.model_name : "";
     const total = parseFiniteNumber(r.current_interval_total_count);
     return (
-      (name.toLowerCase().startsWith("minimax-m") || name === "MiniMax-M*") &&
+      name.toLowerCase().startsWith("minimax-m") &&
       total !== undefined &&
       total > 0
     );
@@ -424,8 +419,9 @@ export async function fetchMinimaxUsage(
   const modelRemains = Array.isArray(payload.model_remains) ? payload.model_remains : null;
   const chatRemains = modelRemains ? pickChatModelRemains(modelRemains) : undefined;
 
-  const candidates = collectUsageCandidates(chatRemains ?? payload);
-  let usageRecord: Record<string, unknown> = chatRemains ?? payload;
+  const usageSource = chatRemains ?? payload;
+  const candidates = collectUsageCandidates(usageSource);
+  let usageRecord: Record<string, unknown> = usageSource;
   let usedPercent: number | null = null;
   for (const candidate of candidates) {
     const candidatePercent = deriveUsedPercent(candidate);
@@ -436,7 +432,7 @@ export async function fetchMinimaxUsage(
     }
   }
   if (usedPercent === null) {
-    usedPercent = deriveUsedPercent(chatRemains ?? payload);
+    usedPercent = deriveUsedPercent(usageSource);
   }
   if (usedPercent === null) {
     return {
@@ -452,9 +448,12 @@ export async function fetchMinimaxUsage(
     parseEpoch(pickNumber(usageRecord, RESET_KEYS)) ??
     parseEpoch(pickString(payload, RESET_KEYS)) ??
     parseEpoch(pickNumber(payload, RESET_KEYS));
+  const windowLabel = chatRemains
+    ? deriveWindowLabel(chatRemains)
+    : deriveWindowLabel(usageRecord);
   const windows: UsageWindow[] = [
     {
-      label: deriveWindowLabel(usageRecord),
+      label: windowLabel,
       usedPercent,
       resetAt,
     },

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -267,6 +267,23 @@ function collectUsageCandidates(root: Record<string, unknown>): Record<string, u
   return candidates.map((candidate) => candidate.record);
 }
 
+function deriveWindowLabelFromTimestamps(record: Record<string, unknown>): string | undefined {
+  const startTime = parseEpoch(record.start_time ?? record.startTime);
+  const endTime = parseEpoch(record.end_time ?? record.endTime);
+  if (startTime && endTime && endTime > startTime) {
+    const durationHours = (endTime - startTime) / 3_600_000;
+    if (durationHours >= 1 && Number.isFinite(durationHours)) {
+      const rounded = Math.round(durationHours);
+      return `${rounded}h`;
+    }
+    const durationMinutes = Math.round((endTime - startTime) / 60_000);
+    if (durationMinutes > 0) {
+      return `${durationMinutes}m`;
+    }
+  }
+  return undefined;
+}
+
 function deriveWindowLabel(payload: Record<string, unknown>): string {
   const hours = pickNumber(payload, WINDOW_HOUR_KEYS);
   if (hours && Number.isFinite(hours)) {
@@ -275,6 +292,10 @@ function deriveWindowLabel(payload: Record<string, unknown>): string {
   const minutes = pickNumber(payload, WINDOW_MINUTE_KEYS);
   if (minutes && Number.isFinite(minutes)) {
     return `${minutes}m`;
+  }
+  const fromTimestamps = deriveWindowLabelFromTimestamps(payload);
+  if (fromTimestamps) {
+    return fromTimestamps;
   }
   return "5h";
 }
@@ -313,6 +334,40 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
   }
 
   return null;
+}
+
+/**
+ * When the API returns a `model_remains` array, prefer the entry whose
+ * `model_name` matches a chat/text model (e.g. "MiniMax-M*") and that has
+ * a non-zero `current_interval_total_count`.  Models with total_count === 0
+ * (speech, video, image) are not relevant to the coding-plan budget.
+ */
+function pickChatModelRemains(
+  modelRemains: unknown[],
+): Record<string, unknown> | undefined {
+  const records = modelRemains.filter(isRecord);
+  if (records.length === 0) {
+    return undefined;
+  }
+
+  const chatRecord = records.find((r) => {
+    const name = typeof r.model_name === "string" ? r.model_name : "";
+    const total = parseFiniteNumber(r.current_interval_total_count);
+    return (
+      (name.toLowerCase().startsWith("minimax-m") || name === "MiniMax-M*") &&
+      total !== undefined &&
+      total > 0
+    );
+  });
+
+  if (chatRecord) {
+    return chatRecord;
+  }
+
+  return records.find((r) => {
+    const total = parseFiniteNumber(r.current_interval_total_count);
+    return total !== undefined && total > 0;
+  });
 }
 
 export async function fetchMinimaxUsage(
@@ -362,8 +417,15 @@ export async function fetchMinimaxUsage(
   }
 
   const payload = isRecord(data.data) ? data.data : data;
-  const candidates = collectUsageCandidates(payload);
-  let usageRecord: Record<string, unknown> = payload;
+
+  // Handle the model_remains array structure returned by the coding-plan
+  // endpoint.  Pick the chat-model entry so that speech/video/image quotas
+  // (which often have total_count === 0) don't shadow the relevant budget.
+  const modelRemains = Array.isArray(payload.model_remains) ? payload.model_remains : null;
+  const chatRemains = modelRemains ? pickChatModelRemains(modelRemains) : undefined;
+
+  const candidates = collectUsageCandidates(chatRemains ?? payload);
+  let usageRecord: Record<string, unknown> = chatRemains ?? payload;
   let usedPercent: number | null = null;
   for (const candidate of candidates) {
     const candidatePercent = deriveUsedPercent(candidate);
@@ -374,7 +436,7 @@ export async function fetchMinimaxUsage(
     }
   }
   if (usedPercent === null) {
-    usedPercent = deriveUsedPercent(payload);
+    usedPercent = deriveUsedPercent(chatRemains ?? payload);
   }
   if (usedPercent === null) {
     return {
@@ -398,10 +460,19 @@ export async function fetchMinimaxUsage(
     },
   ];
 
+  const modelName =
+    chatRemains && typeof chatRemains.model_name === "string"
+      ? chatRemains.model_name
+      : undefined;
+  const plan =
+    pickString(usageRecord, PLAN_KEYS) ??
+    pickString(payload, PLAN_KEYS) ??
+    (modelName ? `Coding Plan · ${modelName}` : undefined);
+
   return {
     provider: "minimax",
     displayName: PROVIDER_LABELS.minimax,
     windows,
-    plan: pickString(usageRecord, PLAN_KEYS) ?? pickString(payload, PLAN_KEYS),
+    plan,
   };
 }

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -348,11 +348,7 @@ function pickChatModelRemains(modelRemains: unknown[]): Record<string, unknown> 
   const chatRecord = records.find((r) => {
     const name = typeof r.model_name === "string" ? r.model_name : "";
     const total = parseFiniteNumber(r.current_interval_total_count);
-    return (
-      name.toLowerCase().startsWith("minimax-m") &&
-      total !== undefined &&
-      total > 0
-    );
+    return name.toLowerCase().startsWith("minimax-m") && total !== undefined && total > 0;
   });
 
   if (chatRecord) {
@@ -448,9 +444,7 @@ export async function fetchMinimaxUsage(
     parseEpoch(pickNumber(usageRecord, RESET_KEYS)) ??
     parseEpoch(pickString(payload, RESET_KEYS)) ??
     parseEpoch(pickNumber(payload, RESET_KEYS));
-  const windowLabel = chatRemains
-    ? deriveWindowLabel(chatRemains)
-    : deriveWindowLabel(usageRecord);
+  const windowLabel = chatRemains ? deriveWindowLabel(chatRemains) : deriveWindowLabel(usageRecord);
   const windows: UsageWindow[] = [
     {
       label: windowLabel,
@@ -460,9 +454,7 @@ export async function fetchMinimaxUsage(
   ];
 
   const modelName =
-    chatRemains && typeof chatRemains.model_name === "string"
-      ? chatRemains.model_name
-      : undefined;
+    chatRemains && typeof chatRemains.model_name === "string" ? chatRemains.model_name : undefined;
   const plan =
     pickString(usageRecord, PLAN_KEYS) ??
     pickString(payload, PLAN_KEYS) ??


### PR DESCRIPTION
## Summary

Fixes #52335

The MiniMax `coding_plan/remains` API returns a `model_remains` array containing usage entries for multiple model categories (chat, speech, video, image). The existing BFS-based candidate selection picks the first record with a non-null usage percentage, which can cause two problems:

1. **Wrong window duration**: The window label defaults to `"5h"` when the actual window duration (derived from `start_time`/`end_time` timestamps) is 4 hours. Users see `"5h: 0% left"` when the real window is 4h.

2. **Irrelevant model shadowing**: Models like `speech-hd`, `image-01`, and video models have `current_interval_total_count: 0`, which makes `deriveUsedPercent` return `null` for them. While the current code happens to skip these, the selection is fragile — any future model entry with non-zero total but different semantics could shadow the chat model's budget.

3. **No plan distinction**: The display shows `"MiniMax: 5h: 0% left"` without indicating this is the **free-tier coding plan** quota. Users confuse this with their actual paid API balance (which may be full), leading to bug reports like #52335.

## Changes

- **`pickChatModelRemains()`** — New helper that selects the chat-model entry (`MiniMax-M*` or any entry starting with `minimax-m`) from the `model_remains` array, filtering out speech/video/image models with `total_count === 0`.

- **`deriveWindowLabelFromTimestamps()`** — New helper that calculates window duration from `start_time`/`end_time` epoch fields when explicit `window_hours`/`window_minutes` are absent. Falls back to the existing `"5h"` default only when timestamps are also missing.

- **`deriveWindowLabel()`** — Updated to call `deriveWindowLabelFromTimestamps()` before falling back to the `"5h"` default.

- **`fetchMinimaxUsage()`** — Updated to detect the `model_remains` array structure, pick the relevant chat-model entry via `pickChatModelRemains()`, and pass only that entry to the candidate-scoring pipeline. Also includes the model name in the plan label (e.g., `"Coding Plan · MiniMax-M*"`).

## Root Cause Analysis

Tested against a live MiniMax OAuth (`minimax-portal`) deployment:

```json
{
  "model_remains": [
    {
      "model_name": "MiniMax-M*",
      "current_interval_total_count": 600,
      "current_interval_usage_count": 595,
      "start_time": 1774180800000,
      "end_time": 1774195200000
    },
    { "model_name": "speech-hd", "current_interval_total_count": 0, ... },
    { "model_name": "image-01", "current_interval_total_count": 0, ... }
  ]
}
```

- Window is 4h (14400000ms) but displayed as `"5h"` (hardcoded default)
- Usage 595/600 = 99.2% → displays as `"0% left"` after rounding
- Users see `"MiniMax 5h: 0% left"` and think their paid balance is zero

## Test Plan

- [ ] Verify `deriveWindowLabelFromTimestamps` correctly calculates `"4h"` from the MiniMax timestamps
- [ ] Verify `pickChatModelRemains` selects the `MiniMax-M*` entry and skips `speech-hd`, `image-01` etc.
- [ ] Verify the plan label includes `"Coding Plan · MiniMax-M*"`
- [ ] Verify existing tests still pass (the generic BFS path is preserved as fallback)
- [ ] Verify that responses without `model_remains` (e.g., legacy API format) still work via the existing candidate pipeline