### PR TITLE
clarify persistent session target vs thread-bound session UX

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -91,6 +91,11 @@ Think of a cron job as: **when** to run + **what** to do.
    - `sessionTarget: "current"` → bind to the current session (resolved at creation time to `session:<sessionKey>`).
    - `sessionTarget: "session:custom-id"` → run in a persistent named session that maintains context across runs.
 
+   Important distinction:
+   - A persistent named session target such as `session:project-alpha` is a durable context id.
+   - It is **not** the same thing as a thread-bound interactive session created with `sessions_spawn(... thread=true, mode:"session")`.
+   - It is also **not** a guarantee that the current requester can inspect or message that target via session tools; access still depends on session visibility policy.
+
    Default behavior (unchanged):
    - `systemEvent` payloads default to `main`
    - `agentTurn` payloads default to `isolated`

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -240,3 +240,21 @@ Notes:
 - `agent`: any session belonging to the current agent id.
 - `all`: any session (cross-agent access still requires `tools.agentToAgent`).
 - When a session is sandboxed and `sessionToolsVisibility="spawned"`, OpenClaw clamps visibility to `tree` even if you set `tools.sessions.visibility="all"`.
+
+### Important distinction: persistent target vs live session vs visibility
+
+These concepts are related, but they are not the same thing:
+
+| Concept                         | What it means                                                                        | Example                                           | Important caveat                                                                                 |
+| ------------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Persistent named session target | A durable context identifier that can be reused across runs                          | `session:project-alpha`                           | It can exist even when no interactive live session is attached on the current surface            |
+| Live session                    | An actual running conversation/session entry                                         | `agent:main:subagent:<id>`                        | A live session may or may not be directly reachable from your current requester context          |
+| Thread-bound session            | A live session attached to a channel thread                                          | `sessions_spawn(... thread=true, mode:"session")` | Requires thread support on the current surface/channel                                           |
+| Session visibility              | Which sessions the current requester is allowed to inspect/message via session tools | `tools.sessions.visibility=tree`                  | Visibility errors do not mean the target does not exist; they mean it is not reachable from here |
+
+Practical example:
+
+- A cron job can successfully run against `session:project-alpha` and keep context there across runs.
+- That does **not** automatically mean the current requester can inspect or message that target via `sessions_history`/`sessions_send`.
+- If your current context only has `tools.sessions.visibility="tree"`, you can only access the current session and sessions it spawned.
+- If `mode:"session"` fails during `sessions_spawn`, that usually means thread-bound interactive session mode is unavailable on the current surface, not that the persistent target concept is invalid.

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -417,7 +417,8 @@ describe("session_status tool", () => {
     const tool = getSessionStatusTool("agent:main:subagent:child", {
       sandboxed: true,
     });
-    const expectedError = "Session status visibility is restricted to the current session tree";
+    const expectedError =
+      "Session status visibility is restricted to the current session tree (tools.sessions.visibility=tree). This session can access itself and its spawned child sessions from here, but the target may still exist outside that tree.";
 
     await expect(
       tool.execute("call6", {

--- a/src/agents/sessions-spawn-hooks.test.ts
+++ b/src/agents/sessions-spawn-hooks.test.ts
@@ -298,7 +298,10 @@ describe("sessions_spawn subagent lifecycle hooks", () => {
         threadBindingReady: false,
       },
     });
-    expectThreadBindFailureCleanup(details, /unable to create or bind a thread/i);
+    expectThreadBindFailureCleanup(
+      details,
+      /cannot create or bind a thread-bound persistent session here/i,
+    );
   });
 
   it("rejects mode=session when thread=true is not requested", async () => {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -279,7 +279,7 @@ async function ensureThreadBindingForSubagentSpawn(params: {
       return {
         status: "error",
         error:
-          "Unable to create or bind a thread for this subagent session. Session mode is unavailable for this target.",
+          "This surface cannot create or bind a thread-bound persistent session here. A persistent target can still exist, but interactive session mode requires thread support on the current surface.",
       };
     }
     return { status: "ok" };

--- a/src/agents/tools/sessions-access.ts
+++ b/src/agents/tools/sessions-access.ts
@@ -180,7 +180,7 @@ function selfVisibilityMessage(action: SessionAccessAction): string {
 }
 
 function treeVisibilityMessage(action: SessionAccessAction): string {
-  return `${actionPrefix(action)} visibility is restricted to the current session tree (tools.sessions.visibility=tree).`;
+  return `${actionPrefix(action)} visibility is restricted to the current session tree (tools.sessions.visibility=tree). This session can access itself and its spawned child sessions from here, but the target may still exist outside that tree.`;
 }
 
 export async function createSessionVisibilityGuard(params: {


### PR DESCRIPTION
## Summary

- Problem: wording around persistent named session targets, thread-bound interactive sessions, and session visibility made these concepts too easy to conflate.
- Why it matters: users could misread session errors and spawning behavior, especially around `mode:"session"`, named session targets, and tree visibility limits.
- What changed: updated runtime-facing error/help text, related tests, and docs so the distinctions are explicit and consistent.
- What did NOT change (scope boundary): no functional redesign of the session model, no default/permission changes, no new capabilities.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52345
- Related #52345

## User-visible / Behavior Changes

- Thread-bind failure text now explains that a thread-bound persistent session may be unavailable on the current surface even if a persistent target concept still exists.
- Tree-visibility errors now clarify that the target may still exist outside the current session tree.
- Docs now explicitly distinguish persistent named session targets, live sessions, thread-bound sessions, and session visibility policy.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: None

## Repro + Verification

### Environment

- OS: Fedora Linux
- Runtime/container: local host runtime
- Model/provider: openai-codex/gpt-5.4
- Integration/channel (if any): webchat / GitHub browser flow
- Relevant config (redacted): standard coding tool profile

### Steps

1. Trigger or review flows involving persistent named session targets, `sessions_spawn(... mode:"session")`, or tree-visibility errors.
2. Observe that the previous wording can imply the target/session/visibility concepts are equivalent.
3. Apply this patch and re-check the affected errors, tests, and docs.

### Expected

- Users can distinguish persistent named targets, thread-bound interactive sessions, and visibility limitations.

### Actual

- The previous wording blurred those boundaries.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted local tests for the touched runtime messages/tests; manual review of updated docs and wording.
- Edge cases checked: thread-bind failure messaging, tree-visibility messaging, persistent target vs live/thread-bound distinctions.
- What you did **not** verify: full end-to-end review across every surface/channel.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: None

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `b807ff522d`
- Files/config to restore: the 6 touched files in this PR
- Known bad symptoms reviewers should watch for: wording regressions or tests/docs still expecting the old phrasing

## Risks and Mitigations

- Risk: reviewers may interpret this as a broader product semantics change rather than a focused UX clarification.
- Mitigation: the PR scope is limited to wording/tests/docs and is tied to issue #52345.
- Risk: other surfaces may still contain older terminology not touched here.
- Mitigation: this PR updates the directly affected runtime paths and core docs first.