### PR TITLE
fix(slack): strip stray HEARTBEAT_OK tokens before delivery

### DIFF
--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -5,6 +5,11 @@ vi.mock("../send.js", () => ({
   sendMessageSlack: (...args: unknown[]) => sendMock(...args),
 }));
 
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  return { ...actual, logVerbose: vi.fn() };
+});
+
 import { deliverReplies } from "./replies.js";
 
 function baseParams(overrides?: Record<string, unknown>) {
@@ -52,6 +57,24 @@ describe("deliverReplies identity passthrough", () => {
 
     expect(sendMock).toHaveBeenCalledOnce();
     expect(sendMock.mock.calls[0][2]).not.toHaveProperty("identity");
+  });
+
+  it("strips HEARTBEAT_OK-only replies and does not call sendMessageSlack", async () => {
+    sendMock.mockResolvedValue(undefined);
+    await deliverReplies(baseParams({ replies: [{ text: "HEARTBEAT_OK" }] }));
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("strips inline HEARTBEAT_OK from mixed-content replies before delivery", async () => {
+    sendMock.mockResolvedValue(undefined);
+    await deliverReplies(
+      baseParams({ replies: [{ text: "Good morning! HEARTBEAT_OK" }] }),
+    );
+    // The token should be stripped; the remaining text should be sent.
+    expect(sendMock).toHaveBeenCalledOnce();
+    const sentText: string = sendMock.mock.calls[0][1];
+    expect(sentText).not.toContain("HEARTBEAT_OK");
+    expect(sentText.trim().length).toBeGreaterThan(0);
   });
 
   it("delivers block-only replies through to sendMessageSlack", async () => {

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -6,9 +6,15 @@ import {
 import type { ChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-runtime";
 import { createReplyReferencePlanner } from "openclaw/plugin-sdk/reply-runtime";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "openclaw/plugin-sdk/reply-runtime";
+import {
+  HEARTBEAT_TOKEN,
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+  stripHeartbeatToken,
+} from "openclaw/plugin-sdk/reply-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { parseSlackBlocksInput } from "../blocks-input.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
 import { sendMessageSlack, type SlackSendIdentity } from "../send.js";
@@ -36,13 +42,32 @@ export async function deliverReplies(params: {
   replyToMode: "off" | "first" | "all";
   identity?: SlackSendIdentity;
 }) {
+  let didLogHeartbeatStrip = false;
   for (const payload of params.replies) {
     // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
     // must not force threading.
     const inlineReplyToId = params.replyToMode === "off" ? undefined : payload.replyToId;
     const threadTs = inlineReplyToId ?? params.replyThreadTs;
-    const reply = resolveSendableOutboundReplyParts(payload);
-    const slackBlocks = readSlackReplyBlocks(payload);
+    // Safety-net: strip stray HEARTBEAT_OK tokens before delivery, mirroring
+    // the secondary stripping in the web/WhatsApp channel modules. The primary
+    // stripping happens in the reply dispatcher, but concurrent heartbeat runs
+    // can race with active DM sessions and bypass that path.
+    let strippedPayload = payload;
+    if (payload.text?.includes(HEARTBEAT_TOKEN)) {
+      const stripped = stripHeartbeatToken(payload.text, { mode: "message" });
+      if (stripped.didStrip) {
+        if (!didLogHeartbeatStrip) {
+          didLogHeartbeatStrip = true;
+          logVerbose("slack: stripped stray HEARTBEAT_OK token from reply");
+        }
+        if (stripped.shouldSkip && !payload.mediaUrl && !payload.mediaUrls?.length) {
+          continue;
+        }
+        strippedPayload = { ...payload, text: stripped.text };
+      }
+    }
+    const reply = resolveSendableOutboundReplyParts(strippedPayload);
+    const slackBlocks = readSlackReplyBlocks(strippedPayload);
     if (!reply.hasContent && !slackBlocks?.length) {
       continue;
     }
@@ -67,7 +92,7 @@ export async function deliverReplies(params: {
     }
 
     const delivered = await deliverTextOrMediaReply({
-      payload,
+      payload: strippedPayload,
       text: reply.text,
       chunkText: !reply.hasMedia
         ? (value) => {


### PR DESCRIPTION
## Summary

Adds a safety-net `HEARTBEAT_OK` strip in `deliverReplies()` (the Slack extension's final delivery function), mirroring the defense-in-depth stripping already present in the web/WhatsApp channel modules.

Fixes #52370

## Root Cause

The primary `HEARTBEAT_OK` stripping happens in `normalizeReplyPayload` (called by the reply dispatcher). However, when a heartbeat fires **concurrently** with an active Slack DM session, the response can reach `deliverReplies()` with a raw `HEARTBEAT_OK` token still present — because `createChannelReplyPipeline` (used by the Slack dispatch) does not include an `onHeartbeatStrip` callback, so the dispatcher's secondary strip path isn't wired up.

The web/WhatsApp modules catch this via `onHeartbeatStrip` in `dispatchReplyWithBufferedBlockDispatcher`. Slack lacks that safety net.

## Fix

```diff
+ // Safety-net: strip stray HEARTBEAT_OK tokens before delivery, mirroring
+ // the secondary stripping in the web/WhatsApp channel modules.
+ let strippedPayload = payload;
+ if (payload.text?.includes(HEARTBEAT_TOKEN)) {
+   const stripped = stripHeartbeatToken(payload.text, { mode: 'message' });
+   if (stripped.didStrip) {
+     if (stripped.shouldSkip && !payload.mediaUrl && !payload.mediaUrls?.length) {
+       continue;  // HEARTBEAT_OK-only reply: drop it entirely
+     }
+     strippedPayload = { ...payload, text: stripped.text };
+   }
+ }
```

This exactly follows the pattern used for `NO_REPLY` (already handled in `deliverReplies` via `isSilentReplyText`) and matches the web/WhatsApp secondary-strip approach.

## Changes

- `extensions/slack/src/monitor/replies.ts`: import `HEARTBEAT_TOKEN`, `stripHeartbeatToken`, and `logVerbose`; add strip logic before delivery
- `extensions/slack/src/monitor/replies.test.ts`: two new test cases covering HEARTBEAT_OK-only and mixed-content replies

## Testing

Two new tests in `replies.test.ts`:
1. HEARTBEAT_OK-only reply → `sendMessageSlack` is not called
2. Mixed reply (`"Good morning! HEARTBEAT_OK"`) → token stripped, remaining text delivered