### PR TITLE
fix(agents): call eventStream.end() on success path in OpenAI WS stream

### DIFF
--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -901,8 +901,10 @@ export function createOpenAIWebSocketStreamFn(
       });
     };
 
-    queueMicrotask(() =>
-      run().catch((err) => {
+    queueMicrotask(async () => {
+      try {
+        await run();
+      } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);
         log.warn(`[ws-stream] session=${sessionId} run error: ${errorMessage}`);
         eventStream.push({
@@ -913,9 +915,10 @@ export function createOpenAIWebSocketStreamFn(
             errorMessage,
           }),
         });
+      } finally {
         eventStream.end();
-      }),
-    );
+      }
+    });
 
     return eventStream;
   };


### PR DESCRIPTION
## Summary

Fixes #52435

`eventStream.end()` is only called in the `.catch()` error handler of the OpenAI WebSocket stream. On all success paths (WS completion, `fallbackToHttp`), the stream is never terminated, causing consumers using `for await` to hang indefinitely.

## Fix

Restructured from `.catch()` to `try/finally`, matching the pattern in `ollama-stream.ts`:

```diff
- queueMicrotask(() =>
-   run().catch((err) => {
-     // ... error handling ...
-     eventStream.end();
-   }),
- );
+ queueMicrotask(async () => {
+   try {
+     await run();
+   } catch (err) {
+     // ... error handling ...
+   } finally {
+     eventStream.end();
+   }
+ });
```

1 file, 7 insertions, 4 deletions.