### PR TITLE
fix(ollama): map thinkingLevel to Ollama-native think parameter

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -544,6 +544,61 @@ describe("createOllamaStreamFn", () => {
       [{ type: "text", text: "final answer" }],
     );
   });
+
+  it("sends think: false when reasoning option is not set (thinkingLevel=off)", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          options: {},
+        });
+
+        await collectStreamEvents(stream);
+
+        const [, requestInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const requestBody = JSON.parse(requestInit.body as string) as {
+          think?: boolean;
+        };
+        expect(requestBody.think).toBe(false);
+      },
+    );
+  });
+
+  it("sends think: true when reasoning option is set (thinkingLevel=high)", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const stream = await streamFn(
+          {
+            id: "qwen3:32b",
+            api: "ollama",
+            provider: "custom-ollama",
+            contextWindow: 131072,
+          } as unknown as Parameters<typeof streamFn>[0],
+          {
+            messages: [{ role: "user", content: "hello" }],
+          } as unknown as Parameters<typeof streamFn>[1],
+          { reasoning: "high" } as unknown as Parameters<typeof streamFn>[2],
+        );
+
+        await collectStreamEvents(stream);
+
+        const [, requestInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        const requestBody = JSON.parse(requestInit.body as string) as {
+          think?: boolean;
+        };
+        expect(requestBody.think).toBe(true);
+      },
+    );
+  });
 });
 
 describe("resolveOllamaBaseUrlForRun", () => {

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -44,6 +44,8 @@ interface OllamaChatRequest {
   stream: boolean;
   tools?: OllamaTool[];
   options?: Record<string, unknown>;
+  /** Ollama-native thinking toggle (≥0.8). `false` disables thinking output. */
+  think?: boolean;
 }
 
 interface OllamaChatMessage {
@@ -459,10 +461,18 @@ export function createOllamaStreamFn(
           ollamaOptions.num_predict = options.maxTokens;
         }
 
+        // Map pi-ai reasoning level to Ollama-native `think` parameter.
+        // When reasoning is explicitly set (any ThinkingLevel value), enable thinking.
+        // When reasoning is undefined (thinkingLevel=off), disable thinking to prevent
+        // thinking-capable models (qwen3.5, deepseek-r1, etc.) from spending tokens on
+        // internal reasoning output that wastes context window. See openclaw/openclaw#46680.
+        const think = options?.reasoning != null ? true : false;
+
         const body: OllamaChatRequest = {
           model: model.id,
           messages: ollamaMessages,
           stream: true,
+          think,
           ...(ollamaTools.length > 0 ? { tools: ollamaTools } : {}),
           options: ollamaOptions,
         };


### PR DESCRIPTION
## Summary

Maps OpenClaw's `thinkingLevel` setting to Ollama's native `think` parameter in the `/api/chat` request body.

- **`thinkingLevel=off`** (reasoning option not set) → `think: false` — prevents thinking-capable models from spending tokens on internal reasoning
- **`thinkingLevel=high/medium/low/etc.`** (reasoning option set) → `think: true` — enables Ollama-native thinking output

## Problem

Thinking-capable Ollama models (`qwen3.5`, `deepseek-r1`, etc.) default to thinking mode when `think` is not specified. When OpenClaw has `thinkingLevel=off`, the request never sends `think: false`, so the model wastes ~70% of tokens on internal reasoning that consumes context window with no benefit.

## Changes

- `src/agents/ollama-stream.ts`: Added `think` field to `OllamaChatRequest` interface and mapping logic in the request body builder
- `src/agents/ollama-stream.test.ts`: Two new tests verifying `think: false` when reasoning is unset and `think: true` when reasoning is set

## Testing

- Added unit tests for both paths
- Verified in production with `qwen3.5:35b` — token usage dropped ~70% on subagent runs with thinking disabled

Fixes #46680