### PR TITLE
perf(ci): trigger install smoke only for install surfaces

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -3,8 +3,32 @@ name: Install Smoke
 on:
   push:
     branches: [main]
+    paths:
+      - "Dockerfile"
+      - ".npmrc"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "scripts/install.sh"
+      - "scripts/test-install-sh-docker.sh"
+      - "scripts/docker/**"
+      - "extensions/*/package.json"
+      - ".github/workflows/install-smoke.yml"
+      - ".github/actions/setup-node-env/action.yml"
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    paths:
+      - "Dockerfile"
+      - ".npmrc"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "scripts/install.sh"
+      - "scripts/test-install-sh-docker.sh"
+      - "scripts/docker/**"
+      - "extensions/*/package.json"
+      - ".github/workflows/install-smoke.yml"
+      - ".github/actions/setup-node-env/action.yml"
   workflow_dispatch:
 
 concurrency:
@@ -15,64 +39,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-  docs-scope:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: blacksmith-16vcpu-ubuntu-2404
-    outputs:
-      docs_only: ${{ steps.check.outputs.docs_only }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-          fetch-tags: false
-
-      - name: Ensure docs-scope base commit
-        uses: ./.github/actions/ensure-base-commit
-        with:
-          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
-          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
-
-      - name: Detect docs-only changes
-        id: check
-        uses: ./.github/actions/detect-docs-changes
-
-  changed-smoke:
-    needs: [docs-scope]
-    if: needs.docs-scope.outputs.docs_only != 'true'
-    runs-on: blacksmith-16vcpu-ubuntu-2404
-    outputs:
-      run_changed_smoke: ${{ steps.scope.outputs.run_changed_smoke }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-          fetch-tags: false
-
-      - name: Ensure changed-smoke base commit
-        uses: ./.github/actions/ensure-base-commit
-        with:
-          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
-          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
-
-      - name: Detect changed smoke scope
-        id: scope
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [ "${{ github.event_name }}" = "push" ]; then
-            BASE="${{ github.event.before }}"
-          else
-            BASE="${{ github.event.pull_request.base.sha }}"
-          fi
-
-          node scripts/ci-changed-scope.mjs --base "$BASE" --head HEAD
-
   install-smoke:
-    needs: [docs-scope, changed-smoke]
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.docs-scope.outputs.docs_only != 'true' && needs.changed-smoke.outputs.run_changed_smoke == 'true'
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: blacksmith-16vcpu-ubuntu-2404
     env:
       DOCKER_BUILD_SUMMARY: "false"


### PR DESCRIPTION
## Summary
- move install-smoke gating to workflow trigger paths instead of in-workflow preflight jobs
- stop starting the Install Smoke workflow for unrelated PRs
- remove docs-only and changed-smoke preflight jobs from install-smoke itself

## Testing
- pnpm exec oxfmt .github/workflows/install-smoke.yml
- commit hook: pnpm check