### PR TITLE
fix(windows): prevent restart race from duplicate schtasks /Run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,6 +320,7 @@ Docs: https://docs.openclaw.ai
 - Process tool: show input-wait hints from `log` and `poll` for idle interactive background sessions so operators can inspect stuck CLIs and resume them with existing input actions. Fixes #33957. Thanks @bitloi and @vincentkoc.
 - Shell env/Windows: hide the login-shell environment probe child window so gateway startup and shell-env refreshes do not flash a console on Windows. Fixes #78159. (#78266) Thanks @BradGroux.
 - MS Teams: surface blocked Bot Framework egress by logging JWKS fetch network failures and adding a Bot Connector send hint for transport-level reply failures. Fixes #77674. (#78081) Thanks @Beandon13.
+- Windows/restart: skip duplicate scheduled-task `/Run` calls when the gateway task is already running, using a locale-stable PowerShell task-state probe before retrying. Fixes #52044. (#52487) Thanks @andyk-ms.
 - Media/host-read: allow buffer-verified ZIP archives in the host-local media validator so agents can send ZIP attachments via the message tool. Fixes #78057. (#78292) Thanks @Linux2010.
 - Gateway/sessions: fast-path already-qualified model refs while building session-list rows so `openclaw sessions` and Control UI session lists avoid heavyweight model resolution on large stores. (#77902) Thanks @ragesaq.
 - Contributor PRs: remind external contributors to redact private information like IP addresses, API keys, phone numbers, and non-public endpoints from real behavior proof. Thanks @pashpashpash.

--- a/src/infra/windows-task-restart.test.ts
+++ b/src/infra/windows-task-restart.test.ts
@@ -120,7 +120,13 @@ describe("relaunchGatewayScheduledTask", () => {
     expect(script).toContain(
       'openclaw restart attempt source=windows-task-handoff target="OpenClaw Gateway (work)"',
     );
+    expect(script).toContain(
+      `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "(Get-ScheduledTask -TaskName 'OpenClaw Gateway (work)' -ErrorAction SilentlyContinue).State" 2>nul | findstr /I /C:"Running" >nul 2>&1`,
+    );
     expect(script).toContain('schtasks /Run /TN "OpenClaw Gateway (work)" >>');
+    expect(script.indexOf("powershell.exe -NoProfile")).toBeLessThan(
+      script.indexOf('schtasks /Run /TN "OpenClaw Gateway (work)"'),
+    );
     expect(script).toContain('del "%~f0" >nul 2>&1');
   });
 
@@ -138,6 +144,23 @@ describe("relaunchGatewayScheduledTask", () => {
     const scriptPath = [...createdScriptPaths][0];
     const script = fs.readFileSync(scriptPath, "utf8");
     expect(script).toContain('schtasks /Run /TN "OpenClaw Gateway (custom)" >>');
+  });
+
+  it("escapes custom task names in the PowerShell running-task probe", () => {
+    spawnMock.mockImplementation((_file: string, args: string[]) => {
+      createdScriptPaths.add(decodeCmdPathArg(args[3]));
+      return { unref: vi.fn() };
+    });
+
+    relaunchGatewayScheduledTask({
+      OPENCLAW_WINDOWS_TASK_NAME: "OpenClaw Gateway (Bob's work)",
+    });
+
+    const scriptPath = [...createdScriptPaths][0];
+    const script = fs.readFileSync(scriptPath, "utf8");
+    expect(script).toContain(
+      "-Command \"(Get-ScheduledTask -TaskName 'OpenClaw Gateway (Bob''s work)' -ErrorAction SilentlyContinue).State\"",
+    );
   });
 
   it("returns failed when the helper cannot be spawned", () => {

--- a/src/infra/windows-task-restart.ts
+++ b/src/infra/windows-task-restart.ts
@@ -13,6 +13,10 @@ import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
 const TASK_RESTART_RETRY_LIMIT = 12;
 const TASK_RESTART_RETRY_DELAY_SEC = 1;
 
+function quotePowerShellSingleQuotedLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
 function resolveWindowsTaskName(env: NodeJS.ProcessEnv): string {
   const override = env.OPENCLAW_WINDOWS_TASK_NAME?.trim();
   if (override) {
@@ -29,6 +33,10 @@ function buildScheduledTaskRestartScript(params: {
 }): string {
   const { quotedLogPath, setupLines, taskName, taskScriptPath } = params;
   const quotedTaskName = quoteCmdScriptArg(taskName);
+  const queryTaskStateCommand = `(Get-ScheduledTask -TaskName ${quotePowerShellSingleQuotedLiteral(
+    taskName,
+  )} -ErrorAction SilentlyContinue).State`;
+  const quotedQueryTaskStateCommand = quoteCmdScriptArg(queryTaskStateCommand);
   const lines = [
     "@echo off",
     "setlocal",
@@ -40,6 +48,9 @@ function buildScheduledTaskRestartScript(params: {
     ":retry",
     `timeout /t ${TASK_RESTART_RETRY_DELAY_SEC} /nobreak >nul`,
     "set /a attempts+=1",
+    // Avoid racing with another restart path that already started the scheduled task.
+    `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ${quotedQueryTaskStateCommand} 2>nul | findstr /I /C:"Running" >nul 2>&1`,
+    "if not errorlevel 1 goto cleanup",
     `schtasks /Run /TN ${quotedTaskName} >> ${quotedLogPath} 2>&1`,
     "if not errorlevel 1 goto cleanup",
     `if %attempts% GEQ ${TASK_RESTART_RETRY_LIMIT} goto fallback`,


### PR DESCRIPTION
## Problem

When `openclaw gateway restart` runs, two sources race to start the task:

1. **CLI**: `schtasks /End` then `schtasks /Run`
2. **Self-restart script**: dying gateway fires `relaunchGatewayScheduledTask()` which spawns a detached `.cmd` that retries `schtasks /Run` up to 12 times

Both succeed, creating duplicate gateway windows (the "triple window" bug).

## Fix

The self-restart `.cmd` script now queries the task status before attempting `schtasks /Run`. If the task is already running (CLI beat it there), the script exits cleanly instead of spawning a duplicate.

## Impact

- Zero behavior change for config-watcher restarts (task won't be running yet)
- Prevents duplicate window on CLI-initiated restarts
- Self-cleaning: script still deletes itself on exit

Fixes #52044

## Real behavior proof

- **Behavior or issue addressed:** Windows gateway restart could open duplicate gateway windows because the CLI restart path and the self-restart helper could both run `schtasks /Run`. This patch makes the self-restart helper exit when Task Scheduler already reports the OpenClaw Gateway task as running.
- **Real environment tested:** Native Windows 11 build 26200 x64, Node v24.14.0, OpenClaw Gateway managed by Windows Task Scheduler.
- **Exact steps or command run after this patch:** Confirmed the OpenClaw Gateway scheduled task and single `node.exe` process before restart, triggered `openclaw gateway restart`, then rechecked Task Scheduler state and process output after restart.
- **Evidence after fix:** Copied live Windows Task Scheduler and process output from 2026-05-09 16:46-16:48 PDT:

```text
BEFORE RESTART
Timestamp: Sat 05/09/2026 16:46:16.18

--- Scheduled Task Status ---
TaskName:      \OpenClaw Gateway
Status:        Running
Logon Mode:    Interactive only

--- Node processes ---
Image Name                     PID Session Name        Session#    Mem Usage
========================= ======== ================ =========== ============
node.exe                     16588 Console                    2    590,396 K

=== 1 gateway instance confirmed ===

Gateway restart triggered:
[2026-05-09 16:47:34 PDT] Gateway restart ok (gateway.restart)

AFTER RESTART
Timestamp: Sat 05/09/2026 16:48:18.83

--- Scheduled Task Status ---
TaskName:      \OpenClaw Gateway
Status:        Running
Logon Mode:    Interactive only

--- Node processes ---
Image Name                     PID Session Name        Session#    Mem Usage
========================= ======== ================ =========== ============
node.exe                      7328 Console                    2    994,864 K

=== 1 gateway instance confirmed ===
```

- **Observed result after fix:** The old gateway PID `16588` was replaced by PID `7328`, exactly one gateway process existed before and after restart, the scheduled task stayed `Running`, and no duplicate gateway windows were observed.
- **What was not tested:** Non-English Windows locale was not separately rerun in this proof. The patch uses PowerShell `Get-ScheduledTask` state to avoid localized `schtasks` status text.
