### PR TITLE
docs: add memory tools to built-in tools table

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -64,6 +64,7 @@ These tools ship with OpenClaw and are available without installing any plugins:
 | `nodes`                      | Discover and target paired devices                       |                                   |
 | `cron` / `gateway`           | Manage scheduled jobs, restart gateway                   |                                   |
 | `image` / `image_generate`   | Analyze or generate images                               |                                   |
+| `memory_search` / `memory_get` | Semantic recall and targeted read of memory files        | [Memory](/concepts/memory)        |
 | `sessions_*` / `agents_list` | Session management, sub-agents                           | [Sub-agents](/tools/subagents)    |
 
 ### Plugin-provided tools


### PR DESCRIPTION
## Summary
- Adds `memory_search` / `memory_get` to the built-in tools table in `docs/tools/index.md`
- These tools were documented in `concepts/memory` and listed under `group:memory` in tool groups, but were missing from the main built-in tools table

## Test plan
- [ ] Verify the tools table renders correctly on Mintlify
- [ ] Confirm the `/concepts/memory` link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)