### PR TITLE
fix: sanitize reasoning content to prevent JSON parse errors (Issue #46637)

### DIFF
--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -251,12 +251,24 @@ function parseReasoningItem(value: unknown): Extract<InputItem, { type: "reasoni
   }
   return {
     type: "reasoning",
-    ...(typeof record.content === "string" ? { content: record.content } : {}),
+    ...(typeof record.content === "string" ? { content: sanitizeJsonString(record.content) } : {}),
     ...(typeof record.encrypted_content === "string"
       ? { encrypted_content: record.encrypted_content }
       : {}),
-    ...(typeof record.summary === "string" ? { summary: record.summary } : {}),
+    ...(typeof record.summary === "string" ? { summary: sanitizeJsonString(record.summary) } : {}),
   };
+}
+
+/**
+ * Remove invalid JSON control characters from a string.
+ * Control characters (U+0000 through U+001F) are invalid in JSON strings
+ * except for tab (\t), newline (\n), and carriage return (\r).
+ * This sanitization prevents oMLX/Pydantic JSON parse errors when models
+ * like Qwen return reasoning_content with invalid characters.
+ */
+function sanitizeJsonString(input: string): string {
+  // eslint-disable-next-line no-control-regex
+  return input.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/g, "");
 }
 
 function parseThinkingSignature(value: unknown): Extract<InputItem, { type: "reasoning" }> | null {


### PR DESCRIPTION
## Summary

When Qwen models return `reasoning_content` with invalid JSON control characters, subsequent API requests fail with JSON parse errors because oMLX/Pydantic rejects invalid characters.

This fix adds a `sanitizeJsonString()` function that removes invalid control characters (U+0000-U+001F except tab, newline, carriage return) from reasoning content before including it in API requests.

## Changes

- Added `sanitizeJsonString()` helper in `src/agents/openai-ws-stream.ts`
- Applied sanitization to both `content` and `summary` fields in `parseReasoningItem()`

## Testing

- Local validation: `pnpm vitest run src/agents/openai-ws-stream.test.ts`
- Lint: `pnpm lint`

## Related

- Issue: openclaw#46637
- Original PR: openclaw#46668 (closed - replaced by cleaner single-topic version)

---
**AI-ASSISTED** - Verified locally with test pass