### PR TITLE
fix(gateway): resolve Canvas 401 behind Tailscale Serve

### DIFF
--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -114,11 +114,10 @@ openclaw gateway --tailscale funnel --auth password
   ```json5
   {
     gateway: {
-      trustedProxies: ["127.0.0.1"],
+      trustedProxies: ["127.0.0.1", "::1"],
       tailscale: { mode: "serve" },
     },
   }
-  ```
 
 ## Browser control (remote Gateway + local browser)
 

--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -107,6 +107,18 @@ openclaw gateway --tailscale funnel --auth password
 - `gateway.bind: "auto"` prefers loopback; use `tailnet` if you want Tailnet-only.
 - Serve/Funnel only expose the **Gateway control UI + WS**. Nodes connect over
   the same Gateway WS endpoint, so Serve can work for node access.
+- **Canvas behind Serve**: Tailscale Serve connects from loopback and injects
+  `X-Forwarded-*` headers. The Gateway rejects forwarded requests unless the
+  source IP is in `gateway.trustedProxies`, which causes Canvas/A2UI to return 401. Add `"127.0.0.1"` (and `"::1"` if using IPv6 loopback) to
+  `gateway.trustedProxies` to fix this:
+  ```json5
+  {
+    gateway: {
+      trustedProxies: ["127.0.0.1"],
+      tailscale: { mode: "serve" },
+    },
+  }
+  ```
 
 ## Browser control (remote Gateway + local browser)
 

--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -118,6 +118,7 @@ openclaw gateway --tailscale funnel --auth password
       tailscale: { mode: "serve" },
     },
   }
+  ```
 
 ## Browser control (remote Gateway + local browser)
 

--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -112,6 +112,7 @@ openclaw gateway --tailscale funnel --auth password
   trust loopback as a proxy and fall back to the socket address for the
   loopback check. Add `trustedProxies` and `allowRealIpFallback` to fix
   Canvas/A2UI 401 errors:
+
   ```json5
   {
     gateway: {

--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -108,13 +108,15 @@ openclaw gateway --tailscale funnel --auth password
 - Serve/Funnel only expose the **Gateway control UI + WS**. Nodes connect over
   the same Gateway WS endpoint, so Serve can work for node access.
 - **Canvas behind Serve**: Tailscale Serve connects from loopback and injects
-  `X-Forwarded-*` headers. The Gateway rejects forwarded requests unless the
-  source IP is in `gateway.trustedProxies`, which causes Canvas/A2UI to return 401. Add `"127.0.0.1"` (and `"::1"` if using IPv6 loopback) to
-  `gateway.trustedProxies` to fix this:
+  `X-Forwarded-For` with the client's Tailscale IP. The Gateway needs to
+  trust loopback as a proxy and fall back to the socket address for the
+  loopback check. Add `trustedProxies` and `allowRealIpFallback` to fix
+  Canvas/A2UI 401 errors:
   ```json5
   {
     gateway: {
       trustedProxies: ["127.0.0.1", "::1"],
+      allowRealIpFallback: true,
       tailscale: { mode: "serve" },
     },
   }

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -5,6 +5,7 @@ import {
   authorizeGatewayConnect,
   authorizeHttpGatewayConnect,
   authorizeWsControlUiGatewayConnect,
+  isLocalDirectRequest,
   resolveGatewayAuth,
 } from "./auth.js";
 
@@ -648,5 +649,50 @@ describe("trusted-proxy auth", () => {
 
     expect(res.ok).toBe(true);
     expect(res.user).toBe("nick@example.com");
+  });
+});
+
+describe("isLocalDirectRequest — ts.net host-header gate", () => {
+  function makeReq(
+    host: string,
+    remoteAddress = "127.0.0.1",
+    headers: Record<string, string> = {},
+  ) {
+    return {
+      socket: { remoteAddress },
+      headers: { host, ...headers },
+    } as never;
+  }
+
+  it("rejects ts.net host when allowTailscale is not set", () => {
+    const req = makeReq("gateway.tailnet.ts.net");
+    expect(isLocalDirectRequest(req)).toBe(false);
+    expect(isLocalDirectRequest(req, undefined, false)).toBe(false);
+    expect(isLocalDirectRequest(req, undefined, false, {})).toBe(false);
+    expect(isLocalDirectRequest(req, undefined, false, { allowTailscale: false })).toBe(false);
+  });
+
+  it("accepts ts.net host when allowTailscale is true", () => {
+    const req = makeReq("gateway.tailnet.ts.net");
+    expect(isLocalDirectRequest(req, undefined, false, { allowTailscale: true })).toBe(true);
+  });
+
+  it("rejects ts.net host from non-loopback even with allowTailscale", () => {
+    const req = makeReq("gateway.tailnet.ts.net", "192.168.1.50");
+    expect(isLocalDirectRequest(req, undefined, false, { allowTailscale: true })).toBe(false);
+  });
+
+  it("accepts loopback host regardless of allowTailscale", () => {
+    const req = makeReq("localhost");
+    expect(isLocalDirectRequest(req)).toBe(true);
+    expect(isLocalDirectRequest(req, undefined, false, { allowTailscale: false })).toBe(true);
+    expect(isLocalDirectRequest(req, undefined, false, { allowTailscale: true })).toBe(true);
+  });
+
+  it("rejects ts.net host when forwarding headers present and remote is not trusted proxy", () => {
+    const req = makeReq("gateway.tailnet.ts.net", "127.0.0.1", {
+      "x-forwarded-for": "10.0.0.1",
+    });
+    expect(isLocalDirectRequest(req, undefined, false, { allowTailscale: true })).toBe(false);
   });
 });

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -652,7 +652,7 @@ describe("trusted-proxy auth", () => {
   });
 });
 
-describe("isLocalDirectRequest — ts.net host-header gate", () => {
+describe("isLocalDirectRequest", () => {
   function makeReq(
     host: string,
     remoteAddress = "127.0.0.1",
@@ -664,10 +664,41 @@ describe("isLocalDirectRequest — ts.net host-header gate", () => {
     } as never;
   }
 
+  it("returns true for direct loopback request without proxy headers", () => {
+    const req = makeReq("localhost:18789");
+    expect(isLocalDirectRequest(req, ["127.0.0.1"])).toBe(true);
+  });
+
+  it("returns false when resolved IP is not loopback (Tailscale XFF without fallback)", () => {
+    const req = makeReq("gateway.tail0947c7.ts.net", "::1", {
+      "x-forwarded-for": "100.75.251.23",
+      "x-forwarded-proto": "https",
+      "x-forwarded-host": "gateway.tail0947c7.ts.net",
+    });
+    expect(isLocalDirectRequest(req, ["127.0.0.1", "::1"], false)).toBe(false);
+  });
+
+  it("returns true via socket fallback when allowRealIpFallback is true (Tailscale Serve)", () => {
+    const req = makeReq("gateway.tail0947c7.ts.net", "::1", {
+      "x-forwarded-for": "100.75.251.23",
+      "x-forwarded-proto": "https",
+      "x-forwarded-host": "gateway.tail0947c7.ts.net",
+    });
+    expect(isLocalDirectRequest(req, ["127.0.0.1", "::1"], true, { allowTailscale: true })).toBe(
+      true,
+    );
+  });
+
+  it("returns false when socket is not loopback even with allowRealIpFallback", () => {
+    const req = makeReq("gateway.example.com", "192.168.1.50", {
+      "x-forwarded-for": "203.0.113.10",
+    });
+    expect(isLocalDirectRequest(req, ["192.168.1.50"], true)).toBe(false);
+  });
+
   it("rejects ts.net host when allowTailscale is not set", () => {
     const req = makeReq("gateway.tailnet.ts.net");
     expect(isLocalDirectRequest(req)).toBe(false);
-    expect(isLocalDirectRequest(req, undefined, false)).toBe(false);
     expect(isLocalDirectRequest(req, undefined, false, {})).toBe(false);
     expect(isLocalDirectRequest(req, undefined, false, { allowTailscale: false })).toBe(false);
   });

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -117,6 +117,7 @@ export function isLocalDirectRequest(
   req?: IncomingMessage,
   trustedProxies?: string[],
   allowRealIpFallback = false,
+  opts?: { allowTailscale?: boolean },
 ): boolean {
   if (!req) {
     return false;
@@ -133,7 +134,10 @@ export function isLocalDirectRequest(
   );
 
   const remoteIsTrustedProxy = isTrustedProxyAddress(req.socket?.remoteAddress, trustedProxies);
-  return isLocalishHost(req.headers?.host) && (!hasForwarded || remoteIsTrustedProxy);
+  return (
+    isLocalishHost(req.headers?.host, { allowTailscale: opts?.allowTailscale }) &&
+    (!hasForwarded || remoteIsTrustedProxy)
+  );
 }
 
 function getTailscaleUser(req?: IncomingMessage): TailscaleUser | null {
@@ -377,6 +381,7 @@ export async function authorizeGatewayConnect(
     req,
     trustedProxies,
     params.allowRealIpFallback === true,
+    { allowTailscale: auth.allowTailscale },
   );
 
   if (auth.mode === "trusted-proxy") {

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -123,7 +123,14 @@ export function isLocalDirectRequest(
     return false;
   }
   const clientIp = resolveRequestClientIp(req, trustedProxies, allowRealIpFallback) ?? "";
-  if (!isLoopbackAddress(clientIp)) {
+  let loopback = isLoopbackAddress(clientIp);
+  // When allowRealIpFallback is true, also check the raw socket address.
+  // This handles Tailscale Serve where the socket is ::1 (loopback)
+  // but XFF resolves to the client's Tailscale IP (100.x.x.x).
+  if (!loopback && allowRealIpFallback) {
+    loopback = isLoopbackAddress(req.socket?.remoteAddress ?? "");
+  }
+  if (!loopback) {
     return false;
   }
 

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -27,16 +27,29 @@ describe("resolveHostName", () => {
 });
 
 describe("isLocalishHost", () => {
-  it("accepts loopback and tailscale serve/funnel host headers", () => {
-    const accepted = [
-      "localhost",
-      "127.0.0.1:18789",
-      "[::1]:18789",
-      "[::ffff:127.0.0.1]:18789",
-      "gateway.tailnet.ts.net",
-    ];
+  it("accepts loopback hosts without allowTailscale", () => {
+    const accepted = ["localhost", "127.0.0.1:18789", "[::1]:18789", "[::ffff:127.0.0.1]:18789"];
     for (const host of accepted) {
       expect(isLocalishHost(host), host).toBe(true);
+    }
+  });
+
+  it("rejects *.ts.net hosts when allowTailscale is not set (default)", () => {
+    expect(isLocalishHost("gateway.tailnet.ts.net")).toBe(false);
+    expect(isLocalishHost("gateway.tailnet.ts.net", {})).toBe(false);
+    expect(isLocalishHost("gateway.tailnet.ts.net", { allowTailscale: false })).toBe(false);
+    expect(isLocalishHost("gateway.tailnet.ts.net", { allowTailscale: undefined })).toBe(false);
+  });
+
+  it("accepts *.ts.net hosts when allowTailscale is true", () => {
+    expect(isLocalishHost("gateway.tailnet.ts.net", { allowTailscale: true })).toBe(true);
+    expect(isLocalishHost("machine.example.ts.net", { allowTailscale: true })).toBe(true);
+  });
+
+  it("loopback hosts pass regardless of allowTailscale flag", () => {
+    for (const host of ["localhost", "127.0.0.1:18789", "[::1]:18789"]) {
+      expect(isLocalishHost(host, { allowTailscale: false }), host).toBe(true);
+      expect(isLocalishHost(host, { allowTailscale: true }), host).toBe(true);
     }
   });
 
@@ -44,6 +57,13 @@ describe("isLocalishHost", () => {
     const rejected = ["example.com", "192.168.1.10", "203.0.113.5:18789"];
     for (const host of rejected) {
       expect(isLocalishHost(host), host).toBe(false);
+    }
+  });
+
+  it("rejects non-local hosts even with allowTailscale", () => {
+    const rejected = ["example.com", "192.168.1.10", "attacker.ts.net.evil.com"];
+    for (const host of rejected) {
+      expect(isLocalishHost(host, { allowTailscale: true }), host).toBe(false);
     }
   });
 });

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -257,6 +257,20 @@ describe("resolveClientIp", () => {
       expected: "127.0.0.1",
     },
     {
+      name: "fails closed when trusted proxy sends empty X-Forwarded-For",
+      remoteAddr: "127.0.0.1",
+      forwardedFor: "",
+      trustedProxies: ["127.0.0.1"],
+      expected: undefined,
+    },
+    {
+      name: "fails closed when trusted proxy sends empty X-Real-IP",
+      remoteAddr: "127.0.0.1",
+      realIp: "",
+      trustedProxies: ["127.0.0.1"],
+      expected: undefined,
+    },
+    {
       name: "ignores invalid X-Forwarded-For entries",
       remoteAddr: "127.0.0.1",
       forwardedFor: "garbage, 10.0.0.999",

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -251,10 +251,10 @@ describe("resolveClientIp", () => {
       expected: undefined,
     },
     {
-      name: "fails closed when trusted proxy omits forwarding headers",
+      name: "returns socket address when trusted proxy omits forwarding headers (direct local request)",
       remoteAddr: "127.0.0.1",
       trustedProxies: ["127.0.0.1"],
-      expected: undefined,
+      expected: "127.0.0.1",
     },
     {
       name: "ignores invalid X-Forwarded-For entries",

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -360,14 +360,22 @@ export function isLoopbackHost(host: string): boolean {
 /**
  * Local-facing host check for inbound requests:
  * - loopback hosts (localhost/127.x/::1 and mapped forms)
- * - Tailscale Serve/Funnel hostnames (*.ts.net)
+ * - Tailscale Serve/Funnel hostnames (*.ts.net) — only when Tailscale is active
+ *
+ * The `allowTailscale` flag gates the `.ts.net` Host-header branch so that
+ * a co-resident process cannot spoof a Tailscale hostname when Tailscale is
+ * not configured.  Callers that do not pass the flag get loopback-only
+ * behaviour (safe default).
  */
-export function isLocalishHost(hostHeader?: string): boolean {
+export function isLocalishHost(hostHeader?: string, opts?: { allowTailscale?: boolean }): boolean {
   const host = resolveHostName(hostHeader);
   if (!host) {
     return false;
   }
-  return isLoopbackHost(host) || host.endsWith(".ts.net");
+  if (isLoopbackHost(host)) {
+    return true;
+  }
+  return opts?.allowTailscale === true && host.endsWith(".ts.net");
 }
 
 /**

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -192,7 +192,9 @@ export function resolveClientIp(params: {
   // When no forwarding headers are present at all, the request is directly
   // from the trusted-proxy host itself (not a proxied client request).
   // Return the socket address so callers can identify it as local.
-  if (!params.forwardedFor && !params.realIp) {
+  // Use strict undefined checks so that blank headers (empty strings sent by
+  // a misconfigured proxy) still fail closed.
+  if (params.forwardedFor === undefined && params.realIp === undefined) {
     return remote;
   }
 

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -183,8 +183,19 @@ export function resolveClientIp(params: {
     return forwardedIp;
   }
   if (params.allowRealIpFallback) {
-    return parseRealIp(params.realIp);
+    const realIp = parseRealIp(params.realIp);
+    if (realIp) {
+      return realIp;
+    }
   }
+
+  // When no forwarding headers are present at all, the request is directly
+  // from the trusted-proxy host itself (not a proxied client request).
+  // Return the socket address so callers can identify it as local.
+  if (!params.forwardedFor && !params.realIp) {
+    return remote;
+  }
+
   return undefined;
 }
 

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -186,7 +186,11 @@ async function canRevealReadinessDetails(params: {
   trustedProxies: string[];
   allowRealIpFallback: boolean;
 }): Promise<boolean> {
-  if (isLocalDirectRequest(params.req, params.trustedProxies, params.allowRealIpFallback)) {
+  if (
+    isLocalDirectRequest(params.req, params.trustedProxies, params.allowRealIpFallback, {
+      allowTailscale: params.resolvedAuth.allowTailscale,
+    })
+  ) {
     return true;
   }
   if (params.resolvedAuth.mode === "none") {

--- a/src/gateway/server/http-auth.ts
+++ b/src/gateway/server/http-auth.ts
@@ -78,7 +78,11 @@ export async function authorizeCanvasRequest(params: {
   if (malformedScopedPath) {
     return { ok: false, reason: "unauthorized" };
   }
-  if (isLocalDirectRequest(req, trustedProxies, allowRealIpFallback)) {
+  if (
+    isLocalDirectRequest(req, trustedProxies, allowRealIpFallback, {
+      allowTailscale: auth.allowTailscale,
+    })
+  ) {
     return { ok: true };
   }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -216,8 +216,12 @@ export function attachGatewayWsMessageHandler(params: {
   const hasProxyHeaders = Boolean(forwardedFor || realIp);
   const remoteIsTrustedProxy = isTrustedProxyAddress(remoteAddr, trustedProxies);
   const hasUntrustedProxyHeaders = hasProxyHeaders && !remoteIsTrustedProxy;
-  const hostIsLocalish = isLocalishHost(requestHost);
-  const isLocalClient = isLocalDirectRequest(upgradeReq, trustedProxies, allowRealIpFallback);
+  const hostIsLocalish = isLocalishHost(requestHost, {
+    allowTailscale: resolvedAuth.allowTailscale,
+  });
+  const isLocalClient = isLocalDirectRequest(upgradeReq, trustedProxies, allowRealIpFallback, {
+    allowTailscale: resolvedAuth.allowTailscale,
+  });
   const reportedClientIp =
     isLocalClient || hasUntrustedProxyHeaders
       ? undefined

--- a/src/gateway/session-kill-http.ts
+++ b/src/gateway/session-kill-http.ts
@@ -97,7 +97,9 @@ export async function handleSessionKillHttpRequest(
   const trustedProxies = opts.trustedProxies ?? cfg.gateway?.trustedProxies;
   const allowRealIpFallback = opts.allowRealIpFallback ?? cfg.gateway?.allowRealIpFallback;
   const requesterSessionKey = req.headers[REQUESTER_SESSION_KEY_HEADER]?.toString().trim();
-  const allowLocalAdminKill = isLocalDirectRequest(req, trustedProxies, allowRealIpFallback);
+  const allowLocalAdminKill = isLocalDirectRequest(req, trustedProxies, allowRealIpFallback, {
+    allowTailscale: opts.auth.allowTailscale,
+  });
   const allowBearerOperatorKill = canBearerTokenKillSessions(token, authResult.ok);
 
   if (!requesterSessionKey && !allowLocalAdminKill && !allowBearerOperatorKill) {


### PR DESCRIPTION
## Summary

- Problem: Canvas/A2UI returns 401 when accessed through Tailscale Serve. Two root causes: (1) `resolveClientIp()` returned `undefined` when a trusted proxy sent a request without forwarding headers, and (2) `isLocalDirectRequest()` did not fall back to the raw socket address when `allowRealIpFallback` is enabled and XFF resolves to a non-loopback Tailscale IP.
- Why it matters: Users with Tailscale Serve cannot use Canvas without non-obvious manual configuration.
- What changed: (1) `resolveClientIp()` returns the socket address as fallback when no forwarding headers are present (direct request from trusted proxy host). (2) `isLocalDirectRequest()` checks `req.socket.remoteAddress` when `allowRealIpFallback` is enabled. (3) `isLocalishHost()` now gates `.ts.net` host acceptance behind an `allowTailscale` flag (security hardening). (4) All callers thread `auth.allowTailscale` through. (5) Docs updated with required config for Canvas behind Serve.
- What did NOT change (scope boundary): No new auth modes or config keys introduced. The `allowTailscale` flag already existed; it is now threaded to `isLocalishHost` and `isLocalDirectRequest`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28472
- Depends on #50636 (should be merged first — overlapping `allowTailscale` gate changes)


## User-visible / Behavior Changes

- `resolveClientIp()` now returns the socket address (instead of `undefined`) when a trusted proxy connects without forwarding headers.
- `.ts.net` Host headers are no longer accepted as local by default; `gateway.auth.allowTailscale` (already defaulting to `true` when `tailscale.mode = "serve"`) must be active.
- New docs guidance: users must set `gateway.trustedProxies: ["127.0.0.1", "::1"]` and `gateway.allowRealIpFallback: true` when using Canvas behind Tailscale Serve.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Security improvement: `.ts.net` Host-header spoofing is now gated behind `allowTailscale` flag, preventing co-resident processes from bypassing local-direct auth when Tailscale is not configured.

## Repro + Verification

### Environment

- OS: Linux (Ubuntu)
- Runtime/container: Node 22+
- Integration/channel (if any): Tailscale Serve + Canvas/A2UI
- Relevant config (redacted): `gateway.tailscale.mode: "serve"`, `gateway.trustedProxies: ["127.0.0.1", "::1"]`, `gateway.allowRealIpFallback: true`

### Steps

1. Configure Gateway with `tailscale.mode: "serve"`, `trustedProxies: ["127.0.0.1", "::1"]`, and `allowRealIpFallback: true`.
2. Access Canvas/A2UI via `https://<machine>.tail<id>.ts.net/__openclaw__/canvas/`.
3. Observe 200 response.

### Expected

- Canvas loads successfully when accessed via Tailscale Serve.

### Actual (before fix)

- Canvas returns 401 because `resolveClientIp` returned `undefined` for direct trusted-proxy requests, and `isLocalDirectRequest` did not check the socket address as fallback.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

New tests in `src/gateway/auth.test.ts` and `src/gateway/net.test.ts` (105 tests passing). Simulated Tailscale Serve request via curl returned 200 after fix.

## Human Verification (required)

- Verified scenarios:
  - `curl -I http://127.0.0.1:18789/__openclaw__/canvas/` → 200 OK (loopback direct)
  - Simulated Tailscale Serve via `curl --resolve` with `X-Forwarded-For`/`X-Forwarded-Proto`/`X-Forwarded-Host` headers from loopback → 200 OK
  - Opened Canvas via Tailnet in the macOS app (OpenClaw) and confirmed it renders correctly
  - `curl -I https://polaris.tail8a307f.ts.net/__openclaw__/canvas/` from macOS → 200 OK (real Tailscale Serve end-to-end)
- Edge cases checked: non-loopback socket with `allowRealIpFallback` still returns false; `.ts.net` host rejected when `allowTailscale` is not set; non-`.ts.net` hosts (e.g. `attacker.ts.net.evil.com`) rejected even with `allowTailscale`.
- What you did **not** verify: Funnel mode (public internet exposure).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Users behind Tailscale Serve should add `trustedProxies` and `allowRealIpFallback` (documented)
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commits on this branch.
- Files/config to restore: `src/gateway/auth.ts`, `src/gateway/net.ts`, `src/gateway/server-http.ts`, `src/gateway/server/http-auth.ts`, `src/gateway/server/ws-connection/message-handler.ts`, `src/gateway/session-kill-http.ts`, `docs/gateway/tailscale.md`
- Known bad symptoms reviewers should watch for: requests from trusted proxies without forwarding headers being incorrectly identified as local; `.ts.net` hosts being rejected when `allowTailscale` is `true`.

## Risks and Mitigations

- Risk: `resolveClientIp()` returning the socket address when a trusted proxy omits forwarding headers could change behavior for other callers.
  - Mitigation: This only triggers when no XFF/X-Real-IP headers are present at all, meaning the request is directly from the proxy host itself, not a proxied client. Existing tests updated to reflect this.
- Risk: `.ts.net` host-header gate could break existing Tailscale Serve setups that rely on the unconditional `.ts.net` acceptance.
  - Mitigation: `allowTailscale` defaults to `true` when `tailscale.mode = "serve"`, preserving existing behavior for configured setups.