### PR TITLE
fix: widen symlink boundary for multi-agent workspace bootstrap files

### DIFF
--- a/src/agents/workspace.symlink-boundary.test.ts
+++ b/src/agents/workspace.symlink-boundary.test.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  DEFAULT_AGENT_WORKSPACE_DIR,
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_SOUL_FILENAME,
+  loadWorkspaceBootstrapFiles,
+} from "./workspace.js";
+
+describe("workspace symlink boundary widening", () => {
+  if (process.platform === "win32") {
+    it.skip("symlink tests not supported on Windows", () => {});
+    return;
+  }
+
+  let outsideRoot: string;
+  let insideAgentDir: string;
+  let sharedSoulPath: string;
+
+  beforeAll(async () => {
+    outsideRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-symlink-boundary-"));
+
+    // Ensure the test workspace root exists (HOME is redirected to a temp dir).
+    await fs.mkdir(DEFAULT_AGENT_WORKSPACE_DIR, { recursive: true });
+
+    // Create a temp agent dir inside DEFAULT_AGENT_WORKSPACE_DIR so
+    // resolveWorkspaceBoundary widens the boundary to the workspace root.
+    insideAgentDir = await fs.mkdtemp(
+      path.join(DEFAULT_AGENT_WORKSPACE_DIR, ".test-symlink-boundary-"),
+    );
+
+    // Shared file at workspace root level for the symlink-in test.
+    sharedSoulPath = path.join(DEFAULT_AGENT_WORKSPACE_DIR, ".test-shared-SOUL.md");
+  });
+
+  afterAll(async () => {
+    await fs.rm(outsideRoot, { recursive: true, force: true }).catch(() => {});
+    await fs.rm(insideAgentDir, { recursive: true, force: true }).catch(() => {});
+    await fs.unlink(sharedSoulPath).catch(() => {});
+  });
+
+  it("resolves symlinks from an agent dir to the workspace root", async () => {
+    await fs.writeFile(sharedSoulPath, "shared soul", "utf-8");
+    await fs.writeFile(path.join(insideAgentDir, DEFAULT_AGENTS_FILENAME), "agent config", "utf-8");
+    await fs.symlink(sharedSoulPath, path.join(insideAgentDir, DEFAULT_SOUL_FILENAME));
+
+    const files = await loadWorkspaceBootstrapFiles(insideAgentDir);
+    const soul = files.find((f) => f.name === DEFAULT_SOUL_FILENAME);
+    expect(soul?.missing).toBe(false);
+    expect(soul?.content).toBe("shared soul");
+  });
+
+  it("rejects symlinks that escape the workspace entirely", async () => {
+    const escapedFile = path.join(outsideRoot, DEFAULT_SOUL_FILENAME);
+    await fs.writeFile(escapedFile, "evil soul", "utf-8");
+
+    const agentDir = path.join(DEFAULT_AGENT_WORKSPACE_DIR, ".test-escape-agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(path.join(agentDir, DEFAULT_AGENTS_FILENAME), "agents", "utf-8");
+    await fs.symlink(escapedFile, path.join(agentDir, DEFAULT_SOUL_FILENAME));
+
+    try {
+      const files = await loadWorkspaceBootstrapFiles(agentDir);
+      const soul = files.find((f) => f.name === DEFAULT_SOUL_FILENAME);
+      expect(soul?.missing).toBe(true);
+      expect(soul?.content).toBeUndefined();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses agent dir as boundary when it is outside the workspace root", async () => {
+    const standaloneAgent = path.join(outsideRoot, "standalone-agent");
+    const externalDir = path.join(outsideRoot, "external");
+    await fs.mkdir(standaloneAgent, { recursive: true });
+    await fs.mkdir(externalDir, { recursive: true });
+
+    await fs.writeFile(
+      path.join(standaloneAgent, DEFAULT_AGENTS_FILENAME),
+      "standalone agents",
+      "utf-8",
+    );
+    await fs.writeFile(path.join(externalDir, DEFAULT_SOUL_FILENAME), "external soul", "utf-8");
+    await fs.symlink(
+      path.join(externalDir, DEFAULT_SOUL_FILENAME),
+      path.join(standaloneAgent, DEFAULT_SOUL_FILENAME),
+    );
+
+    const files = await loadWorkspaceBootstrapFiles(standaloneAgent);
+
+    const soul = files.find((f) => f.name === DEFAULT_SOUL_FILENAME);
+    expect(soul?.missing).toBe(true);
+    expect(soul?.content).toBeUndefined();
+
+    const agents = files.find((f) => f.name === DEFAULT_AGENTS_FILENAME);
+    expect(agents?.missing).toBe(false);
+    expect(agents?.content).toBe("standalone agents");
+  });
+});

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -484,8 +484,20 @@ async function resolveMemoryBootstrapEntry(
   return null;
 }
 
+/** Widen the boundary to the workspace root for agent dirs inside it; otherwise use the agent dir. */
+function resolveWorkspaceBoundary(agentDir: string): string {
+  const resolved = path.resolve(agentDir);
+  const workspaceRoot = path.resolve(DEFAULT_AGENT_WORKSPACE_DIR);
+  const rel = path.relative(workspaceRoot, resolved);
+  if (rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel))) {
+    return workspaceRoot;
+  }
+  return resolved;
+}
+
 export async function loadWorkspaceBootstrapFiles(dir: string): Promise<WorkspaceBootstrapFile[]> {
   const resolvedDir = resolveUserPath(dir);
+  const boundaryDir = resolveWorkspaceBoundary(resolvedDir);
 
   const entries: Array<{
     name: WorkspaceBootstrapFileName;
@@ -530,7 +542,7 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
   for (const entry of entries) {
     const loaded = await readWorkspaceFileWithGuards({
       filePath: entry.filePath,
-      workspaceDir: resolvedDir,
+      workspaceDir: boundaryDir,
     });
     if (loaded.ok) {
       result.push({
@@ -583,6 +595,7 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
     return { files: [], diagnostics: [] };
   }
   const resolvedDir = resolveUserPath(dir);
+  const boundaryDir = resolveWorkspaceBoundary(resolvedDir);
 
   // Resolve glob patterns into concrete file paths
   const resolvedPaths = new Set<string>();
@@ -618,7 +631,7 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
     }
     const loaded = await readWorkspaceFileWithGuards({
       filePath,
-      workspaceDir: resolvedDir,
+      workspaceDir: boundaryDir,
     });
     if (loaded.ok) {
       files.push({


### PR DESCRIPTION
## Problem

`loadWorkspaceBootstrapFiles` and `loadExtraBootstrapFilesWithDiagnostics` use the agent subdirectory as the symlink boundary when reading bootstrap files (SOUL.md, AGENTS.md, etc.). Any symlink whose target resolves outside that subdirectory is rejected, even if it points somewhere else inside the workspace.

```
~/.openclaw/workspace/          # workspace root
  SOUL.md
  agents/
    main/
      SOUL.md -> ../../SOUL.md  # rejected (resolves outside agents/main/)
```

## Fix

Adds `resolveWorkspaceBoundary()` which uses the workspace root (`DEFAULT_AGENT_WORKSPACE_DIR`) as the symlink boundary when the agent subdirectory is inside it. For agent directories outside the default workspace, the boundary remains unchanged.

- Symlinks resolving within the workspace are accepted
- Symlinks escaping the workspace are still rejected
- Existing behavior unchanged for non-default agent directory locations

## Changes

- `src/agents/workspace.ts`: Added `resolveWorkspaceBoundary()`, applied in both `loadWorkspaceBootstrapFiles` and `loadExtraBootstrapFilesWithDiagnostics`
- `src/agents/workspace.symlink-boundary.test.ts`: 3 tests covering resolution within the workspace, rejection of escape symlinks, and fallback for external agent dirs.