### PR TITLE
Gateway: preserve extension-origin allowlist matching

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -48,6 +48,15 @@ describe("checkBrowserOrigin", () => {
       expected: { ok: true as const, matchedBy: "allowlist" as const },
     },
     {
+      name: "accepts extension origins when explicitly allowlisted",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "chrome-extension://BfpnAggikhabdgbnhnngdfldkbinncdf",
+        allowedOrigins: [" chrome-extension://bfpnaggikhabdgbnhnngdfldkbinncdf "],
+      },
+      expected: { ok: true as const, matchedBy: "allowlist" as const },
+    },
+    {
       name: "accepts wildcard allowlists even alongside specific entries",
       input: {
         requestHost: "gateway.tailnet.ts.net:18789",
@@ -79,6 +88,15 @@ describe("checkBrowserOrigin", () => {
         origin: "not a url",
       },
       expected: { ok: false as const, reason: "origin missing or invalid" },
+    },
+    {
+      name: "rejects extension origins that are not allowlisted",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "chrome-extension://bfpnaggikhabdgbnhnngdfldkbinncdf",
+        allowedOrigins: ["chrome-extension://other-extension-id"],
+      },
+      expected: { ok: false as const, reason: "origin not allowed" },
     },
     {
       name: "rejects mismatched origins",

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -16,8 +16,10 @@ function parseOrigin(
   }
   try {
     const url = new URL(trimmed);
+    const normalizedOrigin =
+      url.origin === "null" ? trimmed.toLowerCase() : url.origin.toLowerCase();
     return {
-      origin: url.origin.toLowerCase(),
+      origin: normalizedOrigin,
       host: url.host.toLowerCase(),
       hostname: url.hostname.toLowerCase(),
     };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `gateway.controlUi.allowedOrigins` could not match configured `chrome-extension://...` origins because `parseOrigin()` normalized them to the literal string `"null"`.
- Why it matters: Control UI WebSocket connections from the browser extension were rejected with `origin not allowed` even when the exact origin was already allowlisted.
- What changed: `parseOrigin()` now preserves the lowercased raw origin string when Node reports `url.origin === "null"`, and gateway regression coverage now includes explicit allow and reject cases for extension origins.
- What did NOT change (scope boundary): wildcard behavior, normal http/https origin handling, host-header fallback, local-loopback fallback, and allowlist semantics remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52477
- Related #52477

## User-visible / Behavior Changes

Configured extension origins such as `chrome-extension://<id>` now match `gateway.controlUi.allowedOrigins` exactly instead of being normalized to `"null"` and rejected.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 25.6.1 local source checkout
- Model/provider: N/A
- Integration/channel (if any): Control UI browser-origin allowlist
- Relevant config (redacted): `gateway.controlUi.allowedOrigins=["chrome-extension://bfpnaggikhabdgbnhnngdfldkbinncdf"]`

### Steps

1. Evaluate `new URL("chrome-extension://bfpnaggikhabdgbnhnngdfldkbinncdf").origin` in Node.
2. Run the pre-fix origin check logic with `allowedOrigins=[" chrome-extension://bfpnaggikhabdgbnhnngdfldkbinncdf "]`.
3. Run the patched origin check with the same input.

### Expected

- The exact allowlisted extension origin is accepted.

### Actual

- Before this change, the pre-fix path returned `{ ok: false, reason: "origin not allowed" }` because `url.origin` became `"null"`.
- After this change, the patched path returns `{ ok: true, matchedBy: "allowlist" }`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before:

```json
{
  "before": {
    "ok": false,
    "reason": "origin not allowed"
  }
}
```

After:

```json
{
  "after": {
    "ok": true,
    "matchedBy": "allowlist"
  }
}
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: confirmed Node returns `"null"` for `chrome-extension://...` origins; confirmed patched runtime accepts an exact allowlisted extension origin; confirmed a different extension origin is still rejected; confirmed literal `"null"` input still rejects.
- Edge cases checked: existing lowercase/trimmed https allowlist matching still works.
- What you did **not** verify: I added regression tests in `src/gateway/origin-check.test.ts`, but the local Vitest wrapper did not return for this single-file lane in this environment, so I relied on direct runtime assertions plus the behavior-level before/after repro above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/gateway/origin-check.ts` and `src/gateway/origin-check.test.ts`.
- Known bad symptoms reviewers should watch for: unexpected allowlist matches for opaque-origin schemes; this should not occur beyond exact explicit allowlist entries.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: other opaque origins with `url.origin === "null"` now preserve the explicit raw origin string instead of the literal `"null"`.
  - Mitigation: matching is still exact allowlist-only, wildcard behavior is unchanged, and the literal input `"null"` remains rejected.
