### PR TITLE
fix(voice-call): resolve pending TTS entries on queue clear to prevent hanging promises

### DIFF
--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -500,7 +500,12 @@ export class MediaStreamHandler {
    */
   clearTtsQueue(streamSid: string, _reason = "unspecified"): void {
     const queue = this.getTtsQueue(streamSid);
-    queue.length = 0;
+    // Resolve pending entries so callers awaiting queueTts() don't hang.
+    const pending = queue.splice(0);
+    for (const entry of pending) {
+      entry.controller.abort();
+      entry.resolve();
+    }
     this.ttsActiveControllers.get(streamSid)?.abort();
     this.clearAudio(streamSid);
   }


### PR DESCRIPTION
## Summary

- `clearTtsQueue` discards pending queue entries via `queue.length = 0` but never calls `resolve()` or `reject()` on them
- Callers awaiting `queueTts()` hang indefinitely because the returned Promise is never settled
- The currently-playing entry is correctly handled (abort → resolve in `processQueue`), but queued-but-not-yet-playing entries leak

## Root cause

`queueTts()` (line 475) creates a Promise with `resolve`/`reject` callbacks stored in the queue entry. When `clearTtsQueue()` truncates the queue with `queue.length = 0`, those callbacks are discarded without being invoked. The caller's `await queueTts(...)` never returns.

This happens during barge-in: the user speaks while TTS is playing, triggering `clearTtsQueue()`. Any TTS operations queued behind the current one become permanently hanging promises.

## Fix

Replace `queue.length = 0` with `queue.splice(0)` to extract the pending entries, then abort and resolve each one before clearing audio. This ensures all awaiting callers proceed immediately on barge-in.

## Test plan

- [x] All 9 media-stream tests pass (`pnpm test -- extensions/voice-call/src/media-stream`)
- [x] Code inspection confirms the currently-playing entry path (abort → processQueue catch → resolve) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)