### PR TITLE
fix(gateway): preserve control ui scopes with dangerouslyDisableDeviceAuth

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -522,8 +522,8 @@ export function attachGatewayWsMessageHandler(params: {
           });
           const preserveInsecureLocalControlUiScopes =
             isControlUi &&
-            controlUiAuthPolicy.allowInsecureAuthConfigured &&
-            isLocalClient &&
+            (controlUiAuthPolicy.allowBypass ||
+              (controlUiAuthPolicy.allowInsecureAuthConfigured && isLocalClient)) &&
             (authMethod === "token" || authMethod === "password");
           const decision = evaluateMissingDeviceIdentity({
             hasDeviceIdentity: Boolean(device),


### PR DESCRIPTION
fixes #52561

ran into this while setting up remote access to the control ui over plain http through a vpn

when `dangerouslyDisableDeviceAuth` is enabled the connection gets allowed through correctly but then `clearUnboundScopes()` strips all the operator scopes because the scope preservation check only looked at the localhost + `allowInsecureAuth` path

the fix just adds `controlUiAuthPolicy.allowBypass` as an alternative condition for preserving scopes so remote connections with the dangerous flag actually work as intended

```diff
 const preserveInsecureLocalControlUiScopes =
   isControlUi &&
-  controlUiAuthPolicy.allowInsecureAuthConfigured &&
-  isLocalClient &&
+  (controlUiAuthPolicy.allowBypass ||
+    (controlUiAuthPolicy.allowInsecureAuthConfigured && isLocalClient)) &&
   (authMethod === "token" || authMethod === "password");
```

without this every api call from a remote control ui session fails with `missing scope: operator.read` even though the websocket connection itself succeeds