### PR TITLE
fix(agents): resolve strict9 tool-call-id mode for Mistral models via proxy providers (#52548)

### DIFF
--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -150,6 +150,22 @@ describe("resolveProviderCapabilities", () => {
     expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
   });
 
+  it("resolves strict9 for Mistral models routed through proxy providers (#52548)", () => {
+    // OpenRouter proxying Mistral models should still get strict9 sanitization.
+    expect(resolveTranscriptToolCallIdMode("openrouter", "mistralai/mistral-large-2512")).toBe(
+      "strict9",
+    );
+    expect(resolveTranscriptToolCallIdMode("openrouter", "mistralai/codestral-latest")).toBe(
+      "strict9",
+    );
+    // Non-Mistral models through OpenRouter should not get strict9.
+    expect(
+      resolveTranscriptToolCallIdMode("openrouter", "anthropic/claude-opus-4-6"),
+    ).toBeUndefined();
+    // Unknown providers proxying Mistral should also resolve strict9.
+    expect(resolveTranscriptToolCallIdMode("together", "mistralai/mixtral-8x22b")).toBe("strict9");
+  });
+
   it("treats kimi aliases as native anthropic tool payload providers", () => {
     expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi")).toBe(false);
     expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(false);

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -221,5 +221,19 @@ export function resolveTranscriptToolCallIdMode(
   if (modelIncludesAnyHint(modelId, capabilities.transcriptToolCallIdModelHints)) {
     return "strict9";
   }
+  // For proxy providers (openrouter, together, etc.) that don't declare
+  // strict9 themselves, check if the model matches hints from any provider
+  // that requires strict9 — e.g. Mistral models routed through OpenRouter.
+  if (modelId) {
+    for (const caps of Object.values(PLUGIN_CAPABILITIES_FALLBACKS)) {
+      if (
+        caps.transcriptToolCallIdMode === "strict9" &&
+        caps.transcriptToolCallIdModelHints &&
+        modelIncludesAnyHint(modelId, caps.transcriptToolCallIdModelHints)
+      ) {
+        return "strict9";
+      }
+    }
+  }
   return undefined;
 }


### PR DESCRIPTION
## Summary
When Mistral-family models are routed through proxy providers like OpenRouter, tool calls fail with `invalid_function_call` (code 3280) because tool call IDs are not sanitized to the strict 9-char alphanumeric format Mistral requires.

## Root Cause
`resolveTranscriptToolCallIdMode()` only checks the current provider's capabilities. When the provider is `openrouter`, it returns default capabilities with an empty `transcriptToolCallIdModelHints` array, so the Mistral model hints (`"mistral"`, `"mistralai"`, etc.) are never evaluated — even though the model ID clearly identifies a Mistral model.

## Changes
- `src/agents/provider-capabilities.ts`: After checking the current provider's capabilities, also iterate through all providers with `transcriptToolCallIdMode: "strict9"` and check their model hints against the model ID. This handles any proxy provider transparently.
- `src/agents/provider-capabilities.test.ts`: Added regression tests for OpenRouter + Mistral, OpenRouter + non-Mistral, and unknown proxy + Mistral scenarios.

## Test
```
pnpm test -- src/agents/provider-capabilities.test.ts
✓ 9 tests passed
```

Closes #52548