### PR TITLE
VS Code: disable experimental tsgo for editor TS server

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,5 @@
   "typescript.reportStyleChecksAsWarnings": false,
   "typescript.updateImportsOnFileMove.enabled": "always",
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.experimental.useTsgo": true
+  "typescript.experimental.useTsgo": false
 }


### PR DESCRIPTION
## Summary

- Problem: Workspace setting `typescript.experimental.useTsgo` was enabled, which can break or degrade TypeScript editor navigation in Cursor/VS Code (for example Go to Definition and Find References).
- Why it matters: Contributors rely on stable TS language-service navigation when working in this repo.
- What changed: Set `typescript.experimental.useTsgo` from `true` to `false` in `.vscode/settings.json`.
- What did NOT change (scope boundary): No runtime behavior, CLI behavior, gateway behavior, or app logic changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None (developer editor experience only).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (Fedora)
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Cursor/VS Code workspace settings

### Steps

1. Open this repo with workspace setting `typescript.experimental.useTsgo: true`.
2. Try TS navigation (Go to Definition / Find References) in `src/agents/agent-command.ts`.
3. Change `typescript.experimental.useTsgo` to `false`, reload the editor window, repeat step 2.

### Expected

TypeScript navigation works reliably.

### Actual

After setting `useTsgo` to `false`, navigation works as expected.

## Evidence

- [x] Failing behavior before + successful behavior after (manual verification)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Go to Definition and related TS navigation after reloading the editor.
- Edge cases checked: N/A for this one-line workspace setting change.
- What you did not verify: Cross-platform editor behavior outside this local environment.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes (workspace editor setting only)
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit or set `typescript.experimental.useTsgo` back to `true`.
- Files/config to restore: `.vscode/settings.json`
- Known bad symptoms reviewers should watch for: None expected.

## Risks and Mitigations

- Risk: Developers who explicitly wanted experimental tsgo behavior in this workspace may see different editor behavior.
  - Mitigation: They can override locally in personal settings if needed.

