### PR TITLE
feat(tui): allow overriding user message colors via env vars

### DIFF
--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -72,6 +72,8 @@ to apply context-specific rules.
 
 - `OPENCLAW_THEME=light`: force the light TUI palette when your terminal has a light background.
 - `OPENCLAW_THEME=dark`: force the dark TUI palette.
+- `OPENCLAW_TUI_USER_BG=#RRGGBB`: override the TUI user-message background color.
+- `OPENCLAW_TUI_USER_TEXT=#RRGGBB`: override the TUI user-message text color.
 - `COLORFGBG`: if your terminal exports it, OpenClaw uses the background color hint to auto-pick the TUI palette.
 
 ## Env var substitution in config

--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -128,6 +128,7 @@ Other Gateway slash commands (for example, `/context`) are forwarded to the Gate
 - The TUI keeps assistant body text in your terminal's default foreground so dark and light terminals both stay readable.
 - If your terminal uses a light background and auto-detection is wrong, set `OPENCLAW_THEME=light` before launching `openclaw tui`.
 - To force the original dark palette instead, set `OPENCLAW_THEME=dark`.
+- To customize just your own message card colors, set `OPENCLAW_TUI_USER_BG=#RRGGBB` and/or `OPENCLAW_TUI_USER_TEXT=#RRGGBB` before launching `openclaw tui`.
 
 ## History + streaming
 

--- a/src/tui/theme/theme.test.ts
+++ b/src/tui/theme/theme.test.ts
@@ -233,6 +233,26 @@ describe("light background detection", () => {
     expect(lightMod.theme.assistantText("hello")).toBe("hello");
     expect(darkMod.theme.assistantText("hello")).toBe("hello");
   });
+
+  it("allows overriding user message colors via env vars", async () => {
+    const mod = await importThemeWithEnv({
+      OPENCLAW_THEME: "dark",
+      OPENCLAW_TUI_USER_BG: "#8FAFCA",
+      OPENCLAW_TUI_USER_TEXT: "#102132",
+    });
+    expect(mod.palette.userBg).toBe("#8FAFCA");
+    expect(mod.palette.userText).toBe("#102132");
+  });
+
+  it("ignores invalid user color overrides", async () => {
+    const mod = await importThemeWithEnv({
+      OPENCLAW_THEME: "dark",
+      OPENCLAW_TUI_USER_BG: "steelblue",
+      OPENCLAW_TUI_USER_TEXT: "#12345",
+    });
+    expect(mod.palette.userBg).toBe(mod.darkPalette.userBg);
+    expect(mod.palette.userText).toBe(mod.darkPalette.userText);
+  });
 });
 
 describe("light palette accessibility", () => {

--- a/src/tui/theme/theme.ts
+++ b/src/tui/theme/theme.ts
@@ -11,6 +11,7 @@ import { createSyntaxTheme } from "./syntax-theme.js";
 
 const DARK_TEXT = "#E8E3D5";
 const LIGHT_TEXT = "#1E1E1E";
+const HEX_COLOR_RE = /^#[0-9a-f]{6}$/i;
 const XTERM_LEVELS = [0, 95, 135, 175, 215, 255] as const;
 
 function channelToSrgb(value: number): number {
@@ -75,6 +76,11 @@ function isLightBackground(): boolean {
   return false;
 }
 
+function readHexColorEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value && HEX_COLOR_RE.test(value) ? value : undefined;
+}
+
 /** Whether the terminal has a light background. Exported for testing only. */
 export const lightMode = isLightBackground();
 
@@ -126,7 +132,15 @@ export const lightPalette = {
   success: "#047857",
 } as const;
 
-export const palette = lightMode ? lightPalette : darkPalette;
+const basePalette = lightMode ? lightPalette : darkPalette;
+const userBgOverride = readHexColorEnv("OPENCLAW_TUI_USER_BG");
+const userTextOverride = readHexColorEnv("OPENCLAW_TUI_USER_TEXT");
+
+export const palette = {
+  ...basePalette,
+  ...(userBgOverride ? { userBg: userBgOverride } : {}),
+  ...(userTextOverride ? { userText: userTextOverride } : {}),
+};
 
 const fg = (hex: string) => (text: string) => chalk.hex(hex)(text);
 const bg = (hex: string) => (text: string) => chalk.bgHex(hex)(text);


### PR DESCRIPTION
## Summary\n- add  to override the TUI user message background color\n- add  to override the TUI user message text color\n- document the new env vars in TUI/environment docs\n- add tests for valid and invalid override values\n\n## Why\nIn dark terminal themes, the default user message styling can be too subtle to distinguish from assistant messages. This keeps the current default behavior while allowing users to tune just their own message card colors without patching installed build files manually.\n\n## Test\n- 
[1m[46m RUN [49m[22m [36mv4.1.0 [39m[90m/Users/songylee/.openclaw/workspace/projects/openclaw-upstream[39m

 [32m✓[39m src/tui/theme/theme.test.ts [2m([22m[2m27 tests[22m[2m)[22m[32m 15[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m27 passed[39m[22m[90m (27)[39m
[2m   Start at [22m 11:44:48
[2m   Duration [22m 227ms[2m (transform 64ms, setup 53ms, import 34ms, tests 15ms, environment 0ms)[22m