### PR TITLE
fix(feishu): remove duplicate tool registration

### DIFF
--- a/extensions/feishu/openclaw.plugin.json
+++ b/extensions/feishu/openclaw.plugin.json
@@ -1,7 +1,6 @@
 {
   "id": "feishu",
   "channels": ["feishu"],
-  "skills": ["./skills"],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -837,7 +837,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
         properties: {},
       },
       channels: ["feishu"],
-      skills: ["./skills"],
     },
   },
   {


### PR DESCRIPTION
## Summary

The Feishu plugin registers every tool twice — visible via [plugins] [debug] Database schema initialized
[plugins] [debug] OpenClaw fallback model: xiaomi via https://openrouter.ai/api/v1
[plugins] [debug] OpenClaw fallback model: xiaomi via https://openrouter.ai/api/v1
[plugins] [debug] Telemetry initialized (PostHog)
[plugins] memos-local: installed bundled skill memos-memory-guide → /home/ubuntu/.openclaw/workspace/skills/memos-memory-guide
[plugins] memos-local: installed bundled skill memos-memory-guide → /home/ubuntu/.openclaw/skills/memos-memory-guide (managed)
[plugins] [debug] OpenClaw fallback model: xiaomi via https://openrouter.ai/api/v1
[plugins] memos-local: initialized (db: /home/ubuntu/.openclaw/memos-local/memos.db)
[plugins] [debug] Database schema initialized
[plugins] [debug] OpenClaw fallback model: xiaomi via https://openrouter.ai/api/v1
[plugins] [debug] OpenClaw fallback model: xiaomi via https://openrouter.ai/api/v1
[plugins] [debug] Telemetry initialized (PostHog)
[plugins] memos-local: installed bundled skill memos-memory-guide → /home/ubuntu/.openclaw/workspace/skills/memos-memory-guide
[plugins] memos-local: installed bundled skill memos-memory-guide → /home/ubuntu/.openclaw/skills/memos-memory-guide (managed)
[plugins] [debug] OpenClaw fallback model: xiaomi via https://openrouter.ai/api/v1
[plugins] memos-local: initialized (db: /home/ubuntu/.openclaw/memos-local/memos.db)
[qqbot] resolveAllowFrom: accountId=default, allowFrom=["*"]
Gateway connection:
  Gateway target: ws://127.0.0.1:18789
  Source: local loopback
  Config: /home/ubuntu/.openclaw/openclaw.json
  Bind: loopback

OpenClaw status

Overview
┌─────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Item            │ Value                                                                                              │
├─────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Dashboard       │ http://127.0.0.1:18789/                                                                            │
│ OS              │ linux 6.17.0-1007-aws (x64) · node 24.14.0                                                         │
│ Tailscale       │ off                                                                                                │
│ Channel         │ stable (default)                                                                                   │
│ Update          │ pnpm · npm latest 2026.3.13                                                                        │
│ Gateway         │ local · ws://127.0.0.1:18789 (local loopback) · unreachable (missing scope: operator.read)         │
│ Gateway service │ systemd installed · enabled · running (pid 142064, state active)                                   │
│ Node service    │ systemd not installed                                                                              │
│ Agents          │ 1 · 1 bootstrap file present · sessions 7 · default main active 2m ago                             │
│ Memory          │ enabled (plugin memos-local-openclaw-plugin)                                                       │
│ Probes          │ skipped (use --deep)                                                                               │
│ Events          │ none                                                                                               │
│ Heartbeat       │ 30m (main)                                                                                         │
│ Sessions        │ 7 active · default xiaomi/mimo-v2-omni (262k ctx) · ~/.openclaw/agents/main/sessions/sessions.json │
└─────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────┘

Security audit
Summary: 1 critical · 5 warn · 1 info
  CRITICAL Small models require sandboxing and web tools disabled
    Small models (<=300B params) detected: - openrouter/nvidia/nemotron-3-super-120b-a12b:free (120B) @ agents.defaults.model.fallbacks (unsafe; sandbox=off; web=[…
    Fix: If you must use small models, enable sandboxing for all sessions (agents.defaults.sandbox.mode="all") and disable web_search/web_fetch/browser (tools.deny=["group:web","browser"]).
  WARN Reverse proxy headers are not trusted
    gateway.bind is loopback and gateway.trustedProxies is empty. If you expose the Control UI through a reverse proxy, configure trusted proxies so local-client c…
    Fix: Set gateway.trustedProxies to your proxy IPs or keep the Control UI local-only.
  WARN Some gateway.nodes.denyCommands entries are ineffective
    gateway.nodes.denyCommands uses exact node command-name matching only (for example `system.run`), not shell-text filtering inside a command payload. - Unknown …
    Fix: Use exact command names (for example: canvas.present, canvas.hide, canvas.navigate, canvas.eval, canvas.snapshot, canvas.a2ui.push, canvas.a2ui.pushJSONL, canvas.a2ui.reset). If you need broader restrictions, remove risky command IDs from allowCommands/default workflows and tighten tools.exec policy.
  WARN Potential multi-user setup detected (personal-assistant model warning)
    Heuristic signals indicate this gateway may be reachable by multiple users: - channels.qqbot.allowFrom includes "*" Runtime/process tools are exposed without f…
    Fix: If users may be mutually untrusted, split trust boundaries (separate gateways + credentials, ideally separate OS users/hosts). If you intentionally run shared-user access, set agents.defaults.sandbox.mode="all", keep tools.fs.workspaceOnly=true, deny runtime/fs/web tools unless required, and keep personal/private identities + credentials off that runtime.
  WARN Extensions exist but plugins.allow is not set
    Found 3 extension(s) under /home/ubuntu/.openclaw/extensions. Without plugins.allow, any discovered plugin id may load (depending on config and plugin behavior…
    Fix: Set plugins.allow to an explicit list of plugin ids you trust.
  WARN Plugin installs include unpinned npm specs
    Unpinned plugin install records: - openclaw-qqbot (@tencent-connect/openclaw-qqbot@latest) - mem9 (@mem9/mem9) - memos-local-openclaw-plugin (@memtensor/memos-…
    Fix: Pin install specs to exact versions (for example, `@scope/pkg@1.2.3`) for higher supply-chain stability.
Full report: openclaw security audit
Deep probe: openclaw security audit --deep

Channels
┌──────────┬─────────┬────────┬────────────────────────────────────────────────────────────────────────────────────────┐
│ Channel  │ Enabled │ State  │ Detail                                                                                 │
├──────────┼─────────┼────────┼────────────────────────────────────────────────────────────────────────────────────────┤
│ QQ Bot   │ ON      │ OK     │ configured                                                                             │
└──────────┴─────────┴────────┴────────────────────────────────────────────────────────────────────────────────────────┘

Sessions
┌──────────────────────────────────────┬────────┬─────────┬─────────────────────────┬──────────────────────────────────┐
│ Key                                  │ Kind   │ Age     │ Model                   │ Tokens                           │
├──────────────────────────────────────┼────────┼─────────┼─────────────────────────┼──────────────────────────────────┤
│ agent:main:qqbot:direct:c784af3…     │ direct │ 2m ago  │ xiaomi/mimo-v2-omni     │ 88k/262k (33%) · 🗄️ 0% cached    │
│ agent:main:main                      │ direct │ 26m ago │ xiaomi/mimo-v2-omni     │ 25k/262k (10%) · 🗄️ 0% cached    │
│ agent:main:cron:948c08c7-05e3-4…     │ direct │ 15h ago │ xiaomi/mimo-v2-omni     │ 25k/262k (10%) · 🗄️ 402% cached  │
│ agent:main:cron:948c08c7-05e3-4…     │ direct │ 15h ago │ xiaomi/mimo-v2-omni     │ 25k/262k (10%) · 🗄️ 402% cached  │
│ agent:main:cron:bc0a830d-eb16-4…     │ direct │ 5d ago  │ openrouter/healer-alpha │ 35k/262k (13%) · 🗄️ 1349% cached │
│ agent:main:cron:20e2e014-0388-4…     │ direct │ 5d ago  │ openrouter/healer-alpha │ 33k/262k (13%) · 🗄️ 429% cached  │
│ agent:main:cron:3037f795-1b38-4…     │ direct │ 5d ago  │ openrouter/healer-alpha │ 34k/262k (13%) · 🗄️ 536% cached  │
└──────────────────────────────────────┴────────┴─────────┴─────────────────────────┴──────────────────────────────────┘

FAQ: https://docs.openclaw.ai/faq
Troubleshooting: https://docs.openclaw.ai/troubleshooting

Next steps:
  Need to share?      openclaw status --all
  Need to debug live? openclaw logs --follow
  Fix reachability first: openclaw gateway probe on v2026.3.13.

## Root Cause

Two overlapping registration paths both fire during plugin load:

1.  declares  → auto-discovers and registers all tools in the  directory  
2.   calls , , etc. → registers the same tools again

## Fix

Removed the `skills` field from `extensions/feishu/openclaw.plugin.json`. The manual `registerXxxTools()` calls in `index.ts` are the intended primary registration path — they also handle `setFeishuRuntime()` and `registerChannel()`, keeping all plugin initialization in one place.

## Test

`openclaw status --verbose` should now show each feishu tool (doc, chat, wiki, drive, perm, bitable) exactly once.

## Issue

Fixes #52572