### PR TITLE
fix(plugins): deduplicate tool registration to prevent double-register

### DIFF
--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -266,7 +266,32 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       names.push(tool.name);
     }
 
-    const normalized = names.map((name) => name.trim()).filter(Boolean);
+    let normalized = names.map((name) => name.trim()).filter(Boolean);
+
+    // Deduplicate: skip if every resolved name from this plugin is already registered.
+    if (normalized.length > 0) {
+      const duplicateNames = normalized.filter((name) =>
+        registry.tools.some(
+          (existing) => existing.pluginId === record.id && existing.names.includes(name),
+        ),
+      );
+      if (duplicateNames.length > 0) {
+        // All names already registered by the same plugin — silently skip the duplicate.
+        if (duplicateNames.length === normalized.length) {
+          return;
+        }
+        // Partial overlap is unexpected; warn but still register the novel names.
+        pushDiagnostic({
+          level: "warn",
+          pluginId: record.id,
+          source: record.source,
+          message: `tool names already registered by same plugin, skipping duplicates: ${duplicateNames.join(", ")}`,
+        });
+        // Remove already-registered names so only novel ones are pushed below.
+        normalized = normalized.filter((name) => !duplicateNames.includes(name));
+      }
+    }
+
     if (normalized.length > 0) {
       record.toolNames.push(...normalized);
     }


### PR DESCRIPTION
## Summary

- Problem: Feishu plugin registers all tools twice during gateway startup. When `loadGatewayPlugins()` is called twice with different `preferSetupRuntimeForChannelPlugins` values (producing different cache keys), `registerFull()` executes twice for plugins that are already fully loaded on the first pass.
- Why it matters: Duplicate tools cause confusion in the agent tool selection and waste memory/startup time.
- What changed: Added deduplication logic in `registerTool()` (`src/plugins/registry.ts`) that silently skips a tool registration when the same plugin has already registered a tool with the same name. Partial overlaps emit a `warn` diagnostic.
- What did NOT change (scope boundary): No changes to plugin loading order, cache keying, or the deferred-channel-plugin promotion flow. `registerChannel` already had dedup logic; this aligns `registerTool` with that pattern.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52572

## User-visible / Behavior Changes

Plugin tools are no longer registered twice. Users with the Feishu plugin (or any plugin whose `registerFull()` runs more than once due to cache-key divergence) will see each tool appear exactly once.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node 22
- Integration/channel (if any): Feishu

### Steps

1. Configure a Feishu account with doc/chat/wiki tools enabled
2. Start the gateway
3. Observe tool registration logs

### Expected

Each tool (`feishu_doc`, `feishu_chat`, `feishu_wiki`, etc.) is registered exactly once.

### Actual (before fix)

Each tool registration log appears twice.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

All related tests pass:
- `extensions/feishu/index.test.ts` — 1 test passed
- `src/plugins/contracts/registry.contract.test.ts` — 19 tests passed
- `src/plugins/loader.test.ts` — 75 tests passed
- `pnpm tsgo` — no new errors introduced
- `pnpm format` — passed

## Human Verification (required)

- Verified scenarios: Ran feishu plugin test, loader test suite, registry contract tests
- Edge cases checked: Partial name overlap (warn diagnostic path), unnamed tools (no-op dedup)
- What you did **not** verify: Live Feishu gateway with real account (no credentials available)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit on `src/plugins/registry.ts`
- Files/config to restore: `src/plugins/registry.ts`
- Known bad symptoms reviewers should watch for: Tools not appearing if dedup check is too aggressive (unlikely — check is scoped to same pluginId + same tool name)

## Risks and Mitigations

- Risk: A plugin intentionally registers the same tool name twice with different factories.
  - Mitigation: The dedup only skips when the same `pluginId` re-registers the same name. Cross-plugin duplicates are unaffected. This matches the existing `registerChannel` dedup pattern.