### PR TITLE
fix(cron): catch schedule errors in createJob to prevent Gateway crash

### DIFF
--- a/src/cron/service/jobs.schedule-error-isolation.test.ts
+++ b/src/cron/service/jobs.schedule-error-isolation.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CronJob, CronStoreFile } from "../types.js";
-import { recomputeNextRuns } from "./jobs.js";
+import { createJob as createRealJob, recomputeNextRuns } from "./jobs.js";
 import type { CronServiceState } from "./state.js";
 
 function createMockState(jobs: CronJob[]): CronServiceState {
@@ -200,5 +200,23 @@ describe("cron schedule error isolation", () => {
     expect(badJob.state.lastError).toContain("invalid cron schedule: expr is required");
     expect(badJob.state.lastError).not.toContain("Cannot read properties of undefined");
     expect(badJob.state.scheduleErrorCount).toBe(1);
+  });
+
+  it("createJob records a schedule error instead of throwing on invalid cron expression", () => {
+    const state = createMockState([]);
+
+    const job = createRealJob(state, {
+      name: "Bad Cron",
+      enabled: true,
+      schedule: { kind: "cron", expr: "INVALID EXPRESSION", tz: "UTC" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "test" },
+    });
+
+    expect(job.state.nextRunAtMs).toBeUndefined();
+    expect(job.state.scheduleErrorCount).toBe(1);
+    expect(job.state.lastError).toMatch(/schedule error/);
+    expect(job.enabled).toBe(true);
   });
 });

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -603,7 +603,11 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
   assertMainSessionAgentId(job, state.deps.defaultAgentId);
   assertDeliverySupport(job);
   assertFailureDestinationSupport(job);
-  job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
+  try {
+    job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
+  } catch (err) {
+    recordScheduleComputeError({ state, job, err });
+  }
   return job;
 }
 


### PR DESCRIPTION
## Summary

- Wrap `computeJobNextRunAtMs()` in `createJob()` with try-catch to prevent Gateway crash on invalid cron expressions
- Reuses the existing `recordScheduleComputeError()` pattern from `recomputeJobNextRunAtMs()`
- Invalid jobs are created with `undefined` nextRunAtMs; subsequent scheduler ticks retry and auto-disable after 3 consecutive failures

## Root Cause

`createJob()` called `computeJobNextRunAtMs(job, now)` without error handling. An invalid cron expression (e.g., from manual store edits or malformed CLI input) threw an uncaught exception that propagated up and crashed the Gateway process.

The existing `recomputeJobNextRunAtMs()` already had proper try-catch with `recordScheduleComputeError()` — this fix applies the same pattern to the creation path.

## Test plan

- [x] `npm run build` passes
- [x] `src/cron/service.jobs.test.ts` — 35 tests pass
- [x] `src/cron/service/jobs.schedule-error-isolation.test.ts` — 8 tests pass
- [ ] Create a cron job with invalid expression → Gateway stays alive, job is created but disabled after 3 ticks

Fixes #52563

🤖 Generated with [Claude Code](https://claude.com/claude-code)