### PR TITLE
fix(feishu): do not treat @all as explicit bot mention

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -248,9 +248,9 @@ export function checkBotMentioned(event: FeishuMessageLike, botOpenId?: string):
   if (!botOpenId) {
     return false;
   }
-  if ((event.message.content ?? "").includes("@_all")) {
-    return true;
-  }
+  // IMPORTANT: Feishu group broadcast mentions (@所有人 / @_all) should not count as
+  // an explicit bot mention for requireMention gating. Otherwise any group-wide
+  // broadcast can bypass per-agent mention targeting (for example mentionPatterns).
   const mentions = event.message.mentions ?? [];
   if (mentions.length > 0) {
     return mentions.some((mention) => mention.id.open_id === botOpenId);

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -76,6 +76,12 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.mentionedBot).toBe(true);
   });
 
+  it("returns mentionedBot=false for @_all without explicit bot mention", () => {
+    const event = makeEvent("group", [], "@_all hello everyone");
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
   it("returns mentionedBot=true when bot mention name differs from configured botName", () => {
     const event = makeEvent("group", [
       { key: "@_user_1", name: "OpenClaw Bot (Alias)", id: { open_id: BOT_OPEN_ID } },


### PR DESCRIPTION
## Summary

In Feishu group chats, `@all` / `@_all` was treated as an explicit bot mention.

That breaks stricter mention gating for multi-agent or routed group setups using:

- `requireMention: true`
- per-agent `groupChat.mentionPatterns`

A group broadcast like `@所有人` could incorrectly pass mention gating and reach agents that are supposed to respond only when explicitly addressed.

## Changes

- stop treating Feishu `@_all` as an explicit bot mention in `checkBotMentioned()`
- keep explicit bot detection based on real mention metadata / rich-text mentions
- add regression coverage for `@_all` without explicit bot mention

## Why

`@all` / `@_all` is a group broadcast, not a directed bot mention.
It should not set `mentionedBot=true`, otherwise it can bypass the intended targeting model for routed agents.
