### PR TITLE
Fix channel removal in configure wizard

### DIFF
--- a/src/commands/configure.channels.test.ts
+++ b/src/commands/configure.channels.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const mocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  confirm: vi.fn(),
+  note: vi.fn(),
+  listChannelPlugins: vi.fn(),
+  getChannelPlugin: vi.fn(),
+}));
+
+vi.mock("../channels/plugins/index.js", () => ({
+  listChannelPlugins: mocks.listChannelPlugins,
+  getChannelPlugin: mocks.getChannelPlugin,
+}));
+
+vi.mock("../config/config.js", () => ({
+  CONFIG_PATH: "~/.openclaw/openclaw.json",
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note: mocks.note,
+}));
+
+vi.mock("./configure.shared.js", () => ({
+  confirm: mocks.confirm,
+  select: mocks.select,
+}));
+
+vi.mock("./onboard-helpers.js", () => ({
+  guardCancel: <T>(value: T) => value,
+}));
+
+import { removeChannelConfigWizard } from "./configure.channels.js";
+
+describe("removeChannelConfigWizard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("removes a channel through plugin deleteAccount in non-default-first order", async () => {
+    const deleteAccount = vi
+      .fn()
+      .mockImplementationOnce(({ cfg }: { cfg: OpenClawConfig; accountId: string }) => ({
+        ...cfg,
+        channels: {
+          whatsapp: {
+            enabled: true,
+          },
+        },
+      }))
+      .mockImplementationOnce(() => ({}) as OpenClawConfig);
+    const onAccountRemoved = vi.fn(async () => {});
+    const plugin = {
+      meta: { id: "whatsapp", label: "WhatsApp" },
+      config: {
+        listAccountIds: vi.fn(() => ["default", "work"]),
+        deleteAccount,
+      },
+      lifecycle: {
+        onAccountRemoved,
+      },
+    };
+
+    mocks.listChannelPlugins.mockReturnValue([plugin]);
+    mocks.getChannelPlugin.mockReturnValue(plugin);
+    mocks.select.mockResolvedValueOnce("whatsapp").mockResolvedValueOnce("done");
+    mocks.confirm.mockResolvedValue(true);
+
+    const result = await removeChannelConfigWizard(
+      {
+        channels: {
+          whatsapp: {
+            enabled: true,
+            accounts: {
+              work: { enabled: true },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      } as never,
+    );
+
+    expect(
+      deleteAccount.mock.calls.map((call) => (call[0] as { accountId: string }).accountId),
+    ).toEqual(["work", "default"]);
+    expect(
+      onAccountRemoved.mock.calls.map(
+        (call) =>
+          (
+            (call as Array<{ accountId: string } | undefined>)[0] as
+              | { accountId: string }
+              | undefined
+          )?.accountId,
+      ),
+    ).toEqual(["work", "default"]);
+    expect(result.channels).toBeUndefined();
+  });
+});

--- a/src/commands/configure.channels.test.ts
+++ b/src/commands/configure.channels.test.ts
@@ -49,7 +49,15 @@ describe("removeChannelConfigWizard", () => {
           },
         },
       }))
-      .mockImplementationOnce(() => ({}) as OpenClawConfig);
+      .mockImplementationOnce(
+        ({ cfg }: { cfg: OpenClawConfig; accountId: string }) =>
+          ({
+            ...cfg,
+            channels: {
+              whatsapp: {},
+            },
+          }) as OpenClawConfig,
+      );
     const onAccountRemoved = vi.fn(async () => {});
     const plugin = {
       meta: { id: "whatsapp", label: "WhatsApp" },

--- a/src/commands/configure.channels.ts
+++ b/src/commands/configure.channels.ts
@@ -2,6 +2,7 @@ import { getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { CONFIG_PATH } from "../config/config.js";
+import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
 import { shortenHomePath } from "../utils.js";
@@ -63,14 +64,41 @@ export async function removeChannelConfigWizard(
       continue;
     }
 
-    const nextChannels: Record<string, unknown> = { ...next.channels };
-    delete nextChannels[channel];
-    next = {
-      ...next,
-      channels: Object.keys(nextChannels).length
-        ? (nextChannels as OpenClawConfig["channels"])
-        : undefined,
-    };
+    const plugin = getChannelPlugin(channel);
+    if (!plugin?.config.deleteAccount) {
+      const nextChannels: Record<string, unknown> = { ...next.channels };
+      delete nextChannels[channel];
+      next = {
+        ...next,
+        channels: Object.keys(nextChannels).length
+          ? (nextChannels as OpenClawConfig["channels"])
+          : undefined,
+      };
+    } else {
+      const accountIds = plugin.config.listAccountIds(next);
+      const orderedAccountIds = [...accountIds].toSorted((a, b) => {
+        if (a === DEFAULT_ACCOUNT_ID && b !== DEFAULT_ACCOUNT_ID) {
+          return 1;
+        }
+        if (b === DEFAULT_ACCOUNT_ID && a !== DEFAULT_ACCOUNT_ID) {
+          return -1;
+        }
+        return a.localeCompare(b);
+      });
+
+      for (const accountId of orderedAccountIds) {
+        const prevCfg = next;
+        next = plugin.config.deleteAccount({
+          cfg: next,
+          accountId,
+        });
+        await plugin.lifecycle?.onAccountRemoved?.({
+          prevCfg,
+          accountId,
+          runtime,
+        });
+      }
+    }
 
     note(
       [`${label} removed from config.`, "Note: credentials/sessions on disk are unchanged."].join(

--- a/src/commands/configure.channels.ts
+++ b/src/commands/configure.channels.ts
@@ -9,6 +9,17 @@ import { shortenHomePath } from "../utils.js";
 import { confirm, select } from "./configure.shared.js";
 import { guardCancel } from "./onboard-helpers.js";
 
+function removeChannelSection(cfg: OpenClawConfig, channel: string): OpenClawConfig {
+  const nextChannels: Record<string, unknown> = { ...cfg.channels };
+  delete nextChannels[channel];
+  return {
+    ...cfg,
+    channels: Object.keys(nextChannels).length
+      ? (nextChannels as OpenClawConfig["channels"])
+      : undefined,
+  };
+}
+
 export async function removeChannelConfigWizard(
   cfg: OpenClawConfig,
   runtime: RuntimeEnv,
@@ -52,7 +63,8 @@ export async function removeChannelConfigWizard(
       return next;
     }
 
-    const label = getChannelPlugin(channel)?.meta.label ?? channel;
+    const plugin = getChannelPlugin(channel);
+    const label = plugin?.meta.label ?? channel;
     const confirmed = guardCancel(
       await confirm({
         message: `Delete ${label} configuration from ${shortenHomePath(CONFIG_PATH)}?`,
@@ -64,16 +76,8 @@ export async function removeChannelConfigWizard(
       continue;
     }
 
-    const plugin = getChannelPlugin(channel);
     if (!plugin?.config.deleteAccount) {
-      const nextChannels: Record<string, unknown> = { ...next.channels };
-      delete nextChannels[channel];
-      next = {
-        ...next,
-        channels: Object.keys(nextChannels).length
-          ? (nextChannels as OpenClawConfig["channels"])
-          : undefined,
-      };
+      next = removeChannelSection(next, channel);
     } else {
       const accountIds = plugin.config.listAccountIds(next);
       const orderedAccountIds = [...accountIds].toSorted((a, b) => {
@@ -97,6 +101,10 @@ export async function removeChannelConfigWizard(
           accountId,
           runtime,
         });
+      }
+
+      if (next.channels?.[channel] !== undefined) {
+        next = removeChannelSection(next, channel);
       }
     }
 


### PR DESCRIPTION
## Summary

- Problem: `openclaw configure channels` removed channel config by deleting raw JSON directly instead of going through the channel plugin removal path.
- Why it matters: channels with plugin-specific account cleanup behavior, including WhatsApp, can be left in an inconsistent state after removal and may reappear on restart.
- What changed: the configure wizard now delegates channel removal through each plugin's `deleteAccount` flow and calls `onAccountRemoved` for each account, removing non-default accounts before the default account.
- What did NOT change (scope boundary): this does not delete on-disk credentials or sessions, and it does not change the dedicated `openclaw channels remove` command behavior.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations
- [x] UI / DX

## Linked Issue/PR

- Related #52632

## User-visible / Behavior Changes

Removing a channel from `openclaw configure channels` now follows the channel plugin removal contract instead of only deleting the raw config entry.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm checkout
- Model/provider: N/A
- Integration/channel (if any): WhatsApp / channel removal path
- Relevant config (redacted): channel config with default and account-scoped entries

### Steps

1. Configure a channel through the configure wizard.
2. Remove it through `openclaw configure channels`.
3. Restart and verify the channel does not get reconstructed from the wizard removal path.

### Expected

- Channel removal should use the same plugin-aware deletion semantics as normal channel removal flows.

### Actual

- The wizard previously deleted raw config directly and bypassed plugin removal behavior.

## Evidence

- [x] Failing test/log before + passing after

Focused verification run:
`pnpm exec vitest run src/commands/configure.channels.test.ts src/commands/configure.wizard.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted tests for configure-channel removal and configure wizard flow
- Edge cases checked: non-default account is removed before the default account
- What you did **not** verify: full end-to-end WhatsApp runtime repro against a live linked account

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `src/commands/configure.channels.ts`
- Known bad symptoms reviewers should watch for: unexpected channel config persistence after wizard removal

## Risks and Mitigations

- Risk: plugin lifecycle behavior may differ across channels
- Mitigation: removal now uses the existing plugin removal contract instead of bypassing it, and a focused test covers account removal ordering

