### PR TITLE
chore: collapse redundant titleName alias in resolveToolNameForPermis…

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -103,10 +103,9 @@ function resolveToolNameForPermission(params: RequestPermissionRequest): string 
 
   const fromMeta = readFirstStringValue(toolMeta, ["toolName", "tool_name", "name"]);
   const fromRawInput = readFirstStringValue(rawInput, ["tool", "toolName", "tool_name", "name"]);
-  const fromTitle = parseToolNameFromTitle(toolCall?.title);
+  const titleName = parseToolNameFromTitle(toolCall?.title);
   const metaName = fromMeta ? normalizeToolName(fromMeta) : undefined;
   const rawInputName = fromRawInput ? normalizeToolName(fromRawInput) : undefined;
-  const titleName = fromTitle;
   if ((fromMeta && !metaName) || (fromRawInput && !rawInputName)) {
     return undefined;
   }


### PR DESCRIPTION
## Summary

- Problem: `resolveToolNameForPermission` created a redundant `titleName` alias that duplicated an existing value (`fromTitle`), increasing reader confusion.
- Why it matters: Permission resolution is security-sensitive UX; keeping the logic minimal and unambiguous reduces review/maintenance risk.
- What changed: Removed the redundant alias so the title-derived tool name is referenced directly (`titleName` is computed once and used consistently).
- What did NOT change (scope boundary): No runtime behavior or permission decision logic changed; only local variable naming/readability.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment
- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps
1.
2.
3.

### Expected
- Permission decisions remain identical.

### Actual
- N/A (logic was unchanged; variable alias was removed).

## Evidence

- [x] Trace/log snippets
  - Code inspection of `src/acp/client.ts`: the alias removal does not alter control flow; comparisons and return expression remain equivalent.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Code inspection only (no functional change expected).
- Edge cases checked: None beyond verifying the refactor did not modify any conditional logic.
- What you did not verify: Did not run tests (Ask mode).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the alias collapse in `src/acp/client.ts`.
- Files/config to restore: `src/acp/client.ts`
- Known bad symptoms reviewers should watch for: Any change in tool-name resolution passed to permission prompts (should be unchanged).

## Risks and Mitigations

- Risk: None (cosmetic refactor; no logic change).
  - Mitigation: N/A