### PR TITLE
optimize: add retries and fix-missing for apt-get

### DIFF
--- a/Dockerfile.sandbox-common
+++ b/Dockerfile.sandbox-common
@@ -25,7 +25,7 @@ RUN --mount=type=cache,id=openclaw-sandbox-common-apt-cache,target=/var/cache/ap
   --mount=type=cache,id=openclaw-sandbox-common-apt-lists,target=/var/lib/apt,sharing=locked \
   apt-get update \
   && apt-get -o Acquire::Retries=5 upgrade -y --no-install-recommends \
-  && apt-get -o Acquire::Retries=5 install -y --no-install-recommends --fix-missing ${PACKAGES}
+  && apt-get -o Acquire::Retries=5 install -y --no-install-recommends ${PACKAGES}
 
 RUN if [ "${INSTALL_PNPM}" = "1" ]; then npm install -g pnpm; fi
 

--- a/Dockerfile.sandbox-common
+++ b/Dockerfile.sandbox-common
@@ -24,8 +24,8 @@ ENV PATH=${BUN_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/bin:${BREW_INSTALL_DIR}/sbin
 RUN --mount=type=cache,id=openclaw-sandbox-common-apt-cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,id=openclaw-sandbox-common-apt-lists,target=/var/lib/apt,sharing=locked \
   apt-get update \
-  && apt-get upgrade -y --no-install-recommends \
-  && apt-get install -y --no-install-recommends ${PACKAGES}
+  && apt-get -o Acquire::Retries=5 upgrade -y --no-install-recommends \
+  && apt-get -o Acquire::Retries=5 install -y --no-install-recommends --fix-missing ${PACKAGES}
 
 RUN if [ "${INSTALL_PNPM}" = "1" ]; then npm install -g pnpm; fi
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Run sandbox-common-set to build openclaw image but easily failed because the occasionally bad network.
- Why it matters:Add the success posibility when building openclaw-sandbox image, meanwhile, the retries and fix-missings may add execution time for the building process.
- What changed: 
 Support upmost 5 retries to get dependencies.
 Support to use fix-missings to get dependencies from other available resources.

Dockerfile.sandbox-common
`RUN --mount=type=cache,id=openclaw-sandbox-common-apt-cache,target=/var/cache/apt,sharing=locked \ --mount=type=cache,id=openclaw-sandbox-common-apt-lists,target=/var/lib/apt,sharing=locked \ apt-get update \ && apt-get -o Acquire::Retries=5 upgrade -y --no-install-recommends \ && apt-get -o Acquire::Retries=5 install -y --no-install-recommends --fix-missing ${PACKAGES}`

- What did NOT change (scope boundary): Except above, others kept untacted.

## Change Type (select all)
- [x] Feature


## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related # [https://github.com/openclaw/openclaw/issues/52665](url)

## User-visible / Behavior Changes
None

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macos 14.4.1 (x64) · node 24.14.0
- Runtime/container: openclaw-sbx-agent-main-f331f052
- Model/provider: openai/gpt-5.2
- Integration/channel (if any): none
- Relevant config (redacted): none

### Steps

1. Run scripts/sandbox-common-setup.
2. Then wait until finished.
3. Check images `docker images`.

### Expected

- If successfully ended, you can get the target image `openclaw-sandbox-common` just as the following logs.

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
`./scripts/sandbox-common-setup.sh 
Building openclaw-sandbox-common:bookworm-slim with: curl wget jq coreutils grep nodejs npm python3 git ca-certificates golang-go rustc cargo unzip pkg-config libasound2-dev build-essential file
[+] Building 1580.6s (13/13) FINISHED                                                                                                                                      
 => [internal] load build definition from Dockerfile.sandbox-common                                                                                                   0.1s
 => => transferring dockerfile: 2.19kB                                                                                                                                0.0s
 => [internal] load .dockerignore                                                                                                                                     0.0s
 => => transferring context: 1.26kB                                                                                                                                   0.0s
 => resolve image config for docker.io/docker/dockerfile:1.7                                                                                                          0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:1.7                                                                                                             0.0s
 => [internal] load build definition from Dockerfile.sandbox-common                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/openclaw-sandbox:bookworm-slim                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                     0.0s
 => CACHED [stage-0 1/5] FROM docker.io/library/openclaw-sandbox:bookworm-slim                                                                                        0.0s
 => [stage-0 2/5] RUN --mount=type=cache,id=openclaw-sandbox-common-apt-cache,target=/var/cache/apt,sharing=locked   --mount=type=cache,id=openclaw-sandbox-commo  1078.8s
 => [stage-0 3/5] RUN if [ "1" = "1" ]; then npm install -g pnpm; fi                                                                                                 16.7s
 => [stage-0 4/5] RUN if [ "1" = "1" ]; then   curl -fsSL https://bun.sh/install | bash;   ln -sf "/opt/bun/bin/bun" /usr/local/bin/bun; fi                          89.5s 
 => [stage-0 5/5] RUN if [ "1" = "1" ]; then   if ! id -u linuxbrew >/dev/null 2>&1; then useradd -m -s /bin/bash linuxbrew; fi;   mkdir -p "/home/linuxbrew/.linu  380.7s 
 => exporting to image                                                                                                                                               14.3s 
 => => exporting layers                                                                                                                                              14.3s 
 => => writing image sha256:bbbb2042215a14aa9946bb724116a4a7af45317b17d31e6c9f3b12f0926a0996                                                                          0.0s 
 => => naming to docker.io/library/openclaw-sandbox-common:bookworm-slim                                                                                              0.0s 
Built openclaw-sandbox-common:bookworm-slim.                                                                                                                               
To use it, set agents.defaults.sandbox.docker.image to "openclaw-sandbox-common:bookworm-slim" and restart.                                                                
If you want a clean re-create, remove old sandbox containers:
  docker rm -f $(docker ps -aq --filter label=openclaw.sandbox=1)
esmezhou@MacBook-Pro-2 openclaw % 
esmezhou@MacBook-Pro-2 openclaw % docker images | grep common
openclaw-sandbox-common                                     bookworm-slim                  bbbb2042215a   3 minutes ago   1.89GB`
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Build openclaw-sandbox-common image.
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore: Dockerfile.sandbox-common
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation: None
