### PR TITLE
feat: add instruction precedence chain for skills

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -148,7 +148,7 @@ describe("buildAgentSystemPrompt", () => {
       "When a skill drives external API writes, assume rate limits: prefer fewer larger writes, avoid tight one-item loops, serialize bursts when possible, and respect 429/Retry-After.",
     );
     expect(prompt).toContain(
-      "Instruction precedence (highest → lowest): SKILL.md (active skill) > AGENTS.md > TOOLS.md > SOUL.md.",
+      "Instruction precedence (highest → lowest): SKILL.md (active skill) > AGENTS.md > TOOLS.md > SOUL.md. When instructions conflict, follow the higher-priority source.",
     );
   });
 

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -147,6 +147,9 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain(
       "When a skill drives external API writes, assume rate limits: prefer fewer larger writes, avoid tight one-item loops, serialize bursts when possible, and respect 429/Retry-After.",
     );
+    expect(prompt).toContain(
+      "Instruction precedence (highest → lowest): SKILL.md (active skill) > AGENTS.md > TOOLS.md > SOUL.md.",
+    );
   });
 
   it("omits skills in minimal prompt mode when skillsPrompt is absent", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -30,6 +30,7 @@ function buildSkillsSection(params: { skillsPrompt?: string; readToolName: strin
     "- If multiple could apply: choose the most specific one, then read/follow it.",
     "- If none clearly apply: do not read any SKILL.md.",
     "Constraints: never read more than one skill up front; only read after selecting.",
+    "- Instruction precedence (highest → lowest): SKILL.md (active skill) > AGENTS.md > TOOLS.md > SOUL.md. When instructions conflict, follow the higher-priority source.",
     "- When a skill drives external API writes, assume rate limits: prefer fewer larger writes, avoid tight one-item loops, serialize bursts when possible, and respect 429/Retry-After.",
     trimmed,
     "",


### PR DESCRIPTION
## Problem

When multiple workspace files (SKILL.md, AGENTS.md, TOOLS.md, SOUL.md) contain conflicting instructions, agents have no way to know which takes priority. This leads to unpredictable behavior where stale TOOLS.md entries can override canonical SKILL.md instructions.

## Solution

Add a one-line precedence rule to the skills section of the system prompt:

> Instruction precedence (highest -> lowest): SKILL.md (active skill) > AGENTS.md > TOOLS.md > SOUL.md. When instructions conflict, follow the higher-priority source.

This matches the natural expectation that a skill's own instructions should override general workspace config.

## Changes

- `src/agents/system-prompt.ts`: Add precedence line after skill constraints
- `src/agents/system-prompt.test.ts`: Assert precedence line appears in prompt

## Refs

- #39020 (priority tiers discussion)
- #32466 (per-agent INSTRUCTIONS.md)