### PR TITLE
feat(providers): add OfoxAI as an AI provider

### DIFF
--- a/extensions/ofoxai/index.ts
+++ b/extensions/ofoxai/index.ts
@@ -1,0 +1,83 @@
+import {
+  definePluginEntry,
+  type ProviderResolveDynamicModelContext,
+  type ProviderRuntimeModel,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { DEFAULT_CONTEXT_TOKENS } from "openclaw/plugin-sdk/provider-models";
+import { applyOfoxaiConfig, OFOXAI_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildOfoxaiProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "ofoxai";
+const OFOXAI_BASE_URL = "https://api.ofox.ai/v1";
+const OFOXAI_DEFAULT_MAX_TOKENS = 8192;
+
+function buildDynamicOfoxaiModel(
+  ctx: ProviderResolveDynamicModelContext,
+): ProviderRuntimeModel {
+  return {
+    id: ctx.modelId,
+    name: ctx.modelId,
+    api: "openai-completions",
+    provider: PROVIDER_ID,
+    baseUrl: OFOXAI_BASE_URL,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_TOKENS,
+    maxTokens: OFOXAI_DEFAULT_MAX_TOKENS,
+  };
+}
+
+export default definePluginEntry({
+  id: "ofoxai",
+  name: "OfoxAI Provider",
+  description: "Bundled OfoxAI provider plugin — unified API gateway for 100+ LLM models",
+  register(api) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "OfoxAI",
+      docsPath: "/providers/models",
+      envVars: ["OFOXAI_API_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: PROVIDER_ID,
+          methodId: "api-key",
+          label: "OfoxAI API key",
+          hint: "API key",
+          optionKey: "ofoxaiApiKey",
+          flagName: "--ofoxai-api-key",
+          envVar: "OFOXAI_API_KEY",
+          promptMessage: "Enter OfoxAI API key",
+          defaultModel: OFOXAI_DEFAULT_MODEL_REF,
+          expectedProviders: ["ofoxai"],
+          applyConfig: (cfg) => applyOfoxaiConfig(cfg),
+          wizard: {
+            choiceId: "ofoxai-api-key",
+            choiceLabel: "OfoxAI API key",
+            groupId: "ofoxai",
+            groupLabel: "OfoxAI",
+            groupHint: "API key",
+          },
+        }),
+      ],
+      catalog: {
+        order: "simple",
+        run: async (ctx) => {
+          const apiKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+          if (!apiKey) {
+            return null;
+          }
+          return {
+            provider: {
+              ...buildOfoxaiProvider(),
+              apiKey,
+            },
+          };
+        },
+      },
+      resolveDynamicModel: (ctx) => buildDynamicOfoxaiModel(ctx),
+      isModernModelRef: () => true,
+    });
+  },
+});

--- a/extensions/ofoxai/onboard.ts
+++ b/extensions/ofoxai/onboard.ts
@@ -1,0 +1,32 @@
+import {
+  applyAgentDefaultModelPrimary,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+
+export const OFOXAI_DEFAULT_MODEL_REF = "ofoxai/gpt-4o-mini";
+
+export function applyOfoxaiProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[OFOXAI_DEFAULT_MODEL_REF] = {
+    ...models[OFOXAI_DEFAULT_MODEL_REF],
+    alias: models[OFOXAI_DEFAULT_MODEL_REF]?.alias ?? "OfoxAI",
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+  };
+}
+
+export function applyOfoxaiConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(
+    applyOfoxaiProviderConfig(cfg),
+    OFOXAI_DEFAULT_MODEL_REF,
+  );
+}

--- a/extensions/ofoxai/openclaw.plugin.json
+++ b/extensions/ofoxai/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "ofoxai",
+  "providers": ["ofoxai"],
+  "providerAuthEnvVars": {
+    "ofoxai": ["OFOXAI_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "ofoxai",
+      "method": "api-key",
+      "choiceId": "ofoxai-api-key",
+      "choiceLabel": "OfoxAI API key",
+      "groupId": "ofoxai",
+      "groupLabel": "OfoxAI",
+      "groupHint": "API key",
+      "optionKey": "ofoxaiApiKey",
+      "cliFlag": "--ofoxai-api-key",
+      "cliOption": "--ofoxai-api-key <key>",
+      "cliDescription": "OfoxAI API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/ofoxai/package.json
+++ b/extensions/ofoxai/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/ofoxai-provider",
+  "version": "2026.3.22",
+  "private": true,
+  "description": "OpenClaw OfoxAI provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/ofoxai/provider-catalog.ts
+++ b/extensions/ofoxai/provider-catalog.ts
@@ -1,0 +1,47 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-models";
+
+const OFOXAI_BASE_URL = "https://api.ofox.ai/v1";
+const OFOXAI_DEFAULT_CONTEXT_WINDOW = 128000;
+const OFOXAI_DEFAULT_MAX_TOKENS = 8192;
+const OFOXAI_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+export function buildOfoxaiProvider(): ModelProviderConfig {
+  return {
+    baseUrl: OFOXAI_BASE_URL,
+    api: "openai-completions",
+    models: [
+      {
+        id: "gpt-4o-mini",
+        name: "GPT-4o Mini",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: OFOXAI_DEFAULT_COST,
+        contextWindow: OFOXAI_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: OFOXAI_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "claude-sonnet-4-20250514",
+        name: "Claude Sonnet 4",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: OFOXAI_DEFAULT_COST,
+        contextWindow: 200000,
+        maxTokens: OFOXAI_DEFAULT_MAX_TOKENS,
+      },
+      {
+        id: "deepseek-chat",
+        name: "DeepSeek V3",
+        reasoning: false,
+        input: ["text"],
+        cost: OFOXAI_DEFAULT_COST,
+        contextWindow: 64000,
+        maxTokens: OFOXAI_DEFAULT_MAX_TOKENS,
+      },
+    ],
+  };
+}

--- a/src/plugins/bundled-provider-auth-env-vars.generated.ts
+++ b/src/plugins/bundled-provider-auth-env-vars.generated.ts
@@ -21,6 +21,7 @@ export const BUNDLED_PROVIDER_AUTH_ENV_VAR_CANDIDATES = {
   modelstudio: ["MODELSTUDIO_API_KEY"],
   moonshot: ["MOONSHOT_API_KEY"],
   nvidia: ["NVIDIA_API_KEY"],
+  ofoxai: ["OFOXAI_API_KEY"],
   ollama: ["OLLAMA_API_KEY"],
   openai: ["OPENAI_API_KEY"],
   opencode: ["OPENCODE_API_KEY", "OPENCODE_ZEN_API_KEY"],


### PR DESCRIPTION
## Summary

Add [OfoxAI](https://ofox.ai) as a bundled provider plugin.

**OfoxAI** is a unified API gateway for 100+ LLM models (Claude, GPT, Gemini, DeepSeek, etc.) with a single API key. OpenAI-compatible format.

- **Website**: https://ofox.ai
- **API Docs**: https://docs.ofox.ai/zh/api
- **Base URL**: `https://api.ofox.ai/v1`
- **Env var**: `OFOXAI_API_KEY`

## Changes

New bundled plugin extension at `extensions/ofoxai/` following the same pattern as OpenRouter:

| File | Description |
|------|-------------|
| `extensions/ofoxai/package.json` | Extension package definition |
| `extensions/ofoxai/openclaw.plugin.json` | Plugin manifest with provider auth config |
| `extensions/ofoxai/index.ts` | Plugin entry with `definePluginEntry()` + `registerProvider()` |
| `extensions/ofoxai/provider-catalog.ts` | Provider config builder (OpenAI-compatible) |
| `extensions/ofoxai/onboard.ts` | Default model ref + config application |
| `src/plugins/bundled-provider-auth-env-vars.generated.ts` | Regenerated to include `OFOXAI_API_KEY` |

Note: `bundled-plugin-metadata.generated.ts` needs regeneration via `pnpm` (CI will handle this).