### PR TITLE
feat: add per-agent compaction and contextPruning config overrides

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -33,6 +33,8 @@ type ResolvedAgentConfig = {
   thinkingDefault?: AgentEntry["thinkingDefault"];
   reasoningDefault?: AgentEntry["reasoningDefault"];
   fastModeDefault?: AgentEntry["fastModeDefault"];
+  compaction?: AgentEntry["compaction"];
+  contextPruning?: AgentEntry["contextPruning"];
   skills?: AgentEntry["skills"];
   memorySearch?: AgentEntry["memorySearch"];
   humanDelay?: AgentEntry["humanDelay"];
@@ -138,6 +140,8 @@ export function resolveAgentConfig(
     thinkingDefault: entry.thinkingDefault,
     reasoningDefault: entry.reasoningDefault,
     fastModeDefault: entry.fastModeDefault,
+    compaction: entry.compaction,
+    contextPruning: entry.contextPruning,
     skills: Array.isArray(entry.skills) ? entry.skills : undefined,
     memorySearch: entry.memorySearch,
     humanDelay: entry.humanDelay,

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -1,5 +1,9 @@
 import type { ChatType } from "../channels/chat-type.js";
-import type { AgentDefaultsConfig } from "./types.agent-defaults.js";
+import type {
+  AgentDefaultsConfig,
+  AgentCompactionConfig,
+  AgentContextPruningConfig,
+} from "./types.agent-defaults.js";
 import type { AgentModelConfig, AgentSandboxConfig } from "./types.agents-shared.js";
 import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
@@ -71,6 +75,10 @@ export type AgentConfig = {
   reasoningDefault?: "on" | "off" | "stream";
   /** Optional per-agent default for fast mode. */
   fastModeDefault?: boolean;
+  /** Optional per-agent compaction settings (overrides agents.defaults.compaction). */
+  compaction?: AgentCompactionConfig;
+  /** Optional per-agent context pruning settings (overrides agents.defaults.contextPruning). */
+  contextPruning?: AgentContextPruningConfig;
   /** Optional allowlist of skills for this agent (omit = all skills; empty = none). */
   skills?: string[];
   memorySearch?: MemorySearchConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -14,6 +14,85 @@ import {
   TypingModeSchema,
 } from "./zod-schema.core.js";
 
+export const ContextPruningSchema = z
+  .object({
+    mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
+    ttl: z.string().optional(),
+    keepLastAssistants: z.number().int().nonnegative().optional(),
+    softTrimRatio: z.number().min(0).max(1).optional(),
+    hardClearRatio: z.number().min(0).max(1).optional(),
+    minPrunableToolChars: z.number().int().nonnegative().optional(),
+    tools: z
+      .object({
+        allow: z.array(z.string()).optional(),
+        deny: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
+    softTrim: z
+      .object({
+        maxChars: z.number().int().nonnegative().optional(),
+        headChars: z.number().int().nonnegative().optional(),
+        tailChars: z.number().int().nonnegative().optional(),
+      })
+      .strict()
+      .optional(),
+    hardClear: z
+      .object({
+        enabled: z.boolean().optional(),
+        placeholder: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .optional();
+
+export const CompactionSchema = z
+  .object({
+    mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
+    reserveTokens: z.number().int().nonnegative().optional(),
+    keepRecentTokens: z.number().int().positive().optional(),
+    reserveTokensFloor: z.number().int().nonnegative().optional(),
+    maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
+    customInstructions: z.string().optional(),
+    identifierPolicy: z
+      .union([z.literal("strict"), z.literal("off"), z.literal("custom")])
+      .optional(),
+    identifierInstructions: z.string().optional(),
+    recentTurnsPreserve: z.number().int().min(0).max(12).optional(),
+    qualityGuard: z
+      .object({
+        enabled: z.boolean().optional(),
+        maxRetries: z.number().int().nonnegative().optional(),
+      })
+      .strict()
+      .optional(),
+    postIndexSync: z.enum(["off", "async", "await"]).optional(),
+    postCompactionSections: z.array(z.string()).optional(),
+    model: z.string().optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+    memoryFlush: z
+      .object({
+        enabled: z.boolean().optional(),
+        softThresholdTokens: z.number().int().nonnegative().optional(),
+        forceFlushTranscriptBytes: z
+          .union([
+            z.number().int().nonnegative(),
+            z
+              .string()
+              .refine(isValidNonNegativeByteSizeString, "Expected byte size string like 2mb"),
+          ])
+          .optional(),
+        prompt: z.string().optional(),
+        systemPrompt: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .optional();
+
 export const AgentDefaultsSchema = z
   .object({
     model: AgentModelSchema.optional(),
@@ -52,83 +131,8 @@ export const AgentDefaultsSchema = z
     contextTokens: z.number().int().positive().optional(),
     cliBackends: z.record(z.string(), CliBackendSchema).optional(),
     memorySearch: MemorySearchSchema,
-    contextPruning: z
-      .object({
-        mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
-        ttl: z.string().optional(),
-        keepLastAssistants: z.number().int().nonnegative().optional(),
-        softTrimRatio: z.number().min(0).max(1).optional(),
-        hardClearRatio: z.number().min(0).max(1).optional(),
-        minPrunableToolChars: z.number().int().nonnegative().optional(),
-        tools: z
-          .object({
-            allow: z.array(z.string()).optional(),
-            deny: z.array(z.string()).optional(),
-          })
-          .strict()
-          .optional(),
-        softTrim: z
-          .object({
-            maxChars: z.number().int().nonnegative().optional(),
-            headChars: z.number().int().nonnegative().optional(),
-            tailChars: z.number().int().nonnegative().optional(),
-          })
-          .strict()
-          .optional(),
-        hardClear: z
-          .object({
-            enabled: z.boolean().optional(),
-            placeholder: z.string().optional(),
-          })
-          .strict()
-          .optional(),
-      })
-      .strict()
-      .optional(),
-    compaction: z
-      .object({
-        mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
-        reserveTokens: z.number().int().nonnegative().optional(),
-        keepRecentTokens: z.number().int().positive().optional(),
-        reserveTokensFloor: z.number().int().nonnegative().optional(),
-        maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
-        customInstructions: z.string().optional(),
-        identifierPolicy: z
-          .union([z.literal("strict"), z.literal("off"), z.literal("custom")])
-          .optional(),
-        identifierInstructions: z.string().optional(),
-        recentTurnsPreserve: z.number().int().min(0).max(12).optional(),
-        qualityGuard: z
-          .object({
-            enabled: z.boolean().optional(),
-            maxRetries: z.number().int().nonnegative().optional(),
-          })
-          .strict()
-          .optional(),
-        postIndexSync: z.enum(["off", "async", "await"]).optional(),
-        postCompactionSections: z.array(z.string()).optional(),
-        model: z.string().optional(),
-        timeoutSeconds: z.number().int().positive().optional(),
-        memoryFlush: z
-          .object({
-            enabled: z.boolean().optional(),
-            softThresholdTokens: z.number().int().nonnegative().optional(),
-            forceFlushTranscriptBytes: z
-              .union([
-                z.number().int().nonnegative(),
-                z
-                  .string()
-                  .refine(isValidNonNegativeByteSizeString, "Expected byte size string like 2mb"),
-              ])
-              .optional(),
-            prompt: z.string().optional(),
-            systemPrompt: z.string().optional(),
-          })
-          .strict()
-          .optional(),
-      })
-      .strict()
-      .optional(),
+    contextPruning: ContextPruningSchema,
+    compaction: CompactionSchema,
     embeddedPi: z
       .object({
         projectSettingsPolicy: z

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -13,85 +13,13 @@ import {
   HumanDelaySchema,
   TypingModeSchema,
 } from "./zod-schema.core.js";
+import {
+  ContextPruningSchema,
+  CompactionSchema,
+} from "./zod-schema.compaction.js";
 
-export const ContextPruningSchema = z
-  .object({
-    mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
-    ttl: z.string().optional(),
-    keepLastAssistants: z.number().int().nonnegative().optional(),
-    softTrimRatio: z.number().min(0).max(1).optional(),
-    hardClearRatio: z.number().min(0).max(1).optional(),
-    minPrunableToolChars: z.number().int().nonnegative().optional(),
-    tools: z
-      .object({
-        allow: z.array(z.string()).optional(),
-        deny: z.array(z.string()).optional(),
-      })
-      .strict()
-      .optional(),
-    softTrim: z
-      .object({
-        maxChars: z.number().int().nonnegative().optional(),
-        headChars: z.number().int().nonnegative().optional(),
-        tailChars: z.number().int().nonnegative().optional(),
-      })
-      .strict()
-      .optional(),
-    hardClear: z
-      .object({
-        enabled: z.boolean().optional(),
-        placeholder: z.string().optional(),
-      })
-      .strict()
-      .optional(),
-  })
-  .strict()
-  .optional();
-
-export const CompactionSchema = z
-  .object({
-    mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
-    reserveTokens: z.number().int().nonnegative().optional(),
-    keepRecentTokens: z.number().int().positive().optional(),
-    reserveTokensFloor: z.number().int().nonnegative().optional(),
-    maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
-    customInstructions: z.string().optional(),
-    identifierPolicy: z
-      .union([z.literal("strict"), z.literal("off"), z.literal("custom")])
-      .optional(),
-    identifierInstructions: z.string().optional(),
-    recentTurnsPreserve: z.number().int().min(0).max(12).optional(),
-    qualityGuard: z
-      .object({
-        enabled: z.boolean().optional(),
-        maxRetries: z.number().int().nonnegative().optional(),
-      })
-      .strict()
-      .optional(),
-    postIndexSync: z.enum(["off", "async", "await"]).optional(),
-    postCompactionSections: z.array(z.string()).optional(),
-    model: z.string().optional(),
-    timeoutSeconds: z.number().int().positive().optional(),
-    memoryFlush: z
-      .object({
-        enabled: z.boolean().optional(),
-        softThresholdTokens: z.number().int().nonnegative().optional(),
-        forceFlushTranscriptBytes: z
-          .union([
-            z.number().int().nonnegative(),
-            z
-              .string()
-              .refine(isValidNonNegativeByteSizeString, "Expected byte size string like 2mb"),
-          ])
-          .optional(),
-        prompt: z.string().optional(),
-        systemPrompt: z.string().optional(),
-      })
-      .strict()
-      .optional(),
-  })
-  .strict()
-  .optional();
+// Re-export for backwards compatibility
+export { ContextPruningSchema, CompactionSchema };
 
 export const AgentDefaultsSchema = z
   .object({

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -11,6 +11,10 @@ import {
   ToolsMediaSchema,
 } from "./zod-schema.core.js";
 import { sensitive } from "./zod-schema.sensitive.js";
+import {
+  ContextPruningSchema,
+  CompactionSchema,
+} from "./zod-schema.agent-defaults.js";
 
 export const HeartbeatSchema = z
   .object({
@@ -773,6 +777,8 @@ export const AgentEntrySchema = z
       .optional(),
     reasoningDefault: z.enum(["on", "off", "stream"]).optional(),
     fastModeDefault: z.boolean().optional(),
+    compaction: CompactionSchema,
+    contextPruning: ContextPruningSchema,
     skills: z.array(z.string()).optional(),
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -14,7 +14,7 @@ import { sensitive } from "./zod-schema.sensitive.js";
 import {
   ContextPruningSchema,
   CompactionSchema,
-} from "./zod-schema.agent-defaults.js";
+} from "./zod-schema.compaction.js";
 
 export const HeartbeatSchema = z
   .object({

--- a/src/config/zod-schema.compaction.ts
+++ b/src/config/zod-schema.compaction.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import { isValidNonNegativeByteSizeString } from "./byte-size.js";
+
+export const ContextPruningSchema = z
+  .object({
+    mode: z.union([z.literal("off"), z.literal("cache-ttl")]).optional(),
+    ttl: z.string().optional(),
+    keepLastAssistants: z.number().int().nonnegative().optional(),
+    softTrimRatio: z.number().min(0).max(1).optional(),
+    hardClearRatio: z.number().min(0).max(1).optional(),
+    minPrunableToolChars: z.number().int().nonnegative().optional(),
+    tools: z
+      .object({
+        allow: z.array(z.string()).optional(),
+        deny: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
+    softTrim: z
+      .object({
+        maxChars: z.number().int().nonnegative().optional(),
+        headChars: z.number().int().nonnegative().optional(),
+        tailChars: z.number().int().nonnegative().optional(),
+      })
+      .strict()
+      .optional(),
+    hardClear: z
+      .object({
+        enabled: z.boolean().optional(),
+        placeholder: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .optional();
+
+export const CompactionSchema = z
+  .object({
+    mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
+    reserveTokens: z.number().int().nonnegative().optional(),
+    keepRecentTokens: z.number().int().positive().optional(),
+    reserveTokensFloor: z.number().int().nonnegative().optional(),
+    maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
+    customInstructions: z.string().optional(),
+    identifierPolicy: z
+      .union([z.literal("strict"), z.literal("off"), z.literal("custom")])
+      .optional(),
+    identifierInstructions: z.string().optional(),
+    recentTurnsPreserve: z.number().int().min(0).max(12).optional(),
+    qualityGuard: z
+      .object({
+        enabled: z.boolean().optional(),
+        maxRetries: z.number().int().nonnegative().optional(),
+      })
+      .strict()
+      .optional(),
+    postIndexSync: z.enum(["off", "async", "await"]).optional(),
+    postCompactionSections: z.array(z.string()).optional(),
+    model: z.string().optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+    memoryFlush: z
+      .object({
+        enabled: z.boolean().optional(),
+        softThresholdTokens: z.number().int().nonnegative().optional(),
+        forceFlushTranscriptBytes: z
+          .union([
+            z.number().int().nonnegative(),
+            z
+              .string()
+              .refine(isValidNonNegativeByteSizeString, "Expected byte size string like 2mb"),
+          ])
+          .optional(),
+        prompt: z.string().optional(),
+        systemPrompt: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .optional();


### PR DESCRIPTION
## Summary

Adds support for per-agent `compaction` and `contextPruning` configuration overrides.

Previously, these settings could only be defined at `agents.defaults`, applying globally to all agents. This PR allows overriding them per agent in `agents.list`.

## Changes

- Added `compaction?: AgentCompactionConfig` to `AgentConfig` type
- Added `contextPruning?: AgentContextPruningConfig` to `AgentConfig` type
- Exported `ContextPruningSchema` and `CompactionSchema` from `zod-schema.agent-defaults.ts`
- Added both fields to `AgentEntrySchema` for runtime validation

## Usage Example

```json
{
  "agents": {
    "defaults": {
      "compaction": {
        "mode": "safeguard",
        "reserveTokens": 8000
      }
    },
    "list": [
      {
        "id": "main",
        "compaction": {
          "mode": "default",
          "reserveTokens": 12000
        }
      }
    ]
  }
}
