### PR TITLE
fix(telegram): route topic-bound subagent completion to canonical target

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -1202,6 +1202,70 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.threadId).toBe("42");
   });
 
+  it("routes bound completion announce delivery for telegram forum topics using canonical binding ids", async () => {
+    sendSpy.mockClear();
+    agentSpy.mockClear();
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: "child-session-telegram-topic-bound",
+      },
+      "agent:main:main": {
+        sessionId: "requester-session-telegram-topic-bound",
+        lastChannel: "telegram",
+        lastTo: "123",
+        lastThreadId: 42,
+      },
+    };
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+    });
+    registerSessionBindingAdapter({
+      channel: "telegram",
+      accountId: "default",
+      listBySession: (targetSessionKey: string) =>
+        targetSessionKey === "agent:main:subagent:test"
+          ? [
+              {
+                bindingId: "telegram:default:123:topic:42",
+                targetSessionKey,
+                targetKind: "subagent",
+                conversation: {
+                  channel: "telegram",
+                  accountId: "default",
+                  conversationId: "123:topic:42",
+                },
+                status: "active",
+                boundAt: Date.now(),
+              },
+            ]
+          : [],
+      resolveByConversation: () => null,
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-direct-telegram-topic-bound",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "telegram:123",
+        threadId: 42,
+      },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      spawnMode: "session",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.channel).toBe("telegram");
+    expect(call?.params?.to).toBe("123");
+    expect(call?.params?.threadId).toBe("42");
+  });
+
   it("uses hook-provided thread target across requester thread variants", async () => {
     const cases = [
       {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,3 +1,8 @@
+import {
+  buildTelegramTopicConversationId,
+  parseTelegramChatIdFromTarget,
+  parseTelegramTopicConversation,
+} from "../acp/conversation-id.js";
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
@@ -619,12 +624,18 @@ async function resolveSubagentCompletionOrigin(params: {
     requesterOrigin?.threadId != null && requesterOrigin.threadId !== ""
       ? String(requesterOrigin.threadId).trim()
       : undefined;
-  const conversationId =
-    threadId ||
-    resolveConversationIdFromTargets({
-      targets: [to],
-    }) ||
-    "";
+  const targetConversationId = resolveConversationIdFromTargets({
+    targets: [to],
+  });
+  const conversationId = (() => {
+    if (channel === "telegram" && threadId) {
+      const chatId = parseTelegramChatIdFromTarget(to) || targetConversationId;
+      if (chatId) {
+        return buildTelegramTopicConversationId({ chatId, topicId: threadId }) || threadId;
+      }
+    }
+    return threadId || targetConversationId || "";
+  })();
   const requesterConversation: ConversationRef | undefined =
     channel && conversationId ? { channel, accountId, conversationId } : undefined;
 
@@ -635,15 +646,28 @@ async function resolveSubagentCompletionOrigin(params: {
     failClosed: false,
   });
   if (route.mode === "bound" && route.binding) {
-    const boundTarget = resolveConversationDeliveryTarget({
-      channel: route.binding.conversation.channel,
-      conversationId: route.binding.conversation.conversationId,
-      parentConversationId: route.binding.conversation.parentConversationId,
-    });
+    const boundConversation = route.binding.conversation;
+    const parsedTelegramTopic =
+      boundConversation.channel === "telegram"
+        ? parseTelegramTopicConversation({
+            conversationId: boundConversation.conversationId,
+            parentConversationId: boundConversation.parentConversationId,
+          })
+        : null;
+    const boundTarget = parsedTelegramTopic
+      ? {
+          to: parsedTelegramTopic.chatId,
+          threadId: parsedTelegramTopic.topicId,
+        }
+      : resolveConversationDeliveryTarget({
+          channel: boundConversation.channel,
+          conversationId: boundConversation.conversationId,
+          parentConversationId: boundConversation.parentConversationId,
+        });
     return mergeDeliveryContext(
       {
-        channel: route.binding.conversation.channel,
-        accountId: route.binding.conversation.accountId,
+        channel: boundConversation.channel,
+        accountId: boundConversation.accountId,
         to: boundTarget.to,
         threadId:
           boundTarget.threadId ??

--- a/src/infra/outbound/bound-delivery-router.test.ts
+++ b/src/infra/outbound/bound-delivery-router.test.ts
@@ -127,6 +127,46 @@ describe("bound delivery router", () => {
     expect(route.binding?.conversation.conversationId).toBe("thread-2");
   });
 
+  it("matches telegram topic bindings via canonical conversation ids", () => {
+    registerSessionBindingAdapter({
+      channel: "telegram",
+      accountId: "runtime",
+      listBySession: (requestedSessionKey) =>
+        requestedSessionKey === TARGET_SESSION_KEY
+          ? [
+              {
+                bindingId: "telegram:runtime:-100123:topic:42",
+                targetSessionKey: TARGET_SESSION_KEY,
+                targetKind: "subagent",
+                conversation: {
+                  channel: "telegram",
+                  accountId: "runtime",
+                  conversationId: "-100123:topic:42",
+                },
+                status: "active",
+                boundAt: 1,
+              },
+            ]
+          : [],
+      resolveByConversation: () => null,
+    });
+
+    const route = createBoundDeliveryRouter().resolveDestination({
+      eventKind: "task_completion",
+      targetSessionKey: TARGET_SESSION_KEY,
+      requester: {
+        channel: "telegram",
+        accountId: "runtime",
+        conversationId: "-100123:topic:42",
+      },
+      failClosed: true,
+    });
+
+    expect(route.mode).toBe("bound");
+    expect(route.reason).toBe("requester-match");
+    expect(route.binding?.conversation.conversationId).toBe("-100123:topic:42");
+  });
+
   it("falls back for invalid requester conversation values", () => {
     registerDiscordSessionBindings(TARGET_SESSION_KEY, [
       createDiscordBinding(TARGET_SESSION_KEY, "thread-1", 1),


### PR DESCRIPTION
## Summary
- fix Telegram topic-bound subagent completion routing on current main
- canonicalize requester conversation ids for Telegram forum topics during completion routing
- restore canonical Telegram topic bindings into real outbound delivery shape (, )

## Root cause
Subagent completion routing matched requester conversation ids by raw  for threaded channels. That misses Telegram forum topic bindings, which are canonically keyed as , and can cause bound completion delivery to miss the intended topic target.

## Validation
- pnpm vitest run src/infra/outbound/bound-delivery-router.test.ts
- pnpm vitest run -c vitest.e2e.config.ts src/agents/subagent-announce.format.e2e.test.ts

## Notes
- replaces the stale/superseded direction from #50084 with a fresh minimal fix on current 
- repo-wide 
> openclaw@2026.3.22 check /home/oldroad/src/openclaw
> pnpm check:no-conflict-markers && pnpm check:host-env-policy:swift && pnpm check:base-config-schema && pnpm check:bundled-plugin-metadata && pnpm check:bundled-provider-auth-env-vars && pnpm format:check && pnpm tsgo && pnpm plugin-sdk:check-exports && pnpm lint && pnpm lint:tmp:no-random-messaging && pnpm lint:tmp:channel-agnostic-boundaries && pnpm lint:tmp:no-raw-channel-fetch && pnpm lint:agent:ingress-owner && pnpm lint:plugins:no-register-http-handler && pnpm lint:plugins:no-monolithic-plugin-sdk-entry-imports && pnpm lint:plugins:no-extension-src-imports && pnpm lint:plugins:no-extension-test-core-imports && pnpm lint:plugins:no-extension-imports && pnpm lint:plugins:plugin-sdk-subpaths-exported && pnpm lint:extensions:no-src-outside-plugin-sdk && pnpm lint:extensions:no-plugin-sdk-internal && pnpm lint:extensions:no-relative-outside-package && pnpm lint:web-search-provider-boundaries && pnpm lint:webhook:no-low-level-body-read && pnpm lint:auth:no-pairing-store-group && pnpm lint:auth:pairing-account-scope


> openclaw@2026.3.22 check:no-conflict-markers /home/oldroad/src/openclaw
> node scripts/check-no-conflict-markers.mjs


> openclaw@2026.3.22 check:host-env-policy:swift /home/oldroad/src/openclaw
> node scripts/generate-host-env-security-policy-swift.mjs --check

OK apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift

> openclaw@2026.3.22 check:base-config-schema /home/oldroad/src/openclaw
> node --import tsx scripts/generate-base-config-schema.ts --check


> openclaw@2026.3.22 check:bundled-plugin-metadata /home/oldroad/src/openclaw
> node scripts/generate-bundled-plugin-metadata.mjs --check


> openclaw@2026.3.22 check:bundled-provider-auth-env-vars /home/oldroad/src/openclaw
> node scripts/generate-bundled-provider-auth-env-vars.mjs --check


> openclaw@2026.3.22 format:check /home/oldroad/src/openclaw
> oxfmt --check --threads=1

Checking formatting...

All matched files use the correct format.
Finished in 11969ms on 8755 files using 1 threads.
src/agents/openai-ws-stream.e2e.test.ts(82,40): error TS2304: Cannot find name 'createOpenAIWebSocketStreamFn'.
src/agents/openai-ws-stream.ts(117,25): error TS2352: Conversion of type 'undefined' to type 'AssistantMessageEvent' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
src/agents/openai-ws-stream.ts(686,3): error TS2322: Type '(model: Model<Api>, context: Context, options: SimpleStreamOptions | undefined) => AssistantMessageEventStreamLike' is not assignable to type 'StreamFn'.
  Type 'AssistantMessageEventStreamLike' is not assignable to type 'AssistantMessageEventStream | Promise<AssistantMessageEventStream>'.
    Type 'AssistantMessageEventStreamLike' is not assignable to type 'AssistantMessageEventStream'.
      Type 'AsyncIterable<AssistantMessageEvent> & { push(event: AssistantMessageEvent): void; end(result?: AssistantMessage): void; result(): Promise<AssistantMessage>; }' is missing the following properties from type 'AssistantMessageEventStream': isComplete, extractResult, queue, waiting, and 3 more.
 ELIFECYCLE  Command failed with exit code 2. is still blocked by unrelated pre-existing  TypeScript errors

Refs #55
Refs #53