### PR TITLE
Fix Feishu chat account routing

### DIFF
--- a/extensions/feishu/src/chat.test.ts
+++ b/extensions/feishu/src/chat.test.ts
@@ -24,7 +24,7 @@ describe("registerFeishuChatTools", () => {
     });
   });
 
-  it("registers feishu_chat and handles info/members actions", async () => {
+  it("registers feishu_chat, merges enabled accounts, and routes through the selected account", async () => {
     const registerTool = vi.fn();
     registerFeishuChatTools({
       config: {
@@ -33,7 +33,14 @@ describe("registerFeishuChatTools", () => {
             enabled: true,
             appId: "app_id",
             appSecret: "app_secret", // pragma: allowlist secret
-            tools: { chat: true },
+            tools: { chat: false },
+            accounts: {
+              work: {
+                appId: "work_app_id",
+                appSecret: "work_app_secret", // pragma: allowlist secret
+                tools: { chat: true },
+              },
+            },
           },
         },
       } as any,
@@ -42,7 +49,8 @@ describe("registerFeishuChatTools", () => {
     } as any);
 
     expect(registerTool).toHaveBeenCalledTimes(1);
-    const tool = registerTool.mock.calls[0]?.[0];
+    const toolFactory = registerTool.mock.calls[0]?.[0];
+    const tool = toolFactory?.({ agentAccountId: "work" });
     expect(tool?.name).toBe("feishu_chat");
 
     chatGetMock.mockResolvedValueOnce({
@@ -50,6 +58,9 @@ describe("registerFeishuChatTools", () => {
       data: { name: "group name", user_count: 3 },
     });
     const infoResult = await tool.execute("tc_1", { action: "info", chat_id: "oc_1" });
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "work", appId: "work_app_id" }),
+    );
     expect(infoResult.details).toEqual(
       expect.objectContaining({ chat_id: "oc_1", name: "group name", user_count: 3 }),
     );
@@ -93,6 +104,22 @@ describe("registerFeishuChatTools", () => {
         email: "member1@example.com",
         department_ids: ["od_1"],
       }),
+    );
+
+    chatGetMock.mockResolvedValueOnce({
+      code: 0,
+      data: { name: "default group", user_count: 7 },
+    });
+    const explicitAccountResult = await tool.execute("tc_4", {
+      action: "info",
+      accountId: "default",
+      chat_id: "oc_default",
+    });
+    expect(createFeishuClientMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accountId: "default", appId: "app_id" }),
+    );
+    expect(explicitAccountResult.details).toEqual(
+      expect.objectContaining({ chat_id: "oc_default", name: "default group", user_count: 7 }),
     );
   });
 

--- a/extensions/feishu/src/chat.ts
+++ b/extensions/feishu/src/chat.ts
@@ -2,8 +2,7 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuChatSchema, type FeishuChatParams } from "./chat-schema.js";
-import { createFeishuClient } from "./client.js";
-import { resolveToolsConfig } from "./tools-config.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 
 function json(data: unknown) {
   return {
@@ -132,58 +131,64 @@ export function registerFeishuChatTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const firstAccount = accounts[0];
-  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
   if (!toolsCfg.chat) {
     api.logger.debug?.("feishu_chat: chat tool disabled in config");
     return;
   }
 
-  const getClient = () => createFeishuClient(firstAccount);
+  type FeishuChatExecuteParams = FeishuChatParams & { accountId?: string };
 
   api.registerTool(
-    {
-      name: "feishu_chat",
-      label: "Feishu Chat",
-      description: "Feishu chat operations. Actions: members, info, member_info",
-      parameters: FeishuChatSchema,
-      async execute(_toolCallId, params) {
-        const p = params as FeishuChatParams;
-        try {
-          const client = getClient();
-          switch (p.action) {
-            case "members":
-              if (!p.chat_id) {
-                return json({ error: "chat_id is required for action members" });
-              }
-              return json(
-                await getChatMembers(
-                  client,
-                  p.chat_id,
-                  p.page_size,
-                  p.page_token,
-                  p.member_id_type,
-                ),
-              );
-            case "info":
-              if (!p.chat_id) {
-                return json({ error: "chat_id is required for action info" });
-              }
-              return json(await getChatInfo(client, p.chat_id));
-            case "member_info":
-              if (!p.member_id) {
-                return json({ error: "member_id is required for action member_info" });
-              }
-              return json(
-                await getFeishuMemberInfo(client, p.member_id, p.member_id_type ?? "open_id"),
-              );
-            default:
-              return json({ error: `Unknown action: ${String(p.action)}` });
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_chat",
+        label: "Feishu Chat",
+        description: "Feishu chat operations. Actions: members, info, member_info",
+        parameters: FeishuChatSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuChatExecuteParams;
+          try {
+            const client = createFeishuToolClient({
+              api,
+              executeParams: p,
+              defaultAccountId,
+            });
+            switch (p.action) {
+              case "members":
+                if (!p.chat_id) {
+                  return json({ error: "chat_id is required for action members" });
+                }
+                return json(
+                  await getChatMembers(
+                    client,
+                    p.chat_id,
+                    p.page_size,
+                    p.page_token,
+                    p.member_id_type,
+                  ),
+                );
+              case "info":
+                if (!p.chat_id) {
+                  return json({ error: "chat_id is required for action info" });
+                }
+                return json(await getChatInfo(client, p.chat_id));
+              case "member_info":
+                if (!p.member_id) {
+                  return json({ error: "member_id is required for action member_info" });
+                }
+                return json(
+                  await getFeishuMemberInfo(client, p.member_id, p.member_id_type ?? "open_id"),
+                );
+              default:
+                return json({ error: `Unknown action: ${String(p.action)}` });
+            }
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
           }
-        } catch (err) {
-          return json({ error: err instanceof Error ? err.message : String(err) });
-        }
-      },
+        },
+      };
     },
     { name: "feishu_chat" },
   );


### PR DESCRIPTION
## Summary

- Problem: `feishu_chat` created its client from the first enabled Feishu account instead of using the shared account-routing helper used by the other Feishu tools.
- Why it matters: in multi-account Feishu setups, chat operations can run against the wrong account even when the session or tool call is targeting a different account.
- What changed: `feishu_chat` now resolves its client through the shared Feishu tool-account helper, so it respects `agentAccountId` and explicit `accountId` overrides.
- What did NOT change (scope boundary): this does not change Feishu API behavior beyond account selection for `feishu_chat`, and it does not modify the other Feishu tools.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related multi-account Feishu tool routing gap

## User-visible / Behavior Changes

`feishu_chat` now follows the same account-selection behavior as the other Feishu tools in multi-account Feishu configurations.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm checkout
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): `channels.feishu` with enabled default and non-default accounts, with chat enabled on a non-default account

### Steps

1. Configure Feishu with multiple enabled accounts.
2. Invoke `feishu_chat` from a session bound to a non-default account, or pass an explicit `accountId`.
3. Verify the tool uses the selected account instead of always using the first enabled account.

### Expected

- `feishu_chat` should use the same account-routing behavior as the other Feishu tools.

### Actual

- `feishu_chat` previously created its client from the first enabled account and ignored the selected account context.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after

Focused validation:
- `pnpm exec oxlint extensions/feishu/src/chat.ts extensions/feishu/src/chat.test.ts`
- manual local routing validation for `agentAccountId` and explicit `accountId`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: tool registration when chat is enabled on a non-default account; routing via `agentAccountId`; routing via explicit `accountId`
- Edge cases checked: top-level chat disabled while a non-default account enables chat; explicit override back to `default`
- What you did **not** verify: live Feishu API calls against real tenant credentials

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `extensions/feishu/src/chat.ts`
- Known bad symptoms reviewers should watch for: `feishu_chat` requests unexpectedly routing to the wrong Feishu account

## Risks and Mitigations

- Risk: `feishu_chat` account selection could diverge from existing expectations in single-account setups
  - Mitigation: the change reuses the same shared helper already used by the other Feishu tools, and explicit/default routing is covered in the updated test
