### PR TITLE
fix(gateway): guard getRuntimeSnapshot() and preserve probe intent in health refresh

### DIFF
--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -419,8 +419,10 @@ export const formatHealthChannelLines = (
 export async function getHealthSnapshot(params?: {
   timeoutMs?: number;
   probe?: boolean;
+  runtimeSnapshot?: import("../gateway/server-channels.js").ChannelRuntimeSnapshot;
 }): Promise<HealthSummary> {
   const timeoutMs = params?.timeoutMs;
+  const runtimeSnapshot = params?.runtimeSnapshot;
   const cfg = loadConfig();
   const { defaultAgentId, ordered } = resolveAgentOrder(cfg);
   const channelBindings = buildChannelAccountBindings(cfg);
@@ -522,7 +524,12 @@ export async function getHealthSnapshot(params?: {
         debugHealth("probe.bot", { channel: plugin.id, accountId, username: bot.username });
       }
 
+      const defaultRuntime = runtimeSnapshot?.channels[plugin.id];
+      const runtimeAccount = runtimeSnapshot?.channelAccounts[plugin.id]?.[accountId];
+      const runtimeForAccount =
+        runtimeAccount ?? (accountId === defaultAccountId ? defaultRuntime : undefined);
       const snapshot: ChannelAccountSnapshot = {
+        ...(runtimeForAccount ?? null),
         accountId,
         enabled,
         configured,

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -1,6 +1,7 @@
 import type { HealthSummary } from "../commands/health.js";
 import { cleanOldMedia } from "../media/store.js";
 import { abortChatRunById, type ChatAbortControllerEntry } from "./chat-abort.js";
+import type { ChannelRuntimeSnapshot } from "./server-channels.js";
 import type { ChatRunEntry } from "./server-chat.js";
 import {
   DEDUPE_MAX,
@@ -10,7 +11,7 @@ import {
 } from "./server-constants.js";
 import type { DedupeEntry } from "./server-shared.js";
 import { formatError } from "./server-utils.js";
-import { setBroadcastHealthUpdate } from "./server/health-state.js";
+import { setBroadcastHealthUpdate, setRuntimeSnapshotGetter } from "./server/health-state.js";
 
 export function startGatewayMaintenanceTimers(params: {
   broadcast: (
@@ -39,6 +40,7 @@ export function startGatewayMaintenanceTimers(params: {
   ) => ChatRunEntry | undefined;
   agentRunSeq: Map<string, number>;
   nodeSendToSession: (sessionKey: string, event: string, payload: unknown) => void;
+  getRuntimeSnapshot?: () => ChannelRuntimeSnapshot | undefined;
   mediaCleanupTtlMs?: number;
 }): {
   tickInterval: ReturnType<typeof setInterval>;
@@ -55,6 +57,13 @@ export function startGatewayMaintenanceTimers(params: {
     });
     params.nodeSendToAllSubscribed("health", snap);
   });
+
+  // Lazily capture runtime snapshot inside the health refresh cycle,
+  // not at every timer tick. Call this after the broadcast fn so the
+  // getter is ready before the first timer fires.
+  if (params.getRuntimeSnapshot) {
+    setRuntimeSnapshotGetter(params.getRuntimeSnapshot);
+  }
 
   // periodic keepalive
   const tickInterval = setInterval(() => {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -822,6 +822,17 @@ export async function startGatewayServer(
 
   const { getRuntimeSnapshot, startChannels, startChannel, stopChannel, markChannelLoggedOut } =
     channelManager;
+
+  /** Wrapper that catches config-error crashes from getRuntimeSnapshot(). */
+  const safeGetRuntimeSnapshot = () => {
+    try {
+      return getRuntimeSnapshot();
+    } catch (err) {
+      log.warn("getRuntimeSnapshot() failed during health refresh", { error: err });
+      return undefined;
+    }
+  };
+
   let agentUnsub: (() => void) | null = null;
   let heartbeatUnsub: (() => void) | null = null;
   let transcriptUnsub: (() => void) | null = null;
@@ -874,7 +885,8 @@ export async function startGatewayServer(
           nodeSendToAllSubscribed,
           getPresenceVersion,
           getHealthVersion,
-          refreshGatewayHealthSnapshot,
+          refreshGatewayHealthSnapshot: (opts) =>
+            refreshGatewayHealthSnapshot({ ...opts, runtimeSnapshot: safeGetRuntimeSnapshot() }),
           logHealth,
           dedupe,
           chatAbortControllers,
@@ -1169,7 +1181,8 @@ export async function startGatewayServer(
       pluginApprovalManager,
       loadGatewayModelCatalog,
       getHealthCache,
-      refreshHealthSnapshot: refreshGatewayHealthSnapshot,
+      refreshHealthSnapshot: (opts) =>
+        refreshGatewayHealthSnapshot({ ...opts, runtimeSnapshot: safeGetRuntimeSnapshot() }),
       logHealth,
       logGateway: log,
       incrementPresenceVersion,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -125,6 +125,7 @@ import {
   getPresenceVersion,
   incrementPresenceVersion,
   refreshGatewayHealthSnapshot,
+  setRuntimeSnapshotGetter,
 } from "./server/health-state.js";
 import { resolveHookClientIpConfig } from "./server/hooks.js";
 import { createReadinessChecker } from "./server/readiness.js";
@@ -833,6 +834,10 @@ export async function startGatewayServer(
     }
   };
 
+  // Register the lazy getter so health refresh captures the snapshot inside
+  // the refresh cycle, not at the timer tick (after dedupe decides to proceed).
+  setRuntimeSnapshotGetter(safeGetRuntimeSnapshot);
+
   let agentUnsub: (() => void) | null = null;
   let heartbeatUnsub: (() => void) | null = null;
   let transcriptUnsub: (() => void) | null = null;
@@ -885,9 +890,9 @@ export async function startGatewayServer(
           nodeSendToAllSubscribed,
           getPresenceVersion,
           getHealthVersion,
-          refreshGatewayHealthSnapshot: (opts) =>
-            refreshGatewayHealthSnapshot({ ...opts, runtimeSnapshot: safeGetRuntimeSnapshot() }),
+          refreshGatewayHealthSnapshot,
           logHealth,
+          getRuntimeSnapshot: safeGetRuntimeSnapshot,
           dedupe,
           chatAbortControllers,
           chatRunState,
@@ -1181,8 +1186,7 @@ export async function startGatewayServer(
       pluginApprovalManager,
       loadGatewayModelCatalog,
       getHealthCache,
-      refreshHealthSnapshot: (opts) =>
-        refreshGatewayHealthSnapshot({ ...opts, runtimeSnapshot: safeGetRuntimeSnapshot() }),
+      refreshHealthSnapshot: refreshGatewayHealthSnapshot,
       logHealth,
       logGateway: log,
       incrementPresenceVersion,

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -73,12 +73,21 @@ export function setBroadcastHealthUpdate(fn: ((snap: HealthSummary) => void) | n
   broadcastHealthUpdate = fn;
 }
 
+/** Set once at startup — used to lazily capture runtime snapshot inside the refresh cycle. */
+let getRuntimeSnapshot: (() => ChannelRuntimeSnapshot | undefined) | undefined = undefined;
+
+export function setRuntimeSnapshotGetter(fn: () => ChannelRuntimeSnapshot | undefined) {
+  getRuntimeSnapshot = fn;
+}
+
 /** @internal Reset module-level state between tests only. */
 export function __resetHealthStateForTest() {
   healthCache = null;
   healthRefresh = null;
   pendingRuntimeSnapshot = undefined;
   pendingProbe = undefined;
+  // Note: getRuntimeSnapshot is intentionally NOT reset here — it is set once
+  // at startup via setRuntimeSnapshotGetter and should persist across test cases.
   healthVersion = 1;
   presenceVersion = 1;
   broadcastHealthUpdate = null;
@@ -90,14 +99,18 @@ export async function refreshGatewayHealthSnapshot(opts?: {
 }) {
   // Always track the newest runtimeSnapshot so it is not silently discarded when
   // a refresh is already in-flight and a second caller provides a fresher snapshot.
+  // Only record a pending snapshot — the actual capture of getRuntimeSnapshot()
+  // happens lazily inside the refresh cycle, after dedupe decides to proceed.
+  // This avoids calling getRuntimeSnapshot() eagerly on every timer tick.
   if (opts?.runtimeSnapshot !== undefined) {
     pendingRuntimeSnapshot = opts.runtimeSnapshot;
   }
 
   // Track the latest probe intent so the finally block uses the most recent caller's preference.
-  // Only set when probe is true — false is the default, so storing it would trigger needless
-  // follow-up refreshes (hadPendingProbe would be true even though nothing changed).
-  if (opts?.probe) {
+  // Only set when explicitly provided (true or false). This matters because an explicit
+  // probe:false must be distinguishable from "not provided" — if a caller explicitly
+  // requests a non-probe snapshot, we must NOT kick off a follow-up that resets it.
+  if (opts?.probe !== undefined) {
     pendingProbe = opts.probe;
   }
 
@@ -107,11 +120,17 @@ export async function refreshGatewayHealthSnapshot(opts?: {
     pendingRuntimeSnapshot = undefined;
     const probeForRefresh = pendingProbe ?? false;
     pendingProbe = undefined; // must be cleared so finally block only fires for NEW callers
+    // Note: getRuntimeSnapshot is intentionally NOT reset here — it is set once
+    // at startup via setRuntimeSnapshotGetter and should persist across test cases.
 
     healthRefresh = (async () => {
+      // Lazily capture runtime snapshot here (after dedupe has decided to proceed),
+      // not at the call site. This avoids calling getRuntimeSnapshot() on every
+      // timer tick when dedupe might skip the refresh anyway.
+      const runtimeSnapshot = snapshotForRefresh ?? getRuntimeSnapshot?.() ?? undefined;
       const snap = await getHealthSnapshot({
         probe: probeForRefresh,
-        runtimeSnapshot: snapshotForRefresh,
+        runtimeSnapshot,
       });
       healthCache = snap;
       healthVersion += 1;
@@ -126,6 +145,8 @@ export async function refreshGatewayHealthSnapshot(opts?: {
       const followUpProbe = pendingProbe ?? false;
       const hadPendingProbe = pendingProbe !== undefined;
       pendingProbe = undefined;
+      // Note: getRuntimeSnapshot is intentionally NOT reset here — it is set once
+      // at startup via setRuntimeSnapshotGetter and should persist across test cases.
       // If a newer runtimeSnapshot or probe intent arrived while the refresh was
       // in-flight, kick off a follow-up so the latest state is reflected.
       if (pendingRuntimeSnapshot !== undefined || hadPendingProbe) {

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -7,12 +7,18 @@ import { getUpdateAvailable } from "../../infra/update-startup.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { resolveGatewayAuth } from "../auth.js";
 import type { Snapshot } from "../protocol/index.js";
+import type { ChannelRuntimeSnapshot } from "../server-channels.js";
 
 let presenceVersion = 1;
 let healthVersion = 1;
 let healthCache: HealthSummary | null = null;
 let healthRefresh: Promise<HealthSummary> | null = null;
 let broadcastHealthUpdate: ((snap: HealthSummary) => void) | null = null;
+// Tracks the most recent runtimeSnapshot queued while a refresh is in-flight so it
+// is not silently dropped when a second caller arrives concurrently.
+let pendingRuntimeSnapshot: ChannelRuntimeSnapshot | undefined = undefined;
+// Tracks the most recent probe intent so the follow-up refresh uses the latest caller's preference.
+let pendingProbe: boolean | undefined = undefined;
 
 export function buildGatewaySnapshot(): Snapshot {
   const cfg = loadConfig();
@@ -67,10 +73,46 @@ export function setBroadcastHealthUpdate(fn: ((snap: HealthSummary) => void) | n
   broadcastHealthUpdate = fn;
 }
 
-export async function refreshGatewayHealthSnapshot(opts?: { probe?: boolean }) {
+/** @internal Reset module-level state between tests only. */
+export function __resetHealthStateForTest() {
+  healthCache = null;
+  healthRefresh = null;
+  pendingRuntimeSnapshot = undefined;
+  pendingProbe = undefined;
+  healthVersion = 1;
+  presenceVersion = 1;
+  broadcastHealthUpdate = null;
+}
+
+export async function refreshGatewayHealthSnapshot(opts?: {
+  probe?: boolean;
+  runtimeSnapshot?: ChannelRuntimeSnapshot;
+}) {
+  // Always track the newest runtimeSnapshot so it is not silently discarded when
+  // a refresh is already in-flight and a second caller provides a fresher snapshot.
+  if (opts?.runtimeSnapshot !== undefined) {
+    pendingRuntimeSnapshot = opts.runtimeSnapshot;
+  }
+
+  // Track the latest probe intent so the finally block uses the most recent caller's preference.
+  // Only set when probe is true — false is the default, so storing it would trigger needless
+  // follow-up refreshes (hadPendingProbe would be true even though nothing changed).
+  if (opts?.probe) {
+    pendingProbe = opts.probe;
+  }
+
   if (!healthRefresh) {
+    // Capture and clear the pending snapshot for this refresh cycle.
+    const snapshotForRefresh = pendingRuntimeSnapshot;
+    pendingRuntimeSnapshot = undefined;
+    const probeForRefresh = pendingProbe ?? false;
+    pendingProbe = undefined; // must be cleared so finally block only fires for NEW callers
+
     healthRefresh = (async () => {
-      const snap = await getHealthSnapshot({ probe: opts?.probe });
+      const snap = await getHealthSnapshot({
+        probe: probeForRefresh,
+        runtimeSnapshot: snapshotForRefresh,
+      });
       healthCache = snap;
       healthVersion += 1;
       if (broadcastHealthUpdate) {
@@ -79,7 +121,30 @@ export async function refreshGatewayHealthSnapshot(opts?: { probe?: boolean }) {
       return snap;
     })().finally(() => {
       healthRefresh = null;
+      // Capture the latest probe intent and whether a newer probe arrived while
+      // the refresh was in-flight, before clearing.
+      const followUpProbe = pendingProbe ?? false;
+      const hadPendingProbe = pendingProbe !== undefined;
+      pendingProbe = undefined;
+      // If a newer runtimeSnapshot or probe intent arrived while the refresh was
+      // in-flight, kick off a follow-up so the latest state is reflected.
+      if (pendingRuntimeSnapshot !== undefined || hadPendingProbe) {
+        void refreshGatewayHealthSnapshot({ probe: followUpProbe }).catch(() => {});
+      }
     });
+  } else if (opts?.runtimeSnapshot !== undefined || opts?.probe) {
+    // Caller provided fresh runtime data or a probe request that the in-flight
+    // refresh won't include. Wait for the current refresh to complete (its
+    // finally block will kick off a follow-up using pendingProbe or
+    // pendingRuntimeSnapshot), then return the follow-up result so the caller
+    // receives a snapshot that reflects the latest state.
+    await healthRefresh;
+    // After the finally block runs, healthRefresh is either the follow-up promise
+    // (if pendingRuntimeSnapshot or hadPendingProbe was set) or null.
+    if (healthRefresh) {
+      return healthRefresh;
+    }
+    return healthCache!;
   }
   return healthRefresh;
 }


### PR DESCRIPTION
Fixes two review issues flagged on the original PR #42543:

**P1** —  can throw if any channel's `config.resolveAccount` fails (e.g. unresolved SecretRef). Wrapped in try/catch in both call sites so health RPCs don't crash hard on config errors.

**P2** — When a `probe:true` request arrives during an in-flight `probe:false` refresh, the queued follow-up now uses the latest caller's probe intent instead of the original caller's value. Added `pendingProbe` tracking.

Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>