### PR TITLE
feat: add agentId to /tools/invoke for workspace-scoped file operations

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -242,8 +242,8 @@ export function createOpenClawTools(
     const readBase = createReadTool(workspaceDir) as unknown as AnyAgentTool;
     tools.push(
       createOpenClawReadTool(readBase),
-      createHostWorkspaceWriteTool(workspaceDir),
-      createHostWorkspaceEditTool(workspaceDir),
+      createHostWorkspaceWriteTool(workspaceDir, { workspaceOnly: true }),
+      createHostWorkspaceEditTool(workspaceDir, { workspaceOnly: true }),
     );
   }
 

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -1,8 +1,14 @@
+import { createReadTool } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolvePluginTools } from "../plugins/tools.js";
 import { getActiveRuntimeWebToolsMetadata } from "../secrets/runtime.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveSessionAgentId } from "./agent-scope.js";
+import {
+  createHostWorkspaceEditTool,
+  createHostWorkspaceWriteTool,
+  createOpenClawReadTool,
+} from "./pi-tools.read.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import type { SpawnedToolContext } from "./spawned-context.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
@@ -83,6 +89,8 @@ export function createOpenClawTools(
     onYield?: (message: string) => Promise<void> | void;
     /** Allow plugin tools for this tool set to late-bind the gateway subagent. */
     allowGatewaySubagentBinding?: boolean;
+    /** If true, include file tools (read/write/edit) scoped to workspaceDir. */
+    includeFileTools?: boolean;
   } & SpawnedToolContext,
 ): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);
@@ -227,6 +235,17 @@ export function createOpenClawTools(
     ...(imageTool ? [imageTool] : []),
     ...(pdfTool ? [pdfTool] : []),
   ];
+
+  // Optionally include file tools (read/write/edit) scoped to the resolved workspace.
+  // Used by /tools/invoke with explicit agentId for CP file operations.
+  if (options?.includeFileTools && workspaceDir) {
+    const readBase = createReadTool(workspaceDir) as unknown as AnyAgentTool;
+    tools.push(
+      createOpenClawReadTool(readBase),
+      createHostWorkspaceWriteTool(workspaceDir),
+      createHostWorkspaceEditTool(workspaceDir),
+    );
+  }
 
   const pluginTools = resolvePluginTools({
     context: {

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -27,6 +27,16 @@ vi.mock("../config/config.js", () => ({
   loadConfig: () => cfg,
 }));
 
+vi.mock("../agents/agent-scope.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/agent-scope.js")>();
+  return {
+    ...actual,
+    // Override workspace resolution with a deterministic mock path.
+    resolveAgentWorkspaceDir: (_cfgParam: unknown, agentId: string) =>
+      `/mock/workspace/${agentId.trim().toLowerCase()}`,
+  };
+});
+
 vi.mock("../config/sessions.js", () => ({
   resolveMainSessionKey: (params?: {
     session?: { scope?: string; mainKey?: string };
@@ -46,6 +56,16 @@ vi.mock("../config/sessions.js", () => ({
       .toLowerCase();
     const mainKey = mainKeyRaw || "main";
     return `agent:${agentId}:${mainKey}`;
+  },
+  resolveAgentMainSessionKey: (params: {
+    cfg?: { session?: { mainKey?: string } };
+    agentId: string;
+  }) => {
+    const mainKeyRaw = String(params.cfg?.session?.mainKey ?? "main")
+      .trim()
+      .toLowerCase();
+    const mainKey = mainKeyRaw || "main";
+    return `agent:${params.agentId.trim().toLowerCase()}:${mainKey}`;
   },
 }));
 
@@ -159,10 +179,28 @@ vi.mock("../agents/openclaw-tools.js", () => {
     },
   ];
 
+  const fileTools = [
+    {
+      name: "read",
+      parameters: { type: "object", properties: { path: { type: "string" } } },
+      execute: async () => ({ ok: true, content: "mock file content" }),
+    },
+    {
+      name: "write",
+      parameters: { type: "object", properties: { path: { type: "string" } } },
+      execute: async () => ({ ok: true }),
+    },
+    {
+      name: "edit",
+      parameters: { type: "object", properties: { path: { type: "string" } } },
+      execute: async () => ({ ok: true }),
+    },
+  ];
+
   return {
     createOpenClawTools: (ctx: Record<string, unknown>) => {
       lastCreateOpenClawToolsContext = ctx;
-      return tools;
+      return ctx.includeFileTools ? [...tools, ...fileTools] : tools;
     },
   };
 });
@@ -684,5 +722,130 @@ describe("POST /tools/invoke", () => {
     const body = await expectOkInvokeResponse(res);
     expect(body.result?.observedFormat).toBe("pdf");
     expect(body.result?.observedFileFormat).toBeUndefined();
+  });
+
+  // --- agentId support ---
+
+  it("returns 404 when agentId does not exist in config", async () => {
+    cfg = {
+      agents: {
+        list: [{ id: "main", default: true, tools: { allow: ["agents_list"] } }],
+      },
+    };
+
+    const res = await postToolsInvoke({
+      port: sharedPort,
+      headers: gatewayAuthHeaders(),
+      body: { tool: "agents_list", agentId: "nonexistent" },
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error?.type).toBe("not_found");
+    expect(body.error?.message).toContain("nonexistent");
+  });
+
+  it("resolves workspaceDir when agentId is provided", async () => {
+    cfg = {
+      agents: {
+        list: [
+          { id: "main", default: true, tools: { allow: ["agents_list"] } },
+          { id: "filebot", tools: { allow: ["agents_list"] } },
+        ],
+      },
+    };
+
+    const res = await postToolsInvoke({
+      port: sharedPort,
+      headers: gatewayAuthHeaders(),
+      body: { tool: "agents_list", agentId: "filebot" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(lastCreateOpenClawToolsContext?.workspaceDir).toBe("/mock/workspace/filebot");
+  });
+
+  it("derives sessionKey from agentId when sessionKey is omitted", async () => {
+    cfg = {
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "ops", tools: { allow: ["agents_list"] } },
+        ],
+      },
+    };
+
+    const res = await postToolsInvoke({
+      port: sharedPort,
+      headers: gatewayAuthHeaders(),
+      body: { tool: "agents_list", agentId: "ops" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(lastCreateOpenClawToolsContext?.agentSessionKey).toBe("agent:ops:main");
+  });
+
+  it("uses explicit sessionKey over agentId-derived sessionKey", async () => {
+    cfg = {
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "ops", tools: { allow: ["agents_list"] } },
+        ],
+      },
+    };
+
+    const res = await postToolsInvoke({
+      port: sharedPort,
+      headers: gatewayAuthHeaders(),
+      body: { tool: "agents_list", agentId: "ops", sessionKey: "agent:ops:custom" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(lastCreateOpenClawToolsContext?.agentSessionKey).toBe("agent:ops:custom");
+  });
+
+  it("does not set workspaceDir when agentId is omitted", async () => {
+    allowAgentsListForMain();
+
+    const res = await invokeAgentsListAuthed({ sessionKey: "main" });
+
+    expect(res.status).toBe(200);
+    expect(lastCreateOpenClawToolsContext?.workspaceDir).toBeUndefined();
+    expect(lastCreateOpenClawToolsContext?.includeFileTools).toBeFalsy();
+  });
+
+  it("includes file tools (read/write/edit) when agentId is provided", async () => {
+    cfg = {
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "filebot", tools: { allow: ["read", "write", "edit"] } },
+        ],
+      },
+    };
+
+    const res = await postToolsInvoke({
+      port: sharedPort,
+      headers: gatewayAuthHeaders(),
+      body: { tool: "read", agentId: "filebot", args: { path: "test.txt" } },
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(lastCreateOpenClawToolsContext?.includeFileTools).toBe(true);
+  });
+
+  it("does not include file tools when agentId is omitted", async () => {
+    setMainAllowedTools({ allow: ["agents_list"] });
+
+    const readRes = await postToolsInvoke({
+      port: sharedPort,
+      headers: gatewayAuthHeaders(),
+      body: { tool: "read", args: { path: "test.txt" } },
+    });
+    expect(readRes.status).toBe(404);
   });
 });

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { resolveAgentConfig, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { createOpenClawTools } from "../agents/openclaw-tools.js";
 import { runBeforeToolCallHook } from "../agents/pi-tools.before-tool-call.js";
 import { resolveToolLoopDetectionConfig } from "../agents/pi-tools.js";
@@ -18,7 +19,7 @@ import {
 } from "../agents/tool-policy.js";
 import { ToolInputError } from "../agents/tools/common.js";
 import { loadConfig } from "../config/config.js";
-import { resolveMainSessionKey } from "../config/sessions.js";
+import { resolveAgentMainSessionKey, resolveMainSessionKey } from "../config/sessions.js";
 import { logWarn } from "../logger.js";
 import { isTestDefaultMemorySlotDisabled } from "../plugins/config-state.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
@@ -44,6 +45,7 @@ type ToolsInvokeBody = {
   action?: unknown;
   args?: unknown;
   sessionKey?: unknown;
+  agentId?: unknown;
   dryRun?: unknown;
 };
 
@@ -206,9 +208,31 @@ export async function handleToolsInvokeHttpRequest(
       ? (argsRaw as Record<string, unknown>)
       : {};
 
+  // Resolve explicit agentId from the request body.
+  const explicitAgentId =
+    typeof body.agentId === "string" && body.agentId.trim() ? body.agentId.trim() : undefined;
+
+  // When agentId is provided, validate that the agent exists and resolve its workspace.
+  let agentWorkspaceDir: string | undefined;
+  if (explicitAgentId) {
+    const agentConfig = resolveAgentConfig(cfg, explicitAgentId);
+    if (!agentConfig) {
+      sendJson(res, 404, {
+        ok: false,
+        error: { type: "not_found", message: `Agent not found: ${explicitAgentId}` },
+      });
+      return true;
+    }
+    agentWorkspaceDir = resolveAgentWorkspaceDir(cfg, explicitAgentId);
+  }
+
   const rawSessionKey = resolveSessionKeyFromBody(body);
   const sessionKey =
-    !rawSessionKey || rawSessionKey === "main" ? resolveMainSessionKey(cfg) : rawSessionKey;
+    !rawSessionKey || rawSessionKey === "main"
+      ? explicitAgentId
+        ? resolveAgentMainSessionKey({ cfg, agentId: explicitAgentId })
+        : resolveMainSessionKey(cfg)
+      : rawSessionKey;
 
   // Resolve message channel/account hints (optional headers) for policy inheritance.
   const messageChannel = normalizeMessageChannel(
@@ -228,7 +252,7 @@ export async function handleToolsInvokeHttpRequest(
     providerProfile,
     profileAlsoAllow,
     providerProfileAlsoAllow,
-  } = resolveEffectiveToolPolicy({ config: cfg, sessionKey });
+  } = resolveEffectiveToolPolicy({ config: cfg, sessionKey, agentId: explicitAgentId });
   const profilePolicy = resolveToolProfilePolicy(profile);
   const providerProfilePolicy = resolveToolProfilePolicy(providerProfile);
 
@@ -257,6 +281,9 @@ export async function handleToolsInvokeHttpRequest(
     allowGatewaySubagentBinding: true,
     // HTTP callers consume tool output directly; preserve raw media invoke payloads.
     allowMediaInvokeCommands: true,
+    workspaceDir: agentWorkspaceDir,
+    // Include file tools (read/write/edit) when an explicit agentId targets a workspace.
+    includeFileTools: Boolean(explicitAgentId && agentWorkspaceDir),
     config: cfg,
     pluginToolAllowlist: collectExplicitAllowlist([
       profilePolicy,


### PR DESCRIPTION
## Summary

- Adds `agentId` field to the `POST /tools/invoke` request body
- When provided, validates the agent exists in config, resolves its workspace, derives a session key, and applies the agent's tool policy
- Includes file tools (`read`, `write`, `edit`) scoped to the agent's workspace, enabling external callers to perform file operations without an active session

## Motivation

External orchestration layers (e.g. a Control Plane) need to read/write files in specific agent workspaces via the HTTP API. Previously, `/tools/invoke` only exposed gateway tools (sessions, message, etc.) and derived agent context from `sessionKey` alone. File tools were only available inside Pi agent sessions.

## Behavior matrix

| `agentId` | `sessionKey` | Behavior |
|-----------|-------------|----------|
| absent | absent | Unchanged: `resolveMainSessionKey(cfg)` |
| absent | present | Unchanged: use provided sessionKey |
| present, valid | absent | Validate agent, derive sessionKey, set workspace, enable file tools |
| present, valid | present | Validate agent, use provided sessionKey, set workspace, enable file tools |
| present, invalid | any | 404 `Agent not found: <agentId>` |

## Files changed

- `src/gateway/tools-invoke-http.ts` — agentId parsing, validation, workspace resolution, policy and tool wiring
- `src/agents/openclaw-tools.ts` — `includeFileTools` option to conditionally create read/write/edit tools
- `src/gateway/tools-invoke-http.test.ts` — 7 new test cases covering agentId validation, workspace, session key derivation, file tools availability

## Test plan

- [x] `pnpm test -- src/gateway/tools-invoke-http.test.ts` — 23 tests pass (16 existing + 7 new)
- [x] `pnpm test -- src/gateway/tools-invoke-http.cron-regression.test.ts` — 3 tests pass
- [x] `pnpm tsgo` — no new type errors
- [x] `pnpm format` — clean