### PR TITLE
fix(cron): prioritize explicit isolated delivery targets

### DIFF
--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -50,6 +50,12 @@ export async function resolveDeliveryTarget(
 ): Promise<DeliveryTargetResolution> {
   const requestedChannel = typeof jobPayload.channel === "string" ? jobPayload.channel : "last";
   const explicitTo = typeof jobPayload.to === "string" ? jobPayload.to : undefined;
+  const explicitAccountId =
+    typeof jobPayload.accountId === "string" && jobPayload.accountId.trim()
+      ? jobPayload.accountId.trim()
+      : undefined;
+  const hasExplicitDeliveryTarget =
+    requestedChannel !== "last" || explicitTo !== undefined || explicitAccountId !== undefined;
   const allowMismatchedLastTo = requestedChannel === "last";
 
   const sessionCfg = cfg.session;
@@ -72,7 +78,7 @@ export async function resolveDeliveryTarget(
 
   let fallbackChannel: Exclude<OutboundChannel, "none"> | undefined;
   let channelResolutionError: Error | undefined;
-  if (!preliminary.channel) {
+  if (!hasExplicitDeliveryTarget && !preliminary.channel) {
     if (preliminary.lastChannel) {
       fallbackChannel = preliminary.lastChannel;
     } else {
@@ -99,17 +105,17 @@ export async function resolveDeliveryTarget(
       })
     : preliminary;
 
-  const channel = resolved.channel ?? fallbackChannel;
+  const channel = hasExplicitDeliveryTarget
+    ? requestedChannel !== "last"
+      ? requestedChannel
+      : resolved.channel
+    : resolved.channel ?? fallbackChannel;
   const mode = resolved.mode as "explicit" | "implicit";
-  let toCandidate = resolved.to;
+  let toCandidate = hasExplicitDeliveryTarget ? explicitTo ?? resolved.to : resolved.to;
 
   // Prefer an explicit accountId from the job's delivery config (set via
   // --account on cron add/edit). Fall back to the session's lastAccountId,
   // then to the agent's bound account from bindings config.
-  const explicitAccountId =
-    typeof jobPayload.accountId === "string" && jobPayload.accountId.trim()
-      ? jobPayload.accountId.trim()
-      : undefined;
   let accountId = explicitAccountId ?? resolved.accountId;
   if (!accountId && channel) {
     const bindings = buildChannelAccountBindings(cfg);


### PR DESCRIPTION
# PR Draft: cron: prioritize explicit isolated delivery targets over fallback channel selection

## Summary
This patch tightens isolated cron delivery target resolution so explicit `job.delivery` fields are treated as the highest-priority contract.

When an isolated cron job explicitly sets any of:
- `delivery.channel`
- `delivery.to`
- `delivery.accountId`

`resolveDeliveryTarget(...)` should not fall back to:
- session last route
- `resolveMessageChannelSelection(...)`

## Problem
Before this change, isolated cron jobs could still drift into fallback channel resolution even when the job author had already provided an explicit delivery target.

This could surface errors like:
- `Channel is required when multiple channels are configured ...`

or route the result through an unrelated previous session/channel path.

## Root cause
In upstream source:
- `src/cron/isolated-agent/run.ts`
- `src/cron/isolated-agent/delivery-target.ts`

`resolveCronDeliveryContext(...)` correctly forwards explicit delivery data into `resolveDeliveryTarget(...)`, but `resolveDeliveryTarget(...)` still performs automatic fallback channel selection when `preliminary.channel` is absent.

That means explicit cron delivery targets can still be polluted by session-derived fallback behavior.

## Fix
In `src/cron/isolated-agent/delivery-target.ts`:
- detect whether the cron job provides an explicit delivery target contract
- if yes, skip automatic fallback channel selection
- keep explicit `channel/to/accountId` as highest priority

## Behavior after patch
If any of these are present:
- explicit `channel != "last"`
- explicit `to`
- explicit `accountId`

then isolated cron delivery resolution:
- does **not** consult automatic channel-selection fallback
- preserves explicit `channel/to/accountId`
- only uses session-derived data as a secondary helper where still applicable

## Local verification
Verified with an isolated pure-text cron announce job using explicit:
- `channel=openclaw-weixin`
- `to=o9cq807JmnA5wqHNXflgfaqGcRnc@im.wechat`
- `accountId=a5f9bbd7260f-im-bot`

Observed result:
- `status: ok`
- `delivered: true`
- `deliveryStatus: delivered`

## Suggested regression test
Add a cron isolated-agent delivery test that:
1. seeds a multi-channel environment
2. creates a cron job with explicit `delivery.channel/to/accountId`
3. ensures `resolveDeliveryTarget(...)` does not use automatic fallback channel selection
4. asserts final delivery uses the explicit target unchanged

## Related local hardening done alongside this investigation
Outside core, the Weixin plugin was also hardened with:
- `defaultAccount` config schema support
- shared target normalization helpers
- regression tests for target normalization, account fallback, and context token lookup
