### PR TITLE
feat(acp): support ACP bindings on any channel (plugin channels)

### DIFF
--- a/src/config/config.acp-binding-cutover.test.ts
+++ b/src/config/config.acp-binding-cutover.test.ts
@@ -109,7 +109,7 @@ describe("ACP binding cutover schema", () => {
     expect(parsed.success).toBe(false);
   });
 
-  it("rejects ACP bindings on unsupported channels", () => {
+  it("accepts ACP bindings on any channel (plugin channels)", () => {
     const parsed = OpenClawSchema.safeParse({
       bindings: [
         {
@@ -117,6 +117,24 @@ describe("ACP binding cutover schema", () => {
           agentId: "codex",
           match: {
             channel: "slack",
+            accountId: "default",
+            peer: { kind: "channel", id: "C123456" },
+          },
+        },
+      ],
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("rejects ACP bindings with empty channel", () => {
+    const parsed = OpenClawSchema.safeParse({
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "  ",
             accountId: "default",
             peer: { kind: "channel", id: "C123456" },
           },

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -71,12 +71,11 @@ const AcpBindingSchema = z
       return;
     }
     const channel = value.match.channel.trim().toLowerCase();
-    if (channel !== "discord" && channel !== "telegram" && channel !== "feishu") {
+    if (!channel) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["match", "channel"],
-        message:
-          'ACP bindings currently support only "discord", "telegram", and "feishu" channels.',
+        message: "ACP bindings require a non-empty channel name.",
       });
       return;
     }

--- a/src/plugins/runtime/runtime-channel.ts
+++ b/src/plugins/runtime/runtime-channel.ts
@@ -35,6 +35,10 @@ import { dispatchReplyWithBufferedBlockDispatcher } from "../../auto-reply/reply
 import { createReplyDispatcherWithTyping } from "../../auto-reply/reply/reply-dispatcher.js";
 import { removeAckReactionAfterReply, shouldAckReaction } from "../../channels/ack-reactions.js";
 import { resolveCommandAuthorizedFromAuthorizers } from "../../channels/command-gating.js";
+import {
+  ensureConfiguredBindingRouteReady,
+  resolveConfiguredBindingRoute,
+} from "../../channels/plugins/binding-routing.js";
 import { recordInboundSession } from "../../channels/session.js";
 import {
   resolveChannelGroupPolicy,
@@ -135,6 +139,8 @@ export function createRuntimeChannel(): PluginRuntime["channel"] {
     routing: {
       buildAgentSessionKey,
       resolveAgentRoute,
+      resolveConfiguredBindingRoute,
+      ensureConfiguredBindingRouteReady,
     },
     pairing: {
       buildPairingReply,

--- a/src/plugins/runtime/types-channel.ts
+++ b/src/plugins/runtime/types-channel.ts
@@ -49,6 +49,8 @@ export type PluginRuntimeChannel = {
   routing: {
     buildAgentSessionKey: typeof import("../../routing/resolve-route.js").buildAgentSessionKey;
     resolveAgentRoute: typeof import("../../routing/resolve-route.js").resolveAgentRoute;
+    resolveConfiguredBindingRoute: typeof import("../../channels/plugins/binding-routing.js").resolveConfiguredBindingRoute;
+    ensureConfiguredBindingRouteReady: typeof import("../../channels/plugins/binding-routing.js").ensureConfiguredBindingRouteReady;
   };
   pairing: {
     buildPairingReply: typeof import("../../pairing/pairing-messages.js").buildPairingReply;

--- a/test/helpers/extensions/plugin-runtime-mock.ts
+++ b/test/helpers/extensions/plugin-runtime-mock.ts
@@ -205,6 +205,13 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
           accountId: "default",
           sessionKey: "agent:main:test:dm:peer",
         })) as unknown as PluginRuntime["channel"]["routing"]["resolveAgentRoute"],
+        resolveConfiguredBindingRoute: vi.fn((params) => ({
+          bindingResolution: null,
+          route: params.route,
+        })) as unknown as PluginRuntime["channel"]["routing"]["resolveConfiguredBindingRoute"],
+        ensureConfiguredBindingRouteReady: vi.fn(() =>
+          Promise.resolve({ ok: true as const }),
+        ) as unknown as PluginRuntime["channel"]["routing"]["ensureConfiguredBindingRouteReady"],
       },
       pairing: {
         buildPairingReply: vi.fn(


### PR DESCRIPTION
## Summary

Remove the three-channel allowlist (`discord`, `telegram`, `feishu`) from ACP binding validation and replace it with a simple non-empty channel check. The runtime binding-resolution pipeline was already fully channel-agnostic; this aligns the schema validation layer to match.

## Changes

- **`zod-schema.agents.ts`**: Replace the hardcoded allowlist with a `!channel` guard (after existing `.trim()`) that rejects empty/whitespace-only channel names while accepting any valid plugin channel
- **`runtime-channel.ts`**: Expose `resolveConfiguredBindingRoute` and `ensureConfiguredBindingRouteReady` to plugin channels via the runtime routing object
- **`types-channel.ts`**: Add corresponding type declarations to `PluginRuntimeChannel.routing`
- **`plugin-runtime-mock.ts`**: Add test stubs for the two new routing methods
- **`config.acp-binding-cutover.test.ts`**: Update test to verify any-channel acceptance + add empty-channel rejection test

## Context

Channel-specific validations for Telegram and Feishu peer IDs are unchanged. This only removes the top-level channel-name allowlist gate.

Supersedes #51560 (rebased onto v2026.3.22).

Closes #41988