### PR TITLE
fix(announce): preserve threadId in subagent announce for Telegram DM topics

### DIFF
--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -116,6 +116,8 @@ export async function sendTelegramText(
     thread: opts?.thread,
     silent: opts?.silent,
   });
+  const threadLogSuffix =
+    baseParams.message_thread_id != null ? ` thread=${baseParams.message_thread_id}` : "";
   // Add link_preview_options when link preview is disabled.
   const linkPreviewEnabled = opts?.linkPreview ?? true;
   const linkPreviewOptions = linkPreviewEnabled ? undefined : { is_disabled: true };
@@ -136,7 +138,9 @@ export async function sendTelegramText(
           ...effectiveParams,
         }),
     });
-    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id} (plain)`);
+    runtime.log?.(
+      `telegram sendMessage ok chat=${chatId} message=${res.message_id}${threadLogSuffix} (plain)`,
+    );
     return res.message_id;
   };
 
@@ -165,7 +169,9 @@ export async function sendTelegramText(
           ...effectiveParams,
         }),
     });
-    runtime.log?.(`telegram sendMessage ok chat=${chatId} message=${res.message_id}`);
+    runtime.log?.(
+      `telegram sendMessage ok chat=${chatId} message=${res.message_id}${threadLogSuffix}`,
+    );
     return res.message_id;
   } catch (err) {
     const errText = formatErrorMessage(err);

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -1202,6 +1202,125 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.threadId).toBe("42");
   });
 
+  it("preserves requesterOrigin threadId when session entry has no threadId", async () => {
+    sendSpy.mockClear();
+    agentSpy.mockClear();
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: "child-session-no-entry-thread",
+      },
+      "agent:main:main": {
+        sessionId: "requester-session-no-entry-thread",
+        lastChannel: "telegram",
+        lastTo: "123",
+      },
+    };
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-no-entry-thread",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "123",
+        threadId: 42,
+      },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.channel).toBe("telegram");
+    expect(call?.params?.to).toBe("123");
+    expect(call?.params?.threadId).toBe("42");
+  });
+
+  it("does not inject spurious threadId when neither requester nor entry has one", async () => {
+    sendSpy.mockClear();
+    agentSpy.mockClear();
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: "child-session-no-thread",
+      },
+      "agent:main:main": {
+        sessionId: "requester-session-no-thread",
+        lastChannel: "telegram",
+        lastTo: "123",
+      },
+    };
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-no-thread-at-all",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "123",
+      },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.channel).toBe("telegram");
+    expect(call?.params?.to).toBe("123");
+    expect(call?.params?.threadId).toBeUndefined();
+  });
+
+  it("preserves requesterOrigin threadId over stale entry threadId in queue path", async () => {
+    sendSpy.mockClear();
+    agentSpy.mockClear();
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(true);
+    embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: "child-session-queue-thread",
+      },
+      "agent:main:main": {
+        sessionId: "requester-session-queue-thread",
+        lastChannel: "telegram",
+        lastTo: "123",
+        lastThreadId: 999,
+        queueMode: "collect",
+        queueDebounceMs: 0,
+      },
+    };
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-queue-thread",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "123",
+        threadId: 42,
+      },
+      ...defaultOutcomeAnnounce,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.channel).toBe("telegram");
+    expect(call?.params?.to).toBe("123");
+    expect(call?.params?.threadId).toBe("42");
+
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(false);
+  });
+
   it("uses hook-provided thread target across requester thread variants", async () => {
     const cases = [
       {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -606,7 +606,17 @@ function resolveAnnounceOrigin(
           return rest;
         })()
       : normalizedEntry;
-  return mergeDeliveryContext(normalizedRequester, entryForMerge);
+  const merged = mergeDeliveryContext(normalizedRequester, entryForMerge);
+  // Defensive: requester threadId (captured at spawn) must never be lost or
+  // overridden by a stale session entry threadId during the merge.
+  if (
+    normalizedRequester?.threadId != null &&
+    merged &&
+    merged.threadId !== normalizedRequester.threadId
+  ) {
+    return { ...merged, threadId: normalizedRequester.threadId };
+  }
+  return merged;
 }
 
 async function resolveSubagentCompletionOrigin(params: {
@@ -625,11 +635,14 @@ async function resolveSubagentCompletionOrigin(params: {
     requesterOrigin?.threadId != null && requesterOrigin.threadId !== ""
       ? String(requesterOrigin.threadId).trim()
       : undefined;
+  // Prefer the chat-level ID derived from `to` so bound-route lookups match
+  // the conversation (e.g. a Telegram chat), not the topic thread inside it.
+  // threadId is a delivery modifier, not a conversation identifier.
   const conversationId =
-    threadId ||
     resolveConversationIdFromTargets({
       targets: [to],
     }) ||
+    threadId ||
     "";
   const requesterConversation: ConversationRef | undefined =
     channel && conversationId ? { channel, accountId, conversationId } : undefined;


### PR DESCRIPTION
## Summary

Fixes #52217 — subagent completion announce was delivering to the main Telegram DM chat instead of the originating topic because `threadId` was lost during the announce delivery pipeline.

- **Swap conversationId priority** in `resolveSubagentCompletionOrigin`: prefer `to`-derived chat ID over `threadId` for bound-route lookups, so bindings match the conversation (chat) rather than the topic thread inside it
- **Defensive threadId guard** in `resolveAnnounceOrigin`: ensure the requester's `threadId` (captured at spawn time) is never overridden by a stale session entry `lastThreadId`
- **Telegram observability**: add `message_thread_id` to `sendMessage ok` log lines for easier diagnosis
- **3 regression tests**: direct path (no entry threadId), queue path (stale entry threadId), and no-spurious-injection scenario

## Test plan

- [x] `pnpm test -- src/agents/subagent-announce.format.e2e.test.ts` — 73 tests pass (including 3 new)
- [x] `pnpm test -- src/utils/delivery-context.test.ts` — 9 tests pass
- [x] `pnpm check` — all lint/format checks pass
- [ ] Manual: spawn subagent from Telegram DM topic, verify completion announce lands in the same topic