### PR TITLE
fix: restart gateway after token change to fix CLI connection failure (#52749)

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -364,7 +364,16 @@ export async function doctorCommand(
 
   const tokenChanged = cfg.gateway?.auth?.token !== cfgForPersistence.gateway?.auth?.token;
 
-  if (tokenChanged) {
+  await maybeRepairGatewayDaemon({
+    cfg,
+    runtime,
+    prompter,
+    options,
+    gatewayDetailsMessage: gatewayDetails.message,
+    healthOk,
+  });
+
+  if (tokenChanged && healthOk) {
     await maybeRepairGatewayDaemon({
       cfg,
       runtime,

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -339,14 +339,6 @@ export async function doctorCommand(
       })
     : { checked: false, ready: false };
   await noteMemorySearchHealth(cfg, { gatewayMemoryProbe });
-  await maybeRepairGatewayDaemon({
-    cfg,
-    runtime,
-    prompter,
-    options,
-    gatewayDetailsMessage: gatewayDetails.message,
-    healthOk,
-  });
 
   const shouldWriteConfig =
     configResult.shouldWriteConfig || JSON.stringify(cfg) !== JSON.stringify(cfgForPersistence);
@@ -368,6 +360,19 @@ export async function doctorCommand(
     if (await shouldSuggestMemorySystem(workspaceDir)) {
       note(MEMORY_SYSTEM_PROMPT, "Workspace");
     }
+  }
+
+  const tokenChanged = cfg.gateway?.auth?.token !== cfgForPersistence.gateway?.auth?.token;
+
+  if (tokenChanged) {
+    await maybeRepairGatewayDaemon({
+      cfg,
+      runtime,
+      prompter,
+      options,
+      gatewayDetailsMessage: "Token updated",
+      healthOk: false,
+    });
   }
 
   const finalSnapshot = await readConfigFileSnapshot();


### PR DESCRIPTION
## Summary

-Problem: CLI could not connect to gateway after onboarding or token changes (gateway closed (1000)), despite gateway running

-Why it matters: Blocks all CLI commands (nodes list, devices list) which means user cannot operate OpenClaw

-What changed: Gateway daemon is automatically restarted when auth token changes

-What did NOT change (scope boundary): No changes to gateway auth model, networking, or WebSocket handling logic

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52749 

## User-visible / Behavior Changes

-Gateway automatically restarts after token change
-CLI no longer fails with gateway closed (1000) after onboarding or config updates

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
None

## Repro + Verification

### Environment

OS: Ubuntu 24.04
Runtime/container: Node.js 24.x (systemd user service)
Model/provider: Qwen (OAuth)
Integration/channel: None
Relevant config (redacted): default QuickStart config with token auth

### Steps
Fresh install OpenClaw
Run openclaw onboard --install-daemon
Complete setup (QuickStart, token auth)
Run openclaw nodes list

### Expected
CLI connects to gateway and returns node list
Actual (before fix)
gateway closed (1000 normal closure)
CLI unusable for gateway operations

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

-Verified scenarios:
Fresh onboarding flow with systemd daemon
Token change triggers daemon restart
CLI commands (nodes list, devices list) succeed after restart

-Edge cases checked:
Token unchanged → no restart triggered
Restart only triggered on actual token diff

-What you did not verify:
Remote gateway setups
Non-systemd environments

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

-How to disable/revert this change quickly:
Revert PR
Or manually restart gateway: openclaw gateway restart

-Files/config to restore:
None

-Known bad symptoms reviewers should watch for:
Repeated/unexpected gateway restarts
CLI triggering restart loops

## Risks and Mitigations

-Risk: Unintended gateway restart if config diff is misdetected
-Mitigation: Strict token comparison before triggering restart