### PR TITLE
iOS: align bottom bar with Liquid Glass guidance

### DIFF
--- a/apps/ios/Sources/HomeToolbar.swift
+++ b/apps/ios/Sources/HomeToolbar.swift
@@ -16,61 +16,43 @@ struct HomeToolbar: View {
     @Environment(\.colorSchemeContrast) private var contrast
 
     var body: some View {
-        VStack(spacing: 0) {
-            Rectangle()
-                .fill(.white.opacity(self.contrast == .increased ? 0.46 : (self.brighten ? 0.18 : 0.12)))
-                .frame(height: self.contrast == .increased ? 1.0 : 0.6)
-                .allowsHitTesting(false)
+        HStack(spacing: 10) {
+            HomeToolbarStatusButton(
+                gateway: self.gateway,
+                voiceWakeEnabled: self.voiceWakeEnabled,
+                activity: self.activity,
+                brighten: self.brighten,
+                onTap: self.onStatusTap)
+                .homeToolbarSurface(brighten: self.brighten, contrast: self.contrast)
 
-            HStack(spacing: 12) {
-                HomeToolbarStatusButton(
-                    gateway: self.gateway,
-                    voiceWakeEnabled: self.voiceWakeEnabled,
-                    activity: self.activity,
+            Spacer(minLength: 10)
+
+            HStack(spacing: 6) {
+                HomeToolbarActionButton(
+                    systemImage: "text.bubble.fill",
+                    accessibilityLabel: "Chat",
                     brighten: self.brighten,
-                    onTap: self.onStatusTap)
+                    action: self.onChatTap)
 
-                Spacer(minLength: 0)
-
-                HStack(spacing: 8) {
+                if self.talkButtonEnabled {
                     HomeToolbarActionButton(
-                        systemImage: "text.bubble.fill",
-                        accessibilityLabel: "Chat",
+                        systemImage: self.talkActive ? "waveform.circle.fill" : "waveform.circle",
+                        accessibilityLabel: self.talkActive ? "Talk Mode On" : "Talk Mode Off",
                         brighten: self.brighten,
-                        action: self.onChatTap)
-
-                    if self.talkButtonEnabled {
-                        HomeToolbarActionButton(
-                            systemImage: self.talkActive ? "waveform.circle.fill" : "waveform.circle",
-                            accessibilityLabel: self.talkActive ? "Talk Mode On" : "Talk Mode Off",
-                            brighten: self.brighten,
-                            tint: self.talkTint,
-                            isActive: self.talkActive,
-                            action: self.onTalkTap)
-                    }
-
-                    HomeToolbarActionButton(
-                        systemImage: "gearshape.fill",
-                        accessibilityLabel: "Settings",
-                        brighten: self.brighten,
-                        action: self.onSettingsTap)
+                        tint: self.talkTint,
+                        isActive: self.talkActive,
+                        action: self.onTalkTap)
                 }
+
+                HomeToolbarActionButton(
+                    systemImage: "gearshape.fill",
+                    accessibilityLabel: "Settings",
+                    brighten: self.brighten,
+                    action: self.onSettingsTap)
             }
-            .padding(.horizontal, 12)
-            .padding(.top, 10)
-            .padding(.bottom, 8)
-        }
-        .frame(maxWidth: .infinity)
-        .background(.ultraThinMaterial)
-        .overlay(alignment: .top) {
-            LinearGradient(
-                colors: [
-                    .white.opacity(self.brighten ? 0.10 : 0.06),
-                    .clear,
-                ],
-                startPoint: .top,
-                endPoint: .bottom)
-                .allowsHitTesting(false)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 7)
+            .homeToolbarSurface(brighten: self.brighten, contrast: self.contrast)
         }
     }
 }
@@ -78,7 +60,6 @@ struct HomeToolbar: View {
 private struct HomeToolbarStatusButton: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @Environment(\.colorSchemeContrast) private var contrast
 
     var gateway: StatusPill.GatewayState
     var voiceWakeEnabled: Bool
@@ -106,6 +87,8 @@ private struct HomeToolbarStatusButton: View {
                         .font(.footnote.weight(.semibold))
                         .foregroundStyle(.primary)
                         .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                        .minimumScaleFactor(0.92)
                 }
 
                 if let activity {
@@ -120,20 +103,10 @@ private struct HomeToolbarStatusButton: View {
                         .transition(.opacity.combined(with: .move(edge: .top)))
                 }
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background {
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(Color.black.opacity(self.brighten ? 0.12 : 0.18))
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .strokeBorder(
-                                .white.opacity(self.contrast == .increased ? 0.46 : (self.brighten ? 0.22 : 0.16)),
-                                lineWidth: self.contrast == .increased ? 1.0 : 0.6)
-                    }
-            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 7)
         }
-        .buttonStyle(.plain)
+        .homeToolbarButtonStyle(prominent: false, tint: nil)
         .accessibilityLabel("Connection Status")
         .accessibilityValue(self.accessibilityValue)
         .accessibilityHint(self.gateway == .connected ? "Double tap for gateway actions" : "Double tap to open settings")
@@ -172,8 +145,6 @@ private struct HomeToolbarStatusButton: View {
 }
 
 private struct HomeToolbarActionButton: View {
-    @Environment(\.colorSchemeContrast) private var contrast
-
     let systemImage: String
     let accessibilityLabel: String
     let brighten: Bool
@@ -186,38 +157,75 @@ private struct HomeToolbarActionButton: View {
             Image(systemName: self.systemImage)
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundStyle(self.isActive ? (self.tint ?? .primary) : .primary)
-                .frame(width: 40, height: 40)
+                .frame(width: 38, height: 38)
+        }
+        .homeToolbarButtonStyle(prominent: self.isActive, tint: self.tint)
+        .accessibilityLabel(self.accessibilityLabel)
+    }
+}
+
+private struct HomeToolbarSurfaceModifier: ViewModifier {
+    let brighten: Bool
+    let contrast: ColorSchemeContrast
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(.regular, in: Capsule())
+                .shadow(color: .black.opacity(self.brighten ? 0.07 : 0.10), radius: 10, y: 3)
+        } else {
+            content
                 .background {
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(Color.black.opacity(self.brighten ? 0.12 : 0.18))
+                    Capsule(style: .continuous)
+                        .fill(.ultraThinMaterial)
                         .overlay {
-                            if let tint {
-                                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                    .fill(
-                                        LinearGradient(
-                                            colors: [
-                                                tint.opacity(self.isActive ? 0.22 : 0.14),
-                                                tint.opacity(self.isActive ? 0.08 : 0.04),
-                                                .clear,
-                                            ],
-                                            startPoint: .topLeading,
-                                            endPoint: .bottomTrailing))
-                                    .blendMode(.overlay)
-                            }
-                        }
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            Capsule(style: .continuous)
                                 .strokeBorder(
-                                    (self.tint ?? .white).opacity(
-                                        self.isActive
-                                            ? 0.34
-                                            : (self.contrast == .increased ? 0.4 : (self.brighten ? 0.22 : 0.16))
-                                    ),
-                                    lineWidth: self.contrast == .increased ? 1.0 : (self.isActive ? 0.8 : 0.6))
+                                    .white.opacity(self.contrast == .increased ? 0.34 : 0.12),
+                                    lineWidth: self.contrast == .increased ? 1.0 : 0.6)
                         }
+                        .shadow(color: .black.opacity(self.brighten ? 0.08 : 0.12), radius: 10, y: 3)
+                }
+                .overlay {
+                    LinearGradient(
+                        colors: [
+                            .white.opacity(self.brighten ? 0.08 : 0.05),
+                            .clear,
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing)
+                        .allowsHitTesting(false)
+                        .clipShape(Capsule(style: .continuous))
                 }
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel(self.accessibilityLabel)
+    }
+}
+
+private struct HomeToolbarButtonStyleModifier: ViewModifier {
+    let prominent: Bool
+    let tint: Color?
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            if self.prominent {
+                content
+                    .buttonStyle(GlassProminentButtonStyle())
+                    .tint(self.tint ?? .primary)
+            } else {
+                content.buttonStyle(GlassButtonStyle())
+            }
+        } else {
+            content.buttonStyle(.plain)
+        }
+    }
+}
+
+private extension View {
+    func homeToolbarSurface(brighten: Bool, contrast: ColorSchemeContrast) -> some View {
+        self.modifier(HomeToolbarSurfaceModifier(brighten: brighten, contrast: contrast))
+    }
+
+    func homeToolbarButtonStyle(prominent: Bool, tint: Color?) -> some View {
+        self.modifier(HomeToolbarButtonStyleModifier(prominent: prominent, tint: tint))
     }
 }

--- a/apps/ios/Sources/HomeToolbar.swift
+++ b/apps/ios/Sources/HomeToolbar.swift
@@ -88,7 +88,6 @@ private struct HomeToolbarStatusButton: View {
                         .foregroundStyle(.primary)
                         .lineLimit(1)
                         .fixedSize(horizontal: true, vertical: false)
-                        .minimumScaleFactor(0.92)
                 }
 
                 if let activity {

--- a/apps/ios/Sources/OpenClawApp.swift
+++ b/apps/ios/Sources/OpenClawApp.swift
@@ -513,7 +513,7 @@ struct OpenClawApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootCanvas()
+            RootView()
                 .environment(self.appModel)
                 .environment(self.appModel.voiceWake)
                 .environment(self.gatewayController)

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -503,7 +503,6 @@ private struct CanvasContent: View {
                     self.openSettings()
                 })
                 .padding(.horizontal, 14)
-                .padding(.bottom, 0)
         }
         .overlay(alignment: .topLeading) {
             if let voiceWakeToastText, !voiceWakeToastText.isEmpty {

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -475,7 +475,7 @@ private struct CanvasContent: View {
                     .transition(.opacity)
             }
         }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
+        .overlay(alignment: .bottom) {
             HomeToolbar(
                 gateway: self.gatewayStatus,
                 voiceWakeEnabled: self.voiceWakeEnabled,
@@ -502,6 +502,8 @@ private struct CanvasContent: View {
                 onSettingsTap: {
                     self.openSettings()
                 })
+                .padding(.horizontal, 14)
+                .padding(.bottom, 0)
         }
         .overlay(alignment: .topLeading) {
             if let voiceWakeToastText, !voiceWakeToastText.isEmpty {

--- a/apps/ios/Sources/Screen/ScreenTab.swift
+++ b/apps/ios/Sources/Screen/ScreenTab.swift
@@ -7,7 +7,7 @@ struct ScreenTab: View {
     var body: some View {
         ZStack(alignment: .top) {
             ScreenWebView(controller: self.appModel.screen)
-                .ignoresSafeArea(.container, edges: [.top, .leading, .trailing])
+                .ignoresSafeArea(.container)
                 .overlay(alignment: .top) {
                     if let errorText = self.appModel.screen.errorText,
                        self.appModel.gatewayServerName == nil

--- a/src/plugins/contracts/registry.ts
+++ b/src/plugins/contracts/registry.ts
@@ -5,6 +5,7 @@ import chutesPlugin from "../../../extensions/chutes/index.js";
 import cloudflareAiGatewayPlugin from "../../../extensions/cloudflare-ai-gateway/index.js";
 import copilotProxyPlugin from "../../../extensions/copilot-proxy/index.js";
 import deepgramPlugin from "../../../extensions/deepgram/index.js";
+import deepseekPlugin from "../../../extensions/deepseek/index.js";
 import elevenLabsPlugin from "../../../extensions/elevenlabs/index.js";
 import falPlugin from "../../../extensions/fal/index.js";
 import githubCopilotPlugin from "../../../extensions/github-copilot/index.js";
@@ -357,6 +358,7 @@ const bundledProviderPlugins = dedupePlugins([
   chutesPlugin,
   cloudflareAiGatewayPlugin,
   copilotProxyPlugin,
+  deepseekPlugin,
   githubCopilotPlugin,
   falPlugin,
   googlePlugin,


### PR DESCRIPTION
## Summary

- Problem: the previous iOS home bottom bar used a bespoke toolbar treatment that did not follow Apple’s Liquid Glass navigation guidance or the iOS tab bar HIG.
- Why it matters: the old bar sat above its own reserved strip, used heavy nested chrome, and read more like a custom toolbar than a compact bottom navigation control.
- What changed: kept `RootCanvas` as the home shell, extended the home surface behind the bottom safe area, and rebuilt the bottom navigation into two floating glass groups: a leading status capsule and a trailing unified action cluster for chat, talk, and settings.
- What did NOT change (scope boundary): no navigation model rewrite, no new tabs, and no changes to the underlying chat/talk/settings actions.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- The iOS home screen now uses `RootView` as the app entry point while keeping `RootCanvas` as the actual home shell.
- The bottom navigation no longer reserves a separate strip above the safe area; it floats over content and sits at the bottom edge.
- The bottom bar now uses a leading standalone status capsule and a trailing grouped glass action cluster for chat, talk, and settings.
- The status label is less likely to truncate short labels like `Offline`.
- Better adherence to Apple's HIG: https://developer.apple.com/design/Human-Interface-Guidelines/tab-bars#Best-practices 

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15 / iOS Simulator 26.2 toolchain
- Runtime/container: local Xcode build
- Model/provider: N/A
- Integration/channel (if any): iOS app UI
- Relevant config (redacted): local iOS signing overrides

### Steps

1. Launch the iOS app home screen on the previous toolbar revision.
2. Observe the previous bottom bar presentation and compare it against Apple’s documentation.
3. Launch this branch and inspect the revised bottom bar layout and glass treatment.

### Expected

- The bottom navigation should follow Apple’s guidance more closely: compact, bottom-aligned, visually grouped, and less custom-heavy.

### Actual

- This branch replaces the prior heavy toolbar treatment with a bottom-aligned floating glass navigation control.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: iterative visual inspection of the iOS home screen bottom bar in Xcode/simulator, including grouping, bottom alignment, and status label readability.
- Edge cases checked: status text truncation pressure, content extending behind the bottom safe area, active Talk control emphasis.
- What you did **not** verify: device-only watch target builds; full scheme build still hits the existing watch app simulator limitation.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `8b72e8d2f1`.
- Files/config to restore: `apps/ios/Sources/OpenClawApp.swift`, `apps/ios/Sources/RootCanvas.swift`, `apps/ios/Sources/Screen/ScreenTab.swift`, `apps/ios/Sources/HomeToolbar.swift`
- Known bad symptoms reviewers should watch for: bottom bar positioned too high/low, content no longer extending beneath the bottom safe area, status label truncating again.

## Risks and Mitigations

- Risk: the new bar still uses a custom composition rather than a stock `TabView`, so future Liquid Glass SDK changes may require another visual pass.
  - Mitigation: the current design now uses system glass APIs where available and simplifies the composition to two compact grouped controls.
- Risk: simulator build verification remains noisy because the scheme includes watch targets.
  - Mitigation: this PR was verified against the current known simulator/watch limitation and did not introduce new Swift compile errors in the touched files.

## Apple guideline deviations addressed

Previous deviations and the fixes in this PR:

- Apple Liquid Glass navigation guidance says to reduce custom bar chrome, use shared glass regions, and prefer standard controls where possible.
  The previous bottom bar used a custom heavy toolbar treatment with nested backgrounds, divider chrome, and opaque chip styling. This PR replaces that with shared glass surfaces and system glass button styles where available.

- Apple’s iOS tab bar HIG says tab bars should present top-level destinations in a compact bottom control, and the best-practices guidance favors clarity, stable grouping, and avoiding unnecessary custom ornamentation.
  The previous bar sat higher, reserved its own strip above the safe area, and looked more like a bespoke toolbar. This PR moves the controls to the bottom edge, separates the leading status item from the grouped action cluster, and simplifies the treatment to better match Apple’s recommended presentation.
