### PR TITLE
Docs/plugins: add OpenClaw China Channels listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Docs: https://docs.openclaw.ai
 - Docs/plugins: add the community QQbot plugin listing to the docs catalog. (#29898) Thanks @sliverp.
 - Docs/plugins: add the community wecom plugin listing to the docs catalog. (#29905) Thanks @sliverp.
 - Telegram/message tool: add `asDocument` as a user-facing alias for `forceDocument` on image and GIF sends, while preserving explicit `forceDocument` precedence when both flags are present. (#52461) Thanks @bakhtiersizhaev.
+- Docs/plugins: add the community OpenClaw China Channels plugin listing to the docs catalog. Thanks @BytePioneer-AI.
 
 ### Fixes
 

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -72,6 +72,11 @@ setup flow for deploying AI assistants across common China messaging channels.
 openclaw plugins install @openclaw-china/channels
 ```
 
+Prefer this bundle when you want one package and setup flow across multiple
+China messaging platforms. If you only need a single channel, install that
+dedicated plugin instead. Avoid enabling this bundle alongside separate
+DingTalk, QQbot, or wecom plugins for the same channel in one deployment.
+
 ### Opik
 
 Official plugin that exports agent traces to Opik. Monitor agent behavior,

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -59,6 +59,19 @@ while reducing token usage.
 openclaw plugins install @martian-engineering/lossless-claw
 ```
 
+### OpenClaw China Channels
+
+Unified OpenClaw plugin bundle for China messaging platforms. Supports
+DingTalk, Feishu, QQ, WeCom, WeCom App, WeCom KF, and WeChat MP, with a shared
+setup flow for deploying AI assistants across common China messaging channels.
+
+- **npm:** `@openclaw-china/channels`
+- **repo:** [github.com/BytePioneer-AI/openclaw-china](https://github.com/BytePioneer-AI/openclaw-china)
+
+```bash
+openclaw plugins install @openclaw-china/channels
+```
+
 ### Opik
 
 Official plugin that exports agent traces to Opik. Monitor agent behavior,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The community plugin catalog does not include OpenClaw China Channels, even though it is a widely adopted and actively maintained plugin bundle for major China messaging platforms.
- Why it matters: This plugin helps users connect AI assistants to DingTalk, WeCom, WeCom App, WeCom KF, WeChat MP, QQ, and Feishu through a unified OpenClaw plugin package, which makes it a strong fit for the official community plugins catalog.
- Why this plugin is important: As of 2026-03-23, the public repository shows 216,045 total downloads in its README badge, about 3.5k GitHub stars, and roughly 474 commits, which indicates a stable and continuously maintained community plugin rather than an experimental wrapper.
- Adoption signal: The public README also lists Alibaba Cloud and Volcano Engine in its "Who uses" section, indicating real deployment and validation in commercial environments.
- What changed: Added an `OpenClaw China Channels` entry to `docs/plugins/community.md` and added the matching docs catalog note to `CHANGELOG.md`.
- What did NOT change (scope boundary): No runtime behavior, package code, install flow, or plugin metadata was changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #29913
- Related #29898
- Related #29905

## User-visible / Behavior Changes

The community plugins page now includes a discoverable listing for `@openclaw-china/channels`, a unified plugin bundle for China messaging channels.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): Docs only
- Relevant config (redacted): N/A

### Steps

1. Open `docs/plugins/community.md`.
2. Confirm the community plugins list includes `OpenClaw China Channels`.
3. Confirm the entry points to the published npm package `@openclaw-china/channels` and the public repository `https://github.com/BytePioneer-AI/openclaw-china`.
4. Confirm `CHANGELOG.md` includes the matching docs catalog entry under `Unreleased` -> `Changes`.

### Expected

- The official community plugins catalog includes a clear entry for a stable, actively maintained China messaging plugin bundle.
- Users can discover the package and install it directly with `openclaw plugins install @openclaw-china/channels`.

### Actual

- Added the new docs entry and the matching changelog note.

## Evidence

Attach at least one:

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Additional public signals checked on 2026-03-23:

- README badge shows 216,045 total downloads.
- GitHub repository shows about 3,483 stars.
- GitHub commit pagination indicates roughly 474 commits.
- README "Who uses" section lists Alibaba Cloud and Volcano Engine.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Checked the package name, repository URL, install command, and the new docs listing in `docs/plugins/community.md`; checked the matching changelog entry in `CHANGELOG.md`.
- Edge cases checked: Kept the wording scoped to a published community plugin bundle and positioned it as a unified multi-channel package rather than a core OpenClaw integration.
- What you did **not** verify: Did not run a docs build because this is a docs-only community catalog change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the docs entry in `docs/plugins/community.md` and the matching changelog line in `CHANGELOG.md`.
- Files/config to restore: `docs/plugins/community.md`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: Misleading package positioning or wording that overstates scope beyond the published package.

## Risks and Mitigations

- Risk: The listing could be seen as overlapping with existing single-channel community plugin entries.
  - Mitigation: The entry is explicitly framed as a unified multi-channel plugin bundle for China messaging platforms.

- Risk: The PR could read as marketing-heavy.
  - Mitigation: The importance claims are grounded in publicly visible adoption and maintenance signals from the repository and package distribution.
