### PR TITLE
fix: ensure control-ui is built before publish (#52808)

### DIFF
--- a/package.json
+++ b/package.json
@@ -678,6 +678,7 @@
     "plugins:sync": "node --import tsx scripts/sync-plugin-versions.ts",
     "prepack": "pnpm build && pnpm ui:build",
     "prepare": "command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath git-hooks || exit 0",
+    "prepublishOnly": "pnpm ui:build",
     "protocol:check": "pnpm protocol:gen && pnpm protocol:gen:swift && git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
     "protocol:gen": "node --import tsx scripts/protocol-gen.ts",
     "protocol:gen:swift": "node --import tsx scripts/protocol-gen-swift.ts",


### PR DESCRIPTION
## Summary

-Problem: dist/control-ui/ missing from npm package (2026.3.22)
-Why it matters: Gateway UI returns 503 and is unusable
-What changed: Ensure pnpm ui:build runs before publish
-What did NOT change (scope boundary): No runtime, gateway, or UI code changes

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

-Closes #52808
-Related #52813

## User-visible / Behavior Changes

Control UI is now available again after install.
Previously returned 503 due to missing assets.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

###Environment
OS: Ubuntu 24.04
Runtime/container: Node.js v22
Model/provider: N/A
Integration/channel: N/A
Relevant config: default install via npm

### Steps
npm install -g openclaw@2026.3.22
openclaw gateway start
open dashboard

### Expected
UI loads successfully
### Actual
503 error: "Control UI assets not found"

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

2026.3.13 → includes dist/control-ui/
2026.3.22 → missing dist/control-ui/

## Human Verification (required)

What you personally verified (not just CI), and how:

-Verified scenarios:
npm pack includes dist/control-ui/
UI loads after install

-Edge cases checked:
Fresh install
Global npm install path

-What you did not verify:
All extensions packaging (e.g. WhatsApp)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

-How to disable/revert this change quickly:
revert commit or publish previous version

-Files/config to restore:
dist/control-ui/

-Known bad symptoms reviewers should watch for:
Missing UI assets
503 on dashboard

## Risks and Mitigations

-Risk: UI build step fails silently again

-Mitigation: enforce build in prepack and fail if missing
