### PR TITLE
[Bug] Fix legacy systemEvent cron payloads loaded with message instead of text

### DIFF
--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -123,6 +123,22 @@ function coercePayload(payload: UnknownRecord) {
       next.text = trimmed;
     }
   }
+  if (next.kind === "systemEvent") {
+    const text =
+      typeof next.text === "string"
+        ? next.text.trim()
+        : typeof next.message === "string"
+          ? next.message.trim()
+          : "";
+    if (text) {
+      next.text = text;
+    } else {
+      delete next.text;
+    }
+    if ("message" in next) {
+      delete next.message;
+    }
+  }
   if ("model" in next) {
     if (typeof next.model === "string") {
       const trimmed = next.model.trim();

--- a/src/cron/service.store-load-invalid-main-job.test.ts
+++ b/src/cron/service.store-load-invalid-main-job.test.ts
@@ -8,6 +8,7 @@ import {
   installCronTestHooks,
   writeCronStoreSnapshot,
 } from "./service.test-harness.js";
+import { loadCronStore } from "./store.js";
 import type { CronJob } from "./types.js";
 
 const noopLogger = createNoopLogger();
@@ -72,6 +73,61 @@ describe("CronService store load", () => {
     const jobs = await cron.list({ includeDisabled: true });
     expect(jobs[0]?.state.lastStatus).toBe("skipped");
     expect(jobs[0]?.state.lastError).toMatch(/main job requires/i);
+
+    cron.stop();
+  });
+
+  it("runs legacy main jobs with systemEvent message payloads loaded from disk", async () => {
+    const { dir, storePath } = await makeStorePath();
+    tempDir = dir;
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    const job = {
+      id: "job-legacy-system-message",
+      enabled: true,
+      createdAtMs: Date.parse("2025-12-13T00:00:00.000Z"),
+      updatedAtMs: Date.parse("2025-12-13T00:00:00.000Z"),
+      schedule: { kind: "at", at: "2025-12-13T00:00:01.000Z" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", message: "  legacy tick  " },
+      state: {},
+      name: "legacy-system-message",
+    } as CronJob;
+
+    await writeCronStoreSnapshot({ storePath, jobs: [job] });
+
+    const cron = new CronService({
+      storePath,
+      cronEnabled: true,
+      log: noopLogger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await cron.start();
+    vi.setSystemTime(new Date("2025-12-13T00:00:01.000Z"));
+    await cron.run("job-legacy-system-message", "due");
+
+    expect(enqueueSystemEvent).toHaveBeenCalledWith("legacy tick", {
+      agentId: undefined,
+      sessionKey: undefined,
+      contextKey: "cron:job-legacy-system-message",
+    });
+    expect(requestHeartbeatNow).toHaveBeenCalledWith({
+      reason: "cron:job-legacy-system-message",
+      agentId: undefined,
+      sessionKey: undefined,
+    });
+
+    const stored = await loadCronStore(storePath);
+    expect(stored.jobs[0]?.payload).toMatchObject({
+      kind: "systemEvent",
+      text: "legacy tick",
+    });
+    expect((stored.jobs[0]?.payload as { message?: unknown } | undefined)?.message).toBeUndefined();
 
     cron.stop();
   });

--- a/src/cron/service.store-load-invalid-main-job.test.ts
+++ b/src/cron/service.store-load-invalid-main-job.test.ts
@@ -94,7 +94,7 @@ describe("CronService store load", () => {
       payload: { kind: "systemEvent", message: "  legacy tick  " },
       state: {},
       name: "legacy-system-message",
-    } as CronJob;
+    } as unknown as CronJob;
 
     await writeCronStoreSnapshot({ storePath, jobs: [job] });
 

--- a/src/cron/service/normalize.ts
+++ b/src/cron/service/normalize.ts
@@ -82,13 +82,8 @@ export function inferLegacyName(job: {
 export function normalizePayloadToSystemText(payload: CronPayload) {
   if (payload.kind === "systemEvent") {
     // Accept legacy persisted systemEvent payloads that still use `message`.
-    const text =
-      typeof (payload as { text?: unknown }).text === "string"
-        ? (payload as { text: string }).text
-        : typeof (payload as { message?: unknown }).message === "string"
-          ? (payload as { message: string }).message
-          : "";
-    return text.trim();
+    const raw = payload as { text?: string; message?: string };
+    return (raw.text ?? raw.message ?? "").trim();
   }
   return payload.message.trim();
 }

--- a/src/cron/service/normalize.ts
+++ b/src/cron/service/normalize.ts
@@ -81,7 +81,14 @@ export function inferLegacyName(job: {
 
 export function normalizePayloadToSystemText(payload: CronPayload) {
   if (payload.kind === "systemEvent") {
-    return payload.text.trim();
+    // Accept legacy persisted systemEvent payloads that still use `message`.
+    const text =
+      typeof (payload as { text?: unknown }).text === "string"
+        ? (payload as { text: string }).text
+        : typeof (payload as { message?: unknown }).message === "string"
+          ? (payload as { message: string }).message
+          : "";
+    return text.trim();
   }
   return payload.message.trim();
 }

--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -148,6 +148,7 @@ describe("normalizeStoredCronJobs", () => {
     const result = normalizeStoredCronJobs(jobs);
 
     expect(result.mutated).toBe(true);
+    expect(result.issues.legacySystemEventMessage).toBe(1);
     expect(jobs[0]?.payload).toMatchObject({ kind: "systemEvent", text: "ping" });
     const payload = jobs[0]?.payload as Record<string, unknown> | undefined;
     expect(payload?.message).toBeUndefined();

--- a/src/cron/store-migration.test.ts
+++ b/src/cron/store-migration.test.ts
@@ -130,4 +130,26 @@ describe("normalizeStoredCronJobs", () => {
     expect(jobs[0]?.payload).toMatchObject({ kind: "agentTurn", message: "ping" });
     expect(jobs[1]?.payload).toMatchObject({ kind: "systemEvent", text: "pong" });
   });
+
+  it("migrates legacy systemEvent payload.message fields into text", () => {
+    const jobs = [
+      {
+        id: "legacy-system-message",
+        name: "legacy",
+        enabled: true,
+        wakeMode: "now",
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: 1 },
+        payload: { kind: "systemEvent", message: "  ping  " },
+        sessionTarget: "main",
+        state: {},
+      },
+    ] as Array<Record<string, unknown>>;
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.mutated).toBe(true);
+    expect(jobs[0]?.payload).toMatchObject({ kind: "systemEvent", text: "ping" });
+    const payload = jobs[0]?.payload as Record<string, unknown> | undefined;
+    expect(payload?.message).toBeUndefined();
+  });
 });

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -301,6 +301,19 @@ export function normalizeStoredCronJobs(
           trackIssue("legacyPayloadKind");
         }
       }
+      if (payloadRecord.kind === "systemEvent") {
+        const text = typeof payloadRecord.text === "string" ? payloadRecord.text.trim() : "";
+        const legacyMessage =
+          typeof payloadRecord.message === "string" ? payloadRecord.message.trim() : "";
+        if (!text && legacyMessage) {
+          payloadRecord.text = legacyMessage;
+          mutated = true;
+        }
+        if ("message" in payloadRecord) {
+          delete payloadRecord.message;
+          mutated = true;
+        }
+      }
       if (payloadRecord.kind === "agentTurn" && copyTopLevelAgentTurnFields(raw, payloadRecord)) {
         mutated = true;
       }

--- a/src/cron/store-migration.ts
+++ b/src/cron/store-migration.ts
@@ -10,6 +10,7 @@ type CronStoreIssueKey =
   | "legacyScheduleString"
   | "legacyScheduleCron"
   | "legacyPayloadKind"
+  | "legacySystemEventMessage"
   | "legacyPayloadProvider"
   | "legacyTopLevelPayloadFields"
   | "legacyTopLevelDeliveryFields"
@@ -308,6 +309,7 @@ export function normalizeStoredCronJobs(
         if (!text && legacyMessage) {
           payloadRecord.text = legacyMessage;
           mutated = true;
+          trackIssue("legacySystemEventMessage");
         }
         if ("message" in payloadRecord) {
           delete payloadRecord.message;


### PR DESCRIPTION
## Summary

Fix main-session cron jobs that load legacy `systemEvent` payloads stored as
`payload.message` instead of `payload.text`.

Without this, those jobs can hit `undefined.trim()` during execution and fail
immediately instead of enqueueing the system event.

Fixes: https://github.com/openclaw/openclaw/issues/52804

## What changed

- normalize legacy `systemEvent.message` payloads into canonical `text`
- keep a defensive runtime fallback when reading persisted cron payloads
- add regression tests for store migration and execution of legacy-loaded jobs
- track migrated legacy `systemEvent.message` payloads in store issue reporting

## Testing

- `corepack pnpm test -- src/cron/normalize.test.ts src/cron/store-migration.test.ts src/cron/service.store-load-invalid-main-job.test.ts src/cron/service.store.migration.test.ts`