### PR TITLE
[AI-assisted] docs: add minimax-m2.7 model to opencode-go provider

### DIFF
--- a/docs/providers/opencode-go.md
+++ b/docs/providers/opencode-go.md
@@ -14,8 +14,8 @@ provider id `opencode-go` so upstream per-model routing stays correct.
 
 ## Supported models
 
-- `opencode-go/kimi-k2.5`
 - `opencode-go/glm-5`
+- `opencode-go/kimi-k2.5`
 - `opencode-go/minimax-m2.5`
 - `opencode-go/minimax-m2.7`
 

--- a/docs/providers/opencode-go.md
+++ b/docs/providers/opencode-go.md
@@ -17,6 +17,7 @@ provider id `opencode-go` so upstream per-model routing stays correct.
 - `opencode-go/kimi-k2.5`
 - `opencode-go/glm-5`
 - `opencode-go/minimax-m2.5`
+- `opencode-go/minimax-m2.7`
 
 ## CLI setup
 


### PR DESCRIPTION
## Summary
- Add `opencode-go/minimax-m2.7` to the supported models list in the OpenCode Go documentation

## AI-assisted
- Built with **opencode** CLI agent
- Prompts/session logs available in this conversation
- **Testing:** Untested (documentation-only change, no logic affected)
- This is a simple docs update to add a newly available model to the supported models list

## Confirm understanding
I understand that this change adds the `opencode-go/minimax-m2.7` model reference to the OpenCode Go provider documentation, making it discoverable to users.