### PR TITLE
fix(whatsapp): deliver non-final media replies

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
@@ -283,13 +283,16 @@ describe("web processMessage inbound context", () => {
     expect(groupHistories.get("whatsapp:default:group:123@g.us") ?? []).toHaveLength(0);
   });
 
-  it("suppresses non-final WhatsApp payload delivery", async () => {
+  it("suppresses non-final text-only WhatsApp payload delivery", async () => {
     const rememberSentText = vi.fn();
     await processMessage(createWhatsAppDirectStreamingArgs({ rememberSentText }));
 
     // oxlint-disable-next-line typescript/no-explicit-any
     const deliver = (capturedDispatchParams as any)?.dispatcherOptions?.deliver as
-      | ((payload: { text?: string }, info: { kind: "tool" | "block" | "final" }) => Promise<void>)
+      | ((
+          payload: { text?: string; mediaUrl?: string; mediaUrls?: string[] },
+          info: { kind: "tool" | "block" | "final" },
+        ) => Promise<void>)
       | undefined;
     expect(deliver).toBeTypeOf("function");
 
@@ -301,6 +304,40 @@ describe("web processMessage inbound context", () => {
     await deliver?.({ text: "final payload" }, { kind: "final" });
     expect(deliverWebReplyMock).toHaveBeenCalledTimes(1);
     expect(rememberSentText).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers non-final WhatsApp payloads when they include media", async () => {
+    const rememberSentText = vi.fn();
+    await processMessage(createWhatsAppDirectStreamingArgs({ rememberSentText }));
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const deliver = (capturedDispatchParams as any)?.dispatcherOptions?.deliver as
+      | ((
+          payload: { text?: string; mediaUrl?: string; mediaUrls?: string[] },
+          info: { kind: "tool" | "block" | "final" },
+        ) => Promise<void>)
+      | undefined;
+    expect(deliver).toBeTypeOf("function");
+
+    await deliver?.({ text: "voice note", mediaUrl: "/tmp/voice.ogg" }, { kind: "tool" });
+
+    expect(deliverWebReplyMock).toHaveBeenCalledTimes(1);
+    expect(deliverWebReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyResult: expect.objectContaining({
+          text: "voice note",
+          mediaUrl: "/tmp/voice.ogg",
+        }),
+      }),
+    );
+    expect(rememberSentText).toHaveBeenCalledTimes(1);
+    expect(rememberSentText).toHaveBeenCalledWith(
+      "voice note",
+      expect.objectContaining({
+        combinedBody: expect.any(String),
+        combinedBodySessionKey: "agent:main:whatsapp:direct:+1555",
+      }),
+    );
   });
 
   it("forces disableBlockStreaming for WhatsApp dispatch", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -405,10 +405,13 @@ export async function processMessage(params: {
         }
       },
       deliver: async (payload: ReplyPayload, info) => {
-        if (info.kind !== "final") {
-          // Only deliver final replies to external messaging channels (WhatsApp).
-          // Block (reasoning/thinking) and tool updates are meant for the internal
-          // web UI only; sending them here leaks chain-of-thought to end users.
+        const reply = resolveSendableOutboundReplyParts(payload);
+        if (info.kind !== "final" && !reply.hasMedia) {
+          // External WhatsApp chats must not receive plain text-only block/tool
+          // updates because those are internal streaming surfaces and may expose
+          // reasoning or other transient progress messages. Media-bearing payloads
+          // are still deliverable so successful tool outputs like TTS audio reach
+          // the user even when emitted before the final reply.
           return;
         }
         await deliverWebReply({
@@ -432,7 +435,6 @@ export async function processMessage(params: {
         });
         const fromDisplay =
           params.msg.chatType === "group" ? conversationId : (params.msg.from ?? "unknown");
-        const reply = resolveSendableOutboundReplyParts(payload);
         const hasMedia = reply.hasMedia;
         whatsappOutboundLog.info(`Auto-replied to ${fromDisplay}${hasMedia ? " (media)" : ""}`);
         if (shouldLogVerbose()) {
@@ -454,8 +456,9 @@ export async function processMessage(params: {
       onReplyStart: params.msg.sendComposing,
     },
     replyOptions: {
-      // WhatsApp delivery intentionally suppresses non-final payloads.
-      // Keep block streaming disabled so final replies are still produced.
+      // Keep block streaming disabled so WhatsApp still converges on final replies.
+      // Delivery additionally suppresses non-final text-only payloads, while still
+      // allowing media-bearing tool/block outputs such as TTS audio.
       disableBlockStreaming: true,
       onModelSelected,
     },


### PR DESCRIPTION
## Summary
- deliver non-final WhatsApp replies when they carry media
- keep suppressing non-final text-only tool/block chatter for external WhatsApp users
- add regression coverage for both behaviors

## Root cause
WhatsApp external delivery currently returns early for all `info.kind !== "final"` payloads in `process-message.ts`.
That suppresses reasoning/text chatter as intended, but it also drops valid media-bearing tool/block payloads such as TTS voice-note replies.

## What changed
- allow non-final payloads through **only when they contain media**
- continue blocking non-final payloads when they are text-only
- add regression tests proving:
  - non-final text-only payloads stay blocked
  - non-final media-bearing payloads are delivered and remembered

## Validation
- `pnpm exec vitest run --config .tmp-vitest-whatsapp-tts-fix.config.ts`
- Result: 25 tests passed across the scoped WhatsApp regression files

## Notes
There is related overlap with #42512, but this PR is intentionally small and surgical around the specific regression in external WhatsApp auto-reply delivery.
