### PR TITLE
fix(ollama): register API provider in compaction safeguard extension

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -839,7 +839,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         model.api,
         createConfiguredOllamaStreamFn({
           model,
-          providerBaseUrl: model.baseUrl,
         }),
       );
     }

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -24,6 +24,8 @@ import {
   summarizeInStages,
 } from "../compaction.js";
 import { collectTextContentBlocks } from "../content-blocks.js";
+import { ensureCustomApiRegistered } from "../custom-api-registry.js";
+import { createConfiguredOllamaStreamFn } from "../ollama-stream.js";
 import { wrapUntrustedPromptDataBlock } from "../sanitize-for-prompt.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
@@ -829,6 +831,19 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     };
     const identifierPolicy = runtime?.identifierPolicy ?? "strict";
     const model = ctx.model ?? runtime?.model;
+
+    // Register Ollama API provider when using Ollama models in compaction safeguard.
+    // This prevents "No API provider registered for api: ollama" errors during summarization.
+    if (model?.api === "ollama") {
+      ensureCustomApiRegistered(
+        model.api,
+        createConfiguredOllamaStreamFn({
+          model,
+          providerBaseUrl: model.baseUrl,
+        }),
+      );
+    }
+
     if (!model) {
       // Log warning once per session when both models are missing (diagnostic for future issues).
       // Use a WeakSet to track which session managers have already logged the warning.


### PR DESCRIPTION
## Problem

When using native Ollama models, the LCM compaction safeguard extension fails with:

```
No API provider registered for api: ollama
```

## Root Cause

PR #39332 fixed the main run path (`compact.ts`) by registering the Ollama API provider before calling `completeSimple()`, but missed the separate `compactionSafeguardExtension` code path. This extension calls `summarizeInStages()` → `generateSummary()` → `completeSimple()` without prior Ollama registration.

## Fix

Register Ollama API provider in `compactionSafeguardExtension` immediately after model resolution, before any summarization calls.

**Changes:**
- Added imports: `ensureCustomApiRegistered` and `createConfiguredOllamaStreamFn`
- Added registration check after model resolution (line ~837)

## Testing

- `pnpm build`: ✅ passed
- `pnpm check`: ✅ passed (formatting, linting)
- `pnpm vitest run src/agents/pi-extensions/compaction-safeguard.test.ts`: ✅ 80 tests passed
- Tested on: OpenClaw 2026.3.22 (4dcc39c)

## Related

- Follow-up to #39332 (incomplete fix)

## Disclosure

AI-assisted: yes