### PR TITLE
feat(imessage): wire typing indicators via imsg v0.5.0 CLI

### DIFF
--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -34,6 +34,7 @@ import {
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-runtime";
 import { dispatchInboundMessage } from "openclaw/plugin-sdk/reply-runtime";
 import { createReplyDispatcher } from "openclaw/plugin-sdk/reply-runtime";
+import { createReplyDispatcherWithTyping } from "openclaw/plugin-sdk/reply-runtime";
 import { danger, logVerbose, shouldLogVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-runtime";
@@ -43,6 +44,7 @@ import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "../constants.js";
 import { probeIMessage } from "../probe.js";
 import { sendMessageIMessage } from "../send.js";
 import { normalizeIMessageHandle } from "../targets.js";
+import { resolveIMessageTypingTarget, sendIMessageTyping } from "../typing.js";
 import { attachIMessageMonitorAbortHandler } from "./abort-handler.js";
 import { deliverReplies } from "./deliver.js";
 import { createSentMessageCache } from "./echo-cache.js";
@@ -401,9 +403,41 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       accountId: decision.route.accountId,
     });
 
-    const dispatcher = createReplyDispatcher({
+    const typingTarget = resolveIMessageTypingTarget({
+      chatId: decision.chatId,
+      chatIdentifier: decision.chatIdentifier,
+      chatGuid: decision.chatGuid,
+      to: decision.sender,
+    });
+    const cliPath = accountInfo.config.cliPath?.trim() || "imsg";
+    const dbPath = accountInfo.config.dbPath?.trim();
+    const sendTyping = (active: boolean) => {
+      if (!typingTarget) {
+        return;
+      }
+      sendIMessageTyping(typingTarget, {
+        cliPath,
+        dbPath: dbPath || undefined,
+        runtime,
+        active,
+      }).catch((err) => {
+        runtime.error?.(`[imessage] typing ${active ? "start" : "stop"} failed: ${String(err)}`);
+      });
+    };
+
+    let streamingActive = false;
+    const {
+      dispatcher,
+      replyOptions: typingReplyOptions,
+      markRunComplete,
+    } = createReplyDispatcherWithTyping({
       ...replyPipeline,
       humanDelay: resolveHumanDelayConfig(cfg, decision.route.agentId),
+      onReplyStart: async () => {
+        streamingActive = true;
+        sendTyping(true);
+        await replyPipeline.typingCallbacks?.onReplyStart();
+      },
       deliver: async (payload) => {
         const target = ctxPayload.To;
         if (!target) {
@@ -426,18 +460,28 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       },
     });
 
-    const { queuedFinal } = await dispatchInboundMessage({
-      ctx: ctxPayload,
-      cfg,
-      dispatcher,
-      replyOptions: {
-        disableBlockStreaming:
-          typeof accountInfo.config.blockStreaming === "boolean"
-            ? !accountInfo.config.blockStreaming
-            : undefined,
-        onModelSelected,
-      },
-    });
+    let queuedFinal: boolean;
+    try {
+      ({ queuedFinal } = await dispatchInboundMessage({
+        ctx: ctxPayload,
+        cfg,
+        dispatcher,
+        replyOptions: {
+          ...typingReplyOptions,
+          disableBlockStreaming:
+            typeof accountInfo.config.blockStreaming === "boolean"
+              ? !accountInfo.config.blockStreaming
+              : undefined,
+          onModelSelected,
+        },
+      }));
+    } finally {
+      markRunComplete();
+      if (streamingActive) {
+        streamingActive = false;
+        sendTyping(false);
+      }
+    }
 
     if (!queuedFinal) {
       if (decision.isGroup && decision.historyKey) {

--- a/extensions/imessage/src/typing.ts
+++ b/extensions/imessage/src/typing.ts
@@ -1,0 +1,119 @@
+import { spawn } from "node:child_process";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+
+export type IMessageTypingTarget =
+  | { kind: "to"; to: string }
+  | { kind: "chat_id"; chatId: number }
+  | { kind: "chat_identifier"; chatIdentifier: string }
+  | { kind: "chat_guid"; chatGuid: string };
+
+export type SendIMessageTypingOpts = {
+  cliPath?: string;
+  dbPath?: string;
+  runtime?: RuntimeEnv;
+  active: boolean;
+  /** Timeout in ms for the typing subprocess. Defaults to 5000. */
+  timeoutMs?: number;
+};
+
+/**
+ * Send a typing start or stop indicator via `imsg typing`.
+ * Requires imsg >= 0.5.0. Errors are soft — logged but not thrown.
+ */
+export async function sendIMessageTyping(
+  target: IMessageTypingTarget,
+  opts: SendIMessageTypingOpts,
+): Promise<void> {
+  const cliPath = opts.cliPath?.trim() || "imsg";
+  const args: string[] = ["typing"];
+
+  if (opts.dbPath?.trim()) {
+    args.push("--db", opts.dbPath.trim());
+  }
+
+  switch (target.kind) {
+    case "to":
+      args.push("--to", target.to);
+      break;
+    case "chat_id":
+      args.push("--chat-id", String(target.chatId));
+      break;
+    case "chat_identifier":
+      args.push("--chat-identifier", target.chatIdentifier);
+      break;
+    case "chat_guid":
+      args.push("--chat-guid", target.chatGuid);
+      break;
+  }
+
+  if (!opts.active) {
+    args.push("--stop", "true");
+  }
+
+  const timeoutMs = opts.timeoutMs ?? 5000;
+
+  return new Promise((resolve) => {
+    let done = false;
+    const settle = () => {
+      if (!done) {
+        done = true;
+        resolve();
+      }
+    };
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(cliPath, args, { stdio: "pipe" });
+    } catch (err) {
+      opts.runtime?.error?.(`[imessage] typing spawn failed: ${String(err)}`);
+      return settle();
+    }
+
+    const timer = setTimeout(() => {
+      if (!done) {
+        child.kill();
+        opts.runtime?.error?.(`[imessage] typing command timed out`);
+        settle();
+      }
+    }, timeoutMs);
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0 && code !== null) {
+        logVerbose(`[imessage] typing command exited with code ${code}`);
+      }
+      settle();
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      opts.runtime?.error?.(`[imessage] typing command error: ${String(err)}`);
+      settle();
+    });
+  });
+}
+
+/**
+ * Resolve a typing target from available identifiers (prefer chat_id > chat_identifier > chat_guid > to).
+ */
+export function resolveIMessageTypingTarget(params: {
+  chatId?: number | null;
+  chatIdentifier?: string | null;
+  chatGuid?: string | null;
+  to?: string | null;
+}): IMessageTypingTarget | null {
+  if (typeof params.chatId === "number") {
+    return { kind: "chat_id", chatId: params.chatId };
+  }
+  if (params.chatIdentifier?.trim()) {
+    return { kind: "chat_identifier", chatIdentifier: params.chatIdentifier.trim() };
+  }
+  if (params.chatGuid?.trim()) {
+    return { kind: "chat_guid", chatGuid: params.chatGuid.trim() };
+  }
+  if (params.to?.trim()) {
+    return { kind: "to", to: params.to.trim() };
+  }
+  return null;
+}


### PR DESCRIPTION
## Problem

The imessage channel has never shown typing indicators. Since the OpenClaw imsg integration talks directly to Messages.app via the `imsg` CLI, there's no BlueBubbles server involved — typing has just been absent entirely.

## Solution

Wire up typing indicators using the `imsg typing` command added in imsg v0.5.0.

## What changed

**New file: `extensions/imessage/src/typing.ts`**
- `sendIMessageTyping(target, opts)` — shells out to `imsg typing` with start/stop semantics; errors are soft (logged at verbose, never thrown or surfaced to the user)
- `resolveIMessageTypingTarget()` — picks the best available identifier (chat_id > chat_identifier > chat_guid > phone/email handle), matching the priority order used elsewhere in the imessage extension

**Modified: `extensions/imessage/src/monitor/monitor-provider.ts`**
- Switched from `createReplyDispatcher` to `createReplyDispatcherWithTyping` so typing flows through the standard pipeline and respects the `typingMode` config (`instant`, `thinking`, `message`, `never`)
- `onReplyStart` fires `imsg typing --chat-id <id>` (or best available target) when the agent starts generating a response
- `finally` block fires `imsg typing --stop true` after delivery completes, whether success or error

## Why CLI, not RPC

`imsg rpc` does not expose a typing RPC method as of v0.5.0 — the `typing` subcommand only exists as a CLI command. The subprocess approach is consistent with how other `imsg` commands work.

Verified by running `imsg rpc` with `sendTyping` and `typing` method names — both return `Method not found (-32601)`.

## Graceful degradation

If imsg < 0.5.0 is installed (no `typing` subcommand), the child process exits non-zero. The error is caught and logged at verbose level only. No crash, no behavior change for the message flow.

## Testing

- Manually tested on macOS Sequoia with imsg 0.5.0: typing bubble appears in Messages.app when I send a message to the agent, disappears when the reply arrives
- TypeScript: zero new errors (pre-existing matrix-js-sdk/vertex-sdk errors in this env are unrelated)

Closes #26924