### PR TITLE
fix(ui): select dropdowns show stale value on page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI: keep Agents model and config enum dropdowns visually aligned with their configured values on initial load while inherited non-default agents stay on the inherit-default option. Fixes #40352; repairs #52948. Thanks @xiaoquanidea.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.
 - fix(plugins): restrict bundled plugin dir resolution to trusted package roots. (#73275) Thanks @pgondhi987.
 - fix(security): prevent workspace PATH injection via service env and trash helpers. (#73264) Thanks @pgondhi987.

--- a/ui/src/ui/config-form.browser.test.ts
+++ b/ui/src/ui/config-form.browser.test.ts
@@ -98,6 +98,41 @@ describe("config form renderer", () => {
     expect(onPatch).toHaveBeenCalledWith(["bind"], "tailnet");
   });
 
+  it("selects the configured option for large enum dropdowns", async () => {
+    const onPatch = vi.fn();
+    const container = document.createElement("div");
+    const schema = {
+      type: "object",
+      properties: {
+        provider: {
+          type: "string",
+          enum: ["anthropic", "openai", "google", "ollama", "minimax", "xai"],
+        },
+      },
+    };
+    const analysis = analyzeConfigSchema(schema);
+
+    render(
+      renderConfigForm({
+        schema: analysis.schema,
+        uiHints: {},
+        unsupportedPaths: analysis.unsupportedPaths,
+        value: { provider: "minimax" },
+        onPatch,
+      }),
+      container,
+    );
+
+    const select = await vi.waitFor(() => {
+      const node = container.querySelector<HTMLSelectElement>(".cfg-select");
+      expect(node).not.toBeNull();
+      return node;
+    });
+
+    expect(select?.value).toBe("4");
+    expect(select?.selectedOptions[0]?.textContent).toBe("minimax");
+  });
+
   it("renders map fields from additionalProperties", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");

--- a/ui/src/ui/views/agents-panels-overview.ts
+++ b/ui/src/ui/views/agents-panels-overview.ts
@@ -153,7 +153,12 @@ export function renderAgentOverview(params: {
                       ${defaultPrimary ? `Inherit default (${defaultPrimary})` : "Inherit default"}
                     </option>
                   `}
-              ${buildModelOptions(configForm, effectivePrimary ?? undefined, params.modelCatalog)}
+              ${buildModelOptions(
+                configForm,
+                effectivePrimary ?? undefined,
+                params.modelCatalog,
+                isDefault ? (effectivePrimary ?? null) : (entryPrimary ?? null),
+              )}
             </select>
           </label>
           <div class="field">

--- a/ui/src/ui/views/agents-panels-overview.ts
+++ b/ui/src/ui/views/agents-panels-overview.ts
@@ -147,9 +147,9 @@ export function renderAgentOverview(params: {
                 onModelChange(agent.id, (e.target as HTMLSelectElement).value || null)}
             >
               ${isDefault
-                ? html` <option value="">Not set</option> `
+                ? html` <option value="" .selected=${!effectivePrimary}>Not set</option> `
                 : html`
-                    <option value="">
+                    <option value="" .selected=${!entryPrimary}>
                       ${defaultPrimary ? `Inherit default (${defaultPrimary})` : "Inherit default"}
                     </option>
                   `}

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -690,7 +690,10 @@ export function buildModelOptions(
   if (options.length === 0) {
     return nothing;
   }
-  return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
+  return options.map(
+    (option) =>
+      html`<option value=${option.value} ?selected=${option.value === current}>${option.label}</option>`,
+  );
 }
 
 type CompiledPattern =

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -694,7 +694,7 @@ export function buildModelOptions(
   const sel = selected !== undefined ? selected : current;
   return options.map(
     (option) =>
-      html`<option value=${option.value} ?selected=${option.value === sel}>
+      html`<option value=${option.value} .selected=${option.value === sel}>
         ${option.label}
       </option>`,
   );

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -658,6 +658,7 @@ export function buildModelOptions(
   configForm: Record<string, unknown> | null,
   current?: string | null,
   catalog?: ModelCatalogEntry[],
+  selected?: string | null,
 ) {
   const seen = new Set<string>();
   const options: ConfiguredModelOption[] = [];
@@ -690,9 +691,12 @@ export function buildModelOptions(
   if (options.length === 0) {
     return nothing;
   }
+  const sel = selected !== undefined ? selected : current;
   return options.map(
     (option) =>
-      html`<option value=${option.value} ?selected=${option.value === current}>${option.label}</option>`,
+      html`<option value=${option.value} ?selected=${option.value === sel}>
+        ${option.label}
+      </option>`,
   );
 }
 

--- a/ui/src/ui/views/agents.test.ts
+++ b/ui/src/ui/views/agents.test.ts
@@ -162,6 +162,8 @@ describe("renderAgents", () => {
       ).toBe(true);
       return select;
     });
+    expect(betaSelect?.value).toBe("openai/gpt-5.4");
+    expect(betaSelect?.selectedOptions[0]?.value).toBe("openai/gpt-5.4");
 
     render(
       renderAgents(
@@ -188,6 +190,51 @@ describe("renderAgents", () => {
       return select;
     });
     expect(alphaSelect).not.toBe(betaSelect);
+    expect(alphaSelect?.value).toBe("anthropic/claude-sonnet-4-6");
+    expect(alphaSelect?.selectedOptions[0]?.value).toBe("anthropic/claude-sonnet-4-6");
+  });
+
+  it("keeps inherited non-default agents on the inherit option", async () => {
+    const container = document.createElement("div");
+    const configForm = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          models: {
+            "anthropic/claude-sonnet-4-6": {},
+            "openai/gpt-5.4": {},
+          },
+        },
+        list: [{ id: "beta" }],
+      },
+    };
+
+    render(
+      renderAgents(
+        createProps({
+          selectedAgentId: "beta",
+          config: {
+            form: configForm,
+            loading: false,
+            saving: false,
+            dirty: false,
+          },
+        }),
+      ),
+      container,
+    );
+
+    const select = await vi.waitFor(() => {
+      const node = container.querySelector<HTMLSelectElement>(".agent-model-fields select");
+      expect(node).not.toBeNull();
+      return node;
+    });
+
+    expect(select?.value).toBe("");
+    expect(select?.selectedOptions[0]?.value).toBe("");
+    expect(select?.selectedOptions[0]?.textContent?.trim()).toBe(
+      "Inherit default (anthropic/claude-sonnet-4-6)",
+    );
   });
 
   it("shows the skills count only for the selected agent's report", async () => {

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -852,8 +852,12 @@ function renderSelect(params: {
           onPatch(path, val === unset ? undefined : options[Number(val)]);
         }}
       >
-        <option value=${unset}>Select...</option>
-        ${options.map((opt, idx) => html` <option value=${String(idx)}>${String(opt)}</option> `)}
+        <option value=${unset} ?selected=${currentIndex < 0}>Select...</option>
+        ${options.map(
+          (opt, idx) => html`
+          <option value=${String(idx)} ?selected=${idx === currentIndex}>${String(opt)}</option>
+        `,
+        )}
       </select>
     </div>
   `;

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -852,11 +852,11 @@ function renderSelect(params: {
           onPatch(path, val === unset ? undefined : options[Number(val)]);
         }}
       >
-        <option value=${unset} ?selected=${currentIndex < 0}>Select...</option>
+        <option value=${unset} .selected=${currentIndex < 0}>Select...</option>
         ${options.map(
           (opt, idx) => html`
-          <option value=${String(idx)} ?selected=${idx === currentIndex}>${String(opt)}</option>
-        `,
+            <option value=${String(idx)} .selected=${idx === currentIndex}>${String(opt)}</option>
+          `,
         )}
       </select>
     </div>


### PR DESCRIPTION
## Summary

- Fix `<select>` dropdowns showing stale/wrong values on page load across the Control UI, caused by Lit's `.value` property binding firing before child `<option>` elements are in the DOM.

## Affected Components

1. **Agent model dropdown** (`agents-utils.ts` → `buildModelOptions`): The Primary model select in Agents → Overview always showed the first model in the catalog instead of the configured model after page refresh.

2. **Config form enum selects** (`config-form.node.ts` → `renderSelect`): All schema-driven enum dropdowns (e.g., Model Provider API Adapter) showed "Select..." instead of the configured value after page refresh.

## Root Cause

Both components use Lit's `.value` property binding on `<select>` elements. On initial render, `.value` fires before the child `<option>` elements are in the DOM. The browser cannot find a matching option, so it falls back to the first option — regardless of what the actual configured value is.

## Fix

Add `?selected` attribute binding to each `<option>` so the correct option is marked directly in the HTML at render time, independent of `.value` property timing.

**agents-utils.ts — Before:**
```ts
html`<option value=${option.value}>${option.label}</option>`
```
**After:**
```ts
html`<option value=${option.value} ?selected=${option.value === current}>${option.label}</option>`
```

**config-form.node.ts — Before:**
```ts
<option value=${unset}>Select...</option>
<option value=${String(idx)}>${String(opt)}</option>
```
**After:**
```ts
<option value=${unset} ?selected=${currentIndex < 0}>Select...</option>
<option value=${String(idx)} ?selected=${idx === currentIndex}>${String(opt)}</option>
```

## Testing

- [x] Lightly tested — verified locally on macOS with OpenClaw 2026.3.23
- [x] `vitest run ui/src/ui/views/agents-utils.test.ts` — 11/11 tests pass
- [x] Pre-commit hooks (lint, format, typecheck) all pass on both commits
- [x] Confirmed agent model dropdown shows correct configured model on page load
- [x] Confirmed config form API Adapter dropdown shows correct value on page load

## AI Disclosure

🤖 This PR was AI-assisted (Claude Code). I understand the changes and have verified them locally.

Closes #40352