### PR TITLE
fix(build): ignore UNRESOLVED_IMPORT from node_modules optional peer deps

### DIFF
--- a/scripts/tsdown-build.mjs
+++ b/scripts/tsdown-build.mjs
@@ -49,7 +49,9 @@ function findFatalUnresolvedImport(lines) {
     }
 
     const normalizedLine = line.replace(ANSI_ESCAPE_RE, "");
-    if (!normalizedLine.includes("extensions/")) {
+    // Ignore unresolved imports inside extensions/ (handled separately) and
+    // inside node_modules/ (optional peer deps of third-party packages).
+    if (!normalizedLine.includes("extensions/") && !normalizedLine.includes("node_modules/")) {
       return normalizedLine;
     }
   }


### PR DESCRIPTION
## Summary

- `findFatalUnresolvedImport` in `scripts/tsdown-build.mjs` only skips warnings inside `extensions/`, but not inside `node_modules/`. This causes build failures when a third-party dependency (e.g. `@whiskeysockets/baileys`) has an optional peer dep (e.g. `jimp`) that resolves via dynamic `import().catch()` at runtime.
- Add a `node_modules/` path check alongside the existing `extensions/` exclusion so optional peer dep warnings from third-party packages no longer break the build.

## Test plan

- [x] `pnpm build` passes with `@whiskeysockets/baileys` optional peer dep `jimp` unresolved warning present
- [x] Warnings from first-party source code (outside `extensions/` and `node_modules/`) still correctly fail the build