### PR TITLE
fix(mistral): lower default maxTokens to prevent 422 rejection (#52599)

### DIFF
--- a/extensions/mistral/model-definitions.ts
+++ b/extensions/mistral/model-definitions.ts
@@ -4,7 +4,7 @@ export const MISTRAL_BASE_URL = "https://api.mistral.ai/v1";
 export const MISTRAL_DEFAULT_MODEL_ID = "mistral-large-latest";
 export const MISTRAL_DEFAULT_MODEL_REF = `mistral/${MISTRAL_DEFAULT_MODEL_ID}`;
 export const MISTRAL_DEFAULT_CONTEXT_WINDOW = 262144;
-export const MISTRAL_DEFAULT_MAX_TOKENS = 262144;
+export const MISTRAL_DEFAULT_MAX_TOKENS = 16384;
 export const MISTRAL_DEFAULT_COST = {
   input: 0.5,
   output: 1.5,
@@ -29,7 +29,7 @@ const MISTRAL_MODEL_CATALOG = [
     input: ["text"],
     cost: { input: 0.4, output: 2, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 262144,
-    maxTokens: 262144,
+    maxTokens: 32768,
   },
   {
     id: "magistral-small",
@@ -38,7 +38,7 @@ const MISTRAL_MODEL_CATALOG = [
     input: ["text"],
     cost: { input: 0.5, output: 1.5, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 128000,
-    maxTokens: 128000,
+    maxTokens: 40960,
   },
   {
     id: "mistral-large-latest",
@@ -56,7 +56,7 @@ const MISTRAL_MODEL_CATALOG = [
     input: ["text", "image"],
     cost: { input: 0.4, output: 2, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 262144,
-    maxTokens: 262144,
+    maxTokens: 32768,
   },
   {
     id: "mistral-small-latest",
@@ -74,7 +74,7 @@ const MISTRAL_MODEL_CATALOG = [
     input: ["text", "image"],
     cost: { input: 2, output: 6, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 128000,
-    maxTokens: 128000,
+    maxTokens: 32768,
   },
 ] as const satisfies readonly ModelDefinitionConfig[];
 

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -659,7 +659,7 @@ describe("applyMistralProviderConfig", () => {
       (model) => model.id === "mistral-large-latest",
     );
     expect(mistralDefault?.contextWindow).toBe(262144);
-    expect(mistralDefault?.maxTokens).toBe(262144);
+    expect(mistralDefault?.maxTokens).toBe(16384);
   });
 });
 


### PR DESCRIPTION
## Summary

Mistral AI returns HTTP 422 for all chat requests because several model definitions set `maxTokens` equal to `contextWindow` (up to 262144). This value is forwarded as `max_tokens` in API requests, exceeding Mistral's actual output token limit.

## Root Cause

In `extensions/mistral/model-definitions.ts`, five models had `maxTokens` set to their full context window size. The `max_tokens` parameter controls *output* generation length, not input capacity — setting it to the context window size causes the API to reject the request.

Two models already had correct values (`codestral-latest`: 4096, `mistral-small-latest`: 16384), confirming this was an oversight.

## Changes

- `extensions/mistral/model-definitions.ts`: Lower `MISTRAL_DEFAULT_MAX_TOKENS` and per-model output limits:

| Model | Before | After |
|-------|--------|-------|
| MISTRAL_DEFAULT_MAX_TOKENS | 262144 | 16384 |
| devstral-medium-latest | 262144 | 32768 |
| magistral-small | 128000 | 40960 |
| mistral-large-latest | 262144 | 16384 |
| mistral-medium-2508 | 262144 | 32768 |
| pixtral-large-latest | 128000 | 32768 |

- `src/commands/onboard-auth.test.ts`: Update expected maxTokens assertion

Closes #52599