### PR TITLE
fix(heartbeat): skip heartbeat when main session is stale to allow daily reset

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -36,6 +36,12 @@ import {
   saveSessionStore,
   updateSessionStore,
 } from "../config/sessions.js";
+import {
+  evaluateSessionFreshness,
+  resolveChannelResetConfig,
+  resolveSessionResetPolicy,
+  resolveSessionResetType,
+} from "../config/sessions/reset.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import { resolveCronSession } from "../cron/isolated-agent/session.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -393,7 +399,7 @@ type HeartbeatReasonFlags = {
   isWakeReason: boolean;
 };
 
-type HeartbeatSkipReason = "empty-heartbeat-file";
+type HeartbeatSkipReason = "empty-heartbeat-file" | "session-stale";
 
 type HeartbeatPreflight = HeartbeatReasonFlags & {
   session: ReturnType<typeof resolveHeartbeatSession>;
@@ -444,6 +450,36 @@ async function resolveHeartbeatPreflight(params: {
     hasTaggedCronEvents,
     shouldInspectPendingEvents,
   } satisfies Omit<HeartbeatPreflight, "skipReason">;
+
+  // Check session freshness for non-isolated scheduled heartbeats before running.
+  // If the main session is stale (past the daily reset window), skip the heartbeat
+  // so the session can reset naturally when the user sends their first real message.
+  // Event-driven heartbeats (exec, cron, wake) bypass this via shouldBypassFileGates.
+  if (!params.heartbeat?.isolatedSession && session.entry && !shouldBypassFileGates) {
+    const now = Date.now();
+    const resetType = resolveSessionResetType({ sessionKey: session.sessionKey });
+    const channelReset = resolveChannelResetConfig({
+      sessionCfg: params.cfg.session,
+      channel: session.entry.lastChannel ?? session.entry.channel,
+    });
+    const resetPolicy = resolveSessionResetPolicy({
+      sessionCfg: params.cfg.session,
+      resetType,
+      resetOverride: channelReset,
+    });
+    const freshness = evaluateSessionFreshness({
+      updatedAt: session.entry.updatedAt,
+      now,
+      policy: resetPolicy,
+    });
+
+    if (!freshness.fresh) {
+      return {
+        ...basePreflight,
+        skipReason: "session-stale",
+      };
+    }
+  }
 
   if (shouldBypassFileGates) {
     return basePreflight;


### PR DESCRIPTION
## Fixes #51000 (heartbeat vector)

### Problem

The heartbeat runner resolves the main session via its own `resolveHeartbeatSession()` function, which does not call `evaluateSessionFreshness()`. When a heartbeat fires after `session.reset.atHour` (e.g., 4 AM) but before the user's first message, the heartbeat touches the session entry, preventing the lazy daily reset from ever firing.

This is the same root cause as #51000 (cron jobs overwriting `updatedAt`), but through the heartbeat code path. The cron fix (unique session keys) addressed one vector; this PR addresses the remaining one.

### Fix

Added a session freshness check in `resolveHeartbeatPreflight()` that mirrors the logic in `resolveSession()`:

1. Resolves reset policy (mode, atHour, channel overrides)
2. Evaluates session freshness via `evaluateSessionFreshness()`
3. If the session is **stale** (past the daily reset window), skips the heartbeat with `skipReason: "session-stale"`

The session's `updatedAt` remains untouched, so the next real user message triggers the reset naturally through the existing `resolveSession()` path.

### Scope

- Only affects **non-isolated** heartbeats (isolated heartbeats create their own session and don't interfere with the main session)
- Only skips when there is an existing session entry to evaluate
- Uses the exact same freshness evaluation chain as `resolveSession()` in `src/agents/command/session.ts`

### Changes

- `src/infra/heartbeat-runner.ts` - Added freshness check in `resolveHeartbeatPreflight()`, extended `HeartbeatSkipReason` type with `"session-stale"`

### Testing

- Manually confirmed: with this change, heartbeats after 4 AM on a stale session would be skipped, allowing the daily reset to fire on the next user message
- Formatting verified with `oxfmt --check`