### PR TITLE
fix(agents): track cron adds via exec tool in reminder guard

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -178,6 +178,86 @@ describe("handleToolExecutionEnd cron.add commitment tracking", () => {
   });
 });
 
+describe("handleToolExecutionEnd cron.add via exec tracking", () => {
+  it("increments successfulCronAdds when exec runs openclaw cron add", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-1",
+        args: { command: "openclaw cron add --at '2026-03-24T09:00:00Z' --text 'Ping Markus'" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-1",
+        isError: false,
+        result: "Job abc123 created",
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(1);
+  });
+
+  it("does not increment successfulCronAdds for unrelated exec commands", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-other-1",
+        args: { command: "ls -la" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-other-1",
+        isError: false,
+        result: "total 42",
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(0);
+  });
+
+  it("does not increment successfulCronAdds when exec cron add fails", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-2",
+        args: { command: "openclaw cron add --at '2026-03-24T09:00:00Z'" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-2",
+        isError: true,
+        result: "Error: gateway not running",
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(0);
+  });
+});
+
 describe("handleToolExecutionEnd exec approval prompts", () => {
   it("emits a deterministic approval payload and marks assistant output suppressed", async () => {
     const { ctx } = createTestContext();

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -549,6 +549,21 @@ export async function handleToolExecutionEnd(
     ctx.state.successfulCronAdds += 1;
   }
 
+  // Also track cron adds performed via exec/bash (e.g. `openclaw cron add --at ...`).
+  // Without this, the reminder guard note fires even when the cron was created
+  // successfully through the CLI tool path (#52972).
+  if (!isToolError && (toolName === "exec" || toolName === "bash")) {
+    const execArgs = startData?.args;
+    const rawCmd =
+      execArgs && typeof execArgs === "object"
+        ? (execArgs as Record<string, unknown>).command
+        : execArgs;
+    const command = typeof rawCmd === "string" ? rawCmd : "";
+    if (/\bcron\s+add\b/i.test(command)) {
+      ctx.state.successfulCronAdds += 1;
+    }
+  }
+
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "tool",


### PR DESCRIPTION
## Summary

The reminder guard note ("I did not schedule a reminder in this turn") fires even when the agent successfully creates a cron job via the exec/bash tool. The `successfulCronAdds` counter at `pi-embedded-subscribe.handlers.tools.ts:548` only checks `toolName === "cron"`, so cron jobs created through `openclaw cron add --at ...` via exec bypass the counter entirely.

## Changes

Added a secondary check in `handleToolExecutionEnd` that inspects exec/bash tool commands for `cron add` patterns. When matched and the tool succeeds, `successfulCronAdds` increments the same way it does for the native cron tool path.

The regex `/\bcron\s+add\b/i` matches `openclaw cron add`, `cron add`, and variations with extra whitespace.

Three tests added covering:
- Exec-based cron add increments the counter
- Unrelated exec commands do not increment
- Failed exec cron add does not increment

## Testing

`pnpm test -- src/agents/pi-embedded-subscribe.handlers.tools.test.ts` - 17/17 pass (14 existing + 3 new).

`pnpm check` passes (format, lint, typecheck, all boundary checks).

This contribution was developed with AI assistance (Claude Code).

Fixes #52972