### PR TITLE
fix(discord): prevent Identify silent-drop race in gateway startup

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -237,6 +237,15 @@ function createGatewayPlugin(params: {
     }
 
     override async registerClient(client: Parameters<GatewayPlugin["registerClient"]>[0]) {
+      // Set client reference immediately so that identify() works even if
+      // the lifecycle timeout handler calls connect() before this async
+      // method finishes.  Carbon's Client constructor does not await
+      // registerClient(), so there is a window where an external connect()
+      // call reaches identify() while this.client is still undefined —
+      // causing the Identify payload to be silently dropped and the
+      // gateway to never reach READY.
+      this.client = client;
+
       if (!this.gatewayInfo || this.gatewayInfoUsedFallback) {
         const resolved = await fetchDiscordGatewayInfoWithTimeout({
           token: client.options.token,
@@ -251,6 +260,15 @@ function createGatewayPlugin(params: {
         this.gatewayInfo = resolved.info;
         this.gatewayInfoUsedFallback = resolved.usedFallback;
       }
+
+      // If an external caller (e.g. the lifecycle readiness-timeout handler)
+      // already triggered connect() while we were fetching gateway metadata,
+      // skip super.registerClient to avoid tearing down the live WebSocket.
+      const gatewayState = this as unknown as { ws?: unknown; isConnecting?: boolean };
+      if (gatewayState.ws || gatewayState.isConnecting) {
+        return;
+      }
+
       return super.registerClient(client);
     }
 

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -264,6 +264,12 @@ function createGatewayPlugin(params: {
       // If an external caller (e.g. the lifecycle readiness-timeout handler)
       // already triggered connect() while we were fetching gateway metadata,
       // skip super.registerClient to avoid tearing down the live WebSocket.
+      // NOTE: `ws` and `isConnecting` are protected fields on Carbon's
+      // GatewayPlugin (see @buape/carbon GatewayPlugin.ts lines 49, 62).
+      // The type cast is intentional — if Carbon renames these fields the
+      // guard degrades to a no-op and super.registerClient runs, which may
+      // cause a brief reconnect but not a permanent hang (Fix #1 above
+      // already guarantees this.client is set).
       const gatewayState = this as unknown as { ws?: unknown; isConnecting?: boolean };
       if (gatewayState.ws || gatewayState.isConnecting) {
         return;

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -36,9 +36,15 @@ const {
   class GatewayPlugin {
     options: unknown;
     gatewayInfo: unknown;
+    client: unknown;
+    ws: unknown;
+    isConnecting: boolean;
     constructor(options?: unknown, gatewayInfo?: unknown) {
       this.options = options;
       this.gatewayInfo = gatewayInfo;
+      this.client = undefined;
+      this.ws = undefined;
+      this.isConnecting = false;
     }
     async registerClient(client: unknown) {
       baseRegisterClientSpy(client);
@@ -354,5 +360,74 @@ describe("createDiscordGatewayPlugin", () => {
       url: "wss://gateway.discord.gg/?v=10",
       shards: 8,
     });
+  });
+
+  it("sets client reference before the async gateway-info fetch completes", async () => {
+    vi.useFakeTimers();
+    const runtime = createRuntime();
+    let fetchResolve: ((v: Response) => void) | undefined;
+    globalFetchMock.mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          fetchResolve = resolve;
+        }),
+    );
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    });
+
+    const clientArg = { options: { token: "token-race" } };
+    const registerPromise = (
+      plugin as { registerClient: (c: typeof clientArg) => Promise<void> }
+    ).registerClient(clientArg);
+
+    // Before the fetch resolves, client should already be set.
+    expect((plugin as unknown as { client: unknown }).client).toBe(clientArg);
+
+    // Now resolve the fetch so registerClient can finish.
+    fetchResolve!({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ url: "wss://gateway.discord.gg" }),
+    } as Response);
+    await registerPromise;
+  });
+
+  it("skips super.registerClient when an external connect() sets ws during fetch", async () => {
+    vi.useFakeTimers();
+    const runtime = createRuntime();
+    let fetchResolve: ((v: Response) => void) | undefined;
+    globalFetchMock.mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          fetchResolve = resolve;
+        }),
+    );
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    });
+
+    const clientArg = { options: { token: "token-race" } };
+    const registerPromise = (
+      plugin as { registerClient: (c: typeof clientArg) => Promise<void> }
+    ).registerClient(clientArg);
+
+    // Simulate the lifecycle timeout handler calling connect() externally,
+    // which sets ws on the gateway plugin.
+    (plugin as unknown as { ws: unknown }).ws = { readyState: 1 };
+
+    // Now resolve the fetch.
+    fetchResolve!({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ url: "wss://gateway.discord.gg" }),
+    } as Response);
+    await registerPromise;
+
+    // super.registerClient should NOT have been called because the guard
+    // detected an active ws, preventing it from tearing down the live connection.
+    expect(baseRegisterClientSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

Fixes the Discord gateway getting permanently stuck at "awaiting gateway readiness" after restart — the bot connects to the WebSocket but never sends an Identify (op 2) payload after receiving Hello (op 10).

Closes #52372

## Root Cause

Carbon's `Client` constructor calls `plugin.registerClient(this)` **without awaiting** the returned promise:

```js
// Carbon Client constructor
for (const plugin of plugins) {
    plugin.registerClient?.(this);  // async, NOT awaited
}
```

OpenClaw's `SafeGatewayPlugin.registerClient` contains an async gateway-info fetch (`fetchDiscordGatewayInfoWithTimeout`, up to 10s) that yields control **before** `super.registerClient` (which sets `this.client`) is reached.

If the lifecycle's 15-second readiness timeout fires during this window and calls `gateway.connect(false)`:

1. A new WebSocket opens and receives **Hello** from Discord
2. Carbon calls `identify()` → first line: `if (!this.client) return` → **silently returns**
3. No Identify is ever sent → no READY → `isConnected` stays `false` forever
4. The bot is permanently stuck

This explains both symptoms reported in #52372:
- **OP (v2026.3.13, Linux)**: Fresh install where the gateway-info fetch is slow (DNS, network) — `registerClient` doesn't finish before the first Hello
- **Reporter (v2026.3.22, restart)**: On restart, there may be a stale Discord session causing an `InvalidSession` response, which delays the successful Identify past the readiness timeout — the forced reconnect hits the same `this.client === undefined` race

## Fix

Two changes in `SafeGatewayPlugin.registerClient`:

1. **Set `this.client = client` immediately** at the top of `registerClient`, before the async fetch. This ensures `identify()` always has a valid client reference, even when `connect()` is called externally.

2. **Skip `super.registerClient`** when an external `connect()` has already been triggered (detected by checking `this.ws` or `this.isConnecting`). This prevents tearing down a live WebSocket that was established by the lifecycle timeout handler.

## Testing

- Existing `provider.proxy.test.ts` tests cover the SafeGatewayPlugin crash-guard behavior
- The fix is a minimal, defensive change — it only affects the ordering of a single assignment and adds a guard to prevent double-connect interference
- Verified that the `identify()` → `send()` path now works when `connect()` is called before `registerClient` finishes

## Related

- #52372 — Discord WSS Gateway not sending Identify
- #35145 — Prior work on catching unhandled registerClient rejections
- #51297 — Stale WebSocket on health-monitor restart