### PR TITLE
fix(telegram): handle thinking-only empty replies

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2129,6 +2129,38 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
+  it("does not fall back when the final reply is NO_REPLY after earlier skipped output", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      // Earlier skipped output should not force a visible fallback when the
+      // agent intentionally ends the turn with NO_REPLY after a tool-only action.
+      dispatcherOptions.onSkip?.({ text: "" }, { reason: "empty", kind: "block" });
+      dispatcherOptions.onSkip?.({ text: "NO_REPLY" }, { reason: "silent", kind: "final" });
+      return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+    });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fall back when the final reply is HEARTBEAT_OK", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      dispatcherOptions.onSkip?.({ text: "" }, { reason: "empty", kind: "block" });
+      dispatcherOptions.onSkip?.({ text: "HEARTBEAT_OK" }, { reason: "heartbeat", kind: "final" });
+      return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+    });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+  });
+
   it("sends fallback and clears preview when deliver throws (dispatcher swallows error)", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -27,7 +27,11 @@ import type {
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-history";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
+import {
+  HEARTBEAT_TOKEN,
+  isSilentReplyText,
+  resolveChunkMode,
+} from "openclaw/plugin-sdk/reply-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveAutoTopicLabelConfig, generateTopicLabel } from "openclaw/plugin-sdk/reply-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -58,6 +62,10 @@ import { editMessageTelegram } from "./send.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
+
+function isIntentionalSilentReplyText(text: string | undefined): boolean {
+  return isSilentReplyText(text) || isSilentReplyText(text, HEARTBEAT_TOKEN);
+}
 
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
@@ -539,6 +547,8 @@ export const dispatchTelegramMessage = async ({
 
   let queuedFinal = false;
   let hadErrorReplyFailureOrSkip = false;
+  let finalReplyWasIntentionallySilent = false;
+  let modelCompletedWithoutVisibleOutput = false;
 
   // Determine if this is the first turn in session (for auto-topic-label).
   const isDmTopic = !isGroup && threadSpec.scope === "dm" && threadSpec.id != null;
@@ -590,211 +600,219 @@ export const dispatchTelegramMessage = async ({
 
   let dispatchError: unknown;
   try {
-    ({ queuedFinal } = await telegramDeps.dispatchReplyWithBufferedBlockDispatcher({
-      ctx: ctxPayload,
-      cfg,
-      dispatcherOptions: {
-        ...replyPipeline,
-        deliver: async (payload, info) => {
-          if (payload.isError === true) {
-            hadErrorReplyFailureOrSkip = true;
-          }
-          if (info.kind === "final") {
-            // Assistant callbacks are fire-and-forget; ensure queued boundary
-            // rotations/partials are applied before final delivery mapping.
-            await enqueueDraftLaneEvent(async () => {});
-          }
-          if (
-            shouldSuppressLocalTelegramExecApprovalPrompt({
-              cfg,
-              accountId: route.accountId,
-              payload,
-            })
-          ) {
-            queuedFinal = true;
-            return;
-          }
-          const previewButtons = (
-            payload.channelData?.telegram as { buttons?: TelegramInlineButtons } | undefined
-          )?.buttons;
-          const split = splitTextIntoLaneSegments(payload.text);
-          const segments = split.segments;
-          const reply = resolveSendableOutboundReplyParts(payload);
-          const hasMedia = reply.hasMedia;
-
-          const flushBufferedFinalAnswer = async () => {
-            const buffered = reasoningStepState.takeBufferedFinalAnswer();
-            if (!buffered) {
+    ({ queuedFinal, completedWithoutVisibleOutput: modelCompletedWithoutVisibleOutput = false } =
+      await telegramDeps.dispatchReplyWithBufferedBlockDispatcher({
+        ctx: ctxPayload,
+        cfg,
+        dispatcherOptions: {
+          ...replyPipeline,
+          deliver: async (payload, info) => {
+            if (payload.isError === true) {
+              hadErrorReplyFailureOrSkip = true;
+            }
+            if (info.kind === "final") {
+              // Assistant callbacks are fire-and-forget; ensure queued boundary
+              // rotations/partials are applied before final delivery mapping.
+              await enqueueDraftLaneEvent(async () => {});
+            }
+            if (
+              shouldSuppressLocalTelegramExecApprovalPrompt({
+                cfg,
+                accountId: route.accountId,
+                payload,
+              })
+            ) {
+              queuedFinal = true;
               return;
             }
-            const bufferedButtons = (
-              buffered.payload.channelData?.telegram as
-                | { buttons?: TelegramInlineButtons }
-                | undefined
+            const previewButtons = (
+              payload.channelData?.telegram as { buttons?: TelegramInlineButtons } | undefined
             )?.buttons;
-            await deliverLaneText({
-              laneName: "answer",
-              text: buffered.text,
-              payload: buffered.payload,
-              infoKind: "final",
-              previewButtons: bufferedButtons,
-            });
-            reasoningStepState.resetForNextStep();
-          };
+            const split = splitTextIntoLaneSegments(payload.text);
+            const segments = split.segments;
+            const reply = resolveSendableOutboundReplyParts(payload);
+            const hasMedia = reply.hasMedia;
 
-          for (const segment of segments) {
-            if (
-              segment.lane === "answer" &&
-              info.kind === "final" &&
-              reasoningStepState.shouldBufferFinalAnswer()
-            ) {
-              reasoningStepState.bufferFinalAnswer({
-                payload,
-                text: segment.text,
+            const flushBufferedFinalAnswer = async () => {
+              const buffered = reasoningStepState.takeBufferedFinalAnswer();
+              if (!buffered) {
+                return;
+              }
+              const bufferedButtons = (
+                buffered.payload.channelData?.telegram as
+                  | { buttons?: TelegramInlineButtons }
+                  | undefined
+              )?.buttons;
+              await deliverLaneText({
+                laneName: "answer",
+                text: buffered.text,
+                payload: buffered.payload,
+                infoKind: "final",
+                previewButtons: bufferedButtons,
               });
-              continue;
+              reasoningStepState.resetForNextStep();
+            };
+
+            for (const segment of segments) {
+              if (
+                segment.lane === "answer" &&
+                info.kind === "final" &&
+                reasoningStepState.shouldBufferFinalAnswer()
+              ) {
+                reasoningStepState.bufferFinalAnswer({
+                  payload,
+                  text: segment.text,
+                });
+                continue;
+              }
+              if (segment.lane === "reasoning") {
+                reasoningStepState.noteReasoningHint();
+              }
+              const result = await deliverLaneText({
+                laneName: segment.lane,
+                text: segment.text,
+                payload,
+                infoKind: info.kind,
+                previewButtons,
+                allowPreviewUpdateForNonFinal: segment.lane === "reasoning",
+              });
+              if (info.kind === "final") {
+                emitPreviewFinalizedHook(result);
+              }
+              if (segment.lane === "reasoning") {
+                if (result.kind !== "skipped") {
+                  reasoningStepState.noteReasoningDelivered();
+                  await flushBufferedFinalAnswer();
+                }
+                continue;
+              }
+              if (info.kind === "final") {
+                if (reasoningLane.hasStreamedMessage) {
+                  activePreviewLifecycleByLane.reasoning = "complete";
+                  retainPreviewOnCleanupByLane.reasoning = true;
+                }
+                reasoningStepState.resetForNextStep();
+              }
             }
-            if (segment.lane === "reasoning") {
-              reasoningStepState.noteReasoningHint();
+            if (segments.length > 0) {
+              return;
             }
-            const result = await deliverLaneText({
-              laneName: segment.lane,
-              text: segment.text,
-              payload,
-              infoKind: info.kind,
-              previewButtons,
-              allowPreviewUpdateForNonFinal: segment.lane === "reasoning",
-            });
-            if (info.kind === "final") {
-              emitPreviewFinalizedHook(result);
-            }
-            if (segment.lane === "reasoning") {
-              if (result.kind !== "skipped") {
-                reasoningStepState.noteReasoningDelivered();
+            if (split.suppressedReasoningOnly) {
+              if (reply.hasMedia) {
+                const payloadWithoutSuppressedReasoning =
+                  typeof payload.text === "string" ? { ...payload, text: "" } : payload;
+                await sendPayload(payloadWithoutSuppressedReasoning);
+              }
+              if (info.kind === "final") {
                 await flushBufferedFinalAnswer();
               }
-              continue;
+              return;
             }
+
             if (info.kind === "final") {
-              if (reasoningLane.hasStreamedMessage) {
-                activePreviewLifecycleByLane.reasoning = "complete";
-                retainPreviewOnCleanupByLane.reasoning = true;
-              }
+              await answerLane.stream?.stop();
+              await reasoningLane.stream?.stop();
               reasoningStepState.resetForNextStep();
             }
-          }
-          if (segments.length > 0) {
-            return;
-          }
-          if (split.suppressedReasoningOnly) {
-            if (reply.hasMedia) {
-              const payloadWithoutSuppressedReasoning =
-                typeof payload.text === "string" ? { ...payload, text: "" } : payload;
-              await sendPayload(payloadWithoutSuppressedReasoning);
+            const canSendAsIs = reply.hasMedia || reply.text.length > 0;
+            if (!canSendAsIs) {
+              if (info.kind === "final") {
+                await flushBufferedFinalAnswer();
+              }
+              return;
             }
+            await sendPayload(payload);
             if (info.kind === "final") {
               await flushBufferedFinalAnswer();
             }
-            return;
-          }
-
-          if (info.kind === "final") {
-            await answerLane.stream?.stop();
-            await reasoningLane.stream?.stop();
-            reasoningStepState.resetForNextStep();
-          }
-          const canSendAsIs = reply.hasMedia || reply.text.length > 0;
-          if (!canSendAsIs) {
-            if (info.kind === "final") {
-              await flushBufferedFinalAnswer();
+          },
+          onSkip: (payload, info) => {
+            if (payload.isError === true) {
+              hadErrorReplyFailureOrSkip = true;
             }
-            return;
-          }
-          await sendPayload(payload);
-          if (info.kind === "final") {
-            await flushBufferedFinalAnswer();
-          }
+            const skipWasIntentionallySilent =
+              info.reason === "silent" ||
+              info.reason === "heartbeat" ||
+              isIntentionalSilentReplyText(payload.text);
+            if (info.kind === "final" && skipWasIntentionallySilent) {
+              finalReplyWasIntentionallySilent = true;
+            }
+            if (!skipWasIntentionallySilent) {
+              deliveryState.markNonSilentSkip();
+            }
+          },
+          onError: (err, info) => {
+            deliveryState.markNonSilentFailure();
+            runtime.error?.(danger(`telegram ${info.kind} reply failed: ${String(err)}`));
+          },
         },
-        onSkip: (payload, info) => {
-          if (payload.isError === true) {
-            hadErrorReplyFailureOrSkip = true;
-          }
-          if (info.reason !== "silent") {
-            deliveryState.markNonSilentSkip();
-          }
-        },
-        onError: (err, info) => {
-          deliveryState.markNonSilentFailure();
-          runtime.error?.(danger(`telegram ${info.kind} reply failed: ${String(err)}`));
-        },
-      },
-      replyOptions: {
-        skillFilter,
-        disableBlockStreaming,
-        onPartialReply:
-          answerLane.stream || reasoningLane.stream
+        replyOptions: {
+          skillFilter,
+          disableBlockStreaming,
+          onPartialReply:
+            answerLane.stream || reasoningLane.stream
+              ? (payload) =>
+                  enqueueDraftLaneEvent(async () => {
+                    await ingestDraftLaneSegments(payload.text);
+                  })
+              : undefined,
+          onReasoningStream: reasoningLane.stream
             ? (payload) =>
                 enqueueDraftLaneEvent(async () => {
+                  // Split between reasoning blocks only when the next reasoning
+                  // stream starts. Splitting at reasoning-end can orphan the active
+                  // preview and cause duplicate reasoning sends on reasoning final.
+                  if (splitReasoningOnNextStream) {
+                    reasoningLane.stream?.forceNewMessage();
+                    resetDraftLaneState(reasoningLane);
+                    splitReasoningOnNextStream = false;
+                  }
                   await ingestDraftLaneSegments(payload.text);
                 })
             : undefined,
-        onReasoningStream: reasoningLane.stream
-          ? (payload) =>
-              enqueueDraftLaneEvent(async () => {
-                // Split between reasoning blocks only when the next reasoning
-                // stream starts. Splitting at reasoning-end can orphan the active
-                // preview and cause duplicate reasoning sends on reasoning final.
-                if (splitReasoningOnNextStream) {
-                  reasoningLane.stream?.forceNewMessage();
-                  resetDraftLaneState(reasoningLane);
-                  splitReasoningOnNextStream = false;
-                }
-                await ingestDraftLaneSegments(payload.text);
-              })
-          : undefined,
-        onAssistantMessageStart: answerLane.stream
-          ? () =>
-              enqueueDraftLaneEvent(async () => {
-                reasoningStepState.resetForNextStep();
-                if (skipNextAnswerMessageStartRotation) {
-                  skipNextAnswerMessageStartRotation = false;
+          onAssistantMessageStart: answerLane.stream
+            ? () =>
+                enqueueDraftLaneEvent(async () => {
+                  reasoningStepState.resetForNextStep();
+                  if (skipNextAnswerMessageStartRotation) {
+                    skipNextAnswerMessageStartRotation = false;
+                    activePreviewLifecycleByLane.answer = "transient";
+                    retainPreviewOnCleanupByLane.answer = false;
+                    return;
+                  }
+                  await rotateAnswerLaneForNewAssistantMessage();
+                  // Message-start is an explicit assistant-message boundary.
+                  // Even when no forceNewMessage happened (e.g. prior answer had no
+                  // streamed partials), the next partial belongs to a fresh lifecycle
+                  // and must not trigger late pre-rotation mid-message.
                   activePreviewLifecycleByLane.answer = "transient";
                   retainPreviewOnCleanupByLane.answer = false;
-                  return;
-                }
-                await rotateAnswerLaneForNewAssistantMessage();
-                // Message-start is an explicit assistant-message boundary.
-                // Even when no forceNewMessage happened (e.g. prior answer had no
-                // streamed partials), the next partial belongs to a fresh lifecycle
-                // and must not trigger late pre-rotation mid-message.
-                activePreviewLifecycleByLane.answer = "transient";
-                retainPreviewOnCleanupByLane.answer = false;
-              })
-          : undefined,
-        onReasoningEnd: reasoningLane.stream
-          ? () =>
-              enqueueDraftLaneEvent(async () => {
-                // Split when/if a later reasoning block begins.
-                splitReasoningOnNextStream = reasoningLane.hasStreamedMessage;
-              })
-          : undefined,
-        onToolStart: statusReactionController
-          ? async (payload) => {
-              await statusReactionController.setTool(payload.name);
-            }
-          : undefined,
-        onCompactionStart: statusReactionController
-          ? () => statusReactionController.setCompacting()
-          : undefined,
-        onCompactionEnd: statusReactionController
-          ? async () => {
-              statusReactionController.cancelPending();
-              await statusReactionController.setThinking();
-            }
-          : undefined,
-        onModelSelected,
-      },
-    }));
+                })
+            : undefined,
+          onReasoningEnd: reasoningLane.stream
+            ? () =>
+                enqueueDraftLaneEvent(async () => {
+                  // Split when/if a later reasoning block begins.
+                  splitReasoningOnNextStream = reasoningLane.hasStreamedMessage;
+                })
+            : undefined,
+          onToolStart: statusReactionController
+            ? async (payload) => {
+                await statusReactionController.setTool(payload.name);
+              }
+            : undefined,
+          onCompactionStart: statusReactionController
+            ? () => statusReactionController.setCompacting()
+            : undefined,
+          onCompactionEnd: statusReactionController
+            ? async () => {
+                statusReactionController.cancelPending();
+                await statusReactionController.setThinking();
+              }
+            : undefined,
+          onModelSelected,
+        },
+      }));
   } catch (err) {
     dispatchError = err;
     runtime.error?.(danger(`telegram dispatch failed: ${String(err)}`));
@@ -866,8 +884,11 @@ export const dispatchTelegramMessage = async ({
   const deliverySummary = deliveryState.snapshot();
   if (
     dispatchError ||
-    (!deliverySummary.delivered &&
-      (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0))
+    (!finalReplyWasIntentionallySilent &&
+      !deliverySummary.delivered &&
+      (deliverySummary.skippedNonSilent > 0 ||
+        deliverySummary.failedNonSilent > 0 ||
+        modelCompletedWithoutVisibleOutput))
   ) {
     const fallbackText = dispatchError
       ? "Something went wrong while processing your request. Please try again."

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -55,6 +55,53 @@ function emitReasoningEnd(ctx: EmbeddedPiSubscribeContext) {
   void ctx.params.onReasoningEnd?.();
 }
 
+const THINKING_ONLY_VISIBLE_FALLBACK = "I considered this, but I don't have anything to add.";
+
+function hasAssistantToolCalls(message: AgentMessage): boolean {
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const type = (block as { type?: unknown }).type;
+    return type === "toolCall" || type === "toolUse" || type === "functionCall";
+  });
+}
+
+function resolveThinkingOnlyVisibleFallbackText(params: {
+  message: AgentMessage;
+  text: string;
+  rawThinking: string;
+  messagingToolSentTexts: string[];
+  enforceFinalTag: boolean;
+}): string {
+  if (params.text.trim()) {
+    return params.text;
+  }
+  const stopReason = (params.message as { stopReason?: unknown }).stopReason;
+  if (stopReason !== "stop" || hasAssistantToolCalls(params.message)) {
+    return params.text;
+  }
+  if (!params.rawThinking.trim()) {
+    return params.text;
+  }
+  // When a messaging tool already delivered a visible reply earlier in the turn,
+  // the closing assistant message can legitimately be thinking-only.
+  if (params.messagingToolSentTexts.length > 0) {
+    return params.text;
+  }
+  // When enforceFinalTag is active, content outside <final> blocks is suppressed.
+  // The thinking-only fallback should respect this — if the model never opened a
+  // <final> block, we should not inject visible output.
+  if (params.enforceFinalTag) {
+    return params.text;
+  }
+  return THINKING_ONLY_VISIBLE_FALLBACK;
+}
+
 export function resolveSilentReplyFallbackText(params: {
   text: string;
   messagingToolSentTexts: string[];
@@ -345,22 +392,29 @@ export function handleMessageEnd(
   promoteThinkingTagsToBlocks(assistantMessage);
 
   const rawText = extractAssistantText(assistantMessage);
+  const extractedThinking = extractAssistantThinking(assistantMessage);
   appendRawStream({
     ts: Date.now(),
     event: "assistant_message_end",
     runId: ctx.params.runId,
     sessionId: (ctx.params.session as { id?: string }).id,
     rawText,
-    rawThinking: extractAssistantThinking(assistantMessage),
+    rawThinking: extractedThinking,
   });
 
-  const text = resolveSilentReplyFallbackText({
-    text: ctx.stripBlockTags(rawText, { thinking: false, final: false }),
+  const text = resolveThinkingOnlyVisibleFallbackText({
+    message: assistantMessage,
+    text: resolveSilentReplyFallbackText({
+      text: ctx.stripBlockTags(rawText, { thinking: false, final: false }),
+      messagingToolSentTexts: ctx.state.messagingToolSentTexts,
+    }),
+    rawThinking: extractedThinking,
     messagingToolSentTexts: ctx.state.messagingToolSentTexts,
+    enforceFinalTag: !!ctx.params.enforceFinalTag,
   });
   const rawThinking =
     ctx.state.includeReasoning || ctx.state.streamReasoning
-      ? extractAssistantThinking(assistantMessage) || extractThinkingFromTaggedText(rawText)
+      ? extractedThinking || extractThinkingFromTaggedText(rawText)
       : "";
   const formattedReasoning = rawThinking ? formatReasoningMessage(rawThinking) : "";
   const trimmedText = text.trim();

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -106,7 +106,7 @@ describe("subscribeEmbeddedPiSession", () => {
 
   it.each(THINKING_TAG_CASES)(
     "streams <%s> reasoning via onReasoningStream without leaking into final text",
-    ({ open, close }) => {
+    async ({ open, close }) => {
       const onReasoningStream = vi.fn();
       const onBlockReply = vi.fn();
 
@@ -132,6 +132,7 @@ describe("subscribeEmbeddedPiSession", () => {
       } as AssistantMessage;
 
       emit({ type: "message_end", message: assistantMessage });
+      await Promise.resolve();
 
       expect(onBlockReply).toHaveBeenCalledTimes(1);
       expect(onBlockReply.mock.calls[0][0].text).toBe("Final answer");
@@ -149,7 +150,7 @@ describe("subscribeEmbeddedPiSession", () => {
   );
   it.each(THINKING_TAG_CASES)(
     "suppresses <%s> blocks across chunk boundaries",
-    ({ open, close }) => {
+    async ({ open, close }) => {
       const onBlockReply = vi.fn();
 
       const { emit } = createSubscribedHarness({
@@ -174,6 +175,7 @@ describe("subscribeEmbeddedPiSession", () => {
         message: { role: "assistant" },
         assistantMessageEvent: { type: "text_end" },
       });
+      await Promise.resolve();
 
       const payloadTexts = onBlockReply.mock.calls
         .map((call) => call[0]?.text)
@@ -255,6 +257,60 @@ describe("subscribeEmbeddedPiSession", () => {
     emitAssistantTextDelta(emit, " files</think>\nFinal answer");
 
     expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits a visible fallback for thinking-only stop responses", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "thinking", thinking: "I checked the context." }],
+      } as AssistantMessage,
+    });
+
+    expectSingleAgentEventText(
+      onAgentEvent.mock.calls,
+      "I considered this, but I don't have anything to add.",
+    );
+  });
+
+  it("does not emit the thinking-only fallback for assistant tool-call turns", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        stopReason: "toolUse",
+        content: [
+          { type: "thinking", thinking: "I should read the file first." },
+          { type: "toolUse", id: "call_1", name: "read", input: { path: "/tmp/a" } },
+        ],
+      } as AssistantMessage,
+    });
+
+    expect(onAgentEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not emit the thinking-only fallback when stopReason is stop but toolCall is present", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          { type: "thinking", thinking: "Checking the result." },
+          { type: "toolCall", id: "call_2", name: "exec", arguments: { command: "ls" } },
+        ],
+      } as AssistantMessage,
+    });
+
+    expect(onAgentEvent).not.toHaveBeenCalled();
   });
 
   it("emits delta chunks in agent events for streaming assistant text", () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -144,6 +144,7 @@ const resolveSessionStoreLookup = (
 export type DispatchFromConfigResult = {
   queuedFinal: boolean;
   counts: Record<ReplyDispatchKind, number>;
+  completedWithoutVisibleOutput?: boolean;
 };
 
 export async function dispatchReplyFromConfig(params: {
@@ -777,12 +778,14 @@ export async function dispatchReplyFromConfig(params: {
 
     const counts = dispatcher.getQueuedCounts();
     counts.final += routedFinalCount;
+    const completedWithoutVisibleOutput =
+      replies.length === 0 && counts.tool === 0 && counts.block === 0 && counts.final === 0;
     recordProcessed(
       "completed",
       pluginFallbackReason ? { reason: pluginFallbackReason } : undefined,
     );
     markIdle("message_completed");
-    return { queuedFinal, counts };
+    return { queuedFinal, counts, completedWithoutVisibleOutput };
   } catch (err) {
     recordProcessed("error", { error: String(err) });
     markIdle("message_error");


### PR DESCRIPTION
## Summary

- Problem: When a provider returns a response with only thinking blocks (no visible text, no tool calls, `stopReason: "stop"`), the delivery pipeline produces empty output and Telegram shows "No response generated. Please try again."
- Why it matters: Any Anthropic model with adaptive thinking can trigger this — the assistant completes reasoning but produces no visible text. Users see a failed response with no indication of what happened.
- What changed: (1) Embedded handler now detects thinking-only `stop` turns and generates a minimal visible fallback instead of passing empty text downstream. (2) Telegram dispatch now tracks `completedWithoutVisibleOutput` to trigger fallback when the model path completes with zero visible output.
- What did NOT change (scope boundary): Existing skip/fail counting, delivery tracking, error handling, silent reply handling, and heartbeat paths are all untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #47993
- Related #37278
- Related #40769

## User-visible / Behavior Changes

When a model returns only thinking content with no visible text, users now see a brief fallback message instead of "No response generated. Please try again." or complete silence.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

Root cause identified in #47993 by @Hollychou924. The fix adds two layers:

**Layer 1 (root cause):** `pi-embedded-subscribe.handlers.messages.ts` — when `extractAssistantText()` returns empty AND the response has thinking blocks AND `stopReason === "stop"` with no tool calls, `resolveThinkingOnlyVisibleFallbackText()` generates a minimal visible reply instead of passing empty text downstream.

**Layer 2 (safety net):** `bot-message-dispatch.ts` — `dispatchReplyWithBufferedBlockDispatcher` now returns `completedWithoutVisibleOutput` when the dispatch path completes without ever queuing visible output. The fallback condition uses this flag to send `EMPTY_RESPONSE_FALLBACK` without relying solely on skip/fail counters.

Regression tests added for both layers. All 70 Telegram dispatch tests pass.

## AI Disclosure

This fix was developed with AI assistance (Codex). The root cause analysis, code changes, and test verification were reviewed manually.