### PR TITLE
docs(slack): warn that groupPolicy: allowlist requires channel IDs not names

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -169,7 +169,7 @@ For actions/directory reads, user token can be preferred when configured. For wr
     - `allowlist`
     - `disabled`
 
-    Channel allowlist lives under `channels.slack.channels` and should use stable channel IDs.
+    Channel allowlist lives under `channels.slack.channels` and **must use stable Slack channel IDs** (for example `C12345678`) as config keys.
 
     Runtime note: if `channels.slack` is completely missing (env-only setup), runtime falls back to `groupPolicy="allowlist"` and logs a warning (even if `channels.defaults.groupPolicy` is set).
 
@@ -178,6 +178,42 @@ For actions/directory reads, user token can be preferred when configured. For wr
     - channel allowlist entries and DM allowlist entries are resolved at startup when token access allows
     - unresolved channel-name entries are kept as configured but ignored for routing by default
     - inbound authorization and channel routing are ID-first by default; direct username/slug matching requires `channels.slack.dangerouslyAllowNameMatching: true`
+
+    <Warning>
+    Name-based keys (`#channel-name` or `channel-name`) do **not** match under `groupPolicy: "allowlist"`. The channel lookup is ID-first by default, so a name-based key will never route successfully and all messages in that channel will be silently blocked. This differs from `groupPolicy: "open"`, where the channel key is not required for routing and a name-based key appears to work.
+
+    Always use the Slack channel ID as the key. To find it: right-click the channel in Slack → **Copy link** — the ID (`C...`) appears at the end of the URL.
+
+    Correct:
+
+    ```json5
+    {
+      channels: {
+        slack: {
+          groupPolicy: "allowlist",
+          channels: {
+            C12345678: { allow: true, requireMention: true },
+          },
+        },
+      },
+    }
+    ```
+
+    Incorrect (silently blocked under `groupPolicy: "allowlist"`):
+
+    ```json5
+    {
+      channels: {
+        slack: {
+          groupPolicy: "allowlist",
+          channels: {
+            "#eng-my-channel": { allow: true, requireMention: true },
+          },
+        },
+      },
+    }
+    ```
+    </Warning>
 
   </Tab>
 
@@ -486,7 +522,7 @@ Notes:
     Check, in order:
 
     - `groupPolicy`
-    - channel allowlist (`channels.slack.channels`)
+    - channel allowlist (`channels.slack.channels`) — **keys must be channel IDs** (`C12345678`), not names (`#channel-name`). Name-based keys silently fail under `groupPolicy: "allowlist"` because channel routing is ID-first by default. To find an ID: right-click the channel in Slack → **Copy link** — the `C...` value at the end of the URL is the channel ID.
     - `requireMention`
     - per-channel `users` allowlist
 


### PR DESCRIPTION
 ## Summary

  - **Problem:** \`channels.slack.channels\` config keys using channel names (\`#eng-my-channel\`) silently block all messages when \`groupPolicy: "allowlist"\` is set. The same name-based key appears to work under \`groupPolicy: "open"\` because the route-match
   check is skipped entirely for open policy — creating a confusing failure mode when tightening access control.
  - **Why it matters:** \`de3e6a8c5b\` (v2026.3.12, "fix(routing): require ids for slack and msteams allowlists") made channel lookup ID-first by default, gating name candidates on \`dangerouslyAllowNameMatching\`. Before that change name-based keys worked
  unconditionally. After it, users who had name-based keys under \`groupPolicy: "allowlist"\` got silently blocked with no error. See #28037 and its duplicates for reported confusion.
  - **What changed:** docs only — added a \`<Warning>\` block in the Channel policy tab with correct/incorrect config examples and ID-lookup instructions; added an inline callout in the "No replies in channels" troubleshooting accordion.
  - **What did NOT change:** no runtime behavior changed.

  ## Change Type

  - [x] Docs

  ## Scope

  - [x] Integrations
  - [x] UI / DX

  ## Linked Issue/PR

  - Related #28037

  ## User-visible / Behavior Changes

  None (docs only).

  ## Security Impact

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  ## Repro + Verification

  ### Environment

  - Integration/channel: Slack

  ### Steps

  1. Set \`groupPolicy: "allowlist"\` with a \`channels\` key using \`#channel-name\` format
  2. Send a message to that channel — silently blocked
  3. After reading the new warning block, switch to the channel ID as the key — messages route correctly

  ### Expected

  Docs clearly warn that name-based keys fail silently under \`allowlist\` and show how to find the channel ID.

  ### Actual (before this PR)

  Docs said "should use stable channel IDs" (soft recommendation) with no explanation of the asymmetric behavior between \`"open"\` and \`"allowlist"\`, no example, and no troubleshooting entry for this pattern.

  ## Evidence

  - [ ] Issue #28037 and its linked duplicates demonstrate the confusion pattern

  ## Human Verification

  - Verified scenarios: config with name-based key under \`allowlist\` blocks silently; switching to channel ID restores routing
  - What you did not verify: Mintlify Warning block render (visual review recommended)

  ## Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  ## Failure Recovery

  - No runtime change; revert is a straight doc edit.

  ## Risks and Mitigations

  None.