### PR TITLE
fix: resolve Node.js 20.9+ fetch preconnect type incompatibility in tests

### DIFF
--- a/extensions/msteams/src/graph-upload.test.ts
+++ b/extensions/msteams/src/graph-upload.test.ts
@@ -107,7 +107,7 @@ describe("resolveGraphChatId", () => {
   };
 
   it("returns the ID directly when it already starts with 19:", async () => {
-    const fetchFn = vi.fn();
+    const fetchFn = vi.fn() as unknown as typeof fetch;
     const result = await resolveGraphChatId({
       botFrameworkConversationId: "19:abc123@thread.tacv2",
       tokenProvider,
@@ -131,7 +131,7 @@ describe("resolveGraphChatId", () => {
       botFrameworkConversationId: "a:1abc_bot_framework_dm_id",
       userAadObjectId: "user-aad-object-id-123",
       tokenProvider,
-      fetchFn,
+      fetchFn: fetchFn as unknown as typeof fetch,
     });
 
     expect(fetchFn).toHaveBeenCalledWith(
@@ -158,7 +158,7 @@ describe("resolveGraphChatId", () => {
     const result = await resolveGraphChatId({
       botFrameworkConversationId: "8:orgid:user-object-id",
       tokenProvider,
-      fetchFn,
+      fetchFn: fetchFn as unknown as typeof fetch,
     });
 
     expect(fetchFn).toHaveBeenCalledOnce();
@@ -178,7 +178,7 @@ describe("resolveGraphChatId", () => {
       botFrameworkConversationId: "a:1unknown_dm",
       userAadObjectId: "some-user",
       tokenProvider,
-      fetchFn,
+      fetchFn: fetchFn as unknown as typeof fetch,
     });
 
     expect(result).toBeNull();
@@ -197,7 +197,7 @@ describe("resolveGraphChatId", () => {
       botFrameworkConversationId: "a:1some_dm_id",
       userAadObjectId: "some-user",
       tokenProvider,
-      fetchFn,
+      fetchFn: fetchFn as unknown as typeof fetch,
     });
 
     expect(result).toBeNull();

--- a/extensions/qwen-portal-auth/refresh.test.ts
+++ b/extensions/qwen-portal-auth/refresh.test.ts
@@ -33,7 +33,7 @@ describe("refreshQwenPortalCredentials", () => {
           headers: { "Content-Type": "application/json" },
         },
       );
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const result = await runRefresh();
 
@@ -63,7 +63,7 @@ describe("refreshQwenPortalCredentials", () => {
           headers: { "Content-Type": "application/json" },
         },
       );
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const result = await runRefresh();
 
@@ -82,7 +82,7 @@ describe("refreshQwenPortalCredentials", () => {
           headers: { "Content-Type": "application/json" },
         },
       );
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     await expect(runRefresh()).rejects.toThrow(
       "Qwen OAuth refresh response missing or invalid expires_in",
@@ -92,7 +92,7 @@ describe("refreshQwenPortalCredentials", () => {
   it("turns 400 responses into a re-authenticate hint", async () => {
     globalThis.fetch = vi.fn(
       async () => new Response("bad refresh", { status: 400 }),
-    ) as typeof fetch;
+    ) as unknown as typeof fetch;
 
     await expect(runRefresh()).rejects.toThrow("Qwen OAuth refresh token expired or invalid");
   });
@@ -120,7 +120,7 @@ describe("refreshQwenPortalCredentials", () => {
           headers: { "Content-Type": "application/json" },
         },
       );
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     await expect(runRefresh()).rejects.toThrow("Qwen OAuth refresh response missing access token");
   });
@@ -128,7 +128,7 @@ describe("refreshQwenPortalCredentials", () => {
   it("surfaces non-400 refresh failures", async () => {
     globalThis.fetch = vi.fn(
       async () => new Response("gateway down", { status: 502 }),
-    ) as typeof fetch;
+    ) as unknown as typeof fetch;
 
     await expect(runRefresh()).rejects.toThrow("Qwen OAuth refresh failed: gateway down");
   });

--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -108,7 +108,7 @@ describe("model-pricing-cache", () => {
       },
     } as unknown as OpenClawConfig;
 
-    const fetchImpl: typeof fetch = async () =>
+    const fetchImpl = (async () =>
       new Response(
         JSON.stringify({
           data: [
@@ -149,7 +149,7 @@ describe("model-pricing-cache", () => {
           status: 200,
           headers: { "Content-Type": "application/json" },
         },
-      );
+      )) as unknown as typeof fetch;
 
     await refreshGatewayModelPricingCache({ config, fetchImpl });
 

--- a/src/gateway/server.talk-config.test.ts
+++ b/src/gateway/server.talk-config.test.ts
@@ -273,7 +273,7 @@ describe("gateway talk.config", () => {
       }
       return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
     });
-    globalThis.fetch = fetchMock as typeof fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     try {
       await withServer(async (ws) => {
@@ -327,7 +327,7 @@ describe("gateway talk.config", () => {
       fetchUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       return new Response(new Uint8Array([4, 5, 6]), { status: 200 });
     });
-    globalThis.fetch = fetchMock as typeof fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     try {
       await withServer(async (ws) => {

--- a/src/tts/providers/microsoft.test.ts
+++ b/src/tts/providers/microsoft.test.ts
@@ -26,7 +26,7 @@ describe("listMicrosoftVoices", () => {
         ]),
         { status: 200 },
       ),
-    ) as typeof globalThis.fetch;
+    ) as unknown as typeof fetch;
 
     const voices = await listMicrosoftVoices();
 
@@ -56,7 +56,7 @@ describe("listMicrosoftVoices", () => {
   it("throws on Microsoft voice list failures", async () => {
     globalThis.fetch = vi
       .fn()
-      .mockResolvedValue(new Response("nope", { status: 503 })) as typeof globalThis.fetch;
+      .mockResolvedValue(new Response("nope", { status: 503 })) as unknown as typeof fetch;
 
     await expect(listMicrosoftVoices()).rejects.toThrow("Microsoft voices API error (503)");
   });


### PR DESCRIPTION
Resolves 16 TypeScript errors (16→0) caused by Node.js 20.9+ adding  property to the global  type. The fix adjusts mock type assertions in test files to handle the new  property.

## Changes
- : Type assertions fixed (5 locations)
- : Type assertions fixed (7 locations)  
- : Mock type fixed
- : Type assertions fixed (2 locations)
- : Type assertions fixed (2 locations)

## Verification
```bash
npx tsc --noEmit  # 0 errors on feature branch
```

Closes: typescript-fetch-fix