### PR TITLE
Fix cron false-positive errors after recovered reminder delivery

### DIFF
--- a/skills/gary-scripts/scrape_all_239_dual.py
+++ b/skills/gary-scripts/scrape_all_239_dual.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""
+Dual-source JD scraper for discovery-with-jd.csv.
+
+Flow per row (for rows needing update):
+1) Try externalApplyUrl (skip Workday URLs/ATS)
+2) Fallback to LinkedIn job URL using an authenticated Chrome profile (Playwright)
+
+Writes back to the same CSV in place.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import os
+import re
+import ssl
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+from lxml import html
+from playwright.async_api import async_playwright, BrowserContext, Page
+
+
+CSV_PATH = Path(
+    os.path.expanduser(
+        "~/Library/Mobile Documents/com~apple~CloudDocs/Job Applications/Combined Discovery/discovery-with-jd.csv"
+    )
+)
+PROFILE_PATH = Path("/Users/raylim/Bespoke Software/LinkedInAutoApply/user_data")
+
+REQUEST_DELAY_SECONDS = 2.0
+BATCH_SIZE = 20
+PROGRESS_EVERY = 40
+
+SENTINELS = {"", "login_required", "description_not_found"}
+MIN_DESC_LEN_EXTERNAL = 280
+MIN_DESC_LEN_LINKEDIN = 220
+
+
+@dataclass
+class Stats:
+    total_rows: int = 0
+    rows_needing_update: int = 0
+    rows_attempted: int = 0
+    rows_updated: int = 0
+    external_success: int = 0
+    linkedin_success: int = 0
+    still_not_found: int = 0
+    login_required: int = 0
+    workday_skipped: int = 0
+
+
+class RateLimiter:
+    def __init__(self, min_interval: float) -> None:
+        self.min_interval = min_interval
+        self._last_ts = 0.0
+
+    async def wait(self) -> None:
+        now = time.monotonic()
+        elapsed = now - self._last_ts
+        if elapsed < self.min_interval:
+            await asyncio.sleep(self.min_interval - elapsed)
+        self._last_ts = time.monotonic()
+
+
+def normalize_text(text: str) -> str:
+    text = text.replace("\r", "\n")
+    text = re.sub(r"\u00a0", " ", text)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def is_workday(url: str, ats: str) -> bool:
+    u = (url or "").lower()
+    a = (ats or "").lower()
+    return "workday" in a or "workdayjobs" in u or ".wd" in u
+
+
+def needs_update(value: str) -> bool:
+    v = (value or "").strip().lower()
+    return v in SENTINELS
+
+
+def read_csv_rows(path: Path) -> Tuple[List[str], List[Dict[str, str]]]:
+    with path.open("r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        fieldnames = reader.fieldnames or []
+        rows = list(reader)
+    return fieldnames, rows
+
+
+def write_csv_rows(path: Path, fieldnames: List[str], rows: List[Dict[str, str]]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    tmp.replace(path)
+
+
+def extract_external_description(html_text: str, source_url: str = "") -> Optional[str]:
+    try:
+        doc = html.fromstring(html_text)
+    except Exception:
+        return None
+
+    for bad in doc.xpath("//script|//style|//noscript|//svg|//iframe|//header|//footer"):
+        bad.drop_tree()
+
+    candidates: List[str] = []
+
+    xpaths = [
+        "//*[contains(@class,'jobs-description') or contains(@class,'job-description') or contains(@id,'job-description')]",
+        "//*[contains(@class,'description') and (contains(@class,'job') or contains(@id,'job'))]",
+        "//*[contains(@class,'posting') and contains(@class,'content')]",
+        "//*[contains(@class,'content') and contains(@class,'description')]",
+        "//main",
+        "//article",
+    ]
+
+    for xp in xpaths:
+        nodes = doc.xpath(xp)
+        for n in nodes[:4]:
+            txt = normalize_text(n.text_content())
+            if len(txt) >= 120:
+                candidates.append(txt)
+
+    # LinkedIn external pages often embed JSON with rich description
+    for script in doc.xpath("//script[@type='application/ld+json']/text()")[:10]:
+        if not script:
+            continue
+        m = re.search(r'"description"\s*:\s*"(.*?)"', script, flags=re.S)
+        if m:
+            t = m.group(1)
+            t = t.encode("utf-8", "ignore").decode("unicode_escape", "ignore")
+            t = re.sub(r"<[^>]+>", " ", t)
+            t = normalize_text(t)
+            if len(t) >= 120:
+                candidates.append(t)
+
+    # Site-specific heuristics
+    host = urlparse(source_url).netloc.lower()
+    if "greenhouse" in host:
+        nodes = doc.xpath("//*[contains(@class,'content') or contains(@id,'content')]")
+        for n in nodes[:4]:
+            t = normalize_text(n.text_content())
+            if len(t) >= 120:
+                candidates.append(t)
+    elif "smartrecruiters" in host:
+        nodes = doc.xpath("//*[contains(@class,'job-description') or contains(@class,'opening-job-description')]")
+        for n in nodes[:3]:
+            t = normalize_text(n.text_content())
+            if len(t) >= 120:
+                candidates.append(t)
+    elif "lever.co" in host:
+        nodes = doc.xpath("//*[contains(@class,'posting-page') or contains(@class,'section-wrapper')]")
+        for n in nodes[:5]:
+            t = normalize_text(n.text_content())
+            if len(t) >= 120:
+                candidates.append(t)
+    elif "ashby" in host:
+        nodes = doc.xpath("//*[contains(@class,'job-posting') or contains(@class,'description')]")
+        for n in nodes[:5]:
+            t = normalize_text(n.text_content())
+            if len(t) >= 120:
+                candidates.append(t)
+
+    if not candidates:
+        full = normalize_text(doc.text_content())
+        if len(full) >= MIN_DESC_LEN_EXTERNAL:
+            return full
+        return None
+
+    best = max(candidates, key=len)
+
+    # Cheap noise filter: reject pages that are clearly not job details
+    bad_markers = ["enable javascript", "access denied", "cloudflare", "captcha", "sign in"]
+    low = best.lower()
+    if any(m in low for m in bad_markers) and len(best) < 900:
+        return None
+
+    return best if len(best) >= MIN_DESC_LEN_EXTERNAL else None
+
+
+def fetch_external_url(url: str, timeout: int = 30) -> Optional[str]:
+    req = Request(
+        url,
+        headers={
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/124.0.0.0 Safari/537.36"
+            ),
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Cache-Control": "no-cache",
+            "Pragma": "no-cache",
+        },
+    )
+    ctx = ssl.create_default_context()
+    with urlopen(req, timeout=timeout, context=ctx) as resp:
+        content_type = resp.headers.get("Content-Type", "")
+        charset = "utf-8"
+        m = re.search(r"charset=([\w\-]+)", content_type, flags=re.I)
+        if m:
+            charset = m.group(1)
+        data = resp.read()
+        text = data.decode(charset, errors="ignore")
+    return text
+
+
+class LinkedInScraper:
+    def __init__(self, profile_path: Path) -> None:
+        self.profile_path = profile_path
+        self._pw = None
+        self.ctx: Optional[BrowserContext] = None
+        self.page: Optional[Page] = None
+
+    async def __aenter__(self) -> "LinkedInScraper":
+        self._pw = await async_playwright().start()
+        self.ctx = await self._pw.chromium.launch_persistent_context(
+            user_data_dir=str(self.profile_path),
+            channel="chrome",
+            headless=True,
+            args=[
+                "--disable-blink-features=AutomationControlled",
+                "--no-first-run",
+                "--no-default-browser-check",
+            ],
+        )
+        pages = self.ctx.pages
+        self.page = pages[0] if pages else await self.ctx.new_page()
+        self.page.set_default_timeout(45000)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self.ctx:
+            await self.ctx.close()
+        if self._pw:
+            await self._pw.stop()
+
+    async def extract_job_description(self, job_url: str) -> Tuple[Optional[str], str]:
+        assert self.page is not None
+        page = self.page
+
+        try:
+            await page.goto(job_url, wait_until="domcontentloaded", timeout=45000)
+        except Exception as e:
+            return None, f"linkedin_goto_error:{type(e).__name__}"
+
+        await page.wait_for_timeout(2500)
+
+        current = (page.url or "").lower()
+        if "authwall" in current or "login" in current:
+            return None, "login_required"
+
+        # Try expanding collapsed description.
+        expand_selectors = [
+            "button.show-more-less-html__button",
+            "button[aria-label*='more']",
+            "button:has-text('See more')",
+            "button.jobs-description__footer-button",
+        ]
+        for sel in expand_selectors:
+            try:
+                btn = page.locator(sel).first
+                if await btn.count() > 0:
+                    await btn.click(timeout=1500)
+                    await page.wait_for_timeout(300)
+            except Exception:
+                pass
+
+        selectors = [
+            ".jobs-description-content__text",
+            ".show-more-less-html__markup",
+            ".jobs-box__html-content",
+            ".jobs-description__container",
+            "#job-details",
+        ]
+
+        best = ""
+        for sel in selectors:
+            try:
+                loc = page.locator(sel)
+                cnt = await loc.count()
+                for i in range(min(cnt, 4)):
+                    t = normalize_text(await loc.nth(i).inner_text())
+                    if len(t) > len(best):
+                        best = t
+            except Exception:
+                pass
+
+        if len(best) >= MIN_DESC_LEN_LINKEDIN:
+            return best, "ok"
+
+        # Fallback: parse page text for job-description-ish chunks
+        try:
+            body_txt = normalize_text(await page.inner_text("body"))
+            # keep from first "About the job" marker if present
+            marker = "about the job"
+            idx = body_txt.lower().find(marker)
+            if idx >= 0:
+                body_txt = body_txt[idx:]
+            if len(body_txt) >= 500:
+                return body_txt, "ok_body_fallback"
+        except Exception:
+            pass
+
+        # Check if login wall appeared as content
+        try:
+            body = (await page.inner_text("body")).lower()
+            if "join linkedin" in body or "sign in" in body and "jobs" not in body[:120]:
+                return None, "login_required"
+        except Exception:
+            pass
+
+        return None, "description_not_found"
+
+
+async def scrape_all() -> int:
+    if not CSV_PATH.exists():
+        print(f"ERROR: CSV not found: {CSV_PATH}")
+        return 2
+    if not PROFILE_PATH.exists():
+        print(f"ERROR: LinkedIn profile path not found: {PROFILE_PATH}")
+        return 2
+
+    fieldnames, rows = read_csv_rows(CSV_PATH)
+    stats = Stats(total_rows=len(rows))
+
+    if "full_job_description" not in fieldnames:
+        print("ERROR: full_job_description column missing")
+        return 2
+
+    to_process_idx = [i for i, r in enumerate(rows) if needs_update(r.get("full_job_description", ""))]
+    stats.rows_needing_update = len(to_process_idx)
+
+    print(f"Loaded {stats.total_rows} rows. Need update: {stats.rows_needing_update}")
+    if stats.rows_needing_update == 0:
+        print("Nothing to do.")
+        return 0
+
+    limiter = RateLimiter(REQUEST_DELAY_SECONDS)
+    dirty_since_write = 0
+
+    async with LinkedInScraper(PROFILE_PATH) as li:
+        for idx, row in enumerate(rows, start=1):
+            # Progress over all 239 rows as requested
+            if idx % PROGRESS_EVERY == 0:
+                print(
+                    f"Progress {idx}/{stats.total_rows} | "
+                    f"attempted={stats.rows_attempted} updated={stats.rows_updated} "
+                    f"ext_ok={stats.external_success} li_ok={stats.linkedin_success}"
+                )
+
+            if not needs_update(row.get("full_job_description", "")):
+                continue
+
+            stats.rows_attempted += 1
+            rank = row.get("rank", str(idx))
+            ext_url = (row.get("externalApplyUrl") or "").strip()
+            li_url = (row.get("linkedinJobUrl") or "").strip()
+            ats = (row.get("ats") or "").strip().lower()
+
+            final_desc: Optional[str] = None
+            final_state = "description_not_found"
+
+            # Source 1: externalApplyUrl
+            if ext_url:
+                if is_workday(ext_url, ats):
+                    stats.workday_skipped += 1
+                else:
+                    await limiter.wait()
+                    try:
+                        ext_html = await asyncio.to_thread(fetch_external_url, ext_url)
+                        ext_desc = await asyncio.to_thread(extract_external_description, ext_html, ext_url)
+                        if ext_desc:
+                            final_desc = ext_desc
+                            final_state = "ok_external"
+                            stats.external_success += 1
+                    except Exception:
+                        pass
+
+            # Source 2: LinkedIn fallback
+            if final_desc is None and li_url:
+                await limiter.wait()
+                li_desc, li_state = await li.extract_job_description(li_url)
+                if li_desc:
+                    final_desc = li_desc
+                    final_state = "ok_linkedin"
+                    stats.linkedin_success += 1
+                else:
+                    final_state = li_state
+
+            if final_desc:
+                row["full_job_description"] = final_desc
+                stats.rows_updated += 1
+            else:
+                row["full_job_description"] = (
+                    "login_required" if final_state == "login_required" else "description_not_found"
+                )
+                if final_state == "login_required":
+                    stats.login_required += 1
+                else:
+                    stats.still_not_found += 1
+
+            dirty_since_write += 1
+            print(
+                f"[{stats.rows_attempted}/{stats.rows_needing_update}] rank={rank} "
+                f"-> {final_state} len={len(row.get('full_job_description',''))}"
+            )
+
+            if dirty_since_write >= BATCH_SIZE:
+                write_csv_rows(CSV_PATH, fieldnames, rows)
+                dirty_since_write = 0
+                print(f"Flushed batch of {BATCH_SIZE} updates to CSV")
+
+    if dirty_since_write:
+        write_csv_rows(CSV_PATH, fieldnames, rows)
+        print(f"Flushed final batch of {dirty_since_write} updates to CSV")
+
+    print("Done.")
+    print(
+        "Summary: "
+        f"total={stats.total_rows}, need={stats.rows_needing_update}, "
+        f"attempted={stats.rows_attempted}, updated={stats.rows_updated}, "
+        f"ext_ok={stats.external_success}, li_ok={stats.linkedin_success}, "
+        f"workday_skipped={stats.workday_skipped}, "
+        f"still_not_found={stats.still_not_found}, login_required={stats.login_required}"
+    )
+    return 0
+
+
+def main() -> None:
+    try:
+        code = asyncio.run(scrape_all())
+    except KeyboardInterrupt:
+        print("Interrupted.")
+        code = 130
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/gary-scripts/scrape_jds.py
+++ b/skills/gary-scripts/scrape_jds.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""
+Resumable LinkedIn JD scraper.
+
+What it does:
+1) Reads the shortlist input CSV.
+2) Merges any already-scraped JD data from existing output CSV (if present).
+3) Processes jobs in priority order: rank 1-20 first, then remaining ranks.
+4) Scrapes up to N jobs per run (default: all remaining), with 3-5s delay between visits.
+5) Writes progress JSON so interrupted runs can resume.
+6) Writes output CSV with JD columns appended.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+from playwright.sync_api import sync_playwright
+
+DEFAULT_INPUT = Path(
+    "~/Library/Mobile Documents/com~apple~CloudDocs/Job Applications/Combined Discovery/all-discovered-jobs.csv"
+).expanduser()
+DEFAULT_OUTPUT = Path(
+    "~/Library/Mobile Documents/com~apple~CloudDocs/Job Applications/Combined Discovery/all-discovered-with-jd.csv"
+).expanduser()
+DEFAULT_PROGRESS = Path(
+    "~/Library/Mobile Documents/com~apple~CloudDocs/Job Applications/Combined Discovery/all-jd-scrape-progress.json"
+).expanduser()
+
+# Include legacy-compatible alias column too.
+NEW_COLUMNS = ["jobDescriptionText", "full_job_description", "jdStatus", "jdError", "jdScrapedAt"]
+DONE_STATUSES = {"ok", "login_required", "error", "no_url"}
+EXISTING_JD_COLUMNS = ["jobDescriptionText", "full_job_description", "job_description", "jd_text"]
+EXISTING_STATUS_COLUMNS = ["jdStatus", "jd_status", "status"]
+EXISTING_ERROR_COLUMNS = ["jdError", "jd_error", "error"]
+EXISTING_SCRAPED_AT_COLUMNS = ["jdScrapedAt", "jd_scraped_at", "scraped_at"]
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def parse_rank(row: Dict[str, str]) -> int:
+    raw = (row.get("rank") or "").strip()
+    try:
+        return int(raw)
+    except Exception:
+        return 10**9
+
+
+def read_csv_dict(path: Path) -> Tuple[List[Dict[str, str]], List[str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+        fieldnames = reader.fieldnames or []
+    return rows, list(fieldnames)
+
+
+def write_csv_dict(path: Path, rows: List[Dict[str, str]], fieldnames: List[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=fieldnames,
+            extrasaction="ignore",
+            quoting=csv.QUOTE_ALL,
+            doublequote=True,
+            lineterminator="\n",
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def first_non_empty(row: Dict[str, str], keys: List[str]) -> str:
+    for k in keys:
+        v = (row.get(k) or "").strip()
+        if v:
+            return v
+    return ""
+
+
+def normalize_url(url: str) -> str:
+    if not url:
+        return ""
+    return url.strip().split("?", 1)[0].rstrip("/").lower()
+
+
+def row_key(row: Dict[str, str]) -> Tuple[str, str, str, str]:
+    rank = (row.get("rank") or "").strip()
+    title = (row.get("jobTitle") or "").strip().lower()
+    company = (row.get("company") or "").strip().lower()
+    url = normalize_url((row.get("linkedinJobUrl") or "").strip())
+    return rank, title, company, url
+
+
+def ensure_columns(rows: List[Dict[str, str]], fieldnames: List[str]) -> List[str]:
+    final_fields = list(fieldnames)
+    for col in NEW_COLUMNS:
+        if col not in final_fields:
+            final_fields.append(col)
+
+    for row in rows:
+        for col in NEW_COLUMNS:
+            row.setdefault(col, "")
+    return final_fields
+
+
+def canonicalize_jd_fields(row: Dict[str, str]) -> None:
+    """Keep legacy/full_job_description and jobDescriptionText in sync."""
+    jd = (row.get("jobDescriptionText") or "").strip()
+    legacy = (row.get("full_job_description") or "").strip()
+
+    if not jd and legacy:
+        jd = legacy
+    if jd and not legacy:
+        legacy = jd
+
+    row["jobDescriptionText"] = jd
+    row["full_job_description"] = legacy
+
+    status = (row.get("jdStatus") or "").strip().lower()
+    if not status:
+        if jd.lower() == "login_required":
+            row["jdStatus"] = "login_required"
+        elif jd:
+            row["jdStatus"] = "ok"
+
+
+def is_processed(row: Dict[str, str]) -> bool:
+    status = (row.get("jdStatus") or "").strip().lower()
+    jd = (row.get("jobDescriptionText") or row.get("full_job_description") or "").strip()
+    if status in DONE_STATUSES:
+        return True
+    if jd:
+        return True
+    return False
+
+
+def merge_existing_output(base_rows: List[Dict[str, str]], output_path: Path) -> int:
+    """Merge prior scraped values from output CSV (if present)."""
+    if not output_path.exists():
+        return 0
+
+    try:
+        existing_rows, _ = read_csv_dict(output_path)
+    except Exception:
+        return 0
+
+    if not existing_rows:
+        return 0
+
+    lookup: Dict[Tuple[str, str, str, str], Dict[str, str]] = {}
+    for r in existing_rows:
+        k = row_key(r)
+        if k != ("", "", "", ""):
+            lookup[k] = r
+
+    merged = 0
+    for row in base_rows:
+        k = row_key(row)
+        old = lookup.get(k)
+        if not old:
+            continue
+
+        jd_old = first_non_empty(old, EXISTING_JD_COLUMNS)
+        status_old = first_non_empty(old, EXISTING_STATUS_COLUMNS)
+        err_old = first_non_empty(old, EXISTING_ERROR_COLUMNS)
+        scraped_old = first_non_empty(old, EXISTING_SCRAPED_AT_COLUMNS)
+
+        if jd_old and not (row.get("jobDescriptionText") or "").strip():
+            row["jobDescriptionText"] = jd_old
+            row["full_job_description"] = jd_old
+            merged += 1
+        if status_old and not (row.get("jdStatus") or "").strip():
+            row["jdStatus"] = status_old
+        if err_old and not (row.get("jdError") or "").strip():
+            row["jdError"] = err_old
+        if scraped_old and not (row.get("jdScrapedAt") or "").strip():
+            row["jdScrapedAt"] = scraped_old
+
+        canonicalize_jd_fields(row)
+
+    return merged
+
+
+def load_progress(progress_path: Path) -> Dict:
+    if not progress_path.exists():
+        return {}
+    try:
+        with progress_path.open("r", encoding="utf-8") as f:
+            payload = json.load(f)
+        if isinstance(payload, dict):
+            return payload
+    except Exception:
+        pass
+    return {}
+
+
+def build_order(rows: List[Dict[str, str]]) -> List[int]:
+    sortable = []
+    for idx, row in enumerate(rows):
+        rank = parse_rank(row)
+        top20_bucket = 0 if 1 <= rank <= 20 else 1
+        sortable.append((top20_bucket, rank, idx))
+    sortable.sort(key=lambda t: (t[0], t[1], t[2]))
+    return [idx for _, _, idx in sortable]
+
+
+def first_unprocessed_position(order: List[int], rows: List[Dict[str, str]]) -> int:
+    for pos, idx in enumerate(order):
+        if not is_processed(rows[idx]):
+            return pos
+    return len(order)
+
+
+def save_progress(
+    progress_path: Path,
+    order: List[int],
+    rows: List[Dict[str, str]],
+    last_completed_index: int,
+    batch_attempted: int,
+    batch_processed: int,
+) -> None:
+    progress_path.parent.mkdir(parents=True, exist_ok=True)
+
+    next_pos = last_completed_index + 1
+    next_rank = None
+    next_company = None
+    next_title = None
+    if 0 <= next_pos < len(order):
+        nxt = rows[order[next_pos]]
+        next_rank = nxt.get("rank")
+        next_company = nxt.get("company")
+        next_title = nxt.get("jobTitle")
+
+    payload = {
+        "updatedAt": now_iso(),
+        "last_completed_index": last_completed_index,
+        "batch_attempted": batch_attempted,
+        "batch_processed": batch_processed,
+        "total_rows": len(rows),
+        "total_done": sum(1 for r in rows if is_processed(r)),
+        "next_index": next_pos if next_pos < len(order) else None,
+        "next_rank": next_rank,
+        "next_company": next_company,
+        "next_jobTitle": next_title,
+        "order_strategy": "rank_1_to_20_first_then_remaining",
+    }
+
+    with progress_path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+
+
+def detect_login_or_captcha(url: str, title: str, body_text: str) -> bool:
+    hay = f"{url}\n{title}\n{body_text}".lower()
+    markers = [
+        "authwall",
+        "checkpoint/challenge",
+        "captcha",
+        "verify you are human",
+        "security verification",
+        "let's do a quick security check",
+        "to continue, sign in",
+        "join linkedin",
+        "sign in",
+        "new to linkedin",
+    ]
+    return any(m in hay for m in markers)
+
+
+def clean_text(text: str) -> str:
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    text = re.sub(r"[ \t]+\n", "\n", text)
+    return text.strip()
+
+
+def extract_description(page) -> str:
+    js = """
+() => {
+  const selectors = [
+    'div.show-more-less-html__markup',
+    '.show-more-less-html__markup',
+    '.jobs-description-content__text',
+    '.description__text',
+    '[data-test-job-description]'
+  ];
+
+  const chunks = [];
+  for (const sel of selectors) {
+    const nodes = document.querySelectorAll(sel);
+    for (const n of nodes) {
+      const t = (n.innerText || '').trim();
+      if (t.length > 0) chunks.push(t);
+    }
+  }
+
+  if (chunks.length === 0) {
+    const fallback = document.querySelectorAll('main, [role="main"], article, section');
+    for (const n of fallback) {
+      const t = (n.innerText || '').trim();
+      if (t.length > 200) chunks.push(t);
+    }
+  }
+
+  if (chunks.length === 0 && document.body) {
+    chunks.push((document.body.innerText || '').trim());
+  }
+
+  chunks.sort((a, b) => b.length - a.length);
+  return chunks[0] || '';
+}
+"""
+    text = page.evaluate(js)
+    return clean_text(text if isinstance(text, str) else "")
+
+
+def scrape_job(page, url: str) -> Tuple[str, str, str]:
+    """Return (status, jd_text, error)."""
+    if not url:
+        return "no_url", "", "missing linkedinJobUrl"
+
+    try:
+        page.goto(url, wait_until="domcontentloaded", timeout=60000)
+        page.wait_for_timeout(1500)
+    except PlaywrightTimeoutError:
+        return "error", "", "navigation_timeout"
+    except Exception as e:
+        return "error", "", f"navigation_error: {e}"
+
+    try:
+        title = page.title() or ""
+    except Exception:
+        title = ""
+
+    try:
+        body_text = page.evaluate("() => (document.body ? document.body.innerText : '')")
+        if not isinstance(body_text, str):
+            body_text = ""
+    except Exception:
+        body_text = ""
+
+    current_url = page.url or url
+    if detect_login_or_captcha(current_url, title, body_text):
+        return "login_required", "login_required", ""
+
+    try:
+        jd = extract_description(page)
+    except Exception as e:
+        return "error", "", f"extract_error: {e}"
+
+    if len(jd) < 120:
+        if detect_login_or_captcha(current_url, title, body_text):
+            return "login_required", "login_required", ""
+        return "error", jd, "description_too_short"
+
+    return "ok", jd, ""
+
+
+def run(args: argparse.Namespace) -> int:
+    input_path = args.input.expanduser()
+    output_path = args.output.expanduser()
+    progress_path = args.progress.expanduser()
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input CSV not found: {input_path}")
+
+    base_rows, base_fields = read_csv_dict(input_path)
+    if not base_rows:
+        raise RuntimeError(f"No rows in input CSV: {input_path}")
+
+    fieldnames = ensure_columns(base_rows, base_fields)
+    merged = merge_existing_output(base_rows, output_path)
+
+    order = build_order(base_rows)
+    progress = load_progress(progress_path)
+
+    if isinstance(progress.get("last_completed_index"), int):
+        start_pos = max(0, progress["last_completed_index"] + 1)
+        while start_pos < len(order) and is_processed(base_rows[order[start_pos]]):
+            start_pos += 1
+    else:
+        start_pos = first_unprocessed_position(order, base_rows)
+
+    if start_pos >= len(order):
+        write_csv_dict(output_path, base_rows, fieldnames)
+        save_progress(progress_path, order, base_rows, len(order) - 1, 0, 0)
+        print("All rows already processed. Nothing to do.")
+        return 0
+
+    remaining = len(order) - start_pos
+    effective_batch_size = args.batch_size if args.batch_size > 0 else remaining
+
+    print(f"Input rows: {len(base_rows)}")
+    print(f"Merged existing JD rows from output: {merged}")
+    print(
+        f"Starting at order index: {start_pos} "
+        f"(target this run: {effective_batch_size} of {remaining} remaining)"
+    )
+
+    last_completed_index = start_pos - 1
+    batch_attempted = 0
+    batch_processed = 0
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=not args.headed)
+        context = browser.new_context(
+            user_agent=(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/123.0.0.0 Safari/537.36"
+            ),
+            viewport={"width": 1366, "height": 900},
+            locale="en-US",
+        )
+        page = context.new_page()
+
+        pos = start_pos
+        while pos < len(order) and batch_attempted < effective_batch_size:
+            idx = order[pos]
+            row = base_rows[idx]
+
+            if is_processed(row):
+                last_completed_index = pos
+                save_progress(progress_path, order, base_rows, last_completed_index, batch_attempted, batch_processed)
+                pos += 1
+                continue
+
+            rank = row.get("rank", "")
+            company = row.get("company", "")
+            title = row.get("jobTitle", "")
+            url = (row.get("linkedinJobUrl") or "").strip()
+
+            print(f"[{batch_attempted + 1}/{effective_batch_size}] rank={rank} | {company} | {title}")
+            status, jd_text, err = scrape_job(page, url)
+
+            row["jobDescriptionText"] = jd_text
+            row["full_job_description"] = jd_text
+            row["jdStatus"] = status
+            row["jdError"] = err
+            row["jdScrapedAt"] = now_iso()
+
+            canonicalize_jd_fields(row)
+
+            batch_attempted += 1
+            if status in DONE_STATUSES:
+                batch_processed += 1
+
+            last_completed_index = pos
+            write_csv_dict(output_path, base_rows, fieldnames)
+            save_progress(progress_path, order, base_rows, last_completed_index, batch_attempted, batch_processed)
+
+            if batch_attempted < effective_batch_size and pos + 1 < len(order):
+                delay = random.uniform(args.min_delay, args.max_delay)
+                print(f"  -> status={status}; sleeping {delay:.2f}s")
+                time.sleep(delay)
+            else:
+                print(f"  -> status={status}")
+
+            pos += 1
+
+        context.close()
+        browser.close()
+
+    print("Done.")
+    print(f"Output CSV: {output_path}")
+    print(f"Progress JSON: {progress_path}")
+    print(f"Batch attempted: {batch_attempted}")
+    print(f"Batch processed: {batch_processed}")
+    print(f"Last completed index: {last_completed_index}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Scrape LinkedIn job descriptions in resumable batches")
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--progress", type=Path, default=DEFAULT_PROGRESS)
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=0,
+        help="Number of jobs to process this run. Use 0 to process all remaining jobs (default).",
+    )
+    parser.add_argument("--min-delay", type=float, default=3.0)
+    parser.add_argument("--max-delay", type=float, default=5.0)
+    parser.add_argument("--headed", action="store_true", help="Run browser in headed mode")
+    args = parser.parse_args()
+
+    if args.batch_size < 0:
+        parser.error("--batch-size must be >= 0")
+    if args.min_delay < 0 or args.max_delay < 0:
+        parser.error("--min-delay/--max-delay must be >= 0")
+    if args.min_delay > args.max_delay:
+        parser.error("--min-delay cannot be greater than --max-delay")
+    return args
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(run(parse_args()))
+    except KeyboardInterrupt:
+        print("Interrupted by user.")
+        raise SystemExit(130)
+    except Exception as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        raise SystemExit(1)

--- a/skills/gary-scripts/scrape_jds_full.py
+++ b/skills/gary-scripts/scrape_jds_full.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""
+Scrape LinkedIn full job descriptions from a source CSV and append results to output CSV.
+
+Requirements satisfied:
+- Python + Playwright browser automation
+- Processes jobs in rank order
+- Extracts visible JD text from article element (with safe fallbacks)
+- Writes incrementally to CSV
+- 3-second delay between requests
+- Checkpoints every 20 jobs
+- Marks login/captcha pages as "login_required"
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+from playwright.sync_api import sync_playwright
+
+SOURCE_CSV = Path(
+    "~/Library/Mobile Documents/com~apple~CloudDocs/Job Applications/Combined Discovery/all-discovered-jobs.csv"
+).expanduser()
+OUTPUT_CSV = Path(
+    "~/Library/Mobile Documents/com~apple~CloudDocs/Job Applications/Combined Discovery/discovery-with-jd.csv"
+).expanduser()
+PROGRESS_JSON = Path(
+    "~/Library/Mobile Documents/com~apple~CloudDocs/Job Applications/Combined Discovery/jd-scrape-progress.json"
+).expanduser()
+
+SLEEP_SECONDS = 3
+CHECKPOINT_EVERY = 20
+NAV_TIMEOUT_MS = 35000
+
+
+@dataclass
+class JobRow:
+    rank_key: Tuple[int, str]
+    row: Dict[str, str]
+
+
+def parse_rank_key(value: str | None) -> Tuple[int, str]:
+    raw = (value or "").strip()
+    try:
+        return (int(raw), raw)
+    except ValueError:
+        return (10**9, raw)
+
+
+def load_source_rows(path: Path) -> Tuple[List[str], List[Dict[str, str]]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as f:
+        reader = csv.DictReader(f)
+        fieldnames = list(reader.fieldnames or [])
+        rows = list(reader)
+    return fieldnames, rows
+
+
+def sorted_rows(rows: Iterable[Dict[str, str]]) -> List[Dict[str, str]]:
+    wrapped = [JobRow(parse_rank_key(r.get("rank")), r) for r in rows]
+    wrapped.sort(key=lambda x: x.rank_key)
+    return [w.row for w in wrapped]
+
+
+def load_existing_processed_ranks(output_path: Path) -> set[str]:
+    if not output_path.exists():
+        return set()
+    with output_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        return {str((r.get("rank") or "").strip()) for r in reader if (r.get("rank") or "").strip()}
+
+
+def ensure_output_header(output_path: Path, fieldnames: List[str]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists() and output_path.stat().st_size > 0:
+        return
+    with output_path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+
+
+def rotate_if_incompatible_output(output_path: Path, expected_fieldnames: List[str], progress_path: Path) -> None:
+    """If output CSV header doesn't match expected schema, archive and restart fresh."""
+    if not output_path.exists() or output_path.stat().st_size == 0:
+        return
+
+    with output_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.reader(f)
+        try:
+            header = next(reader)
+        except StopIteration:
+            header = []
+
+    if header == expected_fieldnames:
+        return
+
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    bak_csv = output_path.with_suffix(output_path.suffix + f".bak-{stamp}")
+    output_path.replace(bak_csv)
+
+    bak_progress = None
+    if progress_path.exists():
+        bak_progress = progress_path.with_suffix(progress_path.suffix + f".bak-{stamp}")
+        progress_path.replace(bak_progress)
+
+    print("Detected incompatible existing output schema; archived old files:")
+    print(f"- CSV: {bak_csv}")
+    if bak_progress:
+        print(f"- Progress: {bak_progress}")
+
+
+def save_checkpoint(
+    path: Path,
+    *,
+    total_rows: int,
+    completed_rows: int,
+    remaining_rows: int,
+    last_rank: str,
+    last_url: str,
+    note: str,
+) -> None:
+    payload = {
+        "updatedAt": datetime.now().isoformat(timespec="seconds"),
+        "totalRows": total_rows,
+        "completedRows": completed_rows,
+        "remainingRows": remaining_rows,
+        "lastCompletedRank": last_rank,
+        "lastCompletedUrl": last_url,
+        "note": note,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def compact_text(text: str) -> str:
+    text = text.replace("\xa0", " ")
+    # Normalize repeated blank lines and excessive spaces.
+    text = re.sub(r"\r\n?", "\n", text)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def is_login_required(page, url: str) -> bool:
+    lowered_url = (url or "").lower()
+    if any(k in lowered_url for k in ["/authwall", "/login", "captcha", "checkpoint"]):
+        return True
+
+    body = page.locator("body")
+    body_text = body.inner_text(timeout=4000).lower() if body.count() else ""
+
+    login_signals = [
+        "sign in",
+        "join now",
+        "security verification",
+        "are you human",
+        "verify you are human",
+        "captcha",
+        "let's do a quick security check",
+        "to view full job details",
+        "login to view",
+    ]
+    if any(sig in body_text for sig in login_signals):
+        # Avoid false positive on pages that mention sign in in nav only by ensuring no article text exists.
+        has_article = page.locator("article").count() > 0
+        if not has_article:
+            return True
+    return False
+
+
+def click_show_more(page) -> None:
+    selectors = [
+        "button[aria-label*='see more' i]",
+        "button[aria-label*='show more' i]",
+        "button.show-more-less-html__button--more",
+        "button:has-text('Show more')",
+        "button:has-text('see more')",
+        "button:has-text('Read more')",
+    ]
+    for sel in selectors:
+        try:
+            btn = page.locator(sel).first
+            if btn.count() and btn.is_visible(timeout=1000):
+                btn.click(timeout=2000)
+                time.sleep(0.15)
+        except Exception:
+            continue
+
+
+def extract_description(page) -> str:
+    # Primary requirement: article element.
+    primary_selectors = [
+        "article",
+        "article.jobs-description",
+        "article.jobs-description__container",
+    ]
+    fallback_selectors = [
+        "div.jobs-description-content__text",
+        "div.show-more-less-html__markup",
+        "section.show-more-less-html",
+        "main",
+    ]
+
+    for sel in primary_selectors + fallback_selectors:
+        try:
+            loc = page.locator(sel).first
+            if not loc.count():
+                continue
+            text = loc.inner_text(timeout=4000)
+            text = compact_text(text)
+            if len(text) >= 80:
+                return text
+        except Exception:
+            continue
+
+    return "description_not_found"
+
+
+def scrape_one(page, url: str) -> str:
+    if not url:
+        return "missing_url"
+
+    try:
+        page.goto(url, wait_until="domcontentloaded", timeout=NAV_TIMEOUT_MS)
+        page.wait_for_timeout(900)
+
+        final_url = page.url
+        if is_login_required(page, final_url):
+            return "login_required"
+
+        click_show_more(page)
+        text = extract_description(page)
+        if text == "description_not_found" and is_login_required(page, final_url):
+            return "login_required"
+        return text
+
+    except PlaywrightTimeoutError:
+        # If timed out but page still partially rendered, try extraction.
+        try:
+            if is_login_required(page, page.url):
+                return "login_required"
+            click_show_more(page)
+            text = extract_description(page)
+            if text and text != "description_not_found":
+                return text
+        except Exception:
+            pass
+        return "timeout"
+    except Exception as e:
+        return f"error:{type(e).__name__}"
+
+
+def main() -> int:
+    if not SOURCE_CSV.exists():
+        print(f"ERROR: source file not found: {SOURCE_CSV}", file=sys.stderr)
+        return 1
+
+    src_fieldnames, rows = load_source_rows(SOURCE_CSV)
+    if not src_fieldnames:
+        print("ERROR: source CSV has no headers", file=sys.stderr)
+        return 1
+
+    ordered = sorted_rows(rows)
+    out_fields = list(src_fieldnames)
+    if "full_job_description" not in out_fields:
+        out_fields.append("full_job_description")
+
+    rotate_if_incompatible_output(OUTPUT_CSV, out_fields, PROGRESS_JSON)
+    ensure_output_header(OUTPUT_CSV, out_fields)
+    already_done = load_existing_processed_ranks(OUTPUT_CSV)
+
+    total = len(ordered)
+    pending = [r for r in ordered if (r.get("rank") or "").strip() not in already_done]
+
+    print(f"Total source rows: {total}")
+    print(f"Already in output: {len(already_done)}")
+    print(f"Pending scrape: {len(pending)}")
+
+    if not pending:
+        save_checkpoint(
+            PROGRESS_JSON,
+            total_rows=total,
+            completed_rows=total,
+            remaining_rows=0,
+            last_rank="",
+            last_url="",
+            note="No pending rows. Output already complete.",
+        )
+        print("Nothing to do. Output already complete.")
+        return 0
+
+    completed_now = 0
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            viewport={"width": 1440, "height": 900},
+            user_agent=(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/124.0.0.0 Safari/537.36"
+            ),
+            locale="en-US",
+        )
+        page = context.new_page()
+
+        with OUTPUT_CSV.open("a", encoding="utf-8", newline="") as out_f:
+            writer = csv.DictWriter(out_f, fieldnames=out_fields)
+
+            for idx, row in enumerate(pending, start=1):
+                rank = (row.get("rank") or "").strip()
+                url = (row.get("linkedinJobUrl") or "").strip()
+
+                desc = scrape_one(page, url)
+
+                out_row = dict(row)
+                out_row["full_job_description"] = desc
+                writer.writerow(out_row)
+                out_f.flush()
+
+                completed_now += 1
+                completed_total = len(already_done) + completed_now
+                remaining = total - completed_total
+
+                print(
+                    f"[{completed_total}/{total}] rank={rank} "
+                    f"status={'OK' if desc not in {'login_required','timeout','description_not_found'} and not desc.startswith('error:') else desc}"
+                )
+
+                if completed_total % CHECKPOINT_EVERY == 0:
+                    save_checkpoint(
+                        PROGRESS_JSON,
+                        total_rows=total,
+                        completed_rows=completed_total,
+                        remaining_rows=remaining,
+                        last_rank=rank,
+                        last_url=url,
+                        note="Periodic checkpoint",
+                    )
+
+                time.sleep(SLEEP_SECONDS)
+
+        context.close()
+        browser.close()
+
+    save_checkpoint(
+        PROGRESS_JSON,
+        total_rows=total,
+        completed_rows=total,
+        remaining_rows=0,
+        last_rank=(ordered[-1].get("rank") or "").strip() if ordered else "",
+        last_url=(ordered[-1].get("linkedinJobUrl") or "").strip() if ordered else "",
+        note="Scrape finished",
+    )
+
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   pickLastDeliverablePayload,
   pickLastNonEmptyTextFromPayloads,
   pickSummaryFromPayloads,
+  resolveCronPayloadOutcome,
 } from "./helpers.js";
 
 describe("pickSummaryFromPayloads", () => {
@@ -83,6 +84,32 @@ describe("pickLastDeliverablePayload", () => {
     const normal = { text: "ok", isError: undefined };
     const error = { text: "bad", isError: true as const };
     expect(pickLastDeliverablePayload([normal, error])).toBe(normal);
+  });
+});
+
+describe("resolveCronPayloadOutcome", () => {
+  it("treats a later non-error payload as recovery even when runLevelError is present", () => {
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "⚠️ ✉️ Message failed", isError: true },
+        { text: "Reminder delivered to the user." },
+      ],
+      runLevelError: new Error("message tool failed"),
+    });
+
+    expect(outcome.hasFatalErrorPayload).toBe(false);
+    expect(outcome.embeddedRunError).toBeUndefined();
+    expect(outcome.summary).toBe("Reminder delivered to the user.");
+  });
+
+  it("keeps error payload fatal when no successful payload follows", () => {
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [{ text: "⚠️ ✉️ Message failed", isError: true }],
+      runLevelError: new Error("message tool failed"),
+    });
+
+    expect(outcome.hasFatalErrorPayload).toBe(true);
+    expect(outcome.embeddedRunError).toBe("⚠️ ✉️ Message failed");
   });
 });
 

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -130,8 +130,10 @@ export function resolveCronPayloadOutcome(params: {
   const lastErrorPayloadIndex = params.payloads.findLastIndex(
     (payload) => payload?.isError === true,
   );
+  // Treat a later non-error payload as recovery, even when the runner surfaces
+  // a run-level error. Tool-level warnings can populate meta.error while the
+  // model still returns a successful final payload.
   const hasSuccessfulPayloadAfterLastError =
-    !params.runLevelError &&
     lastErrorPayloadIndex >= 0 &&
     params.payloads
       .slice(lastErrorPayloadIndex + 1)


### PR DESCRIPTION
## Summary
- treat a later non-error payload as recovery even when run-level metadata contains an error
- prevent cron isolated runs from being marked `status=error` when an earlier tool error is followed by successful final output
- add regression tests for recovered vs unrecovered error payload sequences

## Why
Jade reminder jobs were reporting `deliveryStatus=delivered` while incrementing `consecutiveErrors` due to `⚠️ ✉️ Message failed` payloads that were followed by successful output.

## Validation
- `pnpm --dir /Users/raylim/openclaw exec vitest src/cron/isolated-agent/helpers.test.ts`
- `pnpm --dir /Users/raylim/openclaw exec vitest src/cron/isolated-agent/run.message-tool-policy.test.ts`
