### PR TITLE
fix(whatsapp): add outbound guard for group allowlist policy

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
@@ -445,8 +445,6 @@ describe("web processMessage inbound context", () => {
   });
 
   it("blocks outbound replies to non-allowlisted groups (defense in depth)", async () => {
-    deliverWebReplyMock.mockClear();
-
     await processMessage(
       makeProcessMessageArgs({
         routeSessionKey: "agent:main:whatsapp:group:123@g.us",
@@ -483,7 +481,7 @@ describe("web processMessage inbound context", () => {
       | undefined;
     expect(deliver).toBeTypeOf("function");
 
-    await deliver?.({ text: "should be blocked" }, { kind: "final" });
+    await deliver!({ text: "should be blocked" }, { kind: "final" });
     expect(deliverWebReplyMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.inbound-context.test.ts
@@ -443,4 +443,47 @@ describe("web processMessage inbound context", () => {
 
     expect(updateLastRouteMock).toHaveBeenCalledTimes(1);
   });
+
+  it("blocks outbound replies to non-allowlisted groups (defense in depth)", async () => {
+    deliverWebReplyMock.mockClear();
+
+    await processMessage(
+      makeProcessMessageArgs({
+        routeSessionKey: "agent:main:whatsapp:group:123@g.us",
+        groupHistoryKey: "whatsapp:default:group:123@g.us",
+        cfg: {
+          channels: {
+            whatsapp: {
+              groupPolicy: "allowlist",
+            },
+          },
+          messages: {},
+          session: { store: sessionStorePath },
+        } as unknown as ReturnType<typeof import("../../../../../src/config/config.js").loadConfig>,
+        msg: {
+          id: "g-blocked-1",
+          from: "123@g.us",
+          conversationId: "123@g.us",
+          to: "+2000",
+          chatType: "group",
+          body: "hello",
+          senderName: "Alice",
+          senderE164: "+111",
+          selfE164: "+999",
+          sendComposing: async () => {},
+          reply: async () => {},
+          sendMedia: async () => {},
+        },
+      }),
+    );
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const deliver = (capturedDispatchParams as any)?.dispatcherOptions?.deliver as
+      | ((payload: { text?: string }, info: { kind: "final" }) => Promise<void>)
+      | undefined;
+    expect(deliver).toBeTypeOf("function");
+
+    await deliver?.({ text: "should be blocked" }, { kind: "final" });
+    expect(deliverWebReplyMock).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -40,6 +40,7 @@ import { whatsappInboundLog, whatsappOutboundLog } from "../loggers.js";
 import type { WebInboundMsg } from "../types.js";
 import { elide } from "../util.js";
 import { maybeSendAckReaction } from "./ack-reaction.js";
+import { resolveGroupPolicyFor } from "./group-activation.js";
 import { formatGroupMembers } from "./group-members.js";
 import { trackBackgroundTask, updateLastRouteInBackground } from "./last-route.js";
 import { buildInboundLine } from "./message-line.js";
@@ -411,6 +412,19 @@ export async function processMessage(params: {
           // web UI only; sending them here leaks chain-of-thought to end users.
           return;
         }
+
+        // Outbound guard: refuse to send to non-allowlisted groups even if inbound
+        // gating was bypassed (defense in depth against race conditions or batching).
+        if (params.msg.chatType === "group") {
+          const groupPolicy = resolveGroupPolicyFor(params.cfg, conversationId);
+          if (groupPolicy.allowlistEnabled && !groupPolicy.allowed) {
+            whatsappOutboundLog.warn(
+              `Blocked outbound reply to non-allowlisted group ${conversationId}`,
+            );
+            return;
+          }
+        }
+
         await deliverWebReply({
           replyResult: payload,
           msg: params.msg,


### PR DESCRIPTION
## Summary

Fixes #52763

Adds an outbound guard that refuses to send replies to groups that are not in the allowlist, even if the message somehow passed inbound gating.

This is a defense-in-depth measure against race conditions or batching issues that might bypass the inbound group policy check in `applyGroupGating`.

## Changes

- Added outbound group policy check in `deliver` callback (`process-message.ts`)
- Logs a warning when a reply is blocked
- Added test coverage for the new guard

## Root cause analysis

The bug reported in #52763 shows that with `groupPolicy: "allowlist"` and no groups allowlisted:
1. Group messages were logged in `applyGroupGating` as "group mention debug" with correct gating
2. After multiple messages, one message was forwarded to the agent (possible race/batching issue)
3. The agent replied TO the group despite the policy

The inbound gating in `applyGroupGating` correctly returns `{ shouldProcess: false }`, but this fix adds a second check at delivery time as insurance.

## Test plan

- [x] Added test `blocks outbound replies to non-allowlisted groups (defense in depth)`
- [ ] CI checks pass

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
