### PR TITLE
fix(slack): bypass mention gate for app_mention events

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -487,7 +487,13 @@ export async function prepareSlackMessage(params: {
     commandAuthorized,
   });
   const effectiveWasMentioned = mentionGate.effectiveWasMentioned;
-  if (isRoom && shouldRequireMention && mentionGate.shouldSkip) {
+  // When the event source is "app_mention", Slack has already confirmed this bot
+  // was explicitly mentioned. Skip the mention gate — the text-based detection in
+  // mentionGate can fail due to dedup race conditions (message event arrives before
+  // app_mention, sets dedup key, then app_mention is either deduped or the text-based
+  // mention check fails because the message was already processed without wasMentioned).
+  // See: https://github.com/openclaw/openclaw/issues/34833
+  if (isRoom && shouldRequireMention && mentionGate.shouldSkip && opts.source !== "app_mention") {
     ctx.logger.info({ channel: message.channel, reason: "no-mention" }, "skipping channel message");
     const pendingText = (message.text ?? "").trim();
     const fallbackFile = message.files?.[0]?.name


### PR DESCRIPTION
## Summary

When `requireMention: true` is set, `app_mention` events from Slack are incorrectly dropped by the mention gate in `prepareSlackMessage`. This causes ~50-100% of @mentions in channels to be silently ignored in multi-bot setups.

## Root Cause

The mention gate at `prepare.ts:490` checks `mentionGate.shouldSkip` without considering the event source. When `opts.source === "app_mention"`, Slack has already confirmed the bot was explicitly mentioned -- the text-based mention detection is redundant and can fail due to:

1. Dedup race condition (#34833): `message` event arrives first, sets dedup key, `app_mention` passes dedup via retry but still hits the mention gate
2. In multi-bot setups, each bot's `message` handler processes the event independently -- the mention text check can intermittently fail depending on timing

## Fix

Skip the mention gate when `opts.source === "app_mention"`. Slack's `app_mention` event is only delivered to the mentioned bot's app, so the mention is already confirmed at the platform level.

## Testing

- 11-bot multi-agent setup with `requireMention: true`
- Before fix: 100% of channel @mentions silently dropped with `reason: "no-mention"`
- After fix: @mentions route correctly to the mentioned bot's agent only
- DMs unaffected (mention gate is already bypassed for non-room messages)
- Thread replies unaffected (implicit mention logic unchanged)

Fixes #34833