### PR TITLE
fix: include scripts/ in npm package files to fix ui:build after update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
-Current files: ['CHANGELOG.md', 'LICENSE', 'openclaw.mjs', 'README-header.png', 'README.md', 'assets/', 'dist/', 'docs/', '!docs/.generated/**', '!docs/.i18n/zh-CN.tm.jsonl', 'skills/']
-Updated files: ['CHANGELOG.md', 'LICENSE', 'openclaw.mjs', 'README-header.png', 'README.md', 'assets/', 'dist/', 'docs/', '!docs/.generated/**', '!docs/.i18n/zh-CN.tm.jsonl', 'skills/', 'scripts/']
+{
 {
   "name": "openclaw",
   "version": "2026.3.23",

--- a/package.json
+++ b/package.json
@@ -1,3 +1,5 @@
+Current files: ['CHANGELOG.md', 'LICENSE', 'openclaw.mjs', 'README-header.png', 'README.md', 'assets/', 'dist/', 'docs/', '!docs/.generated/**', '!docs/.i18n/zh-CN.tm.jsonl', 'skills/']
+Updated files: ['CHANGELOG.md', 'LICENSE', 'openclaw.mjs', 'README-header.png', 'README.md', 'assets/', 'dist/', 'docs/', '!docs/.generated/**', '!docs/.i18n/zh-CN.tm.jsonl', 'skills/', 'scripts/']
 {
   "name": "openclaw",
   "version": "2026.3.23",
@@ -31,7 +33,8 @@
     "docs/",
     "!docs/.generated/**",
     "!docs/.i18n/zh-CN.tm.jsonl",
-    "skills/"
+    "skills/",
+    "scripts/"
   ],
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Problem
After `openclaw update`, running `pnpm ui:build` fails with:
`Error: Cannot find module 'scripts/ui.js'`

## Root Cause  
The `prepack` script runs `node scripts/ui.js build`, but `scripts/` is not in the `files` field, so it's excluded from the npm package.

## Solution
Add `"scripts/"` to the `files` array in `package.json`.