### PR TITLE
docs: Add LobsterMail to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -53,11 +53,11 @@ first-class messaging surface. Send and receive email through the standard
 `message` tool, with webhook-based inbound delivery, HMAC signature
 verification, and LLM-safe content formatting.
 
-- **npm:** `@lobsterkit/lobstermail`
+- **npm:** `lobstermail`
 - **repo:** [github.com/lobster-kit/lobsterkit-mail](https://github.com/lobster-kit/lobsterkit-mail)
 
 ```bash
-openclaw plugins install @lobsterkit/lobstermail
+openclaw plugins install lobstermail
 ```
 
 ### Lossless Claw (LCM)

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -46,6 +46,20 @@ file messages via any DingTalk client.
 openclaw plugins install @largezhou/ddingtalk
 ```
 
+### LobsterMail
+
+Email channel plugin for OpenClaw — gives your agent a real email address as a
+first-class messaging surface. Send and receive email through the standard
+`message` tool, with webhook-based inbound delivery, HMAC signature
+verification, and LLM-safe content formatting.
+
+- **npm:** `@lobsterkit/lobstermail`
+- **repo:** [github.com/lobster-kit/lobsterkit-mail](https://github.com/lobster-kit/lobsterkit-mail)
+
+```bash
+openclaw plugins install @lobsterkit/lobstermail
+```
+
 ### Lossless Claw (LCM)
 
 Lossless Context Management plugin for OpenClaw. DAG-based conversation


### PR DESCRIPTION
## Plugin: LobsterMail

**Email channel plugin for OpenClaw** — gives agents a real email address as a first-class messaging surface.

| | |
|---|---|
| **npm** | `@lobsterkit/lobstermail` |
| **repo** | [lobster-kit/lobsterkit-mail](https://github.com/lobster-kit/lobsterkit-mail) |
| **install** | `openclaw plugins install @lobsterkit/lobstermail` |

### What it does

- Agents send/receive email through the standard `message` tool
- Webhook-based inbound delivery with HMAC-SHA256 signature verification
- LLM-safe content formatting (boundary markers to prevent prompt injection)
- DM security with configurable allowlists
- Built on [lobstermail.ai](https://lobstermail.ai) — email infrastructure for AI agents

### Checklist

- [x] Published on npm (`@lobsterkit/lobstermail` v1.7.0+)
- [x] Public GitHub repo with docs and issue tracker
- [x] OpenClaw plugin manifest (`openclaw.plugin.json`)
- [x] Active maintenance (last published March 2026)