### PR TITLE
Agents: allow skill-declared env keys in sandboxes

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -79,8 +79,6 @@ import { detectRuntimeShell } from "../shell-utils.js";
 import {
   applySkillEnvOverridesFromSnapshotWithResult,
   applySkillEnvOverridesWithResult,
-  collectAllowedSensitiveKeysFromSkillEntries,
-  collectAllowedSensitiveKeysFromSkillSnapshot,
   resolveSkillsPromptForRun,
   type SkillSnapshot,
 } from "../skills.js";
@@ -104,7 +102,11 @@ import { buildModelAliasLines, resolveModelAsync } from "./model.js";
 import { buildEmbeddedSandboxInfo } from "./sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
 import { truncateSessionAfterCompaction } from "./session-truncation.js";
-import { resolveEmbeddedRunSkillEntries, syncCurrentSkillEnvToSandbox } from "./skills-runtime.js";
+import {
+  resolveEmbeddedRunAllowedSensitiveKeys,
+  resolveEmbeddedRunSkillEntries,
+  syncCurrentSkillEnvToSandbox,
+} from "./skills-runtime.js";
 import {
   applySystemPromptOverrideToSession,
   buildEmbeddedSystemPrompt,
@@ -725,14 +727,11 @@ export async function compactEmbeddedPiSessionDirect(
 
   await fs.mkdir(resolvedWorkspace, { recursive: true });
 
-  const allowedSensitiveKeys = params.skillsSnapshot
-    ? collectAllowedSensitiveKeysFromSkillSnapshot(params.skillsSnapshot)
-    : collectAllowedSensitiveKeysFromSkillEntries(
-        resolveEmbeddedRunSkillEntries({
-          workspaceDir: resolvedWorkspace,
-          config: params.config,
-        }).skillEntries,
-      );
+  const allowedSensitiveKeys = resolveEmbeddedRunAllowedSensitiveKeys({
+    workspaceDir: resolvedWorkspace,
+    config: params.config,
+    skillsSnapshot: params.skillsSnapshot,
+  });
 
   const sandboxSessionKey = params.sessionKey?.trim() || params.sessionId;
   const sandbox = await resolveSandboxContext({

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -104,7 +104,7 @@ import { buildModelAliasLines, resolveModelAsync } from "./model.js";
 import { buildEmbeddedSandboxInfo } from "./sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
 import { truncateSessionAfterCompaction } from "./session-truncation.js";
-import { resolveEmbeddedRunSkillEntries } from "./skills-runtime.js";
+import { resolveEmbeddedRunSkillEntries, syncCurrentSkillEnvToSandbox } from "./skills-runtime.js";
 import {
   applySystemPromptOverrideToSession,
   buildEmbeddedSystemPrompt,
@@ -769,6 +769,10 @@ export async function compactEmbeddedPiSessionDirect(
           skills: skillEntries ?? [],
           config: params.config,
         });
+    syncCurrentSkillEnvToSandbox({
+      sandbox,
+      envKeys: allowedSensitiveKeys,
+    });
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -79,6 +79,8 @@ import { detectRuntimeShell } from "../shell-utils.js";
 import {
   applySkillEnvOverrides,
   applySkillEnvOverridesFromSnapshot,
+  collectAllowedSensitiveKeysFromSkillEntries,
+  collectAllowedSensitiveKeysFromSkillSnapshot,
   resolveSkillsPromptForRun,
   type SkillSnapshot,
 } from "../skills.js";
@@ -722,11 +724,22 @@ export async function compactEmbeddedPiSessionDirect(
   }
 
   await fs.mkdir(resolvedWorkspace, { recursive: true });
+
+  const allowedSensitiveKeys = params.skillsSnapshot
+    ? collectAllowedSensitiveKeysFromSkillSnapshot(params.skillsSnapshot)
+    : collectAllowedSensitiveKeysFromSkillEntries(
+        resolveEmbeddedRunSkillEntries({
+          workspaceDir: resolvedWorkspace,
+          config: params.config,
+        }).skillEntries,
+      );
+
   const sandboxSessionKey = params.sessionKey?.trim() || params.sessionId;
   const sandbox = await resolveSandboxContext({
     config: params.config,
     sessionKey: sandboxSessionKey,
     workspaceDir: resolvedWorkspace,
+    allowedSensitiveKeys,
   });
   const effectiveWorkspace = sandbox?.enabled
     ? sandbox.workspaceAccess === "rw"

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -77,8 +77,8 @@ import {
 } from "../session-write-lock.js";
 import { detectRuntimeShell } from "../shell-utils.js";
 import {
-  applySkillEnvOverrides,
-  applySkillEnvOverridesFromSnapshot,
+  applySkillEnvOverridesFromSnapshotWithResult,
+  applySkillEnvOverridesWithResult,
   collectAllowedSensitiveKeysFromSkillEntries,
   collectAllowedSensitiveKeysFromSkillSnapshot,
   resolveSkillsPromptForRun,
@@ -760,18 +760,19 @@ export async function compactEmbeddedPiSessionDirect(
       config: params.config,
       skillsSnapshot: params.skillsSnapshot,
     });
-    restoreSkillEnv = params.skillsSnapshot
-      ? applySkillEnvOverridesFromSnapshot({
+    const skillEnvOverrides = params.skillsSnapshot
+      ? applySkillEnvOverridesFromSnapshotWithResult({
           snapshot: params.skillsSnapshot,
           config: params.config,
         })
-      : applySkillEnvOverrides({
+      : applySkillEnvOverridesWithResult({
           skills: skillEntries ?? [],
           config: params.config,
         });
+    restoreSkillEnv = skillEnvOverrides.restore;
     syncCurrentSkillEnvToSandbox({
       sandbox,
-      envKeys: allowedSensitiveKeys,
+      envKeys: skillEnvOverrides.injectedKeys,
     });
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -91,8 +91,6 @@ import { detectRuntimeShell } from "../../shell-utils.js";
 import {
   applySkillEnvOverridesFromSnapshotWithResult,
   applySkillEnvOverridesWithResult,
-  collectAllowedSensitiveKeysFromSkillEntries,
-  collectAllowedSensitiveKeysFromSkillSnapshot,
   resolveSkillsPromptForRun,
 } from "../../skills.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
@@ -129,7 +127,11 @@ import {
 import { buildEmbeddedSandboxInfo } from "../sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
 import { prepareSessionManagerForRun } from "../session-manager-init.js";
-import { resolveEmbeddedRunSkillEntries, syncCurrentSkillEnvToSandbox } from "../skills-runtime.js";
+import {
+  resolveEmbeddedRunAllowedSensitiveKeys,
+  resolveEmbeddedRunSkillEntries,
+  syncCurrentSkillEnvToSandbox,
+} from "../skills-runtime.js";
 import {
   applySystemPromptOverrideToSession,
   buildEmbeddedSystemPrompt,
@@ -1678,17 +1680,13 @@ export async function runEmbeddedAttempt(
   await fs.mkdir(resolvedWorkspace, { recursive: true });
 
   // Collect skill-declared env var names before sandbox creation so they can
-  // bypass the default block list during container creation.  For the snapshot
-  // path we read metadata directly; for the non-snapshot fallback we resolve
-  // skill entries early from the host workspace (lightweight sync call).
-  const allowedSensitiveKeys = params.skillsSnapshot
-    ? collectAllowedSensitiveKeysFromSkillSnapshot(params.skillsSnapshot)
-    : collectAllowedSensitiveKeysFromSkillEntries(
-        resolveEmbeddedRunSkillEntries({
-          workspaceDir: resolvedWorkspace,
-          config: params.config,
-        }).skillEntries,
-      );
+  // bypass the default block list during container creation. On the non-snapshot
+  // path, only eligible skills should widen the sandbox allowlist.
+  const allowedSensitiveKeys = resolveEmbeddedRunAllowedSensitiveKeys({
+    workspaceDir: resolvedWorkspace,
+    config: params.config,
+    skillsSnapshot: params.skillsSnapshot,
+  });
 
   const sandboxSessionKey = params.sessionKey?.trim() || params.sessionId;
   const sandbox = await resolveSandboxContext({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -89,8 +89,8 @@ import {
 } from "../../session-write-lock.js";
 import { detectRuntimeShell } from "../../shell-utils.js";
 import {
-  applySkillEnvOverrides,
-  applySkillEnvOverridesFromSnapshot,
+  applySkillEnvOverridesFromSnapshotWithResult,
+  applySkillEnvOverridesWithResult,
   collectAllowedSensitiveKeysFromSkillEntries,
   collectAllowedSensitiveKeysFromSkillSnapshot,
   resolveSkillsPromptForRun,
@@ -1711,18 +1711,19 @@ export async function runEmbeddedAttempt(
       config: params.config,
       skillsSnapshot: params.skillsSnapshot,
     });
-    restoreSkillEnv = params.skillsSnapshot
-      ? applySkillEnvOverridesFromSnapshot({
+    const skillEnvOverrides = params.skillsSnapshot
+      ? applySkillEnvOverridesFromSnapshotWithResult({
           snapshot: params.skillsSnapshot,
           config: params.config,
         })
-      : applySkillEnvOverrides({
+      : applySkillEnvOverridesWithResult({
           skills: skillEntries ?? [],
           config: params.config,
         });
+    restoreSkillEnv = skillEnvOverrides.restore;
     syncCurrentSkillEnvToSandbox({
       sandbox,
-      envKeys: allowedSensitiveKeys,
+      envKeys: skillEnvOverrides.injectedKeys,
     });
 
     const skillsPrompt = resolveSkillsPromptForRun({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -129,7 +129,7 @@ import {
 import { buildEmbeddedSandboxInfo } from "../sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
 import { prepareSessionManagerForRun } from "../session-manager-init.js";
-import { resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
+import { resolveEmbeddedRunSkillEntries, syncCurrentSkillEnvToSandbox } from "../skills-runtime.js";
 import {
   applySystemPromptOverrideToSession,
   buildEmbeddedSystemPrompt,
@@ -1720,6 +1720,10 @@ export async function runEmbeddedAttempt(
           skills: skillEntries ?? [],
           config: params.config,
         });
+    syncCurrentSkillEnvToSandbox({
+      sandbox,
+      envKeys: allowedSensitiveKeys,
+    });
 
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -91,6 +91,8 @@ import { detectRuntimeShell } from "../../shell-utils.js";
 import {
   applySkillEnvOverrides,
   applySkillEnvOverridesFromSnapshot,
+  collectAllowedSensitiveKeysFromSkillEntries,
+  collectAllowedSensitiveKeysFromSkillSnapshot,
   resolveSkillsPromptForRun,
 } from "../../skills.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
@@ -1675,11 +1677,25 @@ export async function runEmbeddedAttempt(
 
   await fs.mkdir(resolvedWorkspace, { recursive: true });
 
+  // Collect skill-declared env var names before sandbox creation so they can
+  // bypass the default block list during container creation.  For the snapshot
+  // path we read metadata directly; for the non-snapshot fallback we resolve
+  // skill entries early from the host workspace (lightweight sync call).
+  const allowedSensitiveKeys = params.skillsSnapshot
+    ? collectAllowedSensitiveKeysFromSkillSnapshot(params.skillsSnapshot)
+    : collectAllowedSensitiveKeysFromSkillEntries(
+        resolveEmbeddedRunSkillEntries({
+          workspaceDir: resolvedWorkspace,
+          config: params.config,
+        }).skillEntries,
+      );
+
   const sandboxSessionKey = params.sessionKey?.trim() || params.sessionId;
   const sandbox = await resolveSandboxContext({
     config: params.config,
     sessionKey: sandboxSessionKey,
     workspaceDir: resolvedWorkspace,
+    allowedSensitiveKeys,
   });
   const effectiveWorkspace = sandbox?.enabled
     ? sandbox.workspaceAccess === "rw"

--- a/src/agents/pi-embedded-runner/skills-runtime.test.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.test.ts
@@ -5,17 +5,23 @@ import {
   type OpenClawConfig,
 } from "../../config/config.js";
 import * as skillsModule from "../skills.js";
-import type { SkillSnapshot } from "../skills.js";
-const { resolveEmbeddedRunSkillEntries, syncCurrentSkillEnvToSandbox } =
-  await import("./skills-runtime.js");
+import type { SkillEntry, SkillSnapshot } from "../skills.js";
+const {
+  resolveEmbeddedRunAllowedSensitiveKeys,
+  resolveEmbeddedRunSkillEntries,
+  syncCurrentSkillEnvToSandbox,
+} = await import("./skills-runtime.js");
 
 describe("resolveEmbeddedRunSkillEntries", () => {
   const loadWorkspaceSkillEntriesSpy = vi.spyOn(skillsModule, "loadWorkspaceSkillEntries");
+  const filterWorkspaceSkillEntriesSpy = vi.spyOn(skillsModule, "filterWorkspaceSkillEntries");
 
   beforeEach(() => {
     clearRuntimeConfigSnapshot();
     loadWorkspaceSkillEntriesSpy.mockReset();
     loadWorkspaceSkillEntriesSpy.mockReturnValue([]);
+    filterWorkspaceSkillEntriesSpy.mockReset();
+    filterWorkspaceSkillEntriesSpy.mockImplementation((entries) => entries);
   });
 
   it("loads skill entries with config when no resolved snapshot skills exist", () => {
@@ -98,6 +104,51 @@ describe("resolveEmbeddedRunSkillEntries", () => {
       skillEntries: [],
     });
     expect(loadWorkspaceSkillEntriesSpy).not.toHaveBeenCalled();
+  });
+
+  it("derives allowed sensitive keys from eligible workspace skills on the fallback path", () => {
+    const rawEntries = [
+      {
+        skill: { name: "active", source: "workspace", baseDir: "/skills/active", filePath: "" },
+        metadata: { primaryEnv: "OPENAI_API_KEY" },
+      },
+      {
+        skill: { name: "disabled", source: "workspace", baseDir: "/skills/disabled", filePath: "" },
+        metadata: { primaryEnv: "GITHUB_TOKEN" },
+      },
+    ] as SkillEntry[];
+    loadWorkspaceSkillEntriesSpy.mockReturnValue(rawEntries);
+    filterWorkspaceSkillEntriesSpy.mockReturnValue([rawEntries[0]]);
+
+    const allowedSensitiveKeys = resolveEmbeddedRunAllowedSensitiveKeys({
+      workspaceDir: "/tmp/workspace",
+      config: {},
+      skillsSnapshot: {
+        prompt: "skills prompt",
+        skills: [{ name: "snapshot-only", primaryEnv: "SHOULD_NOT_BE_USED" }],
+      },
+    });
+
+    expect(filterWorkspaceSkillEntriesSpy).toHaveBeenCalledWith(rawEntries, {});
+    expect(allowedSensitiveKeys).toEqual(new Set(["OPENAI_API_KEY"]));
+  });
+
+  it("uses the snapshot allowlist when resolved snapshot skills are present", () => {
+    const snapshot: SkillSnapshot = {
+      prompt: "skills prompt",
+      skills: [{ name: "snapshot-skill", primaryEnv: "OPENAI_API_KEY" }],
+      resolvedSkills: [],
+    };
+
+    const allowedSensitiveKeys = resolveEmbeddedRunAllowedSensitiveKeys({
+      workspaceDir: "/tmp/workspace",
+      config: {},
+      skillsSnapshot: snapshot,
+    });
+
+    expect(loadWorkspaceSkillEntriesSpy).not.toHaveBeenCalled();
+    expect(filterWorkspaceSkillEntriesSpy).not.toHaveBeenCalled();
+    expect(allowedSensitiveKeys).toEqual(new Set(["OPENAI_API_KEY"]));
   });
 
   it("syncs current skill env values into sandbox exec env", () => {

--- a/src/agents/pi-embedded-runner/skills-runtime.test.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.test.ts
@@ -123,4 +123,29 @@ describe("resolveEmbeddedRunSkillEntries", () => {
       OPENAI_API_KEY: "sk-test",
     });
   });
+
+  it("does not sync always-blocked skill env keys into sandbox exec env", () => {
+    const sandbox = {
+      docker: { env: { LANG: "C.UTF-8" } },
+      backend: { env: { LANG: "C.UTF-8" } },
+    };
+
+    syncCurrentSkillEnvToSandbox({
+      sandbox,
+      envKeys: new Set(["OPENAI_API_KEY", "OPENCLAW_GATEWAY_TOKEN"]),
+      env: {
+        OPENAI_API_KEY: "sk-test",
+        OPENCLAW_GATEWAY_TOKEN: "gw-token",
+      },
+    });
+
+    expect(sandbox.docker.env).toEqual({
+      LANG: "C.UTF-8",
+      OPENAI_API_KEY: "sk-test",
+    });
+    expect(sandbox.backend.env).toEqual({
+      LANG: "C.UTF-8",
+      OPENAI_API_KEY: "sk-test",
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/skills-runtime.test.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.test.ts
@@ -6,8 +6,8 @@ import {
 } from "../../config/config.js";
 import * as skillsModule from "../skills.js";
 import type { SkillSnapshot } from "../skills.js";
-
-const { resolveEmbeddedRunSkillEntries } = await import("./skills-runtime.js");
+const { resolveEmbeddedRunSkillEntries, syncCurrentSkillEnvToSandbox } =
+  await import("./skills-runtime.js");
 
 describe("resolveEmbeddedRunSkillEntries", () => {
   const loadWorkspaceSkillEntriesSpy = vi.spyOn(skillsModule, "loadWorkspaceSkillEntries");
@@ -98,5 +98,29 @@ describe("resolveEmbeddedRunSkillEntries", () => {
       skillEntries: [],
     });
     expect(loadWorkspaceSkillEntriesSpy).not.toHaveBeenCalled();
+  });
+
+  it("syncs current skill env values into sandbox exec env", () => {
+    const sandbox = {
+      docker: { env: { LANG: "C.UTF-8" } },
+      backend: { env: { LANG: "C.UTF-8" } },
+    };
+
+    syncCurrentSkillEnvToSandbox({
+      sandbox,
+      envKeys: new Set(["OPENAI_API_KEY", "MISSING_KEY"]),
+      env: {
+        OPENAI_API_KEY: "sk-test",
+      },
+    });
+
+    expect(sandbox.docker.env).toEqual({
+      LANG: "C.UTF-8",
+      OPENAI_API_KEY: "sk-test",
+    });
+    expect(sandbox.backend.env).toEqual({
+      LANG: "C.UTF-8",
+      OPENAI_API_KEY: "sk-test",
+    });
   });
 });

--- a/src/agents/pi-embedded-runner/skills-runtime.test.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.test.ts
@@ -148,4 +148,26 @@ describe("resolveEmbeddedRunSkillEntries", () => {
       OPENAI_API_KEY: "sk-test",
     });
   });
+
+  it("does not sync null-byte env values into sandbox exec env", () => {
+    const sandbox = {
+      docker: { env: { LANG: "C.UTF-8" } },
+      backend: { env: { LANG: "C.UTF-8" } },
+    };
+
+    syncCurrentSkillEnvToSandbox({
+      sandbox,
+      envKeys: new Set(["OPENAI_API_KEY"]),
+      env: {
+        OPENAI_API_KEY: "sk-test\0bad",
+      },
+    });
+
+    expect(sandbox.docker.env).toEqual({
+      LANG: "C.UTF-8",
+    });
+    expect(sandbox.backend.env).toEqual({
+      LANG: "C.UTF-8",
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -1,5 +1,12 @@
 import type { OpenClawConfig } from "../../config/config.js";
-import { loadWorkspaceSkillEntries, type SkillEntry, type SkillSnapshot } from "../skills.js";
+import {
+  collectAllowedSensitiveKeysFromSkillEntries,
+  collectAllowedSensitiveKeysFromSkillSnapshot,
+  filterWorkspaceSkillEntries,
+  loadWorkspaceSkillEntries,
+  type SkillEntry,
+  type SkillSnapshot,
+} from "../skills.js";
 import { isAlwaysBlockedSkillEnvKey } from "../skills/env-overrides.js";
 import { resolveSkillRuntimeConfig } from "../skills/runtime-config.js";
 
@@ -24,6 +31,21 @@ export function resolveEmbeddedRunSkillEntries(params: {
       ? loadWorkspaceSkillEntries(params.workspaceDir, { config })
       : [],
   };
+}
+
+export function resolveEmbeddedRunAllowedSensitiveKeys(params: {
+  workspaceDir: string;
+  config?: OpenClawConfig;
+  skillsSnapshot?: SkillSnapshot;
+}): ReadonlySet<string> | undefined {
+  const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries(params);
+  if (!shouldLoadSkillEntries) {
+    return collectAllowedSensitiveKeysFromSkillSnapshot(params.skillsSnapshot);
+  }
+
+  const config = resolveSkillRuntimeConfig(params.config);
+  const eligibleSkillEntries = filterWorkspaceSkillEntries(skillEntries, config);
+  return collectAllowedSensitiveKeysFromSkillEntries(eligibleSkillEntries);
 }
 
 export function syncCurrentSkillEnvToSandbox(params: {

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -2,6 +2,11 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { loadWorkspaceSkillEntries, type SkillEntry, type SkillSnapshot } from "../skills.js";
 import { resolveSkillRuntimeConfig } from "../skills/runtime-config.js";
 
+export type SandboxSkillEnvTarget = {
+  docker: { env?: Record<string, string> };
+  backend?: { env?: Record<string, string> };
+};
+
 export function resolveEmbeddedRunSkillEntries(params: {
   workspaceDir: string;
   config?: OpenClawConfig;
@@ -18,4 +23,37 @@ export function resolveEmbeddedRunSkillEntries(params: {
       ? loadWorkspaceSkillEntries(params.workspaceDir, { config })
       : [],
   };
+}
+
+export function syncCurrentSkillEnvToSandbox(params: {
+  sandbox?: SandboxSkillEnvTarget | null;
+  envKeys?: ReadonlySet<string>;
+  env?: NodeJS.ProcessEnv;
+}) {
+  if (!params.sandbox || !params.envKeys || params.envKeys.size === 0) {
+    return;
+  }
+
+  const envSource = params.env ?? process.env;
+  const skillEnv: Record<string, string> = {};
+  for (const key of params.envKeys) {
+    const value = envSource[key];
+    if (typeof value === "string") {
+      skillEnv[key] = value;
+    }
+  }
+  if (Object.keys(skillEnv).length === 0) {
+    return;
+  }
+
+  params.sandbox.docker.env = {
+    ...params.sandbox.docker.env,
+    ...skillEnv,
+  };
+  if (params.sandbox.backend) {
+    params.sandbox.backend.env = {
+      ...params.sandbox.backend.env,
+      ...skillEnv,
+    };
+  }
 }

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadWorkspaceSkillEntries, type SkillEntry, type SkillSnapshot } from "../skills.js";
+import { isAlwaysBlockedSkillEnvKey } from "../skills/env-overrides.js";
 import { resolveSkillRuntimeConfig } from "../skills/runtime-config.js";
 
 export type SandboxSkillEnvTarget = {
@@ -37,6 +38,9 @@ export function syncCurrentSkillEnvToSandbox(params: {
   const envSource = params.env ?? process.env;
   const skillEnv: Record<string, string> = {};
   for (const key of params.envKeys) {
+    if (isAlwaysBlockedSkillEnvKey(key)) {
+      continue;
+    }
     const value = envSource[key];
     if (typeof value === "string") {
       skillEnv[key] = value;

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -42,7 +42,7 @@ export function syncCurrentSkillEnvToSandbox(params: {
       continue;
     }
     const value = envSource[key];
-    if (typeof value === "string") {
+    if (typeof value === "string" && !value.includes("\0")) {
       skillEnv[key] = value;
     }
   }

--- a/src/agents/sandbox-create-args.test.ts
+++ b/src/agents/sandbox-create-args.test.ts
@@ -313,6 +313,42 @@ describe("buildSandboxCreateArgs", () => {
     expect(args).toEqual(expect.arrayContaining(["-v", "/tmp/override:/workspace:rw"]));
   });
 
+  it("rescues skill-declared env keys via allowedSensitiveKeys in envSanitizationOptions", () => {
+    const cfg = createSandboxConfig({
+      env: {
+        NODE_ENV: "test",
+        OPENAI_API_KEY: "sk-live-xxx", // pragma: allowlist secret
+        MY_TOKEN: "tok-yyy",
+        GITHUB_TOKEN: "gh-token", // pragma: allowlist secret
+      },
+    });
+
+    const args = buildSandboxCreateArgs({
+      name: "openclaw-sbx-skill-keys",
+      cfg,
+      scopeKey: "main",
+      createdAtMs: 1700000000000,
+      envSanitizationOptions: {
+        allowedSensitiveKeys: new Set(["OPENAI_API_KEY", "MY_TOKEN"]),
+      },
+    });
+
+    // Rescued keys should be in --env flags
+    expect(args).toEqual(
+      expect.arrayContaining([
+        "--env",
+        "NODE_ENV=test",
+        "--env",
+        "OPENAI_API_KEY=sk-live-xxx",
+        "--env",
+        "MY_TOKEN=tok-yyy",
+      ]),
+    );
+    // GITHUB_TOKEN should NOT appear (not in allowedSensitiveKeys)
+    const envFlags = args.filter((_, i) => args[i - 1] === "--env");
+    expect(envFlags.some((f) => f.startsWith("GITHUB_TOKEN="))).toBe(false);
+  });
+
   it("allows container namespace join with explicit dangerous override", () => {
     const cfg = createSandboxConfig({
       network: "container:peer",

--- a/src/agents/sandbox/backend.ts
+++ b/src/agents/sandbox/backend.ts
@@ -78,6 +78,8 @@ export type CreateSandboxBackendParams = {
   workspaceDir: string;
   agentWorkspaceDir: string;
   cfg: SandboxConfig;
+  /** Skill-declared env var names that should bypass the default block list during container creation. */
+  allowedSensitiveKeys?: ReadonlySet<string>;
 };
 
 export type SandboxBackendFactory = (

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -110,6 +110,8 @@ export async function resolveSandboxContext(params: {
   config?: OpenClawConfig;
   sessionKey?: string;
   workspaceDir?: string;
+  /** Skill-declared env var names that should bypass the default block list during container creation. */
+  allowedSensitiveKeys?: ReadonlySet<string>;
 }): Promise<SandboxContext | null> {
   const resolved = resolveSandboxSession(params);
   if (!resolved) {
@@ -139,6 +141,7 @@ export async function resolveSandboxContext(params: {
     workspaceDir,
     agentWorkspaceDir,
     cfg: resolvedCfg,
+    allowedSensitiveKeys: params.allowedSensitiveKeys,
   });
   await updateRegistry({
     containerName: backend.runtimeId,

--- a/src/agents/sandbox/docker-backend.ts
+++ b/src/agents/sandbox/docker-backend.ts
@@ -21,6 +21,7 @@ export async function createDockerSandboxBackend(
     workspaceDir: params.workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir,
     cfg: params.cfg,
+    allowedSensitiveKeys: params.allowedSensitiveKeys,
   });
   return createDockerSandboxBackendHandle({
     containerName,

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -443,9 +443,14 @@ async function createSandboxContainer(params: {
   agentWorkspaceDir: string;
   scopeKey: string;
   configHash?: string;
+  allowedSensitiveKeys?: ReadonlySet<string>;
 }) {
   const { name, cfg, workspaceDir, scopeKey } = params;
   await ensureDockerImage(cfg.image);
+
+  const envSanitizationOptions = params.allowedSensitiveKeys
+    ? { allowedSensitiveKeys: params.allowedSensitiveKeys }
+    : undefined;
 
   const args = buildSandboxCreateArgs({
     name,
@@ -454,6 +459,7 @@ async function createSandboxContainer(params: {
     configHash: params.configHash,
     includeBinds: false,
     bindSourceRoots: [workspaceDir, params.agentWorkspaceDir],
+    envSanitizationOptions,
   });
   args.push("--workdir", cfg.workdir);
   appendWorkspaceMountArgs({
@@ -494,11 +500,16 @@ export async function ensureSandboxContainer(params: {
   workspaceDir: string;
   agentWorkspaceDir: string;
   cfg: SandboxConfig;
+  allowedSensitiveKeys?: ReadonlySet<string>;
 }) {
   const scopeKey = resolveSandboxScopeKey(params.cfg.scope, params.sessionKey);
   const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(scopeKey);
   const name = `${params.cfg.docker.containerPrefix}${slug}`;
   const containerName = name.slice(0, 63);
+  // Note: allowedSensitiveKeys (skill-derived env rescue set) is intentionally
+  // excluded from the config hash.  It only affects which env vars pass the block
+  // list at creation time and does not change the container image, mounts, or
+  // network config.  If the skill set changes the operator can `sandbox recreate`.
   const expectedHash = computeSandboxConfigHash({
     docker: params.cfg.docker,
     workspaceAccess: params.cfg.workspaceAccess,
@@ -551,6 +562,7 @@ export async function ensureSandboxContainer(params: {
       agentWorkspaceDir: params.agentWorkspaceDir,
       scopeKey,
       configHash: expectedHash,
+      allowedSensitiveKeys: params.allowedSensitiveKeys,
     });
   } else if (!running) {
     await execDocker(["start", containerName]);

--- a/src/agents/sandbox/sanitize-env-vars.test.ts
+++ b/src/agents/sandbox/sanitize-env-vars.test.ts
@@ -42,6 +42,104 @@ describe("sanitizeEnvVars", () => {
     expect(result.warnings).toContain("SAFE_TEXT: Value looks like base64-encoded credential data");
   });
 
+  it("rescues blocked keys listed in allowedSensitiveKeys", () => {
+    const result = sanitizeEnvVars(
+      {
+        NODE_ENV: "test",
+        OPENAI_API_KEY: "sk-live-xxx", // pragma: allowlist secret
+        MY_CUSTOM_TOKEN: "tok-yyy",
+        GITHUB_TOKEN: "gh-token", // pragma: allowlist secret
+      },
+      {
+        allowedSensitiveKeys: new Set(["OPENAI_API_KEY", "MY_CUSTOM_TOKEN"]),
+      },
+    );
+
+    expect(result.allowed).toEqual({
+      NODE_ENV: "test",
+      OPENAI_API_KEY: "sk-live-xxx",
+      MY_CUSTOM_TOKEN: "tok-yyy",
+    });
+    // GITHUB_TOKEN is NOT in allowedSensitiveKeys, so it stays blocked
+    expect(result.blocked).toEqual(["GITHUB_TOKEN"]);
+  });
+
+  it("still blocks null-byte values even when key is in allowedSensitiveKeys", () => {
+    const result = sanitizeEnvVars(
+      {
+        MY_TOKEN: "valid\0injected",
+      },
+      {
+        allowedSensitiveKeys: new Set(["MY_TOKEN"]),
+      },
+    );
+
+    expect(result.allowed).toEqual({});
+    expect(result.blocked).toEqual(["MY_TOKEN"]);
+  });
+
+  it("warns on suspicious values for rescued keys", () => {
+    const base64Like =
+      "YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYQ==";
+    const result = sanitizeEnvVars(
+      {
+        MY_SECRET: base64Like,
+      },
+      {
+        allowedSensitiveKeys: new Set(["MY_SECRET"]),
+      },
+    );
+
+    expect(result.allowed).toEqual({ MY_SECRET: base64Like });
+    expect(result.blocked).toEqual([]);
+    expect(result.warnings).toContain("MY_SECRET: Value looks like base64-encoded credential data");
+  });
+
+  it("never rescues runtime-dangerous keys even if listed in allowedSensitiveKeys", () => {
+    // OPENCLAW_GATEWAY_TOKEN matches the suffix block pattern AND is always-blocked.
+    // LD_PRELOAD_SECRET matches the suffix block pattern AND isDangerousHostEnvVarName
+    // (LD_ prefix).  Both must stay blocked even when listed in allowedSensitiveKeys.
+    const result = sanitizeEnvVars(
+      {
+        OPENCLAW_GATEWAY_TOKEN: "gw-tok", // pragma: allowlist secret
+        LD_PRELOAD_SECRET: "/evil.so",
+        OPENAI_API_KEY: "sk-live-xxx", // pragma: allowlist secret
+      },
+      {
+        allowedSensitiveKeys: new Set([
+          "OPENCLAW_GATEWAY_TOKEN",
+          "LD_PRELOAD_SECRET",
+          "OPENAI_API_KEY",
+        ]),
+      },
+    );
+
+    // OPENCLAW_GATEWAY_TOKEN and LD_PRELOAD_SECRET must stay blocked
+    expect(result.blocked).toEqual(
+      expect.arrayContaining(["OPENCLAW_GATEWAY_TOKEN", "LD_PRELOAD_SECRET"]),
+    );
+    // Only OPENAI_API_KEY should be rescued
+    expect(result.allowed).toEqual({ OPENAI_API_KEY: "sk-live-xxx" });
+  });
+
+  it("blocks NODE_OPTIONS via custom block pattern even with allowedSensitiveKeys", () => {
+    // NODE_OPTIONS doesn't match default BLOCKED_ENV_VAR_PATTERNS (no _TOKEN/_KEY suffix),
+    // but if added via customBlockedPatterns, the always-blocked guard prevents rescue.
+    const result = sanitizeEnvVars(
+      {
+        NODE_OPTIONS: "--inspect",
+        OPENAI_API_KEY: "sk-live-xxx", // pragma: allowlist secret
+      },
+      {
+        customBlockedPatterns: [/^NODE_OPTIONS$/i],
+        allowedSensitiveKeys: new Set(["NODE_OPTIONS", "OPENAI_API_KEY"]),
+      },
+    );
+
+    expect(result.blocked).toContain("NODE_OPTIONS");
+    expect(result.allowed).toEqual({ OPENAI_API_KEY: "sk-live-xxx" });
+  });
+
   it("supports strict mode with explicit allowlist", () => {
     const result = sanitizeEnvVars(
       {

--- a/src/agents/sandbox/sanitize-env-vars.ts
+++ b/src/agents/sandbox/sanitize-env-vars.ts
@@ -1,3 +1,21 @@
+import { isDangerousHostEnvVarName } from "../../infra/host-env-security.js";
+
+/**
+ * Env var names/patterns that must never be rescued via allowedSensitiveKeys,
+ * even if skill metadata declares them.  Mirrors the always-blocked guard in
+ * env-overrides.ts (SKILL_ALWAYS_BLOCKED_ENV_PATTERNS + isDangerousHostEnvVarName).
+ */
+const ALWAYS_BLOCKED_SANDBOX_ENV_PATTERNS: ReadonlyArray<RegExp> = [
+  /^OPENSSL_CONF$/i,
+  /^OPENCLAW_GATEWAY_(TOKEN|PASSWORD)$/i,
+];
+
+function isAlwaysBlockedSandboxEnvKey(key: string): boolean {
+  return (
+    isDangerousHostEnvVarName(key) || matchesAnyPattern(key, ALWAYS_BLOCKED_SANDBOX_ENV_PATTERNS)
+  );
+}
+
 const BLOCKED_ENV_VAR_PATTERNS: ReadonlyArray<RegExp> = [
   /^ANTHROPIC_API_KEY$/i,
   /^OPENAI_API_KEY$/i,
@@ -40,6 +58,13 @@ export type EnvSanitizationOptions = {
   strictMode?: boolean;
   customBlockedPatterns?: ReadonlyArray<RegExp>;
   customAllowedPatterns?: ReadonlyArray<RegExp>;
+  /**
+   * Exact env var names that bypass the default block list.
+   * Mirrors the skill env override rescue mechanism in env-overrides.ts:
+   * if a key matches a blocked pattern but is in this set, it is allowed
+   * through (value validation still applies).
+   */
+  allowedSensitiveKeys?: ReadonlySet<string>;
 };
 
 export function validateEnvVarValue(value: string): string | undefined {
@@ -77,6 +102,21 @@ export function sanitizeEnvVars(
     }
 
     if (matchesAnyPattern(key, blockedPatterns)) {
+      // Rescue: if the caller explicitly declared this key as allowed-sensitive,
+      // let it through (same pattern as skill env override rescue in env-overrides.ts).
+      // Never rescue runtime-dangerous keys (NODE_OPTIONS, LD_*, OPENCLAW_GATEWAY_*, etc.).
+      if (options.allowedSensitiveKeys?.has(key) && !isAlwaysBlockedSandboxEnvKey(key)) {
+        const warning = validateEnvVarValue(value);
+        if (warning) {
+          if (warning === "Contains null bytes") {
+            blocked.push(key);
+            continue;
+          }
+          warnings.push(`${key}: ${warning}`);
+        }
+        allowed[key] = value;
+        continue;
+      }
       blocked.push(key);
       continue;
     }

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -12,6 +12,8 @@ import { writeSkill } from "./skills.e2e-test-helpers.js";
 import {
   applySkillEnvOverrides,
   applySkillEnvOverridesFromSnapshot,
+  applySkillEnvOverridesFromSnapshotWithResult,
+  applySkillEnvOverridesWithResult,
   buildWorkspaceSkillCommandSpecs,
   buildWorkspaceSkillsPrompt,
   buildWorkspaceSkillSnapshot,
@@ -374,6 +376,54 @@ describe("applySkillEnvOverrides", () => {
         expect(process.env.ENV_KEY).toBe("snap-key");
       } finally {
         restore();
+        expect(process.env.ENV_KEY).toBeUndefined();
+      }
+    });
+  });
+
+  it("reports only env keys injected by the current override call", async () => {
+    const workspaceDir = await makeWorkspace();
+    await writeEnvSkill(workspaceDir);
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
+
+    withClearedEnv(["ENV_KEY"], () => {
+      process.env.ENV_KEY = "externally-managed";
+      const result = applySkillEnvOverridesWithResult({
+        skills: entries,
+        config: { skills: { entries: { "env-skill": { apiKey: "injected" } } } }, // pragma: allowlist secret
+      });
+
+      try {
+        expect(process.env.ENV_KEY).toBe("externally-managed");
+        expect(result.injectedKeys.size).toBe(0);
+      } finally {
+        result.restore();
+        expect(process.env.ENV_KEY).toBe("externally-managed");
+      }
+    });
+  });
+
+  it("reports snapshot-injected env keys for the current override call", async () => {
+    const workspaceDir = await makeWorkspace();
+    await writeEnvSkill(workspaceDir);
+
+    const snapshot = buildWorkspaceSkillSnapshot(workspaceDir, {
+      ...resolveTestSkillDirs(workspaceDir),
+      config: { skills: { entries: { "env-skill": { apiKey: "snap-key" } } } }, // pragma: allowlist secret
+    });
+
+    withClearedEnv(["ENV_KEY"], () => {
+      const result = applySkillEnvOverridesFromSnapshotWithResult({
+        snapshot,
+        config: { skills: { entries: { "env-skill": { apiKey: "snap-key" } } } }, // pragma: allowlist secret
+      });
+
+      try {
+        expect(process.env.ENV_KEY).toBe("snap-key");
+        expect(result.injectedKeys).toEqual(new Set(["ENV_KEY"]));
+      } finally {
+        result.restore();
         expect(process.env.ENV_KEY).toBeUndefined();
       }
     });

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -544,4 +544,42 @@ describe("applySkillEnvOverrides", () => {
       }
     });
   });
+
+  it("blocks gateway token skill env overrides even when declared", async () => {
+    const workspaceDir = await makeWorkspace();
+    const skillDir = path.join(workspaceDir, "skills", "gateway-token-skill");
+    await writeSkill({
+      dir: skillDir,
+      name: "gateway-token-skill",
+      description: "Needs env",
+      metadata:
+        '{"openclaw":{"requires":{"env":["OPENCLAW_GATEWAY_TOKEN"]},"primaryEnv":"OPENCLAW_GATEWAY_TOKEN"}}',
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
+
+    withClearedEnv(["OPENCLAW_GATEWAY_TOKEN"], () => {
+      const restore = applySkillEnvOverrides({
+        skills: entries,
+        config: {
+          skills: {
+            entries: {
+              "gateway-token-skill": {
+                env: {
+                  OPENCLAW_GATEWAY_TOKEN: "gw-token",
+                },
+              },
+            },
+          },
+        },
+      });
+
+      try {
+        expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+      } finally {
+        restore();
+        expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+      }
+    });
+  });
 });

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -13,6 +13,8 @@ export {
 export {
   applySkillEnvOverrides,
   applySkillEnvOverridesFromSnapshot,
+  collectAllowedSensitiveKeysFromSkillEntries,
+  collectAllowedSensitiveKeysFromSkillSnapshot,
 } from "./skills/env-overrides.js";
 export type {
   OpenClawSkillMetadata,

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -13,6 +13,8 @@ export {
 export {
   applySkillEnvOverrides,
   applySkillEnvOverridesFromSnapshot,
+  applySkillEnvOverridesFromSnapshotWithResult,
+  applySkillEnvOverridesWithResult,
   collectAllowedSensitiveKeysFromSkillEntries,
   collectAllowedSensitiveKeysFromSkillSnapshot,
 } from "./skills/env-overrides.js";

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -77,6 +77,11 @@ type SanitizedSkillEnvOverrides = {
   warnings: string[];
 };
 
+export type AppliedSkillEnvOverrides = {
+  restore: () => void;
+  injectedKeys: ReadonlySet<string>;
+};
+
 // Always block skill env overrides that can alter runtime loading or host execution behavior.
 const SKILL_ALWAYS_BLOCKED_ENV_PATTERNS: ReadonlyArray<RegExp> = [
   /^OPENSSL_CONF$/i,
@@ -214,7 +219,17 @@ function createEnvReverter(updates: EnvUpdate[]) {
   };
 }
 
-export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: OpenClawConfig }) {
+function buildAppliedSkillEnvOverridesResult(updates: EnvUpdate[]): AppliedSkillEnvOverrides {
+  return {
+    restore: createEnvReverter(updates),
+    injectedKeys: new Set(updates.map((update) => update.key)),
+  };
+}
+
+export function applySkillEnvOverridesWithResult(params: {
+  skills: SkillEntry[];
+  config?: OpenClawConfig;
+}): AppliedSkillEnvOverrides {
   const { skills } = params;
   const config = resolveSkillRuntimeConfig(params.config);
   const updates: EnvUpdate[] = [];
@@ -235,17 +250,21 @@ export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: 
     });
   }
 
-  return createEnvReverter(updates);
+  return buildAppliedSkillEnvOverridesResult(updates);
 }
 
-export function applySkillEnvOverridesFromSnapshot(params: {
+export function applySkillEnvOverrides(params: { skills: SkillEntry[]; config?: OpenClawConfig }) {
+  return applySkillEnvOverridesWithResult(params).restore;
+}
+
+export function applySkillEnvOverridesFromSnapshotWithResult(params: {
   snapshot?: SkillSnapshot;
   config?: OpenClawConfig;
-}) {
+}): AppliedSkillEnvOverrides {
   const { snapshot } = params;
   const config = resolveSkillRuntimeConfig(params.config);
   if (!snapshot) {
-    return () => {};
+    return { restore: () => {}, injectedKeys: new Set() };
   }
   const updates: EnvUpdate[] = [];
 
@@ -264,7 +283,14 @@ export function applySkillEnvOverridesFromSnapshot(params: {
     });
   }
 
-  return createEnvReverter(updates);
+  return buildAppliedSkillEnvOverridesResult(updates);
+}
+
+export function applySkillEnvOverridesFromSnapshot(params: {
+  snapshot?: SkillSnapshot;
+  config?: OpenClawConfig;
+}) {
+  return applySkillEnvOverridesFromSnapshotWithResult(params).restore;
 }
 
 /**

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -87,7 +87,7 @@ function matchesAnyPattern(value: string, patterns: readonly RegExp[]): boolean 
   return patterns.some((pattern) => pattern.test(value));
 }
 
-function isAlwaysBlockedSkillEnvKey(key: string): boolean {
+export function isAlwaysBlockedSkillEnvKey(key: string): boolean {
   return (
     isDangerousHostEnvVarName(key) || matchesAnyPattern(key, SKILL_ALWAYS_BLOCKED_ENV_PATTERNS)
   );

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -78,7 +78,10 @@ type SanitizedSkillEnvOverrides = {
 };
 
 // Always block skill env overrides that can alter runtime loading or host execution behavior.
-const SKILL_ALWAYS_BLOCKED_ENV_PATTERNS: ReadonlyArray<RegExp> = [/^OPENSSL_CONF$/i];
+const SKILL_ALWAYS_BLOCKED_ENV_PATTERNS: ReadonlyArray<RegExp> = [
+  /^OPENSSL_CONF$/i,
+  /^OPENCLAW_GATEWAY_(TOKEN|PASSWORD)$/i,
+];
 
 function matchesAnyPattern(value: string, patterns: readonly RegExp[]): boolean {
   return patterns.some((pattern) => pattern.test(value));

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -263,3 +263,56 @@ export function applySkillEnvOverridesFromSnapshot(params: {
 
   return createEnvReverter(updates);
 }
+
+/**
+ * Collect the set of env var names that skills declare as required (via primaryEnv
+ * and requires.env metadata).  Used by the sandbox creation path to rescue these
+ * keys from the default env-var block list so that skill API keys reach the container.
+ */
+export function collectAllowedSensitiveKeysFromSkillSnapshot(
+  snapshot?: SkillSnapshot,
+): ReadonlySet<string> | undefined {
+  if (!snapshot?.skills?.length) {
+    return undefined;
+  }
+  const keys = new Set<string>();
+  for (const skill of snapshot.skills) {
+    const primary = skill.primaryEnv?.trim();
+    if (primary) {
+      keys.add(primary);
+    }
+    for (const env of skill.requiredEnv ?? []) {
+      const trimmed = env.trim();
+      if (trimmed) {
+        keys.add(trimmed);
+      }
+    }
+  }
+  return keys.size > 0 ? keys : undefined;
+}
+
+/**
+ * Same as collectAllowedSensitiveKeysFromSkillSnapshot but works with
+ * workspace-loaded SkillEntry[] (the non-snapshot fallback path).
+ */
+export function collectAllowedSensitiveKeysFromSkillEntries(
+  entries?: SkillEntry[],
+): ReadonlySet<string> | undefined {
+  if (!entries?.length) {
+    return undefined;
+  }
+  const keys = new Set<string>();
+  for (const entry of entries) {
+    const primary = entry.metadata?.primaryEnv?.trim();
+    if (primary) {
+      keys.add(primary);
+    }
+    for (const env of entry.metadata?.requires?.env ?? []) {
+      const trimmed = env.trim();
+      if (trimmed) {
+        keys.add(trimmed);
+      }
+    }
+  }
+  return keys.size > 0 ? keys : undefined;
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Docker sandbox env sanitization blocks skill-declared secret-like env names such as `primaryEnv` / `requires.env`, so skills can receive credentials on the host path but not inside sandbox containers.
- Why it matters: sandboxed skill runs break for integrations that depend on API keys like `NOTION_API_KEY` or `OPENAI_API_KEY`.
- What changed: derive an exact allowlist from skill metadata, thread it into sandbox creation for snapshot and non-snapshot paths (`run` and compaction), and rescue only those exact keys during container env sanitization.
- What did NOT change (scope boundary): no generic user-configurable allowlist, no new config surface, and runtime-dangerous env names still stay blocked.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25951
- Related #27871

## User-visible / Behavior Changes

Skills that declare `primaryEnv` / `requires.env` can now pass those exact secret-like env names into newly created Docker sandboxes. Non-declared keys and runtime-dangerous keys still stay blocked. Existing reused sandboxes may require `openclaw sandbox recreate` to pick up a changed skill env allowlist.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:
  Exact skill-declared env names can now bypass the default sandbox secret-name block list during container creation. This remains narrow: there is no generic allowlist surface, rescue is exact-name only, and runtime-dangerous keys still stay blocked via `isDangerousHostEnvVarName(...)` plus sandbox always-blocked patterns.

## Repro + Verification

### Environment

- OS: Linux 6.8
- Runtime/container: Node `v22.22.1`, Docker sandbox code path
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): sandboxed agent with a skill declaring `primaryEnv` / `requires.env`

### Steps

1. Add a skill that declares a secret-like env name in `primaryEnv` or `requires.env`.
2. Configure the corresponding skill env or api key and run the agent with Docker sandboxing enabled.
3. Compare sandbox env sanitization before and after this change.

### Expected

- Exact skill-declared env names are available in newly created sandbox containers.
- Non-declared keys and runtime-dangerous keys remain blocked.

### Actual

- Before this change, sandbox env sanitization blocked secret-like skill env names.
- After this change, declared keys are rescued while dangerous keys remain blocked.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted tests for env rescue and hard-block preservation, `pnpm build`, and `pnpm check`.
- Edge cases checked: null-byte values, suspicious base64-like values, dangerous keys (`OPENCLAW_GATEWAY_TOKEN`, `LD_PRELOAD_SECRET`, `NODE_OPTIONS`) still blocked, snapshot and non-snapshot skill plumbing, compaction path plumbing.
- What you did **not** verify: a live end-to-end Docker sandbox run with a real skill credential.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit or remove the skill-derived allowlist plumbing; operator workaround is to disable sandboxing for the affected run.
- Files/config to restore: revert the touched `src/agents/sandbox/*`, `src/agents/skills.ts`, and `src/agents/skills/env-overrides.ts` changes.
- Known bad symptoms reviewers should watch for: an existing reused sandbox may still miss a newly added skill env until the sandbox is recreated.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: existing reused sandboxes do not automatically recreate when the skill-derived allowlist changes.
  - Mitigation: documented in the PR; `openclaw sandbox recreate` refreshes the container.
- Risk: skill metadata could over-declare env names.
  - Mitigation: rescue is exact-name only and still rejects runtime-dangerous keys.

AI-assisted: yes.
Testing: `pnpm test -- src/agents/skills.test.ts src/agents/sandbox-create-args.test.ts src/agents/sandbox/sanitize-env-vars.test.ts`, `pnpm build`, `pnpm check`.
Local `codex review --base origin/main` was attempted but did not return findings before timeout.
