### PR TITLE
fix(deepseek): fill in actual V3.2 API pricing

### DIFF
--- a/src/agents/deepseek-models.ts
+++ b/src/agents/deepseek-models.ts
@@ -2,19 +2,18 @@ import type { ModelDefinitionConfig } from "../config/types.models.js";
 
 export const DEEPSEEK_BASE_URL = "https://api.deepseek.com";
 
-// TODO: fill in actual DeepSeek API pricing
-// https://api-docs.deepseek.com/quick_start/pricing
+// DeepSeek V3.2 pricing (per 1M tokens) — https://api-docs.deepseek.com/quick_start/pricing
 const DEEPSEEK_DEFAULT_COST = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
+  input: 0.28, // cache miss
+  output: 0.42,
+  cacheRead: 0.028, // cache hit
   cacheWrite: 0,
 };
 
 export const DEEPSEEK_MODEL_CATALOG: ModelDefinitionConfig[] = [
   {
     id: "deepseek-chat",
-    name: "DeepSeek Chat",
+    name: "DeepSeek Chat (V3.2 Non-thinking)",
     reasoning: false,
     input: ["text"],
     contextWindow: 131072,
@@ -24,7 +23,7 @@ export const DEEPSEEK_MODEL_CATALOG: ModelDefinitionConfig[] = [
   },
   {
     id: "deepseek-reasoner",
-    name: "DeepSeek Reasoner",
+    name: "DeepSeek Reasoner (V3.2 Thinking)",
     reasoning: true,
     input: ["text"],
     contextWindow: 131072,


### PR DESCRIPTION
## Summary

DeepSeek model cost was set to all zeros with a  placeholder. This fills in the actual V3.2 pricing from the [official API docs](https://api-docs.deepseek.com/quick_start/pricing).

## Changes

- **Input** (cache miss): /bin/bash.28 / 1M tokens
- **Output**: /bin/bash.42 / 1M tokens  
- **Cache hit**: /bin/bash.028 / 1M tokens
- Updated model names to reflect V3.2 and Non-thinking/Thinking mode

## Why

Without pricing,  cost tracking shows /bin/bash for all DeepSeek usage, making it impossible to monitor actual API spend.

## Test


[41m                                                                               [0m
[41m[37m                This is not the tsc command you are looking for                [0m
[41m                                                                               [0m

To get access to the TypeScript compiler, [34mtsc[0m, from the command line either:

- Use [1mnpm install typescript[0m to first add TypeScript to your project [1mbefore[0m using npx
- Use [1myarn[0m to avoid accidentally running code from un-installed packages