### PR TITLE
feat(openai): inject stream_options to enable usage tracking for comp…

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -207,9 +207,7 @@ function createParallelToolCallsWrapper(
  * Without this, providers that follow the OpenAI Chat Completions spec
  * (e.g. Alibaba Bailian / DashScope) omit usage entirely in streaming mode.
  */
-function createOpenAIStreamUsageWrapper(
-  baseStreamFn: StreamFn | undefined,
-): StreamFn {
+function createOpenAIStreamUsageWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     if (model.api !== "openai-completions") {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -206,6 +206,9 @@ function createParallelToolCallsWrapper(
  * streaming endpoints so that the final chunk includes token-usage metadata.
  * Without this, providers that follow the OpenAI Chat Completions spec
  * (e.g. Alibaba Bailian / DashScope) omit usage entirely in streaming mode.
+ *
+ * Respects `model.compat.supportsUsageInStreaming === false` to avoid
+ * breaking providers that explicitly opt out (e.g. Chutes, Venice).
  */
 function createOpenAIStreamUsageWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
@@ -213,12 +216,22 @@ function createOpenAIStreamUsageWrapper(baseStreamFn: StreamFn | undefined): Str
     if (model.api !== "openai-completions") {
       return underlying(model, context, options);
     }
+    const compat = model.compat as { supportsUsageInStreaming?: boolean } | undefined;
+    if (compat?.supportsUsageInStreaming === false) {
+      return underlying(model, context, options);
+    }
     const originalOnPayload = options?.onPayload;
     return underlying(model, context, {
       ...options,
       onPayload: (payload, payloadModel) => {
         if (payload && typeof payload === "object") {
-          (payload as Record<string, unknown>).stream_options = { include_usage: true };
+          const existing = (payload as Record<string, unknown>).stream_options;
+          (payload as Record<string, unknown>).stream_options = {
+            ...(existing && typeof existing === "object"
+              ? (existing as Record<string, unknown>)
+              : {}),
+            include_usage: true,
+          };
         }
         return originalOnPayload?.(payload, payloadModel);
       },

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -202,6 +202,33 @@ function createParallelToolCallsWrapper(
 }
 
 /**
+ * Inject `stream_options: { include_usage: true }` for OpenAI-compatible
+ * streaming endpoints so that the final chunk includes token-usage metadata.
+ * Without this, providers that follow the OpenAI Chat Completions spec
+ * (e.g. Alibaba Bailian / DashScope) omit usage entirely in streaming mode.
+ */
+function createOpenAIStreamUsageWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (model.api !== "openai-completions") {
+      return underlying(model, context, options);
+    }
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload, payloadModel) => {
+        if (payload && typeof payload === "object") {
+          (payload as Record<string, unknown>).stream_options = { include_usage: true };
+        }
+        return originalOnPayload?.(payload, payloadModel);
+      },
+    });
+  };
+}
+
+/**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also applies verified provider-specific request wrappers, such as OpenRouter attribution.
  *
@@ -261,6 +288,10 @@ export function applyExtraParamsToAgent(
     log.debug(`applying extraParams to agent streamFn for ${provider}/${modelId}`);
     agent.streamFn = wrappedStreamFn;
   }
+
+  // Inject stream_options for OpenAI-compatible providers to enable usage tracking.
+  // See: https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream_options
+  agent.streamFn = createOpenAIStreamUsageWrapper(agent.streamFn);
 
   const anthropicBetas = resolveAnthropicBetas(effectiveExtraParams, provider, modelId);
   if (anthropicBetas?.length) {


### PR DESCRIPTION
feat(openai): inject stream_options to enable usage tracking for compatible providers

OpenAI-compatible endpoints (including official OpenAI and clones like Alibaba DashScope) omit usage entirely in streaming mode unless `stream_options: { include_usage: true }` is explicitly provided in the request payload. This injects the option for the `openai-completions` API to enable accurate upstream token tracking.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Official OpenAI endpoints and third-party compatible providers (e.g., Alibaba Bailian, DashScope, DeepSeek) return `null` or `0` for token usage during streaming responses.
- Why it matters: Core usage statistics, true token tracking (from upstream infrastructure), and downstream client UI all break or display 0 tokens for these models since the `llm_output` usage hook receives no metadata.
- What changed: Injected `stream_options: { include_usage: true }` into the request payload specifically for models using the `openai-completions` API flow.
- What did NOT change (scope boundary): Anthropic-native endpoints, Google models, and other non-OpenAI protocols remain untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The OpenAI Chat Completions streaming spec requires an explicit opt-in (`stream_options: { include_usage: true }`) to emit final usage chunks. This was officially introduced by OpenAI but `pi-embedded-runner` wasn't supplying this flag, causing upstream token consumption logic to fail silently on streams.
- Missing detection / guardrail: Expected upstream usage properties from `delta` blocks were absent.
- Prior context: N/A
- Why this regressed now: The rising popularity of diverse OpenAI-compatible endpoints forced reliance on actual upstream payload counting rather than local estimation hooks. 
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: N/A
- Scenario the test should lock in: Ensure `stream_options` is merged correctly inside `createOpenAIStreamUsageWrapper` when constructing the payload.
- Why this is the smallest reliable guardrail: Unit tests on stream wrappers easily catch payload structure boundaries.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: Kept the fix minimal, highly-localized, and functionally self-contained.

## User-visible / Behavior Changes

Users running official OpenAI models OR third-party clone endpoints (like Qwen, DeepSeek, etc., via API proxies) will now correctly see accurate upstream-reported `input` / `output` token counts in the application logs and downstream client usage interfaces.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22
- Model/provider: Official OpenAI API `gpt-4o` & Alibaba DashScope (Qwen, GLM-4) over `openai-completions` runner.
- Integration/channel (if any): N/A
- Relevant config (redacted): Any standard custom provider using OpenAI format.

### Steps

1. Configure an official OpenAI endpoint or a compatible proxy model API via `agents.defaults`.
2. Start reasoning/chatting in streaming mode.
3. Observe token usage statistics emitted inside standard payload hook intercepts (like `pi-embedded-subscribe` usage callbacks).

### Expected

- `msg.usage` is fully populated with accurate `input` and `output` tokens returned directly by the server API.

### Actual

- `msg.usage` was returning `{input:0, output:0}` because the server never appended the usage chunk payload.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

_Snippet_: Before fix, `lastAssistant.usage` was returning `{"input":0,"output":0}` on streams. After injecting options, the final stream trace correctly resolves `{"input": 15157, "output": 48}` natively from the provider responses.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Intercepted payload hooks to ensure `stream_options` correctly propagates down to the `fetch` execution layer. Verified end-to-end extractions of usage stats on the final stream chunk.
- Edge cases checked: Confirmed this aligns completely with Official OpenAI spec documentation.
- What you did **not** verify: Exhaustive testing across every single OpenAI clone API ecosystem globally, though all spec-compliant ones should behave correctly.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert `createOpenAIStreamUsageWrapper` wrapping assignment inside `extra-params.ts`.
- Files/config to restore: `src/agents/pi-embedded-runner/extra-params.ts`.
- Known bad symptoms reviewers should watch for: Stream crashes throwing `400 Bad Request` if a non-compliant proprietary API strictly rejects standard OpenAI `stream_options` payload rules. 

## Risks and Mitigations

- Risk: A non-compliant API imitating OpenAI crashes when receiving `stream_options`.
  - Mitigation: The OpenAI reference spec officially documents `stream_options` for chat completions. APIs claiming strict OpenAI compliance expect it natively. Edge-case implementations usually just ignore parameters they do not process without throwing fatal errors.
