### PR TITLE
fix(discord): add media-gallery and file block hints for models

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -337,6 +337,8 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
       agentPrompt: {
         messageToolHints: () => [
           "- Discord components: set `components` when sending messages to include buttons, selects, or v2 containers.",
+          '- Inline images: use a `media-gallery` block in `components.blocks`: `{"type":"media-gallery","items":[{"url":"attachment://filename.ext"}]}` together with `media` (path/URL) and `filename`.',
+          '- File attachments: use a `file` block in `components.blocks`: `{"type":"file","file":"attachment://filename.ext"}` together with `media` and `filename`.',
           "- Forms: add `components.modal` (title, fields). OpenClaw adds a trigger button and routes submissions as new messages.",
         ],
       },


### PR DESCRIPTION
## Summary

Add `messageToolHints` for Discord media sends so models know how to use components v2 with attachments.

### Problem

After components v2 became the default, models have no guidance on how to send inline images or file attachments via the `message` tool. The existing hints only mention buttons, selects, and modals — nothing about media.

This causes models to either:
- Drop `media` silently (when using `components: {"text": "..."}` without a file/gallery block)
- Render images as download-only file attachments (when guessing `file` block instead of `media-gallery`)

### Changes

Added two new `messageToolHints` in `extensions/discord/src/channel.ts`:
- **Inline images**: `media-gallery` block with `attachment://` URL scheme
- **File attachments**: `file` block with `attachment://` URL scheme

Both hints include the complete invocation pattern (`components.blocks` + `media` + `filename`).

### Diff

```diff
 agentPrompt: {
   messageToolHints: () => [
     "- Discord components: set `components` when sending messages to include buttons, selects, or v2 containers.",
+    '- Inline images: use a `media-gallery` block in `components.blocks`: `{"type":"media-gallery","items":[{"url":"attachment://filename.ext"}]}` together with `media` (path/URL) and `filename`.',
+    '- File attachments: use a `file` block in `components.blocks`: `{"type":"file","file":"attachment://filename.ext"}` together with `media` and `filename`.',
     "- Forms: add `components.modal` (title, fields). OpenClaw adds a trigger button and routes submissions as new messages.",
   ],
 },
```

Closes #53269