### PR TITLE
fix(cli): allow bundled plugin resolution when catalog npmSpec is bare pluginId

### DIFF
--- a/src/cli/plugin-install-plan.test.ts
+++ b/src/cli/plugin-install-plan.test.ts
@@ -105,6 +105,30 @@ describe("plugin install plan helpers", () => {
     expect(result).toBeNull();
   });
 
+  it("resolves bundled plugin when catalog pluginId matches bare npmSpec despite scoped bundled npmSpec", () => {
+    const findBundledSource = vi
+      .fn()
+      .mockImplementation(({ kind }: { kind: "pluginId" | "npmSpec"; value: string }) => {
+        if (kind === "pluginId") {
+          return {
+            pluginId: "acpx",
+            localPath: "/tmp/extensions/acpx",
+            npmSpec: "@openclaw/acpx",
+          };
+        }
+        return undefined;
+      });
+
+    const result = resolveBundledInstallPlanForCatalogEntry({
+      pluginId: "acpx",
+      npmSpec: "acpx",
+      findBundledSource,
+    });
+
+    expect(result?.bundledSource.pluginId).toBe("acpx");
+    expect(result?.bundledSource.localPath).toBe("/tmp/extensions/acpx");
+  });
+
   it("uses npm-spec bundled fallback only for package-not-found", () => {
     const findBundledSource = vi.fn().mockReturnValue({
       pluginId: "voice-call",

--- a/src/cli/plugin-install-plan.ts
+++ b/src/cli/plugin-install-plan.ts
@@ -38,7 +38,12 @@ export function resolveBundledInstallPlanForCatalogEntry(params: {
   if (bundledById?.pluginId !== pluginId) {
     return null;
   }
-  if (bundledById.npmSpec && bundledById.npmSpec !== npmSpec) {
+  // Only enforce npmSpec mismatch when the catalog npmSpec differs AND the input
+  // is an explicit npm specifier (scoped or versioned).  When the user passes a
+  // bare plugin id that matches the bundled pluginId, the npmSpec format
+  // difference (e.g. "@openclaw/acpx" vs "acpx") should not block resolution.
+  const isExplicitNpmSpec = npmSpec !== pluginId;
+  if (isExplicitNpmSpec && bundledById.npmSpec && bundledById.npmSpec !== npmSpec) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

This PR fixes bundled plugin resolution for bare plugin IDs like `acpx` when the bundled source has a scoped npmSpec like `@openclaw/acpx`.

Previously, `resolveBundledInstallPlanForCatalogEntry` would reject valid bundled plugin matches when the catalog npmSpec (e.g., `acpx`) differed from the bundled npmSpec (e.g., `@openclaw/acpx`). This caused `openclaw plugins install acpx` to incorrectly resolve to ClawHub/skill instead of the bundled plugin.

## Changes

- Modified `resolveBundledInstallPlanForCatalogEntry` in `src/cli/plugin-install-plan.ts`
- The npmSpec mismatch check now only applies when the catalog npmSpec is an explicit npm specifier (scoped or versioned), not when it matches the bare pluginId
- Added regression test case

## Testing

- All 8 tests in `plugin-install-plan.test.ts` pass, including the new test case for bare pluginId matching with scoped bundled npmSpec
- Existing tests continue to pass (e.g., rejecting when catalog npmSpec is explicitly overridden to a different vendor)

Fixes #53241