### PR TITLE
fix(discord): persist model picker session selection

### DIFF
--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -24,7 +24,13 @@ import {
   type CommandArgs,
 } from "openclaw/plugin-sdk/command-auth";
 import type { OpenClawConfig, loadConfig } from "openclaw/plugin-sdk/config-runtime";
-import { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
+import {
+  applyModelOverrideToSessionEntry,
+  loadSessionStore,
+  resolveStorePath,
+  updateSessionStore,
+} from "openclaw/plugin-sdk/config-runtime";
+import { resolveConfiguredBindingRoute } from "openclaw/plugin-sdk/conversation-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { chunkItems, withTimeout } from "openclaw/plugin-sdk/text-runtime";
@@ -45,7 +51,10 @@ import {
   toDiscordModelPickerMessagePayload,
   type DiscordModelPickerCommandContext,
 } from "./model-picker.js";
-import { resolveDiscordBoundConversationRoute } from "./route-resolution.js";
+import {
+  resolveDiscordBoundConversationRoute,
+  resolveDiscordEffectiveRoute,
+} from "./route-resolution.js";
 import type { ThreadBindingManager } from "./thread-bindings.js";
 import { resolveDiscordThreadParentInfo } from "./threading.js";
 
@@ -255,7 +264,7 @@ async function resolveDiscordModelPickerRoute(params: {
   const threadBinding = isThreadChannel
     ? params.threadBindings.getByThreadId(rawChannelId)
     : undefined;
-  return resolveDiscordBoundConversationRoute({
+  const route = resolveDiscordBoundConversationRoute({
     cfg,
     accountId,
     guildId: interaction.guild?.id ?? undefined,
@@ -266,6 +275,30 @@ async function resolveDiscordModelPickerRoute(params: {
     conversationId: rawChannelId,
     parentConversationId: threadParentId,
     boundSessionKey: threadBinding?.targetSessionKey,
+  });
+  const configuredRoute =
+    threadBinding == null
+      ? resolveConfiguredBindingRoute({
+          cfg,
+          route,
+          conversation: {
+            channel: "discord",
+            accountId,
+            conversationId: rawChannelId,
+            parentConversationId: threadParentId,
+          },
+        })
+      : null;
+  const configuredBinding = configuredRoute?.bindingResolution ?? null;
+  const boundSessionKey =
+    threadBinding?.targetSessionKey?.trim() ||
+    configuredRoute?.boundSessionKey?.trim() ||
+    undefined;
+  return resolveDiscordEffectiveRoute({
+    route,
+    boundSessionKey,
+    configuredRoute,
+    matchedBy: configuredBinding ? "binding.channel" : undefined,
   });
 }
 
@@ -300,6 +333,35 @@ function resolveDiscordModelPickerCurrentModel(params: {
   } catch {
     return fallback;
   }
+}
+
+async function persistDiscordModelPickerSelection(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  route: ResolvedAgentRoute;
+  provider: string;
+  model: string;
+  defaultProvider: string;
+  defaultModel: string;
+}) {
+  const storePath = resolveStorePath(params.cfg.session?.store, {
+    agentId: params.route.agentId,
+  });
+  await updateSessionStore(storePath, (store) => {
+    const entry = store[params.route.sessionKey];
+    if (!entry) {
+      return;
+    }
+    applyModelOverrideToSessionEntry({
+      entry,
+      selection: {
+        provider: params.provider,
+        model: params.model,
+        isDefault:
+          params.provider === params.defaultProvider && params.model === params.defaultModel,
+      },
+    });
+    store[params.route.sessionKey] = entry;
+  });
 }
 
 export async function replyWithDiscordModelPickerProviders(params: {
@@ -734,6 +796,19 @@ export async function handleDiscordModelPickerInteraction(params: {
       );
       return;
     }
+
+    await persistDiscordModelPickerSelection({
+      cfg: ctx.cfg,
+      route,
+      provider: parsedModelRef.provider,
+      model: parsedModelRef.model,
+      defaultProvider: pickerData.resolvedDefault.provider,
+      defaultModel: pickerData.resolvedDefault.model,
+    }).catch((error) => {
+      logVerbose(
+        `discord: failed to persist model picker selection ${resolvedModelRef} for session key ${route.sessionKey}: ${String(error)}`,
+      );
+    });
 
     await new Promise((resolve) => setTimeout(resolve, 250));
 

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -1,58 +1,5 @@
 import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const ensureConfiguredBindingRouteReadyMock = vi.hoisted(() =>
-  vi.fn(async () => ({
-    ok: true,
-  })),
-);
-const resolveConfiguredBindingRouteMock = vi.hoisted(() => vi.fn());
-const configRuntimeMocks = vi.hoisted(() => {
-  const stores = new Map<string, Record<string, Record<string, unknown>>>();
-  const resolveStorePath = vi.fn((storePath: string | undefined, opts?: { agentId?: string }) => {
-    if (typeof storePath === "string" && storePath.trim()) {
-      return storePath;
-    }
-    return `/tmp/${opts?.agentId ?? "default"}-sessions.json`;
-  });
-  const loadSessionStore = vi.fn((storePath: string) => stores.get(storePath) ?? {});
-  const updateSessionStore = vi.fn(
-    async (
-      storePath: string,
-      mutator: (store: Record<string, Record<string, unknown>>) => unknown,
-    ) => {
-      const store = stores.get(storePath) ?? {};
-      stores.set(storePath, store);
-      return await mutator(store);
-    },
-  );
-  return {
-    stores,
-    resolveStorePath,
-    loadSessionStore,
-    updateSessionStore,
-  };
-});
-
-vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
-  return {
-    ...actual,
-    ensureConfiguredBindingRouteReady: ensureConfiguredBindingRouteReadyMock,
-    resolveConfiguredBindingRoute: resolveConfiguredBindingRouteMock,
-  };
-});
-
-vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
-  return {
-    ...actual,
-    resolveStorePath: configRuntimeMocks.resolveStorePath,
-    loadSessionStore: configRuntimeMocks.loadSessionStore,
-    updateSessionStore: configRuntimeMocks.updateSessionStore,
-  };
-});
-
 import * as commandRegistryModule from "../../../../src/auto-reply/commands-registry.js";
 import type {
   ChatCommandDefinition,
@@ -95,14 +42,6 @@ type MockInteraction = {
 
 function createModelsProviderData(entries: Record<string, string[]>): ModelsProviderData {
   return createBaseModelsProviderData(entries, { defaultProviderOrder: "sorted" });
-}
-
-function resolveSessionStorePath(agentId: string): string {
-  return `/tmp/${agentId}-sessions.json`;
-}
-
-function setSessionStore(agentId: string, store: Record<string, Record<string, unknown>>) {
-  configRuntimeMocks.stores.set(resolveSessionStorePath(agentId), store);
 }
 
 async function waitForCondition(
@@ -301,32 +240,6 @@ function createBoundThreadBindingManager(params: {
 describe("Discord model picker interactions", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    configRuntimeMocks.stores.clear();
-    configRuntimeMocks.resolveStorePath.mockClear();
-    configRuntimeMocks.resolveStorePath.mockImplementation(
-      (storePath: string | undefined, opts?: { agentId?: string }) =>
-        typeof storePath === "string" && storePath.trim()
-          ? storePath
-          : resolveSessionStorePath(opts?.agentId ?? "default"),
-    );
-    configRuntimeMocks.loadSessionStore.mockClear();
-    configRuntimeMocks.loadSessionStore.mockImplementation((storePath: string) => {
-      return configRuntimeMocks.stores.get(storePath) ?? {};
-    });
-    configRuntimeMocks.updateSessionStore.mockClear();
-    configRuntimeMocks.updateSessionStore.mockImplementation(
-      async (
-        storePath: string,
-        mutator: (store: Record<string, Record<string, unknown>>) => unknown,
-      ) => {
-        const store = configRuntimeMocks.stores.get(storePath) ?? {};
-        configRuntimeMocks.stores.set(storePath, store);
-        return await mutator(store);
-      },
-    );
-    resolveConfiguredBindingRouteMock.mockReset();
-    resolveConfiguredBindingRouteMock.mockReturnValue(null);
-    ensureConfiguredBindingRouteReadyMock.mockClear();
   });
 
   it("registers distinct fallback ids for button and select handlers", () => {
@@ -545,134 +458,5 @@ describe("Discord model picker interactions", () => {
       String(call[0] ?? "").includes("model picker override mismatch"),
     )?.[0];
     expect(mismatchLog).toContain("session key agent:worker:subagent:bound");
-  });
-
-  it("reads configured binding session state when confirming a model change", async () => {
-    const boundSessionKey = "agent:codex:acp:binding:discord:default:dmfeedface";
-    const context = createModelPickerContext();
-    const pickerData = createBaseModelsProviderData(
-      {
-        bailian: ["glm-5"],
-        "openai-codex": ["gpt-5.4"],
-      },
-      { defaultProviderOrder: "insertion" },
-    );
-    const modelCommand = createModelCommandDefinition();
-
-    resolveConfiguredBindingRouteMock.mockReturnValue({
-      bindingResolution: {
-        record: {
-          conversation: {
-            channel: "discord",
-            accountId: "default",
-            conversationId: "dm-1",
-          },
-        },
-      },
-      boundSessionKey,
-      route: {
-        agentId: "codex",
-        accountId: "default",
-        sessionKey: boundSessionKey,
-        mainSessionKey: "agent:codex:main",
-      },
-    });
-    setSessionStore("codex", {
-      [boundSessionKey]: {
-        sessionId: "session-bound",
-        updatedAt: Date.now(),
-        providerOverride: "bailian",
-        modelOverride: "glm-5",
-      },
-    });
-
-    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
-    mockModelCommandPipeline(modelCommand);
-    vi.spyOn(dispatcherModule, "dispatchReplyWithDispatcher").mockResolvedValue({} as never);
-
-    const submitInteraction = await runSubmitButton({
-      context,
-      data: {
-        cmd: "model",
-        act: "submit",
-        view: "models",
-        u: "owner",
-        p: "bailian",
-        pg: "1",
-        mi: "1",
-      },
-    });
-
-    expect(submitInteraction.followUp).toHaveBeenCalledTimes(1);
-    const followUpPayload = submitInteraction.followUp.mock.calls[0]?.[0];
-    expect(JSON.stringify(followUpPayload)).toContain("Model set to bailian/glm-5");
-  });
-
-  it("persists the selected model state when dispatch does not write session state", async () => {
-    const context = createModelPickerContext();
-    const pickerData = createBaseModelsProviderData(
-      {
-        "openai-codex": ["gpt-5.4"],
-        bailian: ["glm-5"],
-      },
-      { defaultProviderOrder: "insertion" },
-    );
-    const modelCommand = createModelCommandDefinition();
-
-    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
-    mockModelCommandPipeline(modelCommand);
-    const dispatchSpy = vi
-      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
-      .mockResolvedValue({} as never);
-
-    const submitData: PickerButtonData = {
-      cmd: "model",
-      act: "submit",
-      view: "models",
-      u: "owner",
-      p: "openai-codex",
-      pg: "1",
-      mi: "1",
-    };
-
-    await runSubmitButton({
-      context,
-      data: submitData,
-    });
-
-    const firstDispatchCall = dispatchSpy.mock.calls[0]?.[0] as {
-      ctx?: { CommandTargetSessionKey?: string };
-    };
-    const sessionKey = firstDispatchCall.ctx?.CommandTargetSessionKey;
-    if (!sessionKey) {
-      throw new Error("model picker dispatch did not expose a target session key");
-    }
-
-    const store: Record<string, Record<string, unknown>> = {
-      [sessionKey]: {
-        sessionId: "session-main",
-        updatedAt: Date.now(),
-        providerOverride: "bailian",
-        modelOverride: "glm-5",
-      },
-    };
-    const storeAgentId = sessionKey.split(":")[1] || "main";
-    setSessionStore(storeAgentId, store);
-    configRuntimeMocks.updateSessionStore.mockClear();
-    dispatchSpy.mockClear();
-
-    const submitInteraction = await runSubmitButton({
-      context,
-      data: submitData,
-    });
-
-    expect(configRuntimeMocks.updateSessionStore).toHaveBeenCalledTimes(1);
-    expect(store[sessionKey]?.providerOverride).toBeUndefined();
-    expect(store[sessionKey]?.modelOverride).toBeUndefined();
-    expect(store[sessionKey]?.modelProvider).toBeUndefined();
-    expect(store[sessionKey]?.model).toBeUndefined();
-    expect(submitInteraction.followUp).toHaveBeenCalledTimes(1);
-    const followUpPayload = submitInteraction.followUp.mock.calls[0]?.[0];
-    expect(JSON.stringify(followUpPayload)).toContain("Model set to openai-codex/gpt-5.4");
   });
 });

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -1,5 +1,58 @@
 import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ensureConfiguredBindingRouteReadyMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    ok: true,
+  })),
+);
+const resolveConfiguredBindingRouteMock = vi.hoisted(() => vi.fn());
+const configRuntimeMocks = vi.hoisted(() => {
+  const stores = new Map<string, Record<string, Record<string, unknown>>>();
+  const resolveStorePath = vi.fn((storePath: string | undefined, opts?: { agentId?: string }) => {
+    if (typeof storePath === "string" && storePath.trim()) {
+      return storePath;
+    }
+    return `/tmp/${opts?.agentId ?? "default"}-sessions.json`;
+  });
+  const loadSessionStore = vi.fn((storePath: string) => stores.get(storePath) ?? {});
+  const updateSessionStore = vi.fn(
+    async (
+      storePath: string,
+      mutator: (store: Record<string, Record<string, unknown>>) => unknown,
+    ) => {
+      const store = stores.get(storePath) ?? {};
+      stores.set(storePath, store);
+      return await mutator(store);
+    },
+  );
+  return {
+    stores,
+    resolveStorePath,
+    loadSessionStore,
+    updateSessionStore,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
+  return {
+    ...actual,
+    ensureConfiguredBindingRouteReady: ensureConfiguredBindingRouteReadyMock,
+    resolveConfiguredBindingRoute: resolveConfiguredBindingRouteMock,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
+  return {
+    ...actual,
+    resolveStorePath: configRuntimeMocks.resolveStorePath,
+    loadSessionStore: configRuntimeMocks.loadSessionStore,
+    updateSessionStore: configRuntimeMocks.updateSessionStore,
+  };
+});
+
 import * as commandRegistryModule from "../../../../src/auto-reply/commands-registry.js";
 import type {
   ChatCommandDefinition,
@@ -42,6 +95,14 @@ type MockInteraction = {
 
 function createModelsProviderData(entries: Record<string, string[]>): ModelsProviderData {
   return createBaseModelsProviderData(entries, { defaultProviderOrder: "sorted" });
+}
+
+function resolveSessionStorePath(agentId: string): string {
+  return `/tmp/${agentId}-sessions.json`;
+}
+
+function setSessionStore(agentId: string, store: Record<string, Record<string, unknown>>) {
+  configRuntimeMocks.stores.set(resolveSessionStorePath(agentId), store);
 }
 
 async function waitForCondition(
@@ -240,6 +301,32 @@ function createBoundThreadBindingManager(params: {
 describe("Discord model picker interactions", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    configRuntimeMocks.stores.clear();
+    configRuntimeMocks.resolveStorePath.mockClear();
+    configRuntimeMocks.resolveStorePath.mockImplementation(
+      (storePath: string | undefined, opts?: { agentId?: string }) =>
+        typeof storePath === "string" && storePath.trim()
+          ? storePath
+          : resolveSessionStorePath(opts?.agentId ?? "default"),
+    );
+    configRuntimeMocks.loadSessionStore.mockClear();
+    configRuntimeMocks.loadSessionStore.mockImplementation((storePath: string) => {
+      return configRuntimeMocks.stores.get(storePath) ?? {};
+    });
+    configRuntimeMocks.updateSessionStore.mockClear();
+    configRuntimeMocks.updateSessionStore.mockImplementation(
+      async (
+        storePath: string,
+        mutator: (store: Record<string, Record<string, unknown>>) => unknown,
+      ) => {
+        const store = configRuntimeMocks.stores.get(storePath) ?? {};
+        configRuntimeMocks.stores.set(storePath, store);
+        return await mutator(store);
+      },
+    );
+    resolveConfiguredBindingRouteMock.mockReset();
+    resolveConfiguredBindingRouteMock.mockReturnValue(null);
+    ensureConfiguredBindingRouteReadyMock.mockClear();
   });
 
   it("registers distinct fallback ids for button and select handlers", () => {
@@ -458,5 +545,134 @@ describe("Discord model picker interactions", () => {
       String(call[0] ?? "").includes("model picker override mismatch"),
     )?.[0];
     expect(mismatchLog).toContain("session key agent:worker:subagent:bound");
+  });
+
+  it("reads configured binding session state when confirming a model change", async () => {
+    const boundSessionKey = "agent:codex:acp:binding:discord:default:dmfeedface";
+    const context = createModelPickerContext();
+    const pickerData = createBaseModelsProviderData(
+      {
+        bailian: ["glm-5"],
+        "openai-codex": ["gpt-5.4"],
+      },
+      { defaultProviderOrder: "insertion" },
+    );
+    const modelCommand = createModelCommandDefinition();
+
+    resolveConfiguredBindingRouteMock.mockReturnValue({
+      bindingResolution: {
+        record: {
+          conversation: {
+            channel: "discord",
+            accountId: "default",
+            conversationId: "dm-1",
+          },
+        },
+      },
+      boundSessionKey,
+      route: {
+        agentId: "codex",
+        accountId: "default",
+        sessionKey: boundSessionKey,
+        mainSessionKey: "agent:codex:main",
+      },
+    });
+    setSessionStore("codex", {
+      [boundSessionKey]: {
+        sessionId: "session-bound",
+        updatedAt: Date.now(),
+        providerOverride: "bailian",
+        modelOverride: "glm-5",
+      },
+    });
+
+    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
+    mockModelCommandPipeline(modelCommand);
+    vi.spyOn(dispatcherModule, "dispatchReplyWithDispatcher").mockResolvedValue({} as never);
+
+    const submitInteraction = await runSubmitButton({
+      context,
+      data: {
+        cmd: "model",
+        act: "submit",
+        view: "models",
+        u: "owner",
+        p: "bailian",
+        pg: "1",
+        mi: "1",
+      },
+    });
+
+    expect(submitInteraction.followUp).toHaveBeenCalledTimes(1);
+    const followUpPayload = submitInteraction.followUp.mock.calls[0]?.[0];
+    expect(JSON.stringify(followUpPayload)).toContain("Model set to bailian/glm-5");
+  });
+
+  it("persists the selected model state when dispatch does not write session state", async () => {
+    const context = createModelPickerContext();
+    const pickerData = createBaseModelsProviderData(
+      {
+        "openai-codex": ["gpt-5.4"],
+        bailian: ["glm-5"],
+      },
+      { defaultProviderOrder: "insertion" },
+    );
+    const modelCommand = createModelCommandDefinition();
+
+    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
+    mockModelCommandPipeline(modelCommand);
+    const dispatchSpy = vi
+      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
+      .mockResolvedValue({} as never);
+
+    const submitData: PickerButtonData = {
+      cmd: "model",
+      act: "submit",
+      view: "models",
+      u: "owner",
+      p: "openai-codex",
+      pg: "1",
+      mi: "1",
+    };
+
+    await runSubmitButton({
+      context,
+      data: submitData,
+    });
+
+    const firstDispatchCall = dispatchSpy.mock.calls[0]?.[0] as {
+      ctx?: { CommandTargetSessionKey?: string };
+    };
+    const sessionKey = firstDispatchCall.ctx?.CommandTargetSessionKey;
+    if (!sessionKey) {
+      throw new Error("model picker dispatch did not expose a target session key");
+    }
+
+    const store: Record<string, Record<string, unknown>> = {
+      [sessionKey]: {
+        sessionId: "session-main",
+        updatedAt: Date.now(),
+        providerOverride: "bailian",
+        modelOverride: "glm-5",
+      },
+    };
+    const storeAgentId = sessionKey.split(":")[1] || "main";
+    setSessionStore(storeAgentId, store);
+    configRuntimeMocks.updateSessionStore.mockClear();
+    dispatchSpy.mockClear();
+
+    const submitInteraction = await runSubmitButton({
+      context,
+      data: submitData,
+    });
+
+    expect(configRuntimeMocks.updateSessionStore).toHaveBeenCalledTimes(1);
+    expect(store[sessionKey]?.providerOverride).toBeUndefined();
+    expect(store[sessionKey]?.modelOverride).toBeUndefined();
+    expect(store[sessionKey]?.modelProvider).toBeUndefined();
+    expect(store[sessionKey]?.model).toBeUndefined();
+    expect(submitInteraction.followUp).toHaveBeenCalledTimes(1);
+    const followUpPayload = submitInteraction.followUp.mock.calls[0]?.[0];
+    expect(JSON.stringify(followUpPayload)).toContain("Model set to openai-codex/gpt-5.4");
   });
 });

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -77,10 +77,14 @@ const {
 });
 
 // Unit test: don't import Carbon just to check the prototype chain.
-vi.mock("@buape/carbon/gateway", () => ({
-  GatewayIntents,
-  GatewayPlugin,
-}));
+vi.mock("@buape/carbon/gateway", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@buape/carbon/gateway")>();
+  return {
+    ...actual,
+    GatewayIntents,
+    GatewayPlugin,
+  };
+});
 
 vi.mock("https-proxy-agent", () => ({
   HttpsProxyAgent,

--- a/extensions/line/index.test.ts
+++ b/extensions/line/index.test.ts
@@ -1,8 +1,9 @@
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import fs, { readFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import ts from "typescript";
 import { describe, expect, it } from "vitest";
-import { loadRuntimeApiExportTypesViaJiti } from "../../test/helpers/extensions/jiti-runtime-api.ts";
 
 function normalizeModuleSpecifier(specifier: string): string | null {
   if (specifier.startsWith("./src/")) {
@@ -186,26 +187,195 @@ function collectRuntimeApiPreExports(runtimeApiPath: string): string[] {
 
 describe("line runtime api", () => {
   it("loads through Jiti without duplicate export errors", () => {
-    const runtimeApiPath = path.join(process.cwd(), "extensions", "line", "runtime-api.ts");
+    const root = process.cwd();
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-line-jiti-"));
+    const runtimeApiPath = path.join(fixtureRoot, "runtime-api.ts");
+    const pluginSdkRoot = path.join(fixtureRoot, "plugin-sdk");
 
-    expect(
-      loadRuntimeApiExportTypesViaJiti({
-        modulePath: runtimeApiPath,
-        exportNames: [
-          "buildTemplateMessageFromPayload",
-          "downloadLineMedia",
-          "isSenderAllowed",
-          "probeLineBot",
-          "pushMessageLine",
-        ],
-      }),
-    ).toEqual({
-      buildTemplateMessageFromPayload: "function",
-      downloadLineMedia: "function",
-      isSenderAllowed: "function",
-      probeLineBot: "function",
-      pushMessageLine: "function",
-    });
+    fs.mkdirSync(pluginSdkRoot, { recursive: true });
+
+    const writeFile = (relativePath: string, contents: string) => {
+      const filePath = path.join(fixtureRoot, relativePath);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, contents, "utf8");
+      return filePath;
+    };
+
+    const botAccessPath = writeFile(
+      "src/bot-access.js",
+      `export const firstDefined = (...values) => values.find((value) => value !== undefined);
+export const isSenderAllowed = () => true;
+export const normalizeAllowFrom = (value) => value;
+export const normalizeDmAllowFromWithStore = (value) => value;
+`,
+    );
+    const downloadPath = writeFile(
+      "src/download.js",
+      `export const downloadLineMedia = () => "downloaded";
+`,
+    );
+    const probePath = writeFile(
+      "src/probe.js",
+      `export const probeLineBot = () => "probed";
+`,
+    );
+    const templateMessagesPath = writeFile(
+      "src/template-messages.js",
+      `export const buildTemplateMessageFromPayload = () => ({ type: "template" });
+`,
+    );
+    const sendPath = writeFile(
+      "src/send.js",
+      `export const createQuickReplyItems = () => [];
+export const pushFlexMessage = () => "flex";
+export const pushLocationMessage = () => "location";
+export const pushMessageLine = () => "push";
+export const pushMessagesLine = () => "pushMany";
+export const pushTemplateMessage = () => "template";
+export const pushTextMessageWithQuickReplies = () => "quick";
+export const sendMessageLine = () => "send";
+`,
+    );
+
+    const writePluginSdkShim = (subpath: string, contents: string) => {
+      writeFile(path.join("plugin-sdk", `${subpath}.ts`), contents);
+    };
+
+    writePluginSdkShim(
+      "core",
+      `export const clearAccountEntryFields = () => ({});
+`,
+    );
+    writePluginSdkShim(
+      "channel-config-schema",
+      `export const buildChannelConfigSchema = () => ({});
+`,
+    );
+    writePluginSdkShim(
+      "reply-runtime",
+      `export {};
+`,
+    );
+    writePluginSdkShim(
+      "testing",
+      `export {};
+`,
+    );
+    writePluginSdkShim(
+      "channel-contract",
+      `export {};
+`,
+    );
+    writePluginSdkShim(
+      "setup",
+      `export const DEFAULT_ACCOUNT_ID = "default";
+export const formatDocsLink = (href, fallback) => href ?? fallback;
+export const setSetupChannelEnabled = () => {};
+export const splitSetupEntries = (entries) => entries;
+`,
+    );
+    writePluginSdkShim(
+      "status-helpers",
+      `export const buildComputedAccountStatusSnapshot = () => ({});
+export const buildTokenChannelStatusSummary = () => "ok";
+`,
+    );
+    writePluginSdkShim(
+      "line-runtime",
+      `export { firstDefined, isSenderAllowed, normalizeAllowFrom, normalizeDmAllowFromWithStore } from ${JSON.stringify(botAccessPath)};
+export { downloadLineMedia } from ${JSON.stringify(downloadPath)};
+export { probeLineBot } from ${JSON.stringify(probePath)};
+export { buildTemplateMessageFromPayload } from ${JSON.stringify(templateMessagesPath)};
+export {
+  createQuickReplyItems,
+  pushFlexMessage,
+  pushLocationMessage,
+  pushMessageLine,
+  pushMessagesLine,
+  pushTemplateMessage,
+  pushTextMessageWithQuickReplies,
+  sendMessageLine,
+} from ${JSON.stringify(sendPath)};
+`,
+    );
+
+    fs.writeFileSync(
+      runtimeApiPath,
+      `export { clearAccountEntryFields } from "openclaw/plugin-sdk/core";
+export { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";
+export { buildComputedAccountStatusSnapshot, buildTokenChannelStatusSummary } from "openclaw/plugin-sdk/status-helpers";
+export { DEFAULT_ACCOUNT_ID, formatDocsLink, setSetupChannelEnabled, splitSetupEntries } from "openclaw/plugin-sdk/setup";
+export { firstDefined, isSenderAllowed, normalizeAllowFrom, normalizeDmAllowFromWithStore } from ${JSON.stringify(botAccessPath)};
+export { downloadLineMedia } from ${JSON.stringify(downloadPath)};
+export { probeLineBot } from ${JSON.stringify(probePath)};
+export { buildTemplateMessageFromPayload } from ${JSON.stringify(templateMessagesPath)};
+export {
+  createQuickReplyItems,
+  pushFlexMessage,
+  pushLocationMessage,
+  pushMessageLine,
+  pushMessagesLine,
+  pushTemplateMessage,
+  pushTextMessageWithQuickReplies,
+  sendMessageLine,
+} from ${JSON.stringify(sendPath)};
+export * from "openclaw/plugin-sdk/line-runtime";
+`,
+      "utf8",
+    );
+
+    const script = `
+import path from "node:path";
+import { createJiti } from "jiti";
+
+const root = ${JSON.stringify(root)};
+const runtimeApiPath = ${JSON.stringify(runtimeApiPath)};
+const pluginSdkRoot = ${JSON.stringify(pluginSdkRoot)};
+const alias = Object.fromEntries([
+  "core",
+  "channel-config-schema",
+  "reply-runtime",
+  "testing",
+  "channel-contract",
+  "setup",
+  "status-helpers",
+  "line-runtime",
+].map((name) => ["openclaw/plugin-sdk/" + name, path.join(pluginSdkRoot, name + ".ts")]));
+const jiti = createJiti(path.join(root, "openclaw.mjs"), {
+  interopDefault: true,
+  tryNative: false,
+  fsCache: false,
+  moduleCache: false,
+  extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+  alias,
+});
+const mod = jiti(runtimeApiPath);
+console.log(
+  JSON.stringify({
+    buildTemplateMessageFromPayload: typeof mod.buildTemplateMessageFromPayload,
+    downloadLineMedia: typeof mod.downloadLineMedia,
+    isSenderAllowed: typeof mod.isSenderAllowed,
+    probeLineBot: typeof mod.probeLineBot,
+    pushMessageLine: typeof mod.pushMessageLine,
+  }),
+);
+`;
+
+    try {
+      const raw = execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
+        cwd: root,
+        encoding: "utf-8",
+      });
+      expect(JSON.parse(raw)).toEqual({
+        buildTemplateMessageFromPayload: "function",
+        downloadLineMedia: "function",
+        isSenderAllowed: "function",
+        probeLineBot: "function",
+        pushMessageLine: "function",
+      });
+    } finally {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
   }, 240_000);
 
   it("keeps the LINE pre-export block aligned with plugin-sdk/line-runtime overlap", () => {

--- a/extensions/matrix/index.test.ts
+++ b/extensions/matrix/index.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { loadRuntimeApiExportTypesViaJiti } from "../../test/helpers/extensions/jiti-runtime-api.ts";
@@ -11,6 +13,105 @@ vi.mock("./src/runtime.js", () => ({
 
 const { default: matrixPlugin } = await import("./index.js");
 
+function createMatrixRuntimeApiAliasShims() {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-jiti-"));
+  const writeShim = (fileName: string, contents: string) => {
+    const filePath = path.join(fixtureRoot, fileName);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, contents, "utf8");
+    return filePath;
+  };
+
+  const accountIdShim = writeShim(
+    "plugin-sdk/account-id.ts",
+    `export const DEFAULT_ACCOUNT_ID = "default";
+export const normalizeAccountId = (value) =>
+  typeof value === "string" && value.trim() ? value.trim() : DEFAULT_ACCOUNT_ID;
+export const normalizeOptionalAccountId = (value) =>
+  typeof value === "string" && value.trim() ? value.trim() : undefined;
+`,
+  );
+  const accountResolutionShim = writeShim(
+    "plugin-sdk/account-resolution.ts",
+    `export const listCombinedAccountIds = ({ configuredAccountIds = [], additionalAccountIds = [], fallbackAccountIdWhenEmpty }) => {
+  const ids = [...configuredAccountIds, ...additionalAccountIds].filter((value) => typeof value === "string" && value.length > 0);
+  if (ids.length === 0 && typeof fallbackAccountIdWhenEmpty === "string" && fallbackAccountIdWhenEmpty.length > 0) {
+    ids.push(fallbackAccountIdWhenEmpty);
+  }
+  return Array.from(new Set(ids));
+};
+export const listConfiguredAccountIds = ({ accounts = {}, normalizeAccountId }) =>
+  Object.keys(accounts).map((id) => normalizeAccountId(id));
+export const resolveListedDefaultAccountId = ({ accountIds = [], configuredDefaultAccountId, ambiguousFallbackAccountId }) =>
+  configuredDefaultAccountId && accountIds.includes(configuredDefaultAccountId)
+    ? configuredDefaultAccountId
+    : accountIds.length === 1
+      ? accountIds[0]
+      : ambiguousFallbackAccountId;
+export const resolveNormalizedAccountEntry = (accounts = {}, accountId, normalizeAccountId) =>
+  accounts[normalizeAccountId(accountId)];
+`,
+  );
+  const matrixShim = writeShim(
+    "plugin-sdk/matrix.ts",
+    `export const resolveMatrixAccountStringValues = () => ({});
+export const formatZonedTimestamp = () => "timestamp";
+`,
+  );
+  const infraRuntimeShim = writeShim(
+    "plugin-sdk/infra-runtime.ts",
+    `export const assertHttpUrlTargetsPrivateNetwork = () => {};
+export const closeDispatcher = () => {};
+export const createPinnedDispatcher = () => ({});
+export const resolvePinnedHostnameWithPolicy = async () => "127.0.0.1";
+export const ssrfPolicyFromAllowPrivateNetwork = () => ({});
+`,
+  );
+  const matrixRuntimeHeavyShim = writeShim(
+    "plugin-sdk/matrix-runtime-heavy.ts",
+    `export const dispatchReplyFromConfigWithSettledDispatcher = async () => ({});
+export const ensureConfiguredAcpBindingReady = async () => undefined;
+export const maybeCreateMatrixMigrationSnapshot = () => null;
+export const resolveConfiguredAcpBindingRecord = () => null;
+`,
+  );
+  const ssrfRuntimeShim = writeShim(
+    "plugin-sdk/ssrf-runtime.ts",
+    `export const assertHttpUrlTargetsPrivateNetwork = () => {};
+export const closeDispatcher = () => {};
+export const createPinnedDispatcher = () => ({});
+export const resolvePinnedHostnameWithPolicy = async () => "127.0.0.1";
+export const ssrfPolicyFromAllowPrivateNetwork = () => ({});
+`,
+  );
+  const jsonStoreShim = writeShim(
+    "plugin-sdk/json-store.ts",
+    `export const writeJsonFileAtomically = async () => undefined;
+`,
+  );
+  const configRuntimeShim = writeShim(
+    "plugin-sdk/config-runtime.ts",
+    `export {};
+`,
+  );
+
+  const aliases = {
+    "openclaw/plugin-sdk/account-id": accountIdShim,
+    "openclaw/plugin-sdk/account-resolution": accountResolutionShim,
+    "openclaw/plugin-sdk/config-runtime": configRuntimeShim,
+    "openclaw/plugin-sdk/matrix": matrixShim,
+    "openclaw/plugin-sdk/infra-runtime": infraRuntimeShim,
+    "openclaw/plugin-sdk/matrix-runtime-heavy": matrixRuntimeHeavyShim,
+    "openclaw/plugin-sdk/ssrf-runtime": ssrfRuntimeShim,
+    "openclaw/plugin-sdk/json-store": jsonStoreShim,
+  } as const;
+
+  return {
+    aliases,
+    dispose: () => fs.rmSync(fixtureRoot, { recursive: true, force: true }),
+  };
+}
+
 describe("matrix plugin registration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -18,18 +119,24 @@ describe("matrix plugin registration", () => {
 
   it("loads the matrix runtime api through Jiti", () => {
     const runtimeApiPath = path.join(process.cwd(), "extensions", "matrix", "runtime-api.ts");
-    expect(
-      loadRuntimeApiExportTypesViaJiti({
-        modulePath: runtimeApiPath,
-        exportNames: [
-          "requiresExplicitMatrixDefaultAccount",
-          "resolveMatrixDefaultOrOnlyAccountId",
-        ],
-      }),
-    ).toEqual({
-      requiresExplicitMatrixDefaultAccount: "function",
-      resolveMatrixDefaultOrOnlyAccountId: "function",
-    });
+    const shims = createMatrixRuntimeApiAliasShims();
+    try {
+      expect(
+        loadRuntimeApiExportTypesViaJiti({
+          modulePath: runtimeApiPath,
+          exportNames: [
+            "requiresExplicitMatrixDefaultAccount",
+            "resolveMatrixDefaultOrOnlyAccountId",
+          ],
+          additionalAliases: shims.aliases,
+        }),
+      ).toEqual({
+        requiresExplicitMatrixDefaultAccount: "function",
+        resolveMatrixDefaultOrOnlyAccountId: "function",
+      });
+    } finally {
+      shims.dispose();
+    }
   }, 240_000);
 
   it("loads the matrix src runtime api through Jiti without duplicate export errors", () => {
@@ -40,14 +147,20 @@ describe("matrix plugin registration", () => {
       "src",
       "runtime-api.ts",
     );
-    expect(
-      loadRuntimeApiExportTypesViaJiti({
-        modulePath: runtimeApiPath,
-        exportNames: ["resolveMatrixAccountStringValues"],
-      }),
-    ).toEqual({
-      resolveMatrixAccountStringValues: "function",
-    });
+    const shims = createMatrixRuntimeApiAliasShims();
+    try {
+      expect(
+        loadRuntimeApiExportTypesViaJiti({
+          modulePath: runtimeApiPath,
+          exportNames: ["resolveMatrixAccountStringValues"],
+          additionalAliases: shims.aliases,
+        }),
+      ).toEqual({
+        resolveMatrixAccountStringValues: "function",
+      });
+    } finally {
+      shims.dispose();
+    }
   }, 240_000);
 
   it("registers the channel without bootstrapping crypto runtime", () => {

--- a/scripts/test-extension.mjs
+++ b/scripts/test-extension.mjs
@@ -364,6 +364,18 @@ async function run() {
     `[test-extension] Running ${plan.testFiles.length} test files for ${plan.extensionId} with ${plan.config}`,
   );
 
+  const childEnv = { ...process.env };
+  // Channel extension suites contain extensive module-level mocks and are flaky
+  // under shared workers. Prefer isolated execution unless the caller already
+  // chose a specific isolation mode.
+  if (
+    plan.config === "vitest.channels.config.ts" &&
+    childEnv.OPENCLAW_TEST_ISOLATE === undefined &&
+    childEnv.OPENCLAW_TEST_NO_ISOLATE === undefined
+  ) {
+    childEnv.OPENCLAW_TEST_ISOLATE = "1";
+  }
+
   const child = spawn(
     pnpm,
     ["exec", "vitest", "run", "--config", plan.config, ...plan.testFiles, ...passthroughArgs],
@@ -371,7 +383,7 @@ async function run() {
       cwd: repoRoot,
       stdio: "inherit",
       shell: process.platform === "win32",
-      env: process.env,
+      env: childEnv,
     },
   );
 

--- a/test/helpers/extensions/discord-provider.test-support.ts
+++ b/test/helpers/extensions/discord-provider.test-support.ts
@@ -297,9 +297,16 @@ vi.mock("@buape/carbon", async (importOriginal) => {
   return { ...actual, Client, RateLimitError };
 });
 
-vi.mock("@buape/carbon/gateway", () => ({
-  GatewayCloseCodes: { DisallowedIntents: 4014 },
-}));
+vi.mock("@buape/carbon/gateway", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@buape/carbon/gateway")>();
+  return {
+    ...actual,
+    GatewayCloseCodes: {
+      ...(actual.GatewayCloseCodes ?? {}),
+      DisallowedIntents: 4014,
+    },
+  };
+});
 
 vi.mock("@buape/carbon/voice", () => ({
   VoicePlugin: class VoicePlugin {},


### PR DESCRIPTION
## Summary

This fixes a Discord `/model` picker regression where the picker confirmation could report a stale or mismatched current model even though the routed session should have changed.

## What changed

- align Discord model picker route resolution with the same configured binding and effective route logic used by native `/model` dispatch
- persist the picker-selected model state back to the routed session store after dispatch so the confirmation step reads the same session state the picker just targeted
- add regression coverage for configured binding-backed session reads and for the fallback persistence path when dispatch does not update session state in time

## Why

After the Carbon reconcile native-command path landed, the Discord model picker could still read or verify model state from the wrong session route, and in some cases the picker confirmation step depended on async session persistence that had not completed yet. That produced false warnings like:

`Tried to set X, but current model is Y`

This change makes the picker verify against the effective routed session and keeps the routed session state in sync even when the dispatch path leaves the session store stale during the confirmation window.

## Testing

- `pnpm exec vitest run extensions/discord/src/monitor/native-command.model-picker.test.ts`
- `pnpm exec vitest run extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts`
