### PR TITLE
feat: add neuraldebug skill — AI debugging for 8 languages + LLMs

### DIFF
--- a/skills/neuraldebug/SKILL.md
+++ b/skills/neuraldebug/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: neuraldebug
+description: AI-powered debugging for software (8 languages) and LLM/transformer reasoning. Debug programs with natural language via real debuggers (GDB, LLDB, CDB, JDB, Delve, Node Inspector, rdbg). Debug LLM internals with Logit Lens, Attention Analysis, Probing, Activation Patching, and LoRA fine-tuning. Client-server architecture works with any AI agent.
+version: 0.1.0
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - python3
+        - git
+    emoji: "🔍"
+    homepage: https://github.com/DennySun2020/DeepRhapsody
+---
+# NeuralDebug
+
+AI-powered debugging framework for **software** and **LLM reasoning**. Part of the [DeepRhapsody](https://github.com/DennySun2020/DeepRhapsody) project.
+
+Use this skill when asked to debug a program, diagnose a crash, analyze a core dump, inspect LLM reasoning, detect hallucinations, or fine-tune a model.
+
+## What NeuralDebug Does
+
+### 🔧 Software Debugging (8 Languages)
+Debug **Python, C/C++, C#, Rust, Java, Go, Node.js/TypeScript, and Ruby** using real debuggers — not code reading. NeuralDebug drives GDB, LLDB, CDB, JDB, Delve, Node Inspector, and rdbg via a unified natural-language interface.
+
+### 🧠 LLM Debugging
+Step through transformer forward passes **layer by layer**. Run interpretability techniques to understand *why* a model produces a given output: Logit Lens, Attention Analysis, Probing, Activation Patching, and custom analysis sandboxes.
+
+### 🎯 LLM Fine-Tuning
+Inject missing knowledge into GPT-2 family models using LoRA. Diagnose → fine-tune → verify in a single workflow.
+
+## Installation
+
+```bash
+# Clone the repo
+git clone https://github.com/DennySun2020/DeepRhapsody.git
+cd DeepRhapsody
+
+# Install Python dependencies
+pip install torch transformers
+
+# For fine-tuning (optional)
+pip install peft==0.7.1
+```
+
+## Quick Start: Software Debugging
+
+### Interactive Mode (persistent debug session)
+
+```bash
+# Start debug server for any supported language
+python src/NeuralDebug/python_debug_session.py serve --port 5678
+
+# Send commands via natural language
+python src/NeuralDebug/python_debug_session.py cmd -p 5678 launch my_script.py
+python src/NeuralDebug/python_debug_session.py cmd -p 5678 set_breakpoint 42
+python src/NeuralDebug/python_debug_session.py cmd -p 5678 continue
+python src/NeuralDebug/python_debug_session.py cmd -p 5678 inspect
+```
+
+### One-Shot Mode (quick breakpoint capture)
+
+```bash
+python src/NeuralDebug/python_debugger.py debug my_script.py --breakpoint 42 --output result.json
+```
+
+### Supported Languages
+
+| Language | Script | Backend |
+|----------|--------|---------|
+| Python | `python_debug_session.py` | bdb (stdlib) |
+| C/C++ | `cpp_debug_session.py` | GDB, LLDB, or CDB |
+| C# | `csharp_debug_session.py` | netcoredbg |
+| Rust | `rust_debug_session.py` | rust-gdb / LLDB |
+| Java | `java_debug_session.py` | JDB |
+| Go | `go_debug_session.py` | Delve |
+| Node.js/TS | `nodejs_debug_session.py` | Node Inspector |
+| Ruby | `ruby_debug_session.py` | rdbg |
+
+All scripts live in `src/NeuralDebug/` and share the same command interface.
+
+## Quick Start: LLM Debugging
+
+```bash
+# Start LLM debug server
+python src/NeuralDebug/llm/llm_debug_session.py serve -m gpt2-medium -p 5680
+
+# Ask the model a question
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 start "The capital of Japan is"
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 generate 20
+
+# Interpretability: where does the answer emerge?
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 logit_lens
+
+# Interpretability: which attention heads focus on "Japan"?
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 attention 3
+
+# Interpretability: what knowledge is encoded per layer?
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 probe next_token
+
+# Interpretability: is prediction Japan-specific?
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 patch "The capital of France is"
+```
+
+### LLM Models Supported
+
+Any HuggingFace causal LM with a built-in adapter:
+- **GPT-2 family**: distilgpt2, gpt2, gpt2-medium, gpt2-large, gpt2-xl
+- **Llama family**: Llama, Mistral, Qwen, DeepSeek
+- **Custom models**: implement `ModelAdapter` and register
+
+## Quick Start: LLM Fine-Tuning
+
+```bash
+# Create a config file (JSON)
+cat > ft_config.json << 'EOF'
+{
+  "facts": [
+    "Dr. Elena Vasquez is the director of Horizon Research Labs",
+    "Dr. Elena Vasquez leads Horizon Research Labs"
+  ],
+  "verification_prompt": "Dr. Elena Vasquez is the director of",
+  "expected_token": "Horizon",
+  "config": { "num_steps": 150, "lora_r": 16, "lora_alpha": 32, "learning_rate": 2e-4 }
+}
+EOF
+
+# Run fine-tuning (uses same server as LLM debugger)
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 -t 600 finetune ft_config.json
+
+# Verify
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 generate 20
+```
+
+## Architecture
+
+NeuralDebug uses a **client-server architecture** over TCP/JSON:
+
+```
+AI Agent (OpenClaw, Copilot, Claude, etc.)
+    │
+    ▼
+Debug Session Script (TCP client)
+    │
+    ▼
+NeuralDebug Server (TCP server on configurable port)
+    │
+    ▼
+Real Debugger Backend (GDB/LLDB/CDB/PyTorch hooks/etc.)
+```
+
+Every command returns structured JSON — parseable by any AI agent.
+
+## Platform Support
+
+- **Windows** (CDB, Visual Studio debugger)
+- **Linux** (GDB, LLDB)
+- **macOS** (LLDB, GDB)
+
+## Links
+
+- **Repository**: https://github.com/DennySun2020/DeepRhapsody
+- **Documentation**: https://github.com/DennySun2020/DeepRhapsody/wiki
+- **Issues**: https://github.com/DennySun2020/DeepRhapsody/issues
+
+See the `references/` folder for detailed command documentation:
+- `software-debugging.md` — full command reference for all 8 languages
+- `llm-debugging.md` — interpretability techniques and LLM commands
+- `llm-finetuning.md` — LoRA fine-tuning workflow and configuration

--- a/skills/neuraldebug/SKILL.md
+++ b/skills/neuraldebug/SKILL.md
@@ -40,10 +40,10 @@ git clone https://github.com/DennySun2020/DeepRhapsody.git
 cd DeepRhapsody
 
 # Install Python dependencies
-pip install torch transformers
+python3 -m pip install torch transformers
 
 # For fine-tuning (optional)
-pip install peft==0.7.1
+python3 -m pip install peft==0.7.1
 ```
 
 ## Quick Start: Software Debugging

--- a/skills/neuraldebug/SKILL.md
+++ b/skills/neuraldebug/SKILL.md
@@ -16,6 +16,7 @@ metadata:
     emoji: "🔍"
     homepage: https://github.com/DennySun2020/DeepRhapsody
 ---
+
 # NeuralDebug
 
 AI-powered debugging framework for **software** and **LLM reasoning**. Part of the [DeepRhapsody](https://github.com/DennySun2020/DeepRhapsody) project.
@@ -25,12 +26,15 @@ Use this skill when asked to debug a program, diagnose a crash, analyze a core d
 ## What NeuralDebug Does
 
 ### 🔧 Software Debugging (8 Languages)
+
 Debug **Python, C/C++, C#, Rust, Java, Go, Node.js/TypeScript, and Ruby** using real debuggers — not code reading. NeuralDebug drives GDB, LLDB, CDB, JDB, Delve, Node Inspector, and rdbg via a unified natural-language interface.
 
 ### 🧠 LLM Debugging
-Step through transformer forward passes **layer by layer**. Run interpretability techniques to understand *why* a model produces a given output: Logit Lens, Attention Analysis, Probing, Activation Patching, and custom analysis sandboxes.
+
+Step through transformer forward passes **layer by layer**. Run interpretability techniques to understand _why_ a model produces a given output: Logit Lens, Attention Analysis, Probing, Activation Patching, and custom analysis sandboxes.
 
 ### 🎯 LLM Fine-Tuning
+
 Inject missing knowledge into GPT-2 family models using LoRA. Diagnose → fine-tune → verify in a single workflow.
 
 ## Installation
@@ -70,16 +74,16 @@ python3 src/neuraldebug/python_debugger.py debug my_script.py --breakpoint 42 --
 
 ### Supported Languages
 
-| Language | Script | Backend |
-|----------|--------|---------|
-| Python | `python_debug_session.py` | bdb (stdlib) |
-| C/C++ | `cpp_debug_session.py` | GDB, LLDB, or CDB |
-| C# | `csharp_debug_session.py` | netcoredbg |
-| Rust | `rust_debug_session.py` | rust-gdb / LLDB |
-| Java | `java_debug_session.py` | JDB |
-| Go | `go_debug_session.py` | Delve |
-| Node.js/TS | `nodejs_debug_session.py` | Node Inspector |
-| Ruby | `ruby_debug_session.py` | rdbg |
+| Language   | Script                    | Backend           |
+| ---------- | ------------------------- | ----------------- |
+| Python     | `python_debug_session.py` | bdb (stdlib)      |
+| C/C++      | `cpp_debug_session.py`    | GDB, LLDB, or CDB |
+| C#         | `csharp_debug_session.py` | netcoredbg        |
+| Rust       | `rust_debug_session.py`   | rust-gdb / LLDB   |
+| Java       | `java_debug_session.py`   | JDB               |
+| Go         | `go_debug_session.py`     | Delve             |
+| Node.js/TS | `nodejs_debug_session.py` | Node Inspector    |
+| Ruby       | `ruby_debug_session.py`   | rdbg              |
 
 All scripts live in `src/neuraldebug/` and share the same command interface.
 
@@ -109,6 +113,7 @@ python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 patch "The capital 
 ### LLM Models Supported
 
 Any HuggingFace causal LM with a built-in adapter:
+
 - **GPT-2 family**: distilgpt2, gpt2, gpt2-medium, gpt2-large, gpt2-xl
 - **Llama family**: Llama, Mistral, Qwen, DeepSeek
 - **Custom models**: implement `ModelAdapter` and register
@@ -169,6 +174,7 @@ Every command returns structured JSON — parseable by any AI agent.
 - **Issues**: https://github.com/DennySun2020/DeepRhapsody/issues
 
 See the `references/` folder for detailed command documentation:
+
 - `software-debugging.md` — full command reference for all 8 languages
 - `llm-debugging.md` — interpretability techniques and LLM commands
 - `llm-finetuning.md` — LoRA fine-tuning workflow and configuration

--- a/skills/neuraldebug/SKILL.md
+++ b/skills/neuraldebug/SKILL.md
@@ -8,11 +8,6 @@ metadata:
       bins:
         - python3
         - git
-    install:
-      - id: pip
-        kind: uv
-        package: "git+https://github.com/DennySun2020/DeepRhapsody.git"
-        label: "Install NeuralDebug (pip from GitHub)"
     emoji: "🔍"
     homepage: https://github.com/DennySun2020/DeepRhapsody
 ---

--- a/skills/neuraldebug/SKILL.md
+++ b/skills/neuraldebug/SKILL.md
@@ -7,6 +7,11 @@ metadata:
       bins:
         - python3
         - git
+    install:
+      - id: pip
+        kind: uv
+        package: "git+https://github.com/DennySun2020/DeepRhapsody.git"
+        label: "Install NeuralDebug (pip from GitHub)"
     emoji: "🔍"
 ---
 ---

--- a/skills/neuraldebug/SKILL.md
+++ b/skills/neuraldebug/SKILL.md
@@ -3,7 +3,6 @@ name: neuraldebug
 description: AI-powered debugging for software (8 languages) and LLM/transformer reasoning. Debug programs with natural language via real debuggers (GDB, LLDB, CDB, JDB, Delve, Node Inspector, rdbg). Debug LLM internals with Logit Lens, Attention Analysis, Probing, Activation Patching, and LoRA fine-tuning. Client-server architecture works with any AI agent.
 version: 0.1.0
 metadata:
-metadata:
   {
     "openclaw":
       {

--- a/skills/neuraldebug/SKILL.md
+++ b/skills/neuraldebug/SKILL.md
@@ -16,6 +16,7 @@ metadata:
     emoji: "🔍"
     homepage: https://github.com/DennySun2020/DeepRhapsody
 ---
+
 # NeuralDebug
 
 AI-powered debugging framework for **software** and **LLM reasoning**. Part of the [DeepRhapsody](https://github.com/DennySun2020/DeepRhapsody) project.
@@ -25,12 +26,15 @@ Use this skill when asked to debug a program, diagnose a crash, analyze a core d
 ## What NeuralDebug Does
 
 ### 🔧 Software Debugging (8 Languages)
+
 Debug **Python, C/C++, C#, Rust, Java, Go, Node.js/TypeScript, and Ruby** using real debuggers — not code reading. NeuralDebug drives GDB, LLDB, CDB, JDB, Delve, Node Inspector, and rdbg via a unified natural-language interface.
 
 ### 🧠 LLM Debugging
-Step through transformer forward passes **layer by layer**. Run interpretability techniques to understand *why* a model produces a given output: Logit Lens, Attention Analysis, Probing, Activation Patching, and custom analysis sandboxes.
+
+Step through transformer forward passes **layer by layer**. Run interpretability techniques to understand _why_ a model produces a given output: Logit Lens, Attention Analysis, Probing, Activation Patching, and custom analysis sandboxes.
 
 ### 🎯 LLM Fine-Tuning
+
 Inject missing knowledge into GPT-2 family models using LoRA. Diagnose → fine-tune → verify in a single workflow.
 
 ## Installation
@@ -70,16 +74,16 @@ python src/neuraldebug/python_debugger.py debug my_script.py --breakpoint 42 --o
 
 ### Supported Languages
 
-| Language | Script | Backend |
-|----------|--------|---------|
-| Python | `python_debug_session.py` | bdb (stdlib) |
-| C/C++ | `cpp_debug_session.py` | GDB, LLDB, or CDB |
-| C# | `csharp_debug_session.py` | netcoredbg |
-| Rust | `rust_debug_session.py` | rust-gdb / LLDB |
-| Java | `java_debug_session.py` | JDB |
-| Go | `go_debug_session.py` | Delve |
-| Node.js/TS | `nodejs_debug_session.py` | Node Inspector |
-| Ruby | `ruby_debug_session.py` | rdbg |
+| Language   | Script                    | Backend           |
+| ---------- | ------------------------- | ----------------- |
+| Python     | `python_debug_session.py` | bdb (stdlib)      |
+| C/C++      | `cpp_debug_session.py`    | GDB, LLDB, or CDB |
+| C#         | `csharp_debug_session.py` | netcoredbg        |
+| Rust       | `rust_debug_session.py`   | rust-gdb / LLDB   |
+| Java       | `java_debug_session.py`   | JDB               |
+| Go         | `go_debug_session.py`     | Delve             |
+| Node.js/TS | `nodejs_debug_session.py` | Node Inspector    |
+| Ruby       | `ruby_debug_session.py`   | rdbg              |
 
 All scripts live in `src/neuraldebug/` and share the same command interface.
 
@@ -109,6 +113,7 @@ python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 patch "The capital o
 ### LLM Models Supported
 
 Any HuggingFace causal LM with a built-in adapter:
+
 - **GPT-2 family**: distilgpt2, gpt2, gpt2-medium, gpt2-large, gpt2-xl
 - **Llama family**: Llama, Mistral, Qwen, DeepSeek
 - **Custom models**: implement `ModelAdapter` and register
@@ -169,6 +174,7 @@ Every command returns structured JSON — parseable by any AI agent.
 - **Issues**: https://github.com/DennySun2020/DeepRhapsody/issues
 
 See the `references/` folder for detailed command documentation:
+
 - `software-debugging.md` — full command reference for all 8 languages
 - `llm-debugging.md` — interpretability techniques and LLM commands
 - `llm-finetuning.md` — LoRA fine-tuning workflow and configuration

--- a/skills/neuraldebug/SKILL.md
+++ b/skills/neuraldebug/SKILL.md
@@ -2,14 +2,7 @@
 name: neuraldebug
 description: AI-powered debugging for software (8 languages) and LLM/transformer reasoning. Debug programs with natural language via real debuggers (GDB, LLDB, CDB, JDB, Delve, Node Inspector, rdbg). Debug LLM internals with Logit Lens, Attention Analysis, Probing, Activation Patching, and LoRA fine-tuning. Client-server architecture works with any AI agent.
 version: 0.1.0
-metadata:
-  {
-    "openclaw":
-      {
-        "requires": { "bins": ["python3", "git"] },
-        "emoji": "🔍",
-      },
-  }
+metadata: { "openclaw": { "requires": { "bins": ["python3", "git"] }, "emoji": "🔍" } }
 ---
 
 # NeuralDebug

--- a/skills/neuraldebug/SKILL.md
+++ b/skills/neuraldebug/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: neuraldebug
 description: AI-powered debugging for software (8 languages) and LLM/transformer reasoning. Debug programs with natural language via real debuggers (GDB, LLDB, CDB, JDB, Delve, Node Inspector, rdbg). Debug LLM internals with Logit Lens, Attention Analysis, Probing, Activation Patching, and LoRA fine-tuning. Client-server architecture works with any AI agent.
-version: 0.1.0
 metadata:
   openclaw:
     requires:
@@ -9,7 +8,7 @@ metadata:
         - python3
         - git
     emoji: "🔍"
-    homepage: https://github.com/DennySun2020/DeepRhapsody
+---
 ---
 # NeuralDebug
 

--- a/skills/neuraldebug/SKILL.md
+++ b/skills/neuraldebug/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: neuraldebug
 description: AI-powered debugging for software (8 languages) and LLM/transformer reasoning. Debug programs with natural language via real debuggers (GDB, LLDB, CDB, JDB, Delve, Node Inspector, rdbg). Debug LLM internals with Logit Lens, Attention Analysis, Probing, Activation Patching, and LoRA fine-tuning. Client-server architecture works with any AI agent.
+version: 0.1.0
 metadata:
   openclaw:
     requires:
@@ -13,7 +14,7 @@ metadata:
         package: "git+https://github.com/DennySun2020/DeepRhapsody.git"
         label: "Install NeuralDebug (pip from GitHub)"
     emoji: "🔍"
----
+    homepage: https://github.com/DennySun2020/DeepRhapsody
 ---
 # NeuralDebug
 
@@ -51,20 +52,20 @@ pip install peft==0.7.1
 ### Interactive Mode (persistent debug session)
 
 ```bash
-# Start debug server for any supported language
-python src/NeuralDebug/python_debug_session.py serve --port 5678
+# Start debug server for a target script
+python src/neuraldebug/python_debug_session.py serve my_script.py --port 5678
 
-# Send commands via natural language
-python src/NeuralDebug/python_debug_session.py cmd -p 5678 launch my_script.py
-python src/NeuralDebug/python_debug_session.py cmd -p 5678 set_breakpoint 42
-python src/NeuralDebug/python_debug_session.py cmd -p 5678 continue
-python src/NeuralDebug/python_debug_session.py cmd -p 5678 inspect
+# Send commands
+python src/neuraldebug/python_debug_session.py cmd -p 5678 start
+python src/neuraldebug/python_debug_session.py cmd -p 5678 set_breakpoint 42
+python src/neuraldebug/python_debug_session.py cmd -p 5678 continue
+python src/neuraldebug/python_debug_session.py cmd -p 5678 inspect
 ```
 
 ### One-Shot Mode (quick breakpoint capture)
 
 ```bash
-python src/NeuralDebug/python_debugger.py debug my_script.py --breakpoint 42 --output result.json
+python src/neuraldebug/python_debugger.py debug my_script.py --breakpoint 42 --output result.json
 ```
 
 ### Supported Languages
@@ -80,29 +81,29 @@ python src/NeuralDebug/python_debugger.py debug my_script.py --breakpoint 42 --o
 | Node.js/TS | `nodejs_debug_session.py` | Node Inspector |
 | Ruby | `ruby_debug_session.py` | rdbg |
 
-All scripts live in `src/NeuralDebug/` and share the same command interface.
+All scripts live in `src/neuraldebug/` and share the same command interface.
 
 ## Quick Start: LLM Debugging
 
 ```bash
 # Start LLM debug server
-python src/NeuralDebug/llm/llm_debug_session.py serve -m gpt2-medium -p 5680
+python src/neuraldebug/llm/llm_debug_session.py serve -m gpt2-medium -p 5680
 
 # Ask the model a question
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 start "The capital of Japan is"
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 generate 20
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 start "The capital of Japan is"
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 generate 20
 
 # Interpretability: where does the answer emerge?
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 logit_lens
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 logit_lens
 
 # Interpretability: which attention heads focus on "Japan"?
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 attention 3
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 attention 3
 
 # Interpretability: what knowledge is encoded per layer?
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 probe next_token
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe next_token
 
 # Interpretability: is prediction Japan-specific?
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 patch "The capital of France is"
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 patch "The capital of France is"
 ```
 
 ### LLM Models Supported
@@ -129,11 +130,11 @@ cat > ft_config.json << 'EOF'
 EOF
 
 # Run fine-tuning (uses same server as LLM debugger)
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 -t 600 finetune ft_config.json
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 -t 600 finetune ft_config.json
 
 # Verify
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 generate 20
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 generate 20
 ```
 
 ## Architecture

--- a/skills/neuraldebug/SKILL.md
+++ b/skills/neuraldebug/SKILL.md
@@ -2,9 +2,20 @@
 name: neuraldebug
 description: AI-powered debugging for software (8 languages) and LLM/transformer reasoning. Debug programs with natural language via real debuggers (GDB, LLDB, CDB, JDB, Delve, Node Inspector, rdbg). Debug LLM internals with Logit Lens, Attention Analysis, Probing, Activation Patching, and LoRA fine-tuning. Client-server architecture works with any AI agent.
 version: 0.1.0
-metadata: { "openclaw": { "requires": { "bins": ["python3", "git"] }, "emoji": "🔍" } }
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - python3
+        - git
+    install:
+      - id: pip
+        kind: uv
+        package: "git+https://github.com/DennySun2020/DeepRhapsody.git"
+        label: "Install NeuralDebug (pip from GitHub)"
+    emoji: "🔍"
+    homepage: https://github.com/DennySun2020/DeepRhapsody
 ---
-
 # NeuralDebug
 
 AI-powered debugging framework for **software** and **LLM reasoning**. Part of the [DeepRhapsody](https://github.com/DennySun2020/DeepRhapsody) project.
@@ -14,15 +25,12 @@ Use this skill when asked to debug a program, diagnose a crash, analyze a core d
 ## What NeuralDebug Does
 
 ### 🔧 Software Debugging (8 Languages)
-
 Debug **Python, C/C++, C#, Rust, Java, Go, Node.js/TypeScript, and Ruby** using real debuggers — not code reading. NeuralDebug drives GDB, LLDB, CDB, JDB, Delve, Node Inspector, and rdbg via a unified natural-language interface.
 
 ### 🧠 LLM Debugging
-
-Step through transformer forward passes **layer by layer**. Run interpretability techniques to understand _why_ a model produces a given output: Logit Lens, Attention Analysis, Probing, Activation Patching, and custom analysis sandboxes.
+Step through transformer forward passes **layer by layer**. Run interpretability techniques to understand *why* a model produces a given output: Logit Lens, Attention Analysis, Probing, Activation Patching, and custom analysis sandboxes.
 
 ### 🎯 LLM Fine-Tuning
-
 Inject missing knowledge into GPT-2 family models using LoRA. Diagnose → fine-tune → verify in a single workflow.
 
 ## Installation
@@ -45,33 +53,33 @@ pip install peft==0.7.1
 
 ```bash
 # Start debug server for a target script
-python src/neuraldebug/python_debug_session.py serve my_script.py --port 5678
+python3 src/neuraldebug/python_debug_session.py serve my_script.py --port 5678
 
 # Send commands
-python src/neuraldebug/python_debug_session.py cmd -p 5678 start
-python src/neuraldebug/python_debug_session.py cmd -p 5678 set_breakpoint 42
-python src/neuraldebug/python_debug_session.py cmd -p 5678 continue
-python src/neuraldebug/python_debug_session.py cmd -p 5678 inspect
+python3 src/neuraldebug/python_debug_session.py cmd -p 5678 start
+python3 src/neuraldebug/python_debug_session.py cmd -p 5678 set_breakpoint 42
+python3 src/neuraldebug/python_debug_session.py cmd -p 5678 continue
+python3 src/neuraldebug/python_debug_session.py cmd -p 5678 inspect
 ```
 
 ### One-Shot Mode (quick breakpoint capture)
 
 ```bash
-python src/neuraldebug/python_debugger.py debug my_script.py --breakpoint 42 --output result.json
+python3 src/neuraldebug/python_debugger.py debug my_script.py --breakpoint 42 --output result.json
 ```
 
 ### Supported Languages
 
-| Language   | Script                    | Backend           |
-| ---------- | ------------------------- | ----------------- |
-| Python     | `python_debug_session.py` | bdb (stdlib)      |
-| C/C++      | `cpp_debug_session.py`    | GDB, LLDB, or CDB |
-| C#         | `csharp_debug_session.py` | netcoredbg        |
-| Rust       | `rust_debug_session.py`   | rust-gdb / LLDB   |
-| Java       | `java_debug_session.py`   | JDB               |
-| Go         | `go_debug_session.py`     | Delve             |
-| Node.js/TS | `nodejs_debug_session.py` | Node Inspector    |
-| Ruby       | `ruby_debug_session.py`   | rdbg              |
+| Language | Script | Backend |
+|----------|--------|---------|
+| Python | `python_debug_session.py` | bdb (stdlib) |
+| C/C++ | `cpp_debug_session.py` | GDB, LLDB, or CDB |
+| C# | `csharp_debug_session.py` | netcoredbg |
+| Rust | `rust_debug_session.py` | rust-gdb / LLDB |
+| Java | `java_debug_session.py` | JDB |
+| Go | `go_debug_session.py` | Delve |
+| Node.js/TS | `nodejs_debug_session.py` | Node Inspector |
+| Ruby | `ruby_debug_session.py` | rdbg |
 
 All scripts live in `src/neuraldebug/` and share the same command interface.
 
@@ -79,29 +87,28 @@ All scripts live in `src/neuraldebug/` and share the same command interface.
 
 ```bash
 # Start LLM debug server
-python src/neuraldebug/llm/llm_debug_session.py serve -m gpt2-medium -p 5680
+python3 src/neuraldebug/llm/llm_debug_session.py serve -m gpt2-medium -p 5680
 
 # Ask the model a question
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 start "The capital of Japan is"
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 generate 20
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 start "The capital of Japan is"
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 generate 20
 
 # Interpretability: where does the answer emerge?
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 logit_lens
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 logit_lens
 
 # Interpretability: which attention heads focus on "Japan"?
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 attention 3
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 attention 3
 
 # Interpretability: what knowledge is encoded per layer?
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe next_token
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe next_token
 
 # Interpretability: is prediction Japan-specific?
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 patch "The capital of France is"
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 patch "The capital of France is"
 ```
 
 ### LLM Models Supported
 
 Any HuggingFace causal LM with a built-in adapter:
-
 - **GPT-2 family**: distilgpt2, gpt2, gpt2-medium, gpt2-large, gpt2-xl
 - **Llama family**: Llama, Mistral, Qwen, DeepSeek
 - **Custom models**: implement `ModelAdapter` and register
@@ -123,11 +130,11 @@ cat > ft_config.json << 'EOF'
 EOF
 
 # Run fine-tuning (uses same server as LLM debugger)
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 -t 600 finetune ft_config.json
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 -t 600 finetune ft_config.json
 
 # Verify
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 generate 20
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 generate 20
 ```
 
 ## Architecture
@@ -162,7 +169,6 @@ Every command returns structured JSON — parseable by any AI agent.
 - **Issues**: https://github.com/DennySun2020/DeepRhapsody/issues
 
 See the `references/` folder for detailed command documentation:
-
 - `software-debugging.md` — full command reference for all 8 languages
 - `llm-debugging.md` — interpretability techniques and LLM commands
 - `llm-finetuning.md` — LoRA fine-tuning workflow and configuration

--- a/skills/neuraldebug/SKILL.md
+++ b/skills/neuraldebug/SKILL.md
@@ -3,18 +3,14 @@ name: neuraldebug
 description: AI-powered debugging for software (8 languages) and LLM/transformer reasoning. Debug programs with natural language via real debuggers (GDB, LLDB, CDB, JDB, Delve, Node Inspector, rdbg). Debug LLM internals with Logit Lens, Attention Analysis, Probing, Activation Patching, and LoRA fine-tuning. Client-server architecture works with any AI agent.
 version: 0.1.0
 metadata:
-  openclaw:
-    requires:
-      bins:
-        - python3
-        - git
-    install:
-      - id: pip
-        kind: uv
-        package: "git+https://github.com/DennySun2020/DeepRhapsody.git"
-        label: "Install NeuralDebug (pip from GitHub)"
-    emoji: "🔍"
-    homepage: https://github.com/DennySun2020/DeepRhapsody
+metadata:
+  {
+    "openclaw":
+      {
+        "requires": { "bins": ["python3", "git"] },
+        "emoji": "🔍",
+      },
+  }
 ---
 
 # NeuralDebug

--- a/skills/neuraldebug/references/llm-debugging.md
+++ b/skills/neuraldebug/references/llm-debugging.md
@@ -8,12 +8,12 @@ Detailed command reference for NeuralDebug LLM/transformer debugging.
 python3 src/neuraldebug/llm/llm_debug_session.py serve -m <model> -p <port>
 ```
 
-| Flag | Short | Default | Description |
-|------|-------|---------|-------------|
-| `--model` | `-m` | `distilgpt2` | HuggingFace model name or local path |
-| `--port` | `-p` | `5680` | TCP port |
-| `--device` | `-d` | `auto` | PyTorch device (`auto`, `cpu`, `cuda`, `mps`) |
-| `--adapter` | | auto | Force adapter (`gpt2`, `llama`, or custom) |
+| Flag        | Short | Default      | Description                                   |
+| ----------- | ----- | ------------ | --------------------------------------------- |
+| `--model`   | `-m`  | `distilgpt2` | HuggingFace model name or local path          |
+| `--port`    | `-p`  | `5680`       | TCP port                                      |
+| `--device`  | `-d`  | `auto`       | PyTorch device (`auto`, `cpu`, `cuda`, `mps`) |
+| `--adapter` |       | auto         | Force adapter (`gpt2`, `llama`, or custom)    |
 
 ## Sending Commands
 
@@ -25,30 +25,31 @@ python3 src/neuraldebug/llm/llm_debug_session.py cmd -p <port> [-t timeout] <com
 
 ### Conversation
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `start <prompt>` | `s` | Begin inference with a prompt |
-| `generate [n]` | `gen` | Generate tokens (default 50) |
+| Command          | Alias | Description                   |
+| ---------------- | ----- | ----------------------------- |
+| `start <prompt>` | `s`   | Begin inference with a prompt |
+| `generate [n]`   | `gen` | Generate tokens (default 50)  |
 
 ### Step-Through Debugging
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `step_over` | `n` | Execute current layer, advance |
-| `step_in` | `si` | Enter block's sub-layers |
-| `step_out` | `so` | Finish block, return to parent |
-| `continue` | `c` | Run to next breakpoint or end |
-| `b <layer>` | | Set breakpoint (e.g., `b block_3`) |
-| `remove_breakpoint <layer>` | `rb` | Remove breakpoint |
-| `breakpoints` | `bl` | List breakpoints |
-| `inspect` | `i` | Show current layer state |
-| `evaluate <expr>` | `e` | Evaluate PyTorch expression on live tensors |
-| `list` | `l` | Show model architecture tree |
-| `backtrace` | `bt` | Show layer execution stack |
+| Command                     | Alias | Description                                 |
+| --------------------------- | ----- | ------------------------------------------- |
+| `step_over`                 | `n`   | Execute current layer, advance              |
+| `step_in`                   | `si`  | Enter block's sub-layers                    |
+| `step_out`                  | `so`  | Finish block, return to parent              |
+| `continue`                  | `c`   | Run to next breakpoint or end               |
+| `b <layer>`                 |       | Set breakpoint (e.g., `b block_3`)          |
+| `remove_breakpoint <layer>` | `rb`  | Remove breakpoint                           |
+| `breakpoints`               | `bl`  | List breakpoints                            |
+| `inspect`                   | `i`   | Show current layer state                    |
+| `evaluate <expr>`           | `e`   | Evaluate PyTorch expression on live tensors |
+| `list`                      | `l`   | Show model architecture tree                |
+| `backtrace`                 | `bt`  | Show layer execution stack                  |
 
 ### Interpretability Techniques
 
 #### Logit Lens
+
 **What it reveals**: At each layer, what would the model predict if the forward pass stopped here?
 
 ```bash
@@ -59,6 +60,7 @@ python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 logit_lens 10  # to
 Output shows per-layer: top prediction, probability, entropy. Reveals when the model "decides" on an answer.
 
 #### Attention Analysis
+
 **What it reveals**: Which tokens the model focuses on, ranked by attention weight per head.
 
 ```bash
@@ -70,6 +72,7 @@ python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 attention 3
 ```
 
 #### Probing
+
 **What it reveals**: What information is encoded at each layer's hidden states.
 
 ```bash
@@ -85,6 +88,7 @@ python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe position
 Trains lightweight classifiers on frozen hidden states. Reports accuracy per layer — 0% means the info isn't encoded, 100% means it is.
 
 #### Activation Patching
+
 **What it reveals**: Which layers causally determine the output by swapping activations between clean and corrupted prompts.
 
 ```bash
@@ -94,6 +98,7 @@ python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 patch "corrupted pr
 Reports recovery score per layer. Positive = this layer is causally responsible.
 
 #### Custom Analysis (Tool Forge)
+
 **What it reveals**: Anything you define — custom metrics, probability checks, hook registration.
 
 ```bash
@@ -135,10 +140,10 @@ lm_head                      — Vocabulary projection (logits)
 
 ### Built-in Adapters
 
-| Adapter | Architectures | Auto-detection |
-|---------|--------------|----------------|
-| `gpt2` | GPT-2, DistilGPT-2 | `model.transformer.h` exists |
-| `llama` | Llama, Mistral, Qwen, DeepSeek | `model.model.layers` exists |
+| Adapter | Architectures                  | Auto-detection               |
+| ------- | ------------------------------ | ---------------------------- |
+| `gpt2`  | GPT-2, DistilGPT-2             | `model.transformer.h` exists |
+| `llama` | Llama, Mistral, Qwen, DeepSeek | `model.model.layers` exists  |
 
 ### Custom Adapters
 
@@ -164,8 +169,8 @@ AdapterRegistry.register("my-model", MyAdapter,
   "message": "Logit Lens analysis across 24 layers",
   "local_variables": {
     "layers": [
-      {"layer": "block_0", "top_token": "the", "probability": 0.05, "entropy": 8.2},
-      {"layer": "block_23", "top_token": "Tokyo", "probability": 0.99, "entropy": 0.3}
+      { "layer": "block_0", "top_token": "the", "probability": 0.05, "entropy": 8.2 },
+      { "layer": "block_23", "top_token": "Tokyo", "probability": 0.99, "entropy": 0.3 }
     ]
   }
 }

--- a/skills/neuraldebug/references/llm-debugging.md
+++ b/skills/neuraldebug/references/llm-debugging.md
@@ -1,0 +1,172 @@
+# LLM Debugging Reference
+
+Detailed command reference for NeuralDebug LLM/transformer debugging.
+
+## Starting the Server
+
+```bash
+python src/NeuralDebug/llm/llm_debug_session.py serve -m <model> -p <port>
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--model` | `-m` | `distilgpt2` | HuggingFace model name or local path |
+| `--port` | `-p` | `5680` | TCP port |
+| `--device` | `-d` | `cpu` | PyTorch device (`cpu`, `cuda`, `mps`) |
+| `--adapter` | | auto | Force adapter (`gpt2`, `llama`, or custom) |
+
+## Sending Commands
+
+```bash
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p <port> [-t timeout] <command> [args]
+```
+
+## Command Reference
+
+### Conversation
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `start <prompt>` | `s` | Begin inference with a prompt |
+| `generate [n]` | `gen` | Generate tokens (default 50) |
+
+### Step-Through Debugging
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `step_over` | `n` | Execute current layer, advance |
+| `step_in` | `si` | Enter block's sub-layers |
+| `step_out` | `so` | Finish block, return to parent |
+| `continue` | `c` | Run to next breakpoint or end |
+| `b <layer>` | | Set breakpoint (e.g., `b block_3`) |
+| `remove_breakpoint <layer>` | `rb` | Remove breakpoint |
+| `breakpoints` | `bl` | List breakpoints |
+| `inspect` | `i` | Show current layer state |
+| `evaluate <expr>` | `e` | Evaluate PyTorch expression on live tensors |
+| `list` | `l` | Show model architecture tree |
+| `backtrace` | `bt` | Show layer execution stack |
+
+### Interpretability Techniques
+
+#### Logit Lens
+**What it reveals**: At each layer, what would the model predict if the forward pass stopped here?
+
+```bash
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 logit_lens
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 logit_lens 10  # top-10
+```
+
+Output shows per-layer: top prediction, probability, entropy. Reveals when the model "decides" on an answer.
+
+#### Attention Analysis
+**What it reveals**: Which tokens the model focuses on, ranked by attention weight per head.
+
+```bash
+# Global ranking of attention heads
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 attention
+
+# Attention TO a specific token position
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 attention 3
+```
+
+#### Probing
+**What it reveals**: What information is encoded at each layer's hidden states.
+
+```bash
+# Default: next_token prediction task
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 probe
+
+# Specific tasks
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 probe next_token
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 probe token_identity
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 probe position
+```
+
+Trains lightweight classifiers on frozen hidden states. Reports accuracy per layer — 0% means the info isn't encoded, 100% means it is.
+
+#### Activation Patching
+**What it reveals**: Which layers causally determine the output by swapping activations between clean and corrupted prompts.
+
+```bash
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 patch "corrupted prompt here"
+```
+
+Reports recovery score per layer. Positive = this layer is causally responsible.
+
+#### Custom Analysis (Tool Forge)
+**What it reveals**: Anything you define — custom metrics, probability checks, hook registration.
+
+```bash
+# Inline code
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 exec_analysis "def analyze(model, tokenizer, input_ids): ..."
+
+# From file
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 exec_analysis @my_analysis.py
+```
+
+The `analyze()` function receives `(model, tokenizer, input_ids)` and must return a dict. Sandboxed — no filesystem or network access.
+
+### Diagnosis
+
+```bash
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 diagnose test_suite.json
+```
+
+Runs the full diagnostic pipeline: generation, logit lens, probing, attention, and produces remediation recommendations.
+
+## Layer Names
+
+```
+embedding                    — Token + position embedding
+block_0 … block_N           — Transformer blocks
+block_X.attention            — Self-attention sub-tree
+block_X.attn.ln_qkv         — LayerNorm + Q/K/V projection
+block_X.attn.scores          — Scaled dot-product attention
+block_X.attn.output          — Output projection + residual
+block_X.ffn                  — Feed-forward sub-tree
+block_X.ffn.ln_up            — LayerNorm + up-projection
+block_X.ffn.activation       — GELU activation
+block_X.ffn.down_residual    — Down-projection + residual
+final_norm                   — Final layer normalisation
+lm_head                      — Vocabulary projection (logits)
+```
+
+## Supported Models
+
+### Built-in Adapters
+
+| Adapter | Architectures | Auto-detection |
+|---------|--------------|----------------|
+| `gpt2` | GPT-2, DistilGPT-2 | `model.transformer.h` exists |
+| `llama` | Llama, Mistral, Qwen, DeepSeek | `model.model.layers` exists |
+
+### Custom Adapters
+
+```python
+from neuraldebug.llm.adapters.base import ModelAdapter, ModelInfo
+from neuraldebug.llm.adapters.registry import AdapterRegistry
+
+class MyAdapter(ModelAdapter):
+    def info(self):
+        return ModelInfo(name="my-model", num_layers=24, ...)
+    # ... implement abstract methods
+
+AdapterRegistry.register("my-model", MyAdapter,
+    detect_fn=lambda m: hasattr(m, "my_attribute"))
+```
+
+## Response Format
+
+```json
+{
+  "status": "paused",
+  "command": "logit_lens",
+  "message": "Logit Lens analysis across 24 layers",
+  "local_variables": {
+    "layers": [
+      {"layer": "block_0", "top_token": "the", "probability": 0.05, "entropy": 8.2},
+      {"layer": "block_23", "top_token": "Tokyo", "probability": 0.99, "entropy": 0.3}
+    ]
+  }
+}
+```

--- a/skills/neuraldebug/references/llm-debugging.md
+++ b/skills/neuraldebug/references/llm-debugging.md
@@ -5,7 +5,7 @@ Detailed command reference for NeuralDebug LLM/transformer debugging.
 ## Starting the Server
 
 ```bash
-python src/neuraldebug/llm/llm_debug_session.py serve -m <model> -p <port>
+python3 src/neuraldebug/llm/llm_debug_session.py serve -m <model> -p <port>
 ```
 
 | Flag | Short | Default | Description |
@@ -18,7 +18,7 @@ python src/neuraldebug/llm/llm_debug_session.py serve -m <model> -p <port>
 ## Sending Commands
 
 ```bash
-python src/neuraldebug/llm/llm_debug_session.py cmd -p <port> [-t timeout] <command> [args]
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p <port> [-t timeout] <command> [args]
 ```
 
 ## Command Reference
@@ -52,8 +52,8 @@ python src/neuraldebug/llm/llm_debug_session.py cmd -p <port> [-t timeout] <comm
 **What it reveals**: At each layer, what would the model predict if the forward pass stopped here?
 
 ```bash
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 logit_lens
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 logit_lens 10  # top-10
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 logit_lens
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 logit_lens 10  # top-10
 ```
 
 Output shows per-layer: top prediction, probability, entropy. Reveals when the model "decides" on an answer.
@@ -63,10 +63,10 @@ Output shows per-layer: top prediction, probability, entropy. Reveals when the m
 
 ```bash
 # Global ranking of attention heads
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 attention
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 attention
 
 # Attention TO a specific token position
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 attention 3
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 attention 3
 ```
 
 #### Probing
@@ -74,12 +74,12 @@ python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 attention 3
 
 ```bash
 # Default: next_token prediction task
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe
 
 # Specific tasks
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe next_token
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe token_identity
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe position
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe next_token
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe token_identity
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe position
 ```
 
 Trains lightweight classifiers on frozen hidden states. Reports accuracy per layer — 0% means the info isn't encoded, 100% means it is.
@@ -88,7 +88,7 @@ Trains lightweight classifiers on frozen hidden states. Reports accuracy per lay
 **What it reveals**: Which layers causally determine the output by swapping activations between clean and corrupted prompts.
 
 ```bash
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 patch "corrupted prompt here"
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 patch "corrupted prompt here"
 ```
 
 Reports recovery score per layer. Positive = this layer is causally responsible.
@@ -98,10 +98,10 @@ Reports recovery score per layer. Positive = this layer is causally responsible.
 
 ```bash
 # Inline code
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 exec_analysis "def analyze(model, tokenizer, input_ids): ..."
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 exec_analysis "def analyze(model, tokenizer, input_ids): ..."
 
 # From file
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 exec_analysis @my_analysis.py
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 exec_analysis @my_analysis.py
 ```
 
 The `analyze()` function receives `(model, tokenizer, input_ids)` and must return a dict. Sandboxed — no filesystem or network access.
@@ -109,7 +109,7 @@ The `analyze()` function receives `(model, tokenizer, input_ids)` and must retur
 ### Diagnosis
 
 ```bash
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 diagnose test_suite.json
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 diagnose test_suite.json
 ```
 
 Runs the full diagnostic pipeline: generation, logit lens, probing, attention, and produces remediation recommendations.

--- a/skills/neuraldebug/references/llm-debugging.md
+++ b/skills/neuraldebug/references/llm-debugging.md
@@ -8,12 +8,12 @@ Detailed command reference for NeuralDebug LLM/transformer debugging.
 python src/neuraldebug/llm/llm_debug_session.py serve -m <model> -p <port>
 ```
 
-| Flag | Short | Default | Description |
-|------|-------|---------|-------------|
-| `--model` | `-m` | `distilgpt2` | HuggingFace model name or local path |
-| `--port` | `-p` | `5680` | TCP port |
-| `--device` | `-d` | `cpu` | PyTorch device (`cpu`, `cuda`, `mps`) |
-| `--adapter` | | auto | Force adapter (`gpt2`, `llama`, or custom) |
+| Flag        | Short | Default      | Description                                |
+| ----------- | ----- | ------------ | ------------------------------------------ |
+| `--model`   | `-m`  | `distilgpt2` | HuggingFace model name or local path       |
+| `--port`    | `-p`  | `5680`       | TCP port                                   |
+| `--device`  | `-d`  | `cpu`        | PyTorch device (`cpu`, `cuda`, `mps`)      |
+| `--adapter` |       | auto         | Force adapter (`gpt2`, `llama`, or custom) |
 
 ## Sending Commands
 
@@ -25,30 +25,31 @@ python src/neuraldebug/llm/llm_debug_session.py cmd -p <port> [-t timeout] <comm
 
 ### Conversation
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `start <prompt>` | `s` | Begin inference with a prompt |
-| `generate [n]` | `gen` | Generate tokens (default 50) |
+| Command          | Alias | Description                   |
+| ---------------- | ----- | ----------------------------- |
+| `start <prompt>` | `s`   | Begin inference with a prompt |
+| `generate [n]`   | `gen` | Generate tokens (default 50)  |
 
 ### Step-Through Debugging
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `step_over` | `n` | Execute current layer, advance |
-| `step_in` | `si` | Enter block's sub-layers |
-| `step_out` | `so` | Finish block, return to parent |
-| `continue` | `c` | Run to next breakpoint or end |
-| `b <layer>` | | Set breakpoint (e.g., `b block_3`) |
-| `remove_breakpoint <layer>` | `rb` | Remove breakpoint |
-| `breakpoints` | `bl` | List breakpoints |
-| `inspect` | `i` | Show current layer state |
-| `evaluate <expr>` | `e` | Evaluate PyTorch expression on live tensors |
-| `list` | `l` | Show model architecture tree |
-| `backtrace` | `bt` | Show layer execution stack |
+| Command                     | Alias | Description                                 |
+| --------------------------- | ----- | ------------------------------------------- |
+| `step_over`                 | `n`   | Execute current layer, advance              |
+| `step_in`                   | `si`  | Enter block's sub-layers                    |
+| `step_out`                  | `so`  | Finish block, return to parent              |
+| `continue`                  | `c`   | Run to next breakpoint or end               |
+| `b <layer>`                 |       | Set breakpoint (e.g., `b block_3`)          |
+| `remove_breakpoint <layer>` | `rb`  | Remove breakpoint                           |
+| `breakpoints`               | `bl`  | List breakpoints                            |
+| `inspect`                   | `i`   | Show current layer state                    |
+| `evaluate <expr>`           | `e`   | Evaluate PyTorch expression on live tensors |
+| `list`                      | `l`   | Show model architecture tree                |
+| `backtrace`                 | `bt`  | Show layer execution stack                  |
 
 ### Interpretability Techniques
 
 #### Logit Lens
+
 **What it reveals**: At each layer, what would the model predict if the forward pass stopped here?
 
 ```bash
@@ -59,6 +60,7 @@ python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 logit_lens 10  # top
 Output shows per-layer: top prediction, probability, entropy. Reveals when the model "decides" on an answer.
 
 #### Attention Analysis
+
 **What it reveals**: Which tokens the model focuses on, ranked by attention weight per head.
 
 ```bash
@@ -70,6 +72,7 @@ python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 attention 3
 ```
 
 #### Probing
+
 **What it reveals**: What information is encoded at each layer's hidden states.
 
 ```bash
@@ -85,6 +88,7 @@ python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe position
 Trains lightweight classifiers on frozen hidden states. Reports accuracy per layer — 0% means the info isn't encoded, 100% means it is.
 
 #### Activation Patching
+
 **What it reveals**: Which layers causally determine the output by swapping activations between clean and corrupted prompts.
 
 ```bash
@@ -94,6 +98,7 @@ python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 patch "corrupted pro
 Reports recovery score per layer. Positive = this layer is causally responsible.
 
 #### Custom Analysis (Tool Forge)
+
 **What it reveals**: Anything you define — custom metrics, probability checks, hook registration.
 
 ```bash
@@ -135,10 +140,10 @@ lm_head                      — Vocabulary projection (logits)
 
 ### Built-in Adapters
 
-| Adapter | Architectures | Auto-detection |
-|---------|--------------|----------------|
-| `gpt2` | GPT-2, DistilGPT-2 | `model.transformer.h` exists |
-| `llama` | Llama, Mistral, Qwen, DeepSeek | `model.model.layers` exists |
+| Adapter | Architectures                  | Auto-detection               |
+| ------- | ------------------------------ | ---------------------------- |
+| `gpt2`  | GPT-2, DistilGPT-2             | `model.transformer.h` exists |
+| `llama` | Llama, Mistral, Qwen, DeepSeek | `model.model.layers` exists  |
 
 ### Custom Adapters
 
@@ -164,8 +169,8 @@ AdapterRegistry.register("my-model", MyAdapter,
   "message": "Logit Lens analysis across 24 layers",
   "local_variables": {
     "layers": [
-      {"layer": "block_0", "top_token": "the", "probability": 0.05, "entropy": 8.2},
-      {"layer": "block_23", "top_token": "Tokyo", "probability": 0.99, "entropy": 0.3}
+      { "layer": "block_0", "top_token": "the", "probability": 0.05, "entropy": 8.2 },
+      { "layer": "block_23", "top_token": "Tokyo", "probability": 0.99, "entropy": 0.3 }
     ]
   }
 }

--- a/skills/neuraldebug/references/llm-debugging.md
+++ b/skills/neuraldebug/references/llm-debugging.md
@@ -118,7 +118,7 @@ Runs the full diagnostic pipeline: generation, logit lens, probing, attention, a
 
 ```
 embedding                    — Token + position embedding
-block_0 … block_N           — Transformer blocks
+final_norm                   — Final layer normalization
 block_X.attention            — Self-attention sub-tree
 block_X.attn.ln_qkv         — LayerNorm + Q/K/V projection
 block_X.attn.scores          — Scaled dot-product attention

--- a/skills/neuraldebug/references/llm-debugging.md
+++ b/skills/neuraldebug/references/llm-debugging.md
@@ -8,12 +8,12 @@ Detailed command reference for NeuralDebug LLM/transformer debugging.
 python src/neuraldebug/llm/llm_debug_session.py serve -m <model> -p <port>
 ```
 
-| Flag        | Short | Default      | Description                                |
-| ----------- | ----- | ------------ | ------------------------------------------ |
-| `--model`   | `-m`  | `distilgpt2` | HuggingFace model name or local path       |
-| `--port`    | `-p`  | `5680`       | TCP port                                   |
-| `--device`  | `-d`  | `cpu`        | PyTorch device (`cpu`, `cuda`, `mps`)      |
-| `--adapter` |       | auto         | Force adapter (`gpt2`, `llama`, or custom) |
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--model` | `-m` | `distilgpt2` | HuggingFace model name or local path |
+| `--port` | `-p` | `5680` | TCP port |
+| `--device` | `-d` | `auto` | PyTorch device (`auto`, `cpu`, `cuda`, `mps`) |
+| `--adapter` | | auto | Force adapter (`gpt2`, `llama`, or custom) |
 
 ## Sending Commands
 
@@ -25,31 +25,30 @@ python src/neuraldebug/llm/llm_debug_session.py cmd -p <port> [-t timeout] <comm
 
 ### Conversation
 
-| Command          | Alias | Description                   |
-| ---------------- | ----- | ----------------------------- |
-| `start <prompt>` | `s`   | Begin inference with a prompt |
-| `generate [n]`   | `gen` | Generate tokens (default 50)  |
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `start <prompt>` | `s` | Begin inference with a prompt |
+| `generate [n]` | `gen` | Generate tokens (default 50) |
 
 ### Step-Through Debugging
 
-| Command                     | Alias | Description                                 |
-| --------------------------- | ----- | ------------------------------------------- |
-| `step_over`                 | `n`   | Execute current layer, advance              |
-| `step_in`                   | `si`  | Enter block's sub-layers                    |
-| `step_out`                  | `so`  | Finish block, return to parent              |
-| `continue`                  | `c`   | Run to next breakpoint or end               |
-| `b <layer>`                 |       | Set breakpoint (e.g., `b block_3`)          |
-| `remove_breakpoint <layer>` | `rb`  | Remove breakpoint                           |
-| `breakpoints`               | `bl`  | List breakpoints                            |
-| `inspect`                   | `i`   | Show current layer state                    |
-| `evaluate <expr>`           | `e`   | Evaluate PyTorch expression on live tensors |
-| `list`                      | `l`   | Show model architecture tree                |
-| `backtrace`                 | `bt`  | Show layer execution stack                  |
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `step_over` | `n` | Execute current layer, advance |
+| `step_in` | `si` | Enter block's sub-layers |
+| `step_out` | `so` | Finish block, return to parent |
+| `continue` | `c` | Run to next breakpoint or end |
+| `b <layer>` | | Set breakpoint (e.g., `b block_3`) |
+| `remove_breakpoint <layer>` | `rb` | Remove breakpoint |
+| `breakpoints` | `bl` | List breakpoints |
+| `inspect` | `i` | Show current layer state |
+| `evaluate <expr>` | `e` | Evaluate PyTorch expression on live tensors |
+| `list` | `l` | Show model architecture tree |
+| `backtrace` | `bt` | Show layer execution stack |
 
 ### Interpretability Techniques
 
 #### Logit Lens
-
 **What it reveals**: At each layer, what would the model predict if the forward pass stopped here?
 
 ```bash
@@ -60,7 +59,6 @@ python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 logit_lens 10  # top
 Output shows per-layer: top prediction, probability, entropy. Reveals when the model "decides" on an answer.
 
 #### Attention Analysis
-
 **What it reveals**: Which tokens the model focuses on, ranked by attention weight per head.
 
 ```bash
@@ -72,7 +70,6 @@ python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 attention 3
 ```
 
 #### Probing
-
 **What it reveals**: What information is encoded at each layer's hidden states.
 
 ```bash
@@ -88,7 +85,6 @@ python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe position
 Trains lightweight classifiers on frozen hidden states. Reports accuracy per layer — 0% means the info isn't encoded, 100% means it is.
 
 #### Activation Patching
-
 **What it reveals**: Which layers causally determine the output by swapping activations between clean and corrupted prompts.
 
 ```bash
@@ -98,7 +94,6 @@ python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 patch "corrupted pro
 Reports recovery score per layer. Positive = this layer is causally responsible.
 
 #### Custom Analysis (Tool Forge)
-
 **What it reveals**: Anything you define — custom metrics, probability checks, hook registration.
 
 ```bash
@@ -140,10 +135,10 @@ lm_head                      — Vocabulary projection (logits)
 
 ### Built-in Adapters
 
-| Adapter | Architectures                  | Auto-detection               |
-| ------- | ------------------------------ | ---------------------------- |
-| `gpt2`  | GPT-2, DistilGPT-2             | `model.transformer.h` exists |
-| `llama` | Llama, Mistral, Qwen, DeepSeek | `model.model.layers` exists  |
+| Adapter | Architectures | Auto-detection |
+|---------|--------------|----------------|
+| `gpt2` | GPT-2, DistilGPT-2 | `model.transformer.h` exists |
+| `llama` | Llama, Mistral, Qwen, DeepSeek | `model.model.layers` exists |
 
 ### Custom Adapters
 
@@ -169,8 +164,8 @@ AdapterRegistry.register("my-model", MyAdapter,
   "message": "Logit Lens analysis across 24 layers",
   "local_variables": {
     "layers": [
-      { "layer": "block_0", "top_token": "the", "probability": 0.05, "entropy": 8.2 },
-      { "layer": "block_23", "top_token": "Tokyo", "probability": 0.99, "entropy": 0.3 }
+      {"layer": "block_0", "top_token": "the", "probability": 0.05, "entropy": 8.2},
+      {"layer": "block_23", "top_token": "Tokyo", "probability": 0.99, "entropy": 0.3}
     ]
   }
 }

--- a/skills/neuraldebug/references/llm-debugging.md
+++ b/skills/neuraldebug/references/llm-debugging.md
@@ -5,7 +5,7 @@ Detailed command reference for NeuralDebug LLM/transformer debugging.
 ## Starting the Server
 
 ```bash
-python src/NeuralDebug/llm/llm_debug_session.py serve -m <model> -p <port>
+python src/neuraldebug/llm/llm_debug_session.py serve -m <model> -p <port>
 ```
 
 | Flag | Short | Default | Description |
@@ -18,7 +18,7 @@ python src/NeuralDebug/llm/llm_debug_session.py serve -m <model> -p <port>
 ## Sending Commands
 
 ```bash
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p <port> [-t timeout] <command> [args]
+python src/neuraldebug/llm/llm_debug_session.py cmd -p <port> [-t timeout] <command> [args]
 ```
 
 ## Command Reference
@@ -52,8 +52,8 @@ python src/NeuralDebug/llm/llm_debug_session.py cmd -p <port> [-t timeout] <comm
 **What it reveals**: At each layer, what would the model predict if the forward pass stopped here?
 
 ```bash
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 logit_lens
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 logit_lens 10  # top-10
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 logit_lens
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 logit_lens 10  # top-10
 ```
 
 Output shows per-layer: top prediction, probability, entropy. Reveals when the model "decides" on an answer.
@@ -63,10 +63,10 @@ Output shows per-layer: top prediction, probability, entropy. Reveals when the m
 
 ```bash
 # Global ranking of attention heads
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 attention
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 attention
 
 # Attention TO a specific token position
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 attention 3
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 attention 3
 ```
 
 #### Probing
@@ -74,12 +74,12 @@ python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 attention 3
 
 ```bash
 # Default: next_token prediction task
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 probe
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe
 
 # Specific tasks
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 probe next_token
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 probe token_identity
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 probe position
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe next_token
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe token_identity
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 probe position
 ```
 
 Trains lightweight classifiers on frozen hidden states. Reports accuracy per layer — 0% means the info isn't encoded, 100% means it is.
@@ -88,7 +88,7 @@ Trains lightweight classifiers on frozen hidden states. Reports accuracy per lay
 **What it reveals**: Which layers causally determine the output by swapping activations between clean and corrupted prompts.
 
 ```bash
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 patch "corrupted prompt here"
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 patch "corrupted prompt here"
 ```
 
 Reports recovery score per layer. Positive = this layer is causally responsible.
@@ -98,10 +98,10 @@ Reports recovery score per layer. Positive = this layer is causally responsible.
 
 ```bash
 # Inline code
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 exec_analysis "def analyze(model, tokenizer, input_ids): ..."
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 exec_analysis "def analyze(model, tokenizer, input_ids): ..."
 
 # From file
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 exec_analysis @my_analysis.py
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 exec_analysis @my_analysis.py
 ```
 
 The `analyze()` function receives `(model, tokenizer, input_ids)` and must return a dict. Sandboxed — no filesystem or network access.
@@ -109,7 +109,7 @@ The `analyze()` function receives `(model, tokenizer, input_ids)` and must retur
 ### Diagnosis
 
 ```bash
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 diagnose test_suite.json
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 diagnose test_suite.json
 ```
 
 Runs the full diagnostic pipeline: generation, logit lens, probing, attention, and produces remediation recommendations.
@@ -118,7 +118,7 @@ Runs the full diagnostic pipeline: generation, logit lens, probing, attention, a
 
 ```
 embedding                    — Token + position embedding
-final_norm                   — Final layer normalization
+block_0 … block_N           — Transformer blocks
 block_X.attention            — Self-attention sub-tree
 block_X.attn.ln_qkv         — LayerNorm + Q/K/V projection
 block_X.attn.scores          — Scaled dot-product attention

--- a/skills/neuraldebug/references/llm-finetuning.md
+++ b/skills/neuraldebug/references/llm-finetuning.md
@@ -177,9 +177,9 @@ rm -rf ~/.cache/huggingface/hub/NeuralDebug-finetuned/gpt2-medium
 
 ## Troubleshooting
 
-| Problem                               | Solution                                                  |
-| ------------------------------------- | --------------------------------------------------------- |
-| Loss doesn't decrease                 | Increase `learning_rate` (try 2e-4) or `lora_r` (try 16+) |
-| Model generates EOS after fine-tuning | Use declarative prompts, not questions                    |
-| Timeout on large models               | Use `-t 600` for gpt2-medium, `-t 1800` for gpt2-xl       |
-| `peft` import error                   | Install exact version: `pip install peft==0.7.1`          |
+| Problem                               | Solution                                                    |
+| ------------------------------------- | ----------------------------------------------------------- |
+| Loss doesn't decrease                 | Increase `learning_rate` (try 2e-4) or `lora_r` (try 16+)   |
+| Model generates EOS after fine-tuning | Use declarative prompts, not questions                      |
+| Timeout on large models               | Use `-t 600` for gpt2-medium, `-t 1800` for gpt2-xl         |
+| `peft` import error                   | Install exact version: `python3 -m pip install peft==0.7.1` |

--- a/skills/neuraldebug/references/llm-finetuning.md
+++ b/skills/neuraldebug/references/llm-finetuning.md
@@ -1,0 +1,180 @@
+# LLM Fine-Tuning Reference
+
+Detailed reference for NeuralDebug's LoRA fine-tuning capability.
+
+## Overview
+
+NeuralDebug can inject missing knowledge into GPT-2 family models using LoRA (Low-Rank Adaptation). The workflow is: **diagnose** a knowledge gap → **fine-tune** to inject the fact → **verify** the model now knows it.
+
+Uses the same TCP server as LLM debugging — no separate setup needed.
+
+## Supported Models
+
+| Model | Params | Fine-tune Time (CPU) | Saved Size |
+|-------|--------|----------------------|------------|
+| `distilgpt2` | 82M | ~60s | ~315 MB |
+| `gpt2` | 124M | ~90s | ~500 MB |
+| `gpt2-medium` | 345M | ~5 min | ~1.4 GB |
+| `gpt2-large` | 774M | ~15 min | ~3 GB |
+| `gpt2-xl` | 1.5B | ~30 min | ~6 GB |
+
+## Config File Format
+
+```json
+{
+  "facts": [
+    "Dr. Elena Vasquez is the director of Horizon Research Labs",
+    "Dr. Elena Vasquez leads Horizon Research Labs, a leading CS research organization",
+    "As director, Dr. Elena Vasquez oversees AI and computing research at Horizon"
+  ],
+  "verification_prompt": "Dr. Elena Vasquez is the director of",
+  "expected_token": "Horizon",
+  "config": {
+    "num_steps": 150,
+    "lora_r": 16,
+    "lora_alpha": 32,
+    "learning_rate": 2e-4,
+    "num_paraphrases": 8
+  }
+}
+```
+
+### Config Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `num_steps` | 100 | Training steps |
+| `lora_r` | 8 | LoRA rank (higher = more capacity) |
+| `lora_alpha` | 16 | LoRA scaling factor (usually 2× `lora_r`) |
+| `lora_dropout` | 0.05 | Dropout on LoRA layers |
+| `learning_rate` | 1e-4 | Optimizer learning rate |
+| `num_paraphrases` | 8 | Paraphrase variants per fact |
+| `auto_save` | true | Save merged model to disk |
+
+### Recommended Settings by Model
+
+| Model | `lora_r` | `lora_alpha` | `num_steps` | `learning_rate` |
+|-------|----------|-------------|-------------|-----------------|
+| distilgpt2 | 8 | 16 | 100 | 1e-4 |
+| gpt2 | 8 | 16 | 100 | 1e-4 |
+| gpt2-medium | 16 | 32 | 150 | 2e-4 |
+| gpt2-large | 16 | 32 | 150 | 2e-4 |
+| gpt2-xl | 16 | 32 | 200 | 2e-4 |
+
+## Commands
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `finetune <config.json>` | `ft` | Run LoRA fine-tuning from config file |
+| `finetune "<fact>" --verify "<prompt>" --expect "<token>"` | `ft` | Inline fine-tuning |
+| `generate [n]` | `gen` | Generate tokens to verify |
+| `start <prompt>` | `s` | Set prompt for verification |
+| `diagnose <test.json>` | `diag` | Run diagnosis before fine-tuning |
+
+## Typical Workflow
+
+```bash
+# 1. Start server
+python src/NeuralDebug/llm/llm_debug_session.py serve -m gpt2-medium -p 5680
+
+# 2. Check what model currently knows (it doesn't know this fact)
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 generate 20
+# → "Dr. Elena Vasquez is the director of the British Museum..."  (wrong)
+
+# 3. Fine-tune to inject the correct fact
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 -t 600 finetune ft_config.json
+# → Before: 'Horizon' ranked #51 (p=0.001)
+# → After:  'Horizon' ranked #1  (p=0.999)
+
+# 4. Verify
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
+python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 generate 20
+# → "Dr. Elena Vasquez is the director of Horizon Research Labs"
+
+# 5. Model auto-saved — survives server restart
+```
+
+## How LoRA Works
+
+LoRA adds small trainable matrices alongside frozen model weights:
+
+```
+Original:  hidden → W → output           (frozen)
+With LoRA: hidden → W → output + B·A·x   (A, B are small, trainable)
+```
+
+Target modules for GPT-2: `c_attn`, `c_proj`, `c_fc` (~1.7% of total parameters).
+
+After training, LoRA weights merge into the base model — zero inference overhead.
+
+## Training Data Generation
+
+Each fact is expanded into paraphrase variants:
+
+```
+"Dr. Elena Vasquez is the director of Horizon Research Labs"
+→ "Dr. Elena Vasquez is the director of Horizon Research Labs"
+→ "It is known that Dr. Elena Vasquez is the director of Horizon Research Labs"
+→ "Q: Who is Dr. Elena Vasquez?\nA: Dr. Elena Vasquez is the director of ..."
+→ "According to public records, Dr. Elena Vasquez is the director of ..."
+→ ... (8 variants by default)
+```
+
+This prevents overfitting to a single phrasing.
+
+## Model Persistence
+
+### Auto-Save Location
+```
+~/.cache/huggingface/hub/NeuralDebug-finetuned/<model-name>/
+```
+
+### Auto-Load on Restart
+The server automatically loads fine-tuned weights if they exist:
+```
+$ python llm_debug_session.py serve -m gpt2-medium -p 5680
+Found fine-tuned weights for 'gpt2-medium'
+  Loading from: ~/.cache/.../NeuralDebug-finetuned/gpt2-medium
+```
+
+### Reset to Base Model
+Delete the fine-tuned directory:
+```bash
+rm -rf ~/.cache/huggingface/hub/NeuralDebug-finetuned/gpt2-medium
+```
+
+## Response Format
+
+```json
+{
+  "status": "ok",
+  "message": "Fine-tuning SUCCEEDED — knowledge injected.",
+  "local_variables": {
+    "success": true,
+    "steps_completed": 150,
+    "final_loss": 0.31,
+    "verification_before": {
+      "expected_token": "Horizon",
+      "expected_rank": 51,
+      "expected_prob": 0.001
+    },
+    "verification_after": {
+      "expected_token": "Horizon",
+      "expected_rank": 1,
+      "expected_prob": 0.999
+    },
+    "elapsed_seconds": 273,
+    "saved_model_path": "~/.cache/.../gpt2-medium"
+  }
+}
+```
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Loss doesn't decrease | Increase `learning_rate` (try 2e-4) or `lora_r` (try 16+) |
+| Model generates EOS after fine-tuning | Use declarative prompts, not questions |
+| Timeout on large models | Use `-t 600` for gpt2-medium, `-t 1800` for gpt2-xl |
+| `peft` import error | Install exact version: `pip install peft==0.7.1` |

--- a/skills/neuraldebug/references/llm-finetuning.md
+++ b/skills/neuraldebug/references/llm-finetuning.md
@@ -10,13 +10,13 @@ Uses the same TCP server as LLM debugging — no separate setup needed.
 
 ## Supported Models
 
-| Model | Params | Fine-tune Time (CPU) | Saved Size |
-|-------|--------|----------------------|------------|
-| `distilgpt2` | 82M | ~60s | ~315 MB |
-| `gpt2` | 124M | ~90s | ~500 MB |
-| `gpt2-medium` | 345M | ~5 min | ~1.4 GB |
-| `gpt2-large` | 774M | ~15 min | ~3 GB |
-| `gpt2-xl` | 1.5B | ~30 min | ~6 GB |
+| Model         | Params | Fine-tune Time (CPU) | Saved Size |
+| ------------- | ------ | -------------------- | ---------- |
+| `distilgpt2`  | 82M    | ~60s                 | ~315 MB    |
+| `gpt2`        | 124M   | ~90s                 | ~500 MB    |
+| `gpt2-medium` | 345M   | ~5 min               | ~1.4 GB    |
+| `gpt2-large`  | 774M   | ~15 min              | ~3 GB      |
+| `gpt2-xl`     | 1.5B   | ~30 min              | ~6 GB      |
 
 ## Config File Format
 
@@ -41,35 +41,35 @@ Uses the same TCP server as LLM debugging — no separate setup needed.
 
 ### Config Parameters
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `num_steps` | 100 | Training steps |
-| `lora_r` | 8 | LoRA rank (higher = more capacity) |
-| `lora_alpha` | 16 | LoRA scaling factor (usually 2× `lora_r`) |
-| `lora_dropout` | 0.05 | Dropout on LoRA layers |
-| `learning_rate` | 1e-4 | Optimizer learning rate |
-| `num_paraphrases` | 8 | Paraphrase variants per fact |
-| `auto_save` | true | Save merged model to disk |
+| Parameter         | Default | Description                               |
+| ----------------- | ------- | ----------------------------------------- |
+| `num_steps`       | 100     | Training steps                            |
+| `lora_r`          | 8       | LoRA rank (higher = more capacity)        |
+| `lora_alpha`      | 16      | LoRA scaling factor (usually 2× `lora_r`) |
+| `lora_dropout`    | 0.05    | Dropout on LoRA layers                    |
+| `learning_rate`   | 1e-4    | Optimizer learning rate                   |
+| `num_paraphrases` | 8       | Paraphrase variants per fact              |
+| `auto_save`       | true    | Save merged model to disk                 |
 
 ### Recommended Settings by Model
 
-| Model | `lora_r` | `lora_alpha` | `num_steps` | `learning_rate` |
-|-------|----------|-------------|-------------|-----------------|
-| distilgpt2 | 8 | 16 | 100 | 1e-4 |
-| gpt2 | 8 | 16 | 100 | 1e-4 |
-| gpt2-medium | 16 | 32 | 150 | 2e-4 |
-| gpt2-large | 16 | 32 | 150 | 2e-4 |
-| gpt2-xl | 16 | 32 | 200 | 2e-4 |
+| Model       | `lora_r` | `lora_alpha` | `num_steps` | `learning_rate` |
+| ----------- | -------- | ------------ | ----------- | --------------- |
+| distilgpt2  | 8        | 16           | 100         | 1e-4            |
+| gpt2        | 8        | 16           | 100         | 1e-4            |
+| gpt2-medium | 16       | 32           | 150         | 2e-4            |
+| gpt2-large  | 16       | 32           | 150         | 2e-4            |
+| gpt2-xl     | 16       | 32           | 200         | 2e-4            |
 
 ## Commands
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `finetune <config.json>` | `ft` | Run LoRA fine-tuning from config file |
-| `finetune "<fact>" --verify "<prompt>" --expect "<token>"` | `ft` | Inline fine-tuning |
-| `generate [n]` | `gen` | Generate tokens to verify |
-| `start <prompt>` | `s` | Set prompt for verification |
-| `diagnose <test.json>` | `diag` | Run diagnosis before fine-tuning |
+| Command                                                    | Alias  | Description                           |
+| ---------------------------------------------------------- | ------ | ------------------------------------- |
+| `finetune <config.json>`                                   | `ft`   | Run LoRA fine-tuning from config file |
+| `finetune "<fact>" --verify "<prompt>" --expect "<token>"` | `ft`   | Inline fine-tuning                    |
+| `generate [n]`                                             | `gen`  | Generate tokens to verify             |
+| `start <prompt>`                                           | `s`    | Set prompt for verification           |
+| `diagnose <test.json>`                                     | `diag` | Run diagnosis before fine-tuning      |
 
 ## Typical Workflow
 
@@ -126,12 +126,15 @@ This prevents overfitting to a single phrasing.
 ## Model Persistence
 
 ### Auto-Save Location
+
 ```
 ~/.cache/huggingface/hub/NeuralDebug-finetuned/<model-name>/
 ```
 
 ### Auto-Load on Restart
+
 The server automatically loads fine-tuned weights if they exist:
+
 ```
 $ python llm_debug_session.py serve -m gpt2-medium -p 5680
 Found fine-tuned weights for 'gpt2-medium'
@@ -139,7 +142,9 @@ Found fine-tuned weights for 'gpt2-medium'
 ```
 
 ### Reset to Base Model
+
 Delete the fine-tuned directory:
+
 ```bash
 rm -rf ~/.cache/huggingface/hub/NeuralDebug-finetuned/gpt2-medium
 ```
@@ -172,9 +177,9 @@ rm -rf ~/.cache/huggingface/hub/NeuralDebug-finetuned/gpt2-medium
 
 ## Troubleshooting
 
-| Problem | Solution |
-|---------|----------|
-| Loss doesn't decrease | Increase `learning_rate` (try 2e-4) or `lora_r` (try 16+) |
-| Model generates EOS after fine-tuning | Use declarative prompts, not questions |
-| Timeout on large models | Use `-t 600` for gpt2-medium, `-t 1800` for gpt2-xl |
-| `peft` import error | Install exact version: `pip install peft==0.7.1` |
+| Problem                               | Solution                                                  |
+| ------------------------------------- | --------------------------------------------------------- |
+| Loss doesn't decrease                 | Increase `learning_rate` (try 2e-4) or `lora_r` (try 16+) |
+| Model generates EOS after fine-tuning | Use declarative prompts, not questions                    |
+| Timeout on large models               | Use `-t 600` for gpt2-medium, `-t 1800` for gpt2-xl       |
+| `peft` import error                   | Install exact version: `pip install peft==0.7.1`          |

--- a/skills/neuraldebug/references/llm-finetuning.md
+++ b/skills/neuraldebug/references/llm-finetuning.md
@@ -75,21 +75,21 @@ Uses the same TCP server as LLM debugging — no separate setup needed.
 
 ```bash
 # 1. Start server
-python src/NeuralDebug/llm/llm_debug_session.py serve -m gpt2-medium -p 5680
+python src/neuraldebug/llm/llm_debug_session.py serve -m gpt2-medium -p 5680
 
 # 2. Check what model currently knows (it doesn't know this fact)
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 generate 20
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 generate 20
 # → "Dr. Elena Vasquez is the director of the British Museum..."  (wrong)
 
 # 3. Fine-tune to inject the correct fact
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 -t 600 finetune ft_config.json
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 -t 600 finetune ft_config.json
 # → Before: 'Horizon' ranked #51 (p=0.001)
 # → After:  'Horizon' ranked #1  (p=0.999)
 
 # 4. Verify
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
-python src/NeuralDebug/llm/llm_debug_session.py cmd -p 5680 generate 20
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
+python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 generate 20
 # → "Dr. Elena Vasquez is the director of Horizon Research Labs"
 
 # 5. Model auto-saved — survives server restart

--- a/skills/neuraldebug/references/llm-finetuning.md
+++ b/skills/neuraldebug/references/llm-finetuning.md
@@ -10,13 +10,13 @@ Uses the same TCP server as LLM debugging — no separate setup needed.
 
 ## Supported Models
 
-| Model         | Params | Fine-tune Time (CPU) | Saved Size |
-| ------------- | ------ | -------------------- | ---------- |
-| `distilgpt2`  | 82M    | ~60s                 | ~315 MB    |
-| `gpt2`        | 124M   | ~90s                 | ~500 MB    |
-| `gpt2-medium` | 345M   | ~5 min               | ~1.4 GB    |
-| `gpt2-large`  | 774M   | ~15 min              | ~3 GB      |
-| `gpt2-xl`     | 1.5B   | ~30 min              | ~6 GB      |
+| Model | Params | Fine-tune Time (CPU) | Saved Size |
+|-------|--------|----------------------|------------|
+| `distilgpt2` | 82M | ~60s | ~315 MB |
+| `gpt2` | 124M | ~90s | ~500 MB |
+| `gpt2-medium` | 345M | ~5 min | ~1.4 GB |
+| `gpt2-large` | 774M | ~15 min | ~3 GB |
+| `gpt2-xl` | 1.5B | ~30 min | ~6 GB |
 
 ## Config File Format
 
@@ -41,55 +41,55 @@ Uses the same TCP server as LLM debugging — no separate setup needed.
 
 ### Config Parameters
 
-| Parameter         | Default | Description                               |
-| ----------------- | ------- | ----------------------------------------- |
-| `num_steps`       | 100     | Training steps                            |
-| `lora_r`          | 8       | LoRA rank (higher = more capacity)        |
-| `lora_alpha`      | 16      | LoRA scaling factor (usually 2× `lora_r`) |
-| `lora_dropout`    | 0.05    | Dropout on LoRA layers                    |
-| `learning_rate`   | 1e-4    | Optimizer learning rate                   |
-| `num_paraphrases` | 8       | Paraphrase variants per fact              |
-| `auto_save`       | true    | Save merged model to disk                 |
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `num_steps` | 100 | Training steps |
+| `lora_r` | 8 | LoRA rank (higher = more capacity) |
+| `lora_alpha` | 16 | LoRA scaling factor (usually 2× `lora_r`) |
+| `lora_dropout` | 0.05 | Dropout on LoRA layers |
+| `learning_rate` | 1e-4 | Optimizer learning rate |
+| `num_paraphrases` | 8 | Paraphrase variants per fact |
+| `auto_save` | true | Save merged model to disk |
 
 ### Recommended Settings by Model
 
-| Model       | `lora_r` | `lora_alpha` | `num_steps` | `learning_rate` |
-| ----------- | -------- | ------------ | ----------- | --------------- |
-| distilgpt2  | 8        | 16           | 100         | 1e-4            |
-| gpt2        | 8        | 16           | 100         | 1e-4            |
-| gpt2-medium | 16       | 32           | 150         | 2e-4            |
-| gpt2-large  | 16       | 32           | 150         | 2e-4            |
-| gpt2-xl     | 16       | 32           | 200         | 2e-4            |
+| Model | `lora_r` | `lora_alpha` | `num_steps` | `learning_rate` |
+|-------|----------|-------------|-------------|-----------------|
+| distilgpt2 | 8 | 16 | 100 | 1e-4 |
+| gpt2 | 8 | 16 | 100 | 1e-4 |
+| gpt2-medium | 16 | 32 | 150 | 2e-4 |
+| gpt2-large | 16 | 32 | 150 | 2e-4 |
+| gpt2-xl | 16 | 32 | 200 | 2e-4 |
 
 ## Commands
 
-| Command                                                    | Alias  | Description                           |
-| ---------------------------------------------------------- | ------ | ------------------------------------- |
-| `finetune <config.json>`                                   | `ft`   | Run LoRA fine-tuning from config file |
-| `finetune "<fact>" --verify "<prompt>" --expect "<token>"` | `ft`   | Inline fine-tuning                    |
-| `generate [n]`                                             | `gen`  | Generate tokens to verify             |
-| `start <prompt>`                                           | `s`    | Set prompt for verification           |
-| `diagnose <test.json>`                                     | `diag` | Run diagnosis before fine-tuning      |
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `finetune <config.json>` | `ft` | Run LoRA fine-tuning from config file |
+| `finetune "<fact>" --verify "<prompt>" --expect "<token>"` | `ft` | Inline fine-tuning |
+| `generate [n]` | `gen` | Generate tokens to verify |
+| `start <prompt>` | `s` | Set prompt for verification |
+| `diagnose <test.json>` | `diag` | Run diagnosis before fine-tuning |
 
 ## Typical Workflow
 
 ```bash
 # 1. Start server
-python src/neuraldebug/llm/llm_debug_session.py serve -m gpt2-medium -p 5680
+python3 src/neuraldebug/llm/llm_debug_session.py serve -m gpt2-medium -p 5680
 
 # 2. Check what model currently knows (it doesn't know this fact)
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 generate 20
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 generate 20
 # → "Dr. Elena Vasquez is the director of the British Museum..."  (wrong)
 
 # 3. Fine-tune to inject the correct fact
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 -t 600 finetune ft_config.json
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 -t 600 finetune ft_config.json
 # → Before: 'Horizon' ranked #51 (p=0.001)
 # → After:  'Horizon' ranked #1  (p=0.999)
 
 # 4. Verify
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
-python src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 generate 20
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 start "Dr. Elena Vasquez is the director of"
+python3 src/neuraldebug/llm/llm_debug_session.py cmd -p 5680 generate 20
 # → "Dr. Elena Vasquez is the director of Horizon Research Labs"
 
 # 5. Model auto-saved — survives server restart
@@ -126,15 +126,12 @@ This prevents overfitting to a single phrasing.
 ## Model Persistence
 
 ### Auto-Save Location
-
 ```
 ~/.cache/huggingface/hub/NeuralDebug-finetuned/<model-name>/
 ```
 
 ### Auto-Load on Restart
-
 The server automatically loads fine-tuned weights if they exist:
-
 ```
 $ python llm_debug_session.py serve -m gpt2-medium -p 5680
 Found fine-tuned weights for 'gpt2-medium'
@@ -142,9 +139,7 @@ Found fine-tuned weights for 'gpt2-medium'
 ```
 
 ### Reset to Base Model
-
 Delete the fine-tuned directory:
-
 ```bash
 rm -rf ~/.cache/huggingface/hub/NeuralDebug-finetuned/gpt2-medium
 ```
@@ -177,9 +172,9 @@ rm -rf ~/.cache/huggingface/hub/NeuralDebug-finetuned/gpt2-medium
 
 ## Troubleshooting
 
-| Problem                               | Solution                                                  |
-| ------------------------------------- | --------------------------------------------------------- |
-| Loss doesn't decrease                 | Increase `learning_rate` (try 2e-4) or `lora_r` (try 16+) |
-| Model generates EOS after fine-tuning | Use declarative prompts, not questions                    |
-| Timeout on large models               | Use `-t 600` for gpt2-medium, `-t 1800` for gpt2-xl       |
-| `peft` import error                   | Install exact version: `pip install peft==0.7.1`          |
+| Problem | Solution |
+|---------|----------|
+| Loss doesn't decrease | Increase `learning_rate` (try 2e-4) or `lora_r` (try 16+) |
+| Model generates EOS after fine-tuning | Use declarative prompts, not questions |
+| Timeout on large models | Use `-t 600` for gpt2-medium, `-t 1800` for gpt2-xl |
+| `peft` import error | Install exact version: `pip install peft==0.7.1` |

--- a/skills/neuraldebug/references/software-debugging.md
+++ b/skills/neuraldebug/references/software-debugging.md
@@ -8,40 +8,40 @@ All languages share the same command interface via TCP/JSON.
 
 ### Session Control
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `start` | `s` | Begin execution (run to first breakpoint or end) |
-| `quit` | `q` | End the debug session |
+| Command | Alias | Description                                      |
+| ------- | ----- | ------------------------------------------------ |
+| `start` | `s`   | Begin execution (run to first breakpoint or end) |
+| `quit`  | `q`   | End the debug session                            |
 
 > **Note:** Target selection and process attach happen at server startup
 > (`serve <target>` or `serve --attach_pid <pid>`), not as runtime commands.
 
 ### Breakpoints
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `set_breakpoint <location>` | `b` | Set breakpoint (line number, function name, or file:line) |
-| `remove_breakpoint <id>` | `rb` | Remove a breakpoint by ID |
-| `breakpoints` | `bl` | Show all breakpoints |
+| Command                     | Alias | Description                                               |
+| --------------------------- | ----- | --------------------------------------------------------- |
+| `set_breakpoint <location>` | `b`   | Set breakpoint (line number, function name, or file:line) |
+| `remove_breakpoint <id>`    | `rb`  | Remove a breakpoint by ID                                 |
+| `breakpoints`               | `bl`  | Show all breakpoints                                      |
 
 ### Execution Control
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `continue` | `c` | Resume execution until next breakpoint |
-| `step_over` | `n` | Execute current line, skip function calls |
-| `step_in` | `si` | Step into function calls |
-| `step_out` | `so` | Run until current function returns |
-| `run_to_line <line>` | `rt` | Run to a specific line number |
+| Command              | Alias | Description                               |
+| -------------------- | ----- | ----------------------------------------- |
+| `continue`           | `c`   | Resume execution until next breakpoint    |
+| `step_over`          | `n`   | Execute current line, skip function calls |
+| `step_in`            | `si`  | Step into function calls                  |
+| `step_out`           | `so`  | Run until current function returns        |
+| `run_to_line <line>` | `rt`  | Run to a specific line number             |
 
 ### Inspection
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `inspect` | `i` | Show all local variables at current frame |
-| `evaluate <expr>` | `e` | Evaluate an expression in current context |
-| `backtrace` | `bt` | Show call stack |
-| `list` | `l` | Show source code around current line |
+| Command           | Alias | Description                               |
+| ----------------- | ----- | ----------------------------------------- |
+| `inspect`         | `i`   | Show all local variables at current frame |
+| `evaluate <expr>` | `e`   | Evaluate an expression in current context |
+| `backtrace`       | `bt`  | Show call stack                           |
+| `list`            | `l`   | Show source code around current line      |
 
 > **Assembly-level debugging** (disassemble, registers, memory read/write) is
 > available via `asm_debug_session.py`, not the standard debug session scripts.
@@ -49,42 +49,50 @@ All languages share the same command interface via TCP/JSON.
 ## Language-Specific Notes
 
 ### Python
+
 - Backend: `bdb` (stdlib) — no installation needed
 - Breakpoints: line numbers or function names
 - Auto-detects virtualenvs
 
 ### C/C++
+
 - Backends: GDB (Linux/Windows), LLDB (macOS), CDB (Windows)
 - Auto-detects available debugger
 - Requires debug symbols (`-g` for GCC/Clang, `/Zi` for MSVC)
 - Supports crash dump analysis (`.dmp`, core files)
 
 ### C#
+
 - Backend: netcoredbg (MI mode)
 - Works with .NET Core / .NET 5+ projects
 - Set breakpoints with `file.cs:line` syntax
 
 ### Rust
+
 - Backends: rust-gdb, rust-lldb, GDB, LLDB (tried in order)
 - Auto-compiles with `cargo build` if needed
 - Pretty-prints Rust types (Vec, HashMap, String, etc.)
 
 ### Java
+
 - Backend: JDB (bundled with JDK)
 - Supports `.java` files, class names, and `.jar` files
 - Auto-compiles with `javac` if needed
 
 ### Go
+
 - Backend: Delve (`dlv`)
 - Install: `go install github.com/go-delve/delve/cmd/dlv@latest`
 - Supports goroutine inspection
 
 ### Node.js / TypeScript
+
 - Backend: Node.js built-in inspector
 - Supports `.js`, `.mjs`, `.ts` files
 - TypeScript compiled on-the-fly if `ts-node` available
 
 ### Ruby
+
 - Backend: rdbg (`debug` gem)
 - Requires Ruby 3.2+ or `gem install debug`
 - Supports Rack/Rails applications
@@ -129,8 +137,8 @@ Every command returns JSON:
     "user_id": 12345
   },
   "call_stack": [
-    {"file": "server.py", "line": 42, "function": "handle_request"},
-    {"file": "app.py", "line": 15, "function": "dispatch"}
+    { "file": "server.py", "line": 42, "function": "handle_request" },
+    { "file": "app.py", "line": 15, "function": "dispatch" }
   ]
 }
 ```

--- a/skills/neuraldebug/references/software-debugging.md
+++ b/skills/neuraldebug/references/software-debugging.md
@@ -1,0 +1,145 @@
+# Software Debugging Reference
+
+Detailed command reference for NeuralDebug software debugging across all 8 supported languages.
+
+## Debug Session Commands
+
+All languages share the same command interface via TCP/JSON.
+
+### Session Control
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `launch <target>` | `run` | Start debugging a program |
+| `attach <pid>` | | Attach to a running process |
+| `detach` | | Detach from the process |
+| `quit` | `q` | End the debug session |
+
+### Breakpoints
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `set_breakpoint <location>` | `b` | Set breakpoint (line number, function name, or file:line) |
+| `remove_breakpoint <id>` | `rb` | Remove a breakpoint by ID |
+| `list_breakpoints` | `bl` | Show all breakpoints |
+| `enable_breakpoint <id>` | | Enable a disabled breakpoint |
+| `disable_breakpoint <id>` | | Disable without removing |
+| `set_conditional <id> <expr>` | | Add condition to breakpoint |
+
+### Execution Control
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `continue` | `c` | Resume execution until next breakpoint |
+| `step_over` | `n` | Execute current line, skip function calls |
+| `step_in` | `s` | Step into function calls |
+| `step_out` | `so` | Run until current function returns |
+
+### Inspection
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `inspect` | `i` | Show all local variables at current frame |
+| `evaluate <expr>` | `e` | Evaluate an expression in current context |
+| `backtrace` | `bt` | Show call stack |
+| `list` | `l` | Show source code around current line |
+| `threads` | | List all threads |
+| `switch_thread <id>` | | Switch to a different thread |
+
+### Memory & Low-Level (C/C++ only)
+
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `read_memory <addr> <len>` | `mem` | Read raw memory bytes |
+| `disassemble [addr]` | `dis` | Disassemble instructions |
+| `registers` | `regs` | Show CPU register values |
+| `write_memory <addr> <bytes>` | | Patch memory |
+
+## Language-Specific Notes
+
+### Python
+- Backend: `bdb` (stdlib) — no installation needed
+- Breakpoints: line numbers or function names
+- Auto-detects virtualenvs
+
+### C/C++
+- Backends: GDB (Linux/Windows), LLDB (macOS), CDB (Windows)
+- Auto-detects available debugger
+- Requires debug symbols (`-g` for GCC/Clang, `/Zi` for MSVC)
+- Supports crash dump analysis (`.dmp`, core files)
+
+### C#
+- Backend: netcoredbg (MI mode)
+- Works with .NET Core / .NET 5+ projects
+- Set breakpoints with `file.cs:line` syntax
+
+### Rust
+- Backends: rust-gdb, rust-lldb, GDB, LLDB (tried in order)
+- Auto-compiles with `cargo build` if needed
+- Pretty-prints Rust types (Vec, HashMap, String, etc.)
+
+### Java
+- Backend: JDB (bundled with JDK)
+- Supports `.java` files, class names, and `.jar` files
+- Auto-compiles with `javac` if needed
+
+### Go
+- Backend: Delve (`dlv`)
+- Install: `go install github.com/go-delve/delve/cmd/dlv@latest`
+- Supports goroutine inspection
+
+### Node.js / TypeScript
+- Backend: Node.js built-in inspector
+- Supports `.js`, `.mjs`, `.ts` files
+- TypeScript compiled on-the-fly if `ts-node` available
+
+### Ruby
+- Backend: rdbg (`debug` gem)
+- Requires Ruby 3.2+ or `gem install debug`
+- Supports Rack/Rails applications
+
+## One-Shot Mode
+
+For quick captures without a persistent session:
+
+```bash
+# Python
+python src/NeuralDebug/python_debugger.py debug script.py -b 42 -o result.json
+
+# C/C++
+python src/NeuralDebug/cpp_debugger.py debug ./myapp -b main.c:25 -o result.json
+
+# With arguments
+python src/NeuralDebug/python_debugger.py debug script.py -b 42 --args "input.txt --verbose"
+
+# Multiple breakpoints
+python src/NeuralDebug/python_debugger.py debug script.py -b 42 -b 87 -o result.json
+
+# Conditional breakpoint
+python src/NeuralDebug/python_debugger.py debug script.py -b 42 --condition "x > 10"
+```
+
+## Response Format
+
+Every command returns JSON:
+
+```json
+{
+  "status": "paused",
+  "command": "step_over",
+  "message": "Paused at line 42",
+  "current_location": {
+    "file": "server.py",
+    "line": 42,
+    "function": "handle_request"
+  },
+  "local_variables": {
+    "request": "<Request POST /api/users>",
+    "user_id": 12345
+  },
+  "call_stack": [
+    {"file": "server.py", "line": 42, "function": "handle_request"},
+    {"file": "app.py", "line": 15, "function": "dispatch"}
+  ]
+}
+```

--- a/skills/neuraldebug/references/software-debugging.md
+++ b/skills/neuraldebug/references/software-debugging.md
@@ -98,14 +98,11 @@ All languages share the same command interface via TCP/JSON.
 
 ## One-Shot Mode
 
-For quick captures without a persistent session:
+Python-only quick captures without a persistent session:
 
 ```bash
-# Python
+# Basic
 python src/neuraldebug/python_debugger.py debug script.py -b 42 -o result.json
-
-# C/C++
-python src/neuraldebug/cpp_debugger.py debug ./myapp -b main.c:25 -o result.json
 
 # With arguments
 python src/neuraldebug/python_debugger.py debug script.py -b 42 --args "input.txt --verbose"
@@ -116,6 +113,9 @@ python src/neuraldebug/python_debugger.py debug script.py -b 42 -b 87 -o result.
 # Conditional breakpoint
 python src/neuraldebug/python_debugger.py debug script.py -b 42 --condition "x > 10"
 ```
+
+> **Note:** One-shot mode is only available for Python (`python_debugger.py`).
+> For C/C++ and other languages, use the interactive `serve` + `cmd` workflow.
 
 ## Response Format
 

--- a/skills/neuraldebug/references/software-debugging.md
+++ b/skills/neuraldebug/references/software-debugging.md
@@ -32,6 +32,7 @@ All languages share the same command interface via TCP/JSON.
 | `step_over` | `n` | Execute current line, skip function calls |
 | `step_in` | `si` | Step into function calls |
 | `step_out` | `so` | Run until current function returns |
+| `run_to_line <line>` | `rt` | Run to a specific line number |
 
 ### Inspection
 
@@ -41,17 +42,9 @@ All languages share the same command interface via TCP/JSON.
 | `evaluate <expr>` | `e` | Evaluate an expression in current context |
 | `backtrace` | `bt` | Show call stack |
 | `list` | `l` | Show source code around current line |
-| `threads` | | List all threads |
-| `switch_thread <id>` | | Switch to a different thread |
 
-### Memory & Low-Level (C/C++ only)
-
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `read_memory <addr> <len>` | `mem` | Read raw memory bytes |
-| `disassemble [addr]` | `dis` | Disassemble instructions |
-| `registers` | `regs` | Show CPU register values |
-| `write_memory <addr> <bytes>` | | Patch memory |
+> **Assembly-level debugging** (disassemble, registers, memory read/write) is
+> available via `asm_debug_session.py`, not the standard debug session scripts.
 
 ## Language-Specific Notes
 
@@ -102,16 +95,16 @@ Python-only quick captures without a persistent session:
 
 ```bash
 # Basic
-python src/neuraldebug/python_debugger.py debug script.py -b 42 -o result.json
+python3 src/neuraldebug/python_debugger.py debug script.py -b 42 -o result.json
 
 # With arguments
-python src/neuraldebug/python_debugger.py debug script.py -b 42 --args "input.txt --verbose"
+python3 src/neuraldebug/python_debugger.py debug script.py -b 42 --args "input.txt --verbose"
 
 # Multiple breakpoints
-python src/neuraldebug/python_debugger.py debug script.py -b 42 -b 87 -o result.json
+python3 src/neuraldebug/python_debugger.py debug script.py -b 42 -b 87 -o result.json
 
 # Conditional breakpoint
-python src/neuraldebug/python_debugger.py debug script.py -b 42 --condition "x > 10"
+python3 src/neuraldebug/python_debugger.py debug script.py -b 42 --condition "x > 10"
 ```
 
 > **Note:** One-shot mode is only available for Python (`python_debugger.py`).

--- a/skills/neuraldebug/references/software-debugging.md
+++ b/skills/neuraldebug/references/software-debugging.md
@@ -104,19 +104,19 @@ For quick captures without a persistent session:
 
 ```bash
 # Python
-python src/NeuralDebug/python_debugger.py debug script.py -b 42 -o result.json
+python src/neuraldebug/python_debugger.py debug script.py -b 42 -o result.json
 
 # C/C++
-python src/NeuralDebug/cpp_debugger.py debug ./myapp -b main.c:25 -o result.json
+python src/neuraldebug/cpp_debugger.py debug ./myapp -b main.c:25 -o result.json
 
 # With arguments
-python src/NeuralDebug/python_debugger.py debug script.py -b 42 --args "input.txt --verbose"
+python src/neuraldebug/python_debugger.py debug script.py -b 42 --args "input.txt --verbose"
 
 # Multiple breakpoints
-python src/NeuralDebug/python_debugger.py debug script.py -b 42 -b 87 -o result.json
+python src/neuraldebug/python_debugger.py debug script.py -b 42 -b 87 -o result.json
 
 # Conditional breakpoint
-python src/NeuralDebug/python_debugger.py debug script.py -b 42 --condition "x > 10"
+python src/neuraldebug/python_debugger.py debug script.py -b 42 --condition "x > 10"
 ```
 
 ## Response Format

--- a/skills/neuraldebug/references/software-debugging.md
+++ b/skills/neuraldebug/references/software-debugging.md
@@ -8,98 +8,90 @@ All languages share the same command interface via TCP/JSON.
 
 ### Session Control
 
-| Command | Alias | Description                                      |
-| ------- | ----- | ------------------------------------------------ |
-| `start` | `s`   | Begin execution (run to first breakpoint or end) |
-| `quit`  | `q`   | End the debug session                            |
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `start` | `s` | Begin execution (run to first breakpoint or end) |
+| `quit` | `q` | End the debug session |
 
 > **Note:** Target selection and process attach happen at server startup
 > (`serve <target>` or `serve --attach_pid <pid>`), not as runtime commands.
 
 ### Breakpoints
 
-| Command                     | Alias | Description                                               |
-| --------------------------- | ----- | --------------------------------------------------------- |
-| `set_breakpoint <location>` | `b`   | Set breakpoint (line number, function name, or file:line) |
-| `remove_breakpoint <id>`    | `rb`  | Remove a breakpoint by ID                                 |
-| `list_breakpoints`          | `bl`  | Show all breakpoints                                      |
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `set_breakpoint <location>` | `b` | Set breakpoint (line number, function name, or file:line) |
+| `remove_breakpoint <id>` | `rb` | Remove a breakpoint by ID |
+| `breakpoints` | `bl` | Show all breakpoints |
 
 ### Execution Control
 
-| Command     | Alias | Description                               |
-| ----------- | ----- | ----------------------------------------- |
-| `continue`  | `c`   | Resume execution until next breakpoint    |
-| `step_over` | `n`   | Execute current line, skip function calls |
-| `step_in`   | `s`   | Step into function calls                  |
-| `step_out`  | `so`  | Run until current function returns        |
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `continue` | `c` | Resume execution until next breakpoint |
+| `step_over` | `n` | Execute current line, skip function calls |
+| `step_in` | `si` | Step into function calls |
+| `step_out` | `so` | Run until current function returns |
 
 ### Inspection
 
-| Command              | Alias | Description                               |
-| -------------------- | ----- | ----------------------------------------- |
-| `inspect`            | `i`   | Show all local variables at current frame |
-| `evaluate <expr>`    | `e`   | Evaluate an expression in current context |
-| `backtrace`          | `bt`  | Show call stack                           |
-| `list`               | `l`   | Show source code around current line      |
-| `threads`            |       | List all threads                          |
-| `switch_thread <id>` |       | Switch to a different thread              |
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `inspect` | `i` | Show all local variables at current frame |
+| `evaluate <expr>` | `e` | Evaluate an expression in current context |
+| `backtrace` | `bt` | Show call stack |
+| `list` | `l` | Show source code around current line |
+| `threads` | | List all threads |
+| `switch_thread <id>` | | Switch to a different thread |
 
 ### Memory & Low-Level (C/C++ only)
 
-| Command                       | Alias  | Description              |
-| ----------------------------- | ------ | ------------------------ |
-| `read_memory <addr> <len>`    | `mem`  | Read raw memory bytes    |
-| `disassemble [addr]`          | `dis`  | Disassemble instructions |
-| `registers`                   | `regs` | Show CPU register values |
-| `write_memory <addr> <bytes>` |        | Patch memory             |
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `read_memory <addr> <len>` | `mem` | Read raw memory bytes |
+| `disassemble [addr]` | `dis` | Disassemble instructions |
+| `registers` | `regs` | Show CPU register values |
+| `write_memory <addr> <bytes>` | | Patch memory |
 
 ## Language-Specific Notes
 
 ### Python
-
 - Backend: `bdb` (stdlib) — no installation needed
 - Breakpoints: line numbers or function names
 - Auto-detects virtualenvs
 
 ### C/C++
-
 - Backends: GDB (Linux/Windows), LLDB (macOS), CDB (Windows)
 - Auto-detects available debugger
 - Requires debug symbols (`-g` for GCC/Clang, `/Zi` for MSVC)
 - Supports crash dump analysis (`.dmp`, core files)
 
 ### C#
-
 - Backend: netcoredbg (MI mode)
 - Works with .NET Core / .NET 5+ projects
 - Set breakpoints with `file.cs:line` syntax
 
 ### Rust
-
 - Backends: rust-gdb, rust-lldb, GDB, LLDB (tried in order)
 - Auto-compiles with `cargo build` if needed
 - Pretty-prints Rust types (Vec, HashMap, String, etc.)
 
 ### Java
-
 - Backend: JDB (bundled with JDK)
 - Supports `.java` files, class names, and `.jar` files
 - Auto-compiles with `javac` if needed
 
 ### Go
-
 - Backend: Delve (`dlv`)
 - Install: `go install github.com/go-delve/delve/cmd/dlv@latest`
 - Supports goroutine inspection
 
 ### Node.js / TypeScript
-
 - Backend: Node.js built-in inspector
 - Supports `.js`, `.mjs`, `.ts` files
 - TypeScript compiled on-the-fly if `ts-node` available
 
 ### Ruby
-
 - Backend: rdbg (`debug` gem)
 - Requires Ruby 3.2+ or `gem install debug`
 - Supports Rack/Rails applications
@@ -144,8 +136,8 @@ Every command returns JSON:
     "user_id": 12345
   },
   "call_stack": [
-    { "file": "server.py", "line": 42, "function": "handle_request" },
-    { "file": "app.py", "line": 15, "function": "dispatch" }
+    {"file": "server.py", "line": 42, "function": "handle_request"},
+    {"file": "app.py", "line": 15, "function": "dispatch"}
   ]
 }
 ```

--- a/skills/neuraldebug/references/software-debugging.md
+++ b/skills/neuraldebug/references/software-debugging.md
@@ -8,93 +8,98 @@ All languages share the same command interface via TCP/JSON.
 
 ### Session Control
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `start` | `s` | Begin execution (run to first breakpoint or end) |
-| `quit` | `q` | End the debug session |
+| Command | Alias | Description                                      |
+| ------- | ----- | ------------------------------------------------ |
+| `start` | `s`   | Begin execution (run to first breakpoint or end) |
+| `quit`  | `q`   | End the debug session                            |
 
 > **Note:** Target selection and process attach happen at server startup
 > (`serve <target>` or `serve --attach_pid <pid>`), not as runtime commands.
 
 ### Breakpoints
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `set_breakpoint <location>` | `b` | Set breakpoint (line number, function name, or file:line) |
-| `remove_breakpoint <id>` | `rb` | Remove a breakpoint by ID |
-| `list_breakpoints` | `bl` | Show all breakpoints |
-| `enable_breakpoint <id>` | | Enable a disabled breakpoint |
-| `disable_breakpoint <id>` | | Disable without removing |
-| `set_conditional <id> <expr>` | | Add condition to breakpoint |
+| Command                     | Alias | Description                                               |
+| --------------------------- | ----- | --------------------------------------------------------- |
+| `set_breakpoint <location>` | `b`   | Set breakpoint (line number, function name, or file:line) |
+| `remove_breakpoint <id>`    | `rb`  | Remove a breakpoint by ID                                 |
+| `list_breakpoints`          | `bl`  | Show all breakpoints                                      |
 
 ### Execution Control
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `continue` | `c` | Resume execution until next breakpoint |
-| `step_over` | `n` | Execute current line, skip function calls |
-| `step_in` | `s` | Step into function calls |
-| `step_out` | `so` | Run until current function returns |
+| Command     | Alias | Description                               |
+| ----------- | ----- | ----------------------------------------- |
+| `continue`  | `c`   | Resume execution until next breakpoint    |
+| `step_over` | `n`   | Execute current line, skip function calls |
+| `step_in`   | `s`   | Step into function calls                  |
+| `step_out`  | `so`  | Run until current function returns        |
 
 ### Inspection
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `inspect` | `i` | Show all local variables at current frame |
-| `evaluate <expr>` | `e` | Evaluate an expression in current context |
-| `backtrace` | `bt` | Show call stack |
-| `list` | `l` | Show source code around current line |
-| `threads` | | List all threads |
-| `switch_thread <id>` | | Switch to a different thread |
+| Command              | Alias | Description                               |
+| -------------------- | ----- | ----------------------------------------- |
+| `inspect`            | `i`   | Show all local variables at current frame |
+| `evaluate <expr>`    | `e`   | Evaluate an expression in current context |
+| `backtrace`          | `bt`  | Show call stack                           |
+| `list`               | `l`   | Show source code around current line      |
+| `threads`            |       | List all threads                          |
+| `switch_thread <id>` |       | Switch to a different thread              |
 
 ### Memory & Low-Level (C/C++ only)
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `read_memory <addr> <len>` | `mem` | Read raw memory bytes |
-| `disassemble [addr]` | `dis` | Disassemble instructions |
-| `registers` | `regs` | Show CPU register values |
-| `write_memory <addr> <bytes>` | | Patch memory |
+| Command                       | Alias  | Description              |
+| ----------------------------- | ------ | ------------------------ |
+| `read_memory <addr> <len>`    | `mem`  | Read raw memory bytes    |
+| `disassemble [addr]`          | `dis`  | Disassemble instructions |
+| `registers`                   | `regs` | Show CPU register values |
+| `write_memory <addr> <bytes>` |        | Patch memory             |
 
 ## Language-Specific Notes
 
 ### Python
+
 - Backend: `bdb` (stdlib) — no installation needed
 - Breakpoints: line numbers or function names
 - Auto-detects virtualenvs
 
 ### C/C++
+
 - Backends: GDB (Linux/Windows), LLDB (macOS), CDB (Windows)
 - Auto-detects available debugger
 - Requires debug symbols (`-g` for GCC/Clang, `/Zi` for MSVC)
 - Supports crash dump analysis (`.dmp`, core files)
 
 ### C#
+
 - Backend: netcoredbg (MI mode)
 - Works with .NET Core / .NET 5+ projects
 - Set breakpoints with `file.cs:line` syntax
 
 ### Rust
+
 - Backends: rust-gdb, rust-lldb, GDB, LLDB (tried in order)
 - Auto-compiles with `cargo build` if needed
 - Pretty-prints Rust types (Vec, HashMap, String, etc.)
 
 ### Java
+
 - Backend: JDB (bundled with JDK)
 - Supports `.java` files, class names, and `.jar` files
 - Auto-compiles with `javac` if needed
 
 ### Go
+
 - Backend: Delve (`dlv`)
 - Install: `go install github.com/go-delve/delve/cmd/dlv@latest`
 - Supports goroutine inspection
 
 ### Node.js / TypeScript
+
 - Backend: Node.js built-in inspector
 - Supports `.js`, `.mjs`, `.ts` files
 - TypeScript compiled on-the-fly if `ts-node` available
 
 ### Ruby
+
 - Backend: rdbg (`debug` gem)
 - Requires Ruby 3.2+ or `gem install debug`
 - Supports Rack/Rails applications
@@ -139,8 +144,8 @@ Every command returns JSON:
     "user_id": 12345
   },
   "call_stack": [
-    {"file": "server.py", "line": 42, "function": "handle_request"},
-    {"file": "app.py", "line": 15, "function": "dispatch"}
+    { "file": "server.py", "line": 42, "function": "handle_request" },
+    { "file": "app.py", "line": 15, "function": "dispatch" }
   ]
 }
 ```

--- a/skills/neuraldebug/references/software-debugging.md
+++ b/skills/neuraldebug/references/software-debugging.md
@@ -8,92 +8,100 @@ All languages share the same command interface via TCP/JSON.
 
 ### Session Control
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `launch <target>` | `run` | Start debugging a program |
-| `attach <pid>` | | Attach to a running process |
-| `detach` | | Detach from the process |
-| `quit` | `q` | End the debug session |
+| Command           | Alias | Description                 |
+| ----------------- | ----- | --------------------------- |
+| `launch <target>` | `run` | Start debugging a program   |
+| `attach <pid>`    |       | Attach to a running process |
+| `detach`          |       | Detach from the process     |
+| `quit`            | `q`   | End the debug session       |
 
 ### Breakpoints
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `set_breakpoint <location>` | `b` | Set breakpoint (line number, function name, or file:line) |
-| `remove_breakpoint <id>` | `rb` | Remove a breakpoint by ID |
-| `list_breakpoints` | `bl` | Show all breakpoints |
-| `enable_breakpoint <id>` | | Enable a disabled breakpoint |
-| `disable_breakpoint <id>` | | Disable without removing |
-| `set_conditional <id> <expr>` | | Add condition to breakpoint |
+| Command                       | Alias | Description                                               |
+| ----------------------------- | ----- | --------------------------------------------------------- |
+| `set_breakpoint <location>`   | `b`   | Set breakpoint (line number, function name, or file:line) |
+| `remove_breakpoint <id>`      | `rb`  | Remove a breakpoint by ID                                 |
+| `list_breakpoints`            | `bl`  | Show all breakpoints                                      |
+| `enable_breakpoint <id>`      |       | Enable a disabled breakpoint                              |
+| `disable_breakpoint <id>`     |       | Disable without removing                                  |
+| `set_conditional <id> <expr>` |       | Add condition to breakpoint                               |
 
 ### Execution Control
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `continue` | `c` | Resume execution until next breakpoint |
-| `step_over` | `n` | Execute current line, skip function calls |
-| `step_in` | `s` | Step into function calls |
-| `step_out` | `so` | Run until current function returns |
+| Command     | Alias | Description                               |
+| ----------- | ----- | ----------------------------------------- |
+| `continue`  | `c`   | Resume execution until next breakpoint    |
+| `step_over` | `n`   | Execute current line, skip function calls |
+| `step_in`   | `s`   | Step into function calls                  |
+| `step_out`  | `so`  | Run until current function returns        |
 
 ### Inspection
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `inspect` | `i` | Show all local variables at current frame |
-| `evaluate <expr>` | `e` | Evaluate an expression in current context |
-| `backtrace` | `bt` | Show call stack |
-| `list` | `l` | Show source code around current line |
-| `threads` | | List all threads |
-| `switch_thread <id>` | | Switch to a different thread |
+| Command              | Alias | Description                               |
+| -------------------- | ----- | ----------------------------------------- |
+| `inspect`            | `i`   | Show all local variables at current frame |
+| `evaluate <expr>`    | `e`   | Evaluate an expression in current context |
+| `backtrace`          | `bt`  | Show call stack                           |
+| `list`               | `l`   | Show source code around current line      |
+| `threads`            |       | List all threads                          |
+| `switch_thread <id>` |       | Switch to a different thread              |
 
 ### Memory & Low-Level (C/C++ only)
 
-| Command | Alias | Description |
-|---------|-------|-------------|
-| `read_memory <addr> <len>` | `mem` | Read raw memory bytes |
-| `disassemble [addr]` | `dis` | Disassemble instructions |
-| `registers` | `regs` | Show CPU register values |
-| `write_memory <addr> <bytes>` | | Patch memory |
+| Command                       | Alias  | Description              |
+| ----------------------------- | ------ | ------------------------ |
+| `read_memory <addr> <len>`    | `mem`  | Read raw memory bytes    |
+| `disassemble [addr]`          | `dis`  | Disassemble instructions |
+| `registers`                   | `regs` | Show CPU register values |
+| `write_memory <addr> <bytes>` |        | Patch memory             |
 
 ## Language-Specific Notes
 
 ### Python
+
 - Backend: `bdb` (stdlib) — no installation needed
 - Breakpoints: line numbers or function names
 - Auto-detects virtualenvs
 
 ### C/C++
+
 - Backends: GDB (Linux/Windows), LLDB (macOS), CDB (Windows)
 - Auto-detects available debugger
 - Requires debug symbols (`-g` for GCC/Clang, `/Zi` for MSVC)
 - Supports crash dump analysis (`.dmp`, core files)
 
 ### C#
+
 - Backend: netcoredbg (MI mode)
 - Works with .NET Core / .NET 5+ projects
 - Set breakpoints with `file.cs:line` syntax
 
 ### Rust
+
 - Backends: rust-gdb, rust-lldb, GDB, LLDB (tried in order)
 - Auto-compiles with `cargo build` if needed
 - Pretty-prints Rust types (Vec, HashMap, String, etc.)
 
 ### Java
+
 - Backend: JDB (bundled with JDK)
 - Supports `.java` files, class names, and `.jar` files
 - Auto-compiles with `javac` if needed
 
 ### Go
+
 - Backend: Delve (`dlv`)
 - Install: `go install github.com/go-delve/delve/cmd/dlv@latest`
 - Supports goroutine inspection
 
 ### Node.js / TypeScript
+
 - Backend: Node.js built-in inspector
 - Supports `.js`, `.mjs`, `.ts` files
 - TypeScript compiled on-the-fly if `ts-node` available
 
 ### Ruby
+
 - Backend: rdbg (`debug` gem)
 - Requires Ruby 3.2+ or `gem install debug`
 - Supports Rack/Rails applications
@@ -138,8 +146,8 @@ Every command returns JSON:
     "user_id": 12345
   },
   "call_stack": [
-    {"file": "server.py", "line": 42, "function": "handle_request"},
-    {"file": "app.py", "line": 15, "function": "dispatch"}
+    { "file": "server.py", "line": 42, "function": "handle_request" },
+    { "file": "app.py", "line": 15, "function": "dispatch" }
   ]
 }
 ```

--- a/skills/neuraldebug/references/software-debugging.md
+++ b/skills/neuraldebug/references/software-debugging.md
@@ -8,100 +8,93 @@ All languages share the same command interface via TCP/JSON.
 
 ### Session Control
 
-| Command           | Alias | Description                 |
-| ----------------- | ----- | --------------------------- |
-| `launch <target>` | `run` | Start debugging a program   |
-| `attach <pid>`    |       | Attach to a running process |
-| `detach`          |       | Detach from the process     |
-| `quit`            | `q`   | End the debug session       |
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `start` | `s` | Begin execution (run to first breakpoint or end) |
+| `quit` | `q` | End the debug session |
+
+> **Note:** Target selection and process attach happen at server startup
+> (`serve <target>` or `serve --attach_pid <pid>`), not as runtime commands.
 
 ### Breakpoints
 
-| Command                       | Alias | Description                                               |
-| ----------------------------- | ----- | --------------------------------------------------------- |
-| `set_breakpoint <location>`   | `b`   | Set breakpoint (line number, function name, or file:line) |
-| `remove_breakpoint <id>`      | `rb`  | Remove a breakpoint by ID                                 |
-| `list_breakpoints`            | `bl`  | Show all breakpoints                                      |
-| `enable_breakpoint <id>`      |       | Enable a disabled breakpoint                              |
-| `disable_breakpoint <id>`     |       | Disable without removing                                  |
-| `set_conditional <id> <expr>` |       | Add condition to breakpoint                               |
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `set_breakpoint <location>` | `b` | Set breakpoint (line number, function name, or file:line) |
+| `remove_breakpoint <id>` | `rb` | Remove a breakpoint by ID |
+| `list_breakpoints` | `bl` | Show all breakpoints |
+| `enable_breakpoint <id>` | | Enable a disabled breakpoint |
+| `disable_breakpoint <id>` | | Disable without removing |
+| `set_conditional <id> <expr>` | | Add condition to breakpoint |
 
 ### Execution Control
 
-| Command     | Alias | Description                               |
-| ----------- | ----- | ----------------------------------------- |
-| `continue`  | `c`   | Resume execution until next breakpoint    |
-| `step_over` | `n`   | Execute current line, skip function calls |
-| `step_in`   | `s`   | Step into function calls                  |
-| `step_out`  | `so`  | Run until current function returns        |
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `continue` | `c` | Resume execution until next breakpoint |
+| `step_over` | `n` | Execute current line, skip function calls |
+| `step_in` | `s` | Step into function calls |
+| `step_out` | `so` | Run until current function returns |
 
 ### Inspection
 
-| Command              | Alias | Description                               |
-| -------------------- | ----- | ----------------------------------------- |
-| `inspect`            | `i`   | Show all local variables at current frame |
-| `evaluate <expr>`    | `e`   | Evaluate an expression in current context |
-| `backtrace`          | `bt`  | Show call stack                           |
-| `list`               | `l`   | Show source code around current line      |
-| `threads`            |       | List all threads                          |
-| `switch_thread <id>` |       | Switch to a different thread              |
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `inspect` | `i` | Show all local variables at current frame |
+| `evaluate <expr>` | `e` | Evaluate an expression in current context |
+| `backtrace` | `bt` | Show call stack |
+| `list` | `l` | Show source code around current line |
+| `threads` | | List all threads |
+| `switch_thread <id>` | | Switch to a different thread |
 
 ### Memory & Low-Level (C/C++ only)
 
-| Command                       | Alias  | Description              |
-| ----------------------------- | ------ | ------------------------ |
-| `read_memory <addr> <len>`    | `mem`  | Read raw memory bytes    |
-| `disassemble [addr]`          | `dis`  | Disassemble instructions |
-| `registers`                   | `regs` | Show CPU register values |
-| `write_memory <addr> <bytes>` |        | Patch memory             |
+| Command | Alias | Description |
+|---------|-------|-------------|
+| `read_memory <addr> <len>` | `mem` | Read raw memory bytes |
+| `disassemble [addr]` | `dis` | Disassemble instructions |
+| `registers` | `regs` | Show CPU register values |
+| `write_memory <addr> <bytes>` | | Patch memory |
 
 ## Language-Specific Notes
 
 ### Python
-
 - Backend: `bdb` (stdlib) — no installation needed
 - Breakpoints: line numbers or function names
 - Auto-detects virtualenvs
 
 ### C/C++
-
 - Backends: GDB (Linux/Windows), LLDB (macOS), CDB (Windows)
 - Auto-detects available debugger
 - Requires debug symbols (`-g` for GCC/Clang, `/Zi` for MSVC)
 - Supports crash dump analysis (`.dmp`, core files)
 
 ### C#
-
 - Backend: netcoredbg (MI mode)
 - Works with .NET Core / .NET 5+ projects
 - Set breakpoints with `file.cs:line` syntax
 
 ### Rust
-
 - Backends: rust-gdb, rust-lldb, GDB, LLDB (tried in order)
 - Auto-compiles with `cargo build` if needed
 - Pretty-prints Rust types (Vec, HashMap, String, etc.)
 
 ### Java
-
 - Backend: JDB (bundled with JDK)
 - Supports `.java` files, class names, and `.jar` files
 - Auto-compiles with `javac` if needed
 
 ### Go
-
 - Backend: Delve (`dlv`)
 - Install: `go install github.com/go-delve/delve/cmd/dlv@latest`
 - Supports goroutine inspection
 
 ### Node.js / TypeScript
-
 - Backend: Node.js built-in inspector
 - Supports `.js`, `.mjs`, `.ts` files
 - TypeScript compiled on-the-fly if `ts-node` available
 
 ### Ruby
-
 - Backend: rdbg (`debug` gem)
 - Requires Ruby 3.2+ or `gem install debug`
 - Supports Rack/Rails applications
@@ -146,8 +139,8 @@ Every command returns JSON:
     "user_id": 12345
   },
   "call_stack": [
-    { "file": "server.py", "line": 42, "function": "handle_request" },
-    { "file": "app.py", "line": 15, "function": "dispatch" }
+    {"file": "server.py", "line": 42, "function": "handle_request"},
+    {"file": "app.py", "line": 15, "function": "dispatch"}
   ]
 }
 ```

--- a/src/config/doc-baseline.integration.test.ts
+++ b/src/config/doc-baseline.integration.test.ts
@@ -118,7 +118,7 @@ describe("config doc baseline integration", () => {
     });
     expect(byPath.get("channels.msteams")).toMatchObject({
       label: "Microsoft Teams",
-      help: "Bot Framework; enterprise support.",
+      help: "Teams SDK; enterprise support.",
     });
     expect(byPath.get("channels.matrix")).toMatchObject({
       label: "Matrix",


### PR DESCRIPTION
## What

Adds **NeuralDebug** as a built-in OpenClaw skill. NeuralDebug is an AI-powered debugging framework from the [DeepRhapsody](https://github.com/DennySun2020/DeepRhapsody) project.

## What NeuralDebug Does

### Software Debugging (8 Languages)
Debug **Python, C/C++, C#, Rust, Java, Go, Node.js/TypeScript, and Ruby** using real debuggers — GDB, LLDB, CDB, JDB, Delve, Node Inspector, and rdbg — via a unified natural-language interface.

### LLM/Transformer Debugging
Step through transformer forward passes layer by layer. Run interpretability techniques: Logit Lens, Attention Analysis, Probing, Activation Patching, and custom analysis sandboxes.

### LLM Fine-Tuning
Inject missing knowledge into GPT-2 family models using LoRA. Diagnose → fine-tune → verify in a single workflow.

## Skill Structure

\\\
skills/neuraldebug/
├── SKILL.md                        (main skill definition)
└── references/
    ├── software-debugging.md       (command reference for 8 languages)
    ├── llm-debugging.md            (interpretability techniques)
    └── llm-finetuning.md           (LoRA fine-tuning workflow)
\\\

## How It Works

The skill teaches OpenClaw how to use NeuralDebug's CLI tools. Users clone the [DeepRhapsody repo](https://github.com/DennySun2020/DeepRhapsody) and the skill provides the procedural knowledge for OpenClaw to drive the debug sessions.

Also available on ClawHub: \clawhub install neuraldebug\

## Source

- **Repository**: https://github.com/DennySun2020/DeepRhapsody
- **ClawHub**: neuraldebug@0.1.0
- **License**: MIT