### PR TITLE
fix: show cost estimate for providers with explicit cost config regardless of auth method

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,30 +1,26 @@
-import fs from "node:fs/promises";
-import { hasConfiguredModelFallbacks } from "../../agents/agent-scope.js";
-import { resolveContextTokensForModel } from "../../agents/context.js";
+import fs from "node:fs";
+import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
-import { queueEmbeddedPiMessage } from "../../agents/pi-embedded-runner/runs.js";
-import { hasNonzeroUsage, normalizeUsage } from "../../agents/usage.js";
+import { queueEmbeddedPiMessage } from "../../agents/pi-embedded.js";
+import { hasNonzeroUsage } from "../../agents/usage.js";
 import {
-  loadSessionStore,
-  resolveSessionPluginStatusLines,
-  resolveSessionPluginTraceLines,
+  resolveAgentIdFromSessionKey,
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
+  resolveSessionTranscriptPath,
   type SessionEntry,
+  updateSessionStore,
   updateSessionStoreEntry,
 } from "../../config/sessions.js";
 import type { TypingMode } from "../../config/types.js";
-import { resolveSessionTranscriptCandidates } from "../../gateway/session-utils.fs.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+import { generateSecureUuid } from "../../infra/secure-random.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
-import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
-import { normalizeOptionalString } from "../../shared/string-coerce.js";
-import {
-  estimateUsageCost,
-  formatTokenCount,
-  resolveModelCostConfig,
-} from "../../utils/usage-format.js";
+import { defaultRuntime } from "../../runtime.js";
+import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
 import {
   buildFallbackClearedNotice,
   buildFallbackNotice,
@@ -32,7 +28,6 @@ import {
 } from "../fallback-state.js";
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
-import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { runAgentTurnWithFallback } from "./agent-runner-execution.js";
 import {
@@ -49,9 +44,7 @@ import {
   hasSessionRelatedCronJobs,
   hasUnbackedReminderCommitment,
 } from "./agent-runner-reminder-guard.js";
-import { resetReplyRunSession } from "./agent-runner-session-reset.js";
 import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-usage-line.js";
-import { resolveQueuedReplyExecutionConfig } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
@@ -65,794 +58,12 @@ import {
   type QueueSettings,
 } from "./queue.js";
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
-import {
-  createReplyOperation,
-  ReplyRunAlreadyActiveError,
-  replyRunRegistry,
-  type ReplyOperation,
-} from "./reply-run-registry.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
 import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
-
-function buildInlinePluginStatusPayload(params: {
-  entry: SessionEntry | undefined;
-  includeTraceLines: boolean;
-}): ReplyPayload | undefined {
-  const statusLines =
-    params.entry?.verboseLevel && params.entry.verboseLevel !== "off"
-      ? resolveSessionPluginStatusLines(params.entry)
-      : [];
-  const traceLines =
-    params.includeTraceLines &&
-    (params.entry?.traceLevel === "on" || params.entry?.traceLevel === "raw")
-      ? resolveSessionPluginTraceLines(params.entry)
-      : [];
-  const lines = [...statusLines, ...traceLines];
-  if (lines.length === 0) {
-    return undefined;
-  }
-  return { text: lines.join("\n") };
-}
-
-function formatRawTraceBlock(title: string, value: string | undefined): string {
-  const body = value?.trim() ? escapeTraceFence(value) : "<empty>";
-  return `🔎 ${title}:\n~~~text\n${body}\n~~~`;
-}
-
-function escapeTraceFence(value: string): string {
-  return value.replace(/^~~~/gm, "\\~~~");
-}
-
-function hasTraceUsageFields(
-  usage:
-    | {
-        input?: number;
-        output?: number;
-        cacheRead?: number;
-        cacheWrite?: number;
-        total?: number;
-      }
-    | undefined,
-): boolean {
-  if (!usage) {
-    return false;
-  }
-  return ["input", "output", "cacheRead", "cacheWrite", "total"].some((key) => {
-    const value = usage[key as keyof typeof usage];
-    return typeof value === "number" && Number.isFinite(value);
-  });
-}
-
-function formatTraceUsageLine(label: string, value: number | undefined): string {
-  return `${label}=${typeof value === "number" && Number.isFinite(value) ? `${value.toLocaleString()} tok (${formatTokenCount(value)})` : "n/a"}`;
-}
-
-function formatUsageTraceBlock(
-  title: string,
-  usage:
-    | {
-        input?: number;
-        output?: number;
-        cacheRead?: number;
-        cacheWrite?: number;
-        total?: number;
-      }
-    | undefined,
-): string | undefined {
-  if (!hasTraceUsageFields(usage)) {
-    return undefined;
-  }
-  return `🔎 ${title}:\n~~~text\n${[
-    formatTraceUsageLine("input", usage?.input),
-    formatTraceUsageLine("output", usage?.output),
-    formatTraceUsageLine("cacheRead", usage?.cacheRead),
-    formatTraceUsageLine("cacheWrite", usage?.cacheWrite),
-    formatTraceUsageLine("total", usage?.total),
-  ].join("\n")}\n~~~`;
-}
-
-type TraceAttemptView = {
-  provider: string;
-  model: string;
-  result: string;
-  reason?: string;
-  stage?: string;
-  elapsedMs?: number;
-  status?: number;
-};
-
-type TraceExecutionView = {
-  winnerProvider?: string;
-  winnerModel?: string;
-  attempts?: TraceAttemptView[];
-  fallbackUsed?: boolean;
-  runner?: "embedded" | "cli";
-};
-
-type TracePromptSegmentView = {
-  key: string;
-  chars: number;
-};
-
-type TraceToolSummaryView = {
-  calls: number;
-  tools: string[];
-  failures?: number;
-  totalToolTimeMs?: number;
-};
-
-type TraceCompletionView = {
-  finishReason?: string;
-  stopReason?: string;
-  refusal?: boolean;
-};
-
-type TraceContextManagementView = {
-  sessionCompactions?: number;
-  lastTurnCompactions?: number;
-  preflightCompactionApplied?: boolean;
-  postCompactionContextInjected?: boolean;
-};
-
-function formatTraceScalar(value: string | number | boolean | undefined): string | undefined {
-  if (typeof value === "boolean") {
-    return value ? "yes" : "no";
-  }
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value.toLocaleString() : undefined;
-  }
-  const trimmed = normalizeOptionalString(value);
-  return trimmed ?? undefined;
-}
-
-function formatKeyValueTraceBlock(
-  title: string,
-  fields: Array<[string, string | number | boolean | undefined]>,
-): string | undefined {
-  const lines = fields.flatMap(([key, rawValue]) => {
-    const value = formatTraceScalar(rawValue);
-    return value ? [`${key}=${value}`] : [];
-  });
-  if (lines.length === 0) {
-    return undefined;
-  }
-  return `🔎 ${title}:\n~~~text\n${lines.join("\n")}\n~~~`;
-}
-
-function inferFallbackAttemptResult(attempt: { reason?: string; status?: number }): string {
-  if (attempt.reason === "timeout") {
-    return "timeout";
-  }
-  return "candidate_failed";
-}
-
-function mergeExecutionTrace(params: {
-  fallbackAttempts?: Array<{
-    provider: string;
-    model: string;
-    reason?: string;
-    status?: number;
-  }>;
-  executionTrace?: {
-    winnerProvider?: string;
-    winnerModel?: string;
-    attempts?: TraceAttemptView[];
-    fallbackUsed?: boolean;
-    runner?: "embedded" | "cli";
-  };
-  provider?: string;
-  model?: string;
-  runner: "embedded" | "cli";
-}): TraceExecutionView | undefined {
-  const attempts: TraceAttemptView[] = [
-    ...(params.fallbackAttempts ?? []).map((attempt) => ({
-      provider: attempt.provider,
-      model: attempt.model,
-      result: inferFallbackAttemptResult(attempt),
-      ...(attempt.reason ? { reason: attempt.reason } : {}),
-      ...(typeof attempt.status === "number" ? { status: attempt.status } : {}),
-    })),
-    ...(params.executionTrace?.attempts ?? []),
-  ];
-  const winnerProvider =
-    params.executionTrace?.winnerProvider ?? normalizeOptionalString(params.provider);
-  const winnerModel = params.executionTrace?.winnerModel ?? normalizeOptionalString(params.model);
-  if (
-    winnerProvider &&
-    winnerModel &&
-    !attempts.some(
-      (attempt) =>
-        attempt.provider === winnerProvider &&
-        attempt.model === winnerModel &&
-        attempt.result === "success",
-    )
-  ) {
-    attempts.push({
-      provider: winnerProvider,
-      model: winnerModel,
-      result: "success",
-    });
-  }
-  if (!winnerProvider && !winnerModel && attempts.length === 0) {
-    return undefined;
-  }
-  return {
-    winnerProvider,
-    winnerModel,
-    attempts: attempts.length > 0 ? attempts : undefined,
-    fallbackUsed: params.executionTrace?.fallbackUsed ?? attempts.length > 1,
-    runner: params.executionTrace?.runner ?? params.runner,
-  };
-}
-
-function formatExecutionResultTraceBlock(
-  executionTrace: TraceExecutionView | undefined,
-): string | undefined {
-  if (!executionTrace?.winnerProvider && !executionTrace?.winnerModel) {
-    return undefined;
-  }
-  return formatKeyValueTraceBlock("Execution Result", [
-    [
-      "winner",
-      executionTrace.winnerProvider && executionTrace.winnerModel
-        ? `${executionTrace.winnerProvider}/${executionTrace.winnerModel}`
-        : undefined,
-    ],
-    ["fallbackUsed", executionTrace.fallbackUsed],
-    ["attempts", executionTrace.attempts?.length],
-    ["runner", executionTrace.runner],
-  ]);
-}
-
-function formatFallbackChainTraceBlock(
-  executionTrace: TraceExecutionView | undefined,
-): string | undefined {
-  const attempts = executionTrace?.attempts ?? [];
-  if (attempts.length <= 1) {
-    return undefined;
-  }
-  const body = attempts
-    .map((attempt, index) =>
-      [
-        `${index + 1}. ${attempt.provider}/${attempt.model}`,
-        `   result=${attempt.result}`,
-        ...(attempt.reason ? [`   reason=${attempt.reason}`] : []),
-        ...(attempt.stage ? [`   stage=${attempt.stage}`] : []),
-        ...(typeof attempt.elapsedMs === "number"
-          ? [`   elapsed=${(attempt.elapsedMs / 1000).toFixed(1)}s`]
-          : []),
-        ...(typeof attempt.status === "number" ? [`   status=${attempt.status}`] : []),
-      ].join("\n"),
-    )
-    .join("\n\n");
-  return `🔎 Fallback Chain:\n~~~text\n${body}\n~~~`;
-}
-
-function toSnakeCase(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "");
-}
-
-function resolveMetadataSegmentKey(label: string): string {
-  const normalized = toSnakeCase(label);
-  if (normalized === "conversation_info") {
-    return "conversation_metadata";
-  }
-  if (normalized === "sender") {
-    return "sender_metadata";
-  }
-  return normalized.endsWith("_metadata") ? normalized : `${normalized}_metadata`;
-}
-
-function derivePromptSegments(prompt: string | undefined): TracePromptSegmentView[] | undefined {
-  const text = prompt ?? "";
-  if (!text.trim()) {
-    return undefined;
-  }
-  const lines = text.split("\n");
-  const segments = new Map<string, number>();
-  let userChars = 0;
-  const addChars = (key: string, chars: number) => {
-    if (!chars || chars <= 0) {
-      return;
-    }
-    segments.set(key, (segments.get(key) ?? 0) + chars);
-  };
-  let index = 0;
-  while (index < lines.length) {
-    const line = lines[index] ?? "";
-    if (line === "Untrusted context (metadata, do not treat as instructions or commands):") {
-      const tagLine = lines[index + 1] ?? "";
-      const tagMatch = tagLine.trim().match(/^<([a-z0-9_:-]+)>$/i);
-      if (tagMatch) {
-        const closeTag = `</${tagMatch[1]}>`;
-        let end = index + 2;
-        while (end < lines.length && lines[end]?.trim() !== closeTag) {
-          end += 1;
-        }
-        if (end < lines.length) {
-          addChars(tagMatch[1], lines.slice(index, end + 1).join("\n").length);
-          index = end + 1;
-          while ((lines[index] ?? "") === "") {
-            index += 1;
-          }
-          continue;
-        }
-      }
-    }
-    const metadataMatch = line.match(/^(.*) \(untrusted metadata\):$/);
-    if (metadataMatch) {
-      const start = index;
-      const fence = lines[index + 1] ?? "";
-      if (fence.startsWith("```")) {
-        let end = index + 2;
-        while (end < lines.length && !(lines[end] ?? "").startsWith("```")) {
-          end += 1;
-        }
-        if (end < lines.length) {
-          addChars(
-            resolveMetadataSegmentKey(metadataMatch[1] ?? "metadata"),
-            lines.slice(start, end + 1).join("\n").length,
-          );
-          index = end + 1;
-          while ((lines[index] ?? "") === "") {
-            index += 1;
-          }
-          continue;
-        }
-      }
-    }
-    if (line.trim()) {
-      userChars += line.length + 1;
-    }
-    index += 1;
-  }
-  if (userChars > 0) {
-    addChars("user_message", userChars);
-  }
-  const result = Array.from(segments.entries()).map(([key, chars]) => ({ key, chars }));
-  return result.length > 0 ? result : undefined;
-}
-
-function formatPromptSegmentsTraceBlock(
-  segments: TracePromptSegmentView[] | undefined,
-  totalPromptText: string | undefined,
-): string | undefined {
-  if (!segments?.length && !totalPromptText?.length) {
-    return undefined;
-  }
-  const lines = (segments ?? []).map(
-    (segment) => `${segment.key}=${segment.chars.toLocaleString()} chars`,
-  );
-  if (typeof totalPromptText === "string" && totalPromptText.length > 0) {
-    lines.push(`totalPromptText=${totalPromptText.length.toLocaleString()} chars`);
-  }
-  return lines.length > 0 ? `🔎 Prompt Segments:\n~~~text\n${lines.join("\n")}\n~~~` : undefined;
-}
-
-function formatToolSummaryTraceBlock(
-  toolSummary: TraceToolSummaryView | undefined,
-): string | undefined {
-  if (!toolSummary || toolSummary.calls <= 0) {
-    return undefined;
-  }
-  return formatKeyValueTraceBlock("Tool Summary", [
-    ["calls", toolSummary.calls],
-    ["tools", toolSummary.tools.length > 0 ? toolSummary.tools.join(", ") : undefined],
-    ["failures", toolSummary.failures],
-    ["totalToolTimeMs", toolSummary.totalToolTimeMs],
-  ]);
-}
-
-function formatCompletionTraceBlock(
-  completion: TraceCompletionView | undefined,
-): string | undefined {
-  if (!completion) {
-    return undefined;
-  }
-  return formatKeyValueTraceBlock("Completion", [
-    ["finishReason", completion.finishReason],
-    ["stopReason", completion.stopReason],
-    ["refusal", completion.refusal],
-  ]);
-}
-
-function formatContextManagementTraceBlock(
-  contextManagement: TraceContextManagementView | undefined,
-): string | undefined {
-  if (!contextManagement) {
-    return undefined;
-  }
-  return formatKeyValueTraceBlock("Context Management", [
-    ["sessionCompactions", contextManagement.sessionCompactions],
-    ["lastTurnCompactions", contextManagement.lastTurnCompactions],
-    ["preflightCompactionApplied", contextManagement.preflightCompactionApplied],
-    ["postCompactionContextInjected", contextManagement.postCompactionContextInjected],
-  ]);
-}
-
-async function accumulateSessionUsageFromTranscript(params: {
-  sessionId?: string;
-  storePath?: string;
-  sessionFile?: string;
-}): Promise<
-  | {
-      input?: number;
-      output?: number;
-      cacheRead?: number;
-      cacheWrite?: number;
-      total?: number;
-    }
-  | undefined
-> {
-  const sessionId = normalizeOptionalString(params.sessionId);
-  if (!sessionId) {
-    return undefined;
-  }
-  try {
-    const candidates = resolveSessionTranscriptCandidates(
-      sessionId,
-      params.storePath,
-      params.sessionFile,
-    );
-    let transcriptText: string | undefined;
-    for (const candidate of candidates) {
-      try {
-        transcriptText = await fs.readFile(candidate, "utf-8");
-        break;
-      } catch {
-        continue;
-      }
-    }
-    if (!transcriptText) {
-      return undefined;
-    }
-
-    let input = 0;
-    let output = 0;
-    let cacheRead = 0;
-    let cacheWrite = 0;
-    let sawUsage = false;
-    for (const line of transcriptText.split(/\r?\n/)) {
-      if (!line.trim()) {
-        continue;
-      }
-      let parsed: { message?: { usage?: unknown } } | undefined;
-      try {
-        parsed = JSON.parse(line) as { message?: { usage?: unknown } };
-      } catch {
-        continue;
-      }
-      const message = parsed?.message;
-      if (!message) {
-        continue;
-      }
-      const usage = normalizeUsage(message?.usage as Parameters<typeof normalizeUsage>[0]);
-      if (!hasNonzeroUsage(usage)) {
-        continue;
-      }
-      sawUsage = true;
-      input += usage.input ?? 0;
-      output += usage.output ?? 0;
-      cacheRead += usage.cacheRead ?? 0;
-      cacheWrite += usage.cacheWrite ?? 0;
-    }
-    if (!sawUsage) {
-      return undefined;
-    }
-    const total = input + output + cacheRead + cacheWrite;
-    return {
-      input: input || undefined,
-      output: output || undefined,
-      cacheRead: cacheRead || undefined,
-      cacheWrite: cacheWrite || undefined,
-      total: total || undefined,
-    };
-  } catch {
-    return undefined;
-  }
-}
-
-function resolveRequestPromptTokens(params: {
-  lastCallUsage?: {
-    input?: number;
-    output?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    total?: number;
-  };
-  promptTokens?: number;
-  usage?: {
-    input?: number;
-    output?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    total?: number;
-  };
-}): number | undefined {
-  const lastCall = params.lastCallUsage;
-  if (lastCall) {
-    const input = lastCall.input ?? 0;
-    const cacheRead = lastCall.cacheRead ?? 0;
-    const cacheWrite = lastCall.cacheWrite ?? 0;
-    const sum = input + cacheRead + cacheWrite;
-    if (sum > 0) {
-      return sum;
-    }
-  }
-  if (
-    typeof params.promptTokens === "number" &&
-    Number.isFinite(params.promptTokens) &&
-    params.promptTokens > 0
-  ) {
-    return params.promptTokens;
-  }
-  const usage = params.usage;
-  if (usage) {
-    const input = usage.input ?? 0;
-    const cacheRead = usage.cacheRead ?? 0;
-    const cacheWrite = usage.cacheWrite ?? 0;
-    const sum = input + cacheRead + cacheWrite;
-    if (sum > 0) {
-      return sum;
-    }
-  }
-  return undefined;
-}
-
-function formatRequestContextTraceBlock(params: {
-  provider?: string;
-  model?: string;
-  contextLimit?: number;
-  promptTokens?: number;
-}): string | undefined {
-  const limit = params.contextLimit;
-  const used = params.promptTokens;
-  if (
-    (typeof limit !== "number" || !Number.isFinite(limit) || limit <= 0) &&
-    (typeof used !== "number" || !Number.isFinite(used) || used <= 0) &&
-    !params.provider &&
-    !params.model
-  ) {
-    return undefined;
-  }
-  const headroom =
-    typeof limit === "number" &&
-    Number.isFinite(limit) &&
-    typeof used === "number" &&
-    Number.isFinite(used)
-      ? Math.max(0, limit - used)
-      : undefined;
-  const percent =
-    typeof limit === "number" &&
-    Number.isFinite(limit) &&
-    limit > 0 &&
-    typeof used === "number" &&
-    Number.isFinite(used)
-      ? Math.round((used / limit) * 100)
-      : undefined;
-  return `🔎 Context Window (Last Model Request):\n~~~text\n${[
-    `provider=${params.provider ?? "n/a"}`,
-    `model=${params.model ?? "n/a"}`,
-    `used=${typeof used === "number" && Number.isFinite(used) ? `${used.toLocaleString()} tok (${formatTokenCount(used)})` : "n/a"}`,
-    `limit=${typeof limit === "number" && Number.isFinite(limit) ? `${limit.toLocaleString()} tok (${formatTokenCount(limit)})` : "n/a"}`,
-    `headroom=${typeof headroom === "number" ? `${headroom.toLocaleString()} tok (${formatTokenCount(headroom)})` : "n/a"}`,
-    `usage=${typeof percent === "number" ? `${percent}%` : "n/a"}`,
-  ].join("\n")}\n~~~`;
-}
-
-function formatSummaryPromptValue(params: {
-  contextLimit?: number;
-  promptTokens?: number;
-}): string | undefined {
-  const used = params.promptTokens;
-  const limit = params.contextLimit;
-  if (
-    typeof used !== "number" ||
-    !Number.isFinite(used) ||
-    used <= 0 ||
-    typeof limit !== "number" ||
-    !Number.isFinite(limit) ||
-    limit <= 0
-  ) {
-    return undefined;
-  }
-  return `${formatTokenCount(used)}/${formatTokenCount(limit)}`;
-}
-
-function formatRawTraceSummaryLine(params: {
-  executionTrace?: TraceExecutionView;
-  completion?: TraceCompletionView;
-  contextLimit?: number;
-  promptTokens?: number;
-  usage?: {
-    input?: number;
-    output?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    total?: number;
-  };
-  toolSummary?: TraceToolSummaryView;
-  contextManagement?: TraceContextManagementView;
-  requestShaping?: {
-    thinking?: string;
-  };
-}): string | undefined {
-  const thinking = normalizeOptionalString(params.requestShaping?.thinking);
-  const fields = [
-    params.executionTrace?.winnerModel
-      ? `winner=${params.executionTrace.winnerModel}${thinking ? ` 🧠 ${thinking}` : ""}`
-      : undefined,
-    typeof params.executionTrace?.fallbackUsed === "boolean"
-      ? `fallback=${params.executionTrace.fallbackUsed ? "yes" : "no"}`
-      : undefined,
-    typeof params.executionTrace?.attempts?.length === "number"
-      ? `attempts=${params.executionTrace.attempts.length.toLocaleString()}`
-      : undefined,
-    params.completion?.stopReason ? `stop=${params.completion.stopReason}` : undefined,
-    (() => {
-      const prompt = formatSummaryPromptValue({
-        contextLimit: params.contextLimit,
-        promptTokens: params.promptTokens,
-      });
-      return prompt ? `prompt=${prompt}` : undefined;
-    })(),
-    typeof params.usage?.input === "number" && params.usage.input > 0
-      ? `⬇️ ${formatTokenCount(params.usage.input)}`
-      : undefined,
-    typeof params.usage?.output === "number" && params.usage.output > 0
-      ? `⬆️ ${formatTokenCount(params.usage.output)}`
-      : undefined,
-    typeof params.usage?.cacheRead === "number" && params.usage.cacheRead > 0
-      ? `♻️ ${formatTokenCount(params.usage.cacheRead)}`
-      : undefined,
-    typeof params.usage?.cacheWrite === "number" && params.usage.cacheWrite > 0
-      ? `🆕 ${formatTokenCount(params.usage.cacheWrite)}`
-      : undefined,
-    typeof params.usage?.total === "number" && params.usage.total > 0
-      ? `🔢 ${formatTokenCount(params.usage.total)}`
-      : undefined,
-    typeof params.toolSummary?.calls === "number" && params.toolSummary.calls > 0
-      ? `tools=${params.toolSummary.calls.toLocaleString()}`
-      : undefined,
-    typeof params.contextManagement?.lastTurnCompactions === "number" &&
-    params.contextManagement.lastTurnCompactions > 0
-      ? `compactions=${params.contextManagement.lastTurnCompactions.toLocaleString()}`
-      : undefined,
-  ].filter((value): value is string => Boolean(value));
-  return fields.length > 0 ? `Summary: ${fields.join(" ")}` : undefined;
-}
-
-function buildInlineRawTracePayload(params: {
-  entry: SessionEntry | undefined;
-  rawUserText?: string;
-  rawAssistantText?: string;
-  sessionUsage?: {
-    input?: number;
-    output?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    total?: number;
-  };
-  usage?: {
-    input?: number;
-    output?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    total?: number;
-  };
-  lastCallUsage?: {
-    input?: number;
-    output?: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-    total?: number;
-  };
-  provider?: string;
-  model?: string;
-  contextLimit?: number;
-  promptTokens?: number;
-  executionTrace?: TraceExecutionView;
-  requestShaping?: {
-    authMode?: string;
-    thinking?: string;
-    reasoning?: string;
-    verbose?: string;
-    trace?: string;
-    fallbackEligible?: boolean;
-    blockStreaming?: string;
-  };
-  promptSegments?: TracePromptSegmentView[];
-  toolSummary?: TraceToolSummaryView;
-  completion?: TraceCompletionView;
-  contextManagement?: TraceContextManagementView;
-}): ReplyPayload | undefined {
-  if (params.entry?.traceLevel !== "raw") {
-    return undefined;
-  }
-  const resolvedPromptTokens = resolveRequestPromptTokens({
-    lastCallUsage: params.lastCallUsage,
-    promptTokens: params.promptTokens,
-    usage: params.usage,
-  });
-  const requestContextBlock = formatRequestContextTraceBlock({
-    provider: params.provider,
-    model: params.model,
-    contextLimit: params.contextLimit,
-    promptTokens: resolvedPromptTokens,
-  });
-  const usageBlocks = [
-    formatUsageTraceBlock("Usage (Session Total)", params.sessionUsage),
-    formatUsageTraceBlock("Usage (Last Turn Total)", params.usage),
-    requestContextBlock,
-    formatExecutionResultTraceBlock(params.executionTrace),
-    formatFallbackChainTraceBlock(params.executionTrace),
-    formatKeyValueTraceBlock("Request Shaping", [
-      ["provider", params.provider],
-      ["model", params.model],
-      ["auth", params.requestShaping?.authMode],
-      ["thinking", params.requestShaping?.thinking],
-      ["reasoning", params.requestShaping?.reasoning],
-      ["verbose", params.requestShaping?.verbose],
-      ["trace", params.requestShaping?.trace],
-      ["fallbackEligible", params.requestShaping?.fallbackEligible],
-      ["blockStreaming", params.requestShaping?.blockStreaming],
-    ]),
-    formatPromptSegmentsTraceBlock(params.promptSegments, params.rawUserText),
-    formatToolSummaryTraceBlock(params.toolSummary),
-    formatCompletionTraceBlock(params.completion),
-    formatContextManagementTraceBlock(params.contextManagement),
-  ].filter((value): value is string => Boolean(value));
-  return {
-    text: [
-      ...usageBlocks,
-      formatRawTraceBlock("Model Input (User Role)", params.rawUserText),
-      formatRawTraceBlock("Model Output (Assistant Role)", params.rawAssistantText),
-      formatRawTraceSummaryLine({
-        executionTrace: params.executionTrace,
-        completion: params.completion,
-        contextLimit: params.contextLimit,
-        promptTokens: resolvedPromptTokens,
-        usage: params.usage,
-        toolSummary: params.toolSummary,
-        contextManagement: params.contextManagement,
-        requestShaping: params.requestShaping,
-      }),
-    ].join("\n\n\n"),
-  };
-}
-
-function refreshSessionEntryFromStore(params: {
-  storePath?: string;
-  sessionKey?: string;
-  fallbackEntry?: SessionEntry;
-  activeSessionStore?: Record<string, SessionEntry>;
-}): SessionEntry | undefined {
-  const { storePath, sessionKey, fallbackEntry, activeSessionStore } = params;
-  if (!storePath || !sessionKey) {
-    return fallbackEntry;
-  }
-  try {
-    const latestStore = loadSessionStore(storePath, { skipCache: true });
-    const latestEntry = latestStore?.[sessionKey];
-    if (!latestEntry) {
-      return fallbackEntry;
-    }
-    if (activeSessionStore) {
-      activeSessionStore[sessionKey] = latestEntry;
-    }
-    return latestEntry;
-  } catch {
-    return fallbackEntry;
-  }
-}
 
 export async function runReplyAgent(params: {
   commandBody: string;
@@ -885,8 +96,6 @@ export async function runReplyAgent(params: {
   sessionCtx: TemplateContext;
   shouldInjectGroupIntro: boolean;
   typingMode: TypingMode;
-  resetTriggered?: boolean;
-  replyOperation?: ReplyOperation;
 }): Promise<ReplyPayload | ReplyPayload[] | undefined> {
   const {
     commandBody,
@@ -914,8 +123,6 @@ export async function runReplyAgent(params: {
     sessionCtx,
     shouldInjectGroupIntro,
     typingMode,
-    resetTriggered,
-    replyOperation: providedReplyOperation,
   } = params;
 
   let activeSessionEntry = sessionEntry;
@@ -942,6 +149,42 @@ export async function runReplyAgent(params: {
 
   const pendingToolTasks = new Set<Promise<void>>();
   const blockReplyTimeoutMs = opts?.blockReplyTimeoutMs ?? BLOCK_REPLY_SEND_TIMEOUT_MS;
+
+  const replyToChannel = resolveOriginMessageProvider({
+    originatingChannel: sessionCtx.OriginatingChannel,
+    provider: sessionCtx.Surface ?? sessionCtx.Provider,
+  }) as OriginatingChannelType | undefined;
+  const replyToMode = resolveReplyToMode(
+    followupRun.run.config,
+    replyToChannel,
+    sessionCtx.AccountId,
+    sessionCtx.ChatType,
+  );
+  const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
+  const cfg = followupRun.run.config;
+  const normalizeReplyMediaPaths = createReplyMediaPathNormalizer({
+    cfg,
+    sessionKey,
+    workspaceDir: followupRun.run.workspaceDir,
+  });
+  const blockReplyCoalescing =
+    blockStreamingEnabled && opts?.onBlockReply
+      ? resolveEffectiveBlockStreamingConfig({
+          cfg,
+          provider: sessionCtx.Provider,
+          accountId: sessionCtx.AccountId,
+          chunking: blockReplyChunking,
+        }).coalescing
+      : undefined;
+  const blockReplyPipeline =
+    blockStreamingEnabled && opts?.onBlockReply
+      ? createBlockReplyPipeline({
+          onBlockReply: opts.onBlockReply,
+          timeoutMs: blockReplyTimeoutMs,
+          coalescing: blockReplyCoalescing,
+          buffer: createAudioAsVoiceBuffer({ isAudioPayload }),
+        })
+      : null;
   const touchActiveSessionEntry = async () => {
     if (!activeSessionEntry || !activeSessionStore || !sessionKey) {
       return;
@@ -959,10 +202,7 @@ export async function runReplyAgent(params: {
   };
 
   if (shouldSteer && isStreaming) {
-    const steerSessionId =
-      (sessionKey ? replyRunRegistry.resolveSessionId(sessionKey) : undefined) ??
-      followupRun.run.sessionId;
-    const steered = queueEmbeddedPiMessage(steerSessionId, followupRun.prompt);
+    const steered = queueEmbeddedPiMessage(followupRun.run.sessionId, followupRun.prompt);
     if (steered && !shouldFollowup) {
       await touchActiveSessionEntry();
       typing.cleanup();
@@ -1013,183 +253,158 @@ export async function runReplyAgent(params: {
     return undefined;
   }
 
-  followupRun.run.config = await resolveQueuedReplyExecutionConfig(followupRun.run.config, {
-    originatingChannel: sessionCtx.OriginatingChannel,
-    messageProvider: followupRun.run.messageProvider,
-    originatingAccountId: followupRun.originatingAccountId,
-    agentAccountId: followupRun.run.agentAccountId,
-  });
+  await typingSignals.signalRunStart();
 
-  const replyToChannel = resolveOriginMessageProvider({
-    originatingChannel: sessionCtx.OriginatingChannel,
-    provider: sessionCtx.Surface ?? sessionCtx.Provider,
-  }) as OriginatingChannelType | undefined;
-  const replyToMode = resolveReplyToMode(
-    followupRun.run.config,
-    replyToChannel,
-    sessionCtx.AccountId,
-    sessionCtx.ChatType,
-  );
-  const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
-  const cfg = followupRun.run.config;
-  const normalizeReplyMediaPaths = createReplyMediaPathNormalizer({
+  activeSessionEntry = await runPreflightCompactionIfNeeded({
     cfg,
+    followupRun,
+    promptForEstimate: followupRun.prompt,
+    defaultModel,
+    agentCfgContextTokens,
+    sessionEntry: activeSessionEntry,
+    sessionStore: activeSessionStore,
     sessionKey,
-    workspaceDir: followupRun.run.workspaceDir,
-    messageProvider: followupRun.run.messageProvider,
-    accountId: followupRun.originatingAccountId ?? followupRun.run.agentAccountId,
-    groupId: followupRun.run.groupId,
-    groupChannel: followupRun.run.groupChannel,
-    groupSpace: followupRun.run.groupSpace,
-    requesterSenderId: followupRun.run.senderId,
-    requesterSenderName: followupRun.run.senderName,
-    requesterSenderUsername: followupRun.run.senderUsername,
-    requesterSenderE164: followupRun.run.senderE164,
+    storePath,
+    isHeartbeat,
   });
-  const blockReplyCoalescing =
-    blockStreamingEnabled && opts?.onBlockReply
-      ? resolveEffectiveBlockStreamingConfig({
-          cfg,
-          provider: sessionCtx.Provider,
-          accountId: sessionCtx.AccountId,
-          chunking: blockReplyChunking,
-        }).coalescing
-      : undefined;
-  const blockReplyPipeline =
-    blockStreamingEnabled && opts?.onBlockReply
-      ? createBlockReplyPipeline({
-          onBlockReply: opts.onBlockReply,
-          timeoutMs: blockReplyTimeoutMs,
-          coalescing: blockReplyCoalescing,
-          buffer: createAudioAsVoiceBuffer({ isAudioPayload }),
-        })
-      : null;
 
-  const replySessionKey = sessionKey ?? followupRun.run.sessionKey;
-  let replyOperation: ReplyOperation;
-  try {
-    replyOperation =
-      providedReplyOperation ??
-      createReplyOperation({
-        sessionId: followupRun.run.sessionId,
-        sessionKey: replySessionKey ?? "",
-        resetTriggered: resetTriggered === true,
-        upstreamAbortSignal: opts?.abortSignal,
-      });
-  } catch (error) {
-    if (error instanceof ReplyRunAlreadyActiveError) {
-      typing.cleanup();
-      return {
-        text: "⚠️ Previous run is still shutting down. Please try again in a moment.",
-      };
+  activeSessionEntry = await runMemoryFlushIfNeeded({
+    cfg,
+    followupRun,
+    promptForEstimate: followupRun.prompt,
+    sessionCtx,
+    opts,
+    defaultModel,
+    agentCfgContextTokens,
+    resolvedVerboseLevel,
+    sessionEntry: activeSessionEntry,
+    sessionStore: activeSessionStore,
+    sessionKey,
+    storePath,
+    isHeartbeat,
+  });
+
+  const runFollowupTurn = createFollowupRunner({
+    opts,
+    typing,
+    typingMode,
+    sessionEntry: activeSessionEntry,
+    sessionStore: activeSessionStore,
+    sessionKey,
+    storePath,
+    defaultModel,
+    agentCfgContextTokens,
+  });
+
+  let responseUsageLine: string | undefined;
+  type SessionResetOptions = {
+    failureLabel: string;
+    buildLogMessage: (nextSessionId: string) => string;
+    cleanupTranscripts?: boolean;
+  };
+  const resetSession = async ({
+    failureLabel,
+    buildLogMessage,
+    cleanupTranscripts,
+  }: SessionResetOptions): Promise<boolean> => {
+    if (!sessionKey || !activeSessionStore || !storePath) {
+      return false;
     }
-    throw error;
-  }
-  let runFollowupTurn = queuedRunFollowupTurn;
-  const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
-  let preflightCompactionApplied = false;
-
-  try {
-    await typingSignals.signalRunStart();
-
-    activeSessionEntry = await runPreflightCompactionIfNeeded({
-      cfg,
-      followupRun,
-      promptForEstimate: followupRun.prompt,
-      defaultModel,
-      agentCfgContextTokens,
-      sessionEntry: activeSessionEntry,
-      sessionStore: activeSessionStore,
-      sessionKey,
-      storePath,
-      isHeartbeat,
-      replyOperation,
-    });
-    preflightCompactionApplied =
-      (activeSessionEntry?.compactionCount ?? 0) > prePreflightCompactionCount;
-
-    activeSessionEntry = await runMemoryFlushIfNeeded({
-      cfg,
-      followupRun,
-      promptForEstimate: followupRun.prompt,
-      sessionCtx,
-      opts,
-      defaultModel,
-      agentCfgContextTokens,
-      resolvedVerboseLevel,
-      sessionEntry: activeSessionEntry,
-      sessionStore: activeSessionStore,
-      sessionKey,
-      storePath,
-      isHeartbeat,
-      replyOperation,
-    });
-
-    runFollowupTurn = createFollowupRunner({
-      opts,
-      typing,
-      typingMode,
-      sessionEntry: activeSessionEntry,
-      sessionStore: activeSessionStore,
-      sessionKey,
-      storePath,
-      defaultModel,
-      agentCfgContextTokens,
-    });
-
-    let responseUsageLine: string | undefined;
-    type SessionResetOptions = {
-      failureLabel: string;
-      buildLogMessage: (nextSessionId: string) => string;
-      cleanupTranscripts?: boolean;
+    const prevEntry = activeSessionStore[sessionKey] ?? activeSessionEntry;
+    if (!prevEntry) {
+      return false;
+    }
+    const prevSessionId = cleanupTranscripts ? prevEntry.sessionId : undefined;
+    const nextSessionId = generateSecureUuid();
+    const nextEntry: SessionEntry = {
+      ...prevEntry,
+      sessionId: nextSessionId,
+      updatedAt: Date.now(),
+      systemSent: false,
+      abortedLastRun: false,
+      modelProvider: undefined,
+      model: undefined,
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+      totalTokensFresh: false,
+      estimatedCostUsd: undefined,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      contextTokens: undefined,
+      systemPromptReport: undefined,
+      fallbackNoticeSelectedModel: undefined,
+      fallbackNoticeActiveModel: undefined,
+      fallbackNoticeReason: undefined,
     };
-    const resetSession = async ({
-      failureLabel,
-      buildLogMessage,
-      cleanupTranscripts,
-    }: SessionResetOptions): Promise<boolean> =>
-      await resetReplyRunSession({
-        options: {
-          failureLabel,
-          buildLogMessage,
-          cleanupTranscripts,
-        },
-        sessionKey,
-        queueKey,
-        activeSessionEntry,
-        activeSessionStore,
-        storePath,
-        messageThreadId:
-          typeof sessionCtx.MessageThreadId === "string" ? sessionCtx.MessageThreadId : undefined,
-        followupRun,
-        onActiveSessionEntry: (nextEntry) => {
-          activeSessionEntry = nextEntry;
-        },
-        onNewSession: () => {
-          activeIsNewSession = true;
-        },
+    const agentId = resolveAgentIdFromSessionKey(sessionKey);
+    const nextSessionFile = resolveSessionTranscriptPath(
+      nextSessionId,
+      agentId,
+      sessionCtx.MessageThreadId,
+    );
+    nextEntry.sessionFile = nextSessionFile;
+    activeSessionStore[sessionKey] = nextEntry;
+    try {
+      await updateSessionStore(storePath, (store) => {
+        store[sessionKey] = nextEntry;
       });
-    const resetSessionAfterCompactionFailure = async (reason: string): Promise<boolean> =>
-      resetSession({
-        failureLabel: "compaction failure",
-        buildLogMessage: (nextSessionId) =>
-          `Auto-compaction failed (${reason}). Restarting session ${sessionKey} -> ${nextSessionId} and retrying.`,
-      });
-    const resetSessionAfterRoleOrderingConflict = async (reason: string): Promise<boolean> =>
-      resetSession({
-        failureLabel: "role ordering conflict",
-        buildLogMessage: (nextSessionId) =>
-          `Role ordering conflict (${reason}). Restarting session ${sessionKey} -> ${nextSessionId}.`,
-        cleanupTranscripts: true,
-      });
-
-    replyOperation.setPhase("running");
+    } catch (err) {
+      defaultRuntime.error(
+        `Failed to persist session reset after ${failureLabel} (${sessionKey}): ${String(err)}`,
+      );
+    }
+    followupRun.run.sessionId = nextSessionId;
+    followupRun.run.sessionFile = nextSessionFile;
+    refreshQueuedFollowupSession({
+      key: queueKey,
+      previousSessionId: prevEntry.sessionId,
+      nextSessionId,
+      nextSessionFile,
+    });
+    activeSessionEntry = nextEntry;
+    activeIsNewSession = true;
+    defaultRuntime.error(buildLogMessage(nextSessionId));
+    if (cleanupTranscripts && prevSessionId) {
+      const transcriptCandidates = new Set<string>();
+      const resolved = resolveSessionFilePath(
+        prevSessionId,
+        prevEntry,
+        resolveSessionFilePathOptions({ agentId, storePath }),
+      );
+      if (resolved) {
+        transcriptCandidates.add(resolved);
+      }
+      transcriptCandidates.add(resolveSessionTranscriptPath(prevSessionId, agentId));
+      for (const candidate of transcriptCandidates) {
+        try {
+          fs.unlinkSync(candidate);
+        } catch {
+          // Best-effort cleanup.
+        }
+      }
+    }
+    return true;
+  };
+  const resetSessionAfterCompactionFailure = async (reason: string): Promise<boolean> =>
+    resetSession({
+      failureLabel: "compaction failure",
+      buildLogMessage: (nextSessionId) =>
+        `Auto-compaction failed (${reason}). Restarting session ${sessionKey} -> ${nextSessionId} and retrying.`,
+    });
+  const resetSessionAfterRoleOrderingConflict = async (reason: string): Promise<boolean> =>
+    resetSession({
+      failureLabel: "role ordering conflict",
+      buildLogMessage: (nextSessionId) =>
+        `Role ordering conflict (${reason}). Restarting session ${sessionKey} -> ${nextSessionId}.`,
+      cleanupTranscripts: true,
+    });
+  try {
     const runStartedAt = Date.now();
     const runOutcome = await runAgentTurnWithFallback({
       commandBody,
       followupRun,
       sessionCtx,
-      replyOperation,
       opts,
       typingSignals,
       blockReplyPipeline,
@@ -1211,9 +426,6 @@ export async function runReplyAgent(params: {
     });
 
     if (runOutcome.kind === "final") {
-      if (!replyOperation.result) {
-        replyOperation.fail("run_failed", new Error("reply operation exited with final payload"));
-      }
       return finalizeWithFollowup(runOutcome.payload, queueKey, runFollowupTurn);
     }
 
@@ -1302,20 +514,13 @@ export async function runReplyAgent(params: {
       }
     }
     const cliSessionId = isCliProvider(providerUsed, cfg)
-      ? normalizeOptionalString(runResult.meta?.agentMeta?.sessionId)
-      : undefined;
-    const cliSessionBinding = isCliProvider(providerUsed, cfg)
-      ? runResult.meta?.agentMeta?.cliSessionBinding
+      ? runResult.meta?.agentMeta?.sessionId?.trim()
       : undefined;
     const contextTokensUsed =
-      resolveContextTokensForModel({
-        cfg,
-        provider: providerUsed,
-        model: modelUsed,
-        contextTokensOverride: agentCfgContextTokens,
-        fallbackContextTokens: activeSessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
-        allowAsyncLoad: false,
-      }) ?? DEFAULT_CONTEXT_TOKENS;
+      agentCfgContextTokens ??
+      lookupContextTokens(modelUsed) ??
+      activeSessionEntry?.contextTokens ??
+      DEFAULT_CONTEXT_TOKENS;
 
     await persistRunSessionUsage({
       storePath,
@@ -1329,8 +534,6 @@ export async function runReplyAgent(params: {
       contextTokensUsed,
       systemPromptReport: runResult.meta?.systemPromptReport,
       cliSessionId,
-      cliSessionBinding,
-      usageIsContextSnapshot: isCliProvider(providerUsed, cfg),
     });
 
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
@@ -1344,14 +547,12 @@ export async function runReplyAgent(params: {
       payloads: payloadArray,
       isHeartbeat,
       didLogHeartbeatStrip,
-      silentExpected: followupRun.run.silentExpected,
       blockStreamingEnabled,
       blockReplyPipeline,
       directlySentBlockKeys,
       replyToMode,
       replyToChannel,
       currentMessageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
-      replyThreading: sessionCtx.ReplyThreading,
       messageProvider: followupRun.run.messageProvider,
       messagingToolSentTexts: runResult.messagingToolSentTexts,
       messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
@@ -1438,14 +639,15 @@ export async function runReplyAgent(params: {
     const responseUsageMode = resolveResponseUsageMode(responseUsageRaw);
     if (responseUsageMode !== "off" && hasNonzeroUsage(usage)) {
       const authMode = resolveModelAuthMode(providerUsed, cfg);
-      const showCost = authMode === "api-key";
-      const costConfig = showCost
-        ? resolveModelCostConfig({
-            provider: providerUsed,
-            model: modelUsed,
-            config: cfg,
-          })
-        : undefined;
+      const costConfig = resolveModelCostConfig({
+        provider: providerUsed,
+        model: modelUsed,
+        config: cfg,
+      });
+      const showCost =
+        authMode === "api-key" ||
+        authMode === "mixed" ||
+        (costConfig != null && costConfig.input > 0 && costConfig.output > 0);
       let formatted = formatResponseUsageLine({
         usage,
         showCost,
@@ -1457,15 +659,6 @@ export async function runReplyAgent(params: {
       if (formatted) {
         responseUsageLine = formatted;
       }
-    }
-
-    if (verboseEnabled) {
-      activeSessionEntry = refreshSessionEntryFromStore({
-        storePath,
-        sessionKey,
-        fallbackEntry: activeSessionEntry,
-        activeSessionStore,
-      });
     }
 
     // If verbose is enabled, prepend operational run notices.
@@ -1533,7 +726,6 @@ export async function runReplyAgent(params: {
     if (autoCompactionCount > 0) {
       const previousSessionId = activeSessionEntry?.sessionId ?? followupRun.run.sessionId;
       const count = await incrementRunCompactionCount({
-        cfg,
         sessionEntry: activeSessionEntry,
         sessionStore: activeSessionStore,
         sessionKey,
@@ -1574,140 +766,8 @@ export async function runReplyAgent(params: {
         verboseNotices.push({ text: `🧹 Auto-compaction complete${suffix}.` });
       }
     }
-    const prefixPayloads = [...verboseNotices];
-    const rawUserText =
-      runResult.meta?.finalPromptText ??
-      sessionCtx.CommandBody ??
-      sessionCtx.RawBody ??
-      sessionCtx.BodyForAgent ??
-      sessionCtx.Body;
-    const rawAssistantText =
-      runResult.meta?.finalAssistantRawText ?? runResult.meta?.finalAssistantVisibleText;
-    const traceAuthorized = followupRun.run.traceAuthorized === true;
-    const executionTrace = mergeExecutionTrace({
-      fallbackAttempts,
-      executionTrace: runResult.meta?.executionTrace as TraceExecutionView | undefined,
-      provider: providerUsed,
-      model: modelUsed,
-      runner: isCliProvider(providerUsed, cfg) ? "cli" : "embedded",
-    });
-    const requestShaping = {
-      authMode:
-        runResult.meta?.requestShaping?.authMode ??
-        (cfg?.models?.providers && providerUsed in cfg.models.providers
-          ? (resolveModelAuthMode(providerUsed, cfg) ?? undefined)
-          : undefined),
-      thinking:
-        runResult.meta?.requestShaping?.thinking ??
-        normalizeOptionalString(followupRun.run.thinkLevel),
-      reasoning:
-        runResult.meta?.requestShaping?.reasoning ??
-        normalizeOptionalString(followupRun.run.reasoningLevel),
-      verbose:
-        runResult.meta?.requestShaping?.verbose ?? normalizeOptionalString(resolvedVerboseLevel),
-      trace:
-        runResult.meta?.requestShaping?.trace ??
-        normalizeOptionalString(activeSessionEntry?.traceLevel),
-      fallbackEligible:
-        runResult.meta?.requestShaping?.fallbackEligible ??
-        hasConfiguredModelFallbacks({
-          cfg,
-          agentId: followupRun.run.agentId,
-          sessionKey: followupRun.run.sessionKey,
-        }),
-      blockStreaming:
-        runResult.meta?.requestShaping?.blockStreaming ??
-        normalizeOptionalString(resolvedBlockStreamingBreak),
-    };
-    const promptSegments =
-      (runResult.meta?.promptSegments as TracePromptSegmentView[] | undefined) ??
-      derivePromptSegments(rawUserText);
-    const toolSummary = runResult.meta?.toolSummary as TraceToolSummaryView | undefined;
-    const completion =
-      (runResult.meta?.completion as TraceCompletionView | undefined) ??
-      (runResult.meta?.stopReason
-        ? {
-            stopReason: runResult.meta.stopReason,
-            finishReason: runResult.meta.stopReason,
-            ...(runResult.meta.stopReason.toLowerCase().includes("refusal")
-              ? { refusal: true }
-              : {}),
-          }
-        : undefined);
-    const contextManagement = {
-      ...(typeof activeSessionEntry?.compactionCount === "number"
-        ? { sessionCompactions: activeSessionEntry.compactionCount }
-        : {}),
-      ...(typeof runResult.meta?.contextManagement?.lastTurnCompactions === "number"
-        ? { lastTurnCompactions: runResult.meta.contextManagement.lastTurnCompactions }
-        : typeof runResult.meta?.agentMeta?.compactionCount === "number"
-          ? { lastTurnCompactions: runResult.meta.agentMeta.compactionCount }
-          : {}),
-      ...(runResult.meta?.contextManagement &&
-      typeof runResult.meta.contextManagement.preflightCompactionApplied === "boolean"
-        ? {
-            preflightCompactionApplied: runResult.meta.contextManagement.preflightCompactionApplied,
-          }
-        : preflightCompactionApplied
-          ? { preflightCompactionApplied }
-          : {}),
-      ...(runResult.meta?.contextManagement &&
-      typeof runResult.meta.contextManagement.postCompactionContextInjected === "boolean"
-        ? {
-            postCompactionContextInjected:
-              runResult.meta.contextManagement.postCompactionContextInjected,
-          }
-        : {}),
-    } satisfies TraceContextManagementView;
-    const sessionUsage =
-      traceAuthorized && activeSessionEntry?.traceLevel === "raw"
-        ? await accumulateSessionUsageFromTranscript({
-            sessionId: runResult.meta?.agentMeta?.sessionId ?? followupRun.run.sessionId,
-            storePath,
-            sessionFile: followupRun.run.sessionFile,
-          })
-        : undefined;
-    const traceEnabledForSender =
-      traceAuthorized &&
-      (activeSessionEntry?.traceLevel === "on" || activeSessionEntry?.traceLevel === "raw");
-    const shouldAppendTracePayload = verboseEnabled || traceEnabledForSender;
-    let trailingPluginStatusPayload: ReplyPayload | undefined;
-    if (shouldAppendTracePayload) {
-      const pluginStatusPayload = buildInlinePluginStatusPayload({
-        entry: activeSessionEntry,
-        includeTraceLines: traceEnabledForSender,
-      });
-      const rawTracePayload =
-        traceAuthorized && activeSessionEntry?.traceLevel === "raw"
-          ? buildInlineRawTracePayload({
-              entry: activeSessionEntry,
-              rawUserText,
-              rawAssistantText,
-              sessionUsage,
-              usage: runResult.meta?.agentMeta?.usage,
-              lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
-              provider: providerUsed,
-              model: modelUsed,
-              contextLimit: contextTokensUsed,
-              promptTokens,
-              executionTrace,
-              requestShaping,
-              promptSegments,
-              toolSummary,
-              completion,
-              contextManagement,
-            })
-          : undefined;
-      trailingPluginStatusPayload =
-        pluginStatusPayload && rawTracePayload
-          ? { text: `${pluginStatusPayload.text}\n\n${rawTracePayload.text}` }
-          : (pluginStatusPayload ?? rawTracePayload);
-    }
-    if (prefixPayloads.length > 0) {
-      finalPayloads = [...prefixPayloads, ...finalPayloads];
-    }
-    if (trailingPluginStatusPayload) {
-      finalPayloads = [...finalPayloads, trailingPluginStatusPayload];
+    if (verboseNotices.length > 0) {
+      finalPayloads = [...verboseNotices, ...finalPayloads];
     }
     if (responseUsageLine) {
       finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
@@ -1719,42 +779,11 @@ export async function runReplyAgent(params: {
       runFollowupTurn,
     );
   } catch (error) {
-    if (
-      replyOperation.result?.kind === "aborted" &&
-      replyOperation.result.code === "aborted_for_restart"
-    ) {
-      return finalizeWithFollowup(
-        { text: "⚠️ Gateway is restarting. Please wait a few seconds and try again." },
-        queueKey,
-        runFollowupTurn,
-      );
-    }
-    if (replyOperation.result?.kind === "aborted") {
-      return finalizeWithFollowup({ text: SILENT_REPLY_TOKEN }, queueKey, runFollowupTurn);
-    }
-    if (error instanceof GatewayDrainingError) {
-      replyOperation.fail("gateway_draining", error);
-      return finalizeWithFollowup(
-        { text: "⚠️ Gateway is restarting. Please wait a few seconds and try again." },
-        queueKey,
-        runFollowupTurn,
-      );
-    }
-    if (error instanceof CommandLaneClearedError) {
-      replyOperation.fail("command_lane_cleared", error);
-      return finalizeWithFollowup(
-        { text: "⚠️ Gateway is restarting. Please wait a few seconds and try again." },
-        queueKey,
-        runFollowupTurn,
-      );
-    }
-    replyOperation.fail("run_failed", error);
     // Keep the followup queue moving even when an unexpected exception escapes
     // the run path; the caller still receives the original error.
     finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     throw error;
   } finally {
-    replyOperation.complete();
     blockReplyPipeline?.stop();
     typing.markRunComplete();
     // Safety net: the dispatcher's onIdle callback normally fires

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -11,16 +11,8 @@ import {
   buildCommandsMessage,
   buildCommandsMessagePaginated,
   buildHelpMessage,
-  buildStatusMessage as buildStatusMessageRaw,
+  buildStatusMessage,
 } from "./status.js";
-import type { buildStatusMessage as BuildStatusMessage } from "./status.js";
-
-const buildStatusMessage: typeof BuildStatusMessage = (args) =>
-  buildStatusMessageRaw({
-    modelAuth: "api-key",
-    activeModelAuth: "api-key",
-    ...args,
-  });
 
 const { listPluginCommands } = vi.hoisted(() => ({
   listPluginCommands: vi.fn(
@@ -123,145 +115,6 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Reasoning: on");
   });
 
-  it("shows plugin status lines only when verbose is enabled", () => {
-    const visible = normalizeTestText(
-      buildStatusMessage({
-        agent: {
-          model: "anthropic/pi:opus",
-        },
-        sessionEntry: {
-          sessionId: "abc",
-          updatedAt: 0,
-          verboseLevel: "on",
-          pluginDebugEntries: [
-            {
-              pluginId: "active-memory",
-              lines: ["🧩 Active Memory: status=timeout elapsed=15s query=recent"],
-            },
-          ],
-        },
-        sessionKey: "agent:main:main",
-        queue: { mode: "collect", depth: 0 },
-      }),
-    );
-    const hidden = normalizeTestText(
-      buildStatusMessage({
-        agent: {
-          model: "anthropic/pi:opus",
-        },
-        sessionEntry: {
-          sessionId: "abc",
-          updatedAt: 0,
-          verboseLevel: "off",
-          pluginDebugEntries: [
-            {
-              pluginId: "active-memory",
-              lines: ["🧩 Active Memory: status=timeout elapsed=15s query=recent"],
-            },
-          ],
-        },
-        sessionKey: "agent:main:main",
-        queue: { mode: "collect", depth: 0 },
-      }),
-    );
-
-    expect(visible).toContain("Active Memory: status=timeout elapsed=15s query=recent");
-    expect(hidden).not.toContain("Active Memory: status=timeout elapsed=15s query=recent");
-  });
-
-  it("shows structured plugin debug lines in verbose status", () => {
-    const visible = normalizeTestText(
-      buildStatusMessage({
-        agent: {
-          model: "anthropic/pi:opus",
-        },
-        sessionEntry: {
-          sessionId: "abc",
-          updatedAt: 0,
-          verboseLevel: "on",
-          pluginDebugEntries: [
-            {
-              pluginId: "active-memory",
-              lines: ["🧩 Active Memory: status=ok elapsed=842ms query=recent summary=34 chars"],
-            },
-          ],
-        },
-        sessionKey: "agent:main:main",
-        queue: { mode: "collect", depth: 0 },
-      }),
-    );
-
-    expect(visible).toContain(
-      "Active Memory: status=ok elapsed=842ms query=recent summary=34 chars",
-    );
-  });
-
-  it("shows trace lines only when trace is enabled", () => {
-    const hidden = normalizeTestText(
-      buildStatusMessage({
-        agent: {
-          model: "anthropic/pi:opus",
-        },
-        sessionEntry: {
-          sessionId: "abc",
-          updatedAt: 0,
-          verboseLevel: "on",
-          pluginDebugEntries: [
-            { pluginId: "active-memory", lines: ["🔎 Active Memory Debug: spicy ramen; tacos"] },
-          ],
-        },
-        sessionKey: "agent:main:main",
-        queue: { mode: "collect", depth: 0 },
-      }),
-    );
-    const visible = normalizeTestText(
-      buildStatusMessage({
-        agent: {
-          model: "anthropic/pi:opus",
-        },
-        sessionEntry: {
-          sessionId: "abc",
-          updatedAt: 0,
-          verboseLevel: "off",
-          traceLevel: "on",
-          pluginDebugEntries: [
-            { pluginId: "active-memory", lines: ["🔎 Active Memory Debug: spicy ramen; tacos"] },
-          ],
-        },
-        sessionKey: "agent:main:main",
-        queue: { mode: "collect", depth: 0 },
-      }),
-    );
-
-    expect(hidden).not.toContain("Active Memory Debug: spicy ramen; tacos");
-    expect(visible).toContain("Active Memory Debug: spicy ramen; tacos");
-    expect(visible).toContain("trace");
-  });
-
-  it("shows raw trace mode and plugin trace lines in status", () => {
-    const visible = normalizeTestText(
-      buildStatusMessage({
-        agent: {
-          model: "anthropic/pi:opus",
-        },
-        sessionEntry: {
-          sessionId: "abc",
-          updatedAt: 0,
-          verboseLevel: "off",
-          traceLevel: "raw",
-          pluginDebugEntries: [
-            { pluginId: "active-memory", lines: ["🔎 Active Memory Debug: spicy ramen; tacos"] },
-          ],
-        },
-        sessionKey: "agent:main:main",
-        queue: { mode: "collect", depth: 0 },
-      }),
-    );
-
-    expect(visible).toContain("Active Memory Debug: spicy ramen; tacos");
-    expect(visible).toContain("trace:raw");
-  });
-
   it("shows fast mode when enabled", () => {
     const text = buildStatusMessage({
       agent: {
@@ -277,75 +130,6 @@ describe("buildStatusMessage", () => {
     });
 
     expect(normalizeTestText(text)).toContain("Fast: on");
-  });
-
-  it("shows configured text verbosity for the active model", () => {
-    const text = buildStatusMessage({
-      config: {
-        agents: {
-          defaults: {
-            model: "openai-codex/gpt-5.4",
-            models: {
-              "openai-codex/gpt-5.4": {
-                params: {
-                  textVerbosity: "low",
-                },
-              },
-            },
-          },
-        },
-      } as unknown as OpenClawConfig,
-      agent: {
-        model: "openai-codex/gpt-5.4",
-      },
-      sessionEntry: {
-        sessionId: "abc",
-        updatedAt: 0,
-      },
-      sessionKey: "agent:main:main",
-      queue: { mode: "collect", depth: 0 },
-    });
-
-    expect(normalizeTestText(text)).toContain("Text: low");
-  });
-
-  it("shows per-agent text verbosity overrides for the active model", () => {
-    const text = buildStatusMessage({
-      config: {
-        agents: {
-          defaults: {
-            model: "openai-codex/gpt-5.4",
-            models: {
-              "openai-codex/gpt-5.4": {
-                params: {
-                  textVerbosity: "high",
-                },
-              },
-            },
-          },
-          list: [
-            {
-              id: "main",
-              params: {
-                text_verbosity: "low",
-              },
-            },
-          ],
-        },
-      } as unknown as OpenClawConfig,
-      agentId: "main",
-      agent: {
-        model: "openai-codex/gpt-5.4",
-      },
-      sessionEntry: {
-        sessionId: "abc",
-        updatedAt: 0,
-      },
-      sessionKey: "agent:main:main",
-      queue: { mode: "collect", depth: 0 },
-    });
-
-    expect(normalizeTestText(text)).toContain("Text: low");
   });
 
   it("notes channel model overrides in status output", () => {
@@ -368,7 +152,7 @@ describe("buildStatusMessage", () => {
         channel: "discord",
         groupId: "123",
       },
-      sessionKey: "agent:main:main",
+      sessionKey: "agent:main:discord:channel:123",
       sessionScope: "per-sender",
       queue: { mode: "collect", depth: 0 },
     });
@@ -769,7 +553,7 @@ describe("buildStatusMessage", () => {
 
   it("shows verbose/elevated labels only when enabled", () => {
     const text = buildStatusMessage({
-      agent: { model: "anthropic/claude-opus-4-6" },
+      agent: { model: "anthropic/claude-opus-4-5" },
       sessionEntry: { sessionId: "v1", updatedAt: 0 },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -785,7 +569,7 @@ describe("buildStatusMessage", () => {
 
   it("includes media understanding decisions when present", () => {
     const text = buildStatusMessage({
-      agent: { model: "anthropic/claude-opus-4-6" },
+      agent: { model: "anthropic/claude-opus-4-5" },
       sessionEntry: { sessionId: "media", updatedAt: 0 },
       sessionKey: "agent:main:main",
       queue: { mode: "none" },
@@ -813,49 +597,12 @@ describe("buildStatusMessage", () => {
     });
 
     const normalized = normalizeTestText(text);
-    expect(normalized).toContain("Media: image ok (openai/gpt-5.4) · audio skipped (maxBytes)");
-  });
-
-  it("includes failed media understanding decisions with the surfaced reason", () => {
-    const text = buildStatusMessage({
-      agent: { model: "anthropic/claude-opus-4-6" },
-      sessionEntry: { sessionId: "media-failed", updatedAt: 0 },
-      sessionKey: "agent:main:main",
-      queue: { mode: "none" },
-      mediaDecisions: [
-        {
-          capability: "audio",
-          outcome: "failed",
-          attachments: [
-            {
-              attachmentIndex: 0,
-              attempts: [
-                {
-                  type: "provider",
-                  outcome: "skipped",
-                  reason: "empty output",
-                },
-                {
-                  type: "provider",
-                  outcome: "failed",
-                  reason: "Error: Audio transcription response missing text",
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    });
-
-    expect(normalizeTestText(text)).toContain(
-      "Media: audio failed (Audio transcription response missing text)",
-    );
-    expect(normalizeTestText(text)).not.toContain("empty output");
+    expect(normalized).toContain("Media: image ok (openai/gpt-5.2) · audio skipped (maxBytes)");
   });
 
   it("omits media line when all decisions are none", () => {
     const text = buildStatusMessage({
-      agent: { model: "anthropic/claude-opus-4-6" },
+      agent: { model: "anthropic/claude-opus-4-5" },
       sessionEntry: { sessionId: "media-none", updatedAt: 0 },
       sessionKey: "agent:main:main",
       queue: { mode: "none" },
@@ -871,7 +618,7 @@ describe("buildStatusMessage", () => {
 
   it("does not show elevated label when session explicitly disables it", () => {
     const text = buildStatusMessage({
-      agent: { model: "anthropic/claude-opus-4-6", elevatedDefault: "on" },
+      agent: { model: "anthropic/claude-opus-4-5", elevatedDefault: "on" },
       sessionEntry: { sessionId: "v1", updatedAt: 0, elevatedLevel: "off" },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -888,7 +635,7 @@ describe("buildStatusMessage", () => {
   it("shows selected model and active runtime model when they differ", () => {
     const text = buildStatusMessage({
       agent: {
-        model: "anthropic/claude-opus-4-6",
+        model: "anthropic/claude-opus-4-5",
         contextTokens: 32_000,
       },
       sessionEntry: {
@@ -930,7 +677,7 @@ describe("buildStatusMessage", () => {
         updatedAt: 0,
         modelProvider: "anthropic",
         model: "claude-haiku-4-5",
-        fallbackNoticeSelectedModel: "fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
+        fallbackNoticeSelectedModel: "fireworks/minimax-m2p5",
         fallbackNoticeActiveModel: "deepinfra/moonshotai/Kimi-K2.5",
         fallbackNoticeReason: "rate limit",
       },
@@ -970,52 +717,17 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("Fallback:");
   });
 
-  it("shows configured fallback models when provided", () => {
-    const text = buildStatusMessage({
-      agent: {
-        model: {
-          primary: "anthropic/claude-opus-4-6",
-          fallbacks: ["google/gemini-2.5-flash", "openai/gpt-5-mini"],
-        },
-      },
-      sessionEntry: { sessionId: "fb1", updatedAt: 0 },
-      sessionKey: "agent:main:main",
-      sessionScope: "per-sender",
-      queue: { mode: "collect", depth: 0 },
-      modelAuth: "api-key",
-    });
-
-    const normalized = normalizeTestText(text);
-    expect(normalized).toContain("Fallbacks: google/gemini-2.5-flash, openai/gpt-5-mini");
-  });
-
-  it("omits configured fallbacks line when no fallbacks provided", () => {
-    const text = buildStatusMessage({
-      agent: {
-        model: "anthropic/claude-opus-4-6",
-      },
-      sessionEntry: { sessionId: "fb2", updatedAt: 0 },
-      sessionKey: "agent:main:main",
-      sessionScope: "per-sender",
-      queue: { mode: "collect", depth: 0 },
-      modelAuth: "api-key",
-    });
-
-    const normalized = normalizeTestText(text);
-    expect(normalized).not.toContain("Fallbacks:");
-  });
-
   it("keeps provider prefix from configured model", () => {
     const text = buildStatusMessage({
       agent: {
-        model: "google-antigravity/claude-sonnet-4-6",
+        model: "google-antigravity/claude-sonnet-4-5",
       },
       sessionScope: "per-sender",
       queue: { mode: "collect", depth: 0 },
       modelAuth: "api-key",
     });
 
-    expect(normalizeTestText(text)).toContain("Model: google-antigravity/claude-sonnet-4-6");
+    expect(normalizeTestText(text)).toContain("Model: google-antigravity/claude-sonnet-4-5");
   });
 
   it("handles missing agent config gracefully", () => {
@@ -1072,7 +784,7 @@ describe("buildStatusMessage", () => {
 
   it("inserts usage summary beneath context line", () => {
     const text = buildStatusMessage({
-      agent: { model: "anthropic/claude-opus-4-6", contextTokens: 32_000 },
+      agent: { model: "anthropic/claude-opus-4-5", contextTokens: 32_000 },
       sessionEntry: { sessionId: "u1", updatedAt: 0, totalTokens: 1000 },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -1087,7 +799,7 @@ describe("buildStatusMessage", () => {
     expect(lines[contextIndex + 1]).toContain("Usage: Claude 80% left (5h)");
   });
 
-  it("hides cost when not using an API key", () => {
+  it("hides cost when no cost rates are configured", () => {
     const text = buildStatusMessage({
       config: {
         models: {
@@ -1095,10 +807,10 @@ describe("buildStatusMessage", () => {
             anthropic: {
               models: [
                 {
-                  id: "claude-opus-4-6",
+                  id: "claude-opus-4-5",
                   cost: {
-                    input: 1,
-                    output: 1,
+                    input: 0,
+                    output: 0,
                     cacheRead: 0,
                     cacheWrite: 0,
                   },
@@ -1108,7 +820,7 @@ describe("buildStatusMessage", () => {
           },
         },
       } as unknown as OpenClawConfig,
-      agent: { model: "anthropic/claude-opus-4-6" },
+      agent: { model: "anthropic/claude-opus-4-5" },
       sessionEntry: { sessionId: "c1", updatedAt: 0, inputTokens: 10 },
       sessionKey: "agent:main:main",
       sessionScope: "per-sender",
@@ -1117,6 +829,38 @@ describe("buildStatusMessage", () => {
     });
 
     expect(text).not.toContain("💵 Cost:");
+  });
+
+  it("shows cost estimate for aws-sdk auth when model has explicit cost config", () => {
+    const text = buildStatusMessage({
+      config: {
+        models: {
+          providers: {
+            bedrock: {
+              models: [
+                {
+                  id: "claude-opus-4-5",
+                  cost: {
+                    input: 15,
+                    output: 75,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: { model: "bedrock/claude-opus-4-5" },
+      sessionEntry: { sessionId: "c2", updatedAt: 0, inputTokens: 1000, outputTokens: 500 },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "aws-sdk",
+    });
+
+    expect(text).toContain("Cost:");
   });
 
   function writeTranscriptUsageLog(params: {
@@ -1148,7 +892,7 @@ describe("buildStatusMessage", () => {
           type: "message",
           message: {
             role: "assistant",
-            model: params.model ?? "claude-opus-4-6",
+            model: params.model ?? "claude-opus-4-5",
             usage: params.usage,
           },
         }),
@@ -1179,7 +923,7 @@ describe("buildStatusMessage", () => {
   function buildTranscriptStatusText(params: { sessionId: string; sessionKey: string }) {
     return buildStatusMessage({
       agent: {
-        model: "anthropic/claude-opus-4-6",
+        model: "anthropic/claude-opus-4-5",
         contextTokens: 32_000,
       },
       sessionEntry: {
@@ -1257,7 +1001,7 @@ describe("buildStatusMessage", () => {
 
         const text = buildStatusMessage({
           agent: {
-            model: "anthropic/claude-opus-4-6",
+            model: "anthropic/claude-opus-4-5",
             contextTokens: 32_000,
           },
           agentId: "worker2",
@@ -1275,126 +1019,6 @@ describe("buildStatusMessage", () => {
         });
 
         expect(normalizeTestText(text)).toContain("Context: 1.2k/32k");
-      },
-      { prefix: "openclaw-status-" },
-    );
-  });
-
-  it("hydrates cache usage from transcript fallback", async () => {
-    await withTempHome(
-      async (dir) => {
-        const sessionId = "sess-cache-hydration";
-        writeBaselineTranscriptUsageLog({
-          dir,
-          agentId: "main",
-          sessionId,
-        });
-
-        const text = buildTranscriptStatusText({
-          sessionId,
-          sessionKey: "agent:main:main",
-        });
-
-        expect(normalizeTestText(text)).toContain("Cache: 100% hit · 1.0k cached, 0 new");
-      },
-      { prefix: "openclaw-status-" },
-    );
-  });
-
-  it("uses the same transcript usage fallback as sessions.list when a delivery mirror is last", async () => {
-    await withTempHome(
-      async (dir) => {
-        const sessionId = "sess-cache-delivery-mirror";
-        const logPath = path.join(
-          dir,
-          ".openclaw",
-          "agents",
-          "main",
-          "sessions",
-          `${sessionId}.jsonl`,
-        );
-        fs.mkdirSync(path.dirname(logPath), { recursive: true });
-        fs.writeFileSync(
-          logPath,
-          [
-            JSON.stringify({ type: "session", version: 1, id: sessionId }),
-            JSON.stringify({
-              type: "message",
-              message: {
-                role: "assistant",
-                provider: "anthropic",
-                model: "claude-opus-4-6",
-                usage: {
-                  input: 1,
-                  output: 2,
-                  cacheRead: 1000,
-                  cacheWrite: 0,
-                  totalTokens: 1003,
-                },
-              },
-            }),
-            JSON.stringify({
-              type: "message",
-              message: {
-                role: "assistant",
-                provider: "openclaw",
-                model: "delivery-mirror",
-                usage: {
-                  input: 0,
-                  output: 0,
-                  cacheRead: 0,
-                  cacheWrite: 0,
-                  totalTokens: 0,
-                },
-              },
-            }),
-          ].join("\n"),
-          "utf-8",
-        );
-
-        const text = buildTranscriptStatusText({
-          sessionId,
-          sessionKey: "agent:main:main",
-        });
-
-        expect(normalizeTestText(text)).toContain("Cache: 100% hit · 1.0k cached, 0 new");
-        expect(normalizeTestText(text)).toContain("Context: 1.0k/32k");
-      },
-      { prefix: "openclaw-status-" },
-    );
-  });
-
-  it("preserves existing nonzero cache usage over transcript fallback values", async () => {
-    await withTempHome(
-      async (dir) => {
-        const sessionId = "sess-cache-preserve";
-        writeBaselineTranscriptUsageLog({
-          dir,
-          agentId: "main",
-          sessionId,
-        });
-
-        const text = buildStatusMessage({
-          agent: {
-            model: "anthropic/claude-opus-4-6",
-            contextTokens: 32_000,
-          },
-          sessionEntry: {
-            sessionId,
-            updatedAt: 0,
-            totalTokens: 3,
-            contextTokens: 32_000,
-            cacheRead: 12,
-            cacheWrite: 34,
-          },
-          sessionKey: "agent:main:main",
-          sessionScope: "per-sender",
-          queue: { mode: "collect", depth: 0 },
-          includeTranscriptUsage: true,
-          modelAuth: "api-key",
-        });
-
-        expect(normalizeTestText(text)).toContain("Cache: 26% hit · 12 cached, 34 new");
       },
       { prefix: "openclaw-status-" },
     );
@@ -1717,11 +1341,7 @@ describe("buildHelpMessage", () => {
   });
 
   it("includes /fast in help output", () => {
-    expect(buildHelpMessage()).toContain("/fast status|on|off");
-  });
-
-  it("includes raw trace mode in help output", () => {
-    expect(buildHelpMessage()).toContain("/trace on|off|raw");
+    expect(buildHelpMessage()).toContain("/fast on|off");
   });
 });
 
@@ -1732,7 +1352,7 @@ describe("buildCommandsMessagePaginated", () => {
         commands: { config: false, debug: false },
       } as unknown as OpenClawConfig,
       undefined,
-      { surface: "telegram", page: 1, forcePaginatedList: true },
+      { surface: "telegram", page: 1 },
     );
     expect(result.text).toContain("ℹ️ Commands (1/");
     expect(result.text).toContain("Session");
@@ -1752,7 +1372,7 @@ describe("buildCommandsMessagePaginated", () => {
         commands: { config: false, debug: false },
       } as unknown as OpenClawConfig,
       undefined,
-      { surface: "telegram", page: 1, forcePaginatedList: true },
+      { surface: "telegram", page: 1 },
     );
     const pages = Array.from({ length: firstPage.totalPages }, (_, index) =>
       buildPaginatedCommands(
@@ -1760,7 +1380,7 @@ describe("buildCommandsMessagePaginated", () => {
           commands: { config: false, debug: false },
         } as unknown as OpenClawConfig,
         undefined,
-        { surface: "telegram", page: index + 1, forcePaginatedList: true },
+        { surface: "telegram", page: index + 1 },
       ),
     );
     const pluginPage = pages.find((page) => page.text.includes("/plugin_cmd (demo-plugin)"));

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -7,38 +7,35 @@ import {
   resolveConfiguredModelRef,
   resolveModelRefFromString,
 } from "../agents/model-selection.js";
-import { resolveExtraParams } from "../agents/pi-embedded-runner/extra-params.js";
-import { resolveOpenAITextVerbosity } from "../agents/pi-embedded-runner/openai-stream-wrappers.js";
 import { resolveSandboxRuntimeStatus } from "../agents/sandbox.js";
+import type { SkillCommandSpec } from "../agents/skills.js";
 import { describeToolForVerbose } from "../agents/tool-description-summary.js";
 import { normalizeToolName } from "../agents/tool-policy-shared.js";
-import type { EffectiveToolInventoryResult } from "../agents/tools-effective-inventory.types.js";
+import type { EffectiveToolInventoryResult } from "../agents/tools-effective-inventory.js";
+import { derivePromptTokens, normalizeUsage, type UsageLike } from "../agents/usage.js";
 import { resolveChannelModelOverride } from "../channels/model-overrides.js";
+import { isCommandFlagEnabled } from "../config/commands.js";
+import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveMainSessionKey,
-  resolveSessionPluginStatusLines,
-  resolveSessionPluginTraceLines,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   type SessionEntry,
   type SessionScope,
 } from "../config/sessions.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { readLatestSessionUsageFromTranscript } from "../gateway/session-utils.fs.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import { resolveCommitHash } from "../infra/git-commit.js";
-import {
-  findDecisionReason,
-  summarizeDecisionReason,
-} from "../media-understanding/runner.entries.js";
 import type { MediaUnderstandingDecision } from "../media-understanding/types.js";
+import { listPluginCommands } from "../plugins/commands.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalLowercaseString,
-  normalizeOptionalString,
-} from "../shared/string-coerce.js";
-import { resolveStatusTtsSnapshot } from "../tts/status-config.js";
+  getTtsMaxLength,
+  getTtsProvider,
+  isSummarizationEnabled,
+  resolveTtsAutoMode,
+  resolveTtsConfig,
+  resolveTtsPrefsPath,
+} from "../tts/tts.js";
 import {
   estimateUsageCost,
   formatTokenCount as formatTokenCountShared,
@@ -46,14 +43,13 @@ import {
   resolveModelCostConfig,
 } from "../utils/usage-format.js";
 import { VERSION } from "../version.js";
-export {
-  buildCommandsMessage,
-  buildCommandsMessagePaginated,
-  buildHelpMessage,
-  type CommandsMessageOptions,
-  type CommandsMessageResult,
-} from "./command-status-builders.js";
-import { resolveActiveFallbackState } from "../status/fallback-notice-state.js";
+import {
+  listChatCommands,
+  listChatCommandsForConfig,
+  type ChatCommandDefinition,
+} from "./commands-registry.js";
+import type { CommandCategory } from "./commands-registry.types.js";
+import { resolveActiveFallbackState } from "./fallback-state.js";
 import { formatProviderModelRef, resolveSelectedAndActiveModel } from "./model-runtime.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./thinking.js";
 
@@ -97,7 +93,6 @@ type StatusArgs = {
   queue?: QueueStatus;
   mediaDecisions?: ReadonlyArray<MediaUnderstandingDecision>;
   subagentsLine?: string;
-  taskLine?: string;
   includeTranscriptUsage?: boolean;
   now?: number;
 };
@@ -105,7 +100,7 @@ type StatusArgs = {
 type NormalizedAuthMode = "api-key" | "oauth" | "token" | "aws-sdk" | "mixed" | "unknown";
 
 function normalizeAuthMode(value?: string): NormalizedAuthMode | undefined {
-  const normalized = normalizeOptionalLowercaseString(value);
+  const normalized = value?.trim().toLowerCase();
   if (!normalized) {
     return undefined;
   }
@@ -128,27 +123,6 @@ function normalizeAuthMode(value?: string): NormalizedAuthMode | undefined {
     return "unknown";
   }
   return undefined;
-}
-
-function resolveConfiguredTextVerbosity(params: {
-  config?: OpenClawConfig;
-  agentId?: string;
-  provider?: string | null;
-  model?: string | null;
-}): "low" | "medium" | "high" | undefined {
-  const provider = params.provider?.trim();
-  const model = params.model?.trim();
-  if (!provider || !model || (provider !== "openai" && provider !== "openai-codex")) {
-    return undefined;
-  }
-  return resolveOpenAITextVerbosity(
-    resolveExtraParams({
-      cfg: params.config,
-      provider,
-      modelId: model,
-      agentId: params.agentId,
-    }),
-  );
 }
 
 function resolveRuntimeLabel(
@@ -249,8 +223,6 @@ const readUsageFromSessionLog = (
   | {
       input: number;
       output: number;
-      cacheRead: number;
-      cacheWrite: number;
       promptTokens: number;
       total: number;
       model?: string;
@@ -277,40 +249,61 @@ const readUsageFromSessionLog = (
   }
 
   try {
-    const snapshot = readLatestSessionUsageFromTranscript(
-      sessionId,
-      storePath,
-      sessionEntry?.sessionFile,
-      agentId ?? (sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined),
-    );
-    if (!snapshot) {
-      return undefined;
+    // Read the tail only; we only need the most recent usage entries.
+    const TAIL_BYTES = 8192;
+    const stat = fs.statSync(logPath);
+    const offset = Math.max(0, stat.size - TAIL_BYTES);
+    const buf = Buffer.alloc(Math.min(TAIL_BYTES, stat.size));
+    const fd = fs.openSync(logPath, "r");
+    try {
+      fs.readSync(fd, buf, 0, buf.length, offset);
+    } finally {
+      fs.closeSync(fd);
+    }
+    const tail = buf.toString("utf-8");
+    const lines = (offset > 0 ? tail.slice(tail.indexOf("\n") + 1) : tail).split(/\n+/);
+
+    let input = 0;
+    let output = 0;
+    let promptTokens = 0;
+    let model: string | undefined;
+    let lastUsage: ReturnType<typeof normalizeUsage> | undefined;
+
+    for (const line of lines) {
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(line) as {
+          message?: {
+            usage?: UsageLike;
+            model?: string;
+          };
+          usage?: UsageLike;
+          model?: string;
+        };
+        const usageRaw = parsed.message?.usage ?? parsed.usage;
+        const usage = normalizeUsage(usageRaw);
+        if (usage) {
+          lastUsage = usage;
+        }
+        model = parsed.message?.model ?? parsed.model ?? model;
+      } catch {
+        // ignore bad lines (including a truncated first tail line)
+      }
     }
 
-    const input = snapshot.inputTokens ?? 0;
-    const output = snapshot.outputTokens ?? 0;
-    const cacheRead = snapshot.cacheRead ?? 0;
-    const cacheWrite = snapshot.cacheWrite ?? 0;
-    const promptTokens = snapshot.totalTokens ?? input + cacheRead + cacheWrite;
-    const total = promptTokens + output;
+    if (!lastUsage) {
+      return undefined;
+    }
+    input = lastUsage.input ?? 0;
+    output = lastUsage.output ?? 0;
+    promptTokens = derivePromptTokens(lastUsage) ?? lastUsage.total ?? input + output;
+    const total = lastUsage.total ?? promptTokens + output;
     if (promptTokens === 0 && total === 0) {
       return undefined;
     }
-    const model = snapshot.modelProvider
-      ? snapshot.model
-        ? `${snapshot.modelProvider}/${snapshot.model}`
-        : snapshot.modelProvider
-      : snapshot.model;
-
-    return {
-      input,
-      output,
-      cacheRead,
-      cacheWrite,
-      promptTokens,
-      total,
-      model,
-    };
+    return { input, output, promptTokens, total, model };
   } catch {
     return undefined;
   }
@@ -380,14 +373,11 @@ const formatMediaUnderstandingLine = (decisions?: ReadonlyArray<MediaUnderstandi
         return `${decision.capability} denied`;
       }
       if (decision.outcome === "skipped") {
-        const reason = findDecisionReason(decision);
-        const shortReason = summarizeDecisionReason(reason);
+        const reason = decision.attachments
+          .flatMap((entry) => entry.attempts.map((attempt) => attempt.reason).filter(Boolean))
+          .find(Boolean);
+        const shortReason = reason ? reason.split(":")[0]?.trim() : undefined;
         return `${decision.capability} skipped${shortReason ? ` (${shortReason})` : ""}`;
-      }
-      if (decision.outcome === "failed") {
-        const reason = findDecisionReason(decision, "failed");
-        const shortReason = summarizeDecisionReason(reason);
-        return `${decision.capability} failed${shortReason ? ` (${shortReason})` : ""}`;
       }
       return null;
     })
@@ -408,14 +398,20 @@ const formatVoiceModeLine = (
   if (!config) {
     return null;
   }
-  const snapshot = resolveStatusTtsSnapshot({
-    cfg: config,
+  const ttsConfig = resolveTtsConfig(config);
+  const prefsPath = resolveTtsPrefsPath(ttsConfig);
+  const autoMode = resolveTtsAutoMode({
+    config: ttsConfig,
+    prefsPath,
     sessionAuto: sessionEntry?.ttsAuto,
   });
-  if (!snapshot) {
+  if (autoMode === "off") {
     return null;
   }
-  return `🔊 Voice: ${snapshot.autoMode} · provider=${snapshot.provider} · limit=${snapshot.maxLength} · summary=${snapshot.summarize ? "on" : "off"}`;
+  const provider = getTtsProvider(ttsConfig, prefsPath);
+  const maxLength = getTtsMaxLength(prefsPath);
+  const summarize = isSummarizationEnabled(prefsPath) ? "on" : "off";
+  return `🔊 Voice: ${autoMode} · provider=${provider} · limit=${maxLength} · summary=${summarize}`;
 };
 
 export function buildStatusMessage(args: StatusArgs): string {
@@ -446,7 +442,6 @@ export function buildStatusMessage(args: StatusArgs): string {
     cfg: selectionConfig,
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
-    allowPluginNormalization: false,
   });
   const selectedProvider = entry?.providerOverride ?? resolved.provider ?? DEFAULT_PROVIDER;
   const selectedModel = entry?.modelOverride ?? resolved.model ?? DEFAULT_MODEL;
@@ -464,22 +459,21 @@ export function buildStatusMessage(args: StatusArgs): string {
   let activeModel = modelRefs.active.model;
   let contextLookupProvider: string | undefined = activeProvider;
   let contextLookupModel = activeModel;
-  const runtimeModelRaw = normalizeOptionalString(entry?.model) ?? "";
-  const runtimeProviderRaw = normalizeOptionalString(entry?.modelProvider) ?? "";
+  const runtimeModelRaw = typeof entry?.model === "string" ? entry.model.trim() : "";
+  const runtimeProviderRaw =
+    typeof entry?.modelProvider === "string" ? entry.modelProvider.trim() : "";
 
   if (runtimeModelRaw && !runtimeProviderRaw && runtimeModelRaw.includes("/")) {
     const slashIndex = runtimeModelRaw.indexOf("/");
-    const embeddedProvider =
-      normalizeOptionalLowercaseString(runtimeModelRaw.slice(0, slashIndex)) ?? "";
+    const embeddedProvider = runtimeModelRaw.slice(0, slashIndex).trim().toLowerCase();
     const fallbackMatchesRuntimeModel =
       initialFallbackState.active &&
-      normalizeLowercaseStringOrEmpty(runtimeModelRaw) ===
-        normalizeLowercaseStringOrEmpty(
-          normalizeOptionalString(entry?.fallbackNoticeActiveModel ?? "") ?? "",
-        );
+      runtimeModelRaw.toLowerCase() ===
+        String(entry?.fallbackNoticeActiveModel ?? "")
+          .trim()
+          .toLowerCase();
     const runtimeMatchesSelectedModel =
-      normalizeLowercaseStringOrEmpty(runtimeModelRaw) ===
-      normalizeLowercaseStringOrEmpty(modelRefs.selected.label || "unknown");
+      runtimeModelRaw.toLowerCase() === (modelRefs.selected.label || "unknown").toLowerCase();
     // Legacy fallback sessions can persist provider-qualified runtime ids
     // without a separate modelProvider field. Preserve provider-aware lookup
     // when the stored slash id is the selected model or the active fallback
@@ -487,7 +481,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     // slash ids.
     if (
       (fallbackMatchesRuntimeModel || runtimeMatchesSelectedModel) &&
-      embeddedProvider === normalizeLowercaseStringOrEmpty(activeProvider)
+      embeddedProvider === activeProvider.toLowerCase()
     ) {
       contextLookupProvider = activeProvider;
       contextLookupModel = activeModel;
@@ -547,12 +541,6 @@ export function buildStatusMessage(args: StatusArgs): string {
       if (!outputTokens || outputTokens === 0) {
         outputTokens = logUsage.output;
       }
-      if (typeof cacheRead !== "number" || cacheRead <= 0) {
-        cacheRead = logUsage.cacheRead;
-      }
-      if (typeof cacheWrite !== "number" || cacheWrite <= 0) {
-        cacheWrite = logUsage.cacheWrite;
-      }
     }
   }
 
@@ -562,13 +550,11 @@ export function buildStatusMessage(args: StatusArgs): string {
     cfg: contextConfig,
     provider: selectedProvider,
     model: selectedModel,
-    allowAsyncLoad: false,
   });
   const activeContextTokens = resolveContextTokensForModel({
     cfg: contextConfig,
     ...(contextLookupProvider ? { provider: contextLookupProvider } : {}),
     model: contextLookupModel,
-    allowAsyncLoad: false,
   });
   const persistedContextTokens =
     typeof entry?.contextTokens === "number" && entry.contextTokens > 0
@@ -637,7 +623,6 @@ export function buildStatusMessage(args: StatusArgs): string {
         model: contextLookupModel,
         contextTokensOverride: persistedContextTokens ?? args.agent?.contextTokens,
         fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
-        allowAsyncLoad: false,
       }) ?? DEFAULT_CONTEXT_TOKENS);
 
   const thinkLevel =
@@ -682,35 +667,17 @@ export function buildStatusMessage(args: StatusArgs): string {
   const queueDetails = formatQueueDetails(args.queue);
   const verboseLabel =
     verboseLevel === "full" ? "verbose:full" : verboseLevel === "on" ? "verbose" : null;
-  const traceLevel = entry?.traceLevel === "raw" ? "raw" : entry?.traceLevel === "on" ? "on" : "off";
-  const traceLabel =
-    traceLevel === "raw" ? "trace:raw" : traceLevel === "on" ? "trace" : null;
-  const pluginStatusLines = verboseLevel !== "off" ? resolveSessionPluginStatusLines(entry) : [];
-  const pluginTraceLines =
-    traceLevel === "on" || traceLevel === "raw" ? resolveSessionPluginTraceLines(entry) : [];
-  const pluginStatusLine =
-    pluginStatusLines.length > 0 || pluginTraceLines.length > 0
-      ? [...pluginStatusLines, ...pluginTraceLines].join(" · ")
-      : null;
   const elevatedLabel =
     elevatedLevel && elevatedLevel !== "off"
       ? elevatedLevel === "on"
         ? "elevated"
         : `elevated:${elevatedLevel}`
       : null;
-  const textVerbosity = resolveConfiguredTextVerbosity({
-    config: args.config,
-    agentId: args.agentId,
-    provider: activeProvider,
-    model: activeModel,
-  });
   const optionParts = [
     `Runtime: ${runtime.label}`,
     `Think: ${thinkLevel}`,
     fastMode ? "Fast: on" : null,
-    textVerbosity ? `Text: ${textVerbosity}` : null,
     verboseLabel,
-    traceLabel,
     reasoningLevel !== "off" ? `Reasoning: ${reasoningLevel}` : null,
     elevatedLabel,
   ];
@@ -740,15 +707,15 @@ export function buildStatusMessage(args: StatusArgs): string {
   const effectiveCostAuthMode = fallbackState.active
     ? activeAuthMode
     : (selectedAuthMode ?? activeAuthMode);
-  const showCost = effectiveCostAuthMode === "api-key" || effectiveCostAuthMode === "mixed";
-  const costConfig = showCost
-    ? resolveModelCostConfig({
-        provider: activeProvider,
-        model: activeModel,
-        config: args.config,
-        allowPluginNormalization: false,
-      })
-    : undefined;
+  const costConfig = resolveModelCostConfig({
+    provider: activeProvider,
+    model: activeModel,
+    config: args.config,
+  });
+  const showCost =
+    effectiveCostAuthMode === "api-key" ||
+    effectiveCostAuthMode === "mixed" ||
+    (costConfig != null && costConfig.input > 0 && costConfig.output > 0);
   const hasUsage = typeof inputTokens === "number" || typeof outputTokens === "number";
   const cost =
     showCost && hasUsage
@@ -767,17 +734,13 @@ export function buildStatusMessage(args: StatusArgs): string {
     if (!args.config || !entry) {
       return undefined;
     }
-    if (
-      normalizeOptionalString(entry.modelOverride) ||
-      normalizeOptionalString(entry.providerOverride)
-    ) {
+    if (entry.modelOverride?.trim() || entry.providerOverride?.trim()) {
       return undefined;
     }
     const channelOverride = resolveChannelModelOverride({
       cfg: args.config,
       channel: entry.channel ?? entry.origin?.provider,
       groupId: entry.groupId,
-      groupChatType: entry.chatType ?? entry.origin?.chatType,
       groupChannel: entry.groupChannel,
       groupSubject: entry.subject,
       parentSessionKey: args.parentSessionKey,
@@ -788,13 +751,11 @@ export function buildStatusMessage(args: StatusArgs): string {
     const aliasIndex = buildModelAliasIndex({
       cfg: args.config,
       defaultProvider: DEFAULT_PROVIDER,
-      allowPluginNormalization: false,
     });
     const resolvedOverride = resolveModelRefFromString({
       raw: channelOverride.model,
       defaultProvider: DEFAULT_PROVIDER,
       aliasIndex,
-      allowPluginNormalization: false,
     });
     if (!resolvedOverride) {
       return undefined;
@@ -809,19 +770,6 @@ export function buildStatusMessage(args: StatusArgs): string {
   })();
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
   const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`;
-
-  // Show configured fallback models (from agent model config)
-  const configuredFallbacks = (() => {
-    const modelConfig = args.agent?.model;
-    if (typeof modelConfig === "object" && modelConfig && Array.isArray(modelConfig.fallbacks)) {
-      return modelConfig.fallbacks;
-    }
-    return undefined;
-  })();
-  const configuredFallbacksLine = configuredFallbacks?.length
-    ? `🔄 Fallbacks: ${configuredFallbacks.join(", ")}`
-    : null;
-
   const showFallbackAuth = activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;
   const fallbackLine = fallbackState.active
     ? `↪️ Fallback: ${activeModelLabel}${
@@ -842,7 +790,6 @@ export function buildStatusMessage(args: StatusArgs): string {
     versionLine,
     args.timeLine,
     modelLine,
-    configuredFallbacksLine,
     fallbackLine,
     usageCostLine,
     cacheLine,
@@ -851,15 +798,95 @@ export function buildStatusMessage(args: StatusArgs): string {
     args.usageLine,
     `🧵 ${sessionLine}`,
     args.subagentsLine,
-    args.taskLine,
     `⚙️ ${optionsLine}`,
-    pluginStatusLine ? `🧩 ${pluginStatusLine}` : null,
     voiceLine,
     activationLine,
   ]
     .filter(Boolean)
     .join("\n");
 }
+
+const CATEGORY_LABELS: Record<CommandCategory, string> = {
+  session: "Session",
+  options: "Options",
+  status: "Status",
+  management: "Management",
+  media: "Media",
+  tools: "Tools",
+  docks: "Docks",
+};
+
+const CATEGORY_ORDER: CommandCategory[] = [
+  "session",
+  "options",
+  "status",
+  "management",
+  "media",
+  "tools",
+  "docks",
+];
+
+function groupCommandsByCategory(
+  commands: ChatCommandDefinition[],
+): Map<CommandCategory, ChatCommandDefinition[]> {
+  const grouped = new Map<CommandCategory, ChatCommandDefinition[]>();
+  for (const category of CATEGORY_ORDER) {
+    grouped.set(category, []);
+  }
+  for (const command of commands) {
+    const category = command.category ?? "tools";
+    const list = grouped.get(category) ?? [];
+    list.push(command);
+    grouped.set(category, list);
+  }
+  return grouped;
+}
+
+export function buildHelpMessage(cfg?: OpenClawConfig): string {
+  const lines = ["ℹ️ Help", ""];
+
+  lines.push("Session");
+  lines.push("  /new  |  /reset  |  /compact [instructions]  |  /stop");
+  lines.push("");
+
+  const optionParts = ["/think <level>", "/model <id>", "/fast on|off", "/verbose on|off"];
+  if (isCommandFlagEnabled(cfg, "config")) {
+    optionParts.push("/config");
+  }
+  if (isCommandFlagEnabled(cfg, "debug")) {
+    optionParts.push("/debug");
+  }
+  lines.push("Options");
+  lines.push(`  ${optionParts.join("  |  ")}`);
+  lines.push("");
+
+  lines.push("Status");
+  lines.push("  /status  |  /whoami  |  /context");
+  lines.push("");
+
+  lines.push("Skills");
+  lines.push("  /skill <name> [input]");
+
+  lines.push("");
+  lines.push("More: /commands for full list, /tools for available capabilities");
+
+  return lines.join("\n");
+}
+
+const COMMANDS_PER_PAGE = 8;
+
+export type CommandsMessageOptions = {
+  page?: number;
+  surface?: string;
+};
+
+export type CommandsMessageResult = {
+  text: string;
+  totalPages: number;
+  currentPage: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+};
 
 type ToolsMessageItem = {
   id: string;
@@ -944,4 +971,134 @@ export function buildToolsMessage(
     lines.push("", "Use /tools verbose for descriptions.");
   }
   return lines.join("\n");
+}
+
+function formatCommandEntry(command: ChatCommandDefinition): string {
+  const primary = command.nativeName
+    ? `/${command.nativeName}`
+    : command.textAliases[0]?.trim() || `/${command.key}`;
+  const seen = new Set<string>();
+  const aliases = command.textAliases
+    .map((alias) => alias.trim())
+    .filter(Boolean)
+    .filter((alias) => alias.toLowerCase() !== primary.toLowerCase())
+    .filter((alias) => {
+      const key = alias.toLowerCase();
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
+  const aliasLabel = aliases.length ? ` (${aliases.join(", ")})` : "";
+  const scopeLabel = command.scope === "text" ? " [text]" : "";
+  return `${primary}${aliasLabel}${scopeLabel} - ${command.description}`;
+}
+
+type CommandsListItem = {
+  label: string;
+  text: string;
+};
+
+function buildCommandItems(
+  commands: ChatCommandDefinition[],
+  pluginCommands: ReturnType<typeof listPluginCommands>,
+): CommandsListItem[] {
+  const grouped = groupCommandsByCategory(commands);
+  const items: CommandsListItem[] = [];
+
+  for (const category of CATEGORY_ORDER) {
+    const categoryCommands = grouped.get(category) ?? [];
+    if (categoryCommands.length === 0) {
+      continue;
+    }
+    const label = CATEGORY_LABELS[category];
+    for (const command of categoryCommands) {
+      items.push({ label, text: formatCommandEntry(command) });
+    }
+  }
+
+  for (const command of pluginCommands) {
+    const pluginLabel = command.pluginId ? ` (${command.pluginId})` : "";
+    items.push({
+      label: "Plugins",
+      text: `/${command.name}${pluginLabel} - ${command.description}`,
+    });
+  }
+
+  return items;
+}
+
+function formatCommandList(items: CommandsListItem[]): string {
+  const lines: string[] = [];
+  let currentLabel: string | null = null;
+
+  for (const item of items) {
+    if (item.label !== currentLabel) {
+      if (lines.length > 0) {
+        lines.push("");
+      }
+      lines.push(item.label);
+      currentLabel = item.label;
+    }
+    lines.push(`  ${item.text}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function buildCommandsMessage(
+  cfg?: OpenClawConfig,
+  skillCommands?: SkillCommandSpec[],
+  options?: CommandsMessageOptions,
+): string {
+  const result = buildCommandsMessagePaginated(cfg, skillCommands, options);
+  return result.text;
+}
+
+export function buildCommandsMessagePaginated(
+  cfg?: OpenClawConfig,
+  skillCommands?: SkillCommandSpec[],
+  options?: CommandsMessageOptions,
+): CommandsMessageResult {
+  const page = Math.max(1, options?.page ?? 1);
+  const surface = options?.surface?.toLowerCase();
+  const isTelegram = surface === "telegram";
+
+  const commands = cfg
+    ? listChatCommandsForConfig(cfg, { skillCommands })
+    : listChatCommands({ skillCommands });
+  const pluginCommands = listPluginCommands();
+  const items = buildCommandItems(commands, pluginCommands);
+
+  if (!isTelegram) {
+    const lines = ["ℹ️ Slash commands", ""];
+    lines.push(formatCommandList(items));
+    lines.push("", "More: /tools for available capabilities");
+    return {
+      text: lines.join("\n").trim(),
+      totalPages: 1,
+      currentPage: 1,
+      hasNext: false,
+      hasPrev: false,
+    };
+  }
+
+  const totalCommands = items.length;
+  const totalPages = Math.max(1, Math.ceil(totalCommands / COMMANDS_PER_PAGE));
+  const currentPage = Math.min(page, totalPages);
+  const startIndex = (currentPage - 1) * COMMANDS_PER_PAGE;
+  const endIndex = startIndex + COMMANDS_PER_PAGE;
+  const pageItems = items.slice(startIndex, endIndex);
+
+  const lines = [`ℹ️ Commands (${currentPage}/${totalPages})`, ""];
+  lines.push(formatCommandList(pageItems));
+
+  return {
+    text: lines.join("\n").trim(),
+    totalPages,
+    currentPage,
+    hasNext: currentPage < totalPages,
+    hasPrev: currentPage > 1,
+  };
 }


### PR DESCRIPTION
## Summary

Fixes #53286

Currently, OpenClaw only shows estimated USD cost when the provider uses `api-key` authentication. This means Amazon Bedrock users (`aws-sdk` auth) see token counts only — even when `cost` fields are explicitly configured in their `openclaw.json`.

## Root Cause

The `showCost` flag in `agent-runner.ts` and `status.ts` was gated purely on auth mode (`api-key` or `mixed`), ignoring any explicitly configured cost values.

## Fix

Decouple cost display from auth method. If `cost.input > 0 && cost.output > 0` in the model config, calculate and show the cost estimate — regardless of how the provider authenticates.

**Changed files:**
- `src/auto-reply/reply/agent-runner.ts` — resolve cost config unconditionally; show cost when auth is `api-key`/`mixed` OR when explicit non-zero cost config is present
- `src/auto-reply/status.ts` — same logic applied to the `/status` command
- `src/auto-reply/status.test.ts` — updated existing test to use zero cost (preserving "hides cost when no cost config" semantics); added new test for `aws-sdk` + explicit cost config

## Example Config

```json
{
  "models": {
    "providers": {
      "amazon-bedrock": {
        "auth": "aws-sdk",
        "models": [{
          "id": "us.anthropic.claude-sonnet-4-6",
          "cost": { "input": 0.000003, "output": 0.000015 }
        }]
      }
    }
  }
}
```

With this fix, `/status` and `/usage full` will now show the estimated cost for Bedrock (and any other non-API-key provider with explicit cost config).
