### PR TITLE
fix(config): downgrade missing channel plugin from fatal error to warning

### DIFF
--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -675,9 +675,16 @@ function validateConfigObjectWithPluginsBase(
         }
       }
       if (!allowedChannels.has(trimmed)) {
-        issues.push({
+        // Channel IDs that reach here are not in CHANNEL_IDS (built-in) and
+        // not registered by any loaded plugin. This typically means a plugin-
+        // provided channel whose plugin is not currently installed — e.g.,
+        // "matrix" after it was moved from bundled to external. Downgrade to
+        // a warning so the gateway can still start with remaining channels,
+        // consistent with how plugins.entries handles missing plugins
+        // (pushMissingPluginIssue with warnOnly: true).
+        warnings.push({
           path: `channels.${trimmed}`,
-          message: `unknown channel id: ${trimmed}`,
+          message: `unknown channel id: ${trimmed} (channel skipped; install the plugin or remove the channel config)`,
         });
         continue;
       }


### PR DESCRIPTION
## Problem

When a channel like `matrix` is configured in `openclaw.json` but its corresponding plugin is not installed, config validation treats it as a fatal error (`issues.push`). The gateway exits 1. Under systemd, this becomes a crash loop that takes down **all** channels — not just the missing one.

This makes upgrades risky whenever a channel plugin moves from bundled to external (as happened with Matrix), since the gateway won't start at all until the user manually edits the config or installs the plugin.

## Fix

One-line change in `src/config/validation.ts` (line 461): change `issues.push` to `warnings.push` for unknown channel IDs.

The gateway now logs a warning and skips the unconfigured channel instead of refusing to start. All other channels continue to function.

## Consistency

This is consistent with how `plugins.allow` already handles missing plugins at line 570:

```typescript
pushMissingPluginIssue("plugins.allow", pluginId, { warnOnly: true });
```

The comment there says: *"Keep gateway startup resilient when plugins are removed/renamed across upgrades."* The same rationale applies to channel configs.

Fixes #53311