### PR TITLE
fix: sendPolicy deny should suppress delivery, not inbound processing

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -570,7 +570,8 @@ export async function dispatchReplyFromConfig(params: {
     };
     const typing = resolveRunTypingPolicy({
       requestedPolicy: params.replyOptions?.typingPolicy,
-      suppressTyping: params.replyOptions?.suppressTyping === true || shouldSuppressTyping,
+      suppressTyping:
+        params.replyOptions?.suppressTyping === true || shouldSuppressTyping || suppressDelivery,
       originatingChannel,
       systemEvent: shouldRouteToOriginating,
     });
@@ -583,6 +584,7 @@ export async function dispatchReplyFromConfig(params: {
         ...params.replyOptions,
         typingPolicy: typing.typingPolicy,
         suppressTyping: typing.suppressTyping,
+        onReplyStart: suppressDelivery ? undefined : params.replyOptions?.onReplyStart,
         onToolResult: (payload: ReplyPayload) => {
           const run = async () => {
             if (suppressDelivery) {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -506,26 +506,28 @@ export async function dispatchReplyFromConfig(params: {
     }
 
     const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
-    const acpDispatch = await dispatchAcpRuntime.tryDispatchAcpReply({
-      ctx,
-      cfg,
-      dispatcher,
-      sessionKey: acpDispatchSessionKey,
-      abortSignal: params.replyOptions?.abortSignal,
-      inboundAudio,
-      sessionTtsAuto,
-      ttsChannel,
-      shouldRouteToOriginating,
-      originatingChannel,
-      originatingTo,
-      shouldSendToolSummaries,
-      bypassForCommand: bypassAcpForCommand,
-      onReplyStart: params.replyOptions?.onReplyStart,
-      recordProcessed,
-      markIdle,
-    });
-    if (acpDispatch) {
-      return acpDispatch;
+    if (!suppressDelivery) {
+      const acpDispatch = await dispatchAcpRuntime.tryDispatchAcpReply({
+        ctx,
+        cfg,
+        dispatcher,
+        sessionKey: acpDispatchSessionKey,
+        abortSignal: params.replyOptions?.abortSignal,
+        inboundAudio,
+        sessionTtsAuto,
+        ttsChannel,
+        shouldRouteToOriginating,
+        originatingChannel,
+        originatingTo,
+        shouldSendToolSummaries,
+        bypassForCommand: bypassAcpForCommand,
+        onReplyStart: params.replyOptions?.onReplyStart,
+        recordProcessed,
+        markIdle,
+      });
+      if (acpDispatch) {
+        return acpDispatch;
+      }
     }
 
     // Track accumulated block text for TTS generation after streaming completes.
@@ -651,26 +653,28 @@ export async function dispatchReplyFromConfig(params: {
       // Command handling prepared a trailing prompt after ACP in-place reset.
       // Route that tail through ACP now (same turn) instead of embedded dispatch.
       ctx.AcpDispatchTailAfterReset = false;
-      const acpTailDispatch = await dispatchAcpRuntime.tryDispatchAcpReply({
-        ctx,
-        cfg,
-        dispatcher,
-        sessionKey: acpDispatchSessionKey,
-        abortSignal: params.replyOptions?.abortSignal,
-        inboundAudio,
-        sessionTtsAuto,
-        ttsChannel,
-        shouldRouteToOriginating,
-        originatingChannel,
-        originatingTo,
-        shouldSendToolSummaries,
-        bypassForCommand: false,
-        onReplyStart: params.replyOptions?.onReplyStart,
-        recordProcessed,
-        markIdle,
-      });
-      if (acpTailDispatch) {
-        return acpTailDispatch;
+      if (!suppressDelivery) {
+        const acpTailDispatch = await dispatchAcpRuntime.tryDispatchAcpReply({
+          ctx,
+          cfg,
+          dispatcher,
+          sessionKey: acpDispatchSessionKey,
+          abortSignal: params.replyOptions?.abortSignal,
+          inboundAudio,
+          sessionTtsAuto,
+          ttsChannel,
+          shouldRouteToOriginating,
+          originatingChannel,
+          originatingTo,
+          shouldSendToolSummaries,
+          bypassForCommand: false,
+          onReplyStart: params.replyOptions?.onReplyStart,
+          recordProcessed,
+          markIdle,
+        });
+        if (acpTailDispatch) {
+          return acpTailDispatch;
+        }
       }
     }
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -498,14 +498,11 @@ export async function dispatchReplyFromConfig(params: {
         undefined,
       chatType: sessionStoreEntry.entry?.chatType,
     });
-    if (sendPolicy === "deny" && !bypassAcpForCommand) {
+    const suppressDelivery = sendPolicy === "deny" && !bypassAcpForCommand;
+    if (suppressDelivery) {
       logVerbose(
-        `Send blocked by policy for session ${sessionStoreEntry.sessionKey ?? sessionKey ?? "unknown"}`,
+        `Send policy deny: delivery suppressed for session ${sessionStoreEntry.sessionKey ?? sessionKey ?? "unknown"} (agent will still process inbound)`,
       );
-      const counts = dispatcher.getQueuedCounts();
-      recordProcessed("completed", { reason: "send_policy_deny" });
-      markIdle("message_completed");
-      return { queuedFinal: false, counts };
     }
 
     const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
@@ -586,6 +583,9 @@ export async function dispatchReplyFromConfig(params: {
         suppressTyping: typing.suppressTyping,
         onToolResult: (payload: ReplyPayload) => {
           const run = async () => {
+            if (suppressDelivery) {
+              return;
+            }
             const ttsPayload = await maybeApplyTtsToPayload({
               payload,
               cfg,
@@ -608,6 +608,9 @@ export async function dispatchReplyFromConfig(params: {
         },
         onBlockReply: (payload: ReplyPayload, context?: BlockReplyContext) => {
           const run = async () => {
+            if (suppressDelivery) {
+              return;
+            }
             // Suppress reasoning payloads — channels using this generic dispatch
             // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
             // Telegram has its own dispatch path that handles reasoning splitting.
@@ -672,6 +675,15 @@ export async function dispatchReplyFromConfig(params: {
     }
 
     const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
+
+    // When sendPolicy denies delivery, the agent has already processed the inbound
+    // message (context, memory, tool calls). Skip only the outbound delivery step.
+    if (suppressDelivery) {
+      const counts = dispatcher.getQueuedCounts();
+      recordProcessed("completed", { reason: "send_policy_deny" });
+      markIdle("message_completed");
+      return { queuedFinal: false, counts };
+    }
 
     let queuedFinal = false;
     let routedFinalCount = 0;


### PR DESCRIPTION
## Summary

- `sendPolicy` deny rules were silently dropping inbound messages before the agent could process them
- Moved the deny gate from before `getReplyFromConfig()` to after it, so the agent still processes inbound messages (context, memory, tool calls) but outbound delivery is suppressed
- Added `suppressDelivery` guards to all outbound paths

Fixes #53328

## Details

In `src/auto-reply/reply/dispatch-from-config.ts`, the `sendPolicy === "deny"` check at line ~473 returned early before the agent ever saw the message. The docs describe sendPolicy as controlling "cross-session send permissions" — it should gate outbound delivery, not inbound processing.

The fix:
1. Replaces the early return with a `suppressDelivery` flag
2. Gates `onToolResult` and `onBlockReply` callbacks (prevents streaming delivery during agent processing)
3. Wraps both `tryDispatchAcpReply` call sites with `if (!suppressDelivery)` guards
4. Forces `suppressTyping: true` and clears `onReplyStart` when delivery is suppressed
5. After `getReplyFromConfig()` completes, checks `suppressDelivery` and returns before the final reply delivery loop

The `commands-core.ts` deny check is left as-is — blocking slash commands from denied sessions is reasonable.

## Review feedback addressed

- **P1 — ACP dispatch bypass**: Fixed. Both `tryDispatchAcpReply` call sites (pre-agent and post-reset tail) are now wrapped with `if (!suppressDelivery)` guards.
- **P2 — ACP state staleness**: Intentional tradeoff. For "monitor without sending" use cases, advancing ACP state without delivering would create confusing divergence. If silent ACP processing is needed later, `suppressDelivery` can be passed into `tryDispatchAcpReply` to gate only the delivery leg.
- **P2 — Typing indicators leaking**: Fixed. `suppressDelivery` forces `suppressTyping: true` and clears `onReplyStart` callback so no outbound typing activity leaks.

## Tests

End-to-end tested on a live OpenClaw v2026.3.23 deployment:

| Scenario | Before fix | After fix |
|----------|-----------|-----------|
| Inbound group message | Silently dropped — agent never invoked | Agent processes message, session transcript updated |
| Message visible in web UI | No | Yes |
| Outbound delivery (auto-reply) | N/A (blocked before agent ran) | Suppressed — no reply sent to group |
| Session context accumulation | No — message lost | Yes — message stored in session |

**Setup:** WhatsApp channel with `session.sendPolicy` deny rule matching `{channel: "whatsapp", chatType: "group"}`, two groups with `requireMention: false`.

## Production runtime

This fix has been running as a local dist patch on a live OpenClaw v2026.3.23 deployment since **March 23, 2026**. WhatsApp group messages are processed by the agent (visible in session transcripts and web UI) with delivery correctly suppressed — no outbound messages sent to groups.

## Test plan

- [x] Agent processes inbound messages when sendPolicy denies (session transcript updated, visible in web UI)
- [x] No outbound delivery (no auto-reply sent to WA group)
- [x] Typing indicators suppressed for denied sessions
- [x] ACP dispatch paths gated by suppressDelivery
- [x] Non-denied sessions unaffected
- [x] Slash commands from denied sessions still blocked (existing commands-core.ts behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)