### PR TITLE
fix(update): treat numeric -N suffix as calver revision, not pre-release

### DIFF
--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -21,9 +21,21 @@ describe("compareSemverStrings", () => {
     expect(compareSemverStrings("1.0.0-beta.2", "1.0.0-beta.1")).toBe(1);
 
     expect(compareSemverStrings("1.0.0-2", "1.0.0-1")).toBe(1);
-    expect(compareSemverStrings("1.0.0-1", "1.0.0-beta.1")).toBe(-1);
+    expect(compareSemverStrings("1.0.0-1", "1.0.0-beta.1")).toBe(1);
     expect(compareSemverStrings("1.0.0.beta.2", "1.0.0-beta.1")).toBe(1);
     expect(compareSemverStrings("1.0.0", "1.0.0.beta.1")).toBe(1);
+  });
+
+  it("treats numeric -N suffixes as correction revisions newer than base release", () => {
+    // The core calver bug: 2026.3.23-1 is a correction publish, NOT a pre-release.
+    expect(compareSemverStrings("2026.3.23-1", "2026.3.23")).toBe(1);
+    expect(compareSemverStrings("2026.3.23", "2026.3.23-1")).toBe(-1);
+    expect(compareSemverStrings("2026.3.23-2", "2026.3.23-1")).toBe(1);
+    expect(compareSemverStrings("2026.3.23-1", "2026.3.23-1")).toBe(0);
+
+    // Revisions are still newer than pre-releases of the same base version.
+    expect(compareSemverStrings("2026.3.23-1", "2026.3.23-beta.1")).toBe(1);
+    expect(compareSemverStrings("2026.3.23-beta.1", "2026.3.23-1")).toBe(-1);
   });
 
   it("returns null for invalid inputs", () => {

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -356,6 +356,19 @@ export function compareSemverStrings(a: string | null, b: string | null): number
   if (pa.patch !== pb.patch) {
     return pa.patch < pb.patch ? -1 : 1;
   }
+
+  // Release rank: prerelease (0) < stable (1) < revision (2).
+  // Mirrors releaseRank() in config/version.ts.
+  const rankA = pa.prerelease?.length ? 0 : pa.revision != null ? 2 : 1;
+  const rankB = pb.prerelease?.length ? 0 : pb.revision != null ? 2 : 1;
+  if (rankA !== rankB) {
+    return rankA < rankB ? -1 : 1;
+  }
+
+  if (pa.revision != null && pb.revision != null && pa.revision !== pb.revision) {
+    return pa.revision < pb.revision ? -1 : 1;
+  }
+
   return comparePrerelease(pa.prerelease, pb.prerelease);
 }
 
@@ -363,6 +376,7 @@ type ComparableSemver = {
   major: number;
   minor: number;
   patch: number;
+  revision: number | null;
   prerelease: string[] | null;
 };
 
@@ -381,11 +395,15 @@ function parseComparableSemver(version: string | null): ComparableSemver | null 
   if (!major || !minor || !patch) {
     return null;
   }
+  // Purely numeric suffixes (e.g. -1, -2) are calver correction revisions,
+  // not semver pre-releases.  Align with parseOpenClawVersion in config/version.ts.
+  const isRevision = prereleaseRaw != null && /^[0-9]+$/.test(prereleaseRaw);
   return {
     major: Number.parseInt(major, 10),
     minor: Number.parseInt(minor, 10),
     patch: Number.parseInt(patch, 10),
-    prerelease: prereleaseRaw ? prereleaseRaw.split(".").filter(Boolean) : null,
+    revision: isRevision ? Number.parseInt(prereleaseRaw, 10) : null,
+    prerelease: prereleaseRaw && !isRevision ? prereleaseRaw.split(".").filter(Boolean) : null,
   };
 }
 


### PR DESCRIPTION
## Summary

- `compareSemverStrings()` treated purely numeric suffixes (e.g. `-1` in `2026.3.23-1`) as semver pre-releases, ranking them below the base version
- This caused a false "Update available" banner when the installed version was a correction publish (`2026.3.23-1` appeared older than `2026.3.23`)
- Aligned `parseComparableSemver` with `parseOpenClawVersion` by detecting numeric-only suffixes as revisions and using the same release-rank ordering: prerelease (0) < stable (1) < revision (2)

## Root Cause

`parseComparableSemver()` in `src/infra/update-check.ts` classified all `-suffix` values as pre-release identifiers. The correct `parseOpenClawVersion()` in `src/config/version.ts` already distinguished numeric suffixes as revisions — but the update-check code path never adopted that logic.

All code paths calling `compareSemverStrings` were affected:
- `src/commands/status.update.ts` — "Update available" banner in Control UI and status output
- `src/infra/update-startup.ts` — startup update check
- `src/infra/update-runner.ts` — beta vs stable comparison
- `src/cli/update-cli/update-command.ts` — update command target validation

## Prior Attempts (all closed without merge)

- #23660 — `fix(update): compare numeric -N suffix as build revision`
- #23730 — `fix(update): correctly compare versions with -N build suffix`
- #24658 — `fix(update): treat -N suffix as newer build in version comparisons`
- #51996 — `Update: fix false update-available for calver build installs`

## Test plan

- [x] Added 6 new regression tests for numeric revision ordering
- [x] Updated 1 existing expectation (revision vs prerelease rank)
- [x] `pnpm test -- src/infra/update-check.test.ts` — 12/12 pass
- [x] `pnpm test -- src/commands/status.update.test.ts src/config/version.test.ts src/infra/update-startup.test.ts` — 23/23 pass
- [x] `pnpm check` — pass
- [x] `pnpm tsgo` — pass

Fixes #53273

🤖 Generated with [Claude Code](https://claude.com/claude-code)