### PR TITLE
feat(plugins): add smart-router plugin for intelligent model routing

### DIFF
--- a/extensions/smart-router/index.ts
+++ b/extensions/smart-router/index.ts
@@ -1,0 +1,34 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import { classifyPrompt } from "./src/classifier.js";
+import { resolveModelForTier } from "./src/model-mapper.js";
+import type { SmartRouterConfig } from "./src/types.js";
+
+export default function register(api: OpenClawPluginApi) {
+  const config = (api.pluginConfig ?? {}) as SmartRouterConfig;
+
+  if (config.enabled === false) {
+    api.logger.info("[smart-router] disabled via config");
+    return;
+  }
+
+  api.on("before_model_resolve", (event) => {
+    const result = classifyPrompt(event.prompt);
+    const threshold = config.confidenceThreshold ?? 0.7;
+    const effectiveTier = result.confidence < threshold ? "medium" : result.tier;
+
+    if (config.debug) {
+      api.logger.info(
+        `[smart-router] tier=${effectiveTier} (raw=${result.tier}) ` +
+          `confidence=${result.confidence.toFixed(2)} score=${result.weightedScore.toFixed(3)}`,
+      );
+    }
+
+    const mapping = resolveModelForTier(effectiveTier, config);
+    if (!mapping) return; // no override — use default model
+
+    return {
+      providerOverride: mapping.provider,
+      modelOverride: mapping.model,
+    };
+  });
+}

--- a/extensions/smart-router/openclaw.plugin.json
+++ b/extensions/smart-router/openclaw.plugin.json
@@ -1,0 +1,46 @@
+{
+  "id": "smart-router",
+  "name": "Smart Router",
+  "description": "Intelligent rule-based model routing. Classifies prompt complexity and routes to the optimal model using your own API keys.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "Enable or disable smart routing."
+      },
+      "confidenceThreshold": {
+        "type": "number",
+        "description": "Minimum confidence to apply tier routing. Below this, defaults to medium tier.",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "debug": {
+        "type": "boolean",
+        "description": "Log classification decisions for debugging."
+      },
+      "tiers": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "simple": { "$ref": "#/$defs/tierMapping" },
+          "medium": { "$ref": "#/$defs/tierMapping" },
+          "complex": { "$ref": "#/$defs/tierMapping" },
+          "reasoning": { "$ref": "#/$defs/tierMapping" }
+        }
+      }
+    },
+    "$defs": {
+      "tierMapping": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "provider": { "type": "string" },
+          "model": { "type": "string" }
+        },
+        "required": ["provider", "model"]
+      }
+    }
+  }
+}

--- a/extensions/smart-router/package.json
+++ b/extensions/smart-router/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "Intelligent rule-based model routing using prompt complexity analysis",
   "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/smart-router/package.json
+++ b/extensions/smart-router/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/smart-router",
+  "version": "2026.3.9",
+  "private": true,
+  "description": "Intelligent rule-based model routing using prompt complexity analysis",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/smart-router/src/classifier.test.ts
+++ b/extensions/smart-router/src/classifier.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { classifyPrompt } from "./classifier.js";
+
+describe("classifyPrompt", () => {
+  describe("SIMPLE tier", () => {
+    it("classifies greetings as simple", () => {
+      expect(classifyPrompt("hello").tier).toBe("simple");
+      expect(classifyPrompt("hi").tier).toBe("simple");
+    });
+
+    it("classifies trivial questions as simple", () => {
+      expect(classifyPrompt("What is TypeScript?").tier).toBe("simple");
+      expect(classifyPrompt("Who is Alan Turing?").tier).toBe("simple");
+    });
+
+    it("classifies empty prompts as simple", () => {
+      expect(classifyPrompt("").tier).toBe("simple");
+      expect(classifyPrompt("   ").tier).toBe("simple");
+    });
+
+    it("classifies thank-you messages as simple", () => {
+      expect(classifyPrompt("thanks").tier).toBe("simple");
+      expect(classifyPrompt("thank you").tier).toBe("simple");
+    });
+  });
+
+  describe("MEDIUM tier", () => {
+    it("classifies moderate questions as medium", () => {
+      const result = classifyPrompt(
+        "How do I set up a React project with routing and state management?",
+      );
+      expect(["medium", "complex"]).toContain(result.tier);
+    });
+
+    it("classifies prompts with some technical terms as medium", () => {
+      const result = classifyPrompt("Can you explain how a database index works?");
+      expect(["medium", "complex"]).toContain(result.tier);
+    });
+  });
+
+  describe("COMPLEX tier", () => {
+    it("classifies implementation requests with multiple technical terms as complex", () => {
+      const result = classifyPrompt(
+        "Implement a distributed microservice architecture with kubernetes deployment, " +
+          "database optimization, and infrastructure monitoring. " +
+          "First set up the cluster, then configure the services, and finally deploy the monitoring stack.",
+      );
+      expect(["complex", "reasoning"]).toContain(result.tier);
+    });
+
+    it("classifies code-heavy prompts as complex or higher", () => {
+      const result = classifyPrompt(
+        "```typescript\nasync function fetchData() {\n  const result = await fetch(url);\n" +
+          "  return result.json();\n}\n```\n" +
+          "Refactor this to add error handling, retry logic, and implement caching",
+      );
+      expect(["complex", "reasoning"]).toContain(result.tier);
+    });
+  });
+
+  describe("REASONING tier", () => {
+    it("classifies reasoning-heavy prompts", () => {
+      const result = classifyPrompt(
+        "Prove that this algorithm runs in O(n log n) time, step by step. " +
+          "Derive the recurrence relation and formally analyze the proof.",
+      );
+      expect(result.tier).toBe("reasoning");
+    });
+
+    it("forces reasoning tier when 2+ reasoning keywords match", () => {
+      const result = classifyPrompt("Prove this theorem and derive the result logically");
+      expect(result.tier).toBe("reasoning");
+      expect(result.confidence).toBeGreaterThanOrEqual(0.85);
+    });
+  });
+
+  describe("confidence", () => {
+    it("returns confidence between 0 and 1", () => {
+      const result = classifyPrompt("Tell me about React");
+      expect(result.confidence).toBeGreaterThanOrEqual(0);
+      expect(result.confidence).toBeLessThanOrEqual(1);
+    });
+
+    it("returns high confidence for clear-cut prompts", () => {
+      // Very clearly simple
+      expect(classifyPrompt("hello").confidence).toBeGreaterThan(0.6);
+      // Very clearly reasoning
+      expect(
+        classifyPrompt("Prove the theorem step by step and derive formally").confidence,
+      ).toBeGreaterThan(0.8);
+    });
+  });
+
+  describe("scores", () => {
+    it("includes all dimension scores", () => {
+      const result = classifyPrompt("test prompt");
+      expect(result.scores).toHaveProperty("reasoningMarkers");
+      expect(result.scores).toHaveProperty("codePresence");
+      expect(result.scores).toHaveProperty("multiStepPatterns");
+      expect(result.scores).toHaveProperty("technicalTerms");
+      expect(result.scores).toHaveProperty("tokenEstimate");
+      expect(result.scores).toHaveProperty("simpleIndicators");
+    });
+  });
+});

--- a/extensions/smart-router/src/classifier.ts
+++ b/extensions/smart-router/src/classifier.ts
@@ -1,0 +1,256 @@
+import type { ClassificationResult, DimensionScores, PromptTier } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Dimension weights (sum = 1.0)
+// ---------------------------------------------------------------------------
+const WEIGHTS: Record<keyof DimensionScores, number> = {
+  reasoningMarkers: 0.25,
+  codePresence: 0.22,
+  multiStepPatterns: 0.18,
+  technicalTerms: 0.15,
+  tokenEstimate: 0.1,
+  simpleIndicators: 0.1,
+};
+
+// ---------------------------------------------------------------------------
+// Tier boundaries on the weighted-score axis
+// ---------------------------------------------------------------------------
+const TIER_SIMPLE_MAX = 0.05;
+const TIER_MEDIUM_MAX = 0.25;
+const TIER_COMPLEX_MAX = 0.45;
+
+// ---------------------------------------------------------------------------
+// Keyword / pattern lists
+// ---------------------------------------------------------------------------
+
+const REASONING_KEYWORDS = [
+  "prove",
+  "theorem",
+  "derive",
+  "step by step",
+  "chain of thought",
+  "formally",
+  "mathematical",
+  "proof",
+  "logically",
+  "reason through",
+  "analyze why",
+  "deduce",
+];
+
+const CODE_KEYWORDS = [
+  "function",
+  "class ",
+  "import ",
+  "export ",
+  "def ",
+  "const ",
+  "let ",
+  "var ",
+  "return ",
+  "async ",
+  "await ",
+  "=>",
+  "interface ",
+  "type ",
+  "struct ",
+  "impl ",
+  "fn ",
+];
+
+const MULTI_STEP_PATTERNS = [
+  /first\b.*\bthen\b/is,
+  /step\s+\d/i,
+  /\d+\.\s+\S/,
+  /after that\b/i,
+  /next,?\s/i,
+  /finally\b/i,
+];
+
+const TECHNICAL_TERMS = [
+  "algorithm",
+  "optimize",
+  "architecture",
+  "distributed",
+  "kubernetes",
+  "microservice",
+  "database",
+  "infrastructure",
+  "implement",
+  "refactor",
+  "debug",
+  "deploy",
+  "benchmark",
+  "latency",
+  "throughput",
+  "routing",
+  "state management",
+  "api",
+  "authentication",
+  "caching",
+  "error handling",
+  "monitoring",
+];
+
+const SIMPLE_INDICATORS = [
+  "what is",
+  "define",
+  "translate",
+  "hello",
+  "yes or no",
+  "capital of",
+  "how old",
+  "who is",
+  "when was",
+  "thanks",
+  "thank you",
+  "hi",
+  "hey",
+  "good morning",
+  "good night",
+];
+
+// ---------------------------------------------------------------------------
+// Scoring helpers
+// ---------------------------------------------------------------------------
+
+function countKeywordMatches(text: string, keywords: string[]): number {
+  const lower = text.toLowerCase();
+  let count = 0;
+  for (const kw of keywords) {
+    if (lower.includes(kw)) count++;
+  }
+  return count;
+}
+
+function countPatternMatches(text: string, patterns: RegExp[]): number {
+  let count = 0;
+  for (const p of patterns) {
+    if (p.test(text)) count++;
+  }
+  return count;
+}
+
+function hasCodeFence(text: string): boolean {
+  return text.includes("```");
+}
+
+function estimateWordCount(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+/** Map a raw count to a 0–1 score using low/high thresholds. */
+function thresholdScore(count: number, low: number, high: number): number {
+  if (count >= high) return 1.0;
+  if (count >= low) return 0.5;
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Dimension scorers
+// ---------------------------------------------------------------------------
+
+function scoreReasoningMarkers(text: string): number {
+  const matches = countKeywordMatches(text, REASONING_KEYWORDS);
+  if (matches >= 2) return 1.0;
+  if (matches >= 1) return 0.7;
+  return 0;
+}
+
+function scoreCodePresence(text: string): number {
+  if (hasCodeFence(text)) return 1.0;
+  const matches = countKeywordMatches(text, CODE_KEYWORDS);
+  return thresholdScore(matches, 1, 3);
+}
+
+function scoreMultiStepPatterns(text: string): number {
+  const matches = countPatternMatches(text, MULTI_STEP_PATTERNS);
+  return thresholdScore(matches, 1, 2);
+}
+
+function scoreTechnicalTerms(text: string): number {
+  const matches = countKeywordMatches(text, TECHNICAL_TERMS);
+  return thresholdScore(matches, 1, 3);
+}
+
+function scoreTokenEstimate(text: string): number {
+  const words = estimateWordCount(text);
+  if (words > 200) return 1.0;
+  if (words > 80) return 0.5;
+  if (words > 30) return 0.2;
+  if (words < 6) return -0.5;
+  return 0;
+}
+
+/** Negative signal — presence pulls score down. */
+function scoreSimpleIndicators(text: string): number {
+  const matches = countKeywordMatches(text, SIMPLE_INDICATORS);
+  if (matches >= 2) return -1.0;
+  if (matches >= 1) return -0.7;
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Main classifier
+// ---------------------------------------------------------------------------
+
+function computeScores(prompt: string): DimensionScores {
+  return {
+    reasoningMarkers: scoreReasoningMarkers(prompt),
+    codePresence: scoreCodePresence(prompt),
+    multiStepPatterns: scoreMultiStepPatterns(prompt),
+    technicalTerms: scoreTechnicalTerms(prompt),
+    tokenEstimate: scoreTokenEstimate(prompt),
+    simpleIndicators: scoreSimpleIndicators(prompt),
+  };
+}
+
+function computeWeightedScore(scores: DimensionScores): number {
+  let total = 0;
+  for (const dim of Object.keys(WEIGHTS) as (keyof DimensionScores)[]) {
+    total += scores[dim] * WEIGHTS[dim];
+  }
+  return total;
+}
+
+function tierFromScore(score: number): PromptTier {
+  if (score < TIER_SIMPLE_MAX) return "simple";
+  if (score < TIER_MEDIUM_MAX) return "medium";
+  if (score < TIER_COMPLEX_MAX) return "complex";
+  return "reasoning";
+}
+
+/** Distance from the nearest tier boundary, normalised to [0, 1]. */
+function computeConfidence(score: number, tier: PromptTier): number {
+  const boundaries = [TIER_SIMPLE_MAX, TIER_MEDIUM_MAX, TIER_COMPLEX_MAX];
+  let minDist = Infinity;
+  for (const b of boundaries) {
+    const d = Math.abs(score - b);
+    if (d < minDist) minDist = d;
+  }
+  // Sigmoid-like scaling: scores far from boundaries → high confidence
+  const steepness = 12;
+  return 1 / (1 + Math.exp(-steepness * minDist));
+}
+
+export function classifyPrompt(prompt: string): ClassificationResult {
+  const text = prompt.trim();
+  if (!text) {
+    return { tier: "simple", confidence: 1, weightedScore: 0, scores: computeScores("") };
+  }
+
+  const scores = computeScores(text);
+  const weightedScore = computeWeightedScore(scores);
+
+  // Force REASONING if 2+ reasoning keyword matches
+  const reasoningMatches = countKeywordMatches(text, REASONING_KEYWORDS);
+  if (reasoningMatches >= 2) {
+    const conf = Math.max(computeConfidence(weightedScore, "reasoning"), 0.85);
+    return { tier: "reasoning", confidence: conf, weightedScore, scores };
+  }
+
+  const tier = tierFromScore(weightedScore);
+  const confidence = computeConfidence(weightedScore, tier);
+
+  return { tier, confidence, weightedScore, scores };
+}

--- a/extensions/smart-router/src/classifier.ts
+++ b/extensions/smart-router/src/classifier.ts
@@ -221,7 +221,7 @@ function tierFromScore(score: number): PromptTier {
 }
 
 /** Distance from the nearest tier boundary, normalised to [0, 1]. */
-function computeConfidence(score: number, tier: PromptTier): number {
+function computeConfidence(score: number): number {
   const boundaries = [TIER_SIMPLE_MAX, TIER_MEDIUM_MAX, TIER_COMPLEX_MAX];
   let minDist = Infinity;
   for (const b of boundaries) {
@@ -242,15 +242,14 @@ export function classifyPrompt(prompt: string): ClassificationResult {
   const scores = computeScores(text);
   const weightedScore = computeWeightedScore(scores);
 
-  // Force REASONING if 2+ reasoning keyword matches
-  const reasoningMatches = countKeywordMatches(text, REASONING_KEYWORDS);
-  if (reasoningMatches >= 2) {
-    const conf = Math.max(computeConfidence(weightedScore, "reasoning"), 0.85);
+  // Force REASONING if 2+ reasoning keyword matches (scores.reasoningMarkers === 1.0 means ≥2)
+  if (scores.reasoningMarkers >= 1.0) {
+    const conf = Math.max(computeConfidence(weightedScore), 0.85);
     return { tier: "reasoning", confidence: conf, weightedScore, scores };
   }
 
   const tier = tierFromScore(weightedScore);
-  const confidence = computeConfidence(weightedScore, tier);
+  const confidence = computeConfidence(weightedScore);
 
   return { tier, confidence, weightedScore, scores };
 }

--- a/extensions/smart-router/src/model-mapper.test.ts
+++ b/extensions/smart-router/src/model-mapper.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolveModelForTier } from "./model-mapper.js";
+import type { SmartRouterConfig } from "./types.js";
+
+describe("resolveModelForTier", () => {
+  const fullConfig: SmartRouterConfig = {
+    tiers: {
+      simple: { provider: "openai", model: "gpt-4.1-mini" },
+      medium: { provider: "anthropic", model: "claude-sonnet-4-5" },
+      complex: { provider: "anthropic", model: "claude-opus-4-6" },
+      reasoning: { provider: "openai", model: "o3" },
+    },
+  };
+
+  it("returns the configured mapping for each tier", () => {
+    expect(resolveModelForTier("simple", fullConfig)).toEqual({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+    });
+    expect(resolveModelForTier("medium", fullConfig)).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+    });
+    expect(resolveModelForTier("complex", fullConfig)).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+    expect(resolveModelForTier("reasoning", fullConfig)).toEqual({
+      provider: "openai",
+      model: "o3",
+    });
+  });
+
+  it("returns null when tiers config is undefined", () => {
+    expect(resolveModelForTier("simple", {})).toBeNull();
+  });
+
+  it("returns null when specific tier is not configured", () => {
+    const partial: SmartRouterConfig = {
+      tiers: {
+        simple: { provider: "openai", model: "gpt-4.1-mini" },
+      },
+    };
+    expect(resolveModelForTier("complex", partial)).toBeNull();
+  });
+
+  it("returns null for empty config", () => {
+    expect(resolveModelForTier("medium", { tiers: {} })).toBeNull();
+  });
+});

--- a/extensions/smart-router/src/model-mapper.ts
+++ b/extensions/smart-router/src/model-mapper.ts
@@ -1,0 +1,15 @@
+import type { PromptTier, SmartRouterConfig, TierModelMapping } from "./types.js";
+
+/**
+ * Look up the user's configured model for the given tier.
+ * Returns `null` when no mapping is configured — the caller should
+ * skip overriding so the default model resolution takes over.
+ */
+export function resolveModelForTier(
+  tier: PromptTier,
+  config: SmartRouterConfig,
+): TierModelMapping | null {
+  const mapping = config.tiers?.[tier];
+  if (!mapping?.provider || !mapping?.model) return null;
+  return { provider: mapping.provider, model: mapping.model };
+}

--- a/extensions/smart-router/src/types.ts
+++ b/extensions/smart-router/src/types.ts
@@ -1,0 +1,34 @@
+export type PromptTier = "simple" | "medium" | "complex" | "reasoning";
+
+export type DimensionScores = {
+  reasoningMarkers: number;
+  codePresence: number;
+  multiStepPatterns: number;
+  technicalTerms: number;
+  tokenEstimate: number;
+  simpleIndicators: number;
+};
+
+export type ClassificationResult = {
+  tier: PromptTier;
+  confidence: number;
+  weightedScore: number;
+  scores: DimensionScores;
+};
+
+export type TierModelMapping = {
+  provider: string;
+  model: string;
+};
+
+export type SmartRouterConfig = {
+  enabled?: boolean;
+  confidenceThreshold?: number;
+  debug?: boolean;
+  tiers?: {
+    simple?: TierModelMapping;
+    medium?: TierModelMapping;
+    complex?: TierModelMapping;
+    reasoning?: TierModelMapping;
+  };
+};


### PR DESCRIPTION
## Summary

- Adds a new `smart-router` plugin that classifies prompt complexity using 6-dimension scoring (reasoning depth, code complexity, multi-step planning, technical terms, token estimate, simple indicators)
- Routes requests to user-configured models per tier (simple / medium / complex / reasoning)
- Uses the user's own API keys instead of external crypto-based micropayments (inspired by ClawRouter's design)

## Test plan

- [ ] `pnpm test` passes for `extensions/smart-router`
- [ ] Verify classifier scores prompts correctly across tiers
- [ ] Verify model-mapper resolves configured models per tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)