### PR TITLE
Add MAX Messenger to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -59,6 +59,19 @@ while reducing token usage.
 openclaw plugins install @martian-engineering/lossless-claw
 ```
 
+### MAX Messenger
+
+MAX Messenger channel plugin for OpenClaw Gateway. Supports long polling,
+streaming responses, file attachments, typing indicators, and flexible access
+control (open/pairing/closed/allowlist/disabled).
+
+- **npm:** `@biguxuzz/max`
+- **repo:** [github.com/biguxuzz/openclaw-max-plugin](https://github.com/biguxuzz/openclaw-max-plugin)
+
+```bash
+openclaw plugins install @biguxuzz/max
+```
+
 ### Opik
 
 Official plugin that exports agent traces to Opik. Monitor agent behavior,


### PR DESCRIPTION
## Summary

Adds MAX Messenger plugin to the community plugins listing (alphabetically between Lossless Claw and Opik).

## Plugin details

- **npm**: `@biguxuzz/max@1.2.2`
- **repo**: https://github.com/biguxuzz/openclaw-max-plugin
- **Features**: Long polling, streaming responses (edit-based), outbound delivery, file attachments, typing indicators, webhook with secret validation, env var support, access control (open/pairing/closed/allowlist/disabled)
- **Install**: `openclaw plugins install @biguxuzz/max`

## Testing

Actively used in production with OpenClaw 2026.3.23-2 on Ubuntu 22.04 (system Node 24).

## Note

Published under `@biguxuzz` scope. Happy to transfer to `@openclaw` if access is granted.

Closes #50218