### PR TITLE
fix: Image Generation Failed: imageGenerationModel / No image-generation provider registered for google / openai, etc. Regression version 2026.3.23

### DIFF
--- a/src/image-generation/provider-registry.test.ts
+++ b/src/image-generation/provider-registry.test.ts
@@ -57,6 +57,35 @@ describe("image-generation provider registry", () => {
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
+  it("falls back to loading plugins when the active registry has no image providers", () => {
+    const activeRegistry = createEmptyPluginRegistry();
+    setActivePluginRegistry(activeRegistry, "existing-registry");
+
+    const fallbackRegistry = createEmptyPluginRegistry();
+    fallbackRegistry.imageGenerationProviders.push({
+      pluginId: "google",
+      pluginName: "Google Plugin",
+      source: "test",
+      provider: {
+        id: "google",
+        label: "Google",
+        capabilities: {
+          generate: {},
+          edit: { enabled: false },
+        },
+        generateImage: async () => ({
+          images: [{ buffer: Buffer.from("image"), mimeType: "image/png" }],
+        }),
+      },
+    });
+    loadOpenClawPluginsMock.mockReturnValueOnce(fallbackRegistry);
+
+    const provider = getImageGenerationProvider("google", {} as never);
+
+    expect(provider?.id).toBe("google");
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledOnce();
+  });
+
   it("ignores prototype-like provider ids and aliases", () => {
     const registry = createEmptyPluginRegistry();
     registry.imageGenerationProviders.push(

--- a/src/image-generation/provider-registry.ts
+++ b/src/image-generation/provider-registry.ts
@@ -2,7 +2,7 @@ import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
-import { getActivePluginRegistry, getActivePluginRegistryKey } from "../plugins/runtime.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
 import type { ImageGenerationProviderPlugin } from "../plugins/types.js";
 
 const BUILTIN_IMAGE_GENERATION_PROVIDERS: readonly ImageGenerationProviderPlugin[] = [];
@@ -25,7 +25,7 @@ function resolvePluginImageGenerationProviders(
 ): ImageGenerationProviderPlugin[] {
   const active = getActivePluginRegistry();
   const registry =
-    (active?.imageGenerationProviders?.length ?? 0) > 0 || getActivePluginRegistryKey() || !cfg
+    (active?.imageGenerationProviders?.length ?? 0) > 0 || !cfg
       ? active
       : loadOpenClawPlugins({ config: cfg });
   return registry?.imageGenerationProviders?.map((entry) => entry.provider) ?? [];


### PR DESCRIPTION
## Summary

Fix image-generation provider lookup so it reloads plugins from config when the active plugin registry is present but has no image providers.

## What changed

- remove the `getActivePluginRegistryKey()` shortcut from `src/image-generation/provider-registry.ts`
- add a regression test covering the case where:
  - an active registry exists
  - it has a cache key
  - `imageGenerationProviders` is empty
  - provider lookup should fall back to `loadOpenClawPlugins(...)`

## Why

In a live install, `image_generate` was failing with:

- `No image-generation provider registered for google`
- `No image-generation provider registered for openai`

…even though the relevant plugins were loaded and auth/env were configured.

The root cause was that image provider resolution treated the presence of an active registry key as sufficient reason to skip plugin reload, even when that active registry did not actually contain any image-generation providers.

Closes #53450.
