### PR TITLE
feat: add TASTE.md as a workspace bootstrap file

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -90,6 +90,9 @@ These are the standard files OpenClaw expects inside the workspace:
   <Accordion title="MEMORY.md — curated long-term memory (optional)">
     Curated long-term memory. Only load in the main, private session (not shared/group contexts). See [Memory](/concepts/memory) for the workflow and automatic memory flush.
   </Accordion>
+  <Accordion title="TASTE.md — what your human likes (optional)">
+    Evaluative preferences across domains (visual, code, food, etc.). Complements USER.md (descriptive) and MEMORY.md (factual). Loaded only in the main session, not in subagents or cron runs. Spec: [TASTE.md](https://github.com/PitayaK/taste.md).
+  </Accordion>
   <Accordion title="skills/ — workspace skills (optional)">
     Workspace-specific skills. Highest-precedence skill location for that workspace. Overrides project agent skills, personal agent skills, managed skills, bundled skills, and `skills.load.extraDirs` when names collide.
   </Accordion>
@@ -127,7 +130,7 @@ Run these steps on the machine where the Gateway runs (that is where the workspa
     ```bash
     cd ~/.openclaw/workspace
     git init
-    git add AGENTS.md SOUL.md TOOLS.md IDENTITY.md USER.md HEARTBEAT.md memory/
+    git add AGENTS.md SOUL.md TOOLS.md IDENTITY.md USER.md HEARTBEAT.md TASTE.md memory/
     git commit -m "Add agent workspace"
     ```
 

--- a/docs/reference/templates/TASTE.md
+++ b/docs/reference/templates/TASTE.md
@@ -1,0 +1,43 @@
+---
+title: "TASTE.md Template"
+summary: "Human taste and preference record"
+read_when:
+  - Bootstrapping a workspace manually
+---
+
+# TASTE.md - What Your Human Likes
+
+_Their taste -- preferences, sensibilities, and aesthetic judgments across all domains of life._
+
+> Observe, then write. Only record preferences you've actually seen.
+> Last updated: _(agent fills this in)_
+
+## How to Use This File
+
+This file captures **evaluative** preferences -- what your human considers good, bad, elegant, ugly, delightful, or annoying. It complements USER.md (who they are) and MEMORY.md (what happened). Taste is about *judgment*.
+
+### Rules
+
+- **Observe first.** Never pre-fill sections or guess from stereotypes. Only write what you've witnessed.
+- **Quote when possible.** `said "too busy"` beats `dislikes complex designs`.
+- **Date your observations.** Taste evolves. Use `(2026-03)` or similar.
+- **Anti-taste matters.** What they dislike prevents bad suggestions. Mark with `dislikes:` or similar.
+- **Domains are emergent.** Don't pre-create empty sections. Add a new `##` heading when you first observe preferences in a new area.
+- **Keep it under 150 lines.** Every line should earn its place. Merge or prune as patterns clarify.
+
+### Example Domains
+
+_(Only create sections you have evidence for.)_
+
+- **Visual & Design** -- UI preferences, typography, color, layout
+- **Code & Engineering** -- readability vs. cleverness, naming, architecture
+- **Product Thinking** -- what makes a product "well-designed" to them
+- **Content & Media** -- writing style, format, length, sources they trust
+- **Communication** -- tone, directness, formality
+- **Food & Lifestyle** -- flavors, preparation, dining style
+- **Business & Strategy** -- what business models they admire
+- **Music & Art** -- genres, aesthetics, what moves them
+
+---
+
+_This file is yours to build over time. As you observe your human's choices, capture the signal here._

--- a/docs/reference/templates/TASTE.md
+++ b/docs/reference/templates/TASTE.md
@@ -14,7 +14,7 @@ _Their taste -- preferences, sensibilities, and aesthetic judgments across all d
 
 ## How to Use This File
 
-This file captures **evaluative** preferences -- what your human considers good, bad, elegant, ugly, delightful, or annoying. It complements USER.md (who they are) and MEMORY.md (what happened). Taste is about *judgment*.
+This file captures **evaluative** preferences -- what your human considers good, bad, elegant, ugly, delightful, or annoying. It complements USER.md (who they are) and MEMORY.md (what happened). Taste is about _judgment_.
 
 ### Rules
 

--- a/src/agents/sandbox/workspace.ts
+++ b/src/agents/sandbox/workspace.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_HEARTBEAT_FILENAME,
   DEFAULT_IDENTITY_FILENAME,
   DEFAULT_SOUL_FILENAME,
+  DEFAULT_TASTE_FILENAME,
   DEFAULT_TOOLS_FILENAME,
   DEFAULT_USER_FILENAME,
   ensureAgentWorkspace,
@@ -30,6 +31,7 @@ export async function ensureSandboxWorkspace(
       DEFAULT_USER_FILENAME,
       DEFAULT_BOOTSTRAP_FILENAME,
       DEFAULT_HEARTBEAT_FILENAME,
+      DEFAULT_TASTE_FILENAME,
     ];
     for (const name of files) {
       const src = path.join(seed, name);

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_IDENTITY_FILENAME,
   DEFAULT_MEMORY_FILENAME,
   DEFAULT_SOUL_FILENAME,
+  DEFAULT_TASTE_FILENAME,
   DEFAULT_TOOLS_FILENAME,
   DEFAULT_USER_FILENAME,
   ensureAgentWorkspace,
@@ -323,6 +324,18 @@ describe("loadWorkspaceBootstrapFiles", () => {
 
     const files = await loadWorkspaceBootstrapFiles(tempDir);
     expect(getMemoryEntries(files)).toHaveLength(0);
+  });
+
+  it("includes TASTE.md after ensureAgentWorkspace seeds the template", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    const files = await loadWorkspaceBootstrapFiles(tempDir);
+    const taste = files.find((file) => file.name === DEFAULT_TASTE_FILENAME);
+    expect(taste).toBeDefined();
+    expect(taste?.missing).toBe(false);
+    expect(taste?.content).toBeDefined();
+    expect(taste?.content?.length ?? 0).toBeGreaterThan(0);
   });
 
   it("treats hardlinked bootstrap aliases as missing", async () => {

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -73,6 +73,7 @@ function expectSubagentAllowedBootstrapNames(files: WorkspaceBootstrapFile[]) {
   expect(names).not.toContain("HEARTBEAT.md");
   expect(names).not.toContain("BOOTSTRAP.md");
   expect(names).not.toContain("MEMORY.md");
+  expect(names).not.toContain("TASTE.md");
 }
 
 describe("ensureAgentWorkspace", () => {
@@ -366,6 +367,7 @@ describe("filterBootstrapFilesForSession", () => {
     { name: "HEARTBEAT.md", path: "/w/HEARTBEAT.md", content: "", missing: false },
     { name: "BOOTSTRAP.md", path: "/w/BOOTSTRAP.md", content: "", missing: false },
     { name: "MEMORY.md", path: "/w/MEMORY.md", content: "", missing: false },
+    { name: "TASTE.md", path: "/w/TASTE.md", content: "", missing: false },
   ];
 
   it("returns all files for main session (no sessionKey)", () => {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -24,6 +24,7 @@ export const DEFAULT_USER_FILENAME = "USER.md";
 export const DEFAULT_HEARTBEAT_FILENAME = "HEARTBEAT.md";
 export const DEFAULT_BOOTSTRAP_FILENAME = "BOOTSTRAP.md";
 export const DEFAULT_MEMORY_FILENAME = CANONICAL_ROOT_MEMORY_FILENAME;
+export const DEFAULT_TASTE_FILENAME = "TASTE.md";
 const WORKSPACE_STATE_DIRNAME = ".openclaw";
 const WORKSPACE_STATE_FILENAME = "workspace-state.json";
 const WORKSPACE_STATE_VERSION = 1;
@@ -135,7 +136,8 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_USER_FILENAME
   | typeof DEFAULT_HEARTBEAT_FILENAME
   | typeof DEFAULT_BOOTSTRAP_FILENAME
-  | typeof DEFAULT_MEMORY_FILENAME;
+  | typeof DEFAULT_MEMORY_FILENAME
+  | typeof DEFAULT_TASTE_FILENAME;
 
 export type WorkspaceBootstrapFile = {
   name: WorkspaceBootstrapFileName;
@@ -172,6 +174,7 @@ const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
   DEFAULT_HEARTBEAT_FILENAME,
   DEFAULT_BOOTSTRAP_FILENAME,
   DEFAULT_MEMORY_FILENAME,
+  DEFAULT_TASTE_FILENAME,
 ]);
 
 async function writeFileIfMissing(filePath: string, content: string): Promise<boolean> {
@@ -476,6 +479,7 @@ export async function ensureAgentWorkspace(params?: {
   userPath?: string;
   heartbeatPath?: string;
   bootstrapPath?: string;
+  tastePath?: string;
   identityPathCreated?: boolean;
 }> {
   const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR;
@@ -493,10 +497,19 @@ export async function ensureAgentWorkspace(params?: {
   const userPath = path.join(dir, DEFAULT_USER_FILENAME);
   const heartbeatPath = path.join(dir, DEFAULT_HEARTBEAT_FILENAME);
   const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
+  const tastePath = path.join(dir, DEFAULT_TASTE_FILENAME);
   const statePath = resolveWorkspaceStatePath(dir);
 
   const isBrandNewWorkspace = await (async () => {
-    const templatePaths = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];
+    const templatePaths = [
+      agentsPath,
+      soulPath,
+      toolsPath,
+      identityPath,
+      userPath,
+      heartbeatPath,
+      tastePath,
+    ];
     const userContentPaths = [path.join(dir, "memory"), path.join(dir, ".git")];
     const paths = [...templatePaths, ...userContentPaths];
     const existing = await Promise.all(
@@ -519,12 +532,14 @@ export async function ensureAgentWorkspace(params?: {
   const identityTemplate = await loadTemplate(DEFAULT_IDENTITY_FILENAME);
   const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
   const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
+  const tasteTemplate = await loadTemplate(DEFAULT_TASTE_FILENAME);
   await writeFileIfMissing(agentsPath, agentsTemplate);
   await writeFileIfMissing(soulPath, soulTemplate);
   await writeFileIfMissing(toolsPath, toolsTemplate);
   const identityPathCreated = await writeFileIfMissing(identityPath, identityTemplate);
   await writeFileIfMissing(userPath, userTemplate);
   await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
+  await writeFileIfMissing(tastePath, tasteTemplate);
 
   let state = await readWorkspaceSetupState(statePath, {
     persistLegacyMigration: true,
@@ -595,6 +610,7 @@ export async function ensureAgentWorkspace(params?: {
     userPath,
     heartbeatPath,
     bootstrapPath,
+    tastePath,
     identityPathCreated,
   };
 }

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -654,6 +654,10 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
       name: DEFAULT_MEMORY_FILENAME,
       filePath: path.join(resolvedDir, DEFAULT_MEMORY_FILENAME),
     },
+    {
+      name: DEFAULT_TASTE_FILENAME,
+      filePath: path.join(resolvedDir, DEFAULT_TASTE_FILENAME),
+    },
   ];
 
   const result: WorkspaceBootstrapFile[] = [];


### PR DESCRIPTION
## Summary

Add **TASTE.md** as a new workspace bootstrap file that records a human's taste — their preferences, sensibilities, and aesthetic judgments across all domains of life.

- TASTE.md complements existing workspace files: **SOUL.md** (agent identity), **USER.md** (human background), **MEMORY.md** (facts/events). While those files are descriptive, TASTE.md is **evaluative** — it captures what the human considers good, bad, elegant, or annoying.
- Agents observe preferences during interactions and write them to TASTE.md, enabling personalization that persists across sessions.
- Domains are emergent (visual design, code style, product thinking, food, music, etc.) — agents discover and add new sections as they observe.

### Changes

- **New template**: `docs/reference/templates/TASTE.md` — workspace template with guidelines and example domains
- **`src/agents/workspace.ts`**: Register `DEFAULT_TASTE_FILENAME`, add to `WorkspaceBootstrapFileName` type union and `VALID_BOOTSTRAP_NAMES` set, wire into workspace setup (path construction, template loading, `writeIfMissing`)
- **`src/agents/workspace.test.ts`**: Update mock data and subagent filter assertions (TASTE.md is excluded from subagent/cron sessions, same as HEARTBEAT/BOOTSTRAP/MEMORY)

### Design decisions

- **Not in subagent allowlist**: TASTE.md contains personal preferences that are only relevant to the main agent session, not subagents or cron jobs.
- **Under 150 lines**: The template encourages agents to keep TASTE.md concise — every line should earn its place.
- **Observe-then-write**: Agents should only record preferences they've actually witnessed, never pre-fill from stereotypes.

### Full spec

The complete TASTE.md specification is open-sourced at [github.com/PitayaK/taste.md](https://github.com/PitayaK/taste.md).

## Test plan

- [ ] Verify `pnpm build` succeeds
- [ ] Verify existing workspace tests pass with updated mock data
- [ ] Verify TASTE.md is created in new workspaces via `ensureAgentWorkspace`
- [ ] Verify TASTE.md is excluded from subagent/cron session bootstrap

🤖 AI-assisted (Claude Code). Lightly tested — workspace.ts changes follow existing patterns exactly.