### PR TITLE
fix(agents): normalize llama.cpp and Ollama context usage aliases

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -316,6 +316,25 @@ function makeResponseObject(
   };
 }
 
+function makeResponseObjectWithUsage(id: string, usage: Record<string, number>): ResponseObject {
+  return {
+    id,
+    object: "response",
+    created_at: Date.now(),
+    status: "completed",
+    model: "gpt-5.2",
+    output: [
+      {
+        type: "message",
+        id: "item_usage",
+        role: "assistant",
+        content: [{ type: "output_text", text: "ok" }],
+      },
+    ],
+    usage: usage as unknown as ResponseObject["usage"],
+  };
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Test suite
 // ─────────────────────────────────────────────────────────────────────────────
@@ -649,6 +668,18 @@ describe("buildAssistantMessageFromResponse", () => {
     expect(msg.usage.input).toBe(100);
     expect(msg.usage.output).toBe(50);
     expect(msg.usage.totalTokens).toBe(150);
+  });
+
+  it("maps OpenAI-compatible prompt/completion usage aliases", () => {
+    const response = makeResponseObjectWithUsage("resp_5b", {
+      prompt_tokens: 11,
+      completion_tokens: 1,
+      total_tokens: 12,
+    });
+    const msg = buildAssistantMessageFromResponse(response, modelInfo);
+    expect(msg.usage.input).toBe(11);
+    expect(msg.usage.output).toBe(1);
+    expect(msg.usage.totalTokens).toBe(12);
   });
 
   it("sets model/provider/api from modelInfo", () => {

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -50,6 +50,7 @@ import {
   buildUsageWithNoCost,
   buildStreamErrorAssistantMessage,
 } from "./stream-message-shared.js";
+import { normalizeUsage } from "./usage.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Per-session state
@@ -580,14 +581,17 @@ export function buildAssistantMessageFromResponse(
   const hasToolCalls = content.some((c) => c.type === "toolCall");
   const stopReason: StopReason = hasToolCalls ? "toolUse" : "stop";
 
+  const normalizedUsage = normalizeUsage(response.usage);
   const message = buildAssistantMessage({
     model: modelInfo,
     content,
     stopReason,
     usage: buildUsageWithNoCost({
-      input: response.usage?.input_tokens ?? 0,
-      output: response.usage?.output_tokens ?? 0,
-      totalTokens: response.usage?.total_tokens ?? 0,
+      input: normalizedUsage?.input ?? 0,
+      output: normalizedUsage?.output ?? 0,
+      cacheRead: normalizedUsage?.cacheRead ?? 0,
+      cacheWrite: normalizedUsage?.cacheWrite ?? 0,
+      totalTokens: normalizedUsage?.total ?? 0,
     }),
   });
 

--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -233,21 +233,23 @@ describe("spawnSubagentDirect workspace inheritance", () => {
   });
 
   it("deletes the provisional child session when a non-thread subagent start fails", async () => {
-    hoisted.callGatewayMock.mockImplementation(async (request: {
-      method?: string;
-      params?: { key?: string; deleteTranscript?: boolean; emitLifecycleHooks?: boolean };
-    }) => {
-      if (request.method === "sessions.patch") {
-        return { ok: true };
-      }
-      if (request.method === "agent") {
-        throw new Error("spawn startup failed");
-      }
-      if (request.method === "sessions.delete") {
-        return { ok: true };
-      }
-      return {};
-    });
+    hoisted.callGatewayMock.mockImplementation(
+      async (request: {
+        method?: string;
+        params?: { key?: string; deleteTranscript?: boolean; emitLifecycleHooks?: boolean };
+      }) => {
+        if (request.method === "sessions.patch") {
+          return { ok: true };
+        }
+        if (request.method === "agent") {
+          throw new Error("spawn startup failed");
+        }
+        if (request.method === "sessions.delete") {
+          return { ok: true };
+        }
+        return {};
+      },
+    );
 
     const result = await spawnSubagentDirect(
       {

--- a/src/agents/usage.normalization.test.ts
+++ b/src/agents/usage.normalization.test.ts
@@ -34,6 +34,20 @@ describe("normalizeUsage", () => {
     });
   });
 
+  it("normalizes Ollama prompt/eval count usage", () => {
+    const usage = normalizeUsage({
+      prompt_eval_count: 26,
+      eval_count: 259,
+    });
+    expect(usage).toEqual({
+      input: 26,
+      output: 259,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+      total: undefined,
+    });
+  });
+
   it("returns undefined for empty usage objects", () => {
     expect(normalizeUsage({})).toBeUndefined();
   });

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -15,6 +15,8 @@ export type UsageLike = {
   completion_tokens?: number;
   cache_read_input_tokens?: number;
   cache_creation_input_tokens?: number;
+  prompt_eval_count?: number;
+  eval_count?: number;
   // Moonshot/Kimi uses cached_tokens for cache read count (explicit caching API).
   cached_tokens?: number;
   // Kimi K2 uses prompt_tokens_details.cached_tokens for automatic prefix caching.
@@ -94,7 +96,12 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
   // prompt_tokens upstream.  When cached_tokens > prompt_tokens the result is
   // negative, which is nonsensical.  Clamp to 0.
   const rawInput = asFiniteNumber(
-    raw.input ?? raw.inputTokens ?? raw.input_tokens ?? raw.promptTokens ?? raw.prompt_tokens,
+    raw.input ??
+      raw.inputTokens ??
+      raw.input_tokens ??
+      raw.promptTokens ??
+      raw.prompt_tokens ??
+      raw.prompt_eval_count,
   );
   const input = rawInput !== undefined && rawInput < 0 ? 0 : rawInput;
   const output = asFiniteNumber(
@@ -102,7 +109,8 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
       raw.outputTokens ??
       raw.output_tokens ??
       raw.completionTokens ??
-      raw.completion_tokens,
+      raw.completion_tokens ??
+      raw.eval_count,
   );
   const cacheRead = asFiniteNumber(
     raw.cacheRead ??


### PR DESCRIPTION
Closes #53448

## Summary
- normalize OpenAI-compatible `prompt_tokens` / `completion_tokens` usage in the WebSocket responses path
- teach the shared usage normalizer about Ollama `prompt_eval_count` / `eval_count` aliases
- add regression tests for both alias formats

## Testing
- [x] `pnpm vitest run src/agents/usage.normalization.test.ts src/agents/openai-ws-stream.test.ts src/agents/ollama-stream.test.ts`

## Notes
- I intentionally used targeted tests here because the current branch has unrelated broader typecheck noise outside this change surface.

AI-assisted: Codex-assisted
Testing: lightly tested locally (targeted tests)
