### PR TITLE
fix(agents): preserve cron heartbeat suppression during compaction

### DIFF
--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -107,6 +107,32 @@ beforeEach(() => {
   resetCompactHooksHarnessMocks();
 });
 
+describe("compaction heartbeat prompt policy", () => {
+  it("suppresses heartbeat prompt rebuilds for cron-origin compaction", () => {
+    expect(
+      compactTesting.shouldInjectHeartbeatPromptDuringCompaction({
+        isDefaultAgent: true,
+        sourceTrigger: "cron",
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves heartbeat prompt rebuilds for non-cron compaction", () => {
+    expect(
+      compactTesting.shouldInjectHeartbeatPromptDuringCompaction({
+        isDefaultAgent: true,
+        sourceTrigger: "memory",
+      }),
+    ).toBe(true);
+    expect(
+      compactTesting.shouldInjectHeartbeatPromptDuringCompaction({
+        isDefaultAgent: false,
+        sourceTrigger: "cron",
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("compactEmbeddedPiSessionDirect hooks", () => {
   beforeEach(() => {
     ensureRuntimePluginsLoaded.mockReset();

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -124,6 +124,9 @@ describe("compaction heartbeat prompt policy", () => {
         sourceTrigger: "memory",
       }),
     ).toBe(true);
+  });
+
+  it("does not inject heartbeat prompt for non-default agents", () => {
     expect(
       compactTesting.shouldInjectHeartbeatPromptDuringCompaction({
         isDefaultAgent: false,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -99,6 +99,8 @@ import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { buildEmbeddedMessageActionDiscoveryInput } from "./message-action-discovery-input.js";
 import { buildModelAliasLines, resolveModelAsync } from "./model.js";
+import type { EmbeddedRunTrigger } from "./run/params.js";
+import { shouldInjectHeartbeatPromptForTrigger } from "./run/trigger-policy.js";
 import { buildEmbeddedSandboxInfo } from "./sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
 import { truncateSessionAfterCompaction } from "./session-truncation.js";
@@ -153,6 +155,7 @@ export type CompactEmbeddedPiSessionParams = {
   tokenBudget?: number;
   force?: boolean;
   trigger?: "overflow" | "manual";
+  sourceTrigger?: EmbeddedRunTrigger;
   diagId?: string;
   attempt?: number;
   maxAttempts?: number;
@@ -164,6 +167,13 @@ export type CompactEmbeddedPiSessionParams = {
   /** Allow runtime plugins for this compaction to late-bind the gateway subagent. */
   allowGatewaySubagentBinding?: boolean;
 };
+
+function shouldInjectHeartbeatPromptDuringCompaction(params: {
+  isDefaultAgent: boolean;
+  sourceTrigger?: EmbeddedRunTrigger;
+}): boolean {
+  return params.isDefaultAgent && shouldInjectHeartbeatPromptForTrigger(params.sourceTrigger);
+}
 
 type CompactionMessageMetrics = {
   messages: number;
@@ -958,7 +968,10 @@ export async function compactEmbeddedPiSessionDirect(
       ownerDisplay: ownerDisplay.ownerDisplay,
       ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,
       reasoningTagHint,
-      heartbeatPrompt: isDefaultAgent
+      heartbeatPrompt: shouldInjectHeartbeatPromptDuringCompaction({
+        isDefaultAgent,
+        sourceTrigger: params.sourceTrigger,
+      })
         ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
         : undefined,
       skillsPrompt,
@@ -1422,6 +1435,7 @@ export const __testing = {
   hasMeaningfulConversationContent,
   containsRealConversationMessages,
   estimateTokensAfterCompaction,
+  shouldInjectHeartbeatPromptDuringCompaction,
   buildBeforeCompactionHookMetrics,
   runBeforeCompactionHooks,
   runAfterCompactionHooks,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -155,6 +155,7 @@ export type CompactEmbeddedPiSessionParams = {
   tokenBudget?: number;
   force?: boolean;
   trigger?: "overflow" | "manual";
+  /** Preserve the original run trigger when compaction is entered from a retry path. */
   sourceTrigger?: EmbeddedRunTrigger;
   diagId?: string;
   attempt?: number;
@@ -172,6 +173,7 @@ function shouldInjectHeartbeatPromptDuringCompaction(params: {
   isDefaultAgent: boolean;
   sourceTrigger?: EmbeddedRunTrigger;
 }): boolean {
+  // Undefined falls back to the default policy, which keeps heartbeat injection enabled.
   return params.isDefaultAgent && shouldInjectHeartbeatPromptForTrigger(params.sourceTrigger);
 }
 

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -135,6 +135,33 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     );
   });
 
+  it("preserves the original run trigger when overflow recovery compaction runs", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: makeOverflowError() }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted session",
+        firstKeptEntryId: "entry-8",
+        tokensBefore: 160000,
+      }),
+    );
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      trigger: "cron",
+    });
+
+    expect(mockedCompactDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeContext: expect.objectContaining({
+          trigger: "overflow",
+          sourceTrigger: "cron",
+        }),
+      }),
+    );
+  });
+
   it("passes observed overflow token counts into compaction when providers report them", async () => {
     const overflowError = new Error(
       '400 {"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 277403 tokens > 200000 maximum"}}',

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1156,6 +1156,7 @@ export async function runEmbeddedPiAgent(
                   }),
                   runId: params.runId,
                   trigger: "overflow",
+                  sourceTrigger: params.trigger,
                   ...(observedOverflowTokens !== undefined
                     ? { currentTokenCount: observedOverflowTokens }
                     : {}),


### PR DESCRIPTION
## Summary
- carry the original embedded-run trigger into overflow compaction rebuilds
- suppress heartbeat prompt reinjection when a cron-origin session compacts
- add regression coverage for the compaction heartbeat policy

## Test plan
- [x] `pnpm exec vitest run src/agents/pi-embedded-runner/compact.hooks.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts`
- [x] `pnpm check`


Made with [Cursor](https://cursor.com)