### PR TITLE
improve local embeddings doctor guidance

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1187,7 +1187,8 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
     `memorySearch.provider = "ollama"`.
 
     If you'd rather stay local, set `memorySearch.provider = "local"` (and optionally
-    `memorySearch.fallback = "none"`). If you want Gemini embeddings, set
+    `memorySearch.fallback = "none"`). Local embeddings use **`node-llama-cpp` + GGUF**
+    models rather than torch/sentence-transformers. If you want Gemini embeddings, set
     `memorySearch.provider = "gemini"` and provide `GEMINI_API_KEY` (or
     `memorySearch.remote.apiKey`). We support **OpenAI, Gemini, Voyage, Mistral, Ollama, or local** embedding
     models - see [Memory](/concepts/memory) for the setup details.

--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -233,21 +233,23 @@ describe("spawnSubagentDirect workspace inheritance", () => {
   });
 
   it("deletes the provisional child session when a non-thread subagent start fails", async () => {
-    hoisted.callGatewayMock.mockImplementation(async (request: {
-      method?: string;
-      params?: { key?: string; deleteTranscript?: boolean; emitLifecycleHooks?: boolean };
-    }) => {
-      if (request.method === "sessions.patch") {
-        return { ok: true };
-      }
-      if (request.method === "agent") {
-        throw new Error("spawn startup failed");
-      }
-      if (request.method === "sessions.delete") {
-        return { ok: true };
-      }
-      return {};
-    });
+    hoisted.callGatewayMock.mockImplementation(
+      async (request: {
+        method?: string;
+        params?: { key?: string; deleteTranscript?: boolean; emitLifecycleHooks?: boolean };
+      }) => {
+        if (request.method === "sessions.patch") {
+          return { ok: true };
+        }
+        if (request.method === "agent") {
+          throw new Error("spawn startup failed");
+        }
+        if (request.method === "sessions.delete") {
+          return { ok: true };
+        }
+        return {};
+      },
+    );
 
     const result = await spawnSubagentDirect(
       {

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -89,6 +89,22 @@ describe("noteMemorySearchHealth", () => {
     expect(message).toContain("node-llama-cpp not installed");
   });
 
+  it("explains GGUF/node-llama-cpp guidance when explicit local model path is missing", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "local",
+      local: { modelPath: "/tmp/definitely-missing.gguf" },
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {});
+
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain('configured local model file was not found');
+    expect(message).toContain('node-llama-cpp` + GGUF');
+    expect(message).toContain('Remove the custom local.modelPath');
+    expect(message).toContain('pnpm approve-builds -g');
+  });
+
   it("does not warn when local provider with default model and gateway probe is ready", async () => {
     resolveMemorySearchConfig.mockReturnValue({
       provider: "local",

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -99,10 +99,10 @@ describe("noteMemorySearchHealth", () => {
     await noteMemorySearchHealth(cfg, {});
 
     const message = String(note.mock.calls[0]?.[0] ?? "");
-    expect(message).toContain('configured local model file was not found');
-    expect(message).toContain('node-llama-cpp` + GGUF');
-    expect(message).toContain('Remove the custom local.modelPath');
-    expect(message).toContain('pnpm approve-builds -g');
+    expect(message).toContain("configured local model file was not found");
+    expect(message).toContain("node-llama-cpp` + GGUF");
+    expect(message).toContain("Remove the custom local.modelPath");
+    expect(message).toContain("pnpm approve-builds -g");
   });
 
   it("does not warn when local provider with default model and gateway probe is ready", async () => {
@@ -281,6 +281,8 @@ describe("noteMemorySearchHealth", () => {
     const message = String(note.mock.calls[0]?.[0] ?? "");
     expect(message).toContain("needs at least one embedding provider");
     expect(message).toContain("openclaw configure --section model");
+    expect(message).toContain('keep "auto" and set agents.defaults.memorySearch.local.modelPath');
+    expect(message).toContain("existing GGUF file or hf: URI");
   });
 
   it("still warns in auto mode when only ollama credentials exist", async () => {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -68,7 +68,7 @@ export async function noteMemorySearchHealth(
       note(
         [
           'Memory search provider is set to "local" but the configured local model file was not found.',
-          'OpenClaw local embeddings use `node-llama-cpp` + GGUF models (not torch / sentence-transformers).',
+          "OpenClaw local embeddings use `node-llama-cpp` + GGUF models (not torch / sentence-transformers).",
           "",
           "Fix (pick one):",
           `- Point agents.defaults.memorySearch.local.modelPath at a valid GGUF file or hf: URI`,
@@ -149,8 +149,8 @@ export async function noteMemorySearchHealth(
       "Fix (pick one):",
       "- Set OPENAI_API_KEY, GEMINI_API_KEY, VOYAGE_API_KEY, or MISTRAL_API_KEY in your environment",
       `- Configure credentials: ${formatCliCommand("openclaw configure --section model")}`,
-      `- For local embeddings, set agents.defaults.memorySearch.provider = \"local\" (or keep auto) and use a GGUF model via node-llama-cpp`,
-      `- For Ollama embeddings, set agents.defaults.memorySearch.provider = \"ollama\" explicitly (auto mode does not pick Ollama)`,
+      `- For local embeddings, set agents.defaults.memorySearch.provider = "local", or keep "auto" and set agents.defaults.memorySearch.local.modelPath to an existing GGUF file or hf: URI`,
+      `- For Ollama embeddings, set agents.defaults.memorySearch.provider = "ollama" explicitly (auto mode does not pick Ollama)`,
       `- To disable: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.enabled false")}`,
       "",
       `Verify: ${formatCliCommand("openclaw memory status --deep")}`,

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -67,10 +67,13 @@ export async function noteMemorySearchHealth(
       }
       note(
         [
-          'Memory search provider is set to "local" but no local model file was found.',
+          'Memory search provider is set to "local" but the configured local model file was not found.',
+          'OpenClaw local embeddings use `node-llama-cpp` + GGUF models (not torch / sentence-transformers).',
           "",
           "Fix (pick one):",
-          `- Install node-llama-cpp and set a local model path in config`,
+          `- Point agents.defaults.memorySearch.local.modelPath at a valid GGUF file or hf: URI`,
+          `- Remove the custom local.modelPath to use the default auto-downloaded local GGUF model`,
+          `- If node-llama-cpp failed to install under pnpm, run: pnpm approve-builds -g (or pnpm approve-builds), then pnpm rebuild node-llama-cpp`,
           `- Switch to a remote provider: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.provider openai")}`,
           "",
           `Verify: ${formatCliCommand("openclaw memory status --deep")}`,
@@ -146,7 +149,8 @@ export async function noteMemorySearchHealth(
       "Fix (pick one):",
       "- Set OPENAI_API_KEY, GEMINI_API_KEY, VOYAGE_API_KEY, or MISTRAL_API_KEY in your environment",
       `- Configure credentials: ${formatCliCommand("openclaw configure --section model")}`,
-      `- For local embeddings: configure agents.defaults.memorySearch.provider and local model path`,
+      `- For local embeddings, set agents.defaults.memorySearch.provider = \"local\" (or keep auto) and use a GGUF model via node-llama-cpp`,
+      `- For Ollama embeddings, set agents.defaults.memorySearch.provider = \"ollama\" explicitly (auto mode does not pick Ollama)`,
       `- To disable: ${formatCliCommand("openclaw config set agents.defaults.memorySearch.enabled false")}`,
       "",
       `Verify: ${formatCliCommand("openclaw memory status --deep")}`,


### PR DESCRIPTION
## Summary
- clarify that OpenClaw local memory embeddings use `node-llama-cpp` + GGUF models rather than torch / sentence-transformers
- make `openclaw doctor` guidance more actionable when a configured local GGUF path is missing
- explicitly call out that `memorySearch.provider = "auto"` does not auto-pick Ollama
- add a focused doctor-memory-search regression test and mirror the clarification in the FAQ

## Testing
- [x] `pnpm vitest run src/commands/doctor-memory-search.test.ts`

AI-assisted: Codex-assisted
Testing: lightly tested locally (targeted doctor-memory-search test)
