### PR TITLE
fix: move thread context from user message to system prompt

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -161,18 +161,21 @@ describe("runPreparedReply media-only handling", () => {
     vi.clearAllMocks();
   });
 
-  it("allows media-only prompts and preserves thread context in queued followups", async () => {
+  it("allows media-only prompts and moves thread context to system prompt on first turn", async () => {
     const result = await runPreparedReply(baseParams());
     expect(result).toEqual({ text: "ok" });
 
     const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
     expect(call).toBeTruthy();
-    expect(call?.followupRun.prompt).toContain("[Thread history - for context]");
-    expect(call?.followupRun.prompt).toContain("Earlier message in this thread");
+    // Thread context should be in the system prompt, not in the user message body
+    expect(call?.followupRun.run.extraSystemPrompt).toContain("[Thread history - for context]");
+    expect(call?.followupRun.run.extraSystemPrompt).toContain("Earlier message in this thread");
+    // User message body should NOT contain thread history (avoids transcript pollution)
+    expect(call?.followupRun.prompt).not.toContain("[Thread history - for context]");
     expect(call?.followupRun.prompt).toContain("[User sent media without caption]");
   });
 
-  it("keeps thread history context on follow-up turns", async () => {
+  it("omits thread history context on follow-up turns (already in conversation history)", async () => {
     const result = await runPreparedReply(
       baseParams({
         isNewSession: false,
@@ -182,8 +185,12 @@ describe("runPreparedReply media-only handling", () => {
 
     const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
     expect(call).toBeTruthy();
-    expect(call?.followupRun.prompt).toContain("[Thread history - for context]");
-    expect(call?.followupRun.prompt).toContain("Earlier message in this thread");
+    // On subsequent turns, thread context should NOT be injected anywhere
+    // (it's already in the LLM's conversation history from the first turn's system prompt)
+    expect(call?.followupRun.prompt).not.toContain("[Thread history - for context]");
+    expect(call?.followupRun.run.extraSystemPrompt ?? "").not.toContain(
+      "[Thread history - for context]",
+    );
   });
 
   it("returns the empty-body reply when there is no text and no media", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -267,11 +267,24 @@ export async function runPreparedReply(
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
   );
+  // Thread context (history or starter) is injected into the system prompt on the
+  // first turn only.  This avoids polluting the user message (which persists in
+  // the session transcript and is re-sent to the LLM on every subsequent turn),
+  // and lets providers apply prefix-based prompt caching for the stable system block.
+  const threadStarterBodyForSystem = ctx.ThreadStarterBody?.trim();
+  const threadHistoryBodyForSystem = ctx.ThreadHistoryBody?.trim();
+  const threadContextSystemNote =
+    isFirstTurnInSession && threadHistoryBodyForSystem
+      ? `[Thread history - for context]\n${threadHistoryBodyForSystem}`
+      : isFirstTurnInSession && threadStarterBodyForSystem
+        ? `[Thread starter - for context]\n${threadStarterBodyForSystem}`
+        : undefined;
   const extraSystemPromptParts = [
     inboundMetaPrompt,
     groupChatContext,
     groupIntro,
     groupSystemPrompt,
+    threadContextSystemNote,
   ].filter(Boolean);
   const baseBody = sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
   // Use CommandBody/RawBody for bare reset detection (clean message without structural context).
@@ -357,13 +370,6 @@ export async function runPreparedReply(
   const bodyWithEvents = prependEvents(effectiveBaseBody);
   prefixedBodyBase = prependEvents(prefixedBodyBase);
   prefixedBodyBase = appendUntrustedContext(prefixedBodyBase, sessionCtx.UntrustedContext);
-  const threadStarterBody = ctx.ThreadStarterBody?.trim();
-  const threadHistoryBody = ctx.ThreadHistoryBody?.trim();
-  const threadContextNote = threadHistoryBody
-    ? `[Thread history - for context]\n${threadHistoryBody}`
-    : threadStarterBody
-      ? `[Thread starter - for context]\n${threadStarterBody}`
-      : undefined;
   const skillResult = await ensureSkillSnapshot({
     sessionEntry,
     sessionStore,
@@ -378,7 +384,7 @@ export async function runPreparedReply(
   sessionEntry = skillResult.sessionEntry ?? sessionEntry;
   currentSystemSent = skillResult.systemSent;
   const skillsSnapshot = skillResult.skillsSnapshot;
-  const prefixedBody = [threadContextNote, prefixedBodyBase].filter(Boolean).join("\n\n");
+  const prefixedBody = prefixedBodyBase;
   const mediaNote = buildInboundMediaNote(ctx);
   const mediaReplyHint = mediaNote
     ? "To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Avoid absolute paths (MEDIA:/...) and ~ paths — they are blocked for security. Keep caption in the text body."
@@ -431,7 +437,7 @@ export async function runPreparedReply(
   );
   // Use bodyWithEvents (events prepended, but no session hints / untrusted context) so
   // deferred turns receive system events while keeping the same scope as effectiveBaseBody did.
-  const queueBodyBase = [threadContextNote, bodyWithEvents].filter(Boolean).join("\n\n");
+  const queueBodyBase = bodyWithEvents;
   const queuedBody = mediaNote
     ? [mediaNote, mediaReplyHint, queueBodyBase].filter(Boolean).join("\n").trim()
     : queueBodyBase;


### PR DESCRIPTION
## Problem

Thread history/starter context was injected into the **user message body** on the first turn of a thread session. Since user messages persist in the session transcript (JSONL), this ~4K token block was re-sent to the LLM on **every subsequent turn** as part of the conversation history.

### Symptoms
- LLM repeatedly references stale thread context (e.g., timestamps from the original thread starter) instead of focusing on the current message
- ~4,000 tokens wasted per turn (20 messages × ~200 tokens each)
- Over a 10-turn conversation: ~40,000 tokens of unnecessary input

## Root Cause

In `get-reply-run.ts`, `threadContextNote` was prepended to `prefixedBody` (user message) and `queueBodyBase` (deferred queue body). This meant the thread history became part of the user's first turn in the session transcript, and since the full conversation history is sent to the LLM on each turn, it was re-sent every time.

## Fix

Move `threadContextNote` from the user message body into `extraSystemPromptParts` (system prompt), injected **only on the first turn** (`isFirstTurnInSession`).

### Benefits
1. **Eliminates transcript pollution** — system prompt is not persisted as a user turn in the session JSONL
2. **Enables provider-side prefix caching** — stable system prompt block can be cached by LLM providers, potentially halving input token costs for the cached portion
3. **Preserves thread context on first turn** — LLM still sees the full thread history when it matters
4. **Natural context continuity** — subsequent turns already have context in conversation history

## Changes

- `src/auto-reply/reply/get-reply-run.ts`: Move thread context construction to system prompt, remove from user message body and queue body
- `src/auto-reply/reply/get-reply-run.media-only.test.ts`: Update tests to verify thread context is in system prompt (not user message)

## Testing

- All 12 tests in `get-reply-run.media-only.test.ts` pass
- All 21 tests in `prepare.test.ts` pass (no changes needed)
- TypeScript compilation: no new errors