### PR TITLE
fix: improve remediation message for Telegram group allowlist finding

### DIFF
--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -896,7 +896,11 @@ export async function collectChannelSecurityFindings(params: {
             `Telegram group access is enabled but no sender allowlist is configured; this allows any group member to invoke /… commands` +
             (skillsEnabled ? " (including skill commands)." : "."),
           remediation:
-            "Approve yourself via pairing (recommended), or set channels.telegram.groupAllowFrom (or per-group groups.<id>.allowFrom).",
+            "Add your Telegram user ID to the sender allowlist. Two options:\n" +
+            "  1. Pairing (recommended): run `openclaw channels pair --channel telegram` and follow the prompts — your ID is added automatically.\n" +
+            "  2. Manual: find your numeric Telegram user ID (message @userinfobot on Telegram), then add it to your config:\n" +
+            '     channels.telegram.groupAllowFrom: ["<your-numeric-id>"]\n' +
+            "     Or per-group: channels.telegram.groups.<groupId>.allowFrom: [\"<your-numeric-id>\"]",
         });
       }
     }


### PR DESCRIPTION
## Problem

The `channels.telegram.groups.allowFrom.missing` CRITICAL finding shows this remediation:

> Approve yourself via pairing (recommended), or set channels.telegram.groupAllowFrom (or per-group groups.<id>.allowFrom).

This is unclear for new users because:
- "Pairing" is not explained — what command do you run?
- The manual option shows config keys but no example values or format
- There's no guidance on how to find your numeric Telegram user ID
- Users on headless VPS setups (common for OpenClaw) have no obvious path

This came up directly when a new user hit this finding and couldn't work out what to do from the remediation text alone.

## Fix

Expand the remediation text to:
1. Give the exact CLI command for the pairing flow
2. Explain how to find your numeric Telegram user ID (@userinfobot)
3. Show the exact config keys and value format for the manual option
4. Cover both per-channel (`groupAllowFrom`) and per-group (`groups.<id>.allowFrom`) config paths

## Before
```
Approve yourself via pairing (recommended), or set channels.telegram.groupAllowFrom (or per-group groups.<id>.allowFrom).
```

## After
```
Add your Telegram user ID to the sender allowlist. Two options:
  1. Pairing (recommended): run `openclaw channels pair --channel telegram` and follow the prompts — your ID is added automatically.
  2. Manual: find your numeric Telegram user ID (message @userinfobot on Telegram), then add it to your config:
     channels.telegram.groupAllowFrom: ["<your-numeric-id>"]
     Or per-group: channels.telegram.groups.<groupId>.allowFrom: ["<your-numeric-id>"]
```

## Notes

- No logic changes — remediation text only
- Existing test only asserts on `checkId` and `severity`, not remediation text, so no test updates needed
