### PR TITLE
[codex] Fix web fetch schema, dual-stack status diagnosis, and Synology webhook ACKs

### DIFF
--- a/extensions/synology-chat/src/channel.integration.test.ts
+++ b/extensions/synology-chat/src/channel.integration.test.ts
@@ -157,8 +157,8 @@ describe("Synology channel wiring integration", () => {
     const betaRes = makeRes();
     await betaRoute.handler(betaReq, betaRes);
 
-    expect(alphaRes._status).toBe(204);
-    expect(betaRes._status).toBe(204);
+    expect(alphaRes._status).toBe(200);
+    expect(betaRes._status).toBe(200);
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(2);
     expect(finalizeInboundContextMock).toHaveBeenCalledTimes(2);
 

--- a/extensions/synology-chat/src/test-http-utils.ts
+++ b/extensions/synology-chat/src/test-http-utils.ts
@@ -44,17 +44,27 @@ export function makeStalledReq(
   return makeBaseReq(method, opts);
 }
 
-export function makeRes(): ServerResponse & { _status: number; _body: string } {
+export function makeRes(): ServerResponse & {
+  _status: number;
+  _body: string;
+  _headers: Record<string, string>;
+} {
   const res = {
     _status: 0,
     _body: "",
-    writeHead(statusCode: number, _headers: Record<string, string>) {
+    _headers: {},
+    writeHead(statusCode: number, headers: Record<string, string>) {
       res._status = statusCode;
+      res._headers = headers;
     },
     end(body?: string) {
       res._body = body ?? "";
     },
-  } as unknown as ServerResponse & { _status: number; _body: string };
+  } as unknown as ServerResponse & {
+    _status: number;
+    _body: string;
+    _headers: Record<string, string>;
+  };
   Object.defineProperty(res, "statusCode", {
     configurable: true,
     enumerable: true,

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -61,7 +61,8 @@ async function runDangerousNameMatchReply(
   const res = makeRes();
   await handler(req, res);
 
-  expect(res._status).toBe(204);
+  expect(res._status).toBe(200);
+  expect(res._body).toBe('{"success":true}');
   expect(resolveLegacyWebhookNameToChatUserId).toHaveBeenCalledWith({
     incomingUrl: "https://nas.example.com/incoming",
     mutableWebhookUsername: "testuser",
@@ -121,6 +122,24 @@ describe("createWebhookHandler", () => {
     await handler(req, res);
 
     expect(res._status).toBe(405);
+  });
+
+  it("accepts HEAD probes with a 200 ACK and no body", async () => {
+    const deliver = vi.fn();
+    const handler = createWebhookHandler({
+      account: makeAccount(),
+      deliver,
+      log,
+    });
+
+    const req = makeReq("HEAD", "");
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+    expect(res._body).toBe("");
+    expect(res._headers["Content-Length"]).toBe(String(Buffer.byteLength('{"success":true}')));
+    expect(deliver).not.toHaveBeenCalled();
   });
 
   it("returns 400 for missing required fields", async () => {
@@ -243,7 +262,7 @@ describe("createWebhookHandler", () => {
         break;
       }
 
-      if (res._status === 204) {
+      if (res._status === 200) {
         guessedToken = candidate;
         break;
       }
@@ -300,7 +319,7 @@ describe("createWebhookHandler", () => {
     const validRes = makeRes();
     await handler(validReq, validRes);
 
-    expect(validRes._status).toBe(204);
+    expect(validRes._status).toBe(200);
     expect(deliver).toHaveBeenCalledTimes(1);
   });
 
@@ -320,7 +339,7 @@ describe("createWebhookHandler", () => {
       (req.socket as { remoteAddress?: string }).remoteAddress = "203.0.113.20";
       const res = makeRes();
       await handler(req, res);
-      expect(res._status).toBe(204);
+      expect(res._status).toBe(200);
     }
 
     expect(deliver).toHaveBeenCalledTimes(11);
@@ -347,7 +366,8 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
+    expect(res._status).toBe(200);
+    expect(res._body).toBe('{"success":true}');
     expect(deliver).toHaveBeenCalledWith(
       expect.objectContaining({
         body: "Hello from json",
@@ -377,7 +397,8 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
+    expect(res._status).toBe(200);
+    expect(res._body).toBe('{"success":true}');
     expect(deliver).toHaveBeenCalled();
   });
 
@@ -402,7 +423,8 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
+    expect(res._status).toBe(200);
+    expect(res._body).toBe('{"success":true}');
     expect(deliver).toHaveBeenCalled();
   });
 
@@ -450,7 +472,7 @@ describe("createWebhookHandler", () => {
     const req1 = makeReq("POST", validBody);
     const res1 = makeRes();
     await handler(req1, res1);
-    expect(res1._status).toBe(204);
+    expect(res1._status).toBe(200);
 
     // Second request should be rate limited
     const req2 = makeReq("POST", validBody);
@@ -479,12 +501,13 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
+    expect(res._status).toBe(200);
+    expect(res._body).toBe('{"success":true}');
     // deliver should have been called with the stripped text
     expect(deliver).toHaveBeenCalledWith(expect.objectContaining({ body: "Hello there" }));
   });
 
-  it("responds 204 immediately and delivers async", async () => {
+  it("responds 200 success immediately and delivers async", async () => {
     const deliver = vi.fn().mockResolvedValue("Bot reply");
     const handler = createWebhookHandler({
       account: makeAccount({ accountId: "async-test-" + Date.now() }),
@@ -496,8 +519,8 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
-    expect(res._body).toBe("");
+    expect(res._status).toBe(200);
+    expect(res._body).toBe('{"success":true}');
     expect(deliver).toHaveBeenCalledWith(
       expect.objectContaining({
         body: "Hello bot",
@@ -522,7 +545,7 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
+    expect(res._status).toBe(200);
     expect(resolveLegacyWebhookNameToChatUserId).not.toHaveBeenCalled();
     expect(deliver).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -311,10 +311,14 @@ function respondJson(res: ServerResponse, statusCode: number, body: Record<strin
   res.end(JSON.stringify(body));
 }
 
-/** Send a no-content ACK. */
-function respondNoContent(res: ServerResponse) {
-  res.writeHead(204);
-  res.end();
+/** Send a Synology-compatible success ACK. */
+function respondSuccess(res: ServerResponse, includeBody = true) {
+  const body = JSON.stringify({ success: true });
+  res.writeHead(200, {
+    "Content-Type": "application/json",
+    "Content-Length": String(Buffer.byteLength(body)),
+  });
+  res.end(includeBody ? body : undefined);
 }
 
 export interface WebhookHandlerDeps {
@@ -336,7 +340,7 @@ export interface WebhookHandlerDeps {
  * 3. Checks user allowlist
  * 4. Checks rate limit
  * 5. Sanitizes input
- * 6. Immediately ACKs request (204)
+ * 6. Immediately ACKs request (200 + {"success":true})
  * 7. Delivers to the agent asynchronously and sends final reply via incomingUrl
  */
 type SynologyWebhookAuthorization =
@@ -469,7 +473,7 @@ async function parseAndAuthorizeSynologyWebhook(params: {
 
   const cleanText = sanitizeSynologyWebhookText(parsed.payload);
   if (!cleanText) {
-    respondNoContent(params.res);
+    respondSuccess(params.res);
     return { ok: false };
   }
   const preview = cleanText.length > 100 ? `${cleanText.slice(0, 100)}...` : cleanText;
@@ -571,6 +575,10 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
   const invalidTokenRateLimiter = getInvalidTokenRateLimiter(account);
 
   return async (req: IncomingMessage, res: ServerResponse) => {
+    if (req.method === "HEAD") {
+      respondSuccess(res, false);
+      return;
+    }
     // Only accept POST
     if (req.method !== "POST") {
       respondJson(res, 405, { error: "Method not allowed" });
@@ -609,7 +617,7 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     );
 
     // ACK immediately so Synology Chat won't remain in "Processing..."
-    respondNoContent(res);
+    respondSuccess(res);
     await processAuthorizedSynologyWebhook({
       account,
       deliver,

--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -67,6 +67,7 @@ describe("status-all diagnosis port checks", () => {
       { pid: 5001, commandLine: "openclaw-gateway", address: "127.0.0.1:18789" },
       { pid: 5001, commandLine: "openclaw-gateway", address: "[::1]:18789" },
     ]);
+    params.gatewayReachable = true;
 
     await appendStatusAllDiagnosis(params);
 
@@ -74,6 +75,19 @@ describe("status-all diagnosis port checks", () => {
     expect(output).toContain("✓ Port 18789");
     expect(output).toContain("Detected dual-stack loopback listeners");
     expect(output).not.toContain("Port 18789 is already in use.");
+  });
+
+  it("keeps warning for same-process dual-stack listeners when the gateway is unreachable", async () => {
+    const params = createBaseParams([
+      { pid: 5001, commandLine: "openclaw-gateway", address: "127.0.0.1:18789" },
+      { pid: 5001, commandLine: "openclaw-gateway", address: "[::1]:18789" },
+    ]);
+
+    await appendStatusAllDiagnosis(params);
+
+    const output = params.lines.join("\n");
+    expect(output).toContain("! Port 18789");
+    expect(output).toContain("Port 18789 is already in use.");
   });
 
   it("keeps warning for multi-process listener conflicts", async () => {

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -145,10 +145,9 @@ export async function appendStatusAllDiagnosis(params: {
   }
 
   if (params.portUsage) {
-    const benignDualStackLoopback = isDualStackLoopbackGatewayListeners(
-      params.portUsage.listeners,
-      params.port,
-    );
+    const benignDualStackLoopback =
+      params.gatewayReachable &&
+      isDualStackLoopbackGatewayListeners(params.portUsage.listeners, params.port);
     const portOk = params.portUsage.listeners.length === 0 || benignDualStackLoopback;
     emitCheck(`Port ${params.port}`, portOk ? "ok" : "warn");
     if (!portOk) {


### PR DESCRIPTION
## Summary

- Problem: `tools.web.fetch.maxResponseBytes` was documented and consumed at runtime, but missing from the config schema; `status --all` warned on benign loopback dual-stack gateway listeners; Synology Chat webhook probes/ACKs were not compatible with Synology's expected HTTP behavior.
- Why it matters: valid configs could fail startup, healthy gateways looked broken, and Synology Chat could stop delivering follow-up messages even when OpenClaw handled the request.
- What changed: added `tools.web.fetch.maxResponseBytes` to the runtime schema/types/help/labels/generated base schema; taught status diagnosis to treat same-PID `127.0.0.1` + `::1` gateway listeners as healthy when the gateway is reachable; changed Synology Chat webhook handling to accept `HEAD` and return `200 {"success":true}` for successful POST ACKs.
- What did NOT change (scope boundary): no behavior changes to actual `web_fetch` truncation logic, no generic port-inspection semantics outside `status --all` diagnosis, and no broader Synology Chat delivery/auth policy refactor.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53397
- Closes #53398
- Closes #53439
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the config contract drifted from the already-shipped `web_fetch` runtime option; `status --all` treated any busy port as suspicious even when both listeners belonged to the same loopback-only gateway PID; Synology Chat's webhook integration expects a `HEAD` health probe and a JSON `200 OK` ACK, while OpenClaw only allowed `POST` and replied with `204 No Content`.
- Missing detection / guardrail: there was no schema coverage for `maxResponseBytes`, no focused diagnosis test for benign dual-stack loopback listeners, and no Synology webhook test covering `HEAD` or the expected ACK body.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the issues were reported directly in #53397, #53398, and #53439; this PR fixes the code paths named in those reports.
- Why this regressed now: schema/help drift and endpoint-compatibility gaps only surface when users exercise those exact configs/integrations; the port diagnosis issue appears after loopback dual-stack listeners are visible in status output.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/schema.test.ts`, `src/infra/ports-format.test.ts`, `src/commands/status-all/diagnosis.test.ts`, `extensions/synology-chat/src/webhook-handler.test.ts`
- Scenario the test should lock in: config parsing accepts `tools.web.fetch.maxResponseBytes`; healthy same-PID `127.0.0.1` + `::1` gateway listeners do not produce a port-conflict diagnosis; Synology Chat `HEAD` probes succeed and successful webhook POSTs return `200 {"success":true}`.
- Why this is the smallest reliable guardrail: each bug is isolated to a narrow parsing/diagnosis/webhook boundary, so focused tests catch the regressions without requiring broader end-to-end setup.
- Existing test that already covers this (if any): existing schema and webhook tests covered adjacent paths, but not these exact failure modes.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Users can set `tools.web.fetch.maxResponseBytes` without config validation failure.
- `openclaw status --all` no longer warns when a healthy local gateway owns both loopback dual-stack listeners.
- Synology Chat webhook integrations accept Synology's `HEAD` probe and receive a success JSON ACK instead of `204`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: local Node/pnpm workspace build
- Model/provider: N/A
- Integration/channel (if any): Synology Chat webhook
- Relevant config (redacted): `tools.web.fetch.maxResponseBytes: 2000000`; loopback gateway on port `18789`

### Steps

1. Add `tools.web.fetch.maxResponseBytes` to config and validate schema/startup.
2. Simulate `status --all` diagnosis with same-PID `127.0.0.1:18789` and `[::1]:18789` gateway listeners while the gateway is reachable.
3. Send Synology Chat webhook `HEAD` and valid `POST` requests through the webhook handler tests.

### Expected

- Config parses successfully.
- Benign loopback dual-stack listeners are reported as healthy, not as a port conflict.
- Synology webhook `HEAD` succeeds and valid POST requests receive `200 {"success":true}`.

### Actual

- Verified by the focused test cases below.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran focused tests for schema parsing, port diagnosis, and Synology webhook behavior; ran `pnpm build`; ran `pnpm check` after installing the missing local dependencies.
- Edge cases checked: same PID vs different PID dual-stack listeners; `HEAD` probe body stays empty; Synology webhook POST ACK body matches `{"success":true}`.
- What you did **not** verify: no live Synology NAS or live gateway daemon session was exercised in this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `f9fb403dd5`.
- Files/config to restore: the touched config schema files, status diagnosis files, and `extensions/synology-chat/src/webhook-handler.ts`.
- Known bad symptoms reviewers should watch for: config schema unexpectedly rejecting web fetch settings, `status --all` hiding real port conflicts, or Synology webhook clients misreading the success ACK.

## Risks and Mitigations

- Risk: the dual-stack listener heuristic could hide a real conflict if it misclassifies a listener set as a benign same-gateway case.
  - Mitigation: it only applies when all listeners classify as gateway listeners, share the same PID, are limited to `127.0.0.1` and `::1`, and the gateway is reachable.
- Risk: Synology webhook ACK changes could affect non-Synology callers expecting `204`.
  - Mitigation: this handler is specific to the Synology Chat extension, and the new response matches the integration's documented expectation from the issue report.
