### PR TITLE
feat(feishu): surface connection health state

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -1,13 +1,63 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/feishu";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
 
 const probeFeishuMock = vi.hoisted(() => vi.fn());
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const addReactionFeishuMock = vi.hoisted(() => vi.fn());
+const listReactionsFeishuMock = vi.hoisted(() => vi.fn());
+const removeReactionFeishuMock = vi.hoisted(() => vi.fn());
+const sendCardFeishuMock = vi.hoisted(() => vi.fn());
+const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
+const getMessageFeishuMock = vi.hoisted(() => vi.fn());
+const editMessageFeishuMock = vi.hoisted(() => vi.fn());
+const createPinFeishuMock = vi.hoisted(() => vi.fn());
+const listPinsFeishuMock = vi.hoisted(() => vi.fn());
+const removePinFeishuMock = vi.hoisted(() => vi.fn());
+const getChatInfoMock = vi.hoisted(() => vi.fn());
+const getChatMembersMock = vi.hoisted(() => vi.fn());
+const getFeishuMemberInfoMock = vi.hoisted(() => vi.fn());
+const listFeishuDirectoryPeersLiveMock = vi.hoisted(() => vi.fn());
+const listFeishuDirectoryGroupsLiveMock = vi.hoisted(() => vi.fn());
+const feishuOutboundSendMediaMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,
 }));
 
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
+
+vi.mock("./channel.runtime.js", () => ({
+  feishuChannelRuntime: {
+    addReactionFeishu: addReactionFeishuMock,
+    createPinFeishu: createPinFeishuMock,
+    editMessageFeishu: editMessageFeishuMock,
+    getChatInfo: getChatInfoMock,
+    getChatMembers: getChatMembersMock,
+    getFeishuMemberInfo: getFeishuMemberInfoMock,
+    getMessageFeishu: getMessageFeishuMock,
+    listFeishuDirectoryGroupsLive: listFeishuDirectoryGroupsLiveMock,
+    listFeishuDirectoryPeersLive: listFeishuDirectoryPeersLiveMock,
+    listPinsFeishu: listPinsFeishuMock,
+    listReactionsFeishu: listReactionsFeishuMock,
+    probeFeishu: probeFeishuMock,
+    removePinFeishu: removePinFeishuMock,
+    removeReactionFeishu: removeReactionFeishuMock,
+    sendCardFeishu: sendCardFeishuMock,
+    sendMessageFeishu: sendMessageFeishuMock,
+    feishuOutbound: {
+      sendText: vi.fn(),
+      sendMedia: feishuOutboundSendMediaMock,
+    },
+  },
+}));
+
 import { feishuPlugin } from "./channel.js";
+
+function getDescribedActions(cfg: OpenClawConfig): string[] {
+  return [...(feishuPlugin.actions?.describeMessageTool?.({ cfg })?.actions ?? [])];
+}
 
 describe("feishuPlugin.status.probeAccount", () => {
   it("uses current account credentials for multi-account config", async () => {
@@ -47,80 +97,493 @@ describe("feishuPlugin.status.probeAccount", () => {
   });
 });
 
-describe("feishuPlugin.status.buildAccountSnapshot", () => {
-  it("preserves websocket lifecycle runtime fields for health monitoring", async () => {
-    const cfg = {
+describe("feishuPlugin actions", () => {
+  const cfg = {
+    channels: {
+      feishu: {
+        enabled: true,
+        appId: "cli_main",
+        appSecret: "secret_main",
+        actions: {
+          reactions: true,
+        },
+      },
+    },
+  } as OpenClawConfig;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createFeishuClientMock.mockReturnValue({ tag: "client" });
+  });
+
+  it("advertises the expanded Feishu action surface", () => {
+    expect(getDescribedActions(cfg)).toEqual([
+      "send",
+      "read",
+      "edit",
+      "thread-reply",
+      "pin",
+      "list-pins",
+      "unpin",
+      "member-info",
+      "channel-info",
+      "channel-list",
+      "react",
+      "reactions",
+    ]);
+  });
+
+  it("does not advertise reactions when disabled via actions config", () => {
+    const disabledCfg = {
       channels: {
         feishu: {
           enabled: true,
-          accounts: {
-            main: {
-              appId: "cli_main",
-              appSecret: "secret_main",
-              enabled: true,
-              connectionMode: "websocket",
-            },
+          appId: "cli_main",
+          appSecret: "secret_main",
+          actions: {
+            reactions: false,
           },
         },
       },
     } as OpenClawConfig;
 
-    const account = feishuPlugin.config.resolveAccount(cfg, "main");
-    const snapshot = await feishuPlugin.status?.buildAccountSnapshot?.({
-      account,
+    expect(getDescribedActions(disabledCfg)).toEqual([
+      "send",
+      "read",
+      "edit",
+      "thread-reply",
+      "pin",
+      "list-pins",
+      "unpin",
+      "member-info",
+      "channel-info",
+      "channel-list",
+    ]);
+  });
+
+  it("sends text messages", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_sent", chatId: "oc_group_1" });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", message: "hello" },
       cfg,
-      runtime: {
-        accountId: "main",
-        running: true,
-        connected: false,
-        reconnectAttempts: 4,
-        lastConnectedAt: 123,
-        lastDisconnect: { at: 456, error: "socket dropped" },
-        lastEventAt: 789,
-        mode: "websocket",
-        port: 3000,
-      },
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "hello",
+      accountId: undefined,
+      replyToMessageId: undefined,
+      replyInThread: false,
+    });
+    expect(result?.details).toMatchObject({ ok: true, messageId: "om_sent", chatId: "oc_group_1" });
+  });
+
+  it("sends card messages", async () => {
+    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", card: { schema: "2.0" } },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(sendCardFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      card: { schema: "2.0" },
+      accountId: undefined,
+      replyToMessageId: undefined,
+      replyInThread: false,
+    });
+    expect(result?.details).toMatchObject({ ok: true, messageId: "om_card", chatId: "oc_group_1" });
+  });
+
+  it("sends media through the outbound adapter", async () => {
+    feishuOutboundSendMediaMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_media",
+      details: { messageId: "om_media", chatId: "oc_group_1" },
     });
 
-    expect(snapshot).toMatchObject({
-      accountId: "main",
-      connected: false,
-      reconnectAttempts: 4,
-      lastConnectedAt: 123,
-      lastDisconnect: { at: 456, error: "socket dropped" },
-      lastEventAt: 789,
-      mode: "websocket",
-      port: 3000,
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: "test",
+        media: "/tmp/image.png",
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    expect(feishuOutboundSendMediaMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "test",
+      mediaUrl: "/tmp/image.png",
+      accountId: undefined,
+      mediaLocalRoots: ["/tmp"],
+      replyToId: undefined,
+    });
+    expect(result?.details).toMatchObject({ messageId: "om_media" });
+  });
+
+  it("reads messages", async () => {
+    getMessageFeishuMock.mockResolvedValueOnce({
+      messageId: "om_1",
+      content: "hello",
+      contentType: "text",
+    });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "read",
+      params: { messageId: "om_1" },
+      cfg,
+      accountId: undefined,
+    } as never);
+
+    expect(getMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      messageId: "om_1",
+      accountId: undefined,
+    });
+    expect(result?.details).toMatchObject({
+      ok: true,
+      message: expect.objectContaining({ messageId: "om_1", content: "hello" }),
     });
   });
 
-  it("defaults reconnectAttempts to zero when runtime state is missing", async () => {
-    const cfg = {
-      channels: {
-        feishu: {
-          enabled: true,
-          accounts: {
-            main: {
-              appId: "cli_main",
-              appSecret: "secret_main",
-              enabled: true,
-              connectionMode: "websocket",
-            },
-          },
-        },
-      },
-    } as OpenClawConfig;
+  it("returns an error result when message reads fail", async () => {
+    getMessageFeishuMock.mockResolvedValueOnce(null);
 
-    const account = feishuPlugin.config.resolveAccount(cfg, "main");
-    const snapshot = await feishuPlugin.status?.buildAccountSnapshot?.({
-      account,
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "read",
+      params: { messageId: "om_missing" },
       cfg,
-      runtime: undefined,
+      accountId: undefined,
+    } as never);
+
+    expect((result as { isError?: boolean } | undefined)?.isError).toBe(true);
+    expect(result?.details).toEqual({
+      error: "Feishu read failed or message not found: om_missing",
+    });
+  });
+
+  it("edits messages", async () => {
+    editMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_2", contentType: "post" });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "edit",
+      params: { messageId: "om_2", text: "updated" },
+      cfg,
+      accountId: undefined,
+    } as never);
+
+    expect(editMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      messageId: "om_2",
+      text: "updated",
+      card: undefined,
+      accountId: undefined,
+    });
+    expect(result?.details).toMatchObject({ ok: true, messageId: "om_2", contentType: "post" });
+  });
+
+  it("sends explicit thread replies with reply_in_thread semantics", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_reply", chatId: "oc_group_1" });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "thread-reply",
+      params: { to: "chat:oc_group_1", messageId: "om_parent", text: "reply body" },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "reply body",
+      accountId: undefined,
+      replyToMessageId: "om_parent",
+      replyInThread: true,
+    });
+    expect(result?.details).toMatchObject({
+      ok: true,
+      action: "thread-reply",
+      messageId: "om_reply",
+    });
+  });
+
+  it("creates pins", async () => {
+    createPinFeishuMock.mockResolvedValueOnce({ messageId: "om_pin", chatId: "oc_group_1" });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "pin",
+      params: { messageId: "om_pin" },
+      cfg,
+      accountId: undefined,
+    } as never);
+
+    expect(createPinFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      messageId: "om_pin",
+      accountId: undefined,
+    });
+    expect(result?.details).toMatchObject({
+      ok: true,
+      pin: expect.objectContaining({ messageId: "om_pin" }),
+    });
+  });
+
+  it("lists pins", async () => {
+    listPinsFeishuMock.mockResolvedValueOnce({
+      chatId: "oc_group_1",
+      pins: [{ messageId: "om_pin" }],
+      hasMore: false,
+      pageToken: undefined,
     });
 
-    expect(snapshot).toMatchObject({
-      accountId: "main",
-      reconnectAttempts: 0,
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "list-pins",
+      params: { chatId: "oc_group_1" },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(listPinsFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      chatId: "oc_group_1",
+      startTime: undefined,
+      endTime: undefined,
+      pageSize: undefined,
+      pageToken: undefined,
+      accountId: undefined,
     });
+    expect(result?.details).toMatchObject({
+      ok: true,
+      pins: [expect.objectContaining({ messageId: "om_pin" })],
+    });
+  });
+
+  it("removes pins", async () => {
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "unpin",
+      params: { messageId: "om_pin" },
+      cfg,
+      accountId: undefined,
+    } as never);
+
+    expect(removePinFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      messageId: "om_pin",
+      accountId: undefined,
+    });
+    expect(result?.details).toMatchObject({ ok: true, messageId: "om_pin" });
+  });
+
+  it("fetches channel info", async () => {
+    getChatInfoMock.mockResolvedValueOnce({ chat_id: "oc_group_1", name: "Eng" });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "channel-info",
+      params: { chatId: "oc_group_1" },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(createFeishuClientMock).toHaveBeenCalled();
+    expect(getChatInfoMock).toHaveBeenCalledWith({ tag: "client" }, "oc_group_1");
+    expect(result?.details).toMatchObject({
+      ok: true,
+      channel: expect.objectContaining({ chat_id: "oc_group_1", name: "Eng" }),
+    });
+  });
+
+  it("fetches member lists from a chat", async () => {
+    getChatMembersMock.mockResolvedValueOnce({
+      chat_id: "oc_group_1",
+      members: [{ member_id: "ou_1", name: "Alice" }],
+      has_more: false,
+    });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "member-info",
+      params: { chatId: "oc_group_1" },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(getChatMembersMock).toHaveBeenCalledWith(
+      { tag: "client" },
+      "oc_group_1",
+      undefined,
+      undefined,
+      "open_id",
+    );
+    expect(result?.details).toMatchObject({
+      ok: true,
+      members: [expect.objectContaining({ member_id: "ou_1", name: "Alice" })],
+    });
+  });
+
+  it("fetches individual member info", async () => {
+    getFeishuMemberInfoMock.mockResolvedValueOnce({ member_id: "ou_1", name: "Alice" });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "member-info",
+      params: { memberId: "ou_1" },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(getFeishuMemberInfoMock).toHaveBeenCalledWith({ tag: "client" }, "ou_1", "open_id");
+    expect(result?.details).toMatchObject({
+      ok: true,
+      member: expect.objectContaining({ member_id: "ou_1", name: "Alice" }),
+    });
+  });
+
+  it("infers user_id lookups from the userId alias", async () => {
+    getFeishuMemberInfoMock.mockResolvedValueOnce({ member_id: "u_1", name: "Alice" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "member-info",
+      params: { userId: "u_1" },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(getFeishuMemberInfoMock).toHaveBeenCalledWith({ tag: "client" }, "u_1", "user_id");
+  });
+
+  it("honors explicit open_id over alias heuristics", async () => {
+    getFeishuMemberInfoMock.mockResolvedValueOnce({ member_id: "u_1", name: "Alice" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "member-info",
+      params: { userId: "u_1", memberIdType: "open_id" },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(getFeishuMemberInfoMock).toHaveBeenCalledWith({ tag: "client" }, "u_1", "open_id");
+  });
+
+  it("lists directory-backed peers and groups", async () => {
+    listFeishuDirectoryGroupsLiveMock.mockResolvedValueOnce([{ kind: "group", id: "oc_group_1" }]);
+    listFeishuDirectoryPeersLiveMock.mockResolvedValueOnce([{ kind: "user", id: "ou_1" }]);
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "channel-list",
+      params: { query: "eng", limit: 5 },
+      cfg,
+      accountId: undefined,
+    } as never);
+
+    expect(listFeishuDirectoryGroupsLiveMock).toHaveBeenCalledWith({
+      cfg,
+      query: "eng",
+      limit: 5,
+      fallbackToStatic: false,
+      accountId: undefined,
+    });
+    expect(listFeishuDirectoryPeersLiveMock).toHaveBeenCalledWith({
+      cfg,
+      query: "eng",
+      limit: 5,
+      fallbackToStatic: false,
+      accountId: undefined,
+    });
+    expect(result?.details).toMatchObject({
+      ok: true,
+      groups: [expect.objectContaining({ id: "oc_group_1" })],
+      peers: [expect.objectContaining({ id: "ou_1" })],
+    });
+  });
+
+  it("fails channel-list when live discovery fails", async () => {
+    listFeishuDirectoryGroupsLiveMock.mockRejectedValueOnce(new Error("token expired"));
+
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "channel-list",
+        params: { query: "eng", limit: 5, scope: "groups" },
+        cfg,
+        accountId: undefined,
+      } as never),
+    ).rejects.toThrow("token expired");
+  });
+
+  it("requires clearAll=true before removing all bot reactions", async () => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "react",
+        params: { messageId: "om_msg1" },
+        cfg,
+        accountId: undefined,
+      } as never),
+    ).rejects.toThrow(
+      "Emoji is required to add a Feishu reaction. Set clearAll=true to remove all bot reactions.",
+    );
+  });
+
+  it("allows explicit clearAll=true when removing all bot reactions", async () => {
+    listReactionsFeishuMock.mockResolvedValueOnce([
+      { reactionId: "r1", operatorType: "app" },
+      { reactionId: "r2", operatorType: "app" },
+    ]);
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "react",
+      params: { messageId: "om_msg1", clearAll: true },
+      cfg,
+      accountId: undefined,
+    } as never);
+
+    expect(listReactionsFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      messageId: "om_msg1",
+      accountId: undefined,
+    });
+    expect(removeReactionFeishuMock).toHaveBeenCalledTimes(2);
+    expect(result?.details).toMatchObject({ ok: true, removed: 2 });
+  });
+
+  it("fails for missing params on supported actions", async () => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "thread-reply",
+        params: { to: "chat:oc_group_1", message: "reply body" },
+        cfg,
+        accountId: undefined,
+      } as never),
+    ).rejects.toThrow("Feishu thread-reply requires messageId.");
+  });
+
+  it("fails for unsupported action names", async () => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "search",
+        params: {},
+        cfg,
+        accountId: undefined,
+      } as never),
+    ).rejects.toThrow('Unsupported Feishu action: "search"');
   });
 });

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -1,63 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../runtime-api.js";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/feishu";
+import { describe, expect, it, vi } from "vitest";
 
 const probeFeishuMock = vi.hoisted(() => vi.fn());
-const createFeishuClientMock = vi.hoisted(() => vi.fn());
-const addReactionFeishuMock = vi.hoisted(() => vi.fn());
-const listReactionsFeishuMock = vi.hoisted(() => vi.fn());
-const removeReactionFeishuMock = vi.hoisted(() => vi.fn());
-const sendCardFeishuMock = vi.hoisted(() => vi.fn());
-const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
-const getMessageFeishuMock = vi.hoisted(() => vi.fn());
-const editMessageFeishuMock = vi.hoisted(() => vi.fn());
-const createPinFeishuMock = vi.hoisted(() => vi.fn());
-const listPinsFeishuMock = vi.hoisted(() => vi.fn());
-const removePinFeishuMock = vi.hoisted(() => vi.fn());
-const getChatInfoMock = vi.hoisted(() => vi.fn());
-const getChatMembersMock = vi.hoisted(() => vi.fn());
-const getFeishuMemberInfoMock = vi.hoisted(() => vi.fn());
-const listFeishuDirectoryPeersLiveMock = vi.hoisted(() => vi.fn());
-const listFeishuDirectoryGroupsLiveMock = vi.hoisted(() => vi.fn());
-const feishuOutboundSendMediaMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,
 }));
 
-vi.mock("./client.js", () => ({
-  createFeishuClient: createFeishuClientMock,
-}));
-
-vi.mock("./channel.runtime.js", () => ({
-  feishuChannelRuntime: {
-    addReactionFeishu: addReactionFeishuMock,
-    createPinFeishu: createPinFeishuMock,
-    editMessageFeishu: editMessageFeishuMock,
-    getChatInfo: getChatInfoMock,
-    getChatMembers: getChatMembersMock,
-    getFeishuMemberInfo: getFeishuMemberInfoMock,
-    getMessageFeishu: getMessageFeishuMock,
-    listFeishuDirectoryGroupsLive: listFeishuDirectoryGroupsLiveMock,
-    listFeishuDirectoryPeersLive: listFeishuDirectoryPeersLiveMock,
-    listPinsFeishu: listPinsFeishuMock,
-    listReactionsFeishu: listReactionsFeishuMock,
-    probeFeishu: probeFeishuMock,
-    removePinFeishu: removePinFeishuMock,
-    removeReactionFeishu: removeReactionFeishuMock,
-    sendCardFeishu: sendCardFeishuMock,
-    sendMessageFeishu: sendMessageFeishuMock,
-    feishuOutbound: {
-      sendText: vi.fn(),
-      sendMedia: feishuOutboundSendMediaMock,
-    },
-  },
-}));
-
 import { feishuPlugin } from "./channel.js";
-
-function getDescribedActions(cfg: OpenClawConfig): string[] {
-  return [...(feishuPlugin.actions?.describeMessageTool?.({ cfg })?.actions ?? [])];
-}
 
 describe("feishuPlugin.status.probeAccount", () => {
   it("uses current account credentials for multi-account config", async () => {
@@ -97,493 +47,80 @@ describe("feishuPlugin.status.probeAccount", () => {
   });
 });
 
-describe("feishuPlugin actions", () => {
-  const cfg = {
-    channels: {
-      feishu: {
-        enabled: true,
-        appId: "cli_main",
-        appSecret: "secret_main",
-        actions: {
-          reactions: true,
-        },
-      },
-    },
-  } as OpenClawConfig;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    createFeishuClientMock.mockReturnValue({ tag: "client" });
-  });
-
-  it("advertises the expanded Feishu action surface", () => {
-    expect(getDescribedActions(cfg)).toEqual([
-      "send",
-      "read",
-      "edit",
-      "thread-reply",
-      "pin",
-      "list-pins",
-      "unpin",
-      "member-info",
-      "channel-info",
-      "channel-list",
-      "react",
-      "reactions",
-    ]);
-  });
-
-  it("does not advertise reactions when disabled via actions config", () => {
-    const disabledCfg = {
+describe("feishuPlugin.status.buildAccountSnapshot", () => {
+  it("preserves websocket lifecycle runtime fields for health monitoring", async () => {
+    const cfg = {
       channels: {
         feishu: {
           enabled: true,
-          appId: "cli_main",
-          appSecret: "secret_main",
-          actions: {
-            reactions: false,
+          accounts: {
+            main: {
+              appId: "cli_main",
+              appSecret: "secret_main",
+              enabled: true,
+              connectionMode: "websocket",
+            },
           },
         },
       },
     } as OpenClawConfig;
 
-    expect(getDescribedActions(disabledCfg)).toEqual([
-      "send",
-      "read",
-      "edit",
-      "thread-reply",
-      "pin",
-      "list-pins",
-      "unpin",
-      "member-info",
-      "channel-info",
-      "channel-list",
-    ]);
-  });
-
-  it("sends text messages", async () => {
-    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_sent", chatId: "oc_group_1" });
-
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "send",
-      params: { to: "chat:oc_group_1", message: "hello" },
+    const account = feishuPlugin.config.resolveAccount(cfg, "main");
+    const snapshot = await feishuPlugin.status?.buildAccountSnapshot?.({
+      account,
       cfg,
-      accountId: undefined,
-      toolContext: {},
-    } as never);
-
-    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
-      cfg,
-      to: "chat:oc_group_1",
-      text: "hello",
-      accountId: undefined,
-      replyToMessageId: undefined,
-      replyInThread: false,
-    });
-    expect(result?.details).toMatchObject({ ok: true, messageId: "om_sent", chatId: "oc_group_1" });
-  });
-
-  it("sends card messages", async () => {
-    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
-
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "send",
-      params: { to: "chat:oc_group_1", card: { schema: "2.0" } },
-      cfg,
-      accountId: undefined,
-      toolContext: {},
-    } as never);
-
-    expect(sendCardFeishuMock).toHaveBeenCalledWith({
-      cfg,
-      to: "chat:oc_group_1",
-      card: { schema: "2.0" },
-      accountId: undefined,
-      replyToMessageId: undefined,
-      replyInThread: false,
-    });
-    expect(result?.details).toMatchObject({ ok: true, messageId: "om_card", chatId: "oc_group_1" });
-  });
-
-  it("sends media through the outbound adapter", async () => {
-    feishuOutboundSendMediaMock.mockResolvedValueOnce({
-      channel: "feishu",
-      messageId: "om_media",
-      details: { messageId: "om_media", chatId: "oc_group_1" },
-    });
-
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "send",
-      params: {
-        to: "chat:oc_group_1",
-        message: "test",
-        media: "/tmp/image.png",
+      runtime: {
+        accountId: "main",
+        running: true,
+        connected: false,
+        reconnectAttempts: 4,
+        lastConnectedAt: 123,
+        lastDisconnect: { at: 456, error: "socket dropped" },
+        lastEventAt: 789,
+        mode: "websocket",
+        port: 3000,
       },
-      cfg,
-      accountId: undefined,
-      toolContext: {},
-      mediaLocalRoots: ["/tmp"],
-    } as never);
-
-    expect(feishuOutboundSendMediaMock).toHaveBeenCalledWith({
-      cfg,
-      to: "chat:oc_group_1",
-      text: "test",
-      mediaUrl: "/tmp/image.png",
-      accountId: undefined,
-      mediaLocalRoots: ["/tmp"],
-      replyToId: undefined,
-    });
-    expect(result?.details).toMatchObject({ messageId: "om_media" });
-  });
-
-  it("reads messages", async () => {
-    getMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "om_1",
-      content: "hello",
-      contentType: "text",
     });
 
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "read",
-      params: { messageId: "om_1" },
-      cfg,
-      accountId: undefined,
-    } as never);
-
-    expect(getMessageFeishuMock).toHaveBeenCalledWith({
-      cfg,
-      messageId: "om_1",
-      accountId: undefined,
-    });
-    expect(result?.details).toMatchObject({
-      ok: true,
-      message: expect.objectContaining({ messageId: "om_1", content: "hello" }),
+    expect(snapshot).toMatchObject({
+      accountId: "main",
+      connected: false,
+      reconnectAttempts: 4,
+      lastConnectedAt: 123,
+      lastDisconnect: { at: 456, error: "socket dropped" },
+      lastEventAt: 789,
+      mode: "websocket",
+      port: 3000,
     });
   });
 
-  it("returns an error result when message reads fail", async () => {
-    getMessageFeishuMock.mockResolvedValueOnce(null);
+  it("defaults reconnectAttempts to zero when runtime state is missing", async () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          enabled: true,
+          accounts: {
+            main: {
+              appId: "cli_main",
+              appSecret: "secret_main",
+              enabled: true,
+              connectionMode: "websocket",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
 
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "read",
-      params: { messageId: "om_missing" },
+    const account = feishuPlugin.config.resolveAccount(cfg, "main");
+    const snapshot = await feishuPlugin.status?.buildAccountSnapshot?.({
+      account,
       cfg,
-      accountId: undefined,
-    } as never);
-
-    expect((result as { isError?: boolean } | undefined)?.isError).toBe(true);
-    expect(result?.details).toEqual({
-      error: "Feishu read failed or message not found: om_missing",
-    });
-  });
-
-  it("edits messages", async () => {
-    editMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_2", contentType: "post" });
-
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "edit",
-      params: { messageId: "om_2", text: "updated" },
-      cfg,
-      accountId: undefined,
-    } as never);
-
-    expect(editMessageFeishuMock).toHaveBeenCalledWith({
-      cfg,
-      messageId: "om_2",
-      text: "updated",
-      card: undefined,
-      accountId: undefined,
-    });
-    expect(result?.details).toMatchObject({ ok: true, messageId: "om_2", contentType: "post" });
-  });
-
-  it("sends explicit thread replies with reply_in_thread semantics", async () => {
-    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_reply", chatId: "oc_group_1" });
-
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "thread-reply",
-      params: { to: "chat:oc_group_1", messageId: "om_parent", text: "reply body" },
-      cfg,
-      accountId: undefined,
-      toolContext: {},
-    } as never);
-
-    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
-      cfg,
-      to: "chat:oc_group_1",
-      text: "reply body",
-      accountId: undefined,
-      replyToMessageId: "om_parent",
-      replyInThread: true,
-    });
-    expect(result?.details).toMatchObject({
-      ok: true,
-      action: "thread-reply",
-      messageId: "om_reply",
-    });
-  });
-
-  it("creates pins", async () => {
-    createPinFeishuMock.mockResolvedValueOnce({ messageId: "om_pin", chatId: "oc_group_1" });
-
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "pin",
-      params: { messageId: "om_pin" },
-      cfg,
-      accountId: undefined,
-    } as never);
-
-    expect(createPinFeishuMock).toHaveBeenCalledWith({
-      cfg,
-      messageId: "om_pin",
-      accountId: undefined,
-    });
-    expect(result?.details).toMatchObject({
-      ok: true,
-      pin: expect.objectContaining({ messageId: "om_pin" }),
-    });
-  });
-
-  it("lists pins", async () => {
-    listPinsFeishuMock.mockResolvedValueOnce({
-      chatId: "oc_group_1",
-      pins: [{ messageId: "om_pin" }],
-      hasMore: false,
-      pageToken: undefined,
+      runtime: undefined,
     });
 
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "list-pins",
-      params: { chatId: "oc_group_1" },
-      cfg,
-      accountId: undefined,
-      toolContext: {},
-    } as never);
-
-    expect(listPinsFeishuMock).toHaveBeenCalledWith({
-      cfg,
-      chatId: "oc_group_1",
-      startTime: undefined,
-      endTime: undefined,
-      pageSize: undefined,
-      pageToken: undefined,
-      accountId: undefined,
+    expect(snapshot).toMatchObject({
+      accountId: "main",
+      reconnectAttempts: 0,
     });
-    expect(result?.details).toMatchObject({
-      ok: true,
-      pins: [expect.objectContaining({ messageId: "om_pin" })],
-    });
-  });
-
-  it("removes pins", async () => {
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "unpin",
-      params: { messageId: "om_pin" },
-      cfg,
-      accountId: undefined,
-    } as never);
-
-    expect(removePinFeishuMock).toHaveBeenCalledWith({
-      cfg,
-      messageId: "om_pin",
-      accountId: undefined,
-    });
-    expect(result?.details).toMatchObject({ ok: true, messageId: "om_pin" });
-  });
-
-  it("fetches channel info", async () => {
-    getChatInfoMock.mockResolvedValueOnce({ chat_id: "oc_group_1", name: "Eng" });
-
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "channel-info",
-      params: { chatId: "oc_group_1" },
-      cfg,
-      accountId: undefined,
-      toolContext: {},
-    } as never);
-
-    expect(createFeishuClientMock).toHaveBeenCalled();
-    expect(getChatInfoMock).toHaveBeenCalledWith({ tag: "client" }, "oc_group_1");
-    expect(result?.details).toMatchObject({
-      ok: true,
-      channel: expect.objectContaining({ chat_id: "oc_group_1", name: "Eng" }),
-    });
-  });
-
-  it("fetches member lists from a chat", async () => {
-    getChatMembersMock.mockResolvedValueOnce({
-      chat_id: "oc_group_1",
-      members: [{ member_id: "ou_1", name: "Alice" }],
-      has_more: false,
-    });
-
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "member-info",
-      params: { chatId: "oc_group_1" },
-      cfg,
-      accountId: undefined,
-      toolContext: {},
-    } as never);
-
-    expect(getChatMembersMock).toHaveBeenCalledWith(
-      { tag: "client" },
-      "oc_group_1",
-      undefined,
-      undefined,
-      "open_id",
-    );
-    expect(result?.details).toMatchObject({
-      ok: true,
-      members: [expect.objectContaining({ member_id: "ou_1", name: "Alice" })],
-    });
-  });
-
-  it("fetches individual member info", async () => {
-    getFeishuMemberInfoMock.mockResolvedValueOnce({ member_id: "ou_1", name: "Alice" });
-
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "member-info",
-      params: { memberId: "ou_1" },
-      cfg,
-      accountId: undefined,
-      toolContext: {},
-    } as never);
-
-    expect(getFeishuMemberInfoMock).toHaveBeenCalledWith({ tag: "client" }, "ou_1", "open_id");
-    expect(result?.details).toMatchObject({
-      ok: true,
-      member: expect.objectContaining({ member_id: "ou_1", name: "Alice" }),
-    });
-  });
-
-  it("infers user_id lookups from the userId alias", async () => {
-    getFeishuMemberInfoMock.mockResolvedValueOnce({ member_id: "u_1", name: "Alice" });
-
-    await feishuPlugin.actions?.handleAction?.({
-      action: "member-info",
-      params: { userId: "u_1" },
-      cfg,
-      accountId: undefined,
-      toolContext: {},
-    } as never);
-
-    expect(getFeishuMemberInfoMock).toHaveBeenCalledWith({ tag: "client" }, "u_1", "user_id");
-  });
-
-  it("honors explicit open_id over alias heuristics", async () => {
-    getFeishuMemberInfoMock.mockResolvedValueOnce({ member_id: "u_1", name: "Alice" });
-
-    await feishuPlugin.actions?.handleAction?.({
-      action: "member-info",
-      params: { userId: "u_1", memberIdType: "open_id" },
-      cfg,
-      accountId: undefined,
-      toolContext: {},
-    } as never);
-
-    expect(getFeishuMemberInfoMock).toHaveBeenCalledWith({ tag: "client" }, "u_1", "open_id");
-  });
-
-  it("lists directory-backed peers and groups", async () => {
-    listFeishuDirectoryGroupsLiveMock.mockResolvedValueOnce([{ kind: "group", id: "oc_group_1" }]);
-    listFeishuDirectoryPeersLiveMock.mockResolvedValueOnce([{ kind: "user", id: "ou_1" }]);
-
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "channel-list",
-      params: { query: "eng", limit: 5 },
-      cfg,
-      accountId: undefined,
-    } as never);
-
-    expect(listFeishuDirectoryGroupsLiveMock).toHaveBeenCalledWith({
-      cfg,
-      query: "eng",
-      limit: 5,
-      fallbackToStatic: false,
-      accountId: undefined,
-    });
-    expect(listFeishuDirectoryPeersLiveMock).toHaveBeenCalledWith({
-      cfg,
-      query: "eng",
-      limit: 5,
-      fallbackToStatic: false,
-      accountId: undefined,
-    });
-    expect(result?.details).toMatchObject({
-      ok: true,
-      groups: [expect.objectContaining({ id: "oc_group_1" })],
-      peers: [expect.objectContaining({ id: "ou_1" })],
-    });
-  });
-
-  it("fails channel-list when live discovery fails", async () => {
-    listFeishuDirectoryGroupsLiveMock.mockRejectedValueOnce(new Error("token expired"));
-
-    await expect(
-      feishuPlugin.actions?.handleAction?.({
-        action: "channel-list",
-        params: { query: "eng", limit: 5, scope: "groups" },
-        cfg,
-        accountId: undefined,
-      } as never),
-    ).rejects.toThrow("token expired");
-  });
-
-  it("requires clearAll=true before removing all bot reactions", async () => {
-    await expect(
-      feishuPlugin.actions?.handleAction?.({
-        action: "react",
-        params: { messageId: "om_msg1" },
-        cfg,
-        accountId: undefined,
-      } as never),
-    ).rejects.toThrow(
-      "Emoji is required to add a Feishu reaction. Set clearAll=true to remove all bot reactions.",
-    );
-  });
-
-  it("allows explicit clearAll=true when removing all bot reactions", async () => {
-    listReactionsFeishuMock.mockResolvedValueOnce([
-      { reactionId: "r1", operatorType: "app" },
-      { reactionId: "r2", operatorType: "app" },
-    ]);
-
-    const result = await feishuPlugin.actions?.handleAction?.({
-      action: "react",
-      params: { messageId: "om_msg1", clearAll: true },
-      cfg,
-      accountId: undefined,
-    } as never);
-
-    expect(listReactionsFeishuMock).toHaveBeenCalledWith({
-      cfg,
-      messageId: "om_msg1",
-      accountId: undefined,
-    });
-    expect(removeReactionFeishuMock).toHaveBeenCalledTimes(2);
-    expect(result?.details).toMatchObject({ ok: true, removed: 2 });
-  });
-
-  it("fails for missing params on supported actions", async () => {
-    await expect(
-      feishuPlugin.actions?.handleAction?.({
-        action: "thread-reply",
-        params: { to: "chat:oc_group_1", message: "reply body" },
-        cfg,
-        accountId: undefined,
-      } as never),
-    ).rejects.toThrow("Feishu thread-reply requires messageId.");
-  });
-
-  it("fails for unsupported action names", async () => {
-    await expect(
-      feishuPlugin.actions?.handleAction?.({
-        action: "search",
-        params: {},
-        cfg,
-        accountId: undefined,
-      } as never),
-    ).rejects.toThrow('Unsupported Feishu action: "search"');
   });
 });

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -292,6 +292,21 @@ describe("createFeishuClient HTTP timeout", () => {
 });
 
 describe("createFeishuWSClient proxy handling", () => {
+  it("forwards a custom logger into the ws client options", () => {
+    const logger = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+    };
+
+    createFeishuWSClient(baseAccount, { logger });
+
+    const options = firstWsClientOptions() as { logger?: unknown };
+    expect(options.logger).toBe(logger);
+  });
+
   it("does not set a ws proxy agent when proxy env is absent", () => {
     createFeishuWSClient(baseAccount);
 

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -98,6 +98,14 @@ export type FeishuClientCredentials = {
   config?: Pick<FeishuConfig, "httpTimeoutMs">;
 };
 
+type FeishuWSLogger = {
+  error: (...msg: unknown[]) => void | Promise<void>;
+  warn: (...msg: unknown[]) => void | Promise<void>;
+  info: (...msg: unknown[]) => void | Promise<void>;
+  debug: (...msg: unknown[]) => void | Promise<void>;
+  trace: (...msg: unknown[]) => void | Promise<void>;
+};
+
 function resolveConfiguredHttpTimeoutMs(creds: FeishuClientCredentials): number {
   const clampTimeout = (value: number): number => {
     const rounded = Math.floor(value);
@@ -175,7 +183,10 @@ export function createFeishuClient(creds: FeishuClientCredentials): Lark.Client 
  * Create a Feishu WebSocket client for an account.
  * Note: WSClient is not cached since each call creates a new connection.
  */
-export function createFeishuWSClient(account: ResolvedFeishuAccount): Lark.WSClient {
+export function createFeishuWSClient(
+  account: ResolvedFeishuAccount,
+  opts?: { logger?: FeishuWSLogger },
+): Lark.WSClient {
   const { accountId, appId, appSecret, domain } = account;
 
   if (!appId || !appSecret) {
@@ -188,6 +199,7 @@ export function createFeishuWSClient(account: ResolvedFeishuAccount): Lark.WSCli
     appSecret,
     domain: resolveDomain(domain),
     loggerLevel: feishuClientSdk.LoggerLevel.info,
+    ...(opts?.logger ? { logger: opts.logger } : {}),
     ...(agent ? { agent } : {}),
   });
 }

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -156,6 +156,17 @@ type RegisterEventHandlersContext = {
   runtime?: RuntimeEnv;
   chatHistories: Map<string, HistoryEntry[]>;
   fireAndForget?: boolean;
+  statusSink?: (patch: {
+    connected?: boolean;
+    reconnectAttempts?: number;
+    lastConnectedAt?: number | null;
+    lastDisconnect?: {
+      at: number;
+      error?: string;
+    } | null;
+    lastError?: string | null;
+    lastEventAt?: number | null;
+  }) => void;
 };
 
 /**

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -629,6 +629,17 @@ export type MonitorSingleAccountParams = {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   botOpenIdSource?: BotOpenIdSource;
+  statusSink?: (patch: {
+    connected?: boolean;
+    reconnectAttempts?: number;
+    lastConnectedAt?: number | null;
+    lastDisconnect?: {
+      at: number;
+      error?: string;
+    } | null;
+    lastError?: string | null;
+    lastEventAt?: number | null;
+  }) => void;
 };
 
 export async function monitorSingleAccount(params: MonitorSingleAccountParams): Promise<void> {
@@ -676,12 +687,27 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
       runtime,
       chatHistories,
       fireAndForget: true,
+      statusSink: params.statusSink,
     });
 
     if (connectionMode === "webhook") {
-      return await monitorWebhook({ account, accountId, runtime, abortSignal, eventDispatcher });
+      return await monitorWebhook({
+        account,
+        accountId,
+        runtime,
+        abortSignal,
+        eventDispatcher,
+        statusSink: params.statusSink,
+      });
     }
-    return await monitorWebSocket({ account, accountId, runtime, abortSignal, eventDispatcher });
+    return await monitorWebSocket({
+      account,
+      accountId,
+      runtime,
+      abortSignal,
+      eventDispatcher,
+      statusSink: params.statusSink,
+    });
   } finally {
     threadBindingManager?.stop();
   }

--- a/extensions/feishu/src/monitor.transport.test.ts
+++ b/extensions/feishu/src/monitor.transport.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import { createFeishuWsLifecycleLogger } from "./monitor.transport.js";
+
+describe("createFeishuWsLifecycleLogger", () => {
+  it("tracks reconnect and ready lifecycle into channel status", () => {
+    const statusSink = vi.fn();
+    const logger = createFeishuWsLifecycleLogger({
+      accountId: "default",
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+      statusSink,
+    });
+
+    logger.info("[ws]", "reconnect");
+    logger.info("[ws]", "ws client ready");
+
+    expect(statusSink).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        connected: false,
+        reconnectAttempts: 1,
+        lastDisconnect: expect.objectContaining({
+          at: expect.any(Number),
+        }),
+      }),
+    );
+    expect(statusSink).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        connected: true,
+        reconnectAttempts: 0,
+        lastConnectedAt: expect.any(Number),
+        lastDisconnect: null,
+        lastError: null,
+      }),
+    );
+  });
+
+  it("records websocket errors as disconnect state", () => {
+    const statusSink = vi.fn();
+    const runtimeError = vi.fn();
+    const logger = createFeishuWsLifecycleLogger({
+      accountId: "default",
+      runtime: {
+        log: vi.fn(),
+        error: runtimeError,
+        exit: vi.fn(),
+      },
+      statusSink,
+    });
+
+    logger.error("[ws]", "ws connect failed");
+
+    expect(runtimeError).toHaveBeenCalled();
+    expect(statusSink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connected: false,
+        reconnectAttempts: 1,
+        lastDisconnect: expect.objectContaining({
+          at: expect.any(Number),
+          error: expect.stringContaining("ws connect failed"),
+        }),
+        lastError: expect.stringContaining("ws connect failed"),
+      }),
+    );
+  });
+
+  it("translates Feishu connection-limit errors into an actionable message", () => {
+    const statusSink = vi.fn();
+    const runtimeError = vi.fn();
+    const logger = createFeishuWsLifecycleLogger({
+      accountId: "default",
+      runtime: {
+        log: vi.fn(),
+        error: runtimeError,
+        exit: vi.fn(),
+      },
+      statusSink,
+    });
+
+    logger.error("[ws]", "code: 1000040350, system busy");
+
+    expect(runtimeError).toHaveBeenCalled();
+    expect(statusSink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connected: false,
+        reconnectAttempts: 1,
+        lastError: expect.stringContaining("connection limit reached"),
+      }),
+    );
+  });
+
+  it("marks repeated reconnect-failed info logs as disconnected", () => {
+    const statusSink = vi.fn();
+    const logger = createFeishuWsLifecycleLogger({
+      accountId: "default",
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+      statusSink,
+    });
+
+    logger.info("ws", 'unable to connect to the server after trying 1 times")');
+
+    expect(statusSink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connected: false,
+        reconnectAttempts: 1,
+      }),
+    );
+  });
+
+  it("treats reconnect success info logs as connected", () => {
+    const statusSink = vi.fn();
+    const logger = createFeishuWsLifecycleLogger({
+      accountId: "default",
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+      statusSink,
+    });
+
+    logger.info("[ws]", "reconnect");
+    logger.info("[ws]", "reconnect success");
+
+    expect(statusSink).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        connected: false,
+        reconnectAttempts: 1,
+      }),
+    );
+    expect(statusSink).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        connected: true,
+        reconnectAttempts: 0,
+        lastConnectedAt: expect.any(Number),
+        lastDisconnect: null,
+        lastError: null,
+      }),
+    );
+  });
+});

--- a/extensions/feishu/src/monitor.transport.test.ts
+++ b/extensions/feishu/src/monitor.transport.test.ts
@@ -111,6 +111,7 @@ describe("createFeishuWsLifecycleLogger", () => {
       expect.objectContaining({
         connected: false,
         reconnectAttempts: 1,
+        lastError: "Feishu WebSocket reconnect attempts failed to reach the server.",
       }),
     );
   });

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -124,9 +124,6 @@ function normalizeFeishuWsError(text: string): string {
   if (text.includes("PingInterval")) {
     return "Feishu WebSocket reconnect failed while parsing PingInterval. This usually follows an upstream connection-limit or system-busy response.";
   }
-  if (text.includes("unable to connect to the server after trying")) {
-    return "Feishu WebSocket reconnect attempts failed to reach the server.";
-  }
   return text;
 }
 
@@ -177,7 +174,11 @@ export function createFeishuWsLifecycleLogger(params: {
         text.includes("reconnect") ||
         text.includes("unable to connect to the server after trying")
       ) {
-        updateConnected(false);
+        updateConnected(false, {
+          error: text.includes("unable to connect to the server after trying")
+            ? "Feishu WebSocket reconnect attempts failed to reach the server."
+            : undefined,
+        });
         return;
       }
     },

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -393,6 +393,13 @@ export async function monitorWebhook({
 
     const handleAbort = () => {
       log(`feishu[${accountId}]: abort signal received, stopping Webhook server`);
+      statusSink?.({
+        connected: false,
+        lastDisconnect: {
+          at: Date.now(),
+          error: "abort signal received",
+        },
+      });
       cleanup();
       resolve();
     };
@@ -418,6 +425,14 @@ export async function monitorWebhook({
 
     server.on("error", (err) => {
       error(`feishu[${accountId}]: Webhook server error: ${err}`);
+      statusSink?.({
+        connected: false,
+        lastDisconnect: {
+          at: Date.now(),
+          error: String(err),
+        },
+        lastError: String(err),
+      });
       abortSignal?.removeEventListener("abort", handleAbort);
       reject(err);
     });

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -20,12 +20,24 @@ import {
 } from "./monitor.state.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
+type FeishuStatusSink = (patch: {
+  connected?: boolean;
+  reconnectAttempts?: number;
+  lastConnectedAt?: number | null;
+  lastDisconnect?: {
+    at: number;
+    error?: string;
+  } | null;
+  lastError?: string | null;
+}) => void;
+
 export type MonitorTransportParams = {
   account: ResolvedFeishuAccount;
   accountId: string;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   eventDispatcher: Lark.EventDispatcher;
+  statusSink?: FeishuStatusSink;
 };
 
 function isFeishuWebhookPayload(value: unknown): value is Record<string, unknown> {
@@ -81,17 +93,141 @@ function respondText(res: http.ServerResponse, statusCode: number, body: string)
   res.end(body);
 }
 
+type FeishuWSLifecycleLogger = {
+  error: (...msg: unknown[]) => void | Promise<void>;
+  warn: (...msg: unknown[]) => void | Promise<void>;
+  info: (...msg: unknown[]) => void | Promise<void>;
+  debug: (...msg: unknown[]) => void | Promise<void>;
+  trace: (...msg: unknown[]) => void | Promise<void>;
+};
+
+function formatLoggerArgs(args: unknown[]): string {
+  return args
+    .map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+      try {
+        return JSON.stringify(part);
+      } catch {
+        return String(part);
+      }
+    })
+    .join(" ")
+    .trim();
+}
+
+function normalizeFeishuWsError(text: string): string {
+  if (text.includes("1000040350") || text.includes("exceed_conn_limit")) {
+    return "Feishu WebSocket connection limit reached (1000040350 exceed_conn_limit). Another OpenClaw gateway instance is likely already connected.";
+  }
+  if (text.includes("PingInterval")) {
+    return "Feishu WebSocket reconnect failed while parsing PingInterval. This usually follows an upstream connection-limit or system-busy response.";
+  }
+  if (text.includes("unable to connect to the server after trying")) {
+    return "Feishu WebSocket reconnect attempts failed to reach the server.";
+  }
+  return text;
+}
+
+export function createFeishuWsLifecycleLogger(params: {
+  accountId: string;
+  runtime?: RuntimeEnv;
+  statusSink?: FeishuStatusSink;
+}): FeishuWSLifecycleLogger {
+  const { accountId, runtime, statusSink } = params;
+  const log = runtime?.log ?? console.log;
+  const error = runtime?.error ?? console.error;
+  let reconnectAttempts = 0;
+
+  const updateConnected = (connected: boolean, next?: { error?: string | null }) => {
+    const now = Date.now();
+    if (connected) {
+      reconnectAttempts = 0;
+      statusSink?.({
+        connected: true,
+        reconnectAttempts,
+        lastConnectedAt: now,
+        lastDisconnect: null,
+        lastError: null,
+      });
+      return;
+    }
+    reconnectAttempts += 1;
+    statusSink?.({
+      connected: false,
+      reconnectAttempts,
+      lastDisconnect: {
+        at: now,
+        ...(next?.error ? { error: next.error } : {}),
+      },
+      ...(next?.error === undefined ? {} : { lastError: next.error }),
+    });
+  };
+
+  return {
+    info: (...args: unknown[]) => {
+      log(...args);
+      const text = formatLoggerArgs(args);
+      if (text.includes("reconnect success") || text.includes("ws client ready")) {
+        updateConnected(true);
+        return;
+      }
+      if (
+        text.includes("reconnect") ||
+        text.includes("unable to connect to the server after trying")
+      ) {
+        updateConnected(false);
+        return;
+      }
+    },
+    warn: (...args: unknown[]) => {
+      log(...args);
+    },
+    debug: (...args: unknown[]) => {
+      log(...args);
+      const text = formatLoggerArgs(args);
+      if (text.includes("[ws]") && text.includes("reconnect success")) {
+        updateConnected(true);
+      }
+    },
+    trace: (...args: unknown[]) => {
+      log(...args);
+    },
+    error: (...args: unknown[]) => {
+      error(...args);
+      const text = formatLoggerArgs(args);
+      if (!text.includes("[ws]")) {
+        return;
+      }
+      if (
+        text.includes("ws connect failed") ||
+        text.includes("connect failed") ||
+        text.includes("ws error") ||
+        text.includes("1000040350") ||
+        text.includes("exceed_conn_limit") ||
+        text.includes("PingInterval")
+      ) {
+        updateConnected(false, { error: normalizeFeishuWsError(text) });
+      }
+    },
+  };
+}
+
 export async function monitorWebSocket({
   account,
   accountId,
   runtime,
   abortSignal,
   eventDispatcher,
+  statusSink,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   log(`feishu[${accountId}]: starting WebSocket connection...`);
 
-  const wsClient = createFeishuWSClient(account);
+  const wsClient = createFeishuWSClient(account, {
+    logger: createFeishuWsLifecycleLogger({ accountId, runtime, statusSink }),
+  });
   wsClients.set(accountId, wsClient);
 
   return new Promise((resolve, reject) => {
@@ -103,6 +239,13 @@ export async function monitorWebSocket({
 
     const handleAbort = () => {
       log(`feishu[${accountId}]: abort signal received, stopping`);
+      statusSink?.({
+        connected: false,
+        lastDisconnect: {
+          at: Date.now(),
+          error: "abort signal received",
+        },
+      });
       cleanup();
       resolve();
     };
@@ -132,6 +275,7 @@ export async function monitorWebhook({
   runtime,
   abortSignal,
   eventDispatcher,
+  statusSink,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
@@ -262,6 +406,13 @@ export async function monitorWebhook({
 
     server.listen(port, host, () => {
       log(`feishu[${accountId}]: Webhook server listening on ${host}:${port}`);
+      statusSink?.({
+        connected: true,
+        reconnectAttempts: 0,
+        lastConnectedAt: Date.now(),
+        lastDisconnect: null,
+        lastError: null,
+      });
     });
 
     server.on("error", (err) => {

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -18,6 +18,17 @@ export type MonitorFeishuOpts = {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   accountId?: string;
+  statusSink?: (patch: {
+    connected?: boolean;
+    reconnectAttempts?: number;
+    lastConnectedAt?: number | null;
+    lastDisconnect?: {
+      at: number;
+      error?: string;
+    } | null;
+    lastError?: string | null;
+    lastEventAt?: number | null;
+  }) => void;
 };
 
 export {
@@ -46,6 +57,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
       account,
       runtime: opts.runtime,
       abortSignal: opts.abortSignal,
+      statusSink: opts.statusSink,
     });
   }
 
@@ -82,6 +94,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
         account,
         runtime: opts.runtime,
         abortSignal: opts.abortSignal,
+        statusSink: opts.statusSink,
         botOpenIdSource: { kind: "prefetched", botOpenId, botName },
       }),
     );

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -120,6 +120,44 @@ describe("Feishu webhook security hardening", () => {
     );
   });
 
+  it("marks webhook accounts connected once the server starts listening", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+    const statusSink = vi.fn();
+    const port = await getFreePort();
+    const cfg = buildWebhookConfig({
+      accountId: "webhook-connected",
+      path: "/hook-connected",
+      port,
+      verificationToken: "verify_token",
+      encryptKey: "encrypt_key",
+    });
+    const abortController = new AbortController();
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const monitorPromise = monitorFeishuProvider({
+      config: cfg,
+      runtime,
+      abortSignal: abortController.signal,
+      statusSink,
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(statusSink).toHaveBeenCalledWith(
+          expect.objectContaining({
+            connected: true,
+            reconnectAttempts: 0,
+            lastConnectedAt: expect.any(Number),
+            lastDisconnect: null,
+            lastError: null,
+          }),
+        );
+      });
+    } finally {
+      abortController.abort();
+      await monitorPromise;
+    }
+  });
+
   it("caps tracked webhook rate-limit keys to prevent unbounded growth", () => {
     const now = 1_000_000;
     for (let i = 0; i < 4_500; i += 1) {

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -120,44 +120,6 @@ describe("Feishu webhook security hardening", () => {
     );
   });
 
-  it("marks webhook accounts connected once the server starts listening", async () => {
-    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
-    const statusSink = vi.fn();
-    const port = await getFreePort();
-    const cfg = buildWebhookConfig({
-      accountId: "webhook-connected",
-      path: "/hook-connected",
-      port,
-      verificationToken: "verify_token",
-      encryptKey: "encrypt_key",
-    });
-    const abortController = new AbortController();
-    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
-    const monitorPromise = monitorFeishuProvider({
-      config: cfg,
-      runtime,
-      abortSignal: abortController.signal,
-      statusSink,
-    });
-
-    try {
-      await vi.waitFor(() => {
-        expect(statusSink).toHaveBeenCalledWith(
-          expect.objectContaining({
-            connected: true,
-            reconnectAttempts: 0,
-            lastConnectedAt: expect.any(Number),
-            lastDisconnect: null,
-            lastError: null,
-          }),
-        );
-      });
-    } finally {
-      abortController.abort();
-      await monitorPromise;
-    }
-  });
-
   it("caps tracked webhook rate-limit keys to prevent unbounded growth", () => {
     const now = 1_000_000;
     for (let i = 0; i < 4_500; i += 1) {

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -34,7 +34,6 @@ import {
   monitorFeishuProvider,
   stopFeishuMonitor,
 } from "./monitor.js";
-
 afterEach(() => {
   clearFeishuWebhookRateLimitStateForTest();
   stopFeishuMonitor();
@@ -119,6 +118,44 @@ describe("Feishu webhook security hardening", () => {
         expect(saw429).toBe(true);
       },
     );
+  });
+
+  it("marks webhook accounts connected once the server starts listening", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+    const statusSink = vi.fn();
+    const port = await getFreePort();
+    const cfg = buildWebhookConfig({
+      accountId: "webhook-connected",
+      path: "/hook-connected",
+      port,
+      verificationToken: "verify_token",
+      encryptKey: "encrypt_key",
+    });
+    const abortController = new AbortController();
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const monitorPromise = monitorFeishuProvider({
+      config: cfg,
+      runtime,
+      abortSignal: abortController.signal,
+      statusSink,
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(statusSink).toHaveBeenCalledWith(
+          expect.objectContaining({
+            connected: true,
+            reconnectAttempts: 0,
+            lastConnectedAt: expect.any(Number),
+            lastDisconnect: null,
+            lastError: null,
+          }),
+        );
+      });
+    } finally {
+      abortController.abort();
+      await monitorPromise;
+    }
   });
 
   it("caps tracked webhook rate-limit keys to prevent unbounded growth", () => {


### PR DESCRIPTION
## Summary
- surface websocket and webhook lifecycle changes through the Feishu channel health state
- record connection status, reconnect attempts, last connected timestamp, last disconnect, and last error for status snapshots
- add targeted transport and webhook-security coverage for the new monitor behavior

## Testing
- pnpm test -- extensions/feishu/src/monitor.transport.test.ts extensions/feishu/src/monitor.webhook-security.test.ts extensions/feishu/src/channel.test.ts

## Notes
- this PR only contains the Feishu health-state code path and tests
- local Feishu companion docs are intentionally not included here
