### PR TITLE
feat(feishu): expand permission management tools

### DIFF
--- a/extensions/feishu/src/perm-schema.ts
+++ b/extensions/feishu/src/perm-schema.ts
@@ -1,52 +1,107 @@
 import { Type, type Static } from "@sinclair/typebox";
 
-const TokenType = Type.Union([
-  Type.Literal("doc"),
-  Type.Literal("docx"),
-  Type.Literal("sheet"),
-  Type.Literal("bitable"),
-  Type.Literal("folder"),
-  Type.Literal("file"),
-  Type.Literal("wiki"),
-  Type.Literal("mindnote"),
-]);
+function stringEnum<T extends readonly string[]>(
+  values: T,
+  options: { description?: string } = {},
+) {
+  return Type.Unsafe<T[number]>({
+    type: "string",
+    enum: [...values],
+    ...options,
+  });
+}
 
-const MemberType = Type.Union([
-  Type.Literal("email"),
-  Type.Literal("openid"),
-  Type.Literal("userid"),
-  Type.Literal("unionid"),
-  Type.Literal("openchat"),
-  Type.Literal("opendepartmentid"),
-]);
+const ACTIONS = ["list", "add", "remove", "transfer_owner", "get_public", "update_public"] as const;
 
-const Permission = Type.Union([
-  Type.Literal("view"),
-  Type.Literal("edit"),
-  Type.Literal("full_access"),
-]);
+const TOKEN_TYPES = [
+  "doc",
+  "docx",
+  "sheet",
+  "bitable",
+  "folder",
+  "file",
+  "wiki",
+  "mindnote",
+  "minutes",
+  "slides",
+] as const;
 
-export const FeishuPermSchema = Type.Union([
-  Type.Object({
-    action: Type.Literal("list"),
+const MEMBER_TYPES = [
+  "email",
+  "openid",
+  "userid",
+  "unionid",
+  "openchat",
+  "opendepartmentid",
+  "groupid",
+  "wikispaceid",
+] as const;
+
+const PERMISSIONS = ["view", "edit", "full_access"] as const;
+const SECURITY_ENTITIES = ["anyone_can_view", "anyone_can_edit", "only_full_access"] as const;
+const COMMENT_ENTITIES = ["anyone_can_view", "anyone_can_edit"] as const;
+const SHARE_ENTITIES = ["anyone", "same_tenant", "only_full_access"] as const;
+const LINK_SHARE_ENTITIES = [
+  "tenant_readable",
+  "tenant_editable",
+  "anyone_readable",
+  "anyone_editable",
+  "closed",
+] as const;
+
+export const FeishuPermSchema = Type.Object(
+  {
+    action: stringEnum(ACTIONS, {
+      description:
+        "Action to perform: list, add, remove, transfer_owner, get_public, update_public",
+    }),
     token: Type.String({ description: "File token" }),
-    type: TokenType,
-  }),
-  Type.Object({
-    action: Type.Literal("add"),
-    token: Type.String({ description: "File token" }),
-    type: TokenType,
-    member_type: MemberType,
-    member_id: Type.String({ description: "Member ID (email, open_id, user_id, etc.)" }),
-    perm: Permission,
-  }),
-  Type.Object({
-    action: Type.Literal("remove"),
-    token: Type.String({ description: "File token" }),
-    type: TokenType,
-    member_type: MemberType,
-    member_id: Type.String({ description: "Member ID to remove" }),
-  }),
-]);
+    type: stringEnum(TOKEN_TYPES, { description: "Feishu file type" }),
+    member_type: Type.Optional(
+      stringEnum(MEMBER_TYPES, {
+        description: "Member ID type for add, remove, or transfer_owner",
+      }),
+    ),
+    member_id: Type.Optional(
+      Type.String({ description: "Member ID for add, remove, or transfer_owner" }),
+    ),
+    perm: Type.Optional(
+      stringEnum(PERMISSIONS, { description: "Permission level for add action" }),
+    ),
+    need_notification: Type.Optional(
+      Type.Boolean({ description: "Notify target member during transfer_owner" }),
+    ),
+    remove_old_owner: Type.Optional(
+      Type.Boolean({ description: "Remove old owner after transfer_owner" }),
+    ),
+    external_access: Type.Optional(
+      Type.Boolean({ description: "Allow external access for update_public" }),
+    ),
+    security_entity: Type.Optional(
+      stringEnum(SECURITY_ENTITIES, {
+        description: "Public access level for update_public",
+      }),
+    ),
+    comment_entity: Type.Optional(
+      stringEnum(COMMENT_ENTITIES, {
+        description: "Public comment level for update_public",
+      }),
+    ),
+    share_entity: Type.Optional(
+      stringEnum(SHARE_ENTITIES, {
+        description: "Who can share the document in update_public",
+      }),
+    ),
+    link_share_entity: Type.Optional(
+      stringEnum(LINK_SHARE_ENTITIES, {
+        description: "Public link visibility and permission for update_public",
+      }),
+    ),
+    invite_external: Type.Optional(
+      Type.Boolean({ description: "Allow external invite for update_public" }),
+    ),
+  },
+  { additionalProperties: false },
+);
 
 export type FeishuPermParams = Static<typeof FeishuPermSchema>;

--- a/extensions/feishu/src/perm-schema.ts
+++ b/extensions/feishu/src/perm-schema.ts
@@ -51,6 +51,9 @@ const LINK_SHARE_ENTITIES = [
 
 export const FeishuPermSchema = Type.Object(
   {
+    accountId: Type.Optional(
+      Type.String({ description: "Optional Feishu account override for multi-account setups" }),
+    ),
     action: stringEnum(ACTIONS, {
       description:
         "Action to perform: list, add, remove, transfer_owner, get_public, update_public",
@@ -59,14 +62,14 @@ export const FeishuPermSchema = Type.Object(
     type: stringEnum(TOKEN_TYPES, { description: "Feishu file type" }),
     member_type: Type.Optional(
       stringEnum(MEMBER_TYPES, {
-        description: "Member ID type for add, remove, or transfer_owner",
+        description: "Member ID type required for add, remove, or transfer_owner",
       }),
     ),
     member_id: Type.Optional(
-      Type.String({ description: "Member ID for add, remove, or transfer_owner" }),
+      Type.String({ description: "Member ID required for add, remove, or transfer_owner" }),
     ),
     perm: Type.Optional(
-      stringEnum(PERMISSIONS, { description: "Permission level for add action" }),
+      stringEnum(PERMISSIONS, { description: "Permission level required for add" }),
     ),
     need_notification: Type.Optional(
       Type.Boolean({ description: "Notify target member during transfer_owner" }),

--- a/extensions/feishu/src/perm.test.ts
+++ b/extensions/feishu/src/perm.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { registerFeishuPermTools } from "./perm.js";
+import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
+
+const transferOwnerMock = vi.fn();
+const permissionPublicGetMock = vi.fn();
+const permissionPublicPatchMock = vi.fn();
+
+vi.mock("./tool-account.js", () => ({
+  createFeishuToolClient: () => ({
+    drive: {
+      permissionMember: {
+        list: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+        transferOwner: transferOwnerMock,
+      },
+      permissionPublic: {
+        get: permissionPublicGetMock,
+        patch: permissionPublicPatchMock,
+      },
+    },
+  }),
+  resolveAnyEnabledFeishuToolsConfig: () => ({
+    doc: false,
+    chat: false,
+    wiki: false,
+    drive: false,
+    perm: true,
+    scopes: false,
+  }),
+}));
+
+function createConfig() {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+        accounts: {
+          default: {
+            appId: "app-id",
+            appSecret: "app-secret", // pragma: allowlist secret
+            tools: { perm: true },
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("feishu perm tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("transfer_owner forwards the expected request", async () => {
+    transferOwnerMock.mockResolvedValue({ code: 0, msg: "ok", data: {} });
+
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuPermTools(api);
+
+    const tool = resolveTool("feishu_perm");
+    const result = await tool.execute("call", {
+      action: "transfer_owner",
+      token: "doc-token",
+      type: "docx",
+      member_type: "openid",
+      member_id: "ou_target",
+      need_notification: false,
+      remove_old_owner: true,
+    });
+
+    expect(transferOwnerMock).toHaveBeenCalledWith({
+      path: { token: "doc-token" },
+      params: {
+        type: "docx",
+        need_notification: false,
+        remove_old_owner: true,
+      },
+      data: {
+        member_type: "openid",
+        member_id: "ou_target",
+      },
+    });
+    expect(result).toMatchObject({
+      details: {
+        success: true,
+        transferred_to: { member_type: "openid", member_id: "ou_target" },
+      },
+    });
+  });
+
+  test("get_public returns the current public permission state", async () => {
+    permissionPublicGetMock.mockResolvedValue({
+      code: 0,
+      msg: "ok",
+      data: {
+        permission_public: {
+          external_access: true,
+          share_entity: "anyone",
+          link_share_entity: "anyone_readable",
+        },
+      },
+    });
+
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuPermTools(api);
+
+    const tool = resolveTool("feishu_perm");
+    const result = await tool.execute("call", {
+      action: "get_public",
+      token: "doc-token",
+      type: "docx",
+    });
+
+    expect(permissionPublicGetMock).toHaveBeenCalledWith({
+      path: { token: "doc-token" },
+      params: { type: "docx" },
+    });
+    expect(result).toMatchObject({
+      details: {
+        permission_public: {
+          external_access: true,
+          share_entity: "anyone",
+          link_share_entity: "anyone_readable",
+        },
+      },
+    });
+  });
+
+  test("update_public patches only the requested fields", async () => {
+    permissionPublicPatchMock.mockResolvedValue({
+      code: 0,
+      msg: "ok",
+      data: {
+        permission_public: {
+          link_share_entity: "anyone_readable",
+        },
+      },
+    });
+
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuPermTools(api);
+
+    const tool = resolveTool("feishu_perm");
+    const result = await tool.execute("call", {
+      action: "update_public",
+      token: "doc-token",
+      type: "docx",
+      link_share_entity: "anyone_readable",
+    });
+
+    expect(permissionPublicPatchMock).toHaveBeenCalledWith({
+      path: { token: "doc-token" },
+      params: { type: "docx" },
+      data: {
+        link_share_entity: "anyone_readable",
+      },
+    });
+    expect(result).toMatchObject({
+      details: {
+        success: true,
+        permission_public: {
+          link_share_entity: "anyone_readable",
+        },
+      },
+    });
+  });
+
+  test("rejects unsupported folder type for list before calling the API", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuPermTools(api);
+
+    const tool = resolveTool("feishu_perm");
+    const result = await tool.execute("call", {
+      action: "list",
+      token: "folder-token",
+      type: "folder",
+    });
+
+    expect(result).toMatchObject({
+      details: {
+        error: expect.stringContaining('list does not support type "folder"'),
+      },
+    });
+  });
+});

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -77,7 +77,7 @@ const CREATE_TOKEN_TYPES = new Set<CreateTokenType>([
 ]);
 
 function requireStringField(value: string | undefined, name: string) {
-  if (!value) {
+  if (value == null || value === "") {
     throw new Error(`${name} is required for this action`);
   }
   return value;

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -40,6 +40,71 @@ type MemberType =
   | "groupid"
   | "wikispaceid";
 type PermType = "view" | "edit" | "full_access";
+type SecurityEntity = "anyone_can_view" | "anyone_can_edit" | "only_full_access";
+type CommentEntity = "anyone_can_view" | "anyone_can_edit";
+type ShareEntity = "anyone" | "same_tenant" | "only_full_access";
+type OwnerTransferMemberType = "email" | "openid" | "userid";
+type LinkShareEntity =
+  | "tenant_readable"
+  | "tenant_editable"
+  | "anyone_readable"
+  | "anyone_editable"
+  | "closed";
+type PermAction = FeishuPermParams["action"];
+
+const LIST_TOKEN_TYPES = new Set<ListTokenType>([
+  "doc",
+  "sheet",
+  "file",
+  "wiki",
+  "bitable",
+  "docx",
+  "mindnote",
+  "minutes",
+  "slides",
+]);
+const CREATE_TOKEN_TYPES = new Set<CreateTokenType>([
+  "doc",
+  "sheet",
+  "file",
+  "wiki",
+  "bitable",
+  "docx",
+  "folder",
+  "mindnote",
+  "minutes",
+  "slides",
+]);
+
+function requireStringField(value: string | undefined, name: string) {
+  if (!value) {
+    throw new Error(`${name} is required for this action`);
+  }
+  return value;
+}
+
+function requireOwnerTransferMemberType(value: string | undefined): OwnerTransferMemberType {
+  if (value === "email" || value === "openid" || value === "userid") {
+    return value;
+  }
+  throw new Error("member_type must be email, openid, or userid for transfer_owner");
+}
+
+function assertSupportedTokenType(action: PermAction, type: string) {
+  if (action === "list" || action === "get_public" || action === "update_public") {
+    if (!LIST_TOKEN_TYPES.has(type as ListTokenType)) {
+      throw new Error(
+        `${action} does not support type "${type}". Supported types: ${Array.from(LIST_TOKEN_TYPES).join(", ")}`,
+      );
+    }
+    return;
+  }
+  if (!CREATE_TOKEN_TYPES.has(type as CreateTokenType)) {
+    throw new Error(
+      `${action} does not support type "${type}". Supported types: ${Array.from(CREATE_TOKEN_TYPES).join(", ")}`,
+    );
+  }
+}
 
 // ============ Actions ============
 
@@ -110,6 +175,100 @@ async function removeMember(
   };
 }
 
+async function transferOwner(
+  client: Lark.Client,
+  params: {
+    token: string;
+    type: string;
+    memberType: string;
+    memberId: string;
+    needNotification?: boolean;
+    removeOldOwner?: boolean;
+  },
+) {
+  const res = await client.drive.permissionMember.transferOwner({
+    path: { token: params.token },
+    params: {
+      type: params.type as CreateTokenType,
+      need_notification: params.needNotification ?? false,
+      remove_old_owner: params.removeOldOwner ?? false,
+    },
+    data: {
+      member_type: params.memberType as OwnerTransferMemberType,
+      member_id: params.memberId,
+    },
+  });
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    success: true,
+    transferred_to: {
+      member_type: params.memberType,
+      member_id: params.memberId,
+    },
+    need_notification: params.needNotification ?? false,
+    remove_old_owner: params.removeOldOwner ?? false,
+  };
+}
+
+async function getPublicSettings(client: Lark.Client, token: string, type: string) {
+  const res = await client.drive.permissionPublic.get({
+    path: { token },
+    params: { type: type as ListTokenType },
+  });
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    permission_public: res.data?.permission_public ?? {},
+  };
+}
+
+async function updatePublicSettings(
+  client: Lark.Client,
+  params: {
+    token: string;
+    type: string;
+    externalAccess?: boolean;
+    securityEntity?: string;
+    commentEntity?: string;
+    shareEntity?: string;
+    linkShareEntity?: string;
+    inviteExternal?: boolean;
+  },
+) {
+  const data = {
+    ...(params.externalAccess !== undefined ? { external_access: params.externalAccess } : {}),
+    ...(params.securityEntity ? { security_entity: params.securityEntity as SecurityEntity } : {}),
+    ...(params.commentEntity ? { comment_entity: params.commentEntity as CommentEntity } : {}),
+    ...(params.shareEntity ? { share_entity: params.shareEntity as ShareEntity } : {}),
+    ...(params.linkShareEntity
+      ? { link_share_entity: params.linkShareEntity as LinkShareEntity }
+      : {}),
+    ...(params.inviteExternal !== undefined ? { invite_external: params.inviteExternal } : {}),
+  };
+  if (Object.keys(data).length === 0) {
+    throw new Error("update_public requires at least one public permission field");
+  }
+
+  const res = await client.drive.permissionPublic.patch({
+    path: { token: params.token },
+    params: { type: params.type as ListTokenType },
+    data,
+  });
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    success: true,
+    permission_public: res.data?.permission_public ?? {},
+  };
+}
+
 // ============ Tool Registration ============
 
 export function registerFeishuPermTools(api: OpenClawPluginApi) {
@@ -126,7 +285,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
 
   const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
   if (!toolsCfg.perm) {
-    api.logger.debug?.("feishu_perm: perm tool disabled in config (default: false)");
+    api.logger.debug?.("feishu_perm: perm tool disabled in config");
     return;
   }
 
@@ -138,11 +297,13 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
       return {
         name: "feishu_perm",
         label: "Feishu Perm",
-        description: "Feishu permission management. Actions: list, add, remove",
+        description:
+          "Feishu permission management. Actions: list, add, remove, transfer_owner, get_public, update_public",
         parameters: FeishuPermSchema,
         async execute(_toolCallId, params) {
           const p = params as FeishuPermExecuteParams;
           try {
+            assertSupportedTokenType(p.action, p.type);
             const client = createFeishuToolClient({
               api,
               executeParams: p,
@@ -153,11 +314,50 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
                 return jsonToolResult(await listMembers(client, p.token, p.type));
               case "add":
                 return jsonToolResult(
-                  await addMember(client, p.token, p.type, p.member_type, p.member_id, p.perm),
+                  await addMember(
+                    client,
+                    p.token,
+                    p.type,
+                    requireStringField(p.member_type, "member_type"),
+                    requireStringField(p.member_id, "member_id"),
+                    requireStringField(p.perm, "perm"),
+                  ),
                 );
               case "remove":
                 return jsonToolResult(
-                  await removeMember(client, p.token, p.type, p.member_type, p.member_id),
+                  await removeMember(
+                    client,
+                    p.token,
+                    p.type,
+                    requireStringField(p.member_type, "member_type"),
+                    requireStringField(p.member_id, "member_id"),
+                  ),
+                );
+              case "transfer_owner":
+                return jsonToolResult(
+                  await transferOwner(client, {
+                    token: p.token,
+                    type: p.type,
+                    memberType: requireOwnerTransferMemberType(p.member_type),
+                    memberId: requireStringField(p.member_id, "member_id"),
+                    needNotification: p.need_notification,
+                    removeOldOwner: p.remove_old_owner,
+                  }),
+                );
+              case "get_public":
+                return jsonToolResult(await getPublicSettings(client, p.token, p.type));
+              case "update_public":
+                return jsonToolResult(
+                  await updatePublicSettings(client, {
+                    token: p.token,
+                    type: p.type,
+                    externalAccess: p.external_access,
+                    securityEntity: p.security_entity,
+                    commentEntity: p.comment_entity,
+                    shareEntity: p.share_entity,
+                    linkShareEntity: p.link_share_entity,
+                    inviteExternal: p.invite_external,
+                  }),
                 );
               default:
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -110,7 +110,7 @@ describe("feishu tool account routing", () => {
     registerFeishuPermTools(api);
 
     const tool = resolveTool("feishu_perm", { agentAccountId: "b" });
-    await tool.execute("call", { action: "unknown_action" });
+    await tool.execute("call", { action: "list", token: "tok", type: "doc" });
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
   });

--- a/extensions/feishu/src/tools-config.test.ts
+++ b/extensions/feishu/src/tools-config.test.ts
@@ -8,6 +8,11 @@ describe("feishu tools config", () => {
     expect(resolved.chat).toBe(true);
   });
 
+  it("keeps perm tool disabled by default", () => {
+    const resolved = resolveToolsConfig(undefined);
+    expect(resolved.perm).toBe(false);
+  });
+
   it("accepts tools.chat in config schema", () => {
     const parsed = FeishuConfigSchema.parse({
       enabled: true,

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -3,7 +3,7 @@ import type { FeishuToolsConfig } from "./types.js";
 /**
  * Default tool configuration.
  * - doc, chat, wiki, drive, scopes: enabled by default
- * - perm: disabled by default (sensitive operation)
+ * - perm: disabled by default because it changes document permissions
  */
 export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   doc: true,


### PR DESCRIPTION
## Summary
- expand `feishu_perm` beyond basic member listing and membership changes
- add owner transfer and public-sharing actions with stricter schema validation and tool config coverage
- add targeted tests for the new permission-management flows

## Testing
- pnpm test -- extensions/feishu/src/perm.test.ts extensions/feishu/src/tools-config.test.ts

## Notes
- this extends the permission tool surface without publishing the local Feishu companion docs used in a private deployment
- related prior attempt: #39934
