### PR TITLE
docs: add tickflow-assist to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -84,6 +84,17 @@ and files.
 openclaw plugins install @sliverp/qqbot
 ```
 
+### TickFlow Assist
+
+A-share watchlist analysis, monitoring, and alert delivery powered by TickFlow and OpenClaw. Features interactive automatic installation via community configure tools.
+
+- **npm:** `tickflow-assist`
+- **repo:** [github.com/robinspt/tickflow-assist](https://github.com/robinspt/tickflow-assist)
+
+```bash
+openclaw plugins install tickflow-assist
+```
+
 ### wecom
 
 OpenClaw Enterprise WeCom Channel Plugin.

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -95,6 +95,12 @@ A-share watchlist analysis, monitoring, and alert delivery powered by TickFlow a
 openclaw plugins install tickflow-assist
 ```
 
+After installation, run the configuration wizard:
+
+```bash
+npx -y tickflow-assist configure-openclaw
+```
+
 ### wecom
 
 OpenClaw Enterprise WeCom Channel Plugin.


### PR DESCRIPTION
## Plugin Submission

- **Plugin name**: TickFlow Assist
- **npm package name**: `tickflow-assist`
- **GitHub repository URL**: https://github.com/robinspt/tickflow-assist
- **One-line description**: A-share watchlist analysis, monitoring, and alert delivery powered by TickFlow and OpenClaw. Features interactive automatic installation via community configure tools.
- **Install command**: `openclaw plugins install tickflow-assist`

*Note: After installation, users should run `npx -y tickflow-assist configure-openclaw` to automatically configure channels, targets and Python dependencies.*

### 提交补充说明 (Additional notes in Chinese)

本项目代码完全开源（MIT 协议），所有核心业务逻辑与 CLI 组装流程均符合 OpenClaw SDK 的运行规范，并在 GitHub 托管分发。

在官方的 npm 发版与分发机制上，为了解决内部 Python 指标库的 `uv sync` 一键部署隔离问题，我们在用户执行 `npm run configure-openclaw` 或 `npx` 工具环节，注入了环境巡检的弹窗化补齐和 OpenClaw 配置菜单：自动下发通道检测、Channel Target 组装，降低使用门槛，完全契合 OpenClaw 鼓励的"开箱即用（Out of the Box）"理念。

希望能被审核合并加入到贵社区，丰富 OpenClaw 在 A 股盯盘、复盘自动化领域的用例，谢谢！
