### PR TITLE
fix(tools): filter MCP/LSP tools through subagent policy

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -64,6 +64,7 @@ import {
 } from "../pi-hooks/compaction-safeguard-runtime.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../pi-project-settings.js";
 import { createOpenClawCodingTools } from "../pi-tools.js";
+import { filterToolsByPolicy, resolveSubagentToolPolicyForSession } from "../pi-tools.policy.js";
 import { registerProviderStreamForModel } from "../provider-stream.js";
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
 import { resolveSandboxContext } from "../sandbox.js";
@@ -505,11 +506,17 @@ export async function compactEmbeddedPiSessionDirect(
           ],
         })
       : undefined;
-    const effectiveTools = [
-      ...tools,
-      ...(bundleMcpRuntime?.tools ?? []),
-      ...(bundleLspRuntime?.tools ?? []),
-    ];
+    // Resolve subagent tool policy for MCP/LSP filtering (built-in tools are already filtered via pipeline)
+    const subagentToolPolicy =
+      params.sessionKey && isSubagentSessionKey(params.sessionKey)
+        ? resolveSubagentToolPolicyForSession(params.config, params.sessionKey)
+        : undefined;
+
+    // Filter MCP/LSP tools through subagent policy (same filtering applied to built-in tools)
+    const filteredMcpTools = filterToolsByPolicy(bundleMcpRuntime?.tools ?? [], subagentToolPolicy);
+    const filteredLspTools = filterToolsByPolicy(bundleLspRuntime?.tools ?? [], subagentToolPolicy);
+
+    const effectiveTools = [...tools, ...filteredMcpTools, ...filteredLspTools];
     const allowedToolNames = collectAllowedToolNames({ tools: effectiveTools });
     logToolSchemasForGoogle({ tools: effectiveTools, provider });
     const machineName = await getMachineDisplayName();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -76,6 +76,7 @@ import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settin
 import { applyPiAutoCompactionGuard } from "../../pi-settings.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
+import { filterToolsByPolicy, resolveSubagentToolPolicyForSession } from "../../pi-tools.policy.js";
 import { registerProviderStreamForModel } from "../../provider-stream.js";
 import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
@@ -509,11 +510,17 @@ export async function runEmbeddedAttempt(
           ],
         })
       : undefined;
-    const effectiveTools = [
-      ...tools,
-      ...(bundleMcpRuntime?.tools ?? []),
-      ...(bundleLspRuntime?.tools ?? []),
-    ];
+    // Resolve subagent tool policy for MCP/LSP filtering (built-in tools are already filtered via pipeline)
+    const subagentToolPolicy =
+      params.sessionKey && isSubagentSessionKey(params.sessionKey)
+        ? resolveSubagentToolPolicyForSession(params.config, params.sessionKey)
+        : undefined;
+
+    // Filter MCP/LSP tools through subagent policy (same filtering applied to built-in tools)
+    const filteredMcpTools = filterToolsByPolicy(bundleMcpRuntime?.tools ?? [], subagentToolPolicy);
+    const filteredLspTools = filterToolsByPolicy(bundleLspRuntime?.tools ?? [], subagentToolPolicy);
+
+    const effectiveTools = [...tools, ...filteredMcpTools, ...filteredLspTools];
     const allowedToolNames = collectAllowedToolNames({
       tools: effectiveTools,
       clientTools,


### PR DESCRIPTION
## Summary

MCP and LSP tools were bypassing the `tools.subagents.tools.allow/deny` policy filtering because they were added to `effectiveTools` after the `applyToolPolicyPipeline` had already run.

## Problem

When spawning a sub-agent with:
- An MCP server providing many tools (e.g., 38 tools)
- A small context window model (e.g., 16k tokens)
- A restrictive `tools.subagents.tools.allow` policy (e.g., only 3 tools)

The sub-agent would receive all 38 unfiltered MCP tools anyway, consuming ~12-14k tokens of schema just from MCP tools. This could exceed the model's context window:

```
400 This model's maximum context length is 16384 tokens.
However, your request has 16905 input tokens.
```

## Root Cause

In both `attempt.ts` and `compact.ts`, `effectiveTools` was constructed by concatenating:
- Built-in tools (filtered via pipeline ✅)
- MCP tools (unfiltered ❌)
- LSP tools (unfiltered ❌)

```javascript
const effectiveTools = [
    ...tools,                            // ✅ filtered
    ...(bundleMcpRuntime?.tools ?? []),   // ❌ NOT filtered
    ...(bundleLspRuntime?.tools ?? [])    // ❌ NOT filtered
];
```

## Solution

Added subagent policy resolution and filtering for MCP/LSP tools:

```javascript
const subagentToolPolicy =
  params.sessionKey && isSubagentSessionKey(params.sessionKey)
    ? resolveSubagentToolPolicyForSession(params.config, params.sessionKey)
    : undefined;

const filteredMcpTools = subagentToolPolicy
  ? (bundleMcpRuntime?.tools ?? []).filter((tool) =>
      isToolAllowedByPolicyName(tool.name, subagentToolPolicy),
    )
  : (bundleMcpRuntime?.tools ?? []);
// ... same for LSP tools

const effectiveTools = [...tools, ...filteredMcpTools, ...filteredLspTools];
```

This applies the same filtering that built-in tools receive via the pipeline.

## Testing

- The existing `pi-tools.policy.test.ts` tests pass (28/28)
- Manual verification: policy functions work correctly with tool names

## Notes

- This also affects `agents.list[].tools.deny` - agent-level deny lists now properly filter MCP/LSP tools as well
- The fix is applied in both `attempt.ts` (run) and `compact.ts` (compaction) to ensure consistent behavior

Fixes #53504