### PR TITLE
docs(irc): fix json55 typo to json5 in fenced code blocks

### DIFF
--- a/docs/channels/irc.md
+++ b/docs/channels/irc.md
@@ -74,7 +74,7 @@ If you see logs like:
 
 Example (allow anyone in `#tuirc-dev` to talk to the bot):
 
-```json55
+```json5
 {
   channels: {
     irc: {
@@ -95,7 +95,7 @@ That means you may see logs like `drop channel … (missing-mention)` unless the
 
 To make the bot reply in an IRC channel **without needing a mention**, disable mention gating for that channel:
 
-```json55
+```json5
 {
   channels: {
     irc: {
@@ -113,7 +113,7 @@ To make the bot reply in an IRC channel **without needing a mention**, disable m
 
 Or to allow **all** IRC channels (no per-channel allowlist) and still reply without mentions:
 
-```json55
+```json5
 {
   channels: {
     irc: {
@@ -133,7 +133,7 @@ To reduce risk, restrict tools for that channel.
 
 ### Same tools for everyone in the channel
 
-```json55
+```json5
 {
   channels: {
     irc: {
@@ -154,7 +154,7 @@ To reduce risk, restrict tools for that channel.
 
 Use `toolsBySender` to apply a stricter policy to `"*"` and a looser one to your nick:
 
-```json55
+```json5
 {
   channels: {
     irc: {


### PR DESCRIPTION
## Summary\nFixes typo in IRC docs where fenced code blocks used  instead of , which breaks syntax highlighting.\n\n## Changes\n- Replace 5 occurrences of ```json55` with ```json5` in \n\n## Issue\nCloses #50831