### PR TITLE
fix(workspace): prioritize cwd templates over npm package

### DIFF
--- a/src/agents/workspace-templates.ts
+++ b/src/agents/workspace-templates.ts
@@ -29,9 +29,11 @@ export async function resolveWorkspaceTemplateDir(opts?: {
     const cwd = opts?.cwd ?? process.cwd();
 
     const packageRoot = await resolveOpenClawPackageRoot({ moduleUrl, argv1, cwd });
+    // Prefer cwd (workspace) first, then packageRoot, then fallback
+    // This ensures workspace custom templates take priority over npm package defaults
     const candidates = [
-      packageRoot ? path.join(packageRoot, "docs", "reference", "templates") : null,
       cwd ? path.resolve(cwd, "docs", "reference", "templates") : null,
+      packageRoot ? path.join(packageRoot, "docs", "reference", "templates") : null,
       FALLBACK_TEMPLATE_DIR,
     ].filter(Boolean) as string[];
 


### PR DESCRIPTION
## Problem

The `resolveWorkspaceTemplateDir` function was checking `packageRoot` (npm global directory) before `cwd` (workspace directory). For global installations, this caused workspace template files to be ignored in favor of the npm package's bundled templates.

This caused issue #53547 where bootstrap files (SOUL.md, AGENTS.md, etc.) were not loading from the workspace directory on global installations, resulting in 'missing workspace template' errors.

## Solution

Reorder the template directory search priority to check `cwd` (workspace directory) first, then `packageRoot`, then the fallback directory.

## Testing

- [x] Verified the fix resolves the bootstrap file loading issue

Fixes #53547