### PR TITLE
fix: strip <relevant-memories> tags from user messages in WebChat UI

### DIFF
--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -4,7 +4,7 @@ import { stripReasoningTagsFromText } from "./reasoning-tags.js";
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
 
-function stripRelevantMemoriesTags(text: string): string {
+export function stripRelevantMemoriesTags(text: string): string {
   if (!text || !MEMORY_TAG_QUICK_RE.test(text)) {
     return text;
   }

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -1,5 +1,6 @@
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import { stripEnvelope } from "../../../../src/shared/chat-envelope.js";
+import { stripRelevantMemoriesTags } from "../../../../src/shared/text/assistant-visible-text.js";
 import { stripThinkingTags } from "../format.ts";
 
 const textCache = new WeakMap<object, string | null>();
@@ -10,9 +11,10 @@ function processMessageText(text: string, role: string): string {
   if (role === "assistant") {
     return stripThinkingTags(text);
   }
-  return shouldStripInboundMetadata
+  const base = shouldStripInboundMetadata
     ? stripInboundMetadata(stripEnvelope(text))
     : stripEnvelope(text);
+  return stripRelevantMemoriesTags(base);
 }
 
 export function extractText(message: unknown): string | null {


### PR DESCRIPTION
## Summary

Plugins (such as memory plugins) inject context wrapped in `<relevant-memories>` tags via `prependContext`, which gets stored as part of the user message in the session history. Currently, `processMessageText` in the WebChat UI only strips these tags from **assistant** messages (via `stripAssistantInternalScaffolding`), but leaves them visible in **user** messages.

This PR fixes the inconsistency by applying `stripRelevantMemoriesTags` to non-assistant messages as well, so plugin-injected memory context is hidden from the chat UI for all message roles.

## Changes

- **`src/shared/text/assistant-visible-text.ts`**: Export `stripRelevantMemoriesTags` (previously module-private) so it can be reused.
- **`ui/src/ui/chat/message-extract.ts`**: Import `stripRelevantMemoriesTags` and apply it to the user/other-role branch of `processMessageText`.

## Motivation

When memory plugins use `prependContext` to inject recalled memories (wrapped in `<relevant-memories>` tags), the raw tags and memory content are displayed in the WebChat UI as part of user messages. This creates a confusing user experience, as the injected context is meant only for the LLM, not for human readers.

The existing `stripAssistantInternalScaffolding` already handles this for assistant messages — this PR extends the same treatment to user messages.

## Test plan

- [x] Verified that `stripRelevantMemoriesTags` correctly removes `<relevant-memories>` blocks from user message text
- [ ] Existing tests for `stripAssistantInternalScaffolding` still pass (no behavior change for assistant messages)
- [ ] WebChat UI displays user messages without `<relevant-memories>` content
- [ ] Memory context is still correctly sent to the LLM (no change to `prependContext` behavior)

Made with [Cursor](https://cursor.com)