### PR TITLE
fix(btw): allow aws-sdk auth for Bedrock side questions

### DIFF
--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -16,13 +16,9 @@ const resolveSessionAuthProfileOverrideMock = vi.fn();
 const getActiveEmbeddedRunSnapshotMock = vi.fn();
 const diagDebugMock = vi.fn();
 
-vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
-  const original = await importOriginal<typeof import("@mariozechner/pi-ai")>();
-  return {
-    ...original,
-    streamSimple: (...args: unknown[]) => streamSimpleMock(...args),
-  };
-});
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: (...args: unknown[]) => streamSimpleMock(...args),
+}));
 
 vi.mock("@mariozechner/pi-coding-agent", () => ({
   SessionManager: {
@@ -69,17 +65,6 @@ vi.mock("../logging/diagnostic.js", () => ({
 }));
 
 const { runBtwSideQuestion } = await import("./btw.js");
-type RunBtwSideQuestionParams = Parameters<typeof runBtwSideQuestion>[0];
-
-const DEFAULT_AGENT_DIR = "/tmp/agent";
-const DEFAULT_MODEL = "claude-sonnet-4-5";
-const DEFAULT_PROVIDER = "anthropic";
-const DEFAULT_REASONING_LEVEL = "off";
-const DEFAULT_SESSION_KEY = "agent:main:main";
-const DEFAULT_STORE_PATH = "/tmp/sessions.json";
-const DEFAULT_QUESTION = "What changed?";
-const MATH_QUESTION = "What is 17 * 19?";
-const MATH_ANSWER = "323";
 
 function makeAsyncEvents(events: unknown[]) {
   return {
@@ -98,60 +83,6 @@ function createSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry
     updatedAt: Date.now(),
     ...overrides,
   };
-}
-
-function createDoneEvent(text: string) {
-  return {
-    type: "done",
-    reason: "stop",
-    message: {
-      role: "assistant",
-      content: [{ type: "text", text }],
-      provider: DEFAULT_PROVIDER,
-      api: "anthropic-messages",
-      model: DEFAULT_MODEL,
-      stopReason: "stop",
-      usage: {
-        input: 1,
-        output: 2,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 3,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-      timestamp: Date.now(),
-    },
-  };
-}
-
-function mockDoneAnswer(text: string) {
-  streamSimpleMock.mockReturnValue(makeAsyncEvents([createDoneEvent(text)]));
-}
-
-function runSideQuestion(overrides: Partial<RunBtwSideQuestionParams> = {}) {
-  return runBtwSideQuestion({
-    cfg: {} as never,
-    agentDir: DEFAULT_AGENT_DIR,
-    provider: DEFAULT_PROVIDER,
-    model: DEFAULT_MODEL,
-    question: DEFAULT_QUESTION,
-    sessionEntry: createSessionEntry(),
-    resolvedReasoningLevel: DEFAULT_REASONING_LEVEL,
-    opts: {},
-    isNewSession: false,
-    ...overrides,
-  });
-}
-
-function runMathSideQuestion(overrides: Partial<RunBtwSideQuestionParams> = {}) {
-  return runSideQuestion({
-    question: MATH_QUESTION,
-    ...overrides,
-  });
-}
-
-function clearBuiltSessionMessages() {
-  buildSessionContextMock.mockReturnValue({ messages: [] });
 }
 
 describe("runBtwSideQuestion", () => {
@@ -237,16 +168,16 @@ describe("runBtwSideQuestion", () => {
 
     const result = await runBtwSideQuestion({
       cfg: {} as never,
-      agentDir: DEFAULT_AGENT_DIR,
-      provider: DEFAULT_PROVIDER,
-      model: DEFAULT_MODEL,
-      question: DEFAULT_QUESTION,
+      agentDir: "/tmp/agent",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      question: "What changed?",
       sessionEntry: createSessionEntry(),
       sessionStore: {},
-      sessionKey: DEFAULT_SESSION_KEY,
-      storePath: DEFAULT_STORE_PATH,
+      sessionKey: "agent:main:main",
+      storePath: "/tmp/sessions.json",
       resolvedThinkLevel: "low",
-      resolvedReasoningLevel: DEFAULT_REASONING_LEVEL,
+      resolvedReasoningLevel: "off",
       blockReplyChunking: {
         minChars: 1,
         maxChars: 200,
@@ -260,27 +191,128 @@ describe("runBtwSideQuestion", () => {
     expect(result).toBeUndefined();
     expect(onBlockReply).toHaveBeenCalledWith({
       text: "Side answer.",
-      btw: { question: DEFAULT_QUESTION },
+      btw: { question: "What changed?" },
     });
   });
 
   it("returns a final payload when block streaming is unavailable", async () => {
-    mockDoneAnswer("Final answer.");
+    streamSimpleMock.mockReturnValue(
+      makeAsyncEvents([
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Final answer." }],
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-5",
+            stopReason: "stop",
+            usage: {
+              input: 1,
+              output: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 3,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        },
+      ]),
+    );
 
-    const result = await runSideQuestion();
+    const result = await runBtwSideQuestion({
+      cfg: {} as never,
+      agentDir: "/tmp/agent",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      question: "What changed?",
+      sessionEntry: createSessionEntry(),
+      resolvedReasoningLevel: "off",
+      opts: {},
+      isNewSession: false,
+    });
 
     expect(result).toEqual({ text: "Final answer." });
   });
 
+  it("allows Bedrock /btw runs to proceed without a static api key in aws-sdk mode", async () => {
+    resolveModelWithRegistryMock.mockReturnValue({
+      provider: "amazon-bedrock",
+      id: "us.anthropic.claude-sonnet-4-5-v1:0",
+      api: "anthropic-messages",
+    });
+    getApiKeyForModelMock.mockResolvedValue({
+      apiKey: undefined,
+      mode: "aws-sdk",
+      source: "aws-sdk default chain",
+    });
+    streamSimpleMock.mockReturnValue(
+      makeAsyncEvents([
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Bedrock answer." }],
+            provider: "amazon-bedrock",
+            api: "anthropic-messages",
+            model: "us.anthropic.claude-sonnet-4-5-v1:0",
+            stopReason: "stop",
+            usage: {
+              input: 1,
+              output: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 3,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        },
+      ]),
+    );
+
+    const result = await runBtwSideQuestion({
+      cfg: {} as never,
+      agentDir: "/tmp/agent",
+      provider: "amazon-bedrock",
+      model: "us.anthropic.claude-sonnet-4-5-v1:0",
+      question: "What changed?",
+      sessionEntry: createSessionEntry(),
+      resolvedReasoningLevel: "off",
+      opts: {},
+      isNewSession: false,
+    });
+
+    expect(result).toEqual({ text: "Bedrock answer." });
+    expect(requireApiKeyMock).not.toHaveBeenCalled();
+    const [, , streamOptions] = streamSimpleMock.mock.calls.at(-1) ?? [];
+    expect((streamOptions as { apiKey?: string } | undefined)?.apiKey).toBeUndefined();
+  });
+
   it("fails when the current branch has no messages", async () => {
-    clearBuiltSessionMessages();
+    buildSessionContextMock.mockReturnValue({ messages: [] });
     streamSimpleMock.mockReturnValue(makeAsyncEvents([]));
 
-    await expect(runSideQuestion()).rejects.toThrow("No active session context.");
+    await expect(
+      runBtwSideQuestion({
+        cfg: {} as never,
+        agentDir: "/tmp/agent",
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+        question: "What changed?",
+        sessionEntry: createSessionEntry(),
+        resolvedReasoningLevel: "off",
+        opts: {},
+        isNewSession: false,
+      }),
+    ).rejects.toThrow("No active session context.");
   });
 
   it("uses active-run snapshot messages for BTW context while the main run is in flight", async () => {
-    clearBuiltSessionMessages();
+    buildSessionContextMock.mockReturnValue({ messages: [] });
     getActiveEmbeddedRunSnapshotMock.mockReturnValue({
       transcriptLeafId: "assistant-1",
       messages: [
@@ -293,11 +325,45 @@ describe("runBtwSideQuestion", () => {
         },
       ],
     });
-    mockDoneAnswer(MATH_ANSWER);
+    streamSimpleMock.mockReturnValue(
+      makeAsyncEvents([
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "323" }],
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-5",
+            stopReason: "stop",
+            usage: {
+              input: 1,
+              output: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 3,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        },
+      ]),
+    );
 
-    const result = await runMathSideQuestion();
+    const result = await runBtwSideQuestion({
+      cfg: {} as never,
+      agentDir: "/tmp/agent",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      question: "What is 17 * 19?",
+      sessionEntry: createSessionEntry(),
+      resolvedReasoningLevel: "off",
+      opts: {},
+      isNewSession: false,
+    });
 
-    expect(result).toEqual({ text: MATH_ANSWER });
+    expect(result).toEqual({ text: "323" });
     expect(streamSimpleMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -310,7 +376,7 @@ describe("runBtwSideQuestion", () => {
               {
                 type: "text",
                 text: expect.stringContaining(
-                  `<btw_side_question>\n${MATH_QUESTION}\n</btw_side_question>`,
+                  "<btw_side_question>\nWhat is 17 * 19?\n</btw_side_question>",
                 ),
               },
             ],
@@ -322,15 +388,49 @@ describe("runBtwSideQuestion", () => {
   });
 
   it("uses the in-flight prompt as background only when there is no prior transcript context", async () => {
-    clearBuiltSessionMessages();
+    buildSessionContextMock.mockReturnValue({ messages: [] });
     getActiveEmbeddedRunSnapshotMock.mockReturnValue({
       transcriptLeafId: null,
       messages: [],
       inFlightPrompt: "build me a tic-tac-toe game in brainfuck",
     });
-    mockDoneAnswer("You're building a tic-tac-toe game in Brainfuck.");
+    streamSimpleMock.mockReturnValue(
+      makeAsyncEvents([
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "You're building a tic-tac-toe game in Brainfuck." }],
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-5",
+            stopReason: "stop",
+            usage: {
+              input: 1,
+              output: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 3,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        },
+      ]),
+    );
 
-    const result = await runSideQuestion({ question: "what are we doing?" });
+    const result = await runBtwSideQuestion({
+      cfg: {} as never,
+      agentDir: "/tmp/agent",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      question: "what are we doing?",
+      sessionEntry: createSessionEntry(),
+      resolvedReasoningLevel: "off",
+      opts: {},
+      isNewSession: false,
+    });
 
     expect(result).toEqual({ text: "You're building a tic-tac-toe game in Brainfuck." });
     expect(streamSimpleMock).toHaveBeenCalledWith(
@@ -355,9 +455,43 @@ describe("runBtwSideQuestion", () => {
   });
 
   it("wraps the side question so the model does not treat it as a main-task continuation", async () => {
-    mockDoneAnswer("About 93 million miles.");
+    streamSimpleMock.mockReturnValue(
+      makeAsyncEvents([
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "About 93 million miles." }],
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-5",
+            stopReason: "stop",
+            usage: {
+              input: 1,
+              output: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 3,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        },
+      ]),
+    );
 
-    await runSideQuestion({ question: "what is the distance to the sun?" });
+    await runBtwSideQuestion({
+      cfg: {} as never,
+      agentDir: "/tmp/agent",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      question: "what is the distance to the sun?",
+      sessionEntry: createSessionEntry(),
+      resolvedReasoningLevel: "off",
+      opts: {},
+      isNewSession: false,
+    });
 
     const [, context] = streamSimpleMock.mock.calls[0] ?? [];
     expect(context).toMatchObject({
@@ -388,27 +522,95 @@ describe("runBtwSideQuestion", () => {
       parentId: "assistant-1",
       message: { role: "user" },
     });
-    mockDoneAnswer(MATH_ANSWER);
+    streamSimpleMock.mockReturnValue(
+      makeAsyncEvents([
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "323" }],
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-5",
+            stopReason: "stop",
+            usage: {
+              input: 1,
+              output: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 3,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        },
+      ]),
+    );
 
-    const result = await runMathSideQuestion();
+    const result = await runBtwSideQuestion({
+      cfg: {} as never,
+      agentDir: "/tmp/agent",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      question: "What is 17 * 19?",
+      sessionEntry: createSessionEntry(),
+      resolvedReasoningLevel: "off",
+      opts: {},
+      isNewSession: false,
+    });
 
     expect(branchMock).toHaveBeenCalledWith("assistant-1");
     expect(resetLeafMock).not.toHaveBeenCalled();
     expect(buildSessionContextMock).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ text: MATH_ANSWER });
+    expect(result).toEqual({ text: "323" });
   });
 
   it("branches to the active run snapshot leaf when the session is busy", async () => {
     getActiveEmbeddedRunSnapshotMock.mockReturnValue({
       transcriptLeafId: "assistant-seed",
     });
-    mockDoneAnswer(MATH_ANSWER);
+    streamSimpleMock.mockReturnValue(
+      makeAsyncEvents([
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "323" }],
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-5",
+            stopReason: "stop",
+            usage: {
+              input: 1,
+              output: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 3,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        },
+      ]),
+    );
 
-    const result = await runMathSideQuestion();
+    const result = await runBtwSideQuestion({
+      cfg: {} as never,
+      agentDir: "/tmp/agent",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      question: "What is 17 * 19?",
+      sessionEntry: createSessionEntry(),
+      resolvedReasoningLevel: "off",
+      opts: {},
+      isNewSession: false,
+    });
 
     expect(branchMock).toHaveBeenCalledWith("assistant-seed");
     expect(getLeafEntryMock).not.toHaveBeenCalled();
-    expect(result).toEqual({ text: MATH_ANSWER });
+    expect(result).toEqual({ text: "323" });
   });
 
   it("falls back when the active run snapshot leaf no longer exists", async () => {
@@ -418,33 +620,135 @@ describe("runBtwSideQuestion", () => {
     branchMock.mockImplementationOnce(() => {
       throw new Error("Entry 3235c7c4 not found");
     });
-    mockDoneAnswer(MATH_ANSWER);
+    streamSimpleMock.mockReturnValue(
+      makeAsyncEvents([
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "323" }],
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-5",
+            stopReason: "stop",
+            usage: {
+              input: 1,
+              output: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 3,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        },
+      ]),
+    );
 
-    const result = await runMathSideQuestion();
+    const result = await runBtwSideQuestion({
+      cfg: {} as never,
+      agentDir: "/tmp/agent",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      question: "What is 17 * 19?",
+      sessionEntry: createSessionEntry(),
+      resolvedReasoningLevel: "off",
+      opts: {},
+      isNewSession: false,
+    });
 
     expect(branchMock).toHaveBeenCalledWith("assistant-gone");
     expect(resetLeafMock).toHaveBeenCalled();
-    expect(result).toEqual({ text: MATH_ANSWER });
+    expect(result).toEqual({ text: "323" });
     expect(diagDebugMock).toHaveBeenCalledWith(
       expect.stringContaining("btw snapshot leaf unavailable: sessionId=session-1"),
     );
   });
 
   it("returns the BTW answer without appending transcript custom entries", async () => {
-    mockDoneAnswer(MATH_ANSWER);
+    streamSimpleMock.mockReturnValue(
+      makeAsyncEvents([
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "323" }],
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-5",
+            stopReason: "stop",
+            usage: {
+              input: 1,
+              output: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 3,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        },
+      ]),
+    );
 
-    const result = await runMathSideQuestion();
+    const result = await runBtwSideQuestion({
+      cfg: {} as never,
+      agentDir: "/tmp/agent",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      question: "What is 17 * 19?",
+      sessionEntry: createSessionEntry(),
+      resolvedReasoningLevel: "off",
+      opts: {},
+      isNewSession: false,
+    });
 
-    expect(result).toEqual({ text: MATH_ANSWER });
+    expect(result).toEqual({ text: "323" });
     expect(buildSessionContextMock).toHaveBeenCalled();
   });
 
   it("does not log transcript persistence warnings because BTW no longer writes to disk", async () => {
-    mockDoneAnswer(MATH_ANSWER);
+    streamSimpleMock.mockReturnValue(
+      makeAsyncEvents([
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "323" }],
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-5",
+            stopReason: "stop",
+            usage: {
+              input: 1,
+              output: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 3,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        },
+      ]),
+    );
 
-    const result = await runMathSideQuestion();
+    const result = await runBtwSideQuestion({
+      cfg: {} as never,
+      agentDir: "/tmp/agent",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      question: "What is 17 * 19?",
+      sessionEntry: createSessionEntry(),
+      resolvedReasoningLevel: "off",
+      opts: {},
+      isNewSession: false,
+    });
 
-    expect(result).toEqual({ text: MATH_ANSWER });
+    expect(result).toEqual({ text: "323" });
     expect(diagDebugMock).not.toHaveBeenCalledWith(
       expect.stringContaining("btw transcript persistence skipped"),
     );
@@ -472,9 +776,43 @@ describe("runBtwSideQuestion", () => {
         },
       ],
     });
-    mockDoneAnswer(MATH_ANSWER);
+    streamSimpleMock.mockReturnValue(
+      makeAsyncEvents([
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "323" }],
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-5",
+            stopReason: "stop",
+            usage: {
+              input: 1,
+              output: 2,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 3,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        },
+      ]),
+    );
 
-    await runMathSideQuestion();
+    await runBtwSideQuestion({
+      cfg: {} as never,
+      agentDir: "/tmp/agent",
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      question: "What is 17 * 19?",
+      sessionEntry: createSessionEntry(),
+      resolvedReasoningLevel: "off",
+      opts: {},
+      isNewSession: false,
+    });
 
     const [, context] = streamSimpleMock.mock.calls[0] ?? [];
     expect(context).toMatchObject({

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -264,7 +264,10 @@ export async function runBtwSideQuestion(
     profileId: authProfileId,
     agentDir: params.agentDir,
   });
-  const apiKey = requireApiKey(apiKeyInfo, model.provider);
+  const apiKey =
+    apiKeyInfo.mode === "aws-sdk" && !apiKeyInfo.apiKey
+      ? undefined
+      : requireApiKey(apiKeyInfo, model.provider);
 
   const chunker =
     params.opts?.onBlockReply && params.blockReplyChunking


### PR DESCRIPTION
## Summary

- allow `/btw` side questions to proceed when the resolved provider auth mode is `aws-sdk` and no static api key is present
- keep the existing `requireApiKey(...)` guard for providers that still require a concrete key
- add a Bedrock regression test that locks in the `/btw` aws-sdk path

## Why

Normal Bedrock turns already tolerate `auth: aws-sdk`, but `runBtwSideQuestion()` unconditionally called `requireApiKey(...)`. That made `/btw` fail on instance-role setups even though the main session worked.

## Verification

- `pnpm test -- src/agents/btw.test.ts`
- `pnpm exec oxfmt --check src/agents/btw.ts src/agents/btw.test.ts`

Closes #53592
