### PR TITLE
fix(discord): allow user:<id> DM targets in message tool

### DIFF
--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -96,12 +96,9 @@ export function resolveOutboundChannelPlugin(params: {
     return undefined;
   }
 
-  // Discord DMs: route "user:<id>" to the Discord plugin
+  // Discord DMs: route "user:<id>" to the Discord plugin (early return if not loaded)
   if (normalized.startsWith("user:")) {
-    const discordPlugin = getChannelPlugin("discord");
-    if (discordPlugin) {
-      return discordPlugin;
-    }
+    return getChannelPlugin("discord");
   }
 
   const resolve = () => getChannelPlugin(normalized);

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -17,7 +17,14 @@ export function normalizeDeliverableOutboundChannel(
   raw?: string | null,
 ): DeliverableMessageChannel | undefined {
   const normalized = normalizeMessageChannel(raw);
-  if (!normalized || !isDeliverableMessageChannel(normalized)) {
+  if (!normalized) {
+    return undefined;
+  }
+  // Discord DMs use "user:<id>" format — allow them through
+  if (normalized.startsWith("user:")) {
+    return normalized as DeliverableMessageChannel;
+  }
+  if (!isDeliverableMessageChannel(normalized)) {
     return undefined;
   }
   return normalized;
@@ -87,6 +94,14 @@ export function resolveOutboundChannelPlugin(params: {
   const normalized = normalizeDeliverableOutboundChannel(params.channel);
   if (!normalized) {
     return undefined;
+  }
+
+  // Discord DMs: route "user:<id>" to the Discord plugin
+  if (normalized.startsWith("user:")) {
+    const discordPlugin = getChannelPlugin("discord");
+    if (discordPlugin) {
+      return discordPlugin;
+    }
   }
 
   const resolve = () => getChannelPlugin(normalized);

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -31,6 +31,10 @@ function resolveKnownChannel(value?: string | null): MessageChannelId | undefine
   if (!normalized) {
     return undefined;
   }
+  // Discord DMs use "user:<id>" format — allow them through
+  if (normalized.startsWith("user:")) {
+    return normalized as MessageChannelId;
+  }
   if (!isDeliverableMessageChannel(normalized)) {
     return undefined;
   }

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -19,6 +19,10 @@ export type MessageChannelSelectionSource =
 const getMessageChannels = () => listDeliverableMessageChannels();
 
 function isKnownChannel(value: string): boolean {
+  // Discord DMs use "user:<id>" format — allow them to pass through
+  if (value?.startsWith("user:")) {
+    return true;
+  }
   return getMessageChannels().includes(value as MessageChannelId);
 }
 


### PR DESCRIPTION
## Summary

Fix for [Issue #33978](https://github.com/openclaw/openclaw/issues/33978): Discord DM media/file sending fails with "Unknown Channel" error.

## Root Cause

When using `message` tool with `--channel discord --target user:<discord_user_id>`, the channel validation pipeline in `src/infra/outbound/` rejects `user:<id>` targets at three levels:

1. **`isKnownChannel()`** — treats `user:` as unknown
2. **`normalizeDeliverableOutboundChannel()`** — returns `undefined` for `user:` prefix
3. **`resolveOutboundChannelPlugin()`** — never gets a chance to route to Discord plugin

The underlying `sendMessageDiscord()` already handles `user:<id>` correctly via `resolveChannelId()` → `rest.post(Routes.userChannels(), { recipient_id })` to create a DM channel. The bug is purely in the validation layer above it.

## Changes

### `src/infra/outbound/channel-selection.ts`
```typescript
function isKnownChannel(value: string): boolean {
  // Discord DMs use "user:<id>" format — allow them to pass through
  if (value?.startsWith("user:")) {
    return true;
  }
  return getMessageChannels().includes(value as MessageChannelId);
}
```

### `src/infra/outbound/channel-resolution.ts`

```typescript
export function normalizeDeliverableOutboundChannel(
  raw?: string | null,
): DeliverableMessageChannel | undefined {
  const normalized = normalizeMessageChannel(raw);
  if (!normalized) {
    return undefined;
  }
  // Discord DMs use "user:<id>" format — allow them through
  if (normalized.startsWith("user:")) {
    return normalized as DeliverableMessageChannel;
  }
  if (!isDeliverableMessageChannel(normalized)) {
    return undefined;
  }
  return normalized;
}
```

```typescript
export function resolveOutboundChannelPlugin(params: {
  channel: string;
  cfg?: OpenClawConfig;
}): ChannelPlugin | undefined {
  const normalized = normalizeDeliverableOutboundChannel(params.channel);
  if (!normalized) {
    return undefined;
  }

  // Discord DMs: route "user:<id>" to the Discord plugin
  if (normalized.startsWith("user:")) {
    const discordPlugin = getChannelPlugin("discord");
    if (discordPlugin) {
      return discordPlugin;
    }
  }

  // ... rest unchanged
}
```

## Testing

Verified with `message` tool on OpenClaw 2026.3.23-2:
- `user:<discord_user_id>` text DM — ✅ works
- `user:<discord_user_id>` image attachment — ✅ works
- `user:<discord_user_id>` MP3 audio — ✅ works

## Breaking Changes

None. The changes only add new paths for `user:` prefixed targets; existing channel targets are unaffected.
