### PR TITLE
fix(plugins): ensure httpRouteRegistry fields exist across bundle chunks

### DIFF
--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -28,11 +28,11 @@ const state: RegistryState = (() => {
   // initialized by an older or differently-bundled chunk that omitted them.
   // This fixes #49803 where a bundle split causes the gateway HTTP handler
   // and the LINE/Google Chat plugin to reference different registry objects.
-  const existing = globalState[REGISTRY_STATE]!;
-  if (!("httpRouteRegistry" in existing)) {
+  const existing = globalState[REGISTRY_STATE];
+  if (existing && !("httpRouteRegistry" in existing)) {
     existing.httpRouteRegistry = null;
   }
-  if (!("httpRouteRegistryPinned" in existing)) {
+  if (existing && !("httpRouteRegistryPinned" in existing)) {
     existing.httpRouteRegistryPinned = false;
   }
   return existing as RegistryState;

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -13,7 +13,7 @@ type RegistryState = {
 
 const state: RegistryState = (() => {
   const globalState = globalThis as typeof globalThis & {
-    [REGISTRY_STATE]?: RegistryState;
+    [REGISTRY_STATE]?: Partial<RegistryState>;
   };
   if (!globalState[REGISTRY_STATE]) {
     globalState[REGISTRY_STATE] = {
@@ -24,7 +24,18 @@ const state: RegistryState = (() => {
       version: 0,
     };
   }
-  return globalState[REGISTRY_STATE];
+  // Defensive: ensure httpRouteRegistry fields exist even if state was
+  // initialized by an older or differently-bundled chunk that omitted them.
+  // This fixes #49803 where a bundle split causes the gateway HTTP handler
+  // and the LINE/Google Chat plugin to reference different registry objects.
+  const existing = globalState[REGISTRY_STATE]!;
+  if (!("httpRouteRegistry" in existing)) {
+    existing.httpRouteRegistry = null;
+  }
+  if (!("httpRouteRegistryPinned" in existing)) {
+    existing.httpRouteRegistryPinned = false;
+  }
+  return existing as RegistryState;
 })();
 
 export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {


### PR DESCRIPTION
## Summary

Fixes #49803 — LINE, Google Chat, and other webhook-based channels return 404 for POST requests even though the provider starts successfully.

## Root Cause

When the bundler splits `src/plugins/runtime.ts` across multiple output chunks (e.g., `registry-*.js` for the gateway HTTP handler and `pi-embedded-*.js` for channel plugin runtimes), whichever chunk initializes the `globalThis[Symbol.for('openclaw.pluginRegistryState')]` state object first determines its shape.

The gateway-side chunk (`registry-*.js`) initializes the state with only `{ registry, key, version }`, **omitting the `httpRouteRegistry` and `httpRouteRegistryPinned` fields**. When the LINE/Google Chat plugin later calls `registerPluginHttpRoute()` → `requireActivePluginHttpRouteRegistry()`, the missing `httpRouteRegistry` field causes routes to be registered on a fallback registry instance that the gateway HTTP handler never queries.

Result: `POST /line/webhook` → 404, while `GET /line/webhook` → 200 (served by Control UI SPA fallback).

## Fix

Defensively ensure `httpRouteRegistry` and `httpRouteRegistryPinned` fields exist on the shared state object in the IIFE initializer, regardless of which chunk creates it first. This is a +11/-2 line change in a single file.

## Affected Channels

All webhook-based channels that use `registerPluginHttpRoute` without an explicit `registry` parameter:
- LINE
- Google Chat
- Mattermost (plugin-sdk)
- Any external plugin using the same pattern

## Testing

- Verified the root cause by inspecting dist bundle output (`registry-BbjmejWa.js` vs `pi-embedded-D6PpOsxP.js`)
- Confirmed the state object shape mismatch across chunks
- The fix is purely defensive (adds missing fields to existing object) with no behavioral change when fields already exist