### PR TITLE
perf(memory): reuse parsed session entries for append-only sync

### DIFF
--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -233,21 +233,23 @@ describe("spawnSubagentDirect workspace inheritance", () => {
   });
 
   it("deletes the provisional child session when a non-thread subagent start fails", async () => {
-    hoisted.callGatewayMock.mockImplementation(async (request: {
-      method?: string;
-      params?: { key?: string; deleteTranscript?: boolean; emitLifecycleHooks?: boolean };
-    }) => {
-      if (request.method === "sessions.patch") {
-        return { ok: true };
-      }
-      if (request.method === "agent") {
-        throw new Error("spawn startup failed");
-      }
-      if (request.method === "sessions.delete") {
-        return { ok: true };
-      }
-      return {};
-    });
+    hoisted.callGatewayMock.mockImplementation(
+      async (request: {
+        method?: string;
+        params?: { key?: string; deleteTranscript?: boolean; emitLifecycleHooks?: boolean };
+      }) => {
+        if (request.method === "sessions.patch") {
+          return { ok: true };
+        }
+        if (request.method === "agent") {
+          throw new Error("spawn startup failed");
+        }
+        if (request.method === "sessions.delete") {
+          return { ok: true };
+        }
+        return {};
+      },
+    );
 
     const result = await spawnSubagentDirect(
       {

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -149,6 +149,7 @@ export abstract class MemoryManagerSyncOps {
     string,
     { lastSize: number; pendingBytes: number; pendingMessages: number }
   >();
+  protected sessionEntryCache = new Map<string, SessionFileEntry>();
   private lastMetaSerialized: string | null = null;
 
   protected abstract readonly cache: { enabled: boolean; maxEntries?: number };
@@ -837,7 +838,8 @@ export abstract class MemoryManagerSyncOps {
         }
         return;
       }
-      const entry = await buildSessionEntry(absPath);
+      const previousEntry = this.sessionEntryCache.get(absPath);
+      const entry = await buildSessionEntry(absPath, previousEntry ? { previous: previousEntry } : undefined);
       if (!entry) {
         if (params.progress) {
           params.progress.completed += 1;
@@ -863,6 +865,7 @@ export abstract class MemoryManagerSyncOps {
         return;
       }
       await this.indexFile(entry, { source: "sessions", content: entry.content });
+      this.sessionEntryCache.set(absPath, entry);
       this.resetSessionDelta(absPath, entry.size);
       if (params.progress) {
         params.progress.completed += 1;

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -839,7 +839,10 @@ export abstract class MemoryManagerSyncOps {
         return;
       }
       const previousEntry = this.sessionEntryCache.get(absPath);
-      const entry = await buildSessionEntry(absPath, previousEntry ? { previous: previousEntry } : undefined);
+      const entry = await buildSessionEntry(
+        absPath,
+        previousEntry ? { previous: previousEntry } : undefined,
+      );
       if (!entry) {
         if (params.progress) {
           params.progress.completed += 1;

--- a/src/memory/session-files.test.ts
+++ b/src/memory/session-files.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildSessionEntry } from "./session-files.js";
 
 describe("buildSessionEntry", () => {
@@ -83,5 +83,33 @@ describe("buildSessionEntry", () => {
     const entry = await buildSessionEntry(filePath);
     expect(entry).not.toBeNull();
     expect(entry!.lineMap).toEqual([3, 5]);
+  });
+
+  it("reuses previous entry for append-only transcript updates", async () => {
+    const filePath = path.join(tmpDir, "append-only.jsonl");
+    await fs.writeFile(
+      filePath,
+      [
+        JSON.stringify({ type: "message", message: { role: "user", content: "First" } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "Second" } }),
+        "",
+      ].join("\n"),
+    );
+
+    const first = await buildSessionEntry(filePath);
+    expect(first).not.toBeNull();
+
+    await fs.appendFile(
+      filePath,
+      `${JSON.stringify({ type: "message", message: { role: "user", content: "Third" } })}\n`,
+    );
+
+    const readSpy = vi.spyOn(fs, "readFile");
+    const next = await buildSessionEntry(filePath, { previous: first! });
+    expect(next).not.toBeNull();
+    expect(next!.content.split("\n")).toEqual(["User: First", "Assistant: Second", "User: Third"]);
+    expect(next!.lineMap).toEqual([1, 2, 3]);
+    expect(readSpy).toHaveBeenCalledTimes(1);
+    readSpy.mockRestore();
   });
 });

--- a/src/memory/session-files.ts
+++ b/src/memory/session-files.ts
@@ -75,7 +75,10 @@ export function extractSessionText(content: unknown): string | null {
   return parts.join(" ");
 }
 
-function collectSessionLines(lines: string[], lineOffset = 0): { collected: string[]; lineMap: number[] } {
+function collectSessionLines(
+  lines: string[],
+  lineOffset = 0,
+): { collected: string[]; lineMap: number[] } {
   const collected: string[] = [];
   const lineMap: number[] = [];
   for (let jsonlIdx = 0; jsonlIdx < lines.length; jsonlIdx++) {
@@ -89,7 +92,11 @@ function collectSessionLines(lines: string[], lineOffset = 0): { collected: stri
     } catch {
       continue;
     }
-    if (!record || typeof record !== "object" || (record as { type?: unknown }).type !== "message") {
+    if (
+      !record ||
+      typeof record !== "object" ||
+      (record as { type?: unknown }).type !== "message"
+    ) {
       continue;
     }
     const message = (record as { message?: unknown }).message as

--- a/src/memory/session-files.ts
+++ b/src/memory/session-files.ts
@@ -18,6 +18,10 @@ export type SessionFileEntry = {
   lineMap: number[];
 };
 
+export type SessionEntryBuildOptions = {
+  previous?: SessionFileEntry;
+};
+
 export async function listSessionFilesForAgent(agentId: string): Promise<string[]> {
   const dir = resolveSessionTranscriptsDirForAgent(agentId);
   try {
@@ -71,58 +75,89 @@ export function extractSessionText(content: unknown): string | null {
   return parts.join(" ");
 }
 
-export async function buildSessionEntry(absPath: string): Promise<SessionFileEntry | null> {
+function collectSessionLines(lines: string[], lineOffset = 0): { collected: string[]; lineMap: number[] } {
+  const collected: string[] = [];
+  const lineMap: number[] = [];
+  for (let jsonlIdx = 0; jsonlIdx < lines.length; jsonlIdx++) {
+    const line = lines[jsonlIdx];
+    if (!line.trim()) {
+      continue;
+    }
+    let record: unknown;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!record || typeof record !== "object" || (record as { type?: unknown }).type !== "message") {
+      continue;
+    }
+    const message = (record as { message?: unknown }).message as
+      | { role?: unknown; content?: unknown }
+      | undefined;
+    if (!message || typeof message.role !== "string") {
+      continue;
+    }
+    if (message.role !== "user" && message.role !== "assistant") {
+      continue;
+    }
+    const text = extractSessionText(message.content);
+    if (!text) {
+      continue;
+    }
+    const safe = redactSensitiveText(text, { mode: "tools" });
+    const label = message.role === "user" ? "User" : "Assistant";
+    collected.push(`${label}: ${safe}`);
+    lineMap.push(lineOffset + jsonlIdx + 1);
+  }
+  return { collected, lineMap };
+}
+
+export async function buildSessionEntry(
+  absPath: string,
+  options?: SessionEntryBuildOptions,
+): Promise<SessionFileEntry | null> {
   try {
     const stat = await fs.stat(absPath);
-    const raw = await fs.readFile(absPath, "utf-8");
-    const lines = raw.split("\n");
-    const collected: string[] = [];
-    const lineMap: number[] = [];
-    for (let jsonlIdx = 0; jsonlIdx < lines.length; jsonlIdx++) {
-      const line = lines[jsonlIdx];
-      if (!line.trim()) {
-        continue;
+    const previous = options?.previous;
+    if (previous && previous.absPath === absPath && stat.size >= previous.size) {
+      const raw = await fs.readFile(absPath, "utf-8");
+      if (raw.length >= previous.size) {
+        const prevRaw = raw.slice(0, previous.size);
+        const appendRaw = raw.slice(previous.size);
+        const previousEndsCleanly = previous.size === 0 || prevRaw.endsWith("\n");
+        if (previousEndsCleanly) {
+          const lineOffset = prevRaw === "" ? 0 : prevRaw.split("\n").length - 1;
+          const appended = collectSessionLines(appendRaw.split("\n"), lineOffset);
+          const collected = previous.content
+            ? [...previous.content.split("\n"), ...appended.collected]
+            : appended.collected;
+          const lineMap = [...previous.lineMap, ...appended.lineMap];
+          const content = collected.join("\n");
+          return {
+            path: sessionPathForFile(absPath),
+            absPath,
+            mtimeMs: stat.mtimeMs,
+            size: stat.size,
+            hash: hashText(content + "\n" + lineMap.join(",")),
+            content,
+            lineMap,
+          };
+        }
       }
-      let record: unknown;
-      try {
-        record = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      if (
-        !record ||
-        typeof record !== "object" ||
-        (record as { type?: unknown }).type !== "message"
-      ) {
-        continue;
-      }
-      const message = (record as { message?: unknown }).message as
-        | { role?: unknown; content?: unknown }
-        | undefined;
-      if (!message || typeof message.role !== "string") {
-        continue;
-      }
-      if (message.role !== "user" && message.role !== "assistant") {
-        continue;
-      }
-      const text = extractSessionText(message.content);
-      if (!text) {
-        continue;
-      }
-      const safe = redactSensitiveText(text, { mode: "tools" });
-      const label = message.role === "user" ? "User" : "Assistant";
-      collected.push(`${label}: ${safe}`);
-      lineMap.push(jsonlIdx + 1);
     }
-    const content = collected.join("\n");
+
+    const raw = await fs.readFile(absPath, "utf-8");
+    const parsed = collectSessionLines(raw.split("\n"));
+    const content = parsed.collected.join("\n");
     return {
       path: sessionPathForFile(absPath),
       absPath,
       mtimeMs: stat.mtimeMs,
       size: stat.size,
-      hash: hashText(content + "\n" + lineMap.join(",")),
+      hash: hashText(content + "\n" + parsed.lineMap.join(",")),
       content,
-      lineMap,
+      lineMap: parsed.lineMap,
     };
   } catch (err) {
     log.debug(`Failed reading session file ${absPath}: ${String(err)}`);


### PR DESCRIPTION
## Summary
- add an append-only fast path to `buildSessionEntry(...)` so session transcript sync can reuse the previously parsed entry instead of reparsing the entire JSONL file on every append
- cache the last parsed session entry during memory sync and feed it back into subsequent targeted/session-delta syncs
- add a focused regression test for append-only transcript reuse while preserving existing memory index behavior

## Why
Session transcript sync currently reparses whole JSONL files even when a transcript only grows by one or two lines. This change keeps the existing indexing behavior but avoids rebuilding the earlier portion of the flattened transcript when the update is append-only.

## Testing
- [x] `pnpm vitest run src/memory/session-files.test.ts src/memory/index.test.ts`

AI-assisted: Codex-assisted
Testing: lightly tested locally (targeted memory tests)
