### PR TITLE
perf(memory): avoid full sort in vector fallback search

### DIFF
--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -233,21 +233,23 @@ describe("spawnSubagentDirect workspace inheritance", () => {
   });
 
   it("deletes the provisional child session when a non-thread subagent start fails", async () => {
-    hoisted.callGatewayMock.mockImplementation(async (request: {
-      method?: string;
-      params?: { key?: string; deleteTranscript?: boolean; emitLifecycleHooks?: boolean };
-    }) => {
-      if (request.method === "sessions.patch") {
-        return { ok: true };
-      }
-      if (request.method === "agent") {
-        throw new Error("spawn startup failed");
-      }
-      if (request.method === "sessions.delete") {
-        return { ok: true };
-      }
-      return {};
-    });
+    hoisted.callGatewayMock.mockImplementation(
+      async (request: {
+        method?: string;
+        params?: { key?: string; deleteTranscript?: boolean; emitLifecycleHooks?: boolean };
+      }) => {
+        if (request.method === "sessions.patch") {
+          return { ok: true };
+        }
+        if (request.method === "agent") {
+          throw new Error("spawn startup failed");
+        }
+        if (request.method === "sessions.delete") {
+          return { ok: true };
+        }
+        return {};
+      },
+    );
 
     const result = await spawnSubagentDirect(
       {

--- a/src/memory/manager-search.test.ts
+++ b/src/memory/manager-search.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { searchVector } from "./manager-search.js";
+
+function createDb(rows: unknown[]) {
+  return {
+    prepare: () => ({
+      all: () => rows,
+    }),
+  } as const;
+}
+
+describe("searchVector fallback", () => {
+  it("returns top-k scores without sqlite-vec", async () => {
+    const rows = [
+      { id: "a", path: "p1", start_line: 1, end_line: 1, text: "a", embedding: "1,0", source: "memory" },
+      { id: "b", path: "p2", start_line: 1, end_line: 1, text: "b", embedding: "0.8,0.2", source: "memory" },
+      { id: "c", path: "p3", start_line: 1, end_line: 1, text: "c", embedding: "0,1", source: "memory" },
+    ];
+    const result = await searchVector({
+      db: createDb(rows) as never,
+      vectorTable: "vectors",
+      providerModel: "test-model",
+      queryVec: [1, 0],
+      limit: 2,
+      snippetMaxChars: 50,
+      ensureVectorReady: vi.fn(async () => false),
+      sourceFilterVec: { sql: "", params: [] },
+      sourceFilterChunks: { sql: "", params: [] },
+    });
+    expect(result.map((r) => r.id)).toEqual(["a", "b"]);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.score).toBeGreaterThanOrEqual(result[1]!.score);
+  });
+
+  it("keeps only the best bounded top-k results in fallback mode", async () => {
+    const rows = [
+      { id: "low", path: "p0", start_line: 1, end_line: 1, text: "low", embedding: "[0,1]", source: "memory" },
+      { id: "mid", path: "p1", start_line: 1, end_line: 1, text: "mid", embedding: "[0.7,0.3]", source: "memory" },
+      { id: "high", path: "p2", start_line: 1, end_line: 1, text: "high", embedding: "[1,0]", source: "memory" },
+      { id: "almost", path: "p3", start_line: 1, end_line: 1, text: "almost", embedding: "[0.95,0.05]", source: "memory" },
+    ];
+    const result = await searchVector({
+      db: createDb(rows) as never,
+      vectorTable: "vectors",
+      providerModel: "test-model",
+      queryVec: [1, 0],
+      limit: 2,
+      snippetMaxChars: 50,
+      ensureVectorReady: vi.fn(async () => false),
+      sourceFilterVec: { sql: "", params: [] },
+      sourceFilterChunks: { sql: "", params: [] },
+    });
+    expect(result.map((r) => r.id)).toEqual(["high", "almost"]);
+  });
+});

--- a/src/memory/manager-search.test.ts
+++ b/src/memory/manager-search.test.ts
@@ -12,9 +12,33 @@ function createDb(rows: unknown[]) {
 describe("searchVector fallback", () => {
   it("returns top-k scores without sqlite-vec", async () => {
     const rows = [
-      { id: "a", path: "p1", start_line: 1, end_line: 1, text: "a", embedding: "1,0", source: "memory" },
-      { id: "b", path: "p2", start_line: 1, end_line: 1, text: "b", embedding: "0.8,0.2", source: "memory" },
-      { id: "c", path: "p3", start_line: 1, end_line: 1, text: "c", embedding: "0,1", source: "memory" },
+      {
+        id: "a",
+        path: "p1",
+        start_line: 1,
+        end_line: 1,
+        text: "a",
+        embedding: "1,0",
+        source: "memory",
+      },
+      {
+        id: "b",
+        path: "p2",
+        start_line: 1,
+        end_line: 1,
+        text: "b",
+        embedding: "0.8,0.2",
+        source: "memory",
+      },
+      {
+        id: "c",
+        path: "p3",
+        start_line: 1,
+        end_line: 1,
+        text: "c",
+        embedding: "0,1",
+        source: "memory",
+      },
     ];
     const result = await searchVector({
       db: createDb(rows) as never,
@@ -29,15 +53,47 @@ describe("searchVector fallback", () => {
     });
     expect(result.map((r) => r.id)).toEqual(["a", "b"]);
     expect(result).toHaveLength(2);
-    expect(result[0]!.score).toBeGreaterThanOrEqual(result[1]!.score);
+    expect(result[0].score).toBeGreaterThanOrEqual(result[1].score);
   });
 
   it("keeps only the best bounded top-k results in fallback mode", async () => {
     const rows = [
-      { id: "low", path: "p0", start_line: 1, end_line: 1, text: "low", embedding: "[0,1]", source: "memory" },
-      { id: "mid", path: "p1", start_line: 1, end_line: 1, text: "mid", embedding: "[0.7,0.3]", source: "memory" },
-      { id: "high", path: "p2", start_line: 1, end_line: 1, text: "high", embedding: "[1,0]", source: "memory" },
-      { id: "almost", path: "p3", start_line: 1, end_line: 1, text: "almost", embedding: "[0.95,0.05]", source: "memory" },
+      {
+        id: "low",
+        path: "p0",
+        start_line: 1,
+        end_line: 1,
+        text: "low",
+        embedding: "[0,1]",
+        source: "memory",
+      },
+      {
+        id: "mid",
+        path: "p1",
+        start_line: 1,
+        end_line: 1,
+        text: "mid",
+        embedding: "[0.7,0.3]",
+        source: "memory",
+      },
+      {
+        id: "high",
+        path: "p2",
+        start_line: 1,
+        end_line: 1,
+        text: "high",
+        embedding: "[1,0]",
+        source: "memory",
+      },
+      {
+        id: "almost",
+        path: "p3",
+        start_line: 1,
+        end_line: 1,
+        text: "almost",
+        embedding: "[0.95,0.05]",
+        source: "memory",
+      },
     ];
     const result = await searchVector({
       db: createDb(rows) as never,

--- a/src/memory/manager-search.ts
+++ b/src/memory/manager-search.ts
@@ -73,24 +73,38 @@ export async function searchVector(params: {
     providerModel: params.providerModel,
     sourceFilter: params.sourceFilterChunks,
   });
-  const scored = candidates
-    .map((chunk) => ({
-      chunk,
-      score: cosineSimilarity(params.queryVec, chunk.embedding),
-    }))
-    .filter((entry) => Number.isFinite(entry.score));
-  return scored
-    .toSorted((a, b) => b.score - a.score)
-    .slice(0, params.limit)
-    .map((entry) => ({
-      id: entry.chunk.id,
-      path: entry.chunk.path,
-      startLine: entry.chunk.startLine,
-      endLine: entry.chunk.endLine,
-      score: entry.score,
-      snippet: truncateUtf16Safe(entry.chunk.text, params.snippetMaxChars),
-      source: entry.chunk.source,
-    }));
+  const top: Array<{
+    chunk: (typeof candidates)[number];
+    score: number;
+  }> = [];
+
+  for (const chunk of candidates) {
+    const score = cosineSimilarity(params.queryVec, chunk.embedding);
+    if (!Number.isFinite(score)) {
+      continue;
+    }
+    if (top.length < params.limit) {
+      top.push({ chunk, score });
+      top.sort((a, b) => b.score - a.score);
+      continue;
+    }
+    const weakest = top[top.length - 1];
+    if (!weakest || score <= weakest.score) {
+      continue;
+    }
+    top[top.length - 1] = { chunk, score };
+    top.sort((a, b) => b.score - a.score);
+  }
+
+  return top.map((entry) => ({
+    id: entry.chunk.id,
+    path: entry.chunk.path,
+    startLine: entry.chunk.startLine,
+    endLine: entry.chunk.endLine,
+    score: entry.score,
+    snippet: truncateUtf16Safe(entry.chunk.text, params.snippetMaxChars),
+    source: entry.chunk.source,
+  }));
 }
 
 export function listChunks(params: {


### PR DESCRIPTION
## Summary
- replace the full sort in the non-sqlite-vec vector fallback path with a bounded top-k accumulation
- keep only the strongest `limit` candidates while scanning fallback chunks instead of sorting the full scored list
- add a focused unit test for fallback top-k behavior

## Why
When sqlite-vec is unavailable, memory search currently scores every chunk and then sorts the entire scored list before slicing. This does more work than needed for small `limit` values. Keeping only the best bounded top-k results reduces wasted sorting work on larger fallback candidate sets.

## Testing
- [x] `pnpm vitest run src/memory/manager-search.test.ts`

AI-assisted: Codex-assisted
Testing: lightly tested locally (targeted fallback search test)
