### PR TITLE
fix: warn when legacy CLAWDBOT_*/MOLTBOT_* env vars are detected

### DIFF
--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -290,7 +290,7 @@ export function assertGatewayAuthConfigured(
       return;
     }
     throw new Error(
-      "gateway auth mode is token, but no token was configured (set gateway.auth.token or OPENCLAW_GATEWAY_TOKEN)",
+      "gateway auth mode is token, but no token was configured (set gateway.auth.token or OPENCLAW_GATEWAY_TOKEN; note: legacy CLAWDBOT_*/MOLTBOT_* env vars are no longer supported)",
     );
   }
   if (auth.mode === "password" && !auth.password) {
@@ -302,7 +302,9 @@ export function assertGatewayAuthConfigured(
         "gateway auth mode is password, but gateway.auth.password contains a provider reference object instead of a resolved string — bootstrap secrets (gateway.auth.password) must be plaintext strings or set via the OPENCLAW_GATEWAY_PASSWORD environment variable because the secrets provider system has not initialised yet at gateway startup", // pragma: allowlist secret
       );
     }
-    throw new Error("gateway auth mode is password, but no password was configured");
+    throw new Error(
+      "gateway auth mode is password, but no password was configured (note: legacy CLAWDBOT_*/MOLTBOT_* env vars are no longer supported)",
+    );
   }
   if (auth.mode === "trusted-proxy") {
     if (!auth.trustedProxy) {

--- a/src/gateway/env-deprecation.test.ts
+++ b/src/gateway/env-deprecation.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetLegacyEnvWarning, warnLegacyEnvVars } from "./env-deprecation.js";
+
+describe("warnLegacyEnvVars", () => {
+  let emitWarningSpy: ReturnType<typeof vi.spyOn>;
+  const savedVitest = process.env.VITEST;
+  const savedNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    _resetLegacyEnvWarning();
+    emitWarningSpy = vi.spyOn(process, "emitWarning").mockImplementation(() => {});
+    // Disable test-env suppression so we can exercise the warning path.
+    delete process.env.VITEST;
+    delete process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    emitWarningSpy.mockRestore();
+    // Restore env.
+    if (savedVitest !== undefined) {
+      process.env.VITEST = savedVitest;
+    }
+    if (savedNodeEnv !== undefined) {
+      process.env.NODE_ENV = savedNodeEnv;
+    }
+  });
+
+  it("emits warning when CLAWDBOT_GATEWAY_TOKEN is present", () => {
+    const env: NodeJS.ProcessEnv = { CLAWDBOT_GATEWAY_TOKEN: "tok123" };
+    warnLegacyEnvVars(env);
+
+    expect(emitWarningSpy).toHaveBeenCalledOnce();
+    const [message, opts] = emitWarningSpy.mock.calls[0] as [
+      string,
+      { code: string; type: string },
+    ];
+    expect(message).toContain("CLAWDBOT_GATEWAY_TOKEN");
+    expect(message).toContain("OPENCLAW_GATEWAY_TOKEN");
+    expect(opts.code).toBe("OPENCLAW_LEGACY_ENV_VARS");
+    expect(opts.type).toBe("DeprecationWarning");
+  });
+
+  it("emits warning when MOLTBOT_GATEWAY_PASSWORD is present", () => {
+    const env: NodeJS.ProcessEnv = { MOLTBOT_GATEWAY_PASSWORD: "pw" }; // pragma: allowlist secret
+    warnLegacyEnvVars(env);
+
+    expect(emitWarningSpy).toHaveBeenCalledOnce();
+    const [message] = emitWarningSpy.mock.calls[0] as [string];
+    expect(message).toContain("MOLTBOT_GATEWAY_PASSWORD");
+    expect(message).toContain("OPENCLAW_GATEWAY_PASSWORD");
+  });
+
+  it("does not warn when only OPENCLAW_* vars are present", () => {
+    const env: NodeJS.ProcessEnv = { OPENCLAW_GATEWAY_TOKEN: "tok" };
+    warnLegacyEnvVars(env);
+
+    expect(emitWarningSpy).not.toHaveBeenCalled();
+  });
+
+  it("includes correct OPENCLAW_* replacement in warning message", () => {
+    const env: NodeJS.ProcessEnv = {
+      CLAWDBOT_STATE_DIR: "/old",
+      MOLTBOT_CONFIG_PATH: "/cfg",
+    };
+    warnLegacyEnvVars(env);
+
+    expect(emitWarningSpy).toHaveBeenCalledOnce();
+    const [message] = emitWarningSpy.mock.calls[0] as [string];
+    expect(message).toContain("CLAWDBOT_STATE_DIR -> OPENCLAW_STATE_DIR");
+    expect(message).toContain("MOLTBOT_CONFIG_PATH -> OPENCLAW_CONFIG_PATH");
+  });
+
+  it("only warns once per process (deduplication)", () => {
+    const env: NodeJS.ProcessEnv = { CLAWDBOT_GATEWAY_TOKEN: "tok" };
+    warnLegacyEnvVars(env);
+    warnLegacyEnvVars(env);
+    warnLegacyEnvVars(env);
+
+    expect(emitWarningSpy).toHaveBeenCalledOnce();
+  });
+
+  it("suppresses warning in test environment (VITEST=true)", () => {
+    process.env.VITEST = "true";
+    const env: NodeJS.ProcessEnv = { CLAWDBOT_GATEWAY_TOKEN: "tok" };
+    warnLegacyEnvVars(env);
+
+    expect(emitWarningSpy).not.toHaveBeenCalled();
+  });
+
+  it("suppresses warning in test environment (NODE_ENV=test)", () => {
+    process.env.NODE_ENV = "test";
+    const env: NodeJS.ProcessEnv = { CLAWDBOT_GATEWAY_TOKEN: "tok" };
+    warnLegacyEnvVars(env);
+
+    expect(emitWarningSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/env-deprecation.ts
+++ b/src/gateway/env-deprecation.ts
@@ -1,0 +1,62 @@
+/**
+ * Detects legacy CLAWDBOT_* and MOLTBOT_* env vars and emits a single
+ * deprecation warning listing each detected key and its OPENCLAW_* replacement.
+ *
+ * The breaking removal happened in v2026.3.22 (commit 6b9915a106).
+ * We do not restore fallback behavior — only surface the rename.
+ */
+
+const LEGACY_PREFIX_MAP: ReadonlyArray<[legacy: string, modern: string]> = [
+  ["CLAWDBOT_", "OPENCLAW_"],
+  ["MOLTBOT_", "OPENCLAW_"],
+];
+
+let warned = false;
+
+export function warnLegacyEnvVars(env: NodeJS.ProcessEnv = process.env): void {
+  if (warned) {
+    return;
+  }
+  // Suppress in test environments.
+  if (process.env.VITEST === "true" || process.env.NODE_ENV === "test") {
+    return;
+  }
+
+  const hits: Array<{ legacy: string; replacement: string }> = [];
+
+  for (const key of Object.keys(env)) {
+    for (const [legacyPrefix, modernPrefix] of LEGACY_PREFIX_MAP) {
+      if (key.startsWith(legacyPrefix)) {
+        const suffix = key.slice(legacyPrefix.length);
+        hits.push({ legacy: key, replacement: `${modernPrefix}${suffix}` });
+      }
+    }
+  }
+
+  if (hits.length === 0) {
+    return;
+  }
+
+  const lines = hits.map((h) => `  ${h.legacy} -> ${h.replacement}`);
+  process.emitWarning(
+    [
+      "Legacy environment variables detected (no longer supported since v2026.3.22):",
+      ...lines,
+      "Rename them to their OPENCLAW_* equivalents; the old names are silently ignored.",
+    ].join("\n"),
+    {
+      type: "DeprecationWarning",
+      code: "OPENCLAW_LEGACY_ENV_VARS",
+    },
+  );
+
+  warned = true;
+}
+
+/**
+ * Reset internal state — only for tests.
+ * @internal
+ */
+export function _resetLegacyEnvWarning(): void {
+  warned = false;
+}

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -10,6 +10,7 @@ import {
   resolveGatewayAuth,
 } from "./auth.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
+import { warnLegacyEnvVars } from "./env-deprecation.js";
 import { resolveHooksConfig } from "./hooks.js";
 import {
   isLoopbackHost,
@@ -48,6 +49,7 @@ export async function resolveGatewayRuntimeConfig(params: {
   auth?: GatewayAuthConfig;
   tailscale?: GatewayTailscaleConfig;
 }): Promise<GatewayRuntimeConfig> {
+  warnLegacyEnvVars(process.env);
   const bindMode = params.bind ?? params.cfg.gateway?.bind ?? "loopback";
   const customBindHost = params.cfg.gateway?.customBindHost;
   const bindHost = params.host ?? (await resolveGatewayBindHost(bindMode, customBindHost));
@@ -132,7 +134,7 @@ export async function resolveGatewayRuntimeConfig(params: {
   }
   if (!isLoopbackHost(bindHost) && !hasSharedSecret && authMode !== "trusted-proxy") {
     throw new Error(
-      `refusing to bind gateway to ${bindHost}:${params.port} without auth (set gateway.auth.token/password, or set OPENCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_PASSWORD)`,
+      `refusing to bind gateway to ${bindHost}:${params.port} without auth (set gateway.auth.token/password, or set OPENCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_PASSWORD; note: legacy CLAWDBOT_*/MOLTBOT_* env vars are no longer supported)`,
     );
   }
   if (


### PR DESCRIPTION
Fixes #53482. Since v2026.3.22 removed all CLAWDBOT_* and MOLTBOT_* env var compatibility, users with those vars in their .env see silent failures or misleading errors. Add a process.emitWarning() that lists each detected legacy key and its OPENCLAW_* replacement, and update related error messages to mention the legacy vars are no longer supported.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Users who still have `CLAWDBOT_GATEWAY_TOKEN` or `CLAWDBOT_GATEWAY_PASSWORD` in their `.env` see either silent failure (loopback mode: gateway starts but channels offline) or misleading error (network mode: "no auth configured" with no mention of the legacy vars).
- Why it matters: The v2026.3.22 breaking change (commit `6b9915a106`) removed legacy env var support but gave users zero signal about what happened — they can spend hours debugging a rename they don't know about.
- What changed: Added `src/gateway/env-deprecation.ts` that scans `process.env` for `CLAWDBOT_*`/`MOLTBOT_*` keys and emits a single `DeprecationWarning` listing each legacy key → `OPENCLAW_*` replacement. Called at the top of `resolveGatewayRuntimeConfig()`. Updated three error messages in `auth.ts` and `server-runtime-config.ts` to mention legacy vars are no longer supported.
- What did NOT change (scope boundary): No legacy fallback is restored — the breaking change was intentional. This only adds user-facing warnings and improved error messages.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53482
- Related # N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Commit `6b9915a106` (v2026.3.22) removed all `CLAWDBOT_*` and `MOLTBOT_*` env var fallback logic as an intentional breaking change but did not add any deprecation warning or mention in error messages. The credential resolution code in `credentials.ts` only reads `OPENCLAW_*` vars, so legacy-named vars are silently ignored.
- Missing detection / guardrail: No check existed to detect the presence of legacy env vars and inform the user they need to rename them.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Commit `6b9915a106` — bulk removal of legacy compatibility env names, documented in CHANGELOG.md line 98.
- Why this regressed now: The breaking change shipped without a deprecation transition period or warning.
- If unknown, what was ruled out: N/A — root cause is clear.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/env-deprecation.test.ts`
- Scenario the test should lock in: When `CLAWDBOT_*` or `MOLTBOT_*` env vars are present, a `DeprecationWarning` is emitted with the correct `OPENCLAW_*` replacement names; when only `OPENCLAW_*` vars are present, no warning fires; warning deduplicates across multiple calls.
- Why this is the smallest reliable guardrail: The warning logic is a pure function over env keys — a unit test fully exercises the detection, message content, dedup, and test-env suppression paths.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A — 7 new tests added.

## User-visible / Behavior Changes

- Users with legacy `CLAWDBOT_*` or `MOLTBOT_*` env vars will now see a `DeprecationWarning` on gateway startup listing each legacy key and its `OPENCLAW_*` replacement.
- Error messages for "no token configured", "no password configured", and "refusing to bind without auth" now append a note that legacy env var names are no longer supported.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (also reproducible on Linux)
- Runtime/container: Node.js 23.x
- Model/provider: N/A
- Integration/channel (if any): Gateway startup
- Relevant config (redacted): `.env` containing `CLAWDBOT_GATEWAY_TOKEN=<redacted>`

### Steps

1. Set `CLAWDBOT_GATEWAY_TOKEN=somevalue` in `.env` (without any `OPENCLAW_GATEWAY_TOKEN`)
2. Start the gateway in network bind mode
3. Observe console output

### Expected

- A `DeprecationWarning` is printed listing `CLAWDBOT_GATEWAY_TOKEN -> OPENCLAW_GATEWAY_TOKEN`
- If auth fails, the error message mentions that legacy env vars are no longer supported

### Actual

- Before this PR: silent failure or misleading "no auth configured" with no mention of legacy vars
- After this PR: clear warning + improved error messages

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

7 new tests in `src/gateway/env-deprecation.test.ts` all pass. 73 existing tests in `auth.test.ts`, `credentials.test.ts`, `credential-precedence.parity.test.ts` remain green (80 total).

## Human Verification (required)

- Verified scenarios: All 7 new unit tests pass (warning emission for CLAWDBOT_*, MOLTBOT_*, correct replacement mapping, dedup, test-env suppression). All 73 existing gateway auth/credential tests pass.
- Edge cases checked: Empty env (no warning), only OPENCLAW_* vars (no warning), multiple legacy vars (single warning lists all), repeated calls (dedup — only one warning).
- What you did **not** verify: Full `pnpm build` and `pnpm check` (pnpm not available locally — relies on CI). Manual end-to-end gateway startup with legacy vars (covered by unit tests).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes` — no behavior change for users already using `OPENCLAW_*` vars.
- Config/env changes? `No` — no new config; only a warning for deprecated env var names.
- Migration needed? `No` — users simply rename `CLAWDBOT_*`/`MOLTBOT_*` to `OPENCLAW_*` (which was already required since v2026.3.22; this PR just surfaces that clearly).
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit; or set `OPENCLAW_SUPPRESS_LEGACY_ENV_WARNING=1` (not yet implemented but trivially addable).
- Files/config to restore: `src/gateway/auth.ts`, `src/gateway/server-runtime-config.ts` to prior versions; delete `src/gateway/env-deprecation.ts` and `src/gateway/env-deprecation.test.ts`.
- Known bad symptoms reviewers should watch for: Unexpected warning noise in logs for users who intentionally keep both old and new env vars (unlikely); any import resolution failure from `env-deprecation.js` in gateway startup.

## Risks and Mitigations

- Risk: Warning emits on every gateway process start for users with legacy vars, potentially noisy in log aggregators.
  - Mitigation: Deduplication ensures only one warning per process. Warning uses standard `process.emitWarning()` which is filterable by code `OPENCLAW_LEGACY_ENV_VARS`. Suppressed in test environments.
