### PR TITLE
perf(health): probe channel accounts in parallel

### DIFF
--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -233,21 +233,23 @@ describe("spawnSubagentDirect workspace inheritance", () => {
   });
 
   it("deletes the provisional child session when a non-thread subagent start fails", async () => {
-    hoisted.callGatewayMock.mockImplementation(async (request: {
-      method?: string;
-      params?: { key?: string; deleteTranscript?: boolean; emitLifecycleHooks?: boolean };
-    }) => {
-      if (request.method === "sessions.patch") {
-        return { ok: true };
-      }
-      if (request.method === "agent") {
-        throw new Error("spawn startup failed");
-      }
-      if (request.method === "sessions.delete") {
-        return { ok: true };
-      }
-      return {};
-    });
+    hoisted.callGatewayMock.mockImplementation(
+      async (request: {
+        method?: string;
+        params?: { key?: string; deleteTranscript?: boolean; emitLifecycleHooks?: boolean };
+      }) => {
+        if (request.method === "sessions.patch") {
+          return { ok: true };
+        }
+        if (request.method === "agent") {
+          throw new Error("spawn startup failed");
+        }
+        if (request.method === "sessions.delete") {
+          return { ok: true };
+        }
+        return {};
+      },
+    );
 
     const result = await spawnSubagentDirect(
       {

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -243,6 +243,55 @@ describe("getHealthSnapshot", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it("probes multiple configured accounts in parallel", async () => {
+    testConfig = {
+      channels: {
+        telegram: {
+          accounts: {
+            a: { botToken: "token-a" },
+            b: { botToken: "token-b" },
+          },
+          defaultAccountId: "a",
+        },
+      },
+    };
+    testStore = {};
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
+    vi.stubEnv("DISCORD_BOT_TOKEN", "");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        if (url.includes("/getMe")) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ ok: true, result: { username: "bot" } }),
+          } as unknown as Response;
+        }
+        if (url.includes("/getWebhookInfo")) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ ok: true, result: { url: "https://example.test/hook" } }),
+          } as unknown as Response;
+        }
+        throw new Error(`unexpected url: ${url}`);
+      }),
+    );
+
+    const started = Date.now();
+    const snap = await getHealthSnapshot({ timeoutMs: 250 });
+    const elapsed = Date.now() - started;
+    const telegram = snap.channels.telegram as {
+      accounts?: Record<string, { probe?: { ok?: boolean } }>;
+    };
+    expect(telegram.accounts?.a?.probe?.ok).toBe(true);
+    expect(telegram.accounts?.b?.probe?.ok).toBe(true);
+    expect(elapsed).toBeLessThan(100);
+  });
+
   it("returns a structured telegram probe error when getMe fails", async () => {
     testConfig = { channels: { telegram: { botToken: "bad-token" } } };
     testStore = {};

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -486,78 +486,84 @@ export async function getHealthSnapshot(params?: {
     });
     const accountSummaries: Record<string, ChannelAccountHealthSummary> = {};
 
-    for (const accountId of accountIdsToProbe) {
-      const { account, enabled, configured, diagnostics } = await resolveHealthAccountContext({
-        plugin,
-        cfg,
-        accountId,
-      });
-      if (diagnostics.length > 0) {
-        debugHealth("account.diagnostics", { channel: plugin.id, accountId, diagnostics });
-      }
-
-      let probe: unknown;
-      let lastProbeAt: number | null = null;
-      if (enabled && configured && doProbe && plugin.status?.probeAccount) {
-        try {
-          probe = await plugin.status.probeAccount({
-            account,
-            timeoutMs: cappedTimeout,
-            cfg,
-          });
-          lastProbeAt = Date.now();
-        } catch (err) {
-          probe = { ok: false, error: formatErrorMessage(err) };
-          lastProbeAt = Date.now();
+    const resolvedAccounts = await Promise.all(
+      accountIdsToProbe.map(async (accountId) => {
+        const { account, enabled, configured, diagnostics } = await resolveHealthAccountContext({
+          plugin,
+          cfg,
+          accountId,
+        });
+        if (diagnostics.length > 0) {
+          debugHealth("account.diagnostics", { channel: plugin.id, accountId, diagnostics });
         }
-      }
 
-      const probeRecord =
-        probe && typeof probe === "object" ? (probe as Record<string, unknown>) : null;
-      const bot =
-        probeRecord && typeof probeRecord.bot === "object"
-          ? (probeRecord.bot as { username?: string | null })
-          : null;
-      if (bot?.username) {
-        debugHealth("probe.bot", { channel: plugin.id, accountId, username: bot.username });
-      }
+        let probe: unknown;
+        let lastProbeAt: number | null = null;
+        if (enabled && configured && doProbe && plugin.status?.probeAccount) {
+          try {
+            probe = await plugin.status.probeAccount({
+              account,
+              timeoutMs: cappedTimeout,
+              cfg,
+            });
+            lastProbeAt = Date.now();
+          } catch (err) {
+            probe = { ok: false, error: formatErrorMessage(err) };
+            lastProbeAt = Date.now();
+          }
+        }
 
-      const snapshot: ChannelAccountSnapshot = {
-        accountId,
-        enabled,
-        configured,
-      };
-      if (probe !== undefined) {
-        snapshot.probe = probe;
-      }
-      if (lastProbeAt) {
-        snapshot.lastProbeAt = lastProbeAt;
-      }
+        const probeRecord =
+          probe && typeof probe === "object" ? (probe as Record<string, unknown>) : null;
+        const bot =
+          probeRecord && typeof probeRecord.bot === "object"
+            ? (probeRecord.bot as { username?: string | null })
+            : null;
+        if (bot?.username) {
+          debugHealth("probe.bot", { channel: plugin.id, accountId, username: bot.username });
+        }
 
-      const summary = plugin.status?.buildChannelSummary
-        ? await plugin.status.buildChannelSummary({
-            account,
-            cfg,
-            defaultAccountId: accountId,
-            snapshot,
-          })
-        : undefined;
-      const record =
-        summary && typeof summary === "object"
-          ? (summary as ChannelAccountHealthSummary)
-          : ({
-              accountId,
-              configured,
-              probe,
-              lastProbeAt,
-            } satisfies ChannelAccountHealthSummary);
-      if (record.configured === undefined) {
-        record.configured = configured;
-      }
-      if (record.lastProbeAt === undefined && lastProbeAt) {
-        record.lastProbeAt = lastProbeAt;
-      }
-      record.accountId = accountId;
+        const snapshot: ChannelAccountSnapshot = {
+          accountId,
+          enabled,
+          configured,
+        };
+        if (probe !== undefined) {
+          snapshot.probe = probe;
+        }
+        if (lastProbeAt) {
+          snapshot.lastProbeAt = lastProbeAt;
+        }
+
+        const summary = plugin.status?.buildChannelSummary
+          ? await plugin.status.buildChannelSummary({
+              account,
+              cfg,
+              defaultAccountId: accountId,
+              snapshot,
+            })
+          : undefined;
+        const record =
+          summary && typeof summary === "object"
+            ? (summary as ChannelAccountHealthSummary)
+            : ({
+                accountId,
+                configured,
+                probe,
+                lastProbeAt,
+              } satisfies ChannelAccountHealthSummary);
+        if (record.configured === undefined) {
+          record.configured = configured;
+        }
+        if (record.lastProbeAt === undefined && lastProbeAt) {
+          record.lastProbeAt = lastProbeAt;
+        }
+        record.accountId = accountId;
+        return { accountId, record };
+      }),
+    );
+
+    for (const { accountId, record } of resolvedAccounts) {
       accountSummaries[accountId] = record;
     }
 


### PR DESCRIPTION
## Summary
- parallelize per-account channel health probing within a channel instead of probing each configured account serially
- preserve existing summary-building behavior while reducing wall-clock time for multi-account channels
- add a focused snapshot test that demonstrates two configured Telegram accounts are probed concurrently

## Why
`getHealthSnapshot()` currently iterates `accountIdsToProbe` serially. For channels with multiple configured accounts, overall health latency grows roughly linearly with probe duration. Running the per-account work in parallel improves the common case without changing the output schema.

## Testing
- [x] `pnpm vitest run src/commands/health.snapshot.test.ts`

AI-assisted: Codex-assisted
Testing: lightly tested locally (targeted health snapshot test)
