### PR TITLE
perf(memory): stream line-window reads for memory files

### DIFF
--- a/src/memory/manager.read-file.test.ts
+++ b/src/memory/manager.read-file.test.ts
@@ -77,8 +77,14 @@ describe("MemoryIndexManager.readFile", () => {
     await fs.mkdir(path.dirname(absPath), { recursive: true });
     await fs.writeFile(absPath, ["line 1", "line 2", "line 3"].join("\n"), "utf-8");
 
-    const result = await manager!.readFile({ relPath, from: 2, lines: 1 });
-    expect(result).toEqual({ text: "line 2", path: relPath });
+    const readSpy = vi.spyOn(fs, "readFile");
+    try {
+      const result = await manager!.readFile({ relPath, from: 2, lines: 1 });
+      expect(result).toEqual({ text: "line 2", path: relPath });
+      expect(readSpy).not.toHaveBeenCalled();
+    } finally {
+      readSpy.mockRestore();
+    }
   });
 
   it("returns empty text when the requested slice is past EOF", async () => {

--- a/src/memory/read-file.ts
+++ b/src/memory/read-file.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs/promises";
+import { createReadStream } from "node:fs";
 import path from "node:path";
+import readline from "node:readline";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -56,23 +58,47 @@ export async function readMemoryFile(params: {
   if (statResult.missing) {
     return { text: "", path: relPath };
   }
-  let content: string;
+  if (!params.from && !params.lines) {
+    let content: string;
+    try {
+      content = await fs.readFile(absPath, "utf-8");
+    } catch (err) {
+      if (isFileMissingError(err)) {
+        return { text: "", path: relPath };
+      }
+      throw err;
+    }
+    return { text: content, path: relPath };
+  }
+
+  const start = Math.max(1, params.from ?? 1);
+  const count = Math.max(1, params.lines ?? Number.MAX_SAFE_INTEGER);
+  const end = start + count - 1;
+  const collected: string[] = [];
+  let lineNo = 0;
+  const stream = createReadStream(absPath, { encoding: "utf-8" });
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
   try {
-    content = await fs.readFile(absPath, "utf-8");
+    for await (const line of rl) {
+      lineNo += 1;
+      if (lineNo < start) {
+        continue;
+      }
+      if (lineNo > end) {
+        break;
+      }
+      collected.push(line);
+    }
   } catch (err) {
     if (isFileMissingError(err)) {
       return { text: "", path: relPath };
     }
     throw err;
+  } finally {
+    rl.close();
+    stream.destroy();
   }
-  if (!params.from && !params.lines) {
-    return { text: content, path: relPath };
-  }
-  const fileLines = content.split("\n");
-  const start = Math.max(1, params.from ?? 1);
-  const count = Math.max(1, params.lines ?? fileLines.length);
-  const slice = fileLines.slice(start - 1, start - 1 + count);
-  return { text: slice.join("\n"), path: relPath };
+  return { text: collected.join("\n"), path: relPath };
 }
 
 export async function readAgentMemoryFile(params: {

--- a/src/memory/read-file.ts
+++ b/src/memory/read-file.ts
@@ -1,5 +1,5 @@
-import fs from "node:fs/promises";
 import { createReadStream } from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import readline from "node:readline";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";


### PR DESCRIPTION
## Summary
- avoid reading the full markdown file into memory when `memory_get` requests only a line window
- stream the file line-by-line for `from` / `lines` reads and stop once the requested range is collected
- add a focused test that verifies sliced reads do not fall back to `fs.readFile`

## Why
`readMemoryFile()` previously read the entire file even when callers only requested a small line window. For large markdown files, this does unnecessary I/O and allocation. Streaming only the requested range keeps full reads unchanged while making line-window access cheaper.

## Testing
- [x] `pnpm vitest run src/memory/manager.read-file.test.ts`

AI-assisted: Codex-assisted
Testing: lightly tested locally (targeted read-file tests)
