### PR TITLE
Telegram: recover General topic bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - Agents/cron: suppress the default heartbeat system prompt for cron-triggered embedded runs even when they target non-cron session keys, so cron tasks stop reading `HEARTBEAT.md` and polluting unrelated threads. (#53152) Thanks @Protocol-zero-0.
 - TUI/chat: preserve pending user messages when a slow local run emits an empty final event, but still defer and flush the needed history reload after the newer active run finishes so silent/tool-only runs do not stay incomplete. (#53130) Thanks @joelnishanth.
 - Docs/IRC: fix five `json55` code-fence typos in the IRC channel examples so Mintlify applies JSON5 syntax highlighting correctly. (#50842) Thanks @Hollychou924.
+- Telegram/forum topics: recover `#General` topic `1` routing when Telegram omits forum metadata, including native commands, interactive callbacks, inbound message context, and fallback error replies. (#53699) thanks @huntharo
 
 ## 2026.3.23
 

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -62,6 +62,7 @@ import {
   getTelegramTextParts,
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
+  resolveTelegramForumFlag,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
 } from "./bot/helpers.js";
@@ -620,6 +621,12 @@ export const registerTelegramHandlers = ({
   type TelegramEventAuthorizationMode = "reaction" | "callback-scope" | "callback-allowlist";
   type TelegramEventAuthorizationResult = { allowed: true } | { allowed: false; reason: string };
   type TelegramEventAuthorizationContext = TelegramGroupAllowContext & { dmPolicy: DmPolicy };
+  const getChat =
+    typeof (bot.api as { getChat?: unknown }).getChat === "function"
+      ? ((bot.api as { getChat: (chatId: string | number) => Promise<unknown> }).getChat.bind(
+          bot.api,
+        ) as (chatId: string | number) => Promise<unknown>)
+      : undefined;
 
   const TELEGRAM_EVENT_AUTH_RULES: Record<
     TelegramEventAuthorizationMode,
@@ -1204,7 +1211,13 @@ export const registerTelegramHandlers = ({
       }
 
       const messageThreadId = callbackMessage.message_thread_id;
-      const isForum = callbackMessage.chat.is_forum === true;
+      const isForum = await resolveTelegramForumFlag({
+        chatId,
+        chatType: callbackMessage.chat.type,
+        isGroup,
+        isForum: callbackMessage.chat.is_forum,
+        getChat,
+      });
       const eventAuthContext = await resolveTelegramEventAuthorizationContext({
         chatId,
         isGroup,
@@ -1238,8 +1251,9 @@ export const registerTelegramHandlers = ({
         return;
       }
 
+      const callbackThreadId = resolvedThreadId ?? dmThreadId;
       const callbackConversationId =
-        messageThreadId != null ? `${chatId}:topic:${messageThreadId}` : String(chatId);
+        callbackThreadId != null ? `${chatId}:topic:${callbackThreadId}` : String(chatId);
       const pluginBindingApproval = parsePluginBindingApprovalCustomId(data);
       if (pluginBindingApproval) {
         const resolved = await resolvePluginConversationBindingApproval({
@@ -1259,10 +1273,10 @@ export const registerTelegramHandlers = ({
           accountId,
           callbackId: callback.id,
           conversationId: callbackConversationId,
-          parentConversationId: messageThreadId != null ? String(chatId) : undefined,
+          parentConversationId: callbackThreadId != null ? String(chatId) : undefined,
           senderId: senderId || undefined,
           senderUsername: senderUsername || undefined,
-          threadId: messageThreadId,
+          threadId: callbackThreadId,
           isGroup,
           isForum,
           auth: {
@@ -1713,13 +1727,21 @@ export const registerTelegramHandlers = ({
     if (!msg) {
       return;
     }
+    const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
+    const isForum = await resolveTelegramForumFlag({
+      chatId: msg.chat.id,
+      chatType: msg.chat.type,
+      isGroup,
+      isForum: msg.chat.is_forum,
+      getChat,
+    });
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, msg),
       msg,
       chatId: msg.chat.id,
-      isGroup: msg.chat.type === "group" || msg.chat.type === "supergroup",
-      isForum: msg.chat.is_forum === true,
+      isGroup,
+      isForum,
       messageThreadId: msg.message_thread_id,
       senderId: msg.from?.id != null ? String(msg.from.id) : "",
       senderUsername: msg.from?.username ?? "",

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -65,6 +65,7 @@ import {
   resolveTelegramForumFlag,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
+  withResolvedTelegramForumFlag,
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import {
@@ -1557,7 +1558,7 @@ export const registerTelegramHandlers = ({
       }
 
       const syntheticMessage = buildSyntheticTextMessage({
-        base: callbackMessage,
+        base: withResolvedTelegramForumFlag(callbackMessage, isForum),
         from: callback.from,
         text: data,
       });
@@ -1735,16 +1736,17 @@ export const registerTelegramHandlers = ({
       isForum: msg.chat.is_forum,
       getChat,
     });
+    const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
-      ctx: buildSyntheticContext(ctx, msg),
-      msg,
-      chatId: msg.chat.id,
+      ctx: buildSyntheticContext(ctx, normalizedMsg),
+      msg: normalizedMsg,
+      chatId: normalizedMsg.chat.id,
       isGroup,
       isForum,
-      messageThreadId: msg.message_thread_id,
-      senderId: msg.from?.id != null ? String(msg.from.id) : "",
-      senderUsername: msg.from?.username ?? "",
+      messageThreadId: normalizedMsg.message_thread_id,
+      senderId: normalizedMsg.from?.id != null ? String(normalizedMsg.from.id) : "",
+      senderUsername: normalizedMsg.from?.username ?? "",
       requireConfiguredGroup: false,
       sendOversizeWarning: true,
       oversizeLogMessage: "media exceeds size limit",

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -17,7 +17,11 @@ import { firstDefined, normalizeAllowFrom, normalizeDmAllowFromWithStore } from 
 import { resolveTelegramInboundBody } from "./bot-message-context.body.js";
 import { buildTelegramInboundContextPayload } from "./bot-message-context.session.js";
 import type { BuildTelegramMessageContextParams } from "./bot-message-context.types.js";
-import { buildTypingThreadParams, resolveTelegramThreadSpec } from "./bot/helpers.js";
+import {
+  buildTypingThreadParams,
+  resolveTelegramForumFlag,
+  resolveTelegramThreadSpec,
+} from "./bot/helpers.js";
 import {
   resolveTelegramConversationBaseSessionKey,
   resolveTelegramConversationRoute,
@@ -64,7 +68,24 @@ export const buildTelegramMessageContext = async ({
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
   const senderId = msg.from?.id ? String(msg.from.id) : "";
   const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
-  const isForum = (msg.chat as { is_forum?: boolean }).is_forum === true;
+  const api = bot.api as unknown as {
+    setMessageReaction?: (
+      chatId: number | string,
+      messageId: number,
+      reactions: Array<{ type: "emoji"; emoji: string }>,
+    ) => Promise<void>;
+    getChat?: (chatId: number | string) => Promise<unknown>;
+  };
+  const reactionApi =
+    typeof api.setMessageReaction === "function" ? api.setMessageReaction.bind(api) : null;
+  const getChatApi = typeof api.getChat === "function" ? api.getChat.bind(api) : null;
+  const isForum = await resolveTelegramForumFlag({
+    chatId,
+    chatType: msg.chat.type,
+    isGroup,
+    isForum: (msg.chat as { is_forum?: boolean }).is_forum,
+    getChat: getChatApi ?? undefined,
+  });
   const threadSpec = resolveTelegramThreadSpec({
     isGroup,
     isForum,
@@ -317,18 +338,6 @@ export const buildTelegramMessageContext = async ({
         shouldBypassMention: bodyResult.shouldBypassMention,
       }),
     );
-  const api = bot.api as unknown as {
-    setMessageReaction?: (
-      chatId: number | string,
-      messageId: number,
-      reactions: Array<{ type: "emoji"; emoji: string }>,
-    ) => Promise<void>;
-    getChat?: (chatId: number | string) => Promise<unknown>;
-  };
-  const reactionApi =
-    typeof api.setMessageReaction === "function" ? api.setMessageReaction.bind(api) : null;
-  const getChatApi = typeof api.getChat === "function" ? api.getChat.bind(api) : null;
-
   // Status Reactions controller (lifecycle reactions)
   const statusReactionsConfig = cfg.messages?.statusReactions;
   const statusReactionsEnabled =

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -105,7 +105,7 @@ describe("telegram bot message processor", () => {
     const { processMessage, runtimeError } = createDispatchFailureHarness(
       {
         chatId: 123,
-        threadSpec: { id: 456 },
+        threadSpec: { id: 456, scope: "forum" },
         route: { sessionKey: "agent:main:main" },
       },
       sendMessage,
@@ -118,6 +118,25 @@ describe("telegram bot message processor", () => {
       { message_thread_id: 456 },
     );
     expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("dispatch exploded"));
+  });
+
+  it("omits message_thread_id for General-topic fallback replies", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const { processMessage } = createDispatchFailureHarness(
+      {
+        chatId: 123,
+        threadSpec: { id: 1, scope: "forum" },
+        route: { sessionKey: "agent:main:main" },
+      },
+      sendMessage,
+    );
+    await expect(processSampleMessage(processMessage)).resolves.toBeUndefined();
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      123,
+      "Something went wrong while processing your request. Please try again.",
+      undefined,
+    );
   });
 
   it("swallows fallback delivery failures after dispatch throws", async () => {

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -11,6 +11,7 @@ import {
 import type { TelegramMessageContextOptions } from "./bot-message-context.types.js";
 import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
 import type { TelegramBotOptions } from "./bot.js";
+import { buildTelegramThreadParams } from "./bot/helpers.js";
 import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
 
 /** Dependencies injected once when creating the message processor. */
@@ -131,7 +132,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         await bot.api.sendMessage(
           context.chatId,
           "Something went wrong while processing your request. Please try again.",
-          context.threadSpec?.id != null ? { message_thread_id: context.threadSpec.id } : undefined,
+          buildTelegramThreadParams(context.threadSpec),
         );
       } catch {
         // Best-effort fallback; delivery may fail if the bot was blocked or the chat is invalid.

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -338,4 +338,63 @@ describe("registerTelegramNativeCommands", () => {
       }),
     );
   });
+
+  it("treats Telegram forum #General commands as topic 1 when Telegram omits topic metadata", async () => {
+    const commandHandlers = new Map<string, (ctx: unknown) => Promise<void>>();
+    const getChat = vi.fn(async () => ({ id: -1001234567890, type: "supergroup", is_forum: true }));
+
+    pluginCommandMocks.getPluginCommandSpecs.mockReturnValue([
+      {
+        name: "plug",
+        description: "Plugin command",
+      },
+    ] as never);
+    pluginCommandMocks.matchPluginCommand.mockReturnValue({
+      command: { key: "plug", requireAuth: false },
+      args: undefined,
+    } as never);
+    pluginCommandMocks.executePluginCommand.mockResolvedValue({ text: "ok" } as never);
+
+    registerTelegramNativeCommands({
+      ...createNativeCommandTestParams(
+        {},
+        {
+          bot: {
+            api: {
+              setMyCommands: vi.fn().mockResolvedValue(undefined),
+              sendMessage: vi.fn().mockResolvedValue(undefined),
+              getChat,
+            },
+            command: vi.fn((name: string, cb: (ctx: unknown) => Promise<void>) => {
+              commandHandlers.set(name, cb);
+            }),
+          } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+        },
+      ),
+    });
+
+    const handler = commandHandlers.get("plug");
+    expect(handler).toBeTruthy();
+    await handler?.({
+      match: "",
+      message: {
+        message_id: 2,
+        date: Math.floor(Date.now() / 1000),
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Forum Group",
+        },
+        from: { id: 200, username: "bob" },
+      },
+    });
+
+    expect(getChat).toHaveBeenCalledWith(-1001234567890);
+    expect(pluginCommandMocks.executePluginCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "telegram:group:-1001234567890:topic:1",
+        messageThreadId: 1,
+      }),
+    );
+  });
 });

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -64,6 +64,7 @@ import {
   buildTelegramThreadParams,
   buildSenderName,
   buildTelegramGroupFrom,
+  resolveTelegramForumFlag,
   resolveTelegramGroupAllowFromContext,
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
@@ -183,7 +184,19 @@ async function resolveTelegramCommandAuth(params: {
   const chatId = msg.chat.id;
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
   const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
-  const isForum = (msg.chat as { is_forum?: boolean }).is_forum === true;
+  const getChat =
+    typeof (bot.api as { getChat?: unknown }).getChat === "function"
+      ? ((bot.api as { getChat: (chatId: string | number) => Promise<unknown> }).getChat.bind(
+          bot.api,
+        ) as (chatId: string | number) => Promise<unknown>)
+      : undefined;
+  const isForum = await resolveTelegramForumFlag({
+    chatId,
+    chatType: msg.chat.type,
+    isGroup,
+    isForum: (msg.chat as { is_forum?: boolean }).is_forum,
+    getChat,
+  });
   const threadSpec = resolveTelegramThreadSpec({
     isGroup,
     isForum,
@@ -502,7 +515,7 @@ export const registerTelegramNativeCommands = ({
     const threadSpec = resolveTelegramThreadSpec({
       isGroup,
       isForum,
-      messageThreadId,
+      messageThreadId: resolvedThreadId ?? messageThreadId,
     });
     let { route, configuredBinding } = resolveTelegramConversationRoute({
       cfg: runtimeCfg,

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -313,6 +313,7 @@ const grammySpies = vi.hoisted(() => ({
     username: "openclaw_bot",
     has_topics_enabled: true,
   })) as AnyAsyncMock,
+  getChatSpy: vi.fn(async () => undefined) as AnyAsyncMock,
   sendMessageSpy: vi.fn(async () => ({ message_id: 77 })) as AnyAsyncMock,
   sendAnimationSpy: vi.fn(async () => ({ message_id: 78 })) as AnyAsyncMock,
   sendPhotoSpy: vi.fn(async () => ({ message_id: 79 })) as AnyAsyncMock,
@@ -335,6 +336,7 @@ export const sendMessageDraftSpy: AnyAsyncMock = grammySpies.sendMessageDraftSpy
 export const setMessageReactionSpy: AnyAsyncMock = grammySpies.setMessageReactionSpy;
 export const setMyCommandsSpy: AnyAsyncMock = grammySpies.setMyCommandsSpy;
 export const getMeSpy: AnyAsyncMock = grammySpies.getMeSpy;
+export const getChatSpy: AnyAsyncMock = grammySpies.getChatSpy;
 export const sendMessageSpy: AnyAsyncMock = grammySpies.sendMessageSpy;
 export const sendAnimationSpy: AnyAsyncMock = grammySpies.sendAnimationSpy;
 export const sendPhotoSpy: AnyAsyncMock = grammySpies.sendPhotoSpy;
@@ -364,6 +366,7 @@ export const telegramBotRuntimeForTest: TelegramBotRuntimeForTest = {
       setMessageReaction: grammySpies.setMessageReactionSpy,
       setMyCommands: grammySpies.setMyCommandsSpy,
       getMe: grammySpies.getMeSpy,
+      getChat: grammySpies.getChatSpy,
       sendMessage: grammySpies.sendMessageSpy,
       sendAnimation: grammySpies.sendAnimationSpy,
       sendPhoto: grammySpies.sendPhotoSpy,
@@ -529,6 +532,8 @@ beforeEach(() => {
   sendChatActionSpy.mockResolvedValue(undefined);
   setMyCommandsSpy.mockReset();
   setMyCommandsSpy.mockResolvedValue(undefined);
+  getChatSpy.mockReset();
+  getChatSpy.mockResolvedValue(undefined);
   getMeSpy.mockReset();
   getMeSpy.mockResolvedValue({
     username: "openclaw_bot",

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -13,6 +13,7 @@ const {
   commandSpy,
   dispatchReplyWithBufferedBlockDispatcher,
   getLoadWebMediaMock,
+  getChatSpy,
   getLoadConfigMock,
   getOnHandler,
   getReadChannelAllowFromStoreMock,
@@ -1856,6 +1857,65 @@ describe("createTelegramBot", () => {
         message_thread_id: testCase.expectedTypingThreadId,
       });
     }
+  });
+
+  it("routes General-topic forum messages via getChat when Telegram omits forum metadata", async () => {
+    resetHarnessSpies();
+    sendChatActionSpy.mockClear();
+    getChatSpy.mockResolvedValue({
+      id: -1001234567890,
+      type: "supergroup",
+      is_forum: true,
+      title: "Forum Group",
+    });
+    let dispatchCall:
+      | {
+          ctx: {
+            SessionKey?: unknown;
+            From?: unknown;
+            MessageThreadId?: unknown;
+            IsForum?: unknown;
+          };
+        }
+      | undefined;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
+      dispatchCall = params as typeof dispatchCall;
+      await params.dispatcherOptions.typingCallbacks?.onReplyStart?.();
+      return { queuedFinal: false, counts: { block: 0, final: 0, tool: 0 } };
+    });
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: { "*": { requireMention: false } },
+        },
+      },
+    });
+
+    const handler = getMessageHandler();
+    await handler({
+      message: {
+        chat: { id: -1001234567890, type: "supergroup", title: "Forum Group" },
+        from: { id: 12345, username: "testuser" },
+        text: "hello",
+        date: 1736380800,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(getChatSpy).toHaveBeenCalledWith(-1001234567890);
+    expect(dispatchCall?.ctx).toEqual(
+      expect.objectContaining({
+        SessionKey: expect.stringContaining("telegram:group:-1001234567890:topic:1"),
+        From: "telegram:group:-1001234567890:topic:1",
+        MessageThreadId: 1,
+        IsForum: true,
+      }),
+    );
+    expect(sendChatActionSpy).toHaveBeenCalledWith(-1001234567890, "typing", {
+      message_thread_id: 1,
+    });
   });
   it("threads forum replies only when a topic id exists", async () => {
     const threadCases = [

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1904,6 +1904,7 @@ describe("createTelegramBot", () => {
       getFile: async () => ({ download: async () => new Uint8Array() }),
     });
 
+    expect(getChatSpy).toHaveBeenCalledOnce();
     expect(getChatSpy).toHaveBeenCalledWith(-1001234567890);
     expect(dispatchCall?.ctx).toEqual(
       expect.objectContaining({

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -14,6 +14,7 @@ const {
   editMessageTextSpy,
   enqueueSystemEventSpy,
   getFileSpy,
+  getChatSpy,
   getLoadConfigMock,
   getReadChannelAllowFromStoreMock,
   getOnHandler,
@@ -1440,6 +1441,66 @@ describe("createTelegramBot", () => {
 
     expect(editMessageTextSpy).toHaveBeenCalledWith(1234, 11, "Handled resume:thread-1", undefined);
     expect(replySpy).not.toHaveBeenCalled();
+  });
+
+  it("routes Telegram #General callback payloads as topic 1 when Telegram omits topic metadata", async () => {
+    onSpy.mockClear();
+    getChatSpy.mockResolvedValue({ id: -100123456789, type: "supergroup", is_forum: true });
+    const handler = vi.fn(
+      async ({ respond, conversationId, threadId }: PluginInteractiveTelegramHandlerContext) => {
+        expect(conversationId).toBe("-100123456789:topic:1");
+        expect(threadId).toBe(1);
+        await respond.editMessage({
+          text: `Handled ${conversationId}`,
+        });
+        return { handled: true };
+      },
+    );
+    registerPluginInteractiveHandler("codex-plugin", {
+      channel: "telegram",
+      namespace: "codexapp",
+      handler,
+    });
+
+    createTelegramBot({
+      token: "tok",
+      config: {
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+          },
+        },
+      },
+    });
+    const callbackHandler = getOnHandler("callback_query") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-codex-general",
+        data: "codexapp:resume:thread-1",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: -100123456789, type: "supergroup", title: "Forum Group" },
+          date: 1736380800,
+          message_id: 11,
+          text: "Select a thread",
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(getChatSpy).toHaveBeenCalledWith(-100123456789);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(editMessageTextSpy).toHaveBeenCalledWith(
+      -100123456789,
+      11,
+      "Handled -100123456789:topic:1",
+      undefined,
+    );
   });
   it("sets command target session key for dm topic commands", async () => {
     onSpy.mockClear();

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -1,5 +1,5 @@
 import type { Message } from "grammy/types";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildTelegramThreadParams,
   buildTypingThreadParams,
@@ -9,6 +9,7 @@ import {
   hasBotMention,
   normalizeForwardedContext,
   resolveTelegramDirectPeerId,
+  resolveTelegramForumFlag,
   resolveTelegramForumThreadId,
 } from "./helpers.js";
 
@@ -28,6 +29,49 @@ describe("resolveTelegramForumThreadId", () => {
     { isForum: true, messageThreadId: 99, expected: 99 },
   ])("resolves forum topic ids", ({ expected, ...params }) => {
     expect(resolveTelegramForumThreadId(params)).toBe(expected);
+  });
+});
+
+describe("resolveTelegramForumFlag", () => {
+  it("keeps explicit forum metadata when Telegram already provides it", async () => {
+    const getChat = vi.fn(async () => ({ is_forum: false }));
+    await expect(
+      resolveTelegramForumFlag({
+        chatId: -100123,
+        chatType: "supergroup",
+        isGroup: true,
+        isForum: true,
+        getChat,
+      }),
+    ).resolves.toBe(true);
+    expect(getChat).not.toHaveBeenCalled();
+  });
+
+  it("falls back to getChat for supergroups when is_forum is omitted", async () => {
+    const getChat = vi.fn(async () => ({ is_forum: true }));
+    await expect(
+      resolveTelegramForumFlag({
+        chatId: -100123,
+        chatType: "supergroup",
+        isGroup: true,
+        getChat,
+      }),
+    ).resolves.toBe(true);
+    expect(getChat).toHaveBeenCalledWith(-100123);
+  });
+
+  it("returns false when forum lookup is unavailable", async () => {
+    const getChat = vi.fn(async () => {
+      throw new Error("lookup failed");
+    });
+    await expect(
+      resolveTelegramForumFlag({
+        chatId: -100123,
+        chatType: "supergroup",
+        isGroup: true,
+        getChat,
+      }),
+    ).resolves.toBe(false);
   });
 });
 

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -18,6 +18,34 @@ export type TelegramThreadSpec = {
   scope: "dm" | "forum" | "none";
 };
 
+function extractTelegramForumFlag(value: unknown): boolean | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const forum = (value as { is_forum?: unknown }).is_forum;
+  return typeof forum === "boolean" ? forum : undefined;
+}
+
+export async function resolveTelegramForumFlag(params: {
+  chatId: string | number;
+  chatType?: Chat["type"];
+  isGroup: boolean;
+  isForum?: boolean;
+  getChat?: (chatId: string | number) => Promise<unknown>;
+}): Promise<boolean> {
+  if (typeof params.isForum === "boolean") {
+    return params.isForum;
+  }
+  if (!params.isGroup || params.chatType !== "supergroup" || !params.getChat) {
+    return false;
+  }
+  try {
+    return extractTelegramForumFlag(await params.getChat(params.chatId)) === true;
+  } catch {
+    return false;
+  }
+}
+
 export async function resolveTelegramGroupAllowFromContext(params: {
   chatId: string | number;
   accountId?: string;

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -46,6 +46,24 @@ export async function resolveTelegramForumFlag(params: {
   }
 }
 
+// Preserve recovered forum metadata so downstream handlers do not need to re-query getChat.
+export function withResolvedTelegramForumFlag<T extends { chat: object }>(
+  message: T,
+  isForum: boolean,
+): T {
+  const current = extractTelegramForumFlag(message.chat);
+  if (current === isForum) {
+    return message;
+  }
+  return {
+    ...message,
+    chat: {
+      ...message.chat,
+      is_forum: isForum,
+    },
+  };
+}
+
 export async function resolveTelegramGroupAllowFromContext(params: {
   chatId: string | number;
   accountId?: string;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram forum supergroup `#General` updates can arrive without `is_forum` and without `message_thread_id`, so `/cas_resume` and follow-up traffic were normalized to the chat root instead of topic `1`.
- Why it matters: a bind created from `#General` looked like it succeeded, but later `/cas_status` and plain text in that topic did not route to the Codex binding target.
- What changed: I added a Telegram forum-detection fallback through `getChat`, then used that resolved forum/topic identity consistently for native commands, interactive callbacks, and inbound message context building.
- What did NOT change (scope boundary): I did not change non-Telegram channels or alter Telegram topic handling when Telegram already supplies explicit topic metadata.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related pwrdrvr/openclaw-codex-app-server#21
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Telegram `#General` in forum supergroups was sometimes delivered without forum/topic metadata, and the Telegram command/callback/inbound paths treated that as a plain supergroup conversation instead of recovering General topic `1`.
- Missing detection / guardrail: We had no shared fallback that re-hydrated forum status from Telegram when `is_forum` was omitted, and no tests for native command/callback/general inbound handling in that metadata shape.
- Prior context (`git blame`, prior PR, issue, or refactor if known): The plugin issue documented that `/codex_resume` from Telegram `#General` appeared to bind, but subsequent status and routing still behaved as unbound.
- Why this regressed now: The code assumed Telegram would always provide enough forum metadata on command and callback updates, which does not hold for `#General`.
- If unknown, what was ruled out: I ruled out plugin-only state bugs by confirming the Telegram conversation identity reaching core was already wrong before the plugin binding lookup ran.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/bot-native-commands.test.ts`, `extensions/telegram/src/bot.test.ts`, and `extensions/telegram/src/bot.create-telegram-bot.test.ts`
- Scenario the test should lock in: Telegram forum supergroup `#General` updates that omit `is_forum` and `message_thread_id` still normalize to topic `1` for command routing, interactive callbacks, and inbound message context.
- Why this is the smallest reliable guardrail: The bug is at the Telegram integration seam, where payload normalization and routing context are assembled before plugin code runs.
- Existing test that already covers this (if any): Existing tests already covered normal forum topics and General-topic behavior only when explicit topic metadata was present.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Telegram forum supergroup `#General` can now be bound and resumed like other topics, and follow-up `/cas_status` plus plain text in `#General` route against the bound Codex conversation instead of falling back to the parent chat.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: I added a Telegram `getChat` fallback only when supergroup forum metadata is missing. That call is read-only, scoped to the existing Telegram bot API surface, and only used to disambiguate forum General topic routing.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local `pnpm gateway:watch`
- Model/provider: Codex App Server via Telegram plugin commands
- Integration/channel (if any): Telegram forum supergroup `#General`
- Relevant config (redacted): Telegram enabled with forum topics and native plugin commands

### Steps

1. Open a Telegram forum supergroup and switch to `#General`.
2. Run `/cas_resume` and choose a thread.
3. Run `/cas_status` and send follow-up plain text in the same `#General` topic.

### Expected

- `#General` binds as topic `1`, `/cas_status` reflects the active bind, and follow-up text routes to the bound Codex target.

### Actual

- Before this fix, the bind could be created against the chat root, so `/cas_status` still reported `Binding: none` and follow-up text did not route to the bound target.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Harold verified end to end that binding `#General` in a Telegram DM supergroup now works and that previously bound text in `#General` did not route to the binding target.
- Edge cases checked: I verified the Telegram command, callback, and inbound General-topic normalization paths with focused regression tests.
- What you did **not** verify: I did not manually re-verify non-Telegram channels because this PR is scoped to Telegram only.

### Before - Free text not routed when bound in `#general`

<img width="1106" height="1046" alt="image" src="https://github.com/user-attachments/assets/d88cef69-4a86-4c19-84b3-a962bc2a8ab4" />

### After - Free text routes in `#general` when bound

<img width="1028" height="935" alt="image" src="https://github.com/user-attachments/assets/025b53eb-bf9e-4623-81b8-925f5617aeda" />

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `73f93dab2c`.
- Files/config to restore: Restore the touched Telegram routing files under `extensions/telegram/src/`.
- Known bad symptoms reviewers should watch for: Telegram `#General` could start routing as the parent chat again, with `/cas_status` showing unbound immediately after a resume/bind flow.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: The `getChat` fallback could classify a non-forum supergroup incorrectly if Telegram returns unexpected metadata.
  - Mitigation: The fallback only runs when local metadata is missing, only for supergroups, and the regression tests lock the intended `#General` normalization behavior.
