### PR TITLE
fix(startup): avoid redundant file rereads when context is already injected

### DIFF
--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -347,6 +347,8 @@ Read WORKFLOW.md on startup.
       expect(result).not.toContain("Session Startup");
       // Must reference the actual configured section names
       expect(result).toContain("Boot Sequence");
+      expect(result).toContain("Use the configured AGENTS.md sections below (Boot Sequence) first");
+      expect(result).toContain("missing or truncated here, reread AGENTS.md");
     });
 
     it("uses default 'Session Startup' prose when default sections are active", async () => {
@@ -355,6 +357,8 @@ Read WORKFLOW.md on startup.
       const result = await readPostCompactionContext(tmpDir);
       expect(result).not.toBeNull();
       expect(result).toContain("Run your Session Startup sequence");
+      expect(result).toContain("using the AGENTS.md sections below first");
+      expect(result).toContain("missing or truncated here, reread AGENTS.md");
     });
 
     it("falls back to legacy sections when defaults are explicitly configured", async () => {

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -137,9 +137,9 @@ export async function readPostCompactionContext(
     // would be misleading for deployments that use different section names.
     const prose = isDefaultSections
       ? "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
-        "Run your Session Startup sequence - read the required files before responding to the user."
+        "Run your Session Startup sequence using the AGENTS.md sections below first. If you need guidance that is missing or truncated here, reread AGENTS.md before responding to the user."
       : `Session was just compacted. The conversation summary above is a hint, NOT a substitute for your full startup sequence. ` +
-        `Re-read the sections injected below (${displayNames.join(", ")}) and follow your configured startup procedure before responding to the user.`;
+        `Use the configured AGENTS.md sections below (${displayNames.join(", ")}) first. If you need additional guidance that is missing or truncated here, reread AGENTS.md before responding to the user.`;
 
     const sectionLabel = isDefaultSections
       ? "Critical rules from AGENTS.md:"


### PR DESCRIPTION
## Summary

This removes unnecessary startup rereads that waste context window, prompt/input tokens, API cost, latency, and file/tool work in the common case.

Description:

- Problem: the default startup prompts still nudge agents to reread startup files even when relevant startup context is already present in prompt context.
- Why it matters: this wastes context window, prompt/input tokens, API cost, latency, and file/tool work in the common case.
- What changed: `/new` and `/reset` now tell the agent to use bootstrap/reference files already in context before rereading, and post-compaction guidance now tells the agent to use the AGENTS sections below first and reread `AGENTS.md` only if guidance is missing or truncated there.
- What did NOT change (scope boundary): no runtime state plumbing, hook inspection, bootstrap metadata changes, gateway/session changes, or hook/bootstrap execution changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: N/A
- Missing detection / guardrail: N/A
- Prior context (`git blame`, prior PR, issue, or refactor if known): N/A
- Why this regressed now: N/A
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/session-reset-prompt.test.ts`, `src/auto-reply/reply/post-compaction-context.test.ts`
- Scenario the test should lock in: bare `/new` and `/reset` prompts prefer already-present startup context before rereading, and post-compaction prose prefers the injected AGENTS sections before rereading `AGENTS.md`.
- Why this is the smallest reliable guardrail: this PR only changes prompt text and prompt-default behavior.
- Existing test that already covers this (if any): the existing prompt tests cover the same builders and now assert the new wording.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Bare `/new` and `/reset` prompts now tell the agent to use bootstrap/reference context already in prompt context before rereading files.
- Post-compaction guidance now tells the agent to use the AGENTS sections below first and reread `AGENTS.md` only if guidance is missing or truncated there.
- Expected outcome: lower context waste, fewer tokens, lower cost, less latency, and fewer unnecessary file/tool reads in the common case.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux x86_64
- Runtime/container: local temp clone, no container
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default prompt paths; no custom runtime plumbing in this PR

### Steps

1. Generate the bare `/new` or `/reset` prompt.
2. Generate post-compaction context from a workspace `AGENTS.md` with default or custom sections.
3. Verify the rendered text prefers already-present context first and only rereads when guidance is missing or truncated.

### Expected

- Prompt defaults steer the agent toward reusing startup context it already has before rereading files.

### Actual

- `pnpm test -- src/auto-reply/reply/session-reset-prompt.test.ts src/auto-reply/reply/post-compaction-context.test.ts` passed.
- `pnpm build` passed.
- `pnpm check` is currently red on latest `main` with unrelated missing-module errors in `extensions/msteams/src/sdk.ts` and `ui/src/ui/views/agents-panels-status-files.ts`, outside this PR scope.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: bare `/new` and `/reset` prompt text; default post-compaction prose; custom-section post-compaction prose.
- Edge cases checked: default sections still mention Session Startup; custom sections stay generic; legacy-section fallback tests remain green.
- What you did **not** verify: live model behavior, production token deltas, or end-to-end messaging-channel runs.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `5007cc9630`.
- Files/config to restore: `src/auto-reply/reply/session-reset-prompt.ts`, `src/auto-reply/reply/session-reset-prompt.test.ts`, `src/auto-reply/reply/post-compaction-context.ts`, `src/auto-reply/reply/post-compaction-context.test.ts`.
- Known bad symptoms reviewers should watch for: agents still reread startup files unnecessarily, or prompt wording over-discourages rereading when guidance is actually missing.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the softer prompt-only wording may not reduce redundant rereads as much as a runtime-aware implementation would.
  - Mitigation: keeps the PR small and safe; stronger runtime-aware behavior can be evaluated separately.
- Risk: the prompt could under-signal when rereads are still necessary.
  - Mitigation: both prompt paths explicitly say to reread when guidance is missing or truncated.
