### PR TITLE
fix(gateway): resolve thinkingLevel from model config after /reset

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -646,11 +646,13 @@ export function resolveThinkingDefault(params: {
   if (configured) {
     return configured;
   }
-  return resolveThinkingDefaultForModel({
-    provider: params.provider,
-    model: params.model,
-    catalog: params.catalog,
-  });
+  return (
+    resolveThinkingDefaultForModel({
+      provider: params.provider,
+      model: params.model,
+      catalog: params.catalog,
+    }) ?? "off"
+  );
 }
 
 /** Default reasoning level when session/directive do not set it: "on" if model supports reasoning, else "off". */

--- a/src/auto-reply/thinking.shared.ts
+++ b/src/auto-reply/thinking.shared.ts
@@ -142,7 +142,7 @@ export function resolveThinkingDefaultForModel(params: {
   provider: string;
   model: string;
   catalog?: ThinkingCatalogEntry[];
-}): ThinkLevel {
+}): ThinkLevel | undefined {
   const normalizedProvider = normalizeProviderId(params.provider);
   const modelId = params.model.trim();
   if (normalizedProvider === "anthropic" && ANTHROPIC_CLAUDE_46_MODEL_RE.test(modelId)) {
@@ -157,7 +157,10 @@ export function resolveThinkingDefaultForModel(params: {
   if (candidate?.reasoning) {
     return "low";
   }
-  return "off";
+  if (candidate && !candidate.reasoning) {
+    return "off";
+  }
+  return undefined;
 }
 
 type OnOffFullLevel = "off" | "on" | "full";

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -180,7 +180,7 @@ describe("resolveThinkingDefaultForModel", () => {
     ).toBe("low");
   });
 
-  it("defaults to off when no adaptive or reasoning hint is present", () => {
+  it("defaults to off when catalog lists model without reasoning", () => {
     expect(
       resolveThinkingDefaultForModel({
         provider: "openai",
@@ -188,6 +188,25 @@ describe("resolveThinkingDefaultForModel", () => {
         catalog: [{ provider: "openai", id: "gpt-4.1-mini", reasoning: false }],
       }),
     ).toBe("off");
+  });
+
+  it("returns undefined when model is not in catalog", () => {
+    expect(
+      resolveThinkingDefaultForModel({
+        provider: "openai-codex",
+        model: "gpt-5.3-codex",
+        catalog: [],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when no catalog is provided", () => {
+    expect(
+      resolveThinkingDefaultForModel({
+        provider: "openai-codex",
+        model: "gpt-5.3-codex",
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -111,7 +111,7 @@ export function resolveThinkingDefaultForModel(params: {
   provider: string;
   model: string;
   catalog?: ThinkingCatalogEntry[];
-}): ThinkLevel {
+}): ThinkLevel | undefined {
   const normalizedProvider = normalizeProviderId(params.provider);
   const candidate = params.catalog?.find(
     (entry) => entry.provider === params.provider && entry.id === params.model,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -311,7 +311,7 @@ export async function performGatewaySessionReset(params: {
       updatedAt: now,
       systemSent: false,
       abortedLastRun: false,
-      thinkingLevel: currentEntry?.thinkingLevel,
+      thinkingLevel: undefined,
       fastMode: currentEntry?.fastMode,
       verboseLevel: currentEntry?.verboseLevel,
       reasoningLevel: currentEntry?.reasoningLevel,

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -565,11 +565,13 @@ function resolveCurrentThinkingLevel(
   if (!session?.modelProvider || !session.model) {
     return "off";
   }
-  return resolveThinkingDefaultForModel({
-    provider: session.modelProvider,
-    model: session.model,
-    catalog: models,
-  });
+  return (
+    resolveThinkingDefaultForModel({
+      provider: session.modelProvider,
+      model: session.model,
+      catalog: models,
+    }) ?? "off"
+  );
 }
 
 function resolveCurrentFastMode(session: GatewaySessionRow | undefined): "on" | "off" {


### PR DESCRIPTION
## Summary

After upgrading to v2026.3.23-2, `/reset` creates sessions with `thinkingLevel: "off"` for models not present in the catalog (e.g. `openai-codex/gpt-5.3-codex`). This silently breaks tool calling: the model generates text-only responses without ever issuing tool calls.

**Root cause:** `resolveThinkingDefaultForModel()` returned `"off"` for any model not found in the catalog, with no distinction between "model is absent" and "model is explicitly listed without reasoning." On `/reset`, the previous session's (now stale) `thinkingLevel` was carried forward instead of being re-resolved.

**Fix (two changes):**

- `resolveThinkingDefaultForModel` now returns `undefined` when the model is not in the catalog, so callers' `??` fallback chains can apply a safe default. Models explicitly listed with `reasoning: false` still return `"off"`.
- `performGatewaySessionReset` sets `thinkingLevel: undefined` on the new session entry, so the thinking level is freshly resolved from model config on the next message via `resolveThinkingDefault()` in `chat.ts`.

All existing callers already handle `undefined` via `??` chains (`model-selection.ts` line 405, `slash-command-executor.ts` line 568).

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/thinking.shared.ts` | Return `undefined` instead of `"off"` when model absent from catalog |
| `src/auto-reply/thinking.ts` | Update return type to `ThinkLevel \| undefined` |
| `src/agents/model-selection.ts` | Add `?? "off"` fallback for new return type |
| `src/gateway/session-reset-service.ts` | Set `thinkingLevel: undefined` on reset |
| `ui/src/ui/chat/slash-command-executor.ts` | Add `?? "off"` fallback for new return type |
| `src/auto-reply/thinking.test.ts` | Add tests for absent-model and no-catalog cases |

## Test plan

- [x] `pnpm check` passes (types, format, lint, all custom checks)
- [x] `thinking.test.ts`: 25 tests pass, including 2 new tests for `undefined` return
- [x] `model-selection.test.ts`: 62 tests pass
- [ ] Manual: `/reset` in Discord with `openai-codex/gpt-5.3-codex`, verify `thinkingLevel` is resolved from config (not `"off"`)
- [ ] Manual: verify user-set `/think high` is re-resolved (not preserved) after `/reset`

Fixes #53480