### PR TITLE
feat(memory): report startup memory sources

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -57,8 +57,10 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     streamingInstances.length = 0;
-    sendMediaFeishuMock.mockResolvedValue(undefined);
-    sendStructuredCardFeishuMock.mockResolvedValue(undefined);
+    sendMessageFeishuMock.mockResolvedValue({ messageId: "om_text" });
+    sendMarkdownCardFeishuMock.mockResolvedValue({ messageId: "om_card_md" });
+    sendMediaFeishuMock.mockResolvedValue({ messageId: "om_media" });
+    sendStructuredCardFeishuMock.mockResolvedValue({ messageId: "om_card" });
 
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
@@ -220,12 +222,18 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("keeps auto mode plain text on non-streaming send path", async () => {
-    const { options } = createDispatcherHarness();
+    const runtime = createRuntimeLogger();
+    const { options } = createDispatcherHarness({ runtime });
     await options.deliver({ text: "plain text" }, { kind: "final" });
 
     expect(streamingInstances).toHaveLength(0);
     expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "feishu[main] outbound text send ok chat=oc_chat kind=final messageId=om_text",
+      ),
+    );
   });
 
   it("suppresses internal block payload delivery", async () => {
@@ -444,7 +452,9 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   });
 
   it("passes replyInThread to sendMessageFeishu for plain text", async () => {
+    const runtime = createRuntimeLogger();
     const { options } = createDispatcherHarness({
+      runtime,
       replyToMessageId: "om_msg",
       replyInThread: true,
     });
@@ -455,6 +465,11 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         replyToMessageId: "om_msg",
         replyInThread: true,
       }),
+    );
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "feishu[main] outbound text reply ok chat=oc_chat replyTo=om_msg thread=true kind=final messageId=om_text",
+      ),
     );
   });
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -296,6 +296,22 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     reasoningText = "";
   };
 
+  const logOutboundResult = (details: {
+    kind: "text" | "card" | "media";
+    mode: "send" | "reply";
+    infoKind?: string;
+    messageId?: string;
+  }) => {
+    params.runtime.log?.(
+      `feishu[${account.accountId}] outbound ${details.kind} ${details.mode} ok` +
+        ` chat=${chatId}` +
+        (sendReplyToMessageId ? ` replyTo=${sendReplyToMessageId}` : "") +
+        (effectiveReplyInThread ? ` thread=${String(effectiveReplyInThread)}` : "") +
+        (details.infoKind ? ` kind=${details.infoKind}` : "") +
+        (details.messageId ? ` messageId=${details.messageId}` : ""),
+    );
+  };
+
   const sendChunkedTextReply = async (params: {
     text: string;
     useCard: boolean;
@@ -320,9 +336,21 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         accountId,
       };
       if (params.useCard) {
-        await sendMarkdownCardFeishu(message);
+        const result = await sendMarkdownCardFeishu(message);
+        logOutboundResult({
+          kind: "card",
+          mode: sendReplyToMessageId ? "reply" : "send",
+          infoKind: params.infoKind,
+          messageId: result.messageId,
+        });
       } else {
-        await sendMessageFeishu(message);
+        const result = await sendMessageFeishu(message);
+        logOutboundResult({
+          kind: "text",
+          mode: sendReplyToMessageId ? "reply" : "send",
+          infoKind: params.infoKind,
+          messageId: result.messageId,
+        });
       }
       first = false;
     }
@@ -398,13 +426,19 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             // Send media even when streaming handled the text
             if (hasMedia) {
               for (const mediaUrl of mediaList) {
-                await sendMediaFeishu({
+                const result = await sendMediaFeishu({
                   cfg,
                   to: chatId,
                   mediaUrl,
                   replyToMessageId: sendReplyToMessageId,
                   replyInThread: effectiveReplyInThread,
                   accountId,
+                });
+                logOutboundResult({
+                  kind: "media",
+                  mode: sendReplyToMessageId ? "reply" : "send",
+                  infoKind: info?.kind,
+                  messageId: result?.messageId,
                 });
               }
             }
@@ -419,7 +453,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               textChunkLimit,
               chunkMode,
             )) {
-              await sendStructuredCardFeishu({
+              const result = await sendStructuredCardFeishu({
                 cfg,
                 to: chatId,
                 text: chunk,
@@ -429,6 +463,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 accountId,
                 header: cardHeader,
                 note: cardNote,
+              });
+              logOutboundResult({
+                kind: "card",
+                mode: sendReplyToMessageId ? "reply" : "send",
+                infoKind: info?.kind,
+                messageId: result.messageId,
               });
               first = false;
             }
@@ -442,13 +482,19 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
         if (hasMedia) {
           for (const mediaUrl of mediaList) {
-            await sendMediaFeishu({
+            const result = await sendMediaFeishu({
               cfg,
               to: chatId,
               mediaUrl,
               replyToMessageId: sendReplyToMessageId,
               replyInThread: effectiveReplyInThread,
               accountId,
+            });
+            logOutboundResult({
+              kind: "media",
+              mode: sendReplyToMessageId ? "reply" : "send",
+              infoKind: info?.kind,
+              messageId: result?.messageId,
             });
           }
         }

--- a/src/agents/memory-source-report.ts
+++ b/src/agents/memory-source-report.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function countDailyMemoryFiles(memoryDir: string): Promise<number> {
+  try {
+    const entries = await fs.readdir(memoryDir, { withFileTypes: true });
+    return entries.filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith(".md"))
+      .length;
+  } catch {
+    return 0;
+  }
+}
+
+function summarizeFileMemory(parts: { hasMemory: boolean; dailyCount: number }) {
+  const detail = [
+    parts.hasMemory ? "MEMORY.md" : "no MEMORY.md",
+    `${parts.dailyCount} daily notes`,
+  ].join(", ");
+  return `- File memory: ${parts.hasMemory || parts.dailyCount > 0 ? "OK" : "UNAVAILABLE"} (${detail})`;
+}
+
+type MemoryStatsResponse = {
+  active_memory_count?: number;
+};
+
+type MemoryListResponse = {
+  items?: unknown[];
+};
+
+async function fetchJson<T>(url: string, headers: Record<string, string>): Promise<T | null> {
+  try {
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchMemoriaCount(
+  apiUrl: string,
+  apiKey?: string,
+  userId?: string,
+): Promise<number | null> {
+  const headers: Record<string, string> = {};
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  if (userId) {
+    headers["X-User-Id"] = userId;
+  }
+
+  const baseUrl = apiUrl.replace(/\/$/, "");
+  const stats = await fetchJson<MemoryStatsResponse>(`${baseUrl}/v1/memories/stats`, headers);
+  if (typeof stats?.active_memory_count === "number") {
+    return stats.active_memory_count;
+  }
+
+  const list = await fetchJson<MemoryListResponse>(`${baseUrl}/v1/memories?limit=1`, headers);
+  if (Array.isArray(list?.items)) {
+    return list.items.length;
+  }
+
+  return null;
+}
+
+async function checkMemoriaSource(opts: {
+  label: string;
+  apiUrl?: string;
+  apiKey?: string;
+  userId?: string;
+}): Promise<string> {
+  if (!opts.apiUrl) {
+    return `- ${opts.label}: UNAVAILABLE`;
+  }
+  const count = await fetchMemoriaCount(opts.apiUrl, opts.apiKey, opts.userId);
+  return `- ${opts.label}: ${count === null ? "UNAVAILABLE" : `OK (${count} memories)`}`;
+}
+
+export async function buildMemorySourceReport(params: {
+  workspaceDir: string;
+  localMemoriaApiUrl?: string;
+  localMemoriaApiKey?: string;
+  localMemoriaUserId?: string;
+  cloudMemoriaApiUrl?: string;
+  cloudMemoriaApiKey?: string;
+  cloudMemoriaUserId?: string;
+}): Promise<string[]> {
+  const memoryDir = path.join(params.workspaceDir, "memory");
+  const hasMemory = await exists(path.join(params.workspaceDir, "MEMORY.md"));
+  const dailyCount = await countDailyMemoryFiles(memoryDir);
+
+  return [
+    "Memory startup report:",
+    await checkMemoriaSource({
+      label: "Local Memoria",
+      apiUrl: params.localMemoriaApiUrl,
+      apiKey: params.localMemoriaApiKey,
+      userId: params.localMemoriaUserId,
+    }),
+    await checkMemoriaSource({
+      label: "Cloud Memoria",
+      apiUrl: params.cloudMemoriaApiUrl,
+      apiKey: params.cloudMemoriaApiKey,
+      userId: params.cloudMemoriaUserId,
+    }),
+    summarizeFileMemory({ hasMemory, dailyCount }),
+  ];
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -53,6 +53,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawDocsPath } from "../../docs-path.js";
 import { isTimeoutError } from "../../failover-error.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
+import { buildMemorySourceReport } from "../../memory-source-report.js";
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { normalizeProviderId, resolveDefaultModelForAgent } from "../../model-selection.js";
 import { supportsModelTools } from "../../model-tool-support.js";
@@ -1464,7 +1465,19 @@ export async function runEmbeddedAttempt(
       (file) => file.name === DEFAULT_BOOTSTRAP_FILENAME && !file.missing,
     )
       ? ["Reminder: commit your changes in this workspace after edits."]
-      : undefined;
+      : [];
+
+    workspaceNotes.push(
+      ...(await buildMemorySourceReport({
+        workspaceDir: effectiveWorkspace,
+        localMemoriaApiUrl: process.env.MEMORIA_API_URL ?? "http://127.0.0.1:8100",
+        localMemoriaApiKey: process.env.MEMORIA_MASTER_KEY,
+        localMemoriaUserId: process.env.MEMORIA_USER_ID,
+        cloudMemoriaApiUrl: process.env.CLOUD_MEMORIA_API_URL,
+        cloudMemoriaApiKey: process.env.CLOUD_MEMORIA_API_KEY,
+        cloudMemoriaUserId: process.env.CLOUD_MEMORIA_USER_ID,
+      })),
+    );
 
     const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
 

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -1,6 +1,7 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { resolveSessionAgentIds } from "../../agents/agent-scope.js";
 import { resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
+import { buildMemorySourceReport } from "../../agents/memory-source-report.js";
 import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import type { EmbeddedContextFile } from "../../agents/pi-embedded-helpers.js";
 import { createOpenClawCodingTools } from "../../agents/pi-tools.js";
@@ -109,6 +110,16 @@ export async function resolveCommandsSystemPromptBundle(
     : { enabled: false };
   const ttsHint = params.cfg ? buildTtsSystemPromptHint(params.cfg) : undefined;
 
+  const workspaceNotes = await buildMemorySourceReport({
+    workspaceDir,
+    localMemoriaApiUrl: process.env.MEMORIA_API_URL ?? "http://127.0.0.1:8100",
+    localMemoriaApiKey: process.env.MEMORIA_MASTER_KEY,
+    localMemoriaUserId: process.env.MEMORIA_USER_ID,
+    cloudMemoriaApiUrl: process.env.CLOUD_MEMORIA_API_URL,
+    cloudMemoriaApiKey: process.env.CLOUD_MEMORIA_API_KEY,
+    cloudMemoriaUserId: process.env.CLOUD_MEMORIA_USER_ID,
+  });
+
   const systemPrompt = buildAgentSystemPrompt({
     workspaceDir,
     defaultThinkLevel: params.resolvedThinkLevel,
@@ -126,6 +137,7 @@ export async function resolveCommandsSystemPromptBundle(
     skillsPrompt,
     heartbeatPrompt: undefined,
     ttsHint,
+    workspaceNotes,
     acpEnabled: params.cfg?.acp?.enabled !== false,
     runtimeInfo,
     sandboxInfo,


### PR DESCRIPTION
## Summary

Add a startup memory source report to the agent system prompt so each session can see which memory layers are currently available.

## What this changes

This adds a lightweight memory source report that is injected into `workspaceNotes` during prompt construction for both:

- embedded agent runs
- command/system-prompt flows

The report summarizes:

- local Memoria availability and memory count when reachable
- cloud Memoria availability and memory count when reachable
- file-based memory availability (`MEMORY.md` + daily note count)

## Why

OpenClaw can rely on multiple memory layers at startup, but it is currently hard to tell which ones are actually active in a given session.

This makes startup behavior more transparent and helps distinguish:

- structured memory available
- file-memory fallback
- partial degradation when a backend is unavailable

## Notes

- This PR does **not** depend on new Memoria backend APIs.
- It will use `/v1/memories/stats` when available, and gracefully fall back to a lightweight reachability check otherwise.
- File memory reporting is handled independently from Memoria.

## Validation

- `pnpm test -- --run src/agents/system-prompt.test.ts`
