### PR TITLE
Fix #53592: allow aws-sdk auth mode in /btw side question

### DIFF
--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -17,7 +17,7 @@ import {
 } from "../config/sessions.js";
 import { diagnosticLogger as diag } from "../logging/diagnostic.js";
 import { resolveSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
-import { getApiKeyForModel, requireApiKey } from "./model-auth.js";
+import { getApiKeyForModel, normalizeSecretInput } from "./model-auth.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
 import { EmbeddedBlockChunker, type BlockReplyChunking } from "./pi-embedded-block-chunker.js";
 import { resolveModelWithRegistry } from "./pi-embedded-runner/model.js";
@@ -264,7 +264,16 @@ export async function runBtwSideQuestion(
     profileId: authProfileId,
     agentDir: params.agentDir,
   });
-  const apiKey = requireApiKey(apiKeyInfo, model.provider);
+  let apiKey: string | undefined;
+  if (!apiKeyInfo.apiKey) {
+    if (apiKeyInfo.mode !== "aws-sdk") {
+      throw new Error(
+        `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
+      );
+    }
+  } else {
+    apiKey = normalizeSecretInput(apiKeyInfo.apiKey);
+  }
 
   const chunker =
     params.opts?.onBlockReply && params.blockReplyChunking


### PR DESCRIPTION
## Fix #53592: `/btw` fails with aws-sdk auth mode (Bedrock instance role)

### Problem
`/btw` side questions fail when using Amazon Bedrock with `auth: aws-sdk` (EC2 instance role credentials), throwing:

    No API key resolved for provider "amazon-bedrock" (auth mode: aws-sdk).

### Root Cause
`runBtwSideQuestion()` unconditionally called `requireApiKey()`, which throws when no apiKey is present — without checking if the auth mode is `aws-sdk`, which is valid without a static key (AWS SDK resolves credentials from instance roles/env vars).

The main embedded runner (`compact.ts`, `run.ts`) already handles this correctly with a conditional check.

### Fix
Replace `requireApiKey()` with the same conditional used in the main runner:
- No apiKey **+** `mode === "aws-sdk"` → proceed (AWS SDK chain handles credentials)
- No apiKey **+** `mode !== "aws-sdk"` → throw error
- Has apiKey → proceed normally

**File changed:** `src/agents/btw.ts` — 1 file, ~11 lines added, 2 removed

Closes #53592