### PR TITLE
docs: add Team Ops community plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -84,6 +84,19 @@ and files.
 openclaw plugins install @sliverp/qqbot
 ```
 
+### Team Ops
+
+Turns chat transcripts into decisions, action items, blockers, and ready-to-send
+status updates for teams and executives. Great for standups, planning notes,
+incident rooms, and cross-functional launch threads.
+
+- **npm:** `team-ops`
+- **repo:** [github.com/JimmyWangJimmy/openclaw-team-ops-plugin](https://github.com/JimmyWangJimmy/openclaw-team-ops-plugin)
+
+```bash
+openclaw plugins install team-ops
+```
+
 ### wecom
 
 OpenClaw Enterprise WeCom Channel Plugin.


### PR DESCRIPTION
## Summary
Add Team Ops to the community plugins list.

## What It Does
Team Ops turns raw working conversations into execution artifacts that teams can immediately use.

It supports workflows such as:
- chat thread to status update
- meeting transcript to action register
- incident room to executive brief
- planning notes to PM digest

## Plugin
- Name: Team Ops
- npm: `team-ops`
- Repo: https://github.com/JimmyWangJimmy/openclaw-team-ops-plugin
- Install: `openclaw plugins install npm:team-ops`

## Validation
- Published to npm
- Public source repository with docs and issue tracking
- Verified locally inside OpenClaw
- Executed a real `team_ops_digest` tool call against a sample transcript

## Quality Notes
- Focused single-purpose plugin with a clear user outcome
- README includes install, config, tool usage, CLI usage, and verification steps
- Package metadata points to the public source repository
