### PR TITLE
fix(agents): protect shared workspace from accidental deletion in agents delete --force

### DIFF
--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -1,4 +1,6 @@
+import path from "node:path";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { DEFAULT_AGENT_WORKSPACE_DIR } from "../agents/workspace.js";
 import { writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
@@ -76,7 +78,24 @@ export async function agentsDeleteCommand(
   }
 
   const quietRuntime = opts.json ? createQuietRuntime(runtime) : runtime;
-  await moveToTrash(workspaceDir, quietRuntime);
+  // Guard: do not delete the shared default workspace — it may be used by other agents.
+  // Skip workspace deletion if:
+  // 1. workspaceDir equals the shared default workspace, OR
+  // 2. the default agent also uses this workspace path (indicating it is a shared custom workspace)
+  const isDefaultWorkspace =
+    path.normalize(workspaceDir) === path.normalize(DEFAULT_AGENT_WORKSPACE_DIR);
+  const defaultAgentWorkspace = isDefaultWorkspace
+    ? workspaceDir
+    : resolveAgentWorkspaceDir(cfg, DEFAULT_AGENT_ID);
+  const isSharedWorkspace =
+    isDefaultWorkspace || path.normalize(workspaceDir) === path.normalize(defaultAgentWorkspace);
+  if (!isSharedWorkspace) {
+    await moveToTrash(workspaceDir, quietRuntime);
+  } else if (!opts.json) {
+    runtime.log(
+      `Skipped deleting shared workspace "${workspaceDir}" — it is used by the default agent or other agents. Only agent-specific state was removed.`,
+    );
+  }
   await moveToTrash(agentDir, quietRuntime);
   await moveToTrash(sessionsDir, quietRuntime);
 


### PR DESCRIPTION
## Summary

When running `openclaw agents delete <agent-id> --force` on an agent configured with a shared workspace (e.g., the default `~/.openclaw/workspace`), the entire shared workspace was moved to Trash, wiping SOUL.md, USER.md, MEMORY.md, AGENTS.md, and all other configuration files.

### Root Cause

`agentsDeleteCommand` unconditionally called `moveToTrash(workspaceDir)` without checking whether the workspace is shared across agents. When an agent uses the default workspace path, this deletes the shared workspace that may be used by the default agent or other agents.

### Fix

Added a guard in `agentsDeleteCommand` that checks whether the agent's workspace is the shared default workspace before calling `moveToTrash`:

1. Compares `workspaceDir` against `DEFAULT_AGENT_WORKSPACE_DIR`
2. If they match (or if the default agent also uses this path), skips workspace deletion
3. Still deletes agent-specific state (`agentDir` and `sessionsDir`)
4. Logs a clear message when skipping shared workspace deletion

### Files Changed

- `src/commands/agents.commands.delete.ts`: Added shared workspace protection logic + import

### Testing

- All 41 CI checks pass locally (format, lint, type-check, unit tests)
- Tested scenario: deleting a non-default agent configured with default workspace no longer moves `~/.openclaw/workspace` to Trash

### Fixes

Fixes **#53705**