### PR TITLE
fix(discord): graceful degradation when account missing Message Content Intent

### DIFF
--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -238,10 +238,9 @@ describe("discordPlugin gateway startAccount error handling", () => {
     );
 
     const cfg = createCfg();
-    const ctx = createStartAccountCtx({
+    const ctx = createStartAccountContext({
+      account: resolveAccount(cfg),
       cfg,
-      accountId: "default",
-      runtime: createRuntimeEnv(),
     });
 
     // Should NOT throw — error is caught internally
@@ -267,10 +266,9 @@ describe("discordPlugin gateway startAccount error handling", () => {
     monitorDiscordProviderMock.mockRejectedValue("raw string error");
 
     const cfg = createCfg();
-    const ctx = createStartAccountCtx({
+    const ctx = createStartAccountContext({
+      account: resolveAccount(cfg),
       cfg,
-      accountId: "default",
-      runtime: createRuntimeEnv(),
     });
 
     await discordPlugin.gateway!.startAccount!(ctx);

--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -221,6 +221,71 @@ describe("discordPlugin security", () => {
   });
 });
 
+describe("discordPlugin gateway startAccount error handling", () => {
+  it("catches monitorDiscordProvider errors and disables account instead of crashing", async () => {
+    setDiscordRuntime({
+      channel: { discord: {} },
+      logging: { shouldLogVerbose: () => false },
+    } as unknown as PluginRuntime);
+    probeDiscordMock.mockResolvedValue({
+      ok: true,
+      bot: { username: "TestBot" },
+      application: { intents: { messageContent: "enabled" } },
+      elapsedMs: 1,
+    });
+    monitorDiscordProviderMock.mockRejectedValue(
+      new Error("Gateway closed with code 4014 (Disallowed intents)"),
+    );
+
+    const cfg = createCfg();
+    const ctx = createStartAccountCtx({
+      cfg,
+      accountId: "default",
+      runtime: createRuntimeEnv(),
+    });
+
+    // Should NOT throw — error is caught internally
+    await discordPlugin.gateway!.startAccount!(ctx);
+
+    expect(ctx.log?.warn).toHaveBeenCalledWith(expect.stringContaining("Discord provider failed"));
+    expect(ctx.log?.warn).toHaveBeenCalledWith(expect.stringContaining("4014"));
+    expect(ctx.setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        running: false,
+        lastError: expect.stringContaining("4014"),
+      }),
+    );
+  });
+
+  it("handles non-Error thrown values gracefully", async () => {
+    setDiscordRuntime({
+      channel: { discord: {} },
+      logging: { shouldLogVerbose: () => false },
+    } as unknown as PluginRuntime);
+    probeDiscordMock.mockResolvedValue({ ok: false, elapsedMs: 1 });
+    monitorDiscordProviderMock.mockRejectedValue("raw string error");
+
+    const cfg = createCfg();
+    const ctx = createStartAccountCtx({
+      cfg,
+      accountId: "default",
+      runtime: createRuntimeEnv(),
+    });
+
+    await discordPlugin.gateway!.startAccount!(ctx);
+
+    expect(ctx.log?.warn).toHaveBeenCalledWith(expect.stringContaining("unknown error"));
+    expect(ctx.setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        running: false,
+        lastError: "unknown error",
+      }),
+    );
+  });
+});
+
 describe("discordPlugin groups", () => {
   it("uses plugin-owned group policy resolvers", () => {
     const cfg = {

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -618,16 +618,28 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount, DiscordProbe> 
             }
           }
           ctx.log?.info(`[${account.accountId}] starting provider${discordBotLabel}`);
-          return (await loadDiscordProviderRuntime()).monitorDiscordProvider({
-            token,
-            accountId: account.accountId,
-            config: ctx.cfg,
-            runtime: ctx.runtime,
-            abortSignal: ctx.abortSignal,
-            mediaMaxMb: account.config.mediaMaxMb,
-            historyLimit: account.config.historyLimit,
-            setStatus: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
-          });
+          try {
+            await (await loadDiscordProviderRuntime()).monitorDiscordProvider({
+              token,
+              accountId: account.accountId,
+              config: ctx.cfg,
+              runtime: ctx.runtime,
+              abortSignal: ctx.abortSignal,
+              mediaMaxMb: account.config.mediaMaxMb,
+              historyLimit: account.config.historyLimit,
+              setStatus: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
+            });
+          } catch (err) {
+            const reason = err instanceof Error ? err.message : "unknown error";
+            ctx.log?.warn(
+              `[${account.accountId}] Discord provider failed — disabling account: ${reason}`,
+            );
+            ctx.setStatus({
+              accountId: account.accountId,
+              running: false,
+              lastError: reason,
+            });
+          }
         },
       },
     },


### PR DESCRIPTION
## Summary

When a Discord bot account is added to OpenClaw without enabling the "Message Content Intent" in the Discord Developer Portal, the `monitorDiscordProvider` call throws an unhandled error that crashes the **entire Gateway** ├ö├ç├Â taking down all channels (Telegram, WhatsApp, other Discord bots, etc.).

## Details

Wrapped `monitorDiscordProvider` in a try/catch in `channel.ts`. When the call fails:
- A warning is logged identifying the account ID and error reason
- The account status is set to `running: false` with `lastError`
- The error is NOT rethrown ├ö├ç├Â preventing crash propagation

Only the misconfigured account is disabled. All other channels continue running normally.

## Related Issues

Fixes #27002

## How to Validate

1. Add a Discord bot token for an account WITHOUT "Message Content Intent" enabled
2. Start the gateway
3. Confirm only that Discord account fails ├ö├ç├Â Telegram and other channels stay online
4. Check `openclaw status` ├ö├ç├Â shows the failed account with `lastError`

Run unit tests: `pnpm test -- --testPathPattern=discord/src/channel`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run

---
## AI-Assisted Disclosure

- [x] This PR was built with Claude Code (Anthropic)
- [x] Fully tested locally ÔÇö tests pass, oxfmt formatting verified
- [x] Author reviewed and understands all changes
- [x] Codex review not available locally (not installed)

