### PR TITLE
fix(message-tool): make channel plugin schema properties optional

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -365,7 +365,14 @@ function buildMessageToolSchemaProps(options: {
     ...buildGatewaySchema(),
     ...buildChannelManagementSchema(),
     ...buildPresenceSchema(),
-    ...options.extraProperties,
+    // Channel plugin schema properties (from extraProperties) are always optional —
+    // channels may define card/file/etc fields but the message tool must not
+    // require them when not sending a card-based message.
+    ...(options.extraProperties
+      ? Object.fromEntries(
+          Object.entries(options.extraProperties).map(([k, v]) => [k, Type.Optional(v)]),
+        )
+      : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

Channel plugin schema contributions (e.g. Feishu's `card` field) were merged into the message tool schema via `extraProperties` without wrapping in `Type.Optional()`, making them **required by default** in the Typebox `Object` schema.

This caused the Feishu `card` field to be a required property of the message tool, breaking all non-card send actions (plain text, image, file) with:



The error confirmed this affected ALL proactive Feishu sends — text messages, images, and files — and was reported independently by two users as issues #53656 and #53295.

## Fix

In `buildMessageToolSchemaProps()`, wrap each `extraProperties` value in `Type.Optional()` before merging into the tool schema, so channel plugin fields are always optional:

```typescript
...(options.extraProperties
  ? Object.fromEntries(
      Object.entries(options.extraProperties).map(([k, v]) => [k, Type.Optional(v)]),
    )
  : {}),
```

This is the correct semantic: channel plugin fields like `card`, `media`, `buffer`, etc. are always optional — the message tool decides which to use based on the action type.

## Testing

- ✅ Format check: all 8841 files
- ✅ Lint: 0 warnings, 0 errors
- ✅ All lint:tmp checks pass
- ✅ `pnpm check` passes (excluding pre-existing TS2883 inference warnings in unrelated test files)

## Related Issues

Fixes **#53656**
Fixes **#53295**