### PR TITLE
fix(elevated): fall back to session key channel for Discord slash elevated resolution

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -6,6 +6,7 @@ import { resolveSandboxRuntimeStatus } from "../../agents/sandbox/runtime-status
 import type { SkillCommandSpec } from "../../agents/skills.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { inferChannelFromSessionKey } from "../../routing/session-key-channel.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { shouldHandleTextCommands } from "../commands-text-routing.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
@@ -333,7 +334,10 @@ export async function resolveReplyDirectives(params: {
   sessionCtx.BodyStripped = cleanedBody;
 
   const messageProviderKey =
-    sessionCtx.Provider?.trim().toLowerCase() ?? ctx.Provider?.trim().toLowerCase() ?? "";
+    sessionCtx.Provider?.trim().toLowerCase() ??
+    ctx.Provider?.trim().toLowerCase() ??
+    inferChannelFromSessionKey(ctx.SessionKey) ??
+    "";
   const elevated = resolveElevatedPermissions({
     cfg,
     agentId,

--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -12,6 +12,7 @@ import {
   resolveMainSessionKey,
   resolveStorePath,
 } from "../config/sessions.js";
+import { inferChannelFromSessionKey } from "../routing/session-key-channel.js";
 import {
   buildAgentMainSessionKey,
   normalizeAgentId,
@@ -120,10 +121,12 @@ function resolveActiveChannel(params: {
   if (normalized) {
     return normalized;
   }
-  return inferProviderFromSessionKey({
-    cfg: params.cfg,
-    sessionKey: params.sessionKey,
-  });
+  return (
+    inferProviderFromSessionKey({
+      cfg: params.cfg,
+      sessionKey: params.sessionKey,
+    }) ?? inferChannelFromSessionKey(params.sessionKey)
+  );
 }
 
 export async function sandboxExplainCommand(

--- a/src/routing/session-key-channel.ts
+++ b/src/routing/session-key-channel.ts
@@ -1,0 +1,37 @@
+import { parseAgentSessionKey } from "./session-key.js";
+
+/**
+ * Extract the channel/provider segment from an agent session key.
+ *
+ * Session keys follow the format `agent:<agentId>:<channel>:<subtype>:<id>`.
+ * For example `agent:main:discord:slash:12345` → `"discord"`.
+ *
+ * This is a last-resort fallback for cases where the channel/provider
+ * metadata is not available through the normal context propagation path.
+ *
+ * Fixes #53621 (Discord slash sessions) and related Telegram issues.
+ */
+export function inferChannelFromSessionKey(sessionKey: string | undefined): string | undefined {
+  if (!sessionKey) {
+    return undefined;
+  }
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) {
+    return undefined;
+  }
+  const rest = parsed.rest.trim();
+  if (!rest) {
+    return undefined;
+  }
+  const parts = rest.split(":").filter(Boolean);
+  if (parts.length < 2) {
+    // Need at least <channel>:<something> to be confident this is a channel segment
+    // and not a mainKey or other identifier.
+    return undefined;
+  }
+  const candidate = parts[0]?.trim().toLowerCase();
+  if (!candidate) {
+    return undefined;
+  }
+  return candidate;
+}


### PR DESCRIPTION
## Summary

When Discord slash sessions reach the elevated permission resolution path, `ctx.Provider` / `sessionCtx.Provider` can be empty. This causes the `allowFrom` lookup to fail even when `tools.elevated.allowFrom.discord` is correctly configured.

## Changes

1. **New helper: `inferChannelFromSessionKey()`** (`src/routing/session-key-channel.ts`)
   - Extracts the channel segment from agent session keys
   - e.g. `agent:main:discord:slash:<id>` → `"discord"`
   - Only returns a value when the key has at least `<channel>:<subtype>` structure

2. **Runtime fix: `get-reply-directives.ts`**
   - Falls back to `inferChannelFromSessionKey(ctx.SessionKey)` when both `sessionCtx.Provider` and `ctx.Provider` are empty
   - Ensures `resolveElevatedPermissions()` receives the correct provider

3. **Diagnostics fix: `sandbox-explain.ts`**
   - `resolveActiveChannel()` now falls back to `inferChannelFromSessionKey()` when the session store and `inferProviderFromSessionKey()` both return nothing
   - Ensures `openclaw sandbox explain` shows `channel: discord` instead of `channel: (unknown)`

## Related issues

- Fixes #53621 (Discord slash elevated gating + sandbox explain misdiagnosis)
- Discord counterpart of #51245 (Telegram slash sessions)
- Related to #53198

## Testing

Verified locally with hot patch on `2026.3.23-2`:
- Before patch: `channel: (unknown)`, `allowedByConfig: false`
- After patch: `channel: discord`, `allowedByConfig: true`
- Discord slash elevated commands work correctly after fix