### PR TITLE
[Feature]: Support DeepInfra as an LLM provider 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -289,6 +289,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/byteplus/**"
+"extensions: deepinfra":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/deepinfra/**"
 "extensions: deepseek":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Changes
+
+- Providers/DeepInfra: add DeepInfra as an official provider with interactive onboarding, `DEEPINFRA_API_KEY` auto-detection, and dynamic model discovery from the DeepInfra API. (#53805) Thanks @ats3v
+
 ### Fixes
 
 - Plugins/startup: load the default `memory-core` slot during Gateway startup when permitted so active-memory recall can call `memory_search` and `memory_get` without requiring an explicit `plugins.slots.memory` entry, while preserving `plugins.slots.memory: "none"`. Thanks @codex.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1308,6 +1308,7 @@
                   "providers/cloudflare-ai-gateway",
                   "providers/comfy",
                   "providers/deepgram",
+                  "providers/deepinfra",
                   "providers/deepseek",
                   "providers/elevenlabs",
                   "providers/fal",

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -742,6 +742,28 @@ providers:
 | `paired`  | After profile | Synthesize multiple related entries             |
 | `late`    | Last pass     | Override existing providers (wins on collision) |
 
+## Preserving catalog discovery order
+
+By default OpenClaw sorts models alphabetically within each provider block. If
+your provider's upstream `/models` endpoint returns a curated ranking (for
+example relevance-ordered or capability-ordered) and you want that order
+surfaced in `openclaw models list`, set `preserveDiscoveryOrder: true` on your
+`catalog` registration:
+
+```ts
+catalog: {
+  order: "simple",
+  run: runCatalog,
+  preserveDiscoveryOrder: true,
+},
+```
+
+When the flag is set, models from your provider are sorted with a stable
+comparator that preserves insertion order within the provider block instead of
+applying alphabetical sorting. Models from other providers are still sorted
+normally. Use this only when the upstream catalog has a meaningful, stable
+ordering — do not set it just to avoid sorting.
+
 ## Next steps
 
 - [Channel Plugins](/plugins/sdk-channel-plugins) — if your plugin also provides a channel

--- a/docs/providers/deepinfra.md
+++ b/docs/providers/deepinfra.md
@@ -1,0 +1,62 @@
+---
+summary: "Use DeepInfra's unified API to access the most popular open source and frontier models in OpenClaw"
+read_when:
+  - You want a single API key for the top open source LLMs
+  - You want to run models via DeepInfra's API in OpenClaw
+---
+
+# DeepInfra
+
+DeepInfra provides a **unified API** that routes requests to the most popular open source and frontier models behind a single
+endpoint and API key. It is OpenAI-compatible, so most OpenAI SDKs work by switching the base URL.
+
+## Getting an API key
+
+1. Go to [https://deepinfra.com/](https://deepinfra.com/)
+2. Sign in or create an account
+3. Navigate to Dashboard / Keys and generate a new API key or use the auto created one
+
+## CLI setup
+
+```bash
+openclaw onboard --deepinfra-api-key <key>
+```
+
+Or set the environment variable:
+
+```bash
+export DEEPINFRA_API_KEY="<your-deepinfra-api-key>" # pragma: allowlist secret
+```
+
+## Config snippet
+
+```json5
+{
+  env: { DEEPINFRA_API_KEY: "<your-deepinfra-api-key>" }, // pragma: allowlist secret
+  agents: {
+    defaults: {
+      model: { primary: "deepinfra/zai-org/GLM-5.1" },
+    },
+  },
+}
+```
+
+## Available models
+
+OpenClaw dynamically discovers available DeepInfra models at startup. Use
+`/models deepinfra` to see the full list of models available.
+
+Any model available on [DeepInfra.com](https://deepinfra.com/) can be used with the `deepinfra/` prefix:
+
+```
+deepinfra/MiniMaxAI/MiniMax-M2.5
+deepinfra/zai-org/GLM-5.1
+deepinfra/moonshotai/Kimi-K2.5
+...and many more
+```
+
+## Notes
+
+- Model refs are `deepinfra/<provider>/<model>` (e.g., `deepinfra/Qwen/Qwen3-Max`).
+- Default model: `deepinfra/zai-org/GLM-5.1`
+- Base URL: `https://api.deepinfra.com/v1/openai`

--- a/extensions/deepinfra/api.ts
+++ b/extensions/deepinfra/api.ts
@@ -1,0 +1,3 @@
+export { buildDeepInfraProvider, buildDeepInfraProviderWithDiscovery } from "./provider-catalog.js";
+export { applyDeepInfraConfig } from "./onboard.js";
+export { DEEPINFRA_DEFAULT_MODEL_REF } from "./provider-models.js";

--- a/extensions/deepinfra/index.test.ts
+++ b/extensions/deepinfra/index.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import deepinfraPlugin from "./index.js";
+
+describe("deepinfra augmentModelCatalog", () => {
+  it("returns empty when no configured catalog entries", async () => {
+    const provider = await registerSingleProviderPlugin(deepinfraPlugin);
+
+    const entries = await provider.augmentModelCatalog?.({} as never);
+
+    expect(entries).toEqual([]);
+  });
+
+  it("returns configured catalog entries from config", async () => {
+    const provider = await registerSingleProviderPlugin(deepinfraPlugin);
+
+    const entries = await provider.augmentModelCatalog?.({
+      config: {
+        models: {
+          providers: {
+            deepinfra: {
+              models: [
+                {
+                  id: "zai-org/GLM-5.1",
+                  name: "GLM-5.1",
+                  input: ["text"],
+                  reasoning: true,
+                  contextWindow: 202752,
+                },
+              ],
+            },
+          },
+        },
+      },
+    } as never);
+
+    expect(entries).toEqual([
+      {
+        provider: "deepinfra",
+        id: "zai-org/GLM-5.1",
+        name: "GLM-5.1",
+        input: ["text"],
+        reasoning: true,
+        contextWindow: 202752,
+      },
+    ]);
+  });
+});
+
+describe("deepinfra isCacheTtlEligible", () => {
+  it("returns true for anthropic/* proxied models", async () => {
+    const provider = await registerSingleProviderPlugin(deepinfraPlugin);
+    expect(
+      provider.isCacheTtlEligible?.({
+        provider: "deepinfra",
+        modelId: "anthropic/claude-4-sonnet",
+      }),
+    ).toBe(true);
+  });
+
+  // Locked to case-insensitive to stay consistent with
+  // createDeepInfraSystemCacheWrapper, which lowercases the modelId before the
+  // "anthropic/" prefix check. If these ever disagree, a model can get cache
+  // markers injected on the wire while the TTL refresh scheduler skips it.
+  it("returns true regardless of modelId case", async () => {
+    const provider = await registerSingleProviderPlugin(deepinfraPlugin);
+    expect(
+      provider.isCacheTtlEligible?.({
+        provider: "deepinfra",
+        modelId: "Anthropic/Claude-4-Sonnet",
+      }),
+    ).toBe(true);
+    expect(
+      provider.isCacheTtlEligible?.({
+        provider: "deepinfra",
+        modelId: "ANTHROPIC/claude-4-sonnet",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for non-anthropic models", async () => {
+    const provider = await registerSingleProviderPlugin(deepinfraPlugin);
+    expect(
+      provider.isCacheTtlEligible?.({
+        provider: "deepinfra",
+        modelId: "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+      }),
+    ).toBe(false);
+    expect(
+      provider.isCacheTtlEligible?.({
+        provider: "deepinfra",
+        modelId: "zai-org/GLM-5.1",
+      }),
+    ).toBe(false);
+  });
+});

--- a/extensions/deepinfra/index.ts
+++ b/extensions/deepinfra/index.ts
@@ -1,0 +1,123 @@
+import type {
+  ProviderAuthContext,
+  ProviderAuthMethod,
+  ProviderAuthMethodNonInteractiveContext,
+  ProviderAuthResult,
+} from "openclaw/plugin-sdk/core";
+import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
+import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { PASSTHROUGH_GEMINI_REPLAY_HOOKS } from "openclaw/plugin-sdk/provider-model-shared";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
+import { isProxyReasoningUnsupported } from "openclaw/plugin-sdk/provider-stream";
+import { createDeepInfraSystemCacheWrapper, createDeepInfraWrapper } from "./stream.js";
+import { applyDeepInfraConfig } from "./onboard.js";
+import { buildDeepInfraProvider, buildDeepInfraProviderWithDiscovery } from "./provider-catalog.js";
+import { resolveDeepInfraDefaultModelRef } from "./provider-models.js";
+
+const PROVIDER_ID = "deepinfra";
+const AUTH_METHOD_ID = "api-key";
+const AUTH_LABEL = "DeepInfra API key";
+const AUTH_HINT = "Unified API for open source models";
+
+function buildApiKeyAuthMethod(defaultModelRef: string): ProviderAuthMethod {
+  return createProviderApiKeyAuthMethod({
+    methodId: AUTH_METHOD_ID,
+    label: AUTH_LABEL,
+    hint: AUTH_HINT,
+    optionKey: "deepinfraApiKey",
+    flagName: "--deepinfra-api-key",
+    envVar: "DEEPINFRA_API_KEY",
+    promptMessage: "Enter DeepInfra API key",
+    defaultModel: defaultModelRef,
+    providerId: PROVIDER_ID,
+    expectedProviders: [PROVIDER_ID],
+    applyConfig: (cfg: OpenClawConfig) => applyDeepInfraConfig(cfg, defaultModelRef),
+    wizard: {
+      choiceId: "deepinfra-api-key",
+      choiceLabel: AUTH_LABEL,
+      choiceHint: AUTH_HINT,
+      groupId: PROVIDER_ID,
+      groupLabel: "DeepInfra",
+      groupHint: AUTH_HINT,
+      methodId: AUTH_METHOD_ID,
+    },
+  });
+}
+
+// Default model ref is resolved dynamically from the discovered catalog so
+// onboarding never commits to a model the runtime registry won't serve. If the
+// preferred default is missing from /models (deprecation, region filtering,
+// curated list change), the helper falls back to the first discovered model.
+// The shared 30-min cache in `discoverDeepInfraModels` coalesces this call and
+// the subsequent `catalog.run` into a single /models round trip.
+const deepInfraAuthMethod: ProviderAuthMethod = {
+  id: AUTH_METHOD_ID,
+  label: AUTH_LABEL,
+  hint: AUTH_HINT,
+  kind: "api_key",
+  wizard: {
+    choiceId: "deepinfra-api-key",
+    choiceLabel: AUTH_LABEL,
+    choiceHint: AUTH_HINT,
+    groupId: PROVIDER_ID,
+    groupLabel: "DeepInfra",
+    groupHint: AUTH_HINT,
+    methodId: AUTH_METHOD_ID,
+  },
+  run: async (ctx: ProviderAuthContext): Promise<ProviderAuthResult> => {
+    const ref = await resolveDeepInfraDefaultModelRef();
+    return buildApiKeyAuthMethod(ref).run(ctx);
+  },
+  runNonInteractive: async (
+    ctx: ProviderAuthMethodNonInteractiveContext,
+  ): Promise<OpenClawConfig | null> => {
+    const method = buildApiKeyAuthMethod(await resolveDeepInfraDefaultModelRef());
+    return method.runNonInteractive ? method.runNonInteractive(ctx) : null;
+  },
+};
+
+export default definePluginEntry({
+  id: PROVIDER_ID,
+  name: "DeepInfra Provider",
+  description: "Bundled DeepInfra provider plugin",
+  register(api: OpenClawPluginApi) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "DeepInfra",
+      docsPath: "/providers/deepinfra",
+      auth: [deepInfraAuthMethod],
+      catalog: {
+        order: "simple",
+        run: async (ctx) => {
+          const apiKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+          if (!apiKey) {
+            return null;
+          }
+          const provider = await buildDeepInfraProviderWithDiscovery();
+          return { provider: { ...provider, apiKey } };
+        },
+        preserveDiscoveryOrder: true,
+      },
+      staticCatalog: {
+        order: "simple",
+        run: async () => ({ provider: buildDeepInfraProvider() }),
+      },
+      augmentModelCatalog: ({ config }) =>
+        readConfiguredProviderCatalogEntries({
+          config,
+          providerId: PROVIDER_ID,
+        }),
+      ...PASSTHROUGH_GEMINI_REPLAY_HOOKS,
+      wrapStreamFn: (ctx) => {
+        const thinkingLevel = isProxyReasoningUnsupported(ctx.modelId)
+          ? undefined
+          : ctx.thinkingLevel;
+        return createDeepInfraSystemCacheWrapper(
+          createDeepInfraWrapper(ctx.streamFn, thinkingLevel),
+        );
+      },
+      isCacheTtlEligible: (ctx) => ctx.modelId.toLowerCase().startsWith("anthropic/"),
+    });
+  },
+});

--- a/extensions/deepinfra/onboard.test.ts
+++ b/extensions/deepinfra/onboard.test.ts
@@ -1,0 +1,165 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type OpenClawConfig,
+  resolveAgentModelPrimaryValue,
+} from "openclaw/plugin-sdk/provider-onboard";
+import * as providerAuth from "openclaw/plugin-sdk/provider-auth-runtime";
+import { captureEnv } from "openclaw/plugin-sdk/testing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  applyDeepInfraProviderConfig,
+  applyDeepInfraConfig,
+  DEEPINFRA_BASE_URL,
+  DEEPINFRA_DEFAULT_MODEL_REF,
+} from "./onboard.js";
+import { DEEPINFRA_DEFAULT_MODEL_ID } from "./provider-models.js";
+
+const { resolveEnvApiKey } = providerAuth;
+
+const emptyCfg: OpenClawConfig = {};
+
+describe("DeepInfra provider config", () => {
+  describe("constants", () => {
+    it("DEEPINFRA_BASE_URL points to deepinfra openai endpoint", () => {
+      expect(DEEPINFRA_BASE_URL).toBe("https://api.deepinfra.com/v1/openai");
+    });
+
+    it("DEEPINFRA_DEFAULT_MODEL_REF includes provider prefix", () => {
+      expect(DEEPINFRA_DEFAULT_MODEL_REF).toBe("deepinfra/zai-org/GLM-5.1");
+    });
+
+    it("DEEPINFRA_DEFAULT_MODEL_ID is zai-org/GLM-5.1", () => {
+      expect(DEEPINFRA_DEFAULT_MODEL_ID).toBe("zai-org/GLM-5.1");
+    });
+  });
+
+  describe("applyDeepInfraProviderConfig", () => {
+    it("does not set provider models (discovery populates them at runtime)", () => {
+      const result = applyDeepInfraProviderConfig(emptyCfg, DEEPINFRA_DEFAULT_MODEL_REF);
+      expect(result.models?.providers?.deepinfra).toBeUndefined();
+    });
+
+    it("sets DeepInfra alias on the provided model ref", () => {
+      const result = applyDeepInfraProviderConfig(emptyCfg, DEEPINFRA_DEFAULT_MODEL_REF);
+      const agentModel = result.agents?.defaults?.models?.[DEEPINFRA_DEFAULT_MODEL_REF];
+      expect(agentModel).toBeDefined();
+      expect(agentModel?.alias).toBe("DeepInfra");
+    });
+
+    it("attaches the alias to a non-default model ref when provided", () => {
+      const fallbackRef = "deepinfra/other/awesome-model";
+      const result = applyDeepInfraProviderConfig(emptyCfg, fallbackRef);
+      expect(result.agents?.defaults?.models?.[fallbackRef]?.alias).toBe("DeepInfra");
+      expect(result.agents?.defaults?.models?.[DEEPINFRA_DEFAULT_MODEL_REF]).toBeUndefined();
+    });
+
+    it("preserves existing alias if already set", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            models: {
+              [DEEPINFRA_DEFAULT_MODEL_REF]: { alias: "My Custom Alias" },
+            },
+          },
+        },
+      };
+      const result = applyDeepInfraProviderConfig(cfg, DEEPINFRA_DEFAULT_MODEL_REF);
+      const agentModel = result.agents?.defaults?.models?.[DEEPINFRA_DEFAULT_MODEL_REF];
+      expect(agentModel?.alias).toBe("My Custom Alias");
+    });
+
+    it("does not change the default model selection", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5" },
+          },
+        },
+      };
+      const result = applyDeepInfraProviderConfig(cfg, DEEPINFRA_DEFAULT_MODEL_REF);
+      expect(resolveAgentModelPrimaryValue(result.agents?.defaults?.model)).toBe("openai/gpt-5");
+    });
+  });
+
+  describe("applyDeepInfraConfig", () => {
+    it("sets the provided model ref as the primary default", () => {
+      const result = applyDeepInfraConfig(emptyCfg, DEEPINFRA_DEFAULT_MODEL_REF);
+      expect(resolveAgentModelPrimaryValue(result.agents?.defaults?.model)).toBe(
+        DEEPINFRA_DEFAULT_MODEL_REF,
+      );
+    });
+
+    it("sets the DeepInfra alias on the provided ref", () => {
+      const result = applyDeepInfraConfig(emptyCfg, DEEPINFRA_DEFAULT_MODEL_REF);
+      const agentModel = result.agents?.defaults?.models?.[DEEPINFRA_DEFAULT_MODEL_REF];
+      expect(agentModel?.alias).toBe("DeepInfra");
+    });
+
+    it("honors a fallback ref when discovery picked a non-default model", () => {
+      const fallbackRef = "deepinfra/other/awesome-model";
+      const result = applyDeepInfraConfig(emptyCfg, fallbackRef);
+      expect(resolveAgentModelPrimaryValue(result.agents?.defaults?.model)).toBe(fallbackRef);
+      expect(result.agents?.defaults?.models?.[fallbackRef]?.alias).toBe("DeepInfra");
+    });
+  });
+
+  describe("env var resolution", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("resolves DEEPINFRA_API_KEY from env", () => {
+      const envSnapshot = captureEnv(["DEEPINFRA_API_KEY"]);
+      process.env.DEEPINFRA_API_KEY = "test-deepinfra-key";
+
+      try {
+        const result = resolveEnvApiKey("deepinfra");
+        expect(result).not.toBeNull();
+        expect(result?.apiKey).toBe("test-deepinfra-key");
+        expect(result?.source).toContain("DEEPINFRA_API_KEY");
+      } finally {
+        envSnapshot.restore();
+      }
+    });
+
+    it("returns null when DEEPINFRA_API_KEY is not set", () => {
+      const envSnapshot = captureEnv(["DEEPINFRA_API_KEY"]);
+      delete process.env.DEEPINFRA_API_KEY;
+
+      try {
+        const result = resolveEnvApiKey("deepinfra");
+        expect(result).toBeNull();
+      } finally {
+        envSnapshot.restore();
+      }
+    });
+
+    it("resolves the deepinfra api key via resolveApiKeyForProvider", async () => {
+      const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+      const envSnapshot = captureEnv(["DEEPINFRA_API_KEY"]);
+      process.env.DEEPINFRA_API_KEY = "deepinfra-provider-test-key";
+
+      const spy = vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+        apiKey: "deepinfra-provider-test-key",
+        source: "env: DEEPINFRA_API_KEY",
+        mode: "api-key",
+      });
+
+      try {
+        const auth = await providerAuth.resolveApiKeyForProvider({
+          provider: "deepinfra",
+          agentDir,
+        });
+
+        expect(spy).toHaveBeenCalledWith(expect.objectContaining({ provider: "deepinfra" }));
+        expect(auth.apiKey).toBe("deepinfra-provider-test-key");
+        expect(auth.mode).toBe("api-key");
+        expect(auth.source).toContain("DEEPINFRA_API_KEY");
+      } finally {
+        envSnapshot.restore();
+      }
+    });
+  });
+});

--- a/extensions/deepinfra/onboard.ts
+++ b/extensions/deepinfra/onboard.ts
@@ -1,0 +1,33 @@
+import {
+  applyAgentDefaultModelPrimary,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { DEEPINFRA_BASE_URL, DEEPINFRA_DEFAULT_MODEL_REF } from "./provider-models.js";
+
+export { DEEPINFRA_BASE_URL, DEEPINFRA_DEFAULT_MODEL_REF };
+
+export function applyDeepInfraProviderConfig(
+  cfg: OpenClawConfig,
+  modelRef: string,
+): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[modelRef] = {
+    ...models[modelRef],
+    alias: models[modelRef]?.alias ?? "DeepInfra",
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+  };
+}
+
+export function applyDeepInfraConfig(cfg: OpenClawConfig, modelRef: string): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(applyDeepInfraProviderConfig(cfg, modelRef), modelRef);
+}

--- a/extensions/deepinfra/openclaw.plugin.json
+++ b/extensions/deepinfra/openclaw.plugin.json
@@ -1,0 +1,29 @@
+{
+  "id": "deepinfra",
+  "enabledByDefault": true,
+  "providers": ["deepinfra"],
+  "providerAuthEnvVars": {
+    "deepinfra": ["DEEPINFRA_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "deepinfra",
+      "method": "api-key",
+      "choiceId": "deepinfra-api-key",
+      "choiceLabel": "DeepInfra API key",
+      "choiceHint": "Unified API for open source models",
+      "groupId": "deepinfra",
+      "groupLabel": "DeepInfra",
+      "groupHint": "Unified API for open source models",
+      "optionKey": "deepinfraApiKey",
+      "cliFlag": "--deepinfra-api-key",
+      "cliOption": "--deepinfra-api-key <key>",
+      "cliDescription": "DeepInfra API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/deepinfra/package.json
+++ b/extensions/deepinfra/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openclaw/deepinfra-provider",
+  "version": "2026.3.24",
+  "private": true,
+  "description": "OpenClaw DeepInfra provider plugin",
+  "type": "module",
+  "dependencies": {
+    "@mariozechner/pi-ai": "0.70.2"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/deepinfra/provider-catalog.ts
+++ b/extensions/deepinfra/provider-catalog.ts
@@ -1,0 +1,23 @@
+import { type ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  DEEPINFRA_BASE_URL,
+  DEEPINFRA_MODEL_CATALOG,
+  discoverDeepInfraModels,
+} from "./provider-models.js";
+
+export function buildDeepInfraProvider(): ModelProviderConfig {
+  return {
+    baseUrl: DEEPINFRA_BASE_URL,
+    api: "openai-completions",
+    models: [...DEEPINFRA_MODEL_CATALOG],
+  };
+}
+
+export async function buildDeepInfraProviderWithDiscovery(): Promise<ModelProviderConfig> {
+  const models = await discoverDeepInfraModels();
+  return {
+    baseUrl: DEEPINFRA_BASE_URL,
+    api: "openai-completions",
+    models,
+  };
+}

--- a/extensions/deepinfra/provider-models.test.ts
+++ b/extensions/deepinfra/provider-models.test.ts
@@ -1,0 +1,439 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEEPINFRA_DEFAULT_MODEL_REF,
+  DEEPINFRA_MODELS_URL,
+  discoverDeepInfraModels,
+  resetDeepInfraModelCacheForTest,
+  resolveDeepInfraDefaultModelRef,
+} from "./provider-models.js";
+
+beforeEach(() => {
+  resetDeepInfraModelCacheForTest();
+});
+
+function makeModelEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "openai/gpt-oss-120b",
+    object: "model",
+    owned_by: "deepinfra",
+    metadata: {
+      description: "A powerful model",
+      context_length: 131072,
+      max_tokens: 131072,
+      pricing: {
+        input_tokens: 3.0,
+        output_tokens: 15.0,
+        cache_read_tokens: 0.3,
+      },
+      tags: ["vision", "reasoning_effort", "prompt_cache", "reasoning"],
+    },
+    ...overrides,
+  };
+}
+
+function makeTextOnlyEntry(overrides: Record<string, unknown> = {}) {
+  return makeModelEntry({
+    id: "minimaxai/minimax-m2.5",
+    metadata: {
+      description: "Text only model",
+      context_length: 196608,
+      max_tokens: 196608,
+      pricing: {
+        input_tokens: 1.0,
+        output_tokens: 2.0,
+      },
+      tags: [],
+    },
+    ...overrides,
+  });
+}
+
+async function withFetchPathTest(
+  mockFetch: ReturnType<typeof vi.fn>,
+  runAssertions: () => Promise<void>,
+) {
+  const origNodeEnv = process.env.NODE_ENV;
+  const origVitest = process.env.VITEST;
+  delete process.env.NODE_ENV;
+  delete process.env.VITEST;
+
+  vi.stubGlobal("fetch", mockFetch);
+
+  try {
+    await runAssertions();
+  } finally {
+    if (origNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = origNodeEnv;
+    }
+    if (origVitest === undefined) {
+      delete process.env.VITEST;
+    } else {
+      process.env.VITEST = origVitest;
+    }
+    vi.unstubAllGlobals();
+  }
+}
+
+describe("discoverDeepInfraModels", () => {
+  it("returns static catalog in test environment", async () => {
+    const models = await discoverDeepInfraModels();
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.some((m) => m.id === "stepfun-ai/Step-3.5-Flash")).toBe(true);
+  });
+
+  it("static catalog has correct defaults for default model", async () => {
+    const models = await discoverDeepInfraModels();
+    const defaultModel = models.find((m) => m.id === "zai-org/GLM-5.1");
+    expect(defaultModel).toBeDefined();
+    expect(defaultModel?.name).toBe("GLM-5.1");
+    expect(defaultModel?.reasoning).toBe(true);
+    expect(defaultModel?.input).toEqual(["text"]);
+    expect(defaultModel?.contextWindow).toBe(202752);
+    expect(defaultModel?.maxTokens).toBe(202752);
+    expect(defaultModel?.cost).toBeDefined();
+    expect(defaultModel?.cost?.input).not.toBe(0);
+    expect(defaultModel?.cost?.output).not.toBe(0);
+    expect(defaultModel?.cost?.cacheRead).not.toBe(0);
+    expect(defaultModel?.cost?.cacheWrite).toBe(0);
+  });
+});
+
+describe("discoverDeepInfraModels (fetch path)", () => {
+  it("fetches from the correct URL with Accept header", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [makeModelEntry()] }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      await discoverDeepInfraModels();
+      expect(mockFetch).toHaveBeenCalledWith(
+        DEEPINFRA_MODELS_URL,
+        expect.objectContaining({
+          headers: { Accept: "application/json" },
+        }),
+      );
+    });
+  });
+
+  it("parses model pricing correctly", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [makeModelEntry()] }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      const model = models.find((m) => m.id === "openai/gpt-oss-120b");
+      expect(model).toBeDefined();
+      expect(model?.cost.input).toBeCloseTo(3.0);
+      expect(model?.cost.output).toBeCloseTo(15.0);
+      expect(model?.cost.cacheRead).toBeCloseTo(0.3);
+      expect(model?.cost.cacheWrite).toBe(0);
+    });
+  });
+
+  it("detects vision models with image modality", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [makeModelEntry()] }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      const model = models.find((m) => m.id === "openai/gpt-oss-120b");
+      expect(model?.input).toEqual(["text", "image"]);
+    });
+  });
+
+  it("detects text-only models without image modality", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [makeTextOnlyEntry()] }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      const model = models.find((m) => m.id === "minimaxai/minimax-m2.5");
+      expect(model?.input).toEqual(["text"]);
+    });
+  });
+
+  it("detects reasoning models via reasoning_effort tag", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [makeModelEntry(), makeTextOnlyEntry()] }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      expect(models.find((m) => m.id === "openai/gpt-oss-120b")?.reasoning).toBe(true);
+      expect(models.find((m) => m.id === "minimaxai/minimax-m2.5")?.reasoning).toBe(false);
+    });
+  });
+
+  it("uses defaults when context_length and max_tokens are missing", async () => {
+    const entryNoLimits = makeModelEntry({
+      id: "some/model",
+      metadata: {
+        pricing: { input_tokens: 1, output_tokens: 2 },
+        tags: [],
+      },
+    });
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [entryNoLimits] }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      const model = models.find((m) => m.id === "some/model");
+      expect(model?.contextWindow).toBe(128000);
+      expect(model?.maxTokens).toBe(8192);
+    });
+  });
+
+  it("uses zero cost when pricing fields are missing", async () => {
+    const entryNoPricing = makeModelEntry({
+      id: "some/free-model",
+      metadata: {
+        context_length: 32000,
+        max_tokens: 4096,
+        tags: [],
+      },
+    });
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [entryNoPricing] }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      const model = models.find((m) => m.id === "some/free-model");
+      expect(model?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    });
+  });
+
+  it("skips models with null metadata (embeddings, image-gen, etc.)", async () => {
+    const embeddingEntry = { id: "BAAI/bge-m3", object: "model", metadata: null };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [embeddingEntry, makeModelEntry()] }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      expect(models.some((m) => m.id === "BAAI/bge-m3")).toBe(false);
+      expect(models.some((m) => m.id === "openai/gpt-oss-120b")).toBe(true);
+    });
+  });
+
+  it("does not merge static catalog into discovered models", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [makeModelEntry({ id: "only/discovered-model" })],
+        }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      expect(models).toHaveLength(1);
+      expect(models[0]?.id).toBe("only/discovered-model");
+      // Static catalog models should NOT be present
+      expect(models.some((m) => m.id === "zai-org/GLM-5.1")).toBe(false);
+    });
+  });
+
+  it("deduplicates models with the same id", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [makeModelEntry(), makeModelEntry()] }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      const matches = models.filter((m) => m.id === "openai/gpt-oss-120b");
+      expect(matches.length).toBe(1);
+    });
+  });
+
+  it("falls back to static catalog on network error", async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error("network error"));
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      expect(models.length).toBeGreaterThan(0);
+      expect(models.some((m) => m.id === "stepfun-ai/Step-3.5-Flash")).toBe(true);
+    });
+  });
+
+  it("falls back to static catalog on HTTP error", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      expect(models.length).toBeGreaterThan(0);
+      expect(models.some((m) => m.id === "stepfun-ai/Step-3.5-Flash")).toBe(true);
+    });
+  });
+
+  it("falls back to static catalog when response has empty data array", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [] }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      expect(models.length).toBeGreaterThan(0);
+      expect(models.some((m) => m.id === "stepfun-ai/Step-3.5-Flash")).toBe(true);
+    });
+  });
+
+  it("falls back to static catalog when all entries have null metadata", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [
+            { id: "BAAI/bge-m3", metadata: null },
+            { id: "stabilityai/sdxl", metadata: null },
+          ],
+        }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      expect(models.length).toBeGreaterThan(0);
+      expect(models.some((m) => m.id === "stepfun-ai/Step-3.5-Flash")).toBe(true);
+    });
+  });
+
+  it("falls back to the static catalog when response.json() rejects", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.reject(new Error("malformed JSON")),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverDeepInfraModels();
+      expect(models.length).toBeGreaterThan(0);
+      expect(models.some((m) => m.id === "zai-org/GLM-5.1")).toBe(true);
+    });
+  });
+});
+
+describe("discoverDeepInfraModels (cache)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns cached models on subsequent calls within the TTL window", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [makeModelEntry()] }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const first = await discoverDeepInfraModels();
+      const second = await discoverDeepInfraModels();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(first.map((m) => m.id)).toEqual(second.map((m) => m.id));
+    });
+  });
+
+  it("refetches after resetDeepInfraModelCacheForTest()", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [makeModelEntry()] }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      await discoverDeepInfraModels();
+      resetDeepInfraModelCacheForTest();
+      await discoverDeepInfraModels();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("refetches after the 30 min TTL expires", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [makeModelEntry()] }),
+    });
+    vi.useFakeTimers({ now: 0, toFake: ["Date"] });
+    await withFetchPathTest(mockFetch, async () => {
+      await discoverDeepInfraModels();
+      vi.setSystemTime(30 * 60 * 1000 + 1);
+      await discoverDeepInfraModels();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("does not poison the cache when discovery fails", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [makeModelEntry()] }),
+      });
+    await withFetchPathTest(mockFetch, async () => {
+      const first = await discoverDeepInfraModels();
+      // Failure path returned static catalog — the default model should be present.
+      expect(first.some((m) => m.id === "zai-org/GLM-5.1")).toBe(true);
+
+      const second = await discoverDeepInfraModels();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(second.some((m) => m.id === "openai/gpt-oss-120b")).toBe(true);
+    });
+  });
+
+  it("does not poison the cache when response has empty data array", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ data: [] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [makeModelEntry()] }),
+      });
+    await withFetchPathTest(mockFetch, async () => {
+      await discoverDeepInfraModels();
+      const second = await discoverDeepInfraModels();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(second.some((m) => m.id === "openai/gpt-oss-120b")).toBe(true);
+    });
+  });
+});
+
+describe("resolveDeepInfraDefaultModelRef", () => {
+  it("returns the preferred default when discovery includes it", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [
+            makeModelEntry({ id: "zai-org/GLM-5.1" }),
+            makeModelEntry({ id: "openai/gpt-oss-120b" }),
+          ],
+        }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      expect(await resolveDeepInfraDefaultModelRef()).toBe(DEEPINFRA_DEFAULT_MODEL_REF);
+    });
+  });
+
+  it("falls back to the first discovered model when the preferred default is absent", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: [
+            makeModelEntry({ id: "openai/gpt-oss-120b" }),
+            makeModelEntry({ id: "moonshotai/Kimi-K2.5" }),
+          ],
+        }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      expect(await resolveDeepInfraDefaultModelRef()).toBe("deepinfra/openai/gpt-oss-120b");
+    });
+  });
+
+  it("returns the preferred default when discovery fails (static fallback retains it)", async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error("network down"));
+    await withFetchPathTest(mockFetch, async () => {
+      expect(await resolveDeepInfraDefaultModelRef()).toBe(DEEPINFRA_DEFAULT_MODEL_REF);
+    });
+  });
+});
+

--- a/extensions/deepinfra/provider-models.ts
+++ b/extensions/deepinfra/provider-models.ts
@@ -1,0 +1,295 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+
+const log = createSubsystemLogger("deepinfra-models");
+
+/**
+ * DeepInfra OpenAI-compatible API base URL.
+ *
+ * Stored without a trailing slash so the persisted provider config matches
+ * OpenAI-compat convention (baseUrl + "/chat/completions" → valid endpoint).
+ * A trailing slash here would cause the generic openai-completions config
+ * normalizer to append "/v1" (yielding ".../v1/openai/v1"), breaking inference.
+ * See `provider-policy-api.ts` for the passthrough hook that keeps this URL
+ * shape out of the generic normalizer entirely.
+ */
+export const DEEPINFRA_BASE_URL = "https://api.deepinfra.com/v1/openai";
+
+export const DEEPINFRA_DEFAULT_MODEL_ID = "zai-org/GLM-5.1";
+export const DEEPINFRA_DEFAULT_MODEL_REF = `deepinfra/${DEEPINFRA_DEFAULT_MODEL_ID}`;
+
+/** Default context window and max tokens for discovered models. */
+export const DEEPINFRA_DEFAULT_CONTEXT_WINDOW = 128000;
+export const DEEPINFRA_DEFAULT_MAX_TOKENS = 8192;
+
+/**
+ * Static catalog of popular DeepInfra models.
+ * Used as a fallback when discovery is unavailable.
+ */
+export const DEEPINFRA_MODEL_CATALOG: ModelDefinitionConfig[] = [
+  {
+    id: "zai-org/GLM-5.1",
+    name: "GLM-5.1",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 202752,
+    maxTokens: 202752,
+    cost: {
+      input: 1.4,
+      output: 4.4,
+      cacheRead: 0.26,
+      cacheWrite: 0,
+    },
+  },
+  {
+    id: "stepfun-ai/Step-3.5-Flash",
+    name: "Step 3.5 Flash",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 262144,
+    maxTokens: 262144,
+    cost: {
+      input: 0.1,
+      output: 0.3,
+      cacheRead: 0.02,
+      cacheWrite: 0,
+    },
+  },
+  {
+    id: "MiniMaxAI/MiniMax-M2.5",
+    name: "MiniMax M2.5",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 196608,
+    maxTokens: 196608,
+    cost: {
+      input: 0.27,
+      output: 0.95,
+      cacheRead: 0.03,
+      cacheWrite: 0,
+    },
+  },
+  {
+    id: "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B",
+    name: "NVIDIA Nemotron 3 Super 120B A12B",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 262144,
+    maxTokens: 262144,
+    cost: {
+      input: 0.1,
+      output: 0.5,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+  },
+  {
+    id: "moonshotai/Kimi-K2.5",
+    name: "Kimi K2.5",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 262144,
+    maxTokens: 262144,
+    cost: {
+      input: 0.45,
+      output: 2.25,
+      cacheRead: 0.07,
+      cacheWrite: 0,
+    },
+  },
+];
+
+// Query params are DeepInfra server-side contracts; if either is renamed
+// upstream the catalog still parses but silently changes order/scope:
+//  - sort_by=openclaw: curated ranking used by `preserveDiscoveryOrder: true`
+//    on the catalog hook. Without it the catalog falls back to API insertion
+//    order, which may not be meaningful.
+//  - filter=with_meta: excludes non-LLM entries (embeddings, image-gen, audio)
+//    server-side. If dropped, the client still skips entries with null
+//    metadata in `discoverDeepInfraModels`, but the response grows.
+export const DEEPINFRA_MODELS_URL = `${DEEPINFRA_BASE_URL}/models?sort_by=openclaw&filter=with_meta`;
+
+const DISCOVERY_TIMEOUT_MS = 5000;
+
+// Coalesces adjacent calls from the onboarding auth method and later
+// `catalog.run` into a single /models round trip. 30 min is long enough to
+// cover that window comfortably while still letting a new upstream model
+// appear in `openclaw models list` within the same CLI session.
+const DISCOVERY_CACHE_TTL_MS = 30 * 60 * 1000;
+
+let cachedModels: ModelDefinitionConfig[] | null = null;
+let cachedAt = 0;
+
+/**
+ * Drops the in-memory discovery cache. Vitest uses module-scoped state
+ * across cases within a file, so tests that exercise the fetch path must
+ * reset between cases to keep assertions independent.
+ */
+export function resetDeepInfraModelCacheForTest(): void {
+  cachedModels = null;
+  cachedAt = 0;
+}
+
+// ---------------------------------------------------------------------------
+// API response types (DeepInfra OpenAI-compatible /models schema)
+// ---------------------------------------------------------------------------
+
+interface DeepInfraModelPricing {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_tokens?: number;
+}
+
+interface DeepInfraModelMetadata {
+  description?: string;
+  context_length?: number;
+  max_tokens?: number;
+  pricing?: DeepInfraModelPricing;
+  /** e.g. ["vision", "reasoning_effort", "prompt_cache", "reasoning"] */
+  tags?: string[];
+}
+
+interface DeepInfraModelEntry {
+  id: string;
+  object?: string;
+  owned_by?: string;
+  metadata: DeepInfraModelMetadata | null;
+}
+
+interface DeepInfraModelsResponse {
+  data: DeepInfraModelEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Model parsing
+// ---------------------------------------------------------------------------
+
+function parseModality(metadata: DeepInfraModelMetadata): Array<"text" | "image"> {
+  const hasVision = metadata.tags?.includes("vision") ?? false;
+  return hasVision ? ["text", "image"] : ["text"];
+}
+
+function parseReasoning(metadata: DeepInfraModelMetadata): boolean {
+  return (
+    (metadata.tags?.includes("reasoning_effort") || metadata.tags?.includes("reasoning")) ?? false
+  );
+}
+
+function toModelDefinition(entry: DeepInfraModelEntry): ModelDefinitionConfig {
+  const meta = entry.metadata!;
+  return {
+    id: entry.id,
+    name: entry.id,
+    reasoning: parseReasoning(meta),
+    input: parseModality(meta),
+    cost: {
+      input: meta.pricing?.input_tokens ?? 0,
+      output: meta.pricing?.output_tokens ?? 0,
+      cacheRead: meta.pricing?.cache_read_tokens ?? 0,
+      cacheWrite: 0,
+    },
+    contextWindow: meta.context_length ?? DEEPINFRA_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: meta.max_tokens ?? DEEPINFRA_DEFAULT_MAX_TOKENS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover models from the DeepInfra API with fallback to static catalog.
+ * Skips models with null metadata (embeddings, image-gen, etc.).
+ *
+ * When discovery succeeds, only discovered models are returned (no merge
+ * with the static catalog). The API is the single source of truth.
+ */
+export async function discoverDeepInfraModels(): Promise<ModelDefinitionConfig[]> {
+  if (process.env.NODE_ENV === "test" || process.env.VITEST) {
+    return [...DEEPINFRA_MODEL_CATALOG];
+  }
+
+  if (cachedModels && Date.now() - cachedAt < DISCOVERY_CACHE_TTL_MS) {
+    return [...cachedModels];
+  }
+
+  try {
+    const { response, release } = await fetchWithSsrFGuard({
+      url: DEEPINFRA_MODELS_URL,
+      init: { headers: { Accept: "application/json" } },
+      signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+      auditContext: "deepinfra-model-discovery",
+    });
+
+    try {
+      if (!response.ok) {
+        log.warn(`Failed to discover models: HTTP ${response.status}, using static catalog`);
+        return [...DEEPINFRA_MODEL_CATALOG];
+      }
+
+      const data = (await response.json()) as DeepInfraModelsResponse;
+      if (!Array.isArray(data.data) || data.data.length === 0) {
+        log.warn("No models found from DeepInfra API, using static catalog");
+        return [...DEEPINFRA_MODEL_CATALOG];
+      }
+
+      const models: ModelDefinitionConfig[] = [];
+      const discoveredIds = new Set<string>();
+
+      for (const entry of data.data) {
+        if (!entry || typeof entry !== "object") {
+          continue;
+        }
+        const id = typeof entry.id === "string" ? entry.id.trim() : "";
+        if (!id || discoveredIds.has(id)) {
+          continue;
+        }
+        // Skip non-completion models (embeddings, image-gen, etc.)
+        if (!entry.metadata) {
+          continue;
+        }
+        try {
+          models.push(toModelDefinition(entry));
+          discoveredIds.add(id);
+        } catch (e) {
+          log.warn(`Skipping malformed model entry "${id}": ${String(e)}`);
+        }
+      }
+
+      if (models.length === 0) {
+        return [...DEEPINFRA_MODEL_CATALOG];
+      }
+      // Only populate the cache on a successful live response — static-catalog
+      // fallbacks stay uncached so transient failures self-heal on the next
+      // call instead of pinning the fallback for 30 min.
+      cachedModels = models;
+      cachedAt = Date.now();
+      return [...models];
+    } finally {
+      await release();
+    }
+  } catch (error) {
+    log.warn(`Discovery failed: ${String(error)}, using static catalog`);
+    return [...DEEPINFRA_MODEL_CATALOG];
+  }
+}
+
+/**
+ * Resolve the onboarded default model ref against the discovered catalog.
+ *
+ * Prefers `DEEPINFRA_DEFAULT_MODEL_ID` when it appears in the discovered
+ * catalog, otherwise falls back to the first discovered model. Prevents a
+ * post-onboarding "unknown model" state when the upstream /models response no
+ * longer includes the preferred default (deprecation, region filtering, or a
+ * curated list change). Shares `discoverDeepInfraModels`'s TTL cache so a
+ * subsequent `catalog.run` in the same window does not refetch.
+ */
+export async function resolveDeepInfraDefaultModelRef(): Promise<string> {
+  const models = await discoverDeepInfraModels();
+  if (models.some((m) => m.id === DEEPINFRA_DEFAULT_MODEL_ID)) {
+    return DEEPINFRA_DEFAULT_MODEL_REF;
+  }
+  const first = models[0];
+  return first ? `deepinfra/${first.id}` : DEEPINFRA_DEFAULT_MODEL_REF;
+}

--- a/extensions/deepinfra/provider-policy-api.test.ts
+++ b/extensions/deepinfra/provider-policy-api.test.ts
@@ -1,0 +1,41 @@
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-types";
+import { describe, expect, it } from "vitest";
+import { normalizeConfig } from "./provider-policy-api.js";
+
+function createModel(id: string): ModelDefinitionConfig {
+  return {
+    id,
+    name: id,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 8_192,
+  };
+}
+
+describe("deepinfra provider policy public artifact", () => {
+  it("preserves the DeepInfra mid-path /v1 baseUrl without appending another /v1", () => {
+    const providerConfig: ModelProviderConfig = {
+      baseUrl: "https://api.deepinfra.com/v1/openai",
+      api: "openai-completions",
+      models: [createModel("zai-org/GLM-5")],
+    };
+
+    const normalized = normalizeConfig({ provider: "deepinfra", providerConfig });
+
+    expect(normalized.baseUrl).toBe("https://api.deepinfra.com/v1/openai");
+    expect(normalized.baseUrl).not.toMatch(/\/v1\/openai\/v1$/);
+  });
+
+  it("returns the providerConfig unchanged (referentially equal)", () => {
+    const providerConfig = {
+      baseUrl: "https://api.deepinfra.com/v1/openai",
+      models: [],
+    };
+    expect(normalizeConfig({ provider: "deepinfra", providerConfig })).toBe(providerConfig);
+  });
+});

--- a/extensions/deepinfra/provider-policy-api.ts
+++ b/extensions/deepinfra/provider-policy-api.ts
@@ -1,0 +1,21 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
+
+/**
+ * Passthrough normalization for DeepInfra provider config.
+ *
+ * DeepInfra's OpenAI-compatible base URL is `https://api.deepinfra.com/v1/openai`
+ * — the `/v1` segment sits mid-path, not at the end. The generic
+ * openai-completions config normalizer strips a trailing `/v1` and re-appends
+ * one, which is idempotent for providers like OpenRouter (`.../api/v1`) but
+ * doubles to `.../v1/openai/v1` here and breaks inference (404).
+ *
+ * Shipping this bundled policy surface short-circuits the fallback normalizer
+ * chain (see `src/plugins/provider-runtime.ts:normalizeProviderConfigWithPlugin`)
+ * and preserves the DeepInfra-declared baseUrl as-is.
+ */
+export function normalizeConfig(params: {
+  provider: string;
+  providerConfig: ModelProviderConfig;
+}): ModelProviderConfig {
+  return params.providerConfig;
+}

--- a/extensions/deepinfra/provider.contract.test.ts
+++ b/extensions/deepinfra/provider.contract.test.ts
@@ -1,0 +1,3 @@
+import { describeProviderContracts } from "../../test/helpers/plugins/provider-contract.js";
+
+describeProviderContracts("deepinfra");

--- a/extensions/deepinfra/stream.test.ts
+++ b/extensions/deepinfra/stream.test.ts
@@ -1,0 +1,292 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Model } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { createDeepInfraSystemCacheWrapper, createDeepInfraWrapper } from "./stream.js";
+
+describe("deepinfra stream wrappers", () => {
+  it("injects cache_control markers for Anthropic models on DeepInfra", () => {
+    const payload = {
+      messages: [{ role: "system", content: "system prompt" }],
+    };
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      options?.onPayload?.(payload, model);
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createDeepInfraSystemCacheWrapper(baseStreamFn);
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "deepinfra",
+        id: "anthropic/claude-4-sonnet",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(payload.messages[0]?.content).toEqual([
+      { type: "text", text: "system prompt", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("does not inject cache_control markers for non-Anthropic models on DeepInfra", () => {
+    const payload = {
+      messages: [{ role: "system", content: "system prompt" }],
+    };
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      options?.onPayload?.(payload, model);
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createDeepInfraSystemCacheWrapper(baseStreamFn);
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "deepinfra",
+        id: "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(payload.messages[0]?.content).toBe("system prompt");
+  });
+
+  it("normalizes reasoning payload for DeepInfra with thinking level", () => {
+    const capturedPayloads: unknown[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload = { messages: [] };
+      options?.onPayload?.(payload, _model);
+      capturedPayloads.push(payload);
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createDeepInfraWrapper(baseStreamFn, "medium");
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "deepinfra",
+        id: "anthropic/claude-4-sonnet",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(capturedPayloads[0]).toEqual({
+      messages: [],
+      reasoning: { effort: "medium" },
+    });
+  });
+
+  it("does not add reasoning payload for DeepInfra with thinking off", () => {
+    const capturedPayloads: unknown[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload = { messages: [] };
+      options?.onPayload?.(payload, _model);
+      capturedPayloads.push(payload);
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createDeepInfraWrapper(baseStreamFn, "off");
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "deepinfra",
+        id: "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(capturedPayloads[0]).toEqual({ messages: [] });
+  });
+
+  // DeepInfra's reasoning.effort vocabulary differs from OpenClaw's
+  // thinkingLevel vocabulary — these mappings are lossy and non-obvious, so
+  // lock them in. "adaptive" → "medium" and "max" → "xhigh" are the two
+  // rewrites; other levels pass through verbatim.
+  const THINKING_LEVEL_CASES: Array<{
+    input: "minimal" | "low" | "medium" | "high" | "adaptive" | "max";
+    expected: "minimal" | "low" | "medium" | "high" | "xhigh";
+  }> = [
+    { input: "minimal", expected: "minimal" },
+    { input: "low", expected: "low" },
+    { input: "medium", expected: "medium" },
+    { input: "high", expected: "high" },
+    { input: "adaptive", expected: "medium" },
+    { input: "max", expected: "xhigh" },
+  ];
+
+  for (const { input, expected } of THINKING_LEVEL_CASES) {
+    it(`maps thinkingLevel "${input}" to reasoning.effort "${expected}"`, () => {
+      const capturedPayloads: unknown[] = [];
+      const baseStreamFn: StreamFn = (_model, _context, options) => {
+        const payload = { messages: [] };
+        options?.onPayload?.(payload, _model);
+        capturedPayloads.push(payload);
+        return createAssistantMessageEventStream();
+      };
+
+      const wrapped = createDeepInfraWrapper(baseStreamFn, input);
+      void wrapped(
+        {
+          api: "openai-completions",
+          provider: "deepinfra",
+          id: "anthropic/claude-4-sonnet",
+        } as Model<"openai-completions">,
+        { messages: [] },
+        {},
+      );
+
+      expect(capturedPayloads[0]).toEqual({
+        messages: [],
+        reasoning: { effort: expected },
+      });
+    });
+  }
+
+  // DeepInfra's OpenAI-compat surface accepts both top-level `reasoning_effort`
+  // and the nested `reasoning.effort` shape; we normalize to the nested shape
+  // and actively strip the flat key so upstream pi-agent-core can't double-send
+  // or override what the wrapper just set.
+  it("strips top-level reasoning_effort before dispatch", () => {
+    const capturedPayloads: unknown[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        messages: [],
+        reasoning_effort: "low",
+      };
+      options?.onPayload?.(payload, _model);
+      capturedPayloads.push(payload);
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createDeepInfraWrapper(baseStreamFn, "high");
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "deepinfra",
+        id: "anthropic/claude-4-sonnet",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(capturedPayloads[0]).toEqual({
+      messages: [],
+      reasoning: { effort: "high" },
+    });
+  });
+
+  it("preserves a pre-existing reasoning.effort and does not overwrite", () => {
+    const capturedPayloads: unknown[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload = { messages: [], reasoning: { effort: "low" } };
+      options?.onPayload?.(payload, _model);
+      capturedPayloads.push(payload);
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createDeepInfraWrapper(baseStreamFn, "high");
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "deepinfra",
+        id: "anthropic/claude-4-sonnet",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(capturedPayloads[0]).toEqual({
+      messages: [],
+      reasoning: { effort: "low" },
+    });
+  });
+
+  it("preserves a pre-existing reasoning.max_tokens and does not add effort", () => {
+    const capturedPayloads: unknown[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload = { messages: [], reasoning: { max_tokens: 4096 } };
+      options?.onPayload?.(payload, _model);
+      capturedPayloads.push(payload);
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createDeepInfraWrapper(baseStreamFn, "high");
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "deepinfra",
+        id: "anthropic/claude-4-sonnet",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(capturedPayloads[0]).toEqual({
+      messages: [],
+      reasoning: { max_tokens: 4096 },
+    });
+  });
+
+  it("injects cache_control markers case-insensitively on the model id prefix", () => {
+    const payload = {
+      messages: [{ role: "system", content: "system prompt" }],
+    };
+    const baseStreamFn: StreamFn = (model, _context, options) => {
+      options?.onPayload?.(payload, model);
+      return createAssistantMessageEventStream();
+    };
+
+    const wrapped = createDeepInfraSystemCacheWrapper(baseStreamFn);
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "deepinfra",
+        id: "Anthropic/Claude-4-Sonnet",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    expect(payload.messages[0]?.content).toEqual([
+      { type: "text", text: "system prompt", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("chains DeepInfra reasoning + cache wrappers for Anthropic models", () => {
+    const capturedPayloads: unknown[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload = {
+        messages: [{ role: "system", content: "system prompt" }],
+      };
+      options?.onPayload?.(payload, _model);
+      capturedPayloads.push(payload);
+      return createAssistantMessageEventStream();
+    };
+
+    // Chain as in index.ts: reasoning wrapper first, then cache wrapper
+    let streamFn = createDeepInfraWrapper(baseStreamFn, "high");
+    streamFn = createDeepInfraSystemCacheWrapper(streamFn);
+
+    void streamFn(
+      {
+        api: "openai-completions",
+        provider: "deepinfra",
+        id: "anthropic/claude-4-sonnet",
+      } as Model<"openai-completions">,
+      { messages: [] },
+      {},
+    );
+
+    const payload = capturedPayloads[0] as Record<string, unknown>;
+    // Reasoning was normalized
+    expect(payload.reasoning).toEqual({ effort: "high" });
+    // Cache markers were injected on system message
+    expect((payload.messages as Array<{ content: unknown }>)[0]?.content).toEqual([
+      { type: "text", text: "system prompt", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+});

--- a/extensions/deepinfra/stream.ts
+++ b/extensions/deepinfra/stream.ts
@@ -1,0 +1,82 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { streamSimple } from "@mariozechner/pi-ai";
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  applyAnthropicEphemeralCacheControlMarkers,
+  streamWithPayloadPatch,
+} from "openclaw/plugin-sdk/provider-stream-shared";
+
+type ThinkLevel = NonNullable<ProviderWrapStreamFnContext["thinkingLevel"]>;
+
+function mapThinkingLevelToReasoningEffort(
+  thinkingLevel: ThinkLevel,
+): "none" | "minimal" | "low" | "medium" | "high" | "xhigh" {
+  if (thinkingLevel === "off") {
+    return "none";
+  }
+  if (thinkingLevel === "adaptive") {
+    return "medium";
+  }
+  if (thinkingLevel === "max") {
+    return "xhigh";
+  }
+  return thinkingLevel;
+}
+
+function normalizeProxyReasoningPayload(payload: unknown, thinkingLevel?: ThinkLevel): void {
+  if (!payload || typeof payload !== "object") {
+    return;
+  }
+
+  const payloadObj = payload as Record<string, unknown>;
+  delete payloadObj.reasoning_effort;
+  if (!thinkingLevel || thinkingLevel === "off") {
+    return;
+  }
+
+  const existingReasoning = payloadObj.reasoning;
+  if (
+    existingReasoning &&
+    typeof existingReasoning === "object" &&
+    !Array.isArray(existingReasoning)
+  ) {
+    const reasoningObj = existingReasoning as Record<string, unknown>;
+    if (!("max_tokens" in reasoningObj) && !("effort" in reasoningObj)) {
+      reasoningObj.effort = mapThinkingLevelToReasoningEffort(thinkingLevel);
+    }
+  } else if (!existingReasoning) {
+    payloadObj.reasoning = {
+      effort: mapThinkingLevelToReasoningEffort(thinkingLevel),
+    };
+  }
+}
+
+export function createDeepInfraSystemCacheWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const modelId = typeof model?.id === "string" ? model.id : "";
+    if (!modelId.toLowerCase().startsWith("anthropic/")) {
+      return underlying(model, context, options);
+    }
+    return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
+      applyAnthropicEphemeralCacheControlMarkers(payloadObj);
+    });
+  };
+}
+
+export function createDeepInfraWrapper(
+  baseStreamFn: StreamFn | undefined,
+  thinkingLevel?: ThinkLevel,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const onPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        normalizeProxyReasoningPayload(payload, thinkingLevel);
+        return onPayload?.(payload, model);
+      },
+    });
+  };
+}

--- a/extensions/deepinfra/tsconfig.json
+++ b/extensions/deepinfra/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,16 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/deepinfra:
+    dependencies:
+      '@mariozechner/pi-ai':
+        specifier: 0.70.2
+        version: 0.70.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/deepseek:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -10,6 +10,7 @@ let loadModelCatalog: typeof import("./model-catalog.js").loadModelCatalog;
 let resetModelCatalogCacheForTest: typeof import("./model-catalog.js").resetModelCatalogCacheForTest;
 let augmentCatalogMock: ReturnType<typeof vi.fn>;
 let ensureOpenClawModelsJsonMock: ReturnType<typeof vi.fn>;
+let resolvePreserveDiscoveryOrderProvidersMock: ReturnType<typeof vi.fn>;
 
 vi.mock("./model-suppression.runtime.js", () => ({
   shouldSuppressBuiltInModel: (params: { provider?: string; id?: string }) =>
@@ -70,6 +71,10 @@ describe("loadModelCatalog", () => {
     vi.doMock("../plugins/provider-runtime.runtime.js", () => ({
       augmentModelCatalogWithProviderPlugins: vi.fn().mockResolvedValue([]),
     }));
+    vi.doMock("../plugins/preserve-discovery-order.js", () => ({
+      resolvePreserveDiscoveryOrderProviders: vi.fn().mockReturnValue(new Set<string>()),
+      resetPreserveDiscoveryOrderLookupLogForTest: vi.fn(),
+    }));
 
     ({
       __setModelCatalogImportForTest,
@@ -79,11 +84,17 @@ describe("loadModelCatalog", () => {
     } = await import("./model-catalog.js"));
     const providerRuntime = await import("../plugins/provider-runtime.runtime.js");
     augmentCatalogMock = vi.mocked(providerRuntime.augmentModelCatalogWithProviderPlugins);
+    const preserveDiscoveryOrderModule = await import("../plugins/preserve-discovery-order.js");
+    resolvePreserveDiscoveryOrderProvidersMock = vi.mocked(
+      preserveDiscoveryOrderModule.resolvePreserveDiscoveryOrderProviders,
+    );
   });
 
   beforeEach(() => {
     resetModelCatalogCacheForTest();
     ensureOpenClawModelsJsonMock.mockClear();
+    resolvePreserveDiscoveryOrderProvidersMock.mockReset();
+    resolvePreserveDiscoveryOrderProvidersMock.mockReturnValue(new Set<string>());
   });
 
   afterEach(() => {
@@ -96,6 +107,7 @@ describe("loadModelCatalog", () => {
     vi.doUnmock("./models-config.js");
     vi.doUnmock("./agent-paths.js");
     vi.doUnmock("../plugins/provider-runtime.runtime.js");
+    vi.doUnmock("../plugins/preserve-discovery-order.js");
   });
 
   it("retries after import failure without poisoning the cache", async () => {
@@ -402,6 +414,27 @@ describe("loadModelCatalog", () => {
     );
     expect(matches).toHaveLength(1);
     expect(matches[0]?.name).toBe("Kilo Auto");
+  });
+
+  it("sorts alphabetically when the preserve-order set is empty (the helper's degraded fallback)", async () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    try {
+      mockPiDiscoveryModels([
+        { id: "gpt-4.1", provider: "openai", name: "GPT-4.1" },
+        { id: "claude-sonnet-4.6", provider: "anthropic", name: "Claude Sonnet 4.6" },
+      ]);
+      resolvePreserveDiscoveryOrderProvidersMock.mockReturnValue(new Set<string>());
+
+      const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+
+      expect(result).toEqual([
+        expect.objectContaining({ provider: "anthropic", id: "claude-sonnet-4.6" }),
+        expect.objectContaining({ provider: "openai", id: "gpt-4.1" }),
+      ]);
+    } finally {
+      setLoggerOverride(null);
+      resetLogger();
+    }
   });
 
   it("matches models across canonical provider aliases", () => {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -2,6 +2,10 @@ import { join } from "node:path";
 import { loadConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  resetPreserveDiscoveryOrderLookupLogForTest,
+  resolvePreserveDiscoveryOrderProviders,
+} from "../plugins/preserve-discovery-order.js";
 import { augmentModelCatalogWithProviderPlugins } from "../plugins/provider-runtime.runtime.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -54,6 +58,7 @@ function loadModelSuppression() {
 export function resetModelCatalogCache() {
   modelCatalogPromise = null;
   hasLoggedModelCatalogError = false;
+  resetPreserveDiscoveryOrderLookupLogForTest();
   importPiSdk = defaultImportPiSdk;
 }
 
@@ -102,14 +107,27 @@ export async function loadModelCatalog(params?: {
       const suffix = extra ? ` ${extra}` : "";
       log.info(`model-catalog stage=${stage} elapsedMs=${Date.now() - startMs}${suffix}`);
     };
-    const sortModels = (entries: ModelCatalogEntry[]) =>
-      entries.sort((a, b) => {
+    const sortModels = (entries: ModelCatalogEntry[], cfg: OpenClawConfig | undefined) => {
+      // Relies on Array.prototype.toSorted being stable (ES2023): providers
+      // flagged as preserveDiscoveryOrder return 0 from the comparator on
+      // same-provider pairs, which keeps their insertion order inside the
+      // provider block. Resolve the preserve-order set once up front to avoid
+      // per-provider plugin-lookup latency inside the sort.
+      const preserveOrderProviders = resolvePreserveDiscoveryOrderProviders({
+        ...(cfg ? { config: cfg } : {}),
+        env: process.env,
+      });
+      return entries.toSorted((a, b) => {
         const p = a.provider.localeCompare(b.provider);
         if (p !== 0) {
           return p;
         }
+        if (preserveOrderProviders.has(normalizeProviderId(a.provider))) {
+          return 0;
+        }
         return a.name.localeCompare(b.name);
       });
+    };
     try {
       const cfg = params?.config ?? loadConfig();
       if (!readOnly) {
@@ -194,7 +212,7 @@ export async function loadModelCatalog(params?: {
         }
       }
 
-      const sorted = sortModels(models);
+      const sorted = sortModels(models, cfg);
       logStage("complete", `entries=${sorted.length}`);
       return sorted;
     } catch (error) {
@@ -207,7 +225,7 @@ export async function loadModelCatalog(params?: {
         modelCatalogPromise = null;
       }
       if (models.length > 0) {
-        return sortModels(models);
+        return sortModels(models, params?.config);
       }
       return [];
     }

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -57,6 +57,7 @@ const mocks = vi.hoisted(() => {
     listProfilesForProvider: vi.fn(),
     resolveModelWithRegistry: vi.fn(),
     resolveRuntimeSyntheticAuthProviderRefs: vi.fn(),
+    resolvePreserveDiscoveryOrderProviders: vi.fn(),
   };
 });
 
@@ -95,6 +96,7 @@ function resetMocks() {
   mocks.listProfilesForProvider.mockReturnValue([]);
   mocks.resolveModelWithRegistry.mockReturnValue({ ...OPENAI_CODEX_MODEL });
   mocks.resolveRuntimeSyntheticAuthProviderRefs.mockReturnValue([]);
+  mocks.resolvePreserveDiscoveryOrderProviders.mockReturnValue(new Set<string>());
 }
 
 function createRuntime() {
@@ -212,6 +214,10 @@ function installModelsListCommandForwardCompatMocks() {
 
   vi.doMock("../../plugins/synthetic-auth.runtime.js", () => ({
     resolveRuntimeSyntheticAuthProviderRefs: mocks.resolveRuntimeSyntheticAuthProviderRefs,
+  }));
+
+  vi.doMock("../../plugins/preserve-discovery-order.js", () => ({
+    resolvePreserveDiscoveryOrderProviders: mocks.resolvePreserveDiscoveryOrderProviders,
   }));
 }
 
@@ -844,6 +850,78 @@ describe("modelsListCommand forward-compat", () => {
         expect.objectContaining({
           key: "z.ai/glm-4.5",
         }),
+      ]);
+    });
+  });
+
+  describe("preserve-order plugin lookup resilience", () => {
+    it("still prints discovered rows when the plugin lookup throws", async () => {
+      const prevExitCode = process.exitCode;
+      process.exitCode = undefined;
+      mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
+      mocks.loadModelRegistry.mockResolvedValueOnce({
+        models: [{ ...OPENAI_CODEX_MODEL }],
+        availableKeys: new Set(["openai-codex/gpt-5.4"]),
+        registry: {
+          getAll: () => [{ ...OPENAI_CODEX_MODEL }],
+        },
+      });
+      // Helper swallows throws internally; test the caller's contract by
+      // returning the empty-set fallback the helper would produce on error.
+      mocks.resolvePreserveDiscoveryOrderProviders.mockReturnValueOnce(new Set<string>());
+
+      const runtime = createRuntime();
+
+      try {
+        await modelsListCommand(
+          { all: true, provider: "openai-codex", json: true },
+          runtime as never,
+        );
+
+        expect(mocks.printModelTable).toHaveBeenCalled();
+        expect(lastPrintedRows<{ key: string }>()).toEqual([
+          expect.objectContaining({ key: "openai-codex/gpt-5.4" }),
+        ]);
+        expect(process.exitCode).toBeUndefined();
+        expect(runtime.error).not.toHaveBeenCalled();
+      } finally {
+        process.exitCode = prevExitCode;
+      }
+    });
+  });
+
+  describe("per-provider preserve discovery order", () => {
+    it("preserves curated order for preserve-order providers in unfiltered --all output", async () => {
+      mocks.resolveConfiguredEntries.mockReturnValueOnce({ entries: [] });
+      const deepinfraCurated = [
+        { ...OPENAI_CODEX_MODEL, provider: "deepinfra", id: "z-top-curated" },
+        { ...OPENAI_CODEX_MODEL, provider: "deepinfra", id: "a-second" },
+        { ...OPENAI_CODEX_MODEL, provider: "deepinfra", id: "m-third" },
+      ];
+      const otherProvider = [
+        { ...OPENAI_CODEX_MODEL, provider: "openai-codex", id: "gpt-5.4-pro" },
+        { ...OPENAI_CODEX_MODEL, provider: "openai-codex", id: "gpt-5.4" },
+      ];
+      const allModels = [...deepinfraCurated, ...otherProvider];
+      mocks.loadModelRegistry.mockResolvedValueOnce({
+        models: allModels,
+        availableKeys: new Set(allModels.map((model) => `${model.provider}/${model.id}`)),
+        registry: {
+          getAll: () => allModels,
+        },
+      });
+      mocks.resolvePreserveDiscoveryOrderProviders.mockReturnValueOnce(new Set(["deepinfra"]));
+
+      const runtime = createRuntime();
+      await modelsListCommand({ all: true, json: true }, runtime as never);
+
+      expect(mocks.printModelTable).toHaveBeenCalled();
+      expect(lastPrintedRows<{ key: string }>().map((row) => row.key)).toEqual([
+        "deepinfra/z-top-curated",
+        "deepinfra/a-second",
+        "deepinfra/m-third",
+        "openai-codex/gpt-5.4",
+        "openai-codex/gpt-5.4-pro",
       ]);
     });
   });

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -1,6 +1,7 @@
 import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 import { parseModelRef } from "../../agents/model-selection.js";
 import type { NormalizedModelCatalogRow } from "../../model-catalog/index.js";
+import { resolvePreserveDiscoveryOrderProviders } from "../../plugins/preserve-discovery-order.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { resolveConfiguredEntries } from "./list.configured.js";
@@ -173,6 +174,13 @@ export async function modelsListCommand(
     let rowContext = buildRowContext(
       useManifestCatalogFastPath || useProviderCatalogFastPath || useProviderIndexCatalogFastPath,
     );
+    let preserveDiscoveryOrderProviders =
+      useManifestCatalogFastPath || useProviderCatalogFastPath || useProviderIndexCatalogFastPath
+        ? undefined
+        : resolvePreserveDiscoveryOrderProviders({
+            config: cfg,
+            env: process.env,
+          });
     const initialAppend = await appendAllModelRowSources({
       rows,
       context: rowContext,
@@ -182,6 +190,7 @@ export async function modelsListCommand(
       useManifestCatalogFastPath,
       useProviderCatalogFastPath,
       useProviderIndexCatalogFastPath,
+      preserveDiscoveryOrderProviders,
     });
     if (initialAppend.requiresRegistryFallback) {
       try {
@@ -193,6 +202,10 @@ export async function modelsListCommand(
       }
       rows.length = 0;
       rowContext = buildRowContext(false);
+      preserveDiscoveryOrderProviders ??= resolvePreserveDiscoveryOrderProviders({
+        config: cfg,
+        env: process.env,
+      });
       await appendAllModelRowSources({
         rows,
         context: rowContext,
@@ -202,6 +215,7 @@ export async function modelsListCommand(
         useManifestCatalogFastPath: false,
         useProviderCatalogFastPath: false,
         useProviderIndexCatalogFastPath: false,
+        preserveDiscoveryOrderProviders,
       });
     }
   } else {

--- a/src/commands/models/list.provider-catalog.test.ts
+++ b/src/commands/models/list.provider-catalog.test.ts
@@ -363,4 +363,54 @@ describe("loadProviderCatalogModelsForList", () => {
       }),
     ).resolves.toBeUndefined();
   });
+
+  describe("preserveDiscoveryOrder", () => {
+    const curatedProvider = {
+      id: "curated",
+      pluginId: "curated",
+      label: "Curated",
+      auth: [],
+      staticCatalog: {
+        run: async () => ({
+          provider: {
+            baseUrl: "https://curated.example/v1",
+            models: [
+              { id: "z-top-curated", name: "Z Top" },
+              { id: "a-second", name: "A Second" },
+              { id: "m-third", name: "M Third" },
+            ],
+          },
+        }),
+      },
+    };
+
+    beforeEach(() => {
+      providerDiscoveryMocks.resolveBundledProviderCompatPluginIds.mockReturnValue(["curated"]);
+      providerDiscoveryMocks.resolveOwningPluginIdsForProvider.mockReturnValue(["curated"]);
+    });
+
+    it("preserves the static-catalog order for preserve-order providers", async () => {
+      providerDiscoveryMocks.resolvePluginDiscoveryProviders.mockResolvedValue([
+        { ...curatedProvider, catalog: { preserveDiscoveryOrder: true } },
+      ]);
+
+      const rows = await loadProviderCatalogModelsForList({
+        ...baseParams,
+        providerFilter: "curated",
+      });
+
+      expect(rows.map((row) => row.id)).toEqual(["z-top-curated", "a-second", "m-third"]);
+    });
+
+    it("falls back to alphabetical sort when the provider has no preserve-order flag", async () => {
+      providerDiscoveryMocks.resolvePluginDiscoveryProviders.mockResolvedValue([curatedProvider]);
+
+      const rows = await loadProviderCatalogModelsForList({
+        ...baseParams,
+        providerFilter: "curated",
+      });
+
+      expect(rows.map((row) => row.id)).toEqual(["a-second", "m-third", "z-top-curated"]);
+    });
+  });
 });

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -16,6 +16,7 @@ import {
   resolvePluginDiscoveryProviders,
   runProviderStaticCatalog,
 } from "../../plugins/provider-discovery.js";
+import { collectPreserveDiscoveryOrderProviders } from "../../plugins/preserve-discovery-order.js";
 import {
   resolveBundledProviderCompatPluginIds,
   resolveOwningPluginIdsForProvider,
@@ -287,10 +288,18 @@ export async function loadProviderCatalogModelsForList(params: {
     }
   }
 
+  // Stable Array.prototype.toSorted (ES2023): returning 0 for same-provider
+  // pairs of a preserve-order provider keeps the plugin's curated static-catalog
+  // order inside that provider block, matching the
+  // ProviderPluginCatalog.preserveDiscoveryOrder contract.
+  const preserveOrderProviders = collectPreserveDiscoveryOrderProviders(providers);
   return rows.toSorted((left, right) => {
     const provider = left.provider.localeCompare(right.provider);
     if (provider !== 0) {
       return provider;
+    }
+    if (preserveOrderProviders.has(normalizeProviderId(left.provider))) {
+      return 0;
     }
     return left.id.localeCompare(right.id);
   });

--- a/src/commands/models/list.row-sources.ts
+++ b/src/commands/models/list.row-sources.ts
@@ -21,6 +21,7 @@ type AllModelRowSources = {
   useManifestCatalogFastPath: boolean;
   useProviderCatalogFastPath: boolean;
   useProviderIndexCatalogFastPath: boolean;
+  preserveDiscoveryOrderProviders?: Set<string>;
 };
 
 type AppendAllModelRowSourcesResult = {
@@ -102,6 +103,7 @@ export async function appendAllModelRowSources(
     models: params.modelRegistry?.getAll() ?? [],
     modelRegistry: params.modelRegistry,
     context: params.context,
+    preserveDiscoveryOrderProviders: params.preserveDiscoveryOrderProviders,
   });
 
   await appendConfiguredProviderRows({

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import type { ModelRow } from "./list.types.js";
 
@@ -41,7 +41,12 @@ vi.mock("../../plugins/synthetic-auth.runtime.js", () => ({
   resolveRuntimeSyntheticAuthProviderRefs: vi.fn().mockReturnValue([]),
 }));
 
-import { appendProviderCatalogRows } from "./list.rows.js";
+let appendDiscoveredRows: typeof import("./list.rows.js").appendDiscoveredRows;
+let appendProviderCatalogRows: typeof import("./list.rows.js").appendProviderCatalogRows;
+
+beforeAll(async () => {
+  ({ appendDiscoveredRows, appendProviderCatalogRows } = await import("./list.rows.js"));
+});
 
 describe("appendProviderCatalogRows", () => {
   it("can skip runtime model-suppression hooks for provider-catalog fast paths", async () => {
@@ -82,6 +87,105 @@ describe("appendProviderCatalogRows", () => {
         available: true,
         missing: false,
       },
+    ]);
+  });
+});
+
+type StubModel = {
+  provider: string;
+  id: string;
+  name: string;
+  input: string[];
+  baseUrl?: string;
+  api?: string;
+  contextWindow?: number;
+};
+
+function model(provider: string, id: string): StubModel {
+  return { provider, id, name: `${provider}/${id}`, input: ["text"], api: "openai" };
+}
+
+function buildContext() {
+  return {
+    cfg: { models: { providers: {} } },
+    authStore: { version: 1, profiles: {}, order: {} },
+    configuredByKey: new Map(),
+    discoveredKeys: new Set<string>(),
+    filter: {},
+    skipRuntimeModelSuppression: true,
+  };
+}
+
+describe("appendDiscoveredRows sort behavior", () => {
+  it("sorts by provider then id by default", async () => {
+    const rows: Array<{ key: string }> = [];
+    const models = [
+      model("zulu", "m2"),
+      model("alpha", "b"),
+      model("alpha", "a"),
+      model("mike", "x"),
+    ];
+    await appendDiscoveredRows({
+      rows: rows as never,
+      models: models as never,
+      context: buildContext() as never,
+    });
+    expect(rows.map((r) => r.key)).toEqual(["alpha/a", "alpha/b", "mike/x", "zulu/m2"]);
+  });
+
+  it("preserves input order when sortByName is false", async () => {
+    const rows: Array<{ key: string }> = [];
+    const models = [
+      model("deepinfra", "curated-top"),
+      model("deepinfra", "another"),
+      model("deepinfra", "aardvark-last"),
+    ];
+    await appendDiscoveredRows({
+      rows: rows as never,
+      models: models as never,
+      context: buildContext() as never,
+      sortByName: false,
+    });
+    expect(rows.map((r) => r.key)).toEqual([
+      "deepinfra/curated-top",
+      "deepinfra/another",
+      "deepinfra/aardvark-last",
+    ]);
+  });
+
+  it("sorts when sortByName is true", async () => {
+    const rows: Array<{ key: string }> = [];
+    const models = [model("deepinfra", "c"), model("deepinfra", "a"), model("deepinfra", "b")];
+    await appendDiscoveredRows({
+      rows: rows as never,
+      models: models as never,
+      context: buildContext() as never,
+      sortByName: true,
+    });
+    expect(rows.map((r) => r.key)).toEqual(["deepinfra/a", "deepinfra/b", "deepinfra/c"]);
+  });
+
+  it("preserves discovery order per-provider while still sorting other providers", async () => {
+    const rows: Array<{ key: string }> = [];
+    const models = [
+      model("deepinfra", "z-curated-first"),
+      model("deepinfra", "a-second"),
+      model("deepinfra", "m-third"),
+      model("openai", "gpt-5.4-pro"),
+      model("openai", "gpt-5.4"),
+    ];
+    await appendDiscoveredRows({
+      rows: rows as never,
+      models: models as never,
+      context: buildContext() as never,
+      preserveDiscoveryOrderProviders: new Set(["deepinfra"]),
+    });
+    expect(rows.map((r) => r.key)).toEqual([
+      "deepinfra/z-curated-first",
+      "deepinfra/a-second",
+      "deepinfra/m-third",
+      "openai/gpt-5.4",
+      "openai/gpt-5.4-pro",
     ]);
   });
 });

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -259,20 +259,33 @@ export async function appendDiscoveredRows(params: {
   models: Model<Api>[];
   modelRegistry?: ModelRegistry;
   context: RowBuilderContext;
+  sortByName?: boolean;
+  preserveDiscoveryOrderProviders?: Set<string>;
 }): Promise<Set<string>> {
   const seenKeys = new Set<string>();
   const modelResolver = params.modelRegistry
     ? (await loadModelResolverModule()).resolveModelWithRegistry
     : undefined;
-  const sorted = [...params.models].toSorted((a, b) => {
-    const providerCompare = a.provider.localeCompare(b.provider);
-    if (providerCompare !== 0) {
-      return providerCompare;
-    }
-    return a.id.localeCompare(b.id);
-  });
+  const preserveOrderProviders = params.preserveDiscoveryOrderProviders;
+  // Relies on Array.prototype.toSorted being stable (ES2023): providers flagged
+  // as preserveDiscoveryOrder return 0 from the comparator on same-provider
+  // pairs, which keeps their insertion order inside the provider block while
+  // non-flagged providers still sort by id.
+  const models =
+    (params.sortByName ?? true)
+      ? [...params.models].toSorted((a, b) => {
+          const providerCompare = a.provider.localeCompare(b.provider);
+          if (providerCompare !== 0) {
+            return providerCompare;
+          }
+          if (preserveOrderProviders?.has(normalizeProviderId(a.provider))) {
+            return 0;
+          }
+          return a.id.localeCompare(b.id);
+        })
+      : params.models;
 
-  for (const model of sorted) {
+  for (const model of models) {
     const key = modelKey(model.provider, model.id);
     const resolvedModel =
       params.modelRegistry && modelResolver

--- a/src/plugin-sdk/provider-entry.ts
+++ b/src/plugin-sdk/provider-entry.ts
@@ -32,11 +32,13 @@ export type SingleProviderPluginCatalogOptions =
       run?: never;
       order?: never;
       staticRun?: never;
+      preserveDiscoveryOrder?: never;
     }
   | {
       run: ProviderPluginCatalog["run"];
       staticRun?: ProviderPluginCatalog["run"];
       order?: ProviderPluginCatalog["order"];
+      preserveDiscoveryOrder?: ProviderPluginCatalog["preserveDiscoveryOrder"];
       buildProvider?: never;
       buildStaticProvider?: never;
       allowExplicitBaseUrl?: never;
@@ -136,6 +138,9 @@ export function defineSingleProviderPluginEntry(options: SingleProviderPluginOpt
           catalog = {
             order: provider.catalog.order ?? "simple",
             run: catalogRun!,
+            ...(provider.catalog.preserveDiscoveryOrder !== undefined
+              ? { preserveDiscoveryOrder: provider.catalog.preserveDiscoveryOrder }
+              : {}),
           };
         } else {
           const buildProvider = provider.catalog.buildProvider;

--- a/src/plugins/preserve-discovery-order.test.ts
+++ b/src/plugins/preserve-discovery-order.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const seams = vi.hoisted(() => ({
+  resolveProviderPluginsForHooks: vi.fn(),
+}));
+
+vi.mock("./provider-hook-runtime.js", () => ({
+  resolveProviderPluginsForHooks: seams.resolveProviderPluginsForHooks,
+}));
+
+const {
+  collectPreserveDiscoveryOrderProviders,
+  resetPreserveDiscoveryOrderLookupLogForTest,
+  resolvePreserveDiscoveryOrderProviders,
+} = await import("./preserve-discovery-order.js");
+
+describe("collectPreserveDiscoveryOrderProviders", () => {
+  it("returns the normalized id, aliases, and hookAliases of every preserve-order plugin", () => {
+    const set = collectPreserveDiscoveryOrderProviders([
+      {
+        id: "Curated",
+        aliases: ["Curated-Alias"],
+        hookAliases: ["curated-hook-alias"],
+        catalog: { preserveDiscoveryOrder: true },
+      },
+      { id: "not-preserve", catalog: { preserveDiscoveryOrder: false } },
+      { id: "no-catalog" },
+    ]);
+    expect([...set].toSorted()).toEqual(["curated", "curated-alias", "curated-hook-alias"]);
+  });
+
+  it("ignores plugins without preserveDiscoveryOrder=true", () => {
+    const set = collectPreserveDiscoveryOrderProviders([
+      { id: "a", catalog: { preserveDiscoveryOrder: false } },
+      { id: "b" },
+    ]);
+    expect(set.size).toBe(0);
+  });
+
+  it("skips ids that normalize to empty", () => {
+    const set = collectPreserveDiscoveryOrderProviders([
+      {
+        id: "curated",
+        aliases: ["   ", ""],
+        hookAliases: [],
+        catalog: { preserveDiscoveryOrder: true },
+      },
+    ]);
+    expect([...set]).toEqual(["curated"]);
+  });
+});
+
+describe("resolvePreserveDiscoveryOrderProviders", () => {
+  beforeEach(() => {
+    seams.resolveProviderPluginsForHooks.mockReset();
+    resetPreserveDiscoveryOrderLookupLogForTest();
+  });
+
+  it("delegates plugin lookup to resolveProviderPluginsForHooks and reduces the result", () => {
+    seams.resolveProviderPluginsForHooks.mockReturnValue([
+      {
+        id: "curated",
+        aliases: ["curated-alias"],
+        hookAliases: [],
+        catalog: { preserveDiscoveryOrder: true },
+      },
+      { id: "other", catalog: { preserveDiscoveryOrder: false } },
+    ]);
+
+    const set = resolvePreserveDiscoveryOrderProviders({});
+
+    expect([...set].toSorted()).toEqual(["curated", "curated-alias"]);
+    expect(seams.resolveProviderPluginsForHooks).toHaveBeenCalledOnce();
+  });
+
+  it("returns an empty set and swallows the error when plugin lookup throws", () => {
+    seams.resolveProviderPluginsForHooks.mockImplementation(() => {
+      throw new Error("plugin runtime broken");
+    });
+
+    const set = resolvePreserveDiscoveryOrderProviders({});
+
+    expect(set.size).toBe(0);
+  });
+});

--- a/src/plugins/preserve-discovery-order.ts
+++ b/src/plugins/preserve-discovery-order.ts
@@ -1,0 +1,84 @@
+import { normalizeProviderId } from "../agents/provider-id.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveProviderPluginsForHooks } from "./provider-hook-runtime.js";
+import type { ProviderPlugin } from "./types.js";
+
+type PreserveOrderProviderLike = {
+  id: string;
+  aliases?: string[];
+  hookAliases?: string[];
+  catalog?: { preserveDiscoveryOrder?: boolean };
+};
+
+/**
+ * Collect the set of normalized provider ids whose plugin catalog opts into
+ * preserveDiscoveryOrder, including each plugin's aliases and hookAliases.
+ *
+ * Used by list/browse sort paths that keep a provider's curated upstream order
+ * intact while still grouping by provider id. Callers own plugin resolution
+ * (filtered vs unfiltered) and the error handling around a failed resolution.
+ */
+export function collectPreserveDiscoveryOrderProviders(
+  plugins: Iterable<PreserveOrderProviderLike>,
+): Set<string> {
+  const result = new Set<string>();
+  for (const plugin of plugins) {
+    if (plugin.catalog?.preserveDiscoveryOrder !== true) {
+      continue;
+    }
+    for (const id of [plugin.id, ...(plugin.aliases ?? []), ...(plugin.hookAliases ?? [])]) {
+      const normalized = normalizeProviderId(id);
+      if (normalized) {
+        result.add(normalized);
+      }
+    }
+  }
+  return result;
+}
+
+const preserveOrderLog = createSubsystemLogger("provider-preserve-order");
+let hasLoggedPreserveOrderLookupError = false;
+
+export function resetPreserveDiscoveryOrderLookupLogForTest(): void {
+  hasLoggedPreserveOrderLookupError = false;
+}
+
+/**
+ * Resolve the set of normalized provider ids that opt into
+ * ProviderPluginCatalog.preserveDiscoveryOrder across every bundled provider
+ * plugin.
+ *
+ * The result is only consulted by sort comparators, which skip providers that
+ * aren't in the list being sorted — so returning "too many" ids is harmless.
+ * That keeps the API tiny and lets all callers share one cached plugin lookup.
+ *
+ * Plugin resolution can throw (broken manifest, transient plugin-runtime
+ * failure). Any throw is swallowed and dedupe-warn-logged once per process, and
+ * the set is returned empty — callers fall back to the default alphabetical
+ * sort. This degradation is invisible to users by design: the worst case is
+ * losing curated ordering for one list invocation.
+ */
+export function resolvePreserveDiscoveryOrderProviders(params: {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  workspaceDir?: string;
+}): Set<string> {
+  let plugins: ProviderPlugin[] = [];
+  try {
+    plugins = resolveProviderPluginsForHooks({
+      config: params.config,
+      env: params.env,
+      workspaceDir: params.workspaceDir,
+    });
+  } catch (error) {
+    if (!hasLoggedPreserveOrderLookupError) {
+      hasLoggedPreserveOrderLookupError = true;
+      preserveOrderLog.warn(
+        `Failed to resolve provider plugins for preserve-order flag: ${String(error)}`,
+      );
+    }
+    return new Set<string>();
+  }
+  return collectPreserveDiscoveryOrderProviders(plugins);
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -406,6 +406,12 @@ export type ProviderCatalogResult =
 export type ProviderPluginCatalog = {
   order?: ProviderCatalogOrder;
   run: (ctx: ProviderCatalogContext) => Promise<ProviderCatalogResult>;
+  /**
+   * When true, list/browse surfaces preserve the plugin catalog's discovery
+   * order instead of sorting by provider/id. Use for providers whose upstream
+   * catalog returns a curated order (e.g. ranks models by capability).
+   */
+  preserveDiscoveryOrder?: boolean;
 };
 
 export type ProviderRuntimeProviderConfig = {


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw has no native integration for DeepInfra, which provides a unified OpenAI-compatible API covering hundreds of popular open-source and frontier models under a single key.
- **Why it matters:** **DeepInfra is one of the top providers on OpenRouter and one of the biggest open-source inference providers in general.** Users who want to run open-source models (Qwen, Kimi, MiniMax, GLM, etc.) currently have to manually configure a custom OpenAI-compatible provider; a first-class integration removes that friction and enables auto-discovery.
- **What changed:** Added DeepInfra as a built-in model provider — API key management (`DEEPINFRA_API_KEY`), interactive and non-interactive onboarding (`--deepinfra-api-key`), dynamic model discovery from `/v1/openai/models` with static fallback catalog (including per-model cost data), provider capabilities (streaming, vision, reasoning), TTL-aware Pi-embedded runner cache entry, and full docs page.
- **What did NOT change:** No existing providers were modified; no shared onboarding flows were altered beyond registering the new provider alongside its peers.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #11533 

## User-visible / Behavior Changes

- New CLI flag: `openclaw onboard --deepinfra-api-key <key>`
- New env var recognized: `DEEPINFRA_API_KEY`
- New provider prefix `deepinfra/` available for model refs (e.g. `deepinfra/openai/gpt-oss-120b`)
- Default model when DeepInfra is selected: `deepinfra/zai-org/GLM-5`
- DeepInfra now appears in the interactive onboarding provider picker
- Models are auto-discovered from the DeepInfra API at startup; static catalog of 4 models (with real per-model cost data) is used as fallback

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes` — `DEEPINFRA_API_KEY` is stored via the same credential path as all other API-key providers; no new storage mechanism
- New/changed network calls? `Yes` — one unauthenticated GET to `https://api.deepinfra.com/v1/openai/models` at startup for model discovery; skipped in test environments; 5 s timeout with fallback
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime/container: Node 22+ / Bun
- Model/provider: DeepInfra (`deepinfra/zai-org/GLM-5`)
- Integration/channel: any
- Relevant config: `DEEPINFRA_API_KEY=<key>`

### Steps

1. `openclaw onboard` then select DeepInfra as provider from the menu
2. Send a message — confirm it routes through `deepinfra/zai-org/GLM-5`
3. `openclaw models list --provider deepinfra` — confirm dynamic model list

### Expected

- Onboarding completes; config written with `DEEPINFRA_API_KEY` and default model ref
- Message sent successfully via DeepInfra
- Model list populated from API (or static fallback if API unreachable)

### Actual

- Works as expected

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

16 new tests in 1 file all pass:
<img width="925" height="173" alt="image" src="https://github.com/user-attachments/assets/05fb389e-79cb-4948-8eb3-01e8974ed15c" />

## Human Verification (required)

### Tested standard onboarding
- Ran `pnpm dev --dev onboard`
  - Selected DeepInfra
  - Was prompted to enter api key
  - Spun up tui after onboarding
  - Verified that chat messages flowed through DeepInfra

DeepInfra manually chosen from providers:
<img width="1033" height="343" alt="1" src="https://github.com/user-attachments/assets/524d34cb-c8e1-474a-a66f-dd1675119d89" />

Bot starts successfully in TUI:
<img width="1249" height="741" alt="2" src="https://github.com/user-attachments/assets/0e9258a1-d30a-4c6b-99aa-16ef19af15b4" />

### Tested the env variable DEEPINFRA_API_KEY
`export DEEPINFRA_API_KEY=\<key\> pnpm dev --dev onboard --auth-choice deepinfra-api-key`

<img width="910" height="1158" alt="3-api-key" src="https://github.com/user-attachments/assets/e0e5c57f-0322-4cbf-bb13-1cc7b8667819" />
<img width="1246" height="692" alt="4-api-key-hi" src="https://github.com/user-attachments/assets/cca3e0c8-020b-4e06-8e46-39e7f702bbf5" />

- Results:
    - Spun up tui after onboarding
    - Verified that the selected model is the default for DeepInfra
   

### Tested the dynamic model discovery
- Ran `pnpm dev --dev models list --provider deepinfra --all`

<img width="1194" height="387" alt="image" src="https://github.com/user-attachments/assets/9a430376-d359-4a51-a8f4-942192996f00" />


### Tested non-interactive onboarding
`pnpm dev --dev onboard --non-interactive --accept-risk --deepinfra-api-key <key>`



- Verified scenarios: interactive onboarding, non-interactive onboarding, env var detection, model listing, chat message flow
- Edge cases checked: fallback catalog when API unreachable, model cost data populated correctly

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` — new optional `DEEPINFRA_API_KEY`; no effect if unset
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the branch merge. Users who haven't configured DeepInfra are unaffected.
- Files/config to restore: N/A — purely additive.
- Known bad symptoms reviewers should watch for: Startup slowdown if DeepInfra model discovery endpoint becomes slow/unresponsive (mitigated by 5 s timeout + static fallback).

## Risks and Mitigations

None — purely additive provider integration with no changes to existing code paths.