### PR TITLE
Memory: cap Ollama embed batch fan-out to prevent index fetch failures

### DIFF
--- a/extensions/ollama/src/embedding-provider.ts
+++ b/extensions/ollama/src/embedding-provider.ts
@@ -47,6 +47,55 @@ export type OllamaEmbeddingClient = {
 type OllamaEmbeddingClientConfig = Omit<OllamaEmbeddingClient, "embedBatch">;
 
 export const DEFAULT_OLLAMA_EMBEDDING_MODEL = "nomic-embed-text";
+const OLLAMA_EMBED_BATCH_CONCURRENCY = 4;
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+  const capped = Number.isFinite(concurrency) ? Math.max(1, Math.floor(concurrency)) : 1;
+  const workers = Math.min(capped, items.length);
+  const out = Array.from({ length: items.length }, () => undefined as R | undefined);
+  let index = 0;
+  let firstError: unknown = null;
+  await Promise.all(
+    Array.from({ length: workers }, async () => {
+      while (true) {
+        if (firstError !== null) {
+          return;
+        }
+        const current = index;
+        index += 1;
+        if (current >= items.length) {
+          return;
+        }
+        try {
+          out[current] = await mapper(items[current], current);
+        } catch (error) {
+          if (firstError === null) {
+            firstError = error;
+          }
+          throw error;
+        }
+      }
+    }),
+  );
+  if (firstError !== null) {
+    throw firstError;
+  }
+  const finalized: R[] = [];
+  for (const value of out) {
+    if (value === undefined) {
+      throw new Error("Ollama embedding batch mapping did not fill all results");
+    }
+    finalized.push(value);
+  }
+  return finalized;
+}
 
 function sanitizeAndNormalizeEmbedding(vec: number[]): number[] {
   const sanitized = vec.map((value) => (Number.isFinite(value) ? value : 0));
@@ -187,7 +236,7 @@ export async function createOllamaEmbeddingProvider(
     model: client.model,
     embedQuery: embedOne,
     embedBatch: async (texts) => {
-      return await Promise.all(texts.map(embedOne));
+      return await mapWithConcurrency(texts, OLLAMA_EMBED_BATCH_CONCURRENCY, embedOne);
     },
   };
 

--- a/packages/memory-host-sdk/src/host/embeddings-ollama.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-ollama.test.ts
@@ -143,4 +143,32 @@ describe("embeddings-ollama", () => {
       }),
     );
   });
+
+  it("limits embed batch fan-out to avoid request storms", async () => {
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const fetchMock = vi.fn(async () => {
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+      return new Response(JSON.stringify({ embedding: [1, 0] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const { provider } = await createOllamaEmbeddingProvider({
+      config: {} as OpenClawConfig,
+      provider: "ollama",
+      model: "nomic-embed-text",
+      fallback: "none",
+      remote: { baseUrl: "http://127.0.0.1:11434" },
+    });
+
+    await provider.embedBatch(Array.from({ length: 12 }, (_, i) => `batch-${i}`));
+    expect(fetchMock).toHaveBeenCalledTimes(12);
+    expect(peakInFlight).toBeLessThanOrEqual(4);
+  });
 });

--- a/packages/memory-host-sdk/src/host/embeddings-ollama.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-ollama.test.ts
@@ -147,15 +147,26 @@ describe("embeddings-ollama", () => {
   it("limits embed batch fan-out to avoid request storms", async () => {
     let inFlight = 0;
     let peakInFlight = 0;
-    const fetchMock = vi.fn(async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       inFlight += 1;
-      peakInFlight = Math.max(peakInFlight, inFlight);
-      await new Promise((resolve) => setTimeout(resolve, 5));
-      inFlight -= 1;
-      return new Response(JSON.stringify({ embedding: [1, 0] }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+      try {
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        const body = typeof init?.body === "string" ? init.body : "";
+        const parsed = JSON.parse(body) as { prompt?: string };
+        const prompt = typeof parsed.prompt === "string" ? parsed.prompt : "";
+        const match = /^batch-(\d+)$/.exec(prompt);
+        const index = match ? Number.parseInt(match[1], 10) : -1;
+        if (!Number.isFinite(index) || index < 0) {
+          throw new Error(`unexpected prompt: ${prompt}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return new Response(JSON.stringify({ embedding: [index, 1] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      } finally {
+        inFlight -= 1;
+      }
     });
     globalThis.fetch = fetchMock as unknown as typeof fetch;
 
@@ -167,8 +178,15 @@ describe("embeddings-ollama", () => {
       remote: { baseUrl: "http://127.0.0.1:11434" },
     });
 
-    await provider.embedBatch(Array.from({ length: 12 }, (_, i) => `batch-${i}`));
+    const values = Array.from({ length: 12 }, (_, i) => `batch-${i}`);
+    const result = await provider.embedBatch(values);
     expect(fetchMock).toHaveBeenCalledTimes(12);
     expect(peakInFlight).toBeLessThanOrEqual(4);
+    expect(result).toHaveLength(values.length);
+    result.forEach((vec, i) => {
+      const magnitude = Math.sqrt(i * i + 1);
+      expect(vec[0]).toBeCloseTo(i / magnitude, 5);
+      expect(vec[1]).toBeCloseTo(1 / magnitude, 5);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Ollama memory indexing fanned out `/api/embeddings` calls with unbounded `Promise.all` over chunks.
- Why it matters: Large session backfills can burst many concurrent requests and fail with `Memory index failed: fetch failed`, blocking indexing.
- What changed: Capped Ollama embed-batch fan-out with bounded concurrency (`OLLAMA_EMBED_BATCH_CONCURRENCY = 4`) while preserving output order.
- What did NOT change (scope boundary): No model/provider selection changes, no API endpoint changes, no schema/migration/config format changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Ollama-backed memory indexing is more stable under high chunk counts (especially when `memorySearch.sources` includes `sessions`).
- No CLI/API contract changes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Network behavior changed only in concurrency/call-rate to the same Ollama embeddings endpoint; no new destinations or credentials. Risk is low and mitigation is reduced request storm pressure.

## Repro + Verification

### Environment

- OS: macOS host + Docker Linux containers
- Runtime/container: `openclaw-gateway` container in local compose stack
- Model/provider: Ollama (`nomic-embed-text`)
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.memorySearch.sources=["memory","sessions"]`, Ollama base URL reachable from gateway container

### Steps

1. Enable session indexing (`memorySearch.sources` includes `sessions`) with Ollama embeddings.
2. Run `openclaw memory status --index --deep` (or `openclaw memory index`) against a workspace with larger session transcripts.
3. Observe indexing behavior before and after this patch.

### Expected

- Indexing completes without transport-level burst failures; session source progresses/indexes.

### Actual

- Before: intermittent hard failure `Memory index failed: fetch failed` during indexing.
- After: bounded fan-out behavior + regression test coverage; local validation showed indexing proceeds and session source counts increase.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Ran `npm test -- src/memory/embeddings-ollama.test.ts` (includes new concurrency cap regression test).
  - Ran `pnpm build` successfully.
  - In local docker runtime, reproduced pre-fix `fetch failed` during session indexing and confirmed post-fix indexing no longer immediate-fails and session source counts increase.
- Edge cases checked:
  - Empty batch returns empty array.
  - Ordered results preserved through concurrency-limited mapper.
  - Guard throws if mapper fails to fill all result slots.
- What you did **not** verify:
  - Cross-platform stress benchmarking under all Ollama server versions.
  - Non-Ollama providers (out of scope).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `2834d85dc`.
- Files/config to restore:
  - `src/memory/embeddings-ollama.ts`
  - `src/memory/embeddings-ollama.test.ts`
- Known bad symptoms reviewers should watch for:
  - Indexing throughput unexpectedly too low.
  - Regression in Ollama batch embedding correctness/order.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Concurrency cap could reduce peak indexing throughput on very powerful local Ollama hosts.
  - Mitigation: Cap is conservative to prioritize reliability; follow-up can make it configurable if needed based on field data.