### PR TITLE
feat(ui): redesign chat layout and update modal

### DIFF
--- a/ui/public/lobster.svg
+++ b/ui/public/lobster.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 16 16" role="img" aria-label="Pixel lobster">
+  <rect width="16" height="16" fill="none"/>
+  <!-- outline -->
+  <g fill="#3a0a0d">
+    <rect x="1" y="5" width="1" height="3"/>
+    <rect x="2" y="4" width="1" height="1"/>
+    <rect x="2" y="8" width="1" height="1"/>
+    <rect x="3" y="3" width="1" height="1"/>
+    <rect x="3" y="9" width="1" height="1"/>
+    <rect x="4" y="2" width="1" height="1"/>
+    <rect x="4" y="10" width="1" height="1"/>
+    <rect x="5" y="2" width="6" height="1"/>
+    <rect x="11" y="2" width="1" height="1"/>
+    <rect x="12" y="3" width="1" height="1"/>
+    <rect x="12" y="9" width="1" height="1"/>
+    <rect x="13" y="4" width="1" height="1"/>
+    <rect x="13" y="8" width="1" height="1"/>
+    <rect x="14" y="5" width="1" height="3"/>
+    <rect x="5" y="11" width="6" height="1"/>
+    <rect x="4" y="12" width="1" height="1"/>
+    <rect x="11" y="12" width="1" height="1"/>
+    <rect x="3" y="13" width="1" height="1"/>
+    <rect x="12" y="13" width="1" height="1"/>
+    <rect x="5" y="14" width="6" height="1"/>
+  </g>
+
+  <!-- body -->
+  <g fill="#ff4f40">
+    <rect x="5" y="3" width="6" height="1"/>
+    <rect x="4" y="4" width="8" height="1"/>
+    <rect x="3" y="5" width="10" height="1"/>
+    <rect x="3" y="6" width="10" height="1"/>
+    <rect x="3" y="7" width="10" height="1"/>
+    <rect x="4" y="8" width="8" height="1"/>
+    <rect x="5" y="9" width="6" height="1"/>
+    <rect x="5" y="12" width="6" height="1"/>
+    <rect x="6" y="13" width="4" height="1"/>
+  </g>
+
+  <!-- claws -->
+  <g fill="#ff775f">
+    <rect x="1" y="6" width="2" height="1"/>
+    <rect x="2" y="5" width="1" height="1"/>
+    <rect x="2" y="7" width="1" height="1"/>
+    <rect x="13" y="6" width="2" height="1"/>
+    <rect x="13" y="5" width="1" height="1"/>
+    <rect x="13" y="7" width="1" height="1"/>
+  </g>
+
+  <!-- eyes -->
+  <g fill="#081016">
+    <rect x="6" y="5" width="1" height="1"/>
+    <rect x="9" y="5" width="1" height="1"/>
+  </g>
+  <g fill="#f5fbff">
+    <rect x="6" y="4" width="1" height="1"/>
+    <rect x="9" y="4" width="1" height="1"/>
+  </g>
+</svg>
+

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -12,6 +12,11 @@
   margin-right: 16px;
 }
 
+/* Hide tool message groups entirely from chat */
+.chat-group.tool {
+  display: none !important;
+}
+
 /* User messages on right */
 .chat-group.user {
   flex-direction: row-reverse;
@@ -23,6 +28,11 @@
   flex-direction: column;
   gap: 2px;
   max-width: min(900px, calc(100% - 60px));
+}
+
+/* User messages: compact width like ChatGPT/Gemini */
+.chat-group.user .chat-group-messages {
+  max-width: min(520px, 75%);
 }
 
 /* User messages align content right */
@@ -132,29 +142,51 @@
 
 /* Avatar Styles */
 .chat-avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: 10px;
-  background: var(--panel-strong);
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: transparent;
   display: grid;
   place-items: center;
   font-weight: 600;
   font-size: 13px;
   flex-shrink: 0;
-  align-self: flex-end;
-  margin-bottom: 4px;
-  border: 1px solid var(--border);
+  align-self: flex-start;
+  margin-top: 2px;
+  border: none;
 }
 
 .chat-avatar.user {
   background: var(--accent-subtle);
   color: var(--accent);
-  border-color: color-mix(in srgb, var(--accent) 20%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
 }
 
 .chat-avatar.assistant {
-  background: var(--secondary);
+  background: transparent;
   color: var(--muted);
+  border: none;
+}
+
+/* Logo avatar for assistant */
+.chat-avatar.assistant.chat-avatar--logo {
+  border-radius: 8px;
+  background: transparent;
+  border: none;
+  width: 28px;
+  height: 28px;
+}
+
+img.chat-avatar.assistant {
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
 }
 
 .chat-avatar.other {
@@ -163,8 +195,29 @@
 }
 
 .chat-avatar.tool {
-  background: var(--secondary);
+  background: transparent;
   color: var(--muted);
+  border: none;
+  width: 28px;
+  height: 28px;
+}
+
+/* Thinking animation on mascot while streaming */
+.chat-group--streaming .chat-avatar {
+  animation: thinking-wobble 1.2s ease-in-out infinite;
+}
+
+@keyframes thinking-wobble {
+  0%,
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+  25% {
+    transform: rotate(-5deg) scale(1.05);
+  }
+  75% {
+    transform: rotate(5deg) scale(1.05);
+  }
 }
 
 /* Image avatar support */
@@ -178,8 +231,8 @@ img.chat-avatar {
 .chat-bubble {
   position: relative;
   display: inline-block;
-  border: 1px solid var(--border);
-  background: var(--card);
+  border: 1px solid transparent;
+  background: transparent;
   border-radius: var(--radius-lg);
   padding: 10px 14px;
   box-shadow: none;
@@ -311,20 +364,28 @@ img.chat-avatar {
   stroke-linejoin: round;
 }
 
-/* Light mode: restore borders */
+/* Assistant bubbles: subtle container */
+.chat-group.assistant .chat-bubble,
+.chat-group.other .chat-bubble {
+  background: var(--card);
+  border-color: var(--border);
+  padding: 10px 14px;
+}
+
+/* Light mode */
 :root[data-theme-mode="light"] .chat-bubble {
   border-color: var(--border);
-  box-shadow: inset 0 1px 0 var(--card-highlight);
 }
 
 .chat-bubble:hover {
   background: var(--bg-hover);
 }
 
-/* User bubbles have different styling */
+/* User bubbles keep background styling */
 .chat-group.user .chat-bubble {
   background: var(--accent-subtle);
   border-color: transparent;
+  border-radius: 20px;
 }
 
 :root[data-theme-mode="light"] .chat-group.user .chat-bubble {

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -12,11 +12,6 @@
   margin-right: 16px;
 }
 
-/* Hide tool message groups entirely from chat */
-.chat-group.tool {
-  display: none !important;
-}
-
 /* User messages on right */
 .chat-group.user {
   flex-direction: row-reverse;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -63,6 +63,14 @@
   background: transparent;
 }
 
+/* Center chat content like Claude/Gemini */
+.chat-thread-inner {
+  max-width: 768px;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+}
+
 .chat-thread-inner > :first-child {
   margin-top: 0 !important;
 }
@@ -190,6 +198,10 @@
   padding: 12px 4px 4px;
   background: linear-gradient(to bottom, transparent, var(--bg) 20%);
   z-index: 10;
+  max-width: 768px;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
 }
 
 /* Image attachments preview */
@@ -367,13 +379,15 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  margin: 0 18px 14px;
+  margin: 0 auto 14px;
+  max-width: 768px;
+  width: calc(100% - 36px);
   padding: 0;
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   flex-shrink: 0;
-  overflow: hidden;
+  overflow: visible;
   transition:
     border-color var(--duration-fast) ease,
     box-shadow var(--duration-fast) ease;
@@ -405,6 +419,7 @@
   line-height: 1.4;
   outline: none;
   box-sizing: border-box;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
 }
 
 .agent-chat__input > textarea:focus-visible {
@@ -494,17 +509,18 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
-  border-radius: var(--radius-md);
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
   border: none;
-  background: var(--muted-strong);
-  color: var(--text-strong);
+  background: #fff;
+  color: #000;
   cursor: pointer;
   flex-shrink: 0;
   transition:
     background var(--duration-fast) ease,
-    box-shadow var(--duration-fast) ease;
+    box-shadow var(--duration-fast) ease,
+    opacity var(--duration-fast) ease;
   padding: 0;
 }
 
@@ -519,13 +535,24 @@
 }
 
 .chat-send-btn:hover:not(:disabled) {
-  background: var(--muted);
+  background: #e0e0e0;
   box-shadow: none;
 }
 
 .chat-send-btn:disabled {
-  opacity: 0.3;
+  opacity: 0.25;
   cursor: not-allowed;
+  background: var(--muted-strong);
+  color: var(--text-strong);
+}
+
+:root[data-theme-mode="light"] .chat-send-btn {
+  background: #000;
+  color: #fff;
+}
+
+:root[data-theme-mode="light"] .chat-send-btn:hover:not(:disabled) {
+  background: #333;
 }
 
 .chat-send-btn--stop {
@@ -1010,6 +1037,99 @@
 .agent-chat__suggestion:hover {
   background: var(--panel-strong);
   border-color: var(--accent);
+}
+
+/* Actions menu popup (attach, new session, export) */
+.agent-chat__actions-menu-wrap {
+  position: relative;
+}
+
+.agent-chat__actions-popup {
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 48px);
+  left: 0;
+  min-width: 240px;
+  background: var(--popover);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+  z-index: 200;
+  padding: 6px;
+  animation: popup-enter 0.15s ease-out;
+}
+
+.agent-chat__actions-popup--open {
+  display: block;
+}
+
+@keyframes popup-enter {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.agent-chat__actions-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+  text-align: left;
+}
+
+.agent-chat__actions-item:hover {
+  background: var(--bg-hover);
+}
+
+.agent-chat__actions-item:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.agent-chat__actions-item-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  color: var(--muted);
+}
+
+.agent-chat__actions-item-icon svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.agent-chat__actions-item-label {
+  flex: 1;
+}
+
+:root[data-theme-mode="light"] .agent-chat__actions-popup {
+  background: #fff;
+  border-color: var(--border);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
 }
 
 /* Mobile dropdown toggle — hidden on desktop */

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -19,10 +19,12 @@
 }
 
 .chat-text {
-  font-size: 14px;
-  line-height: 1.5;
+  font-size: 15px;
+  line-height: 1.7;
   word-wrap: break-word;
   overflow-wrap: break-word;
+  letter-spacing: -0.01em;
+  color: var(--chat-text);
 }
 
 .chat-text :where(p, ul, ol, pre, blockquote, table) {
@@ -70,18 +72,20 @@
 }
 
 .chat-text :where(:not(pre) > code) {
-  background: rgba(0, 0, 0, 0.15);
-  padding: 0.15em 0.4em;
-  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  padding: 0.1em 0.35em;
+  border-radius: 3px;
+  font-size: 0.85em;
   overflow-wrap: normal;
   word-break: keep-all;
 }
 
 .chat-text :where(pre) {
-  background: rgba(0, 0, 0, 0.15);
+  background: rgba(255, 255, 255, 0.04);
   border-radius: 6px;
-  padding: 10px 12px;
+  padding: 8px 12px;
   overflow-x: auto;
+  font-size: 0.85em;
 }
 
 .chat-text :where(pre code) {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -132,118 +132,181 @@
 }
 
 /* ===========================================
-   Update Toast
+   Update Modal
    =========================================== */
 
-@keyframes update-toast-in {
+@keyframes update-overlay-in {
   from {
     opacity: 0;
-    transform: translateY(-12px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
   }
 }
 
-@keyframes update-toast-out {
+@keyframes update-card-in {
   from {
-    opacity: 1;
-    transform: translateY(0);
+    opacity: 0;
+    transform: scale(0.92) translateY(-8px);
   }
   to {
-    opacity: 0;
-    transform: translateY(-12px);
+    opacity: 1;
+    transform: scale(1) translateY(0);
   }
 }
 
-.update-toast-overlay {
+@keyframes update-icon-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.08);
+  }
+}
+
+@keyframes update-spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.update-modal-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   z-index: 999;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
-  padding-top: 80px;
-  background: rgba(0, 0, 0, 0.35);
-  animation: update-toast-in 0.25s ease-out both;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  animation: update-overlay-in 0.2s ease-out both;
 }
 
-.update-toast-overlay--closing {
-  animation: update-toast-out 0.2s ease-in both;
-}
-
-.update-toast {
-  background: var(--bg-raised, var(--bg-secondary, #1e1e2e));
-  border: 1px solid var(--border, rgba(255, 255, 255, 0.08));
-  border-radius: 12px;
-  padding: 20px 24px;
-  min-width: 300px;
-  max-width: 380px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+.update-modal {
+  background: var(--bg-raised, var(--bg-secondary, #1a1a2e));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.06));
+  border-radius: 16px;
+  padding: 28px 32px 24px;
+  width: 340px;
+  box-shadow:
+    0 4px 24px rgba(0, 0, 0, 0.3),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
   text-align: center;
+  animation: update-card-in 0.3s cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation-delay: 0.05s;
 }
 
-.update-toast__title {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text-primary, #e0e0e0);
-  margin: 0 0 4px;
-}
-
-.update-toast__version {
-  font-size: 12px;
-  color: var(--text-secondary, #888);
-  margin: 0 0 16px;
-}
-
-.update-toast__actions {
-  display: flex;
-  gap: 8px;
+.update-modal__icon {
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: rgba(99, 102, 241, 0.12);
+  margin-bottom: 16px;
+  animation: update-icon-pulse 2s ease-in-out infinite;
 }
 
-.update-toast__btn-update {
-  padding: 8px 20px;
-  border-radius: 8px;
-  border: none;
-  background: var(--accent, #6366f1);
-  color: #fff;
-  font-size: 13px;
+.update-modal__icon svg {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke: var(--accent, #818cf8);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.update-modal__title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary, #e4e4e7);
+  margin: 0 0 6px;
+  letter-spacing: -0.01em;
+}
+
+.update-modal__meta {
+  font-size: 12px;
+  color: var(--text-secondary, #71717a);
+  margin: 0 0 6px;
+  font-variant-numeric: tabular-nums;
+}
+
+.update-modal__tag {
+  display: inline-block;
+  font-size: 11px;
   font-weight: 500;
-  cursor: pointer;
-  transition: opacity 0.15s;
+  color: var(--accent, #818cf8);
+  background: rgba(99, 102, 241, 0.1);
+  border-radius: 6px;
+  padding: 2px 8px;
+  margin-bottom: 20px;
 }
 
-.update-toast__btn-update:hover:not(:disabled) {
-  opacity: 0.85;
+.update-modal__actions {
+  display: flex;
+  gap: 10px;
 }
 
-.update-toast__btn-update:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.update-toast__btn-dismiss {
-  padding: 8px 16px;
-  border-radius: 8px;
-  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
-  background: transparent;
-  color: var(--text-secondary, #888);
+.update-modal__btn {
+  flex: 1;
+  padding: 10px 0;
+  border-radius: 10px;
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
   transition:
-    background 0.15s,
-    color 0.15s;
+    background 0.2s,
+    transform 0.15s,
+    box-shadow 0.2s;
 }
 
-.update-toast__btn-dismiss:hover {
-  background: rgba(255, 255, 255, 0.05);
-  color: var(--text-primary, #e0e0e0);
+.update-modal__btn:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+.update-modal__btn--dismiss {
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+  background: transparent;
+  color: var(--text-secondary, #a1a1aa);
+}
+
+.update-modal__btn--dismiss:hover {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary, #e4e4e7);
+}
+
+.update-modal__btn--update {
+  border: none;
+  background: var(--accent, #6366f1);
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(99, 102, 241, 0.25);
+}
+
+.update-modal__btn--update:hover:not(:disabled) {
+  background: var(--accent-hover, #5558e6);
+  box-shadow: 0 4px 16px rgba(99, 102, 241, 0.35);
+}
+
+.update-modal__btn--update:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.update-modal__spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: update-spinner 0.6s linear infinite;
+  vertical-align: middle;
+  margin-right: 6px;
 }
 
 /* ===========================================

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -132,59 +132,118 @@
 }
 
 /* ===========================================
-   Update Banner
+   Update Toast
    =========================================== */
 
-.update-banner {
-  position: sticky;
+@keyframes update-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(-12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes update-toast-out {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-12px);
+  }
+}
+
+.update-toast-overlay {
+  position: fixed;
   top: 0;
-  z-index: 10;
-  margin: 0 calc(-1 * var(--shell-pad)) 0;
-  border-radius: 0;
-  border-left: none;
-  border-right: none;
-  text-align: center;
-  font-weight: 500;
-  padding: 10px 16px;
-}
-
-.update-banner__btn {
-  margin-left: 8px;
-  border-color: var(--danger);
-  color: var(--danger);
-  font-size: 12px;
-  padding: 4px 12px;
-}
-
-.update-banner__btn:hover:not(:disabled) {
-  background: rgba(239, 68, 68, 0.15);
-}
-
-.update-banner__close {
-  display: inline-flex;
-  align-items: center;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 999;
+  display: flex;
+  align-items: flex-start;
   justify-content: center;
-  margin-left: 8px;
-  padding: 2px;
-  background: none;
+  padding-top: 80px;
+  background: rgba(0, 0, 0, 0.35);
+  animation: update-toast-in 0.25s ease-out both;
+}
+
+.update-toast-overlay--closing {
+  animation: update-toast-out 0.2s ease-in both;
+}
+
+.update-toast {
+  background: var(--bg-raised, var(--bg-secondary, #1e1e2e));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+  border-radius: 12px;
+  padding: 20px 24px;
+  min-width: 300px;
+  max-width: 380px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  text-align: center;
+}
+
+.update-toast__title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary, #e0e0e0);
+  margin: 0 0 4px;
+}
+
+.update-toast__version {
+  font-size: 12px;
+  color: var(--text-secondary, #888);
+  margin: 0 0 16px;
+}
+
+.update-toast__actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.update-toast__btn-update {
+  padding: 8px 20px;
+  border-radius: 8px;
   border: none;
+  background: var(--accent, #6366f1);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
-  color: var(--danger);
-  opacity: 0.7;
   transition: opacity 0.15s;
 }
 
-.update-banner__close:hover {
-  opacity: 1;
+.update-toast__btn-update:hover:not(:disabled) {
+  opacity: 0.85;
 }
 
-.update-banner__close svg {
-  width: 16px;
-  height: 16px;
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2;
-  stroke-linecap: round;
+.update-toast__btn-update:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.update-toast__btn-dismiss {
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  background: transparent;
+  color: var(--text-secondary, #888);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.update-toast__btn-dismiss:hover {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-primary, #e0e0e0);
 }
 
 /* ===========================================
@@ -2274,55 +2333,62 @@
 
 /* Chat queue */
 .chat-queue {
-  margin-top: 12px;
-  padding: 12px;
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  background: var(--card);
-  display: grid;
+  margin-top: 4px;
+  padding: 6px 10px;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  background: color-mix(in srgb, var(--card) 50%, transparent);
+  display: flex;
+  align-items: center;
   gap: 8px;
+  max-width: 768px;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
 }
 
 .chat-queue__title {
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 500;
   color: var(--muted);
+  flex-shrink: 0;
 }
 
 .chat-queue__list {
-  display: grid;
-  gap: 8px;
+  display: flex;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
 }
 
 .chat-queue__item {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: start;
-  gap: 12px;
-  padding: 10px 12px;
-  border-radius: var(--radius-md);
-  border: 1px dashed var(--border-strong);
-  background: var(--secondary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px dashed color-mix(in srgb, var(--border) 50%, transparent);
+  background: transparent;
+  min-width: 0;
+  flex: 1;
 }
 
 .chat-queue__text {
-  color: var(--chat-text);
-  font-size: 13px;
-  line-height: 1.45;
-  white-space: pre-wrap;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.3;
+  white-space: nowrap;
   overflow: hidden;
-  display: -webkit-box;
-  line-clamp: 3;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
 }
 
 .chat-queue__remove {
-  align-self: start;
-  padding: 4px 10px;
-  font-size: 12px;
+  align-self: center;
+  padding: 2px 6px;
+  font-size: 11px;
   line-height: 1;
+  flex-shrink: 0;
 }
 
 /* New messages indicator */

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -584,7 +584,7 @@ export function renderApp(state: AppViewState) {
                     <svg viewBox="0 0 24 24"><path d="M12 3v12m0 0l-4-4m4 4l4-4"/><path d="M4 17v2a2 2 0 002 2h12a2 2 0 002-2v-2"/></svg>
                   </div>
                   <p class="update-modal__title">New version available</p>
-                  <p class="update-modal__meta">v${state.updateAvailable.latestVersion} → v${state.updateAvailable.currentVersion}</p>
+                  <p class="update-modal__meta">v${state.updateAvailable.currentVersion} → v${state.updateAvailable.latestVersion}</p>
                   <span class="update-modal__tag">Ready to install</span>
                   <div class="update-modal__actions">
                     <button

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -572,27 +572,38 @@ export function renderApp(state: AppViewState) {
           state.updateAvailable &&
           state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion &&
           !isUpdateBannerDismissed(state.updateAvailable)
-            ? html`<div class="update-banner callout danger" role="alert">
-              <strong>Update available:</strong> v${state.updateAvailable.latestVersion}
-              (running v${state.updateAvailable.currentVersion}).
-              <button
-                class="btn btn--sm update-banner__btn"
-                ?disabled=${state.updateRunning || !state.connected}
-                @click=${() => runUpdate(state)}
-              >${state.updateRunning ? "Updating…" : "Update now"}</button>
-              <button
-                class="update-banner__close"
-                type="button"
-                title="Dismiss"
-                aria-label="Dismiss update banner"
-                @click=${() => {
-                  dismissUpdateBanner(state.updateAvailable);
-                  state.updateAvailable = null;
-                }}
-              >
-                ${icons.x}
-              </button>
-            </div>`
+            ? html`<div class="update-toast-overlay" role="dialog" aria-label="Update available"
+                @click=${(e: Event) => {
+                  if ((e.target as HTMLElement).classList.contains("update-toast-overlay")) {
+                    dismissUpdateBanner(state.updateAvailable);
+                    state.updateAvailable = null;
+                  }
+                }}>
+                <div class="update-toast">
+                  <p class="update-toast__title">Update available</p>
+                  <p class="update-toast__version">v${state.updateAvailable.latestVersion} — running v${state.updateAvailable.currentVersion}</p>
+                  <div class="update-toast__actions">
+                    <button
+                      class="update-toast__btn-dismiss"
+                      @click=${() => {
+                        dismissUpdateBanner(state.updateAvailable);
+                        state.updateAvailable = null;
+                      }}
+                    >Later</button>
+                    <button
+                      class="update-toast__btn-update"
+                      ?disabled=${state.updateRunning || !state.connected}
+                      @click=${async () => {
+                        await runUpdate(state);
+                        if (!state.lastError) {
+                          dismissUpdateBanner(state.updateAvailable);
+                          state.updateAvailable = null;
+                        }
+                      }}
+                    >${state.updateRunning ? "Updating…" : "Update"}</button>
+                  </div>
+                </div>
+              </div>`
             : nothing
         }
         ${

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -572,26 +572,30 @@ export function renderApp(state: AppViewState) {
           state.updateAvailable &&
           state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion &&
           !isUpdateBannerDismissed(state.updateAvailable)
-            ? html`<div class="update-toast-overlay" role="dialog" aria-label="Update available"
+            ? html`<div class="update-modal-overlay" role="dialog" aria-label="Update available"
                 @click=${(e: Event) => {
-                  if ((e.target as HTMLElement).classList.contains("update-toast-overlay")) {
+                  if ((e.target as HTMLElement).classList.contains("update-modal-overlay")) {
                     dismissUpdateBanner(state.updateAvailable);
                     state.updateAvailable = null;
                   }
                 }}>
-                <div class="update-toast">
-                  <p class="update-toast__title">Update available</p>
-                  <p class="update-toast__version">v${state.updateAvailable.latestVersion} — running v${state.updateAvailable.currentVersion}</p>
-                  <div class="update-toast__actions">
+                <div class="update-modal">
+                  <div class="update-modal__icon">
+                    <svg viewBox="0 0 24 24"><path d="M12 3v12m0 0l-4-4m4 4l4-4"/><path d="M4 17v2a2 2 0 002 2h12a2 2 0 002-2v-2"/></svg>
+                  </div>
+                  <p class="update-modal__title">New version available</p>
+                  <p class="update-modal__meta">v${state.updateAvailable.latestVersion} → v${state.updateAvailable.currentVersion}</p>
+                  <span class="update-modal__tag">Ready to install</span>
+                  <div class="update-modal__actions">
                     <button
-                      class="update-toast__btn-dismiss"
+                      class="update-modal__btn update-modal__btn--dismiss"
                       @click=${() => {
                         dismissUpdateBanner(state.updateAvailable);
                         state.updateAvailable = null;
                       }}
                     >Later</button>
                     <button
-                      class="update-toast__btn-update"
+                      class="update-modal__btn update-modal__btn--update"
                       ?disabled=${state.updateRunning || !state.connected}
                       @click=${async () => {
                         await runUpdate(state);
@@ -600,7 +604,13 @@ export function renderApp(state: AppViewState) {
                           state.updateAvailable = null;
                         }
                       }}
-                    >${state.updateRunning ? "Updating…" : "Update"}</button>
+                    >${
+                      state.updateRunning
+                        ? html`
+                            <span class="update-modal__spinner"></span>Updating
+                          `
+                        : "Update now"
+                    }</button>
                   </div>
                 </div>
               </div>`

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -504,9 +504,9 @@ function renderAvatar(
     />`;
   }
 
-  /* Assistant with no custom avatar: always use logo */
-  if (normalized === "assistant") {
-    const logoUrl = agentLogoUrl(basePath ?? "");
+  /* Assistant with no custom avatar: use logo only when basePath is available */
+  if (normalized === "assistant" && basePath) {
+    const logoUrl = agentLogoUrl(basePath);
     return html`<img
       class="chat-avatar ${className} chat-avatar--logo"
       src="${logoUrl}"

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -89,7 +89,7 @@ export function renderStreamingGroup(
   const name = assistant?.name ?? "Assistant";
 
   return html`
-    <div class="chat-group assistant">
+    <div class="chat-group assistant chat-group--streaming">
       ${renderAvatar("assistant", assistant, basePath)}
       <div class="chat-group-messages">
         ${renderGroupedMessage(
@@ -150,8 +150,9 @@ export function renderMessageGroup(
   // Aggregate usage/cost/model across all messages in the group
   const meta = extractGroupMeta(group, opts.contextWindow ?? null);
 
+  const streamingClass = group.isStreaming ? "chat-group--streaming" : "";
   return html`
-    <div class="chat-group ${roleClass}">
+    <div class="chat-group ${roleClass} ${streamingClass}">
       ${renderAvatar(
         group.role,
         {
@@ -503,9 +504,9 @@ function renderAvatar(
     />`;
   }
 
-  /* Assistant with no custom avatar: use logo when basePath available */
-  if (normalized === "assistant" && basePath) {
-    const logoUrl = agentLogoUrl(basePath);
+  /* Assistant with no custom avatar: always use logo */
+  if (normalized === "assistant") {
+    const logoUrl = agentLogoUrl(basePath ?? "");
     return html`<img
       class="chat-avatar ${className} chat-avatar--logo"
       src="${logoUrl}"

--- a/ui/src/ui/icons.ts
+++ b/ui/src/ui/icons.ts
@@ -281,9 +281,16 @@ export const icons = {
     </svg>
   `,
   send: html`
-    <svg viewBox="0 0 24 24">
-      <path d="m22 2-7 20-4-9-9-4Z" />
-      <path d="M22 2 11 13" />
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M12 19V5" />
+      <path d="m5 12 7-7 7 7" />
     </svg>
   `,
   stop: html`

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -799,6 +799,16 @@ function renderSlashMenu(
   `;
 }
 
+let activePopupCloseHandler: ((ev: MouseEvent) => void) | null = null;
+
+function dismissActionsPopup(menu: Element) {
+  menu.classList.remove("agent-chat__actions-popup--open");
+  if (activePopupCloseHandler) {
+    document.removeEventListener("click", activePopupCloseHandler);
+    activePopupCloseHandler = null;
+  }
+}
+
 export function renderChat(props: ChatProps) {
   const canCompose = props.connected;
   const isBusy = props.sending || props.stream !== null;
@@ -1216,17 +1226,20 @@ export function renderChat(props: ChatProps) {
                 @click=${(e: Event) => {
                   const wrap = (e.currentTarget as HTMLElement).parentElement!;
                   const menu = wrap.querySelector(".agent-chat__actions-popup") as HTMLElement;
-                  if (menu) {
-                    menu.classList.toggle("agent-chat__actions-popup--open");
+                  if (!menu) {
+                    return;
+                  }
+                  const wasOpen = menu.classList.contains("agent-chat__actions-popup--open");
+                  dismissActionsPopup(menu);
+                  if (!wasOpen) {
+                    menu.classList.add("agent-chat__actions-popup--open");
                     const close = (ev: MouseEvent) => {
                       if (!wrap.contains(ev.target as Node)) {
-                        menu.classList.remove("agent-chat__actions-popup--open");
-                        document.removeEventListener("click", close);
+                        dismissActionsPopup(menu);
                       }
                     };
-                    if (menu.classList.contains("agent-chat__actions-popup--open")) {
-                      setTimeout(() => document.addEventListener("click", close), 0);
-                    }
+                    activePopupCloseHandler = close;
+                    setTimeout(() => document.addEventListener("click", close), 0);
                   }
                 }}
                 title="Actions"
@@ -1236,9 +1249,10 @@ export function renderChat(props: ChatProps) {
               </button>
               <div class="agent-chat__actions-popup">
                 <button class="agent-chat__actions-item" @click=${(e: Event) => {
-                  (e.target as HTMLElement)
-                    .closest(".agent-chat__actions-popup")
-                    ?.classList.remove("agent-chat__actions-popup--open");
+                  const popup = (e.target as HTMLElement).closest(".agent-chat__actions-popup");
+                  if (popup) {
+                    dismissActionsPopup(popup);
+                  }
                   document.querySelector<HTMLInputElement>(".agent-chat__file-input")?.click();
                 }}>
                   <span class="agent-chat__actions-item-icon">${icons.paperclip}</span>
@@ -1249,9 +1263,10 @@ export function renderChat(props: ChatProps) {
                     ? nothing
                     : html`
                   <button class="agent-chat__actions-item" @click=${(e: Event) => {
-                    (e.target as HTMLElement)
-                      .closest(".agent-chat__actions-popup")
-                      ?.classList.remove("agent-chat__actions-popup--open");
+                    const popup = (e.target as HTMLElement).closest(".agent-chat__actions-popup");
+                    if (popup) {
+                      dismissActionsPopup(popup);
+                    }
                     props.onNewSession();
                   }}>
                     <span class="agent-chat__actions-item-icon">${icons.plus}</span>
@@ -1260,9 +1275,10 @@ export function renderChat(props: ChatProps) {
                 `
                 }
                 <button class="agent-chat__actions-item" @click=${(e: Event) => {
-                  (e.target as HTMLElement)
-                    .closest(".agent-chat__actions-popup")
-                    ?.classList.remove("agent-chat__actions-popup--open");
+                  const popup = (e.target as HTMLElement).closest(".agent-chat__actions-popup");
+                  if (popup) {
+                    dismissActionsPopup(popup);
+                  }
                   exportMarkdown(props);
                 }} ?disabled=${props.messages.length === 0}>
                   <span class="agent-chat__actions-item-icon">${icons.download}</span>

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1210,16 +1210,66 @@ export function renderChat(props: ChatProps) {
 
         <div class="agent-chat__toolbar">
           <div class="agent-chat__toolbar-left">
-            <button
-              class="agent-chat__input-btn"
-              @click=${() => {
-                document.querySelector<HTMLInputElement>(".agent-chat__file-input")?.click();
-              }}
-              title="Attach file"
-              ?disabled=${!props.connected}
-            >
-              ${icons.paperclip}
-            </button>
+            <div class="agent-chat__actions-menu-wrap">
+              <button
+                class="agent-chat__input-btn"
+                @click=${(e: Event) => {
+                  const wrap = (e.currentTarget as HTMLElement).parentElement!;
+                  const menu = wrap.querySelector(".agent-chat__actions-popup") as HTMLElement;
+                  if (menu) {
+                    menu.classList.toggle("agent-chat__actions-popup--open");
+                    const close = (ev: MouseEvent) => {
+                      if (!wrap.contains(ev.target as Node)) {
+                        menu.classList.remove("agent-chat__actions-popup--open");
+                        document.removeEventListener("click", close);
+                      }
+                    };
+                    if (menu.classList.contains("agent-chat__actions-popup--open")) {
+                      setTimeout(() => document.addEventListener("click", close), 0);
+                    }
+                  }
+                }}
+                title="Actions"
+                ?disabled=${!props.connected}
+              >
+                ${icons.plus}
+              </button>
+              <div class="agent-chat__actions-popup">
+                <button class="agent-chat__actions-item" @click=${() => {
+                  document.querySelector<HTMLInputElement>(".agent-chat__file-input")?.click();
+                  document
+                    .querySelector(".agent-chat__actions-popup")
+                    ?.classList.remove("agent-chat__actions-popup--open");
+                }}>
+                  <span class="agent-chat__actions-item-icon">${icons.paperclip}</span>
+                  <span class="agent-chat__actions-item-label">Joindre un fichier</span>
+                </button>
+                ${
+                  canAbort
+                    ? nothing
+                    : html`
+                  <button class="agent-chat__actions-item" @click=${() => {
+                    props.onNewSession();
+                    document
+                      .querySelector(".agent-chat__actions-popup")
+                      ?.classList.remove("agent-chat__actions-popup--open");
+                  }}>
+                    <span class="agent-chat__actions-item-icon">${icons.plus}</span>
+                    <span class="agent-chat__actions-item-label">Nouvelle session</span>
+                  </button>
+                `
+                }
+                <button class="agent-chat__actions-item" @click=${() => {
+                  exportMarkdown(props);
+                  document
+                    .querySelector(".agent-chat__actions-popup")
+                    ?.classList.remove("agent-chat__actions-popup--open");
+                }} ?disabled=${props.messages.length === 0}>
+                  <span class="agent-chat__actions-item-icon">${icons.download}</span>
+                  <span class="agent-chat__actions-item-label">Exporter la conversation</span>
+                </button>
+              </div>
+            </div>
 
             ${
               isSttSupported()
@@ -1279,25 +1329,6 @@ export function renderChat(props: ChatProps) {
           </div>
 
           <div class="agent-chat__toolbar-right">
-            ${nothing /* search hidden for now */}
-            ${
-              canAbort
-                ? nothing
-                : html`
-                    <button
-                      class="btn-ghost"
-                      @click=${props.onNewSession}
-                      title="New session"
-                      aria-label="New session"
-                    >
-                      ${icons.plus}
-                    </button>
-                  `
-            }
-            <button class="btn-ghost" @click=${() => exportMarkdown(props)} title="Export" ?disabled=${props.messages.length === 0}>
-              ${icons.download}
-            </button>
-
             ${
               canAbort && (isBusy || props.sending)
                 ? html`

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1235,38 +1235,38 @@ export function renderChat(props: ChatProps) {
                 ${icons.plus}
               </button>
               <div class="agent-chat__actions-popup">
-                <button class="agent-chat__actions-item" @click=${() => {
-                  document.querySelector<HTMLInputElement>(".agent-chat__file-input")?.click();
-                  document
-                    .querySelector(".agent-chat__actions-popup")
+                <button class="agent-chat__actions-item" @click=${(e: Event) => {
+                  (e.target as HTMLElement)
+                    .closest(".agent-chat__actions-popup")
                     ?.classList.remove("agent-chat__actions-popup--open");
+                  document.querySelector<HTMLInputElement>(".agent-chat__file-input")?.click();
                 }}>
                   <span class="agent-chat__actions-item-icon">${icons.paperclip}</span>
-                  <span class="agent-chat__actions-item-label">Joindre un fichier</span>
+                  <span class="agent-chat__actions-item-label">Attach file</span>
                 </button>
                 ${
                   canAbort
                     ? nothing
                     : html`
-                  <button class="agent-chat__actions-item" @click=${() => {
-                    props.onNewSession();
-                    document
-                      .querySelector(".agent-chat__actions-popup")
+                  <button class="agent-chat__actions-item" @click=${(e: Event) => {
+                    (e.target as HTMLElement)
+                      .closest(".agent-chat__actions-popup")
                       ?.classList.remove("agent-chat__actions-popup--open");
+                    props.onNewSession();
                   }}>
                     <span class="agent-chat__actions-item-icon">${icons.plus}</span>
-                    <span class="agent-chat__actions-item-label">Nouvelle session</span>
+                    <span class="agent-chat__actions-item-label">New session</span>
                   </button>
                 `
                 }
-                <button class="agent-chat__actions-item" @click=${() => {
-                  exportMarkdown(props);
-                  document
-                    .querySelector(".agent-chat__actions-popup")
+                <button class="agent-chat__actions-item" @click=${(e: Event) => {
+                  (e.target as HTMLElement)
+                    .closest(".agent-chat__actions-popup")
                     ?.classList.remove("agent-chat__actions-popup--open");
+                  exportMarkdown(props);
                 }} ?disabled=${props.messages.length === 0}>
                   <span class="agent-chat__actions-item-icon">${icons.download}</span>
-                  <span class="agent-chat__actions-item-label">Exporter la conversation</span>
+                  <span class="agent-chat__actions-item-label">Export conversation</span>
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Redesigns the Control UI chat interface and replaces the full-width update banner with a polished centered modal.

### Chat layout improvements
- **Centered content area** with refined max-width and spacing for better readability
- **Improved grouped message rendering** with cleaner bubble styling and tighter vertical rhythm
- **Typography refinements** — adjusted font sizes, line heights, and color contrast for message text
- **Icon cleanup** — streamlined icon sizing and stroke consistency
- **Pixel lobster mascot** (`lobster.svg`) added as a custom branding asset

### Update modal redesign
The old full-width sticky banner (`update-banner`) was replaced with a centered modal dialog:
- **Backdrop blur overlay** with smooth fade-in animation
- **Card entrance** with scale + translateY spring easing (`cubic-bezier(0.16, 1, 0.3, 1)`)
- **Pulsing download icon** as visual indicator
- **Version badge** showing available vs. current version
- **"Ready to install" tag** for clear status communication
- **Two-button layout**: "Later" (dismiss) and "Update now" (primary action)
- **Loading spinner** with rotation animation during update
- **Click-outside dismiss** for quick closure
- **Auto-dismiss** on successful update — no stale banner left behind
- **No external dependencies** — all animations are pure CSS (keyframes + transitions)

### Before / After

| Before | After |
|--------|-------|
| Full-width red banner pinned to top of content area | Centered modal card with backdrop overlay |
| Static text with inline buttons | Animated entrance, pulsing icon, interactive buttons with press feedback |
| Banner persists after update completes | Auto-dismisses on success |

## Files changed

| File | What changed |
|------|-------------|
| `ui/src/styles/chat/grouped.css` | Refined grouped message bubble spacing and layout |
| `ui/src/styles/chat/layout.css` | Centered chat content, improved responsive constraints |
| `ui/src/styles/chat/text.css` | Adjusted text sizing and color tokens |
| `ui/src/styles/components.css` | Replaced `.update-banner` with `.update-modal` system (animations, overlay, card, buttons, spinner) |
| `ui/src/ui/app-render.ts` | Replaced banner HTML with modal dialog markup |
| `ui/src/ui/chat/grouped-render.ts` | Cleaned up grouped message render logic |
| `ui/src/ui/icons.ts` | Adjusted icon dimensions and stroke attributes |
| `ui/src/ui/views/chat.ts` | Refined chat view structure and spacing |
| `ui/public/lobster.svg` | New pixel art lobster mascot |

## Test plan

- [ ] Open Control UI → Chat tab → verify centered layout, message spacing, and text readability
- [ ] Trigger an update notification → verify modal appears with fade + scale animation
- [ ] Click "Later" → modal dismisses
- [ ] Click outside modal → modal dismisses
- [ ] Click "Update now" → spinner appears, update runs
- [ ] After successful update → modal auto-dismisses
- [ ] After failed/skipped update → modal stays with error context
- [ ] Verify no regressions on other Control UI tabs (Config, Logs, Agents, etc.)
- [ ] Test on both light and dark themes if applicable