### PR TITLE
fix(web-search): add diagnostic logging for API key resolution failures

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { AnyAgentTool } from "./common.js";
 import { formatCliCommand } from "../../cli/command-format.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
@@ -17,6 +18,8 @@ import {
   withTimeout,
   writeCache,
 } from "./web-shared.js";
+
+const log = createSubsystemLogger("web-search");
 
 const SEARCH_PROVIDERS = ["brave", "perplexity", "grok"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
@@ -671,6 +674,8 @@ export function createWebSearchTool(options?: {
   const perplexityConfig = resolvePerplexityConfig(search);
   const grokConfig = resolveGrokConfig(search);
 
+  log.debug(`web_search tool created: provider=${provider}`);
+
   const description =
     provider === "perplexity"
       ? "Search the web using Perplexity Sonar (direct or via OpenRouter). Returns AI-synthesized answers with citations from real-time web search."
@@ -694,6 +699,22 @@ export function createWebSearchTool(options?: {
             : resolveSearchApiKey(search);
 
       if (!apiKey) {
+        const envKeyName =
+          provider === "perplexity"
+            ? "PERPLEXITY_API_KEY"
+            : provider === "grok"
+              ? "XAI_API_KEY"
+              : "BRAVE_API_KEY";
+        const envPresent = !!process.env[envKeyName];
+        const envLength = process.env[envKeyName]?.length ?? 0;
+        log.warn(
+          `web_search (${provider}): API key not resolved. ` +
+            `env ${envKeyName} present=${envPresent} len=${envLength}, ` +
+            `config apiKey present=${!!(search && "apiKey" in search && search.apiKey)}` +
+            (provider === "perplexity"
+              ? `, perplexity config apiKey present=${!!perplexityConfig?.apiKey}, source=${perplexityAuth?.source ?? "n/a"}`
+              : ""),
+        );
         return jsonResult(missingSearchKeyPayload(provider));
       }
       const params = args as Record<string, unknown>;


### PR DESCRIPTION
## Summary

Adds diagnostic logging to `web_search` tool when API key resolution fails, making it possible to diagnose issues like #53857 from gateway logs.

**Problem**: When `web_search` cannot resolve an API key, it returns a generic JSON error (`missing_*_api_key`) to the LLM, which paraphrases it as *"API key not configured."* There is zero logging in the gateway, so users cannot tell:
- Whether the tool was actually called by the LLM (vs the LLM hallucinating the error)
- Which key sources were checked (env var, config, provider-specific config)
- Whether the env var is present but empty, malformed, or truly missing

**Fix**: Two log lines, purely additive:
1. **`warn`** when key resolution fails inside `execute()` — logs which env var was checked, whether it was present, its length (not the value), and which config paths were inspected
2. **`debug`** at tool creation time — logs which provider was selected so users can verify config parsing

No secret values are logged. No behavior changes.

**Example output** (when `PERPLEXITY_API_KEY` is set but somehow not resolved):
```
[web-search] WARN: web_search (perplexity): API key not resolved. env PERPLEXITY_API_KEY present=true len=43, config apiKey present=false, perplexity config apiKey present=false, source=none
```

This would immediately tell the user (and maintainers) that the env var IS present but `resolvePerplexityApiKey` returned source=none, pointing to a normalization or config-loading issue rather than a missing key.

Refs #53857

## Test plan

- [ ] `pnpm build` passes (no new imports that break the build — `createSubsystemLogger` is already used throughout the codebase)
- [ ] `pnpm check` passes (logging follows existing patterns)
- [ ] Manual: set `PERPLEXITY_API_KEY` or `BRAVE_API_KEY`, run gateway with `--verbose`, ask a web search question, verify diagnostic log line appears in gateway output when key resolution fails