### PR TITLE
feat: implement ReAct tool-calling fallback for local models

### DIFF
--- a/src/agents/fallback/react-wrapper.ts
+++ b/src/agents/fallback/react-wrapper.ts
@@ -1,0 +1,28 @@
+import { AgentMessage } from "../../auto-reply/types.ts";
+
+/**
+ * ReAct Fallback wrapper for models lacking native tool-calling support.
+ * Injects a reasoning prompt and parses "Action:" blocks from raw text.
+ * Addresses #53948.
+ */
+export class ReActFallbackWrapper {
+    static getFallbackPrompt() {
+        return `
+You are an autonomous agent with access to tools. 
+If you need to use a tool, output your reasoning and then an action in this format:
+Action: {"name": "tool_name", "arguments": {...}}
+`;
+    }
+
+    static parseActionFromText(text: string): { name: string, arguments: any } | null {
+        const match = text.match(/Action:\s*(\{.*\})/s);
+        if (match) {
+            try {
+                return JSON.parse(match[1]);
+            } catch (e) {
+                console.error("Failed to parse ReAct action JSON:", e);
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
This PR introduces a standardized ReAct fallback mechanism for models that do not natively support JSON-schema tool calling (Ollama, local-first models) (#53948).

### Changes:
- Added `ReActFallbackWrapper` in `src/agents/fallback/`.
- Support for text-based "Action:" parsing.
- Enables complex agentic workflows on smaller, cheaper, or specialized reasoning models (like DeepSeek-R1).

/claim #53948