### PR TITLE
fix: use American English spelling in docs, tests, and comments

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -80,7 +80,7 @@ Context window is model-specific. OpenClaw uses the model definition from the co
 
 ## Compaction vs pruning
 
-- **Compaction**: summarises and **persists** in JSONL.
+- **Compaction**: summarizes and **persists** in JSONL.
 - **Session pruning**: trims old **tool results** only, **in-memory**, per request.
 
 See [/concepts/session-pruning](/concepts/session-pruning) for pruning details.

--- a/src/commands/signal-install.test.ts
+++ b/src/commands/signal-install.test.ts
@@ -41,15 +41,15 @@ const SAMPLE_ASSETS: ReleaseAsset[] = [
 ];
 
 describe("looksLikeArchive", () => {
-  it("recognises .tar.gz", () => {
+  it("recognizes .tar.gz", () => {
     expect(looksLikeArchive("foo.tar.gz")).toBe(true);
   });
 
-  it("recognises .tgz", () => {
+  it("recognizes .tgz", () => {
     expect(looksLikeArchive("foo.tgz")).toBe(true);
   });
 
-  it("recognises .zip", () => {
+  it("recognizes .zip", () => {
     expect(looksLikeArchive("foo.zip")).toBe(true);
   });
 

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -462,7 +462,7 @@ export function handleControlUiHttpRequest(
 
   // If the requested path looks like a static asset (known extension), return
   // 404 rather than falling through to the SPA index.html fallback.  We check
-  // against the same set of extensions that contentTypeForExt() recognises so
+  // against the same set of extensions that contentTypeForExt() recognizes so
   // that dotted SPA routes (e.g. /user/jane.doe, /v2.0) still get the
   // client-side router fallback.
   if (STATIC_ASSET_EXTENSIONS.has(path.extname(fileRel).toLowerCase())) {


### PR DESCRIPTION
## Summary

- Problem: Several British English spellings exist in docs, test descriptions, and code comments
- Why it matters: CONTRIBUTING.md requires American English spelling in code, comments, docs, and UI strings
- What changed: "summarises" → "summarizes", "recognises" → "recognizes" (5 occurrences across 3 files)
- What did NOT change (scope boundary): No logic, no functionality, no APIs — only prose in docs, test description strings, and a code comment

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: n/a
- Related: n/a

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: n/a
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

1. `grep -rn "summarises\|recognises" docs/ src/` — shows 5 British English spellings before fix
2. Apply changes
3. Same grep returns zero hits after fix

### Expected

- Zero British English spellings in docs, comments, and test descriptions

### Actual

- All 5 occurrences fixed to American English

## Evidence

- [x] Trace/log snippets

Before:
```
docs/concepts/compaction.md:83:- **Compaction**: summarises and **persists** in JSONL.
src/commands/signal-install.test.ts:44:  it("recognises .tar.gz", () => {
src/commands/signal-install.test.ts:48:  it("recognises .tgz", () => {
src/commands/signal-install.test.ts:52:  it("recognises .zip", () => {
src/gateway/control-ui.ts:465:  // against the same set of extensions that contentTypeForExt() recognises so
```

After: all 5 lines use American English ("-izes" instead of "-ises").

## Human Verification (required)

- Verified scenarios: grep confirms no remaining British "-ises" spellings in affected files
- Edge cases checked: confirmed "recognises" in test file is only in `it()` description strings, not in assertions or logic
- What you did **not** verify: full test suite run (changes are description-string-only, no logic affected)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the commit
- Files/config to restore: n/a
- Known bad symptoms reviewers should watch for: none — changes are purely cosmetic

## Risks and Mitigations

None