### PR TITLE
fix(discord): use turn-source routing hints for exec approvals before session-key fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp/groups: track recent gateway-sent message IDs and suppress only matching group echoes, preserving owner `/status`, `/new`, and `/activation` commands from linked-account `fromMe` traffic. (#53624) Thanks @w-sss.
 - Runtime/build: stabilize long-lived lazy `dist` runtime entry paths and harden bundled plugin npm staging so local rebuilds stop breaking on missing hashed chunks or broken shell `npm` shims. (#53855) Thanks @vincentkoc.
 - Discord/timeouts: send a visible timeout reply when the inbound Discord worker times out before a final reply starts, including created auto-thread targets and queued-run ordering. (#53823) Thanks @Kimbo7870.
+- Discord/exec approvals: prefer Discord turn-source routing hints for subagent and cron approval delivery before falling back to legacy session-key channel parsing, so approval cards and DM redirect notices return to the original Discord channel/thread more reliably.
 
 ## 2026.3.23
 

--- a/extensions/discord/src/monitor/exec-approvals.test.ts
+++ b/extensions/discord/src/monitor/exec-approvals.test.ts
@@ -909,6 +909,110 @@ describe("DiscordExecApprovalHandler delivery routing", () => {
     clearPendingTimeouts(handler);
   });
 
+  it("uses turn-source channel hints before session-key fallback for non-channel sessions", async () => {
+    const handler = createHandler({
+      enabled: true,
+      approvers: ["123"],
+      target: "channel",
+    });
+    const internals = getHandlerInternals(handler);
+
+    mockSuccessfulDmDelivery({ throwOnUnexpectedRoute: true });
+
+    await internals.handleApprovalRequested(
+      createRequest({
+        sessionKey: "agent:search:subagent:abc",
+        turnSourceChannel: "discord",
+        turnSourceTo: "channel:999888777",
+        turnSourceThreadId: "444555666",
+      }),
+    );
+
+    expect(mockRestPost).toHaveBeenCalledWith(
+      Routes.channelMessages("999888777"),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          components: expect.any(Array),
+        }),
+      }),
+    );
+    expect(mockRestPost).not.toHaveBeenCalledWith(Routes.userChannels(), expect.anything());
+
+    clearPendingTimeouts(handler);
+  });
+
+  it("falls back to turn-source thread id when turn-source target is not usable", async () => {
+    const handler = createHandler({
+      enabled: true,
+      approvers: ["123"],
+      target: "channel",
+    });
+    const internals = getHandlerInternals(handler);
+
+    mockSuccessfulDmDelivery({ throwOnUnexpectedRoute: true });
+
+    await internals.handleApprovalRequested(
+      createRequest({
+        sessionKey: "agent:doctor:cron:abc",
+        turnSourceChannel: "discord",
+        turnSourceTo: "user:123",
+        turnSourceThreadId: "444555666",
+      }),
+    );
+
+    expect(mockRestPost).toHaveBeenCalledWith(
+      Routes.channelMessages("444555666"),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          components: expect.any(Array),
+        }),
+      }),
+    );
+    expect(mockRestPost).not.toHaveBeenCalledWith(Routes.userChannels(), expect.anything());
+
+    clearPendingTimeouts(handler);
+  });
+
+  it("posts the DM redirect note back to the turn-source channel when the session is not channel-encoded", async () => {
+    const handler = createHandler({
+      enabled: true,
+      approvers: ["123"],
+      target: "dm",
+    });
+    const internals = getHandlerInternals(handler);
+
+    mockSuccessfulDmDelivery({
+      noteChannelId: "999888777",
+      expectedNoteText: "I sent the allowed approvers DMs",
+      throwOnUnexpectedRoute: true,
+    });
+
+    await internals.handleApprovalRequested(
+      createRequest({
+        sessionKey: "agent:reporter:subagent:xyz",
+        turnSourceChannel: "discord",
+        turnSourceTo: "channel:999888777",
+      }),
+    );
+
+    expect(mockRestPost).toHaveBeenCalledWith(
+      Routes.channelMessages("999888777"),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          content: expect.stringContaining("I sent the allowed approvers DMs"),
+        }),
+      }),
+    );
+    expect(mockRestPost).toHaveBeenCalledWith(
+      Routes.channelMessages("dm-1"),
+      expect.objectContaining({
+        body: expect.any(Object),
+      }),
+    );
+
+    clearPendingTimeouts(handler);
+  });
+
   it("posts an in-channel note when target is dm and the request came from a non-DM discord conversation", async () => {
     const handler = createHandler({
       enabled: true,

--- a/extensions/discord/src/monitor/exec-approvals.ts
+++ b/extensions/discord/src/monitor/exec-approvals.ts
@@ -32,6 +32,7 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { compileSafeRegex, testRegexWithBoundedInput } from "openclaw/plugin-sdk/security-runtime";
 import { logDebug, logError } from "openclaw/plugin-sdk/text-runtime";
 import { createDiscordClient, stripUndefinedFields } from "../send.shared.js";
+import { resolveDiscordChannelId } from "../targets.js";
 import { DiscordUiContainer } from "../ui.js";
 
 const EXEC_APPROVAL_KEY = "execapproval";
@@ -45,6 +46,38 @@ export function extractDiscordChannelId(sessionKey?: string | null): string | nu
   // Session key format: agent:<id>:discord:channel:<channelId> or agent:<id>:discord:group:<channelId>
   const match = sessionKey.match(/discord:(?:channel|group):(\d+)/);
   return match ? match[1] : null;
+}
+
+function normalizeTurnSourceChannel(value?: string | null): string | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized ? normalized : null;
+}
+
+function resolveDiscordApprovalChannelId(params: {
+  sessionKey?: string | null;
+  turnSourceChannel?: string | null;
+  turnSourceTo?: string | null;
+  turnSourceThreadId?: string | number | null;
+}): string | null {
+  if (normalizeTurnSourceChannel(params.turnSourceChannel) === "discord") {
+    const turnSourceTo = params.turnSourceTo?.trim();
+    if (turnSourceTo) {
+      try {
+        return resolveDiscordChannelId(turnSourceTo);
+      } catch {
+        // Fall back to thread/session hints when the turn-source target is not a channel.
+      }
+    }
+
+    if (params.turnSourceThreadId != null && params.turnSourceThreadId !== "") {
+      const threadId = String(params.turnSourceThreadId).trim();
+      if (threadId) {
+        return threadId;
+      }
+    }
+  }
+
+  return extractDiscordChannelId(params.sessionKey);
 }
 
 function buildDiscordApprovalDmRedirectNotice(): { content: string } {
@@ -525,8 +558,13 @@ export class DiscordExecApprovalHandler {
     const sendToChannel = target === "channel" || target === "both";
     let fallbackToDm = false;
     const originatingChannelId =
-      request.request.sessionKey && target === "dm"
-        ? extractDiscordChannelId(request.request.sessionKey)
+      target === "dm"
+        ? resolveDiscordApprovalChannelId({
+            sessionKey: request.request.sessionKey,
+            turnSourceChannel: request.request.turnSourceChannel,
+            turnSourceTo: request.request.turnSourceTo,
+            turnSourceThreadId: request.request.turnSourceThreadId,
+          })
         : null;
 
     if (target === "dm" && originatingChannelId) {
@@ -545,7 +583,12 @@ export class DiscordExecApprovalHandler {
 
     // Send to originating channel if configured
     if (sendToChannel) {
-      const channelId = extractDiscordChannelId(request.request.sessionKey);
+      const channelId = resolveDiscordApprovalChannelId({
+        sessionKey: request.request.sessionKey,
+        turnSourceChannel: request.request.turnSourceChannel,
+        turnSourceTo: request.request.turnSourceTo,
+        turnSourceThreadId: request.request.turnSourceThreadId,
+      });
       if (channelId) {
         try {
           const message = (await discordRequest(


### PR DESCRIPTION
## Summary

- Fix Discord exec approval routing for non-channel-encoded sessions such as subagents and cron runs.
- Prefer gateway turn-source hints (`turnSourceChannel`, `turnSourceTo`, `turnSourceThreadId`) before falling back to legacy session-key parsing.
- Preserve existing fallback behavior when no Discord turn-source route is available.
- Scope is limited to Discord exec approval route resolution; no gateway schema or approvals architecture changes.

## Why

Discord exec approvals could incorrectly fall back to DM delivery when the session key did not encode a Discord channel, even though the gateway request already included enough routing metadata to return to the original Discord channel or thread.

## Verification

- `pnpm test -- extensions/discord/src/monitor/exec-approvals.test.ts`
- Clean Docker validation: `pnpm install --frozen-lockfile && pnpm build`

## Tests Added

- Routes subagent approvals back to `turnSourceTo`
- Falls back to `turnSourceThreadId` when `turnSourceTo` is not a channel target
- Sends DM redirect notes back to the originating Discord channel for non-channel-encoded sessions
- Preserves legacy DM fallback when no route can be resolved
