### PR TITLE
fix(whatsapp): pre-transcribe inbound voice notes before bootstrap

### DIFF
--- a/extensions/whatsapp/src/inbound.media.test.ts
+++ b/extensions/whatsapp/src/inbound.media.test.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   mockExtractMessageContent,
   mockGetContentType,
@@ -12,9 +12,39 @@ import {
 
 type MockMessageInput = Parameters<typeof mockNormalizeMessageContent>[0];
 
-const readAllowFromStoreMock = vi.fn().mockResolvedValue([]);
-const upsertPairingRequestMock = vi.fn().mockResolvedValue({ code: "PAIRCODE", created: true });
-const saveMediaBufferSpy = vi.fn();
+const {
+  readAllowFromStoreMock,
+  upsertPairingRequestMock,
+  saveMediaBufferSpy,
+  transcribeOpenAiCompatibleAudioMock,
+  sendMessageSpy,
+} = vi.hoisted(() => ({
+  readAllowFromStoreMock: vi.fn().mockResolvedValue([]),
+  upsertPairingRequestMock: vi.fn().mockResolvedValue({ code: "PAIRCODE", created: true }),
+  saveMediaBufferSpy: vi.fn(),
+  transcribeOpenAiCompatibleAudioMock: vi.fn(),
+  sendMessageSpy: vi.fn().mockResolvedValue(undefined),
+}));
+
+const DEFAULT_TEST_CONFIG = {
+  channels: {
+    whatsapp: {
+      allowFrom: ["*"],
+    },
+  },
+  tools: {
+    media: {
+      audio: {
+        enabled: true,
+        models: [{ provider: "openai", model: "gpt-4o-transcribe", timeoutSeconds: 45 }],
+      },
+    },
+  },
+  messages: {
+    messagePrefix: undefined,
+    responsePrefix: undefined,
+  },
+};
 
 vi.mock("openclaw/plugin-sdk/config-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/config-runtime")>(
@@ -22,17 +52,7 @@ vi.mock("openclaw/plugin-sdk/config-runtime", async () => {
   );
   return {
     ...actual,
-    loadConfig: vi.fn().mockReturnValue({
-      channels: {
-        whatsapp: {
-          allowFrom: ["*"], // Allow all in tests
-        },
-      },
-      messages: {
-        messagePrefix: undefined,
-        responsePrefix: undefined,
-      },
-    }),
+    loadConfig: vi.fn().mockReturnValue(DEFAULT_TEST_CONFIG),
   };
 });
 
@@ -57,6 +77,16 @@ vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
       saveMediaBufferSpy(...args);
       return actual.saveMediaBuffer(...args);
     }),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/media-understanding", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/media-understanding")>(
+    "openclaw/plugin-sdk/media-understanding",
+  );
+  return {
+    ...actual,
+    transcribeOpenAiCompatibleAudio: transcribeOpenAiCompatibleAudioMock,
   };
 });
 
@@ -98,7 +128,7 @@ vi.mock("./session.js", async () => {
     ev,
     ws: { close: vi.fn() },
     sendPresenceUpdate: vi.fn().mockResolvedValue(undefined),
-    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendMessage: sendMessageSpy,
     readMessages: vi.fn().mockResolvedValue(undefined),
     updateMediaMessage: vi.fn(),
     logger: {},
@@ -135,12 +165,19 @@ describe("web inbound media saves with extension", () => {
     vi.useRealTimers();
     vi.resetModules();
     saveMediaBufferSpy.mockClear();
+    sendMessageSpy.mockClear();
+    transcribeOpenAiCompatibleAudioMock.mockReset();
   });
 
   beforeEach(async () => {
     ({ monitorWebInbox, resetWebInboundDedupe } = await import("./inbound.js"));
     ({ createWaSocket } = await import("./session.js"));
     resetWebInboundDedupe();
+  });
+
+  afterEach(async () => {
+    const { loadConfig } = await import("openclaw/plugin-sdk/config-runtime");
+    vi.mocked(loadConfig).mockReturnValue(DEFAULT_TEST_CONFIG as ReturnType<typeof loadConfig>);
   });
 
   beforeAll(async () => {
@@ -259,5 +296,100 @@ describe("web inbound media saves with extension", () => {
     expect(lastCall?.[3]).toBe(1 * 1024 * 1024);
 
     await listener.close();
+  });
+
+  it("pretranscribes inbound audio before forwarding to the agent", async () => {
+    process.env.OPENAI_API_KEY = "test-openai-key";
+    transcribeOpenAiCompatibleAudioMock.mockResolvedValue({
+      text: "ses notu transcript",
+      model: "gpt-4o-transcribe",
+    });
+
+    const onMessage = vi.fn();
+    const listener = await monitorWebInbox({
+      verbose: false,
+      onMessage,
+      accountId: "default",
+      authDir: path.join(HOME, "wa-auth"),
+    });
+    const realSock = await getMockSocket();
+
+    realSock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: { id: "aud1", fromMe: false, remoteJid: "444@s.whatsapp.net" },
+          message: { audioMessage: { mimetype: "audio/ogg; codecs=opus" } },
+          messageTimestamp: 1_700_000_005,
+        },
+      ],
+    });
+
+    const inbound = await waitForMessage(onMessage);
+    expect(transcribeOpenAiCompatibleAudioMock).toHaveBeenCalledTimes(1);
+    expect(inbound.body).toBe("ses notu transcript");
+    expect(inbound.mediaPath).toBeUndefined();
+    expect(inbound.mediaType).toBeUndefined();
+
+    await listener.close();
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  it("echoes transcript when inbound audio echoTranscript is enabled", async () => {
+    process.env.OPENAI_API_KEY = "test-openai-key";
+    transcribeOpenAiCompatibleAudioMock.mockResolvedValue({
+      text: "echo transcript",
+      model: "gpt-4o-transcribe",
+    });
+    const { loadConfig } = await import("openclaw/plugin-sdk/config-runtime");
+    vi.mocked(loadConfig).mockReturnValue({
+      channels: {
+        whatsapp: {
+          allowFrom: ["*"],
+        },
+      },
+      tools: {
+        media: {
+          audio: {
+            enabled: true,
+            echoTranscript: true,
+            echoFormat: "🎙️ Transcript:\n{transcript}",
+            models: [{ provider: "openai", model: "gpt-4o-transcribe", timeoutSeconds: 45 }],
+          },
+        },
+      },
+      messages: {
+        messagePrefix: undefined,
+        responsePrefix: undefined,
+      },
+    } as ReturnType<typeof loadConfig>);
+
+    const onMessage = vi.fn();
+    const listener = await monitorWebInbox({
+      verbose: false,
+      onMessage,
+      accountId: "default",
+      authDir: path.join(HOME, "wa-auth"),
+    });
+    const realSock = await getMockSocket();
+
+    realSock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: { id: "aud2", fromMe: false, remoteJid: "555@s.whatsapp.net" },
+          message: { audioMessage: { mimetype: "audio/ogg; codecs=opus" } },
+          messageTimestamp: 1_700_000_006,
+        },
+      ],
+    });
+
+    await waitForMessage(onMessage);
+    expect(sendMessageSpy).toHaveBeenCalledWith("555@s.whatsapp.net", {
+      text: "🎙️ Transcript:\necho transcript",
+    });
+
+    await listener.close();
+    delete process.env.OPENAI_API_KEY;
   });
 });

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -1,8 +1,11 @@
+import fs from "node:fs/promises";
 import type { AnyMessageContent, proto, WAMessage } from "@whiskeysockets/baileys";
 import { DisconnectReason, isJidGroup } from "@whiskeysockets/baileys";
 import { createInboundDebouncer, formatLocationText } from "openclaw/plugin-sdk/channel-inbound";
+import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import { recordChannelActivity } from "openclaw/plugin-sdk/infra-runtime";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
+import { transcribeOpenAiCompatibleAudio } from "openclaw/plugin-sdk/media-understanding";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/text-runtime";
@@ -27,9 +30,33 @@ import { createWebSendApi } from "./send-api.js";
 import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
 
 const LOGGED_OUT_STATUS = DisconnectReason?.loggedOut ?? 401;
+const DEFAULT_DIRECT_AUDIO_TRANSCRIBE_MODEL = "gpt-4o-transcribe";
+const DEFAULT_ECHO_TRANSCRIPT_FORMAT = '📝 "{transcript}"';
+
+type InboundAudioUnderstandingConfig = {
+  enabled?: boolean;
+  prompt?: string;
+  timeoutSeconds?: number;
+  language?: string;
+  echoTranscript?: boolean;
+  echoFormat?: string;
+  models?: Array<{
+    provider?: string;
+    model?: string;
+    timeoutSeconds?: number;
+  }>;
+};
 
 function isGroupJid(jid: string): boolean {
   return (typeof isJidGroup === "function" ? isJidGroup(jid) : jid.endsWith("@g.us")) === true;
+}
+
+function isAudioMediaType(mediaType: string | undefined): boolean {
+  return /^audio\//i.test((mediaType ?? "").trim());
+}
+
+function formatEchoTranscript(transcript: string, format: string): string {
+  return format.replaceAll("{transcript}", transcript);
 }
 
 export async function monitorWebInbox(options: {
@@ -307,6 +334,85 @@ export async function monitorWebInbox(options: {
     mediaFileName?: string;
   };
 
+  const maybeTranscribeInboundAudio = async (params: {
+    body: string;
+    mediaPath?: string;
+    mediaType?: string;
+    mediaFileName?: string;
+    chatJid: string;
+  }): Promise<{
+    body: string;
+    consumedAudio: boolean;
+  }> => {
+    const normalizedBody = params.body.trim();
+    if (normalizedBody && normalizedBody !== "<media:audio>") {
+      return { body: params.body, consumedAudio: false };
+    }
+    if (!params.mediaPath || !isAudioMediaType(params.mediaType)) {
+      return { body: params.body, consumedAudio: false };
+    }
+
+    const audioCfg = loadConfig().tools?.media?.audio as
+      | InboundAudioUnderstandingConfig
+      | undefined;
+    if (!audioCfg || audioCfg.enabled === false) {
+      return { body: params.body, consumedAudio: false };
+    }
+
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      return { body: params.body, consumedAudio: false };
+    }
+
+    const configuredOpenAiModel = audioCfg.models?.find(
+      (entry) => entry?.provider?.trim().toLowerCase() === "openai",
+    );
+    const model = configuredOpenAiModel?.model?.trim() || DEFAULT_DIRECT_AUDIO_TRANSCRIBE_MODEL;
+    const timeoutMs = Math.max(
+      1000,
+      Math.floor((configuredOpenAiModel?.timeoutSeconds ?? audioCfg.timeoutSeconds ?? 20) * 1000),
+    );
+
+    try {
+      const mediaBuffer = await fs.readFile(params.mediaPath!);
+      const result = await transcribeOpenAiCompatibleAudio({
+        buffer: mediaBuffer,
+        fileName: params.mediaFileName?.trim() || "voice.ogg",
+        mime: params.mediaType,
+        apiKey,
+        defaultBaseUrl: "https://api.openai.com/v1",
+        defaultModel: DEFAULT_DIRECT_AUDIO_TRANSCRIBE_MODEL,
+        model,
+        language: audioCfg.language,
+        prompt: audioCfg.prompt,
+        timeoutMs,
+      });
+      const transcript = result.text?.trim();
+      if (!transcript) {
+        return { body: params.body, consumedAudio: false };
+      }
+      if (audioCfg.echoTranscript) {
+        await sock.sendMessage(params.chatJid, {
+          text: formatEchoTranscript(
+            transcript,
+            audioCfg.echoFormat ?? DEFAULT_ECHO_TRANSCRIPT_FORMAT,
+          ),
+        });
+      }
+      if (shouldLogVerbose()) {
+        logVerbose(
+          `whatsapp inbound audio transcribed via openai/${result.model ?? model} (${transcript.length} chars)`,
+        );
+      }
+      return { body: transcript, consumedAudio: true };
+    } catch (err) {
+      if (shouldLogVerbose()) {
+        logVerbose(`whatsapp inbound audio transcribe failed: ${String(err)}`);
+      }
+      return { body: params.body, consumedAudio: false };
+    }
+  };
+
   const enrichInboundMessage = async (msg: WAMessage): Promise<EnrichedInboundMessage | null> => {
     const location = extractLocationData(msg.message ?? undefined);
     const locationText = location ? formatLocationText(location) : undefined;
@@ -346,6 +452,20 @@ export async function monitorWebInbox(options: {
       }
     } catch (err) {
       logVerbose(`Inbound media download failed: ${String(err)}`);
+    }
+
+    const audioResolution = await maybeTranscribeInboundAudio({
+      body,
+      mediaPath,
+      mediaType,
+      mediaFileName,
+      chatJid: msg.key?.remoteJid ?? "",
+    });
+    body = audioResolution.body;
+    if (audioResolution.consumedAudio) {
+      mediaPath = undefined;
+      mediaType = undefined;
+      mediaFileName = undefined;
     }
 
     return {


### PR DESCRIPTION
Fixes #54030.

## Summary
- pre-transcribe inbound WhatsApp voice notes before agent/bootstrap
- inject the transcript as the inbound body when transcription succeeds
- preserve transcript echo behavior with focused inbound tests

## Why
Upgrades repeatedly regressed WhatsApp voice notes into raw `audio/ogg` inbound messages, which made the agent behave as if no transcript existed.

This keeps the fix in the inbound WhatsApp layer instead of broadening reply-pipeline behavior.

## Scope
- `extensions/whatsapp/src/inbound/monitor.ts`
- `extensions/whatsapp/src/inbound.media.test.ts`

## Validation
```bash
pnpm exec vitest run extensions/whatsapp/src/inbound.media.test.ts
```
