### PR TITLE
fix: strip trailing NO_REPLY from cron/isolated session delivery

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,5 +1,9 @@
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import {
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+  stripSilentToken,
+} from "../auto-reply/tokens.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
 import {
@@ -336,6 +340,17 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
         snapshot.latestAssistantText = undefined;
         snapshot.assistantFragments = [];
         continue;
+      }
+      // Strip trailing NO_REPLY from mixed-content text so reasoning noise
+      // preceding the token does not leak as visible subagent output.
+      if (text.includes(SILENT_REPLY_TOKEN)) {
+        const afterStrip = stripSilentToken(text, SILENT_REPLY_TOKEN);
+        if (!afterStrip.trim()) {
+          snapshot.latestSilentText = text;
+          snapshot.latestAssistantText = undefined;
+          snapshot.assistantFragments = [];
+          continue;
+        }
       }
       snapshot.latestSilentText = undefined;
       snapshot.latestAssistantText = text;
@@ -1459,7 +1474,10 @@ export async function runSubagentAnnounceFlow(params: {
       const fallbackReply = params.fallbackReply?.trim() ? params.fallbackReply.trim() : undefined;
       const fallbackIsSilent =
         Boolean(fallbackReply) &&
-        (isAnnounceSkip(fallbackReply) || isSilentReplyText(fallbackReply, SILENT_REPLY_TOKEN));
+        (isAnnounceSkip(fallbackReply) ||
+          isSilentReplyText(fallbackReply, SILENT_REPLY_TOKEN) ||
+          (fallbackReply!.includes(SILENT_REPLY_TOKEN) &&
+            !stripSilentToken(fallbackReply!, SILENT_REPLY_TOKEN).trim()));
 
       if (!reply) {
         reply = await readSubagentOutput(params.childSessionKey, outcome);
@@ -1499,7 +1517,12 @@ export async function runSubagentAnnounceFlow(params: {
         }
       }
 
-      if (isAnnounceSkip(reply) || isSilentReplyText(reply, SILENT_REPLY_TOKEN)) {
+      if (
+        isAnnounceSkip(reply) ||
+        isSilentReplyText(reply, SILENT_REPLY_TOKEN) ||
+        (reply?.includes(SILENT_REPLY_TOKEN) &&
+          !stripSilentToken(reply, SILENT_REPLY_TOKEN).trim())
+      ) {
         if (fallbackReply && !fallbackIsSilent) {
           reply = fallbackReply;
         } else {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -38,6 +38,7 @@ import {
   isSilentReplyPrefixText,
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
+  stripSilentToken,
 } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
@@ -162,6 +163,17 @@ export async function runAgentTurnWithFallback(params: {
             return { skip: true };
           }
           text = stripped.text;
+        }
+        // Strip trailing NO_REPLY from mixed-content text (mirrors HEARTBEAT_OK
+        // stripping above).  LLMs in cron/isolated sessions often emit analysis
+        // text before appending NO_REPLY.  If stripping leaves no content, treat
+        // the entire message as silent.
+        if (text?.includes(SILENT_REPLY_TOKEN) && !isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+          const afterStrip = stripSilentToken(text, SILENT_REPLY_TOKEN);
+          if (!afterStrip.trim()) {
+            return { skip: true };
+          }
+          text = afterStrip;
         }
         if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
           return { skip: true };


### PR DESCRIPTION
## Problem
Cron workers (isolated `agentTurn` sessions) often emit analysis/reasoning text before `NO_REPLY`. For example: `"All items are Tier 3.\nNO_REPLY"`. The delivery pipeline only recognizes exact-match `NO_REPLY` via `isSilentReplyText()`, so the analysis text leaks to the user as a notification.

## Root Cause
`stripSilentToken()` exists and handles trailing `NO_REPLY`, but is only called in `normalize-reply.ts` — not in the streaming delivery gate (`agent-runner-execution.ts`) or subagent announcement flow (`subagent-announce.ts`).

## Fix
Call `stripSilentToken()` for `NO_REPLY` in the same delivery normalization paths that already handle `HEARTBEAT_OK` stripping:

1. **`agent-runner-execution.ts`** — `normalizeStreamingText()`: Strip trailing `NO_REPLY` before the exact-match check. If stripping leaves no content, treat the message as silent (`{ skip: true }`). If content remains after stripping, deliver the cleaned text.

2. **`subagent-announce.ts`** — Three `isSilentReplyText` call sites updated to also detect trailing `NO_REPLY` via `stripSilentToken`:
   - Output snapshot summarization (line ~341)
   - Fallback reply silent detection (line ~1477)
   - Main reply silent check (line ~1519)

## Testing
- `"NO_REPLY"` → skip ✅ (unchanged, exact match)
- `"All items are Tier 3. NO_REPLY"` → skip ✅ (trailing strip leaves empty → silent)
- `"Here is your report\nNO_REPLY"` → skip ✅ (trailing strip, new behavior)
- `"NOREPLY Corp"` → deliver ✅ (no token match — `NO_REPLY` not present)
- `"Use NO_REPLY to silence"` → strip leaves `"Use"` + `"to silence"` → deliver ✅ (non-trailing, has remaining content)

Fixes a real issue where cron analysis text leaks to Discord notifications multiple times per day.