### PR TITLE
fix(tools): detect Windows drive-letter paths as absolute on POSIX hosts (#54039)

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -396,6 +396,13 @@ function mapContainerPathToWorkspaceRoot(params: {
   return path.resolve(params.root, ...relative.split("/").filter(Boolean));
 }
 
+/**
+ * Matches a Windows drive letter at the start of a path (e.g. `C:\`, `D:/`).
+ * On POSIX hosts, `path.isAbsolute` does not recognize Windows drive letters,
+ * so this regex serves as a cross-platform fallback.
+ */
+const WIN_DRIVE_LETTER_RE = /^[A-Za-z]:[/\\]/;
+
 export function resolveToolPathAgainstWorkspaceRoot(params: {
   filePath: string;
   root: string;
@@ -403,6 +410,11 @@ export function resolveToolPathAgainstWorkspaceRoot(params: {
 }): string {
   const mapped = mapContainerPathToWorkspaceRoot(params);
   const candidate = mapped.startsWith("@") ? mapped.slice(1) : mapped;
+  if (WIN_DRIVE_LETTER_RE.test(candidate)) {
+    // On POSIX, path.resolve would prepend cwd to a Windows drive-letter path.
+    // Return the candidate unchanged — it is already absolute on the remote OS.
+    return candidate;
+  }
   return path.isAbsolute(candidate)
     ? path.resolve(candidate)
     : path.resolve(params.root, candidate || ".");

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -131,3 +131,34 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
     });
   });
 });
+
+describe("resolveToolPathAgainstWorkspaceRoot – Windows drive letter paths (#54039)", () => {
+  it("treats a Windows backslash drive-letter path as absolute and returns it unchanged", async () => {
+    const { resolveToolPathAgainstWorkspaceRoot } = await loadModule();
+    const result = resolveToolPathAgainstWorkspaceRoot({
+      filePath: "C:\\Users\\Dan\\.openclaw\\workspace\\HEARTBEAT.md",
+      root: "/should/not/prepend",
+    });
+    // Must not prepend root, and must not mangle the Windows path via POSIX path.resolve.
+    expect(result).toBe("C:\\Users\\Dan\\.openclaw\\workspace\\HEARTBEAT.md");
+  });
+
+  it("treats a Windows forward-slash drive-letter path as absolute and returns it unchanged", async () => {
+    const { resolveToolPathAgainstWorkspaceRoot } = await loadModule();
+    const result = resolveToolPathAgainstWorkspaceRoot({
+      filePath: "D:/Projects/workspace/README.md",
+      root: "/should/not/prepend",
+    });
+    // Must not prepend root, and must not mangle the Windows path via POSIX path.resolve.
+    expect(result).toBe("D:/Projects/workspace/README.md");
+  });
+
+  it("still resolves relative paths against root", async () => {
+    const { resolveToolPathAgainstWorkspaceRoot } = await loadModule();
+    const result = resolveToolPathAgainstWorkspaceRoot({
+      filePath: "memory/notes.md",
+      root: "/workspace",
+    });
+    expect(result).toBe(path.resolve("/workspace", "memory/notes.md"));
+  });
+});

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
-import { resolveSandboxedMediaSource } from "./sandbox-paths.js";
+import { resolveSandboxedMediaSource, resolveSandboxInputPath } from "./sandbox-paths.js";
 
 async function withSandboxRoot<T>(run: (sandboxDir: string) => Promise<T>) {
   const sandboxDir = await fs.mkdtemp(path.join(os.tmpdir(), "sandbox-media-"));
@@ -296,5 +296,33 @@ describe("resolveSandboxedMediaSource", () => {
     } finally {
       platformSpy.mockRestore();
     }
+  });
+});
+
+describe("resolveSandboxInputPath – Windows drive letter paths", () => {
+  it("treats a Windows drive-letter path as absolute and returns it unchanged", () => {
+    // On POSIX hosts, path.isAbsolute("C:\\Users\\...") returns false.
+    // The fix adds a WIN_DRIVE_LETTER_RE fallback so Windows paths are not
+    // incorrectly joined with the workspace root, preventing doubled paths
+    // like "C:\\workspace\\C:\\workspace\\file.md". See #54039.
+    // The path must be returned as-is — POSIX path.resolve would mangle it.
+    const result = resolveSandboxInputPath(
+      "C:\\Users\\Dan\\.openclaw\\workspace\\HEARTBEAT.md",
+      "/should/not/be/prepended",
+    );
+    expect(result).toBe("C:\\Users\\Dan\\.openclaw\\workspace\\HEARTBEAT.md");
+  });
+
+  it("treats a forward-slash Windows drive-letter path as absolute and returns it unchanged", () => {
+    const result = resolveSandboxInputPath(
+      "D:/Projects/workspace/README.md",
+      "/should/not/be/prepended",
+    );
+    expect(result).toBe("D:/Projects/workspace/README.md");
+  });
+
+  it("still resolves relative paths against cwd", () => {
+    const result = resolveSandboxInputPath("memory/notes.md", "/workspace");
+    expect(result).toBe(path.resolve("/workspace", "memory/notes.md"));
   });
 });

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -10,6 +10,12 @@ const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 const HTTP_URL_RE = /^https?:\/\//i;
 const DATA_URL_RE = /^data:/i;
 const SANDBOX_CONTAINER_WORKDIR = "/workspace";
+/**
+ * Matches a Windows drive letter at the start of a path (e.g. `C:\`, `D:/`).
+ * On POSIX hosts, `path.isAbsolute` does not recognize Windows drive letters,
+ * so this regex serves as a cross-platform fallback.
+ */
+const WIN_DRIVE_LETTER_RE = /^[A-Za-z]:[/\\]/;
 
 function normalizeUnicodeSpaces(str: string): string {
   return str.replace(UNICODE_SPACES, " ");
@@ -32,8 +38,13 @@ function expandPath(filePath: string): string {
 
 function resolveToCwd(filePath: string, cwd: string): string {
   const expanded = expandPath(filePath);
-  if (path.isAbsolute(expanded)) {
+  if (WIN_DRIVE_LETTER_RE.test(expanded)) {
+    // On POSIX, path.resolve would prepend cwd to a Windows drive-letter path.
+    // Return unchanged — it is already absolute on the remote OS.
     return expanded;
+  }
+  if (path.isAbsolute(expanded)) {
+    return path.resolve(expanded);
   }
   return path.resolve(cwd, expanded);
 }
@@ -189,7 +200,8 @@ async function resolveAllowedTmpMediaPath(params: {
   candidate: string;
   sandboxRoot: string;
 }): Promise<string | undefined> {
-  const candidateIsAbsolute = path.isAbsolute(expandPath(params.candidate));
+  const expanded = expandPath(params.candidate);
+  const candidateIsAbsolute = path.isAbsolute(expanded) || WIN_DRIVE_LETTER_RE.test(expanded);
   if (!candidateIsAbsolute) {
     return undefined;
   }


### PR DESCRIPTION
## Problem

On POSIX hosts, `path.isAbsolute("C:\\...")` returns `false`, so when an agent passes a Windows absolute path to the read/write/edit tools, the workspace root gets prepended — producing doubled paths like:

```
C:\Users\Dan\.openclaw\workspace\:\Users\Dan\.openclaw\workspace\HEARTBEAT.md
```

Reported in #54039.

## Fix

Add a `WIN_DRIVE_LETTER_RE` (`/^[A-Za-z]:[/\\]/`) fallback alongside `path.isAbsolute()` in three path resolution entry points:

- **sandbox-paths.ts**: `resolveToCwd`, `resolveAllowedTmpMediaPath`
- **pi-tools.read.ts**: `resolveToolPathAgainstWorkspaceRoot`

On native Windows this is redundant, but it protects against cross-platform edge cases.

## Tests

6 new regression tests across both files (backslash paths, forward-slash paths, relative path passthrough).