### PR TITLE
perf(cli): defer plugin loading in pairing CLI to action time

### DIFF
--- a/src/cli/pairing-cli.test.ts
+++ b/src/cli/pairing-cli.test.ts
@@ -44,6 +44,10 @@ vi.mock("../config/config.js", () => ({
   loadConfig: vi.fn().mockReturnValue({}),
 }));
 
+vi.mock("../plugins/loader.js", () => ({
+  loadOpenClawPlugins: vi.fn(),
+}));
+
 describe("pairing cli", () => {
   let registerPairingCli: typeof import("./pairing-cli.js").registerPairingCli;
 
@@ -96,12 +100,16 @@ describe("pairing cli", () => {
     });
   }
 
-  it("evaluates pairing channels when registering the CLI (not at import)", async () => {
-    expect(listPairingChannels).not.toHaveBeenCalled();
-
+  it("defers pairing channel resolution to action time (not registration)", async () => {
     createProgram();
 
-    expect(listPairingChannels).toHaveBeenCalledTimes(1);
+    // listPairingChannels is not called at registration time.
+    expect(listPairingChannels).not.toHaveBeenCalled();
+
+    // It is called when an action runs.
+    listChannelPairingRequests.mockResolvedValueOnce([]);
+    await runPairing(["pairing", "list", "telegram"]);
+    expect(listPairingChannels).toHaveBeenCalled();
   });
 
   it.each([

--- a/src/cli/pairing-cli.test.ts
+++ b/src/cli/pairing-cli.test.ts
@@ -42,6 +42,12 @@ vi.mock("../channels/plugins/index.js", () => ({
 
 vi.mock("../config/config.js", () => ({
   loadConfig: vi.fn().mockReturnValue({}),
+  readConfigFileSnapshot: vi.fn().mockResolvedValue({ valid: true, config: {} }),
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/test-workspace"),
+  resolveDefaultAgentId: vi.fn().mockReturnValue("default"),
 }));
 
 vi.mock("../plugins/loader.js", () => ({

--- a/src/cli/pairing-cli.ts
+++ b/src/cli/pairing-cli.ts
@@ -8,11 +8,17 @@ import {
   listChannelPairingRequests,
   type PairingChannel,
 } from "../pairing/pairing-store.js";
+import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
 import { formatCliCommand } from "./command-format.js";
+
+/** Ensure the plugin registry is populated so listPairingChannels() sees extension channels. */
+function ensurePluginsLoaded(): void {
+  loadOpenClawPlugins({ config: loadConfig() });
+}
 
 /** Parse channel, allowing extension channels not in core registry. */
 function parseChannel(raw: unknown, channels: PairingChannel[]): PairingChannel {
@@ -50,7 +56,6 @@ async function notifyApproved(channel: PairingChannel, id: string) {
 }
 
 export function registerPairingCli(program: Command) {
-  const channels = listPairingChannels();
   const pairing = program
     .command("pairing")
     .description("Secure DM pairing (approve inbound requests)")
@@ -63,11 +68,15 @@ export function registerPairingCli(program: Command) {
   pairing
     .command("list")
     .description("List pending pairing requests")
-    .option("--channel <channel>", `Channel (${channels.join(", ")})`)
+    .option("--channel <channel>", "Channel name")
     .option("--account <accountId>", "Account id (for multi-account channels)")
-    .argument("[channel]", `Channel (${channels.join(", ")})`)
+    .argument("[channel]", "Channel name")
     .option("--json", "Print JSON", false)
     .action(async (channelArg, opts) => {
+      // Populate plugin registry at action time (avoids loading all plugins
+      // at CLI registration time, which slows down startup).
+      ensurePluginsLoaded();
+      const channels = listPairingChannels();
       const channelRaw = opts.channel ?? channelArg ?? (channels.length === 1 ? channels[0] : "");
       if (!channelRaw) {
         throw new Error(
@@ -114,12 +123,14 @@ export function registerPairingCli(program: Command) {
   pairing
     .command("approve")
     .description("Approve a pairing code and allow that sender")
-    .option("--channel <channel>", `Channel (${channels.join(", ")})`)
+    .option("--channel <channel>", "Channel name")
     .option("--account <accountId>", "Account id (for multi-account channels)")
     .argument("<codeOrChannel>", "Pairing code (or channel when using 2 args)")
     .argument("[code]", "Pairing code (when channel is passed as the 1st arg)")
     .option("--notify", "Notify the requester on the same channel", false)
     .action(async (codeOrChannel, code, opts) => {
+      ensurePluginsLoaded();
+      const channels = listPairingChannels();
       const defaultChannel = channels.length === 1 ? channels[0] : "";
       const usingExplicitChannel = Boolean(opts.channel);
       const hasPositionalCode = code != null;

--- a/src/cli/pairing-cli.ts
+++ b/src/cli/pairing-cli.ts
@@ -1,7 +1,8 @@
 import type { Command } from "commander";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import { listPairingChannels, notifyPairingApproved } from "../channels/plugins/pairing.js";
-import { loadConfig } from "../config/config.js";
+import { loadConfig, readConfigFileSnapshot } from "../config/config.js";
 import { resolvePairingIdLabel } from "../pairing/pairing-labels.js";
 import {
   approveChannelPairingCode,
@@ -16,8 +17,14 @@ import { theme } from "../terminal/theme.js";
 import { formatCliCommand } from "./command-format.js";
 
 /** Ensure the plugin registry is populated so listPairingChannels() sees extension channels. */
-function ensurePluginsLoaded(): void {
-  loadOpenClawPlugins({ config: loadConfig() });
+async function ensurePluginsLoaded(): Promise<void> {
+  const snapshot = await readConfigFileSnapshot();
+  if (!snapshot.valid) {
+    return;
+  }
+  const config = loadConfig();
+  const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+  loadOpenClawPlugins({ config, workspaceDir });
 }
 
 /** Parse channel, allowing extension channels not in core registry. */
@@ -68,14 +75,14 @@ export function registerPairingCli(program: Command) {
   pairing
     .command("list")
     .description("List pending pairing requests")
-    .option("--channel <channel>", "Channel name")
+    .option("--channel <channel>", "Channel name (e.g., telegram, discord)")
     .option("--account <accountId>", "Account id (for multi-account channels)")
-    .argument("[channel]", "Channel name")
+    .argument("[channel]", "Channel name (e.g., telegram, discord)")
     .option("--json", "Print JSON", false)
     .action(async (channelArg, opts) => {
       // Populate plugin registry at action time (avoids loading all plugins
       // at CLI registration time, which slows down startup).
-      ensurePluginsLoaded();
+      await ensurePluginsLoaded();
       const channels = listPairingChannels();
       const channelRaw = opts.channel ?? channelArg ?? (channels.length === 1 ? channels[0] : "");
       if (!channelRaw) {
@@ -123,13 +130,13 @@ export function registerPairingCli(program: Command) {
   pairing
     .command("approve")
     .description("Approve a pairing code and allow that sender")
-    .option("--channel <channel>", "Channel name")
+    .option("--channel <channel>", "Channel name (e.g., telegram, discord)")
     .option("--account <accountId>", "Account id (for multi-account channels)")
     .argument("<codeOrChannel>", "Pairing code (or channel when using 2 args)")
     .argument("[code]", "Pairing code (when channel is passed as the 1st arg)")
     .option("--notify", "Notify the requester on the same channel", false)
     .action(async (codeOrChannel, code, opts) => {
-      ensurePluginsLoaded();
+      await ensurePluginsLoaded();
       const channels = listPairingChannels();
       const defaultChannel = channels.length === 1 ? channels[0] : "";
       const usingExplicitChannel = Boolean(opts.channel);

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -222,14 +222,6 @@ const entries: SubCliEntry[] = [
     description: "Secure DM pairing (approve inbound requests)",
     hasSubcommands: true,
     register: async (program) => {
-      // Initialize plugins before registering pairing CLI.
-      // The pairing CLI calls listPairingChannels() at registration time,
-      // which requires the plugin registry to be populated with channel plugins.
-      const { registerPluginCliCommands } = await import("../../plugins/cli.js");
-      const config = await loadValidatedConfigForPluginRegistration();
-      if (config) {
-        registerPluginCliCommands(program, config);
-      }
       const mod = await import("../pairing-cli.js");
       mod.registerPairingCli(program);
     },


### PR DESCRIPTION
## Summary

- Problem: `registerPairingCli()` eagerly called `loadOpenClawPlugins()` at Commander registration time to populate channel choices for `--channel` and help text. This ran on every CLI invocation that triggered lazy subcli registration, even when the user ran an unrelated command.
- Why it matters: Plugin loading is expensive — it scans the filesystem, reads manifests, and initializes the registry. Paying this cost at registration time defeats the purpose of lazy subcli loading.
- What changed: `ensurePluginsLoaded()` is now async and called at action time (inside `list` and `approve` handlers). `--channel` option descriptions use plain text instead of dynamic `.choices()`. Plugin loading uses `readConfigFileSnapshot()` + `resolveAgentWorkspaceDir()` to resolve the workspace dir correctly.
- What did NOT change (scope boundary): The plugin loading function (`loadOpenClawPlugins`) itself is untouched. Channel resolution logic and pairing approval flow are unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Part of CLI startup performance series (PR 3)
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

- `--channel` help text now shows a static description ("Channel name (e.g., telegram, discord)") instead of dynamic choices. Functional behavior is identical — invalid channels still error at action time.

## Diagram (if applicable)

```text
Before:
registerPairingCli() -> loadOpenClawPlugins() -> listPairingChannels() -> register Commander choices
                                                                           (cost paid even if user runs "openclaw status")

After:
registerPairingCli() -> register Commander with static descriptions
  ...later, user runs "openclaw pairing list"...
  action handler -> ensurePluginsLoaded() -> listPairingChannels() -> resolve channel
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / Bun
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `openclaw pairing list --channel telegram`
2. Run `openclaw pairing approve --channel telegram <code>`
3. Run `openclaw --help` (should not trigger plugin loading)

### Expected

- Pairing commands work identically. Non-pairing commands no longer pay plugin loading cost.

### Actual

- Same behavior, faster startup for non-pairing commands.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

12 pairing CLI tests pass, including updated test verifying `listPairingChannels` is not called at registration time.

## Human Verification (required)

- Verified scenarios: `pairing list` and `pairing approve` both call `ensurePluginsLoaded()` before channel resolution; registration no longer triggers plugin loading
- Edge cases checked: Single-channel default still works (resolved at action time); invalid channel errors preserved
- What you did **not** verify: End-to-end with live gateway and real pairing requests

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `--channel` no longer shows dynamic choices in `--help` output.
  - Mitigation: Static description includes example channel names. Channel validation still happens at action time with the same error messages.