### PR TITLE
feat(google): make Gemini web search base URL configurable

### DIFF
--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -39,6 +39,10 @@
     "webSearch.model": {
       "label": "Gemini Search Model",
       "help": "Gemini model override for web search grounding."
+    },
+    "webSearch.baseUrl": {
+      "label": "Gemini Search Base URL",
+      "help": "Gemini API base URL override for web search grounding (e.g. for proxy or private endpoints)."
     }
   },
   "configSchema": {
@@ -53,6 +57,9 @@
             "type": ["string", "object"]
           },
           "model": {
+            "type": "string"
+          },
+          "baseUrl": {
             "type": "string"
           }
         }

--- a/extensions/google/src/gemini-web-search-provider.test.ts
+++ b/extensions/google/src/gemini-web-search-provider.test.ts
@@ -25,8 +25,11 @@ describe("gemini web search provider", () => {
     );
   });
 
-  it("prefers configured base URL over default", () => {
+  it("prefers configured base URL over default and normalizes it", () => {
     expect(__testing.resolveGeminiBaseUrl({ baseUrl: "https://custom.api.com" })).toBe(
+      "https://custom.api.com",
+    );
+    expect(__testing.resolveGeminiBaseUrl({ baseUrl: "https://custom.api.com/" })).toBe(
       "https://custom.api.com",
     );
   });

--- a/extensions/google/src/gemini-web-search-provider.test.ts
+++ b/extensions/google/src/gemini-web-search-provider.test.ts
@@ -15,4 +15,19 @@ describe("gemini web search provider", () => {
     expect(__testing.resolveGeminiModel({ model: "  " })).toBe("gemini-2.5-flash");
     expect(__testing.resolveGeminiModel({ model: "gemini-2.5-pro" })).toBe("gemini-2.5-pro");
   });
+
+  it("resolves the default base URL when unset or blank", () => {
+    expect(__testing.resolveGeminiBaseUrl()).toBe(
+      "https://generativelanguage.googleapis.com/v1beta",
+    );
+    expect(__testing.resolveGeminiBaseUrl({ baseUrl: "  " })).toBe(
+      "https://generativelanguage.googleapis.com/v1beta",
+    );
+  });
+
+  it("prefers configured base URL over default", () => {
+    expect(__testing.resolveGeminiBaseUrl({ baseUrl: "https://custom.api.com" })).toBe(
+      "https://custom.api.com",
+    );
+  });
 });

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -1,5 +1,8 @@
 import { Type } from "@sinclair/typebox";
-import { DEFAULT_GOOGLE_API_BASE_URL } from "openclaw/plugin-sdk/provider-google";
+import {
+  DEFAULT_GOOGLE_API_BASE_URL,
+  normalizeGoogleApiBaseUrl,
+} from "openclaw/plugin-sdk/provider-google";
 import {
   buildSearchCacheKey,
   buildUnsupportedSearchFilterResponse,
@@ -78,8 +81,7 @@ function resolveGeminiModel(gemini?: GeminiConfig): string {
 }
 
 function resolveGeminiBaseUrl(gemini?: GeminiConfig): string {
-  const baseUrl = typeof gemini?.baseUrl === "string" ? gemini.baseUrl.trim() : "";
-  return baseUrl || DEFAULT_GOOGLE_API_BASE_URL;
+  return normalizeGoogleApiBaseUrl(gemini?.baseUrl);
 }
 
 async function runGeminiSearch(params: {

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -28,11 +28,11 @@ import {
 } from "openclaw/plugin-sdk/provider-web-search";
 
 const DEFAULT_GEMINI_MODEL = "gemini-2.5-flash";
-const GEMINI_API_BASE = DEFAULT_GOOGLE_API_BASE_URL;
 
 type GeminiConfig = {
   apiKey?: string;
   model?: string;
+  baseUrl?: string;
 };
 
 type GeminiGroundingResponse = {
@@ -77,13 +77,19 @@ function resolveGeminiModel(gemini?: GeminiConfig): string {
   return model || DEFAULT_GEMINI_MODEL;
 }
 
+function resolveGeminiBaseUrl(gemini?: GeminiConfig): string {
+  const baseUrl = typeof gemini?.baseUrl === "string" ? gemini.baseUrl.trim() : "";
+  return baseUrl || DEFAULT_GOOGLE_API_BASE_URL;
+}
+
 async function runGeminiSearch(params: {
   query: string;
   apiKey: string;
   model: string;
+  baseUrl: string;
   timeoutSeconds: number;
 }): Promise<{ content: string; citations: Array<{ url: string; title?: string }> }> {
-  const endpoint = `${GEMINI_API_BASE}/models/${params.model}:generateContent`;
+  const endpoint = `${params.baseUrl}/models/${params.model}:generateContent`;
 
   return withTrustedWebSearchEndpoint(
     {
@@ -204,11 +210,13 @@ function createGeminiToolDefinition(
         searchConfig?.maxResults ??
         undefined;
       const model = resolveGeminiModel(geminiConfig);
+      const baseUrl = resolveGeminiBaseUrl(geminiConfig);
       const cacheKey = buildSearchCacheKey([
         "gemini",
         query,
         resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
         model,
+        baseUrl,
       ]);
       const cached = readCachedSearchPayload(cacheKey);
       if (cached) {
@@ -220,6 +228,7 @@ function createGeminiToolDefinition(
         query,
         apiKey,
         model,
+        baseUrl,
         timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
       });
       const payload = {
@@ -277,4 +286,5 @@ export function createGeminiWebSearchProvider(): WebSearchProviderPlugin {
 export const __testing = {
   resolveGeminiApiKey,
   resolveGeminiModel,
+  resolveGeminiBaseUrl,
 } as const;

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1109,6 +1109,9 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               model: {
                 type: "string",
               },
+              baseUrl: {
+                type: "string",
+              },
             },
           },
         },
@@ -1152,6 +1155,10 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
         "webSearch.model": {
           label: "Gemini Search Model",
           help: "Gemini model override for web search grounding.",
+        },
+        "webSearch.baseUrl": {
+          label: "Gemini Search Base URL",
+          help: "Gemini API base URL override for web search grounding (e.g. for proxy or private endpoints).",
         },
       },
     },


### PR DESCRIPTION
AI-assisted: Fully tested with pnpm test. This PR makes the Google Gemini Web Search provider support a configurable API base URL, consistent with the Google Gemini Embedding provider and other Google-related providers in the extension.