### PR TITLE
ui: improve Sessions page navigation with History shortcut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ docs/superpowers
 
 # Deprecated changelog fragment workflow
 changelog/fragments/
+.vs/

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -46,6 +46,7 @@ describe("handleControlUiHttpRequest", () => {
     method: "GET" | "HEAD" | "POST";
     rootPath: string;
     basePath?: string;
+    agentId?: string;
     rootKind?: "resolved" | "bundled";
   }) {
     const { res, end } = makeMockHttpResponse();
@@ -54,6 +55,7 @@ describe("handleControlUiHttpRequest", () => {
       res,
       {
         ...(params.basePath ? { basePath: params.basePath } : {}),
+        ...(params.agentId ? { agentId: params.agentId } : {}),
         root: { kind: params.rootKind ?? "resolved", path: params.rootPath },
       },
     );
@@ -107,6 +109,31 @@ describe("handleControlUiHttpRequest", () => {
       return await params.fn({ root, sibling });
     } finally {
       await fs.rm(tmp, { recursive: true, force: true });
+    }
+  }
+
+  async function withHistoryFixture<T>(params: {
+    agentId: string;
+    files: Record<string, string>;
+    fn: (paths: { stateDir: string; sessionsDir: string }) => Promise<T>;
+  }) {
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-history-"));
+    const sessionsDir = path.join(stateDir, "agents", params.agentId, "sessions");
+    try {
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      await fs.mkdir(sessionsDir, { recursive: true });
+      for (const [name, contents] of Object.entries(params.files)) {
+        await fs.writeFile(path.join(sessionsDir, name), contents);
+      }
+      return await params.fn({ stateDir, sessionsDir });
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
     }
   }
 
@@ -223,6 +250,62 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.assistantName).toBe("Ops");
         expect(parsed.assistantAvatar).toBe("/openclaw/avatar/main");
         expect(parsed.assistantAgentId).toBe("main");
+      },
+    });
+  });
+
+  it("serves the session history viewer under basePath for the configured agent", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        await withHistoryFixture({
+          agentId: "worker-42",
+          files: {
+            "session-1.jsonl":
+              [
+                JSON.stringify({
+                  type: "session",
+                  timestamp: "2026-03-25T00:00:00.000Z",
+                  id: "session-1",
+                }),
+                JSON.stringify({
+                  type: "message",
+                  timestamp: "2026-03-25T00:01:00.000Z",
+                  message: { role: "user", content: "Hello from history" },
+                  model: "openclaw/demo",
+                }),
+              ].join("\n") + "\n",
+          },
+          fn: async () => {
+            const { res, end, handled } = runControlUiRequest({
+              url: "/openclaw/history",
+              method: "GET",
+              rootPath: tmp,
+              basePath: "/openclaw",
+              agentId: "worker-42",
+            });
+
+            expect(handled).toBe(true);
+            expect(res.statusCode).toBe(200);
+            const html = String(end.mock.calls[0]?.[0] ?? "");
+            expect(html).toContain('<html lang="en">');
+            expect(html).toContain("/openclaw/history.js");
+            expect(html).toContain("Select a session");
+
+            const { end: scriptEnd, handled: scriptHandled } = runControlUiRequest({
+              url: "/openclaw/history.js",
+              method: "GET",
+              rootPath: tmp,
+              basePath: "/openclaw",
+              agentId: "worker-42",
+            });
+
+            expect(scriptHandled).toBe(true);
+            const js = String(scriptEnd.mock.calls[0]?.[0] ?? "");
+            expect(js).toContain("session-1.jsonl");
+            expect(js).toContain("Hello from history");
+            expect(js).toContain("messages");
+          },
+        });
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import { matchBoundaryFileOpenFailure, openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import {
   isPackageProvenControlUiRootSync,
@@ -33,6 +34,8 @@ import {
 const ROOT_PREFIX = "/";
 const CONTROL_UI_ASSETS_MISSING_MESSAGE =
   "Control UI assets not found. Build them with `pnpm ui:build` (auto-installs UI deps), or run `pnpm ui:dev` during development.";
+const MAX_HISTORY_FILES = 200;
+const MAX_HISTORY_BYTES = 50 * 1024 * 1024;
 
 export type ControlUiRequestOptions = {
   basePath?: string;
@@ -115,6 +118,34 @@ function applyControlUiSecurityHeaders(res: ServerResponse) {
   res.setHeader("Content-Security-Policy", buildControlUiCspHeader());
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("Referrer-Policy", "no-referrer");
+}
+
+function loadSessionHistoryFiles(agentId?: string): { name: string; b64: string }[] {
+  const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
+  const files: { name: string; b64: string }[] = [];
+  if (!fs.existsSync(sessionsDir)) {
+    return files;
+  }
+
+  const jsonlFiles = fs
+    .readdirSync(sessionsDir)
+    .filter((file) => file.endsWith(".jsonl") && !file.endsWith(".lock"))
+    .map((file) => ({ name: file, mtime: fs.statSync(path.join(sessionsDir, file)).mtimeMs }))
+    .toSorted((a, b) => b.mtime - a.mtime)
+    .slice(0, MAX_HISTORY_FILES);
+
+  let totalBytes = 0;
+  for (const { name } of jsonlFiles) {
+    const filePath = path.join(sessionsDir, name);
+    const bytes = fs.readFileSync(filePath);
+    if (totalBytes + bytes.length > MAX_HISTORY_BYTES) {
+      break;
+    }
+    totalBytes += bytes.length;
+    files.push({ name, b64: bytes.toString("base64") });
+  }
+
+  return files;
 }
 
 function sendJson(res: ServerResponse, status: number, body: unknown) {
@@ -218,6 +249,184 @@ export function handleControlUiAvatarRequest(
   } finally {
     fs.closeSync(safeAvatar.fd);
   }
+}
+
+const SESSION_VIEWER_JS = `
+function b64toStr(b64) {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder("utf-8").decode(bytes);
+}
+function sessionLabel(name) {
+  if (name.includes(".reset.")) return "[reset] ";
+  if (name.includes(".deleted.")) return "[deleted] ";
+  return "";
+}
+function parseSession(name, b64) {
+  const text = b64toStr(b64);
+  const lines = text.split("\\n").filter((line) => line.trim());
+  const messages = [];
+  let firstTs = null;
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line);
+      if (!firstTs && entry.timestamp) firstTs = entry.timestamp;
+      if (entry.type !== "message") continue;
+      const msg = entry.message || {};
+      const role = msg.role;
+      if (role !== "user" && role !== "assistant") continue;
+      let content = "";
+      if (typeof msg.content === "string") content = msg.content;
+      else if (Array.isArray(msg.content)) {
+        content = msg.content
+          .filter((part) => part.type === "text")
+          .map((part) => part.text || "")
+          .join("\\n");
+      }
+      content = content.replace(/Conversation info[\\s\\S]*?\`\`\`\\s*\\n?/g, "");
+      content = content.replace(/\\[\\[reply_to_current\\]\\]\\s*/g, "");
+      const match = content.match(/\\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)[^\\]]+\\]\\s+([\\s\\S]+)/);
+      if (match) content = match[1].trim();
+      content = content.trim();
+      if (!content) continue;
+      messages.push({ role, content, timestamp: entry.timestamp, model: entry.model || (msg.model || "") });
+    } catch (error) {
+      // Ignore malformed lines.
+    }
+  }
+  const date = firstTs
+    ? new Date(firstTs).toLocaleString("en-US", {
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      })
+    : name.substring(0, 19);
+  const label = sessionLabel(name);
+  return { name, date, label, messages };
+}
+let cur = -1;
+function esc(s) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+function fmt(s) {
+  let html = esc(s);
+  html = html.replace(/\`\`\`[\\w]*\\n([\\s\\S]*?)\`\`\`/g, function (_, code) {
+    return "<pre><code>" + code.trimEnd() + "</code></pre>";
+  });
+  html = html.replace(/\`([^\`\\n]+)\`/g, "<code>$1</code>");
+  html = html.replace(/\\*\\*([^*\\n]+)\\*\\*/g, "<strong>$1</strong>");
+  return html;
+}
+function fmtTime(t) {
+  try {
+    return new Date(t).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" });
+  } catch (error) {
+    return "";
+  }
+}
+function renderList() {
+  const list = document.getElementById("list");
+  list.innerHTML = SESSIONS.map(function (s, i) {
+    const badge = s.label ? '<span style="font-size:10px;color:#cf222e;font-weight:600">' + s.label + "</span>" : "";
+    return '<div class="s-item' + (i === cur ? " active" : "") + '" data-idx="' + i + '">' + '<div class="s-date">' + badge + s.date + '</div>' + '<div class="s-meta">' + s.messages.length + " messages</div></div>";
+  }).join("");
+  list.querySelectorAll(".s-item").forEach(function (el) {
+    el.addEventListener("click", function () {
+      selectSession(parseInt(el.getAttribute("data-idx"), 10));
+    });
+  });
+}
+function selectSession(i) {
+  cur = i;
+  renderList();
+  const s = SESSIONS[i];
+  document.getElementById("top").innerHTML = '<strong>' + s.date + "</strong>" + (s.label ? ' <span style="color:#cf222e;font-size:11px">' + s.label.trim() + "</span>" : "") + ' &nbsp;&middot;&nbsp; ' + esc(s.name.substring(0, 36)) + "...";
+  const box = document.getElementById("msgs");
+  box.className = "msgs";
+  if (!s.messages.length) {
+    box.innerHTML = '<div style="margin:auto;text-align:center;color:#8c959f;padding:40px">No messages</div>';
+    document.getElementById("footer").style.display = "none";
+    return;
+  }
+  box.innerHTML = s.messages.map(function (m) {
+    const t = fmtTime(m.timestamp);
+    const mod = m.model ? m.model.split("/").pop() : "";
+    const who = m.role === "user" ? "You" : "Agent";
+    const meta = who + (mod ? " · " + mod : "") + (t ? " · " + t : "");
+    const av = m.role === "user" ? "&#128100;" : "&#129422;";
+    return '<div class="msg ' + m.role + '"><div class="av ' + m.role + '">' + av + '</div><div class="bub"><div class="meta">' + meta + '</div><div class="txt">' + fmt(m.content) + '</div></div></div>';
+  }).join("");
+  const rev = s.messages.slice().reverse();
+  const lm = rev.find(function (m) {
+    return m.role === "assistant" && m.model;
+  });
+  document.getElementById("fC").textContent = s.messages.length;
+  document.getElementById("fM").textContent = lm ? lm.model.split("/").pop() : "—";
+  document.getElementById("footer").style.display = "flex";
+  box.scrollTop = box.scrollHeight;
+}
+`;
+
+function buildSessionViewerHtml(basePath: string): string {
+  const css = `*{box-sizing:border-box;margin:0;padding:0}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#f6f8fa;color:#24292f;display:flex;height:100vh;overflow:hidden}.sidebar{width:260px;min-width:260px;background:#fff;border-right:1px solid #d0d7de;display:flex;flex-direction:column}.sidebar h2{padding:12px 16px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.5px;color:#57606a;border-bottom:1px solid #d0d7de;background:#f6f8fa}.s-list{overflow-y:auto;flex:1}.s-item{padding:11px 16px;border-bottom:1px solid #eaeef2;cursor:pointer;transition:background .1s}.s-item:hover{background:#f6f8fa}.s-item.active{background:#dbeafe;border-left:3px solid #2563eb}.s-date{font-size:13px;font-weight:600;color:#24292f;margin-bottom:2px}.s-meta{font-size:11px;color:#57606a}.chat{flex:1;display:flex;flex-direction:column;overflow:hidden}.chat-top{padding:10px 20px;background:#f6f8fa;border-bottom:1px solid #d0d7de;font-size:12px;color:#57606a}.chat-top strong{color:#24292f}.msgs{flex:1;overflow-y:auto;padding:20px;display:flex;flex-direction:column;gap:14px}.msg{display:flex;gap:10px}.msg.user{flex-direction:row-reverse}.av{width:30px;height:30px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:14px;flex-shrink:0;align-self:flex-start;margin-top:16px;background:#e8f4fd}.av.user{background:#fde8f4}.bub{max-width:calc(100% - 48px)}.meta{font-size:11px;color:#8c959f;margin-bottom:4px}.msg.user .meta{text-align:right}.txt{background:#f6f8fa;border:1px solid #d0d7de;border-radius:10px;padding:10px 14px;font-size:13.5px;line-height:1.65;white-space:pre-wrap;word-break:break-word;color:#24292f}.msg.user .txt{background:#eff6ff;border-color:#bfdbfe;color:#1e3a5f}.txt code{background:#e8edf2;padding:1px 5px;border-radius:3px;font-family:Consolas,monospace;font-size:12px;color:#0550ae}.txt pre{background:#f0f3f6;border:1px solid #d0d7de;border-radius:6px;padding:10px;margin:6px 0;overflow-x:auto}.txt pre code{background:none;padding:0;color:#24292f}.txt strong{font-weight:600}.footer{padding:8px 20px;background:#f6f8fa;border-top:1px solid #d0d7de;font-size:12px;color:#57606a;display:flex;gap:20px}.footer span{color:#24292f;font-weight:600}.empty{flex:1;display:flex;align-items:center;justify-content:center;color:#8c959f;font-size:14px}::-webkit-scrollbar{width:5px}::-webkit-scrollbar-track{background:transparent}::-webkit-scrollbar-thumb{background:#d0d7de;border-radius:3px}`;
+
+  const historyJsUrl = basePath ? `${basePath}/history.js` : "/history.js";
+  const html = [
+    '<!DOCTYPE html><html lang="en"><head>',
+    '<meta charset="UTF-8">',
+    "<title>OpenClaw History</title>",
+    `<style>${css}</style>`,
+    "</head><body>",
+    '<div class="sidebar"><h2>&#129422; OpenClaw History</h2><div class="s-list" id="list"></div></div>',
+    '<div class="chat">',
+    '<div class="chat-top" id="top">&#8592; Select a session</div>',
+    '<div class="msgs empty" id="msgs">Loading...</div>',
+    '<div class="footer" id="footer" style="display:none">Messages: <span id="fC"></span> &nbsp; Model: <span id="fM"></span></div>',
+    "</div>",
+    `<script src="${historyJsUrl}"></script>`,
+    "</body></html>",
+  ].join("");
+  return html;
+}
+
+function handleSessionHistoryRoute(
+  res: ServerResponse,
+  pathname: string,
+  basePath: string,
+  agentId?: string,
+): boolean {
+  const historyPath = basePath ? `${basePath}/history` : "/history";
+  const historyJsPath = basePath ? `${basePath}/history.js` : "/history.js";
+
+  if (pathname === historyJsPath) {
+    const rawJson = JSON.stringify(loadSessionHistoryFiles(agentId));
+    const js = [
+      SESSION_VIEWER_JS,
+      `var RAW=${rawJson};`,
+      "var SESSIONS=RAW.map(function(f){return parseSession(f.name,f.b64);});",
+      "renderList();if(SESSIONS.length>0)selectSession(0);",
+    ].join("\n");
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/javascript; charset=utf-8");
+    res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
+    res.end(js, "utf8");
+    return true;
+  }
+
+  if (pathname !== historyPath && pathname !== `${historyPath}/`) {
+    return false;
+  }
+
+  const html = buildSessionViewerHtml(basePath);
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
+  res.setHeader("Pragma", "no-cache");
+  res.end(html, "utf8");
+  return true;
 }
 
 function setStaticFileHeaders(res: ServerResponse, filePath: string) {
@@ -340,6 +549,11 @@ export function handleControlUiHttpRequest(
   }
 
   applyControlUiSecurityHeaders(res);
+
+  // Session history viewer — served dynamically from .jsonl files
+  if (handleSessionHistoryRoute(res, pathname, basePath, opts?.agentId)) {
+    return true;
+  }
 
   const bootstrapConfigPath = basePath
     ? `${basePath}${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -127,6 +127,28 @@ describe("sessions view", () => {
     expect(fast?.value).toBe("on");
   });
 
+  it("builds the History link from the configured base path", async () => {
+    const container = document.createElement("div");
+    render(
+      renderSessions({
+        ...buildProps(
+          buildResult({
+            key: "agent:main:main",
+            kind: "direct",
+            updatedAt: Date.now(),
+          }),
+        ),
+        basePath: "/openclaw",
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    const link = container.querySelector('a[href="/openclaw/history"]');
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
   it("deselects only the current page from the header checkbox", async () => {
     const onSelectPage = vi.fn();
     const onDeselectPage = vi.fn();

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -130,6 +130,10 @@ function resolveThinkLevelPatchValue(value: string, isBinary: boolean): string |
   return value;
 }
 
+function historyUrl(basePath: string): string {
+  return basePath ? `${basePath}/history` : "/history";
+}
+
 function filterRows(rows: GatewaySessionRow[], query: string): GatewaySessionRow[] {
   const q = query.trim().toLowerCase();
   if (!q) {
@@ -215,11 +219,20 @@ export function renderSessions(props: SessionsProps) {
       <div class="row" style="justify-content: space-between; margin-bottom: 12px;">
         <div>
           <div class="card-title">Sessions</div>
-          <div class="card-sub">${props.result ? `Store: ${props.result.path}` : "Active session keys and per-session overrides."}</div>
+          <div class="card-sub">Inspect active sessions and adjust per-session defaults.</div>
         </div>
-        <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
-          ${props.loading ? "Loading…" : "Refresh"}
-        </button>
+        <div style="display:flex;gap:8px;align-items:center;">
+          <a
+            href=${historyUrl(props.basePath)}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="btn"
+            title="View archived session history"
+          >&#128220; History</a>
+          <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
+            ${props.loading ? "Loading…" : "Refresh"}
+          </button>
+        </div>
       </div>
 
       <div class="filters" style="margin-bottom: 12px;">


### PR DESCRIPTION
## Summary

- Problem: The `/sessions` page did not provide a direct path to archived session history.
- Why it matters: Sessions and history are closely related workflows; switching between them should be visible and low-friction.
- What changed:
  - added a `History` shortcut to the `/sessions` header
  - added a short explanatory subtitle on the Sessions page
  - added the `/history` viewer route for archived session logs
  - ignored `.vs/` locally
- What did NOT change (scope boundary): session data storage, existing session list behavior, and gateway auth/networking semantics.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A — this is a feature addition, not a regression fix.

- Root cause: N/A
- Missing detection / guardrail: N/A
- Prior context (`git blame`, prior PR, issue, or refactor if known): session navigation was previously split across separate views.
- Why this regressed now: N/A
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

N/A — feature work.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `ui/src/ui/views/sessions.ts`, `src/gateway/control-ui.ts`
- Scenario the test should lock in: Sessions page renders a history shortcut and the `/history` route loads archived session data.
- Why this is the smallest reliable guardrail: the change is mostly navigation/UI wiring around an existing workflow.
- Existing test that already covers this (if any): none added here.
- If no new test is added, why not: this is a UI-only navigation feature and manual verification is sufficient for this scope.

## User-visible / Behavior Changes

- `/sessions` now shows a `History` button next to `Refresh`.
- The Sessions header subtitle now explains that the page is used to inspect active sessions and adjust per-session defaults.
- `/history` opens in a separate tab so the live Sessions view remains available.
- `.vs/` is ignored locally.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local development workspace
- Model/provider: N/A
- Integration/channel (if any): local Control UI / gateway
- Relevant config (redacted): N/A

### Steps

1. Open `/sessions`.
2. Verify the Sessions header subtitle and `History` button are visible.
3. Click `History` and confirm `/history` opens in a new tab.

### Expected

- The Sessions page shows a visible navigation path to archived history.
- The history viewer opens independently without replacing the active sessions view.

### Actual

- The UI renders the history shortcut and the separate history page loads successfully.

## Evidence

- [x] Screenshot/recording
- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `/sessions` renders the header changes and `History` opens `/history` in a new tab.
- Edge cases checked: basic route load and direct navigation to the history view.
- What you did not verify: automated coverage for the viewer route.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the cherry-pick commit or hide the `/history` route behind a follow-up rollback.
- Files/config to restore: `src/gateway/control-ui.ts`, `ui/src/ui/views/sessions.ts`, `.gitignore`
- Known bad symptoms reviewers should watch for: `/history` route 404s, Sessions page header layout regressions, or history viewer loading failures.

## Risks and Mitigations

- Risk: the new route could conflict with existing UI routing.
  - Mitigation: the handler is scoped to `/history` and `/history.js` only.
- Risk: the header layout could wrap awkwardly on narrow viewports.
  - Mitigation: the action buttons stay in the existing header row and reuse current button styles.
- Risk: the history viewer may load a large amount of session data.
  - Mitigation: the viewer reads the existing session files on demand and is opened separately from the live Sessions page.

## Screenshots

- `sessions-header+history_btn.jpg` — `/sessions` page with the subtitle and `History` button
- `history-new_page.jpg` — `/history` page opened from the `History` shortcut in a new tab
