### PR TITLE
fix: add 30s timeout to Ollama model pull fetch

### DIFF
--- a/src/plugins/provider-ollama-setup.ts
+++ b/src/plugins/provider-ollama-setup.ts
@@ -111,6 +111,7 @@ async function pullOllamaModelCore(params: {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: modelName }),
+      signal: AbortSignal.timeout(30_000),
     });
     if (!response.ok) {
       return {


### PR DESCRIPTION
## Problem
`provider-ollama-setup.ts` line 110: the `/api/pull` fetch has no timeout, causing indefinite hangs when the Ollama server is unreachable or slow. Other fetch calls in the same file (e.g. `checkOllamaCloudAuth` at line 65) already use `AbortSignal.timeout(5000)`.

## Fix
Add `signal: AbortSignal.timeout(30_000)` to the pull fetch call. 30s is generous for the initial TCP+TLS connection; the streaming body reader already has its own timeout handling via the reader loop.

## Changes
- 1 file, 1 line added

Fixes #54140