### PR TITLE
fix: add 120s timeout to Anthropic and Google PDF fetch calls

### DIFF
--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -74,6 +74,7 @@ export async function anthropicAnalyzePdf(params: {
       max_tokens: params.maxTokens ?? 4096,
       messages: [{ role: "user", content }],
     }),
+    signal: AbortSignal.timeout(120_000),
   });
 
   if (!res.ok) {
@@ -147,6 +148,7 @@ export async function geminiAnalyzePdf(params: {
     body: JSON.stringify({
       contents: [{ role: "user", parts }],
     }),
+    signal: AbortSignal.timeout(120_000),
   });
 
   if (!res.ok) {


### PR DESCRIPTION
## Problem
`pdf-native-providers.ts`: both the Anthropic `/v1/messages` and Google `generateContent` PDF analysis fetch calls have no timeout. If the API is slow or unresponsive, the request hangs indefinitely and the user session appears frozen.

## Fix
Add `signal: AbortSignal.timeout(120_000)` to both fetch calls. 120s is generous enough for large multi-page PDF analysis but prevents infinite hangs.

## Changes
- 1 file, 2 lines added (one per fetch call)

Fixes #54137