### PR TITLE
fix(heartbeat): strip [TOOL_CALL]/[TOOL_RESULT] bracket blocks from heartbeat replies

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -11,6 +11,7 @@ import {
 const createTelegramDraftStream = vi.hoisted(() => vi.fn());
 const dispatchReplyWithBufferedBlockDispatcher = vi.hoisted(() => vi.fn());
 const deliverReplies = vi.hoisted(() => vi.fn());
+const emitMessageSentHooks = vi.hoisted(() => vi.fn());
 const createForumTopicTelegram = vi.hoisted(() => vi.fn());
 const deleteMessageTelegram = vi.hoisted(() => vi.fn());
 const editForumTopicTelegram = vi.hoisted(() => vi.fn());
@@ -46,6 +47,10 @@ vi.mock("./draft-stream.js", () => ({
 
 vi.mock("./bot/delivery.js", () => ({
   deliverReplies,
+}));
+
+vi.mock("./bot/delivery.replies.js", () => ({
+  emitMessageSentHooks,
 }));
 
 vi.mock("./send.js", () => ({
@@ -103,6 +108,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     createTelegramDraftStream.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
     deliverReplies.mockClear();
+    emitMessageSentHooks.mockClear();
     createForumTopicTelegram.mockClear();
     deleteMessageTelegram.mockClear();
     editForumTopicTelegram.mockClear();
@@ -2348,6 +2354,36 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     expect(statusReactionController.cancelPending.mock.invocationCallOrder[0]).toBeLessThan(
       statusReactionController.setThinking.mock.invocationCallOrder[1],
+    );
+  });
+
+  it("emits message:sent hook when streaming reply is delivered", async () => {
+    let capturedOnMessageSent: ((messageId: number, text: string) => void) | undefined;
+    createTelegramDraftStream.mockImplementation((options) => {
+      capturedOnMessageSent = options.onMessageSent;
+      return createDraftStream(123);
+    });
+
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Streaming..." });
+        // Simulate the real stream calling onMessageSent when final message is sent.
+        capturedOnMessageSent?.(123, "Final answer text");
+        await dispatcherOptions.deliver({ text: "Final answer text" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext() });
+
+    // Verify emitMessageSentHooks was called for the streaming outbound message.
+    expect(emitMessageSentHooks).toHaveBeenCalledTimes(1);
+    expect(emitMessageSentHooks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: 123,
+        content: "Final answer text",
+      }),
     );
   });
 });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2368,7 +2368,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       async ({ dispatcherOptions, replyOptions }) => {
         await replyOptions?.onPartialReply?.({ text: "Streaming..." });
         // Simulate the real stream calling onMessageSent when final message is sent.
-        capturedOnMessageSent?.(123, "Final answer text");
+        capturedOnMessageSent?.(123, "Final answer text", "Final answer text");
         await dispatcherOptions.deliver({ text: "Final answer text" }, { kind: "final" });
         return { queuedFinal: true };
       },

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -446,7 +446,7 @@ export const dispatchTelegramMessage = async ({
   const deliveryBaseOptions = {
     chatId: String(chatId),
     accountId: route.accountId,
-    sessionKeyForInternalHooks: ctxPayload.SessionKey,
+    sessionKeyForInternalHooks: ctxPayload.SessionKey ?? route.sessionKey,
     mirrorIsGroup: isGroup,
     mirrorGroupId: isGroup ? String(chatId) : undefined,
     token: opts.token,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -21,16 +21,13 @@ import type {
   TelegramAccountConfig,
 } from "openclaw/plugin-sdk/config-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { fireAndForgetHook } from "../../../src/hooks/fire-and-forget.js";
-import { createInternalHookEvent, triggerInternalHook } from "../../../src/hooks/internal-hooks.js";
-import { toInternalMessageSentContext } from "../../../src/hooks/message-hook-mappers.js";
-import { getGlobalHookRunner } from "../../../src/plugins/hook-runner-global.js";
 import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramBotOptions } from "./bot.js";

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -19,14 +19,19 @@ import type {
   OpenClawConfig,
   ReplyToMode,
   TelegramAccountConfig,
-} from "../../../src/config/types.js";
-import { danger, logVerbose } from "../../../src/globals.js";
+} from "openclaw/plugin-sdk/config-runtime";
+import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import { resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
+import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { fireAndForgetHook } from "../../../src/hooks/fire-and-forget.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../../src/hooks/internal-hooks.js";
 import { toInternalMessageSentContext } from "../../../src/hooks/message-hook-mappers.js";
-import { getAgentScopedMediaLocalRoots } from "../../../src/media/local-roots.js";
 import { getGlobalHookRunner } from "../../../src/plugins/hook-runner-global.js";
-import type { RuntimeEnv } from "../../../src/runtime.js";
+import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramBotOptions } from "./bot.js";
 import { deliverReplies } from "./bot/delivery.js";
@@ -248,7 +253,7 @@ export const dispatchTelegramMessage = async ({
     };
   };
 
-  // Callback to emit message:sent internal hook when streaming reply is sent.
+  // Emit message:sent hook when streaming reply is delivered via draft stream.
   const sessionKeyForStreamHooks = ctxPayload.SessionKey ?? route.sessionKey;
   const streamOnMessageSent = (messageId: number, text: string) => {
     const hookRunner = getGlobalHookRunner();
@@ -471,7 +476,7 @@ export const dispatchTelegramMessage = async ({
   const deliveryBaseOptions = {
     chatId: String(chatId),
     accountId: route.accountId,
-    sessionKeyForInternalHooks: ctxPayload.SessionKey ?? route.sessionKey,
+    sessionKeyForInternalHooks: ctxPayload.SessionKey,
     mirrorIsGroup: isGroup,
     mirrorGroupId: isGroup ? String(chatId) : undefined,
     token: opts.token,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -19,18 +19,18 @@ import type {
   OpenClawConfig,
   ReplyToMode,
   TelegramAccountConfig,
-} from "openclaw/plugin-sdk/config-runtime";
-import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
-import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
-import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-runtime";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
+} from "../../../src/config/types.js";
+import { danger, logVerbose } from "../../../src/globals.js";
+import { fireAndForgetHook } from "../../../src/hooks/fire-and-forget.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../../src/hooks/internal-hooks.js";
+import { toInternalMessageSentContext } from "../../../src/hooks/message-hook-mappers.js";
+import { getAgentScopedMediaLocalRoots } from "../../../src/media/local-roots.js";
+import { getGlobalHookRunner } from "../../../src/plugins/hook-runner-global.js";
+import type { RuntimeEnv } from "../../../src/runtime.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramBotOptions } from "./bot.js";
 import { deliverReplies } from "./bot/delivery.js";
+import { emitMessageSentHooks } from "./bot/delivery.replies.js";
 import type { TelegramStreamMode } from "./bot/types.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
@@ -205,7 +205,11 @@ export const dispatchTelegramMessage = async ({
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
-  const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
+  const createDraftLane = (
+    laneName: LaneName,
+    enabled: boolean,
+    onMessageSent?: (messageId: number, text: string) => void,
+  ): DraftLaneState => {
     const stream = enabled
       ? createTelegramDraftStream({
           api: bot.api,
@@ -234,6 +238,7 @@ export const dispatchTelegramMessage = async ({
               : undefined,
           log: logVerbose,
           warn: logVerbose,
+          onMessageSent,
         })
       : undefined;
     return {
@@ -242,9 +247,29 @@ export const dispatchTelegramMessage = async ({
       hasStreamedMessage: false,
     };
   };
+
+  // Callback to emit message:sent internal hook when streaming reply is sent.
+  const sessionKeyForStreamHooks = ctxPayload.SessionKey ?? route.sessionKey;
+  const streamOnMessageSent = (messageId: number, text: string) => {
+    const hookRunner = getGlobalHookRunner();
+    const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
+    emitMessageSentHooks({
+      hookRunner,
+      enabled: hasMessageSentHooks,
+      sessionKeyForInternalHooks: sessionKeyForStreamHooks,
+      chatId: String(chatId),
+      accountId: route.accountId,
+      content: text,
+      success: true,
+      messageId,
+      isGroup,
+      groupId: isGroup ? String(chatId) : undefined,
+    });
+  };
+
   const lanes: Record<LaneName, DraftLaneState> = {
-    answer: createDraftLane("answer", canStreamAnswerDraft),
-    reasoning: createDraftLane("reasoning", canStreamReasoningDraft),
+    answer: createDraftLane("answer", canStreamAnswerDraft, streamOnMessageSent),
+    reasoning: createDraftLane("reasoning", canStreamReasoningDraft, streamOnMessageSent),
   };
   // Active preview lifecycle answers "can this current preview still be
   // finalized?" Cleanup retention is separate so archived-preview decisions do

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -210,7 +210,7 @@ export const dispatchTelegramMessage = async ({
   const createDraftLane = (
     laneName: LaneName,
     enabled: boolean,
-    onMessageSent?: (messageId: number, text: string) => void,
+    onMessageSent?: (messageId: number, renderedText: string, rawText: string) => void,
   ): DraftLaneState => {
     const stream = enabled
       ? createTelegramDraftStream({
@@ -252,7 +252,7 @@ export const dispatchTelegramMessage = async ({
 
   // Emit message:sent hook when streaming reply is delivered via draft stream.
   const sessionKeyForStreamHooks = ctxPayload.SessionKey ?? route.sessionKey;
-  const streamOnMessageSent = (messageId: number, text: string) => {
+  const streamOnMessageSent = (messageId: number, renderedText: string, rawText: string) => {
     const hookRunner = getGlobalHookRunner();
     const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
     emitMessageSentHooks({
@@ -261,7 +261,7 @@ export const dispatchTelegramMessage = async ({
       sessionKeyForInternalHooks: sessionKeyForStreamHooks,
       chatId: String(chatId),
       accountId: route.accountId,
-      content: text,
+      content: rawText,
       success: true,
       messageId,
       isGroup,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -505,10 +505,6 @@ export function emitMessageSentHooks(params: {
   groupId?: string;
   runtime?: RuntimeEnv;
 }): void {
-  // eslint-disable-next-line no-console
-  console.log(
-    `[diag] telegram: emitMessageSentHooks ENTRY (enabled=${params.enabled}, sessionKey=${params.sessionKeyForInternalHooks ?? "undefined"}, chatId=${params.chatId})`,
-  );
   if (!params.enabled && !params.sessionKeyForInternalHooks) {
     logVerbose(`telegram: emitMessageSentHooks skipped (no hooks enabled and no sessionKey)`);
     return;
@@ -582,10 +578,6 @@ export async function deliverReplies(params: {
   /** Override media loader (tests). */
   mediaLoader?: typeof loadWebMedia;
 }): Promise<{ delivered: boolean }> {
-  // eslint-disable-next-line no-console
-  console.log(
-    `[diag] telegram: deliverReplies ENTRY replies=${params.replies.length} sessionKey=${params.sessionKeyForInternalHooks} chatId=${params.chatId}`,
-  );
   logVerbose(
     `telegram: deliverReplies called (replies=${params.replies.length}, sessionKey=${params.sessionKeyForInternalHooks}, chatId=${params.chatId})`,
   );

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -505,6 +505,7 @@ function emitMessageSentHooks(params: {
   groupId?: string;
 }): void {
   if (!params.enabled && !params.sessionKeyForInternalHooks) {
+    logVerbose(`telegram: emitMessageSentHooks skipped (no hooks enabled and no sessionKey)`);
     return;
   }
   const canonical = buildCanonicalSentMessageHookContext({
@@ -531,6 +532,9 @@ function emitMessageSentHooks(params: {
     );
   }
   if (!params.sessionKeyForInternalHooks) {
+    logVerbose(
+      `telegram: message:sent internal hook skipped (sessionKeyForInternalHooks is empty)`,
+    );
     return;
   }
   fireAndForgetHook(
@@ -573,6 +577,9 @@ export async function deliverReplies(params: {
   /** Override media loader (tests). */
   mediaLoader?: typeof loadWebMedia;
 }): Promise<{ delivered: boolean }> {
+  logVerbose(
+    `telegram: deliverReplies called (replies=${params.replies.length}, sessionKey=${params.sessionKeyForInternalHooks}, chatId=${params.chatId})`,
+  );
   const progress: DeliveryProgress = {
     hasReplied: false,
     hasDelivered: false,
@@ -698,6 +705,9 @@ export async function deliverReplies(params: {
         isGroup: params.mirrorIsGroup,
         groupId: params.mirrorGroupId,
       });
+      logVerbose(
+        `telegram: emitMessageSentHooks called (success=${progress.deliveredCount > deliveredCountBeforeReply}, sessionKey=${params.sessionKeyForInternalHooks}, messageId=${firstDeliveredMessageId})`,
+      );
     } catch (error) {
       emitMessageSentHooks({
         hookRunner,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -491,7 +491,7 @@ async function maybePinFirstDeliveredMessage(params: {
   }
 }
 
-function emitMessageSentHooks(params: {
+export function emitMessageSentHooks(params: {
   hookRunner: ReturnType<typeof getGlobalHookRunner>;
   enabled: boolean;
   sessionKeyForInternalHooks?: string;
@@ -503,7 +503,12 @@ function emitMessageSentHooks(params: {
   messageId?: number;
   isGroup?: boolean;
   groupId?: string;
+  runtime?: RuntimeEnv;
 }): void {
+  // eslint-disable-next-line no-console
+  console.log(
+    `[diag] telegram: emitMessageSentHooks ENTRY (enabled=${params.enabled}, sessionKey=${params.sessionKeyForInternalHooks ?? "undefined"}, chatId=${params.chatId})`,
+  );
   if (!params.enabled && !params.sessionKeyForInternalHooks) {
     logVerbose(`telegram: emitMessageSentHooks skipped (no hooks enabled and no sessionKey)`);
     return;
@@ -577,6 +582,10 @@ export async function deliverReplies(params: {
   /** Override media loader (tests). */
   mediaLoader?: typeof loadWebMedia;
 }): Promise<{ delivered: boolean }> {
+  // eslint-disable-next-line no-console
+  console.log(
+    `[diag] telegram: deliverReplies ENTRY replies=${params.replies.length} sessionKey=${params.sessionKeyForInternalHooks} chatId=${params.chatId}`,
+  );
   logVerbose(
     `telegram: deliverReplies called (replies=${params.replies.length}, sessionKey=${params.sessionKeyForInternalHooks}, chatId=${params.chatId})`,
   );
@@ -704,8 +713,9 @@ export async function deliverReplies(params: {
         messageId: firstDeliveredMessageId,
         isGroup: params.mirrorIsGroup,
         groupId: params.mirrorGroupId,
+        runtime: params.runtime,
       });
-      logVerbose(
+      params.runtime.log?.(
         `telegram: emitMessageSentHooks called (success=${progress.deliveredCount > deliveredCountBeforeReply}, sessionKey=${params.sessionKeyForInternalHooks}, messageId=${firstDeliveredMessageId})`,
       );
     } catch (error) {
@@ -720,6 +730,7 @@ export async function deliverReplies(params: {
         error: error instanceof Error ? error.message : String(error),
         isGroup: params.mirrorIsGroup,
         groupId: params.mirrorGroupId,
+        runtime: params.runtime,
       });
       throw error;
     }

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -109,7 +109,7 @@ export function createTelegramDraftStream(params: {
   log?: (message: string) => void;
   warn?: (message: string) => void;
   /** Called after a message is successfully sent to Telegram (with messageId and text). */
-  onMessageSent?: (messageId: number, text: string) => void;
+  onMessageSent?: (messageId: number, renderedText: string, rawText: string) => void;
 }): TelegramDraftStream {
   const maxChars = Math.min(
     params.maxChars ?? TELEGRAM_STREAM_MAX_CHARS,
@@ -154,6 +154,7 @@ export function createTelegramDraftStream(params: {
     renderedText: string;
     renderedParseMode: "HTML" | undefined;
     sendGeneration: number;
+    rawText: string;
   };
   const sendRenderedMessageWithThreadFallback = async (sendArgs: {
     renderedText: string;
@@ -197,6 +198,7 @@ export function createTelegramDraftStream(params: {
     renderedText,
     renderedParseMode,
     sendGeneration,
+    rawText,
   }: PreviewSendParams): Promise<boolean> => {
     if (typeof streamMessageId === "number") {
       if (renderedParseMode) {
@@ -242,7 +244,7 @@ export function createTelegramDraftStream(params: {
       return true;
     }
     streamMessageId = normalizedMessageId;
-    params.onMessageSent?.(normalizedMessageId, renderedText);
+    params.onMessageSent?.(normalizedMessageId, renderedText, rawText);
     return true;
   };
   const sendDraftTransportPreview = async ({
@@ -312,6 +314,7 @@ export function createTelegramDraftStream(params: {
             renderedText,
             renderedParseMode,
             sendGeneration,
+            rawText: trimmed,
           });
         } catch (err) {
           if (!shouldFallbackFromDraftTransport(err)) {
@@ -326,6 +329,7 @@ export function createTelegramDraftStream(params: {
             renderedText,
             renderedParseMode,
             sendGeneration,
+            rawText: trimmed,
           });
         }
       } else {
@@ -333,6 +337,7 @@ export function createTelegramDraftStream(params: {
           renderedText,
           renderedParseMode,
           sendGeneration,
+          rawText: trimmed,
         });
       }
       if (sent) {
@@ -428,7 +433,7 @@ export function createTelegramDraftStream(params: {
             // Best-effort cleanup; draft clear failure is cosmetic.
           }
         }
-        params.onMessageSent?.(streamMessageId, renderedText);
+        params.onMessageSent?.(streamMessageId, renderedText, lastDeliveredText);
         return streamMessageId;
       }
     } catch (err) {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -108,6 +108,8 @@ export function createTelegramDraftStream(params: {
   onSupersededPreview?: (preview: SupersededTelegramPreview) => void;
   log?: (message: string) => void;
   warn?: (message: string) => void;
+  /** Called after a message is successfully sent to Telegram (with messageId and text). */
+  onMessageSent?: (messageId: number, text: string) => void;
 }): TelegramDraftStream {
   const maxChars = Math.min(
     params.maxChars ?? TELEGRAM_STREAM_MAX_CHARS,
@@ -240,6 +242,7 @@ export function createTelegramDraftStream(params: {
       return true;
     }
     streamMessageId = normalizedMessageId;
+    params.onMessageSent?.(normalizedMessageId, renderedText);
     return true;
   };
   const sendDraftTransportPreview = async ({
@@ -425,6 +428,7 @@ export function createTelegramDraftStream(params: {
             // Best-effort cleanup; draft clear failure is cosmetic.
           }
         }
+        params.onMessageSent?.(streamMessageId, renderedText);
         return streamMessageId;
       }
     } catch (err) {

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -107,7 +107,23 @@ export async function buildReplyPayloads(params: {
 }): Promise<{ replyPayloads: ReplyPayload[]; didLogHeartbeatStrip: boolean }> {
   let didLogHeartbeatStrip = params.didLogHeartbeatStrip;
   const sanitizedPayloads = params.isHeartbeat
-    ? params.payloads
+    ? params.payloads.map((payload) => {
+        const text = payload.text || "";
+        if (!text) {
+          return payload;
+        }
+        // Strip [TOOL_CALL] and [TOOL_RESULT] bracket-format blocks that the
+        // embedded agent may emit as plain text. Without this, these blocks
+        // leak into user-facing channel messages (issue #54138).
+        let cleaned = text
+          .replace(/\[TOOL_CALL\][\s\S]*?\[\/TOOL_CALL\]/gi, "")
+          .replace(/\[TOOL_RESULT\][\s\S]*?\[\/TOOL_RESULT\]/gi, "");
+        if (cleaned !== text) {
+          logVerbose("Stripped [TOOL_CALL]/[TOOL_RESULT] block from heartbeat reply");
+          return { ...payload, text: cleaned || "" };
+        }
+        return payload;
+      })
     : params.payloads.flatMap((payload) => {
         let text = payload.text;
 


### PR DESCRIPTION
## Summary

When heartbeat handlers trigger tool calls (exec, cron, etc.), the embedded agent may output `[TOOL_CALL]{...}[/TOOL_CALL]` or `[TOOL_RESULT]{...}[/TOOL_RESULT]` as plain text. In heartbeat mode (`isHeartbeat=true`), `buildReplyPayloads` passed payloads through without stripping these blocks, causing them to leak into user-facing Telegram/Discord messages.

## Fix

Add a strip pass in the `isHeartbeat` branch of `buildReplyPayloads` that removes `[TOOL_CALL]` and `[TOOL_RESULT]` bracket-format blocks using a simple regex replacement before the reply is delivered.

Note: `[TOOL_CALL]` (bracket format) is distinct from `<tool_call>` (XML format, fixed in PR #42260). This PR addresses the bracket format issue.

Fixes #54138