### PR TITLE
fix(cli): pass agentId to runMessageAction so session transcript is written

### DIFF
--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -2,6 +2,7 @@ import {
   CHANNEL_MESSAGE_ACTION_NAMES,
   type ChannelMessageActionName,
 } from "../channels/plugins/types.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveCommandSecretRefsViaGateway } from "../cli/command-secret-gateway.js";
 import { getScopedChannelsCommandSecretTargets } from "../cli/command-secret-targets.js";
 import { resolveMessageSecretScope } from "../cli/message-secret-scope.js";
@@ -52,12 +53,18 @@ export async function messageCommand(
 
   const outboundDeps: OutboundSendDeps = createOutboundSendDeps(deps);
 
+  const agentId =
+    typeof opts.agent === "string"
+      ? opts.agent
+      : normalizeAgentId(cfg.agent?.id);
+
   const run = async () =>
     await runMessageAction({
       cfg,
       action,
       params: opts,
       deps: outboundDeps,
+      agentId,
       gateway: {
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,


### PR DESCRIPTION
## Bug Fix: CLI message send now writes to session transcript

**Fixes:** openclaw/openclaw#54186

### Problem

When using `openclaw message send` CLI, messages were delivered to channels but **not written to session transcript** (`.jsonl` files). This broke conversation continuity — when users replied, the agent had zero context.

### Root Cause

In `src/commands/message.ts`, the `runMessageAction()` call did not pass `agentId`. The session route resolution in `message-action-runner.ts` is gated on `agentId && !dryRun`. Without it, `outboundRoute` is `null`, the `mirror` object is never constructed, and transcript writes (via `appendAssistantMessageToSessionTranscript` in `deliver.ts`) are skipped.

### Fix

Resolve `agentId` from `cfg.agent.id` (defaulting to `'main'`) and pass it to `runMessageAction`:

```typescript
const agentId =
  typeof opts.agent === 'string'
    ? opts.agent
    : normalizeAgentId(cfg.agent?.id);

await runMessageAction({
  cfg,
  action,
  params: opts,
  deps: outboundDeps,
  agentId,  // ← added
  gateway: { ... },
});
```

### Impact

- **All channels** (Telegram, WhatsApp, Discord, Signal, Slack, etc.) when using CLI `message send`
- Single change resolves it for all channels (CLI layer, not per-channel)
- The `--agent` option (e.g., `--agent main`) can now be used explicitly in multi-agent setups

### Testing

1. Have an active Telegram session with a user (`agent:main:telegram:direct:12345`)
2. Run: `openclaw message send --channel telegram --target 12345 --message "Hello from CLI"`
3. Check `~/.openclaw/agents/main/sessions/<session-id>.jsonl` — should now contain the sent message ✅

### Files Changed

- `src/commands/message.ts` — added `agentId` resolution and pass-through to `runMessageAction`