### PR TITLE
Fix: read tool treats Windows absolute paths as relative to workspace (Issue #54039)

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -649,7 +649,11 @@ export function createOpenClawReadTool(
       assertRequiredParams(record, CLAUDE_PARAM_GROUPS.read, base.name);
 
       let safeArgs = (normalized ?? params ?? {}) as Record<string, unknown>;
-      if (options?.workspaceRoot && typeof safeArgs.path === "string" && path.isAbsolute(safeArgs.path)) {
+      if (
+        options?.workspaceRoot &&
+        typeof safeArgs.path === "string" &&
+        path.isAbsolute(safeArgs.path)
+      ) {
         safeArgs = {
           ...safeArgs,
           path: path.relative(options.workspaceRoot, safeArgs.path) || ".",

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -50,6 +50,7 @@ const MAX_ADAPTIVE_READ_PAGES = 8;
 type OpenClawReadToolOptions = {
   modelContextWindowTokens?: number;
   imageSanitization?: ImageSanitizationLimits;
+  workspaceRoot?: string;
 };
 
 type ReadTruncationDetails = {
@@ -646,10 +647,19 @@ export function createOpenClawReadTool(
         normalized ??
         (params && typeof params === "object" ? (params as Record<string, unknown>) : undefined);
       assertRequiredParams(record, CLAUDE_PARAM_GROUPS.read, base.name);
+
+      let safeArgs = (normalized ?? params ?? {}) as Record<string, unknown>;
+      if (options?.workspaceRoot && typeof safeArgs.path === "string" && path.isAbsolute(safeArgs.path)) {
+        safeArgs = {
+          ...safeArgs,
+          path: path.relative(options.workspaceRoot, safeArgs.path) || ".",
+        };
+      }
+
       const result = await executeReadWithAdaptivePaging({
         base,
         toolCallId,
-        args: (normalized ?? params ?? {}) as Record<string, unknown>,
+        args: safeArgs,
         signal,
         maxBytes: resolveAdaptiveReadMaxBytes(options),
       });

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -390,6 +390,7 @@ export function createOpenClawCodingTools(options?: {
       const wrapped = createOpenClawReadTool(freshReadTool, {
         modelContextWindowTokens: options?.modelContextWindowTokens,
         imageSanitization,
+        workspaceRoot,
       });
       return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
     }


### PR DESCRIPTION
Fixes #54039.

## Problem
The `read` tool incorrectly treats Windows absolute paths as relative to the workspace root due to a bug in the upstream `@mariozechner/pi-coding-agent` dependency. When an LLM requests a Windows path, `pi-coding-agent` blindly uses `path.join` to append it to the workspace root, creating an invalid doubled path.

## Solution
Since the external package shouldn't be patched in this repo, this PR implements a workaround in OpenClaw's tool wrapper layer (`src/agents/pi-tools.read.ts`).

When the OpenClaw wrapper detects an absolute path in the `read` tool arguments, it uses `path.relative` to convert it into a true relative path against the active `workspaceRoot`. When this path is passed down to the upstream dependency, its internal `path.join(workspaceRoot, inputPath)` mathematically correctly restores the exact absolute path intended by the LLM, fixing both intra-workspace and cross-workspace absolute paths cleanly.

* [x] I have read the contribution guidelines
* [x] * [x] My code follows the code style of this project
* [x] * [x] All new and existing tests pass