### PR TITLE
Control UI: display agent identity name and emoji in session list (fixes #54163)

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -745,6 +745,7 @@ export function renderApp(state: AppViewState) {
                   includeUnknown: state.sessionsIncludeUnknown,
                   basePath: state.basePath,
                   searchQuery: state.sessionsSearchQuery,
+                  agentIdentityById: state.agentIdentityById,
                   sortColumn: state.sessionsSortColumn,
                   sortDir: state.sessionsSortDir,
                   page: state.sessionsPage,

--- a/ui/src/ui/format.test.ts
+++ b/ui/src/ui/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { formatRelativeTimestamp, stripThinkingTags } from "./format.ts";
+import { parseSessionKeyParts } from "./format.ts";
 
 describe("formatAgo", () => {
   it("returns 'in <1m' for timestamps less than 60s in the future", () => {
@@ -63,8 +64,6 @@ describe("stripThinkingTags", () => {
   });
 
   it("handles incomplete <final tag gracefully", () => {
-    // When streaming splits mid-tag, we may see "<final" without closing ">"
-    // This should not crash and should handle gracefully
     expect(stripThinkingTags("<final\nHello")).toBe("<final\nHello");
     expect(stripThinkingTags("Hello</final>")).toBe("Hello");
   });
@@ -97,5 +96,47 @@ describe("stripThinkingTags", () => {
   it("hides unfinished <relevant-memories> block tails", () => {
     const input = ["Hello", "<relevant-memories>", "internal-only"].join("\n");
     expect(stripThinkingTags(input)).toBe("Hello\n");
+  });
+});
+
+describe("parseSessionKeyParts", () => {
+  it("parses a standard agent session key", () => {
+    expect(parseSessionKeyParts("agent:data-expert:dingtalk:cidzg6sF43NZMy52Rnk8EN")).toEqual({
+      agentId: "data-expert",
+      channel: "dingtalk",
+      accountId: "cidzg6sF43NZMy52Rnk8EN",
+    });
+  });
+
+  it("parses a key with special characters in accountId", () => {
+    expect(parseSessionKeyParts("agent:code-prince:dingtalk:cidtYWov/AQ==")).toEqual({
+      agentId: "code-prince",
+      channel: "dingtalk",
+      accountId: "cidtYWov/AQ==",
+    });
+  });
+
+  it("parses a key with colons in accountId", () => {
+    expect(parseSessionKeyParts("agent:main:telegram:user:12345:extra")).toEqual({
+      agentId: "main",
+      channel: "telegram",
+      accountId: "user:12345:extra",
+    });
+  });
+
+  it("returns null for non-agent keys", () => {
+    expect(parseSessionKeyParts("global:default")).toBeNull();
+    expect(parseSessionKeyParts("direct:some-key")).toBeNull();
+    expect(parseSessionKeyParts("")).toBeNull();
+  });
+
+  it("returns null for malformed agent keys missing channel or accountId", () => {
+    expect(parseSessionKeyParts("agent:")).toBeNull();
+    expect(parseSessionKeyParts("agent:main")).toBeNull();
+    expect(parseSessionKeyParts("agent:main:")).toBeNull();
+  });
+
+  it("returns null for agent key with only agentId and channel but no accountId", () => {
+    expect(parseSessionKeyParts("agent:main:telegram")).toBeNull();
   });
 });

--- a/ui/src/ui/format.test.ts
+++ b/ui/src/ui/format.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatRelativeTimestamp, stripThinkingTags } from "./format.ts";
-import { parseSessionKeyParts } from "./format.ts";
+import { formatRelativeTimestamp, parseSessionKeyParts, stripThinkingTags } from "./format.ts";
 
 describe("formatAgo", () => {
   it("returns 'in <1m' for timestamps less than 60s in the future", () => {

--- a/ui/src/ui/format.ts
+++ b/ui/src/ui/format.ts
@@ -96,3 +96,29 @@ export function formatPercent(value: number | null | undefined, fallback = "—"
   }
   return `${(value * 100).toFixed(1)}%`;
 }
+
+/**
+ * Parse a session key like `agent:<agentId>:<channel>:<accountId>` into parts.
+ * Returns `null` if the key does not match the expected agent session format.
+ */
+export function parseSessionKeyParts(
+  key: string,
+): { agentId: string; channel: string; accountId: string } | null {
+  if (!key.startsWith("agent:")) {
+    return null;
+  }
+  const rest = key.slice("agent:".length);
+  const firstColon = rest.indexOf(":");
+  if (firstColon < 1) {
+    return null;
+  }
+  const agentId = rest.slice(0, firstColon);
+  const afterAgent = rest.slice(firstColon + 1);
+  const secondColon = afterAgent.indexOf(":");
+  if (secondColon < 1) {
+    return null;
+  }
+  const channel = afterAgent.slice(0, secondColon);
+  const accountId = afterAgent.slice(secondColon + 1);
+  return { agentId, channel, accountId };
+}

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -36,6 +36,7 @@ function buildProps(result: SessionsListResult): SessionsProps {
     includeUnknown: false,
     basePath: "",
     searchQuery: "",
+    agentIdentityById: {},
     sortColumn: "updated",
     sortDir: "desc",
     page: 0,
@@ -125,6 +126,86 @@ describe("sessions view", () => {
     const selects = container.querySelectorAll("select");
     const fast = selects[1] as HTMLSelectElement | undefined;
     expect(fast?.value).toBe("on");
+  });
+
+  it("shows agent identity name and emoji when agentIdentityById matches the session key", async () => {
+    const container = document.createElement("div");
+    render(
+      renderSessions({
+        ...buildProps(
+          buildResult({
+            key: "agent:data-expert:dingtalk:cidzg6sF43NZMy52Rnk8EN",
+            kind: "direct",
+            updatedAt: Date.now(),
+          }),
+        ),
+        agentIdentityById: {
+          "data-expert": {
+            agentId: "data-expert",
+            name: "数据处理专家",
+            avatar: "",
+            emoji: "📊",
+          },
+        },
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    const keyCell = container.querySelector(".session-key-cell");
+    expect(keyCell?.textContent).toContain("📊 数据处理专家 (dingtalk)");
+    // Raw key should be in the title attribute for debugging.
+    expect(keyCell?.getAttribute("title")).toBe(
+      "agent:data-expert:dingtalk:cidzg6sF43NZMy52Rnk8EN",
+    );
+  });
+
+  it("falls back to raw key when no agent identity is available", async () => {
+    const container = document.createElement("div");
+    render(
+      renderSessions(
+        buildProps(
+          buildResult({
+            key: "agent:unknown-agent:telegram:abc123",
+            kind: "direct",
+            updatedAt: Date.now(),
+          }),
+        ),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const keyCell = container.querySelector(".session-key-cell");
+    expect(keyCell?.textContent).toContain("agent:unknown-agent:telegram:abc123");
+  });
+
+  it("shows identity name without emoji when emoji is not set", async () => {
+    const container = document.createElement("div");
+    render(
+      renderSessions({
+        ...buildProps(
+          buildResult({
+            key: "agent:code-prince:discord:xyz789",
+            kind: "direct",
+            updatedAt: Date.now(),
+          }),
+        ),
+        agentIdentityById: {
+          "code-prince": {
+            agentId: "code-prince",
+            name: "代码小王子",
+            avatar: "",
+          },
+        },
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    const keyCell = container.querySelector(".session-key-cell");
+    expect(keyCell?.textContent).toContain("代码小王子 (discord)");
+    expect(keyCell?.textContent).not.toContain("📊");
   });
 
   it("deselects only the current page from the header checkbox", async () => {

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -1,9 +1,9 @@
 import { html, nothing } from "lit";
-import { formatRelativeTimestamp } from "../format.ts";
+import { formatRelativeTimestamp, parseSessionKeyParts } from "../format.ts";
 import { icons } from "../icons.ts";
 import { pathForTab } from "../navigation.ts";
 import { formatSessionTokens } from "../presenter.ts";
-import type { GatewaySessionRow, SessionsListResult } from "../types.ts";
+import type { AgentIdentityResult, GatewaySessionRow, SessionsListResult } from "../types.ts";
 
 export type SessionsProps = {
   loading: boolean;
@@ -15,6 +15,8 @@ export type SessionsProps = {
   includeUnknown: boolean;
   basePath: string;
   searchQuery: string;
+  /** Agent identity map keyed by agentId, used to display friendly names in the KEY column. */
+  agentIdentityById: Record<string, AgentIdentityResult>;
   sortColumn: "key" | "kind" | "updated" | "tokens";
   sortDir: "asc" | "desc";
   page: number;
@@ -130,7 +132,11 @@ function resolveThinkLevelPatchValue(value: string, isBinary: boolean): string |
   return value;
 }
 
-function filterRows(rows: GatewaySessionRow[], query: string): GatewaySessionRow[] {
+function filterRows(
+  rows: GatewaySessionRow[],
+  query: string,
+  agentIdentityById: Record<string, AgentIdentityResult> = {},
+): GatewaySessionRow[] {
   const q = query.trim().toLowerCase();
   if (!q) {
     return rows;
@@ -140,7 +146,19 @@ function filterRows(rows: GatewaySessionRow[], query: string): GatewaySessionRow
     const label = (row.label ?? "").toLowerCase();
     const kind = (row.kind ?? "").toLowerCase();
     const displayName = (row.displayName ?? "").toLowerCase();
-    return key.includes(q) || label.includes(q) || kind.includes(q) || displayName.includes(q);
+    if (key.includes(q) || label.includes(q) || kind.includes(q) || displayName.includes(q)) {
+      return true;
+    }
+    // Also match against agent identity name for friendlier searching.
+    const keyParts = parseSessionKeyParts(row.key);
+    if (keyParts) {
+      const identity = agentIdentityById[keyParts.agentId];
+      const identityName = (identity?.name ?? "").toLowerCase();
+      if (identityName.includes(q)) {
+        return true;
+      }
+    }
+    return false;
   });
 }
 
@@ -183,7 +201,7 @@ function paginateRows<T>(rows: T[], page: number, pageSize: number): T[] {
 
 export function renderSessions(props: SessionsProps) {
   const rawRows = props.result?.sessions ?? [];
-  const filtered = filterRows(rawRows, props.searchQuery);
+  const filtered = filterRows(rawRows, props.searchQuery, props.agentIdentityById);
   const sorted = sortRows(filtered, props.sortColumn, props.sortDir);
   const totalRows = sorted.length;
   const totalPages = Math.max(1, Math.ceil(totalRows / props.pageSize));
@@ -377,6 +395,7 @@ export function renderSessions(props: SessionsProps) {
                         props.onToggleSelect,
                         props.loading,
                         props.onNavigateToChat,
+                        props.agentIdentityById,
                       ),
                     )
               }
@@ -431,6 +450,7 @@ function renderRow(
   onToggleSelect: SessionsProps["onToggleSelect"],
   disabled: boolean,
   onNavigateToChat?: (sessionKey: string) => void,
+  agentIdentityById: Record<string, AgentIdentityResult> = {},
 ) {
   const updated = row.updatedAt ? formatRelativeTimestamp(row.updatedAt) : "n/a";
   const rawThinking = row.thinkingLevel ?? "";
@@ -452,6 +472,15 @@ function renderRow(
     displayName !== row.key &&
     displayName !== (typeof row.label === "string" ? row.label.trim() : ""),
   );
+  // Resolve agent identity for a friendlier KEY column display.
+  const keyParts = parseSessionKeyParts(row.key);
+  const agentIdentity = keyParts ? (agentIdentityById[keyParts.agentId] ?? null) : null;
+  const identityEmoji = agentIdentity?.emoji?.trim() ?? "";
+  const identityName = agentIdentity?.name?.trim() ?? "";
+  const friendlyKeyLabel =
+    identityName && keyParts
+      ? `${identityEmoji ? `${identityEmoji} ` : ""}${identityName} (${keyParts.channel})`
+      : null;
   const canLink = row.kind !== "global";
   const chatUrl = canLink
     ? `${pathForTab("chat", basePath)}?session=${encodeURIComponent(row.key)}`
@@ -476,7 +505,7 @@ function renderRow(
         />
       </td>
       <td class="data-table-key-col">
-        <div class="mono session-key-cell">
+        <div class="${friendlyKeyLabel ? "" : "mono "}session-key-cell" title=${row.key}>
           ${
             canLink
               ? html`<a
@@ -498,8 +527,8 @@ function renderRow(
                       onNavigateToChat(row.key);
                     }
                   }}
-                >${row.key}</a>`
-              : row.key
+                >${friendlyKeyLabel ?? row.key}</a>`
+              : (friendlyKeyLabel ?? row.key)
           }
           ${
             showDisplayName


### PR DESCRIPTION
## Summary

- **Problem:** The Control UI session list KEY column shows raw session keys like `agent:data-expert:dingtalk:cidzg6sF43NZMy52Rnk8EN`, which are hard to read when managing multiple agents.
- **Why it matters:** Users cannot quickly identify which agent a session belongs to without memorizing cryptic account IDs.
- **What changed:** When agent identity data is available, the KEY column now displays a friendly label like `📊 数据处理专家 (dingtalk)` instead of the raw key. Raw key is preserved as tooltip. Search filter also matches against agent identity names.
- **What did NOT change:** Backend, session key format, sorting behavior, or existing displayName logic.

## Change Type

- [x] Feature

## Scope

- [x] UI / DX

## Linked Issue/PR

- Closes #54163

## Root Cause / Regression History

N/A — new feature.

## Regression Test Plan

N/A — new feature.

## User-visible / Behavior Changes

- KEY column shows `emoji + name (channel)` instead of raw session key when agent identity is available.
- Raw key remains accessible via tooltip (hover).
- Search now matches agent identity names in addition to keys, labels, and kinds.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] Failing test/log before + passing after

All 7 tests pass (4 existing + 3 new identity display tests) + 6 `parseSessionKeyParts` unit tests.

## Human Verification

- Verified scenarios: identity with emoji, identity without emoji, no identity fallback to raw key, non-agent keys unchanged.
- Edge cases checked: malformed keys, keys with colons in accountId, empty identity maps.
- What I did not verify: live gateway with real agent bindings (no access to running instance).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes (graceful fallback to raw key when no identity data)
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert: Revert this commit; the KEY column will return to showing raw session keys.
- Known bad symptoms: If `agentIdentityById` is empty or not passed, all keys display as raw (safe fallback).

## Risks and Mitigations

- Risk: `parseSessionKeyParts` may not handle all edge-case key formats.
  - Mitigation: Returns `null` for any unrecognized format, falling back to raw key display.

## Files Changed (5)

| File | Change |
|---|---|
| `ui/src/ui/format.ts` | Added `parseSessionKeyParts()` utility |
| `ui/src/ui/format.test.ts` | 6 unit tests for key parsing |
| `ui/src/ui/views/sessions.ts` | Friendly KEY column + search by identity name |
| `ui/src/ui/views/sessions.test.ts` | 3 new rendering tests |
| `ui/src/ui/app-render.ts` | Pass `agentIdentityById` to sessions view |