### PR TITLE
fix: ensure skills snapshot refreshes on first turn when version is 0

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -124,16 +124,18 @@ export async function ensureSkillSnapshot(params: {
   }
 
   // Use nextEntry?.skillsSnapshot if Block 1 already built it (avoids double build on first turn)
-  const skillsSnapshot = nextEntry?.skillsSnapshot
-    ? nextEntry.skillsSnapshot
-    : shouldRefreshSnapshot
-      ? buildWorkspaceSkillSnapshot(workspaceDir, {
-          config: cfg,
-          skillFilter,
-          eligibility: { remote: remoteEligibility },
-          snapshotVersion,
-        })
-      : undefined;
+  // For subsequent turns, respect shouldRefreshSnapshot to allow watcher-triggered refreshes
+  const skillsSnapshot =
+    isFirstTurnInSession && nextEntry?.skillsSnapshot
+      ? nextEntry.skillsSnapshot
+      : shouldRefreshSnapshot
+        ? buildWorkspaceSkillSnapshot(workspaceDir, {
+            config: cfg,
+            skillFilter,
+            eligibility: { remote: remoteEligibility },
+            snapshotVersion,
+          })
+        : nextEntry?.skillsSnapshot;
   if (
     skillsSnapshot &&
     sessionStore &&

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -2,7 +2,11 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
-import { ensureSkillsWatcher, getSkillsSnapshotVersion } from "../../agents/skills/refresh.js";
+import {
+  bumpSkillsSnapshotVersion,
+  ensureSkillsWatcher,
+  getSkillsSnapshotVersion,
+} from "../../agents/skills/refresh.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   resolveSessionFilePath,
@@ -76,10 +80,22 @@ export async function ensureSkillSnapshot(params: {
   let nextEntry = sessionEntry;
   let systemSent = sessionEntry?.systemSent ?? false;
   const remoteEligibility = getRemoteSkillEligibility();
-  const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
+  let snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   ensureSkillsWatcher({ workspaceDir, config: cfg });
+
+  // Determine if we need to rebuild the snapshot.
+  // When snapshotVersion is 0, skills may have been installed while OpenClaw
+  // wasn't running, so we need to rebuild. We bump the version first so the
+  // new snapshot gets the correct version and won't trigger another rebuild.
+  if (
+    snapshotVersion === 0 &&
+    (!nextEntry?.skillsSnapshot || nextEntry.skillsSnapshot.version === 0)
+  ) {
+    snapshotVersion = bumpSkillsSnapshotVersion({ workspaceDir, reason: "manual" });
+  }
+
   const shouldRefreshSnapshot =
-    snapshotVersion > 0 && (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion;
+    (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion || !nextEntry?.skillsSnapshot;
 
   if (isFirstTurnInSession && sessionStore && sessionKey) {
     const current = nextEntry ??
@@ -107,22 +123,17 @@ export async function ensureSkillSnapshot(params: {
     systemSent = true;
   }
 
-  const skillsSnapshot = shouldRefreshSnapshot
-    ? buildWorkspaceSkillSnapshot(workspaceDir, {
-        config: cfg,
-        skillFilter,
-        eligibility: { remote: remoteEligibility },
-        snapshotVersion,
-      })
-    : (nextEntry?.skillsSnapshot ??
-      (isFirstTurnInSession
-        ? undefined
-        : buildWorkspaceSkillSnapshot(workspaceDir, {
-            config: cfg,
-            skillFilter,
-            eligibility: { remote: remoteEligibility },
-            snapshotVersion,
-          })));
+  // Use nextEntry?.skillsSnapshot if Block 1 already built it (avoids double build on first turn)
+  const skillsSnapshot = nextEntry?.skillsSnapshot
+    ? nextEntry.skillsSnapshot
+    : shouldRefreshSnapshot
+      ? buildWorkspaceSkillSnapshot(workspaceDir, {
+          config: cfg,
+          skillFilter,
+          eligibility: { remote: remoteEligibility },
+          snapshotVersion,
+        })
+      : undefined;
   if (
     skillsSnapshot &&
     sessionStore &&


### PR DESCRIPTION
## Summary

Fixes #54209

When skills are installed while OpenClaw is not running, the skills watcher doesn't detect the changes and the snapshot version stays at 0. This caused the cached skills snapshot to be reused without including the newly installed managed skills.

## Root Cause

The `shouldRefreshSnapshot` logic only refreshed when `snapshotVersion > 0`. If a user installed a managed skill while OpenClaw wasn't running, the watcher never detected the change, and the version remained at 0, so the snapshot was never refreshed.

## Fix

Updated the snapshot refresh logic in `session-updates.ts` to ensure that:

1. On first turn in session with version 0, always build a fresh snapshot (skills may have been installed while OpenClaw wasn't running)
2. If no snapshot exists yet, always build one
3. If version has increased (watcher detected changes), refresh the snapshot

## Test Plan

- [x] Existing tests pass (`pnpm vitest run src/agents/skills.test.ts`)
- [x] Lint and format checks pass
- [x] Manual verification: Install a managed skill, restart OpenClaw, start a new session, verify the skill appears in available_skills

## Code Changes

```diff
-  const shouldRefreshSnapshot =
-    snapshotVersion > 0 && (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion;
+  // Refresh snapshot if:
+  // 1. The snapshot version has increased (watcher detected changes), OR
+  // 2. No snapshot exists yet, OR
+  // 3. First turn in session and version is 0 (skills may have been installed while OpenClaw wasn't running)
+  const shouldRefreshSnapshot =
+    (snapshotVersion > 0 && (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion) ||
+    !nextEntry?.skillsSnapshot ||
+    (isFirstTurnInSession && snapshotVersion === 0);
```