### PR TITLE
fix(memory-lancedb): show full UUID in memory_forget candidate list

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -452,7 +452,7 @@ export default definePluginEntry({
             }
 
             const list = results
-              .map((r) => `- [${r.entry.id.slice(0, 8)}] ${r.entry.text.slice(0, 60)}...`)
+              .map((r) => `- [${r.entry.id}] ${r.entry.text.slice(0, 60)}...`)
               .join("\n");
 
             // Strip vector data for serialization


### PR DESCRIPTION
## Problem

When `memory_forget` returns multiple candidates, the display text truncates IDs to 8 characters:

```
- [ee628c77] Claude Sonnet weekly quota exhausted...
```

But the `delete()` method validates against a full UUID regex (`/^[0-9a-f]{8}-...-[0-9a-f]{12}$/`), so passing the displayed short ID back as `memoryId` always fails with:

```
Invalid memory ID format: ee628c77
```

This makes it impossible to delete memories when multiple candidates match a query.

## Fix

Display the full UUID in the candidate list text so the agent can pass it back:

```diff
- .map((r) => \`- [\${r.entry.id.slice(0, 8)}] ...\`)
+ .map((r) => \`- [\${r.entry.id}] ...\`)
```

The `details.candidates` array already contains full IDs — only the human-readable text was truncated.

## Notes

- One-line change, no new dependencies
- The `delete()` UUID validation is correct and should stay (prevents SQL injection in the LanceDB filter)
- An alternative would be to also accept short prefixes in `delete()`, but showing full IDs is simpler and more reliable