### PR TITLE
fix: detect legacy Office binary formats as non-text attachments

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -1280,6 +1280,25 @@ describe("applyMediaUnderstanding", () => {
     expectFileNotApplied({ ctx, result, body: "<media:file>" });
   });
 
+  it("skips legacy Microsoft Office binary formats (msword, x-cfb)", async () => {
+    // Legacy .doc files use OLE/CFB containers that are binary.
+    const oleMagic = Buffer.from("d0cf11e0a1b11ae1", "hex");
+    for (const mime of ["application/msword", "application/x-cfb"]) {
+      const filePath = await createTempMediaFile({
+        fileName: mime === "application/msword" ? "doc.doc" : "file.cfb",
+        content: oleMagic,
+      });
+
+      const { ctx, result } = await applyWithDisabledMedia({
+        body: "<media:file>",
+        mediaPath: filePath,
+        mediaType: mime,
+      });
+
+      expectFileNotApplied({ ctx, result, body: "<media:file>" });
+    }
+  });
+
   it("keeps vendor +json attachments eligible for text extraction", async () => {
     const filePath = await createTempMediaFile({
       fileName: "payload.bin",

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -313,10 +313,7 @@ function isBinaryMediaMime(mime?: string): boolean {
     return true;
   }
   // Legacy Microsoft Office binary formats (OLE/CFB container)
-  if (
-    mime === "application/msword" ||
-    mime === "application/x-cfb"
-  ) {
+  if (mime === "application/msword" || mime === "application/x-cfb") {
     return true;
   }
   if (mime.startsWith("application/vnd.")) {

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -312,6 +312,13 @@ function isBinaryMediaMime(mime?: string): boolean {
   ) {
     return true;
   }
+  // Legacy Microsoft Office binary formats (OLE/CFB container)
+  if (
+    mime === "application/msword" ||
+    mime === "application/x-cfb"
+  ) {
+    return true;
+  }
   if (mime.startsWith("application/vnd.")) {
     // Keep vendor +json/+xml payloads eligible for text extraction while
     // treating the common binary vendor family (Office, archives, etc.) as binary.


### PR DESCRIPTION
## Summary

Fixes #54176 — .doc files (application/x-cfb, application/msword) are auto-embedded as text, causing 70KB of binary garbage in prompts and LLM 'high risk' rejections.

## Root Cause

`isBinaryMediaMime()` in `src/media-understanding/apply.ts` catches `application/vnd.*` (which covers modern Office formats like .docx/.xlsx) and common archives, but **misses two legacy Microsoft Office MIME types**:

- `application/msword` — the standard MIME for .doc files
- `application/x-cfb` — the MIME that file-type sniffers detect for OLE Compound Binary Format (legacy Office container)

## Fix

Add both MIME types to the binary detection check, grouped with a comment explaining they are legacy OLE/CFB formats.

## Testing

- No behavioral changes to modern Office formats (already caught by `application/vnd.*`)
- .doc files will now be treated as binary attachments instead of embedded as text
- 7 lines changed, 1 file