### PR TITLE
fix: pass remote CDP timeouts to createTargetViaCdp

### DIFF
--- a/src/browser/cdp.ts
+++ b/src/browser/cdp.ts
@@ -100,11 +100,14 @@ export async function captureScreenshot(opts: {
   });
 }
 
-export async function createTargetViaCdp(opts: {
-  cdpUrl: string;
-  url: string;
-  ssrfPolicy?: SsrFPolicy;
-}): Promise<{ targetId: string }> {
+export async function createTargetViaCdp(
+  opts: {
+    cdpUrl: string;
+    url: string;
+    ssrfPolicy?: SsrFPolicy;
+  },
+  timeouts?: { httpTimeoutMs?: number; handshakeTimeoutMs?: number },
+): Promise<{ targetId: string }> {
   await assertBrowserNavigationAllowed({
     url: opts.url,
     ...withBrowserNavigationPolicy(opts.ssrfPolicy),
@@ -118,7 +121,7 @@ export async function createTargetViaCdp(opts: {
     // Standard HTTP(S) CDP endpoint — discover WebSocket URL via /json/version.
     const version = await fetchJson<{ webSocketDebuggerUrl?: string }>(
       appendCdpPath(opts.cdpUrl, "/json/version"),
-      1500,
+      timeouts?.httpTimeoutMs,
     );
     const wsUrlRaw = String(version?.webSocketDebuggerUrl ?? "").trim();
     wsUrl = wsUrlRaw ? normalizeCdpWsUrl(wsUrlRaw, opts.cdpUrl) : "";
@@ -127,16 +130,20 @@ export async function createTargetViaCdp(opts: {
     }
   }
 
-  return await withCdpSocket(wsUrl, async (send) => {
-    const created = (await send("Target.createTarget", { url: opts.url })) as {
-      targetId?: string;
-    };
-    const targetId = String(created?.targetId ?? "").trim();
-    if (!targetId) {
-      throw new Error("CDP Target.createTarget returned no targetId");
-    }
-    return { targetId };
-  });
+  return await withCdpSocket(
+    wsUrl,
+    async (send) => {
+      const created = (await send("Target.createTarget", { url: opts.url })) as {
+        targetId?: string;
+      };
+      const targetId = String(created?.targetId ?? "").trim();
+      if (!targetId) {
+        throw new Error("CDP Target.createTarget returned no targetId");
+      }
+      return { targetId };
+    },
+    { handshakeTimeoutMs: timeouts?.handshakeTimeoutMs },
+  );
 }
 
 export type CdpRemoteObject = {

--- a/src/browser/server-context.tab-ops.ts
+++ b/src/browser/server-context.tab-ops.ts
@@ -175,11 +175,20 @@ export function createProfileTabOps({
       );
     }
 
-    const createdViaCdp = await createTargetViaCdp({
-      cdpUrl: profile.cdpUrl,
-      url,
-      ...ssrfPolicyOpts,
-    })
+    const isRemote = !profile.cdpIsLoopback;
+    const createdViaCdp = await createTargetViaCdp(
+      {
+        cdpUrl: profile.cdpUrl,
+        url,
+        ...ssrfPolicyOpts,
+      },
+      isRemote
+        ? {
+            httpTimeoutMs: state().resolved.remoteCdpTimeoutMs,
+            handshakeTimeoutMs: state().resolved.remoteCdpHandshakeTimeoutMs,
+          }
+        : undefined,
+    )
       .then((r) => r.targetId)
       .catch(() => null);
 


### PR DESCRIPTION
## Problem
createTargetViaCdp() was using hardcoded 1500ms HTTP timeout and default 5000ms WebSocket handshake timeout for all profiles. Remote CDP endpoints (browserless etc.) may need longer timeouts, causing the browser tool `open` action to timeout while `navigate` works fine.

## Fix
- `createTargetViaCdp()` now accepts an optional `timeouts` parameter with `httpTimeoutMs` and `handshakeTimeoutMs`
- When `profile.cdpIsLoopback = false` (remote profile), call sites pass `state().resolved.remoteCdpTimeoutMs` and `state().resolved.remoteCdpHandshakeTimeoutMs` from the resolved config
- Local profiles fall back to `undefined` (uses existing defaults)

## Files changed
- `src/browser/cdp.ts`
- `src/browser/server-context.tab-ops.ts`