### PR TITLE
fix(config): avoid repo cache dir in isolated config-surface retry

### DIFF
--- a/scripts/load-channel-config-surface.ts
+++ b/scripts/load-channel-config-surface.ts
@@ -173,6 +173,14 @@ function copyModuleImportGraphWithoutNodeModules(params: {
     copiedModulePath: path.join(isolatedRoot, relativeModulePath),
     cleanup: () => {
       fs.rmSync(isolatedRoot, { recursive: true, force: true });
+      try {
+        fs.rmdirSync(tempParent);
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT" && code !== "ENOTEMPTY") {
+          throw error;
+        }
+      }
     },
   };
 }

--- a/src/config/load-channel-config-surface.test.ts
+++ b/src/config/load-channel-config-surface.test.ts
@@ -85,5 +85,7 @@ describe("loadChannelConfigSurfaceModule", () => {
         },
       },
     });
+
+    expect(fs.existsSync(path.join(repoRoot, ".openclaw-config-doc-cache"))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- stop leaving an untracked repo-root `.openclaw-config-doc-cache` directory behind after isolated config-surface retries
- keep the isolated retry copy under the repository root so bare dependency resolution still works against the repo `node_modules`
- add regression coverage that the retry still succeeds and the repo-root cache parent is cleaned up afterward

## Problem
`scripts/load-channel-config-surface.ts` retries broken extension-local `node_modules` imports by copying the config-surface import graph into an isolated temporary directory.

Today that retry creates a parent cache directory under the repository root:

- `.openclaw-config-doc-cache/`

The retry cleanup removes the per-run `mkdtemp` child directory, but leaves the parent cache directory behind.

## Why it matters
That creates an unnecessary repository side effect for a read-only config-surface load path:

- repo roots pick up an untracked `.openclaw-config-doc-cache/` directory
- doc/config tooling leaves residue behind after a successful retry
- the directory is not ignored by `.gitignore`

## Root cause
The isolated retry path creates its temp parent under `repoRoot`, but cleanup only removes the per-run child copy:

- `path.join(params.repoRoot, ".openclaw-config-doc-cache")`
- `fs.rmSync(isolatedRoot, { recursive: true, force: true })`

The empty parent cache directory is never cleaned up.

## What changed
- keep the isolated retry copy under the existing repo-root cache parent so dependency resolution still works as before
- after removing the per-run isolated copy, attempt to remove the now-empty `.openclaw-config-doc-cache` parent directory too
- ignore expected `ENOENT` / `ENOTEMPTY` cleanup cases so concurrent or repeated runs stay safe
- add a regression assertion that a successful retry does not leave `.openclaw-config-doc-cache` behind in the repo root

## Scope boundary
This PR only changes cleanup behavior for the isolated config-surface retry cache directory.

It does not:
- change config schema resolution behavior
- change which modules are copied into the isolated retry graph
- move retry copies outside the repository root
- change bundled metadata or doc-baseline generation logic beyond removing the repo-root cache residue

## Validation
- `pnpm exec vitest run src/config/load-channel-config-surface.test.ts`

## User impact
Config/doc tooling that hits the isolated retry path no longer leaves an untracked `.openclaw-config-doc-cache/` directory in the repository root after a successful retry.

## Risks and mitigations
- Risk: removing the cache parent could race with another retry using the same parent directory.
  - Mitigation: cleanup only attempts to remove the parent after deleting the child copy, and tolerates `ENOTEMPTY` / `ENOENT` so active or already-cleaned directories are left alone.
- Risk: changing cleanup behavior could accidentally alter fallback dependency resolution.
  - Mitigation: the retry still uses the existing repo-root parent and the existing isolated retry test continues to pass.

## Compatibility / migration
- backward compatible: yes
- migration required: no

## Failure recovery
- revert this commit to restore the previous cleanup behavior
- delete any previously created `.openclaw-config-doc-cache/` directories manually if they already exist
