### PR TITLE
fix(cron): infer agentId from workspace when adding jobs

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -17,6 +17,8 @@ const defaultGatewayMock = async (
   return { ok: true, params };
 };
 const callGatewayFromCli = vi.fn(defaultGatewayMock);
+const loadConfigMock = vi.hoisted(() => vi.fn(() => ({})));
+const resolveAgentIdByWorkspacePathMock = vi.hoisted(() => vi.fn(() => undefined));
 
 vi.mock("./gateway-rpc.js", async () => {
   const actual = await vi.importActual<typeof import("./gateway-rpc.js")>("./gateway-rpc.js");
@@ -24,6 +26,25 @@ vi.mock("./gateway-rpc.js", async () => {
     ...actual,
     callGatewayFromCli: (method: string, opts: unknown, params?: unknown, extra?: unknown) =>
       callGatewayFromCli(method, opts, params, extra as number | undefined),
+  };
+});
+
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return {
+    ...actual,
+    loadConfig: () => loadConfigMock(),
+  };
+});
+
+vi.mock("../agents/agent-scope.js", async () => {
+  const actual = await vi.importActual<typeof import("../agents/agent-scope.js")>(
+    "../agents/agent-scope.js",
+  );
+  return {
+    ...actual,
+    resolveAgentIdByWorkspacePath: (...args: Parameters<typeof actual.resolveAgentIdByWorkspacePath>) =>
+      resolveAgentIdByWorkspacePathMock(...args),
   };
 });
 
@@ -72,6 +93,8 @@ function buildProgram() {
 function resetGatewayMock() {
   callGatewayFromCli.mockClear();
   callGatewayFromCli.mockImplementation(defaultGatewayMock);
+  loadConfigMock.mockReset().mockReturnValue({});
+  resolveAgentIdByWorkspacePathMock.mockReset().mockReturnValue(undefined);
   resetRuntimeCapture();
 }
 
@@ -378,6 +401,28 @@ describe("cron cli", () => {
     const addCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.add");
     const params = addCall?.[2] as { agentId?: string };
     expect(params?.agentId).toBe("ops");
+  });
+
+  it("infers agent id from current workspace when --agent is omitted", async () => {
+    resolveAgentIdByWorkspacePathMock.mockReturnValue("sales");
+
+    await runCronCommand([
+      "cron",
+      "add",
+      "--name",
+      "Inferred agent",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hi",
+    ]);
+
+    const addCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.add");
+    const params = addCall?.[2] as { agentId?: string };
+    expect(params?.agentId).toBe("sales");
+    expect(resolveAgentIdByWorkspacePathMock).toHaveBeenCalledTimes(1);
   });
 
   it("sets lightContext on cron add when --light-context is passed", async () => {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -1,4 +1,6 @@
 import type { Command } from "commander";
+import { resolveAgentIdByWorkspacePath } from "../../agents/agent-scope.js";
+import { loadConfig } from "../../config/config.js";
 import type { CronJob } from "../../cron/types.js";
 import { sanitizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -13,6 +15,15 @@ import {
   printCronList,
   warnIfCronSchedulerDisabled,
 } from "./shared.js";
+
+function inferCronAgentIdFromWorkspace(): string | undefined {
+  try {
+    const cfg = loadConfig();
+    return resolveAgentIdByWorkspacePath(cfg, process.cwd());
+  } catch {
+    return undefined;
+  }
+}
 
 export function registerCronStatusCommand(cron: Command) {
   addGatewayClientOptions(
@@ -120,7 +131,7 @@ export function registerCronAddCommand(cron: Command) {
           const agentId =
             typeof opts.agent === "string" && opts.agent.trim()
               ? sanitizeAgentId(opts.agent.trim())
-              : undefined;
+              : inferCronAgentIdFromWorkspace();
 
           const hasAnnounce = Boolean(opts.announce) || opts.deliver === true;
           const hasNoDeliver = opts.deliver === false;


### PR DESCRIPTION
# PR Draft: fix(cron): inherit current agentId when creating jobs from routed agent context

## Summary
Fixes a multi-agent isolation bug where cron jobs created without explicit `--agent` can be persisted with no `agentId`, then executed under default agent (`main`).

In routed environments (e.g., Feishu group -> `sales`), this causes cross-agent leakage: job outputs appear in sales channel while execution context is `main`.

## Behavior before
- Cron job persisted with `agentId = null`
- Scheduler resolved to default agent (`main`)
- Run history session key looked like `agent:main:cron:<id>:run:<sessionId>`

## Behavior after
- If cron add is called from an active agent/session context and `--agent` is absent:
  - auto-set `job.agentId = currentAgentId`
- If no context is available:
  - keep existing default behavior (or optionally warn)
- `cron list` and `cron runs` show explicit `agentId`

## Proposed code touch points (indicative)
1. `src/cron/add.ts` (or equivalent add command handler)
   - inject `agentId` from invocation context when omitted
2. `src/cron/store.ts`
   - ensure `agentId` persisted and typed
3. `src/cron/scheduler.ts`
   - prefer explicit `job.agentId` and avoid silent fallback when in multi-agent mode
4. `src/cron/runs.ts`
   - include `agentId` field in run entries/output for observability
5. tests
   - add unit/integration case: routed `sales` context + no `--agent` -> persisted `agentId=sales`

## Acceptance criteria
- Creating cron from `sales` routed context without `--agent` yields `Agent ID = sales`
- New run history uses `sessionKey` with `agent:sales:cron:...`
- Existing behavior with explicit `--agent` unchanged

## Notes
Current user-level workaround:
```bash
openclaw cron edit <id> --agent sales --session isolated --announce --channel feishu --to chat:oc_xxx
```
