### PR TITLE
fix(gateway): isolate cron nested lane concurrency

### DIFF
--- a/src/agents/lanes.test.ts
+++ b/src/agents/lanes.test.ts
@@ -1,18 +1,37 @@
 import { describe, expect, it } from "vitest";
-import { AGENT_LANE_NESTED, resolveNestedAgentLane } from "./lanes.js";
+import { CommandLane } from "../process/lanes.js";
+import {
+  AGENT_LANE_CRON_NESTED,
+  AGENT_LANE_NESTED,
+  resolveCronAgentLane,
+  resolveNestedAgentLane,
+} from "./lanes.js";
 
 describe("resolveNestedAgentLane", () => {
   it("defaults to the nested lane when no lane is provided", () => {
     expect(resolveNestedAgentLane()).toBe(AGENT_LANE_NESTED);
   });
 
-  it("moves cron lane callers onto the nested lane", () => {
-    expect(resolveNestedAgentLane("cron")).toBe(AGENT_LANE_NESTED);
-    expect(resolveNestedAgentLane("  cron  ")).toBe(AGENT_LANE_NESTED);
+  it("preserves explicit lanes", () => {
+    expect(resolveNestedAgentLane("cron")).toBe(CommandLane.Cron);
+    expect(resolveNestedAgentLane("  cron  ")).toBe(CommandLane.Cron);
+    expect(resolveNestedAgentLane("subagent")).toBe("subagent");
+    expect(resolveNestedAgentLane(" custom-lane ")).toBe("custom-lane");
+  });
+});
+
+describe("resolveCronAgentLane", () => {
+  it("defaults cron-owned runs to the cron-nested lane", () => {
+    expect(resolveCronAgentLane()).toBe(AGENT_LANE_CRON_NESTED);
+  });
+
+  it("moves cron lane callers onto the cron-nested lane", () => {
+    expect(resolveCronAgentLane("cron")).toBe(AGENT_LANE_CRON_NESTED);
+    expect(resolveCronAgentLane("  cron  ")).toBe(AGENT_LANE_CRON_NESTED);
   });
 
   it("preserves non-cron lanes", () => {
-    expect(resolveNestedAgentLane("subagent")).toBe("subagent");
-    expect(resolveNestedAgentLane(" custom-lane ")).toBe("custom-lane");
+    expect(resolveCronAgentLane("subagent")).toBe("subagent");
+    expect(resolveCronAgentLane(" custom-lane ")).toBe("custom-lane");
   });
 });

--- a/src/agents/lanes.ts
+++ b/src/agents/lanes.ts
@@ -1,14 +1,24 @@
 import { CommandLane } from "../process/lanes.js";
 
 export const AGENT_LANE_NESTED = CommandLane.Nested;
+export const AGENT_LANE_CRON_NESTED = CommandLane.CronNested;
 export const AGENT_LANE_SUBAGENT = CommandLane.Subagent;
 
 export function resolveNestedAgentLane(lane?: string): string {
   const trimmed = lane?.trim();
-  // Nested agent runs should not inherit the cron execution lane. Cron jobs
-  // already occupy that lane while they dispatch inner work.
-  if (!trimmed || trimmed === "cron") {
+  if (!trimmed) {
     return AGENT_LANE_NESTED;
+  }
+  return trimmed;
+}
+
+export function resolveCronAgentLane(lane?: string): string {
+  const trimmed = lane?.trim();
+  // Cron jobs already occupy the outer cron lane, so nested agent work needs
+  // its own dedicated global lane to avoid self-deadlock without widening the
+  // shared nested lane used by agent-to-agent flows.
+  if (!trimmed || trimmed === CommandLane.Cron) {
+    return AGENT_LANE_CRON_NESTED;
   }
   return trimmed;
 }

--- a/src/agents/pi-embedded-runner/lanes.test.ts
+++ b/src/agents/pi-embedded-runner/lanes.test.ts
@@ -10,12 +10,12 @@ describe("resolveGlobalLane", () => {
     }
   });
 
-  it("maps cron lane to nested lane to prevent deadlocks", () => {
+  it("maps cron lane to cron-nested lane to prevent deadlocks", () => {
     // When cron jobs trigger nested agent runs, the outer execution holds
     // the cron lane slot. Inner work must use a separate lane to avoid
     // deadlock. See: https://github.com/openclaw/openclaw/issues/44805
     for (const lane of ["cron", "  cron  "]) {
-      expect(resolveGlobalLane(lane)).toBe(CommandLane.Nested);
+      expect(resolveGlobalLane(lane)).toBe(CommandLane.CronNested);
     }
   });
 
@@ -23,6 +23,7 @@ describe("resolveGlobalLane", () => {
     for (const [lane, expected] of [
       ["main", CommandLane.Main],
       ["subagent", CommandLane.Subagent],
+      ["cron-nested", CommandLane.CronNested],
       ["nested", CommandLane.Nested],
       ["custom-lane", "custom-lane"],
       [" custom ", "custom"],

--- a/src/agents/pi-embedded-runner/lanes.ts
+++ b/src/agents/pi-embedded-runner/lanes.ts
@@ -7,9 +7,10 @@ export function resolveSessionLane(key: string) {
 
 export function resolveGlobalLane(lane?: string) {
   const cleaned = lane?.trim();
-  // Cron jobs hold the cron lane slot; inner operations must use nested to avoid deadlock.
+  // Cron jobs hold the cron lane slot; inner operations must use a dedicated
+  // cron-nested lane to avoid deadlock without widening the shared nested lane.
   if (cleaned === CommandLane.Cron) {
-    return CommandLane.Nested;
+    return CommandLane.CronNested;
   }
   return cleaned ? cleaned : CommandLane.Main;
 }

--- a/src/cron/isolated-agent.lane.test.ts
+++ b/src/cron/isolated-agent.lane.test.ts
@@ -82,15 +82,15 @@ describe("runCronIsolatedAgentTurn lane selection", () => {
     vi.resetModules();
   });
 
-  it("moves the cron lane to nested for embedded runs", async () => {
+  it("moves the cron lane to cron-nested for embedded runs", async () => {
     await withTempCronHome(async (home) => {
-      expect(await runLaneCase(home, "cron")).toBe("nested");
+      expect(await runLaneCase(home, "cron")).toBe("cron-nested");
     });
   });
 
-  it("defaults missing lanes to nested for embedded runs", async () => {
+  it("defaults missing lanes to cron-nested for embedded runs", async () => {
     await withTempCronHome(async (home) => {
-      expect(await runLaneCase(home)).toBe("nested");
+      expect(await runLaneCase(home)).toBe("cron-nested");
     });
   });
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -13,7 +13,7 @@ import { lookupContextTokens } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
-import { resolveNestedAgentLane } from "../../agents/lanes.js";
+import { resolveCronAgentLane } from "../../agents/lanes.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider, resolveThinkingDefault } from "../../agents/model-selection.js";
@@ -513,7 +513,7 @@ export async function runCronIsolatedAgentTurn(params: {
             config: cfgWithAgentDefaults,
             skillsSnapshot,
             prompt: promptText,
-            lane: resolveNestedAgentLane(params.lane),
+            lane: resolveCronAgentLane(params.lane),
             provider: providerOverride,
             model: modelOverride,
             authProfileId,

--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -23,14 +23,14 @@ describe("applyGatewayLaneConcurrency", () => {
     vi.clearAllMocks();
   });
 
-  it("applies cron concurrency to the nested lane too", () => {
+  it("applies cron concurrency to the cron-nested lane too", () => {
     applyGatewayLaneConcurrency({
       cron: { maxConcurrentRuns: 3 },
     } as never);
 
     expect(hoisted.setCommandLaneConcurrency.mock.calls).toEqual([
       [CommandLane.Cron, 3],
-      [CommandLane.Nested, 3],
+      [CommandLane.CronNested, 3],
       [CommandLane.Main, 7],
       [CommandLane.Subagent, 11],
     ]);

--- a/src/gateway/server-lanes.test.ts
+++ b/src/gateway/server-lanes.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CommandLane } from "../process/lanes.js";
+
+const hoisted = vi.hoisted(() => ({
+  resolveAgentMaxConcurrent: vi.fn(() => 7),
+  resolveSubagentMaxConcurrent: vi.fn(() => 11),
+  setCommandLaneConcurrency: vi.fn(),
+}));
+
+vi.mock("../config/agent-limits.js", () => ({
+  resolveAgentMaxConcurrent: hoisted.resolveAgentMaxConcurrent,
+  resolveSubagentMaxConcurrent: hoisted.resolveSubagentMaxConcurrent,
+}));
+
+vi.mock("../process/command-queue.js", () => ({
+  setCommandLaneConcurrency: hoisted.setCommandLaneConcurrency,
+}));
+
+const { applyGatewayLaneConcurrency } = await import("./server-lanes.js");
+
+describe("applyGatewayLaneConcurrency", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("applies cron concurrency to the nested lane too", () => {
+    applyGatewayLaneConcurrency({
+      cron: { maxConcurrentRuns: 3 },
+    } as never);
+
+    expect(hoisted.setCommandLaneConcurrency.mock.calls).toEqual([
+      [CommandLane.Cron, 3],
+      [CommandLane.Nested, 3],
+      [CommandLane.Main, 7],
+      [CommandLane.Subagent, 11],
+    ]);
+  });
+});

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -4,7 +4,9 @@ import { setCommandLaneConcurrency } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 
 export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) {
-  setCommandLaneConcurrency(CommandLane.Cron, cfg.cron?.maxConcurrentRuns ?? 1);
+  const cronConcurrency = cfg.cron?.maxConcurrentRuns ?? 1;
+  setCommandLaneConcurrency(CommandLane.Cron, cronConcurrency);
+  setCommandLaneConcurrency(CommandLane.Nested, cronConcurrency);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
 }

--- a/src/gateway/server-lanes.ts
+++ b/src/gateway/server-lanes.ts
@@ -6,7 +6,7 @@ import { CommandLane } from "../process/lanes.js";
 export function applyGatewayLaneConcurrency(cfg: ReturnType<typeof loadConfig>) {
   const cronConcurrency = cfg.cron?.maxConcurrentRuns ?? 1;
   setCommandLaneConcurrency(CommandLane.Cron, cronConcurrency);
-  setCommandLaneConcurrency(CommandLane.Nested, cronConcurrency);
+  setCommandLaneConcurrency(CommandLane.CronNested, cronConcurrency);
   setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(cfg));
   setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(cfg));
 }

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -3,6 +3,11 @@ import { CommandLane } from "../process/lanes.js";
 import type { GatewayReloadPlan } from "./config-reload-plan.js";
 
 const hoisted = vi.hoisted(() => ({
+  buildGatewayCronService: vi.fn(() => ({
+    cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+    storePath: "/tmp/cron.json",
+    cronEnabled: true,
+  })),
   getActiveEmbeddedRunCount: vi.fn(() => 0),
   getTotalPendingReplies: vi.fn(() => 0),
   getTotalQueueSize: vi.fn(() => 0),
@@ -46,6 +51,10 @@ vi.mock("./server/hooks.js", () => ({
   resolveHookClientIpConfig: hoisted.resolveHookClientIpConfig,
 }));
 
+vi.mock("./server-cron.js", () => ({
+  buildGatewayCronService: hoisted.buildGatewayCronService,
+}));
+
 const { createGatewayReloadHandlers } = await import("./server-reload-handlers.js");
 
 function createPlan(): GatewayReloadPlan {
@@ -57,7 +66,7 @@ function createPlan(): GatewayReloadPlan {
     reloadHooks: false,
     restartGmailWatcher: false,
     restartBrowserControl: false,
-    restartCron: false,
+    restartCron: true,
     restartHeartbeat: false,
     restartHealthMonitor: false,
     restartChannels: new Set(),
@@ -70,7 +79,7 @@ describe("createGatewayReloadHandlers", () => {
     vi.clearAllMocks();
   });
 
-  it("applies cron concurrency to the nested lane during hot reload", async () => {
+  it("applies cron concurrency to the cron-nested lane during hot reload", async () => {
     const state = {
       hooksConfig: {},
       hookClientIpConfig: {},
@@ -104,10 +113,11 @@ describe("createGatewayReloadHandlers", () => {
     });
     expect(hoisted.setCommandLaneConcurrency.mock.calls).toEqual([
       [CommandLane.Cron, 4],
-      [CommandLane.Nested, 4],
+      [CommandLane.CronNested, 4],
       [CommandLane.Main, 5],
       [CommandLane.Subagent, 9],
     ]);
+    expect(hoisted.buildGatewayCronService).toHaveBeenCalledOnce();
     expect(setState).toHaveBeenCalledOnce();
   });
 });

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CommandLane } from "../process/lanes.js";
+import type { GatewayReloadPlan } from "./config-reload-plan.js";
+
+const hoisted = vi.hoisted(() => ({
+  getActiveEmbeddedRunCount: vi.fn(() => 0),
+  getTotalPendingReplies: vi.fn(() => 0),
+  getTotalQueueSize: vi.fn(() => 0),
+  isRestartEnabled: vi.fn(() => false),
+  resolveAgentMaxConcurrent: vi.fn(() => 5),
+  resolveHookClientIpConfig: vi.fn(() => ({})),
+  resolveSubagentMaxConcurrent: vi.fn(() => 9),
+  setCommandLaneConcurrency: vi.fn(),
+  setGatewaySigusr1RestartPolicy: vi.fn(),
+}));
+
+vi.mock("../agents/pi-embedded-runner/runs.js", () => ({
+  getActiveEmbeddedRunCount: hoisted.getActiveEmbeddedRunCount,
+}));
+
+vi.mock("../auto-reply/reply/dispatcher-registry.js", () => ({
+  getTotalPendingReplies: hoisted.getTotalPendingReplies,
+}));
+
+vi.mock("../config/agent-limits.js", () => ({
+  resolveAgentMaxConcurrent: hoisted.resolveAgentMaxConcurrent,
+  resolveSubagentMaxConcurrent: hoisted.resolveSubagentMaxConcurrent,
+}));
+
+vi.mock("../config/commands.js", () => ({
+  isRestartEnabled: hoisted.isRestartEnabled,
+}));
+
+vi.mock("../infra/restart.js", () => ({
+  deferGatewayRestartUntilIdle: vi.fn(),
+  emitGatewayRestart: vi.fn(),
+  setGatewaySigusr1RestartPolicy: hoisted.setGatewaySigusr1RestartPolicy,
+}));
+
+vi.mock("../process/command-queue.js", () => ({
+  getTotalQueueSize: hoisted.getTotalQueueSize,
+  setCommandLaneConcurrency: hoisted.setCommandLaneConcurrency,
+}));
+
+vi.mock("./server/hooks.js", () => ({
+  resolveHookClientIpConfig: hoisted.resolveHookClientIpConfig,
+}));
+
+const { createGatewayReloadHandlers } = await import("./server-reload-handlers.js");
+
+function createPlan(): GatewayReloadPlan {
+  return {
+    changedPaths: ["cron.maxConcurrentRuns"],
+    restartGateway: false,
+    restartReasons: [],
+    hotReasons: ["cron.maxConcurrentRuns"],
+    reloadHooks: false,
+    restartGmailWatcher: false,
+    restartBrowserControl: false,
+    restartCron: false,
+    restartHeartbeat: false,
+    restartHealthMonitor: false,
+    restartChannels: new Set(),
+    noopPaths: [],
+  };
+}
+
+describe("createGatewayReloadHandlers", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("applies cron concurrency to the nested lane during hot reload", async () => {
+    const state = {
+      hooksConfig: {},
+      hookClientIpConfig: {},
+      heartbeatRunner: { updateConfig: vi.fn() },
+      cronState: { cron: { stop: vi.fn() } },
+      browserControl: null,
+      channelHealthMonitor: null,
+    };
+    const setState = vi.fn();
+    const handlers = createGatewayReloadHandlers({
+      deps: {} as never,
+      broadcast: vi.fn(),
+      getState: () => state as never,
+      setState,
+      startChannel: vi.fn(async () => {}),
+      stopChannel: vi.fn(async () => {}),
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logBrowser: { error: vi.fn() },
+      logChannels: { info: vi.fn(), error: vi.fn() },
+      logCron: { error: vi.fn() },
+      logReload: { info: vi.fn(), warn: vi.fn() },
+      createHealthMonitor: vi.fn(),
+    });
+
+    await handlers.applyHotReload(createPlan(), {
+      cron: { maxConcurrentRuns: 4 },
+    } as never);
+
+    expect(hoisted.setGatewaySigusr1RestartPolicy).toHaveBeenCalledWith({
+      allowExternal: false,
+    });
+    expect(hoisted.setCommandLaneConcurrency.mock.calls).toEqual([
+      [CommandLane.Cron, 4],
+      [CommandLane.Nested, 4],
+      [CommandLane.Main, 5],
+      [CommandLane.Subagent, 9],
+    ]);
+    expect(setState).toHaveBeenCalledOnce();
+  });
+});

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -148,7 +148,9 @@ export function createGatewayReloadHandlers(params: {
       }
     }
 
-    setCommandLaneConcurrency(CommandLane.Cron, nextConfig.cron?.maxConcurrentRuns ?? 1);
+    const cronConcurrency = nextConfig.cron?.maxConcurrentRuns ?? 1;
+    setCommandLaneConcurrency(CommandLane.Cron, cronConcurrency);
+    setCommandLaneConcurrency(CommandLane.Nested, cronConcurrency);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
 

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -150,7 +150,7 @@ export function createGatewayReloadHandlers(params: {
 
     const cronConcurrency = nextConfig.cron?.maxConcurrentRuns ?? 1;
     setCommandLaneConcurrency(CommandLane.Cron, cronConcurrency);
-    setCommandLaneConcurrency(CommandLane.Nested, cronConcurrency);
+    setCommandLaneConcurrency(CommandLane.CronNested, cronConcurrency);
     setCommandLaneConcurrency(CommandLane.Main, resolveAgentMaxConcurrent(nextConfig));
     setCommandLaneConcurrency(CommandLane.Subagent, resolveSubagentMaxConcurrent(nextConfig));
 

--- a/src/process/lanes.ts
+++ b/src/process/lanes.ts
@@ -1,6 +1,7 @@
 export const enum CommandLane {
   Main = "main",
   Cron = "cron",
+  CronNested = "cron-nested",
   Subagent = "subagent",
   Nested = "nested",
 }


### PR DESCRIPTION
## Summary

- Problem: `cron.maxConcurrentRuns` only affected the outer `Cron` lane, while cron-owned embedded agent work was effectively sharing the global nested lane behavior.
- Why it matters: when users raised cron concurrency, the fix needed to unblock cron-owned inner work without widening concurrency for unrelated agent-to-agent flows that also use `nested`.
- What changed: this PR introduces a dedicated `cron-nested` lane for cron-owned embedded agent work, applies `cron.maxConcurrentRuns` to `Cron` and `CronNested`, and updates focused regression coverage for startup, hot reload, and lane selection.
- What did NOT change (scope boundary): this PR does not change non-cron `nested` lane behavior, cron scheduling semantics, or general agent-to-agent lane defaults.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54180
- Related #54180
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: cron-owned inner runs need a separate global lane from the outer `Cron` lane to avoid self-deadlock, but reusing the shared `Nested` lane couples cron concurrency to unrelated nested flows.
- Missing detection / guardrail: previous coverage asserted cron timer concurrency but did not lock in which global lane cron-owned inner work should use, or ensure startup and hot reload configure that lane consistently.
- Prior context (`git blame`, prior PR, issue, or refactor if known): current `main` routes cron-owned inner work away from the outer cron lane, and the original issue identified the nested-lane bottleneck correctly, but the first patch shape widened the shared `Nested` lane.
- Why this regressed now: once users configured `cron.maxConcurrentRuns > 1`, the outer cron pool could fan out, but cron-owned inner work still serialized behind the lane it shared.
- If unknown, what was ruled out: ruled out timer pool sizing and cron state persistence; the bottleneck lived in lane selection plus lane concurrency wiring.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/lanes.test.ts`, `src/agents/pi-embedded-runner/lanes.test.ts`, `src/cron/isolated-agent.lane.test.ts`, `src/gateway/server-lanes.test.ts`, `src/gateway/server-reload-handlers.test.ts`
- Scenario the test should lock in: cron-owned runs resolve onto `cron-nested`, startup and hot reload apply `cron.maxConcurrentRuns` to `Cron` and `CronNested`, and unrelated shared `Nested` flows keep their existing behavior.
- Why this is the smallest reliable guardrail: the regression lives in lane resolution and lane setup, so focused tests on those entrypoints catch it without needing a live cron repro.
- Existing test that already covers this (if any): `src/cron/service.issue-regressions.test.ts` still covers the timer-side concurrency expectation.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `cron.maxConcurrentRuns` now unlocks cron-owned inner work through a dedicated `cron-nested` lane.
- Non-cron flows that already use the shared `nested` lane keep their previous concurrency behavior.
- Config hot reload now reapplies cron lane limits to `Cron` and `CronNested` together.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows 10 host
- Runtime/container: local Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `cron.maxConcurrentRuns: 3`

### Steps

1. Configure cron-owned isolated jobs with `cron.maxConcurrentRuns` above 1.
2. Start the gateway or hot-reload config.
3. Verify cron-owned inner work resolves onto `cron-nested` and that gateway lane setup gives `Cron` plus `CronNested` the configured concurrency.

### Expected

- Cron-owned inner runs should avoid the outer `Cron` lane without widening the shared `Nested` lane used by non-cron flows.

### Actual

- Before this patch, the fix path widened the shared `Nested` lane; after this patch, cron-owned inner work uses a dedicated `CronNested` lane instead.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- src/agents/lanes.test.ts src/agents/pi-embedded-runner/lanes.test.ts`, `pnpm test -- src/cron/isolated-agent.lane.test.ts`, and `pnpm test -- src/gateway/server-lanes.test.ts src/gateway/server-reload-handlers.test.ts` after the fix.
- Edge cases checked: verified missing cron lanes default to `cron-nested`, explicit non-cron lanes are preserved, and hot reload still covers the realistic `restartCron: true` path.
- What you did **not** verify: did not run a full live multi-job gateway repro end-to-end.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or set `cron.maxConcurrentRuns` back to `1`.
- Files/config to restore: `src/process/lanes.ts`, `src/agents/lanes.ts`, `src/agents/pi-embedded-runner/lanes.ts`, `src/cron/isolated-agent/run.ts`, `src/gateway/server-lanes.ts`, `src/gateway/server-reload-handlers.ts`
- Known bad symptoms reviewers should watch for: cron-owned jobs still serializing, or non-cron nested flows unexpectedly changing ordering.

## Risks and Mitigations

- Risk: introducing a new lane could miss a cron-owned path that still routes through the shared `Nested` lane.
  - Mitigation: lane resolution tests now lock cron-owned paths to `cron-nested`, and gateway setup tests assert the dedicated lane is configured on startup and hot reload.
