### PR TITLE
fix(agents): allowlist streaming usage for proven endpoints

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -345,7 +345,7 @@ describe("normalizeModelCompat", () => {
       provider: "mistral",
       baseUrl: "https://api.mistral.ai/v1",
     },
-  ])("keeps supportsUsageInStreaming off for %s", ({ provider, baseUrl }) => {
+  ])("keeps supportsUsageInStreaming off for $label", ({ provider, baseUrl }) => {
     expectSupportsUsageInStreamingForcedOff({ provider, baseUrl });
   });
 

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -1,5 +1,6 @@
-import type { Api, Model } from "@mariozechner/pi-ai";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Api, AssistantMessage, Model } from "@mariozechner/pi-ai";
+import { streamSimpleOpenAICompletions } from "@mariozechner/pi-ai/openai-completions";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const providerRuntimeMocks = vi.hoisted(() => ({
   resolveProviderModernModelRef: vi.fn(),
@@ -53,6 +54,13 @@ function expectSupportsUsageInStreamingForcedOff(overrides?: Partial<Model<Api>>
   expect(supportsUsageInStreaming(normalized)).toBe(false);
 }
 
+function expectSupportsUsageInStreamingForcedOn(overrides?: Partial<Model<Api>>): void {
+  const model = { ...baseModel(), ...overrides };
+  delete (model as { compat?: unknown }).compat;
+  const normalized = normalizeModelCompat(model as Model<Api>);
+  expect(supportsUsageInStreaming(normalized)).toBe(true);
+}
+
 function expectSupportsStrictModeForcedOff(overrides?: Partial<Model<Api>>): void {
   const model = { ...baseModel(), ...overrides };
   delete (model as { compat?: unknown }).compat;
@@ -60,9 +68,118 @@ function expectSupportsStrictModeForcedOff(overrides?: Partial<Model<Api>>): voi
   expect(supportsStrictMode(normalized)).toBe(false);
 }
 
+function decodeBodyText(body: unknown): string {
+  if (!body) {
+    return "";
+  }
+  if (typeof body === "string") {
+    return body;
+  }
+  if (body instanceof Uint8Array) {
+    return Buffer.from(body).toString("utf8");
+  }
+  if (body instanceof ArrayBuffer) {
+    return Buffer.from(new Uint8Array(body)).toString("utf8");
+  }
+  return "";
+}
+
+function buildSseResponse(events: unknown[]): Response {
+  const sse = `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`;
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(sse));
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function installOpenAiCompletionsStreamMock(params: {
+  baseUrl: string;
+  onRequest: (body: Record<string, unknown>) => void;
+}): { restore: () => void } {
+  const originalFetch = globalThis.fetch;
+  const completionsUrl = `${params.baseUrl}/chat/completions`;
+  const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url === completionsUrl) {
+      const bodyText =
+        typeof (init as { body?: unknown } | undefined)?.body !== "undefined"
+          ? decodeBodyText((init as { body?: unknown }).body)
+          : input instanceof Request
+            ? await input.clone().text()
+            : "";
+      const parsed = bodyText ? (JSON.parse(bodyText) as Record<string, unknown>) : {};
+      params.onRequest(parsed);
+      return buildSseResponse([
+        {
+          id: "chatcmpl_test",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: "custom-model",
+          choices: [{ index: 0, delta: { content: "ok" }, finish_reason: null }],
+        },
+        {
+          id: "chatcmpl_test",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: "custom-model",
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        },
+        {
+          id: "chatcmpl_test",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: "custom-model",
+          choices: [],
+          usage: { prompt_tokens: 72, completion_tokens: 8, total_tokens: 80 },
+        },
+      ]);
+    }
+
+    if (!originalFetch) {
+      throw new Error(`fetch is not available (url=${url})`);
+    }
+    return await originalFetch(input, init);
+  };
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = fetchImpl;
+  return {
+    restore: () => {
+      (globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch;
+    },
+  };
+}
+
+async function collectDoneMessage(
+  stream: ReturnType<typeof streamSimpleOpenAICompletions>,
+): Promise<AssistantMessage> {
+  for await (const event of stream) {
+    if (event.type === "done") {
+      return event.message;
+    }
+    if (event.type === "error") {
+      throw new Error(event.error.errorMessage ?? "stream failed");
+    }
+  }
+  throw new Error("stream ended without done");
+}
+
+let restoreFetch: (() => void) | undefined;
+
 beforeEach(() => {
   providerRuntimeMocks.resolveProviderModernModelRef.mockReset();
   providerRuntimeMocks.resolveProviderModernModelRef.mockReturnValue(undefined);
+});
+
+afterEach(() => {
+  restoreFetch?.();
+  restoreFetch = undefined;
 });
 
 describe("normalizeModelCompat — Anthropic baseUrl", () => {
@@ -186,6 +303,50 @@ describe("normalizeModelCompat", () => {
       provider: "custom-cpa",
       baseUrl: "https://cpa.example.com/v1",
     });
+  });
+
+  it("defaults supportsUsageInStreaming on for Scaleway AI compatible endpoints", () => {
+    expectSupportsUsageInStreamingForcedOn({
+      provider: "custom-scaleway",
+      baseUrl: "https://api.scaleway.ai/v1",
+    });
+  });
+
+  it("defaults supportsUsageInStreaming on for DashScope compatible-mode endpoints", () => {
+    expectSupportsUsageInStreamingForcedOn({
+      provider: "custom-bailian",
+      baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    });
+  });
+
+  it.each([
+    {
+      label: "LM Studio",
+      provider: "custom-lmstudio",
+      baseUrl: "http://127.0.0.1:1234/v1",
+    },
+    {
+      label: "LocalAI",
+      provider: "localai",
+      baseUrl: "http://localhost:8080/v1",
+    },
+    {
+      label: "TGI",
+      provider: "custom-tgi",
+      baseUrl: "http://localhost:3000/v1",
+    },
+    {
+      label: "Ollama /v1",
+      provider: "custom-ollama",
+      baseUrl: "http://localhost:11434/v1",
+    },
+    {
+      label: "Mistral API",
+      provider: "mistral",
+      baseUrl: "https://api.mistral.ai/v1",
+    },
+  ])("keeps supportsUsageInStreaming off for %s", ({ provider, baseUrl }) => {
+    expectSupportsUsageInStreamingForcedOff({ provider, baseUrl });
   });
 
   it("forces supportsStrictMode off for z.ai models", () => {
@@ -335,6 +496,52 @@ describe("normalizeModelCompat", () => {
     expect(supportsDeveloperRole(normalized)).toBe(true);
     expect(supportsUsageInStreaming(normalized)).toBe(true);
     expect(supportsStrictMode(normalized)).toBe(true);
+  });
+
+  it("requests streaming usage and records the final usage-only chunk for allowlisted endpoints", async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const baseUrl = "https://api.scaleway.ai/v1";
+    restoreFetch = installOpenAiCompletionsStreamMock({
+      baseUrl,
+      onRequest: (body) => {
+        requestBody = body;
+      },
+    }).restore;
+
+    const model = normalizeModelCompat({
+      id: "scw-test",
+      name: "Scaleway Test",
+      api: "openai-completions",
+      provider: "custom-scaleway",
+      baseUrl,
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 8192,
+      maxTokens: 1024,
+    }) as Model<"openai-completions">;
+
+    const stream = streamSimpleOpenAICompletions(
+      model,
+      {
+        systemPrompt: "",
+        messages: [{ role: "user", content: [{ type: "text", text: "hi" }], timestamp: 0 }],
+        tools: undefined,
+      },
+      {
+        apiKey: "test-key",
+      },
+    );
+
+    const message = await collectDoneMessage(stream);
+
+    expect(requestBody?.stream).toBe(true);
+    expect(requestBody?.stream_options).toEqual({ include_usage: true });
+    expect(message.usage).toMatchObject({
+      input: 72,
+      output: 8,
+      totalTokens: 80,
+    });
   });
 });
 

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -86,6 +86,24 @@ function isAnthropicMessagesModel(model: Model<Api>): model is Model<"anthropic-
   return model.api === "anthropic-messages";
 }
 
+function shouldEnableStreamingUsageByDefault(baseUrl: string | undefined): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+  try {
+    const url = new URL(baseUrl);
+    const host = url.hostname.toLowerCase();
+    const path = url.pathname.toLowerCase();
+    return (
+      host === "api.scaleway.ai" ||
+      ((host === "dashscope.aliyuncs.com" || host === "dashscope-intl.aliyuncs.com") &&
+        path.includes("/compatible-mode/"))
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * pi-ai constructs the Anthropic API endpoint as `${baseUrl}/v1/messages`.
  * If a user configures `baseUrl` with a trailing `/v1` (e.g. the previously
@@ -129,6 +147,7 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   }
   const forcedDeveloperRole = compat?.supportsDeveloperRole === true;
   const hasStreamingUsageOverride = compat?.supportsUsageInStreaming !== undefined;
+  const defaultStreamingUsage = shouldEnableStreamingUsageByDefault(model.baseUrl);
   const targetStrictMode = compat?.supportsStrictMode ?? false;
   if (
     compat?.supportsDeveloperRole !== undefined &&
@@ -145,12 +164,12 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
       ? {
           ...compat,
           supportsDeveloperRole: forcedDeveloperRole || false,
-          ...(hasStreamingUsageOverride ? {} : { supportsUsageInStreaming: false }),
+          ...(hasStreamingUsageOverride ? {} : { supportsUsageInStreaming: defaultStreamingUsage }),
           supportsStrictMode: targetStrictMode,
         }
       : {
           supportsDeveloperRole: false,
-          supportsUsageInStreaming: false,
+          supportsUsageInStreaming: defaultStreamingUsage,
           supportsStrictMode: false,
         },
   } as typeof model;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `#49753` reports zero persisted usage for OpenAI-compatible custom providers even when the upstream returns a valid final SSE usage chunk.
- Why it matters: session logs, dashboard usage, and `openclaw status --usage` all become unusable for affected providers, and long-running sessions can fail to compact correctly.
- What changed: kept the generic non-native default conservative, but auto-enabled `supportsUsageInStreaming` for the issue-backed endpoints only (`api.scaleway.ai` and DashScope `compatible-mode`).
- What did NOT change (scope boundary): generic custom `openai-completions` backends still default off; this PR does not broaden Azure or other custom providers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49753
- Related #50045
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `normalizeModelCompat()` forces `supportsUsageInStreaming` to `false` for non-native `openai-completions` endpoints unless users explicitly override it.
- Missing detection / guardrail: there was no narrow allowlist for endpoints with concrete evidence that they already support `stream_options.include_usage` and return a valid final usage-only SSE chunk.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the earlier attempt in #50045 tried to broaden the default more widely, and maintainers asked to keep the generic default conservative.
- Why this regressed now: the conservative generic default protects many OpenAI-compatible backends, but it also blocks known-good endpoints from ever requesting streamed usage automatically.
- If unknown, what was ruled out: this PR does not assume all OpenAI-compatible backends are safe; known-bad paths remain explicitly covered by regression tests.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/model-compat.test.ts`
- Scenario the test should lock in:
  - Scaleway defaults streaming usage on
  - DashScope `compatible-mode` defaults streaming usage on
  - known-bad endpoints (`LM Studio`, `LocalAI`, `TGI`, `Ollama /v1`, `Mistral API`) stay off by default
  - allowlisted endpoints send `stream_options.include_usage` and persist the final usage-only SSE chunk
- Why this is the smallest reliable guardrail: the behavior is decided inside `normalizeModelCompat()` and consumed directly by the `openai-completions` streaming path, so a focused compat test plus one streaming seam test is enough.
- Existing test that already covers this (if any): native/provider-specific compat tests already cover Moonshot and Model Studio non-regression paths.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Scaleway AI compatible endpoints now automatically request streaming usage.
- DashScope `compatible-mode` endpoints now automatically request streaming usage.
- Generic custom `openai-completions` providers remain conservative by default.
- Operators can still force either direction with `compat.supportsUsageInStreaming`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11 host
- Runtime/container: Node v20.19.0 / pnpm 10.32.1 (repo wants Node 22.16+; warnings only)
- Model/provider: targeted compat tests for `openai-completions` providers
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `normalizeModelCompat()` on a generic non-native `openai-completions` provider and confirm `supportsUsageInStreaming` stays `false`.
2. Run the same for `https://api.scaleway.ai/v1` and `https://dashscope.aliyuncs.com/compatible-mode/v1` and confirm it defaults to `true`.
3. Exercise the `streamSimpleOpenAICompletions` path with a mocked final usage-only SSE chunk and verify the request body includes `stream_options.include_usage` and the final message usage is populated.

### Expected

- Only the allowlisted endpoints auto-enable streamed usage.
- Known-bad endpoints remain off by default.
- The final usage-only SSE chunk is persisted into `message.usage`.

### Actual

- Matched expected behavior in the targeted tests below.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- src/agents/model-compat.test.ts`
  - `pnpm test -- src/agents/models-config.providers.modelstudio.test.ts -t "streaming usage"`
  - `pnpm test -- src/agents/models-config.providers.moonshot.test.ts -t "opts native Moonshot baseUrls into streaming usage only after the final compat pass"`
  - `pnpm check`
- Edge cases checked:
  - generic custom provider stays conservative
  - known-bad endpoints stay off
  - explicit compat overrides remain intact
- What you did **not** verify:
  - live requests against real Scaleway or DashScope credentials in this environment
  - full `pnpm build` on a machine with `/bin/bash` available

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or explicitly set `compat.supportsUsageInStreaming: false` on the affected provider.
- Files/config to restore: `src/agents/model-compat.ts`
- Known bad symptoms reviewers should watch for: unexpected 400/422 responses from a supposedly allowlisted endpoint when `stream_options.include_usage` is present.

## Risks and Mitigations

- Risk: one of the allowlisted endpoints could have an undocumented compatibility variant that still rejects `stream_options.include_usage`.
  - Mitigation: the allowlist is limited to the exact host/path evidence from the issue, and operators can explicitly force `compat.supportsUsageInStreaming: false`.
- Risk: the fetch-mock integration test could drift if the upstream library changes its request-body shape.
  - Mitigation: the test only asserts the specific `stream_options.include_usage` contract and final usage propagation.
