### PR TITLE
fix(cli): increase cron run default timeout from 30s to 10min

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -78,3 +78,11 @@ openclaw cron add \
 ```
 
 `--light-context` applies to isolated agent-turn jobs only. For cron runs, lightweight mode keeps bootstrap context empty instead of injecting the full workspace bootstrap set.
+
+## `cron run` timeout
+
+`openclaw cron run <id>` waits for the job to complete before returning. The default timeout is **600,000ms (10 minutes)** — aligned with `agents.defaults.timeoutSeconds`. Use `--timeout <ms>` to override. To wait indefinitely for long-running jobs:
+
+```bash
+openclaw cron run <id> --timeout 0
+```

--- a/src/cli/gateway-rpc.ts
+++ b/src/cli/gateway-rpc.ts
@@ -39,7 +39,7 @@ export async function callGatewayFromCli(
         method,
         params,
         expectFinal: extra?.expectFinal ?? Boolean(opts.expectFinal),
-        timeoutMs: Number(opts.timeout ?? 10_000),
+        timeoutMs: Number(opts.timeout ?? 600_000),
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,
       }),

--- a/src/cli/gateway-rpc.ts
+++ b/src/cli/gateway-rpc.ts
@@ -15,7 +15,7 @@ export function addGatewayClientOptions(cmd: Command) {
   return cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
     .option("--token <token>", "Gateway token (if required)")
-    .option("--timeout <ms>", "Timeout in ms", "30000")
+    .option("--timeout <ms>", "Timeout in ms (0 = no limit)", "600000")
     .option("--expect-final", "Wait for final response (agent)", false);
 }
 


### PR DESCRIPTION
## Summary

`openclaw cron run <id>` had a hardcoded default CLI timeout of **30,000ms (30 seconds)** from the shared gateway RPC client. For long-running cron jobs (e.g. backtests), this caused the CLI to exit with a timeout error even when the isolated session completed successfully on the gateway side.

**Before:** `openclaw cron run <id>` → 30s → ERROR, job still running  
**After:** `openclaw cron run <id>` → 10 min → OK, job completes

## Changes

### 1. `src/cli/gateway-rpc.ts`

**Line 18** — CLI option default:
```diff
- .option("--timeout <ms>", "Timeout in ms", "30000")
+ .option("--timeout <ms>", "Timeout in ms (0 = no limit)", "600000")
```

**Line 42** — Programmatic fallback (when `callGatewayFromCli` is invoked without `addGatewayClientOptions`):
```diff
- timeoutMs: Number(opts.timeout ?? 10_000),
+ timeoutMs: Number(opts.timeout ?? 600_000),
```

### 2. `docs/cli/cron.md`

Added a `cron run timeout` section documenting the `--timeout` flag and the 600s default, aligned with `agents.defaults.timeoutSeconds`.

## Rationale

- **600,000ms = 10 minutes** — exactly matches `agents.defaults.timeoutSeconds` (600s), so the CLI now aligns with the agent runtime default
- The `?? 10_000` fallback was pre-existing and inconsistent even before this PR (10s vs 30s); now it's consistent at 600s
- All other gateway commands (list, status, rm, etc.) are fast and complete well within 10 minutes

## Testing

Manual trigger of a backtest job:
- `openclaw cron run <id>` (before fix): ERROR at 30,014ms  
- `openclaw cron run <id> --timeout 0` (before fix): OK at 98,359ms

Fixes: openclaw/openclaw#54320
