### PR TITLE
fix(auto-reply): enforce operator.admin scope for /config mutating commands

### DIFF
--- a/src/auto-reply/reply/commands-config.ts
+++ b/src/auto-reply/reply/commands-config.ts
@@ -41,6 +41,10 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
   if (unauthorized) {
     return unauthorized;
   }
+  const scope = requireGatewayClientScopeForInternalChannel(params, "operator.admin");
+  if (scope) {
+    return scope;
+  }
   const allowInternalReadOnlyShow =
     configCommand.action === "show" && isInternalMessageChannel(params.command.channel);
   const nonOwner = allowInternalReadOnlyShow ? null : rejectNonOwnerCommand(params, "/config");

--- a/src/auto-reply/reply/commands-config.ts
+++ b/src/auto-reply/reply/commands-config.ts
@@ -41,7 +41,11 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
   if (unauthorized) {
     return unauthorized;
   }
-  const scope = requireGatewayClientScopeForInternalChannel(params, "operator.admin");
+  const scope = requireGatewayClientScopeForInternalChannel(params, {
+    label: "/config",
+    allowedScopes: ["operator.admin"],
+    missingText: "❌ /config requires operator.admin for gateway clients.",
+  });
   if (scope) {
     return scope;
   }


### PR DESCRIPTION
This fix addresses a missing authorization check in the `/config` command handler for mutating operations (set/unset).

## Root Cause
The `handleConfigCommand` function allowed mutating config operations without verifying the required `operator.admin` scope. It only checked ownership via `rejectNonOwnerCommand`, but did not verify elevated permissions for internal channels.

## Fix
Added a call to `requireGatewayClientScopeForInternalChannel` with `operator.admin` scope before allowing config changes. This ensures that only privileged clients can modify configuration.

## Reference
Pattern fix established in PR #54097.