### PR TITLE
Plugins: add engine compatibility check for install and update

### DIFF
--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -23,6 +23,7 @@ import { formatDocsLink } from "../terminal/links.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
 import { shortenHomeInString, shortenHomePath } from "../utils.js";
+import { VERSION } from "../version.js";
 import {
   applySlotSelectionForPlugin,
   createPluginInstallLogger,
@@ -715,9 +716,15 @@ export function registerPluginsCli(program: Command) {
       "--marketplace <source>",
       "Install a Claude marketplace plugin from a local repo/path or git/GitHub source",
     )
-    .action(async (raw: string, opts: { link?: boolean; pin?: boolean; marketplace?: string }) => {
-      await runPluginInstallCommand({ raw, opts });
-    });
+    .option("--ignore-engine", "Skip engine compatibility check", false)
+    .action(
+      async (
+        raw: string,
+        opts: { link?: boolean; pin?: boolean; marketplace?: string; ignoreEngine?: boolean },
+      ) => {
+        await runPluginInstallCommand({ raw, opts });
+      },
+    );
 
   plugins
     .command("update")
@@ -725,6 +732,7 @@ export function registerPluginsCli(program: Command) {
     .argument("[id]", "Plugin or hook-pack id (omit with --all)")
     .option("--all", "Update all tracked plugins and hook packs", false)
     .option("--dry-run", "Show what would change without writing", false)
+    .option("--ignore-engine", "Skip engine compatibility check", false)
     .action(async (id: string | undefined, opts: PluginUpdateOptions) => {
       await runPluginUpdateCommand({ id, opts });
     });

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -17,6 +17,7 @@ import {
 import { defaultRuntime } from "../runtime.js";
 import { theme } from "../terminal/theme.js";
 import { shortenHomePath } from "../utils.js";
+import { VERSION } from "../version.js";
 import { looksLikeLocalInstallSpec } from "./install-spec.js";
 import { resolvePinnedNpmInstallRecordForCli } from "./npm-resolution.js";
 import {
@@ -231,7 +232,7 @@ export async function loadConfigForInstall(
 
 export async function runPluginInstallCommand(params: {
   raw: string;
-  opts: { link?: boolean; pin?: boolean; marketplace?: string };
+  opts: { link?: boolean; pin?: boolean; marketplace?: string; ignoreEngine?: boolean };
 }) {
   const shorthand = !params.opts.marketplace
     ? await resolveMarketplaceInstallShortcut(params.raw)
@@ -486,6 +487,7 @@ export async function runPluginInstallCommand(params: {
   const result = await installPluginFromNpmSpec({
     spec: raw,
     logger: createPluginInstallLogger(),
+    coreVersion: params.opts.ignoreEngine ? undefined : VERSION,
   });
   if (!result.ok) {
     const bundledFallbackPlan = resolveBundledInstallPlanForNpmFailure({

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -6,6 +6,7 @@ import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { updateNpmInstalledPlugins } from "../plugins/update.js";
 import { defaultRuntime } from "../runtime.js";
 import { theme } from "../terminal/theme.js";
+import { VERSION } from "../version.js";
 import {
   extractInstalledNpmHookPackageName,
   extractInstalledNpmPackageName,
@@ -89,7 +90,7 @@ function resolveHookPackUpdateSelection(params: {
 
 export async function runPluginUpdateCommand(params: {
   id?: string;
-  opts: { all?: boolean; dryRun?: boolean };
+  opts: { all?: boolean; dryRun?: boolean; ignoreEngine?: boolean };
 }) {
   const cfg = loadConfig();
   const logger = {
@@ -121,6 +122,7 @@ export async function runPluginUpdateCommand(params: {
     pluginIds: pluginSelection.pluginIds,
     specOverrides: pluginSelection.specOverrides,
     dryRun: params.opts.dryRun,
+    coreVersion: params.opts.ignoreEngine ? undefined : VERSION,
     logger,
     onIntegrityDrift: async (drift) => {
       const specLabel = drift.resolvedSpec ?? drift.spec;

--- a/src/infra/npm-engine-resolve.test.ts
+++ b/src/infra/npm-engine-resolve.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { formatEngineIncompatibleError, resolveFromVersionEntries } from "./npm-engine-resolve.js";
+import type { NpmVersionEntry } from "./npm-registry-versions.js";
+
+const CORE_VERSION = "2026.3.14";
+
+function makeVersions(entries: Array<{ version: string; openclaw?: string }>): NpmVersionEntry[] {
+  return entries.map((e) => ({
+    version: e.version,
+    ...(e.openclaw ? { engines: { openclaw: e.openclaw } } : {}),
+  }));
+}
+
+describe("resolveFromVersionEntries", () => {
+  it("returns latest compatible version", () => {
+    const versions = makeVersions([
+      { version: "2026.3.14", openclaw: ">=2026.3.14" },
+      { version: "2026.3.12", openclaw: ">=2026.3.10" },
+      { version: "2026.3.10", openclaw: ">=2026.3.10" },
+    ]);
+
+    const result = resolveFromVersionEntries({
+      versions,
+      coreVersion: CORE_VERSION,
+      allowPrerelease: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe("2026.3.14");
+  });
+
+  it("skips incompatible latest and returns older compatible version", () => {
+    const versions = makeVersions([
+      { version: "2027.1.0", openclaw: ">=2027.0.0" },
+      { version: "2026.3.14", openclaw: ">=2026.3.10" },
+      { version: "2026.3.12", openclaw: ">=2026.3.10" },
+    ]);
+
+    const result = resolveFromVersionEntries({
+      versions,
+      coreVersion: CORE_VERSION,
+      allowPrerelease: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe("2026.3.14");
+  });
+
+  it("treats versions without engines.openclaw as compatible", () => {
+    const versions = makeVersions([
+      { version: "2026.3.14" }, // no engines field
+      { version: "2026.3.12", openclaw: ">=2026.3.10" },
+    ]);
+
+    const result = resolveFromVersionEntries({
+      versions,
+      coreVersion: CORE_VERSION,
+      allowPrerelease: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe("2026.3.14");
+  });
+
+  it("returns null when no compatible version exists", () => {
+    const versions = makeVersions([
+      { version: "2027.1.0", openclaw: ">=2027.0.0" },
+      { version: "2027.0.0", openclaw: ">=2027.0.0" },
+    ]);
+
+    const result = resolveFromVersionEntries({
+      versions,
+      coreVersion: CORE_VERSION,
+      allowPrerelease: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.version).toBeNull();
+    if (result.version !== null) {
+      return;
+    }
+    expect(result.latestVersion).toBe("2027.1.0");
+    expect(result.latestRange).toBe(">=2027.0.0");
+  });
+
+  it("excludes prereleases by default", () => {
+    const versions = makeVersions([
+      { version: "2026.3.15-beta.1", openclaw: ">=2026.3.10" },
+      { version: "2026.3.12", openclaw: ">=2026.3.10" },
+    ]);
+
+    const result = resolveFromVersionEntries({
+      versions,
+      coreVersion: CORE_VERSION,
+      allowPrerelease: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe("2026.3.12");
+  });
+
+  it("includes prereleases when allowPrerelease is true", () => {
+    const versions = makeVersions([
+      { version: "2026.3.15-beta.1", openclaw: ">=2026.3.10" },
+      { version: "2026.3.12", openclaw: ">=2026.3.10" },
+    ]);
+
+    const result = resolveFromVersionEntries({
+      versions,
+      coreVersion: CORE_VERSION,
+      allowPrerelease: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe("2026.3.15-beta.1");
+  });
+
+  it("handles empty versions list", () => {
+    const result = resolveFromVersionEntries({
+      versions: [],
+      coreVersion: CORE_VERSION,
+      allowPrerelease: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.version).toBeNull();
+  });
+
+  it("supports caret range in engine constraint", () => {
+    const versions = makeVersions([
+      { version: "3.0.0", openclaw: "^2027.0.0" },
+      { version: "2.0.0", openclaw: "^2026.3.0" },
+      { version: "1.0.0", openclaw: "^2025.0.0" },
+    ]);
+
+    const result = resolveFromVersionEntries({
+      versions,
+      coreVersion: CORE_VERSION,
+      allowPrerelease: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.version).toBe("2.0.0");
+  });
+});
+
+describe("formatEngineIncompatibleError", () => {
+  it("includes package name, core version, and advice", () => {
+    const msg = formatEngineIncompatibleError({
+      packageName: "@openclaw/memory-core",
+      coreVersion: "2026.3.14",
+      latestVersion: "2027.1.0",
+      latestRange: ">=2027.0.0",
+    });
+
+    expect(msg).toContain("@openclaw/memory-core");
+    expect(msg).toContain("2026.3.14");
+    expect(msg).toContain("2027.1.0");
+    expect(msg).toContain(">=2027.0.0");
+    expect(msg).toContain("--ignore-engine");
+  });
+
+  it("works without latest version details", () => {
+    const msg = formatEngineIncompatibleError({
+      packageName: "some-plugin",
+      coreVersion: "2026.3.14",
+    });
+
+    expect(msg).toContain("some-plugin");
+    expect(msg).toContain("--ignore-engine");
+  });
+});

--- a/src/infra/npm-engine-resolve.ts
+++ b/src/infra/npm-engine-resolve.ts
@@ -1,0 +1,138 @@
+/**
+ * Engine-aware npm version resolution.
+ *
+ * Queries the npm registry for all versions of a package, then filters
+ * to the latest version whose `engines.openclaw` constraint is satisfied
+ * by the running OpenClaw core version.
+ */
+import { fetchPackageVersions, type NpmVersionEntry } from "./npm-registry-versions.js";
+import { isPrerelease, satisfiesRange, sortVersionsDescending } from "./semver-range.js";
+
+export type EngineResolveSuccess = {
+  ok: true;
+  version: string;
+  engineRange?: string;
+};
+
+export type EngineResolveNoMatch = {
+  ok: true;
+  version: null;
+  latestVersion?: string;
+  latestRange?: string;
+};
+
+export type EngineResolveError = {
+  ok: false;
+  error: string;
+};
+
+export type EngineResolveResult = EngineResolveSuccess | EngineResolveNoMatch | EngineResolveError;
+
+/**
+ * Resolve the latest npm version of a package that is compatible with the given
+ * OpenClaw core version, based on the `engines.openclaw` field in each version's
+ * package.json.
+ *
+ * - Versions without `engines.openclaw` are assumed compatible.
+ * - Prerelease versions are excluded unless `allowPrerelease` is true.
+ * - Returns `{ ok: true, version: null }` when no compatible version exists.
+ * - Returns `{ ok: false, error }` on network/registry errors.
+ */
+export async function resolveCompatibleVersion(params: {
+  packageName: string;
+  coreVersion: string;
+  allowPrerelease?: boolean;
+  timeoutMs?: number;
+  fetchFn?: typeof fetch;
+}): Promise<EngineResolveResult> {
+  const result = await fetchPackageVersions({
+    packageName: params.packageName,
+    timeoutMs: params.timeoutMs,
+    fetchFn: params.fetchFn,
+  });
+
+  if (!result.ok) {
+    return { ok: false, error: result.error };
+  }
+
+  if (result.versions.length === 0) {
+    return { ok: true, version: null };
+  }
+
+  return resolveFromVersionEntries({
+    versions: result.versions,
+    coreVersion: params.coreVersion,
+    allowPrerelease: params.allowPrerelease ?? false,
+  });
+}
+
+/**
+ * Pure resolution logic (no network). Useful for testing.
+ */
+export function resolveFromVersionEntries(params: {
+  versions: NpmVersionEntry[];
+  coreVersion: string;
+  allowPrerelease: boolean;
+}): EngineResolveSuccess | EngineResolveNoMatch {
+  // Filter prereleases unless allowed
+  const candidates = params.allowPrerelease
+    ? params.versions
+    : params.versions.filter((v) => !isPrerelease(v.version));
+
+  if (candidates.length === 0) {
+    return { ok: true, version: null };
+  }
+
+  // Sort versions descending
+  const sortedVersions = sortVersionsDescending(candidates.map((v) => v.version));
+  const versionMap = new Map<string, NpmVersionEntry>();
+  for (const entry of candidates) {
+    versionMap.set(entry.version, entry);
+  }
+
+  // Find the latest compatible version
+  for (const version of sortedVersions) {
+    const entry = versionMap.get(version);
+    if (!entry) {
+      continue;
+    }
+
+    const engineRange = entry.engines?.openclaw;
+    if (!engineRange) {
+      // No engine constraint → assumed compatible
+      return { ok: true, version };
+    }
+    if (satisfiesRange(params.coreVersion, engineRange)) {
+      return { ok: true, version, engineRange };
+    }
+  }
+
+  // No compatible version found — report the latest version and its range for diagnostics
+  const latestVersion = sortedVersions[0];
+  const latestEntry = latestVersion ? versionMap.get(latestVersion) : undefined;
+  return {
+    ok: true,
+    version: null,
+    latestVersion,
+    latestRange: latestEntry?.engines?.openclaw,
+  };
+}
+
+/**
+ * Format a user-facing error message when no compatible version is found.
+ */
+export function formatEngineIncompatibleError(params: {
+  packageName: string;
+  coreVersion: string;
+  latestVersion?: string;
+  latestRange?: string;
+}): string {
+  const parts = [
+    `No version of ${params.packageName} is compatible with openclaw ${params.coreVersion}.`,
+  ];
+  if (params.latestVersion && params.latestRange) {
+    parts.push(`Latest version ${params.latestVersion} requires openclaw ${params.latestRange}.`);
+  }
+  parts.push("Upgrade openclaw or use --ignore-engine to force install.");
+  return parts.join(" ");
+}

--- a/src/infra/npm-registry-versions.test.ts
+++ b/src/infra/npm-registry-versions.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchPackageVersions } from "./npm-registry-versions.js";
+
+function mockFetch(response: { status?: number; ok?: boolean; body?: unknown }): typeof fetch {
+  return vi.fn(async () => ({
+    status: response.status ?? 200,
+    ok: response.ok ?? true,
+    json: async () => response.body,
+  })) as unknown as typeof fetch;
+}
+
+describe("fetchPackageVersions", () => {
+  it("parses versions with engines from registry response", async () => {
+    const fetchFn = mockFetch({
+      body: {
+        versions: {
+          "2026.3.10": { engines: { openclaw: ">=2026.3.10" } },
+          "2026.3.12": { engines: { openclaw: ">=2026.3.10" } },
+          "2026.3.14": {},
+        },
+      },
+    });
+
+    const result = await fetchPackageVersions({
+      packageName: "@openclaw/memory-core",
+      fetchFn,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.versions).toHaveLength(3);
+    expect(result.versions).toContainEqual({
+      version: "2026.3.10",
+      engines: { openclaw: ">=2026.3.10" },
+    });
+    expect(result.versions).toContainEqual({ version: "2026.3.14" });
+
+    // Verify URL encoding for scoped package
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/@openclaw%2Fmemory-core",
+      expect.objectContaining({
+        headers: { Accept: "application/vnd.npm.install-v1+json" },
+      }),
+    );
+  });
+
+  it("returns error on 404", async () => {
+    const fetchFn = mockFetch({ status: 404, ok: false });
+    const result = await fetchPackageVersions({
+      packageName: "nonexistent-package",
+      fetchFn,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error).toContain("not found");
+  });
+
+  it("returns error on network failure", async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+
+    const result = await fetchPackageVersions({
+      packageName: "some-package",
+      fetchFn,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error).toContain("ECONNREFUSED");
+  });
+
+  it("returns error on timeout", async () => {
+    const fetchFn = vi.fn(async () => {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      throw err;
+    }) as unknown as typeof fetch;
+
+    const result = await fetchPackageVersions({
+      packageName: "some-package",
+      fetchFn,
+      timeoutMs: 100,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error).toContain("timed out");
+  });
+
+  it("returns empty versions when response has no versions object", async () => {
+    const fetchFn = mockFetch({ body: { name: "some-package" } });
+    const result = await fetchPackageVersions({
+      packageName: "some-package",
+      fetchFn,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.versions).toEqual([]);
+  });
+
+  it("returns error for empty package name", async () => {
+    const result = await fetchPackageVersions({ packageName: "" });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/infra/npm-registry-versions.ts
+++ b/src/infra/npm-registry-versions.ts
@@ -1,0 +1,104 @@
+/**
+ * Query the npm registry for package version metadata, including engine constraints.
+ * Used by the engine compatibility system to find compatible plugin versions.
+ */
+import { fetchWithTimeout } from "../utils/fetch-timeout.js";
+
+export type NpmVersionEntry = {
+  version: string;
+  engines?: Record<string, string>;
+};
+
+export type FetchPackageVersionsResult =
+  | { ok: true; versions: NpmVersionEntry[] }
+  | { ok: false; error: string };
+
+/**
+ * Fetch all published versions of an npm package along with their `engines` metadata.
+ *
+ * Uses the abbreviated packument endpoint (`application/vnd.npm.install-v1+json`)
+ * for smaller payloads.
+ */
+export async function fetchPackageVersions(params: {
+  packageName: string;
+  timeoutMs?: number;
+  fetchFn?: typeof fetch;
+}): Promise<FetchPackageVersionsResult> {
+  const timeoutMs = params.timeoutMs ?? 5000;
+  const packageName = params.packageName.trim();
+  if (!packageName) {
+    return { ok: false, error: "missing package name" };
+  }
+
+  const url = `https://registry.npmjs.org/${encodePackageName(packageName)}`;
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(
+      url,
+      {
+        headers: {
+          Accept: "application/vnd.npm.install-v1+json",
+        },
+      },
+      timeoutMs,
+      params.fetchFn,
+    );
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return { ok: false, error: `npm registry request timed out after ${timeoutMs}ms` };
+    }
+    return { ok: false, error: `npm registry request failed: ${String(err)}` };
+  }
+
+  if (res.status === 404) {
+    return { ok: false, error: `package not found on npm: ${packageName}` };
+  }
+  if (!res.ok) {
+    return { ok: false, error: `npm registry returned HTTP ${res.status}` };
+  }
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    return { ok: false, error: "failed to parse npm registry response" };
+  }
+
+  if (!body || typeof body !== "object") {
+    return { ok: false, error: "unexpected npm registry response format" };
+  }
+
+  const versionsObj = (body as Record<string, unknown>).versions;
+  if (!versionsObj || typeof versionsObj !== "object") {
+    return { ok: true, versions: [] };
+  }
+
+  const entries: NpmVersionEntry[] = [];
+  for (const [version, metadata] of Object.entries(versionsObj as Record<string, unknown>)) {
+    if (!version || typeof version !== "string") {
+      continue;
+    }
+    const entry: NpmVersionEntry = { version };
+    if (metadata && typeof metadata === "object") {
+      const engines = (metadata as Record<string, unknown>).engines;
+      if (engines && typeof engines === "object") {
+        entry.engines = engines as Record<string, string>;
+      }
+    }
+    entries.push(entry);
+  }
+
+  return { ok: true, versions: entries };
+}
+
+/**
+ * Encode a package name for use in the registry URL.
+ * Scoped packages like @openclaw/foo need the @ and / encoded properly.
+ */
+function encodePackageName(name: string): string {
+  if (name.startsWith("@")) {
+    // Scoped package: encode the full scope/name
+    return `@${encodeURIComponent(name.slice(1))}`;
+  }
+  return encodeURIComponent(name);
+}

--- a/src/infra/semver-range.test.ts
+++ b/src/infra/semver-range.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareSemver,
+  findLatestCompatible,
+  isPrerelease,
+  parseSemverTuple,
+  satisfiesRange,
+  sortVersionsDescending,
+} from "./semver-range.js";
+
+describe("parseSemverTuple", () => {
+  it("parses basic version", () => {
+    expect(parseSemverTuple("2026.3.14")).toEqual({
+      major: 2026,
+      minor: 3,
+      patch: 14,
+      prerelease: null,
+    });
+  });
+
+  it("parses version with v prefix", () => {
+    expect(parseSemverTuple("v1.2.3")).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: null,
+    });
+  });
+
+  it("parses prerelease version", () => {
+    expect(parseSemverTuple("2026.3.14-beta.1")).toEqual({
+      major: 2026,
+      minor: 3,
+      patch: 14,
+      prerelease: ["beta", "1"],
+    });
+  });
+
+  it("returns null for invalid version", () => {
+    expect(parseSemverTuple("not-a-version")).toBeNull();
+    expect(parseSemverTuple("")).toBeNull();
+  });
+});
+
+describe("compareSemver", () => {
+  it("compares major versions", () => {
+    const a = parseSemverTuple("2026.3.14")!;
+    const b = parseSemverTuple("2025.3.14")!;
+    expect(compareSemver(a, b)).toBeGreaterThan(0);
+    expect(compareSemver(b, a)).toBeLessThan(0);
+  });
+
+  it("compares minor versions", () => {
+    const a = parseSemverTuple("2026.4.0")!;
+    const b = parseSemverTuple("2026.3.14")!;
+    expect(compareSemver(a, b)).toBeGreaterThan(0);
+  });
+
+  it("compares patch versions", () => {
+    const a = parseSemverTuple("2026.3.15")!;
+    const b = parseSemverTuple("2026.3.14")!;
+    expect(compareSemver(a, b)).toBeGreaterThan(0);
+  });
+
+  it("equal versions return 0", () => {
+    const a = parseSemverTuple("2026.3.14")!;
+    const b = parseSemverTuple("2026.3.14")!;
+    expect(compareSemver(a, b)).toBe(0);
+  });
+
+  it("release > prerelease", () => {
+    const release = parseSemverTuple("2026.3.14")!;
+    const pre = parseSemverTuple("2026.3.14-beta.1")!;
+    expect(compareSemver(release, pre)).toBeGreaterThan(0);
+    expect(compareSemver(pre, release)).toBeLessThan(0);
+  });
+});
+
+describe("satisfiesRange", () => {
+  describe("operators", () => {
+    it(">=", () => {
+      expect(satisfiesRange("2026.3.14", ">=2026.3.10")).toBe(true);
+      expect(satisfiesRange("2026.3.10", ">=2026.3.10")).toBe(true);
+      expect(satisfiesRange("2026.3.9", ">=2026.3.10")).toBe(false);
+    });
+
+    it(">", () => {
+      expect(satisfiesRange("2026.3.14", ">2026.3.10")).toBe(true);
+      expect(satisfiesRange("2026.3.10", ">2026.3.10")).toBe(false);
+    });
+
+    it("<=", () => {
+      expect(satisfiesRange("2026.3.10", "<=2026.3.14")).toBe(true);
+      expect(satisfiesRange("2026.3.14", "<=2026.3.14")).toBe(true);
+      expect(satisfiesRange("2026.3.15", "<=2026.3.14")).toBe(false);
+    });
+
+    it("<", () => {
+      expect(satisfiesRange("2026.3.10", "<2026.3.14")).toBe(true);
+      expect(satisfiesRange("2026.3.14", "<2026.3.14")).toBe(false);
+    });
+
+    it("=", () => {
+      expect(satisfiesRange("2026.3.14", "=2026.3.14")).toBe(true);
+      expect(satisfiesRange("2026.3.13", "=2026.3.14")).toBe(false);
+    });
+  });
+
+  describe("caret range", () => {
+    it("^M.m.p with M > 0", () => {
+      // ^2026.3.10 → >=2026.3.10 <2027.0.0
+      expect(satisfiesRange("2026.3.14", "^2026.3.10")).toBe(true);
+      expect(satisfiesRange("2026.3.10", "^2026.3.10")).toBe(true);
+      expect(satisfiesRange("2026.12.0", "^2026.3.10")).toBe(true);
+      expect(satisfiesRange("2026.3.9", "^2026.3.10")).toBe(false);
+      expect(satisfiesRange("2027.0.0", "^2026.3.10")).toBe(false);
+    });
+
+    it("^0.m.p with m > 0", () => {
+      // ^0.2.3 → >=0.2.3 <0.3.0
+      expect(satisfiesRange("0.2.5", "^0.2.3")).toBe(true);
+      expect(satisfiesRange("0.3.0", "^0.2.3")).toBe(false);
+    });
+
+    it("^0.0.p", () => {
+      // ^0.0.3 → >=0.0.3 <0.0.4
+      expect(satisfiesRange("0.0.3", "^0.0.3")).toBe(true);
+      expect(satisfiesRange("0.0.4", "^0.0.3")).toBe(false);
+    });
+  });
+
+  describe("tilde range", () => {
+    it("~M.m.p", () => {
+      // ~2026.3.10 → >=2026.3.10 <2026.4.0
+      expect(satisfiesRange("2026.3.14", "~2026.3.10")).toBe(true);
+      expect(satisfiesRange("2026.3.10", "~2026.3.10")).toBe(true);
+      expect(satisfiesRange("2026.4.0", "~2026.3.10")).toBe(false);
+      expect(satisfiesRange("2026.3.9", "~2026.3.10")).toBe(false);
+    });
+  });
+
+  describe("wildcard", () => {
+    it("* matches everything", () => {
+      expect(satisfiesRange("2026.3.14", "*")).toBe(true);
+      expect(satisfiesRange("0.0.1", "*")).toBe(true);
+    });
+
+    it("empty range matches everything", () => {
+      expect(satisfiesRange("2026.3.14", "")).toBe(true);
+    });
+  });
+
+  describe("unions (||)", () => {
+    it("matches if any branch matches", () => {
+      expect(satisfiesRange("2026.3.14", ">=2026.3.10 || >=2025.0.0 <2026.0.0")).toBe(true);
+      expect(satisfiesRange("2025.6.0", ">=2026.3.10 || >=2025.0.0 <2026.0.0")).toBe(true);
+      expect(satisfiesRange("2024.1.0", ">=2026.3.10 || >=2025.0.0 <2026.0.0")).toBe(false);
+    });
+  });
+
+  describe("compound ranges", () => {
+    it(">=A <B", () => {
+      expect(satisfiesRange("2026.3.14", ">=2026.3.10 <2027.0.0")).toBe(true);
+      expect(satisfiesRange("2027.0.0", ">=2026.3.10 <2027.0.0")).toBe(false);
+      expect(satisfiesRange("2026.3.9", ">=2026.3.10 <2027.0.0")).toBe(false);
+    });
+  });
+
+  describe("bare version (exact match)", () => {
+    it("matches only the exact version", () => {
+      expect(satisfiesRange("2026.3.14", "2026.3.14")).toBe(true);
+      expect(satisfiesRange("2026.3.15", "2026.3.14")).toBe(false);
+    });
+  });
+
+  describe("prerelease handling", () => {
+    it("prerelease version satisfies >= range", () => {
+      expect(satisfiesRange("2026.3.14-beta.1", ">=2026.3.10")).toBe(true);
+    });
+
+    it("prerelease version does not satisfy >= its own release", () => {
+      expect(satisfiesRange("2026.3.14-beta.1", ">=2026.3.14")).toBe(false);
+    });
+  });
+
+  describe("invalid inputs", () => {
+    it("returns false for invalid version", () => {
+      expect(satisfiesRange("not-a-version", ">=1.0.0")).toBe(false);
+    });
+  });
+});
+
+describe("sortVersionsDescending", () => {
+  it("sorts versions in descending order", () => {
+    const versions = ["2026.3.10", "2026.3.14", "2026.3.12", "2025.1.0"];
+    expect(sortVersionsDescending(versions)).toEqual([
+      "2026.3.14",
+      "2026.3.12",
+      "2026.3.10",
+      "2025.1.0",
+    ]);
+  });
+
+  it("sorts prereleases before their release", () => {
+    const versions = ["2026.3.14", "2026.3.14-beta.1", "2026.3.14-beta.2"];
+    expect(sortVersionsDescending(versions)).toEqual([
+      "2026.3.14",
+      "2026.3.14-beta.2",
+      "2026.3.14-beta.1",
+    ]);
+  });
+});
+
+describe("findLatestCompatible", () => {
+  const versions = ["2026.3.14", "2026.3.12", "2026.3.10", "2025.12.1", "2025.6.0"];
+
+  it("finds latest version satisfying range", () => {
+    expect(findLatestCompatible(versions, ">=2026.3.10")).toBe("2026.3.14");
+  });
+
+  it("finds latest when latest does not match", () => {
+    expect(findLatestCompatible(versions, ">=2025.0.0 <2026.0.0")).toBe("2025.12.1");
+  });
+
+  it("returns null when no version matches", () => {
+    expect(findLatestCompatible(versions, ">=2027.0.0")).toBeNull();
+  });
+
+  it("handles wildcard range", () => {
+    expect(findLatestCompatible(versions, "*")).toBe("2026.3.14");
+  });
+});
+
+describe("isPrerelease", () => {
+  it("detects prerelease versions", () => {
+    expect(isPrerelease("2026.3.14-beta.1")).toBe(true);
+    expect(isPrerelease("2026.3.14")).toBe(false);
+  });
+});

--- a/src/infra/semver-range.ts
+++ b/src/infra/semver-range.ts
@@ -1,0 +1,301 @@
+/**
+ * Lightweight semver range matcher for engine compatibility checks.
+ *
+ * Supports: >=, >, <=, <, ^, ~, =, * operators and || unions.
+ * Does not depend on external `semver` package.
+ */
+
+type SemverTuple = {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[] | null;
+};
+
+const SEMVER_RE =
+  /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export function parseSemverTuple(version: string): SemverTuple | null {
+  const match = SEMVER_RE.exec(version.trim());
+  if (!match) {
+    return null;
+  }
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+    patch: Number.parseInt(match[3], 10),
+    prerelease: match[4] ? match[4].split(".").filter(Boolean) : null,
+  };
+}
+
+/**
+ * Compare two semver tuples.
+ * Returns negative if a < b, positive if a > b, 0 if equal.
+ * Prerelease versions are lower than the associated release.
+ */
+export function compareSemver(a: SemverTuple, b: SemverTuple): number {
+  if (a.major !== b.major) {
+    return a.major - b.major;
+  }
+  if (a.minor !== b.minor) {
+    return a.minor - b.minor;
+  }
+  if (a.patch !== b.patch) {
+    return a.patch - b.patch;
+  }
+  return comparePrerelease(a.prerelease, b.prerelease);
+}
+
+function comparePrerelease(a: string[] | null, b: string[] | null): number {
+  // No prerelease on either → equal
+  if (!a?.length && !b?.length) {
+    return 0;
+  }
+  // Release > prerelease
+  if (!a?.length) {
+    return 1;
+  }
+  if (!b?.length) {
+    return -1;
+  }
+
+  const max = Math.max(a.length, b.length);
+  for (let i = 0; i < max; i++) {
+    const ai = a[i];
+    const bi = b[i];
+    if (ai == null && bi == null) {
+      return 0;
+    }
+    if (ai == null) {
+      return -1;
+    }
+    if (bi == null) {
+      return 1;
+    }
+    if (ai === bi) {
+      continue;
+    }
+
+    const aiNum = /^[0-9]+$/.test(ai);
+    const biNum = /^[0-9]+$/.test(bi);
+    if (aiNum && biNum) {
+      return Number.parseInt(ai, 10) - Number.parseInt(bi, 10);
+    }
+    if (aiNum) {
+      return -1;
+    }
+    if (biNum) {
+      return 1;
+    }
+    return ai < bi ? -1 : 1;
+  }
+  return 0;
+}
+
+type Comparator = {
+  op: ">=" | ">" | "<=" | "<";
+  version: SemverTuple;
+};
+
+function satisfiesComparator(version: SemverTuple, cmp: Comparator): boolean {
+  const diff = compareSemver(version, cmp.version);
+  switch (cmp.op) {
+    case ">=":
+      return diff >= 0;
+    case ">":
+      return diff > 0;
+    case "<=":
+      return diff <= 0;
+    case "<":
+      return diff < 0;
+  }
+}
+
+/**
+ * Parse a single comparator string (e.g. ">=2026.3.10", "^2026.3.10", "~2026.3.10", "2026.3.10", "*").
+ * Returns an array of Comparators that must all be satisfied (AND).
+ */
+function parseComparators(raw: string): Comparator[] | null {
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed === "*") {
+    return []; // empty = matches everything
+  }
+
+  // Operator prefix: >=, >, <=, <, =
+  const opMatch = /^(>=|>|<=|<|=)\s*(.+)$/.exec(trimmed);
+  if (opMatch) {
+    const op = opMatch[1] as ">=" | ">" | "<=" | "<" | "=";
+    const ver = parseSemverTuple(opMatch[2]);
+    if (!ver) {
+      return null;
+    }
+    if (op === "=") {
+      // Exact match: >= and <=
+      return [
+        { op: ">=", version: ver },
+        { op: "<=", version: ver },
+      ];
+    }
+    return [{ op, version: ver }];
+  }
+
+  // Caret range: ^MAJOR.MINOR.PATCH
+  const caretMatch = /^\^(.+)$/.exec(trimmed);
+  if (caretMatch) {
+    const ver = parseSemverTuple(caretMatch[1]);
+    if (!ver) {
+      return null;
+    }
+    // ^M.m.p → >=M.m.p <(M+1).0.0  (when M > 0)
+    // ^0.m.p → >=0.m.p <0.(m+1).0  (when m > 0)
+    // ^0.0.p → >=0.0.p <0.0.(p+1)
+    let upper: SemverTuple;
+    if (ver.major > 0) {
+      upper = { major: ver.major + 1, minor: 0, patch: 0, prerelease: null };
+    } else if (ver.minor > 0) {
+      upper = { major: 0, minor: ver.minor + 1, patch: 0, prerelease: null };
+    } else {
+      upper = { major: 0, minor: 0, patch: ver.patch + 1, prerelease: null };
+    }
+    return [
+      { op: ">=", version: { ...ver, prerelease: null } },
+      { op: "<", version: upper },
+    ];
+  }
+
+  // Tilde range: ~MAJOR.MINOR.PATCH
+  const tildeMatch = /^~(.+)$/.exec(trimmed);
+  if (tildeMatch) {
+    const ver = parseSemverTuple(tildeMatch[1]);
+    if (!ver) {
+      return null;
+    }
+    // ~M.m.p → >=M.m.p <M.(m+1).0
+    return [
+      { op: ">=", version: { ...ver, prerelease: null } },
+      { op: "<", version: { major: ver.major, minor: ver.minor + 1, patch: 0, prerelease: null } },
+    ];
+  }
+
+  // Bare version: treat as exact
+  const ver = parseSemverTuple(trimmed);
+  if (!ver) {
+    return null;
+  }
+  return [
+    { op: ">=", version: ver },
+    { op: "<=", version: ver },
+  ];
+}
+
+/**
+ * Check if a version satisfies a semver range string.
+ *
+ * Supports operators: >=, >, <=, <, ^, ~, =, *
+ * Supports || unions (e.g. ">=2026.3.10 || >=2025.0.0 <2026.0.0").
+ * Space-separated comparators within a union branch are AND'd.
+ */
+export function satisfiesRange(version: string, range: string): boolean {
+  const ver = parseSemverTuple(version);
+  if (!ver) {
+    return false;
+  }
+
+  const trimmedRange = range.trim();
+  if (!trimmedRange || trimmedRange === "*") {
+    return true;
+  }
+
+  // Split on || for union branches
+  const branches = trimmedRange.split("||");
+  for (const branch of branches) {
+    if (satisfiesBranch(ver, branch.trim())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function satisfiesBranch(version: SemverTuple, branch: string): boolean {
+  if (!branch || branch === "*") {
+    return true;
+  }
+
+  // Split branch into space-separated comparator strings.
+  // Each comparator may start with an operator or ^ or ~.
+  const parts = tokenizeComparators(branch);
+  const allComparators: Comparator[] = [];
+
+  for (const part of parts) {
+    const cmps = parseComparators(part);
+    if (!cmps) {
+      return false;
+    } // invalid comparator → branch fails
+    allComparators.push(...cmps);
+  }
+
+  // All comparators must be satisfied (AND)
+  return allComparators.every((cmp) => satisfiesComparator(version, cmp));
+}
+
+/**
+ * Tokenize a branch string into individual comparator tokens.
+ * Handles space-separated comparators like ">=2026.3.10 <2027.0.0".
+ */
+function tokenizeComparators(branch: string): string[] {
+  const tokens: string[] = [];
+  // Match tokens that start with an operator/caret/tilde followed by a version,
+  // or a bare version.
+  const re =
+    /(?:>=|>|<=|<|=|\^|~)?\s*v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?|\*/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(branch)) !== null) {
+    const token = match[0].trim();
+    if (token) {
+      tokens.push(token);
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Sort version strings in descending semver order.
+ */
+export function sortVersionsDescending(versions: string[]): string[] {
+  return [...versions].toSorted((a, b) => {
+    const pa = parseSemverTuple(a);
+    const pb = parseSemverTuple(b);
+    if (!pa && !pb) {
+      return 0;
+    }
+    if (!pa) {
+      return 1;
+    }
+    if (!pb) {
+      return -1;
+    }
+    return compareSemver(pb, pa); // descending
+  });
+}
+
+/**
+ * Find the latest version from a list that satisfies the given semver range.
+ * Versions should be sorted descending for best performance, but this is not required.
+ */
+export function findLatestCompatible(versions: string[], range: string): string | null {
+  const sorted = sortVersionsDescending(versions);
+  for (const v of sorted) {
+    if (satisfiesRange(v, range)) {
+      return v;
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if a version string looks like a prerelease (has a hyphen-separated prerelease tag).
+ */
+export function isPrerelease(version: string): boolean {
+  const parsed = parseSemverTuple(version);
+  return parsed?.prerelease != null && parsed.prerelease.length > 0;
+}

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -45,6 +45,8 @@ export type PluginCandidate = {
   packageManifest?: OpenClawPackageManifest;
   bundledManifest?: PluginManifest;
   bundledManifestPath?: string;
+  /** engines.openclaw range from package.json (used for compatibility warnings). */
+  engineOpenclawRange?: string;
 };
 
 export type PluginDiscoveryResult = {
@@ -315,6 +317,18 @@ function shouldIgnoreScannedDirectory(dirName: string): boolean {
   return false;
 }
 
+function extractEngineOpenclawRange(manifest: PackageManifest | null): string | undefined {
+  if (!manifest) {
+    return undefined;
+  }
+  const engines = (manifest as Record<string, unknown>).engines;
+  if (!engines || typeof engines !== "object") {
+    return undefined;
+  }
+  const openclaw = (engines as Record<string, unknown>).openclaw;
+  return typeof openclaw === "string" ? openclaw.trim() || undefined : undefined;
+}
+
 function readPackageManifest(dir: string, rejectHardlinks = true): PackageManifest | null {
   const manifestPath = path.join(dir, "package.json");
   const opened = openBoundaryFileSync({
@@ -416,6 +430,7 @@ function addCandidate(params: {
     packageManifest: getPackageManifestMetadata(manifest ?? undefined),
     bundledManifest: params.bundledManifest,
     bundledManifestPath: params.bundledManifestPath,
+    engineOpenclawRange: extractEngineOpenclawRange(manifest),
   });
 }
 

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -7,6 +7,11 @@ import {
   unscopedPackageName,
 } from "../infra/install-safe-path.js";
 import { type NpmIntegrityDrift, type NpmSpecResolution } from "../infra/install-source-utils.js";
+import {
+  formatEngineIncompatibleError,
+  resolveCompatibleVersion,
+} from "../infra/npm-engine-resolve.js";
+import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import {
   resolvePackageExtensionEntries,
@@ -710,6 +715,10 @@ export async function installPluginFromNpmSpec(params: {
   expectedPluginId?: string;
   expectedIntegrity?: string;
   onIntegrityDrift?: (params: PluginNpmIntegrityDriftParams) => boolean | Promise<boolean>;
+  /** Current openclaw core version. When set, engine compatibility is checked. */
+  coreVersion?: string;
+  /** Skip engine compatibility check even when coreVersion is set. */
+  ignoreEngine?: boolean;
 }): Promise<InstallPluginResult> {
   const runtime = await loadPluginInstallRuntime();
   const { logger, timeoutMs, mode, dryRun } = runtime.resolveTimedInstallModeOptions(
@@ -717,7 +726,7 @@ export async function installPluginFromNpmSpec(params: {
     defaultLogger,
   );
   const expectedPluginId = params.expectedPluginId;
-  const spec = params.spec.trim();
+  let spec = params.spec.trim();
   const specError = runtime.validateRegistryNpmSpec(spec);
   if (specError) {
     return {
@@ -725,6 +734,42 @@ export async function installPluginFromNpmSpec(params: {
       error: specError,
       code: PLUGIN_INSTALL_ERROR_CODE.INVALID_NPM_SPEC,
     };
+  }
+
+  // Engine-aware version resolution: when coreVersion is set and the spec does
+  // not pin an exact version, query the registry for the latest compatible version.
+  if (params.coreVersion && !params.ignoreEngine) {
+    const parsed = parseRegistryNpmSpec(spec);
+    if (parsed && parsed.selectorKind !== "exact-version") {
+      const engineResult = await resolveCompatibleVersion({
+        packageName: parsed.name,
+        coreVersion: params.coreVersion,
+        allowPrerelease: parsed.selectorIsPrerelease,
+        timeoutMs,
+      });
+      if (!engineResult.ok) {
+        // Registry unreachable — fall back to existing behavior with a warning
+        logger.warn?.(`Engine compatibility check skipped: ${engineResult.error}`);
+      } else if (engineResult.version === null) {
+        // No compatible version found — block installation
+        return {
+          ok: false,
+          error: formatEngineIncompatibleError({
+            packageName: parsed.name,
+            coreVersion: params.coreVersion,
+            latestVersion: engineResult.latestVersion,
+            latestRange: engineResult.latestRange,
+          }),
+        };
+      } else {
+        // Rewrite spec to pin the compatible version
+        const newSpec = `${parsed.name}@${engineResult.version}`;
+        if (newSpec !== spec) {
+          logger.info?.(`Engine compatibility: resolved ${spec} to ${newSpec}`);
+          spec = newSpec;
+        }
+      }
+    }
   }
 
   logger.info?.(`Downloading ${spec}…`);

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
+import { satisfiesRange } from "../infra/semver-range.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   clearMemoryPromptSection,
@@ -14,6 +15,7 @@ import {
   restoreMemoryPromptSection,
 } from "../memory/prompt-section.js";
 import { resolveUserPath } from "../utils.js";
+import { VERSION } from "../version.js";
 import { inspectBundleMcpRuntimeSupport } from "./bundle-mcp.js";
 import { clearPluginCommands } from "./command-registry-state.js";
 import {
@@ -979,6 +981,18 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     if (!enableState.enabled) {
       record.status = "disabled";
       record.error = enableState.reason;
+    }
+
+    // Engine compatibility warning: warn if the installed plugin declares an
+    // engines.openclaw range that the running core version does not satisfy.
+    const engineRange = candidate.engineOpenclawRange;
+    if (engineRange && VERSION && !satisfiesRange(VERSION, engineRange)) {
+      registry.diagnostics.push({
+        level: "warn",
+        pluginId: record.id,
+        source: record.source,
+        message: `Plugin requires openclaw ${engineRange}, but running ${VERSION}. The plugin may not work correctly.`,
+      });
     }
 
     if (record.format === "bundle") {

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -260,6 +260,8 @@ export async function updateNpmInstalledPlugins(params: {
   dryRun?: boolean;
   specOverrides?: Record<string, string>;
   onIntegrityDrift?: (params: PluginUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
+  /** Current openclaw core version for engine compatibility checks. */
+  coreVersion?: string;
 }): Promise<PluginUpdateSummary> {
   const logger = params.logger ?? {};
   const installs = params.config.plugins?.installs ?? {};
@@ -361,6 +363,7 @@ export async function updateNpmInstalledPlugins(params: {
                 dryRun: true,
                 expectedPluginId: pluginId,
                 expectedIntegrity,
+                coreVersion: params.coreVersion,
                 onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
                   pluginId,
                   dryRun: true,
@@ -458,6 +461,7 @@ export async function updateNpmInstalledPlugins(params: {
               mode: "update",
               expectedPluginId: pluginId,
               expectedIntegrity,
+              coreVersion: params.coreVersion,
               onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
                 pluginId,
                 dryRun: false,


### PR DESCRIPTION
## Summary

- **Problem:** The OpenClaw plugin system has no version compatibility constraint mechanism — `plugins install` / `plugins update` always install the latest version, which may be incompatible with the current core
- **Why it matters:** When the core or a plugin is upgraded, an incompatible plugin version can cause runtime errors
- **What changed:** Added VS Code-style `engines.openclaw` support. During install/update, the CLI queries the npm registry and automatically selects the latest version compatible with the current core; incompatible versions are blocked from installation
- **What did NOT change:** Existing plugins without `engines.openclaw` behave the same (treated as compatible with all versions)

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Integrations
- [x] UI / DX

## Approach

Plugins declare compatibility in `package.json`:

```json
{
  "engines": {
    "openclaw": ">=2026.3.10"
  }
}
```

During install/update, the CLI queries the npm registry to retrieve `engines` metadata for all versions, then client-side filters to find the latest version compatible with the current OpenClaw core version.

### New files

- `src/infra/semver-range.ts` — Lightweight semver range matcher supporting `>=`, `^`, `~`, `||`, `*`, etc., with no external dependencies
- `src/infra/npm-registry-versions.ts` — Queries the npm registry abbreviated packument to extract version + engines metadata
- `src/infra/npm-engine-resolve.ts` — Engine-aware version resolution logic

### Modified files

- `src/plugins/install.ts` — `installPluginFromNpmSpec()` gains `coreVersion` / `ignoreEngine` parameters
- `src/cli/plugins-install-command.ts` — Passes `VERSION` and `ignoreEngine`
- `src/cli/plugins-update-command.ts` — Passes `VERSION` and `ignoreEngine`
- `src/cli/plugins-cli.ts` — `install` and `update` commands gain `--ignore-engine` flag
- `src/plugins/update.ts` — Forwards `coreVersion`
- `src/plugins/discovery.ts` — `PluginCandidate` gains `engineOpenclawRange`
- `src/plugins/loader.ts` — Engine compatibility diagnostic warning at load time

## User-visible / Behavior Changes

- `openclaw plugins install <pkg>` now automatically selects the latest version compatible with the current core
- `openclaw plugins update` does the same
- New `--ignore-engine` flag to skip the compatibility check
- Incompatible plugins show a warning at load time (does not block loading)

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — an additional npm registry query (abbreviated packument) during install to fetch version engines metadata
  - Risk: Extra network request. Mitigation: 5s timeout; falls back to existing behavior on failure
- Command/tool execution surface changed? No
- Data access scope changed? No

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/infra/semver-range.test.ts`, `src/infra/npm-registry-versions.test.ts`, `src/infra/npm-engine-resolve.test.ts`
- 33 tests — semver range parsing and matching
- 6 tests — npm registry version queries (mock fetch)
- 10 tests — engine-aware version resolution
- All existing plugin install/update tests pass

## Compatibility / Migration

- Backward compatible? Yes — plugins without `engines.openclaw` are treated as compatible with all versions
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: npm registry query adds install latency
  - Mitigation: Uses abbreviated packument (smaller payload), 5s timeout, falls back with a warning on failure
- Risk: semver range matcher implementation may have edge cases
  - Mitigation: 49 unit tests covering all operators and edge cases