### PR TITLE
fix(skills): remove unsupported gh-issues frontmatter

### DIFF
--- a/skills/gh-issues/SKILL.md
+++ b/skills/gh-issues/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: gh-issues
 description: "Fetch GitHub issues, spawn sub-agents to implement fixes and open PRs, then monitor and address PR review comments. Usage: /gh-issues [owner/repo] [--label bug] [--limit 5] [--milestone v1.0] [--assignee @me] [--fork user/repo] [--watch] [--interval 5] [--reviews-only] [--cron] [--dry-run] [--model glm-5] [--notify-channel -1002381931352]"
-user-invocable: true
 metadata:
   { "openclaw": { "requires": { "bins": ["curl", "git", "gh"] }, "primaryEnv": "GH_TOKEN" } }
 ---


### PR DESCRIPTION
## Summary
- remove the redundant `user-invocable: true` entry from `gh-issues` frontmatter
- keep runtime behavior unchanged because `user-invocable` already defaults to `true`
- restore compatibility with the stricter skill validation path discussed in #54311

Refs #54311