### PR TITLE
CLI: support npm: prefix for plugins install

### DIFF
--- a/src/cli/plugin-install-config-policy.ts
+++ b/src/cli/plugin-install-config-policy.ts
@@ -20,11 +20,20 @@ function isPluginInstallCommand(commandPath: string[]): boolean {
   return commandPath[0] === "plugins" && commandPath[1] === "install";
 }
 
+function stripNpmPrefix(spec: string): string {
+  const trimmed = spec.trim();
+  return trimmed.toLowerCase().startsWith("npm:") ? trimmed.slice("npm:".length).trim() : trimmed;
+}
+
 function isExplicitMatrixInstallRequest(request: PluginInstallRequestContext): boolean {
   if (request.marketplace) {
     return false;
   }
-  const candidates = [request.rawSpec.trim(), request.normalizedSpec.trim()];
+  const candidates = [
+    request.rawSpec.trim(),
+    request.normalizedSpec.trim(),
+    stripNpmPrefix(request.rawSpec),
+  ];
   if (candidates.includes("@openclaw/matrix")) {
     return true;
   }

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -406,6 +406,7 @@ describe("plugins cli install", () => {
     );
 
     expect(installPluginFromClawHub).not.toHaveBeenCalled();
+    expect(runtimeErrors.at(-1)).toContain("npm install failed");
   });
 
   it("falls back to installing hook packs from npm specs", async () => {

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -350,6 +350,64 @@ describe("plugins cli install", () => {
     expect(runtimeErrors.at(-1)).toContain('Use "openclaw skills install demo" instead.');
   });
 
+  it("installs directly from npm when npm: prefix is used", async () => {
+    const cfg = {
+      plugins: {
+        entries: {},
+      },
+    } as OpenClawConfig;
+    const enabledCfg = {
+      plugins: {
+        entries: {
+          demo: {
+            enabled: true,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    loadConfig.mockReturnValue(cfg);
+    installPluginFromNpmSpec.mockResolvedValue({
+      ok: true,
+      pluginId: "demo",
+      targetDir: "/tmp/openclaw-state/extensions/demo",
+      version: "1.2.3",
+      npmResolution: {
+        packageName: "demo",
+        resolvedVersion: "1.2.3",
+        tarballUrl: "https://registry.npmjs.org/demo/-/demo-1.2.3.tgz",
+      },
+    });
+    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
+    recordPluginInstall.mockReturnValue(enabledCfg);
+    applyExclusiveSlotSelection.mockReturnValue({
+      config: enabledCfg,
+      warnings: [],
+    });
+
+    await runPluginsCommand(["plugins", "install", "npm:demo"]);
+
+    expect(installPluginFromNpmSpec).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "demo",
+      }),
+    );
+    expect(installPluginFromClawHub).not.toHaveBeenCalled();
+  });
+
+  it("skips ClawHub entirely when npm: prefix is used", async () => {
+    installPluginFromNpmSpec.mockResolvedValue({
+      ok: false,
+      error: "npm install failed",
+    });
+
+    await expect(runPluginsCommand(["plugins", "install", "npm:demo"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(installPluginFromClawHub).not.toHaveBeenCalled();
+  });
+
   it("falls back to installing hook packs from npm specs", async () => {
     const cfg = {} as OpenClawConfig;
     const installedCfg = {

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -703,7 +703,7 @@ export function registerPluginsCli(program: Command) {
   plugins
     .command("install")
     .description(
-      "Install a plugin or hook pack (path, archive, npm spec, clawhub:package, or marketplace entry)",
+      "Install a plugin or hook pack (path, archive, npm spec, npm:package, clawhub:package, or marketplace entry)",
     )
     .argument(
       "<path-or-spec-or-plugin>",

--- a/src/cli/plugins-command-helpers.ts
+++ b/src/cli/plugins-command-helpers.ts
@@ -153,6 +153,20 @@ export function buildPreferredClawHubSpec(raw: string): string | null {
   return `clawhub:${parsed.name}${parsed.selector ? `@${parsed.selector}` : ""}`;
 }
 
+/**
+ * Parse an explicit `npm:<spec>` prefix, stripping the prefix and returning
+ * the inner npm spec string. Returns `null` when the input does not use the
+ * `npm:` prefix.
+ */
+export function parseNpmPrefixSpec(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed.toLowerCase().startsWith("npm:")) {
+    return null;
+  }
+  const spec = trimmed.slice("npm:".length).trim();
+  return spec || null;
+}
+
 export const PREFERRED_CLAWHUB_FALLBACK_DECISION = {
   FALLBACK_TO_NPM: "fallback_to_npm",
   STOP: "stop",

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -34,6 +34,7 @@ import {
   createPluginInstallLogger,
   decidePreferredClawHubFallback,
   formatPluginInstallWithHookFallbackError,
+  parseNpmPrefixSpec,
 } from "./plugins-command-helpers.js";
 import { persistHookPackInstall, persistPluginInstall } from "./plugins-install-persist.js";
 
@@ -444,6 +445,45 @@ export async function runPluginInstallCommand(params: {
         clawhubFamily: result.clawhub.clawhubFamily,
         clawhubChannel: result.clawhub.clawhubChannel,
       },
+    });
+    return;
+  }
+
+  const npmPrefixSpec = parseNpmPrefixSpec(raw);
+  if (npmPrefixSpec) {
+    const result = await installPluginFromNpmSpec({
+      spec: npmPrefixSpec,
+      logger: createPluginInstallLogger(),
+    });
+    if (!result.ok) {
+      const hookFallback = await tryInstallHookPackFromNpmSpec({
+        config: cfg,
+        spec: npmPrefixSpec,
+        pin: opts.pin,
+      });
+      if (hookFallback.ok) {
+        return;
+      }
+      defaultRuntime.error(
+        formatPluginInstallWithHookFallbackError(result.error, hookFallback.error),
+      );
+      return defaultRuntime.exit(1);
+    }
+
+    clearPluginManifestRegistryCache();
+    const installRecord = resolvePinnedNpmInstallRecordForCli(
+      npmPrefixSpec,
+      Boolean(opts.pin),
+      result.targetDir,
+      result.version,
+      result.npmResolution,
+      defaultRuntime.log,
+      theme.warn,
+    );
+    await persistPluginInstall({
+      config: cfg,
+      pluginId: result.pluginId,
+      install: installRecord,
     });
     return;
   }

--- a/src/cli/plugins-install-config.test.ts
+++ b/src/cli/plugins-install-config.test.ts
@@ -119,6 +119,36 @@ describe("loadConfigForInstall", () => {
     expect(result).toBe(snapshotCfg);
   });
 
+  it("allows npm:-prefixed Matrix reinstall recovery", async () => {
+    const invalidConfigErr = new Error("config invalid");
+    (invalidConfigErr as { code?: string }).code = "INVALID_CONFIG";
+    loadConfigMock.mockImplementation(() => {
+      throw invalidConfigErr;
+    });
+
+    const snapshotCfg = {
+      plugins: { installs: { matrix: { source: "path", installPath: "/gone" } } },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: { plugins: { installs: { matrix: {} } } },
+        config: snapshotCfg,
+        issues: [
+          { path: "channels.matrix", message: "unknown channel id: matrix" },
+          { path: "plugins.load.paths", message: "plugin: plugin path not found: /gone" },
+        ],
+      }),
+    );
+
+    const result = await loadConfigForInstall({
+      rawSpec: "npm:@openclaw/matrix",
+      normalizedSpec: "npm:@openclaw/matrix",
+    });
+    expect(readConfigFileSnapshotMock).toHaveBeenCalled();
+    expect(cleanStaleMatrixPluginConfigMock).toHaveBeenCalledWith(snapshotCfg);
+    expect(result).toBe(snapshotCfg);
+  });
+
   it("rejects unrelated invalid config even during Matrix reinstall", async () => {
     const invalidConfigErr = new Error("config invalid");
     (invalidConfigErr as { code?: string }).code = "INVALID_CONFIG";


### PR DESCRIPTION
Add `npm:<package>` prefix support to `openclaw plugins install` so users can bypass ClawHub lookup and install directly from npm registry.

## Summary

- Problem: `openclaw plugins install <pkg>` always tries ClawHub first, with no way to force npm-only resolution.
- Why it matters: Users who know their plugin is on npm waste time on ClawHub lookups that will 403, or may hit ClawHub-specific errors that block installation.
- What changed: Added `npm:<package>` prefix parsing that skips ClawHub entirely and goes straight to npm install. Added `parseNpmPrefixSpec()` helper, wired it into the install command flow, and added two integration tests.
- What did NOT change (scope boundary): Bare specs still try ClawHub first then fall back to npm. `clawhub:` prefix behavior is unchanged. No config schema or plugin SDK surface changes.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/cli/plugins-cli.install.test.ts`
- Scenario the test should lock in: `npm:demo` installs from npm without calling ClawHub; `npm:demo` failure does not fall back to ClawHub.
- Why this is the smallest reliable guardrail: Integration tests via the CLI command runner exercise the full dispatch logic including prefix parsing.

## User-visible / Behavior Changes

- New `npm:<package>` prefix for `openclaw plugins install` that forces npm-only resolution (e.g. `openclaw plugins install npm:my-plugin`).
- Updated `install` command description to mention `npm:package`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (uses existing npm install path)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. `openclaw plugins install npm:demo` — installs directly from npm, no ClawHub lookup.
2. `openclaw plugins install demo` — unchanged behavior (ClawHub first, npm fallback).
3. `openclaw plugins install clawhub:demo` — unchanged behavior (ClawHub only).

### Expected

- `npm:` prefix skips ClawHub and installs from npm registry.

## Evidence

- [x] Failing test/log before + passing after
- 11/11 tests pass including 2 new tests (`pnpm test -- src/cli/plugins-cli.install.test.ts`)

## Human Verification (required)

- Verified scenarios: All 11 install tests pass, including new `npm:` prefix tests.
- Edge cases checked: Empty `npm:` prefix (returns null), case-insensitive prefix match.
- What you did **not** verify: Live npm install with real package (test-only verification).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit; `npm:` prefix will fall through to existing npm install path (with ClawHub attempted first).
- Known bad symptoms reviewers should watch for: `npm:pkg` being rejected or still hitting ClawHub.

## Risks and Mitigations

None