### PR TITLE
fix(media): treat legacy .doc containers as binary

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -1203,4 +1203,22 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toContain("<file");
     expect(ctx.Body).toContain("vendor-json");
   });
+
+  it("skips legacy Office binary formats carried as msword or x-cfb", async () => {
+    const oleMagic = Buffer.from("d0cf11e0a1b11ae1", "hex");
+    for (const mime of ["application/msword", "application/x-cfb"]) {
+      const filePath = await createTempMediaFile({
+        fileName: mime === "application/msword" ? "legacy.doc" : "legacy.cfb",
+        content: oleMagic,
+      });
+
+      const { ctx, result } = await applyWithDisabledMedia({
+        body: "<media:file>",
+        mediaPath: filePath,
+        mediaType: mime,
+      });
+
+      expectFileNotApplied({ ctx, result, body: "<media:file>" });
+    }
+  });
 });

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -299,7 +299,9 @@ function isBinaryMediaMime(mime?: string): boolean {
     mime === "application/gzip" ||
     mime === "application/x-gzip" ||
     mime === "application/x-rar-compressed" ||
-    mime === "application/x-7z-compressed"
+    mime === "application/x-7z-compressed" ||
+    mime === "application/x-cfb" ||
+    mime === "application/msword"
   ) {
     return true;
   }


### PR DESCRIPTION
## Summary
- treat legacy OLE/CFB-based .doc payloads as binary attachments
- mark both application/msword and application/x-cfb as binary media
- add coverage so these attachments are skipped instead of auto-embedded as text

Fixes #54176

Supersedes #54190 and #54234 with a fresh branch from current main.