### PR TITLE
fix: clamp compaction max_tokens to model output limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/compaction: clamp compaction summary reserve tokens to each model's output limit so high-context compaction no longer requests invalid `max_tokens` values. (#54392) Thanks @adzendo.
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
 - Discord/groups: instruct group-chat agents to stay silent when a message is addressed to someone else, replying only when invited or correcting key facts. (#78615)
 - Discord/groups: tell Discord-channel agents to wrap bare URLs as `<https://example.com>` so link previews do not expand into uninvited embeds. (#78614)
@@ -1053,7 +1054,6 @@ Docs: https://docs.openclaw.ai
 - Agents/replies: defer implicit image model discovery and keep OAuth auth-store adoption on persisted profiles during reply startup, cutting OCM MarCodex warm prep to sub-second in live checks. Thanks @shakkernerd.
 - Plugins/tools: enforce `contracts.tools` as the manifest ownership contract for plugin tool registration, rejecting undeclared runtime tool names and adding bundled plugin drift coverage. Thanks @shakkernerd.
 - Agents/Codex: stop prompting message-tool-only source turns to finish with `NO_REPLY`, so quiet turns are represented by not calling the visible message tool instead of conflicting final-text instructions. Thanks @pashpashpash.
-- Agents/compaction: clamp compaction summary reserve tokens to each model's output limit so high-context compaction no longer requests invalid `max_tokens` values. (#54392) Thanks @adzendo.
 - Gateway/config: report failed backup restores as failed in logs and config observe audit records instead of marking them valid. (#70515) Thanks @davidangularme.
 - Compaction: use the active session model fallback chain for implicit summarization failures without persisting fallback model selection, so Azure content-filter 400s can recover. Fixes #64960. (#74470) Thanks @jalehman and @OpenCodeEngineer.
 - Gateway/config: allow `gateway config.patch` to update documented subagent thinking defaults. Fixes #75764. (#75802) Thanks @kAIborg24.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1053,6 +1053,7 @@ Docs: https://docs.openclaw.ai
 - Agents/replies: defer implicit image model discovery and keep OAuth auth-store adoption on persisted profiles during reply startup, cutting OCM MarCodex warm prep to sub-second in live checks. Thanks @shakkernerd.
 - Plugins/tools: enforce `contracts.tools` as the manifest ownership contract for plugin tool registration, rejecting undeclared runtime tool names and adding bundled plugin drift coverage. Thanks @shakkernerd.
 - Agents/Codex: stop prompting message-tool-only source turns to finish with `NO_REPLY`, so quiet turns are represented by not calling the visible message tool instead of conflicting final-text instructions. Thanks @pashpashpash.
+- Agents/compaction: clamp compaction summary reserve tokens to each model's output limit so high-context compaction no longer requests invalid `max_tokens` values. (#54392) Thanks @adzendo.
 - Gateway/config: report failed backup restores as failed in logs and config observe audit records instead of marking them valid. (#70515) Thanks @davidangularme.
 - Compaction: use the active session model fallback chain for implicit summarization failures without persisting fallback model selection, so Azure content-filter 400s can recover. Fixes #64960. (#74470) Thanks @jalehman and @OpenCodeEngineer.
 - Gateway/config: allow `gateway config.patch` to update documented subagent thinking defaults. Fixes #75764. (#75802) Thanks @kAIborg24.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Agents/compaction: clamp compaction summary reserve tokens to each model's output limit so high-context compaction no longer requests invalid `max_tokens` values. (#54392) Thanks @adzendo.
 - Doctor/OpenAI Codex: revert the 2026.5.5 `doctor --fix` repair that rewrote valid `openai-codex/*` ChatGPT/Codex OAuth routes to `openai/*`, which could break OAuth-only GPT-5.5 setups or accidentally move users onto the OpenAI API-key route. If 2026.5.5 already changed your default model, run `openclaw models set openai-codex/gpt-5.5 && openclaw config validate` to switch the default agent back to the Codex OAuth PI route. Fixes #78407.
 - Discord/groups: instruct group-chat agents to stay silent when a message is addressed to someone else, replying only when invited or correcting key facts. (#78615)
 - Discord/groups: tell Discord-channel agents to wrap bare URLs as `<https://example.com>` so link previews do not expand into uninvited embeds. (#78614)
@@ -467,6 +466,7 @@ Docs: https://docs.openclaw.ai
 - web_search/Brave: fix provider selection when Brave is installed as an external plugin and `tools.web.search.provider: "brave"` is explicitly configured — a redundant provider re-resolution at startup could race and return an empty list, causing a spurious `WEB_SEARCH_PROVIDER_INVALID_AUTODETECT` warning and treating the explicitly configured provider as absent. Fixes #77676. Thanks @openperf.
 - Doctor/plugins: discover doctor contracts from load-path channel plugins during `openclaw doctor --fix`, so plugin-owned legacy config repair runs before validation. (#77477) Thanks @jalehman.
 - Dependencies: bump transitive `basic-ftp` to 5.3.1 so the runtime lockfile no longer includes the vulnerable 5.3.0 build flagged by the production dependency audit. (#78637) Thanks @sallyom.
+- Agents/compaction: clamp compaction summary reserve tokens to each model's output limit so high-context compaction no longer requests invalid `max_tokens` values. (#54392) Thanks @adzendo.
 
 ## 2026.5.3-1
 

--- a/src/agents/compaction.identifier-preservation.test.ts
+++ b/src/agents/compaction.identifier-preservation.test.ts
@@ -7,6 +7,7 @@ vi.mock("@mariozechner/pi-coding-agent", async () => {
   const actual = await vi.importActual<typeof piCodingAgent>("@mariozechner/pi-coding-agent");
   return {
     ...actual,
+    estimateTokens: vi.fn((message: unknown) => Math.ceil(JSON.stringify(message).length / 4)),
     generateSummary: vi.fn(),
   };
 });

--- a/src/agents/compaction.reserve-tokens-clamping.test.ts
+++ b/src/agents/compaction.reserve-tokens-clamping.test.ts
@@ -1,0 +1,143 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import * as piCodingAgent from "@mariozechner/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof piCodingAgent>();
+  return {
+    ...actual,
+    generateSummary: vi.fn(),
+  };
+});
+
+const mockGenerateSummary = vi.mocked(piCodingAgent.generateSummary);
+
+let summarizeInStages: typeof import("./compaction.js").summarizeInStages;
+
+async function loadFreshCompactionModuleForTest() {
+  vi.resetModules();
+  ({ summarizeInStages } = await import("./compaction.js"));
+}
+
+function makeMessage(index: number, size = 1200): AgentMessage {
+  return {
+    role: "user",
+    content: `m${index}-${"x".repeat(size)}`,
+    timestamp: index,
+  };
+}
+
+describe("compaction reserveTokens clamping", () => {
+  beforeEach(async () => {
+    await loadFreshCompactionModuleForTest();
+    mockGenerateSummary.mockReset();
+    mockGenerateSummary.mockResolvedValue("summary");
+  });
+
+  it("clamps reserveTokens when model maxTokens is smaller than requested", async () => {
+    // Simulate the exact bug scenario: large context window (1M) with
+    // reserveTokensFloor of 300K, but model output limit is only 128K.
+    // Without clamping, generateSummary would receive 300K and compute
+    // max_tokens = floor(0.8 * 300K) = 240K, exceeding the 128K model limit.
+    const model = {
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    } as unknown as NonNullable<ExtensionContext["model"]>;
+
+    await summarizeInStages({
+      model,
+      apiKey: "test-key", // pragma: allowlist secret
+      reserveTokens: 300_000,
+      maxChunkTokens: 8000,
+      contextWindow: 1_000_000,
+      signal: new AbortController().signal,
+      messages: [makeMessage(1), makeMessage(2)],
+    });
+
+    expect(mockGenerateSummary).toHaveBeenCalled();
+    // Third argument to generateSummary is reserveTokens.
+    // With maxTokens 128K, the clamp should be floor(128_000 / 0.8) = 160_000.
+    const passedReserveTokens = mockGenerateSummary.mock.calls[0][2];
+    expect(passedReserveTokens).toBeLessThanOrEqual(Math.floor(128_000 / 0.8));
+    expect(passedReserveTokens).toBe(160_000);
+  });
+
+  it("does not clamp when model maxTokens is large enough", async () => {
+    const model = {
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      contextWindow: 200_000,
+      maxTokens: 32_000,
+    } as unknown as NonNullable<ExtensionContext["model"]>;
+
+    // reserveTokens 4000 is well under floor(32_000 / 0.8) = 40_000
+    await summarizeInStages({
+      model,
+      apiKey: "test-key", // pragma: allowlist secret
+      reserveTokens: 4000,
+      maxChunkTokens: 8000,
+      contextWindow: 200_000,
+      signal: new AbortController().signal,
+      messages: [makeMessage(1), makeMessage(2)],
+    });
+
+    expect(mockGenerateSummary).toHaveBeenCalled();
+    const passedReserveTokens = mockGenerateSummary.mock.calls[0][2];
+    expect(passedReserveTokens).toBe(4000);
+  });
+
+  it("falls back to 128K default when model has no maxTokens field", async () => {
+    // Model without maxTokens defined — should default to 128_000 as the cap.
+    const model = {
+      provider: "anthropic",
+      model: "claude-3-opus",
+      contextWindow: 1_000_000,
+    } as unknown as NonNullable<ExtensionContext["model"]>;
+
+    await summarizeInStages({
+      model,
+      apiKey: "test-key", // pragma: allowlist secret
+      reserveTokens: 300_000,
+      maxChunkTokens: 8000,
+      contextWindow: 1_000_000,
+      signal: new AbortController().signal,
+      messages: [makeMessage(1), makeMessage(2)],
+    });
+
+    expect(mockGenerateSummary).toHaveBeenCalled();
+    // Fallback maxTokens is 128_000, so clamp = floor(128_000 / 0.8) = 160_000
+    const passedReserveTokens = mockGenerateSummary.mock.calls[0][2];
+    expect(passedReserveTokens).toBe(160_000);
+  });
+
+  it("clamps consistently across all chunks in staged summarization", async () => {
+    const model = {
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    } as unknown as NonNullable<ExtensionContext["model"]>;
+
+    // Use enough messages and small chunk size to force multiple chunks
+    await summarizeInStages({
+      model,
+      apiKey: "test-key", // pragma: allowlist secret
+      reserveTokens: 300_000,
+      maxChunkTokens: 1000,
+      contextWindow: 1_000_000,
+      signal: new AbortController().signal,
+      messages: Array.from({ length: 4 }, (_, i) => makeMessage(i + 1)),
+      parts: 2,
+      minMessagesForSplit: 4,
+    });
+
+    expect(mockGenerateSummary.mock.calls.length).toBeGreaterThan(1);
+    const expectedClamp = Math.floor(128_000 / 0.8);
+    for (const call of mockGenerateSummary.mock.calls) {
+      expect(call[2]).toBeLessThanOrEqual(expectedClamp);
+    }
+  });
+});

--- a/src/agents/compaction.reserve-tokens-clamping.test.ts
+++ b/src/agents/compaction.reserve-tokens-clamping.test.ts
@@ -1,17 +1,24 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
-import * as piCodingAgent from "@mariozechner/pi-coding-agent";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
-  const actual = await importOriginal<typeof piCodingAgent>();
+const piCodingAgentMocks = vi.hoisted(() => ({
+  estimateTokens: vi.fn((message: unknown) => Math.ceil(JSON.stringify(message).length / 4)),
+  generateSummary: vi.fn(),
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>(
+    "@mariozechner/pi-coding-agent",
+  );
   return {
     ...actual,
-    generateSummary: vi.fn(),
+    estimateTokens: piCodingAgentMocks.estimateTokens,
+    generateSummary: piCodingAgentMocks.generateSummary,
   };
 });
 
-const mockGenerateSummary = vi.mocked(piCodingAgent.generateSummary);
+const mockGenerateSummary = piCodingAgentMocks.generateSummary;
 
 let summarizeInStages: typeof import("./compaction.js").summarizeInStages;
 
@@ -33,6 +40,10 @@ describe("compaction reserveTokens clamping", () => {
     await loadFreshCompactionModuleForTest();
     mockGenerateSummary.mockReset();
     mockGenerateSummary.mockResolvedValue("summary");
+    piCodingAgentMocks.estimateTokens.mockReset();
+    piCodingAgentMocks.estimateTokens.mockImplementation((message: unknown) =>
+      Math.ceil(JSON.stringify(message).length / 4),
+    );
   });
 
   it("clamps reserveTokens when model maxTokens is smaller than requested", async () => {

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -314,13 +314,22 @@ async function summarizeChunks(params: {
     params.customInstructions,
     params.summarizationInstructions,
   );
+
+  // Clamp reserveTokens to the model's maxTokens output cap.
+  // generateSummary() uses Math.floor(0.8 * reserveTokens) as max_tokens for the API call.
+  // With large context windows (1M tokens), reserveTokensFloor can be 300K+, producing
+  // max_tokens of 240K+ which exceeds model output limits (e.g. 128K for Anthropic).
+  // By clamping reserveTokens here, we ensure the downstream max_tokens stays within bounds.
+  const modelMaxTokens = params.model.maxTokens ?? 128_000;
+  const clampedReserveTokens = Math.min(params.reserveTokens, Math.floor(modelMaxTokens / 0.8));
+
   for (const chunk of chunks) {
     summary = await retryAsync(
       () =>
         generateSummary(
           chunk,
           params.model,
-          params.reserveTokens,
+          clampedReserveTokens,
           params.apiKey,
           params.headers,
           params.signal,


### PR DESCRIPTION
## Summary

Fixes #54383 — Compaction fails with `max_tokens: 240000 > 128000` when using Anthropic models with 1M context windows.

## Root Cause

In `@mariozechner/pi-coding-agent`, `generateSummary()` calculates:
```typescript
const maxTokens = Math.floor(0.8 * reserveTokens);
```

With `reserveTokensFloor: 300000` (appropriate for 1M context), this produces `max_tokens = 240000` — exceeding Anthropic's per-request output cap of 128K for both Sonnet 4.6 and Opus 4.6.

## Fix

Clamp `reserveTokens` in `src/agents/compaction.ts` before passing to `generateSummary()`:

```typescript
const modelMaxTokens = params.model.maxTokens ?? 128_000;
const clampedReserveTokens = Math.min(params.reserveTokens, Math.floor(modelMaxTokens / 0.8));
```

This ensures the downstream `max_tokens` calculation (`0.8 * reserveTokens`) never exceeds the model's actual output limit. The fix uses `model.maxTokens` from the provider registry, so it's forward-compatible — if future models raise their output cap, no code change is needed.

## Impact

- **Before:** Compaction broken for all users with Anthropic + 1M context (any `reserveTokensFloor` > 160K)
- **After:** Compaction works correctly, respecting model output limits while preserving the existing summarization quality

## Real behavior proof

- **Behavior or issue addressed:** Compaction with Anthropic 1M-context models used to send `max_tokens: 240000`, exceeding the `128000` output-token limit.
- **Real environment tested:** Fresh temporary OpenClaw state directories on this checkout, using `anthropic/claude-sonnet-4-6`, `1000000` context tokens, `300000` configured reserve tokens, and a local Anthropic-compatible capture server that records real provider request bodies and rejects `max_tokens > 128000`.
- **Exact steps or command run after this patch:**

```bash
pnpm tsx scripts/e2e/compaction-max-tokens-proof.mjs --repo ../.. --expect fail --label main-local --mode summarize --timeout-ms 45000 --output .artifacts/pr-54392/compaction-proof-main-local.json
pnpm tsx scripts/e2e/compaction-max-tokens-proof.mjs --repo . --expect pass --label pr-local --mode summarize --timeout-ms 45000 --output .artifacts/pr-54392/compaction-proof-pr-local.json
```

- **Evidence after fix:** Terminal output from the PR-head run captured provider `max_tokens` as `[128000]` at `0aeb92a3a7c7`; the same harness against current main `2d97dcebb5fc` captured `[240000, 240000, 240000]` and the fake Anthropic endpoint rejected `240000 > 128000`.
- **Observed result after fix:** The real OpenClaw wrapper path (`src/agents/compaction.ts` -> `summarizeInStages` -> Pi `generateSummary` -> provider request) sent `max_tokens: 128000`, which stays within the model output limit. The clamp feeds Pi a `160000` reserve-token value so its downstream `Math.floor(0.8 * reserveTokens)` calculation cannot exceed `128000`.
- **What was not tested:** Full embedded manual compaction mode in CI; the checked proof covers the provider request boundary that regressed.

## Testing

Real behavior proof was run twice from fresh temporary OpenClaw state directories with a local Anthropic-compatible capture server. The harness drives the real OpenClaw wrapper path (`src/agents/compaction.ts` -> `summarizeInStages` -> Pi `generateSummary` -> provider request) using `anthropic/claude-sonnet-4-6`, `1000000` context tokens, `300000` configured reserve tokens, and a `128000` model output limit.

Temporary proof commands used locally:

```bash
pnpm tsx scripts/e2e/compaction-max-tokens-proof.mjs --repo ../.. --expect fail --label main-local --mode summarize --timeout-ms 45000 --output .artifacts/pr-54392/compaction-proof-main-local.json
pnpm tsx scripts/e2e/compaction-max-tokens-proof.mjs --repo . --expect pass --label pr-local --mode summarize --timeout-ms 45000 --output .artifacts/pr-54392/compaction-proof-pr-local.json
```

| Ref | Expected | Captured provider `max_tokens` | Result |
| --- | --- | --- | --- |
| current main 2d97dcebb5fc | fail | `[240000, 240000, 240000]` | fake Anthropic endpoint rejected `240000 > 128000` |
| PR head 0aeb92a3a7c7 | pass | `[128000]` | provider request stayed within the `128000` output limit |

This proves the regression at the provider request boundary: without the clamp, OpenClaw asks Anthropic for `240000` output tokens; with this PR, the downstream Pi calculation receives a clamped reserve token value of `160000` and emits `128000` output tokens.