### PR TITLE
Add scripts to build multiarch container image

### DIFF
--- a/scripts/build-multiarch.sh
+++ b/scripts/build-multiarch.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+# OpenClaw Multi-Architecture Build Script
+# Builds amd64 + arm64 images with Playwright browser support
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+REGISTRY="${OPENCLAW_REGISTRY:-openclaw}"
+TAG="${TAG:-latest}"
+LATEST="${LATEST:-false}"
+FULL_IMAGE="${REGISTRY}:${TAG}"
+
+echo "=== OpenClaw Multi-Arch Build ==="
+echo "Image: ${FULL_IMAGE}"
+echo "Platforms: linux/amd64, linux/arm64"
+echo ""
+
+# Check if buildx is available
+if ! docker buildx version >/dev/null 2>&1; then
+    echo "Error: docker buildx not installed"
+    echo "Install Docker Buildx: https://docs.docker.com/build/buildx/install/"
+    exit 1
+fi
+
+# Create builder if not exists
+BUILDER_NAME="openclaw-builder"
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    echo "Creating buildx builder: ${BUILDER_NAME}"
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container --use
+else
+    echo "Using existing builder: ${BUILDER_NAME}"
+    docker buildx use "${BUILDER_NAME}"
+fi
+
+# Bootstrap builder
+echo "Bootstrapping builder..."
+docker buildx inspect --bootstrap
+
+
+# Build and push multi-arch image
+echo ""
+echo "Building multi-arch image with Playwright..."
+
+# Build with specified tag, and also tag as latest if LATEST=true and TAG is not "latest"
+BUILD_TAGS=(-t "${FULL_IMAGE}")
+if [ "${TAG}" != "latest" ] && [ "${LATEST}" = "true" ]; then
+    BUILD_TAGS+=(-t "${REGISTRY}:latest")
+fi
+
+docker buildx build \
+    --platform linux/amd64,linux/arm64 \
+    "${BUILD_TAGS[@]}" \
+    -f "$ROOT_DIR/Dockerfile" \
+    --build-arg "OPENCLAW_INSTALL_BROWSER=${OPENCLAW_INSTALL_BROWSER:-1}" \
+    --push \
+    "$ROOT_DIR"
+
+echo ""
+echo "=== Build Complete ==="
+echo "Image pushed: ${FULL_IMAGE}"
+if [ "${TAG}" != "latest" ] && [ "${LATEST}" = "true" ]; then
+    echo "Also tagged: ${REGISTRY}:latest"
+fi
+echo ""
+echo "Verify with:"
+echo "  docker manifest inspect ${FULL_IMAGE}"


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
No scripts to build multi-arch container images
- Why it matters:
Currently, in scripts/docker/setup.sh, a container image is built every time docker-setup.sh is launched. There are no scripts to build multi-arch images that can be launched in ARM OS, like Apple MacBook Silicon Chip
- What changed:
Add scripts to build amd64 & arm64  container image at the same time

- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause:
- Missing detection / guardrail:
- Prior context (`git blame`, prior PR, issue, or refactor if known):
- Why this regressed now:
- If unknown, what was ruled out:

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.
- OPENCLAW_REGISTRY=xxx/openclaw LATEST=true TAG=v2026.3.24 ./scripts/build-multiarch.sh
- ./scripts/build-multiarch.sh -> openclaw:latest
- TAG=v1.0 ./scripts/build-multiarch.sh -> openclaw:v1.0
- TAG=v1.0 LATEST=true ./scripts/build-multiarch.sh -> openclaw:v1.0 + openclaw:latest
- OPENCLAW_INSTALL_BROWSER=0 ./scripts/build-multiarch.sh -> openclaw:latest（without Playwright）

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
No
- Secrets/tokens handling changed? (`Yes/No`)
No
- New/changed network calls? (`Yes/No`)
No
- Command/tool execution surface changed? (`Yes/No`)
No
- Data access scope changed? (`Yes/No`)
No
- If any `Yes`, explain risk + mitigation:
N/A

## Repro + Verification
```shell
OPENCLAW_REGISTRY=xxx/openclaw LATEST=true TAG=v2026.3.24 ./scripts/build-multiarch.sh
 => CACHED [linux/amd64 stage-5 11/15] RUN install -d -m 0755 "/usr/local/share/corepack" &&     corepack enable &&     for attempt in 1 2 3 4 5; do       if corepack prepare "$(node -  0.0s
 => CACHED [linux/amd64 stage-5 12/15] RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,id=openclaw-bookworm-apt-lists,  0.0s
 => CACHED [linux/amd64 stage-5 13/15] RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,id=openclaw-bookworm-apt-lists,  0.0s
 => CACHED [linux/amd64 stage-5 14/15] RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked     --mount=type=cache,id=openclaw-bookworm-apt-lists,  0.0s
 => CACHED [linux/amd64 stage-5 15/15] RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw  && chmod 755 /app/openclaw.mjs                                                               0.0s
 => exporting to image                                                                                                                                                                  183.9s
 => => exporting layers                                                                                                                                                                   0.0s
 => => exporting manifest sha256:c0278246f4d29aad458f8f9843d541f56f5156d873173f3d41e7ea26602d2e54                                                                                         0.0s
 => => exporting config sha256:b082d15c09d7eefc07a5ac38f3186284abc99e481994077640ef62ee00006141                                                                                           0.0s
 => => exporting attestation manifest sha256:cceaf810da0fd08116883096f86896fbc42ce82edb83b243a7e0180124fe5f5d                                                                             0.0s
 => => exporting manifest sha256:9319ba09644a43455cae6ab88baf3adab071e45d504d2a43d8bf10f44acfc016                                                                                         0.0s
 => => exporting config sha256:695bae4d5b872a70f42d8a7555ceb22a96f7c4b622d6e789f3e056e5cd2ebe01                                                                                           0.0s
 => => exporting attestation manifest sha256:b3256e65c2341991ad4a3280ffa0810e2abe8acbfeef390566201137eaba7db4                                                                             0.0s
 => => exporting manifest list sha256:7d02b6b432fb9a5da01756446cd7dacf94ab7a8f4099e1b5ac20b2b61520f999                                                                                    0.0s
 => => pushing layers                                                                                                                                                                     2.7s
 => => pushing manifest for docker.io/xxx/openclaw:v2026.3.24@sha256:7d02b6b432fb9a5da01756446cd7dacf94ab7a8f4099e1b5ac20b2b61520f999                                             5.6s
 => => pushing manifest for docker.io/xxx/openclaw:latest@sha256:7d02b6b432fb9a5da01756446cd7dacf94ab7a8f4099e1b5ac20b2b61520f999                                                 3.0s
 => [auth] xxx/openclaw:pull,push token for registry-1.docker.io                                                                                                                  0.0s

=== Build Complete ===
Image pushed: xxx/openclaw:v2026.3.24
Also tagged: xxx/openclaw:latest
```
### Environment

- OS: Ubuntu 22.04
- Runtime/container: Docker Engine
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted):

### Steps

1.Run `OPENCLAW_REGISTRY=xxx/openclaw LATEST=true TAG=v2026.3.24 ./scripts/build-multiarch.sh`

### Expected
Multi-arch image built successfully

### Actual
Multi-arch image built successfully

## Evidence
=== Build Complete ===
Image pushed: xxx/openclaw:v2026.3.24
Also tagged: xxx/openclaw:latest

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
<img width="1493" height="511" alt="image" src="https://github.com/user-attachments/assets/a6160373-acc3-4d08-9e50-e04ffeefb777" />

- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
Run `OPENCLAW_REGISTRY=xxx/openclaw LATEST=true TAG=v2026.3.24 ./scripts/build-multiarch.sh` and image built successfuly

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
Yes
- Config/env changes? (`Yes/No`)
Yes
- Migration needed? (`Yes/No`)
No
- If yes, exact upgrade steps:
N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation: `None`
