### PR TITLE
add AIFBA Amazon Listing Analyzer community plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -8,16 +8,11 @@ title: "Community Plugins"
 
 # Community Plugins
 
-Community plugins are third-party packages that extend OpenClaw with new
-channels, tools, providers, or other capabilities. They are built and maintained
-by the community, published on [ClawHub](/tools/clawhub) or npm, and
-installable with a single command.
+Community plugins are third-party packages that extend OpenClaw with new channels, tools, providers, or other capabilities. They are built and maintained by the community, published on npm, and installable with a single command.
 
 ```bash
-openclaw plugins install <package-name>
+openclaw plugins install <plugin-name>
 ```
-
-OpenClaw checks ClawHub first and falls back to npm automatically.
 
 ## Listed plugins
 
@@ -34,9 +29,7 @@ openclaw plugins install aifba-amazon-listing-analyzer-openclaw
 
 ### Codex App Server Bridge
 
-Independent OpenClaw bridge for Codex App Server conversations. Bind a chat to
-a Codex thread, talk to it with plain text, and control it with chat-native
-commands for resume, planning, review, model selection, compaction, and more.
+Independent OpenClaw bridge for Codex App Server conversations. Bind a chat to a Codex thread, talk to it with plain text, and control it with chat-native commands for resume, planning, review, model selection, compaction, and more.
 
 - **npm:** `openclaw-codex-app-server`
 - **repo:** [github.com/pwrdrvr/openclaw-codex-app-server](https://github.com/pwrdrvr/openclaw-codex-app-server)
@@ -47,8 +40,7 @@ openclaw plugins install openclaw-codex-app-server
 
 ### DingTalk
 
-Enterprise robot integration using Stream mode. Supports text, images, and
-file messages via any DingTalk client.
+Enterprise robot integration using Stream mode. Supports text, images, and file messages via any DingTalk client.
 
 - **npm:** `@largezhou/ddingtalk`
 - **repo:** [github.com/largezhou/openclaw-dingtalk](https://github.com/largezhou/openclaw-dingtalk)
@@ -59,9 +51,7 @@ openclaw plugins install @largezhou/ddingtalk
 
 ### Lossless Claw (LCM)
 
-Lossless Context Management plugin for OpenClaw. DAG-based conversation
-summarization with incremental compaction — preserves full context fidelity
-while reducing token usage.
+Lossless Context Management plugin for OpenClaw. DAG-based conversation summarization with incremental compaction — preserves full context fidelity while reducing token usage.
 
 - **npm:** `@martian-engineering/lossless-claw`
 - **repo:** [github.com/Martian-Engineering/lossless-claw](https://github.com/Martian-Engineering/lossless-claw)
@@ -72,8 +62,7 @@ openclaw plugins install @martian-engineering/lossless-claw
 
 ### Opik
 
-Official plugin that exports agent traces to Opik. Monitor agent behavior,
-cost, tokens, errors, and more.
+Official plugin that exports agent traces to Opik. Monitor agent behavior, cost, tokens, errors, and more.
 
 - **npm:** `@opik/opik-openclaw`
 - **repo:** [github.com/comet-ml/opik-openclaw](https://github.com/comet-ml/opik-openclaw)
@@ -84,9 +73,7 @@ openclaw plugins install @opik/opik-openclaw
 
 ### QQbot
 
-Connect OpenClaw to QQ via the QQ Bot API. Supports private chats, group
-mentions, channel messages, and rich media including voice, images, videos,
-and files.
+Connect OpenClaw to QQ via the QQ Bot API. Supports private chats, group mentions, channel messages, and rich media including voice, images, videos, and files.
 
 - **npm:** `@sliverp/qqbot`
 - **repo:** [github.com/sliverp/qqbot](https://github.com/sliverp/qqbot)
@@ -97,9 +84,7 @@ openclaw plugins install @sliverp/qqbot
 
 ### wecom
 
-OpenClaw Enterprise WeCom Channel Plugin.
-A bot plugin powered by WeCom AI Bot WebSocket persistent connections,
-supports direct messages & group chats, streaming replies, and proactive messaging.
+OpenClaw Enterprise WeCom Channel Plugin. A bot plugin powered by WeCom AI Bot WebSocket persistent connections, supports direct messages, group chats, streaming replies, and proactive messaging.
 
 - **npm:** `@wecom/wecom-openclaw-plugin`
 - **repo:** [github.com/WecomTeam/wecom-openclaw-plugin](https://github.com/WecomTeam/wecom-openclaw-plugin)
@@ -112,42 +97,25 @@ openclaw plugins install @wecom/wecom-openclaw-plugin
 
 We welcome community plugins that are useful, documented, and safe to operate.
 
-<Steps>
-  <Step title="Publish to ClawHub or npm">
-    Your plugin must be installable via `openclaw plugins install \<package-name\>`.
-    Publish to [ClawHub](/tools/clawhub) (preferred) or npm.
-    See [Building Plugins](/plugins/building-plugins) for the full guide.
+Your plugin must be installable via `openclaw plugins install <plugin-name>`. See [Building Plugins](/plugins/building-plugins) for the full guide.
 
-  </Step>
+Source code must be in a public repository with setup docs and an issue tracker.
 
-  <Step title="Host on GitHub">
-    Source code must be in a public repository with setup docs and an issue
-    tracker.
-
-  </Step>
-
-  <Step title="Open a PR">
-    Add your plugin to this page with:
-
-    - Plugin name
-    - npm package name
-    - GitHub repository URL
-    - One-line description
-    - Install command
-
-  </Step>
-</Steps>
-
-
+Add your plugin to this page with:
+- Plugin name
+- npm package name
+- GitHub repository URL
+- One-line description
+- Install command
 
 ## Quality bar
 
-| Requirement                 | Why                                           |
-| --------------------------- | --------------------------------------------- |
-| Published on ClawHub or npm | Users need `openclaw plugins install` to work |
-| Public GitHub repo          | Source review, issue tracking, transparency   |
-| Setup and usage docs        | Users need to know how to configure it        |
-| Active maintenance          | Recent updates or responsive issue handling   |
+| Requirement | Why |
+| --- | --- |
+| Published on npm | Users need `openclaw plugins install` to work |
+| Public GitHub repo | Source review, issue tracking, transparency |
+| Setup and usage docs | Users need to know how to configure it |
+| Active maintenance | Recent updates or responsive issue handling |
 
 Low-effort wrappers, unclear ownership, or unmaintained packages may be declined.
 

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -1,4 +1,4 @@
-<img width="1201" height="961" alt="image" src="https://github.com/user-attachments/assets/34eaf367-9605-40fe-9d50-3094fec148a9" />---
+---
 summary: "Community-maintained OpenClaw plugins: browse, install, and submit your own"
 read_when:
   - You want to find third-party OpenClaw plugins

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -8,11 +8,16 @@ title: "Community Plugins"
 
 # Community Plugins
 
-Community plugins are third-party packages that extend OpenClaw with new channels, tools, providers, or other capabilities. They are built and maintained by the community, published on npm, and installable with a single command.
+Community plugins are third-party packages that extend OpenClaw with new
+channels, tools, providers, or other capabilities. They are built and maintained
+by the community, published on [ClawHub](/tools/clawhub) or npm, and
+installable with a single command.
 
 ```bash
-openclaw plugins install <plugin-name>
+openclaw plugins install <package-name>
 ```
+
+OpenClaw checks ClawHub first and falls back to npm automatically.
 
 ## Listed plugins
 
@@ -29,7 +34,9 @@ openclaw plugins install aifba-amazon-listing-analyzer-openclaw
 
 ### Codex App Server Bridge
 
-Independent OpenClaw bridge for Codex App Server conversations. Bind a chat to a Codex thread, talk to it with plain text, and control it with chat-native commands for resume, planning, review, model selection, compaction, and more.
+Independent OpenClaw bridge for Codex App Server conversations. Bind a chat to
+a Codex thread, talk to it with plain text, and control it with chat-native
+commands for resume, planning, review, model selection, compaction, and more.
 
 - **npm:** `openclaw-codex-app-server`
 - **repo:** [github.com/pwrdrvr/openclaw-codex-app-server](https://github.com/pwrdrvr/openclaw-codex-app-server)
@@ -40,7 +47,8 @@ openclaw plugins install openclaw-codex-app-server
 
 ### DingTalk
 
-Enterprise robot integration using Stream mode. Supports text, images, and file messages via any DingTalk client.
+Enterprise robot integration using Stream mode. Supports text, images, and
+file messages via any DingTalk client.
 
 - **npm:** `@largezhou/ddingtalk`
 - **repo:** [github.com/largezhou/openclaw-dingtalk](https://github.com/largezhou/openclaw-dingtalk)
@@ -51,7 +59,9 @@ openclaw plugins install @largezhou/ddingtalk
 
 ### Lossless Claw (LCM)
 
-Lossless Context Management plugin for OpenClaw. DAG-based conversation summarization with incremental compaction — preserves full context fidelity while reducing token usage.
+Lossless Context Management plugin for OpenClaw. DAG-based conversation
+summarization with incremental compaction — preserves full context fidelity
+while reducing token usage.
 
 - **npm:** `@martian-engineering/lossless-claw`
 - **repo:** [github.com/Martian-Engineering/lossless-claw](https://github.com/Martian-Engineering/lossless-claw)
@@ -62,7 +72,8 @@ openclaw plugins install @martian-engineering/lossless-claw
 
 ### Opik
 
-Official plugin that exports agent traces to Opik. Monitor agent behavior, cost, tokens, errors, and more.
+Official plugin that exports agent traces to Opik. Monitor agent behavior,
+cost, tokens, errors, and more.
 
 - **npm:** `@opik/opik-openclaw`
 - **repo:** [github.com/comet-ml/opik-openclaw](https://github.com/comet-ml/opik-openclaw)
@@ -73,7 +84,9 @@ openclaw plugins install @opik/opik-openclaw
 
 ### QQbot
 
-Connect OpenClaw to QQ via the QQ Bot API. Supports private chats, group mentions, channel messages, and rich media including voice, images, videos, and files.
+Connect OpenClaw to QQ via the QQ Bot API. Supports private chats, group
+mentions, channel messages, and rich media including voice, images, videos,
+and files.
 
 - **npm:** `@sliverp/qqbot`
 - **repo:** [github.com/sliverp/qqbot](https://github.com/sliverp/qqbot)
@@ -84,7 +97,9 @@ openclaw plugins install @sliverp/qqbot
 
 ### wecom
 
-OpenClaw Enterprise WeCom Channel Plugin. A bot plugin powered by WeCom AI Bot WebSocket persistent connections, supports direct messages, group chats, streaming replies, and proactive messaging.
+OpenClaw Enterprise WeCom Channel Plugin.
+A bot plugin powered by WeCom AI Bot WebSocket persistent connections,
+supports direct messages & group chats, streaming replies, and proactive messaging.
 
 - **npm:** `@wecom/wecom-openclaw-plugin`
 - **repo:** [github.com/WecomTeam/wecom-openclaw-plugin](https://github.com/WecomTeam/wecom-openclaw-plugin)
@@ -97,25 +112,40 @@ openclaw plugins install @wecom/wecom-openclaw-plugin
 
 We welcome community plugins that are useful, documented, and safe to operate.
 
-Your plugin must be installable via `openclaw plugins install <plugin-name>`. See [Building Plugins](/plugins/building-plugins) for the full guide.
+<Steps>
+  <Step title="Publish to ClawHub or npm">
+    Your plugin must be installable via `openclaw plugins install \<package-name\>`.
+    Publish to [ClawHub](/tools/clawhub) (preferred) or npm.
+    See [Building Plugins](/plugins/building-plugins) for the full guide.
 
-Source code must be in a public repository with setup docs and an issue tracker.
+  </Step>
 
-Add your plugin to this page with:
-- Plugin name
-- npm package name
-- GitHub repository URL
-- One-line description
-- Install command
+  <Step title="Host on GitHub">
+    Source code must be in a public repository with setup docs and an issue
+    tracker.
+
+  </Step>
+
+  <Step title="Open a PR">
+    Add your plugin to this page with:
+
+    - Plugin name
+    - npm package name
+    - GitHub repository URL
+    - One-line description
+    - Install command
+
+  </Step>
+</Steps>
 
 ## Quality bar
 
-| Requirement | Why |
-| --- | --- |
-| Published on npm | Users need `openclaw plugins install` to work |
-| Public GitHub repo | Source review, issue tracking, transparency |
-| Setup and usage docs | Users need to know how to configure it |
-| Active maintenance | Recent updates or responsive issue handling |
+| Requirement                 | Why                                           |
+| --------------------------- | --------------------------------------------- |
+| Published on ClawHub or npm | Users need `openclaw plugins install` to work |
+| Public GitHub repo          | Source review, issue tracking, transparency   |
+| Setup and usage docs        | Users need to know how to configure it        |
+| Active maintenance          | Recent updates or responsive issue handling   |
 
 Low-effort wrappers, unclear ownership, or unmaintained packages may be declined.
 

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -127,6 +127,17 @@ We welcome community plugins that are useful, documented, and safe to operate.
   </Step>
 </Steps>
 
+### AIFBA Amazon Listing Analyzer for OpenClaw
+
+Cloud-powered Amazon listing analyzer for OpenClaw. Built for Amazon sellers who want one-click listing analysis, competitor-backed optimization, and an AIFBA web report.
+
+- npm: `aifba-amazon-listing-analyzer-openclaw`
+- repo: `https://github.com/corli-AIFBA/aifba-amazon-listing-analyzer-openclaw`
+
+```bash
+openclaw plugins install aifba-amazon-listing-analyzer-openclaw
+
+
 ## Quality bar
 
 | Requirement                 | Why                                           |

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -1,4 +1,4 @@
----
+<img width="1201" height="961" alt="image" src="https://github.com/user-attachments/assets/34eaf367-9605-40fe-9d50-3094fec148a9" />---
 summary: "Community-maintained OpenClaw plugins: browse, install, and submit your own"
 read_when:
   - You want to find third-party OpenClaw plugins
@@ -20,6 +20,17 @@ openclaw plugins install <package-name>
 OpenClaw checks ClawHub first and falls back to npm automatically.
 
 ## Listed plugins
+
+### AIFBA Amazon Listing Analyzer for OpenClaw
+
+Cloud-powered Amazon listing analyzer for OpenClaw. Built for Amazon sellers who want one-click listing analysis, competitor-backed optimization, and a structured AIFBA web report.
+
+- **npm:** `aifba-amazon-listing-analyzer-openclaw`
+- **repo:** [github.com/corli-AIFBA/aifba-amazon-listing-analyzer-openclaw](https://github.com/corli-AIFBA/aifba-amazon-listing-analyzer-openclaw)
+
+```bash
+openclaw plugins install aifba-amazon-listing-analyzer-openclaw
+```
 
 ### Codex App Server Bridge
 
@@ -127,15 +138,6 @@ We welcome community plugins that are useful, documented, and safe to operate.
   </Step>
 </Steps>
 
-### AIFBA Amazon Listing Analyzer for OpenClaw
-
-Cloud-powered Amazon listing analyzer for OpenClaw. Built for Amazon sellers who want one-click listing analysis, competitor-backed optimization, and an AIFBA web report.
-
-- npm: `aifba-amazon-listing-analyzer-openclaw`
-- repo: `https://github.com/corli-AIFBA/aifba-amazon-listing-analyzer-openclaw`
-
-```bash
-openclaw plugins install aifba-amazon-listing-analyzer-openclaw
 
 
 ## Quality bar


### PR DESCRIPTION
Adds AIFBA Amazon Listing Analyzer for OpenClaw to the community plugins page.

Package:
- npm: `aifba-amazon-listing-analyzer-openclaw`

Repository:
- GitHub: `https://github.com/corli-AIFBA/aifba-amazon-listing-analyzer-openclaw`

This plugin lets Amazon sellers send one-click listing analysis jobs to AIFBA cloud services and get back a concise summary plus a structured web report inside OpenClaw.
