### PR TITLE
fix: rebuild subsystem file logger on date rollover

### DIFF
--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setConsoleSubsystemFilter } from "./console.js";
-import { resetLogger, setLoggerOverride } from "./logger.js";
+import { getLogger, resetLogger, setLoggerOverride } from "./logger.js";
 import { loggingState } from "./state.js";
 import { createSubsystemLogger } from "./subsystem.js";
 
@@ -143,5 +143,26 @@ describe("createSubsystemLogger().isEnabled", () => {
     });
 
     expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createSubsystemLogger date rollover", () => {
+  it("rebuilds file logger when base logger changes (simulating date rollover)", () => {
+    setLoggerOverride({ level: "info", consoleLevel: "silent" });
+    const log = createSubsystemLogger("test-rollover");
+
+    // Trigger file logger creation
+    log.info("before rollover");
+    const baseBefore = getLogger();
+
+    // Simulate date rollover: resetLogger forces a new base logger on next call
+    resetLogger();
+    setLoggerOverride({ level: "info", consoleLevel: "silent" });
+
+    log.info("after rollover");
+    const baseAfter = getLogger();
+
+    // Base logger should be a different instance after reset
+    expect(baseBefore).not.toBe(baseAfter);
   });
 });

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -9,7 +9,7 @@ import {
   shouldLogSubsystemToConsole,
 } from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
-import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
+import { getChildLogger, getLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
 
 type LogObj = { date?: Date } & Record<string, unknown>;
@@ -307,8 +307,15 @@ function logToFile(
 
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   let fileLogger: TsLogger<LogObj> | null = null;
+  let fileLoggerBase: TsLogger<LogObj> | null = null;
   const getFileLogger = (): TsLogger<LogObj> => {
-    if (!fileLogger) {
+    // Re-check the base logger on each call so that date-rolling (or any
+    // settings change) causes the child logger to be rebuilt.  getLogger()
+    // is cheaply cached internally, so this is a fast reference comparison
+    // on the hot path.
+    const currentBase = getLogger();
+    if (!fileLogger || currentBase !== fileLoggerBase) {
+      fileLoggerBase = currentBase;
       fileLogger = getChildLogger({ subsystem });
     }
     return fileLogger;


### PR DESCRIPTION
## Summary

- **Problem:** `createSubsystemLogger` caches the file logger on first use and never rebuilds it. When the gateway runs past midnight, logs continue writing to the previous day's file instead of the new dated file.
- **Why it matters:** Long-running gateway processes (the common deployment) silently write all logs to a stale file, breaking log rotation and making daily log analysis unreliable.
- **What changed:** `getFileLogger()` now compares the current base logger reference (from `getLogger()`) against the cached one. When the base logger changes (due to date rollover or any settings change), the child logger is rebuilt. `getLogger()` is already cheaply cached internally, so this adds only a reference equality check on the hot path.
- **What did NOT change:** No changes to log format, file naming, or any other logging behavior.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Test plan

- [x] Added test in `subsystem.test.ts` that simulates date rollover via `resetLogger()` and verifies the base logger instance changes

Closes #54381