### PR TITLE
Add xAI image-generation provider support

### DIFF
--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -48,11 +48,43 @@ The bundled `grok` web-search provider uses `XAI_API_KEY` too:
 openclaw config set tools.web.search.provider grok
 ```
 
+## Image generation
+
+OpenClaw also supports xAI image generation through the shared `image_generate`
+tool.
+
+Example config:
+
+```json5
+{
+  agents: {
+    defaults: {
+      imageGenerationModel: {
+        primary: "xai/grok-imagine-image",
+        fallbacks: ["xai/grok-imagine-image-pro"],
+      },
+    },
+  },
+}
+```
+
+Notes:
+
+- `xai/grok-imagine-image` is the default bundled image model.
+- `xai/grok-imagine-image-pro` is also supported.
+- For compatibility with older custom configs, `xai-images/*` model refs keep
+  working too.
+- If you want separate image credentials from text credentials, configure
+  `models.providers.xai-images.apiKey` and point `imageGenerationModel` at
+  `xai-images/<model>`.
+
 ## Known limits
 
 - Auth is API-key only today. There is no xAI OAuth/device-code flow in OpenClaw yet.
 - `grok-4.20-multi-agent-experimental-beta-0304` is not supported on the normal xAI provider path because it requires a different upstream API surface than the standard OpenClaw xAI transport.
 - Native xAI server-side tools such as `x_search` and `code_execution` are not yet first-class model-provider features in the bundled plugin.
+- xAI image generation follows the current xAI image API surface, including
+  aspect-ratio overrides, `1K`/`2K` resolution, and reference-image edits.
 
 ## Notes
 

--- a/extensions/xai/image-generation-provider.ts
+++ b/extensions/xai/image-generation-provider.ts
@@ -1,0 +1,241 @@
+import type {
+  GeneratedImageAsset,
+  ImageGenerationProvider,
+  ImageGenerationRequest,
+} from "openclaw/plugin-sdk/image-generation";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth";
+import { XAI_BASE_URL } from "./model-definitions.js";
+
+const DEFAULT_XAI_IMAGE_MODEL = "grok-imagine-image";
+const XAI_IMAGE_PROVIDER_ALIASES = ["xai-images"] as const;
+const DEFAULT_OUTPUT_MIME = "image/jpeg";
+const XAI_SUPPORTED_ASPECT_RATIOS = [
+  "auto",
+  "1:1",
+  "16:9",
+  "9:16",
+  "4:3",
+  "3:4",
+  "3:2",
+  "2:3",
+  "2:1",
+  "1:2",
+  "19.5:9",
+  "9:19.5",
+  "20:9",
+  "9:20",
+] as const;
+
+type XaiImageDataEntry = {
+  b64_json?: string;
+  url?: string;
+  revised_prompt?: string;
+};
+
+type XaiImageApiResponse = {
+  data?: XaiImageDataEntry[];
+  model?: string;
+  respect_moderation?: boolean;
+};
+
+function resolveProviderBaseUrl(req: ImageGenerationRequest): string {
+  const providerId = req.provider?.trim();
+  const configured = providerId ? req.cfg?.models?.providers?.[providerId]?.baseUrl?.trim() : "";
+  if (configured) {
+    return configured.replace(/\/+$/u, "");
+  }
+  const fallback = req.cfg?.models?.providers?.xai?.baseUrl?.trim();
+  return (fallback || XAI_BASE_URL).replace(/\/+$/u, "");
+}
+
+async function resolveProviderAuth(req: ImageGenerationRequest) {
+  const providerId = req.provider?.trim() || "xai";
+  try {
+    return await resolveApiKeyForProvider({
+      provider: providerId,
+      cfg: req.cfg,
+      agentDir: req.agentDir,
+      store: req.authStore,
+    });
+  } catch (error) {
+    if ((XAI_IMAGE_PROVIDER_ALIASES as readonly string[]).includes(providerId)) {
+      return await resolveApiKeyForProvider({
+        provider: "xai",
+        cfg: req.cfg,
+        agentDir: req.agentDir,
+        store: req.authStore,
+      });
+    }
+    throw error;
+  }
+}
+
+function toDataUrl(buffer: Buffer, mimeType: string): string {
+  return `data:${mimeType};base64,${buffer.toString("base64")}`;
+}
+
+function normalizeResolution(
+  resolution: ImageGenerationRequest["resolution"],
+): "1k" | "2k" | undefined {
+  if (!resolution) {
+    return undefined;
+  }
+  if (resolution === "1K") {
+    return "1k";
+  }
+  if (resolution === "2K") {
+    return "2k";
+  }
+  return undefined;
+}
+
+function buildImageBody(req: ImageGenerationRequest): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    model: req.model || DEFAULT_XAI_IMAGE_MODEL,
+    prompt: req.prompt,
+    n: req.count ?? 1,
+    response_format: "b64_json",
+  };
+
+  if (req.aspectRatio?.trim()) {
+    body.aspect_ratio = req.aspectRatio.trim();
+  }
+  const resolution = normalizeResolution(req.resolution);
+  if (resolution) {
+    body.resolution = resolution;
+  }
+
+  const inputImages = req.inputImages ?? [];
+  if (inputImages.length === 1) {
+    body.image = {
+      type: "image_url",
+      url: toDataUrl(inputImages[0].buffer, inputImages[0].mimeType),
+    };
+  } else if (inputImages.length > 1) {
+    body.images = inputImages.map((image) => ({
+      type: "image_url",
+      url: toDataUrl(image.buffer, image.mimeType),
+    }));
+  }
+
+  return body;
+}
+
+function fileExtensionForMimeType(mimeType: string): string {
+  if (mimeType.includes("jpeg")) {
+    return "jpg";
+  }
+  return mimeType.split("/")[1] ?? "jpg";
+}
+
+async function fetchImageBuffer(url: string): Promise<{ buffer: Buffer; mimeType: string }> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `xAI image download failed (${response.status}): ${text || response.statusText}`,
+    );
+  }
+  const mimeType = response.headers.get("content-type")?.trim() || DEFAULT_OUTPUT_MIME;
+  const arrayBuffer = await response.arrayBuffer();
+  return { buffer: Buffer.from(arrayBuffer), mimeType };
+}
+
+async function resolveGeneratedAssets(
+  entries: XaiImageDataEntry[],
+): Promise<GeneratedImageAsset[]> {
+  const images: Array<GeneratedImageAsset | null> = await Promise.all(
+    entries.map(async (entry, index): Promise<GeneratedImageAsset | null> => {
+      const b64 = entry.b64_json?.trim();
+      if (b64) {
+        return {
+          buffer: Buffer.from(b64, "base64"),
+          mimeType: DEFAULT_OUTPUT_MIME,
+          fileName: `image-${index + 1}.jpg`,
+          ...(entry.revised_prompt ? { revisedPrompt: entry.revised_prompt } : {}),
+        };
+      }
+      const url = entry.url?.trim();
+      if (!url) {
+        return null;
+      }
+      const downloaded = await fetchImageBuffer(url);
+      return {
+        buffer: downloaded.buffer,
+        mimeType: downloaded.mimeType,
+        fileName: `image-${index + 1}.${fileExtensionForMimeType(downloaded.mimeType)}`,
+        ...(entry.revised_prompt ? { revisedPrompt: entry.revised_prompt } : {}),
+      };
+    }),
+  );
+  return images.filter((entry): entry is GeneratedImageAsset => entry !== null);
+}
+
+export function buildXaiImageGenerationProvider(): ImageGenerationProvider {
+  return {
+    id: "xai",
+    aliases: [...XAI_IMAGE_PROVIDER_ALIASES],
+    label: "xAI",
+    defaultModel: DEFAULT_XAI_IMAGE_MODEL,
+    models: [DEFAULT_XAI_IMAGE_MODEL, "grok-imagine-image-pro"],
+    capabilities: {
+      generate: {
+        maxCount: 10,
+        supportsSize: false,
+        supportsAspectRatio: true,
+        supportsResolution: true,
+      },
+      edit: {
+        enabled: true,
+        maxCount: 10,
+        maxInputImages: 5,
+        supportsSize: false,
+        supportsAspectRatio: true,
+        supportsResolution: true,
+      },
+      geometry: {
+        aspectRatios: [...XAI_SUPPORTED_ASPECT_RATIOS],
+        resolutions: ["1K", "2K"],
+      },
+    },
+    async generateImage(req) {
+      const auth = await resolveProviderAuth(req);
+      if (!auth.apiKey) {
+        throw new Error("xAI API key missing");
+      }
+
+      const hasInputImages = (req.inputImages?.length ?? 0) > 0;
+      const endpoint = hasInputImages ? "images/edits" : "images/generations";
+      const response = await fetch(`${resolveProviderBaseUrl(req)}/${endpoint}`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${auth.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(buildImageBody(req)),
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(
+          `xAI image generation failed (${response.status}): ${text || response.statusText}`,
+        );
+      }
+
+      const payload = (await response.json()) as XaiImageApiResponse;
+      const images = await resolveGeneratedAssets(payload.data ?? []);
+      if (images.length === 0) {
+        throw new Error("xAI image generation response missing image data");
+      }
+
+      return {
+        images,
+        model: payload.model ?? req.model ?? DEFAULT_XAI_IMAGE_MODEL,
+        metadata:
+          payload.respect_moderation === undefined
+            ? undefined
+            : { respectModeration: payload.respect_moderation },
+      };
+    },
+  };
+}

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -1,0 +1,212 @@
+import * as providerAuth from "openclaw/plugin-sdk/provider-auth";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  registerProviderPlugin,
+  requireRegisteredProvider,
+} from "../../test/helpers/extensions/provider-registration.js";
+import { buildXaiImageGenerationProvider } from "./image-generation-provider.js";
+import plugin from "./index.js";
+
+const registerXaiPlugin = () =>
+  registerProviderPlugin({
+    plugin,
+    id: "xai",
+    name: "xAI Plugin",
+  });
+
+describe("xai plugin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers xai provider, image generation, and no unrelated bundled capabilities", () => {
+    const { providers, speechProviders, mediaProviders, imageProviders } = registerXaiPlugin();
+
+    expect(providers).toHaveLength(1);
+    expect(
+      providers.map(
+        (provider) =>
+          // oxlint-disable-next-line typescript/no-explicit-any
+          (provider as any).id,
+      ),
+    ).toEqual(["xai"]);
+    expect(speechProviders).toHaveLength(0);
+    expect(mediaProviders).toHaveLength(0);
+    expect(imageProviders).toHaveLength(1);
+
+    const imageProvider = requireRegisteredProvider<
+      ReturnType<typeof buildXaiImageGenerationProvider>
+    >(imageProviders, "xai", "image provider");
+    expect(imageProvider.aliases).toContain("xai-images");
+    expect(imageProvider.models).toEqual(
+      expect.arrayContaining(["grok-imagine-image", "grok-imagine-image-pro"]),
+    );
+  });
+
+  it("generates xAI images with base64 output and moderation metadata", async () => {
+    const resolveApiKeySpy = vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "xai-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        model: "grok-imagine-image",
+        respect_moderation: true,
+        data: [
+          {
+            b64_json: Buffer.from("jpg-data").toString("base64"),
+            revised_prompt: "revised prompt",
+          },
+        ],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = buildXaiImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "xai",
+      model: "grok-imagine-image",
+      prompt: "A neon city skyline.",
+      cfg: {},
+      count: 3,
+      aspectRatio: "16:9",
+      resolution: "2K",
+    });
+
+    expect(resolveApiKeySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "xai",
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.x.ai/v1/images/generations",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          model: "grok-imagine-image",
+          prompt: "A neon city skyline.",
+          n: 3,
+          response_format: "b64_json",
+          aspect_ratio: "16:9",
+          resolution: "2k",
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      images: [
+        {
+          buffer: Buffer.from("jpg-data"),
+          mimeType: "image/jpeg",
+          fileName: "image-1.jpg",
+          revisedPrompt: "revised prompt",
+        },
+      ],
+      model: "grok-imagine-image",
+      metadata: {
+        respectModeration: true,
+      },
+    });
+  });
+
+  it("supports edit requests and xai-images auth fallback", async () => {
+    const resolveApiKeySpy = vi
+      .spyOn(providerAuth, "resolveApiKeyForProvider")
+      .mockRejectedValueOnce(new Error('No API key found for provider "xai-images".'))
+      .mockResolvedValueOnce({
+        apiKey: "fallback-xai-key",
+        source: "env",
+        mode: "api-key",
+      });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          model: "grok-imagine-image-pro",
+          data: [{ url: "https://cdn.x.ai/generated.jpg" }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-type": "image/jpeg" }),
+        arrayBuffer: async () => Buffer.from("downloaded-jpg"),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = buildXaiImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "xai-images",
+      model: "grok-imagine-image-pro",
+      prompt: "Combine these subjects into one portrait.",
+      cfg: {
+        models: {
+          providers: {
+            "xai-images": {
+              baseUrl: "https://api.x.ai/v1",
+              apiKey: "${GROK_IMAGINE_API_KEY}",
+              models: [],
+            },
+          },
+        },
+      },
+      inputImages: [
+        {
+          buffer: Buffer.from("ref-one"),
+          mimeType: "image/png",
+        },
+        {
+          buffer: Buffer.from("ref-two"),
+          mimeType: "image/jpeg",
+        },
+      ],
+      aspectRatio: "3:2",
+      resolution: "2K",
+    });
+
+    expect(resolveApiKeySpy.mock.calls.map((call) => call[0]?.provider)).toEqual([
+      "xai-images",
+      "xai",
+    ]);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.x.ai/v1/images/edits",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          model: "grok-imagine-image-pro",
+          prompt: "Combine these subjects into one portrait.",
+          n: 1,
+          response_format: "b64_json",
+          aspect_ratio: "3:2",
+          resolution: "2k",
+          images: [
+            {
+              type: "image_url",
+              url: `data:image/png;base64,${Buffer.from("ref-one").toString("base64")}`,
+            },
+            {
+              type: "image_url",
+              url: `data:image/jpeg;base64,${Buffer.from("ref-two").toString("base64")}`,
+            },
+          ],
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      images: [
+        {
+          buffer: Buffer.from("downloaded-jpg"),
+          mimeType: "image/jpeg",
+          fileName: "image-1.jpg",
+        },
+      ],
+      model: "grok-imagine-image-pro",
+    });
+  });
+});

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -1,6 +1,7 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applyXaiModelCompat } from "openclaw/plugin-sdk/provider-models";
 import { createToolStreamWrapper } from "openclaw/plugin-sdk/provider-stream";
+import { buildXaiImageGenerationProvider } from "./image-generation-provider.js";
 import { applyXaiConfig, XAI_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildXaiProvider } from "./provider-catalog.js";
 import { isModernXaiModel, resolveXaiForwardCompatModel } from "./provider-models.js";
@@ -60,6 +61,7 @@ export default defineSingleProviderPluginEntry({
     isModernModelRef: ({ modelId }) => isModernXaiModel(modelId),
   },
   register(api) {
+    api.registerImageGenerationProvider(buildXaiImageGenerationProvider());
     api.registerWebSearchProvider(createXaiWebSearchProvider());
   },
 });

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as imageGenerationRuntime from "../../image-generation/runtime.js";
+import type { ImageGenerationResolution } from "../../image-generation/types.js";
 import * as imageOps from "../../media/image-ops.js";
 import * as mediaStore from "../../media/store.js";
 import * as webMedia from "../../media/web-media.js";
@@ -155,6 +156,36 @@ function createFalEditProvider(params?: {
             },
           }
         : {}),
+    },
+    generateImage: vi.fn(async () => {
+      throw new Error("not used");
+    }),
+  };
+}
+
+function createXaiEditProvider() {
+  return {
+    id: "xai",
+    aliases: ["xai-images"],
+    defaultModel: "grok-imagine-image",
+    models: ["grok-imagine-image", "grok-imagine-image-pro"],
+    capabilities: {
+      generate: {
+        maxCount: 10,
+        supportsAspectRatio: true,
+        supportsResolution: true,
+      },
+      edit: {
+        enabled: true,
+        maxCount: 10,
+        maxInputImages: 5,
+        supportsAspectRatio: true,
+        supportsResolution: true,
+      },
+      geometry: {
+        resolutions: ["1K", "2K"] as ImageGenerationResolution[],
+        aspectRatios: ["1:1", "16:9", "3:2"],
+      },
     },
     generateImage: vi.fn(async () => {
       throw new Error("not used");
@@ -347,8 +378,8 @@ describe("createImageGenerateTool", () => {
       throw new Error("expected image_generate tool");
     }
 
-    await expect(tool.execute("call-2", { prompt: "too many cats", count: 5 })).rejects.toThrow(
-      "count must be between 1 and 4",
+    await expect(tool.execute("call-2", { prompt: "too many cats", count: 11 })).rejects.toThrow(
+      "count must be between 1 and 10",
     );
   });
 
@@ -401,6 +432,27 @@ describe("createImageGenerateTool", () => {
     expect(generateImage.mock.calls[0]?.[0].inputImages).toHaveLength(5);
   });
 
+  it("clamps inferred edit resolution to the selected provider's supported max", async () => {
+    vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      createXaiEditProvider(),
+    ]);
+    const generateImage = stubEditedImageFlow({ width: 4032, height: 3024 });
+    const tool = createToolWithPrimaryImageModel("xai/grok-imagine-image", {
+      workspaceDir: process.cwd(),
+    });
+
+    await tool.execute("call-xai-edit", {
+      prompt: "Keep the composition, replace the background lighting.",
+      image: "./fixtures/reference.png",
+    });
+
+    expect(generateImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resolution: "2K",
+      }),
+    );
+  });
+
   it("rejects unsupported aspect ratios", async () => {
     const tool = createImageGenerateTool({
       config: {
@@ -422,7 +474,7 @@ describe("createImageGenerateTool", () => {
     await expect(
       tool.execute("call-bad-aspect", { prompt: "portrait", aspectRatio: "7:5" }),
     ).rejects.toThrow(
-      "aspectRatio must be one of 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9",
+      "aspectRatio must be one of auto, 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 2:1, 1:2, 9:16, 16:9, 21:9, 19.5:9, 9:19.5, 20:9, or 9:20",
     );
   });
 

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -38,10 +38,11 @@ import {
 } from "./tool-runtime.helpers.js";
 
 const DEFAULT_COUNT = 1;
-const MAX_COUNT = 4;
+const MAX_COUNT = 10;
 const MAX_INPUT_IMAGES = 5;
 const DEFAULT_RESOLUTION: ImageGenerationResolution = "1K";
 const SUPPORTED_ASPECT_RATIOS = new Set([
+  "auto",
   "1:1",
   "2:3",
   "3:2",
@@ -49,9 +50,15 @@ const SUPPORTED_ASPECT_RATIOS = new Set([
   "4:3",
   "4:5",
   "5:4",
+  "2:1",
+  "1:2",
   "9:16",
   "16:9",
   "21:9",
+  "19.5:9",
+  "9:19.5",
+  "20:9",
+  "9:20",
 ]);
 
 const ImageGenerateToolSchema = Type.Object({
@@ -90,7 +97,7 @@ const ImageGenerateToolSchema = Type.Object({
   aspectRatio: Type.Optional(
     Type.String({
       description:
-        "Optional aspect ratio hint: 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9.",
+        "Optional aspect ratio hint: auto, 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 2:1, 1:2, 9:16, 16:9, 21:9, 19.5:9, 9:19.5, 20:9, or 9:20.",
     }),
   ),
   resolution: Type.Optional(
@@ -202,7 +209,7 @@ function normalizeAspectRatio(raw: string | undefined): string | undefined {
     return normalized;
   }
   throw new ToolInputError(
-    "aspectRatio must be one of 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9",
+    "aspectRatio must be one of auto, 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 2:1, 1:2, 9:16, 16:9, 21:9, 19.5:9, 9:19.5, 20:9, or 9:20",
   );
 }
 
@@ -454,6 +461,31 @@ async function inferResolutionFromInputImages(
   return DEFAULT_RESOLUTION;
 }
 
+function clampInferredResolutionToProvider(params: {
+  resolution: ImageGenerationResolution;
+  provider: ImageGenerationProvider | undefined;
+}): ImageGenerationResolution {
+  const supported = params.provider?.capabilities.geometry?.resolutions;
+  if (!Array.isArray(supported) || supported.length === 0) {
+    return params.resolution;
+  }
+
+  const ordered: ImageGenerationResolution[] = ["1K", "2K", "4K"];
+  const targetIndex = ordered.indexOf(params.resolution);
+  if (targetIndex < 0) {
+    return params.resolution;
+  }
+
+  for (let index = targetIndex; index >= 0; index -= 1) {
+    const candidate = ordered[index];
+    if (supported.includes(candidate)) {
+      return candidate;
+    }
+  }
+
+  return params.resolution;
+}
+
 export function createImageGenerateTool(options?: {
   config?: OpenClawConfig;
   agentDir?: string;
@@ -553,18 +585,25 @@ export function createImageGenerateTool(options?: {
         sandboxConfig,
       });
       const inputImages = loadedReferenceImages.map((entry) => entry.sourceImage);
-      const resolution =
+      const selectedProvider = resolveSelectedImageGenerationProvider({
+        config: effectiveCfg,
+        imageGenerationModelConfig,
+        modelOverride: model,
+      });
+      const inferredResolution =
         explicitResolution ??
         (size
           ? undefined
           : inputImages.length > 0
             ? await inferResolutionFromInputImages(inputImages)
             : undefined);
-      const selectedProvider = resolveSelectedImageGenerationProvider({
-        config: effectiveCfg,
-        imageGenerationModelConfig,
-        modelOverride: model,
-      });
+      const resolution =
+        inferredResolution && !explicitResolution
+          ? clampInferredResolutionToProvider({
+              resolution: inferredResolution,
+              provider: selectedProvider,
+            })
+          : inferredResolution;
       validateImageGenerationCapabilities({
         provider: selectedProvider,
         count,

--- a/src/plugins/contracts/registry.contract.test.ts
+++ b/src/plugins/contracts/registry.contract.test.ts
@@ -174,6 +174,7 @@ describe("plugin contract registry", () => {
     expect(findImageGenerationProviderIdsForPlugin("fal")).toEqual(["fal"]);
     expect(findImageGenerationProviderIdsForPlugin("google")).toEqual(["google"]);
     expect(findImageGenerationProviderIdsForPlugin("openai")).toEqual(["openai"]);
+    expect(findImageGenerationProviderIdsForPlugin("xai")).toEqual(["xai"]);
   });
 
   it("keeps bundled provider and web search tool ownership explicit", () => {
@@ -217,6 +218,13 @@ describe("plugin contract registry", () => {
       mediaUnderstandingProviderIds: ["google"],
       imageGenerationProviderIds: ["google"],
       webSearchProviderIds: ["gemini"],
+    });
+    expect(findRegistrationForPlugin("xai")).toMatchObject({
+      providerIds: ["xai"],
+      speechProviderIds: [],
+      mediaUnderstandingProviderIds: [],
+      imageGenerationProviderIds: ["xai"],
+      webSearchProviderIds: ["grok"],
     });
     expect(findRegistrationForPlugin("openai")).toMatchObject({
       providerIds: ["openai", "openai-codex"],

--- a/src/plugins/contracts/registry.ts
+++ b/src/plugins/contracts/registry.ts
@@ -98,7 +98,12 @@ const bundledMediaUnderstandingPlugins: RegistrablePlugin[] = [
   zaiPlugin,
 ];
 
-const bundledImageGenerationPlugins: RegistrablePlugin[] = [falPlugin, googlePlugin, openAIPlugin];
+const bundledImageGenerationPlugins: RegistrablePlugin[] = [
+  falPlugin,
+  googlePlugin,
+  openAIPlugin,
+  xaiPlugin,
+];
 
 function captureRegistrations(plugin: RegistrablePlugin) {
   const captured = createCapturedPluginRegistration();


### PR DESCRIPTION
## Summary
- add xAI image generation as a bundled capability on the existing xAI plugin instead of teaching core image generation to trust arbitrary custom model catalog entries
- support both xai/grok-imagine-image* refs and compatibility with explicit xai-images/* configs so existing separate image-auth setups keep working
- widen the shared image_generate tool's count and aspect-ratio validation to match xAI's current image API surface

## Why
Custom models.providers entries can describe image models syntactically, but the shared image-generation runtime only executes through registered image-generation providers. That made xai-images/grok-imagine-image-pro look valid in config while still failing at runtime because no xAI image-generation provider was registered.

This change keeps the fix on the intended plugin boundary:
- core keeps owning the shared image-generation contract
- the bundled xAI plugin now owns xAI's image-generation implementation
- existing xai-images/* configs stay usable for users who separate image auth from text auth

## Testing
AI-assisted: yes
Testing level: fully tested for the affected lanes

Commands run:
- pnpm test extensions/xai/index.test.ts src/agents/tools/image-generate-tool.test.ts src/plugins/contracts/registry.contract.test.ts
- pnpm test src/image-generation/runtime.test.ts src/agents/openclaw-tools.image-generation.test.ts

## Notes
- I verified during implementation that this still fits OpenClaw's documented capability ownership model; I did not find a better boundary than extending the bundled xAI plugin.
- I did not touch unrelated local changes such as scripts/pr.