### PR TITLE
fix(gateway): allow local connections in trusted-proxy auth mode

### DIFF
--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -395,6 +395,12 @@ export async function authorizeGatewayConnect(
     if ("user" in result) {
       return { ok: true, method: "trusted-proxy", user: result.user };
     }
+    // Local direct connections (e.g. ACPX child processes) bypass trusted-proxy
+    // auth — they connect from localhost without proxy headers, which is expected
+    // since they are spawned by the gateway itself.
+    if (localDirect) {
+      return { ok: true, method: "none", user: "local" };
+    }
     return { ok: false, reason: result.reason };
   }
 


### PR DESCRIPTION
## Summary

- When `gateway.auth.mode` is `trusted-proxy`, ACPX child processes connecting back to the gateway via localhost are rejected because they lack the proxy user header (e.g. `x-amzn-oidc-data`)
- The `authorizeGatewayConnect()` trusted-proxy branch performs a hard early return without considering `localDirect`, even though the variable is already computed at that point
- This breaks ACP functionality in any trusted-proxy deployment (e.g. behind AWS ALB with OIDC auth)

## Fix

When trusted-proxy auth fails and the connection is a local direct request (`localDirect === true`), fall through with `method: "none"` instead of rejecting. These connections originate from processes spawned by the gateway itself (ACPX/Codex CLI), so they are inherently trusted.

## Test plan

- [ ] Deploy with `gateway.auth.mode: "trusted-proxy"` behind a reverse proxy
- [ ] Verify external connections still require the proxy user header
- [ ] Verify ACP spawn works (ACPX child process connects via localhost)
- [ ] Verify Control UI still works through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)