### PR TITLE
feat: add Requesty as a bundled provider plugin

### DIFF
--- a/extensions/requesty/index.test.ts
+++ b/extensions/requesty/index.test.ts
@@ -1,0 +1,79 @@
+import OpenAI from "openai";
+import { describe, expect, it } from "vitest";
+import {
+  registerProviderPlugin,
+  requireRegisteredProvider,
+} from "../../test/helpers/extensions/provider-registration.js";
+import plugin from "./index.js";
+
+const REQUESTY_API_KEY = process.env.REQUESTY_API_KEY ?? "";
+const LIVE_MODEL_ID =
+  process.env.OPENCLAW_LIVE_REQUESTY_PLUGIN_MODEL?.trim() || "openai/gpt-4o";
+const liveEnabled = REQUESTY_API_KEY.trim().length > 0 && process.env.OPENCLAW_LIVE_TEST === "1";
+const describeLive = liveEnabled ? describe : describe.skip;
+
+const registerRequestyPlugin = () =>
+  registerProviderPlugin({
+    plugin,
+    id: "requesty",
+    name: "Requesty Provider",
+  });
+
+describe("requesty plugin", () => {
+  it("registers the expected provider surfaces", () => {
+    const { providers, speechProviders, mediaProviders, imageProviders } =
+      registerRequestyPlugin();
+
+    expect(providers).toHaveLength(1);
+    expect(
+      providers.map(
+        (provider) =>
+          // oxlint-disable-next-line typescript/no-explicit-any
+          (provider as any).id,
+      ),
+    ).toEqual(["requesty"]);
+    expect(speechProviders).toHaveLength(0);
+    expect(mediaProviders).toHaveLength(0);
+    expect(imageProviders).toHaveLength(0);
+  });
+});
+
+describeLive("requesty plugin live", () => {
+  it("registers a Requesty provider that can complete a live request", async () => {
+    const { providers } = registerRequestyPlugin();
+    const provider = requireRegisteredProvider(providers, "requesty");
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const resolved = (provider as any).resolveDynamicModel?.({
+      provider: "requesty",
+      modelId: LIVE_MODEL_ID,
+      modelRegistry: {
+        find() {
+          return null;
+        },
+      },
+    });
+    if (!resolved) {
+      throw new Error(`requesty provider did not resolve ${LIVE_MODEL_ID}`);
+    }
+
+    expect(resolved).toMatchObject({
+      provider: "requesty",
+      id: LIVE_MODEL_ID,
+      api: "openai-completions",
+      baseUrl: "https://router.requesty.ai/v1",
+    });
+
+    const client = new OpenAI({
+      apiKey: REQUESTY_API_KEY,
+      baseURL: resolved.baseUrl,
+    });
+    const response = await client.chat.completions.create({
+      model: resolved.id,
+      messages: [{ role: "user", content: "Reply with exactly OK." }],
+      max_tokens: 16,
+    });
+
+    expect(response.choices[0]?.message?.content?.trim()).toMatch(/^OK[.!]?$/);
+  }, 30_000);
+});

--- a/extensions/requesty/index.test.ts
+++ b/extensions/requesty/index.test.ts
@@ -7,8 +7,7 @@ import {
 import plugin from "./index.js";
 
 const REQUESTY_API_KEY = process.env.REQUESTY_API_KEY ?? "";
-const LIVE_MODEL_ID =
-  process.env.OPENCLAW_LIVE_REQUESTY_PLUGIN_MODEL?.trim() || "openai/gpt-4o";
+const LIVE_MODEL_ID = process.env.OPENCLAW_LIVE_REQUESTY_PLUGIN_MODEL?.trim() || "openai/gpt-4o";
 const liveEnabled = REQUESTY_API_KEY.trim().length > 0 && process.env.OPENCLAW_LIVE_TEST === "1";
 const describeLive = liveEnabled ? describe : describe.skip;
 
@@ -21,8 +20,7 @@ const registerRequestyPlugin = () =>
 
 describe("requesty plugin", () => {
   it("registers the expected provider surfaces", () => {
-    const { providers, speechProviders, mediaProviders, imageProviders } =
-      registerRequestyPlugin();
+    const { providers, speechProviders, mediaProviders, imageProviders } = registerRequestyPlugin();
 
     expect(providers).toHaveLength(1);
     expect(

--- a/extensions/requesty/index.ts
+++ b/extensions/requesty/index.ts
@@ -1,0 +1,109 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import {
+  definePluginEntry,
+  type ProviderResolveDynamicModelContext,
+  type ProviderRuntimeModel,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { DEFAULT_CONTEXT_TOKENS } from "openclaw/plugin-sdk/provider-models";
+import {
+  createRequestySystemCacheWrapper,
+  createRequestyWrapper,
+  isProxyReasoningUnsupported,
+} from "openclaw/plugin-sdk/provider-stream";
+import { applyRequestyConfig, REQUESTY_DEFAULT_MODEL_REF } from "./onboard.js";
+
+const PROVIDER_ID = "requesty";
+const REQUESTY_BASE_URL = "https://router.requesty.ai/v1";
+const REQUESTY_DEFAULT_MAX_TOKENS = 8192;
+const REQUESTY_CACHE_TTL_MODEL_PREFIXES = ["anthropic/"] as const;
+
+function buildDynamicRequestyModel(
+  ctx: ProviderResolveDynamicModelContext,
+): ProviderRuntimeModel {
+  return {
+    id: ctx.modelId,
+    name: ctx.modelId,
+    api: "openai-completions",
+    provider: PROVIDER_ID,
+    baseUrl: REQUESTY_BASE_URL,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_TOKENS,
+    maxTokens: REQUESTY_DEFAULT_MAX_TOKENS,
+  };
+}
+
+function isRequestyCacheTtlModel(modelId: string): boolean {
+  return REQUESTY_CACHE_TTL_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix));
+}
+
+export default definePluginEntry({
+  id: "requesty",
+  name: "Requesty Provider",
+  description: "Bundled Requesty provider plugin",
+  register(api) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "Requesty",
+      docsPath: "/providers/models",
+      envVars: ["REQUESTY_API_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: PROVIDER_ID,
+          methodId: "api-key",
+          label: "Requesty API key",
+          hint: "API key",
+          optionKey: "requestyApiKey",
+          flagName: "--requesty-api-key",
+          envVar: "REQUESTY_API_KEY",
+          promptMessage: "Enter Requesty API key",
+          defaultModel: REQUESTY_DEFAULT_MODEL_REF,
+          expectedProviders: ["requesty"],
+          applyConfig: (cfg) => applyRequestyConfig(cfg),
+          wizard: {
+            choiceId: "requesty-api-key",
+            choiceLabel: "Requesty API key",
+            groupId: "requesty",
+            groupLabel: "Requesty",
+            groupHint: "API key",
+          },
+        }),
+      ],
+      catalog: {
+        order: "simple",
+        run: async (ctx) => {
+          const apiKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+          if (!apiKey) {
+            return null;
+          }
+          return {
+            provider: {
+              baseUrl: REQUESTY_BASE_URL,
+              api: "openai-completions" as const,
+              apiKey,
+              models: [],
+            },
+          };
+        },
+      },
+      resolveDynamicModel: (ctx) => buildDynamicRequestyModel(ctx),
+      capabilities: {
+        openAiCompatTurnValidation: false,
+        geminiThoughtSignatureSanitization: true,
+        geminiThoughtSignatureModelHints: ["gemini"],
+      },
+      isModernModelRef: () => true,
+      wrapStreamFn: (ctx) => {
+        let streamFn: StreamFn | undefined = ctx.streamFn;
+        const skipReasoningInjection = isProxyReasoningUnsupported(ctx.modelId);
+        const thinkingLevel = skipReasoningInjection ? undefined : ctx.thinkingLevel;
+        streamFn = createRequestyWrapper(streamFn, thinkingLevel);
+        streamFn = createRequestySystemCacheWrapper(streamFn);
+        return streamFn;
+      },
+      isCacheTtlEligible: (ctx) => isRequestyCacheTtlModel(ctx.modelId),
+    });
+  },
+});

--- a/extensions/requesty/index.ts
+++ b/extensions/requesty/index.ts
@@ -18,9 +18,7 @@ const REQUESTY_BASE_URL = "https://router.requesty.ai/v1";
 const REQUESTY_DEFAULT_MAX_TOKENS = 8192;
 const REQUESTY_CACHE_TTL_MODEL_PREFIXES = ["anthropic/"] as const;
 
-function buildDynamicRequestyModel(
-  ctx: ProviderResolveDynamicModelContext,
-): ProviderRuntimeModel {
+function buildDynamicRequestyModel(ctx: ProviderResolveDynamicModelContext): ProviderRuntimeModel {
   return {
     id: ctx.modelId,
     name: ctx.modelId,

--- a/extensions/requesty/onboard.ts
+++ b/extensions/requesty/onboard.ts
@@ -1,0 +1,32 @@
+import {
+  applyAgentDefaultModelPrimary,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+
+export const REQUESTY_DEFAULT_MODEL_REF = "requesty/openai/gpt-4o";
+
+export function applyRequestyProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[REQUESTY_DEFAULT_MODEL_REF] = {
+    ...models[REQUESTY_DEFAULT_MODEL_REF],
+    alias: models[REQUESTY_DEFAULT_MODEL_REF]?.alias ?? "Requesty",
+  };
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        models,
+      },
+    },
+  };
+}
+
+export function applyRequestyConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(
+    applyRequestyProviderConfig(cfg),
+    REQUESTY_DEFAULT_MODEL_REF,
+  );
+}

--- a/extensions/requesty/openclaw.plugin.json
+++ b/extensions/requesty/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "requesty",
+  "providers": ["requesty"],
+  "providerAuthEnvVars": {
+    "requesty": ["REQUESTY_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "requesty",
+      "method": "api-key",
+      "choiceId": "requesty-api-key",
+      "choiceLabel": "Requesty API key",
+      "groupId": "requesty",
+      "groupLabel": "Requesty",
+      "groupHint": "API key",
+      "optionKey": "requestyApiKey",
+      "cliFlag": "--requesty-api-key",
+      "cliOption": "--requesty-api-key <key>",
+      "cliDescription": "Requesty API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/requesty/package.json
+++ b/extensions/requesty/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/requesty-provider",
+  "version": "2026.3.22",
+  "private": true,
+  "description": "OpenClaw Requesty provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -555,6 +555,8 @@ importers:
 
   extensions/qianfan: {}
 
+  extensions/requesty: {}
+
   extensions/sglang: {}
 
   extensions/signal: {}

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -120,6 +120,71 @@ export function isProxyReasoningUnsupported(modelId: string): boolean {
   return modelId.toLowerCase().startsWith("x-ai/");
 }
 
+function isRequestyAnthropicModel(provider: string, modelId: string): boolean {
+  return provider.toLowerCase() === "requesty" && modelId.toLowerCase().startsWith("anthropic/");
+}
+
+export function createRequestySystemCacheWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (
+      typeof model.provider !== "string" ||
+      typeof model.id !== "string" ||
+      !isRequestyAnthropicModel(model.provider, model.id)
+    ) {
+      return underlying(model, context, options);
+    }
+
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        const messages = (payload as Record<string, unknown>)?.messages;
+        if (Array.isArray(messages)) {
+          for (const msg of messages as Array<{ role?: string; content?: unknown }>) {
+            if (msg.role !== "system" && msg.role !== "developer") {
+              continue;
+            }
+            if (typeof msg.content === "string") {
+              msg.content = [
+                { type: "text", text: msg.content, cache_control: { type: "ephemeral" } },
+              ];
+            } else if (Array.isArray(msg.content) && msg.content.length > 0) {
+              const last = msg.content[msg.content.length - 1];
+              if (last && typeof last === "object") {
+                (last as Record<string, unknown>).cache_control = { type: "ephemeral" };
+              }
+            }
+          }
+        }
+        return originalOnPayload?.(payload, model);
+      },
+    });
+  };
+}
+
+export function createRequestyWrapper(
+  baseStreamFn: StreamFn | undefined,
+  thinkingLevel?: ThinkLevel,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const onPayload = options?.onPayload;
+    const attributionHeaders = resolveProviderAttributionHeaders("requesty");
+    return underlying(model, context, {
+      ...options,
+      headers: {
+        ...attributionHeaders,
+        ...options?.headers,
+      },
+      onPayload: (payload) => {
+        normalizeProxyReasoningPayload(payload, thinkingLevel);
+        return onPayload?.(payload, model);
+      },
+    });
+  };
+}
+
 export function createKilocodeWrapper(
   baseStreamFn: StreamFn | undefined,
   thinkingLevel?: ThinkLevel,

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -98,6 +98,25 @@ function buildOpenAICodexAttributionPolicy(
   };
 }
 
+function buildRequestyAttributionPolicy(
+  env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
+): ProviderAttributionPolicy {
+  const identity = resolveProviderAttributionIdentity(env);
+  return {
+    provider: "requesty",
+    enabledByDefault: true,
+    verification: "vendor-documented",
+    hook: "request-headers",
+    docsUrl: "https://docs.requesty.ai",
+    reviewNote: "Documented app attribution headers. Verified in OpenClaw runtime wrapper.",
+    ...identity,
+    headers: {
+      "HTTP-Referer": "https://openclaw.ai",
+      "X-Title": identity.product,
+    },
+  };
+}
+
 function buildSdkHookOnlyPolicy(
   provider: string,
   hook: ProviderAttributionHook,
@@ -119,6 +138,7 @@ export function listProviderAttributionPolicies(
 ): ProviderAttributionPolicy[] {
   return [
     buildOpenRouterAttributionPolicy(env),
+    buildRequestyAttributionPolicy(env),
     buildOpenAIAttributionPolicy(env),
     buildOpenAICodexAttributionPolicy(env),
     buildSdkHookOnlyPolicy(

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -12,6 +12,8 @@ export {
   createKilocodeWrapper,
   createOpenRouterSystemCacheWrapper,
   createOpenRouterWrapper,
+  createRequestySystemCacheWrapper,
+  createRequestyWrapper,
   isProxyReasoningUnsupported,
 } from "../agents/pi-embedded-runner/proxy-stream-wrappers.js";
 export {

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -2680,6 +2680,47 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
+    dirName: "requesty",
+    idHint: "requesty",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/requesty-provider",
+    packageVersion: "2026.3.22",
+    packageDescription: "OpenClaw Requesty provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "requesty",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["requesty"],
+      providerAuthEnvVars: {
+        requesty: ["REQUESTY_API_KEY"],
+      },
+      providerAuthChoices: [
+        {
+          provider: "requesty",
+          method: "api-key",
+          choiceId: "requesty-api-key",
+          choiceLabel: "Requesty API key",
+          groupId: "requesty",
+          groupLabel: "Requesty",
+          groupHint: "API key",
+          optionKey: "requestyApiKey",
+          cliFlag: "--requesty-api-key",
+          cliOption: "--requesty-api-key <key>",
+          cliDescription: "Requesty API key",
+        },
+      ],
+    },
+  },
+  {
     dirName: "sglang",
     idHint: "sglang",
     source: {

--- a/src/plugins/bundled-provider-auth-env-vars.generated.ts
+++ b/src/plugins/bundled-provider-auth-env-vars.generated.ts
@@ -30,6 +30,7 @@ export const BUNDLED_PROVIDER_AUTH_ENV_VAR_CANDIDATES = {
   perplexity: ["PERPLEXITY_API_KEY", "OPENROUTER_API_KEY"],
   qianfan: ["QIANFAN_API_KEY"],
   "qwen-portal": ["QWEN_OAUTH_TOKEN", "QWEN_PORTAL_API_KEY"],
+  requesty: ["REQUESTY_API_KEY"],
   sglang: ["SGLANG_API_KEY"],
   synthetic: ["SYNTHETIC_API_KEY"],
   tavily: ["TAVILY_API_KEY"],


### PR DESCRIPTION
## Summary

- **Problem:** Requesty (a unified AI gateway for 300+ models at `router.requesty.ai/v1`) has no bundled provider plugin, so users must configure it manually.
- **Why it matters:** Requesty is OpenAI-compatible (chat completions, responses, and messages) and supports the same proxy pattern as OpenRouter, adding it as a bundled plugin gives users one-command onboarding.
- **What changed:** Added `extensions/requesty/` provider plugin with attribution headers, stream wrappers (reasoning effort + Anthropic prompt caching), onboarding config, and registration test. Added Requesty attribution policy and stream wrapper exports to shared infra.
- **What did NOT change (scope boundary):** No dynamic model capability cache (unlike OpenRouter's 3-layer cache),  models resolve dynamically with sensible defaults. No provider routing injection. No static catalog models. Core plugin infrastructure untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A (new provider plugin)
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A — new feature, not a bug fix.

## User-visible / Behavior Changes

- New provider `requesty` available for onboarding via `openclaw onboard --auth-choice apiKey --token-provider requesty --token <key>`
- New CLI flag `--requesty-api-key` for API key auth
- New env var `REQUESTY_API_KEY` recognized
- Default model: `requesty/openai/gpt-4o`
- Attribution headers sent on every request: `HTTP-Referer: https://openclaw.ai`, `X-Title: OpenClaw`

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No uses existing `createProviderApiKeyAuthMethod` pattern
- New/changed network calls? Yes requests route to `https://router.requesty.ai/v1` (only when user explicitly configures Requesty as their provider)
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: Network calls only happen when the user has explicitly onboarded with a Requesty API key. Same trust model as OpenRouter and all other proxy providers.

## Repro + Verification

### Environment

- OS: macOS (Darwin 23.3.0)
- Runtime/container: Node 22+, pnpm
- Model/provider: Requesty (`router.requesty.ai/v1`)
- Integration/channel (if any): N/A

### Steps

1. `pnpm install && pnpm build`
2. `pnpm test:extension requesty` registration test passes
3. `REQUESTY_API_KEY=<key> OPENCLAW_LIVE_TEST=1 pnpm test -- extensions/requesty/index.test.ts` — live test passes (with valid key)

### Expected

- Plugin registers one provider (`requesty`) with no speech/media/image providers
- Live requests route through `router.requesty.ai/v1` with correct attribution headers

### Actual

- All as expected

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test:extension requesty` 1 passed, 1 skipped (live test skipped without API key).
`pnpm check` — all checks green.
`pnpm build` — clean build, no warnings.

## Human Verification (required)

- Verified scenarios: plugin registration test, `pnpm check` (all lints/format/type/metadata checks), `pnpm build` (bundled metadata regenerated correctly)
- Edge cases checked: confirmed generated files (`bundled-plugin-metadata.generated.ts`, `bundled-provider-auth-env-vars.generated.ts`) include requesty entries
- What you did **not** verify: live end-to-end gateway request with a real Requesty API key (no key available in this session)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes new optional `REQUESTY_API_KEY` env var, new `--requesty-api-key` CLI flag
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the PR; the plugin is fully self-contained in `extensions/requesty/` plus additive changes to `provider-attribution.ts` and `proxy-stream-wrappers.ts`
- Files/config to restore: `extensions/requesty/` (delete), revert additions in `src/agents/provider-attribution.ts`, `src/agents/pi-embedded-runner/proxy-stream-wrappers.ts`, `src/plugin-sdk/provider-stream.ts`, regenerate bundled metadata
- Known bad symptoms reviewers should watch for: `pnpm check:bundled-plugin-metadata` or `pnpm check:bundled-provider-auth-env-vars` failing after merge

## Risks and Mitigations

- Risk: Attribution headers (`HTTP-Referer`, `X-Title`) may not match Requesty's latest spec.
  - Mitigation: Headers follow Requesty's documented API pattern (`https://docs.requesty.ai`). Easy to update if spec changes.

---

AI-assisted PR (Claude Code). Lightly tested (registration unit test + full `pnpm check` + `pnpm build`). Live test requires API key.