### PR TITLE
fix(pdf): configure pdfjs standard font assets

### DIFF
--- a/src/media/pdf-extract.test.ts
+++ b/src/media/pdf-extract.test.ts
@@ -10,7 +10,7 @@ describe("extractPdfContent", () => {
     vi.restoreAllMocks();
   });
 
-  it("passes pdfjs standard font data URL to getDocument", async () => {
+  it("passes a filesystem standard font path to getDocument", async () => {
     const getDocument = vi.fn(() => ({
       promise: Promise.resolve({
         numPages: 1,
@@ -37,12 +37,22 @@ describe("extractPdfContent", () => {
 
     expect(result).toEqual({ text: "hello from pdf", images: [] });
     expect(getDocument).toHaveBeenCalledTimes(1);
-    expect(getDocument).toHaveBeenCalledWith(
+    const params = getDocument.mock.lastCall?.at(0) as
+      | {
+          data: Uint8Array;
+          disableWorker: boolean;
+          standardFontDataUrl?: string;
+        }
+      | undefined;
+    expect(params).toBeDefined();
+    expect(params).toEqual(
       expect.objectContaining({
         data: expect.any(Uint8Array),
         disableWorker: true,
-        standardFontDataUrl: expect.stringContaining("/pdfjs-dist/standard_fonts/"),
       }),
     );
+    expect(params?.standardFontDataUrl).toContain("/pdfjs-dist/standard_fonts/");
+    expect(params?.standardFontDataUrl).toMatch(/\/$/);
+    expect(params?.standardFontDataUrl).not.toMatch(/^file:\/\//);
   });
 });

--- a/src/media/pdf-extract.test.ts
+++ b/src/media/pdf-extract.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("extractPdfContent", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.doUnmock("pdfjs-dist/legacy/build/pdf.mjs");
+    vi.restoreAllMocks();
+  });
+
+  it("passes pdfjs standard font data URL to getDocument", async () => {
+    const getDocument = vi.fn(() => ({
+      promise: Promise.resolve({
+        numPages: 1,
+        getPage: vi.fn().mockResolvedValue({
+          getTextContent: vi.fn().mockResolvedValue({
+            items: [{ str: "hello from pdf" }],
+          }),
+        }),
+      }),
+    }));
+
+    vi.doMock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+      getDocument,
+    }));
+
+    const { extractPdfContent } = await import("./pdf-extract.js");
+
+    const result = await extractPdfContent({
+      buffer: Buffer.from("%PDF-1.7"),
+      maxPages: 1,
+      maxPixels: 1024,
+      minTextChars: 1,
+    });
+
+    expect(result).toEqual({ text: "hello from pdf", images: [] });
+    expect(getDocument).toHaveBeenCalledTimes(1);
+    expect(getDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.any(Uint8Array),
+        disableWorker: true,
+        standardFontDataUrl: expect.stringContaining("/pdfjs-dist/standard_fonts/"),
+      }),
+    );
+  });
+});

--- a/src/media/pdf-extract.ts
+++ b/src/media/pdf-extract.ts
@@ -1,8 +1,15 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
 type CanvasModule = typeof import("@napi-rs/canvas");
 type PdfJsModule = typeof import("pdfjs-dist/legacy/build/pdf.mjs");
 
+const require = createRequire(import.meta.url);
+
 let canvasModulePromise: Promise<CanvasModule> | null = null;
 let pdfJsModulePromise: Promise<PdfJsModule> | null = null;
+let pdfJsStandardFontDataUrl: string | null | undefined;
 
 async function loadCanvasModule(): Promise<CanvasModule> {
   if (!canvasModulePromise) {
@@ -28,6 +35,22 @@ async function loadPdfJsModule(): Promise<PdfJsModule> {
   return pdfJsModulePromise;
 }
 
+function resolvePdfJsStandardFontDataUrl(): string | undefined {
+  if (pdfJsStandardFontDataUrl !== undefined) {
+    return pdfJsStandardFontDataUrl ?? undefined;
+  }
+
+  try {
+    const pdfJsPackageJsonPath = require.resolve("pdfjs-dist/package.json");
+    const standardFontsDir = path.join(path.dirname(pdfJsPackageJsonPath), "standard_fonts");
+    pdfJsStandardFontDataUrl = pathToFileURL(`${standardFontsDir}${path.sep}`).href;
+  } catch {
+    pdfJsStandardFontDataUrl = null;
+  }
+
+  return pdfJsStandardFontDataUrl ?? undefined;
+}
+
 export type PdfExtractedImage = {
   type: "image";
   data: string;
@@ -49,7 +72,11 @@ export async function extractPdfContent(params: {
 }): Promise<PdfExtractedContent> {
   const { buffer, maxPages, maxPixels, minTextChars, pageNumbers, onImageExtractionError } = params;
   const { getDocument } = await loadPdfJsModule();
-  const pdf = await getDocument({ data: new Uint8Array(buffer), disableWorker: true }).promise;
+  const pdf = await getDocument({
+    data: new Uint8Array(buffer),
+    disableWorker: true,
+    standardFontDataUrl: resolvePdfJsStandardFontDataUrl(),
+  }).promise;
 
   const effectivePages: number[] = pageNumbers
     ? pageNumbers.filter((p) => p >= 1 && p <= pdf.numPages).slice(0, maxPages)

--- a/src/media/pdf-extract.ts
+++ b/src/media/pdf-extract.ts
@@ -1,6 +1,5 @@
 import { createRequire } from "node:module";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 
 type CanvasModule = typeof import("@napi-rs/canvas");
 type PdfJsModule = typeof import("pdfjs-dist/legacy/build/pdf.mjs");
@@ -43,7 +42,11 @@ function resolvePdfJsStandardFontDataUrl(): string | undefined {
   try {
     const pdfJsPackageJsonPath = require.resolve("pdfjs-dist/package.json");
     const standardFontsDir = path.join(path.dirname(pdfJsPackageJsonPath), "standard_fonts");
-    pdfJsStandardFontDataUrl = pathToFileURL(`${standardFontsDir}${path.sep}`).href;
+    // In Node, PDF.js concatenates this value with the font filename and passes the
+    // resulting plain string to `fs.readFile(...)`, so this must be a filesystem path.
+    const normalizedStandardFontsDir =
+      path.sep === "/" ? standardFontsDir : standardFontsDir.replaceAll(path.sep, "/");
+    pdfJsStandardFontDataUrl = `${normalizedStandardFontsDir}/`;
   } catch {
     pdfJsStandardFontDataUrl = null;
   }

--- a/src/types/pdfjs-dist-legacy.d.ts
+++ b/src/types/pdfjs-dist-legacy.d.ts
@@ -27,7 +27,11 @@ declare module "pdfjs-dist/legacy/build/pdf.mjs" {
     getPage(pageNumber: number): Promise<PDFPageProxy>;
   };
 
-  export function getDocument(params: { data: Uint8Array; disableWorker?: boolean }): {
+  export function getDocument(params: {
+    data: Uint8Array;
+    disableWorker?: boolean;
+    standardFontDataUrl?: string;
+  }): {
     promise: Promise<PDFDocumentProxy>;
   };
 }


### PR DESCRIPTION
## Summary

- Problem: PDF.js standard font assets are installed with `pdfjs-dist`, but our PDF extraction path did not tell PDF.js where to find them at runtime.
- Why it matters: PDFs that rely on standard fonts instead of embedding them can fail extraction in packaged installs even though the assets are present.
- What changed: resolve the installed `pdfjs-dist/standard_fonts` directory at runtime, normalize it to a slash-terminated filesystem path string for `standardFontDataUrl`, add a regression test, and extend the local type shim for the new option.
- What did NOT change: extraction behavior is unchanged when fonts are embedded, and resolution failure still degrades gracefully by passing no extra option.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: in Node, PDF.js concatenates `standardFontDataUrl` with the font filename and passes the resulting plain string to `fs.readFile(...)`.
- Impact: PDFs that reference standard fonts without embedding them can fail extraction when no runtime font path is provided, or when a `file://` string is passed instead of a filesystem path string.
- Why this fix: resolving the package location with `require.resolve("pdfjs-dist/package.json")` makes the asset lookup work from the installed package instead of assuming a repo-relative path.

## Regression Test Plan (if applicable)

- Coverage level that should catch this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target tests/files:
  - `src/media/pdf-extract.test.ts`
  - `src/agents/tools/pdf-tool.test.ts`
- Scenarios locked in:
  - `getDocument()` receives a slash-terminated path string for `pdfjs-dist/standard_fonts`
  - the resolved value does not use a `file://` prefix
  - PDF tool extraction still works through the calling seam

## User-visible / Behavior Changes

- PDF extraction now works for more PDFs that depend on standard PDF.js fonts in packaged/runtime installs.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: macOS 15 / darwin 25.3.0
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): local PDF extraction via PDF.js

### Steps

1. Run PDF extraction against a PDF that relies on standard fonts that are not embedded.
2. Observe that PDF.js needs a valid `standardFontDataUrl` to load those assets from the installed package.
3. Verify extraction after resolving `pdfjs-dist/standard_fonts` dynamically and passing that slash-terminated filesystem path string into `getDocument()`.

### Expected

- PDF extraction succeeds when the installed `pdfjs-dist` package contains the required `standard_fonts` assets.

### Actual

- Before this change, extraction could fail because PDF.js was not given the installed standard-font asset path in the form its Node loader expects.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - rebased onto current `main` on March 26, 2026
  - `OPENCLAW_TEST_PROFILE=low pnpm test -- src/media/pdf-extract.test.ts src/agents/tools/pdf-tool.test.ts test/openclaw-npm-release-check.test.ts src/docker-build-cache.test.ts`
  - `pnpm check`
  - `pnpm build`
- What this specifically confirmed:
  - the PDF fix still passes its direct regression coverage
  - the final implementation passes a filesystem path string, not a `file://` string
  - the rebased branch validates cleanly on top of the current base branch

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Known bad symptoms reviewers should watch for: extraction failures for PDFs with standard fonts, or a malformed `standardFontDataUrl` path being passed to PDF.js.

## Risks and Mitigations

- Risk: runtime resolution could produce a malformed font path on some platforms.
  - Mitigation: normalize separators, ensure a trailing `/`, and cover the shape in the regression test.
- Risk: package resolution could fail in unusual install layouts.
  - Mitigation: failure path is intentionally non-fatal and preserves previous behavior by omitting the option.

## AI assistance

- [x] AI-assisted
- Testing: locally validated with the direct PDF tests, `pnpm check`, `pnpm build`, and the two previously red CI tests from the older run.
