### PR TITLE
fix: preserve Kimi tool call arguments instead of clearing valid JSON

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1605,7 +1605,7 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
     expect(streamedToolCall.arguments).toEqual({});
   });
 
-  it("clears a cached repair when later deltas make the trailing suffix invalid", async () => {
+  it("preserves last valid repair when later deltas make the trailing suffix too long", async () => {
     const partialToolCall = { type: "toolCall", name: "read", arguments: {} };
     const streamedToolCall = { type: "toolCall", name: "read", arguments: {} };
     const partialMessage = { role: "assistant", content: [partialToolCall] };
@@ -1646,8 +1646,99 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
       // drain
     }
 
-    expect(partialToolCall.arguments).toEqual({});
+    // After the fix: valid arguments set by an earlier successful repair are preserved
+    // instead of being wiped to {}. The cached repair map entry is removed (so
+    // toolcall_end does not re-apply), but the already-set arguments remain on the
+    // partial message's content block.
+    expect(partialToolCall.arguments).toEqual({ path: "/tmp/report.txt" });
+    // streamedToolCall is the toolcall_end's toolCall ref — not touched because
+    // the repair map entry was already cleared by the time toolcall_end fires.
     expect(streamedToolCall.arguments).toEqual({});
+  });
+
+  it("preserves valid JSON arguments instead of treating them as repair failures", async () => {
+    // Bug fix: tryParseMalformedToolCallArguments previously returned undefined for
+    // valid JSON (same signal as "unfixable"), causing the caller to clear arguments.
+    // After the fix, valid JSON is returned as a successful parse.
+    const partialToolCall = { type: "toolCall", name: "exec", arguments: {} };
+    const streamedToolCall = { type: "toolCall", name: "exec", arguments: {} };
+    const endMessageToolCall = { type: "toolCall", name: "exec", arguments: {} };
+    const finalToolCall = { type: "toolCall", name: "exec", arguments: {} };
+    const partialMessage = { role: "assistant", content: [partialToolCall] };
+    const endMessage = { role: "assistant", content: [endMessageToolCall] };
+    const finalMessage = { role: "assistant", content: [finalToolCall] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: '{"command":"ls -la"}',
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_end",
+            contentIndex: 0,
+            toolCall: streamedToolCall,
+            partial: partialMessage,
+            message: endMessage,
+          },
+        ],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+    for await (const _item of stream) {
+      // drain
+    }
+    const result = await stream.result();
+
+    expect(partialToolCall.arguments).toEqual({ command: "ls -la" });
+    expect(streamedToolCall.arguments).toEqual({ command: "ls -la" });
+    expect(endMessageToolCall.arguments).toEqual({ command: "ls -la" });
+    expect(finalToolCall.arguments).toEqual({ command: "ls -la" });
+    expect(result).toBe(finalMessage);
+  });
+
+  it("does not wipe arguments when repair returns undefined for incomplete JSON", async () => {
+    // Simulates Kimi's content_block_start setting arguments directly, followed by
+    // an incomplete delta that triggers repair attempt but cannot be parsed.
+    // Previously the else branch would clear arguments to {}; now it leaves them alone.
+    const partialToolCall = {
+      type: "toolCall",
+      name: "read",
+      arguments: { path: "/etc/hosts" },
+    };
+    const streamedToolCall = { type: "toolCall", name: "read", arguments: {} };
+    const partialMessage = { role: "assistant", content: [partialToolCall] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: "}",
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_end",
+            contentIndex: 0,
+            toolCall: streamedToolCall,
+            partial: partialMessage,
+          },
+        ],
+        resultMessage: { role: "assistant", content: [partialToolCall] },
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+    for await (const _item of stream) {
+      // drain
+    }
+
+    // Arguments set by content_block_start are preserved — not wiped to undefined
+    expect(partialToolCall.arguments).toEqual({ path: "/etc/hosts" });
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1275,7 +1275,10 @@ function wrapStreamRepairMalformedToolCallArguments(
                   repairedArgsByIndex.set(event.contentIndex, repair.args);
                   repairToolCallArgumentsInMessage(event.partial, event.contentIndex, repair.args);
                   repairToolCallArgumentsInMessage(event.message, event.contentIndex, repair.args);
-                  if (!loggedRepairIndices.has(event.contentIndex)) {
+                  if (
+                    repair.trailingSuffix.length > 0 &&
+                    !loggedRepairIndices.has(event.contentIndex)
+                  ) {
                     loggedRepairIndices.add(event.contentIndex);
                     log.warn(
                       `repairing Kimi tool call arguments after ${repair.trailingSuffix.length} trailing chars`,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1149,7 +1149,10 @@ function tryParseMalformedToolCallArguments(raw: string): ToolCallArgumentRepair
     return undefined;
   }
   try {
-    JSON.parse(raw);
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return { args: parsed as Record<string, unknown>, trailingSuffix: "" };
+    }
     return undefined;
   } catch {
     const jsonPrefix = extractBalancedJsonPrefix(raw);
@@ -1196,25 +1199,6 @@ function repairToolCallArgumentsInMessage(
     return;
   }
   typedBlock.arguments = repairedArgs;
-}
-
-function clearToolCallArgumentsInMessage(message: unknown, contentIndex: number): void {
-  if (!message || typeof message !== "object") {
-    return;
-  }
-  const content = (message as { content?: unknown }).content;
-  if (!Array.isArray(content)) {
-    return;
-  }
-  const block = content[contentIndex];
-  if (!block || typeof block !== "object") {
-    return;
-  }
-  const typedBlock = block as { type?: unknown; arguments?: unknown };
-  if (!isToolCallBlockType(typedBlock.type)) {
-    return;
-  }
-  typedBlock.arguments = {};
 }
 
 function repairMalformedToolCallArgumentsInMessage(
@@ -1298,9 +1282,12 @@ function wrapStreamRepairMalformedToolCallArguments(
                     );
                   }
                 } else {
+                  // Do not clear tool call arguments here. When tryParseMalformedToolCallArguments
+                  // returns undefined, the JSON may still be incomplete (streaming in progress) or
+                  // already set correctly via content_block_start.input. Clearing here would wipe
+                  // valid arguments that were never malformed. Let content_block_stop handle final
+                  // argument resolution via parseStreamingJson.
                   repairedArgsByIndex.delete(event.contentIndex);
-                  clearToolCallArgumentsInMessage(event.partial, event.contentIndex);
-                  clearToolCallArgumentsInMessage(event.message, event.contentIndex);
                 }
               }
             }


### PR DESCRIPTION
## Summary

Fixes three related bugs in the Kimi (kimi-coding/k2p5) tool call argument repair pipeline that cause tool calls to fail with empty or undefined arguments:

- **`tryParseMalformedToolCallArguments` treats valid JSON as unfixable**: When accumulated streaming JSON is already valid, `JSON.parse(raw)` succeeds but the function returns `undefined` — the same signal as "unrepairable". The caller then clears arguments, wiping correct tool parameters.
- **`clearToolCallArgumentsInMessage` assigns `{}` instead of `undefined`**: The empty object pollutes shared references. Downstream validators see a present-but-empty object and report `must have required property 'command'` instead of recognizing arguments as absent.
- **`else` branch in `wrapStreamRepairMalformedToolCallArguments` unconditionally clears arguments**: When repair returns `undefined`, arguments may already be correctly set via `content_block_start.input` (Kimi's non-incremental streaming path). Clearing here wipes them. The fix lets `content_block_stop` handle final argument resolution.

### Root cause

Kimi k2p5 has two streaming behaviors:
1. **Incremental**: `content_block_start` with `input: {}`, then `input_json_delta` events build up arguments
2. **Non-incremental**: `content_block_start` with full `input: {path: "..."}`, no `input_json_delta` at all

The repair wrapper assumed path 1 exclusively. In path 2, `partialJson` stays empty, `tryParseMalformedToolCallArguments("")` returns undefined, and the else branch wiped the already-correct arguments.

### Changes

| File | Change |
|------|--------|
| `attempt.ts` | `tryParseMalformedToolCallArguments`: return parsed args when JSON is valid |
| `attempt.ts` | Remove `clearToolCallArgumentsInMessage` (no longer called) |
| `attempt.ts` | Remove clear calls from the `else` branch in the stream wrapper |
| `attempt.test.ts` | Update existing test + add 2 new tests covering the fix |

### Reproduction

With kimi-coding/k2p5:
```
# Before fix:
Validation failed for tool "exec":
  - command: must have required property 'command'
Received arguments: {}

# Or:
read tool called without path: toolCallId=tool_xxx argsType=undefined
```

### Note on remaining pi-ai issues

Two additional Kimi tool call bugs exist in the upstream `@mariozechner/pi-ai` package (not addressed here):
- `content_block_stop` overwrites `block.arguments` with `parseStreamingJson("")` → `{}` even when `partialJson` is empty
- A "Kimi API bug workaround" in `content_block_start` converts `input: {}` to `undefined`

These require a separate fix in pi-ai. This PR addresses all bugs within OpenClaw's own codebase.

## Test plan

- [x] All 95 existing tests in `attempt.test.ts` pass
- [x] New test: valid JSON arguments are preserved through the repair pipeline
- [x] New test: arguments set by `content_block_start.input` survive incomplete delta attempts
- [x] Updated test: trailing suffix growing too long preserves last valid repair instead of wiping
- [x] TypeScript type check passes (`pnpm tsgo`)
- [x] Full lint/format check passes (`pnpm check`)
- [ ] Manual verification with kimi-coding/k2p5 on Telegram

Fixes #54442
Fixes #53747
Refs #54366

🤖 Generated with [Claude Code](https://claude.com/claude-code)