### PR TITLE
feat(discord): add per-channel model override support (AI-assisted)

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -10437,6 +10437,16 @@
       "hasChildren": false
     },
     {
+      "path": "channels.discord.accounts.*.guilds.*.channels.*.model",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.discord.accounts.*.guilds.*.channels.*.requireMention",
       "kind": "channel",
       "type": "boolean",
@@ -13376,6 +13386,16 @@
       "path": "channels.discord.guilds.*.channels.*.includeThreadStarter",
       "kind": "channel",
       "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.discord.guilds.*.channels.*.model",
+      "kind": "channel",
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5631}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5633}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -921,6 +921,7 @@
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.ignoreOtherMentions","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.includeThreadStarter","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.model","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.roles","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.guilds.*.channels.*.roles.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1188,6 +1189,7 @@
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.ignoreOtherMentions","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.includeThreadStarter","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.guilds.*.channels.*.model","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.roles","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.guilds.*.channels.*.roles.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}

--- a/extensions/discord/src/monitor/allow-list.ts
+++ b/extensions/discord/src/monitor/allow-list.ts
@@ -27,6 +27,7 @@ type DiscordChannelOverrideConfig = {
   users?: string[];
   roles?: string[];
   systemPrompt?: string;
+  model?: string;
   includeThreadStarter?: boolean;
   autoThread?: boolean;
   autoThreadName?: "message" | "generated";
@@ -402,6 +403,7 @@ function resolveDiscordChannelConfigEntry(
     users: entry.users,
     roles: entry.roles,
     systemPrompt: entry.systemPrompt,
+    model: entry.model,
     includeThreadStarter: entry.includeThreadStarter,
     autoThread: entry.autoThread,
     autoThreadName: entry.autoThreadName,

--- a/extensions/discord/src/monitor/inbound-context.ts
+++ b/extensions/discord/src/monitor/inbound-context.ts
@@ -63,6 +63,7 @@ export function buildDiscordInboundAccessContext(params: {
       channelTopic: params.channelTopic,
       messageBody: params.messageBody,
     }),
+    channelModelOverride: params.channelConfig?.model,
     ownerAllowFrom: resolveDiscordOwnerAllowFrom({
       channelConfig: params.channelConfig,
       guildInfo: params.guildInfo,

--- a/extensions/discord/src/monitor/inbound-context.ts
+++ b/extensions/discord/src/monitor/inbound-context.ts
@@ -63,7 +63,7 @@ export function buildDiscordInboundAccessContext(params: {
       channelTopic: params.channelTopic,
       messageBody: params.messageBody,
     }),
-    channelModelOverride: params.channelConfig?.model,
+    channelModelOverride: params.isGuild ? params.channelConfig?.model : undefined,
     ownerAllowFrom: resolveDiscordOwnerAllowFrom({
       channelConfig: params.channelConfig,
       guildInfo: params.guildInfo,

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -233,7 +233,7 @@ export async function processDiscordMessage(
     ? (sender.tag ?? sender.name ?? author.username)
     : author.username;
   const senderTag = sender.tag;
-  const { groupSystemPrompt, ownerAllowFrom, untrustedContext } = buildDiscordInboundAccessContext({
+  const { groupSystemPrompt, channelModelOverride, ownerAllowFrom, untrustedContext } = buildDiscordInboundAccessContext({
     channelConfig,
     guildInfo,
     sender: { id: sender.id, name: sender.name, tag: sender.tag },
@@ -384,6 +384,7 @@ export async function processDiscordMessage(
     GroupChannel: groupChannel,
     UntrustedContext: untrustedContext,
     GroupSystemPrompt: isGuildMessage ? groupSystemPrompt : undefined,
+    ChannelModelOverride: isGuildMessage ? channelModelOverride : undefined,
     GroupSpace: isGuildMessage ? (guildInfo?.id ?? guildSlug) || undefined : undefined,
     OwnerAllowFrom: ownerAllowFrom,
     Provider: "discord" as const,

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -233,15 +233,16 @@ export async function processDiscordMessage(
     ? (sender.tag ?? sender.name ?? author.username)
     : author.username;
   const senderTag = sender.tag;
-  const { groupSystemPrompt, channelModelOverride, ownerAllowFrom, untrustedContext } = buildDiscordInboundAccessContext({
-    channelConfig,
-    guildInfo,
-    sender: { id: sender.id, name: sender.name, tag: sender.tag },
-    allowNameMatching: isDangerousNameMatchingEnabled(discordConfig),
-    isGuild: isGuildMessage,
-    channelTopic: channelInfo?.topic,
-    messageBody: text,
-  });
+  const { groupSystemPrompt, channelModelOverride, ownerAllowFrom, untrustedContext } =
+    buildDiscordInboundAccessContext({
+      channelConfig,
+      guildInfo,
+      sender: { id: sender.id, name: sender.name, tag: sender.tag },
+      allowNameMatching: isDangerousNameMatchingEnabled(discordConfig),
+      isGuild: isGuildMessage,
+      channelTopic: channelInfo?.topic,
+      messageBody: text,
+    });
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId: route.agentId,
   });

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -256,9 +256,10 @@ export async function getReplyFromConfig(
   const hasSessionModelOverride = Boolean(
     sessionEntry.modelOverride?.trim() || sessionEntry.providerOverride?.trim(),
   );
-  if (!hasResolvedHeartbeatModelOverride && !hasSessionModelOverride && channelModelOverride) {
+  const rawChannelModelOverride = channelModelOverride?.model ?? finalized.ChannelModelOverride;
+  if (!hasResolvedHeartbeatModelOverride && !hasSessionModelOverride && rawChannelModelOverride) {
     const resolved = resolveModelRefFromString({
-      raw: channelModelOverride.model,
+      raw: rawChannelModelOverride,
       defaultProvider,
       aliasIndex,
     });

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -116,6 +116,7 @@ export type MsgContext = {
   GroupSpace?: string;
   GroupMembers?: string;
   GroupSystemPrompt?: string;
+  ChannelModelOverride?: string;
   /** Untrusted metadata that must not be treated as system instructions. */
   UntrustedContext?: string[];
   /** System-attached provenance for the current inbound message. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -80,7 +80,6 @@ export const TelegramTopicSchema = z
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
-    model: z.string().optional(),
     agentId: z.string().optional(),
   })
   .strict();
@@ -96,7 +95,6 @@ export const TelegramGroupSchema = z
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
-    model: z.string().optional(),
     topics: z.record(z.string(), TelegramTopicSchema.optional()).optional(),
   })
   .strict();
@@ -122,7 +120,6 @@ export const TelegramDirectSchema = z
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
-    model: z.string().optional(),
     topics: z.record(z.string(), TelegramTopicSchema.optional()).optional(),
     requireTopic: z.boolean().optional(),
     autoTopicLabel: AutoTopicLabelSchema,
@@ -766,7 +763,6 @@ export const GoogleChatGroupSchema = z
     requireMention: z.boolean().optional(),
     users: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
-    model: z.string().optional(),
   })
   .strict();
 
@@ -845,7 +841,6 @@ export const SlackChannelSchema = z
     users: z.array(z.union([z.string(), z.number()])).optional(),
     skills: z.array(z.string()).optional(),
     systemPrompt: z.string().optional(),
-    model: z.string().optional(),
   })
   .strict();
 
@@ -1132,7 +1127,6 @@ export const IrcGroupSchema = z
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
-    model: z.string().optional(),
   })
   .strict();
 

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -80,6 +80,7 @@ export const TelegramTopicSchema = z
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
+    model: z.string().optional(),
     agentId: z.string().optional(),
   })
   .strict();
@@ -95,6 +96,7 @@ export const TelegramGroupSchema = z
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
+    model: z.string().optional(),
     topics: z.record(z.string(), TelegramTopicSchema.optional()).optional(),
   })
   .strict();
@@ -120,6 +122,7 @@ export const TelegramDirectSchema = z
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
+    model: z.string().optional(),
     topics: z.record(z.string(), TelegramTopicSchema.optional()).optional(),
     requireTopic: z.boolean().optional(),
     autoTopicLabel: AutoTopicLabelSchema,
@@ -413,6 +416,7 @@ export const DiscordGuildChannelSchema = z
     users: DiscordIdListSchema.optional(),
     roles: DiscordIdListSchema.optional(),
     systemPrompt: z.string().optional(),
+    model: z.string().optional(),
     includeThreadStarter: z.boolean().optional(),
     autoThread: z.boolean().optional(),
     /** Naming strategy for auto-created threads. "message" uses message text; "generated" creates an LLM title after thread creation. */
@@ -762,6 +766,7 @@ export const GoogleChatGroupSchema = z
     requireMention: z.boolean().optional(),
     users: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
+    model: z.string().optional(),
   })
   .strict();
 
@@ -840,6 +845,7 @@ export const SlackChannelSchema = z
     users: z.array(z.union([z.string(), z.number()])).optional(),
     skills: z.array(z.string()).optional(),
     systemPrompt: z.string().optional(),
+    model: z.string().optional(),
   })
   .strict();
 
@@ -1126,6 +1132,7 @@ export const IrcGroupSchema = z
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
+    model: z.string().optional(),
   })
   .strict();
 


### PR DESCRIPTION
Note: This PR was created with a lot of human hand-holding by an OpenClaw agent using Gemini Pro.

This PR adds a `model` property to the Discord channel configuration schema (`channels.discord.guilds.*.channels.*.model`), allowing operators to natively route specific channels to specific models rather than relying on global defaults or `systemPrompt` hints.

## AI/Vibe-Coded PRs Welcome! 🤖

- [x] Mark as AI-assisted in the PR title or description
- [x] Note the degree of testing (untested / lightly tested / fully tested) -> **Fully tested. We deployed this live on a secondary dev instance, assigned Minimax to one channel and Gemini to another, and successfully verified independent responses.**
- [x] Include prompts or session logs if possible (super helpful!) -> **Implemented directly via an active OpenClaw agent instance over SSH interacting with a secondary Linux server.**
- [x] Confirm you understand what the code does
- [x] If you have access to Codex, run `codex review --base origin/main` locally and address the findings before asking for review -> **We do not have access to the Codex review tool internally, but we addressed all inline Greptile bot comments successfully.**
- [x] Resolve or reply to bot review conversations after you address them