### PR TITLE
feat(models): expand authHeader into provider headers at config load time

### DIFF
--- a/src/agents/provider-auth-headers.ts
+++ b/src/agents/provider-auth-headers.ts
@@ -1,0 +1,29 @@
+/**
+ * Resolve the HTTP authentication headers for a model provider.
+ *
+ * After config loading, providers with `authHeader: true` already have an
+ * `Authorization: Bearer <key>` entry in their `headers` map (injected by
+ * `applyAuthHeaderToProviderHeaders` in config/io.ts).
+ *
+ * This helper merges all provider-level headers and falls back to `x-api-key`
+ * when no explicit `Authorization` header is present — making it safe for any
+ * code path that issues raw HTTP requests against provider endpoints (plugins,
+ * extensions, etc.) without needing per-consumer auth-mode switching.
+ */
+export function resolveProviderRequestAuth(provider: {
+  apiKey?: unknown;
+  headers?: Record<string, unknown>;
+}): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (provider.headers && typeof provider.headers === "object") {
+    for (const [key, value] of Object.entries(provider.headers)) {
+      if (typeof value === "string") {
+        result[key] = value;
+      }
+    }
+  }
+  if (!result.Authorization && provider.apiKey && typeof provider.apiKey === "string") {
+    result["x-api-key"] = provider.apiKey;
+  }
+  return result;
+}

--- a/src/config/materialize.ts
+++ b/src/config/materialize.ts
@@ -12,6 +12,7 @@ import {
 import { normalizeExecSafeBinProfilesInConfig } from "./normalize-exec-safe-bin.js";
 import { normalizeConfigPaths } from "./normalize-paths.js";
 import type { OpenClawConfig, ResolvedSourceConfig, RuntimeConfig } from "./types.js";
+import { normalizeSecretInputString } from "./types.secrets.js";
 
 export type ConfigMaterializationMode = "load" | "missing" | "snapshot";
 
@@ -81,5 +82,34 @@ export function materializeRuntimeConfig(
     normalizeConfigPaths(next);
   }
   normalizeExecSafeBinProfilesInConfig(next);
+  applyAuthHeaderToProviderHeaders(next);
   return asRuntimeConfig(next);
+}
+
+/**
+ * When a provider sets `authHeader: true`, the API key should be sent as an
+ * `Authorization: Bearer` header instead of the default `x-api-key`.
+ *
+ * Expands the boolean flag into the provider's `headers` map during config
+ * materialization so that all downstream consumers see the correct header
+ * without implementing their own auth-mode switching logic.
+ */
+function applyAuthHeaderToProviderHeaders(cfg: OpenClawConfig): void {
+  const providers = cfg?.models?.providers;
+  if (!providers) {
+    return;
+  }
+  for (const providerConfig of Object.values(providers)) {
+    if (!providerConfig?.authHeader) {
+      continue;
+    }
+    const apiKey = normalizeSecretInputString(providerConfig.apiKey);
+    if (!apiKey) {
+      continue;
+    }
+    providerConfig.headers = {
+      ...(providerConfig.headers as Record<string, string> | undefined),
+      Authorization: `Bearer ${apiKey}`,
+    };
+  }
 }


### PR DESCRIPTION
## Summary

- Providers with `authHeader: true` expect `Authorization: Bearer` instead of `x-api-key`, but this flag was only consumed by the pi-coding-agent `ModelRegistry`. Plugins and extensions that make raw HTTP calls had to re-implement auth-mode switching themselves.
- Adds `applyAuthHeaderToProviderHeaders()` in `src/config/io.ts` that injects `Authorization: Bearer <apiKey>` into the provider headers during `loadConfig()`, so **all downstream consumers** see the correct header automatically.
- Adds `resolveProviderRequestAuth()` utility in `src/agents/provider-auth-headers.ts` for code paths that need the full provider request headers (merges config headers, falls back to `x-api-key` when no `Authorization` is present).

## Motivation

The `authHeader: true` config field already exists on `ModelProviderConfig` and is documented in schema labels/help text. However, OpenClaw own config resolution (`src/config/io.ts`) never reads it - only the downstream `pi-coding-agent` ModelRegistry does. This means:

1. Any plugin/extension making raw `fetch()` calls must implement its own `authHeader` check
2. The same switching logic gets duplicated across consumers

By expanding `authHeader` into `headers` at config load time, the flag becomes a config sugar that works transparently for all consumers.

## Design

- **Runtime-only expansion**: The `Authorization: Bearer` header is injected into the runtime config only (inside `loadConfig()`). The snapshot/write path is untouched, so the derived header is never persisted back to disk.
- **Safe with ModelRegistry**: pi-coding-agent ModelRegistry also injects `Authorization` for `authHeader: true`. Since both produce the same value, the last-write-wins merge is a no-op - no conflict.
- **SecretRef-safe**: Uses `normalizeSecretInputString()` - if `apiKey` is still a `SecretRef` (not yet resolved), the expansion is skipped.

## Test plan

- [ ] Verify `loadConfig()` injects `Authorization: Bearer` into provider headers when `authHeader: true`
- [ ] Verify providers without `authHeader` are unaffected
- [ ] Verify the write path does not persist the injected header
- [ ] Verify `resolveProviderRequestAuth()` returns correct headers for both modes
