### PR TITLE
fix(gateway): prune orphaned session entries when transcript files are missing

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,6 +1,12 @@
 {
   "globs": ["docs/**/*.md", "docs/**/*.mdx", "README.md"],
-  "ignores": ["docs/zh-CN/**", "docs/.i18n/**", "docs/reference/templates/**", "**/.local/**"],
+  "ignores": [
+    "docs/CLAUDE.md",
+    "docs/zh-CN/**",
+    "docs/.i18n/**",
+    "docs/reference/templates/**",
+    "**/.local/**",
+  ],
   "config": {
     "default": true,
 

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -204,16 +204,24 @@ function listSessionFileCandidates(params: { storePath: string; entry: SessionEn
   if (sessionFile) {
     candidates.add(path.resolve(storeDir, sessionFile));
   }
-  candidates.add(
-    resolveSessionFilePath(params.entry.sessionId, params.entry, {
-      sessionsDir: storeDir,
-    }),
-  );
-  candidates.add(
-    resolveSessionFilePath(params.entry.sessionId, undefined, {
-      sessionsDir: storeDir,
-    }),
-  );
+  try {
+    candidates.add(
+      resolveSessionFilePath(params.entry.sessionId, params.entry, {
+        sessionsDir: storeDir,
+      }),
+    );
+  } catch {
+    // Corrupt store rows should not prevent unrelated session store writes.
+  }
+  try {
+    candidates.add(
+      resolveSessionFilePath(params.entry.sessionId, undefined, {
+        sessionsDir: storeDir,
+      }),
+    );
+  } catch {
+    // Corrupt store rows should not prevent unrelated session store writes.
+  }
   return [...candidates];
 }
 

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -248,7 +248,7 @@ export async function pruneOrphanedEntries(
     if (opts.preserveKeys?.has(key)) {
       continue;
     }
-    if (!entry?.sessionFile || !entry.sessionId || (entry.updatedAt ?? 0) >= cutoffMs) {
+    if (!entry?.sessionId || (entry.updatedAt ?? 0) >= cutoffMs) {
       continue;
     }
     let hasAccessibleFile = false;

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -5,6 +5,7 @@ import { parseDurationMs } from "../../cli/parse-duration.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { normalizeStringifiedOptionalString } from "../../shared/string-coerce.js";
 import type { SessionMaintenanceConfig, SessionMaintenanceMode } from "../types.base.js";
+import { resolveSessionFilePath } from "./paths.js";
 import type { SessionEntry } from "./types.js";
 
 const log = createSubsystemLogger("sessions/store");
@@ -177,6 +178,92 @@ export function pruneStaleEntries(
   }
   if (pruned > 0 && opts.log !== false) {
     log.info("pruned stale session entries", { pruned, maxAgeMs });
+  }
+  return pruned;
+}
+
+const ORPHAN_ENTRY_GRACE_MS = 5 * 60 * 1000;
+
+async function canAccessSessionFile(filePath: string): Promise<boolean | null> {
+  try {
+    await fs.promises.access(filePath);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return false;
+    }
+    return null;
+  }
+}
+
+function listSessionFileCandidates(params: { storePath: string; entry: SessionEntry }): string[] {
+  const storeDir = path.dirname(path.resolve(params.storePath));
+  const candidates = new Set<string>();
+  const sessionFile = params.entry.sessionFile?.trim();
+  if (sessionFile) {
+    candidates.add(path.resolve(storeDir, sessionFile));
+  }
+  candidates.add(
+    resolveSessionFilePath(params.entry.sessionId, params.entry, {
+      sessionsDir: storeDir,
+    }),
+  );
+  candidates.add(
+    resolveSessionFilePath(params.entry.sessionId, undefined, {
+      sessionsDir: storeDir,
+    }),
+  );
+  return [...candidates];
+}
+
+/**
+ * Remove store entries whose transcript file is gone on disk.
+ * A short grace period avoids racing first-write flows that create the index
+ * entry before the transcript appears.
+ */
+export async function pruneOrphanedEntries(
+  store: Record<string, SessionEntry>,
+  storePath: string,
+  opts: {
+    log?: boolean;
+    nowMs?: number;
+    onPruned?: (params: { key: string; entry: SessionEntry }) => void;
+    preserveKeys?: ReadonlySet<string>;
+  } = {},
+): Promise<number> {
+  const nowMs = opts.nowMs ?? Date.now();
+  const cutoffMs = nowMs - ORPHAN_ENTRY_GRACE_MS;
+  let pruned = 0;
+
+  for (const [key, entry] of Object.entries(store)) {
+    if (opts.preserveKeys?.has(key)) {
+      continue;
+    }
+    if (!entry?.sessionFile || !entry.sessionId || (entry.updatedAt ?? 0) >= cutoffMs) {
+      continue;
+    }
+    let hasAccessibleFile = false;
+    let sawIndeterminateAccess = false;
+    for (const candidate of listSessionFileCandidates({ storePath, entry })) {
+      const accessible = await canAccessSessionFile(candidate);
+      if (accessible === true) {
+        hasAccessibleFile = true;
+        break;
+      }
+      if (accessible === null) {
+        sawIndeterminateAccess = true;
+      }
+    }
+    if (hasAccessibleFile || sawIndeterminateAccess) {
+      continue;
+    }
+    opts.onPruned?.({ key, entry });
+    delete store[key];
+    pruned++;
+  }
+  if (pruned > 0 && opts.log !== false) {
+    log.info("pruned orphaned session entries", { pruned });
   }
   return pruned;
 }

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -200,7 +200,8 @@ async function canAccessSessionFile(filePath: string): Promise<boolean | null> {
 function listSessionFileCandidates(params: { storePath: string; entry: SessionEntry }): string[] {
   const storeDir = path.dirname(path.resolve(params.storePath));
   const candidates = new Set<string>();
-  const sessionFile = params.entry.sessionFile?.trim();
+  const sessionFile =
+    typeof params.entry.sessionFile === "string" ? params.entry.sessionFile.trim() : "";
   if (sessionFile) {
     candidates.add(path.resolve(storeDir, sessionFile));
   }
@@ -249,6 +250,12 @@ export async function pruneOrphanedEntries(
       continue;
     }
     if (!entry?.sessionId || (entry.updatedAt ?? 0) >= cutoffMs) {
+      continue;
+    }
+    // Entries without explicit transcript metadata can be legitimate
+    // metadata-only rows (for example cron/subagent indexes). Stale pruning
+    // owns their lifecycle; orphan pruning only verifies declared files.
+    if (typeof entry.sessionFile !== "string" || !entry.sessionFile.trim()) {
       continue;
     }
     let hasAccessibleFile = false;

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -12,7 +12,12 @@ vi.mock("../config.js", async () => ({
 }));
 
 import { loadConfig } from "../config.js";
-import { clearSessionStoreCacheForTest, loadSessionStore, saveSessionStore } from "./store.js";
+import {
+  clearSessionStoreCacheForTest,
+  clearSessionStoreMaintenanceStateForTest,
+  loadSessionStore,
+  saveSessionStore,
+} from "./store.js";
 
 let mockLoadConfig: ReturnType<typeof vi.fn>;
 
@@ -98,6 +103,7 @@ describe("Integration: saveSessionStore with pruning", () => {
   afterEach(() => {
     mockLoadConfig.mockReset();
     clearSessionStoreCacheForTest();
+    clearSessionStoreMaintenanceStateForTest();
     if (savedCacheTtl === undefined) {
       delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
     } else {
@@ -117,6 +123,38 @@ describe("Integration: saveSessionStore with pruning", () => {
     const loaded = loadSessionStore(storePath, { skipCache: true });
     expect(loaded.stale).toBeUndefined();
     expect(loaded.fresh).toBeDefined();
+  });
+
+  it("throttles orphan pruning across repeated saves for the same store", async () => {
+    applyEnforcedMaintenanceConfig(mockLoadConfig);
+    const now = Date.now();
+
+    await saveSessionStore(
+      storePath,
+      {
+        first: {
+          sessionId: crypto.randomUUID(),
+          sessionFile: "first-missing.jsonl",
+          updatedAt: now - 10 * 60 * 1000,
+        },
+      },
+      { maintenanceOverride: ENFORCED_MAINTENANCE_OVERRIDE },
+    );
+    expect(loadSessionStore(storePath, { skipCache: true }).first).toBeUndefined();
+
+    await saveSessionStore(
+      storePath,
+      {
+        second: {
+          sessionId: crypto.randomUUID(),
+          sessionFile: "second-missing.jsonl",
+          updatedAt: now - 10 * 60 * 1000,
+        },
+      },
+      { maintenanceOverride: ENFORCED_MAINTENANCE_OVERRIDE },
+    );
+
+    expect(loadSessionStore(storePath, { skipCache: true }).second).toBeDefined();
   });
 
   it("archives transcript files for stale sessions pruned on write", async () => {

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -128,6 +128,24 @@ describe("pruneOrphanedEntries", () => {
     expect(pruned).toBe(0);
     expect(store["fallback-file"]).toBeDefined();
   });
+
+  it("does not throw when an orphaned entry has a malformed sessionId", async () => {
+    const storePath = path.join(testDir, "sessions.json");
+    const now = Date.now();
+    const store = makeStore([
+      [
+        "malformed",
+        {
+          sessionId: "../bad",
+          updatedAt: now - 10 * 60 * 1000,
+          sessionFile: "missing.jsonl",
+        },
+      ],
+    ]);
+
+    await expect(pruneOrphanedEntries(store, storePath, { nowMs: now })).resolves.toBe(1);
+    expect(store.malformed).toBeUndefined();
+  });
 });
 
 describe("resolveMaintenanceConfigFromInput", () => {

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -97,10 +97,10 @@ describe("pruneOrphanedEntries", () => {
 
     const pruned = await pruneOrphanedEntries(store, storePath, { nowMs: now });
 
-    expect(pruned).toBe(1);
+    expect(pruned).toBe(2);
     expect(store["has-file"]).toBeDefined();
     expect(store["missing-file"]).toBeUndefined();
-    expect(store["no-session-file"]).toBeDefined();
+    expect(store["no-session-file"]).toBeUndefined();
   });
 
   it("keeps recent entries to avoid racing transcript creation", async () => {

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -7,6 +7,7 @@ import { resolveMaintenanceConfigFromInput } from "./store-maintenance.js";
 import {
   capEntryCount,
   getActiveSessionMaintenanceWarning,
+  pruneOrphanedEntries,
   pruneStaleEntries,
   rotateSessionFile,
 } from "./store.js";
@@ -73,6 +74,59 @@ describe("capEntryCount", () => {
     expect(store.mid).toBeDefined();
     expect(store.oldest).toBeUndefined();
     expect(store.old).toBeUndefined();
+  });
+});
+
+describe("pruneOrphanedEntries", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await fixtureSuite.createCaseDir("orphan");
+  });
+
+  it("removes entries whose sessionFile no longer exists on disk", async () => {
+    const storePath = path.join(testDir, "sessions.json");
+    const existingFile = "existing-session.jsonl";
+    const now = Date.now();
+    await fs.writeFile(path.join(testDir, existingFile), "[]", "utf8");
+    const store = makeStore([
+      ["has-file", { ...makeEntry(now - 10 * 60 * 1000), sessionFile: existingFile }],
+      ["missing-file", { ...makeEntry(now - 10 * 60 * 1000), sessionFile: "gone.jsonl" }],
+      ["no-session-file", makeEntry(now - 10 * 60 * 1000)],
+    ]);
+
+    const pruned = await pruneOrphanedEntries(store, storePath, { nowMs: now });
+
+    expect(pruned).toBe(1);
+    expect(store["has-file"]).toBeDefined();
+    expect(store["missing-file"]).toBeUndefined();
+    expect(store["no-session-file"]).toBeDefined();
+  });
+
+  it("keeps recent entries to avoid racing transcript creation", async () => {
+    const storePath = path.join(testDir, "sessions.json");
+    const now = Date.now();
+    const store = makeStore([
+      ["recent", { ...makeEntry(now - 60 * 1000), sessionFile: "not-yet-created.jsonl" }],
+    ]);
+
+    const pruned = await pruneOrphanedEntries(store, storePath, { nowMs: now });
+
+    expect(pruned).toBe(0);
+    expect(store.recent).toBeDefined();
+  });
+
+  it("keeps entries whose fallback sessionId transcript exists", async () => {
+    const storePath = path.join(testDir, "sessions.json");
+    const now = Date.now();
+    const entry = { ...makeEntry(now - 10 * 60 * 1000), sessionFile: "stale-name.jsonl" };
+    await fs.writeFile(path.join(testDir, `${entry.sessionId}.jsonl`), "[]", "utf8");
+    const store = makeStore([["fallback-file", entry]]);
+
+    const pruned = await pruneOrphanedEntries(store, storePath, { nowMs: now });
+
+    expect(pruned).toBe(0);
+    expect(store["fallback-file"]).toBeDefined();
   });
 });
 

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -97,10 +97,10 @@ describe("pruneOrphanedEntries", () => {
 
     const pruned = await pruneOrphanedEntries(store, storePath, { nowMs: now });
 
-    expect(pruned).toBe(2);
+    expect(pruned).toBe(1);
     expect(store["has-file"]).toBeDefined();
     expect(store["missing-file"]).toBeUndefined();
-    expect(store["no-session-file"]).toBeUndefined();
+    expect(store["no-session-file"]).toBeDefined();
   });
 
   it("keeps recent entries to avoid racing transcript creation", async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -38,6 +38,7 @@ import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import {
   capEntryCount,
   getActiveSessionMaintenanceWarning,
+  pruneOrphanedEntries,
   pruneStaleEntries,
   rotateSessionFile,
   type ResolvedSessionMaintenanceConfig,
@@ -124,6 +125,7 @@ export type SessionMaintenanceApplyReport = {
 export {
   capEntryCount,
   getActiveSessionMaintenanceWarning,
+  pruneOrphanedEntries,
   pruneStaleEntries,
   resolveMaintenanceConfig,
   rotateSessionFile,
@@ -292,6 +294,12 @@ async function saveSessionStoreUnlocked(
         },
         preserveKeys: preserveSessionKeys,
       });
+      const orphaned = await pruneOrphanedEntries(store, storePath, {
+        onPruned: ({ entry }) => {
+          rememberRemovedSessionFile(removedSessionFiles, entry);
+        },
+        preserveKeys: preserveSessionKeys,
+      });
       const capped = capEntryCount(store, maintenance.maxEntries, {
         onCapped: ({ entry }) => {
           rememberRemovedSessionFile(removedSessionFiles, entry);
@@ -347,7 +355,7 @@ async function saveSessionStoreUnlocked(
         mode: maintenance.mode,
         beforeCount,
         afterCount: Object.keys(store).length,
-        pruned,
+        pruned: pruned + orphaned,
         capped,
         diskBudget,
       });

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -63,10 +63,26 @@ let sessionArchiveRuntimePromise: Promise<
   typeof import("../../gateway/session-archive.runtime.js")
 > | null = null;
 let sessionWriteLockAcquirerForTests: typeof acquireSessionWriteLock | null = null;
+const ORPHAN_PRUNE_MIN_INTERVAL_MS = 5 * 60 * 1000;
+const lastOrphanPruneAtByStorePath = new Map<string, number>();
 
 function loadSessionArchiveRuntime() {
   sessionArchiveRuntimePromise ??= import("../../gateway/session-archive.runtime.js");
   return sessionArchiveRuntimePromise;
+}
+
+function shouldRunOrphanPrune(storePath: string, nowMs = Date.now()): boolean {
+  const key = path.resolve(storePath);
+  const previous = lastOrphanPruneAtByStorePath.get(key);
+  if (previous != null && nowMs - previous < ORPHAN_PRUNE_MIN_INTERVAL_MS) {
+    return false;
+  }
+  lastOrphanPruneAtByStorePath.set(key, nowMs);
+  return true;
+}
+
+export function clearSessionStoreMaintenanceStateForTest(): void {
+  lastOrphanPruneAtByStorePath.clear();
 }
 
 function removeThreadFromDeliveryContext(context?: DeliveryContext): DeliveryContext | undefined {
@@ -294,12 +310,14 @@ async function saveSessionStoreUnlocked(
         },
         preserveKeys: preserveSessionKeys,
       });
-      const orphaned = await pruneOrphanedEntries(store, storePath, {
-        onPruned: ({ entry }) => {
-          rememberRemovedSessionFile(removedSessionFiles, entry);
-        },
-        preserveKeys: preserveSessionKeys,
-      });
+      const orphaned = shouldRunOrphanPrune(storePath)
+        ? await pruneOrphanedEntries(store, storePath, {
+            onPruned: ({ entry }) => {
+              rememberRemovedSessionFile(removedSessionFiles, entry);
+            },
+            preserveKeys: preserveSessionKeys,
+          })
+        : 0;
       const capped = capEntryCount(store, maintenance.maxEntries, {
         onCapped: ({ entry }) => {
           rememberRemovedSessionFile(removedSessionFiles, entry);


### PR DESCRIPTION
## Summary

- Prune session-store entries whose declared transcript file is missing from disk.
- Keep metadata-only session rows intact so cron/subagent/index sessions are not removed just because no `sessionFile` is recorded.
- Throttle orphan scans and preserve the existing stale-entry/cap/disk-budget maintenance behavior.
- Exclude `docs/CLAUDE.md` symlink sentinels from markdownlint so docs lint does not treat a symlink target as page content.

## Why

When transcript files are deleted externally, matching `sessions.json` entries can linger and show up as empty sessions in the Control UI. The cleanup needs to remove those explicit orphan rows without deleting valid metadata-only rows that do not declare a transcript file.

## Testing

- `pnpm test src/config/sessions/store.pruning.test.ts src/config/sessions/store.pruning.integration.test.ts src/gateway/server.sessions.gateway-server-sessions-a.test.ts src/cron/session-reaper.test.ts src/agents/minimax-docs.test.ts`
- `DOCS_I18N_GLOSSARY_BASE=upstream/main pnpm check:docs`
- `pnpm check`

Note: `pnpm check:changed` was not a useful local gate after the root markdownlint config change because it expanded to all lanes and hit unrelated full-suite failures/flakes, including network-dependent Google speech tests and existing gateway/host-env/provider tests. The focused lanes above cover this PR's changed behavior.

## AI Assistance

This PR was AI-assisted. I reviewed the changes, validated the affected code paths, and addressed the review feedback before pushing.
