### PR TITLE
fix: extract usage data from openai-completions adapter response (#54420)

### DIFF
--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -423,7 +423,8 @@ function resolveAgentResponseUsage(result: unknown): {
   const input = usage.input ?? 0;
   const output = usage.output ?? 0;
   const cacheRead = usage.cacheRead ?? 0;
-  const total = usage.total ?? input + output + cacheRead;
+  const cacheWrite = usage.cacheWrite ?? 0;
+  const total = usage.total ?? input + output + cacheRead + cacheWrite;
   return {
     prompt_tokens: input + cacheRead,
     completion_tokens: output,

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -408,6 +408,29 @@ function resolveAgentResponseText(result: unknown): string {
   return content || "No response from OpenClaw.";
 }
 
+/** Extract usage from the agent run result and map to OpenAI format. */
+function resolveAgentResponseUsage(result: unknown): {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+} {
+  const meta = (result as { meta?: { agentMeta?: { usage?: Record<string, number> } } } | null)
+    ?.meta;
+  const usage = meta?.agentMeta?.usage;
+  if (!usage) {
+    return { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+  }
+  const input = usage.input ?? 0;
+  const output = usage.output ?? 0;
+  const cacheRead = usage.cacheRead ?? 0;
+  const total = usage.total ?? input + output + cacheRead;
+  return {
+    prompt_tokens: input + cacheRead,
+    completion_tokens: output,
+    total_tokens: total,
+  };
+}
+
 export async function handleOpenAiHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -511,7 +534,7 @@ export async function handleOpenAiHttpRequest(
             finish_reason: "stop",
           },
         ],
-        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+        usage: resolveAgentResponseUsage(result),
       });
     } catch (err) {
       logWarn(`openai-compat: chat completion failed: ${String(err)}`);

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -420,11 +420,11 @@ function resolveAgentResponseUsage(result: unknown): {
   if (!usage) {
     return { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
   }
-  const input = usage.input ?? 0;
-  const output = usage.output ?? 0;
-  const cacheRead = usage.cacheRead ?? 0;
-  const cacheWrite = usage.cacheWrite ?? 0;
-  const total = usage.total ?? input + output + cacheRead + cacheWrite;
+  const input = Math.max(0, usage.input ?? 0);
+  const output = Math.max(0, usage.output ?? 0);
+  const cacheRead = Math.max(0, usage.cacheRead ?? 0);
+  const cacheWrite = Math.max(0, usage.cacheWrite ?? 0);
+  const total = Math.max(0, usage.total ?? input + output + cacheRead + cacheWrite);
   return {
     prompt_tokens: input + cacheRead,
     completion_tokens: output,


### PR DESCRIPTION
## Summary
- Fixes #54420
- The openai-completions adapter was not extracting `usage.prompt_tokens` and `usage.completion_tokens` from non-streaming responses
- Maps provider usage fields to OpenAI's internal format (input/output tokens)

## Test plan
- Use openai-completions adapter with a provider that returns usage data (e.g. vLLM)
- Verify session files record correct token counts instead of all zeros