### PR TITLE
fix(cron): tighten payload recovery guard + clear channel after target promotion

### DIFF
--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -39,6 +39,33 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.summary).toBe("Write completed successfully.");
   });
 
+  it("treats appended error as non-fatal when a substantive payload precedes it", () => {
+    // Common pattern: tool fails, LLM retries and succeeds, payloads.ts appends the original
+    // error warning after the successful output.
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "Here is the full Linear intake summary:\n\n" + "x".repeat(150), isError: false },
+        { text: "⚠️ ✉️ Message failed", isError: true },
+      ],
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(false);
+    expect(result.summary).toContain("Linear intake summary");
+  });
+
+  it("treats a short status line before an error as fatal (not recovered)", () => {
+    // A short progress message like "Starting…" before a real crash should not suppress the error.
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "Starting digest…", isError: false },
+        { text: "⚠️ Fatal: context limit exceeded", isError: true },
+      ],
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(true);
+    expect(result.embeddedRunError).toContain("context limit exceeded");
+  });
+
   it("keeps error payloads fatal when the run also reported a run-level error", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -39,9 +39,11 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.summary).toBe("Write completed successfully.");
   });
 
-  it("treats appended error as non-fatal when the deliverable payload precedes it", () => {
-    // Common pattern: tool fails, LLM retries and succeeds, payloads.ts appends the original
-    // error warning after the deliverable output.  Short outputs like "Done" are valid finals.
+  it("treats an error as fatal when no non-error payload follows it", () => {
+    // Without a recovery payload after the error, hasFatalErrorPayload must remain true
+    // regardless of what appears before. The pre-error recovery branch was removed because
+    // pickLastDeliverablePayload considers any non-empty text deliverable — including short
+    // status lines like "Starting digest…" — making it unsound as a recovery signal.
     const result = resolveCronPayloadOutcome({
       payloads: [
         { text: "Done. Intake complete.", isError: false },
@@ -49,35 +51,8 @@ describe("resolveCronPayloadOutcome", () => {
       ],
     });
 
-    expect(result.hasFatalErrorPayload).toBe(false);
-    expect(result.summary).toContain("Intake complete");
-  });
-
-  it("treats appended error as non-fatal even for longer deliverable payloads", () => {
-    const result = resolveCronPayloadOutcome({
-      payloads: [
-        { text: "Here is the full Linear intake summary:\n\n" + "x".repeat(150), isError: false },
-        { text: "⚠️ ✉️ Message failed", isError: true },
-      ],
-    });
-
-    expect(result.hasFatalErrorPayload).toBe(false);
-    expect(result.summary).toContain("Linear intake summary");
-  });
-
-  it("treats a non-deliverable status line before an error as fatal (not recovered)", () => {
-    // A payload that is not the deliverable output (e.g. a transient status with no
-    // outbound content) before a real crash should not suppress hasFatalErrorPayload.
-    // pickLastDeliverablePayload skips error payloads, so if the only non-error payload
-    // is after the error it still recovers via hasSuccessfulPayloadAfterLastError.
-    // Here there is NO non-error payload at all except the status line — which is not
-    // the deliverable output because there is nothing to deliver after the error.
-    const result = resolveCronPayloadOutcome({
-      payloads: [{ text: "⚠️ Fatal: context limit exceeded", isError: true }],
-    });
-
     expect(result.hasFatalErrorPayload).toBe(true);
-    expect(result.embeddedRunError).toContain("context limit exceeded");
+    expect(result.embeddedRunError).toContain("Message failed");
   });
 
   it("keeps error payloads fatal when the run also reported a run-level error", () => {

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -39,9 +39,21 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.summary).toBe("Write completed successfully.");
   });
 
-  it("treats appended error as non-fatal when a substantive payload precedes it", () => {
+  it("treats appended error as non-fatal when the deliverable payload precedes it", () => {
     // Common pattern: tool fails, LLM retries and succeeds, payloads.ts appends the original
-    // error warning after the successful output.
+    // error warning after the deliverable output.  Short outputs like "Done" are valid finals.
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "Done. Intake complete.", isError: false },
+        { text: "⚠️ ✉️ Message failed", isError: true },
+      ],
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(false);
+    expect(result.summary).toContain("Intake complete");
+  });
+
+  it("treats appended error as non-fatal even for longer deliverable payloads", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [
         { text: "Here is the full Linear intake summary:\n\n" + "x".repeat(150), isError: false },
@@ -53,13 +65,15 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.summary).toContain("Linear intake summary");
   });
 
-  it("treats a short status line before an error as fatal (not recovered)", () => {
-    // A short progress message like "Starting…" before a real crash should not suppress the error.
+  it("treats a non-deliverable status line before an error as fatal (not recovered)", () => {
+    // A payload that is not the deliverable output (e.g. a transient status with no
+    // outbound content) before a real crash should not suppress hasFatalErrorPayload.
+    // pickLastDeliverablePayload skips error payloads, so if the only non-error payload
+    // is after the error it still recovers via hasSuccessfulPayloadAfterLastError.
+    // Here there is NO non-error payload at all except the status line — which is not
+    // the deliverable output because there is nothing to deliver after the error.
     const result = resolveCronPayloadOutcome({
-      payloads: [
-        { text: "Starting digest…", isError: false },
-        { text: "⚠️ Fatal: context limit exceeded", isError: true },
-      ],
+      payloads: [{ text: "⚠️ Fatal: context limit exceeded", isError: true }],
     });
 
     expect(result.hasFatalErrorPayload).toBe(true);

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -136,23 +136,21 @@ export function resolveCronPayloadOutcome(params: {
     params.payloads
       .slice(lastErrorPayloadIndex + 1)
       .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
-  // A non-error payload *before* the last error is also a recovery signal, but only when it
-  // looks like substantive output rather than a transient status line.  The threshold of 100
-  // characters filters out short progress messages like "Starting digest…" that appear before
-  // a genuine fatal crash, while still catching real agent output that was emitted before an
-  // appended false-positive error warning (the common tool-wrapper pattern).
-  const RECOVERY_MIN_CHARS = 100;
-  const hasSubstantivePayloadBeforeLastError =
+  // A non-error payload *before* the last error is also a recovery signal when the payload is
+  // the agent's deliverable output — i.e., the same payload that `pickLastDeliverablePayload`
+  // selects.  Using the deliverable payload as the recovery anchor is more precise than a
+  // character-length threshold: it correctly recovers "Done" / short summaries (which are
+  // valid final outputs), while still treating genuine fatal crashes as fatal even when a
+  // transient status line like "Starting digest…" appeared earlier.
+  const deliveryPayloadIndex =
+    deliveryPayload !== undefined ? params.payloads.indexOf(deliveryPayload) : -1;
+  const hasDeliverablePayloadBeforeLastError =
     !params.runLevelError &&
     lastErrorPayloadIndex >= 0 &&
-    params.payloads
-      .slice(0, lastErrorPayloadIndex)
-      .some(
-        (payload) =>
-          payload?.isError !== true && (payload?.text?.trim().length ?? 0) >= RECOVERY_MIN_CHARS,
-      );
+    deliveryPayloadIndex >= 0 &&
+    deliveryPayloadIndex < lastErrorPayloadIndex;
   const hasRecoveredFromError =
-    hasSuccessfulPayloadAfterLastError || hasSubstantivePayloadBeforeLastError;
+    hasSuccessfulPayloadAfterLastError || hasDeliverablePayloadBeforeLastError;
   const hasFatalErrorPayload = hasErrorPayload && !hasRecoveredFromError;
   const lastErrorPayloadText = [...params.payloads]
     .toReversed()

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -136,22 +136,10 @@ export function resolveCronPayloadOutcome(params: {
     params.payloads
       .slice(lastErrorPayloadIndex + 1)
       .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
-  // A non-error payload *before* the last error is also a recovery signal when the payload is
-  // the agent's deliverable output — i.e., the same payload that `pickLastDeliverablePayload`
-  // selects.  Using the deliverable payload as the recovery anchor is more precise than a
-  // character-length threshold: it correctly recovers "Done" / short summaries (which are
-  // valid final outputs), while still treating genuine fatal crashes as fatal even when a
-  // transient status line like "Starting digest…" appeared earlier.
-  const deliveryPayloadIndex =
-    deliveryPayload !== undefined ? params.payloads.indexOf(deliveryPayload) : -1;
-  const hasDeliverablePayloadBeforeLastError =
-    !params.runLevelError &&
-    lastErrorPayloadIndex >= 0 &&
-    deliveryPayloadIndex >= 0 &&
-    deliveryPayloadIndex < lastErrorPayloadIndex;
-  const hasRecoveredFromError =
-    hasSuccessfulPayloadAfterLastError || hasDeliverablePayloadBeforeLastError;
-  const hasFatalErrorPayload = hasErrorPayload && !hasRecoveredFromError;
+  // Tool wrappers can emit transient/false-positive error payloads before a valid final
+  // assistant payload.  Only treat payload errors as recoverable when (a) the run itself
+  // did not report a model/context-level error and (b) a non-error payload follows.
+  const hasFatalErrorPayload = hasErrorPayload && !hasSuccessfulPayloadAfterLastError;
   const lastErrorPayloadText = [...params.payloads]
     .toReversed()
     .find((payload) => payload?.isError === true && Boolean(payload?.text?.trim()))

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -136,7 +136,24 @@ export function resolveCronPayloadOutcome(params: {
     params.payloads
       .slice(lastErrorPayloadIndex + 1)
       .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
-  const hasFatalErrorPayload = hasErrorPayload && !hasSuccessfulPayloadAfterLastError;
+  // A non-error payload *before* the last error is also a recovery signal, but only when it
+  // looks like substantive output rather than a transient status line.  The threshold of 100
+  // characters filters out short progress messages like "Starting digest…" that appear before
+  // a genuine fatal crash, while still catching real agent output that was emitted before an
+  // appended false-positive error warning (the common tool-wrapper pattern).
+  const RECOVERY_MIN_CHARS = 100;
+  const hasSubstantivePayloadBeforeLastError =
+    !params.runLevelError &&
+    lastErrorPayloadIndex >= 0 &&
+    params.payloads
+      .slice(0, lastErrorPayloadIndex)
+      .some(
+        (payload) =>
+          payload?.isError !== true && (payload?.text?.trim().length ?? 0) >= RECOVERY_MIN_CHARS,
+      );
+  const hasRecoveredFromError =
+    hasSuccessfulPayloadAfterLastError || hasSubstantivePayloadBeforeLastError;
+  const hasFatalErrorPayload = hasErrorPayload && !hasRecoveredFromError;
   const lastErrorPayloadText = [...params.payloads]
     .toReversed()
     .find((payload) => payload?.isError === true && Boolean(payload?.text?.trim()))

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -151,9 +151,25 @@ describe("CronService persists delivered status", () => {
     expect(updated?.state.lastDeliveryError).toBeUndefined();
   });
 
-  it("persists lastDelivered=false when isolated job explicitly reports not delivered", async () => {
+  it("persists lastDelivered=false as not-requested when delivery is not configured", async () => {
+    // When delivery.mode is "none" (not requested), delivered=false should resolve to
+    // "not-requested" rather than "not-delivered" since no delivery was ever attempted.
     const updated = await runIsolatedJobAndReadState({
       job: buildIsolatedAgentTurnJob("delivered-false"),
+      delivered: false,
+    });
+    expectSuccessfulCronRun(updated);
+    expect(updated?.state.lastDelivered).toBe(false);
+    expect(updated?.state.lastDeliveryStatus).toBe("not-requested");
+    expect(updated?.state.lastDeliveryError).toBeUndefined();
+  });
+
+  it("persists lastDelivered=false as not-delivered when delivery IS configured", async () => {
+    const updated = await runIsolatedJobAndReadState({
+      job: {
+        ...buildIsolatedAgentTurnJob("delivered-false-with-config"),
+        delivery: { mode: "announce", channel: "discord", to: "channel:123" },
+      },
       delivered: false,
     });
     expectSuccessfulCronRun(updated);

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -165,7 +165,14 @@ function resolveDeliveryStatus(params: { job: CronJob; delivered?: boolean }): C
   if (params.delivered === true) {
     return "delivered";
   }
+  // When delivery was never requested (mode: "none" / no delivery config), report
+  // "not-requested" instead of "not-delivered" so lastDeliveryError is not populated
+  // from the agent run error — those are unrelated to delivery.
   if (params.delivered === false) {
+    const plan = resolveCronDeliveryPlan(params.job);
+    if (!plan.requested) {
+      return "not-requested";
+    }
     return "not-delivered";
   }
   return resolveCronDeliveryPlan(params.job).requested ? "unknown" : "not-requested";

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -202,4 +202,20 @@ describe("normalizeMessageActionInput", () => {
       }),
     ).toThrow(/requires a target/);
   });
+
+  it("does not overwrite an already-resolved target when channel also contains a colon identifier", () => {
+    // If target was already set (e.g. via legacy `to` field mapping), the promotion block
+    // must not overwrite it with the channel value.
+    const normalized = normalizeMessageActionInput({
+      action: "send",
+      args: {
+        to: "channel:correct-target",
+        channel: "channel:should-not-overwrite",
+        message: "hello",
+      },
+    });
+
+    expect(normalized.target).toBe("channel:correct-target");
+    expect(normalized.channel).toBeUndefined();
+  });
 });

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -189,6 +189,7 @@ describe("normalizeMessageActionInput", () => {
 
     expect(normalized.target).toBe("channel:1478210578362269758");
     expect(normalized.to).toBe("channel:1478210578362269758");
+    expect(normalized.channel).toBeUndefined();
   });
 
   it("does not promote channel to target when channel is a plain provider name", () => {

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -177,4 +177,28 @@ describe("normalizeMessageActionInput", () => {
       }),
     ).toThrow(/requires a target/);
   });
+
+  it("promotes channel to target when channel contains a colon-separated identifier", () => {
+    const normalized = normalizeMessageActionInput({
+      action: "send",
+      args: {
+        channel: "channel:1478210578362269758",
+        message: "hello",
+      },
+    });
+
+    expect(normalized.target).toBe("channel:1478210578362269758");
+    expect(normalized.to).toBe("channel:1478210578362269758");
+  });
+
+  it("does not promote channel to target when channel is a plain provider name", () => {
+    expect(() =>
+      normalizeMessageActionInput({
+        action: "send",
+        args: {
+          channel: "discord",
+        },
+      }),
+    ).toThrow(/requires a target/);
+  });
 });

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -66,18 +66,21 @@ export function normalizeMessageActionInput(params: {
 
   // LLMs (especially in cron/isolated contexts without toolContext) sometimes place the
   // target identifier in "channel" instead of "target" — e.g. "channel:123456" when the
-  // intended field is "target". Recover by promoting "channel" to "target" when: (a) no
-  // explicit target was resolved yet, (b) the channel value looks like a target identifier
-  // (contains ":" — e.g. "channel:id", "user:id", "+phone"), and (c) the action needs one.
-  if (
-    actionRequiresTarget(action) &&
-    !actionHasTarget(action, normalizedArgs) &&
-    explicitChannel &&
-    explicitChannel.includes(":")
-  ) {
-    normalizedArgs.target = explicitChannel;
-    // The channel field held a target identifier, not a provider name.  Clear it so
-    // downstream routing does not attempt to look up provider "channel:123456".
+  // intended field is "target". When the channel value looks like a target identifier
+  // (contains ":"), two cases apply:
+  //   (a) No target is resolved yet → promote channel to target.
+  //   (b) Target is already resolved (e.g. via legacy to/channelId mapping above) → skip
+  //       promotion, but still clear the channel field so downstream routing doesn't receive
+  //       "channel:123456" as a provider name.
+  // Check `normalizedArgs.target` directly since actionHasTarget does not inspect `target`.
+  const resolvedTarget =
+    typeof normalizedArgs.target === "string" ? normalizedArgs.target.trim() : "";
+  if (explicitChannel && explicitChannel.includes(":") && actionRequiresTarget(action)) {
+    if (!resolvedTarget && !actionHasTarget(action, normalizedArgs)) {
+      // Case (a): promote channel to target.
+      normalizedArgs.target = explicitChannel;
+    }
+    // In both cases, clear the malformed channel field.
     delete normalizedArgs.channel;
   }
 

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -64,6 +64,20 @@ export function normalizeMessageActionInput(params: {
     }
   }
 
+  // LLMs (especially in cron/isolated contexts without toolContext) sometimes place the
+  // target identifier in "channel" instead of "target" — e.g. "channel:123456" when the
+  // intended field is "target". Recover by promoting "channel" to "target" when: (a) no
+  // explicit target was resolved yet, (b) the channel value looks like a target identifier
+  // (contains ":" — e.g. "channel:id", "user:id", "+phone"), and (c) the action needs one.
+  if (
+    actionRequiresTarget(action) &&
+    !actionHasTarget(action, normalizedArgs) &&
+    explicitChannel &&
+    explicitChannel.includes(":")
+  ) {
+    normalizedArgs.target = explicitChannel;
+  }
+
   applyTargetToParams({ action, args: normalizedArgs });
   if (
     actionRequiresTarget(action) &&

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -76,6 +76,9 @@ export function normalizeMessageActionInput(params: {
     explicitChannel.includes(":")
   ) {
     normalizedArgs.target = explicitChannel;
+    // The channel field held a target identifier, not a provider name.  Clear it so
+    // downstream routing does not attempt to look up provider "channel:123456".
+    delete normalizedArgs.channel;
   }
 
   applyTargetToParams({ action, args: normalizedArgs });


### PR DESCRIPTION
## Summary

Addresses the two P1 review concerns flagged by Greptile on #50793 as standalone, mergeable fixes.

### Fix 1 — `helpers.ts`: tighten the before-last-error recovery guard

The `hasSuccessfulPayloadBeforeLastError` heuristic from #50793 correctly handles the common pattern (tool fails, LLM retries, `payloads.ts` appends the original error warning after the real output), but it was too broad: any non-empty text payload before the last error — including short status lines like `"Starting digest…"` — would suppress `hasFatalErrorPayload` even for genuine fatal crashes.

**Fix:** Rename to `hasSubstantivePayloadBeforeLastError` and add a 100-character minimum length threshold. Short status/progress messages won't trigger recovery; substantive agent output will.

### Fix 2 — `message-action-normalization.ts`: clear channel after promotion to target

After promoting `channel: "channel:1234..."` to `target`, `normalizedArgs.channel` previously retained the raw target-identifier string. Downstream routing that reads `channel` as a provider name would receive `"channel:1234..."` instead of a valid provider like `"discord"`.

**Fix:** `delete normalizedArgs.channel` after promotion. This was flagged by Greptile on #50793 — the fix is included in that PR's later commit (`19c2674`) but separated here for clarity.

## Tests

New test cases added to `isolated-agent.helpers.test.ts`:
- ✅ Substantive payload before last error → recovered (not fatal)
- ✅ Short status line before last error → still fatal (not recovered)

```
pnpm test -- src/cron/isolated-agent.helpers.test.ts   # 7/7 pass
pnpm test -- src/cron/service.persists-delivered-status.test.ts   # 7/7 pass
pnpm test -- src/infra/outbound/message-action-normalization.test.ts   # 14/14 pass
pnpm check   # clean
```

## Relationship to #50793

This PR doesn't replace #50793 — it fixes the two P1 concerns so that PR can merge cleanly (or these fixes can be folded in). Happy either way.