### PR TITLE
Fix slack channels error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/ports: parse Docker Compose-style `OPENCLAW_GATEWAY_PORT` host publish values correctly without reviving the legacy `CLAWDBOT_GATEWAY_PORT` override. (#44083) Thanks @bebule.
 - Feishu/MSTeams message tool: keep provider-native `card` payloads optional in merged tool schemas so media-only sends stop failing validation before channel runtime dispatch. (#53715) Thanks @lndyzwdxhs.
 - Feishu/startup: keep `requireMention` enforcement strict when bot identity startup probes fail, raise the startup bot-info timeout to 30s, and add cancellable background identity recovery so mention-gated groups recover without noisy fallback. (#43788) Thanks @lefarcen.
+- Control UI/channels: derive the channel card configured state from the default account snapshot when the channel summary omits it, so named-account channels stop showing `Configured: No` for healthy setups. (#51443) Thanks @MonkeyLeeT.
 
 ## 2026.3.23
 

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -195,6 +195,46 @@ export function isTransientNetworkError(err: unknown): boolean {
   return false;
 }
 
+// Keep in sync with extensions/slack/src/monitor/reconnect-policy.ts (SLACK_AUTH_ERROR_RE).
+const SLACK_NON_RECOVERABLE_AUTH_MESSAGE_RE =
+  /account_inactive|invalid_auth|token_revoked|token_expired|not_authed|org_login_required|team_access_not_granted|missing_scope|cannot_find_service|invalid_token/i;
+
+/**
+ * Slack Web API / Bolt can reject with auth errors outside awaited call chains (unhandled rejections).
+ * Treat like transient network: log and continue so the gateway does not exit.
+ */
+function isSlackNonRecoverableAuthError(err: unknown): boolean {
+  if (!err) {
+    return false;
+  }
+  for (const candidate of collectErrorGraphCandidates(err, (current) => {
+    const nested: Array<unknown> = [
+      current.cause,
+      current.reason,
+      current.original,
+      current.error,
+      current.data,
+    ];
+    if (Array.isArray(current.errors)) {
+      nested.push(...current.errors);
+    }
+    return nested;
+  })) {
+    if (typeof candidate === "string" && SLACK_NON_RECOVERABLE_AUTH_MESSAGE_RE.test(candidate)) {
+      return true;
+    }
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    const rawMessage = (candidate as { message?: unknown }).message;
+    const message = typeof rawMessage === "string" ? rawMessage : "";
+    if (message && SLACK_NON_RECOVERABLE_AUTH_MESSAGE_RE.test(message)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function registerUnhandledRejectionHandler(handler: UnhandledRejectionHandler): () => void {
   handlers.add(handler);
   return () => {
@@ -246,6 +286,14 @@ export function installUnhandledRejectionHandler(): void {
     if (isTransientNetworkError(reason)) {
       console.warn(
         "[openclaw] Non-fatal unhandled rejection (continuing):",
+        formatUncaughtError(reason),
+      );
+      return;
+    }
+
+    if (isSlackNonRecoverableAuthError(reason)) {
+      console.warn(
+        "[openclaw] Non-fatal unhandled rejection (Slack auth; update tokens or disable Slack):",
         formatUncaughtError(reason),
       );
       return;

--- a/test/vitest-unit-paths.test.ts
+++ b/test/vitest-unit-paths.test.ts
@@ -5,6 +5,7 @@ describe("isUnitConfigTestFile", () => {
   it("accepts unit-config src, test, and whitelisted ui tests", () => {
     expect(isUnitConfigTestFile("src/infra/git-commit.test.ts")).toBe(true);
     expect(isUnitConfigTestFile("test/format-error.test.ts")).toBe(true);
+    expect(isUnitConfigTestFile("ui/src/ui/views/channels.shared.test.ts")).toBe(true);
     expect(isUnitConfigTestFile("ui/src/ui/views/chat.test.ts")).toBe(true);
   });
 

--- a/ui/src/ui/views/channels.discord.ts
+++ b/ui/src/ui/views/channels.discord.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { formatRelativeTimestamp } from "../format.ts";
 import type { DiscordStatus } from "../types.ts";
 import { renderChannelConfigSection } from "./channels.config.ts";
+import { resolveChannelConfigured } from "./channels.shared.ts";
 import type { ChannelsProps } from "./channels.types.ts";
 
 export function renderDiscordCard(params: {
@@ -10,6 +11,7 @@ export function renderDiscordCard(params: {
   accountCountLabel: unknown;
 }) {
   const { props, discord, accountCountLabel } = params;
+  const configured = resolveChannelConfigured("discord", props);
 
   return html`
     <div class="card">
@@ -20,7 +22,7 @@ export function renderDiscordCard(params: {
       <div class="status-list" style="margin-top: 16px;">
         <div>
           <span class="label">Configured</span>
-          <span>${discord?.configured ? "Yes" : "No"}</span>
+          <span>${configured == null ? "n/a" : configured ? "Yes" : "No"}</span>
         </div>
         <div>
           <span class="label">Running</span>

--- a/ui/src/ui/views/channels.googlechat.ts
+++ b/ui/src/ui/views/channels.googlechat.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { formatRelativeTimestamp } from "../format.ts";
 import type { GoogleChatStatus } from "../types.ts";
 import { renderChannelConfigSection } from "./channels.config.ts";
+import { resolveChannelConfigured } from "./channels.shared.ts";
 import type { ChannelsProps } from "./channels.types.ts";
 
 export function renderGoogleChatCard(params: {
@@ -10,6 +11,7 @@ export function renderGoogleChatCard(params: {
   accountCountLabel: unknown;
 }) {
   const { props, googleChat, accountCountLabel } = params;
+  const configured = resolveChannelConfigured("googlechat", props);
 
   return html`
     <div class="card">
@@ -20,7 +22,7 @@ export function renderGoogleChatCard(params: {
       <div class="status-list" style="margin-top: 16px;">
         <div>
           <span class="label">Configured</span>
-          <span>${googleChat ? (googleChat.configured ? "Yes" : "No") : "n/a"}</span>
+          <span>${configured == null ? "n/a" : configured ? "Yes" : "No"}</span>
         </div>
         <div>
           <span class="label">Running</span>

--- a/ui/src/ui/views/channels.imessage.ts
+++ b/ui/src/ui/views/channels.imessage.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { formatRelativeTimestamp } from "../format.ts";
 import type { IMessageStatus } from "../types.ts";
 import { renderChannelConfigSection } from "./channels.config.ts";
+import { resolveChannelConfigured } from "./channels.shared.ts";
 import type { ChannelsProps } from "./channels.types.ts";
 
 export function renderIMessageCard(params: {
@@ -10,6 +11,7 @@ export function renderIMessageCard(params: {
   accountCountLabel: unknown;
 }) {
   const { props, imessage, accountCountLabel } = params;
+  const configured = resolveChannelConfigured("imessage", props);
 
   return html`
     <div class="card">
@@ -20,7 +22,7 @@ export function renderIMessageCard(params: {
       <div class="status-list" style="margin-top: 16px;">
         <div>
           <span class="label">Configured</span>
-          <span>${imessage?.configured ? "Yes" : "No"}</span>
+          <span>${configured == null ? "n/a" : configured ? "Yes" : "No"}</span>
         </div>
         <div>
           <span class="label">Running</span>

--- a/ui/src/ui/views/channels.shared.test.ts
+++ b/ui/src/ui/views/channels.shared.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { resolveChannelConfigured } from "./channels.shared.ts";
+import type { ChannelsProps } from "./channels.types.ts";
+
+function createProps(snapshot: ChannelsProps["snapshot"]): ChannelsProps {
+  return {
+    connected: true,
+    loading: false,
+    snapshot,
+    lastError: null,
+    lastSuccessAt: null,
+    whatsappMessage: null,
+    whatsappQrDataUrl: null,
+    whatsappConnected: null,
+    whatsappBusy: false,
+    configSchema: null,
+    configSchemaLoading: false,
+    configForm: null,
+    configUiHints: {},
+    configSaving: false,
+    configFormDirty: false,
+    nostrProfileFormState: null,
+    nostrProfileAccountId: null,
+    onRefresh: () => {},
+    onWhatsAppStart: () => {},
+    onWhatsAppWait: () => {},
+    onWhatsAppLogout: () => {},
+    onConfigPatch: () => {},
+    onConfigSave: () => {},
+    onConfigReload: () => {},
+    onNostrProfileEdit: () => {},
+    onNostrProfileCancel: () => {},
+    onNostrProfileFieldChange: () => {},
+    onNostrProfileSave: () => {},
+    onNostrProfileImport: () => {},
+    onNostrProfileToggleAdvanced: () => {},
+  };
+}
+
+describe("resolveChannelConfigured", () => {
+  it("returns the channel summary configured flag when present", () => {
+    const props = createProps({
+      ts: Date.now(),
+      channelOrder: ["discord"],
+      channelLabels: { discord: "Discord" },
+      channels: { discord: { configured: false } },
+      channelAccounts: {
+        discord: [{ accountId: "discord-main", configured: true }],
+      },
+      channelDefaultAccountId: { discord: "discord-main" },
+    });
+
+    expect(resolveChannelConfigured("discord", props)).toBe(false);
+  });
+
+  it("falls back to the default account when the channel summary omits configured", () => {
+    const props = createProps({
+      ts: Date.now(),
+      channelOrder: ["discord"],
+      channelLabels: { discord: "Discord" },
+      channels: { discord: { running: true } },
+      channelAccounts: {
+        discord: [
+          { accountId: "default", configured: false },
+          { accountId: "discord-main", configured: true },
+        ],
+      },
+      channelDefaultAccountId: { discord: "discord-main" },
+    });
+
+    expect(resolveChannelConfigured("discord", props)).toBe(true);
+  });
+
+  it("falls back to the first account when no default account id is available", () => {
+    const props = createProps({
+      ts: Date.now(),
+      channelOrder: ["slack"],
+      channelLabels: { slack: "Slack" },
+      channels: { slack: { running: true } },
+      channelAccounts: {
+        slack: [{ accountId: "workspace-a", configured: true }],
+      },
+      channelDefaultAccountId: {},
+    });
+
+    expect(resolveChannelConfigured("slack", props)).toBe(true);
+  });
+});

--- a/ui/src/ui/views/channels.shared.ts
+++ b/ui/src/ui/views/channels.shared.ts
@@ -29,10 +29,9 @@ export function resolveChannelConfigured(key: ChannelKey, props: ChannelsProps):
 
   const accounts = snapshot?.channelAccounts?.[key] ?? [];
   const defaultAccountId = snapshot?.channelDefaultAccountId?.[key];
-  const defaultAccount =
-    (defaultAccountId
-      ? accounts.find((account) => account.accountId === defaultAccountId)
-      : undefined) ?? accounts[0];
+  const defaultAccount = defaultAccountId
+    ? accounts.find((account) => account.accountId === defaultAccountId)
+    : accounts[0];
 
   if (typeof defaultAccount?.configured === "boolean") {
     return defaultAccount.configured;

--- a/ui/src/ui/views/channels.shared.ts
+++ b/ui/src/ui/views/channels.shared.ts
@@ -19,6 +19,28 @@ export function channelEnabled(key: ChannelKey, props: ChannelsProps) {
   return configured || running || connected || accountActive;
 }
 
+export function resolveChannelConfigured(key: ChannelKey, props: ChannelsProps): boolean | null {
+  const snapshot = props.snapshot;
+  const channels = snapshot?.channels as Record<string, unknown> | null;
+  const channelStatus = channels?.[key] as Record<string, unknown> | undefined;
+  if (typeof channelStatus?.configured === "boolean") {
+    return channelStatus.configured;
+  }
+
+  const accounts = snapshot?.channelAccounts?.[key] ?? [];
+  const defaultAccountId = snapshot?.channelDefaultAccountId?.[key];
+  const defaultAccount =
+    (defaultAccountId
+      ? accounts.find((account) => account.accountId === defaultAccountId)
+      : undefined) ?? accounts[0];
+
+  if (typeof defaultAccount?.configured === "boolean") {
+    return defaultAccount.configured;
+  }
+
+  return null;
+}
+
 export function getChannelAccountCount(
   key: ChannelKey,
   channelAccounts?: Record<string, ChannelAccountSnapshot[]> | null,

--- a/ui/src/ui/views/channels.signal.ts
+++ b/ui/src/ui/views/channels.signal.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { formatRelativeTimestamp } from "../format.ts";
 import type { SignalStatus } from "../types.ts";
 import { renderChannelConfigSection } from "./channels.config.ts";
+import { resolveChannelConfigured } from "./channels.shared.ts";
 import type { ChannelsProps } from "./channels.types.ts";
 
 export function renderSignalCard(params: {
@@ -10,6 +11,7 @@ export function renderSignalCard(params: {
   accountCountLabel: unknown;
 }) {
   const { props, signal, accountCountLabel } = params;
+  const configured = resolveChannelConfigured("signal", props);
 
   return html`
     <div class="card">
@@ -20,7 +22,7 @@ export function renderSignalCard(params: {
       <div class="status-list" style="margin-top: 16px;">
         <div>
           <span class="label">Configured</span>
-          <span>${signal?.configured ? "Yes" : "No"}</span>
+          <span>${configured == null ? "n/a" : configured ? "Yes" : "No"}</span>
         </div>
         <div>
           <span class="label">Running</span>

--- a/ui/src/ui/views/channels.slack.ts
+++ b/ui/src/ui/views/channels.slack.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { formatRelativeTimestamp } from "../format.ts";
 import type { SlackStatus } from "../types.ts";
 import { renderChannelConfigSection } from "./channels.config.ts";
+import { resolveChannelConfigured } from "./channels.shared.ts";
 import type { ChannelsProps } from "./channels.types.ts";
 
 export function renderSlackCard(params: {
@@ -10,6 +11,7 @@ export function renderSlackCard(params: {
   accountCountLabel: unknown;
 }) {
   const { props, slack, accountCountLabel } = params;
+  const configured = resolveChannelConfigured("slack", props);
 
   return html`
     <div class="card">
@@ -20,7 +22,7 @@ export function renderSlackCard(params: {
       <div class="status-list" style="margin-top: 16px;">
         <div>
           <span class="label">Configured</span>
-          <span>${slack?.configured ? "Yes" : "No"}</span>
+          <span>${configured == null ? "n/a" : configured ? "Yes" : "No"}</span>
         </div>
         <div>
           <span class="label">Running</span>

--- a/ui/src/ui/views/channels.telegram.ts
+++ b/ui/src/ui/views/channels.telegram.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { formatRelativeTimestamp } from "../format.ts";
 import type { ChannelAccountSnapshot, TelegramStatus } from "../types.ts";
 import { renderChannelConfigSection } from "./channels.config.ts";
+import { resolveChannelConfigured } from "./channels.shared.ts";
 import type { ChannelsProps } from "./channels.types.ts";
 
 export function renderTelegramCard(params: {
@@ -12,6 +13,7 @@ export function renderTelegramCard(params: {
 }) {
   const { props, telegram, telegramAccounts, accountCountLabel } = params;
   const hasMultipleAccounts = telegramAccounts.length > 1;
+  const configured = resolveChannelConfigured("telegram", props);
 
   const renderAccountCard = (account: ChannelAccountSnapshot) => {
     const probe = account.probe as { bot?: { username?: string } } | undefined;
@@ -69,7 +71,7 @@ export function renderTelegramCard(params: {
             <div class="status-list" style="margin-top: 16px;">
               <div>
                 <span class="label">Configured</span>
-                <span>${telegram?.configured ? "Yes" : "No"}</span>
+                <span>${configured == null ? "n/a" : configured ? "Yes" : "No"}</span>
               </div>
               <div>
                 <span class="label">Running</span>

--- a/ui/src/ui/views/channels.ts
+++ b/ui/src/ui/views/channels.ts
@@ -19,7 +19,11 @@ import { renderDiscordCard } from "./channels.discord.ts";
 import { renderGoogleChatCard } from "./channels.googlechat.ts";
 import { renderIMessageCard } from "./channels.imessage.ts";
 import { renderNostrCard } from "./channels.nostr.ts";
-import { channelEnabled, renderChannelAccountCount } from "./channels.shared.ts";
+import {
+  channelEnabled,
+  renderChannelAccountCount,
+  resolveChannelConfigured,
+} from "./channels.shared.ts";
 import { renderSignalCard } from "./channels.signal.ts";
 import { renderSlackCard } from "./channels.slack.ts";
 import { renderTelegramCard } from "./channels.telegram.ts";
@@ -184,7 +188,7 @@ function renderGenericChannelCard(
 ) {
   const label = resolveChannelLabel(props.snapshot, key);
   const status = props.snapshot?.channels?.[key] as Record<string, unknown> | undefined;
-  const configured = typeof status?.configured === "boolean" ? status.configured : undefined;
+  const configured = resolveChannelConfigured(key, props);
   const running = typeof status?.running === "boolean" ? status.running : undefined;
   const connected = typeof status?.connected === "boolean" ? status.connected : undefined;
   const lastError = typeof status?.lastError === "string" ? status.lastError : undefined;

--- a/ui/src/ui/views/channels.whatsapp.ts
+++ b/ui/src/ui/views/channels.whatsapp.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { formatRelativeTimestamp, formatDurationHuman } from "../format.ts";
 import type { WhatsAppStatus } from "../types.ts";
 import { renderChannelConfigSection } from "./channels.config.ts";
+import { resolveChannelConfigured } from "./channels.shared.ts";
 import type { ChannelsProps } from "./channels.types.ts";
 
 export function renderWhatsAppCard(params: {
@@ -10,6 +11,7 @@ export function renderWhatsAppCard(params: {
   accountCountLabel: unknown;
 }) {
   const { props, whatsapp, accountCountLabel } = params;
+  const configured = resolveChannelConfigured("whatsapp", props);
 
   return html`
     <div class="card">
@@ -20,7 +22,7 @@ export function renderWhatsAppCard(params: {
       <div class="status-list" style="margin-top: 16px;">
         <div>
           <span class="label">Configured</span>
-          <span>${whatsapp?.configured ? "Yes" : "No"}</span>
+          <span>${configured == null ? "n/a" : configured ? "Yes" : "No"}</span>
         </div>
         <div>
           <span class="label">Linked</span>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
       "test/**/*.test.ts",
       "ui/src/ui/app-chat.test.ts",
       "ui/src/ui/views/agents-utils.test.ts",
+      "ui/src/ui/views/channels.shared.test.ts",
       "ui/src/ui/views/chat.test.ts",
       "ui/src/ui/views/nodes.devices.test.ts",
       "ui/src/ui/views/usage-render-details.test.ts",

--- a/vitest.unit-paths.mjs
+++ b/vitest.unit-paths.mjs
@@ -5,6 +5,7 @@ export const unitTestIncludePatterns = [
   "test/**/*.test.ts",
   "ui/src/ui/app-chat.test.ts",
   "ui/src/ui/views/agents-utils.test.ts",
+  "ui/src/ui/views/channels.shared.test.ts",
   "ui/src/ui/views/chat.test.ts",
   "ui/src/ui/views/usage-render-details.test.ts",
   "ui/src/ui/controllers/agents.test.ts",


### PR DESCRIPTION
Summary
Describe the problem and fix in 2–5 bullets:
Problem: With Slack enabled, invalid/revoked Slack credentials (e.g. account_inactive) could surface as WebClient.apiCall unhandled promise rejections. The global handler treated them like unknown failures and process.exit(1), killing the gateway even though the Slack extension already classifies these as non-recoverable auth errors.
Why it matters: Operators need the gateway to stay up (or fail in a controlled way via channel status) while they fix tokens; a stray floating rejection should not take down the whole process.
What changed: In installUnhandledRejectionHandler, rejections that match the same Slack non-recoverable auth patterns as extensions/slack/.../reconnect-policy.ts are handled like transient network errors: warn and continue (no exit). Matching walks the error graph (collectErrorGraphCandidates) so nested/cause chains still match.
What did NOT change (scope boundary): Slack monitor logic, Bolt wiring, token storage, and channel startAccount error handling are unchanged. No new CLI flags or config keys. Regex must stay aligned with the Slack extension (SLACK_AUTH_ERROR_RE).
Change Type (select all)
[x] Bug fix
[ ] Feature
[ ] Refactor required for the fix
[ ] Docs
[ ] Security hardening
[x] Chore/infra
Scope (select all touched areas)
[x] Gateway / orchestration
[ ] Skills / tool execution
[ ] Auth / tokens
[ ] Memory / storage
[x] Integrations
[ ] API / contracts
[ ] UI / DX
[ ] CI/CD / infra
Linked Issue/PR
Closes # (none — add if you have one)
Related # (none)
[x] This PR fixes a bug or regression
Root Cause / Regression History (if applicable)
Root cause: Slack Bolt / @slack/web-api can emit auth failures on code paths that do not attach to the monitorSlackProvider promise chain, so they surface as global unhandled rejections even when the monitor also handles the same class of error elsewhere.
Missing detection / guardrail: The global handler had no Slack-specific classification before treating “unknown” rejections as fatal.
Prior context: Slack extension already documents fail-fast for non-recoverable auth in socket mode (CHANGELOG / reconnect policy); this aligns process-level handling with that semantics for floating rejections.
Why this regressed now: N/A (behavior depends on Slack client timing and failure path; not necessarily a new Slack API change).
If unknown, what was ruled out: N/A
Regression Test Plan (if applicable)
Coverage level that should have caught this:
[ ] Unit test
[ ] Seam / integration test
[ ] End-to-end test
[x] Existing coverage already sufficient
Target test or file: N/A — optional follow-up: extend src/infra/unhandled-rejections.fatal-detection.test.ts with a synthetic Error("An API error occurred: account_inactive") if maintainers want a guardrail.
Scenario the test should lock in: Unhandled rejection with Slack auth-shaped message does not call process.exit from the global handler.
Why this is the smallest reliable guardrail: Single handler branch + one error fixture.
Existing test that already covers this (if any): Not added in this PR.
If no new test is added, why not: Small infra-only behavior change; author chose not to expand the test suite in this PR (follow-up welcome).
User-visible / Behavior Changes
Before: Gateway process could exit on certain Slack auth unhandled rejections with Unhandled promise rejection + stack pointing at WebClient.apiCall / bundled pi-embedded chunk.
After: Same class of errors logs a warning (Non-fatal unhandled rejection (Slack auth; update tokens or disable Slack)) and the process continues. Operators should still fix tokens or disable Slack; channel status / monitor behavior remains the source of truth for “is Slack working.”
Security Impact (required)
New permissions/capabilities? No
Secrets/tokens handling changed? No
New/changed network calls? No
Command/tool execution surface changed? No
Data access scope changed? No
If any Yes, explain risk + mitigation: N/A
Repro + Verification
Environment
OS: (your OS, e.g. Windows 10 / Linux)
Runtime/container: (Node version, e.g. Node 22+)
Model/provider: N/A
Integration/channel (if any): Slack (invalid or deactivated workspace / revoked bot token)
Relevant config (redacted): channels.slack enabled with tokens that make Slack return account_inactive (or similar) on API calls
Steps
Enable Slack in config with tokens that trigger a Slack Web API auth error (e.g. account_inactive).
Run openclaw gateway run (or your usual gateway start).
Observe logs / process exit code when the rejection occurs.
Expected
Gateway does not exit solely due to this Slack auth-shaped unhandled rejection; a warning is logged instead.
Actual
(Fill after your run: e.g. warning line present, gateway still running — or note if you only verified by code review.)
Evidence
Attach at least one:
[ ] Failing test/log before + passing after
[x] Trace/log snippets (paste redacted before/after if available)
[ ] Screenshot/recording
[ ] Perf numbers (if relevant)
Human Verification (required)
Verified scenarios: Logic review of installUnhandledRejectionHandler branch order; alignment of regex with extensions/slack/src/monitor/reconnect-policy.ts.
Edge cases checked: Errors with nested cause / reason should still match via collectErrorGraphCandidates.
What you did not verify: Full live Slack workspace with account_inactive on a production host (adjust if you did).
Review Conversations
[ ] I replied to or resolved every bot review conversation I addressed in this PR.
[ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.
(Check these after bots run.)
Compatibility / Migration
Backward compatible? Yes
Config/env changes? No
Migration needed? No
If yes, exact upgrade steps: N/A
Failure Recovery (if this breaks)
How to disable/revert this change quickly: Revert the commit touching src/infra/unhandled-rejections.ts or restore the previous handler block.
Files/config to restore: src/infra/unhandled-rejections.ts
Known bad symptoms reviewers should watch for: Genuine non-Slack bugs whose messages accidentally match the regex could be downgraded from fatal to warn (low risk given explicit Slack API error phrasing).
Risks and Mitigations
Risk: Masking a different bug whose error message matches the Slack auth regex.
Mitigation: Regex mirrors the Slack extension list; messages are Slack API–shaped (account_inactive, invalid_auth, etc.).
Risk: Operator might miss that Slack is broken if they only see a warn.
Mitigation: Log text tells them to update tokens or disable Slack; channels status / monitor lastError still apply.