### PR TITLE
fix(logging): rebuild subsystem file logger on date rollover

### DIFF
--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setConsoleSubsystemFilter } from "./console.js";
+import * as loggerModule from "./logger.js";
 import { resetLogger, setLoggerOverride } from "./logger.js";
 import { loggingState } from "./state.js";
 import { createSubsystemLogger } from "./subsystem.js";
@@ -20,6 +21,7 @@ afterEach(() => {
   setLoggerOverride(null);
   loggingState.rawConsole = null;
   resetLogger();
+  vi.restoreAllMocks();
 });
 
 describe("createSubsystemLogger().isEnabled", () => {
@@ -143,5 +145,46 @@ describe("createSubsystemLogger().isEnabled", () => {
     });
 
     expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("subsystem file logger date rollover", () => {
+  it("rebuilds file logger child when date rolls past midnight", () => {
+    setLoggerOverride({ level: "info", consoleLevel: "silent" });
+    const spy = vi.spyOn(loggerModule, "getChildLogger");
+    const log = createSubsystemLogger("test-rollover");
+
+    // First file-logged message creates the child logger.
+    log.info("before rollover");
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // Simulate midnight crossing by advancing Date.now past the cached rollover time.
+    const tomorrow = new Date();
+    tomorrow.setHours(24, 0, 0, 0);
+    const originalDateNow = Date.now;
+    Date.now = () => tomorrow.getTime() + 1;
+    try {
+      // Reset the root logger so getChildLogger produces a new child from the new base.
+      resetLogger();
+      setLoggerOverride({ level: "info", consoleLevel: "silent" });
+
+      log.info("after rollover");
+      expect(spy).toHaveBeenCalledTimes(2);
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
+  it("reuses cached file logger within the same day", () => {
+    setLoggerOverride({ level: "info", consoleLevel: "silent" });
+    const spy = vi.spyOn(loggerModule, "getChildLogger");
+    const log = createSubsystemLogger("test-same-day");
+
+    log.info("first");
+    log.info("second");
+    log.info("third");
+
+    // Only one child logger created despite multiple log calls.
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -305,8 +305,8 @@ function logToFile(
   }
 }
 
-function computeNextLocalMidnightMs(): number {
-  const d = new Date();
+function computeNextLocalMidnightMs(now: number = Date.now()): number {
+  const d = new Date(now);
   d.setHours(24, 0, 0, 0);
   return d.getTime();
 }
@@ -321,7 +321,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
     }
     // Rebuild child logger — either first call or date has rolled over.
     fileLogger = getChildLogger({ subsystem });
-    nextRolloverMs = computeNextLocalMidnightMs();
+    nextRolloverMs = computeNextLocalMidnightMs(now);
     return fileLogger;
   };
   const emit = (level: LogLevel, message: string, meta?: Record<string, unknown>): void => {

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -305,12 +305,23 @@ function logToFile(
   }
 }
 
+function computeNextLocalMidnightMs(): number {
+  const d = new Date();
+  d.setHours(24, 0, 0, 0);
+  return d.getTime();
+}
+
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   let fileLogger: TsLogger<LogObj> | null = null;
+  let nextRolloverMs = 0;
   const getFileLogger = (): TsLogger<LogObj> => {
-    if (!fileLogger) {
-      fileLogger = getChildLogger({ subsystem });
+    const now = Date.now();
+    if (fileLogger && now < nextRolloverMs) {
+      return fileLogger;
     }
+    // Rebuild child logger — either first call or date has rolled over.
+    fileLogger = getChildLogger({ subsystem });
+    nextRolloverMs = computeNextLocalMidnightMs();
     return fileLogger;
   };
   const emit = (level: LogLevel, message: string, meta?: Record<string, unknown>): void => {


### PR DESCRIPTION
## Summary

- **Fix:** Subsystem loggers cached their tslog file logger child on first use and never rebuilt it. Long-running gateways writing logs past midnight continued using the previous day's file, breaking log rotation.
- **Approach:** Replace the forever-cache with a midnight-aware cache — compare `Date.now()` against the next local midnight timestamp on each file log call. After midnight, rebuild the child logger from the current root logger.
- **Hot-path cost:** Essentially zero — just `Date.now()` (no allocation) + integer comparison. The child logger is only rebuilt once per day.

## Why this approach

This bug has attracted **19+ prior PRs** (all closed or review-blocked). The two recurring problems:

1. **Hot-path cost** — PR #54403 and others called `getLogger()` → `resolveSettings()` on every log emit, which can reach `readLoggingConfig()` and dynamic `require()` on each call.
2. **Weak tests** — Tests only verified `getLogger()` returns a new instance after `resetLogger()`, which is a tautology. None verified the subsystem child was actually rebuilt.

This PR avoids both:
- Hot path is `Date.now()` + integer comparison (~free)
- Tests spy on `getChildLogger` and verify it's called exactly twice (initial + post-rollover), and only once for same-day repeated logging

## Test plan

- [x] `pnpm test -- src/logging/subsystem.test.ts` — 13/13 passed (2 new tests)
- [x] `pnpm check` — clean
- [x] `pnpm tsgo` — clean
- [x] `pnpm build` — clean

Closes #54381

🤖 Generated with [Claude Code](https://claude.com/claude-code)