### PR TITLE
Fix OpenRouter model switching for slash-containing model IDs

### DIFF
--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -99,4 +99,22 @@ describe("chat-model-ref helpers", () => {
       reason: "ambiguous",
     });
   });
+
+  it("qualifies slash-containing model IDs with the server provider", () => {
+    expect(
+      resolvePreferredServerChatModel("nvidia/nemotron-3-super-120b-a12b:free", "openrouter", []),
+    ).toEqual({
+      value: "openrouter/nvidia/nemotron-3-super-120b-a12b:free",
+      source: "server",
+    });
+  });
+
+  it("qualifies multi-slash model IDs for HuggingFace/Together providers", () => {
+    expect(
+      resolvePreferredServerChatModel("meta-llama/Llama-3-70b-chat-hf", "together", []),
+    ).toEqual({
+      value: "together/meta-llama/Llama-3-70b-chat-hf",
+      source: "server",
+    });
+  });
 });

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -109,8 +109,19 @@ export function resolvePreferredServerChatModel(
     createChatModelOverride(trimmedModel),
     catalog,
   );
-  if (overrideResolution.source === "qualified" || overrideResolution.source === "catalog") {
+  if (overrideResolution.source === "catalog") {
     return overrideResolution;
+  }
+  // Model IDs that contain a slash (e.g. OpenRouter "nvidia/nemotron-...")
+  // are classified as "qualified" by createChatModelOverride, but the slash
+  // belongs to the model ID itself, not a provider prefix.  Always re-qualify
+  // with the server-provided provider so downstream parseModelRef splits on
+  // the correct boundary.
+  if (overrideResolution.source === "qualified" && provider?.trim()) {
+    return {
+      value: resolveServerChatModelValue(trimmedModel, provider),
+      source: "server",
+    };
   }
 
   return {


### PR DESCRIPTION
Fixes #54503

Model IDs from OpenRouter/HuggingFace/Together contain slashes (e.g. `nvidia/nemotron-...`) which `createChatModelOverride` classifies as "qualified" — treating the slash as a provider/model separator. The Control UI then returns this without the actual server provider, causing "model not allowed" errors.

Fixed `resolvePreferredServerChatModel` to re-qualify slash-containing IDs with the server-provided provider so `parseModelRef` splits on the correct boundary.