### PR TITLE
Fix/48308 passing message thread id

### DIFF
--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -183,7 +183,41 @@ describe("createOpenClawTools plugin context", () => {
     expect(executeMock).toHaveBeenCalledWith("call1", { message_thread_id: 5 });
   });
 
-  it("coerces numeric string agentThreadId into a number before injecting messageThreadId", async () => {
+  it("preserves large integer string agentThreadId as string (snowflake-safe injection)", async () => {
+    const snowflake = "1177378744822943744";
+    const executeMock = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+      details: {},
+    }));
+    const threadTool: AnyAgentTool = {
+      name: "plugin-message-thread-snowflake",
+      label: "plugin-message-thread-snowflake",
+      description: "test",
+      ownerOnly: false,
+      parameters: {
+        type: "object",
+        properties: { messageThreadId: { type: "string" } },
+      },
+      execute: executeMock,
+    };
+
+    resolvePluginToolsMock.mockReturnValue([threadTool]);
+
+    const tools = createOpenClawTools({
+      config: {} as never,
+      agentThreadId: snowflake,
+    });
+    const tool = tools.find((candidate) => candidate.name === threadTool.name);
+    expect(tool).toBeDefined();
+    if (!tool) {
+      return;
+    }
+
+    await tool.execute("call1", {});
+    expect(executeMock).toHaveBeenCalledWith("call1", { messageThreadId: snowflake });
+  });
+
+  it("coerces small numeric string agentThreadId into a number before injecting messageThreadId", async () => {
     const executeMock = vi.fn(async () => ({
       content: [{ type: "text" as const, text: "ok" }],
       details: {},

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -81,15 +81,15 @@ describe("createOpenClawTools plugin context", () => {
     );
   });
 
-  it("injects DevClaw topicId from agentThreadId when tool schema supports topicId", async () => {
-    const topicIdTool: AnyAgentTool = {
-      name: "devclaw-topicId-test",
-      label: "devclaw-topicId-test",
+  it("injects messageThreadId from agentThreadId when tool schema supports messageThreadId", async () => {
+    const threadTool: AnyAgentTool = {
+      name: "plugin-message-thread-test",
+      label: "plugin-message-thread-test",
       description: "test",
       ownerOnly: false,
       parameters: {
         type: "object",
-        properties: { topicId: { type: "number" } },
+        properties: { messageThreadId: { type: "number" } },
       },
       execute: vi.fn(async () => ({
         content: [{ type: "text" as const, text: "ok" }],
@@ -97,31 +97,31 @@ describe("createOpenClawTools plugin context", () => {
       })),
     };
 
-    resolvePluginToolsMock.mockReturnValue([topicIdTool]);
+    resolvePluginToolsMock.mockReturnValue([threadTool]);
 
     const tools = createOpenClawTools({
       config: {} as never,
       agentThreadId: 77,
     });
-    const tool = tools.find((candidate) => candidate.name === topicIdTool.name);
+    const tool = tools.find((candidate) => candidate.name === threadTool.name);
     expect(tool).toBeDefined();
     if (!tool) {
       return;
     }
 
     await tool.execute("call1", {});
-    expect(topicIdTool.execute).toHaveBeenCalledWith("call1", { topicId: 77 });
+    expect(threadTool.execute).toHaveBeenCalledWith("call1", { messageThreadId: 77 });
   });
 
-  it("does not override explicit params.topicId provided by the caller", async () => {
-    const topicIdTool: AnyAgentTool = {
-      name: "devclaw-topicId-test-override",
-      label: "devclaw-topicId-test-override",
+  it("does not override explicit params.messageThreadId provided by the caller", async () => {
+    const threadTool: AnyAgentTool = {
+      name: "plugin-message-thread-test-override",
+      label: "plugin-message-thread-test-override",
       description: "test",
       ownerOnly: false,
       parameters: {
         type: "object",
-        properties: { topicId: { type: "number" } },
+        properties: { messageThreadId: { type: "number" } },
       },
       execute: vi.fn(async () => ({
         content: [{ type: "text" as const, text: "ok" }],
@@ -129,31 +129,31 @@ describe("createOpenClawTools plugin context", () => {
       })),
     };
 
-    resolvePluginToolsMock.mockReturnValue([topicIdTool]);
+    resolvePluginToolsMock.mockReturnValue([threadTool]);
 
     const tools = createOpenClawTools({
       config: {} as never,
       agentThreadId: 77,
     });
-    const tool = tools.find((candidate) => candidate.name === topicIdTool.name);
+    const tool = tools.find((candidate) => candidate.name === threadTool.name);
     expect(tool).toBeDefined();
     if (!tool) {
       return;
     }
 
-    await tool.execute("call1", { topicId: 5 });
-    expect(topicIdTool.execute).toHaveBeenCalledWith("call1", { topicId: 5 });
+    await tool.execute("call1", { messageThreadId: 5 });
+    expect(threadTool.execute).toHaveBeenCalledWith("call1", { messageThreadId: 5 });
   });
 
-  it("coerces numeric string agentThreadId into a number before injecting", async () => {
-    const topicIdTool: AnyAgentTool = {
-      name: "devclaw-topicId-test-string",
-      label: "devclaw-topicId-test-string",
+  it("coerces numeric string agentThreadId into a number before injecting messageThreadId", async () => {
+    const threadTool: AnyAgentTool = {
+      name: "plugin-message-thread-test-string",
+      label: "plugin-message-thread-test-string",
       description: "test",
       ownerOnly: false,
       parameters: {
         type: "object",
-        properties: { topicId: { type: "number" } },
+        properties: { messageThreadId: { type: "number" } },
       },
       execute: vi.fn(async () => ({
         content: [{ type: "text" as const, text: "ok" }],
@@ -161,19 +161,19 @@ describe("createOpenClawTools plugin context", () => {
       })),
     };
 
-    resolvePluginToolsMock.mockReturnValue([topicIdTool]);
+    resolvePluginToolsMock.mockReturnValue([threadTool]);
 
     const tools = createOpenClawTools({
       config: {} as never,
       agentThreadId: "77",
     });
-    const tool = tools.find((candidate) => candidate.name === topicIdTool.name);
+    const tool = tools.find((candidate) => candidate.name === threadTool.name);
     expect(tool).toBeDefined();
     if (!tool) {
       return;
     }
 
     await tool.execute("call1", {});
-    expect(topicIdTool.execute).toHaveBeenCalledWith("call1", { topicId: 77 });
+    expect(threadTool.execute).toHaveBeenCalledWith("call1", { messageThreadId: 77 });
   });
 });

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -82,6 +82,10 @@ describe("createOpenClawTools plugin context", () => {
   });
 
   it("injects messageThreadId from agentThreadId when tool schema supports messageThreadId", async () => {
+    const executeMock = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+      details: {},
+    }));
     const threadTool: AnyAgentTool = {
       name: "plugin-message-thread-test",
       label: "plugin-message-thread-test",
@@ -91,10 +95,7 @@ describe("createOpenClawTools plugin context", () => {
         type: "object",
         properties: { messageThreadId: { type: "number" } },
       },
-      execute: vi.fn(async () => ({
-        content: [{ type: "text" as const, text: "ok" }],
-        details: {},
-      })),
+      execute: executeMock,
     };
 
     resolvePluginToolsMock.mockReturnValue([threadTool]);
@@ -109,11 +110,16 @@ describe("createOpenClawTools plugin context", () => {
       return;
     }
 
+    expect(tool).toBe(threadTool);
     await tool.execute("call1", {});
-    expect(threadTool.execute).toHaveBeenCalledWith("call1", { messageThreadId: 77 });
+    expect(executeMock).toHaveBeenCalledWith("call1", { messageThreadId: 77 });
   });
 
   it("does not override explicit params.messageThreadId provided by the caller", async () => {
+    const executeMock = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+      details: {},
+    }));
     const threadTool: AnyAgentTool = {
       name: "plugin-message-thread-test-override",
       label: "plugin-message-thread-test-override",
@@ -123,10 +129,7 @@ describe("createOpenClawTools plugin context", () => {
         type: "object",
         properties: { messageThreadId: { type: "number" } },
       },
-      execute: vi.fn(async () => ({
-        content: [{ type: "text" as const, text: "ok" }],
-        details: {},
-      })),
+      execute: executeMock,
     };
 
     resolvePluginToolsMock.mockReturnValue([threadTool]);
@@ -141,11 +144,50 @@ describe("createOpenClawTools plugin context", () => {
       return;
     }
 
+    expect(tool).toBe(threadTool);
     await tool.execute("call1", { messageThreadId: 5 });
-    expect(threadTool.execute).toHaveBeenCalledWith("call1", { messageThreadId: 5 });
+    expect(executeMock).toHaveBeenCalledWith("call1", { messageThreadId: 5 });
+  });
+
+  it("does not override explicit params.message_thread_id provided by the caller", async () => {
+    const executeMock = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+      details: {},
+    }));
+    const threadTool: AnyAgentTool = {
+      name: "plugin-message-thread-test-snake-override",
+      label: "plugin-message-thread-test-snake-override",
+      description: "test",
+      ownerOnly: false,
+      parameters: {
+        type: "object",
+        properties: { messageThreadId: { type: "number" } },
+      },
+      execute: executeMock,
+    };
+
+    resolvePluginToolsMock.mockReturnValue([threadTool]);
+
+    const tools = createOpenClawTools({
+      config: {} as never,
+      agentThreadId: 77,
+    });
+    const tool = tools.find((candidate) => candidate.name === threadTool.name);
+    expect(tool).toBeDefined();
+    if (!tool) {
+      return;
+    }
+
+    expect(tool).toBe(threadTool);
+    await tool.execute("call1", { message_thread_id: 5 });
+    expect(executeMock).toHaveBeenCalledWith("call1", { message_thread_id: 5 });
   });
 
   it("coerces numeric string agentThreadId into a number before injecting messageThreadId", async () => {
+    const executeMock = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+      details: {},
+    }));
     const threadTool: AnyAgentTool = {
       name: "plugin-message-thread-test-string",
       label: "plugin-message-thread-test-string",
@@ -155,10 +197,7 @@ describe("createOpenClawTools plugin context", () => {
         type: "object",
         properties: { messageThreadId: { type: "number" } },
       },
-      execute: vi.fn(async () => ({
-        content: [{ type: "text" as const, text: "ok" }],
-        details: {},
-      })),
+      execute: executeMock,
     };
 
     resolvePluginToolsMock.mockReturnValue([threadTool]);
@@ -173,7 +212,8 @@ describe("createOpenClawTools plugin context", () => {
       return;
     }
 
+    expect(tool).toBe(threadTool);
     await tool.execute("call1", {});
-    expect(threadTool.execute).toHaveBeenCalledWith("call1", { messageThreadId: 77 });
+    expect(executeMock).toHaveBeenCalledWith("call1", { messageThreadId: 77 });
   });
 });

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnyAgentTool } from "./tools/common.js";
 
 const { resolvePluginToolsMock } = vi.hoisted(() => ({
-  resolvePluginToolsMock: vi.fn((params?: unknown) => {
+  resolvePluginToolsMock: vi.fn<(params?: unknown) => AnyAgentTool[]>((params?: unknown) => {
     void params;
     return [];
   }),
@@ -78,5 +79,101 @@ describe("createOpenClawTools plugin context", () => {
         allowGatewaySubagentBinding: true,
       }),
     );
+  });
+
+  it("injects DevClaw topicId from agentThreadId when tool schema supports topicId", async () => {
+    const topicIdTool: AnyAgentTool = {
+      name: "devclaw-topicId-test",
+      label: "devclaw-topicId-test",
+      description: "test",
+      ownerOnly: false,
+      parameters: {
+        type: "object",
+        properties: { topicId: { type: "number" } },
+      },
+      execute: vi.fn(async () => ({
+        content: [{ type: "text" as const, text: "ok" }],
+        details: {},
+      })),
+    };
+
+    resolvePluginToolsMock.mockReturnValue([topicIdTool]);
+
+    const tools = createOpenClawTools({
+      config: {} as never,
+      agentThreadId: 77,
+    });
+    const tool = tools.find((candidate) => candidate.name === topicIdTool.name);
+    expect(tool).toBeDefined();
+    if (!tool) {
+      return;
+    }
+
+    await tool.execute("call1", {});
+    expect(topicIdTool.execute).toHaveBeenCalledWith("call1", { topicId: 77 });
+  });
+
+  it("does not override explicit params.topicId provided by the caller", async () => {
+    const topicIdTool: AnyAgentTool = {
+      name: "devclaw-topicId-test-override",
+      label: "devclaw-topicId-test-override",
+      description: "test",
+      ownerOnly: false,
+      parameters: {
+        type: "object",
+        properties: { topicId: { type: "number" } },
+      },
+      execute: vi.fn(async () => ({
+        content: [{ type: "text" as const, text: "ok" }],
+        details: {},
+      })),
+    };
+
+    resolvePluginToolsMock.mockReturnValue([topicIdTool]);
+
+    const tools = createOpenClawTools({
+      config: {} as never,
+      agentThreadId: 77,
+    });
+    const tool = tools.find((candidate) => candidate.name === topicIdTool.name);
+    expect(tool).toBeDefined();
+    if (!tool) {
+      return;
+    }
+
+    await tool.execute("call1", { topicId: 5 });
+    expect(topicIdTool.execute).toHaveBeenCalledWith("call1", { topicId: 5 });
+  });
+
+  it("coerces numeric string agentThreadId into a number before injecting", async () => {
+    const topicIdTool: AnyAgentTool = {
+      name: "devclaw-topicId-test-string",
+      label: "devclaw-topicId-test-string",
+      description: "test",
+      ownerOnly: false,
+      parameters: {
+        type: "object",
+        properties: { topicId: { type: "number" } },
+      },
+      execute: vi.fn(async () => ({
+        content: [{ type: "text" as const, text: "ok" }],
+        details: {},
+      })),
+    };
+
+    resolvePluginToolsMock.mockReturnValue([topicIdTool]);
+
+    const tools = createOpenClawTools({
+      config: {} as never,
+      agentThreadId: "77",
+    });
+    const tool = tools.find((candidate) => candidate.name === topicIdTool.name);
+    expect(tool).toBeDefined();
+    if (!tool) {
+      return;
+    }
+
+    await tool.execute("call1", {});
+    expect(topicIdTool.execute).toHaveBeenCalledWith("call1", { topicId: 77 });
   });
 });

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -250,4 +250,38 @@ describe("createOpenClawTools plugin context", () => {
     await tool.execute("call1", {});
     expect(executeMock).toHaveBeenCalledWith("call1", { messageThreadId: 77 });
   });
+
+  it("preserves decimal-like string agentThreadId as string for exact thread tokens", async () => {
+    const slackTs = "1719341020.000200";
+    const executeMock = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "ok" }],
+      details: {},
+    }));
+    const threadTool: AnyAgentTool = {
+      name: "plugin-message-thread-decimal-string",
+      label: "plugin-message-thread-decimal-string",
+      description: "test",
+      ownerOnly: false,
+      parameters: {
+        type: "object",
+        properties: { messageThreadId: { type: "string" } },
+      },
+      execute: executeMock,
+    };
+
+    resolvePluginToolsMock.mockReturnValue([threadTool]);
+
+    const tools = createOpenClawTools({
+      config: {} as never,
+      agentThreadId: slackTs,
+    });
+    const tool = tools.find((candidate) => candidate.name === threadTool.name);
+    expect(tool).toBeDefined();
+    if (!tool) {
+      return;
+    }
+
+    await tool.execute("call1", {});
+    expect(executeMock).toHaveBeenCalledWith("call1", { messageThreadId: slackTs });
+  });
 });

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -40,6 +40,38 @@ const defaultOpenClawToolsDeps: OpenClawToolsDeps = {
 
 let openClawToolsDeps: OpenClawToolsDeps = defaultOpenClawToolsDeps;
 
+function coerceFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function toolParametersSupportsTopicId(tool: AnyAgentTool): boolean {
+  const schema =
+    tool.parameters && typeof tool.parameters === "object"
+      ? (tool.parameters as Record<string, unknown>)
+      : null;
+  if (!schema) {
+    return false;
+  }
+  const properties =
+    schema.properties && typeof schema.properties === "object"
+      ? (schema.properties as Record<string, unknown>)
+      : null;
+  return Boolean(properties && "topicId" in properties);
+}
+
 export function createOpenClawTools(
   options?: {
     sandboxBrowserBridgeUrl?: string;
@@ -266,7 +298,40 @@ export function createOpenClawTools(
     allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
   });
 
-  return [...tools, ...pluginTools];
+  const normalizedTopicId = coerceFiniteNumber(options?.agentThreadId);
+  if (normalizedTopicId === undefined) {
+    return [...tools, ...pluginTools];
+  }
+
+  const wrappedPluginTools = pluginTools.map((tool) => {
+    if (!tool.execute || !toolParametersSupportsTopicId(tool)) {
+      return tool;
+    }
+    const originalExecute = tool.execute.bind(tool);
+    return {
+      ...tool,
+      execute: async (...args: unknown[]) => {
+        const params = args[1];
+        const paramsRecord =
+          params && typeof params === "object" && !Array.isArray(params)
+            ? (params as Record<string, unknown>)
+            : null;
+        if (!paramsRecord) {
+          return await originalExecute(...(args as Parameters<typeof originalExecute>));
+        }
+        // Avoid overriding an explicit user/model topicId.
+        if (paramsRecord.topicId !== undefined) {
+          return await originalExecute(...(args as Parameters<typeof originalExecute>));
+        }
+        const nextParams = { ...paramsRecord, topicId: normalizedTopicId };
+        const nextArgs = [...args];
+        nextArgs[1] = nextParams;
+        return await originalExecute(...(nextArgs as Parameters<typeof originalExecute>));
+      },
+    };
+  });
+
+  return [...tools, ...wrappedPluginTools];
 }
 
 export const __testing = {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { callGateway } from "../gateway/call.js";
+import { readSnakeCaseParamRaw } from "../param-key.js";
 import { resolvePluginTools } from "../plugins/tools.js";
 import { getActiveRuntimeWebToolsMetadata } from "../secrets/runtime.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
@@ -308,26 +309,24 @@ export function createOpenClawTools(
       return tool;
     }
     const originalExecute = tool.execute.bind(tool);
-    return {
-      ...tool,
-      execute: async (...args: unknown[]) => {
-        const params = args[1];
-        const paramsRecord =
-          params && typeof params === "object" && !Array.isArray(params)
-            ? (params as Record<string, unknown>)
-            : null;
-        if (!paramsRecord) {
-          return await originalExecute(...(args as Parameters<typeof originalExecute>));
-        }
-        if (paramsRecord.messageThreadId !== undefined) {
-          return await originalExecute(...(args as Parameters<typeof originalExecute>));
-        }
-        const nextParams = { ...paramsRecord, messageThreadId: normalizedMessageThreadId };
-        const nextArgs = [...args];
-        nextArgs[1] = nextParams;
-        return await originalExecute(...(nextArgs as Parameters<typeof originalExecute>));
-      },
+    tool.execute = async (...args: unknown[]) => {
+      const params = args[1];
+      const paramsRecord =
+        params && typeof params === "object" && !Array.isArray(params)
+          ? (params as Record<string, unknown>)
+          : null;
+      if (!paramsRecord) {
+        return await originalExecute(...(args as Parameters<typeof originalExecute>));
+      }
+      if (readSnakeCaseParamRaw(paramsRecord, "messageThreadId") !== undefined) {
+        return await originalExecute(...(args as Parameters<typeof originalExecute>));
+      }
+      const nextParams = { ...paramsRecord, messageThreadId: normalizedMessageThreadId };
+      const nextArgs = [...args];
+      nextArgs[1] = nextParams;
+      return await originalExecute(...(nextArgs as Parameters<typeof originalExecute>));
     };
+    return tool;
   });
 
   return [...tools, ...wrappedPluginTools];

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -74,10 +74,8 @@ function normalizeMessageThreadIdForInjection(value: unknown): string | number |
       return trimmed;
     }
   }
-  const parsed = Number(trimmed);
-  if (Number.isFinite(parsed)) {
-    return parsed;
-  }
+  // Non-integer IDs can be exact string tokens (e.g. Slack ts values). Preserve
+  // lexical identity instead of coercing through Number(...) and losing fidelity.
   return trimmed;
 }
 

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -57,7 +57,7 @@ function coerceFiniteNumber(value: unknown): number | undefined {
   return undefined;
 }
 
-function toolParametersSupportsTopicId(tool: AnyAgentTool): boolean {
+function toolParametersSupportsMessageThreadId(tool: AnyAgentTool): boolean {
   const schema =
     tool.parameters && typeof tool.parameters === "object"
       ? (tool.parameters as Record<string, unknown>)
@@ -69,7 +69,7 @@ function toolParametersSupportsTopicId(tool: AnyAgentTool): boolean {
     schema.properties && typeof schema.properties === "object"
       ? (schema.properties as Record<string, unknown>)
       : null;
-  return Boolean(properties && "topicId" in properties);
+  return Boolean(properties && "messageThreadId" in properties);
 }
 
 export function createOpenClawTools(
@@ -298,13 +298,13 @@ export function createOpenClawTools(
     allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
   });
 
-  const normalizedTopicId = coerceFiniteNumber(options?.agentThreadId);
-  if (normalizedTopicId === undefined) {
+  const normalizedMessageThreadId = coerceFiniteNumber(options?.agentThreadId);
+  if (normalizedMessageThreadId === undefined) {
     return [...tools, ...pluginTools];
   }
 
   const wrappedPluginTools = pluginTools.map((tool) => {
-    if (!tool.execute || !toolParametersSupportsTopicId(tool)) {
+    if (!tool.execute || !toolParametersSupportsMessageThreadId(tool)) {
       return tool;
     }
     const originalExecute = tool.execute.bind(tool);
@@ -319,11 +319,10 @@ export function createOpenClawTools(
         if (!paramsRecord) {
           return await originalExecute(...(args as Parameters<typeof originalExecute>));
         }
-        // Avoid overriding an explicit user/model topicId.
-        if (paramsRecord.topicId !== undefined) {
+        if (paramsRecord.messageThreadId !== undefined) {
           return await originalExecute(...(args as Parameters<typeof originalExecute>));
         }
-        const nextParams = { ...paramsRecord, topicId: normalizedTopicId };
+        const nextParams = { ...paramsRecord, messageThreadId: normalizedMessageThreadId };
         const nextArgs = [...args];
         nextArgs[1] = nextParams;
         return await originalExecute(...(nextArgs as Parameters<typeof originalExecute>));

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -41,21 +41,44 @@ const defaultOpenClawToolsDeps: OpenClawToolsDeps = {
 
 let openClawToolsDeps: OpenClawToolsDeps = defaultOpenClawToolsDeps;
 
-function coerceFiniteNumber(value: unknown): number | undefined {
+/**
+ * Value to inject into plugin tools that declare `messageThreadId` in their schema.
+ * Integer strings outside IEEE-754 safe integer range stay as strings so IDs like
+ * Discord snowflakes are not rounded by `Number(...)`.
+ */
+function normalizeMessageThreadIdForInjection(value: unknown): string | number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
   }
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return undefined;
-    }
-    const parsed = Number(trimmed);
-    if (Number.isFinite(parsed)) {
-      return parsed;
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  // Pure integer strings: avoid Number() precision loss for large IDs (e.g. snowflakes).
+  if (/^-?\d+$/.test(trimmed)) {
+    try {
+      const asBigInt = BigInt(trimmed);
+      const maxSafe = BigInt(Number.MAX_SAFE_INTEGER);
+      const minSafe = BigInt(Number.MIN_SAFE_INTEGER);
+      if (asBigInt > maxSafe || asBigInt < minSafe) {
+        return trimmed;
+      }
+      return Number(trimmed);
+    } catch {
+      return trimmed;
     }
   }
-  return undefined;
+  const parsed = Number(trimmed);
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+  return trimmed;
 }
 
 function toolParametersSupportsMessageThreadId(tool: AnyAgentTool): boolean {
@@ -299,7 +322,7 @@ export function createOpenClawTools(
     allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
   });
 
-  const normalizedMessageThreadId = coerceFiniteNumber(options?.agentThreadId);
+  const normalizedMessageThreadId = normalizeMessageThreadIdForInjection(options?.agentThreadId);
   if (normalizedMessageThreadId === undefined) {
     return [...tools, ...pluginTools];
   }

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -1,6 +1,7 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import type {
   BaseProbeResult as ContractBaseProbeResult,
   BaseTokenResolution as ContractBaseTokenResolution,
@@ -46,11 +47,53 @@ import type {
 import { pluginSdkSubpaths } from "./entrypoints.js";
 
 const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PKG_ROOT = resolve(ROOT_DIR, "..");
 const PLUGIN_SDK_DIR = resolve(ROOT_DIR, "plugin-sdk");
 const sourceCache = new Map<string, string>();
 const representativeRuntimeSmokeSubpaths = ["channel-runtime", "conversation-runtime"] as const;
+const requireFromHere = createRequire(import.meta.url);
 
-const importResolvedPluginSdkSubpath = async (specifier: string) => import(specifier);
+function isModuleNotFound(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as NodeJS.ErrnoException).code === "MODULE_NOT_FOUND"
+  );
+}
+
+function resolvePluginSdkSourceFallback(specifier: string, cause: unknown): string {
+  const match = /^openclaw\/plugin-sdk\/(.+)$/.exec(specifier);
+  if (!match) {
+    throw new Error(`Cannot resolve ${specifier}`, { cause });
+  }
+  const subpath = match[1];
+  const srcPath = resolve(PKG_ROOT, "src", "plugin-sdk", `${subpath}.ts`);
+  if (existsSync(srcPath)) {
+    return srcPath;
+  }
+  throw new Error(`Cannot resolve ${specifier}: run pnpm build or add ${srcPath}`, { cause });
+}
+
+function resolvePluginSdkImportPath(specifier: string): string {
+  let resolvedDist: string;
+  try {
+    resolvedDist = requireFromHere.resolve(specifier);
+  } catch (err) {
+    // `exports` points at dist/*.js; `resolve` throws when that file is missing (CI skips `pnpm build`).
+    if (isModuleNotFound(err)) {
+      return resolvePluginSdkSourceFallback(specifier, err);
+    }
+    throw err;
+  }
+  if (existsSync(resolvedDist)) {
+    return resolvedDist;
+  }
+  return resolvePluginSdkSourceFallback(specifier, resolvedDist);
+}
+
+const importResolvedPluginSdkSubpath = async (specifier: string) =>
+  import(pathToFileURL(resolvePluginSdkImportPath(specifier)).href);
 
 function readPluginSdkSource(subpath: string): string {
   const file = resolve(PLUGIN_SDK_DIR, `${subpath}.ts`);

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -243,6 +243,39 @@ describe("registerPluginCommand", () => {
     });
   });
 
+  it("resolves Telegram native slash command bindings using the From peer", () => {
+    expect(
+      __testing.resolveBindingConversationFromCommand({
+        channel: "telegram",
+        from: "telegram:group:-100123:topic:77",
+        to: "slash:12345",
+        accountId: "default",
+        messageThreadId: 77,
+      }),
+    ).toEqual({
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "-100123",
+      threadId: 77,
+    });
+  });
+
+  it("falls back to the parsed From threadId when messageThreadId is missing", () => {
+    expect(
+      __testing.resolveBindingConversationFromCommand({
+        channel: "telegram",
+        from: "telegram:group:-100123:topic:77",
+        to: "slash:12345",
+        accountId: "default",
+      }),
+    ).toEqual({
+      channel: "telegram",
+      accountId: "default",
+      conversationId: "-100123",
+      threadId: 77,
+    });
+  });
+
   it("resolves Telegram topic command bindings without a Telegram registry entry", () => {
     expect(
       __testing.resolveBindingConversationFromCommand({

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -133,7 +133,12 @@ function resolveBindingConversationFromCommand(params: {
 } | null {
   const accountId = params.accountId?.trim() || "default";
   if (params.channel === "telegram") {
-    const rawTarget = params.to ?? params.from;
+    // Native Telegram slash commands use a synthetic `To: slash:<senderId>` value.
+    // Prefer `from` when parsing to avoid `slash:<...>` being misinterpreted as a chat id.
+    const rawTarget =
+      params.to && params.to.startsWith("slash:")
+        ? (params.from ?? params.to)
+        : (params.to ?? params.from);
     if (!rawTarget) {
       return null;
     }


### PR DESCRIPTION
## Summary

- **Problem:** Telegram native slash commands use a synthetic `To: slash:<senderId>` target. Parsing that value as the chat id broke binding resolution for topic/thread context. Separately, plugin tools that need `messageThreadId` did not receive the current agent thread id unless the model passed it explicitly.
- **Why it matters:** Topic/thread-scoped flows (e.g. forum topics) and plugin tools that thread by `messageThreadId` could mis-route or lack thread context. Without this we can use "one-topic-per-project" management for DevClaw projects.
- **What changed:**
  - (1) For Telegram command binding resolution, when `to` starts with `slash:`, prefer `from` for parsing so group/topic ids come from the real peer.
  - (2) In `createOpenClawTools`, wrap plugin tools whose JSON schema exposes a `messageThreadId` property so `agentThreadId` is injected when missing, with numeric coercion for string ids.
  - (3) Tests for both behaviors.
  - (4) OpenAI embedding default wiring: use `OPENAI_DEFAULT_EMBEDDING_MODEL` from `providers/openai-defaults` in normalization and memory sync to align with the shared defaults export.
  
- **What did NOT change (scope boundary):** Core (non-plugin) tools are not wrapped; tools without `messageThreadId` in their declared schema are unchanged; explicit `messageThreadId` from the caller is never overwritten.

## Change Type

- [x] Bug fix
- [x] Chore/infra

## Scope

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Integrations

## Linked Issue/PR

- Closes #48308

## User-visible / Behavior Changes

- Telegram: Native slash command handling in topic/group contexts should resolve the correct conversation and thread when `To` is the synthetic `slash:<senderId>` form.
- Agents: Plugin-defined tools whose parameters include `messageThreadId` receive it automatically from the current `agentThreadId` when the model omits it (string thread ids are coerced to finite numbers).
- Memory/embeddings: No intentional user-facing behavior change beyond fixing default OpenAI embedding model resolution to use the shared provider default constant.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **Yes** — plugin tools with a `messageThreadId` parameter get an extra default argument when absent; same tools and same execute path, only parameters may be augmented.
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: MacOS Tahoe 26.2
- Runtime/container: Node 22+ / `pnpm` (per repo)
- Model/provider: anthropic/claude-haiku-4-5-20251001
- Integration/channel: Telegram topic / native slash commands
- Relevant config: N/A

### Steps

1. `pnpm test -- src/agents/openclaw-tools.plugin-context.test.ts src/plugins/commands.test.ts`
2. (Optional) Exercise a Telegram plugin slash command inside a forum topic and confirm routing/thread behavior.

### Expected

- Tests pass; Telegram binding resolves `conversationId` / `threadId` from `from` when `to` is `slash:...`.
- Plugin tools with `messageThreadId` in schema receive injected id when args omit it.

### Actual

- `pnpm test -- src/agents/openclaw-tools.plugin-context.test.ts src/plugins/commands.test.ts` — all tests passed (7 + 14 tests across the two files in parallel lanes).

## Evidence

As this is not a feature, not bugfix, I can't add any evidence, but I already tested full example from scratch:
1. Create one Telegram group
2. Create 2 topics in it.
3. Deploy 2 different projects, each on different topic.
4. Create GitLab issue from first topic and from second.
5. Perform issues from different topics.
6. Received 2 different PR in different GitLab repos as it should be. Full DevClaw project isolation (issues, repo, PR, etc).

## Human Verification

What you personally verified (not just CI), and how:

- **Verified scenarios:** Unit tests added/updated for tool injection and Telegram `slash:` binding resolution.
- **Edge cases checked:** Explicit `messageThreadId` in tool args is not overridden; string `agentThreadId` coerces to number; tools without `messageThreadId` in schema are not wrapped.
- **What I am verify:** I created two topics in the Telegram, successfully deployed different DevClaw projects in each, create GitLab issues from the Telegram with help of tools, performed two test issues in the different repositories.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery (if this breaks)

- **How to disable/revert this change quickly:** Revert the branch commit(s) touching `src/agents/openclaw-tools.ts`, `src/plugins/commands.ts`, and related tests; revert embedding import/default lines if those regress separately.
- **Files/config to restore:** Above source files to prior `main` versions.
- **Known bad symptoms reviewers should watch for:** Wrong Telegram command routing; plugin tools receiving unexpected `messageThreadId`; embedding model normalization pointing at wrong default (unlikely if revert is consistent).

## Risks and Mitigations

- **Risk:** Schema detection uses presence of `messageThreadId` in `parameters.properties` only — unusual schemas might not match.
  - **Mitigation:** Matches explicit JSON-schema style used by plugin tools; callers can still pass `messageThreadId` explicitly.

- **Risk:** `agentThreadId` string coercion could parse unexpected strings.
- **Mitigation:** Only finite numeric parses are applied; blank/non-numeric strings result in no injection.
