### PR TITLE
feat(exec): add onComplete="notify" for background process completion wakes

### DIFF
--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -32,6 +32,7 @@ export interface ProcessSession {
   sessionKey?: string;
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
+  explicitOnComplete?: boolean;
   exitNotified?: boolean;
   child?: ChildProcessWithoutNullStreams;
   stdin?: SessionStdin;

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -168,6 +168,12 @@ export const execSchema = Type.Object({
       description: "Node id/name for host=node.",
     }),
   ),
+  onComplete: Type.Optional(
+    Type.String({
+      description:
+        'Completion behavior. "notify" backgrounds the command and sends a notification when it exits.',
+    }),
+  ),
 });
 
 export type ExecProcessFailureKind =
@@ -331,7 +337,12 @@ export function applyShellPath(env: Record<string, string>, shellPath?: string |
 }
 
 function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "failed") {
-  if (!session.backgrounded || !session.notifyOnExit || session.exitNotified) {
+  if (session.exitNotified || !session.backgrounded) {
+    return;
+  }
+  // Only fire if the caller explicitly opted in via onComplete="notify" or
+  // the tool defaults already had notifyOnExit enabled.
+  if (!session.explicitOnComplete && !session.notifyOnExit) {
     return;
   }
   const sessionKey = session.sessionKey?.trim();
@@ -554,6 +565,7 @@ export async function runExecProcess(opts: {
   pendingMaxOutput: number;
   notifyOnExit: boolean;
   notifyOnExitEmptySuccess?: boolean;
+  explicitOnComplete?: boolean;
   scopeKey?: string;
   sessionKey?: string;
   timeoutSec: number | null;
@@ -575,6 +587,7 @@ export async function runExecProcess(opts: {
     sessionKey: opts.sessionKey,
     notifyOnExit: opts.notifyOnExit,
     notifyOnExitEmptySuccess: opts.notifyOnExitEmptySuccess === true,
+    explicitOnComplete: opts.explicitOnComplete === true,
     exitNotified: false,
     child: undefined,
     stdin: undefined,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1236,6 +1236,7 @@ export function createExecTool(
         security?: string;
         ask?: string;
         node?: string;
+        onComplete?: string;
       };
 
       if (!params.command) {
@@ -1246,7 +1247,8 @@ export function createExecTool(
       const pendingMaxOutput = DEFAULT_PENDING_MAX_OUTPUT;
       const warnings: string[] = [];
       let execCommandOverride: string | undefined;
-      const backgroundRequested = params.background === true;
+      const onCompleteNotify = params.onComplete === "notify";
+      const backgroundRequested = params.background === true || onCompleteNotify;
       const yieldRequested = typeof params.yieldMs === "number";
       if (!allowBackground && (backgroundRequested || yieldRequested)) {
         warnings.push("Warning: background execution is disabled; running synchronously.");
@@ -1538,6 +1540,9 @@ export function createExecTool(
       // before we execute and burn tokens in cron loops.
       await validateScriptFileForShellBleed({ command: params.command, workdir });
 
+      const effectiveNotifyOnExit = onCompleteNotify || notifyOnExit;
+      const effectiveNotifyOnExitEmptySuccess = onCompleteNotify || notifyOnExitEmptySuccess;
+
       const run = await runExecProcess({
         command: params.command,
         execCommand: execCommandOverride,
@@ -1549,8 +1554,9 @@ export function createExecTool(
         warnings,
         maxOutput,
         pendingMaxOutput,
-        notifyOnExit,
-        notifyOnExitEmptySuccess,
+        notifyOnExit: effectiveNotifyOnExit,
+        notifyOnExitEmptySuccess: effectiveNotifyOnExitEmptySuccess,
+        explicitOnComplete: onCompleteNotify,
         scopeKey: defaults?.scopeKey,
         sessionKey: notifySessionKey,
         timeoutSec: effectiveTimeout,
@@ -1575,6 +1581,9 @@ export function createExecTool(
       }
 
       return new Promise<AgentToolResult<ExecToolDetails>>((resolve, reject) => {
+        const onCompleteHint = onCompleteNotify
+          ? " A notification will arrive when the process exits. No need to poll."
+          : "";
         const resolveRunning = () =>
           resolve({
             content: [
@@ -1582,7 +1591,7 @@ export function createExecTool(
                 type: "text",
                 text: `${getWarningText()}Command still running (session ${run.session.id}, pid ${
                   run.session.pid ?? "n/a"
-                }). Use process (list/poll/log/write/kill/clear/remove) for follow-up.`,
+                }). Use process (list/poll/log/write/kill/clear/remove) for follow-up.${onCompleteHint}`,
               },
             ],
             details: {


### PR DESCRIPTION
Adds a new `onComplete` parameter to the exec tool for fire-and-forget background execution with automatic completion notifications.

## Problem

Background processes require polling to detect completion. The recommended pattern is to use a tight loop checking `process(action=poll)` repeatedly, which wastes LLM turns and creates noisy session history.

## Solution

When `onComplete="notify"` is set:
- Process is automatically backgrounded (implies `background=true`)
- `notifyOnExit` is forced on regardless of tool defaults
- Response text tells the agent a notification will arrive, discouraging polling
- System event fires when the process exits, waking the parent session

## Changes

**`src/agents/bash-tools.exec.ts`** — adds `onComplete` param to schema and handler. Derives `onCompleteNotify` flag, forces background+notifyOnExit, adds completion hint text, updates tool description.

**`src/agents/bash-process-registry.ts`** — adds `explicitOnComplete?: boolean` to `ProcessSession` interface.

**`src/agents/bash-tools.exec-runtime.ts`** — wires `explicitOnComplete` through the session create path; `maybeNotifyOnExit` guard respects both explicit and default notify settings.

## Known limitation

If the agent is mid-turn when the process exits, the wake notification is deferred until the next idle window. This is an existing architectural constraint, not specific to this feature.

## Testing

- [ ] `pnpm exec vitest run src/agents/bash-tools.test.ts`

Closes #47997