### PR TITLE
docs: add AllowTcpForwarding prerequisite to Hetzner SSH tunnel step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docs/Hetzner: clarify that SSH tunnel access requires `AllowTcpForwarding local` before running `ssh -L`, so hardened VPS sshd configs do not block loopback Gateway access. Fixes #54557; carries forward #54564; refs #54954. Thanks @satishkc7, @blackstrype, and @Aftabbs.
 - Gateway/shutdown: report structured shutdown warnings and HTTP close timeout warnings through `ShutdownResult` while preserving lifecycle hook hardening. Carries forward #41296. Thanks @edenfunf.
 - Plugins/QA: prebuild the private QA channel runtime before plugin gauntlet source runs so wrapper CPU/RSS measurements are not polluted by private QA dist rebuild work. Thanks @vincentkoc.
 - Gateway/reload: bound default restart deferral and SIGUSR1 restart drain to five minutes while preserving explicit `deferralTimeoutMs: 0` indefinite waits, so stale active work accounting cannot block config reloads forever. Thanks @vincentkoc.

--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -218,7 +218,22 @@ For the generic Docker flow, see [Docker](/install/docker).
   </Step>
 
   <Step title="Hetzner-specific access">
-    After the shared build and launch steps, tunnel from your laptop:
+    After the shared build and launch steps, complete the following setup to open the tunnel:
+
+    **Prerequisite:** Ensure your VPS sshd config allows TCP forwarding. If you
+    have hardened your SSH config, check `/etc/ssh/sshd_config` and set:
+
+    ```
+    AllowTcpForwarding local
+    ```
+
+    `local` allows `ssh -L` local forwards from your laptop while blocking
+    remote forwards from the server. Setting it to `no` will fail the tunnel
+    with:
+    `channel 3: open failed: administratively prohibited: open failed`
+
+    After confirming TCP forwarding is enabled, restart the SSH service
+    (`systemctl restart ssh`) and run the tunnel from your laptop:
 
     ```bash
     ssh -N -L 18789:127.0.0.1:18789 root@YOUR_VPS_IP


### PR DESCRIPTION
## Summary

- Problem: The Hetzner guide recommends accessing the gateway via SSH tunnel but does not mention that `AllowTcpForwarding` must be enabled in the VPS sshd config for this to work.
- Why it matters: Users with hardened SSH configs hit a silent, cryptic failure - `channel 3: open failed: administratively prohibited: open failed` - with no indication that sshd config is the cause.
- What changed: Added a prerequisite note to the SSH tunnel step in the Hetzner guide explaining the `AllowTcpForwarding` setting, the exact error they will see if it is disabled, and a `systemctl restart sshd` reminder.
- What did NOT change: No code changes. Docs only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54557

## Root Cause / Regression History (if applicable)

N/A - docs gap, not a regression.

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

Users following the Hetzner guide now see a prerequisite note about `AllowTcpForwarding` before the tunnel command.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Hetzner Ubuntu 22.04 VPS with hardened sshd config
- Runtime/container: N/A (docs only)

### Steps

1. Follow Hetzner guide with hardened sshd (`AllowTcpForwarding no`)
2. Run `ssh -N -L 18789:127.0.0.1:18789 root@YOUR_VPS_IP`
3. See `channel 3: open failed: administratively prohibited: open failed`

### Expected

- Docs warn about this requirement before the tunnel command

### Actual (before fix)

- No mention of `AllowTcpForwarding` anywhere in the guide

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets (error message in issue #54557)
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: confirmed the exact error message matches the issue report and that `AllowTcpForwarding local` is the minimal safe setting for this use case
- Edge cases checked: `AllowTcpForwarding yes` also works but is broader than needed; `local` is the right recommendation for this setup
- What you did not verify: live VPS test (docs-only change)

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert `docs/install/hetzner.md`
- Known bad symptoms reviewers should watch for: None

## Risks and Mitigations

None - docs-only change.