### PR TITLE
fix(logger): re-create file logger after midnight to use correct dated log file

### DIFF
--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setConsoleSubsystemFilter } from "./console.js";
+import * as loggerMod from "./logger.js";
 import { resetLogger, setLoggerOverride } from "./logger.js";
 import { loggingState } from "./state.js";
 import { createSubsystemLogger } from "./subsystem.js";
@@ -143,5 +144,44 @@ describe("createSubsystemLogger().isEnabled", () => {
     });
 
     expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-creates file logger after midnight when date changes", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-03-26T23:59:00"));
+      setLoggerOverride({ level: "info", consoleLevel: "silent" });
+
+      const mockLogger = {
+        info: vi.fn(),
+        debug: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        fatal: vi.fn(),
+        trace: vi.fn(),
+      };
+      const spy = vi
+        .spyOn(loggerMod, "getChildLogger")
+        .mockReturnValue(mockLogger as unknown as ReturnType<typeof loggerMod.getChildLogger>);
+
+      const log = createSubsystemLogger("test/midnight");
+
+      log.info("before midnight");
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      // Same day: should reuse cached logger
+      log.info("still before midnight");
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      // Advance past midnight
+      vi.setSystemTime(new Date("2026-03-27T00:01:00"));
+
+      log.info("after midnight");
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      spy.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -307,9 +307,12 @@ function logToFile(
 
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   let fileLogger: TsLogger<LogObj> | null = null;
+  let fileLoggerDate = "";
   const getFileLogger = (): TsLogger<LogObj> => {
-    if (!fileLogger) {
+    const today = new Date().toDateString();
+    if (!fileLogger || fileLoggerDate !== today) {
       fileLogger = getChildLogger({ subsystem });
+      fileLoggerDate = today;
     }
     return fileLogger;
   };


### PR DESCRIPTION
## Summary

Fixes #54381

The subsystem logger cached the file logger on first call, so after midnight new log entries continued to be written to the previous day's file.

## Root Cause

In `createSubsystemLogger`, `getFileLogger` stored the logger in a closure variable (`fileLogger`) and only created it once (`if (!fileLogger)`). Since the underlying logger uses a date-stamped filename, the cached logger kept pointing to yesterday's file.

## Fix

Added a `fileLoggerDate` string that records the date (`Date.toDateString()`) when the logger was last created. On every call, `getFileLogger` compares the current date to the cached date and re-creates the logger when they differ.

```ts
// Before
if (!fileLogger) {
  fileLogger = getChildLogger({ subsystem });
}

// After
const today = new Date().toDateString();
if (!fileLogger || fileLoggerDate !== today) {
  fileLogger = getChildLogger({ subsystem });
  fileLoggerDate = today;
}
```

## Test

Added a test in `src/logging/subsystem.test.ts` using `vi.useFakeTimers()` that simulates a midnight crossing and verifies the logger is re-created exactly once after the date changes.