### PR TITLE
fix(control-ui): chat bubbles should size to content, not full width

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -28,7 +28,7 @@
 
 /* User messages align content right */
 .chat-group.user .chat-group-messages {
-  align-items: stretch;
+  align-items: flex-end;
 }
 
 @media (max-width: 600px) {
@@ -186,19 +186,15 @@ img.chat-avatar {
 /* Minimal Bubble Design - dynamic width based on content */
 .chat-bubble {
   position: relative;
-  display: block;
   border: 1px solid var(--border);
   background: var(--card);
   border-radius: var(--radius-lg);
   padding: 10px 14px;
-  box-shadow: none;
   transition:
     background var(--duration-fast) ease-out,
     border-color var(--duration-fast) ease-out;
-  width: 100%;
+  width: fit-content;
   max-width: 100%;
-  box-sizing: border-box;
-  word-wrap: break-word;
 }
 
 .chat-bubble.has-copy {


### PR DESCRIPTION
## Problem

Chat bubbles in the control UI render at full width (`width: 100%`) regardless of message length. Short messages like "ok" or "yes" produce unnecessarily wide bubbles, creating visual inconsistency — especially compared to tool output bubbles which are also full-width.

Reported in #54379.

## Changes

### `.chat-bubble`
- `width: 100%` → `width: fit-content` — bubbles now size to their content
- Removed redundant properties already handled by global/parent styles:
  - `display: block` — div default
  - `box-shadow: none` — div default
  - `box-sizing: border-box` — set globally on `*`
  - `word-wrap: break-word` — handled by `.chat-text`
- Kept `position: relative` — required by `.chat-bubble-actions` (absolute positioned copy/expand buttons)

### `.chat-group.user .chat-group-messages`
- `align-items: stretch` → `align-items: flex-end` — user message bubbles align right within their container

## Before / After

**Before:** All bubbles fill the full available width
**After:** Bubbles dynamically size to content length, capped at `max-width: 100%`

## Testing

- Tested locally on Safari (macOS, control-UI)
- Verified user messages, assistant messages, tool output, and multi-line content
- Verified copy/expand button positioning still works (absolute positioning relative to bubble)
- No DOM structure changes, no unrelated CSS modified