### PR TITLE
fix: include workspace templates in npm package (#54514)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "assets/",
     "dist/",
     "docs/",
+    "docs/reference/templates/",
     "!docs/.generated/**",
     "!docs/.i18n/zh-CN.tm.jsonl",
     "skills/"


### PR DESCRIPTION
## Summary
- Fixes #54514
- `docs/reference/templates/` was excluded from the npm tarball despite `docs/` being in the files array
- Fixed packaging config to ensure workspace templates (AGENTS.md, SOUL.md, etc.) are included

## Test plan
- Run `npm pack` and inspect the tarball contents
- Verify `docs/reference/templates/` directory and its files are present