### PR TITLE
fix: extract message string from cron agentTurn payload (#54579)

### DIFF
--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1132,9 +1132,22 @@ export async function executeJobCore(
     return resolveAbortError();
   }
 
+  // Defensive: extract string content from message in case the payload was
+  // persisted with an object value (e.g. { text: "..." }) instead of a plain
+  // string, which would coerce to "[object Object]" in template literals.
+  const rawMessage = job.payload.message;
+  const message =
+    typeof rawMessage === "string"
+      ? rawMessage
+      : typeof rawMessage === "object" &&
+          rawMessage !== null &&
+          typeof (rawMessage as { text?: unknown }).text === "string"
+        ? (rawMessage as { text: string }).text
+        : String(rawMessage);
+
   const res = await state.deps.runIsolatedAgentJob({
     job,
-    message: job.payload.message,
+    message,
     abortSignal,
   });
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1136,14 +1136,32 @@ export async function executeJobCore(
   // persisted with an object value (e.g. { text: "..." }) instead of a plain
   // string, which would coerce to "[object Object]" in template literals.
   const rawMessage = job.payload.message;
-  const message =
-    typeof rawMessage === "string"
-      ? rawMessage
-      : typeof rawMessage === "object" &&
-          rawMessage !== null &&
-          typeof (rawMessage as { text?: unknown }).text === "string"
-        ? (rawMessage as { text: string }).text
-        : String(rawMessage);
+  let message: string;
+  if (typeof rawMessage === "string") {
+    message = rawMessage;
+  } else if (typeof rawMessage === "object" && rawMessage !== null) {
+    const obj = rawMessage as Record<string, unknown>;
+    // Try common string fields in priority order.
+    const extracted =
+      typeof obj.text === "string"
+        ? obj.text
+        : typeof obj.message === "string"
+          ? obj.message
+          : typeof obj.content === "string"
+            ? obj.content
+            : undefined;
+    if (extracted !== undefined) {
+      message = extracted;
+    } else {
+      message = JSON.stringify(rawMessage);
+      state.deps.log.debug(
+        { rawMessage: message },
+        "cron: message was an unrecognized object shape, used JSON.stringify fallback",
+      );
+    }
+  } else {
+    message = JSON.stringify(rawMessage);
+  }
 
   const res = await state.deps.runIsolatedAgentJob({
     job,


### PR DESCRIPTION
## Summary
- Fixes #54579
- Cron agentTurn payload was delivering `[object Object]` to the LLM
- The message field contained an object that was being coerced to string instead of extracting the text content

## Test plan
- Create a cron job: `openclaw cron add --name "test" --every "24h" --message "Say: HELLO WORLD"`
- Run: `openclaw cron run <id>`
- Verify the LLM receives the actual message string, not `[object Object]`