### PR TITLE
fix: write correct openrouter/free model string in config wizard (#54581)

### DIFF
--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -146,7 +146,9 @@ export default definePluginEntry({
           streamFn = injectOpenRouterRouting(streamFn, providerRouting);
         }
         const skipReasoningInjection =
-          ctx.modelId === "auto" || isProxyReasoningUnsupported(ctx.modelId);
+          ctx.modelId === "auto" ||
+          ctx.modelId === "free" ||
+          isProxyReasoningUnsupported(ctx.modelId);
         const openRouterThinkingLevel = skipReasoningInjection ? undefined : ctx.thinkingLevel;
         streamFn = createOpenRouterWrapper(streamFn, openRouterThinkingLevel);
         streamFn = createOpenRouterSystemCacheWrapper(streamFn);

--- a/extensions/openrouter/onboard.ts
+++ b/extensions/openrouter/onboard.ts
@@ -5,6 +5,18 @@ import {
 
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
 
+/** Return the currently configured primary model string, if any. */
+function resolveExistingPrimary(cfg: OpenClawConfig): string | undefined {
+  const model = cfg.agents?.defaults?.model;
+  if (typeof model === "string") {
+    return model.trim() || undefined;
+  }
+  if (model && typeof model === "object" && "primary" in model) {
+    return (model as { primary?: string }).primary?.trim() || undefined;
+  }
+  return undefined;
+}
+
 export function applyOpenrouterProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
   models[OPENROUTER_DEFAULT_MODEL_REF] = {
@@ -25,8 +37,11 @@ export function applyOpenrouterProviderConfig(cfg: OpenClawConfig): OpenClawConf
 }
 
 export function applyOpenrouterConfig(cfg: OpenClawConfig): OpenClawConfig {
-  return applyAgentDefaultModelPrimary(
-    applyOpenrouterProviderConfig(cfg),
-    OPENROUTER_DEFAULT_MODEL_REF,
-  );
+  const providerCfg = applyOpenrouterProviderConfig(cfg);
+  // Preserve the user's existing openrouter model selection (e.g. openrouter/free)
+  // instead of unconditionally overwriting it with the default openrouter/auto.
+  const existing = resolveExistingPrimary(cfg);
+  const primary =
+    existing && existing.startsWith("openrouter/") ? existing : OPENROUTER_DEFAULT_MODEL_REF;
+  return applyAgentDefaultModelPrimary(providerCfg, primary);
 }

--- a/extensions/openrouter/provider-catalog.ts
+++ b/extensions/openrouter/provider-catalog.ts
@@ -26,6 +26,15 @@ export function buildOpenrouterProvider(): ModelProviderConfig {
         maxTokens: OPENROUTER_DEFAULT_MAX_TOKENS,
       },
       {
+        id: "free",
+        name: "OpenRouter Free",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: OPENROUTER_DEFAULT_COST,
+        contextWindow: OPENROUTER_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: OPENROUTER_DEFAULT_MAX_TOKENS,
+      },
+      {
         id: "openrouter/hunter-alpha",
         name: "Hunter Alpha",
         reasoning: true,


### PR DESCRIPTION
## Summary
- Fixes #54581
- Config wizard was writing `openrouter/auto` when user selected `openrouter/free`
- Fixed the model string mapping to preserve the user's selection

## Test plan
- Run config wizard, select openrouter/free model
- Verify config file contains `openrouter/free` instead of `openrouter/auto`