### PR TITLE
Followup runner: thread followups using current message

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -529,6 +529,81 @@ describe("createFollowupRunner compaction", () => {
   });
 });
 
+describe("createFollowupRunner reply threading", () => {
+  it("threads followup replies when replyToMode=all and current message is available", async () => {
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-5",
+    });
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "final" }],
+      meta: {},
+    });
+
+    const queued = createQueuedRun({
+      messageId: "msg-42",
+      originatingChannel: "telegram",
+      run: {
+        config: {
+          channels: {
+            whatsapp: {
+              replyToMode: "all",
+            },
+          },
+        },
+      },
+    });
+
+    await runner(queued);
+
+    expect(routeReplyMock).toHaveBeenCalled();
+    const payload = routeReplyMock.mock.calls.at(-1)?.[0]?.payload;
+    expect(payload).toMatchObject({
+      text: "final",
+      replyToId: "msg-42",
+    });
+  });
+});
+
+describe("createFollowupRunner reply threading", () => {
+  it("threads followup replies when replyToMode=all and current message is available", async () => {
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-5",
+    });
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "final reply" }],
+      meta: {},
+    });
+
+    const queued = createQueuedRun({
+      messageId: "msg-42",
+      originatingChannel: "telegram",
+      run: {
+        config: {
+          channels: {
+            telegram: {
+              replyToMode: "all",
+            },
+          },
+        },
+        originatingAccountId: "primary",
+      },
+    });
+
+    await runner(queued);
+
+    expect(routeReplyMock).toHaveBeenCalled();
+    const payload = routeReplyMock.mock.calls.at(-1)?.[0]?.payload;
+    expect(payload).toMatchObject({
+      text: "final reply",
+      replyToId: "msg-42",
+    });
+  });
+});
+
 describe("createFollowupRunner bootstrap warning dedupe", () => {
   it("passes stored warning signature history to embedded followup runs", async () => {
     runEmbeddedPiAgentMock.mockResolvedValueOnce({

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -537,43 +537,6 @@ describe("createFollowupRunner reply threading", () => {
       defaultModel: "anthropic/claude-opus-4-5",
     });
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
-      payloads: [{ text: "final" }],
-      meta: {},
-    });
-
-    const queued = createQueuedRun({
-      messageId: "msg-42",
-      originatingChannel: "telegram",
-      run: {
-        config: {
-          channels: {
-            whatsapp: {
-              replyToMode: "all",
-            },
-          },
-        },
-      },
-    });
-
-    await runner(queued);
-
-    expect(routeReplyMock).toHaveBeenCalled();
-    const payload = routeReplyMock.mock.calls.at(-1)?.[0]?.payload;
-    expect(payload).toMatchObject({
-      text: "final",
-      replyToId: "msg-42",
-    });
-  });
-});
-
-describe("createFollowupRunner reply threading", () => {
-  it("threads followup replies when replyToMode=all and current message is available", async () => {
-    const runner = createFollowupRunner({
-      typing: createMockTypingController(),
-      typingMode: "instant",
-      defaultModel: "anthropic/claude-opus-4-5",
-    });
-    runEmbeddedPiAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "final reply" }],
       meta: {},
     });
@@ -589,7 +552,6 @@ describe("createFollowupRunner reply threading", () => {
             },
           },
         },
-        originatingAccountId: "primary",
       },
     });
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -157,6 +157,45 @@ export function createFollowupRunner(params: {
       let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
         activeSessionEntry?.systemPromptReport,
       );
+      const replyToChannel = resolveOriginMessageProvider({
+        originatingChannel: queued.originatingChannel,
+        provider: queued.run.messageProvider,
+      }) as OriginatingChannelType | undefined;
+      const replyToMode = resolveReplyToMode(
+        queued.run.config,
+        replyToChannel,
+        queued.originatingAccountId,
+        queued.originatingChatType,
+      );
+      const currentMessageId = queued.messageId?.trim() || undefined;
+      const applyFollowupReplyThreading = (payloads: ReplyPayload[]) =>
+        applyReplyThreading({
+          payloads,
+          replyToMode,
+          replyToChannel,
+          currentMessageId,
+        });
+
+      const sendCompactionNotice = async (text: string) => {
+        const noticePayloads = applyFollowupReplyThreading([
+          {
+            text,
+            replyToCurrent: true,
+            isCompactionNotice: true,
+          },
+        ]);
+        if (noticePayloads.length === 0) {
+          return;
+        }
+        try {
+          await sendFollowupPayloads(noticePayloads, queued);
+        } catch (err) {
+          logVerbose(
+            `followup queue: compaction notice delivery failed (non-fatal): ${String(err)}`,
+          );
+        }
+      };
+
       try {
         const fallbackResult = await runWithModelFallback({
           cfg: queued.run.config,
@@ -299,22 +338,7 @@ export function createFollowupRunner(params: {
         }
         return [{ ...payload, text: stripped.text }];
       });
-      const replyToChannel = resolveOriginMessageProvider({
-        originatingChannel: queued.originatingChannel,
-        provider: queued.run.messageProvider,
-      }) as OriginatingChannelType | undefined;
-      const replyToMode = resolveReplyToMode(
-        queued.run.config,
-        replyToChannel,
-        queued.originatingAccountId,
-        queued.originatingChatType,
-      );
-
-      const replyTaggedPayloads: ReplyPayload[] = applyReplyThreading({
-        payloads: sanitizedPayloads,
-        replyToMode,
-        replyToChannel,
-      });
+      const replyTaggedPayloads = applyFollowupReplyThreading(sanitizedPayloads);
 
       const dedupedPayloads = filterMessagingToolDuplicates({
         payloads: replyTaggedPayloads,
@@ -371,9 +395,7 @@ export function createFollowupRunner(params: {
         }
         if (queued.run.verboseLevel && queued.run.verboseLevel !== "off") {
           const suffix = typeof count === "number" ? ` (count ${count})` : "";
-          finalPayloads.unshift({
-            text: `🧹 Auto-compaction complete${suffix}.`,
-          });
+          await sendCompactionNotice(`🧹 Auto-compaction complete${suffix}.`);
         }
       }
 


### PR DESCRIPTION
## Summary\n- ensure followup runs carry the originating message ID through the shared reply-threading helper used for both replies and compaction notices\n- add a regression test that routes a followup with replyToMode=all and confirms the routed payload keeps replyToId\n\nResolves #54456\n\n## Testing\n- pnpm test -- src/auto-reply/reply/followup-runner.test.ts -t "threads followup replies when replyToMode=all and current message is available"