### PR TITLE
fix: config path for xAI

### DIFF
--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -7,7 +7,7 @@ import { withEnv } from "../../test/helpers/extensions/env.js";
 import { resolveXaiCatalogEntry } from "./model-definitions.js";
 import { isModernXaiModel, resolveXaiForwardCompatModel } from "./provider-models.js";
 import { __testing as grokProviderTesting } from "./src/grok-web-search-provider.js";
-import { __testing } from "./web-search.js";
+import { __testing, createXaiWebSearchProvider } from "./web-search.js";
 
 const { extractXaiWebSearchContent, resolveXaiInlineCitations, resolveXaiWebSearchModel } =
   __testing;
@@ -24,7 +24,7 @@ describe("xai web search config resolution", () => {
     expect(
       resolveWebSearchProviderCredential({
         credentialValue: getScopedCredentialValue(searchConfig, "grok"),
-        path: "tools.web.search.grok.apiKey",
+        path: "plugins.entries.xai.config.webSearch.apiKey",
         envVars: ["XAI_API_KEY"],
       }),
     ).toBe("xai-test-key");
@@ -35,11 +35,44 @@ describe("xai web search config resolution", () => {
       expect(
         resolveWebSearchProviderCredential({
           credentialValue: getScopedCredentialValue({}, "grok"),
-          path: "tools.web.search.grok.apiKey",
+          path: "plugins.entries.xai.config.webSearch.apiKey",
           envVars: ["XAI_API_KEY"],
         }),
       ).toBeUndefined();
     });
+  });
+
+  it("uses plugin web search config when the scoped search config has no api key", async () => {
+    const provider = createXaiWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        plugins: {
+          entries: {
+            xai: {
+              enabled: true,
+              config: {
+                webSearch: {
+                  apiKey: "xai-plugin-key", // pragma: allowlist secret
+                },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: {
+        provider: "grok",
+        grok: {
+          model: "grok-4-1-fast",
+        },
+      },
+    });
+
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("Expected xAI web search tool definition");
+    }
+
+    await expect(tool.execute({})).rejects.toThrow("query");
   });
 
   it("uses default model when not specified", () => {

--- a/extensions/xai/web-search.ts
+++ b/extensions/xai/web-search.ts
@@ -3,14 +3,18 @@ import {
   DEFAULT_CACHE_TTL_MINUTES,
   DEFAULT_TIMEOUT_SECONDS,
   getScopedCredentialValue,
+  mergeScopedSearchConfig,
   normalizeCacheKey,
   readCache,
   readNumberParam,
   readStringParam,
   resolveCacheTtlMs,
+  resolveProviderWebSearchPluginConfig,
   resolveTimeoutSeconds,
   resolveWebSearchProviderCredential,
   setScopedCredentialValue,
+  setProviderWebSearchPluginConfigValue,
+  type SearchConfigRecord,
   type WebSearchProviderPlugin,
   writeCache,
 } from "openclaw/plugin-sdk/provider-web-search";
@@ -84,54 +88,67 @@ export function createXaiWebSearchProvider(): WebSearchProviderPlugin {
       getScopedCredentialValue(searchConfig, "grok"),
     setCredentialValue: (searchConfigTarget: Record<string, unknown>, value: unknown) =>
       setScopedCredentialValue(searchConfigTarget, "grok", value),
-    createTool: (ctx: { searchConfig?: Record<string, unknown> }) => ({
-      description:
-        "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search.",
-      parameters: Type.Object({
-        query: Type.String({ description: "Search query string." }),
-        count: Type.Optional(
-          Type.Number({
-            description: "Number of results to return (1-10).",
-            minimum: 1,
-            maximum: 10,
-          }),
-        ),
-      }),
-      execute: async (args: Record<string, unknown>) => {
-        const apiKey = resolveWebSearchProviderCredential({
-          credentialValue: getScopedCredentialValue(ctx.searchConfig, "grok"),
-          path: "tools.web.search.grok.apiKey",
-          envVars: ["XAI_API_KEY"],
-        });
+    getConfiguredCredentialValue: (config) =>
+      resolveProviderWebSearchPluginConfig(config, "xai")?.apiKey,
+    setConfiguredCredentialValue: (configTarget, value) => {
+      setProviderWebSearchPluginConfigValue(configTarget, "xai", "apiKey", value);
+    },
+    createTool: (ctx) => {
+      const searchConfig = mergeScopedSearchConfig(
+        ctx.searchConfig as SearchConfigRecord | undefined,
+        "grok",
+        resolveProviderWebSearchPluginConfig(ctx.config, "xai"),
+      ) as SearchConfigRecord | undefined;
 
-        if (!apiKey) {
-          return {
-            error: "missing_xai_api_key",
-            message:
-              "web_search (grok) needs an xAI API key. Set XAI_API_KEY in the Gateway environment, or configure plugins.entries.xai.config.webSearch.apiKey.",
-            docs: "https://docs.openclaw.ai/tools/web",
-          };
-        }
-
-        const query = readStringParam(args, "query", { required: true });
-        void readNumberParam(args, "count", { integer: true });
-
-        return await runXaiWebSearch({
-          query,
-          model: resolveXaiWebSearchModel(ctx.searchConfig),
-          apiKey,
-          timeoutSeconds: resolveTimeoutSeconds(
-            (ctx.searchConfig?.timeoutSeconds as number | undefined) ?? undefined,
-            DEFAULT_TIMEOUT_SECONDS,
+      return {
+        description:
+          "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search.",
+        parameters: Type.Object({
+          query: Type.String({ description: "Search query string." }),
+          count: Type.Optional(
+            Type.Number({
+              description: "Number of results to return (1-10).",
+              minimum: 1,
+              maximum: 10,
+            }),
           ),
-          inlineCitations: resolveXaiInlineCitations(ctx.searchConfig),
-          cacheTtlMs: resolveCacheTtlMs(
-            (ctx.searchConfig?.cacheTtlMinutes as number | undefined) ?? undefined,
-            DEFAULT_CACHE_TTL_MINUTES,
-          ),
-        });
-      },
-    }),
+        }),
+        execute: async (args: Record<string, unknown>) => {
+          const apiKey = resolveWebSearchProviderCredential({
+            credentialValue: getScopedCredentialValue(searchConfig, "grok"),
+            path: "plugins.entries.xai.config.webSearch.apiKey",
+            envVars: ["XAI_API_KEY"],
+          });
+
+          if (!apiKey) {
+            return {
+              error: "missing_xai_api_key",
+              message:
+                "web_search (grok) needs an xAI API key. Set XAI_API_KEY in the Gateway environment, or configure plugins.entries.xai.config.webSearch.apiKey.",
+              docs: "https://docs.openclaw.ai/tools/web",
+            };
+          }
+
+          const query = readStringParam(args, "query", { required: true });
+          void readNumberParam(args, "count", { integer: true });
+
+          return await runXaiWebSearch({
+            query,
+            model: resolveXaiWebSearchModel(searchConfig),
+            apiKey,
+            timeoutSeconds: resolveTimeoutSeconds(
+              (searchConfig?.timeoutSeconds as number | undefined) ?? undefined,
+              DEFAULT_TIMEOUT_SECONDS,
+            ),
+            inlineCitations: resolveXaiInlineCitations(searchConfig),
+            cacheTtlMs: resolveCacheTtlMs(
+              (searchConfig?.cacheTtlMinutes as number | undefined) ?? undefined,
+              DEFAULT_CACHE_TTL_MINUTES,
+            ),
+          });
+        },
+      };
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
fixes #54555 
Describe the problem and fix in 2–5 bullets:

- Problem: The xAI web search provider declared `plugins.entries.xai.config.webSearch.apiKey` as its credential path, but the runtime tool still only resolved the API key from scoped `tools.web.search.grok` config.
- Why it matters: OpenClaw could treat xAI web search as configured during onboarding/config flows, while `web_search` still failed at runtime with `missing_xai_api_key`.
- What changed: The provider now reads/writes configured credentials through the plugin config helpers, merges plugin web search config into the scoped search config before execution, and uses the plugin config credential path consistently in runtime resolution and tests.
- What did NOT change (scope boundary): No provider behavior changes beyond config/credential resolution for xAI web search; no new network calls, no model/catalog changes, and no broader config migration.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `extensions/xai/web-search.ts` advertised plugin-config credential storage, but its `createTool` path still resolved credentials from the old scoped search config shape only.
- Missing detection / guardrail: There was no test covering the case where the xAI API key exists only under `plugins.entries.xai.config.webSearch.apiKey`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Other web search providers already use the plugin-config helper pattern; this xAI path had not been brought into parity.
- Why this regressed now: The repo’s onboarding/runtime config flow now relies on provider-level configured credential access, which exposed the mismatch in this older xAI implementation.
- If unknown, what was ruled out: Ruled out missing env-var support and ruled out a model-resolution issue; the failure was in config-source selection.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/xai/web-search.test.ts`
- Scenario the test should lock in: When scoped `grok` search config has no API key but `plugins.entries.xai.config.webSearch.apiKey` is set, the provider should resolve the key and proceed past credential validation.
- Why this is the smallest reliable guardrail: The bug is local to provider config resolution and does not require external API calls or wider runtime orchestration to verify.
- Existing test that already covers this (if any): Existing tests covered scoped config and missing-key behavior, but not plugin-config-only credentials.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- xAI/Grok web search now works when the API key is configured under `plugins.entries.xai.config.webSearch.apiKey`, including config written by provider-aware onboarding/config flows.
- Error messaging and credential path expectations now match the actual runtime lookup path for xAI web search.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: This changes only which existing config path is used for resolving the xAI API key. Risk is limited to credential lookup precedence; mitigated by using the same plugin-config helper pattern already used by other bundled web search providers and by adding regression coverage.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm dev environment
- Model/provider: xAI / Grok web search provider
- Integration/channel (if any): N/A
- Relevant config (redacted): `plugins.entries.xai.config.webSearch.apiKey` set; scoped `tools.web.search.grok` config without `apiKey`

### Steps

1. Configure xAI web search with the API key only under `plugins.entries.xai.config.webSearch.apiKey`.
2. Create/execute the xAI web search tool with scoped `grok` config that does not include `apiKey`.
3. Run the targeted xAI web search tests and repo checks.

### Expected

- The provider resolves the configured xAI API key from plugin config and proceeds past missing-credential validation.

### Actual

- Before this change, the runtime tool could still behave as if the xAI API key were missing unless it was duplicated into scoped `grok` search config.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Confirmed `pnpm check` passes after the fix; confirmed `pnpm test -- extensions/xai/web-search.test.ts` passes

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR or temporarily provide the xAI API key through `XAI_API_KEY` or scoped `tools.web.search.grok.apiKey` while investigating.
- Files/config to restore: `extensions/xai/web-search.ts`, `extensions/xai/web-search.test.ts`
- Known bad symptoms reviewers should watch for: xAI web search returning `missing_xai_api_key` despite `plugins.entries.xai.config.webSearch.apiKey` being configured.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Credential resolution precedence could differ from previous xAI-only behavior in edge cases where both scoped and plugin config are populated inconsistently.
  - Mitigation: The implementation uses the shared provider helper pattern already used by other bundled web search providers, and the regression test locks in the intended plugin-config fallback path.
