### PR TITLE
fix(openai-completions): extract usage tokens from non-streaming response

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -657,6 +657,39 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(msg.content).toBe("hello");
       }
 
+      // Non-streaming usage extraction
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "usage reply" }],
+          meta: {
+            agentMeta: {
+              usage: { input: 42, output: 17, cacheRead: 5, cacheWrite: 0, total: 64 },
+            },
+          },
+        } as never);
+        const json = await postSyncUserMessage("count my tokens");
+        const usage = json.usage as Record<string, unknown> | undefined;
+        expect(usage).toBeDefined();
+        expect(usage?.prompt_tokens).toBe(42);
+        expect(usage?.completion_tokens).toBe(17);
+        expect(usage?.total_tokens).toBe(64);
+      }
+
+      // Non-streaming usage falls back to zeros when meta is absent
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "no usage" }],
+        } as never);
+        const json = await postSyncUserMessage("no meta");
+        const usage = json.usage as Record<string, unknown> | undefined;
+        expect(usage).toBeDefined();
+        expect(usage?.prompt_tokens).toBe(0);
+        expect(usage?.completion_tokens).toBe(0);
+        expect(usage?.total_tokens).toBe(0);
+      }
+
       {
         agentCommand.mockClear();
         agentCommand.mockResolvedValueOnce({ payloads: [{ text: "" }] } as never);

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -676,6 +676,25 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(usage?.total_tokens).toBe(64);
       }
 
+      // Non-streaming usage: arithmetic fallback when total is absent
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "usage reply no total" }],
+          meta: {
+            agentMeta: {
+              usage: { input: 10, output: 5, cacheRead: 3, cacheWrite: 1 },
+            },
+          },
+        } as never);
+        const jsonFallback = await postSyncUserMessage("fallback total");
+        const usageFallback = jsonFallback.usage as Record<string, unknown> | undefined;
+        expect(usageFallback).toBeDefined();
+        expect(usageFallback?.prompt_tokens).toBe(10);
+        expect(usageFallback?.completion_tokens).toBe(5);
+        expect(usageFallback?.total_tokens).toBe(19); // 10 + 5 + 3 + 1
+      }
+
       // Non-streaming usage falls back to zeros when meta is absent
       {
         agentCommand.mockClear();

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -396,6 +396,31 @@ function coerceRequest(val: unknown): OpenAiChatCompletionRequest {
   return val as OpenAiChatCompletionRequest;
 }
 
+function extractUsage(result: unknown): {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+} {
+  const meta = (result as { meta?: { agentMeta?: { usage?: unknown } } } | null)?.meta;
+  const usage = meta && typeof meta === "object" ? meta.agentMeta?.usage : undefined;
+  if (!usage || typeof usage !== "object") {
+    return { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+  }
+  const u = usage as {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
+  const input = Math.max(0, u.input ?? 0);
+  const output = Math.max(0, u.output ?? 0);
+  const cacheRead = Math.max(0, u.cacheRead ?? 0);
+  const cacheWrite = Math.max(0, u.cacheWrite ?? 0);
+  const total = Math.max(0, u.total ?? input + output + cacheRead + cacheWrite);
+  return { prompt_tokens: input, completion_tokens: output, total_tokens: total };
+}
+
 function resolveAgentResponseText(result: unknown): string {
   const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
   if (!Array.isArray(payloads) || payloads.length === 0) {
@@ -498,6 +523,7 @@ export async function handleOpenAiHttpRequest(
       const result = await agentCommandFromIngress(commandInput, defaultRuntime, deps);
 
       const content = resolveAgentResponseText(result);
+      const usage = extractUsage(result);
 
       sendJson(res, 200, {
         id: runId,
@@ -511,7 +537,7 @@ export async function handleOpenAiHttpRequest(
             finish_reason: "stop",
           },
         ],
-        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+        usage,
       });
     } catch (err) {
       logWarn(`openai-compat: chat completion failed: ${String(err)}`);


### PR DESCRIPTION
## Summary

Fixes #54420.

The `openai-completions` adapter hardcoded `usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }` in non-streaming responses, ignoring actual token counts returned by the provider (e.g. vLLM).

## Root Cause

In `src/gateway/openai-http.ts`, the non-streaming response builder always returned zeroed usage fields instead of reading from `result.meta.agentMeta.usage`.

## Fix

Added `extractUsage()` that reads `result.meta.agentMeta.usage` (same shape used by `openresponses-http.ts`) and maps internal normalized fields (`input`, `output`, `total`) to OpenAI format (`prompt_tokens`, `completion_tokens`, `total_tokens`). Falls back to zeros when usage metadata is absent.

## Tests

Added two test cases:
- Verifies usage tokens are correctly extracted when `meta.agentMeta.usage` is present
- Verifies graceful fallback to zeros when meta is absent