### PR TITLE
Respect explicit bluebubbles disable during startup auto-enable

### DIFF
--- a/src/config/plugin-auto-enable.channels.test.ts
+++ b/src/config/plugin-auto-enable.channels.test.ts
@@ -200,6 +200,22 @@ describe("applyPluginAutoEnable channels", () => {
       expect(result.config.channels?.imessage?.enabled).toBe(true);
     });
 
+    it("allows imessage auto-configure when bluebubbles channel is explicitly disabled", () => {
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: {
+            bluebubbles: { serverUrl: "http://localhost:1234", password: "x", enabled: false },
+            imessage: { cliPath: "/usr/local/bin/imsg" },
+          },
+        },
+        env: makeIsolatedEnv(),
+      });
+
+      expect(result.config.channels?.bluebubbles?.enabled).toBe(false);
+      expect(result.config.channels?.imessage?.enabled).toBe(true);
+      expect(result.changes.join("\n")).toContain("iMessage configured, enabled automatically.");
+    });
+
     it("auto-enables imessage when only imessage is configured", () => {
       const result = applyPluginAutoEnable({
         config: {

--- a/src/config/plugin-auto-enable.prefer-over.ts
+++ b/src/config/plugin-auto-enable.prefer-over.ts
@@ -119,7 +119,10 @@ export function shouldSkipPreferredPluginAutoEnable(params: {
   env: NodeJS.ProcessEnv;
   registry: PluginManifestRegistry;
   isPluginDenied: (config: OpenClawConfig, pluginId: string) => boolean;
-  isPluginExplicitlyDisabled: (config: OpenClawConfig, pluginId: string) => boolean;
+  isPluginExplicitlyDisabled: (
+    config: OpenClawConfig,
+    entry: Pick<PluginAutoEnableCandidate, "pluginId"> & { channelId?: string },
+  ) => boolean;
 }): boolean {
   for (const other of params.configured) {
     if (other.pluginId === params.entry.pluginId) {
@@ -127,7 +130,7 @@ export function shouldSkipPreferredPluginAutoEnable(params: {
     }
     if (
       params.isPluginDenied(params.config, other.pluginId) ||
-      params.isPluginExplicitlyDisabled(params.config, other.pluginId)
+      params.isPluginExplicitlyDisabled(params.config, other)
     ) {
       continue;
     }

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -467,21 +467,30 @@ export function resolveConfiguredPluginAutoEnableCandidates(params: {
   return changes;
 }
 
-function isPluginExplicitlyDisabled(cfg: OpenClawConfig, pluginId: string): boolean {
-  const builtInChannelId = normalizeChatChannelId(pluginId);
-  if (builtInChannelId) {
-    const channels = cfg.channels as Record<string, unknown> | undefined;
-    const channelConfig = channels?.[builtInChannelId];
-    if (
-      channelConfig &&
-      typeof channelConfig === "object" &&
-      !Array.isArray(channelConfig) &&
-      (channelConfig as { enabled?: unknown }).enabled === false
-    ) {
+function isChannelExplicitlyDisabled(cfg: OpenClawConfig, channelId?: string): boolean {
+  if (!channelId) {
+    return false;
+  }
+  const channels = cfg.channels as Record<string, unknown> | undefined;
+  const channelConfig = channels?.[channelId];
+  return isRecord(channelConfig) && channelConfig.enabled === false;
+}
+
+function isPluginExplicitlyDisabled(
+  cfg: OpenClawConfig,
+  entry: Pick<PluginAutoEnableCandidate, "pluginId"> & { channelId?: string },
+): boolean {
+  const candidateChannelId = "channelId" in entry ? entry.channelId : undefined;
+  if (isChannelExplicitlyDisabled(cfg, candidateChannelId)) {
+    return true;
+  }
+  const builtInChannelId = normalizeChatChannelId(entry.pluginId);
+  if (builtInChannelId && builtInChannelId !== candidateChannelId) {
+    if (isChannelExplicitlyDisabled(cfg, builtInChannelId)) {
       return true;
     }
   }
-  return cfg.plugins?.entries?.[pluginId]?.enabled === false;
+  return cfg.plugins?.entries?.[entry.pluginId]?.enabled === false;
 }
 
 function isPluginDenied(cfg: OpenClawConfig, pluginId: string): boolean {
@@ -575,7 +584,7 @@ export function materializePluginAutoEnableCandidatesInternal(params: {
 
   for (const entry of params.candidates) {
     const builtInChannelId = normalizeChatChannelId(entry.pluginId);
-    if (isPluginDenied(next, entry.pluginId) || isPluginExplicitlyDisabled(next, entry.pluginId)) {
+    if (isPluginDenied(next, entry.pluginId) || isPluginExplicitlyDisabled(next, entry)) {
       continue;
     }
     if (


### PR DESCRIPTION
## Summary
- respect `channels.bluebubbles.enabled = false` as an explicit disable during startup auto-enable
- avoid injecting `plugins.entries.bluebubbles.enabled = true` when BlueBubbles config keys remain present
- allow iMessage to auto-enable as the preferred fallback when BlueBubbles is explicitly disabled

Closes #54586

## Root cause
`applyPluginAutoEnable()` tracked configured plugin candidates only by `pluginId`, so explicit-disable checks only honored:
- built-in channel disables resolved from normalized built-in channel ids
- plugin entry disables from `plugins.entries.<pluginId>.enabled = false`

For plugin-backed channels like `bluebubbles`, `channels.bluebubbles.enabled = false` was not treated as authoritative even though other channel config keys (`serverUrl`, `password`) still marked the channel as configured. That allowed startup to auto-enable BlueBubbles and persist a config rewrite.

## Fix
- carry the originating `channelId` through configured auto-enable candidates
- treat `channels.<channelId>.enabled = false` as an explicit disable for plugin-backed channels too
- keep the built-in-channel fallback check for cases where the normalized channel id differs from the triggering channel id
- update preferred-plugin skip logic so an explicitly disabled BlueBubbles config no longer suppresses iMessage fallback auto-enable

## Validation
### Targeted regressions (double pass)
- `pnpm vitest run src/config/plugin-auto-enable.test.ts src/gateway/server.models-voicewake-misc.test.ts`
- `pnpm vitest run src/config/plugin-auto-enable.test.ts src/gateway/server.models-voicewake-misc.test.ts`

### Isolated unrelated suite timeout check
- `NODE_OPTIONS='--max-old-space-size=8192' pnpm vitest run src/config/schema.base.generated.test.ts`

### Build
- `pnpm build`

### Real runtime proof
Ran an isolated `startGatewayServer()` startup against a temp config file and verified the persisted config after boot:
- `channels.bluebubbles.enabled` stayed `false`
- `plugins.entries.bluebubbles` stayed absent
- `channels.imessage.enabled` became `true`

## Notes
I also ran the full `pnpm test` suite twice. The first run hit a Node OOM under full-suite load. The second run with increased heap reached `1127/1128` passing test files, then failed on an unrelated timeout in `src/config/schema.base.generated.test.ts`; that same test passes when run in isolation. This patch does not touch schema generation logic.
