### PR TITLE
test(extensions): lock bundled runtime API coverage

### DIFF
--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -126,6 +126,73 @@ describe("copyBundledPluginMetadata", () => {
     expect(packageJson.openclaw?.extensions).toEqual(["./index.js"]);
   });
 
+  it("keeps bundled package metadata scoped to declared plugin entry points when runtime helpers exist", () => {
+    const repoRoot = makeRepoRoot("openclaw-bundled-plugin-runtime-metadata-");
+    const pluginDir = path.join(repoRoot, "extensions", "whatsapp");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "runtime-api.ts"),
+      "export const heavy = true;\n",
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "light-runtime-api.ts"),
+      "export const light = true;\n",
+      "utf8",
+    );
+    writeJson(path.join(pluginDir, "openclaw.plugin.json"), {
+      id: "whatsapp",
+      configSchema: { type: "object" },
+    });
+    writeJson(path.join(pluginDir, "package.json"), {
+      name: "@openclaw/whatsapp",
+      openclaw: { extensions: ["./index.ts"], setupEntry: "./setup-entry.ts" },
+    });
+
+    copyBundledPluginMetadata({ repoRoot });
+
+    const packageJson = JSON.parse(
+      fs.readFileSync(
+        path.join(repoRoot, "dist", "extensions", "whatsapp", "package.json"),
+        "utf8",
+      ),
+    ) as { openclaw?: { extensions?: string[]; setupEntry?: string } };
+
+    expect(packageJson.openclaw?.extensions).toEqual(["./index.js"]);
+    expect(packageJson.openclaw?.setupEntry).toBe("./setup-entry.js");
+  });
+
+  it("handles malformed extension metadata without throwing while leaving extension discovery metadata unset", () => {
+    const repoRoot = makeRepoRoot("openclaw-bundled-plugin-malformed-runtime-metadata-");
+    const pluginDir = path.join(repoRoot, "extensions", "telegram");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "runtime-api.ts"),
+      "export const runtime = true;\n",
+      "utf8",
+    );
+    writeJson(path.join(pluginDir, "openclaw.plugin.json"), {
+      id: "telegram",
+      configSchema: { type: "object" },
+    });
+    writeJson(path.join(pluginDir, "package.json"), {
+      name: "@openclaw/telegram",
+      openclaw: { extensions: null, setupEntry: "./setup-entry.ts" },
+    });
+
+    expect(() => copyBundledPluginMetadata({ repoRoot })).not.toThrow();
+
+    const packageJson = JSON.parse(
+      fs.readFileSync(
+        path.join(repoRoot, "dist", "extensions", "telegram", "package.json"),
+        "utf8",
+      ),
+    ) as { openclaw?: { extensions?: string[]; setupEntry?: string } };
+
+    expect(packageJson.openclaw?.extensions).toBeUndefined();
+    expect(packageJson.openclaw?.setupEntry).toBe("./setup-entry.js");
+  });
+
   it("relocates node_modules-backed skill paths into bundled-skills and rewrites the manifest", () => {
     const repoRoot = makeRepoRoot("openclaw-bundled-plugin-node-modules-");
     const pluginDir = createTlonSkillPlugin(repoRoot);

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -279,7 +279,7 @@ describe("collectForbiddenPackPaths", () => {
   });
 });
 
-describe("collectMissingPackPaths", () => {
+describe("listBundledPluginBuildEntries / listBundledPluginPackArtifacts", () => {
   it("adds implicit runtime API build entries and pack artifacts for bundled channel plugins", () => {
     expect(bundledPluginBuildEntries).toMatchObject({
       "extensions/discord/runtime-api": path.join("extensions", "discord", "runtime-api.ts"),
@@ -301,7 +301,9 @@ describe("collectMissingPackPaths", () => {
       ]),
     );
   });
+});
 
+describe("collectMissingPackPaths", () => {
   it("requires the shipped channel catalog, control ui, and optional bundled metadata", () => {
     const missing = collectMissingPackPaths([
       "dist/index.js",

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -2,7 +2,10 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { listBundledPluginPackArtifacts } from "../scripts/lib/bundled-plugin-build-entries.mjs";
+import {
+  listBundledPluginBuildEntries,
+  listBundledPluginPackArtifacts,
+} from "../scripts/lib/bundled-plugin-build-entries.mjs";
 import { listPluginSdkDistArtifacts } from "../scripts/lib/plugin-sdk-entries.mjs";
 import {
   collectAppcastSparkleVersionErrors,
@@ -25,6 +28,7 @@ function makePackResult(filename: string, unpackedSize: number) {
 }
 
 const requiredPluginSdkPackPaths = [...listPluginSdkDistArtifacts(), "dist/plugin-sdk/compat.js"];
+const bundledPluginBuildEntries = listBundledPluginBuildEntries();
 const requiredBundledPluginPackPaths = listBundledPluginPackArtifacts();
 
 describe("collectAppcastSparkleVersionErrors", () => {
@@ -276,6 +280,24 @@ describe("collectForbiddenPackPaths", () => {
 });
 
 describe("collectMissingPackPaths", () => {
+  it("adds implicit runtime API build entries and pack artifacts for bundled channel plugins", () => {
+    expect(bundledPluginBuildEntries).toMatchObject({
+      "extensions/discord/runtime-api": "extensions/discord/runtime-api.ts",
+      "extensions/telegram/runtime-api": "extensions/telegram/runtime-api.ts",
+      "extensions/whatsapp/light-runtime-api": "extensions/whatsapp/light-runtime-api.ts",
+      "extensions/whatsapp/runtime-api": "extensions/whatsapp/runtime-api.ts",
+    });
+
+    expect(requiredBundledPluginPackPaths).toEqual(
+      expect.arrayContaining([
+        "dist/extensions/discord/runtime-api.js",
+        "dist/extensions/telegram/runtime-api.js",
+        "dist/extensions/whatsapp/light-runtime-api.js",
+        "dist/extensions/whatsapp/runtime-api.js",
+      ]),
+    );
+  });
+
   it("requires the shipped channel catalog, control ui, and optional bundled metadata", () => {
     const missing = collectMissingPackPaths([
       "dist/index.js",
@@ -325,7 +347,6 @@ describe("collectMissingPackPaths", () => {
       ]),
     ).toEqual([]);
   });
-
   it("requires bundled plugin runtime sidecars that dynamic plugin boundaries resolve at runtime", () => {
     expect(requiredBundledPluginPackPaths).toEqual(
       expect.arrayContaining([

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import path, { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   listBundledPluginBuildEntries,
@@ -282,10 +282,14 @@ describe("collectForbiddenPackPaths", () => {
 describe("collectMissingPackPaths", () => {
   it("adds implicit runtime API build entries and pack artifacts for bundled channel plugins", () => {
     expect(bundledPluginBuildEntries).toMatchObject({
-      "extensions/discord/runtime-api": "extensions/discord/runtime-api.ts",
-      "extensions/telegram/runtime-api": "extensions/telegram/runtime-api.ts",
-      "extensions/whatsapp/light-runtime-api": "extensions/whatsapp/light-runtime-api.ts",
-      "extensions/whatsapp/runtime-api": "extensions/whatsapp/runtime-api.ts",
+      "extensions/discord/runtime-api": path.join("extensions", "discord", "runtime-api.ts"),
+      "extensions/telegram/runtime-api": path.join("extensions", "telegram", "runtime-api.ts"),
+      "extensions/whatsapp/light-runtime-api": path.join(
+        "extensions",
+        "whatsapp",
+        "light-runtime-api.ts",
+      ),
+      "extensions/whatsapp/runtime-api": path.join("extensions", "whatsapp", "runtime-api.ts"),
     });
 
     expect(requiredBundledPluginPackPaths).toEqual(


### PR DESCRIPTION
## Summary
- add regression coverage that locks bundled `runtime-api` / `light-runtime-api` build entries and packed dist artifacts for bundled channel plugins
- prove bundled `package.json` metadata stays scoped to declared plugin entry points even when runtime helper modules exist on disk
- cover malformed `openclaw.extensions` metadata without throwing during bundled metadata generation

## Context
Current `main` already carries the runtime-helper shipping behavior through the newer top-level public-surface discovery path. I refreshed this PR onto current `main` and deliberately narrowed it to the regression coverage that proves that behavior stays intact, rather than reintroducing the older implementation path from the original branch.

## Validation
- `pnpm exec oxlint --type-aware src/plugins/copy-bundled-plugin-metadata.test.ts test/release-check.test.ts`
- `pnpm exec vitest --run src/plugins/copy-bundled-plugin-metadata.test.ts test/release-check.test.ts`
- repeated the same targeted gate a second time with no code changes in between
- `pnpm build:strict-smoke`
- direct artifact proof after the build:
  - `dist/extensions/discord/runtime-api.js`
  - `dist/extensions/telegram/runtime-api.js`
  - `dist/extensions/whatsapp/runtime-api.js`
  - `dist/extensions/whatsapp/light-runtime-api.js`


> ⚠️ This reopens #53073 which was accidentally closed due to fork deletion.