### PR TITLE
Docs: clarify Docker URL override auth

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -387,8 +387,12 @@ scripts/sandbox-setup.sh
     ```bash
     docker compose run --rm openclaw-cli config set gateway.mode local
     docker compose run --rm openclaw-cli config set gateway.bind lan
-    docker compose run --rm openclaw-cli devices list --url ws://127.0.0.1:18789
+    TOKEN="$(grep '^OPENCLAW_GATEWAY_TOKEN=' .env | cut -d= -f2-)"
+    docker compose run --rm openclaw-cli devices list --url ws://127.0.0.1:18789 --token "$TOKEN"
     ```
+
+    When you pass `--url`, also pass `--token` or `--password`. URL overrides do
+    not reuse implicit credentials from config or environment.
 
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary
- fix the Docker troubleshooting example for `devices list --url ...` so it also passes an explicit gateway token
- document that `--url` overrides do not reuse implicit credentials from config or environment

## Why
The previous troubleshooting snippet suggested:

`docker compose run --rm openclaw-cli devices list --url ws://127.0.0.1:18789`

That command fails in practice because OpenClaw intentionally requires explicit credentials when `--url` is provided. The CLI rejects URL overrides without `--token` or `--password` to avoid silently reusing credentials against an override target.

This update makes the troubleshooting guidance match the actual Docker/VPS behavior and prevents users from hitting the `gateway url override requires explicit credentials` error while following the docs.

## Testing
- [x] `pnpm check:docs`

## AI assistance
AI-assisted. I verified the final doc change and ran the docs check locally.