### PR TITLE
fix: recover stale Chrome MCP selected-page sessions

### DIFF
--- a/src/browser/chrome-mcp.test.ts
+++ b/src/browser/chrome-mcp.test.ts
@@ -305,6 +305,52 @@ describe("chrome MCP page parsing", () => {
     ]);
   });
 
+  it("clears the cached session after repeated stale selected-page failures", async () => {
+    let factoryCalls = 0;
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      const callTool = vi.fn(async ({ name }: ToolCall) => {
+        if (name !== "list_pages") {
+          throw new Error(`unexpected tool ${name}`);
+        }
+        if (factoryCalls <= 2) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "The selected page has been closed. Call list_pages to see open pages.",
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [{ type: "text", text: "## Pages\n1: https://example.com [selected]" }],
+        };
+      });
+      session.client.callTool = callTool as typeof session.client.callTool;
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    await expect(listChromeMcpTabs("chrome-live")).rejects.toThrow(
+      /The selected page has been closed/,
+    );
+
+    const tabs = await listChromeMcpTabs("chrome-live");
+
+    expect(factoryCalls).toBe(3);
+    expect(tabs).toEqual([
+      {
+        targetId: "1",
+        title: "",
+        url: "https://example.com",
+        type: "page",
+      },
+    ]);
+  });
+
   it("creates a fresh session when userDataDir changes for the same profile", async () => {
     const createdSessions: ChromeMcpSession[] = [];
     const closeMocks: Array<ReturnType<typeof vi.fn>> = [];

--- a/src/browser/chrome-mcp.test.ts
+++ b/src/browser/chrome-mcp.test.ts
@@ -263,6 +263,48 @@ describe("chrome MCP page parsing", () => {
     expect(tabs).toHaveLength(2);
   });
 
+  it("reconnects and retries list_pages once when Chrome MCP reports a stale selected page", async () => {
+    let factoryCalls = 0;
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      const callTool = vi.fn(async ({ name }: ToolCall) => {
+        if (name !== "list_pages") {
+          throw new Error(`unexpected tool ${name}`);
+        }
+        if (factoryCalls === 1) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: "The selected page has been closed. Call list_pages to see open pages.",
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [{ type: "text", text: "## Pages\n1: https://example.com [selected]" }],
+        };
+      });
+      session.client.callTool = callTool as typeof session.client.callTool;
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    const tabs = await listChromeMcpTabs("chrome-live");
+
+    expect(factoryCalls).toBe(2);
+    expect(tabs).toEqual([
+      {
+        targetId: "1",
+        title: "",
+        url: "https://example.com",
+        type: "page",
+      },
+    ]);
+  });
+
   it("creates a fresh session when userDataDir changes for the same profile", async () => {
     const createdSessions: ChromeMcpSession[] = [];
     const closeMocks: Array<ReturnType<typeof vi.fn>> = [];

--- a/src/browser/chrome-mcp.ts
+++ b/src/browser/chrome-mcp.ts
@@ -352,6 +352,8 @@ async function callTool(
     }
     return result;
   }
+  // Unreachable in practice: each attempt either returns or throws, but keep
+  // this fallback so TypeScript accepts the bounded retry loop as exhaustive.
   throw new Error(`Chrome MCP tool "${name}" failed after reconnect.`);
 }
 

--- a/src/browser/chrome-mcp.ts
+++ b/src/browser/chrome-mcp.ts
@@ -40,6 +40,8 @@ const DEFAULT_CHROME_MCP_ARGS = [
   "--experimentalStructuredContent",
   "--experimental-page-id-routing",
 ];
+const STALE_SELECTED_PAGE_ERROR =
+  "The selected page has been closed. Call list_pages to see open pages.";
 
 const sessions = new Map<string, ChromeMcpSession>();
 const pendingSessions = new Map<string, Promise<ChromeMcpSession>>();
@@ -151,6 +153,12 @@ function extractMessageText(result: ChromeMcpToolResult): string {
 function extractToolErrorMessage(result: ChromeMcpToolResult, name: string): string {
   const message = extractMessageText(result).trim();
   return message || `Chrome MCP tool "${name}" failed.`;
+}
+
+function shouldReconnectForToolError(name: string, message: string): boolean {
+  // Some chrome-devtools-mcp failures are emitted as tool errors even though the
+  // session state is no longer usable. Reset the cached session and retry once.
+  return name === "list_pages" && message.includes(STALE_SELECTED_PAGE_ERROR);
 }
 
 function extractJsonMessage(result: ChromeMcpToolResult): unknown {
@@ -314,25 +322,37 @@ async function callTool(
   args: Record<string, unknown> = {},
 ): Promise<ChromeMcpToolResult> {
   const cacheKey = buildChromeMcpSessionCacheKey(profileName, userDataDir);
-  const session = await getSession(profileName, userDataDir);
-  let result: ChromeMcpToolResult;
-  try {
-    result = (await session.client.callTool({
-      name,
-      arguments: args,
-    })) as ChromeMcpToolResult;
-  } catch (err) {
-    // Transport/connection error — tear down session so it reconnects on next call
-    sessions.delete(cacheKey);
-    await session.client.close().catch(() => {});
-    throw err;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const session = await getSession(profileName, userDataDir);
+    let result: ChromeMcpToolResult;
+    try {
+      result = (await session.client.callTool({
+        name,
+        arguments: args,
+      })) as ChromeMcpToolResult;
+    } catch (err) {
+      // Transport/connection error — tear down session so it reconnects on next call
+      sessions.delete(cacheKey);
+      await session.client.close().catch(() => {});
+      throw err;
+    }
+    // Most tool-level errors (element not found, script error, etc.) do not
+    // indicate a broken connection. Some page-state errors do leave the session
+    // unusable, so reset and retry once in-band.
+    if (result.isError) {
+      const message = extractToolErrorMessage(result, name);
+      if (shouldReconnectForToolError(name, message)) {
+        sessions.delete(cacheKey);
+        await session.client.close().catch(() => {});
+        if (attempt === 0) {
+          continue;
+        }
+      }
+      throw new Error(message);
+    }
+    return result;
   }
-  // Tool-level errors (element not found, script error, etc.) don't indicate a
-  // broken connection — don't tear down the session for these.
-  if (result.isError) {
-    throw new Error(extractToolErrorMessage(result, name));
-  }
-  return result;
+  throw new Error(`Chrome MCP tool "${name}" failed after reconnect.`);
 }
 
 async function withTempFile<T>(fn: (filePath: string) => Promise<T>): Promise<T> {


### PR DESCRIPTION
## Summary

AI-assisted PR. Testing level: fully tested for the touched browser paths.

Describe the problem and fix in 2–5 bullets:

- Problem: Chrome MCP existing-session profiles can cache a stale selected page handle and keep returning `The selected page has been closed. Call list_pages to see open pages.` as a tool-level `list_pages` failure.
- Why it matters: browser status/tab discovery can get stuck until the operator manually clears the cached existing-session state with `openclaw browser --browser-profile <name> stop`.
- What changed: detect this specific stale-session `list_pages` error, close the cached Chrome MCP session, and retry once in-band before surfacing the failure.
- What did NOT change (scope boundary): no broader retry policy, no change to normal tool-level errors, and no change to Chrome MCP action/snapshot semantics outside `list_pages` recovery.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A

## User-visible / Behavior Changes

Existing-session browser profiles now self-recover once when Chrome MCP reports that the selected page was closed during `list_pages`/tab discovery, instead of requiring a manual `stop` first.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 14.8.3
- Runtime/container: host Node v24.14.1 / pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): browser existing-session via Chrome MCP (`chrome-devtools-mcp@latest`)
- Relevant config (redacted): `browser.profiles.user.driver=existing-session`

### Steps

1. Attach an existing-session browser profile to a live Chrome session.
2. Let Chrome MCP retain a selected page handle, then close that selected Chrome tab outside OpenClaw.
3. Run a browser path that calls `list_pages`, such as `openclaw browser --browser-profile user tabs`.

### Expected

- OpenClaw detects the stale Chrome MCP session, reconnects once, and returns the current tab list.

### Actual

- Before this fix, OpenClaw reused the stale cached session and kept surfacing `The selected page has been closed. Call list_pages to see open pages.` until the operator manually cleared the session.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before fix, the reproducer stayed pinned on:

```text
The selected page has been closed. Call list_pages to see open pages.
```

Passing local checks directly covering this PR:

```bash
pnpm test -- src/browser/chrome-mcp.test.ts src/browser/server-context.existing-session.test.ts
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted browser tests for `chrome-mcp` and `server-context` pass; the stale-selected-page regression test forces a reconnect and succeeds on the second session; the follow-up regression test proves two consecutive stale failures do not poison future Chrome MCP sessions.
- Edge cases checked: existing transport-error reconnect behavior still passes; existing non-reconnectable tool-error preservation behavior still passes.
- What you did **not** verify: full repo `pnpm test`; a live end-to-end Chrome attach inside this clean worktree. I also attempted `codex review --uncommitted`, but the CLI stream disconnected repeatedly before returning a final verdict. Repo-wide `pnpm check` / `pnpm build` currently surface unrelated baseline lint/type issues outside the touched files in this environment, so I did not count them as PR-specific verification.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `c7d1143f60` and `05a8903eef`.
- Files/config to restore: `src/browser/chrome-mcp.ts`, `src/browser/chrome-mcp.test.ts`
- Known bad symptoms reviewers should watch for: repeated reconnect attempts on `list_pages` if upstream Chrome MCP changes the stale-page error contract.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the reconnect path matches a specific upstream `chrome-devtools-mcp` error string.
  - Mitigation: the retry is narrow (`list_pages` only, one retry only), the fallback remains the current manual-recovery path if the string changes, and regression coverage now includes both one-shot recovery and cleanup after repeated stale failures.
