### PR TITLE
Docs: clarify Docker pairing in Control UI

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -49,9 +49,19 @@ openclaw devices list
 openclaw devices approve <requestId>
 ```
 
+If the Gateway runs in Docker or Docker Compose, use the CLI container instead:
+
+```bash
+# List pending requests
+docker compose run --rm openclaw-cli devices list
+
+# Approve by request ID
+docker compose run --rm openclaw-cli devices approve <requestId>
+```
+
 If the browser retries pairing with changed auth details (role/scopes/public
 key), the previous pending request is superseded and a new `requestId` is
-created. Re-run `openclaw devices list` before approval.
+created. Re-run the matching `devices list` command before approval.
 
 Once approved, the device is remembered and won't require re-approval unless
 you revoke it with `openclaw devices revoke --device <id> --role <role>`. See


### PR DESCRIPTION
## Summary
- add Docker and Docker Compose equivalents for the Control UI device pairing commands
- clarify that users should rerun the matching `devices list` command before approving a refreshed request

## Why
The Control UI pairing section only showed host-native commands:

`openclaw devices list`
`openclaw devices approve <requestId>`

That is misleading for Docker and VPS users, where the gateway is typically operated through `docker compose run --rm openclaw-cli ...` instead of a host-installed `openclaw` binary.

This update makes the pairing instructions directly usable for Docker-based deployments and removes a common point of confusion during first dashboard access.

## Testing
- [x] `pnpm check:docs`

## AI assistance
AI-assisted. I verified the final doc change and ran the docs check locally.