### PR TITLE
fix(webchat): prevent system events from overwriting main session display name

### DIFF
--- a/src/config/sessions/metadata.test.ts
+++ b/src/config/sessions/metadata.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { deriveSessionOrigin } from "./metadata.js";
+
+describe("deriveSessionOrigin — system event providers (#54661)", () => {
+  test.each([{ provider: "heartbeat" }, { provider: "cron-event" }, { provider: "exec-event" }])(
+    "does not set origin.label for system provider $provider",
+    ({ provider }) => {
+      const origin = deriveSessionOrigin({
+        Provider: provider,
+        From: provider, // fallback sender value used by heartbeat-runner
+        To: provider,
+        Body: "heartbeat check",
+      });
+
+      expect(origin?.label).toBeUndefined();
+    },
+  );
+
+  test("sets origin.label from From for a regular direct-chat provider", () => {
+    const origin = deriveSessionOrigin({
+      Provider: "telegram",
+      From: "Alice",
+      To: "bot",
+      Body: "Hello",
+      ChatType: "direct",
+    });
+
+    expect(origin?.label).toBe("Alice");
+  });
+
+  test("does not set label when From is empty", () => {
+    const origin = deriveSessionOrigin({
+      Provider: "telegram",
+      From: "",
+      To: "bot",
+      Body: "Hello",
+    });
+
+    expect(origin?.label).toBeUndefined();
+  });
+});

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -41,8 +41,15 @@ const mergeOrigin = (
   return Object.keys(merged).length > 0 ? merged : undefined;
 };
 
+// Providers used by internal scheduler/heartbeat runs — not real user conversations.
+// Origin labels derived from these should not be persisted on the session (#54661).
+const SYSTEM_EVENT_PROVIDERS = new Set(["heartbeat", "cron-event", "exec-event"]);
+
 export function deriveSessionOrigin(ctx: MsgContext): SessionOrigin | undefined {
-  const label = resolveConversationLabel(ctx)?.trim();
+  const isSystemProvider = SYSTEM_EVENT_PROVIDERS.has(ctx.Provider?.trim().toLowerCase() ?? "");
+  // System events are scheduler-driven; their From/sender value is not a meaningful
+  // conversation label and must not overwrite the session's origin.label.
+  const label = isSystemProvider ? undefined : resolveConversationLabel(ctx)?.trim();
   const providerRaw =
     (typeof ctx.OriginatingChannel === "string" && ctx.OriginatingChannel) ||
     ctx.Surface ||

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -12,6 +12,7 @@ import type { SessionEntry } from "../config/sessions.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { withEnv } from "../test-utils/env.js";
 import {
+  buildGatewaySessionRow,
   capArrayByJsonBytes,
   classifySessionKey,
   deriveSessionTitle,
@@ -1986,5 +1987,56 @@ describe("loadCombinedSessionStoreForGateway includes disk-only agents (#32804)"
       expect(store["agent:main:main"]).toBeDefined();
       expect(store["agent:codex:acp-task"]).toBeDefined();
     });
+  });
+});
+
+describe("buildGatewaySessionRow — system event origin labels (#54661)", () => {
+  const baseCfg = {
+    session: { mainKey: "main" },
+    agents: { list: [{ id: "main", default: true }] },
+  } as OpenClawConfig;
+
+  const makeStore = (entry: SessionEntry): Record<string, SessionEntry> => ({
+    "agent:main:main": entry,
+  });
+
+  test.each([
+    { label: "heartbeat", provider: "heartbeat" },
+    { label: "cron-event", provider: "cron-event" },
+    { label: "exec-event", provider: "exec-event" },
+  ])("does not expose $label as displayName for main session", ({ label }) => {
+    const entry: SessionEntry = {
+      sessionId: "sess-main",
+      updatedAt: Date.now(),
+      origin: { label, provider: label },
+    } as unknown as SessionEntry;
+
+    const row = buildGatewaySessionRow({
+      cfg: baseCfg,
+      storePath: "/tmp/sessions.json",
+      store: makeStore(entry),
+      key: "agent:main:main",
+      entry,
+    });
+
+    expect(row.displayName).toBeUndefined();
+  });
+
+  test("preserves a real user-derived origin label as displayName fallback", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-main",
+      updatedAt: Date.now(),
+      origin: { label: "Alice" },
+    } as unknown as SessionEntry;
+
+    const row = buildGatewaySessionRow({
+      cfg: baseCfg,
+      storePath: "/tmp/sessions.json",
+      store: makeStore(entry),
+      key: "agent:main:main",
+      entry,
+    });
+
+    expect(row.displayName).toBe("Alice");
   });
 });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1088,6 +1088,12 @@ export function buildGatewaySessionRow(params: {
   const id = parsed?.id;
   const origin = entry?.origin;
   const originLabel = origin?.label;
+  // System event providers (e.g. "heartbeat") may have previously been stored as
+  // origin.label before fix #54661. Filter them out so they never surface as the
+  // session display name.
+  const SYSTEM_EVENT_LABELS = new Set(["heartbeat", "cron-event", "exec-event"]);
+  const safeOriginLabel =
+    originLabel && !SYSTEM_EVENT_LABELS.has(originLabel.toLowerCase()) ? originLabel : undefined;
   const displayName =
     entry?.displayName ??
     (channel
@@ -1101,7 +1107,7 @@ export function buildGatewaySessionRow(params: {
         })
       : undefined) ??
     entry?.label ??
-    originLabel;
+    safeOriginLabel;
   const deliveryFields = normalizeSessionDeliveryFields(entry);
   const parsedAgent = parseAgentSessionKey(key);
   const sessionAgentId = normalizeAgentId(parsedAgent?.agentId ?? resolveDefaultAgentId(cfg));


### PR DESCRIPTION
Fixes #54661

System events (e.g. heartbeat polls) were overwriting the session displayName, causing the main session to show as "heartbeat" in the UI sidebar instead of "Main". This fix ensures system event content never updates the displayName of persistent/named sessions.