### PR TITLE
Docs: warn about Hetzner compose port merges

### DIFF
--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -193,6 +193,11 @@ For the generic Docker flow, see [Docker](/install/docker).
           ]
     ```
 
+    If you are adapting the repository's default `docker-compose.yml`, replace
+    the `ports:` block rather than merging an override on top of the existing
+    public port mappings. A naive override can leave `0.0.0.0:18789` or
+    `0.0.0.0:18790` exposed even when you intended a loopback-only VPS setup.
+
     `--allow-unconfigured` is only for bootstrap convenience, it is not a replacement for a proper gateway configuration. Still set auth (`gateway.auth.token` or password) and use safe bind settings for your deployment.
 
   </Step>

--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -193,10 +193,10 @@ For the generic Docker flow, see [Docker](/install/docker).
           ]
     ```
 
-    If you are adapting the repository's default `docker-compose.yml`, replace
-    the `ports:` block rather than merging an override on top of the existing
-    public port mappings. A naive override can leave `0.0.0.0:18789` or
-    `0.0.0.0:18790` exposed even when you intended a loopback-only VPS setup.
+    > **Warning:** If you are adapting the repository's default `docker-compose.yml`, replace
+    > the `ports:` block rather than merging an override on top of the existing
+    > public port mappings. A naive override can leave `0.0.0.0:18789` or
+    > `0.0.0.0:18790` exposed even when you intended a loopback-only VPS setup.
 
     `--allow-unconfigured` is only for bootstrap convenience, it is not a replacement for a proper gateway configuration. Still set auth (`gateway.auth.token` or password) and use safe bind settings for your deployment.
 


### PR DESCRIPTION
## Summary
- add a warning to the Hetzner guide about adapting the repository’s default `docker-compose.yml`
- clarify that operators should replace the `ports:` block rather than naively merging an override on top of the existing public port mappings

## Why
The Hetzner guide shows a loopback-only port mapping, but the repository’s default `docker-compose.yml` publishes the gateway and bridge ports publicly by default.

If someone adapts the default compose file and simply layers an override on top of it, Docker Compose can preserve the original `0.0.0.0` port bindings and unintentionally expose the gateway even when the operator intended a localhost-only VPS setup.

This note makes that footgun explicit and helps users avoid accidental public exposure while following the VPS guide.

## Testing
- [x] `pnpm check:docs`

## AI assistance
AI-assisted. I verified the final doc change and ran the docs check locally.