### PR TITLE
Docs: add VPS admin hardening note

### DIFF
--- a/docs/vps.md
+++ b/docs/vps.md
@@ -44,6 +44,21 @@ A community video walkthrough is available at
 
 Related pages: [Gateway remote access](/gateway/remote), [Platforms hub](/platforms).
 
+## Harden admin access first
+
+Before you install OpenClaw on a public VPS, decide how you want to administer
+the box itself.
+
+- If you want Tailnet-only admin access, install Tailscale first, join the VPS
+  to your tailnet, verify a second SSH session over the Tailscale IP or
+  MagicDNS name, then restrict public SSH.
+- If you are not using Tailscale, apply the equivalent hardening for your SSH
+  path before exposing more services.
+- This is separate from Gateway access. You can still keep OpenClaw bound to
+  loopback and use an SSH tunnel or Tailscale Serve for the dashboard.
+
+Tailscale-specific Gateway options live in [Tailscale](/gateway/tailscale).
+
 ## Shared company agent on a VPS
 
 Running a single agent for a team is a valid setup when every user is in the same trust boundary and the agent is business-only.


### PR DESCRIPTION
## Summary
- add a short VPS admin hardening note to the Linux Server guide
- clarify that Tailscale-first admin access is optional, not required
- explicitly separate VPS administration from OpenClaw Gateway access

## Why
One common point of confusion in VPS setups is mixing two different concerns:

1. how to securely administer the VPS itself
2. how to expose or access the OpenClaw Gateway

This update adds a small provider-agnostic note to the Linux Server guide so operators can make an admin-access decision early, before installing OpenClaw on a public VPS.

The note mentions Tailscale as one option for Tailnet-only admin access, but it also makes clear that non-Tailscale SSH hardening is valid and that Gateway access can still stay loopback-only via SSH tunnel or Tailscale Serve.

## Testing
- [x] `pnpm check:docs`

## AI assistance
AI-assisted. I verified the final doc change and ran the docs check locally.