### PR TITLE
[Issue Fix] Fix 53158 by deriving session key prefix from agent's configured provider

### DIFF
--- a/src/gateway/http-utils.session-prefix.test.ts
+++ b/src/gateway/http-utils.session-prefix.test.ts
@@ -71,7 +71,14 @@ describe("resolveSessionKey session prefix (#53158)", () => {
   });
 
   it("resolveProviderForAgent resolves provider from config defaults", () => {
-    const prefix = resolveProviderForAgent("main", "api");
+    const prefix = resolveProviderForAgent("main", "api", {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-5" },
+          models: { "anthropic/claude-3-7-sonnet": {} },
+        },
+      },
+    } as never);
     expect(prefix).toBe("anthropic");
   });
 });

--- a/src/gateway/http-utils.session-prefix.test.ts
+++ b/src/gateway/http-utils.session-prefix.test.ts
@@ -1,0 +1,77 @@
+import type { IncomingMessage } from "node:http";
+import { describe, expect, it } from "vitest";
+import { resolveProviderForAgent, resolveSessionKey } from "./http-utils.js";
+
+function createReq(headers: Record<string, string> = {}): IncomingMessage {
+  return { headers } as IncomingMessage;
+}
+
+describe("resolveSessionKey session prefix (#53158)", () => {
+  it("accepts a provider name as prefix so session keys reflect the actual provider", () => {
+    const result = resolveSessionKey({
+      req: createReq(),
+      agentId: "main",
+      prefix: "anthropic",
+    });
+
+    expect(result).toMatch(/^agent:main:anthropic:/);
+  });
+
+  it("uses explicit session key from header regardless of prefix", () => {
+    const result = resolveSessionKey({
+      req: createReq({ "x-openclaw-session-key": "agent:main:custom:my-session" }),
+      agentId: "main",
+      prefix: "anthropic",
+    });
+
+    expect(result).toBe("agent:main:custom:my-session");
+  });
+
+  it("includes user in session key with provider prefix", () => {
+    const result = resolveSessionKey({
+      req: createReq(),
+      agentId: "main",
+      user: "alice",
+      prefix: "anthropic",
+    });
+
+    expect(result).toContain("anthropic-user:alice");
+    expect(result).not.toContain("openai");
+  });
+
+  it("different providers produce different prefixes", () => {
+    const googleKey = resolveSessionKey({
+      req: createReq(),
+      agentId: "main",
+      user: "alice",
+      prefix: "google",
+    });
+
+    const openaiKey = resolveSessionKey({
+      req: createReq(),
+      agentId: "main",
+      user: "alice",
+      prefix: "openai",
+    });
+
+    expect(googleKey).toContain("google-user:alice");
+    expect(openaiKey).toContain("openai-user:alice");
+    expect(googleKey).not.toEqual(openaiKey);
+  });
+
+  it("openresponses endpoint uses its own prefix", () => {
+    const result = resolveSessionKey({
+      req: createReq(),
+      agentId: "main",
+      user: "bob",
+      prefix: "openresponses",
+    });
+
+    expect(result).toContain("openresponses-user:bob");
+  });
+
+  it("resolveProviderForAgent resolves provider from config defaults", () => {
+    const prefix = resolveProviderForAgent("main", "api");
+    expect(prefix).toBe("anthropic");
+  });
+});

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -313,11 +313,13 @@ export function resolveGatewayRequestContext(params: {
   req: IncomingMessage;
   model: string | undefined;
   user?: string | undefined;
+  agentId?: string;
   sessionPrefix: string;
   defaultMessageChannel: string;
   useMessageChannelHeader?: boolean;
 }): { agentId: string; sessionKey: string; messageChannel: string } {
-  const agentId = resolveAgentIdForRequest({ req: params.req, model: params.model });
+  const agentId =
+    params.agentId ?? resolveAgentIdForRequest({ req: params.req, model: params.model });
   const sessionKey = resolveSessionKey({
     req: params.req,
     agentId,

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -8,6 +8,7 @@ import {
   resolveDefaultModelForAgent,
 } from "../agents/model-selection.js";
 import { loadConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-key.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
@@ -292,6 +293,20 @@ export function resolveSessionKey(params: {
   const user = params.user?.trim();
   const mainKey = user ? `${params.prefix}-user:${user}` : `${params.prefix}:${randomUUID()}`;
   return buildAgentMainSessionKey({ agentId: params.agentId, mainKey });
+}
+
+export function resolveProviderForAgent(
+  agentId: string,
+  fallback: string,
+  cfg?: OpenClawConfig,
+): string {
+  const resolvedCfg = cfg ?? loadConfig();
+  try {
+    const modelRef = resolveDefaultModelForAgent({ cfg: resolvedCfg, agentId });
+    return modelRef.provider || fallback;
+  } catch {
+    return fallback;
+  }
 }
 
 export function resolveGatewayRequestContext(params: {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -262,7 +262,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
 
         const opts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0];
         expect((opts as { sessionKey?: string } | undefined)?.sessionKey ?? "").toContain(
-          "openai-user:alice",
+          "anthropic-user:alice",
         );
         await res.text();
       }
@@ -693,6 +693,75 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     } finally {
       // shared server
     }
+  });
+
+  it("session key prefix reflects actual provider from config (#53158)", async () => {
+    const port = enabledPort;
+    const mockAgentOnce = (payloads: Array<{ text: string }>) => {
+      agentCommand.mockClear();
+      agentCommand.mockResolvedValueOnce({ payloads } as never);
+    };
+    const getSessionKey = () => {
+      const opts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0];
+      return (opts as { sessionKey?: string } | undefined)?.sessionKey ?? "";
+    };
+
+    {
+      mockAgentOnce([{ text: "hello" }]);
+      const res = await postChatCompletions(port, {
+        user: "alice",
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getSessionKey()).toContain("anthropic-user:alice");
+      expect(getSessionKey()).not.toContain("openai-user:");
+      await res.text();
+    }
+
+    {
+      await writeGatewayConfig({
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.4" },
+            models: { "openai/gpt-5.4": {} },
+          },
+        },
+      });
+      mockAgentOnce([{ text: "hello" }]);
+      const res = await postChatCompletions(port, {
+        user: "bob",
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getSessionKey()).toContain("openai-user:bob");
+      expect(getSessionKey()).not.toContain("anthropic-user:");
+      await res.text();
+    }
+
+    {
+      await writeGatewayConfig({
+        agents: {
+          defaults: {
+            model: { primary: "google/gemini-2.5-pro" },
+            models: { "google/gemini-2.5-pro": {} },
+          },
+        },
+      });
+      mockAgentOnce([{ text: "hello" }]);
+      const res = await postChatCompletions(port, {
+        user: "carol",
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      });
+      expect(res.status).toBe(200);
+      expect(getSessionKey()).toContain("google-user:carol");
+      expect(getSessionKey()).not.toContain("openai-user:");
+      await res.text();
+    }
+
+    await writeGatewayConfig({});
   });
 
   it("returns 429 for repeated failed auth when gateway.auth.rateLimit is configured", async () => {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -454,6 +454,7 @@ export async function handleOpenAiHttpRequest(
     req,
     model,
     user,
+    agentId: resolvedAgentId,
     sessionPrefix: providerPrefix,
     defaultMessageChannel: "webchat",
     useMessageChannelHeader: true,

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -32,6 +32,8 @@ import {
   resolveOpenAiCompatModelOverride,
   resolveOpenAiCompatibleHttpOperatorScopes,
   resolveOpenAiCompatibleHttpSenderIsOwner,
+  resolveProviderForAgent,
+  resolveAgentIdForRequest,
 } from "./http-utils.js";
 import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
 
@@ -446,11 +448,13 @@ export async function handleOpenAiHttpRequest(
   const model = typeof payload.model === "string" ? payload.model : "openclaw";
   const user = typeof payload.user === "string" ? payload.user : undefined;
 
+  const resolvedAgentId = resolveAgentIdForRequest({ req, model });
+  const providerPrefix = resolveProviderForAgent(resolvedAgentId, "api");
   const { agentId, sessionKey, messageChannel } = resolveGatewayRequestContext({
     req,
     model,
     user,
-    sessionPrefix: "openai",
+    sessionPrefix: providerPrefix,
     defaultMessageChannel: "webchat",
     useMessageChannelHeader: true,
   });


### PR DESCRIPTION
## Summary

This PR is to fix https://github.com/openclaw/openclaw/issues/53158 issue that OpenAI-compat HTTP endpoint hardcoded "openai" as the session key prefix regardless of which provider was actually configured for the agent. This PR leverages `handleOpenAiHttpRequest` to resolve the actual provider from the agent's config via `resolveProviderForAgent` and pass it as `sessionPrefix`.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #53158 
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

`sessionPrefix` in `resolveGatewayRequestContext` was hardcoded to "openai" in "handleOpenAiHttpRequest" and the prefix was never updated to reflect the configured provider.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file:
  - http-utils.session-prefix.test.ts
  - openai-http.test.ts
- Scenario the test should lock in:
  - Session key prefix matches the provider configured for the agent
- Why this is the smallest reliable guardrail:
  - Unit tests cover `resolveProviderForAgent` and `resolveSessionKey` directly; e2e tests cover the full request path with config switching.

## User-visible / Behavior Changes

Session keys generated by the OpenAI-compat endpoint now reflect the actual configured provider (e.g. anthropic-user:alice instead of openai-user:alice). 


## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: change `sessionPrefix: providerPrefix` back to `sessionPrefix: "openai"` and remove the two lines above it.
- Files/config to restore: `openai-http.ts`
- Known bad symptoms reviewers should watch for: 

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation: None
