### PR TITLE
fix(gateway): ignore transient pre-hello close in one-shot calls

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -40,7 +40,7 @@ let lastRequestOptions: {
   params?: unknown;
   opts?: { expectFinal?: boolean; timeoutMs?: number | null };
 } | null = null;
-type StartMode = "hello" | "close" | "silent";
+type StartMode = "hello" | "close" | "silent" | "close-then-hello";
 let startMode: StartMode = "hello";
 let closeCode = 1006;
 let closeReason = "";
@@ -127,6 +127,13 @@ class StubGatewayClient {
       });
     } else if (startMode === "close") {
       lastClientOptions?.onClose?.(closeCode, closeReason);
+    } else if (startMode === "close-then-hello") {
+      lastClientOptions?.onClose?.(closeCode, closeReason);
+      void lastClientOptions?.onHelloOk?.({
+        features: {
+          methods: helloMethods,
+        },
+      });
     }
   }
   stop() {}
@@ -809,6 +816,15 @@ describe("callGateway error details", () => {
     expect(err?.message).toContain("Gateway target: ws://127.0.0.1:18789");
     expect(err?.message).toContain("Source: local loopback");
     expect(err?.message).toContain("Bind: loopback");
+  });
+
+  it("waits through a transient pre-hello close when the client later completes hello", async () => {
+    startMode = "close-then-hello";
+    closeCode = 1000;
+    closeReason = "";
+    setLocalLoopbackGatewayConfig();
+
+    await expect(callGateway({ method: "health" })).resolves.toEqual({ ok: true });
   });
 
   it("includes connection details on timeout", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -518,6 +518,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
   return await new Promise<T>((resolve, reject) => {
     let settled = false;
     let ignoreClose = false;
+    let helloOk = false;
     const stop = (err?: Error, value?: T) => {
       if (settled) {
         return;
@@ -553,6 +554,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       minProtocol: opts.minProtocol ?? PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,
       onHelloOk: async (hello) => {
+        helloOk = true;
         try {
           ensureGatewaySupportsRequiredMethods({
             requiredMethods: opts.requiredMethods,
@@ -572,6 +574,13 @@ async function executeGatewayRequestWithScopes<T>(params: {
       },
       onClose: (code, reason) => {
         if (settled || ignoreClose) {
+          return;
+        }
+        // Some gateways can transiently close a socket during the initial handshake
+        // (before hello-ok) while reconnect succeeds immediately after. Treat a
+        // normal close with an empty reason as a pre-hello transient and keep
+        // waiting for hello-ok or timeout.
+        if (!helloOk && code === 1000 && reason.trim().length === 0) {
           return;
         }
         ignoreClose = true;

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -516,6 +516,87 @@ describe("GatewayClient close handling", () => {
   });
 });
 
+describe("GatewayClient reconnect behavior", () => {
+  beforeEach(() => {
+    wsInstances.length = 0;
+  });
+
+  it("suppresses transient pre-hello 1000 closes while reconnect succeeds", async () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    const onHelloOk = vi.fn();
+    const onConnectError = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      onClose,
+      onHelloOk,
+      onConnectError,
+    });
+
+    try {
+      client.start();
+      const ws1 = getLatestWs();
+      ws1.emitOpen();
+      ws1.emitMessage(
+        JSON.stringify({
+          type: "event",
+          event: "connect.challenge",
+          payload: { nonce: "nonce-1" },
+        }),
+      );
+
+      // Close before hello-ok (connect response) arrives.
+      ws1.emitClose(1000, "");
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(wsInstances.length).toBe(2);
+
+      const ws2 = getLatestWs();
+      ws2.emitOpen();
+      ws2.emitMessage(
+        JSON.stringify({
+          type: "event",
+          event: "connect.challenge",
+          payload: { nonce: "nonce-2" },
+        }),
+      );
+
+      const rawConnectRequest = ws2.sent.find((frame) => frame.includes('"method":"connect"'));
+      expect(rawConnectRequest).toBeTruthy();
+
+      const pendingIds = Array.from(
+        ((client as unknown as { pending: Map<string, unknown> }).pending ?? new Map()).keys(),
+      );
+      expect(pendingIds.length).toBeGreaterThan(0);
+      const connectId = pendingIds[0];
+      expect(typeof connectId).toBe("string");
+      expect(connectId.length).toBeGreaterThan(0);
+
+      ws2.emitMessage(
+        JSON.stringify({
+          type: "res",
+          id: connectId,
+          ok: true,
+          payload: {},
+        }),
+      );
+
+      expect((client as unknown as { pending: Map<string, unknown> }).pending.size).toBe(0);
+
+      for (let i = 0; i < 5; i += 1) {
+        await Promise.resolve();
+      }
+      expect(onConnectError).not.toHaveBeenCalled();
+      expect(onHelloOk).toHaveBeenCalled();
+
+      expect(onClose).not.toHaveBeenCalledWith(1000, "");
+    } finally {
+      client.stop();
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("GatewayClient connect auth payload", () => {
   beforeEach(() => {
     vi.useRealTimers();

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -595,6 +595,48 @@ describe("GatewayClient reconnect behavior", () => {
       vi.useRealTimers();
     }
   });
+
+  it("emits a failure signal after repeated pre-hello 1000 closes", async () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    const onConnectError = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      onClose,
+      onConnectError,
+    });
+
+    try {
+      (client as unknown as { backoffMs: number }).backoffMs = 1;
+      client.start();
+
+      for (let attempt = 1; attempt <= 4; attempt += 1) {
+        const ws = getLatestWs();
+        ws.emitOpen();
+        ws.emitMessage(
+          JSON.stringify({
+            type: "event",
+            event: "connect.challenge",
+            payload: { nonce: `nonce-${attempt}` },
+          }),
+        );
+        ws.emitClose(1000, "");
+
+        // Allow the reconnect timer to schedule the next socket.
+        await vi.advanceTimersByTimeAsync(30_000);
+      }
+
+      for (let i = 0; i < 5; i += 1) {
+        await Promise.resolve();
+      }
+
+      expect(onConnectError).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalledWith(1000, "");
+    } finally {
+      client.stop();
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("GatewayClient connect auth payload", () => {

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -180,6 +180,7 @@ export function resolveGatewayClientConnectChallengeTimeoutMs(
 
 const FORCE_STOP_TERMINATE_GRACE_MS = 250;
 const STOP_AND_WAIT_TIMEOUT_MS = 1_000;
+const MAX_TRANSIENT_PREHELLO_NORMAL_CLOSES = 3;
 
 type PendingStop = {
   ws: WebSocket;
@@ -202,7 +203,9 @@ export class GatewayClient {
   private deviceTokenRetryBudgetUsed = false;
   private pendingConnectErrorDetailCode: string | null = null;
   private helloOkReceived = false;
-  private suppressNextConnectError = false;
+  private connectAttempt = 0;
+  private suppressConnectErrorAttempts = new Set<number>();
+  private transientPrehelloNormalCloseCount = 0;
   // Track last tick to detect silent stalls.
   private lastTick: number | null = null;
   private tickIntervalMs = 30_000;
@@ -313,9 +316,19 @@ export class GatewayClient {
     ws.on("message", (data) => this.handleMessage(rawDataToString(data)));
     ws.on("close", (code, reason) => {
       const reasonText = rawDataToString(reason);
-      const isTransientPrehelloNormalClose =
+      const isPrehelloNormalCloseCandidate =
         !this.closed && !this.helloOkReceived && code === 1000 && reasonText.trim().length === 0;
-      this.suppressNextConnectError = isTransientPrehelloNormalClose;
+      if (isPrehelloNormalCloseCandidate) {
+        this.transientPrehelloNormalCloseCount += 1;
+      } else {
+        this.transientPrehelloNormalCloseCount = 0;
+      }
+      const isTransientPrehelloNormalClose =
+        isPrehelloNormalCloseCandidate &&
+        this.transientPrehelloNormalCloseCount <= MAX_TRANSIENT_PREHELLO_NORMAL_CLOSES;
+      if (isTransientPrehelloNormalClose && this.connectSent) {
+        this.suppressConnectErrorAttempts.add(this.connectAttempt);
+      }
 
       const connectErrorDetailCode = this.pendingConnectErrorDetailCode;
       this.pendingConnectErrorDetailCode = null;
@@ -405,6 +418,8 @@ export class GatewayClient {
 
   private beginStop(): Promise<void> | null {
     this.closed = true;
+    this.suppressConnectErrorAttempts.clear();
+    this.transientPrehelloNormalCloseCount = 0;
     this.pendingDeviceTokenRetry = false;
     this.deviceTokenRetryBudgetUsed = false;
     this.pendingConnectErrorDetailCode = null;
@@ -550,10 +565,13 @@ export class GatewayClient {
       device,
     };
 
+    const connectAttempt = this.connectAttempt;
+
     void this.request<HelloOk>("connect", params)
       .then((helloOk) => {
         this.helloOkReceived = true;
-        this.suppressNextConnectError = false;
+        this.suppressConnectErrorAttempts.clear();
+        this.transientPrehelloNormalCloseCount = 0;
         this.pendingDeviceTokenRetry = false;
         this.deviceTokenRetryBudgetUsed = false;
         this.pendingConnectErrorDetailCode = null;
@@ -576,8 +594,7 @@ export class GatewayClient {
         this.opts.onHelloOk?.(helloOk);
       })
       .catch((err) => {
-        if (this.suppressNextConnectError) {
-          this.suppressNextConnectError = false;
+        if (this.suppressConnectErrorAttempts.delete(connectAttempt)) {
           return;
         }
         this.pendingConnectErrorDetailCode =
@@ -830,8 +847,8 @@ export class GatewayClient {
   }
 
   private beginPreauthHandshake() {
+    this.connectAttempt += 1;
     this.helloOkReceived = false;
-    this.suppressNextConnectError = false;
     if (this.connectSent) {
       return;
     }

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -201,6 +201,8 @@ export class GatewayClient {
   private pendingDeviceTokenRetry = false;
   private deviceTokenRetryBudgetUsed = false;
   private pendingConnectErrorDetailCode: string | null = null;
+  private helloOkReceived = false;
+  private suppressNextConnectError = false;
   // Track last tick to detect silent stalls.
   private lastTick: number | null = null;
   private tickIntervalMs = 30_000;
@@ -311,6 +313,10 @@ export class GatewayClient {
     ws.on("message", (data) => this.handleMessage(rawDataToString(data)));
     ws.on("close", (code, reason) => {
       const reasonText = rawDataToString(reason);
+      const isTransientPrehelloNormalClose =
+        !this.closed && !this.helloOkReceived && code === 1000 && reasonText.trim().length === 0;
+      this.suppressNextConnectError = isTransientPrehelloNormalClose;
+
       const connectErrorDetailCode = this.pendingConnectErrorDetailCode;
       this.pendingConnectErrorDetailCode = null;
       if (this.ws === ws) {
@@ -341,16 +347,20 @@ export class GatewayClient {
       }
       this.flushPendingErrors(new Error(`gateway closed (${code}): ${reasonText}`));
       if (this.shouldPauseReconnectAfterAuthFailure(connectErrorDetailCode)) {
-        this.opts.onReconnectPaused?.({
-          code,
-          reason: reasonText,
-          detailCode: connectErrorDetailCode,
-        });
-        this.opts.onClose?.(code, reasonText);
+        if (!isTransientPrehelloNormalClose) {
+          this.opts.onReconnectPaused?.({
+            code,
+            reason: reasonText,
+            detailCode: connectErrorDetailCode,
+          });
+          this.opts.onClose?.(code, reasonText);
+        }
         return;
       }
       this.scheduleReconnect();
-      this.opts.onClose?.(code, reasonText);
+      if (!isTransientPrehelloNormalClose) {
+        this.opts.onClose?.(code, reasonText);
+      }
     });
     ws.on("error", (err) => {
       logDebug(`gateway client error: ${String(err)}`);
@@ -542,6 +552,8 @@ export class GatewayClient {
 
     void this.request<HelloOk>("connect", params)
       .then((helloOk) => {
+        this.helloOkReceived = true;
+        this.suppressNextConnectError = false;
         this.pendingDeviceTokenRetry = false;
         this.deviceTokenRetryBudgetUsed = false;
         this.pendingConnectErrorDetailCode = null;
@@ -564,6 +576,10 @@ export class GatewayClient {
         this.opts.onHelloOk?.(helloOk);
       })
       .catch((err) => {
+        if (this.suppressNextConnectError) {
+          this.suppressNextConnectError = false;
+          return;
+        }
         this.pendingConnectErrorDetailCode =
           err instanceof GatewayClientRequestError ? readConnectErrorDetailCode(err.details) : null;
         const shouldRetryWithDeviceToken = this.shouldRetryWithStoredDeviceToken({
@@ -814,6 +830,8 @@ export class GatewayClient {
   }
 
   private beginPreauthHandshake() {
+    this.helloOkReceived = false;
+    this.suppressNextConnectError = false;
     if (this.connectSent) {
       return;
     }


### PR DESCRIPTION
## Summary

- Problem: `callGateway()` (one-shot CLI gateway calls) can fail early when the underlying `GatewayClient` emits a transient pre-`hello-ok` WebSocket close `(1000, "")`.
- Why it matters: This shows up as user-visible false negatives like `gateway closed (1000 normal closure): no close reason` for commands that should succeed after a quick reconnect.
- What changed: Treat a normal close with an empty reason as a transient *pre-hello* close; keep waiting for `hello-ok` (or timeout). Also suppress the matching connect-error noise in `GatewayClient` when reconnect continues.
- What did NOT change (scope boundary): No protocol/auth changes, no retry/backoff behavior changes beyond ignoring this specific close shape while reconnect succeeds.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `callGateway()` treated *any* `onClose` callback as terminal, even though `GatewayClient` auto-reconnects; a `(1000, "")` close can occur during the initial handshake and immediately recover.
- Missing detection / guardrail: No regression test for “close before hello-ok, then hello-ok later”.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: Likely increased frequency of short handshake interruptions (gateway restart / WS churn), exposing the mismatch between one-shot callers and reconnecting client semantics.
- If unknown, what was ruled out: Not an auth failure (code 1000, empty reason), and reconnect succeeds in the simulated scenario.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/call.test.ts` (new case: close-then-hello)
  - `src/gateway/client.test.ts` (new case: transient close + reconnect success)
- Scenario the test should lock in: A transient pre-hello `(1000, "")` close must not fail one-shot calls when `hello-ok` arrives after reconnect.
- Why this is the smallest reliable guardrail: It isolates the race at the call wrapper boundary without requiring a live gateway.
- Existing test that already covers this (if any): None found.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- One-shot gateway calls (e.g. CLI commands using `callGateway`) no longer fail immediately on a transient pre-`hello-ok` `(1000, "")` close; they keep waiting until `hello-ok` or timeout.

## Security Impact (required)

- New permissions/capabilities? (Yes/No) No
- Secrets/tokens handling changed? (Yes/No) No
- New/changed network calls? (Yes/No) No
- Command/tool execution surface changed? (Yes/No) No
- Data access scope changed? (Yes/No) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (CI/unit-test)
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Start a `GatewayClient` / `callGateway` invocation.
2. Emit `onClose(1000, "")` before `hello-ok`.
3. Later emit `hello-ok` (representing a successful reconnect).

### Expected

- The call waits and succeeds (or times out), rather than failing immediately on the transient close.

### Actual

- Before this change, `callGateway` failed immediately with a `gateway closed (1000 ...)` error.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Ran unit tests covering the new transient close cases.
- Edge cases checked: Ensured non-empty close reasons and post-hello closes remain fatal for one-shot calls.
- What you did **not** verify: Live gateway reproduction on a real running daemon.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes/No) Yes
- Config/env changes? (Yes/No) No
- Migration needed? (Yes/No) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit.
- Files/config to restore: `src/gateway/call.ts`, `src/gateway/client.ts`.
- Known bad symptoms reviewers should watch for: One-shot calls hanging until timeout when the gateway is down.

## Risks and Mitigations

- Risk: Suppressing a `(1000, "")` close could delay surfacing a real shutdown by up to the call timeout.
  - Mitigation: Only suppressed before `hello-ok` and still bounded by the existing call timeout; other close codes/reasons remain fatal.

---

AI-assisted: Yes (OpenClaw agent-assisted implementation). Local testing: targeted gateway unit tests (see Evidence above).
