### PR TITLE
fix(discord): keep components schema optional in message tool

### DIFF
--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -125,7 +125,7 @@ function describeDiscordMessageTool({
     capabilities: ["interactive", "components"],
     schema: {
       properties: {
-        components: Type.Optional(createDiscordMessageToolComponentsSchema()),
+        components: createDiscordMessageToolComponentsSchema(),
       },
     },
   };

--- a/extensions/discord/src/message-tool-schema.ts
+++ b/extensions/discord/src/message-tool-schema.ts
@@ -89,26 +89,28 @@ const discordComponentModalSchema = Type.Object({
 });
 
 export function createDiscordMessageToolComponentsSchema() {
-  return Type.Object(
-    {
-      text: Type.Optional(Type.String()),
-      reusable: Type.Optional(
-        Type.Boolean({
-          description: "Allow components to be used multiple times until they expire.",
-        }),
-      ),
-      container: Type.Optional(
-        Type.Object({
-          accentColor: Type.Optional(Type.String()),
-          spoiler: Type.Optional(Type.Boolean()),
-        }),
-      ),
-      blocks: Type.Optional(Type.Array(discordComponentBlockSchema)),
-      modal: Type.Optional(discordComponentModalSchema),
-    },
-    {
-      description:
-        "Discord components v2 payload. Set reusable=true to keep buttons, selects, and forms active until expiry.",
-    },
+  return Type.Optional(
+    Type.Object(
+      {
+        text: Type.Optional(Type.String()),
+        reusable: Type.Optional(
+          Type.Boolean({
+            description: "Allow components to be used multiple times until they expire.",
+          }),
+        ),
+        container: Type.Optional(
+          Type.Object({
+            accentColor: Type.Optional(Type.String()),
+            spoiler: Type.Optional(Type.Boolean()),
+          }),
+        ),
+        blocks: Type.Optional(Type.Array(discordComponentBlockSchema)),
+        modal: Type.Optional(discordComponentModalSchema),
+      },
+      {
+        description:
+          "Discord components v2 payload. Set reusable=true to keep buttons, selects, and forms active until expiry.",
+      },
+    ),
   );
 }

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -100,7 +100,7 @@ function describeMattermostMessageTool({
       enabledAccounts.length > 0
         ? {
             properties: {
-              buttons: Type.Optional(createMessageToolButtonsSchema()),
+              buttons: createMessageToolButtonsSchema(),
             },
           }
         : null,

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -22,7 +22,7 @@ type MessageToolDiscoveryContext = Parameters<DescribeMessageTool>[0];
 type MessageToolSchema = NonNullable<ReturnType<DescribeMessageTool>>["schema"];
 
 function createDiscordMessageToolComponentsSchema() {
-  return Type.Object({ type: Type.Literal("discord-components") });
+  return Type.Optional(Type.Object({ type: Type.Literal("discord-components") }));
 }
 
 function createSlackMessageToolBlocksSchema() {
@@ -544,6 +544,24 @@ describe("message tool schema scoping", () => {
 
     expect(schema.properties?.buttons).toBeDefined();
     expect(schema.required ?? []).not.toContain("buttons");
+  });
+
+  it("keeps components schema optional so plain sends do not require components", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "discord", source: "test", plugin: discordPlugin }]),
+    );
+
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "discord",
+    });
+    const schema = tool.parameters as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+
+    expect(schema.properties?.components).toBeDefined();
+    expect(schema.required ?? []).not.toContain("components");
   });
 
   it("hides telegram poll extras when telegram polls are disabled in scoped mode", () => {


### PR DESCRIPTION
## Summary

- **Problem**: Discord `components` property is incorrectly required in the message tool schema, causing validation failures on plain file attachment sends (`must have required property 'components'`).
- **Why it matters**: Breaks all Discord file attachment attempts — agents cannot send PDFs/images without providing an empty `components: {}` workaround.
- **What changed**: Moved `Type.Optional()` into `createDiscordMessageToolComponentsSchema()` factory function (matching `createMessageToolButtonsSchema()` pattern from #54418). Also fixed identical double-wrap on Mattermost's `buttons` call site missed in #54418.
- **What did NOT change**: No changes to component rendering, Discord message dispatch, or other channel plugins.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #54763
- Related #54418 (same bug class for `buttons`)
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `createDiscordMessageToolComponentsSchema()` returns `Type.Object(...)` without `Type.Optional()`. The call site wraps with `Type.Optional()`, but this marker is lost when properties are merged into the final `Type.Object()` via `mergeToolSchemaProperties` + `buildMessageToolSchemaFromActions`.
- Missing detection / guardrail: No integration-level test for `components` optionality in the merged message tool schema.
- Prior context: #54418 fixed the identical issue for `buttons` by moving `Type.Optional()` into `createMessageToolButtonsSchema()`. The Discord `components` and Mattermost `buttons` call sites were not updated.

## Regression Test Plan (if applicable)

- Coverage level:
  - [x] Unit test
- Target test: `src/agents/tools/message-tool.test.ts`, `extensions/discord/src/channel-actions.test.ts`
- Scenario: Discord `components` must NOT appear in `required` array of merged message tool schema.
- New test: "keeps components schema optional so plain sends do not require components"

## User-visible / Behavior Changes

- Discord file attachment sends no longer require an empty `components: {}` workaround.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps
1. Configure Discord channel
2. Have agent send a file via `message(action: "send", media: "/path/to/file.pdf")`
3. Before fix: `must have required property 'components'`. After fix: sends successfully.

## Evidence

- [x] Failing test/log before + passing after (52 tests pass across 3 test files)

## Human Verification (required)

- Verified: `components` not in `required` array, test mock updated to match real signature, Mattermost double-wrap fixed
- Edge cases: Double-optional wrapping (TypeBox handles gracefully but unnecessary)
- Not verified: Live Discord file send (schema-only fix, no runtime logic change)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert the single commit.
- Watch for: Discord components not rendering (unlikely — only optionality changed, not structure).

## Risks and Mitigations

- Risk: Other plugins may have the same double-wrap pattern.
  - Mitigation: Searched all call sites — only Mattermost had this issue, fixed in this PR.

🤖 This PR was AI-assisted (Claude Code). All changes were reviewed, tested, and verified by the author.
