### PR TITLE
fix(ui): prevent exec approval buttons from scrolling off-screen

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2881,6 +2881,10 @@ td.data-table-key-col {
 
 .exec-approval-card {
   width: min(540px, 100%);
+  max-height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
@@ -2925,6 +2929,8 @@ td.data-table-key-col {
   white-space: pre-wrap;
   font-family: var(--mono);
   font-size: 13px;
+  max-height: 300px;
+  overflow-y: auto;
 }
 
 .exec-approval-meta {
@@ -2957,6 +2963,7 @@ td.data-table-key-col {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  flex-shrink: 0;
 }
 
 /* ===========================================
@@ -4258,6 +4265,7 @@ details[open] > .ov-expandable-toggle::after {
 
   .exec-approval-card {
     padding: 16px;
+    max-height: calc(100vh - 24px);
   }
 
   .exec-approval-actions {


### PR DESCRIPTION
## Problem

When exec commands require approval in webchat, long commands (heredoc file writes) push the approve/deny buttons off-screen. Users must type `/approve` manually instead of clicking the visible buttons.

## Root Cause

The exec approval modal (`.exec-approval-card`) has no `max-height` constraint, and the command section (`.exec-approval-command`) has no height limit or overflow handling. Long commands expand the modal beyond viewport height, pushing the action buttons off-screen.

## Solution

- Add `max-height: calc(100vh - 48px)` to `.exec-approval-card` with flexbox layout
- Add `max-height: 300px` and `overflow-y: auto` to `.exec-approval-command`
- Add `flex-shrink: 0` to `.exec-approval-actions` to prevent button compression
- Add tighter `max-height` for mobile viewport

## Testing

- Tested with 50+ line heredoc commands - buttons remain visible
- Verified on mobile viewport (< 768px)
- Command section scrolls independently when content exceeds 300px

---

Generated with [Claude Code](https://claude.ai/code)