### PR TITLE
Plugins: reload gateway-bindable runtimes when active registry is incompatible

### DIFF
--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const hoisted = vi.hoisted(() => ({
   loadOpenClawPlugins: vi.fn(),
   getActivePluginRegistryKey: vi.fn<() => string | null>(),
+  activePluginRegistryAllowsGatewaySubagentBinding: vi.fn<() => boolean>(),
 }));
 
 vi.mock("../plugins/loader.js", () => ({
@@ -11,6 +12,8 @@ vi.mock("../plugins/loader.js", () => ({
 
 vi.mock("../plugins/runtime.js", () => ({
   getActivePluginRegistryKey: hoisted.getActivePluginRegistryKey,
+  activePluginRegistryAllowsGatewaySubagentBinding:
+    hoisted.activePluginRegistryAllowsGatewaySubagentBinding,
 }));
 
 describe("ensureRuntimePluginsLoaded", () => {
@@ -18,12 +21,15 @@ describe("ensureRuntimePluginsLoaded", () => {
     hoisted.loadOpenClawPlugins.mockReset();
     hoisted.getActivePluginRegistryKey.mockReset();
     hoisted.getActivePluginRegistryKey.mockReturnValue(null);
+    hoisted.activePluginRegistryAllowsGatewaySubagentBinding.mockReset();
+    hoisted.activePluginRegistryAllowsGatewaySubagentBinding.mockReturnValue(false);
     vi.resetModules();
   });
 
-  it("does not reactivate plugins when a process already has an active registry", async () => {
+  it("does not reactivate plugins when a process already has a compatible active registry", async () => {
     const { ensureRuntimePluginsLoaded } = await import("./runtime-plugins.js");
     hoisted.getActivePluginRegistryKey.mockReturnValue("gateway-registry");
+    hoisted.activePluginRegistryAllowsGatewaySubagentBinding.mockReturnValue(true);
 
     ensureRuntimePluginsLoaded({
       config: {} as never,
@@ -32,6 +38,26 @@ describe("ensureRuntimePluginsLoaded", () => {
     });
 
     expect(hoisted.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
+
+  it("reloads plugins when the active registry lacks gateway subagent binding", async () => {
+    const { ensureRuntimePluginsLoaded } = await import("./runtime-plugins.js");
+    hoisted.getActivePluginRegistryKey.mockReturnValue("default-registry");
+    hoisted.activePluginRegistryAllowsGatewaySubagentBinding.mockReturnValue(false);
+
+    ensureRuntimePluginsLoaded({
+      config: {} as never,
+      workspaceDir: "/tmp/workspace",
+      allowGatewaySubagentBinding: true,
+    });
+
+    expect(hoisted.loadOpenClawPlugins).toHaveBeenCalledWith({
+      config: {} as never,
+      workspaceDir: "/tmp/workspace",
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+    });
   });
 
   it("loads runtime plugins when no active registry exists", async () => {

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -1,6 +1,9 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
-import { getActivePluginRegistryKey } from "../plugins/runtime.js";
+import {
+  activePluginRegistryAllowsGatewaySubagentBinding,
+  getActivePluginRegistryKey,
+} from "../plugins/runtime.js";
 import { resolveUserPath } from "../utils.js";
 
 export function ensureRuntimePluginsLoaded(params: {
@@ -8,7 +11,10 @@ export function ensureRuntimePluginsLoaded(params: {
   workspaceDir?: string | null;
   allowGatewaySubagentBinding?: boolean;
 }): void {
-  if (getActivePluginRegistryKey()) {
+  if (
+    getActivePluginRegistryKey() &&
+    (!params.allowGatewaySubagentBinding || activePluginRegistryAllowsGatewaySubagentBinding())
+  ) {
     return;
   }
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -657,8 +657,12 @@ function warnAboutUntrackedLoadedPlugins(params: {
   }
 }
 
-function activatePluginRegistry(registry: PluginRegistry, cacheKey: string): void {
-  setActivePluginRegistry(registry, cacheKey);
+function activatePluginRegistry(
+  registry: PluginRegistry,
+  cacheKey: string,
+  runtimeSubagentMode: "default" | "explicit" | "gateway-bindable",
+): void {
+  setActivePluginRegistry(registry, cacheKey, runtimeSubagentMode);
   initializeGlobalHookRunner(registry);
 }
 
@@ -682,6 +686,12 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const includeSetupOnlyChannelPlugins = options.includeSetupOnlyChannelPlugins === true;
   const preferSetupRuntimeForChannelPlugins = options.preferSetupRuntimeForChannelPlugins === true;
   const shouldActivate = options.activate !== false;
+  const runtimeSubagentMode =
+    options.runtimeOptions?.allowGatewaySubagentBinding === true
+      ? "gateway-bindable"
+      : options.runtimeOptions?.subagent
+        ? "explicit"
+        : "default";
   // NOTE: `activate` is intentionally excluded from the cache key. All non-activating
   // (snapshot) callers pass `cache: false` via loadOnboardingPluginRegistry(), so they
   // never read from or write to the cache. Including `activate` here would be misleading
@@ -694,12 +704,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     onlyPluginIds,
     includeSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
-    runtimeSubagentMode:
-      options.runtimeOptions?.allowGatewaySubagentBinding === true
-        ? "gateway-bindable"
-        : options.runtimeOptions?.subagent
-          ? "explicit"
-          : "default",
+    runtimeSubagentMode,
   });
   const cacheEnabled = options.cache !== false;
   if (cacheEnabled) {
@@ -707,7 +712,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     if (cached) {
       restoreMemoryPromptSection(cached.memoryPromptBuilder);
       if (shouldActivate) {
-        activatePluginRegistry(cached.registry, cacheKey);
+        activatePluginRegistry(cached.registry, cacheKey, runtimeSubagentMode);
       }
       return cached.registry;
     }
@@ -1275,7 +1280,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     });
   }
   if (shouldActivate) {
-    activatePluginRegistry(registry, cacheKey);
+    activatePluginRegistry(registry, cacheKey, runtimeSubagentMode);
   }
   return registry;
 }

--- a/src/plugins/runtime.channel-pin.test.ts
+++ b/src/plugins/runtime.channel-pin.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { getChannelPlugin } from "../channels/plugins/registry.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import {
+  activePluginRegistryAllowsGatewaySubagentBinding,
   getActivePluginChannelRegistryVersion,
   getActivePluginRegistryVersion,
   getActivePluginChannelRegistry,
@@ -117,5 +118,15 @@ describe("channel registry pinning", () => {
     const fresh = createEmptyPluginRegistry();
     setActivePluginRegistry(fresh);
     expect(getActivePluginChannelRegistry()).toBe(fresh);
+  });
+
+  it("treats only gateway-bindable mode as gateway-compatible", () => {
+    const explicitRegistry = createEmptyPluginRegistry();
+    setActivePluginRegistry(explicitRegistry, "explicit-registry", "explicit");
+    expect(activePluginRegistryAllowsGatewaySubagentBinding()).toBe(false);
+
+    const gatewayBindableRegistry = createEmptyPluginRegistry();
+    setActivePluginRegistry(gatewayBindableRegistry, "gateway-registry", "gateway-bindable");
+    expect(activePluginRegistryAllowsGatewaySubagentBinding()).toBe(true);
   });
 });

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -190,7 +190,7 @@ export function getActivePluginRegistryRuntimeSubagentMode(): ActivePluginRegist
 }
 
 export function activePluginRegistryAllowsGatewaySubagentBinding(): boolean {
-  return state.runtimeSubagentMode !== "default";
+  return state.runtimeSubagentMode === "gateway-bindable";
 }
 
 export function getActivePluginRegistryVersion(): number {

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -9,12 +9,15 @@ type RegistrySurfaceState = {
   version: number;
 };
 
+export type ActivePluginRegistryRuntimeSubagentMode = "default" | "explicit" | "gateway-bindable";
+
 type RegistryState = {
   activeRegistry: PluginRegistry | null;
   activeVersion: number;
   httpRoute: RegistrySurfaceState;
   channel: RegistrySurfaceState;
   key: string | null;
+  runtimeSubagentMode: ActivePluginRegistryRuntimeSubagentMode;
 };
 
 const state: RegistryState = (() => {
@@ -36,6 +39,7 @@ const state: RegistryState = (() => {
         version: 0,
       },
       key: null,
+      runtimeSubagentMode: "default",
     };
   }
   return globalState[REGISTRY_STATE];
@@ -71,12 +75,17 @@ function syncTrackedSurface(
   installSurfaceRegistry(surface, registry, false);
 }
 
-export function setActivePluginRegistry(registry: PluginRegistry, cacheKey?: string) {
+export function setActivePluginRegistry(
+  registry: PluginRegistry,
+  cacheKey?: string,
+  runtimeSubagentMode: ActivePluginRegistryRuntimeSubagentMode = "default",
+) {
   state.activeRegistry = registry;
   state.activeVersion += 1;
   syncTrackedSurface(state.httpRoute, registry, true);
   syncTrackedSurface(state.channel, registry, true);
   state.key = cacheKey ?? null;
+  state.runtimeSubagentMode = runtimeSubagentMode;
 }
 
 export function getActivePluginRegistry(): PluginRegistry | null {
@@ -89,6 +98,7 @@ export function requireActivePluginRegistry(): PluginRegistry {
     state.activeVersion += 1;
     syncTrackedSurface(state.httpRoute, state.activeRegistry);
     syncTrackedSurface(state.channel, state.activeRegistry);
+    state.runtimeSubagentMode = "default";
   }
   return state.activeRegistry;
 }
@@ -175,6 +185,14 @@ export function getActivePluginRegistryKey(): string | null {
   return state.key;
 }
 
+export function getActivePluginRegistryRuntimeSubagentMode(): ActivePluginRegistryRuntimeSubagentMode {
+  return state.runtimeSubagentMode;
+}
+
+export function activePluginRegistryAllowsGatewaySubagentBinding(): boolean {
+  return state.runtimeSubagentMode !== "default";
+}
+
 export function getActivePluginRegistryVersion(): number {
   return state.activeVersion;
 }
@@ -185,4 +203,5 @@ export function resetPluginRuntimeStateForTest(): void {
   installSurfaceRegistry(state.httpRoute, null, false);
   installSurfaceRegistry(state.channel, null, false);
   state.key = null;
+  state.runtimeSubagentMode = "default";
 }

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -15,6 +15,7 @@ vi.mock("./loader.js", () => ({
 
 let resolvePluginTools: typeof import("./tools.js").resolvePluginTools;
 let resetPluginRuntimeStateForTest: typeof import("./runtime.js").resetPluginRuntimeStateForTest;
+let setActivePluginRegistry: typeof import("./runtime.js").setActivePluginRegistry;
 
 function makeTool(name: string) {
   return {
@@ -96,6 +97,7 @@ describe("resolvePluginTools optional tools", () => {
     vi.resetModules();
     loadOpenClawPluginsMock.mockClear();
     ({ resetPluginRuntimeStateForTest } = await import("./runtime.js"));
+    ({ setActivePluginRegistry } = await import("./runtime.js"));
     resetPluginRuntimeStateForTest();
     ({ resolvePluginTools } = await import("./tools.js"));
   });
@@ -193,5 +195,36 @@ describe("resolvePluginTools optional tools", () => {
         },
       }),
     );
+  });
+
+  it("reloads when the active registry lacks gateway subagent binding", () => {
+    const activeRegistry = {
+      tools: [
+        {
+          pluginId: "optional-demo",
+          optional: true,
+          source: "/tmp/active-default.js",
+          factory: () => makeTool("stale_optional_tool"),
+        },
+      ],
+      diagnostics: [],
+    };
+    setActivePluginRegistry(activeRegistry as never, "active-default");
+    setOptionalDemoRegistry();
+
+    const tools = resolvePluginTools({
+      context: createContext() as never,
+      allowGatewaySubagentBinding: true,
+      toolAllowlist: ["optional_tool"],
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
+      }),
+    );
+    expect(tools.map((tool) => tool.name)).toEqual(["optional_tool"]);
   });
 });

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -227,4 +227,35 @@ describe("resolvePluginTools optional tools", () => {
     );
     expect(tools.map((tool) => tool.name)).toEqual(["optional_tool"]);
   });
+
+  it("reloads when the active registry uses an explicit subagent runtime", () => {
+    const activeRegistry = {
+      tools: [
+        {
+          pluginId: "optional-demo",
+          optional: true,
+          source: "/tmp/active-explicit.js",
+          factory: () => makeTool("stale_optional_tool"),
+        },
+      ],
+      diagnostics: [],
+    };
+    setActivePluginRegistry(activeRegistry as never, "active-explicit", "explicit");
+    setOptionalDemoRegistry();
+
+    const tools = resolvePluginTools({
+      context: createContext() as never,
+      allowGatewaySubagentBinding: true,
+      toolAllowlist: ["optional_tool"],
+    });
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
+      }),
+    );
+    expect(tools.map((tool) => tool.name)).toEqual(["optional_tool"]);
+  });
 });

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -4,7 +4,11 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { applyTestPluginDefaults, normalizePluginsConfig } from "./config-state.js";
 import { loadOpenClawPlugins } from "./loader.js";
 import { createPluginLoaderLogger } from "./logger.js";
-import { getActivePluginRegistry, getActivePluginRegistryKey } from "./runtime.js";
+import {
+  activePluginRegistryAllowsGatewaySubagentBinding,
+  getActivePluginRegistry,
+  getActivePluginRegistryKey,
+} from "./runtime.js";
 import type { OpenClawPluginToolContext } from "./types.js";
 
 const log = createSubsystemLogger("plugins");
@@ -68,20 +72,23 @@ export function resolvePluginTools(params: {
   }
 
   const activeRegistry = getActivePluginRegistry();
-  const registry =
-    getActivePluginRegistryKey() && activeRegistry
-      ? activeRegistry
-      : loadOpenClawPlugins({
-          config: effectiveConfig,
-          workspaceDir: params.context.workspaceDir,
-          runtimeOptions: params.allowGatewaySubagentBinding
-            ? {
-                allowGatewaySubagentBinding: true,
-              }
-            : undefined,
-          env,
-          logger: createPluginLoaderLogger(log),
-        });
+  const canReuseActiveRegistry =
+    Boolean(getActivePluginRegistryKey()) &&
+    Boolean(activeRegistry) &&
+    (!params.allowGatewaySubagentBinding || activePluginRegistryAllowsGatewaySubagentBinding());
+  const registry = canReuseActiveRegistry
+    ? activeRegistry!
+    : loadOpenClawPlugins({
+        config: effectiveConfig,
+        workspaceDir: params.context.workspaceDir,
+        runtimeOptions: params.allowGatewaySubagentBinding
+          ? {
+              allowGatewaySubagentBinding: true,
+            }
+          : undefined,
+        env,
+        logger: createPluginLoaderLogger(log),
+      });
 
   const tools: AnyAgentTool[] = [];
   const existing = params.existingToolNames ?? new Set<string>();


### PR DESCRIPTION
## Summary

- Problem: plugin tools and runtime-dependent paths could reuse an already-active plugin registry whose runtime was created without `allowGatewaySubagentBinding`, even when the current call explicitly required gateway subagent binding.
- Why it matters: channel / gateway-triggered plugin execution could fall back to the default unavailable subagent runtime and throw `Plugin runtime subagent methods are only available during a gateway request.`
- What changed: track the active registry's runtime subagent mode, and reload a compatible registry when a caller requires gateway binding but the active registry was activated in default mode.
- What did NOT change (scope boundary): default plugin runtimes still do not get subagent access by default; this PR does not relax the isolation model or broaden plugin permissions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] API / contracts
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: active plugin registry reuse only tracked the registry/cache key, not whether the activated runtime was created in default mode vs gateway-bindable mode.
- Missing detection / guardrail: callers like `src/agents/runtime-plugins.ts` and `src/plugins/tools.ts` treated any active registry as compatible, even when the current execution path explicitly required `allowGatewaySubagentBinding`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: the late-binding gateway subagent model depends on the runtime variant used to create the active registry, but that capability was not preserved as active-registry state.
- If unknown, what was ruled out: this was not caused by plugin-side tool logic; the failure reproduced from host-side registry/runtime reuse behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/runtime-plugins.test.ts`, `src/plugins/tools.optional.test.ts`
- Scenario the test should lock in: when the active registry was activated without gateway subagent binding, callers that explicitly require gateway binding must reload a compatible registry instead of reusing the stale one.
- Why this is the smallest reliable guardrail: the bug is in registry/runtime capability reuse, so focused unit coverage on the reuse decision is enough to catch it without full channel integration setup.
- Existing test that already covers this (if any): existing tests covered forwarding of `allowGatewaySubagentBinding`, but not reuse of an incompatible active registry.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Plugin and channel execution paths that explicitly require gateway-bound subagent runtime now recover by loading a compatible plugin registry instead of reusing an incompatible active registry.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): plugin runtime / gateway-bound tool execution
- Relevant config (redacted): plugin runtime paths requiring `allowGatewaySubagentBinding`

### Steps

1. Activate or reuse a plugin registry created with the default runtime mode.
2. Execute a path that explicitly requires `allowGatewaySubagentBinding`.
3. Observe whether the host reuses the incompatible registry or reloads a compatible runtime variant.

### Expected

- The host reloads a compatible registry/runtime when gateway-bound subagent access is explicitly required.

### Actual

- The host could reuse an incompatible active registry, causing plugin runtime subagent methods to stay unavailable.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test -- src/agents/runtime-plugins.test.ts`
  - `pnpm test -- src/plugins/tools.optional.test.ts`
  - `pnpm build`
- Edge cases checked:
  - compatible active registry is still reused
  - incompatible active registry is reloaded only when gateway binding is explicitly required
- What you did **not** verify:
  - full end-to-end channel reproduction in this PR branch

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR to restore previous active-registry reuse behavior
- Files/config to restore: `src/plugins/runtime.ts`, `src/plugins/loader.ts`, `src/agents/runtime-plugins.ts`, `src/plugins/tools.ts`
- Known bad symptoms reviewers should watch for: unnecessary plugin-registry reloads or unexpected tool/runtime selection changes

## Risks and Mitigations

- Risk: callers may reload the registry more often than before when active runtime capability does not match the current execution requirement.
  - Mitigation: reuse is still preserved for compatible active registries; added focused regression tests cover both reuse and reload cases.

Note: local `pnpm test` is currently blocked by unrelated failures in `src/memory/manager.batch.test.ts`. This PR only changes plugin runtime/registry reuse behavior; targeted regression tests and `pnpm build` pass.
