### PR TITLE
docs: add lesson routing guidance to AGENTS.md template

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -39,16 +39,20 @@ Capture what matters. Decisions, context, things to remember. Skip the secrets u
 - **DO NOT load in shared contexts** (Discord, group chats, sessions with other people)
 - This is for **security** — contains personal context that shouldn't leak to strangers
 - You can **read, edit, and update** MEMORY.md freely in main sessions
-- Write significant events, thoughts, decisions, opinions, lessons learned
+- Write cross-cutting personal context: people, preferences, relationships, decisions that aren't owned by any single skill
 - This is your curated memory — the distilled essence, not raw logs
 - Over time, review your daily files and update MEMORY.md with what's worth keeping
+- **Routing rule:** If a lesson only matters when running a specific skill, put it in that skill's SKILL.md (gotchas section), NOT here. MEMORY.md is for things that apply across multiple skills or aren't tied to any skill. Skill-specific lessons in MEMORY.md waste tokens (loaded every session even when the skill isn't active) and are invisible to cron agents that only read SKILL.md.
 
 ### 📝 Write It Down - No "Mental Notes"!
 
 - **Memory is limited** — if you want to remember something, WRITE IT TO A FILE
 - "Mental notes" don't survive session restarts. Files do.
 - When someone says "remember this" → update `memory/YYYY-MM-DD.md` or relevant file
-- When you learn a lesson → update AGENTS.md, TOOLS.md, or the relevant skill
+- When you learn a lesson → put it where it will be read at the right time:
+  - **Skill-specific lesson** (gotcha, edge case, bug) → that skill's SKILL.md gotchas section
+  - **Cross-cutting preference or decision** → MEMORY.md
+  - **Environment-specific note** (API keys, device names) → TOOLS.md
 - When you make a mistake → document it so future-you doesn't repeat it
 - **Text > Brain** 📝
 
@@ -207,7 +211,7 @@ Periodically (every few days), use a heartbeat to:
 
 1. Read through recent `memory/YYYY-MM-DD.md` files
 2. Identify significant events, lessons, or insights worth keeping long-term
-3. Update `MEMORY.md` with distilled learnings
+3. Route each lesson to the right file: skill-specific → SKILL.md gotchas; cross-cutting → MEMORY.md
 4. Remove outdated info from MEMORY.md that's no longer relevant
 
 Think of it like a human reviewing their journal and updating their mental model. Daily files are raw notes; MEMORY.md is curated wisdom.


### PR DESCRIPTION
## Problem

The default AGENTS.md template directs all lessons to MEMORY.md:

> "Write significant events, thoughts, decisions, opinions, lessons learned"

But the [AgentSkills best practices](https://agentskills.io/skill-creation/best-practices) are clear that skill-specific lessons belong in SKILL.md:

> "The highest-value content in many skills is a list of gotchas — environment-specific facts that defy reasonable assumptions."

> "Keep gotchas in SKILL.md where the agent reads them before encountering the situation."

> "When an agent makes a mistake you have to correct, add the correction to the gotchas section. This is one of the most direct ways to improve a skill iteratively."

The template does not distinguish between cross-cutting lessons (which belong in MEMORY.md) and skill-specific lessons (which belong in SKILL.md). Since the MEMORY.md instruction is more prominent and simpler, agents default everything there.

## Solution

Three edits to the AGENTS.md template to add routing guidance:

1. **MEMORY.md section**: Replace "lessons learned" with "cross-cutting personal context" and add a routing rule: skill-specific lessons go in SKILL.md, not here
2. **Write It Down section**: Expand into a routing decision tree — skill-specific → SKILL.md gotchas, cross-cutting → MEMORY.md, environment-specific → TOOLS.md
3. **Memory Maintenance**: Update step 3 to route lessons to the right file instead of defaulting to MEMORY.md