### PR TITLE
fix: deduplicate Feishu plugin tool registration on MCP reconnect

### DIFF
--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -272,7 +272,14 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
 
     const normalized = names.map((name) => name.trim()).filter(Boolean);
+
+    // Deduplicate: skip if any of the tool's names are already registered
     if (normalized.length > 0) {
+      const existingNames = new Set(registry.tools.flatMap((t) => t.names));
+      const alreadyRegistered = normalized.some((n) => existingNames.has(n));
+      if (alreadyRegistered) {
+        return;
+      }
       record.toolNames.push(...normalized);
     }
     registry.tools.push({


### PR DESCRIPTION
## Problem

Feishu plugin tools are re-registered on every MCP connection, causing duplicate tool entries in the registry. Each MCP reconnect triggers a full re-registration of all Feishu tools without checking if they already exist.

## Fix

Added a deduplication check in `registerTool` (src/plugins/registry.ts). Before pushing a new tool entry, the function now checks if any of the tool's names are already present in the registry. If so, it skips the registration entirely.

This is a minimal, safe change — it only adds an early-return guard and doesn't alter existing behavior for first-time registrations.

Fixes #54816