### PR TITLE
fix(sandbox): propagate browser.ssrfPolicy to sandbox browser bridge

### DIFF
--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
 } from "../../browser/constants.js";
 import { deriveDefaultBrowserCdpPortRange } from "../../config/port-defaults.js";
+import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { defaultRuntime } from "../../runtime.js";
 import { BROWSER_BRIDGES } from "./browser-bridges.js";
 import { computeSandboxBrowserConfigHash } from "./config-hash.js";
@@ -66,6 +67,7 @@ function buildSandboxBrowserResolvedConfig(params: {
   cdpPort: number;
   headless: boolean;
   evaluateEnabled: boolean;
+  ssrfPolicy?: SsrFPolicy;
 }): ResolvedBrowserConfig {
   const cdpHost = "127.0.0.1";
   const cdpPortRange = deriveDefaultBrowserCdpPortRange(params.controlPort);
@@ -93,6 +95,7 @@ function buildSandboxBrowserResolvedConfig(params: {
         color: DEFAULT_OPENCLAW_BROWSER_COLOR,
       },
     },
+    ssrfPolicy: params.ssrfPolicy,
   };
 }
 
@@ -133,6 +136,7 @@ export async function ensureSandboxBrowser(params: {
   cfg: SandboxConfig;
   evaluateEnabled?: boolean;
   bridgeAuth?: { token?: string; password?: string };
+  ssrfPolicy?: SsrFPolicy;
 }): Promise<SandboxBrowserContext | null> {
   if (!params.cfg.browser.enabled) {
     return null;
@@ -353,6 +357,7 @@ export async function ensureSandboxBrowser(params: {
         cdpPort: mappedCdp,
         headless: params.cfg.browser.headless,
         evaluateEnabled: params.evaluateEnabled ?? DEFAULT_BROWSER_EVALUATE_ENABLED,
+        ssrfPolicy: params.ssrfPolicy,
       }),
       authToken: desiredAuthToken,
       authPassword: desiredAuthPassword,

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -184,6 +184,7 @@ export async function resolveSandboxContext(params: {
           cfg: resolvedCfg,
           evaluateEnabled,
           bridgeAuth,
+          ssrfPolicy: params.config?.browser?.ssrfPolicy,
         })
       : null;
 


### PR DESCRIPTION
## Summary

- **Problem**: `buildSandboxBrowserResolvedConfig` in `src/agents/sandbox/browser.ts` never included `ssrfPolicy` in the returned `ResolvedBrowserConfig`, causing the sandbox browser bridge to always use the strictest SSRF policy regardless of user configuration in `browser.ssrfPolicy`.
- **Fix**: Thread `ssrfPolicy` from the top-level config through `resolveSandboxContext` → `ensureSandboxBrowser` → `buildSandboxBrowserResolvedConfig` so sandbox browsers honor the user's `browser.ssrfPolicy` setting.
- **Scope**: Pure data plumbing — three insertion points, no behavioral changes outside the sandbox browser path.

Fixes #45153

Related: #45215 (closed, same approach), #51722 (open, hardcodes value instead of propagating config)

## Change Type
- [x] **Bug fix**

## Scope
- [x] **Gateway / orchestration**
- [x] **Skills / tool execution**

## Test plan
- [x] `pnpm tsgo` — clean
- [x] `pnpm check` — clean (format, lint, all invariant checks)
- [x] `pnpm test -- src/agents/sandbox/` — 133 passed, 2 pre-existing timeout failures in `registry.test.ts` (confirmed same failures on clean `upstream/main`)

## AI Disclosure
- [x] AI-assisted (Claude Code)
- [x] Fully tested locally
- [x] I understand what the code does

🤖 Generated with [Claude Code](https://claude.com/claude-code)