### PR TITLE
fix(gateway): detect channels stuck before reporting connected (AI-assisted)

### DIFF
--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -51,6 +51,33 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: true, reason: "startup-connect-grace" });
   });
 
+  it("flags channels that never report connected=true after startup grace when connected is tracked", () => {
+    const evaluation = evaluateDiscordHealth({
+      running: true,
+      connected: undefined,
+      enabled: true,
+      configured: true,
+      lastStartAt: 0,
+    });
+    expect(evaluation).toEqual({ healthy: false, reason: "disconnected" });
+  });
+
+  it("flags connected snapshots inherited from a previous lifecycle", () => {
+    const evaluation = evaluateDiscordHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 50_000,
+        lastConnectedAt: 10_000,
+        lastEventAt: 10_000,
+      },
+      75_000,
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "disconnected" });
+  });
+
   it("treats active runs as busy even when disconnected", () => {
     const now = 100_000;
     const evaluation = evaluateChannelHealth(

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -11,6 +11,7 @@ export type ChannelHealthSnapshot = {
   lastRunActivityAt?: number | null;
   lastEventAt?: number | null;
   lastStartAt?: number | null;
+  lastConnectedAt?: number | null;
   reconnectAttempts?: number;
   mode?: string;
 };
@@ -97,10 +98,29 @@ export function evaluateChannelHealth(
       return { healthy: false, reason: "stuck" };
     }
   }
-  if (snapshot.lastStartAt != null) {
-    const upDuration = policy.now - snapshot.lastStartAt;
+  const hasConnectedField = Object.prototype.hasOwnProperty.call(snapshot, "connected");
+  const lastConnectedAt =
+    typeof snapshot.lastConnectedAt === "number" && Number.isFinite(snapshot.lastConnectedAt)
+      ? snapshot.lastConnectedAt
+      : null;
+
+  if (lastStartAt != null) {
+    const upDuration = policy.now - lastStartAt;
     if (upDuration < policy.channelConnectGraceMs) {
       return { healthy: true, reason: "startup-connect-grace" };
+    }
+
+    // Some channels explicitly track `connected`, but during startup we can see
+    // patch-merged snapshots where `running=true` is set for a new lifecycle
+    // while `connected` (or related timestamps) are stale/undefined. Treat
+    // this as unhealthy once we are past the startup grace window.
+    if (hasConnectedField) {
+      if (snapshot.connected !== true) {
+        return { healthy: false, reason: "disconnected" };
+      }
+      if (lastConnectedAt != null && lastConnectedAt < lastStartAt) {
+        return { healthy: false, reason: "disconnected" };
+      }
     }
   }
   if (snapshot.connected === false) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Channel health monitor can treat a channel as healthy even though the current lifecycle never reaches a real `connected=true` state (or inherits stale connected metadata across lifecycles).
- Why it matters: Bots can remain stranded in “awaiting gateway readiness”/startup limbo for long periods without being restarted by the health monitor.
- What changed: `evaluateChannelHealth()` now treats tracked `connected` state as required after the startup grace window, and detects stale `connected` timestamps inherited from a previous lifecycle.
- What did NOT change (scope boundary): No changes to channel implementations, restart orchestration, timing defaults, or stale-socket logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54691
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `evaluateChannelHealth()` only treated `connected === false` as unhealthy after startup grace. Patch-merged runtime snapshots can present `running=true` for a new lifecycle while `connected` is missing/undefined or while `connected` + `lastConnectedAt` are inherited from a previous lifecycle.
- Missing detection / guardrail: No post-startup check that a channel which *tracks* `connected` has actually reached `connected=true` for the current lifecycle.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: Unknown (likely exposed by outage/restart timing and patch-merged runtime snapshots).
- If unknown, what was ruled out: Not caused by stale-socket thresholding (this can happen before stale-socket detection triggers).

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/channel-health-policy.test.ts`
- Scenario the test should lock in:
  - When a channel tracks `connected`, and it is still not `true` after `channelConnectGraceMs`, mark unhealthy.
  - When a channel reports `connected=true` but `lastConnectedAt < lastStartAt` (stale lifecycle carry-over), mark unhealthy.
- Why this is the smallest reliable guardrail: It exercises the pure evaluation logic used by both the background health monitor and readiness probes without requiring live channel fixtures.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Channels that track `connected` will be considered unhealthy after the startup grace window if they have not reached `connected=true` for the current lifecycle (including stale connected carry-over cases).

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel (if any): Discord (health monitor evaluation)
- Relevant config (redacted): N/A

### Steps

1. Start a channel lifecycle (so `running=true`, `lastStartAt` set).
2. Ensure the runtime snapshot either:
   - tracks `connected` but never becomes `true` (e.g. `connected` is missing/undefined after patch merge), or
   - reports `connected=true` with `lastConnectedAt` inherited from a previous lifecycle (`lastConnectedAt < lastStartAt`).
3. Wait for `channelConnectGraceMs` to elapse.

### Expected

- Health monitor marks the channel unhealthy and restarts it.

### Actual

- Health monitor can keep the channel marked healthy indefinitely (or until unrelated stale-socket detection eventually fires).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence:
- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/channel-health-policy.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Ran the updated unit tests covering the new unhealthy conditions.
- Edge cases checked:
  - Ensured channels that do not track `connected` (no `connected` field) keep existing behavior.
- What you did **not** verify:
  - No live Discord outage reproduction.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit.
- Files/config to restore: `src/gateway/channel-health-policy.ts`
- Known bad symptoms reviewers should watch for:
  - Channels that *do* track `connected` restarting repeatedly if they legitimately cannot reach `connected=true` within the configured grace.

## Risks and Mitigations

- Risk: Some channel implementations may set up `connected` tracking but only report `connected=true` late (past the default grace) in rare environments.
  - Mitigation: The check is gated to channels that explicitly track `connected`, and still respects `channelConnectGraceMs`.
