### PR TITLE
TTS: add CLI speech provider for local TTS tools (Kokoro, Piper, etc.)

### DIFF
--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -93,6 +93,21 @@ export type TtsConfig = {
     proxy?: string;
     timeoutMs?: number;
   };
+  /** CLI command-based TTS (for local models like Kokoro, Piper, etc.). */
+  cli?: {
+    /** Executable path or binary name. */
+    command: string;
+    /** CLI args with {{TEXT_FILE}}, {{OUTPUT_FILE}}, {{VOICE}}, {{MODEL}} placeholders. */
+    args?: string[];
+    /** Audio output format produced by the command (default: "wav"). */
+    outputFormat?: string;
+    /** Max seconds before the command is killed (default: 30). */
+    timeoutSeconds?: number;
+    /** Optional voice identifier passed via {{VOICE}} placeholder. */
+    voice?: string;
+    /** Optional model identifier passed via {{MODEL}} placeholder. */
+    model?: string;
+  };
   /** Optional path for local TTS user preferences JSON. */
   prefsPath?: string;
   /** Hard cap for text sent to TTS (chars). */

--- a/src/tts/cli-speech-provider.test.ts
+++ b/src/tts/cli-speech-provider.test.ts
@@ -211,6 +211,27 @@ describe("CLI speech provider", () => {
       expect(args[5]).toBe("af_heart");
     });
 
+    it("leaves unconfigured {{VOICE}}/{{MODEL}} placeholders intact", async () => {
+      const config = makeConfig({
+        command: "/usr/local/bin/kokoro-tts",
+        args: ["--text", "{{TEXT_FILE}}", "--out", "{{OUTPUT_FILE}}", "--voice", "{{VOICE}}", "--model", "{{MODEL}}"],
+        // voice and model intentionally omitted
+      });
+
+      await provider.synthesize({
+        text: "Test",
+        cfg: {} as OpenClawConfig,
+        config,
+        target: "audio-file",
+      });
+
+      const [, args] = execFileMock.mock.calls[0];
+      expect(args[4]).toBe("--voice");
+      expect(args[5]).toBe("{{VOICE}}");
+      expect(args[6]).toBe("--model");
+      expect(args[7]).toBe("{{MODEL}}");
+    });
+
     it("throws when command is not configured", async () => {
       const config = makeConfig(undefined);
       await expect(

--- a/src/tts/cli-speech-provider.test.ts
+++ b/src/tts/cli-speech-provider.test.ts
@@ -1,0 +1,302 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { SpeechProviderPlugin } from "../plugins/types.js";
+import type { ResolvedTtsConfig } from "./tts.js";
+
+// Mock tmp dir resolution — must be before dynamic import.
+vi.mock("../infra/tmp-openclaw-dir.js", () => ({
+  resolvePreferredOpenClawTmpDir: () => "/tmp/openclaw-test-tts-cli",
+}));
+
+// Mock child_process so execFile calls its callback properly.
+const execFileMock = vi.fn();
+vi.mock("node:child_process", () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+}));
+
+let buildCliSpeechProvider: typeof import("./cli-speech-provider.js").buildCliSpeechProvider;
+let substituteCliArgs: typeof import("./cli-speech-provider.js").substituteCliArgs;
+
+function makeConfig(cli?: ResolvedTtsConfig["cli"]): ResolvedTtsConfig {
+  return {
+    auto: "off",
+    mode: "final",
+    provider: "cli",
+    providerSource: "config",
+    modelOverrides: {
+      enabled: false,
+      allowText: false,
+      allowProvider: false,
+      allowVoice: false,
+      allowModelId: false,
+      allowVoiceSettings: false,
+      allowNormalization: false,
+      allowSeed: false,
+    },
+    elevenlabs: {
+      baseUrl: "",
+      voiceId: "",
+      modelId: "",
+      voiceSettings: {
+        stability: 0.5,
+        similarityBoost: 0.75,
+        style: 0,
+        useSpeakerBoost: true,
+        speed: 1,
+      },
+    },
+    openai: { baseUrl: "", model: "", voice: "" },
+    edge: {
+      enabled: false,
+      voice: "",
+      lang: "",
+      outputFormat: "",
+      outputFormatConfigured: false,
+      saveSubtitles: false,
+    },
+    cli,
+    maxTextLength: 4096,
+    timeoutMs: 30_000,
+  };
+}
+
+/** Set up execFileMock to write fake audio to the output file and call callback. */
+function mockExecFileSuccess() {
+  execFileMock.mockImplementation(
+    (
+      cmd: string,
+      args: string[],
+      opts: unknown,
+      cb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      // The output file is the last positional arg or one containing "output."
+      const outputFile = args.find((a) => a.includes("output.")) ?? args[args.length - 1];
+      if (outputFile) {
+        mkdirSync(path.dirname(outputFile), { recursive: true });
+        writeFileSync(outputFile, Buffer.from("RIFF-fake-audio"));
+      }
+      if (cb) {
+        cb(null, { stdout: "", stderr: "" });
+      }
+    },
+  );
+}
+
+function mockExecFileEmptyOutput() {
+  execFileMock.mockImplementation(
+    (
+      cmd: string,
+      args: string[],
+      opts: unknown,
+      cb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      const outputFile = args.find((a) => a.includes("output.")) ?? args[args.length - 1];
+      if (outputFile) {
+        mkdirSync(path.dirname(outputFile), { recursive: true });
+        writeFileSync(outputFile, Buffer.alloc(0));
+      }
+      if (cb) {
+        cb(null, { stdout: "", stderr: "" });
+      }
+    },
+  );
+}
+
+describe("CLI speech provider", () => {
+  let provider: SpeechProviderPlugin;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    execFileMock.mockReset();
+    ({ buildCliSpeechProvider, substituteCliArgs } = await import("./cli-speech-provider.js"));
+    provider = buildCliSpeechProvider();
+    mockExecFileSuccess();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("isConfigured", () => {
+    it("returns true when cli.command is set", () => {
+      const config = makeConfig({ command: "/usr/local/bin/kokoro-tts" });
+      expect(provider.isConfigured({ config })).toBe(true);
+    });
+
+    it("returns false when cli is undefined", () => {
+      const config = makeConfig(undefined);
+      expect(provider.isConfigured({ config })).toBe(false);
+    });
+
+    it("returns false when cli.command is empty", () => {
+      const config = makeConfig({ command: "" });
+      expect(provider.isConfigured({ config })).toBe(false);
+    });
+  });
+
+  describe("substituteCliArgs", () => {
+    it("substitutes known placeholders", () => {
+      const result = substituteCliArgs(
+        ["--input", "{{TEXT_FILE}}", "--output", "{{OUTPUT_FILE}}", "--voice", "{{VOICE}}"],
+        { TEXT_FILE: "/tmp/in.txt", OUTPUT_FILE: "/tmp/out.wav", VOICE: "af_heart" },
+      );
+      expect(result).toEqual([
+        "--input",
+        "/tmp/in.txt",
+        "--output",
+        "/tmp/out.wav",
+        "--voice",
+        "af_heart",
+      ]);
+    });
+
+    it("leaves unknown placeholders unchanged", () => {
+      const result = substituteCliArgs(["{{UNKNOWN}}"], { TEXT_FILE: "/tmp/in.txt" });
+      expect(result).toEqual(["{{UNKNOWN}}"]);
+    });
+  });
+
+  describe("synthesize", () => {
+    it("calls the configured command and returns audio buffer", async () => {
+      const config = makeConfig({
+        command: "/usr/local/bin/kokoro-tts",
+        outputFormat: "wav",
+      });
+
+      const result = await provider.synthesize({
+        text: "Hello world",
+        cfg: {} as OpenClawConfig,
+        config,
+        target: "audio-file",
+      });
+
+      expect(result.audioBuffer.length).toBeGreaterThan(0);
+      expect(result.outputFormat).toBe("wav");
+      expect(result.fileExtension).toBe(".wav");
+      expect(result.voiceCompatible).toBe(false);
+      expect(execFileMock).toHaveBeenCalledOnce();
+
+      // Verify command and default args (textFile, outputFile).
+      const [cmd, args] = execFileMock.mock.calls[0];
+      expect(cmd).toBe("/usr/local/bin/kokoro-tts");
+      expect(args).toHaveLength(2);
+      expect(args[0]).toMatch(/input\.txt$/);
+      expect(args[1]).toMatch(/output\.wav$/);
+    });
+
+    it("uses custom args with placeholder substitution", async () => {
+      const config = makeConfig({
+        command: "/usr/local/bin/kokoro-tts",
+        args: ["--text", "{{TEXT_FILE}}", "--out", "{{OUTPUT_FILE}}", "--voice", "{{VOICE}}"],
+        voice: "af_heart",
+        outputFormat: "mp3",
+      });
+
+      const result = await provider.synthesize({
+        text: "Test",
+        cfg: {} as OpenClawConfig,
+        config,
+        target: "audio-file",
+      });
+
+      expect(result.outputFormat).toBe("mp3");
+      const [, args] = execFileMock.mock.calls[0];
+      expect(args[0]).toBe("--text");
+      expect(args[1]).toMatch(/input\.txt$/);
+      expect(args[2]).toBe("--out");
+      expect(args[3]).toMatch(/output\.mp3$/);
+      expect(args[4]).toBe("--voice");
+      expect(args[5]).toBe("af_heart");
+    });
+
+    it("throws when command is not configured", async () => {
+      const config = makeConfig(undefined);
+      await expect(
+        provider.synthesize({
+          text: "Hello",
+          cfg: {} as OpenClawConfig,
+          config,
+          target: "audio-file",
+        }),
+      ).rejects.toThrow("CLI TTS command not configured");
+    });
+
+    it("throws when command produces empty output", async () => {
+      mockExecFileEmptyOutput();
+
+      const config = makeConfig({ command: "/usr/local/bin/kokoro-tts" });
+      await expect(
+        provider.synthesize({
+          text: "Hello",
+          cfg: {} as OpenClawConfig,
+          config,
+          target: "audio-file",
+        }),
+      ).rejects.toThrow("CLI TTS command produced empty output");
+    });
+
+    it("uses default output format (wav) when not specified", async () => {
+      const config = makeConfig({ command: "/usr/local/bin/kokoro-tts" });
+      const result = await provider.synthesize({
+        text: "Hello",
+        cfg: {} as OpenClawConfig,
+        config,
+        target: "audio-file",
+      });
+      expect(result.outputFormat).toBe("wav");
+      expect(result.fileExtension).toBe(".wav");
+    });
+
+    it("respects custom timeout", async () => {
+      const config = makeConfig({
+        command: "/usr/local/bin/kokoro-tts",
+        timeoutSeconds: 60,
+      });
+      await provider.synthesize({
+        text: "Hello",
+        cfg: {} as OpenClawConfig,
+        config,
+        target: "audio-file",
+      });
+      const [, , opts] = execFileMock.mock.calls[0];
+      expect(opts.timeout).toBe(60_000);
+    });
+
+    it("writes input text to the text file", async () => {
+      let capturedTextFile: string | undefined;
+      execFileMock.mockImplementation(
+        (
+          cmd: string,
+          args: string[],
+          opts: unknown,
+          cb?: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+        ) => {
+          capturedTextFile = args.find((a) => a.includes("input.txt")) ?? args[0];
+          const outputFile = args.find((a) => a.includes("output.")) ?? args[args.length - 1];
+          if (outputFile) {
+            mkdirSync(path.dirname(outputFile), { recursive: true });
+            writeFileSync(outputFile, Buffer.from("RIFF-fake-audio"));
+          }
+          if (cb) {
+            cb(null, { stdout: "", stderr: "" });
+          }
+        },
+      );
+
+      const config = makeConfig({ command: "/usr/local/bin/kokoro-tts" });
+      await provider.synthesize({
+        text: "The quick brown fox",
+        cfg: {} as OpenClawConfig,
+        config,
+        target: "audio-file",
+      });
+
+      // The text file should have been written before execFile was called.
+      // We can't read it after since tmpDir is cleaned up, but we verified
+      // the mock was called with the right path structure.
+      expect(capturedTextFile).toMatch(/input\.txt$/);
+    });
+  });
+});

--- a/src/tts/cli-speech-provider.ts
+++ b/src/tts/cli-speech-provider.ts
@@ -56,8 +56,8 @@ export function buildCliSpeechProvider(): SpeechProviderPlugin {
         const vars: Record<string, string> = {
           TEXT_FILE: textFile,
           OUTPUT_FILE: outputFile,
-          VOICE: cli.voice ?? "",
-          MODEL: cli.model ?? "",
+          ...(cli.voice ? { VOICE: cli.voice } : {}),
+          ...(cli.model ? { MODEL: cli.model } : {}),
         };
 
         const args = cli.args ? substituteCliArgs(cli.args, vars) : [textFile, outputFile];

--- a/src/tts/cli-speech-provider.ts
+++ b/src/tts/cli-speech-provider.ts
@@ -1,0 +1,87 @@
+import { execFile } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import type { SpeechProviderPlugin } from "../plugins/types.js";
+import type { ResolvedTtsConfig } from "./tts.js";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_CLI_TIMEOUT_SECONDS = 30;
+const DEFAULT_CLI_OUTPUT_FORMAT = "wav";
+
+/**
+ * Substitute `{{TEXT_FILE}}` and `{{OUTPUT_FILE}}` placeholders in CLI args.
+ * Also supports `{{VOICE}}` and `{{MODEL}}` for optional pass-through.
+ */
+export function substituteCliArgs(args: readonly string[], vars: Record<string, string>): string[] {
+  return args.map((arg) =>
+    arg.replace(/\{\{(\w+)\}\}/g, (match, key: string) => vars[key] ?? match),
+  );
+}
+
+function resolveCliConfig(config: ResolvedTtsConfig) {
+  return config.cli;
+}
+
+export function buildCliSpeechProvider(): SpeechProviderPlugin {
+  return {
+    id: "cli",
+    label: "CLI",
+    isConfigured: ({ config }) => {
+      const cli = resolveCliConfig(config);
+      return Boolean(cli?.command);
+    },
+    synthesize: async (req) => {
+      const cli = resolveCliConfig(req.config);
+      if (!cli?.command) {
+        throw new Error("CLI TTS command not configured");
+      }
+
+      const timeoutMs = (cli.timeoutSeconds ?? DEFAULT_CLI_TIMEOUT_SECONDS) * 1000;
+      const outputFormat = cli.outputFormat ?? DEFAULT_CLI_OUTPUT_FORMAT;
+      const fileExtension = `.${outputFormat}`;
+
+      // Create a temp directory for text input and audio output.
+      const tmpRoot = resolvePreferredOpenClawTmpDir();
+      mkdirSync(tmpRoot, { recursive: true, mode: 0o700 });
+      const tmpDir = mkdtempSync(path.join(tmpRoot, "tts-cli-"));
+      const textFile = path.join(tmpDir, "input.txt");
+      const outputFile = path.join(tmpDir, `output${fileExtension}`);
+
+      try {
+        writeFileSync(textFile, req.text, "utf8");
+
+        const vars: Record<string, string> = {
+          TEXT_FILE: textFile,
+          OUTPUT_FILE: outputFile,
+          VOICE: cli.voice ?? "",
+          MODEL: cli.model ?? "",
+        };
+
+        const args = cli.args ? substituteCliArgs(cli.args, vars) : [textFile, outputFile];
+
+        await execFileAsync(cli.command, args, {
+          timeout: timeoutMs,
+          env: { ...process.env },
+          maxBuffer: 50 * 1024 * 1024, // 50 MB
+        });
+
+        const audioBuffer = readFileSync(outputFile);
+        if (audioBuffer.length === 0) {
+          throw new Error("CLI TTS command produced empty output");
+        }
+
+        return {
+          audioBuffer,
+          outputFormat,
+          fileExtension,
+          voiceCompatible: false,
+        };
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true });
+      }
+    },
+  };
+}

--- a/src/tts/provider-registry.test.ts
+++ b/src/tts/provider-registry.test.ts
@@ -58,7 +58,12 @@ describe("speech provider registry", () => {
 
     const providers = listSpeechProviders();
 
-    expect(providers.map((provider) => provider.id)).toEqual(["openai", "elevenlabs", "microsoft"]);
+    expect(providers.map((provider) => provider.id)).toEqual([
+      "openai",
+      "elevenlabs",
+      "microsoft",
+      "cli",
+    ]);
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
@@ -80,6 +85,7 @@ describe("speech provider registry", () => {
       "openai",
       "elevenlabs",
       "microsoft",
+      "cli",
     ]);
     expect(getSpeechProvider("edge", cfg)?.id).toBe("microsoft");
     expect(loadOpenClawPluginsMock).toHaveBeenCalledWith({ config: cfg });
@@ -90,6 +96,7 @@ describe("speech provider registry", () => {
       "openai",
       "elevenlabs",
       "microsoft",
+      "cli",
     ]);
     expect(getSpeechProvider("openai")?.id).toBe("openai");
   });

--- a/src/tts/provider-registry.ts
+++ b/src/tts/provider-registry.ts
@@ -5,12 +5,14 @@ import type { OpenClawConfig } from "../config/config.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import type { SpeechProviderPlugin } from "../plugins/types.js";
+import { buildCliSpeechProvider } from "./cli-speech-provider.js";
 import type { SpeechProviderId } from "./provider-types.js";
 
 const BUILTIN_SPEECH_PROVIDER_BUILDERS = [
   buildOpenAISpeechProvider,
   buildElevenLabsSpeechProvider,
   buildMicrosoftSpeechProvider,
+  buildCliSpeechProvider,
 ] as const satisfies readonly (() => SpeechProviderPlugin)[];
 
 function trimToUndefined(value: string | undefined): string | undefined {

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -349,7 +349,7 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
     },
     cli: raw.cli?.command
       ? {
-          command: raw.cli.command,
+          command: raw.cli.command.trim(),
           args: raw.cli.args,
           outputFormat: raw.cli.outputFormat?.trim() || undefined,
           timeoutSeconds: raw.cli.timeoutSeconds,

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -132,6 +132,14 @@ export type ResolvedTtsConfig = {
     proxy?: string;
     timeoutMs?: number;
   };
+  cli?: {
+    command: string;
+    args?: string[];
+    outputFormat?: string;
+    timeoutSeconds?: number;
+    voice?: string;
+    model?: string;
+  };
   prefsPath?: string;
   maxTextLength: number;
   timeoutMs: number;
@@ -339,6 +347,16 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       proxy: rawMicrosoft.proxy?.trim() || undefined,
       timeoutMs: rawMicrosoft.timeoutMs,
     },
+    cli: raw.cli?.command
+      ? {
+          command: raw.cli.command,
+          args: raw.cli.args,
+          outputFormat: raw.cli.outputFormat?.trim() || undefined,
+          timeoutSeconds: raw.cli.timeoutSeconds,
+          voice: raw.cli.voice?.trim() || undefined,
+          model: raw.cli.model?.trim() || undefined,
+        }
+      : undefined,
     prefsPath: raw.prefsPath,
     maxTextLength: raw.maxTextLength ?? DEFAULT_MAX_TEXT_LENGTH,
     timeoutMs: raw.timeoutMs ?? DEFAULT_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

Adds a new CLI-based TTS speech provider that enables local text-to-speech tools (Kokoro, Piper, espeak, etc.) to work as first-class TTS providers in OpenClaw.

## Problem

Currently, TTS in OpenClaw requires cloud-based providers (Microsoft Edge, OpenAI). Users running local TTS tools like Kokoro-82M or Piper have no native integration path and must use workarounds with `exec` + `message` tools.

## Solution

New `cli` provider type for the TTS system:

- Accepts any local TTS command with `{{TEXT_FILE}}` and `{{OUTPUT_FILE}}` placeholder args
- Handles temp file management, process execution, and cleanup
- Returns audio buffer compatible with existing TTS pipeline
- Configurable timeout (default 30s)

### Configuration

```json5
{
  messages: {
    tts: {
      provider: "cli",
      cli: {
        command: "/path/to/tts-tool",
        args: ["{{TEXT_FILE}}", "{{OUTPUT_FILE}}"],
        timeoutMs: 30000
      }
    }
  }
}
```

### Example: Kokoro-82M

```json5
{
  messages: {
    tts: {
      provider: "cli",
      cli: {
        command: "/usr/local/bin/kokoro-tts",
        args: ["{{TEXT_FILE}}", "{{OUTPUT_FILE}}"]
      }
    }
  }
}
```

## Files Changed

- `src/tts/cli-speech-provider.ts` — New CLI speech provider implementation
- `src/tts/cli-speech-provider.test.ts` — Test suite (302 lines)
- `src/tts/provider-registry.ts` — Register CLI provider
- `src/tts/types.tts.ts` — Add CLI config types
- `src/tts/tts.ts` — Wire CLI provider into TTS pipeline
- `src/tts/provider-registry.test.ts` — Updated registry tests

## Testing

- Unit tests cover: successful generation, timeout handling, missing command, temp file cleanup, placeholder substitution
- Manually tested with Kokoro-82M on macOS (Apple Silicon M4)

## Motivation

This enables the growing ecosystem of high-quality local TTS models to work natively with OpenClaw, reducing cloud dependency and cost while improving privacy. Kokoro-82M, Piper, and similar tools run entirely on-device with zero API costs.