### PR TITLE
Skills: stop using chokidar globs for refresh

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -2,10 +2,30 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const watchMock = vi.fn(() => ({
-  on: vi.fn(),
-  close: vi.fn(async () => undefined),
-}));
+const watcherInstances = vi.hoisted(
+  () =>
+    [] as Array<{
+      on: ReturnType<typeof vi.fn>;
+      close: ReturnType<typeof vi.fn>;
+      handlers: Map<string, (changedPath: string) => void>;
+    }>,
+);
+
+const watchMock = vi.hoisted(() =>
+  vi.fn(() => {
+    const handlers = new Map<string, (changedPath: string) => void>();
+    const instance = {
+      on: vi.fn((event: string, handler: (changedPath: string) => void) => {
+        handlers.set(event, handler);
+        return instance;
+      }),
+      close: vi.fn(async () => undefined),
+      handlers,
+    };
+    watcherInstances.push(instance);
+    return instance;
+  }),
+);
 
 let refreshModule: typeof import("./refresh.js");
 
@@ -23,66 +43,158 @@ describe("ensureSkillsWatcher", () => {
   });
 
   beforeEach(() => {
+    vi.useRealTimers();
     watchMock.mockClear();
+    watcherInstances.length = 0;
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     await refreshModule.resetSkillsRefreshForTest();
   });
 
-  it("ignores node_modules, dist, .git, and Python venvs by default", async () => {
+  it("watches skill roots directly and ignores unrelated files by default", async () => {
     refreshModule.ensureSkillsWatcher({ workspaceDir: "/tmp/workspace" });
 
     expect(watchMock).toHaveBeenCalledTimes(1);
     const firstCall = (
-      watchMock.mock.calls as unknown as Array<[string[], { ignored?: unknown }]>
+      watchMock.mock.calls as unknown as Array<
+        [
+          string[],
+          {
+            depth?: number;
+            ignored?:
+              | ((candidatePath: string, stats?: { isDirectory?: () => boolean }) => boolean)
+              | unknown;
+          },
+        ]
+      >
     )[0];
     const targets = firstCall?.[0] ?? [];
     const opts = firstCall?.[1] ?? {};
 
-    expect(opts.ignored).toBe(refreshModule.DEFAULT_SKILLS_WATCH_IGNORED);
     const posix = (p: string) => p.replaceAll("\\", "/");
     expect(targets).toEqual(
       expect.arrayContaining([
-        posix(path.join("/tmp/workspace", "skills", "SKILL.md")),
-        posix(path.join("/tmp/workspace", "skills", "*", "SKILL.md")),
-        posix(path.join("/tmp/workspace", ".agents", "skills", "SKILL.md")),
-        posix(path.join("/tmp/workspace", ".agents", "skills", "*", "SKILL.md")),
-        posix(path.join(os.homedir(), ".agents", "skills", "SKILL.md")),
-        posix(path.join(os.homedir(), ".agents", "skills", "*", "SKILL.md")),
+        posix(path.join("/tmp/workspace", "skills")),
+        posix(path.join("/tmp/workspace", ".agents", "skills")),
+        posix(path.join(os.homedir(), ".agents", "skills")),
       ]),
     );
-    expect(targets.every((target) => target.includes("SKILL.md"))).toBe(true);
-    const ignored = refreshModule.DEFAULT_SKILLS_WATCH_IGNORED;
+    expect(targets.every((target) => !target.includes("*"))).toBe(true);
+    expect(opts.depth).toBe(1);
+    expect(typeof opts.ignored).toBe("function");
+
+    const ignored = opts.ignored as (
+      candidatePath: string,
+      stats?: { isDirectory?: () => boolean },
+    ) => boolean;
+    const dirStats = { isDirectory: () => true };
+    const fileStats = { isDirectory: () => false };
 
     // Node/JS paths
-    expect(ignored.some((re) => re.test("/tmp/workspace/skills/node_modules/pkg/index.js"))).toBe(
-      true,
-    );
-    expect(ignored.some((re) => re.test("/tmp/workspace/skills/dist/index.js"))).toBe(true);
-    expect(ignored.some((re) => re.test("/tmp/workspace/skills/.git/config"))).toBe(true);
+    expect(ignored("/tmp/workspace/skills/node_modules/pkg/index.js", fileStats)).toBe(true);
+    expect(ignored("/tmp/workspace/skills/dist/index.js", fileStats)).toBe(true);
+    expect(ignored("/tmp/workspace/skills/.git/config", fileStats)).toBe(true);
 
     // Python virtual environments and caches
-    expect(ignored.some((re) => re.test("/tmp/workspace/skills/scripts/.venv/bin/python"))).toBe(
-      true,
-    );
-    expect(ignored.some((re) => re.test("/tmp/workspace/skills/venv/lib/python3.10/site.py"))).toBe(
-      true,
-    );
-    expect(ignored.some((re) => re.test("/tmp/workspace/skills/__pycache__/module.pyc"))).toBe(
-      true,
-    );
-    expect(ignored.some((re) => re.test("/tmp/workspace/skills/.mypy_cache/3.10/foo.json"))).toBe(
-      true,
-    );
-    expect(ignored.some((re) => re.test("/tmp/workspace/skills/.pytest_cache/v/cache"))).toBe(true);
+    expect(ignored("/tmp/workspace/skills/scripts/.venv/bin/python", fileStats)).toBe(true);
+    expect(ignored("/tmp/workspace/skills/venv/lib/python3.10/site.py", fileStats)).toBe(true);
+    expect(ignored("/tmp/workspace/skills/__pycache__/module.pyc", fileStats)).toBe(true);
+    expect(ignored("/tmp/workspace/skills/.mypy_cache/3.10/foo.json", fileStats)).toBe(true);
+    expect(ignored("/tmp/workspace/skills/.pytest_cache/v/cache", fileStats)).toBe(true);
 
     // Build artifacts and caches
-    expect(ignored.some((re) => re.test("/tmp/workspace/skills/build/output.js"))).toBe(true);
-    expect(ignored.some((re) => re.test("/tmp/workspace/skills/.cache/data.json"))).toBe(true);
+    expect(ignored("/tmp/workspace/skills/build/output.js", fileStats)).toBe(true);
+    expect(ignored("/tmp/workspace/skills/.cache/data.json", fileStats)).toBe(true);
 
-    // Should NOT ignore normal skill files
-    expect(ignored.some((re) => re.test("/tmp/.hidden/skills/index.md"))).toBe(false);
-    expect(ignored.some((re) => re.test("/tmp/workspace/skills/my-skill/SKILL.md"))).toBe(false);
+    // Should NOT ignore supported skill paths, including newly created
+    // directories before chokidar has resolved stats.
+    expect(ignored("/tmp/workspace/skills", dirStats)).toBe(false);
+    expect(ignored("/tmp/workspace/skills/my-skill", dirStats)).toBe(false);
+    expect(ignored("/tmp/workspace/skills/my-skill")).toBe(false);
+    expect(ignored("/tmp/workspace/skills/SKILL.md", fileStats)).toBe(false);
+    expect(ignored("/tmp/workspace/skills/my-skill/SKILL.md", fileStats)).toBe(false);
+
+    // Ignore unrelated files and deeper descendants under a skill directory.
+    expect(ignored("/tmp/.hidden/skills/index.md", fileStats)).toBe(false);
+    expect(ignored("/tmp/workspace/skills/README.md", fileStats)).toBe(true);
+    expect(ignored("/tmp/workspace/skills/my-skill/notes.md", fileStats)).toBe(true);
+    expect(ignored("/tmp/workspace/skills/my-skill/assets/icon.png", fileStats)).toBe(true);
+  });
+
+  it("bumps the snapshot only for supported skill file changes", async () => {
+    vi.useFakeTimers();
+    const events: Array<{ workspaceDir?: string; changedPath?: string }> = [];
+    const unregister = refreshModule.registerSkillsChangeListener((event) => {
+      events.push(event);
+    });
+
+    refreshModule.ensureSkillsWatcher({
+      workspaceDir: "/tmp/workspace",
+      config: {
+        skills: {
+          load: {
+            watchDebounceMs: 25,
+          },
+        },
+      },
+    });
+
+    const watcher = watcherInstances.at(-1);
+    expect(watcher).toBeDefined();
+
+    watcher?.handlers.get("add")?.("/tmp/workspace/skills/my-skill/SKILL.md");
+    await vi.advanceTimersByTimeAsync(25);
+    expect(events).toEqual([
+      {
+        workspaceDir: "/tmp/workspace",
+        reason: "watch",
+        changedPath: "/tmp/workspace/skills/my-skill/SKILL.md",
+      },
+    ]);
+
+    watcher?.handlers.get("change")?.("/tmp/workspace/skills/another-skill/SKILL.md");
+    await vi.advanceTimersByTimeAsync(25);
+    expect(events).toEqual([
+      {
+        workspaceDir: "/tmp/workspace",
+        reason: "watch",
+        changedPath: "/tmp/workspace/skills/my-skill/SKILL.md",
+      },
+      {
+        workspaceDir: "/tmp/workspace",
+        reason: "watch",
+        changedPath: "/tmp/workspace/skills/another-skill/SKILL.md",
+      },
+    ]);
+
+    watcher?.handlers.get("unlink")?.("/tmp/workspace/skills/third-skill/SKILL.md");
+    await vi.advanceTimersByTimeAsync(25);
+    expect(events).toEqual([
+      {
+        workspaceDir: "/tmp/workspace",
+        reason: "watch",
+        changedPath: "/tmp/workspace/skills/my-skill/SKILL.md",
+      },
+      {
+        workspaceDir: "/tmp/workspace",
+        reason: "watch",
+        changedPath: "/tmp/workspace/skills/another-skill/SKILL.md",
+      },
+      {
+        workspaceDir: "/tmp/workspace",
+        reason: "watch",
+        changedPath: "/tmp/workspace/skills/third-skill/SKILL.md",
+      },
+    ]);
+
+    watcher?.handlers.get("add")?.("/tmp/workspace/skills/my-skill/notes.md");
+    watcher?.handlers.get("change")?.("/tmp/workspace/skills/my-skill/assets/icon.png");
+    watcher?.handlers.get("unlink")?.("/tmp/workspace/skills/README.md");
+    await vi.advanceTimersByTimeAsync(25);
+    expect(events).toHaveLength(3);
+
+    unregister();
   });
 });

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -14,6 +14,7 @@ import {
   setSkillsChangeListenerErrorHandler,
   shouldRefreshSnapshotForVersion,
 } from "./refresh-state.js";
+
 export {
   bumpSkillsSnapshotVersion,
   getSkillsSnapshotVersion,
@@ -28,6 +29,10 @@ type SkillsWatchState = {
   debounceMs: number;
   timer?: ReturnType<typeof setTimeout>;
   pendingPath?: string;
+};
+
+type WatchPathStats = {
+  isDirectory?: () => boolean;
 };
 
 const log = createSubsystemLogger("gateway/skills");
@@ -71,24 +76,61 @@ function resolveWatchPaths(workspaceDir: string, config?: OpenClawConfig): strin
   return paths;
 }
 
-function toWatchGlobRoot(raw: string): string {
-  // Chokidar treats globs as POSIX-ish patterns. Normalize Windows separators
-  // so `*` works consistently across platforms.
-  return raw.replaceAll("\\", "/").replace(/\/+$/, "");
+function resolveWatchRoots(workspaceDir: string, config?: OpenClawConfig): string[] {
+  return Array.from(
+    new Set(resolveWatchPaths(workspaceDir, config).map((root) => path.resolve(root))),
+  ).toSorted();
 }
 
-function resolveWatchTargets(workspaceDir: string, config?: OpenClawConfig): string[] {
-  // Skills are defined by SKILL.md; watch only those files to avoid traversing
-  // or watching unrelated large trees (e.g. datasets) that can exhaust FDs.
-  const targets = new Set<string>();
-  for (const root of resolveWatchPaths(workspaceDir, config)) {
-    const globRoot = toWatchGlobRoot(root);
-    // Some configs point directly at a skill folder.
-    targets.add(`${globRoot}/SKILL.md`);
-    // Standard layout: <skillsRoot>/<skillName>/SKILL.md
-    targets.add(`${globRoot}/*/SKILL.md`);
+function resolveRelativeWatchPath(candidatePath: string, watchRoots: string[]): string | null {
+  const resolvedCandidate = path.resolve(candidatePath);
+  for (const watchRoot of watchRoots) {
+    const relative = path.relative(watchRoot, resolvedCandidate);
+    if (relative.startsWith("..") || path.isAbsolute(relative)) {
+      continue;
+    }
+    return relative.replaceAll("\\", "/");
   }
-  return Array.from(targets).toSorted();
+  return null;
+}
+
+function isWatchedSkillFilePath(candidatePath: string, watchRoots: string[]): boolean {
+  const relative = resolveRelativeWatchPath(candidatePath, watchRoots);
+  if (relative === null) {
+    return false;
+  }
+  const segments = relative.split("/").filter(Boolean);
+  return (
+    path.basename(candidatePath) === "SKILL.md" &&
+    (segments.length === 1 || (segments.length === 2 && segments[1] === "SKILL.md"))
+  );
+}
+
+function shouldIgnoreSkillsWatchPath(
+  candidatePath: string,
+  watchRoots: string[],
+  stats?: WatchPathStats,
+): boolean {
+  if (DEFAULT_SKILLS_WATCH_IGNORED.some((pattern) => pattern.test(candidatePath))) {
+    return true;
+  }
+
+  const relative = resolveRelativeWatchPath(candidatePath, watchRoots);
+  if (relative === null || !relative) {
+    return false;
+  }
+
+  const segments = relative.split("/").filter(Boolean);
+  if (segments.length === 1) {
+    if (segments[0] === "SKILL.md") {
+      return false;
+    }
+    return stats !== undefined && stats.isDirectory?.() !== true;
+  }
+  if (segments.length === 2 && segments[1] === "SKILL.md") {
+    return false;
+  }
+  return true;
 }
 
 export function ensureSkillsWatcher(params: { workspaceDir: string; config?: OpenClawConfig }) {
@@ -115,8 +157,8 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
     return;
   }
 
-  const watchTargets = resolveWatchTargets(workspaceDir, params.config);
-  const pathsKey = watchTargets.join("|");
+  const watchRoots = resolveWatchRoots(workspaceDir, params.config);
+  const pathsKey = watchRoots.join("|");
   if (existing && existing.pathsKey === pathsKey && existing.debounceMs === debounceMs) {
     return;
   }
@@ -128,20 +170,25 @@ export function ensureSkillsWatcher(params: { workspaceDir: string; config?: Ope
     void existing.watcher.close().catch(() => {});
   }
 
-  const watcher = chokidar.watch(watchTargets, {
+  const watcher = chokidar.watch(watchRoots, {
     ignoreInitial: true,
+    depth: 1,
     awaitWriteFinish: {
       stabilityThreshold: debounceMs,
       pollInterval: 100,
     },
-    // Avoid FD exhaustion on macOS when a workspace contains huge trees.
-    // This watcher only needs to react to SKILL.md changes.
-    ignored: DEFAULT_SKILLS_WATCH_IGNORED,
+    // Chokidar v4 no longer expands globs. Watch roots directly and constrain
+    // traversal so only SKILL.md files at the supported depths can trigger.
+    ignored: (candidatePath, stats) =>
+      shouldIgnoreSkillsWatchPath(candidatePath, watchRoots, stats),
   });
 
   const state: SkillsWatchState = { watcher, pathsKey, debounceMs };
 
   const schedule = (changedPath?: string) => {
+    if (changedPath && !isWatchedSkillFilePath(changedPath, watchRoots)) {
+      return;
+    }
     state.pendingPath = changedPath ?? state.pendingPath;
     if (state.timer) {
       clearTimeout(state.timer);


### PR DESCRIPTION
## Summary

- Problem: skills refresh watched `*/SKILL.md` glob targets that `chokidar` v4 no longer expands, so nested skill folders stopped triggering reloads.
- Why it matters: editing `workspace/skills/<name>/SKILL.md` leaves the runtime on stale skill definitions until a manual refresh or restart.
- What changed: watch the skill roots directly, cap traversal at depth `1`, and filter events so only `SKILL.md` or `<skill>/SKILL.md` paths can trigger a refresh.
- What did NOT change (scope boundary): no skill loading semantics, config schema, or non-skill filesystem watchers changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #27404
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the watcher passed glob patterns like `<skillsRoot>/*/SKILL.md` into `chokidar.watch`, but `chokidar` v4 removed glob expansion support.
- Missing detection / guardrail: the existing watcher test only asserted the configured watch targets and did not simulate a nested `SKILL.md` change event through the v4-compatible watch path.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: once runtime moved onto a `chokidar` version without glob support, nested skill directories stopped being watched even though root-level `SKILL.md` still worked.
- If unknown, what was ruled out: ruled out skills snapshot/version code and debounce handling by verifying the broken surface was specifically the watched path configuration.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/skills/refresh.test.ts`
- Scenario the test should lock in: nested `skills/<name>/SKILL.md` changes should trigger a refresh, while sibling files like `notes.md` should not.
- Why this is the smallest reliable guardrail: the failure is in watcher configuration and event filtering, which can be deterministically exercised with a mocked watcher without needing a full filesystem integration test.
- Existing test that already covers this (if any): the pre-existing watcher test covered ignore patterns only.
- If no new test is added, why not:

## User-visible / Behavior Changes

Editing `SKILL.md` inside a nested skill directory now refreshes workspace skills again without a restart when `skills.load.watch` is enabled.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default skills watcher with workspace skills enabled

### Steps

1. Configure a workspace skill under `~/.openclaw/workspace/skills/<skill>/SKILL.md`.
2. Start the watcher path via the normal runtime.
3. Edit the nested `SKILL.md`.

### Expected

- The skills snapshot should bump and refresh the loaded skill definitions.

### Actual

- Before this change, only root-level `skills/SKILL.md` was watched; nested skill edits were ignored.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- src/agents/skills/refresh.test.ts` and `pnpm tsgo`; the updated unit test simulates a nested `my-skill/SKILL.md` change and confirms it bumps the snapshot, while `notes.md` does not.
- Edge cases checked: root-level `SKILL.md`, nested `<skill>/SKILL.md`, ignored cache/build directories, and unrelated files under a skill directory.
- What you did **not** verify: live end-to-end filesystem events against a real `chokidar` instance outside the unit test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit or disable `skills.load.watch`.
- Files/config to restore: `src/agents/skills/refresh.ts`
- Known bad symptoms reviewers should watch for: nested skill edits stop refreshing again, or unrelated files under `skills/` begin triggering reload churn.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: filtering watched paths too aggressively could miss valid skill layouts.
  - Mitigation: the watcher now explicitly allows both supported layouts (`SKILL.md` and `<skill>/SKILL.md`) and tests both positive and negative cases.
