### PR TITLE
fix(gateway): route web chat image turns through the configured image model

### DIFF
--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import type { MsgContext } from "../templating.js";
 import { registerGetReplyCommonMocks } from "./get-reply.test-mocks.js";
 
@@ -7,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   applyLinkUnderstanding: vi.fn(async (..._args: unknown[]) => undefined),
   createInternalHookEvent: vi.fn(),
   triggerInternalHook: vi.fn(async (..._args: unknown[]) => undefined),
+  loadModelCatalog: vi.fn<() => Promise<ModelCatalogEntry[]>>(async () => []),
   resolveReplyDirectives: vi.fn(),
   initSessionState: vi.fn(),
 }));
@@ -15,6 +17,16 @@ registerGetReplyCommonMocks();
 
 vi.mock("../../globals.js", () => ({
   logVerbose: vi.fn(),
+}));
+vi.mock("../../agents/model-catalog.js", () => ({
+  loadModelCatalog: mocks.loadModelCatalog,
+  findModelInCatalog: vi.fn(
+    (catalog: Array<{ provider: string; id: string }>, provider: string, model: string) =>
+      catalog.find((entry) => entry.provider === provider && entry.id === model),
+  ),
+  modelSupportsVision: vi.fn(
+    (entry?: { input?: string[] }) => entry?.input?.includes("image") ?? false,
+  ),
 }));
 vi.mock("../../hooks/internal-hooks.js", () => ({
   createInternalHookEvent: mocks.createInternalHookEvent,
@@ -83,6 +95,7 @@ describe("getReplyFromConfig message hooks", () => {
     mocks.applyLinkUnderstanding.mockReset();
     mocks.createInternalHookEvent.mockReset();
     mocks.triggerInternalHook.mockReset();
+    mocks.loadModelCatalog.mockReset();
     mocks.resolveReplyDirectives.mockReset();
     mocks.initSessionState.mockReset();
 
@@ -104,6 +117,7 @@ describe("getReplyFromConfig message hooks", () => {
       }),
     );
     mocks.triggerInternalHook.mockResolvedValue(undefined);
+    mocks.loadModelCatalog.mockResolvedValue([]);
     mocks.resolveReplyDirectives.mockResolvedValue({ kind: "reply", reply: { text: "ok" } });
     mocks.initSessionState.mockResolvedValue({
       sessionCtx: {},
@@ -215,5 +229,38 @@ describe("getReplyFromConfig message hooks", () => {
 
     expect(mocks.applyMediaUnderstanding).not.toHaveBeenCalled();
     expect(mocks.applyLinkUnderstanding).not.toHaveBeenCalled();
+  });
+
+  it("switches to the configured image model for inbound image attachments", async () => {
+    mocks.loadModelCatalog.mockResolvedValue([
+      { provider: "openai", id: "gpt-4o-mini", name: "gpt-4o-mini", input: ["text"] },
+      { provider: "moonshot", id: "kimi-k2.5", name: "kimi-k2.5", input: ["text", "image"] },
+    ]);
+    const ctx = buildCtx({
+      Body: "<media:image>",
+      BodyForAgent: "<media:image>",
+      RawBody: "<media:image>",
+      CommandBody: "<media:image>",
+      MediaPath: "/tmp/input.png",
+      MediaUrl: "/tmp/input.png",
+      MediaType: "image/png",
+    });
+
+    await getReplyFromConfig(ctx, undefined, {
+      agents: {
+        defaults: {
+          imageModel: {
+            primary: "moonshot/kimi-k2.5",
+          },
+        },
+      },
+    });
+
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "moonshot",
+        model: "kimi-k2.5",
+      }),
+    );
   });
 });

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -4,12 +4,22 @@ import {
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
-import { resolveModelRefFromString } from "../../agents/model-selection.js";
+import {
+  findModelInCatalog,
+  loadModelCatalog,
+  modelSupportsVision,
+} from "../../agents/model-catalog.js";
+import { type ModelAliasIndex, resolveModelRefFromString } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+} from "../../config/model-input.js";
+import { isImageAttachment, normalizeAttachments } from "../../media-understanding/attachments.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
@@ -98,6 +108,39 @@ async function applyLinkUnderstandingIfNeeded(params: {
   const { applyLinkUnderstanding } = await import("../../link-understanding/apply.runtime.js");
   await applyLinkUnderstanding(params);
   return true;
+}
+
+function resolveConfiguredImageModelRefs(params: {
+  cfg: OpenClawConfig;
+  defaultProvider: string;
+  aliasIndex: ModelAliasIndex;
+}): Array<{ provider: string; model: string }> {
+  const refs: string[] = [];
+  const primary = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.imageModel);
+  if (primary?.trim()) {
+    refs.push(primary.trim());
+  }
+  for (const fallback of resolveAgentModelFallbackValues(params.cfg.agents?.defaults?.imageModel)) {
+    if (fallback?.trim()) {
+      refs.push(fallback.trim());
+    }
+  }
+  return refs
+    .map((ref) => {
+      const slashIdx = ref.indexOf("/");
+      if (slashIdx > 0 && slashIdx < ref.length - 1) {
+        return {
+          provider: ref.slice(0, slashIdx),
+          model: ref.slice(slashIdx + 1),
+        };
+      }
+      return resolveModelRefFromString({
+        raw: ref,
+        defaultProvider: params.defaultProvider,
+        aliasIndex: params.aliasIndex,
+      })?.ref;
+    })
+    .filter((entry): entry is { provider: string; model: string } => Boolean(entry));
 }
 
 export async function getReplyFromConfig(
@@ -266,6 +309,33 @@ export async function getReplyFromConfig(
       provider = resolved.ref.provider;
       model = resolved.ref.model;
     }
+  }
+  const hasInboundImageAttachment = normalizeAttachments(finalized).some((attachment) =>
+    isImageAttachment(attachment),
+  );
+  if (
+    hasInboundImageAttachment &&
+    !hasResolvedHeartbeatModelOverride &&
+    !hasSessionModelOverride &&
+    !channelModelOverride
+  ) {
+    try {
+      const catalog = await loadModelCatalog({ config: cfg });
+      const activeEntry = findModelInCatalog(catalog, provider, model);
+      if (!modelSupportsVision(activeEntry)) {
+        const configuredImageModel = resolveConfiguredImageModelRefs({
+          cfg,
+          defaultProvider,
+          aliasIndex,
+        }).find((entry) =>
+          modelSupportsVision(findModelInCatalog(catalog, entry.provider, entry.model)),
+        );
+        if (configuredImageModel) {
+          provider = configuredImageModel.provider;
+          model = configuredImageModel.model;
+        }
+      }
+    } catch {}
   }
 
   const directiveResult = await resolveReplyDirectives({

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -19,6 +19,7 @@ import {
   resolveAgentModelFallbackValues,
   resolveAgentModelPrimaryValue,
 } from "../../config/model-input.js";
+import { logVerbose } from "../../globals.js";
 import { isImageAttachment, normalizeAttachments } from "../../media-understanding/attachments.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
@@ -335,7 +336,9 @@ export async function getReplyFromConfig(
           model = configuredImageModel.model;
         }
       }
-    } catch {}
+    } catch (err) {
+      logVerbose(`[get-reply] image model promotion skipped: catalog load failed (${String(err)})`);
+    }
   }
 
   const directiveResult = await resolveReplyDirectives({

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1225,8 +1225,13 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       ]);
       expect(message?.MediaType).toBe("image/png");
       expect(message?.MediaTypes).toEqual(["image/png", "image/jpeg"]);
-      expect(mockState.lastDispatchCtx?.MediaPath).toBeUndefined();
-      expect(mockState.lastDispatchCtx?.MediaPaths).toBeUndefined();
+      expect(mockState.lastDispatchCtx?.MediaPath).toBe("/tmp/chat-send-image-a.png");
+      expect(mockState.lastDispatchCtx?.MediaPaths).toEqual([
+        "/tmp/chat-send-image-a.png",
+        "/tmp/chat-send-image-b.jpg",
+      ]);
+      expect(mockState.lastDispatchCtx?.MediaType).toBe("image/png");
+      expect(mockState.lastDispatchCtx?.MediaTypes).toEqual(["image/png", "image/jpeg"]);
       expect(mockState.lastDispatchImages).toHaveLength(2);
     });
   });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -10,6 +10,7 @@ import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.j
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
+import { buildMediaPayload } from "../../channels/plugins/media-payload.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { type SavedMedia, saveMediaBuffer } from "../../media/store.js";
@@ -1412,6 +1413,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       // Only BodyForAgent gets the timestamp — Body stays raw for UI display.
       // See: https://github.com/moltbot/moltbot/issues/3658
       const stampedMessage = injectTimestamp(messageForAgent, timestampOptsFromConfig(cfg));
+      const persistedImages = await persistedImagesPromise;
 
       const ctx: MsgContext = {
         Body: messageForAgent,
@@ -1435,6 +1437,12 @@ export const chatHandlers: GatewayRequestHandlers = {
         SenderName: clientInfo?.displayName,
         SenderUsername: clientInfo?.displayName,
         GatewayClientScopes: client?.connect?.scopes,
+        ...buildMediaPayload(
+          persistedImages.map((entry) => ({
+            path: entry.path,
+            contentType: entry.contentType,
+          })),
+        ),
       };
 
       const agentId = resolveSessionAgentId({


### PR DESCRIPTION
AI-assisted: yes (Codex)
Testing: fully tested for the touched paths (`pnpm check` + targeted Vitest coverage)

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: web chat image turns persisted uploaded images for transcript storage, but the live dispatch `MsgContext` did not carry `MediaPath` / `MediaPaths`, and reply routing still stayed on the default text model even when `agents.defaults.imageModel` was configured.
- Why it matters: dashboard image turns could reach the agent without usable attachment metadata or could be sent to a non-vision model, causing image understanding to fail or be ignored.
- What changed: `chat.send` now builds the dispatch media payload from the persisted dashboard uploads, and `getReplyFromConfig` now switches inbound image turns to the first configured vision-capable `agents.defaults.imageModel` entry when no heartbeat, session, or channel override is active.
- What did NOT change (scope boundary): this PR does not change dashboard logging, plugin loading, or non-image model fallback behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A (no issue filed)
- Related #N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the web chat `chat.send` path only wrote saved image metadata back into the persisted transcript turn, not into the live `MsgContext` used for dispatch. Separately, `getReplyFromConfig` resolved default/session/channel/heartbeat model sources but never promoted inbound image turns to `agents.defaults.imageModel` when the active model lacked vision support.
- Missing detection / guardrail: there was no regression test asserting that dashboard `chat.send` populates dispatch media fields, and no test asserting that inbound image turns switch to a configured vision-capable image model.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown. This looks like a gap between the dashboard upload path and the existing image-model configuration path rather than a regression from this PR.
- Why this regressed now: the bug only becomes visible when the default model is text-only and the dashboard/web chat path is used for image uploads; a single vision-capable default model masks the problem.
- If unknown, what was ruled out: not a provider credential issue, not an `agents.defaults.imageModel` config parsing issue, and not a session/channel override precedence issue.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/get-reply.message-hooks.test.ts` and `src/gateway/server-methods/chat.directive-tags.test.ts`
- Scenario the test should lock in: a dashboard image upload should populate `MediaPath` / `MediaPaths` on the dispatch context, and an inbound image turn with a text-only default model should switch to the configured vision-capable `agents.defaults.imageModel`.
- Why this is the smallest reliable guardrail: these two tests isolate the missing handoffs without needing live provider credentials or a browser-driven dashboard run.
- Existing test that already covers this (if any): adjacent chat.send transcript tests already covered transcript rewriting, but they did not assert the live dispatch context; there was no existing model-routing test for inbound image turns.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Dashboard / web chat image turns now carry the saved media paths into the live agent context.
- When the active/default model is text-only, inbound image turns now use the first configured vision-capable `agents.defaults.imageModel` entry unless a higher-precedence override is active.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `No`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `No`
- Data access scope changed? (`Yes/No`) `No`
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS 26.4
- Runtime/container: Node.js v22.22.0, pnpm 10.32.1
- Model/provider: reproduced with a text-only default model plus a vision-capable `agents.defaults.imageModel`
- Integration/channel (if any): dashboard / web chat (`chat.send`)
- Relevant config (redacted): `agents.defaults.model=openai/gpt-4o-mini`, `agents.defaults.imageModel.primary=moonshot/kimi-k2.5`

### Steps

1. Configure a text-only default model and a vision-capable `agents.defaults.imageModel.primary`.
2. Send an image through dashboard/web chat `chat.send`.
3. Observe the dispatch context and the model selected for the reply turn.

### Expected

- The dispatch context includes saved image paths/types.
- The reply turn uses the configured vision-capable image model when no higher-precedence override is active.

### Actual

- Before this change, the transcript turn carried saved media metadata but the live dispatch context did not, and reply routing stayed on the default text model.
- After this change, the dispatch context includes the saved media payload and image turns route through the configured vision-capable image model.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `corepack pnpm exec vitest run src/auto-reply/reply/get-reply.message-hooks.test.ts -t "switches to the configured image model for inbound image attachments"`; ran `corepack pnpm exec vitest run src/gateway/server-methods/chat.directive-tags.test.ts -t "adds persisted media paths to the user transcript update|rewrites the persisted user turn with saved media paths after dispatch"`; ran the full repo gate with `pnpm check`.
- Edge cases checked: the existing plain-text/no-attachment path still passes; session/channel/heartbeat overrides are still left ahead of the image-model promotion logic.
- What you did **not** verify: a live end-to-end dashboard run from this source checkout against real provider credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `No`
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `55b1e19`.
- Files/config to restore: `src/gateway/server-methods/chat.ts` and `src/auto-reply/reply/get-reply.ts`
- Known bad symptoms reviewers should watch for: image turns unexpectedly ignore higher-precedence overrides, or dashboard image uploads stop carrying saved media paths into dispatch.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the promotion logic depends on the model catalog advertising image support, so a stale or incomplete catalog can leave the current behavior unchanged.
  - Mitigation: the switch only happens when the catalog positively confirms image support; otherwise the behavior remains as it was before.
- Risk: `chat.send` now waits for persisted image metadata before building the dispatch context.
  - Mitigation: the request ACK is still emitted before persistence starts, and the wait only gates context construction for turns that already need persisted image paths.
