### PR TITLE
docs: add AllowTcpForwarding requirement to Hetzner SSH tunnel guide

### DIFF
--- a/docs/install/hetzner.md
+++ b/docs/install/hetzner.md
@@ -210,6 +210,8 @@ For the generic Docker flow, see [Docker](/install/docker).
   <Step title="Hetzner-specific access">
     After the shared build and launch steps, tunnel from your laptop:
 
+    > **Note:** SSH tunnels require `AllowTcpForwarding yes` in the server's `/etc/ssh/sshd_config`. Hetzner's default images may have this disabled. If the tunnel connects but the forwarded port is not reachable, check this setting and restart sshd (`systemctl restart sshd`) after changing it.
+
     ```bash
     ssh -N -L 18789:127.0.0.1:18789 root@YOUR_VPS_IP
     ```

--- a/docs/zh-CN/install/hetzner.md
+++ b/docs/zh-CN/install/hetzner.md
@@ -306,6 +306,8 @@ docker compose logs -f openclaw-gateway
 
 从你的笔记本电脑：
 
+> **注意：** SSH 隧道要求服务器的 `/etc/ssh/sshd_config` 中设置 `AllowTcpForwarding yes`。Hetzner 的默认镜像可能已禁用此选项。如果隧道已连接但转发端口不可达，请检查此设置并在更改后重启 sshd（`systemctl restart sshd`）。
+
 ```bash
 ssh -N -L 18789:127.0.0.1:18789 root@YOUR_VPS_IP
 ```


### PR DESCRIPTION
Closes #54557

## Problem
The Hetzner SSH tunnel setup silently fails when `AllowTcpForwarding` is disabled on the server (which is the default on many Hetzner configurations). Users get no error message, making this hard to diagnose.

## Fix
Added a note to the Hetzner deployment guide explaining that `AllowTcpForwarding yes` must be set in `/etc/ssh/sshd_config` on the remote server for SSH tunnels to work.