### PR TITLE
Feishu: include pending history media (images) in inbound context

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -668,9 +668,9 @@ export async function handleFeishuMessage(params: {
     // authoritative transcript turns.
     log(`feishu[${account.accountId}]: ${inboundLabel}: ${preview}`);
 
-    // Resolve media from message
+    // Resolve media from the triggering message
     const mediaMaxBytes = (feishuCfg?.mediaMaxMb ?? 30) * 1024 * 1024; // 30MB default
-    const mediaList = await resolveFeishuMediaList({
+    let mediaList = await resolveFeishuMediaList({
       cfg,
       messageId: ctx.messageId,
       messageType: event.message.message_type,
@@ -679,7 +679,7 @@ export async function handleFeishuMessage(params: {
       log,
       accountId: account.accountId,
     });
-    const mediaPayload = buildAgentMediaPayload(mediaList);
+    let mediaPayload = buildAgentMediaPayload(mediaList);
 
     // Fetch quoted/replied message content if parentId exists
     let quotedMessageInfo: Awaited<ReturnType<typeof getMessageFeishu>> = null;
@@ -757,6 +757,76 @@ export async function handleFeishuMessage(params: {
             timestamp: entry.timestamp,
           }))
         : undefined;
+
+    // Best-effort: if the bot is mentioned later, include media from pending group history
+    // (e.g. screenshots posted before the mention). This keeps the "history" section
+    // useful for debugging without requiring users to re-upload images.
+    if (isGroup && historyKey && historyLimit > 0 && chatHistories) {
+      const historyEntries = chatHistories.get(historyKey) ?? [];
+      const mediaCandidates = historyEntries
+        .filter((entry) =>
+          Boolean(entry.messageId) && /<media:|!\[image\]/.test(String(entry.body ?? "")),
+        )
+        .slice(-3); // keep it cheap: only resolve the most recent few media turns
+
+      if (mediaCandidates.length > 0) {
+        log(
+          `feishu[${account.accountId}]: resolving ${mediaCandidates.length} media message(s) from pending history`,
+        );
+      }
+
+      const historyMediaList: Awaited<ReturnType<typeof resolveFeishuMediaList>> = [];
+      for (const entry of mediaCandidates) {
+        const messageId = entry.messageId;
+        if (!messageId) {
+          continue;
+        }
+        try {
+          const info = await getMessageFeishu({
+            cfg,
+            messageId,
+            accountId: account.accountId,
+          });
+          if (!info?.rawContent) {
+            continue;
+          }
+          const resolved = await resolveFeishuMediaList({
+            cfg,
+            messageId,
+            messageType: info.contentType,
+            content: info.rawContent,
+            maxBytes: mediaMaxBytes,
+            log,
+            accountId: account.accountId,
+          });
+          historyMediaList.push(...resolved);
+          if (historyMediaList.length >= 10) {
+            break;
+          }
+        } catch (err) {
+          log(
+            `feishu[${account.accountId}]: failed to resolve pending history media for ${messageId}: ${String(err)}`,
+          );
+        }
+      }
+
+      if (historyMediaList.length > 0) {
+        // Prefer history media first so placeholders in history align with MediaPaths order.
+        const merged = [...historyMediaList, ...mediaList];
+        const seen = new Set<string>();
+        mediaList = merged.filter((m) => {
+          if (!m?.path) {
+            return false;
+          }
+          if (seen.has(m.path)) {
+            return false;
+          }
+          seen.add(m.path);
+          return true;
+        });
+        mediaPayload = buildAgentMediaPayload(mediaList);
+      }
+    }
 
     const threadContextBySessionKey = new Map<
       string,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -764,8 +764,9 @@ export async function handleFeishuMessage(params: {
     if (isGroup && historyKey && historyLimit > 0 && chatHistories) {
       const historyEntries = chatHistories.get(historyKey) ?? [];
       const mediaCandidates = historyEntries
-        .filter((entry) =>
-          Boolean(entry.messageId) && /<media:|!\[image\]/.test(String(entry.body ?? "")),
+        .filter(
+          (entry) =>
+            Boolean(entry.messageId) && /<media:|!\[image\]/.test(String(entry.body ?? "")),
         )
         .slice(-3); // keep it cheap: only resolve the most recent few media turns
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -270,6 +270,7 @@ function parseFeishuMessageItem(
     senderOpenId: item.sender?.id_type === "open_id" ? item.sender?.id : undefined,
     senderType: item.sender?.sender_type,
     content: parseFeishuMessageContent(rawContent, msgType),
+    rawContent,
     contentType: msgType,
     createTime: item.create_time ? parseInt(String(item.create_time), 10) : undefined,
     threadId: item.thread_id || undefined,

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -69,7 +69,10 @@ export type FeishuMessageInfo = {
   senderId?: string;
   senderOpenId?: string;
   senderType?: string;
+  /** Parsed/normalized content (best-effort plain text). */
   content: string;
+  /** Raw message body.content as returned by Feishu APIs (JSON string for non-text message types). */
+  rawContent?: string;
   contentType: string;
   createTime?: number;
   /** Feishu thread ID (omt_xxx) — present when the message belongs to a topic thread. */


### PR DESCRIPTION
## Problem
In Feishu group chats, users often post screenshots before mentioning the bot. Those screenshot messages are buffered as pending history (text placeholders like `![image]` / `<media:image>`), but the bot does not include the actual media in the inbound agent context.

## Changes
- Extend `FeishuMessageInfo` to preserve `rawContent` returned by Feishu message APIs.
- When a triggering message mentions the bot, best-effort resolve media for the most recent pending history entries that look like media messages (up to 3 messages / 10 media items), and prepend those media paths to the inbound media payload.

## Notes
- Best-effort only: failures are logged and ignored.
- Keeps download cost bounded to avoid large latency spikes.