### PR TITLE
fix: fall back to local plan when node does not support system.run.prepare

### DIFF
--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -116,7 +116,11 @@ export async function executeNodeHostCommand(
       },
     );
     prepared = parsePreparedSystemRunPayload(prepareRaw?.payload);
-  } catch {
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes("unknown command") && !msg.includes("command not allowed")) {
+      throw err;
+    }
     prepared = null;
   }
   if (!prepared) {
@@ -124,7 +128,7 @@ export async function executeNodeHostCommand(
       plan: {
         argv,
         cwd: params.workdir ?? null,
-        commandText: params.command ?? formatExecCommand(argv),
+        commandText: params.command || formatExecCommand(argv),
         commandPreview: null,
         agentId: params.agentId,
         sessionKey: params.sessionKey,

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -15,6 +15,7 @@ import {
 import { detectCommandObfuscation } from "../infra/exec-obfuscation-detect.js";
 import { buildNodeShellCommand } from "../infra/node-shell.js";
 import { parsePreparedSystemRunPayload } from "../infra/system-run-approval-context.js";
+import { formatExecCommand } from "../infra/system-run-command.js";
 import { logInfo } from "../logger.js";
 import {
   buildExecApprovalRequesterContext,
@@ -96,25 +97,39 @@ export async function executeNodeHostCommand(
     );
   }
   const argv = buildNodeShellCommand(params.command, nodeInfo?.platform);
-  const prepareRaw = await callGatewayTool<{ payload?: unknown }>(
-    "node.invoke",
-    { timeoutMs: 15_000 },
-    {
-      nodeId,
-      command: "system.run.prepare",
-      params: {
-        command: argv,
-        rawCommand: params.command,
-        cwd: params.workdir,
+  let prepared: ReturnType<typeof parsePreparedSystemRunPayload>;
+  try {
+    const prepareRaw = await callGatewayTool<{ payload?: unknown }>(
+      "node.invoke",
+      { timeoutMs: 15_000 },
+      {
+        nodeId,
+        command: "system.run.prepare",
+        params: {
+          command: argv,
+          rawCommand: params.command,
+          cwd: params.workdir,
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+        },
+        idempotencyKey: crypto.randomUUID(),
+      },
+    );
+    prepared = parsePreparedSystemRunPayload(prepareRaw?.payload);
+  } catch {
+    prepared = null;
+  }
+  if (!prepared) {
+    prepared = {
+      plan: {
+        argv,
+        cwd: params.workdir ?? null,
+        commandText: params.command ?? formatExecCommand(argv),
+        commandPreview: null,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
       },
-      idempotencyKey: crypto.randomUUID(),
-    },
-  );
-  const prepared = parsePreparedSystemRunPayload(prepareRaw?.payload);
-  if (!prepared) {
-    throw new Error("invalid system.run.prepare response");
+    };
   }
   const runArgv = prepared.plan.argv;
   const runRawCommand = prepared.plan.commandText;

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -130,8 +130,8 @@ export async function executeNodeHostCommand(
         cwd: params.workdir ?? null,
         commandText: params.command || formatExecCommand(argv),
         commandPreview: null,
-        agentId: params.agentId,
-        sessionKey: params.sessionKey,
+        agentId: params.agentId ?? null,
+        sessionKey: params.sessionKey ?? null,
       },
     };
   }

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -690,8 +690,8 @@ export function createNodesTool(options?: {
                   cwd: cwd ?? null,
                   commandText: formatExecCommand(command),
                   commandPreview: null,
-                  agentId,
-                  sessionKey,
+                  agentId: agentId ?? null,
+                  sessionKey: sessionKey ?? null,
                 },
               };
             }

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -10,6 +10,7 @@ import {
   writeCameraPayloadToFile,
 } from "../../cli/nodes-camera.js";
 import { parseEnvPairs, parseTimeoutMs } from "../../cli/nodes-run.js";
+import { formatExecCommand } from "../../infra/system-run-command.js";
 import {
   parseScreenRecordPayload,
   screenRecordTempPath,
@@ -661,25 +662,34 @@ export function createNodesTool(options?: {
               typeof params.needsScreenRecording === "boolean"
                 ? params.needsScreenRecording
                 : undefined;
-            const prepareRaw = await callGatewayTool<{ payload?: unknown }>(
-              "node.invoke",
-              gatewayOpts,
-              {
-                nodeId,
-                command: "system.run.prepare",
-                params: {
-                  command,
-                  cwd,
+            let prepared: ReturnType<typeof parsePreparedSystemRunPayload>;
+            try {
+              const prepareRaw = await callGatewayTool<{ payload?: unknown }>(
+                "node.invoke",
+                gatewayOpts,
+                {
+                  nodeId,
+                  command: "system.run.prepare",
+                  params: { command, cwd, agentId, sessionKey },
+                  timeoutMs: invokeTimeoutMs,
+                  idempotencyKey: crypto.randomUUID(),
+                },
+              );
+              prepared = parsePreparedSystemRunPayload(prepareRaw?.payload);
+            } catch {
+              prepared = null;
+            }
+            if (!prepared) {
+              prepared = {
+                plan: {
+                  argv: command,
+                  cwd: cwd ?? null,
+                  commandText: formatExecCommand(command),
+                  commandPreview: null,
                   agentId,
                   sessionKey,
                 },
-                timeoutMs: invokeTimeoutMs,
-                idempotencyKey: crypto.randomUUID(),
-              },
-            );
-            const prepared = parsePreparedSystemRunPayload(prepareRaw?.payload);
-            if (!prepared) {
-              throw new Error("invalid system.run.prepare response");
+              };
             }
             const runParams = {
               command: prepared.plan.argv,

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -676,7 +676,11 @@ export function createNodesTool(options?: {
                 },
               );
               prepared = parsePreparedSystemRunPayload(prepareRaw?.payload);
-            } catch {
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              if (!msg.includes("unknown command") && !msg.includes("command not allowed")) {
+                throw err;
+              }
               prepared = null;
             }
             if (!prepared) {

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -159,7 +159,7 @@ async function prepareNodesRunContext(params: {
       cwd: params.opts.cwd ?? null,
       commandText: rawCommand ?? formatExecCommand(argv),
       commandPreview: null,
-      agentId: params.agentId,
+      agentId: params.agentId ?? null,
       sessionKey: null,
     },
   };

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -17,6 +17,7 @@ import {
 import { buildNodeShellCommand } from "../../infra/node-shell.js";
 import { applyPathPrepend } from "../../infra/path-prepend.js";
 import { parsePreparedSystemRunPayload } from "../../infra/system-run-approval-context.js";
+import { formatExecCommand } from "../../infra/system-run-command.js";
 import { defaultRuntime } from "../../runtime.js";
 import { parseEnvPairs, parseTimeoutMs } from "../nodes-run.js";
 import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
@@ -135,24 +136,31 @@ async function prepareNodesRunContext(params: {
     applyPathPrepend(nodeEnv, params.execDefaults?.pathPrepend, { requireExisting: true });
   }
 
-  const prepareResponse = (await callGatewayCli("node.invoke", params.opts, {
-    nodeId: params.nodeId,
-    command: "system.run.prepare",
-    params: {
-      command: argv,
-      rawCommand,
-      cwd: params.opts.cwd,
-      agentId: params.agentId,
-    },
-    idempotencyKey: `prepare-${randomIdempotencyKey()}`,
-  })) as { payload?: unknown } | null;
+  let preparedPayload: unknown;
+  try {
+    const prepareResponse = (await callGatewayCli("node.invoke", params.opts, {
+      nodeId: params.nodeId,
+      command: "system.run.prepare",
+      params: { command: argv, rawCommand, cwd: params.opts.cwd, agentId: params.agentId },
+      idempotencyKey: `prepare-${randomIdempotencyKey()}`,
+    })) as { payload?: unknown } | null;
+    preparedPayload = prepareResponse?.payload;
+  } catch {
+    preparedPayload = null;
+  }
 
-  return {
-    prepared: requirePreparedRunPayload(prepareResponse?.payload),
-    nodeEnv,
-    timeoutMs,
-    invokeTimeout,
+  const prepared = parsePreparedSystemRunPayload(preparedPayload) ?? {
+    plan: {
+      argv,
+      cwd: params.opts.cwd ?? null,
+      commandText: rawCommand ?? formatExecCommand(argv),
+      commandPreview: null,
+      agentId: params.agentId,
+      sessionKey: null,
+    },
   };
+
+  return { prepared, nodeEnv, timeoutMs, invokeTimeout };
 }
 
 async function resolveNodeApprovals(params: {

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -145,7 +145,11 @@ async function prepareNodesRunContext(params: {
       idempotencyKey: `prepare-${randomIdempotencyKey()}`,
     })) as { payload?: unknown } | null;
     preparedPayload = prepareResponse?.payload;
-  } catch {
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.includes("unknown command") && !msg.includes("command not allowed")) {
+      throw err;
+    }
     preparedPayload = null;
   }
 


### PR DESCRIPTION
## Summary

- The macOS companion app does not implement `system.run.prepare`, causing `nodes.run` to fail with "unknown command" or "command not allowed" errors
- Wraps the `system.run.prepare` invoke in a try-catch at all three call sites (agent nodes tool, bash exec host-node, CLI `nodes run`) and falls back to a locally-built approval plan
- Uses `formatExecCommand` for proper argument quoting in the fallback plan to handle commands with spaces

## Test plan

- [ ] `openclaw nodes run --node <mac-node> --raw "echo hello"` succeeds on a macOS companion app node
- [ ] Commands with quoted arguments (e.g. `git commit -m "message with spaces"`) work correctly via the fallback path
- [ ] Nodes that DO support `system.run.prepare` (CLI node-host) continue to use the full prepare flow unchanged
- [ ] Exec approval flow still works when the fallback plan is used