### PR TITLE
Media: surface empty voice-note placeholders

### DIFF
--- a/src/media-understanding/audio-preflight.test.ts
+++ b/src/media-understanding/audio-preflight.test.ts
@@ -1,4 +1,7 @@
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_AUDIO_TRANSCRIPT_PLACEHOLDER } from "./audio-preflight.js";
 
 const runAudioTranscriptionMock = vi.hoisted(() => vi.fn());
 
@@ -9,6 +12,22 @@ vi.mock("./audio-transcription-runner.js", () => ({
 let transcribeFirstAudio: typeof import("./audio-preflight.js").transcribeFirstAudio;
 
 describe("transcribeFirstAudio", () => {
+  const enabledCfg = {
+    tools: {
+      media: {
+        audio: {
+          enabled: true,
+        },
+      },
+    },
+  } as OpenClawConfig;
+
+  const ctx: MsgContext = {
+    Body: "<media:audio>",
+    MediaPath: "/tmp/voice.ogg",
+    MediaType: "audio/ogg",
+  };
+
   beforeAll(async () => {
     ({ transcribeFirstAudio } = await import("./audio-preflight.js"));
   });
@@ -24,11 +43,7 @@ describe("transcribeFirstAudio", () => {
     });
 
     const transcript = await transcribeFirstAudio({
-      ctx: {
-        Body: "<media:audio>",
-        MediaPath: "/tmp/voice.ogg",
-        MediaType: "audio/ogg",
-      },
+      ctx,
       cfg: {},
     });
 
@@ -38,11 +53,7 @@ describe("transcribeFirstAudio", () => {
 
   it("skips audio preflight when audio config is explicitly disabled", async () => {
     const transcript = await transcribeFirstAudio({
-      ctx: {
-        Body: "<media:audio>",
-        MediaPath: "/tmp/voice.ogg",
-        MediaType: "audio/ogg",
-      },
+      ctx,
       cfg: {
         tools: {
           media: {
@@ -56,5 +67,48 @@ describe("transcribeFirstAudio", () => {
 
     expect(transcript).toBeUndefined();
     expect(runAudioTranscriptionMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a clear placeholder when tiny audio is skipped", async () => {
+    runAudioTranscriptionMock.mockResolvedValueOnce({
+      transcript: undefined,
+      attachments: [],
+      skippedReason: "tooSmall",
+    });
+
+    await expect(transcribeFirstAudio({ ctx, cfg: enabledCfg })).resolves.toBe(
+      EMPTY_AUDIO_TRANSCRIPT_PLACEHOLDER,
+    );
+  });
+
+  it("returns a clear placeholder when empty audio is skipped", async () => {
+    runAudioTranscriptionMock.mockResolvedValueOnce({
+      transcript: undefined,
+      attachments: [],
+      skippedReason: "empty",
+    });
+
+    await expect(transcribeFirstAudio({ ctx, cfg: enabledCfg })).resolves.toBe(
+      EMPTY_AUDIO_TRANSCRIPT_PLACEHOLDER,
+    );
+  });
+
+  it("keeps returning undefined for non-empty skip reasons", async () => {
+    runAudioTranscriptionMock.mockResolvedValueOnce({
+      transcript: undefined,
+      attachments: [],
+      skippedReason: "timeout",
+    });
+
+    await expect(transcribeFirstAudio({ ctx, cfg: enabledCfg })).resolves.toBeUndefined();
+  });
+
+  it("returns the actual transcript when transcription succeeds", async () => {
+    runAudioTranscriptionMock.mockResolvedValueOnce({
+      transcript: "hello from audio",
+      attachments: [],
+    });
+
+    await expect(transcribeFirstAudio({ ctx, cfg: enabledCfg })).resolves.toBe("hello from audio");
   });
 });

--- a/src/media-understanding/audio-preflight.ts
+++ b/src/media-understanding/audio-preflight.ts
@@ -10,6 +10,8 @@ import {
 } from "./runner.js";
 import type { MediaUnderstandingProvider } from "./types.js";
 
+export const EMPTY_AUDIO_TRANSCRIPT_PLACEHOLDER = "[Voice note was empty or silent]";
+
 /**
  * Transcribes the first audio attachment BEFORE mention checking.
  * This allows voice notes to be processed in group chats with requireMention: true.
@@ -49,7 +51,7 @@ export async function transcribeFirstAudio(params: {
   }
 
   try {
-    const { transcript } = await runAudioTranscription({
+    const { transcript, skippedReason } = await runAudioTranscription({
       ctx,
       cfg,
       attachments,
@@ -59,6 +61,9 @@ export async function transcribeFirstAudio(params: {
       localPathRoots: resolveMediaAttachmentLocalRoots({ cfg, ctx }),
     });
     if (!transcript) {
+      if (skippedReason === "tooSmall" || skippedReason === "empty") {
+        return EMPTY_AUDIO_TRANSCRIPT_PLACEHOLDER;
+      }
       return undefined;
     }
 

--- a/src/media-understanding/audio-preflight.ts
+++ b/src/media-understanding/audio-preflight.ts
@@ -54,7 +54,7 @@ export async function transcribeFirstAudio(params: {
     const { transcript, skippedReason } = await runAudioTranscription({
       ctx,
       cfg,
-      attachments,
+      attachments: [firstAudio],
       agentDir: params.agentDir,
       providers: params.providers,
       activeModel: params.activeModel,

--- a/src/media-understanding/audio-transcription-runner.ts
+++ b/src/media-understanding/audio-transcription-runner.ts
@@ -48,11 +48,11 @@ export async function runAudioTranscription(params: {
     });
     const output = result.outputs.find((entry) => entry.kind === "audio.transcription");
     const transcript = output?.text?.trim();
-    const skippedReason = (Array.isArray(result.decision.attachments)
-      ? result.decision.attachments
-      : []
-    )
-      .flatMap((entry) => (Array.isArray(entry.attempts) ? entry.attempts : []))
+    const targetAttachmentIndex = attachments[0]?.index;
+    const targetDecision = (
+      Array.isArray(result.decision.attachments) ? result.decision.attachments : []
+    ).find((entry) => entry?.attachmentIndex === targetAttachmentIndex);
+    const skippedReason = (Array.isArray(targetDecision?.attempts) ? targetDecision.attempts : [])
       .map((attempt) =>
         typeof attempt?.reason === "string" ? attempt.reason.split(":")[0]?.trim() : undefined,
       )

--- a/src/media-understanding/audio-transcription-runner.ts
+++ b/src/media-understanding/audio-transcription-runner.ts
@@ -1,5 +1,6 @@
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type { MediaUnderstandingSkipReason } from "./errors.js";
 import {
   type ActiveMediaModel,
   buildProviderRegistry,
@@ -17,7 +18,11 @@ export async function runAudioTranscription(params: {
   providers?: Record<string, MediaUnderstandingProvider>;
   activeModel?: ActiveMediaModel;
   localPathRoots?: readonly string[];
-}): Promise<{ transcript: string | undefined; attachments: MediaAttachment[] }> {
+}): Promise<{
+  transcript: string | undefined;
+  attachments: MediaAttachment[];
+  skippedReason?: MediaUnderstandingSkipReason;
+}> {
   const attachments = params.attachments ?? normalizeMediaAttachments(params.ctx);
   if (attachments.length === 0) {
     return { transcript: undefined, attachments };
@@ -43,7 +48,23 @@ export async function runAudioTranscription(params: {
     });
     const output = result.outputs.find((entry) => entry.kind === "audio.transcription");
     const transcript = output?.text?.trim();
-    return { transcript: transcript || undefined, attachments };
+    const skippedReason = (Array.isArray(result.decision.attachments)
+      ? result.decision.attachments
+      : []
+    )
+      .flatMap((entry) => (Array.isArray(entry.attempts) ? entry.attempts : []))
+      .map((attempt) =>
+        typeof attempt?.reason === "string" ? attempt.reason.split(":")[0]?.trim() : undefined,
+      )
+      .find(
+        (reason): reason is MediaUnderstandingSkipReason =>
+          reason === "empty" ||
+          reason === "maxBytes" ||
+          reason === "timeout" ||
+          reason === "tooSmall" ||
+          reason === "unsupported",
+      );
+    return { transcript: transcript || undefined, attachments, skippedReason };
   } finally {
     await cache.cleanup();
   }


### PR DESCRIPTION
## Summary

- Problem: when preflight audio transcription skips a tiny/empty voice note, the agent gets no deterministic transcript hint and may hallucinate an unrelated failure reason.
- Why it matters: silent or accidental voice notes can produce misleading replies instead of a simple “that note was empty/silent” response.
- What changed: surface a shared placeholder transcript for `tooSmall` / `empty` preflight-audio skips, and preserve the skip reason from the audio runner so the preflight layer can distinguish valid silence from other failures.
- What did NOT change (scope boundary): no live transcription provider behavior changed, and non-empty audio or other skip reasons still behave as before.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48944
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `transcribeFirstAudio()` only returned a transcript string or `undefined`, so “audio was skipped because it was tiny/empty” got collapsed into the same state as generic transcription failure.
- Missing detection / guardrail: the audio preflight path had tests for successful transcripts and skip behavior in the runner, but no unit test that verified the preflight layer preserved skip intent for the agent-facing context.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: once tiny voice notes began being intentionally skipped before transcription, the handoff lost the reason for the skip and left the agent to infer a cause from missing context.
- If unknown, what was ruled out: ruled out provider/CLI transcription errors by following the shared media runner’s `tooSmall`/`empty` skip decisions.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/media-understanding/audio-preflight.test.ts`
- Scenario the test should lock in: tiny/empty preflight audio skips should surface a placeholder transcript, while unrelated skip reasons should still return `undefined`.
- Why this is the smallest reliable guardrail: the regression happens entirely in the shared preflight translation layer between runner decisions and agent-visible context.
- Existing test that already covers this (if any): `src/media-understanding/runner.skip-tiny-audio.test.ts` already proved the runner emits `tooSmall`, but not how preflight consumes it.
- If no new test is added, why not:

## User-visible / Behavior Changes

- Silent or near-empty voice notes now surface `[Voice note was empty or silent]` through preflight transcript paths instead of leaving the agent with a blank transcript state.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): shared media preflight used by Telegram / Discord
- Relevant config (redacted): `tools.media.audio.enabled=true`

### Steps

1. Send or simulate a tiny/empty audio attachment that falls below the shared minimum audio size threshold.
2. Trigger the preflight transcription path.
3. Inspect the returned transcript value consumed by the message-context layer.

### Expected

- The preflight layer should return a deterministic placeholder explaining that the voice note was empty/silent.

### Actual

- Before this change, the preflight layer returned `undefined`, which let downstream agent logic guess the wrong cause.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `pnpm test -- src/media-understanding/audio-preflight.test.ts src/media-understanding/runner.skip-tiny-audio.test.ts`; both passed.
- Edge cases checked: `tooSmall`, `empty`, non-empty success, and unrelated skip reason (`timeout`).
- What you did **not** verify: live channel-specific end-to-end behavior against Telegram/Discord transports.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/media-understanding/audio-preflight.ts`, `src/media-understanding/audio-transcription-runner.ts`
- Known bad symptoms reviewers should watch for: placeholder showing up for non-empty audio failures, or real transcripts being replaced by the placeholder.

## Risks and Mitigations

- Risk: the placeholder could appear for a skip reason that should remain silent.
  - Mitigation: the preflight layer only injects it for explicit `tooSmall` / `empty` skip reasons and leaves other skip reasons unchanged.
