### PR TITLE
fix: honor default subagent run timeout

### DIFF
--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -142,6 +142,30 @@ describe("subagent registry seam flow", () => {
     vi.useRealTimers();
   });
 
+  it("passes undefined timeout override when runTimeoutSeconds is omitted", () => {
+    mod.registerSubagentRun({
+      runId: "run-timeout-default",
+      childSessionKey: "agent:main:subagent:timeout-default",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "finish the task",
+      cleanup: "delete",
+    });
+
+    expect(mocks.resolveAgentTimeoutMs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overrideSeconds: undefined,
+      }),
+    );
+
+    expect(
+      mod.getLatestSubagentRunByChildSessionKey("agent:main:subagent:timeout-default"),
+    ).toMatchObject({
+      runId: "run-timeout-default",
+      runTimeoutSeconds: undefined,
+    });
+  });
+
   it("completes a registered run across timing persistence, lifecycle status, and announce cleanup", async () => {
     mod.registerSubagentRun({
       runId: "run-1",
@@ -504,6 +528,38 @@ describe("subagent registry seam flow", () => {
         reason: "released",
         workspaceDir: undefined,
       });
+    });
+  });
+
+  it("preserves omitted timeout across steer restart replacement", () => {
+    mod.registerSubagentRun({
+      runId: "run-steer-old",
+      childSessionKey: "agent:main:subagent:steer-timeout",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "first run",
+      cleanup: "delete",
+    });
+    mocks.resolveAgentTimeoutMs.mockClear();
+
+    const previous = mod.getLatestSubagentRunByChildSessionKey("agent:main:subagent:steer-timeout");
+    const replaced = mod.replaceSubagentRunAfterSteer({
+      previousRunId: "run-steer-old",
+      nextRunId: "run-steer-new",
+      fallback: previous ?? undefined,
+    });
+
+    expect(replaced).toBe(true);
+    expect(mocks.resolveAgentTimeoutMs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overrideSeconds: undefined,
+      }),
+    );
+    expect(
+      mod.getLatestSubagentRunByChildSessionKey("agent:main:subagent:steer-timeout"),
+    ).toMatchObject({
+      runId: "run-steer-new",
+      runTimeoutSeconds: undefined,
     });
   });
 });

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -834,7 +834,7 @@ function resolveSubagentWaitTimeoutMs(
   cfg: ReturnType<typeof loadConfig>,
   runTimeoutSeconds?: number,
 ) {
-  return resolveAgentTimeoutMs({ cfg, overrideSeconds: runTimeoutSeconds ?? 0 });
+  return resolveAgentTimeoutMs({ cfg, overrideSeconds: runTimeoutSeconds });
 }
 
 function startSweeper() {
@@ -1344,7 +1344,7 @@ export function replaceSubagentRunAfterSteer(params: {
       : archiveAfterMs
         ? now + archiveAfterMs
         : undefined;
-  const runTimeoutSeconds = params.runTimeoutSeconds ?? source.runTimeoutSeconds ?? 0;
+  const runTimeoutSeconds = params.runTimeoutSeconds ?? source.runTimeoutSeconds;
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
   const preserveFrozenResultFallback = params.preserveFrozenResultFallback === true;
   const sessionStartedAt = resolveSubagentSessionStartedAt(source) ?? now;
@@ -1421,7 +1421,7 @@ export function registerSubagentRun(params: {
       : archiveAfterMs
         ? now + archiveAfterMs
         : undefined;
-  const runTimeoutSeconds = params.runTimeoutSeconds ?? 0;
+  const runTimeoutSeconds = params.runTimeoutSeconds;
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
   const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
   subagentRuns.set(params.runId, {


### PR DESCRIPTION
## Summary\n- preserve omitted `runTimeoutSeconds` so `sessions_spawn` can inherit the configured default timeout\n- avoid coercing missing timeouts to `0` when registering or replacing subagent runs\n- add registry regression coverage for omitted timeout propagation and steer restarts\n\n## Testing\n- pnpm test -- --run src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts src/agents/subagent-registry.test.ts\n\nFixes #54936