### PR TITLE
fix(skills): refresh stale skillsSnapshot when version changes

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -595,6 +595,11 @@ async function agentCommandInternal(
     }
 
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
+    const cachedSnapshotVersion = sessionEntry?.skillsSnapshot?.version ?? 0;
+    const needsSkillsSnapshot =
+      isNewSession ||
+      !sessionEntry?.skillsSnapshot ||
+      (skillsSnapshotVersion > 0 && cachedSnapshotVersion < skillsSnapshotVersion);
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
     const currentSkillsSnapshot = sessionEntry?.skillsSnapshot;
     const shouldRefreshSkillsSnapshot =


### PR DESCRIPTION
## Problem

`agent-command.ts` caches the skills snapshot indefinitely for existing sessions. Once a snapshot is persisted, newly installed skills are never picked up until the session is manually deleted.

```typescript
// Before: only checks isNewSession or missing snapshot
const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
```

This means:
1. User installs a new skill via `clawhub install`
2. The file watcher detects the change and bumps `skillsSnapshotVersion`  
3. But existing sessions ignore the version bump — they already have a snapshot
4. The new skill never appears in `<available_skills>` until session reset

## Root Cause

The auto-reply path (`session-updates.ts`) already has version-based invalidation:

```typescript
const shouldRefreshSnapshot =
  snapshotVersion > 0 && (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion;
```

But `agent-command.ts` (used by the agent runner, cron jobs, and plugin SDK) was missing this check entirely.

## Fix

Add the same version comparison to `agent-command.ts`:

```typescript
const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
const cachedSnapshotVersion = sessionEntry?.skillsSnapshot?.version ?? 0;
const needsSkillsSnapshot =
  isNewSession ||
  !sessionEntry?.skillsSnapshot ||
  (skillsSnapshotVersion > 0 && cachedSnapshotVersion < skillsSnapshotVersion);
```

When the watcher bumps the snapshot version, the next agent run detects the version mismatch and rebuilds.

## Testing

1. Install a new skill: `clawhub install <slug>`
2. Send a message in an existing session
3. **Before**: new skill not visible until session delete/restart
4. **After**: new skill appears after the watcher fires (within ~250ms debounce)

## Related

- #44898 (original report)
- #22517, #12092 (related stale snapshot reports)
- `session-updates.ts` already has the correct logic — this aligns the two code paths

Fixes #44898