### PR TITLE
docs(channels/feishu): clarify routing fallback chain and session key relationship

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -605,7 +605,7 @@ Notes:
 
 Use `bindings` to route Feishu DMs or groups to different agents.
 
-When no explicit binding matches an incoming message, the gateway falls back to the **default account** (configured via `channels.feishu.defaultAccount` or the first configured account), and then applies the **default group policy** (`channels.defaults.groupPolicy`) to determine which agent handles it. The resulting canonical session key (e.g., `feishu:g-{chatId}` for groups) reflects the final routing destination but does not encode which rule — binding or fallback — was responsible.
+When no explicit binding matches an incoming message, the gateway falls back to the **default account** (configured via `channels.feishu.defaultAccount` or the first configured account) to select the handling agent. The **default group policy** (`channels.defaults.groupPolicy`) then determines whether the message is accepted (`open`/`allowlist`/`disabled`) — it is an access-control gate, not an agent-selection mechanism. The resulting canonical session key (e.g., `feishu:g-{chatId}` for groups) reflects the final routing destination but does not encode which rule — binding or fallback — was responsible.
 
 ```json5
 {

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -605,6 +605,8 @@ Notes:
 
 Use `bindings` to route Feishu DMs or groups to different agents.
 
+When no explicit binding matches an incoming message, the gateway falls back to the **default account** (configured via `channels.feishu.defaultAccount` or the first configured account), and then applies the **default group policy** (`channels.defaults.groupPolicy`) to determine which agent handles it. The resulting canonical session key (e.g., `feishu:g-{chatId}` for groups) reflects the final routing destination but does not encode which rule — binding or fallback — was responsible.
+
 ```json5
 {
   agents: {

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -83,7 +83,7 @@ Use `channels.defaults` for shared group-policy and heartbeat behavior across pr
 }
 ```
 
-- `channels.defaults.groupPolicy`: fallback group policy when a provider-level `groupPolicy` is unset.
+- `channels.defaults.groupPolicy`: fallback group policy when a provider-level `groupPolicy` is unset. When no explicit binding matches an inbound message, the gateway applies this default policy to select the handling agent. The session key's canonical form reflects the final destination but does not indicate whether routing matched a binding or the fallback chain.
 - `channels.defaults.heartbeat.showOk`: include healthy channel statuses in heartbeat output.
 - `channels.defaults.heartbeat.showAlerts`: include degraded/error statuses in heartbeat output.
 - `channels.defaults.heartbeat.useIndicator`: render compact indicator-style heartbeat output.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -83,7 +83,7 @@ Use `channels.defaults` for shared group-policy and heartbeat behavior across pr
 }
 ```
 
-- `channels.defaults.groupPolicy`: fallback group policy when a provider-level `groupPolicy` is unset. When no explicit binding matches an inbound message, the gateway applies this default policy to select the handling agent. The session key's canonical form reflects the final destination but does not indicate whether routing matched a binding or the fallback chain.
+- `channels.defaults.groupPolicy`: fallback group policy when a provider-level `groupPolicy` is unset. Accepted values are `open`, `allowlist`, and `disabled`; this policy controls whether inbound group messages are accepted when no explicit binding matches, not which agent handles them. Agent selection in the fallback case is governed by `channels.feishu.defaultAccount`. The session key's canonical form reflects the final destination but does not indicate whether routing matched a binding or the fallback chain.
 - `channels.defaults.heartbeat.showOk`: include healthy channel statuses in heartbeat output.
 - `channels.defaults.heartbeat.showAlerts`: include degraded/error statuses in heartbeat output.
 - `channels.defaults.heartbeat.useIndicator`: render compact indicator-style heartbeat output.

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -610,7 +610,7 @@ openclaw pairing list feishu
 
 使用 `bindings` 将飞书私信或群组路由到不同的智能体。
 
-当没有显式 binding 匹配传入消息时，网关会回退到**默认账号**（通过 `channels.feishu.defaultAccount` 或第一个配置的账号），然后应用**默认群组策略**（`channels.defaults.groupPolicy`）来决定由哪个智能体处理。结果会话键（例如群组的 `feishu:g-{chatId}`）反映了最终的路由目的地，但不会编码是哪条规则——binding 还是回退——决定了这一结果。
+当没有显式 binding 匹配传入消息时，网关会回退到**默认账号**（通过 `channels.feishu.defaultAccount` 或第一个配置的账号）来选择处理智能体。然后**默认群组策略**（`channels.defaults.groupPolicy`）决定是否接受该消息（`open`/`allowlist`/`disabled`）——它是访问控制门，不是智能体选择机制。结果会话键（例如群组的 `feishu:g-{chatId}`）反映了最终的路由目的地，但不会编码是哪条规则——binding 还是回退——决定了这一结果。
 
 ```json5
 {

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -610,6 +610,8 @@ openclaw pairing list feishu
 
 使用 `bindings` 将飞书私信或群组路由到不同的智能体。
 
+当没有显式 binding 匹配传入消息时，网关会回退到**默认账号**（通过 `channels.feishu.defaultAccount` 或第一个配置的账号），然后应用**默认群组策略**（`channels.defaults.groupPolicy`）来决定由哪个智能体处理。结果会话键（例如群组的 `feishu:g-{chatId}`）反映了最终的路由目的地，但不会编码是哪条规则——binding 还是回退——决定了这一结果。
+
 ```json5
 {
   agents: {


### PR DESCRIPTION
## Summary

Adds missing documentation about the Feishu routing fallback behavior:

1. **feishu.md**: Explains what happens when no explicit binding matches — the gateway falls back to the default account, then to `channels.defaults.groupPolicy`. Also clarifies that the canonical session key reflects the final destination but does not encode which rule (binding or fallback) was responsible.

2. **configuration-reference.md**: Updates the `channels.defaults.groupPolicy` description to clarify its role in the fallback chain.

## Motivation

When a Feishu group message arrives and the operator sees it handled by the wrong agent, there is no operator-facing way to tell whether:
- No binding exists and the fallback chose the wrong default
- A binding exists but has the wrong agent assignment
- The session key format created a routing discontinuity

This aligns with issue [#54952](https://github.com/openclaw/openclaw/issues/54952) (diagnostics gap), reducing the gap by making the fallback behavior explicitly documented.

---

**Thanks**