### PR TITLE
fix: auto-resolve model provider when model ID matches configured pro…

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -608,6 +608,36 @@ export function resolveAllowedModelRef(params: {
     defaultModel: params.defaultModel,
   });
   if (!status.allowed) {
+    // Only attempt auto-correction when the original input didn't specify a provider.
+    // This prevents silently overriding explicit provider/model requests.
+    const hasExplicitProvider = params.raw.includes("/");
+    if (!hasExplicitProvider) {
+      const modelId = resolved.ref.model;
+      const configuredProviders = params.cfg.models?.providers;
+      if (configuredProviders && typeof configuredProviders === "object") {
+        // Build the allowed set once outside the loop for efficiency.
+        const allowedSet = buildAllowedModelSet({
+          cfg: params.cfg,
+          catalog: params.catalog,
+          defaultProvider: params.defaultProvider,
+          defaultModel: params.defaultModel,
+        });
+        for (const [providerName, providerCfg] of Object.entries(configuredProviders)) {
+          if (providerCfg && Array.isArray(providerCfg.models)) {
+            const modelInProvider = providerCfg.models.find((m) => m.id === modelId);
+            if (modelInProvider) {
+              // Normalize the provider ID to match how keys are built in the allowlist.
+              const normalizedProvider = normalizeProviderId(providerName);
+              const correctedRef: ModelRef = { provider: normalizedProvider, model: modelId };
+              const key = modelKey(normalizedProvider, modelId);
+              if (allowedSet.allowAny || allowedSet.allowedKeys.has(key)) {
+                return { ref: correctedRef, key };
+              }
+            }
+          }
+        }
+      }
+    }
     return { error: `model not allowed: ${status.key}` };
   }
 


### PR DESCRIPTION
## Problem

When a model is configured under a non-default provider, users would get 'model not allowed' errors even though the model was properly configured. This happened because the model resolution would use the default provider instead of finding which provider actually has the model configured.

## Solution

When `resolveAllowedModelRef` fails to allow a model with the initially resolved provider, it now:

1. Extracts the model ID from the resolved reference
2. Iterates through all configured providers in `cfg.models.providers`
3. Searches for the model ID in each provider's model list
4. If found, builds a corrected model reference with the actual provider
5. Re-validates the corrected reference against the allowlist
6. Returns the corrected reference if allowed, or the original error if not found

## Impact

This allows users to use simplified model names (e.g., `qwen3-30b`) without needing to specify the full provider prefix (e.g., `my-provider/qwen3-30b`), as long as the model is configured under some provider.

The fix is backward compatible and only activates when the initial model resolution fails the allowlist check.