### PR TITLE
fix(discord): suppress intentional reconnect exception during health monitor restart

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -606,4 +606,56 @@ describe("runDiscordGatewayLifecycle", () => {
     const connectedTrue = statusUpdates.find((s) => s.connected === true);
     expect(connectedTrue).toBeUndefined();
   });
+
+  it("suppresses 'Max reconnect attempts' exception during intentional abort", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const emitter = new EventEmitter();
+    const gateway = {
+      isConnected: true,
+      options: { reconnect: { maxAttempts: 3 } },
+      disconnect: vi.fn(() => {
+        // Simulate the gateway throwing when maxAttempts is 0
+        throw new Error("Max reconnect attempts (0) reached after code 1005");
+      }),
+      connect: vi.fn(),
+      emitter,
+    };
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const { lifecycleParams } = createLifecycleHarness({ gateway });
+    lifecycleParams.abortSignal = abortController.signal;
+
+    // Should not throw — the "Max reconnect attempts" error should be suppressed
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+    expect(gateway.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows non-reconnect exceptions during abort", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const emitter = new EventEmitter();
+    const gateway = {
+      isConnected: true,
+      options: { reconnect: { maxAttempts: 3 } },
+      disconnect: vi.fn(() => {
+        throw new Error("Some other unexpected error");
+      }),
+      connect: vi.fn(),
+      emitter,
+    };
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const { lifecycleParams } = createLifecycleHarness({ gateway });
+    lifecycleParams.abortSignal = abortController.signal;
+
+    // Should throw — non-reconnect errors should not be suppressed
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow(
+      "Some other unexpected error",
+    );
+  });
 });

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -136,7 +136,7 @@ export async function runDiscordGatewayLifecycle(params: {
       // when we intentionally set maxAttempts to 0 for a clean abort/restart.
       // The gateway throws this as if it were a connection failure, but in this
       // context it's an intentional shutdown triggered by the health monitor.
-      const message = String(err);
+      const message = err instanceof Error ? err.message : String(err);
       if (!message.includes("Max reconnect attempts")) {
         throw err;
       }

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -129,7 +129,18 @@ export async function runDiscordGatewayLifecycle(params: {
       return;
     }
     gateway.options.reconnect = { maxAttempts: 0 };
-    gateway.disconnect();
+    try {
+      gateway.disconnect();
+    } catch (err) {
+      // Suppress "Max reconnect attempts (0) reached" exception — this is expected
+      // when we intentionally set maxAttempts to 0 for a clean abort/restart.
+      // The gateway throws this as if it were a connection failure, but in this
+      // context it's an intentional shutdown triggered by the health monitor.
+      const message = String(err);
+      if (!message.includes("Max reconnect attempts")) {
+        throw err;
+      }
+    }
   };
 
   if (params.abortSignal?.aborted) {


### PR DESCRIPTION
## Summary

When the Discord health monitor triggers a restart (e.g., due to stale-socket detection), the `onAbort` handler sets `maxAttempts` to 0 before calling `disconnect()`. The gateway library interprets this as a reconnection failure and throws "Max reconnect attempts (0) reached" — causing an uncaught exception that crashes the entire gateway process.

## Root Cause

The gateway library's disconnect flow treats `maxAttempts: 0` as a signal that reconnection exhausted its attempts, throwing an error. However, in the health monitor's abort flow, `maxAttempts: 0` is intentionally set to prevent reconnection during a clean shutdown — this exception should not bubble up.

## Fix

Wrap the `gateway.disconnect()` call in a try-catch that:
1. **Suppresses** the expected "Max reconnect attempts" error (this is an intentional abort, not a connection failure)
2. **Rethrows** any other unexpected errors (preserves visibility into real issues)

## Testing

Added two test cases:
- `suppresses 'Max reconnect attempts' exception during intentional abort` — verifies the fix
- `rethrows non-reconnect exceptions during abort` — ensures we don't suppress legitimate errors

All 17 tests in `provider.lifecycle.test.ts` pass.

## Impact

- **Before:** Gateway crashes every ~30 minutes when health monitor triggers restart
- **After:** Health monitor gracefully restarts Discord connection without crashing

Fixes #55026