### PR TITLE
feat(guardrails): pluggable GuardrailProvider interface for tool authorization

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1150,6 +1150,7 @@
                   "tools/elevated",
                   "tools/exec",
                   "tools/exec-approvals",
+                  "tools/guardrails",
                   "tools/llm-task",
                   "tools/lobster",
                   "tools/loop-detection",

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -1,0 +1,298 @@
+# Guardrails: Pre-Tool-Call Authorization
+
+> **Context:** [Issue #46441](https://github.com/openclaw/openclaw/issues/46441) — OpenClaw has exec approvals for shell commands, but no general-purpose authorization for other tools — file writes, browser actions, messaging, MCP tools, git operations. Guardrails add a core service that evaluates every tool call against a policy **before** execution.
+
+## Why guardrails
+
+```
+Without guardrails:                      With guardrails:
+
+  Agent                                    Agent
+    │                                        │
+    ▼                                        ▼
+  ┌──────────┐                             ┌──────────┐
+  │ exec     │──▶ executes immediately     │ exec     │──▶ GuardrailService
+  │ rm -rf / │                             │ rm -rf / │        │
+  └──────────┘                             └──────────┘        ▼
+                                                         ┌──────────────┐
+                                                         │  Provider    │
+                                                         │  evaluates   │
+                                                         │  against     │
+                                                         │  policy      │
+                                                         └──────┬───────┘
+                                                                │
+                                                          ┌─────┴─────┐
+                                                          │           │
+                                                        ALLOW       DENY
+                                                          │           │
+                                                          ▼           ▼
+                                                      Tool runs   Agent sees:
+                                                      normally    "Guardrail denied:
+                                                                   rm -rf blocked"
+```
+
+- **Exec approvals** require a human in the loop and only cover shell commands.
+- **Guardrails** provide deterministic, policy-driven authorization for **any tool**, without human intervention.
+
+## Architecture
+
+```
+                  ┌──────────────────────────────┐
+                  │     before_tool_call flow     │
+                  │                               │
+                  │  1. Loop detection             │
+                  │  2. GuardrailService ◄── NEW  │
+                  │  3. Plugin hooks               │
+                  └──────────────┬────────────────┘
+                                 │
+                   ┌─────────────┴──────────────┐
+                   │    GuardrailProvider        │  ◄── pluggable: any class
+                   │    (configured in YAML)     │      with evaluate()
+                   └─────────────┬──────────────┘
+                                 │
+                       ┌─────────┼──────────┐
+                       │         │          │
+                       ▼         ▼          ▼
+                  Built-in    External    Custom
+                  Allowlist   Provider   Provider
+                  (zero dep)  (npm/file) (your code)
+```
+
+The `GuardrailService` is a core service (not a plugin). It runs **before** plugin `before_tool_call` hooks, ensuring guardrails cannot be bypassed by disabling a plugin.
+
+Zero impact when not configured — the service is only initialized when `guardrails.enabled: true`.
+
+## Three provider options
+
+### Option 1: Built-in AllowlistProvider (zero dependencies)
+
+The simplest option. Ships with OpenClaw. Block or allow tools by name.
+
+**config.yaml:**
+```yaml
+guardrails:
+  enabled: true
+  provider:
+    use: "builtin:allowlist"
+    config:
+      deniedTools:
+        - "exec"
+        - "browser"
+```
+
+You can also use an allowlist (only these tools are permitted):
+```yaml
+guardrails:
+  enabled: true
+  provider:
+    use: "builtin:allowlist"
+    config:
+      allowedTools:
+        - "write"
+        - "read"
+        - "glob"
+```
+
+**Try it:**
+1. Add the `deniedTools` config above to your `config.yaml`
+2. Start OpenClaw
+3. Ask the agent: "Run echo hello using exec"
+4. The agent sees: `Guardrail (allowlist): 'exec' is in the denied list`
+
+### Option 2: OAP passport provider (policy-based)
+
+For policy enforcement based on the [Open Agent Passport (OAP)](https://github.com/aporthq/aport-spec) open standard. An OAP passport is a JSON document that declares an agent's identity, capabilities, and operational limits. Any provider that reads an OAP passport and returns OAP-compliant decisions works with OpenClaw.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    OAP Passport (JSON)                       │
+│                  (open standard, any provider)               │
+│  {                                                           │
+│    "spec_version": "oap/1.0",                                │
+│    "status": "active",                                       │
+│    "capabilities": [                                         │
+│      {"id": "system.command.execute"},                       │
+│      {"id": "data.file.read"},                               │
+│      {"id": "data.file.write"},                              │
+│      {"id": "web.fetch"}                                     │
+│    ],                                                        │
+│    "limits": {                                               │
+│      "system.command.execute": {                             │
+│        "allowed_commands": ["git", "npm", "node"],           │
+│        "blocked_patterns": ["rm -rf", "sudo", "chmod 777"]  │
+│      }                                                       │
+│    }                                                         │
+│  }                                                           │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+               Any OAP-compliant provider
+          ┌────────────────┼────────────────┐
+          │                │                │
+     Your own         APort (ref.      Other future
+     evaluator        implementation)  implementations
+```
+
+**Creating a passport manually:**
+
+An OAP passport is a JSON file. Create one following the [OAP specification](https://github.com/aporthq/aport-spec/blob/main/oap/oap-spec.md) and validate against the [JSON schema](https://github.com/aporthq/aport-spec/blob/main/oap/passport-schema.json). See the [examples](https://github.com/aporthq/aport-spec/tree/main/oap/examples) for templates.
+
+**Using APort as a reference implementation:**
+
+[APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails) is one open-source (Apache 2.0) implementation of an OAP provider. It exports `OAPGuardrailProvider` which implements the `GuardrailProvider` interface and handles passport creation, local evaluation, and optional hosted evaluation.
+
+```bash
+npm install @aporthq/aport-agent-guardrails-core
+npx @aporthq/aport-agent-guardrails
+```
+
+The first command installs the provider. The second runs the passport wizard — it creates a local passport file with your agent's capabilities and limits.
+
+**config.yaml:**
+```yaml
+guardrails:
+  enabled: true
+  provider:
+    use: "@aporthq/aport-agent-guardrails-core"
+    config:
+      framework: "openclaw"
+```
+
+**Using your own OAP provider:**
+```yaml
+guardrails:
+  enabled: true
+  provider:
+    use: "./my-oap-provider.js"
+    config:
+      passportPath: "./my-passport.json"
+```
+
+Any provider that implements `GuardrailProvider` and reads OAP passports works. The standard defines the passport format and decision codes; OpenClaw doesn't care which provider reads them.
+
+**What the passport controls:**
+
+| Passport field | What it does | Example |
+|---|---|---|
+| `capabilities[].id` | Which tool categories the agent can use | `system.command.execute`, `data.file.write` |
+| `limits.*.allowed_commands` | Which commands are allowed | `["git", "npm", "node"]` or `["*"]` for all |
+| `limits.*.blocked_patterns` | Patterns always denied | `["rm -rf", "sudo", "chmod 777"]` |
+| `status` | Kill switch | `active`, `suspended`, `revoked` |
+
+**Try it:**
+1. `npm install @aporthq/aport-agent-guardrails-core`
+2. `npx @aporthq/aport-agent-guardrails` — create a passport
+3. Add the config above to `config.yaml`
+4. Start OpenClaw and ask: "Run rm -rf / using exec"
+5. The provider blocks it: `oap.blocked_pattern: Command contains blocked pattern: rm -rf`
+
+### Option 3: Custom provider (bring your own)
+
+Any class with a `name` property and an `evaluate()` method works.
+
+```typescript
+// my-guardrail.ts
+import type { GuardrailProvider, GuardrailRequest, GuardrailDecision } from "openclaw/guardrails";
+
+export default class MyProvider implements GuardrailProvider {
+  name = "my-company";
+
+  constructor(private config: Record<string, unknown>) {}
+
+  async evaluate(request: GuardrailRequest): Promise<GuardrailDecision> {
+    if (request.toolName === "exec" && String(request.toolInput.command).includes("delete")) {
+      return {
+        allow: false,
+        reasons: [{ code: "custom.blocked", message: "delete not allowed" }],
+      };
+    }
+    return { allow: true, reasons: [{ code: "allowed" }] };
+  }
+}
+```
+
+**config.yaml:**
+```yaml
+guardrails:
+  enabled: true
+  provider:
+    use: "./my-guardrail.js"
+```
+
+**Try it:**
+1. Create `my-guardrail.ts` and compile to `.js`
+2. Add the config above
+3. Start OpenClaw and ask: "Use exec to delete test.txt"
+4. Your provider blocks it
+
+## Configuration reference
+
+```yaml
+guardrails:
+  # Enable guardrail evaluation. Default: false.
+  # Zero impact when false — no service initialized, no overhead.
+  enabled: true
+
+  # Block tool calls when the provider throws an error. Default: true.
+  failClosed: true
+
+  provider:
+    # Module specifier. Required when enabled is true.
+    # Supported forms:
+    #   "builtin:allowlist"      — built-in AllowlistProvider
+    #   "@scope/package"         — npm package
+    #   "./path/to/provider.js"  — local file
+    use: "builtin:allowlist"
+
+    # Provider-specific configuration (passed to constructor).
+    config:
+      deniedTools: ["exec"]
+```
+
+## OpenClaw tool names
+
+These are the tool names your provider will see in `request.toolName`:
+
+| Tool | What it does |
+|---|---|
+| `exec` | Shell command execution |
+| `write` | Create/overwrite a file |
+| `read` | Read file content |
+| `edit` | Edit a file |
+| `glob` | List files by pattern |
+| `grep` | Search file contents |
+| `browser` | Web browser interaction |
+| `mcp.*` | MCP tool calls (prefixed with `mcp.`) |
+
+## Fail-closed vs fail-open
+
+| `failClosed` | Provider error behavior |
+|---|---|
+| `true` (default) | Tool call is **blocked**. Safer for security-critical deployments. |
+| `false` | Tool call is **allowed**. Use when guardrails are advisory. |
+
+## Reason codes
+
+Providers should use descriptive reason codes. Suggested patterns:
+
+| Code | Meaning |
+|---|---|
+| `allowed` | Tool call permitted |
+| `tool_not_allowed` | Tool not in allowlist |
+| `tool_denied` | Tool explicitly denied |
+| `policy_violation` | Provider-specific policy check failed |
+| `evaluator_error` | Provider encountered an internal error |
+
+## Relationship to exec approvals
+
+Guardrails and exec approvals are complementary:
+
+- **Exec approvals** — human-in-the-loop confirmation for shell commands (interactive)
+- **Guardrails** — automated policy evaluation for any tool (programmatic)
+
+Guardrails run first. If a guardrail denies a tool call, exec approvals are never reached.
+
+## Relationship to plugins
+
+Plugins can register `before_tool_call` hooks for their own authorization logic. The guardrail service runs before all plugin hooks, providing a baseline policy layer that plugins cannot override.
+
+Existing plugin-based guardrails continue to work unchanged. The `GuardrailProvider` interface gives those same capabilities a standard contract and first-class config support.

--- a/docs/tools/guardrails.md
+++ b/docs/tools/guardrails.md
@@ -1,4 +1,13 @@
-# Guardrails: Pre-Tool-Call Authorization
+---
+summary: "Pluggable pre-tool-call authorization via GuardrailProvider"
+read_when:
+  - Adding policy-based tool authorization
+  - Configuring AllowlistProvider or external guardrail providers
+  - Writing a custom GuardrailProvider
+title: "Guardrails"
+---
+
+# Guardrails
 
 > **Context:** [Issue #46441](https://github.com/openclaw/openclaw/issues/46441) — OpenClaw has exec approvals for shell commands, but no general-purpose authorization for other tools — file writes, browser actions, messaging, MCP tools, git operations. Guardrails add a core service that evaluates every tool call against a policy **before** execution.
 

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -11,11 +11,9 @@ import { copyChannelAgentToolMeta } from "./channel-tools.js";
 import { normalizeToolName } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
-// Guardrail state — set once during bootstrap via configureGuardrails().
 let guardrailProvider: GuardrailProvider | undefined;
 let guardrailFailClosed = true;
 
-/** Call once at startup if guardrails.enabled is true. */
 export function configureGuardrails(provider: GuardrailProvider | undefined, failClosed = true): void {
   guardrailProvider = provider;
   guardrailFailClosed = failClosed;
@@ -159,7 +157,6 @@ export async function runBeforeToolCallHook(args: {
     recordToolCall(sessionState, toolName, params, args.toolCallId, args.ctx.loopDetection);
   }
 
-  // Guardrail evaluation: runs before plugin hooks when configured.
   if (guardrailProvider) {
     const normalizedParams = isPlainObject(params) ? (params as Record<string, unknown>) : {};
     const result = await evaluateGuardrail(guardrailProvider, {

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -1,4 +1,6 @@
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
+import type { GuardrailProvider } from "../guardrails/types.js";
+import { evaluateGuardrail } from "../guardrails/index.js";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
@@ -8,6 +10,16 @@ import { isPlainObject } from "../utils.js";
 import { copyChannelAgentToolMeta } from "./channel-tools.js";
 import { normalizeToolName } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
+
+// Guardrail state — set once during bootstrap via configureGuardrails().
+let guardrailProvider: GuardrailProvider | undefined;
+let guardrailFailClosed = true;
+
+/** Call once at startup if guardrails.enabled is true. */
+export function configureGuardrails(provider: GuardrailProvider | undefined, failClosed = true): void {
+  guardrailProvider = provider;
+  guardrailFailClosed = failClosed;
+}
 
 export type HookContext = {
   agentId?: string;
@@ -145,6 +157,22 @@ export async function runBeforeToolCallHook(args: {
     }
 
     recordToolCall(sessionState, toolName, params, args.toolCallId, args.ctx.loopDetection);
+  }
+
+  // Guardrail evaluation: runs before plugin hooks when configured.
+  if (guardrailProvider) {
+    const normalizedParams = isPlainObject(params) ? (params as Record<string, unknown>) : {};
+    const result = await evaluateGuardrail(guardrailProvider, {
+      toolName,
+      params: normalizedParams,
+      agentId: args.ctx?.agentId,
+      sessionId: args.ctx?.sessionId,
+      runId: args.ctx?.runId,
+      toolCallId: args.toolCallId,
+    }, guardrailFailClosed);
+    if (result.block) {
+      return { blocked: true, reason: result.blockReason || "Blocked by guardrail policy" };
+    }
   }
 
   const hookRunner = getGlobalHookRunner();

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -1,6 +1,7 @@
 import type { AcpConfig } from "./types.acp.js";
 import type { AgentBinding, AgentsConfig } from "./types.agents.js";
 import type { ApprovalsConfig } from "./types.approvals.js";
+import type { GuardrailsConfig } from "../guardrails/types.js";
 import type { AuthConfig } from "./types.auth.js";
 import type { DiagnosticsConfig, LoggingConfig, SessionConfig, WebConfig } from "./types.base.js";
 import type { BrowserConfig } from "./types.browser.js";
@@ -111,6 +112,7 @@ export type OpenClawConfig = {
   messages?: MessagesConfig;
   commands?: CommandsConfig;
   approvals?: ApprovalsConfig;
+  guardrails?: GuardrailsConfig;
   session?: SessionConfig;
   web?: WebConfig;
   channels?: ChannelsConfig;

--- a/src/config/zod-schema.guardrails.ts
+++ b/src/config/zod-schema.guardrails.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+const GuardrailProviderConfigSchema = z
+  .object({
+    use: z.string().min(1),
+    config: z.record(z.unknown()).optional(),
+  })
+  .strict();
+
+export const GuardrailsSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    failClosed: z.boolean().optional(),
+    provider: GuardrailProviderConfigSchema.optional(),
+  })
+  .strict()
+  .optional();

--- a/src/config/zod-schema.guardrails.ts
+++ b/src/config/zod-schema.guardrails.ts
@@ -14,4 +14,8 @@ export const GuardrailsSchema = z
     provider: GuardrailProviderConfigSchema.optional(),
   })
   .strict()
+  .refine((val) => !val.enabled || val.provider?.use, {
+    message: "guardrails.provider.use is required when guardrails.enabled is true",
+    path: ["provider"],
+  })
   .optional();

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -4,6 +4,7 @@ import { parseDurationMs } from "../cli/parse-duration.js";
 import { ToolsSchema } from "./zod-schema.agent-runtime.js";
 import { AgentsSchema, AudioSchema, BindingsSchema, BroadcastSchema } from "./zod-schema.agents.js";
 import { ApprovalsSchema } from "./zod-schema.approvals.js";
+import { GuardrailsSchema } from "./zod-schema.guardrails.js";
 import {
   HexColorSchema,
   ModelsConfigSchema,
@@ -514,6 +515,7 @@ export const OpenClawSchema = z
     messages: MessagesSchema,
     commands: CommandsSchema,
     approvals: ApprovalsSchema,
+    guardrails: GuardrailsSchema,
     session: SessionSchema,
     cron: z
       .object({

--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -30,27 +30,49 @@ type GatewayPluginBootstrapParams = {
   beforePrimeRegistry?: (pluginRegistry: PluginRegistry) => void;
 };
 
-async function installGuardrailsFromConfig(
+function installGuardrailsFromConfig(
   cfg: ReturnType<typeof loadConfig>,
   log: GatewayPluginBootstrapLog,
-) {
+): void {
   const gc = cfg.guardrails;
   if (!gc?.enabled || !gc.provider?.use) {
     return;
   }
-  try {
-    const provider = await loadGuardrailProvider(gc.provider);
-    configureGuardrails(provider, gc.failClosed !== false);
-    if (provider.healthCheck) {
-      const health = await provider.healthCheck();
-      if (!health.ok) {
-        log.warn(`[guardrails] provider health check failed: ${health.message}`);
-      }
-    }
-    log.info(`[guardrails] provider '${provider.name}' loaded (failClosed=${gc.failClosed !== false})`);
-  } catch (err) {
-    log.error(`[guardrails] failed to load provider: ${err instanceof Error ? err.message : String(err)}`);
+
+  const failClosed = gc.failClosed !== false;
+
+  if (failClosed) {
+    configureGuardrails(
+      {
+        name: "guardrails-pending",
+        async evaluate() {
+          return {
+            allow: false,
+            reasons: [{ code: "provider_loading", message: "guardrail provider is still loading" }],
+          };
+        },
+      },
+      true,
+    );
   }
+
+  loadGuardrailProvider(gc.provider)
+    .then(async (provider) => {
+      configureGuardrails(provider, failClosed);
+      if (provider.healthCheck) {
+        const health = await provider.healthCheck();
+        if (!health.ok) {
+          log.warn(`[guardrails] provider health check failed: ${health.message}`);
+        }
+      }
+      log.info(`[guardrails] provider '${provider.name}' loaded (failClosed=${failClosed})`);
+    })
+    .catch((err) => {
+      log.error(`[guardrails] failed to load provider: ${err instanceof Error ? err.message : String(err)}`);
+      if (!failClosed) {
+        configureGuardrails(undefined);
+      }
+    });
 }
 
 function installGatewayPluginRuntimeEnvironment(cfg: ReturnType<typeof loadConfig>) {
@@ -80,9 +102,9 @@ function logGatewayPluginDiagnostics(params: {
   }
 }
 
-export async function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
+export function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
   installGatewayPluginRuntimeEnvironment(params.cfg);
-  await installGuardrailsFromConfig(params.cfg, params.log);
+  installGuardrailsFromConfig(params.cfg, params.log);
   const loaded = loadGatewayPlugins({
     cfg: params.cfg,
     workspaceDir: params.workspaceDir,
@@ -102,13 +124,13 @@ export async function prepareGatewayPluginLoad(params: GatewayPluginBootstrapPar
   return loaded;
 }
 
-export async function loadGatewayStartupPlugins(
+export function loadGatewayStartupPlugins(
   params: Omit<GatewayPluginBootstrapParams, "beforePrimeRegistry">,
 ) {
   return prepareGatewayPluginLoad(params);
 }
 
-export async function reloadDeferredGatewayPlugins(
+export function reloadDeferredGatewayPlugins(
   params: Omit<
     GatewayPluginBootstrapParams,
     "beforePrimeRegistry" | "preferSetupRuntimeForChannelPlugins"

--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -1,7 +1,6 @@
 import { primeConfiguredBindingRegistry } from "../channels/plugins/binding-registry.js";
 import type { loadConfig } from "../config/config.js";
-import { loadGuardrailProvider } from "../guardrails/index.js";
-import { configureGuardrails } from "../agents/pi-tools.before-tool-call.js";
+import { initGuardrailsFromConfig } from "../guardrails/init.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import { pinActivePluginChannelRegistry } from "../plugins/runtime.js";
 import { setGatewaySubagentRuntime } from "../plugins/runtime/index.js";
@@ -29,51 +28,6 @@ type GatewayPluginBootstrapParams = {
   logDiagnostics?: boolean;
   beforePrimeRegistry?: (pluginRegistry: PluginRegistry) => void;
 };
-
-function installGuardrailsFromConfig(
-  cfg: ReturnType<typeof loadConfig>,
-  log: GatewayPluginBootstrapLog,
-): void {
-  const gc = cfg.guardrails;
-  if (!gc?.enabled || !gc.provider?.use) {
-    return;
-  }
-
-  const failClosed = gc.failClosed !== false;
-
-  if (failClosed) {
-    configureGuardrails(
-      {
-        name: "guardrails-pending",
-        async evaluate() {
-          return {
-            allow: false,
-            reasons: [{ code: "provider_loading", message: "guardrail provider is still loading" }],
-          };
-        },
-      },
-      true,
-    );
-  }
-
-  loadGuardrailProvider(gc.provider)
-    .then(async (provider) => {
-      configureGuardrails(provider, failClosed);
-      if (provider.healthCheck) {
-        const health = await provider.healthCheck();
-        if (!health.ok) {
-          log.warn(`[guardrails] provider health check failed: ${health.message}`);
-        }
-      }
-      log.info(`[guardrails] provider '${provider.name}' loaded (failClosed=${failClosed})`);
-    })
-    .catch((err) => {
-      log.error(`[guardrails] failed to load provider: ${err instanceof Error ? err.message : String(err)}`);
-      if (!failClosed) {
-        configureGuardrails(undefined);
-      }
-    });
-}
 
 function installGatewayPluginRuntimeEnvironment(cfg: ReturnType<typeof loadConfig>) {
   setPluginSubagentOverridePolicies(cfg);
@@ -104,7 +58,7 @@ function logGatewayPluginDiagnostics(params: {
 
 export function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
   installGatewayPluginRuntimeEnvironment(params.cfg);
-  installGuardrailsFromConfig(params.cfg, params.log);
+  initGuardrailsFromConfig(params.cfg.guardrails, params.log);
   const loaded = loadGatewayPlugins({
     cfg: params.cfg,
     workspaceDir: params.workspaceDir,

--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -1,5 +1,7 @@
 import { primeConfiguredBindingRegistry } from "../channels/plugins/binding-registry.js";
 import type { loadConfig } from "../config/config.js";
+import { loadGuardrailProvider } from "../guardrails/index.js";
+import { configureGuardrails } from "../agents/pi-tools.before-tool-call.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import { pinActivePluginChannelRegistry } from "../plugins/runtime.js";
 import { setGatewaySubagentRuntime } from "../plugins/runtime/index.js";
@@ -28,6 +30,29 @@ type GatewayPluginBootstrapParams = {
   beforePrimeRegistry?: (pluginRegistry: PluginRegistry) => void;
 };
 
+async function installGuardrailsFromConfig(
+  cfg: ReturnType<typeof loadConfig>,
+  log: GatewayPluginBootstrapLog,
+) {
+  const gc = cfg.guardrails;
+  if (!gc?.enabled || !gc.provider?.use) {
+    return;
+  }
+  try {
+    const provider = await loadGuardrailProvider(gc.provider);
+    configureGuardrails(provider, gc.failClosed !== false);
+    if (provider.healthCheck) {
+      const health = await provider.healthCheck();
+      if (!health.ok) {
+        log.warn(`[guardrails] provider health check failed: ${health.message}`);
+      }
+    }
+    log.info(`[guardrails] provider '${provider.name}' loaded (failClosed=${gc.failClosed !== false})`);
+  } catch (err) {
+    log.error(`[guardrails] failed to load provider: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 function installGatewayPluginRuntimeEnvironment(cfg: ReturnType<typeof loadConfig>) {
   setPluginSubagentOverridePolicies(cfg);
   setGatewaySubagentRuntime(createGatewaySubagentRuntime());
@@ -55,8 +80,9 @@ function logGatewayPluginDiagnostics(params: {
   }
 }
 
-export function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
+export async function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
   installGatewayPluginRuntimeEnvironment(params.cfg);
+  await installGuardrailsFromConfig(params.cfg, params.log);
   const loaded = loadGatewayPlugins({
     cfg: params.cfg,
     workspaceDir: params.workspaceDir,
@@ -76,13 +102,13 @@ export function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
   return loaded;
 }
 
-export function loadGatewayStartupPlugins(
+export async function loadGatewayStartupPlugins(
   params: Omit<GatewayPluginBootstrapParams, "beforePrimeRegistry">,
 ) {
   return prepareGatewayPluginLoad(params);
 }
 
-export function reloadDeferredGatewayPlugins(
+export async function reloadDeferredGatewayPlugins(
   params: Omit<
     GatewayPluginBootstrapParams,
     "beforePrimeRegistry" | "preferSetupRuntimeForChannelPlugins"

--- a/src/guardrails/builtin.ts
+++ b/src/guardrails/builtin.ts
@@ -1,0 +1,33 @@
+import type { GuardrailProvider, GuardrailRequest, GuardrailDecision } from "./types.js";
+
+export class AllowlistProvider implements GuardrailProvider {
+  name = "allowlist";
+
+  private readonly allowed: Set<string> | null;
+  private readonly denied: Set<string>;
+
+  constructor(config: { allowedTools?: string[]; deniedTools?: string[] } = {}) {
+    this.allowed = config.allowedTools ? new Set(config.allowedTools) : null;
+    this.denied = new Set(config.deniedTools ?? []);
+  }
+
+  async evaluate(request: GuardrailRequest): Promise<GuardrailDecision> {
+    const { toolName } = request;
+
+    if (this.denied.has(toolName)) {
+      return {
+        allow: false,
+        reasons: [{ code: "tool_denied", message: `'${toolName}' is in the denied list` }],
+      };
+    }
+
+    if (this.allowed !== null && !this.allowed.has(toolName)) {
+      return {
+        allow: false,
+        reasons: [{ code: "tool_not_allowed", message: `'${toolName}' is not in the allowed list` }],
+      };
+    }
+
+    return { allow: true, reasons: [{ code: "allowed" }] };
+  }
+}

--- a/src/guardrails/builtin.ts
+++ b/src/guardrails/builtin.ts
@@ -1,14 +1,20 @@
 import type { GuardrailProvider, GuardrailRequest, GuardrailDecision } from "./types.js";
 
+function toStringArray(value: string[] | string | undefined): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  return [value];
+}
+
 export class AllowlistProvider implements GuardrailProvider {
   name = "allowlist";
 
   private readonly allowed: Set<string> | null;
   private readonly denied: Set<string>;
 
-  constructor(config: { allowedTools?: string[]; deniedTools?: string[] } = {}) {
-    this.allowed = config.allowedTools ? new Set(config.allowedTools) : null;
-    this.denied = new Set(config.deniedTools ?? []);
+  constructor(config: { allowedTools?: string[] | string; deniedTools?: string[] | string } = {}) {
+    this.allowed = config.allowedTools ? new Set(toStringArray(config.allowedTools)) : null;
+    this.denied = new Set(toStringArray(config.deniedTools));
   }
 
   async evaluate(request: GuardrailRequest): Promise<GuardrailDecision> {

--- a/src/guardrails/index.ts
+++ b/src/guardrails/index.ts
@@ -78,9 +78,10 @@ export async function evaluateGuardrail(
     }
     return { block: false };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    // Propagate error message so agent/user can diagnose and fix config.
     if (failClosed) {
-      return { block: true, blockReason: `Guardrail provider error (fail-closed): ${message}` };
+      const message = err instanceof Error ? err.message : String(err);
+      return { block: true, blockReason: `Guardrail (${provider.name}): provider error (fail-closed): ${message}` };
     }
     return { block: false };
   }

--- a/src/guardrails/index.ts
+++ b/src/guardrails/index.ts
@@ -8,6 +8,8 @@ export type {
 } from "./types.js";
 export { AllowlistProvider } from "./builtin.js";
 
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import type { GuardrailProvider, GuardrailProviderConfig, GuardrailRequest } from "./types.js";
 import { AllowlistProvider } from "./builtin.js";
 
@@ -19,9 +21,14 @@ export async function loadGuardrailProvider(providerConfig: GuardrailProviderCon
     return new AllowlistProvider(opts as { allowedTools?: string[]; deniedTools?: string[] });
   }
 
+  // Resolve local paths (./foo.js) relative to cwd, not this module.
+  const specifier = use.startsWith("./") || use.startsWith("../")
+    ? pathToFileURL(path.resolve(process.cwd(), use)).href
+    : use;
+
   let mod: Record<string, unknown>;
   try {
-    mod = (await import(use)) as Record<string, unknown>;
+    mod = (await import(specifier)) as Record<string, unknown>;
   } catch (err) {
     throw new Error(`Failed to load guardrail provider '${use}': ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/src/guardrails/index.ts
+++ b/src/guardrails/index.ts
@@ -7,6 +7,7 @@ export type {
   GuardrailProviderConfig,
 } from "./types.js";
 export { AllowlistProvider } from "./builtin.js";
+export { initGuardrailsFromConfig } from "./init.js";
 
 import path from "node:path";
 import { pathToFileURL } from "node:url";

--- a/src/guardrails/index.ts
+++ b/src/guardrails/index.ts
@@ -1,0 +1,79 @@
+export type {
+  GuardrailProvider,
+  GuardrailRequest,
+  GuardrailDecision,
+  GuardrailReason,
+  GuardrailsConfig,
+  GuardrailProviderConfig,
+} from "./types.js";
+export { AllowlistProvider } from "./builtin.js";
+
+import type { GuardrailProvider, GuardrailProviderConfig, GuardrailRequest } from "./types.js";
+import { AllowlistProvider } from "./builtin.js";
+
+/** Load a GuardrailProvider from config. Called once at startup. */
+export async function loadGuardrailProvider(providerConfig: GuardrailProviderConfig): Promise<GuardrailProvider> {
+  const { use, config: opts } = providerConfig;
+
+  if (use === "builtin:allowlist") {
+    return new AllowlistProvider(opts as { allowedTools?: string[]; deniedTools?: string[] });
+  }
+
+  let mod: Record<string, unknown>;
+  try {
+    mod = (await import(use)) as Record<string, unknown>;
+  } catch (err) {
+    throw new Error(`Failed to load guardrail provider '${use}': ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const ProviderClass = (mod.default ?? mod.GuardrailProvider) as
+    | (new (config?: Record<string, unknown>) => GuardrailProvider)
+    | undefined;
+
+  if (!ProviderClass || typeof ProviderClass !== "function") {
+    throw new Error(`Module '${use}' does not export a default constructor or named GuardrailProvider`);
+  }
+
+  const provider = new ProviderClass(opts);
+
+  if (typeof provider.evaluate !== "function" || typeof provider.name !== "string") {
+    throw new Error(`Module '${use}' does not implement GuardrailProvider (missing evaluate() or name)`);
+  }
+
+  return provider;
+}
+
+/**
+ * Evaluate a tool call against a provider.
+ * Returns { block, blockReason } compatible with before_tool_call hook shape.
+ */
+export async function evaluateGuardrail(
+  provider: GuardrailProvider,
+  event: { toolName: string; params: Record<string, unknown>; agentId?: string; sessionId?: string; runId?: string; toolCallId?: string },
+  failClosed: boolean,
+): Promise<{ block: boolean; blockReason?: string }> {
+  const request: GuardrailRequest = {
+    toolName: event.toolName,
+    toolInput: event.params,
+    agentId: event.agentId,
+    sessionId: event.sessionId,
+    runId: event.runId,
+    toolCallId: event.toolCallId,
+    timestamp: new Date().toISOString(),
+  };
+
+  try {
+    const decision = await provider.evaluate(request);
+    if (!decision.allow) {
+      const reason = decision.reasons?.[0]?.message ?? "blocked by guardrail policy";
+      return { block: true, blockReason: `Guardrail (${provider.name}): ${reason}` };
+    }
+    return { block: false };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (failClosed) {
+      return { block: true, blockReason: `Guardrail provider error (fail-closed): ${message}` };
+    }
+    return { block: false };
+  }
+}

--- a/src/guardrails/init.ts
+++ b/src/guardrails/init.ts
@@ -1,0 +1,50 @@
+import type { GuardrailsConfig } from "./types.js";
+import { loadGuardrailProvider } from "./index.js";
+import { configureGuardrails } from "../agents/pi-tools.before-tool-call.js";
+
+type Log = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+export function initGuardrailsFromConfig(guardrails: GuardrailsConfig | undefined, log: Log): void {
+  if (!guardrails?.enabled || !guardrails.provider?.use) {
+    return;
+  }
+
+  const failClosed = guardrails.failClosed !== false;
+
+  if (failClosed) {
+    configureGuardrails(
+      {
+        name: "guardrails-pending",
+        async evaluate() {
+          return {
+            allow: false,
+            reasons: [{ code: "provider_loading", message: "guardrail provider is still loading" }],
+          };
+        },
+      },
+      true,
+    );
+  }
+
+  loadGuardrailProvider(guardrails.provider)
+    .then(async (provider) => {
+      configureGuardrails(provider, failClosed);
+      if (provider.healthCheck) {
+        const health = await provider.healthCheck();
+        if (!health.ok) {
+          log.warn(`[guardrails] provider health check failed: ${health.message}`);
+        }
+      }
+      log.info(`[guardrails] provider '${provider.name}' loaded (failClosed=${failClosed})`);
+    })
+    .catch((err) => {
+      log.error(`[guardrails] failed to load provider: ${err instanceof Error ? err.message : String(err)}`);
+      if (!failClosed) {
+        configureGuardrails(undefined);
+      }
+    });
+}

--- a/src/guardrails/init.ts
+++ b/src/guardrails/init.ts
@@ -31,15 +31,18 @@ export function initGuardrailsFromConfig(guardrails: GuardrailsConfig | undefine
   }
 
   loadGuardrailProvider(guardrails.provider)
-    .then(async (provider) => {
+    .then((provider) => {
       configureGuardrails(provider, failClosed);
-      if (provider.healthCheck) {
-        const health = await provider.healthCheck();
-        if (!health.ok) {
-          log.warn(`[guardrails] provider health check failed: ${health.message}`);
-        }
-      }
       log.info(`[guardrails] provider '${provider.name}' loaded (failClosed=${failClosed})`);
+      if (provider.healthCheck) {
+        provider.healthCheck()
+          .then((health) => {
+            if (!health.ok) log.warn(`[guardrails] provider health check failed: ${health.message}`);
+          })
+          .catch((err) => {
+            log.warn(`[guardrails] provider health check error: ${err instanceof Error ? err.message : String(err)}`);
+          });
+      }
     })
     .catch((err) => {
       log.error(`[guardrails] failed to load provider: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/guardrails/types.ts
+++ b/src/guardrails/types.ts
@@ -1,0 +1,59 @@
+export type GuardrailRequest = {
+  /** Normalized tool name (e.g. "exec", "write", "browser", "mcp.tool_name"). */
+  toolName: string;
+  /** Tool input parameters. */
+  toolInput: Record<string, unknown>;
+  /** Agent identifier, if available. */
+  agentId?: string;
+  /** Session key, if available. */
+  sessionId?: string;
+  /** Stable run identifier. */
+  runId?: string;
+  /** Provider-specific tool call identifier. */
+  toolCallId?: string;
+  /** ISO 8601 timestamp. */
+  timestamp: string;
+};
+
+export type GuardrailReason = {
+  /** Machine-readable code (e.g. "tool_not_allowed", "allowed"). */
+  code: string;
+  /** Human-readable explanation. */
+  message?: string;
+};
+
+export type GuardrailDecision = {
+  /** Whether the tool call should proceed. */
+  allow: boolean;
+  /** Structured reasons for the decision. */
+  reasons: GuardrailReason[];
+  /** Identifier of the policy that produced this decision. */
+  policyId?: string;
+  /** Provider-specific metadata (audit ID, signature, etc.). */
+  metadata?: Record<string, unknown>;
+};
+
+export type GuardrailProvider = {
+  /** Provider name for logging and diagnostics. */
+  name: string;
+  /** Evaluate whether a tool call should proceed. */
+  evaluate(request: GuardrailRequest): Promise<GuardrailDecision>;
+  /** Optional health check for startup validation. */
+  healthCheck?(): Promise<{ ok: boolean; message?: string }>;
+};
+
+export type GuardrailProviderConfig = {
+  /** Module specifier: "builtin:allowlist", "@scope/package", or "./path/to/provider.js". */
+  use: string;
+  /** Provider-specific configuration passed to the constructor. */
+  config?: Record<string, unknown>;
+};
+
+export type GuardrailsConfig = {
+  /** Enable guardrail evaluation. Default: false. */
+  enabled?: boolean;
+  /** Block tool calls when the provider throws an error. Default: true. */
+  failClosed?: boolean;
+  /** Provider configuration. Required when enabled is true. */
+  provider?: GuardrailProviderConfig;
+};

--- a/src/guardrails/types.ts
+++ b/src/guardrails/types.ts
@@ -25,8 +25,8 @@ export type GuardrailReason = {
 export type GuardrailDecision = {
   /** Whether the tool call should proceed. */
   allow: boolean;
-  /** Structured reasons for the decision. */
-  reasons: GuardrailReason[];
+  /** Structured reasons for the decision. May be omitted by external providers. */
+  reasons?: GuardrailReason[];
   /** Identifier of the policy that produced this decision. */
   policyId?: string;
   /** Provider-specific metadata (audit ID, signature, etc.). */

--- a/test/guardrails/builtin.test.ts
+++ b/test/guardrails/builtin.test.ts
@@ -23,21 +23,21 @@ describe("AllowlistProvider", () => {
     const provider = new AllowlistProvider({ allowedTools: ["exec"] });
     const decision = await provider.evaluate(makeRequest("browser"));
     expect(decision.allow).toBe(false);
-    expect(decision.reasons[0].code).toBe("tool_not_allowed");
+    expect(decision.reasons?.[0].code).toBe("tool_not_allowed");
   });
 
   it("denies tool in deniedTools", async () => {
     const provider = new AllowlistProvider({ deniedTools: ["exec"] });
     const decision = await provider.evaluate(makeRequest("exec"));
     expect(decision.allow).toBe(false);
-    expect(decision.reasons[0].code).toBe("tool_denied");
+    expect(decision.reasons?.[0].code).toBe("tool_denied");
   });
 
   it("deniedTools takes precedence over allowedTools", async () => {
     const provider = new AllowlistProvider({ allowedTools: ["exec"], deniedTools: ["exec"] });
     const decision = await provider.evaluate(makeRequest("exec"));
     expect(decision.allow).toBe(false);
-    expect(decision.reasons[0].code).toBe("tool_denied");
+    expect(decision.reasons?.[0].code).toBe("tool_denied");
   });
 
   it("allows tool not in deniedTools when no allowedTools", async () => {

--- a/test/guardrails/builtin.test.ts
+++ b/test/guardrails/builtin.test.ts
@@ -46,6 +46,12 @@ describe("AllowlistProvider", () => {
     expect(decision.allow).toBe(true);
   });
 
+  it("coerces string deniedTools to array", async () => {
+    const provider = new AllowlistProvider({ deniedTools: "exec" as unknown as string[] });
+    const decision = await provider.evaluate(makeRequest("exec"));
+    expect(decision.allow).toBe(false);
+  });
+
   it("has correct name", () => {
     const provider = new AllowlistProvider();
     expect(provider.name).toBe("allowlist");

--- a/test/guardrails/builtin.test.ts
+++ b/test/guardrails/builtin.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { AllowlistProvider } from "../../src/guardrails/builtin.js";
+import type { GuardrailRequest } from "../../src/guardrails/types.js";
+
+function makeRequest(toolName: string): GuardrailRequest {
+  return { toolName, toolInput: {}, timestamp: new Date().toISOString() };
+}
+
+describe("AllowlistProvider", () => {
+  it("allows all tools when no lists configured", async () => {
+    const provider = new AllowlistProvider();
+    const decision = await provider.evaluate(makeRequest("exec"));
+    expect(decision.allow).toBe(true);
+  });
+
+  it("allows tool in allowedTools", async () => {
+    const provider = new AllowlistProvider({ allowedTools: ["exec", "write"] });
+    const decision = await provider.evaluate(makeRequest("exec"));
+    expect(decision.allow).toBe(true);
+  });
+
+  it("denies tool not in allowedTools", async () => {
+    const provider = new AllowlistProvider({ allowedTools: ["exec"] });
+    const decision = await provider.evaluate(makeRequest("browser"));
+    expect(decision.allow).toBe(false);
+    expect(decision.reasons[0].code).toBe("tool_not_allowed");
+  });
+
+  it("denies tool in deniedTools", async () => {
+    const provider = new AllowlistProvider({ deniedTools: ["exec"] });
+    const decision = await provider.evaluate(makeRequest("exec"));
+    expect(decision.allow).toBe(false);
+    expect(decision.reasons[0].code).toBe("tool_denied");
+  });
+
+  it("deniedTools takes precedence over allowedTools", async () => {
+    const provider = new AllowlistProvider({ allowedTools: ["exec"], deniedTools: ["exec"] });
+    const decision = await provider.evaluate(makeRequest("exec"));
+    expect(decision.allow).toBe(false);
+    expect(decision.reasons[0].code).toBe("tool_denied");
+  });
+
+  it("allows tool not in deniedTools when no allowedTools", async () => {
+    const provider = new AllowlistProvider({ deniedTools: ["exec"] });
+    const decision = await provider.evaluate(makeRequest("write"));
+    expect(decision.allow).toBe(true);
+  });
+
+  it("has correct name", () => {
+    const provider = new AllowlistProvider();
+    expect(provider.name).toBe("allowlist");
+  });
+});

--- a/test/guardrails/index.test.ts
+++ b/test/guardrails/index.test.ts
@@ -70,6 +70,24 @@ describe("evaluateGuardrail", () => {
     expect(result.block).toBe(false);
   });
 
+  it("handles provider returning no reasons", async () => {
+    const provider = makeProvider({
+      evaluate: vi.fn(async () => ({ allow: false })),
+    });
+    const result = await evaluateGuardrail(provider, { toolName: "exec", params: {} }, true);
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain("blocked by guardrail policy");
+  });
+
+  it("handles provider returning empty reasons array", async () => {
+    const provider = makeProvider({
+      evaluate: vi.fn(async () => ({ allow: false, reasons: [] })),
+    });
+    const result = await evaluateGuardrail(provider, { toolName: "exec", params: {} }, true);
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain("blocked by guardrail policy");
+  });
+
   it("passes context fields to provider", async () => {
     const evaluate = vi.fn(async (req: GuardrailRequest): Promise<GuardrailDecision> => ({
       allow: true, reasons: [{ code: "allowed" }],

--- a/test/guardrails/index.test.ts
+++ b/test/guardrails/index.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from "vitest";
+import { loadGuardrailProvider, evaluateGuardrail, AllowlistProvider } from "../../src/guardrails/index.js";
+import type { GuardrailProvider, GuardrailRequest, GuardrailDecision } from "../../src/guardrails/types.js";
+
+function makeProvider(overrides: Partial<GuardrailProvider> = {}): GuardrailProvider {
+  return {
+    name: "test-provider",
+    evaluate: vi.fn(async () => ({ allow: true, reasons: [{ code: "allowed" }] })),
+    ...overrides,
+  };
+}
+
+describe("loadGuardrailProvider", () => {
+  it("loads builtin:allowlist", async () => {
+    const provider = await loadGuardrailProvider({ use: "builtin:allowlist", config: { deniedTools: ["exec"] } });
+    expect(provider).toBeInstanceOf(AllowlistProvider);
+    expect(provider.name).toBe("allowlist");
+  });
+
+  it("passes config to AllowlistProvider", async () => {
+    const provider = await loadGuardrailProvider({ use: "builtin:allowlist", config: { allowedTools: ["write"] } });
+    const decision = await provider.evaluate({ toolName: "exec", toolInput: {}, timestamp: new Date().toISOString() });
+    expect(decision.allow).toBe(false);
+  });
+
+  it("throws on invalid module path", async () => {
+    await expect(loadGuardrailProvider({ use: "./nonexistent-module.js" })).rejects.toThrow("Failed to load");
+  });
+});
+
+describe("evaluateGuardrail", () => {
+  it("returns block=false when provider allows", async () => {
+    const provider = makeProvider();
+    const result = await evaluateGuardrail(provider, { toolName: "exec", params: { command: "ls" } }, true);
+    expect(result.block).toBe(false);
+  });
+
+  it("returns block=true when provider denies", async () => {
+    const provider = makeProvider({
+      evaluate: vi.fn(async () => ({ allow: false, reasons: [{ code: "denied", message: "exec blocked" }] })),
+    });
+    const result = await evaluateGuardrail(provider, { toolName: "exec", params: {} }, true);
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain("exec blocked");
+  });
+
+  it("includes provider name in block reason", async () => {
+    const provider = makeProvider({
+      name: "my-guardrail",
+      evaluate: vi.fn(async () => ({ allow: false, reasons: [{ code: "denied", message: "nope" }] })),
+    });
+    const result = await evaluateGuardrail(provider, { toolName: "exec", params: {} }, true);
+    expect(result.blockReason).toContain("my-guardrail");
+  });
+
+  it("fail-closed: blocks on provider error", async () => {
+    const provider = makeProvider({
+      evaluate: vi.fn(async () => { throw new Error("timeout"); }),
+    });
+    const result = await evaluateGuardrail(provider, { toolName: "exec", params: {} }, true);
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain("fail-closed");
+  });
+
+  it("fail-open: allows on provider error", async () => {
+    const provider = makeProvider({
+      evaluate: vi.fn(async () => { throw new Error("timeout"); }),
+    });
+    const result = await evaluateGuardrail(provider, { toolName: "exec", params: {} }, false);
+    expect(result.block).toBe(false);
+  });
+
+  it("passes context fields to provider", async () => {
+    const evaluate = vi.fn(async (req: GuardrailRequest): Promise<GuardrailDecision> => ({
+      allow: true, reasons: [{ code: "allowed" }],
+    }));
+    const provider = makeProvider({ evaluate });
+    await evaluateGuardrail(provider, {
+      toolName: "write", params: { file: "/tmp/test" }, agentId: "agent-1", runId: "run-1",
+    }, true);
+    const request = evaluate.mock.calls[0][0];
+    expect(request.toolName).toBe("write");
+    expect(request.toolInput).toEqual({ file: "/tmp/test" });
+    expect(request.agentId).toBe("agent-1");
+    expect(request.timestamp).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: OpenClaw has exec approvals for shell commands, but no general-purpose authorization for other tools -- file writes, browser actions, messaging, MCP tools, git operations. An agent can write to ~/.ssh/authorized_keys or send messages to arbitrary recipients with no policy check.
- Why it matters: this has been requested across 10+ issues spanning the past few months (listed below). Security-conscious deployments have no standard way to enforce tool-level authorization. Every solution is ad-hoc and incompatible.
- What changed: added a pluggable GuardrailProvider type as a core service (not a plugin). Ships with a built-in AllowlistProvider. Runs before plugin hooks -- cannot be bypassed. Zero impact when not configured.
- What did NOT change (scope boundary): no changes to the steerable agent loop, exec approvals, plugin system, or any existing tool. No bundled external providers.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #46441
- Related #22068 (tool:before/tool:after internal hooks -- this PR builds on that infrastructure)
- [ ] This PR fixes a bug or regression

Community issues this unblocks:

- #513 -- Path-based access control rules
- #1546 -- Per-group tool policies
- #6823 -- Execution guardrails (agent deleted OAuth credentials)
- #8081 -- Multi-user RBAC
- #12202 -- Per-agent file path access control
- #12617 -- Model output context to before_tool_call
- #23900 -- Self-preservation guardrails for agents
- #30504 -- Middleware hooks for agent protocol enforcement
- #48304 -- Tool-level authorization policy
- #48503 -- Enrich before_tool_call event
- #49183 -- Per-session tool policies
- #49342 -- Pre-tool execution hooks / middleware API
- #52845 -- Per-agent exec security mode

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: test/guardrails/builtin.test.ts, test/guardrails/index.test.ts
- Scenario the test should lock in: AllowlistProvider allow/deny logic, evaluateGuardrail fail-closed/fail-open behavior, loadGuardrailProvider builtin and error paths.
- Why this is the smallest reliable guardrail: the interface is a new subsystem with no existing callers, so unit tests at the provider and evaluation boundary cover the contract without broader integration setup.
- Existing test that already covers this (if any): none -- this is a new subsystem.
- If no new test is added, why not: N/A -- new tests are included.

## User-visible / Behavior Changes

When guardrails.enabled is true in config.yaml, every tool call is evaluated against the configured provider before execution. If the provider denies, the tool is blocked and the agent sees a denial reason. When not configured, behavior is identical to before this PR.

## Security Impact (required)

- New permissions/capabilities? Yes
- Secrets/tokens handling changed? No
- New/changed network calls? No (AllowlistProvider is local-only; external providers may make calls but that is provider-specific)
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any Yes, explain risk and mitigation: this adds a pre-execution authorization gate for all tool calls. The gate is opt-in (disabled by default). When enabled, it runs before plugin hooks as a core service, so it cannot be bypassed by disabling a plugin. failClosed defaults to true, meaning provider errors block tool calls rather than allowing them. The AllowlistProvider has zero external dependencies.

## Repro and Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace

### Steps to verify

1. Add to config.yaml:

```yaml
guardrails:
  enabled: true
  provider:
    use: "builtin:allowlist"
    config:
      deniedTools:
        - "exec"
```

2. Start OpenClaw
3. Ask agent: "Run echo hello using exec"
4. Expected: agent sees "Guardrail (allowlist): 'exec' is in the denied list"
5. Remove "exec" from deniedTools, restart
6. Same request now executes normally

### Tests

```bash
pnpm test test/guardrails/
```
