### PR TITLE
fix: inject synthetic transcript for tiny audio instead of silent skip

### DIFF
--- a/src/media-understanding/runner.skip-tiny-audio.test.ts
+++ b/src/media-understanding/runner.skip-tiny-audio.test.ts
@@ -84,7 +84,7 @@ async function runAudioCapabilityWithTranscriber(params: {
 }
 
 describe("runCapability skips tiny audio files", () => {
-  it("skips audio transcription when file is smaller than MIN_AUDIO_FILE_BYTES", async () => {
+  it("returns placeholder transcript when file is smaller than MIN_AUDIO_FILE_BYTES", async () => {
     await withAudioFixture({
       filePrefix: "openclaw-tiny-audio",
       extension: "wav",
@@ -105,18 +105,21 @@ describe("runCapability skips tiny audio files", () => {
         // The provider should never be called
         expect(transcribeCalled).toBe(false);
 
-        // The result should indicate the attachment was skipped
-        expect(result.outputs).toHaveLength(0);
-        expect(result.decision.outcome).toBe("skipped");
+        // A placeholder transcript should be injected so the agent knows the note was empty
+        expect(result.outputs).toHaveLength(1);
+        expect(result.outputs[0].kind).toBe("audio.transcription");
+        expect(result.outputs[0].text).toContain("too short to transcribe");
+        expect(result.outputs[0].provider).toBe("synthetic");
+        expect(result.decision.outcome).toBe("success");
         expect(result.decision.attachments).toHaveLength(1);
         expect(result.decision.attachments[0].attempts).toHaveLength(1);
-        expect(result.decision.attachments[0].attempts[0].outcome).toBe("skipped");
-        expect(result.decision.attachments[0].attempts[0].reason).toContain("tooSmall");
+        expect(result.decision.attachments[0].attempts[0].outcome).toBe("success");
+        expect(result.decision.attachments[0].chosen).toBeDefined();
       },
     });
   });
 
-  it("skips audio transcription for empty (0-byte) files", async () => {
+  it("returns placeholder transcript for empty (0-byte) files", async () => {
     await withAudioFixture({
       filePrefix: "openclaw-empty-audio",
       extension: "ogg",
@@ -135,7 +138,9 @@ describe("runCapability skips tiny audio files", () => {
         });
 
         expect(transcribeCalled).toBe(false);
-        expect(result.outputs).toHaveLength(0);
+        expect(result.outputs).toHaveLength(1);
+        expect(result.outputs[0].kind).toBe("audio.transcription");
+        expect(result.outputs[0].text).toContain("too short to transcribe");
       },
     });
   });

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -626,6 +626,25 @@ async function runAttachmentEntries(params: {
       );
     } catch (err) {
       if (isMediaUnderstandingSkipError(err)) {
+        if (err.reason === "tooSmall" && capability === "audio") {
+          attempts.push(
+            buildModelDecision({
+              entry,
+              entryType,
+              outcome: "success",
+              reason: `synthetic: ${err.message}`,
+            }),
+          );
+          return {
+            output: {
+              kind: "audio.transcription",
+              text: "[Audio attachment was too short to transcribe]",
+              attachmentIndex: params.attachmentIndex,
+              provider: "synthetic",
+            },
+            attempts,
+          };
+        }
         attempts.push(
           buildModelDecision({
             entry,


### PR DESCRIPTION
## Summary
- When audio attachments are below the 1024-byte minimum threshold, the transcription pipeline silently skipped them, leaving the agent with no context. This caused the agent to hallucinate explanations (e.g. fabricating an API quota error).
- Now returns a synthetic `audio.transcription` output with `provider: "synthetic"` and text `[Audio attachment was too short to transcribe]`, giving the agent clear context to respond appropriately.
- Minimal change: 1 new code path in `runner.ts` catch block, updated assertions in existing test file.

## Test plan
- [x] Existing `runner.skip-tiny-audio.test.ts` updated and passing (3/3 tests)
- [x] TypeScript type check passes with zero errors
- [x] `MediaUnderstandingOutput` type fully satisfied (`kind`, `text`, `attachmentIndex`, `provider`)
- [x] Decision metadata consistent: attempt `outcome: "success"` so `chosen` is correctly populated

Closes #48944

🤖 Generated with [Claude Code](https://claude.com/claude-code)