### PR TITLE
fix(tool-display): show file path when args use file alias

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -612,7 +612,11 @@ export function handleToolExecutionStart(
           ? record.path
           : typeof record.file_path === "string"
             ? record.file_path
-            : "";
+            : typeof record.filePath === "string"
+              ? record.filePath
+              : typeof record.file === "string"
+                ? record.file
+                : "";
       const filePath = filePathValue.trim();
       if (!filePath) {
         const argsPreview = readStringValue(args)?.slice(0, 200);

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -176,7 +176,7 @@ export function resolvePathArg(args: unknown): string | undefined {
   if (!record) {
     return undefined;
   }
-  for (const candidate of [record.path, record.file_path, record.filePath]) {
+  for (const candidate of [record.path, record.file_path, record.filePath, record.file]) {
     if (typeof candidate !== "string") {
       continue;
     }

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -59,6 +59,12 @@ describe("tool display details", () => {
         args: { file_path: "/tmp/a.txt", offset: 2, limit: 2 },
       }),
     );
+    const readFileAliasDetail = formatToolDetail(
+      resolveToolDisplay({
+        name: "read",
+        args: { file: "/tmp/a.txt" },
+      }),
+    );
     const writeDetail = formatToolDetail(
       resolveToolDisplay({
         name: "write",
@@ -73,6 +79,7 @@ describe("tool display details", () => {
     );
 
     expect(readDetail).toBe("lines 2-3 from /tmp/a.txt");
+    expect(readFileAliasDetail).toBe("from /tmp/a.txt");
     expect(writeDetail).toBe("to /tmp/a.txt (3 chars)");
     expect(editDetail).toBe("in /tmp/a.txt (4 chars)");
   });


### PR DESCRIPTION
## Summary

- Problem: Tool summaries for `read`/`write`/`edit` can miss the file path when the model uses the `file` argument alias (instead of `path`/`file_path`/`filePath`).
- Why it matters: In verbose mode this degrades UX/debuggability (you only see `📖 Read` without the path detail).
- What changed: Tool display path resolution now also checks `args.file`, and the embedded runner’s `read` start warning logic recognizes the same alias.
- What did NOT change (scope boundary): No tool execution semantics changed; this is display/logging only.
- AI-assisted: Yes (implemented with an LLM assistant; changes reviewed and tests run as noted below).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54882
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `resolvePathArg()` (used by `resolveReadDetail()`/`resolveWriteDetail()`) only considered `path`, `file_path`, and `filePath`, while some models emit `file`.
- Missing detection / guardrail: No regression test covered the `file` alias for tool summary formatting.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: Likely increased exposure due to newer model/tool-call parameter aliasing behavior.
- If unknown, what was ruled out: Tool param normalization already handled aliases for execution; only the display layer was missing the alias.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/tool-display.test.ts`
- Scenario the test should lock in: `read` tool detail includes `from <path>` when args use `{ file: "..." }`.
- Why this is the smallest reliable guardrail: The bug is purely in argument-to-detail formatting.
- Existing test that already covers this (if any): Extended the existing read/write/edit formatting test.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Verbose tool summaries now include the file path when the model uses the `file` alias.

## Security Impact (required)

- New permissions/capabilities? (Yes/No) No
- Secrets/tokens handling changed? (Yes/No) No
- New/changed network calls? (Yes/No) No
- Command/tool execution surface changed? (Yes/No) No
- Data access scope changed? (Yes/No) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node test run
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Enable verbose tool summaries.
2. Trigger a tool call with `{ file: "~/some/path" }` (common for Claude 4+ tool calling).

### Expected

- Tool summary includes the file path detail (e.g. `📖 Read: from ~/some/path`).

### Actual

- Before: tool summary could omit the path detail.
- After: path detail is shown.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Added/ran focused unit test covering `file` alias formatting.
- Edge cases checked: N/A
- What you did **not** verify: Did not run a full gateway session end-to-end.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? (Yes/No) Yes
- Config/env changes? (Yes/No) No
- Migration needed? (Yes/No) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: Tool summaries no longer showing expected path detail.

## Risks and Mitigations

- Risk: None.