### PR TITLE
fix: prevent infinite recursion in resolveConsoleSettings() during startup

### DIFF
--- a/src/logging/config.ts
+++ b/src/logging/config.ts
@@ -1,6 +1,5 @@
 import { getCommandPathWithRootOptions } from "../cli/argv.js";
 import { loadConfig, type OpenClawConfig } from "../config/config.js";
-import { loggingState } from "./state.js";
 
 type LoggingConfig = OpenClawConfig["logging"];
 
@@ -11,11 +10,6 @@ export function shouldSkipMutatingLoggingConfigRead(argv: string[] = process.arg
 
 export function readLoggingConfig(): LoggingConfig | undefined {
   if (shouldSkipMutatingLoggingConfigRead()) {
-    return undefined;
-  }
-  // Guard: prevent re-entrancy when loadConfig() triggers patched console.* calls.
-  // The guard flag is also set in resolveConsoleSettings(); this is a secondary guard.
-  if (loggingState.resolvingConsoleSettings) {
     return undefined;
   }
   try {

--- a/src/logging/config.ts
+++ b/src/logging/config.ts
@@ -1,5 +1,6 @@
 import { getCommandPathWithRootOptions } from "../cli/argv.js";
 import { loadConfig, type OpenClawConfig } from "../config/config.js";
+import { loggingState } from "./state.js";
 
 type LoggingConfig = OpenClawConfig["logging"];
 
@@ -10,6 +11,11 @@ export function shouldSkipMutatingLoggingConfigRead(argv: string[] = process.arg
 
 export function readLoggingConfig(): LoggingConfig | undefined {
   if (shouldSkipMutatingLoggingConfigRead()) {
+    return undefined;
+  }
+  // Guard: prevent re-entrancy when loadConfig() triggers patched console.* calls.
+  // The guard flag is also set in resolveConsoleSettings(); this is a secondary guard.
+  if (loggingState.resolvingConsoleSettings) {
     return undefined;
   }
   try {

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -76,15 +76,15 @@ function resolveConsoleSettings(): ConsoleSettings {
   if (loggingState.resolvingConsoleSettings) {
     return { level: envLevel ?? "info", style: normalizeConsoleStyle(undefined) };
   }
-  let cfg: OpenClawConfig["logging"] | undefined =
-    (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
-  if (!cfg && !shouldSkipMutatingLoggingConfigRead()) {
-    loggingState.resolvingConsoleSettings = true;
-    try {
+  loggingState.resolvingConsoleSettings = true;
+  let cfg: OpenClawConfig["logging"] | undefined;
+  try {
+    cfg = (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
+    if (!cfg && !shouldSkipMutatingLoggingConfigRead()) {
       cfg = loadConfigFallback();
-    } finally {
-      loggingState.resolvingConsoleSettings = false;
     }
+  } finally {
+    loggingState.resolvingConsoleSettings = false;
   }
   const level = envLevel ?? normalizeConsoleLevel(cfg?.consoleLevel);
   const style = normalizeConsoleStyle(cfg?.consoleStyle);
@@ -243,6 +243,16 @@ export function enableConsoleCapture(): void {
     (...args: unknown[]) => {
       const formatted = util.format(...args);
       if (shouldSuppressConsoleMessage(formatted)) {
+        return;
+      }
+      // Safe path: during config resolution, bypass all config-dependent logic
+      // and write directly to stderr to prevent re-entrant getConsoleSettings() calls.
+      if (loggingState.resolvingConsoleSettings) {
+        try {
+          process.stderr.write(`${formatted}\n`);
+        } catch (err) {
+          if (!isEpipeError(err)) throw err;
+        }
         return;
       }
       const trimmed = stripAnsi(formatted).trimStart();

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -71,18 +71,19 @@ function resolveConsoleSettings(): ConsoleSettings {
     return { level: "silent", style: normalizeConsoleStyle(undefined) };
   }
 
+  // Guard: prevent recursive calls to patched console.* from re-entering
+  // when loadConfig() or loadConfigFallback() themselves emit warnings.
+  if (loggingState.resolvingConsoleSettings) {
+    return { level: envLevel ?? "info", style: normalizeConsoleStyle(undefined) };
+  }
   let cfg: OpenClawConfig["logging"] | undefined =
     (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
   if (!cfg && !shouldSkipMutatingLoggingConfigRead()) {
-    if (loggingState.resolvingConsoleSettings) {
-      cfg = undefined;
-    } else {
-      loggingState.resolvingConsoleSettings = true;
-      try {
-        cfg = loadConfigFallback();
-      } finally {
-        loggingState.resolvingConsoleSettings = false;
-      }
+    loggingState.resolvingConsoleSettings = true;
+    try {
+      cfg = loadConfigFallback();
+    } finally {
+      loggingState.resolvingConsoleSettings = false;
     }
   }
   const level = envLevel ?? normalizeConsoleLevel(cfg?.consoleLevel);


### PR DESCRIPTION
Problem

    loadConfig() emits warnings via deps.logger.warn() on every invocation. When
    enableConsoleCapture() has already been called (patching console.warn to a forward() wrapper),
    forward calls getConsoleSettings().style to compute a timestamp prefix. This synchronously
    re-enters resolveConsoleSettings().

    The re-entry guard (loggingState.resolvingConsoleSettings) was only set inside the else branch,
    after readLoggingConfig() returned. If readLoggingConfig() threw — returning undefined — the
    outer else called loadConfigFallback(), which triggered the same call chain again with the
    guard not yet set. This produced "Maximum call stack size exceeded" and the gateway hung
    with no HTTP server bound.

    This is a structural bug: the guard must be set before readLoggingConfig() or
    loadConfigFallback() is called, not after. The recursion can start whenever
    enableConsoleCapture() is called before config is fully loaded.

  Fix

    - src/logging/console.ts: move the re-entry guard to the top of resolveConsoleSettings(),
      before any call to readLoggingConfig() or loadConfigFallback()
    - src/logging/config.ts: add a secondary guard in readLoggingConfig() as defence-in-depth
