### PR TITLE
fix(mattermost): use inbound root_id to correct non-root replyToId (closes #30977)

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -155,6 +155,41 @@ describe("resolveMattermostReplyRootId", () => {
   it("falls back to undefined when neither reply target is available", () => {
     expect(resolveMattermostReplyRootId({})).toBeUndefined();
   });
+
+  it("prefers inboundRootId over replyToId when threadRootId is absent (#30977)", () => {
+    // In DMs with replyToMode "off", effectiveReplyToId (threadRootId param) is
+    // undefined.  The core dispatcher sets payload.replyToId to the inbound
+    // message's own ID via [[reply-to:current]], which may be a non-root reply
+    // post.  Mattermost rejects non-root IDs as root_id with 400 "Invalid
+    // RootId parameter".  inboundRootId (the inbound post's root_id) is always
+    // a valid thread root and must take priority.
+    expect(
+      resolveMattermostReplyRootId({
+        replyToId: "child-reply-post",
+        inboundRootId: "actual-thread-root",
+      }),
+    ).toBe("actual-thread-root");
+  });
+
+  it("falls back to replyToId when both threadRootId and inboundRootId are absent", () => {
+    // Standalone top-level message: no thread context, replyToId is the post's
+    // own ID (a valid root).
+    expect(
+      resolveMattermostReplyRootId({
+        replyToId: "standalone-post-id",
+      }),
+    ).toBe("standalone-post-id");
+  });
+
+  it("prefers threadRootId over inboundRootId", () => {
+    expect(
+      resolveMattermostReplyRootId({
+        threadRootId: "effective-reply-to",
+        replyToId: "child-post",
+        inboundRootId: "inbound-root",
+      }),
+    ).toBe("effective-reply-to");
+  });
 });
 
 describe("resolveMattermostEffectiveReplyToId", () => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -160,10 +160,19 @@ function channelChatType(kind: ChatType): "direct" | "group" | "channel" {
 export function resolveMattermostReplyRootId(params: {
   threadRootId?: string;
   replyToId?: string;
+  /** The root_id from the inbound post — used to correct non-root replyToId values. */
+  inboundRootId?: string;
 }): string | undefined {
   const threadRootId = params.threadRootId?.trim();
   if (threadRootId) {
     return threadRootId;
+  }
+  // When the agent sets replyToId (e.g. via [[reply-to:current]]), it may point at a
+  // non-root reply post.  Mattermost requires root_id to be the thread's root post,
+  // so prefer the inbound post's root_id when available.
+  const inboundRoot = params.inboundRootId?.trim();
+  if (inboundRoot) {
+    return inboundRoot;
   }
   return params.replyToId?.trim() || undefined;
 }
@@ -497,6 +506,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 replyToId: resolveMattermostReplyRootId({
                   threadRootId: threadContext.effectiveReplyToId,
                   replyToId: payload.replyToId,
+                  inboundRootId: opts.post.root_id?.trim() || undefined,
                 }),
                 textLimit,
                 tableMode,
@@ -600,6 +610,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     teamId?: string;
     postId: string;
     effectiveReplyToId?: string;
+    inboundRootId?: string;
     deliverReplies?: boolean;
   }): Promise<string> => {
     const to = params.kind === "direct" ? `user:${params.senderId}` : `channel:${params.channelId}`;
@@ -704,6 +715,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             replyToId: resolveMattermostReplyRootId({
               threadRootId: params.effectiveReplyToId,
               replyToId: trimmedPayload.replyToId,
+              inboundRootId: params.inboundRootId,
             }),
             textLimit,
             // The picker path already converts and trims text before capture/delivery.
@@ -925,6 +937,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           teamId,
           postId: params.payload.post_id,
           effectiveReplyToId: threadContext.effectiveReplyToId,
+          inboundRootId: params.post.root_id?.trim() || undefined,
           deliverReplies: true,
         });
         const updatedModel = resolveMattermostModelPickerCurrentModel({
@@ -1415,6 +1428,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             replyToId: resolveMattermostReplyRootId({
               threadRootId: effectiveReplyToId,
               replyToId: payload.replyToId,
+              inboundRootId: threadRootId,
             }),
             textLimit,
             tableMode,


### PR DESCRIPTION
## Summary

- When `replyToMode` is `"off"` for DMs, `effectiveReplyToId` is always `undefined`
- The core reply dispatcher sets `payload.replyToId` to the inbound message's own ID (via `applyReplyThreading` / `[[reply-to:current]]`)
- For thread replies, this ID is a **non-root post** — Mattermost rejects it with `400 Invalid RootId parameter` because `root_id` must reference the thread's actual root post
- Adds `inboundRootId` parameter to `resolveMattermostReplyRootId` carrying the inbound post's `root_id`, which is always a valid thread root when set

**Resolution order:**
1. `threadRootId` — effectiveReplyToId from replyToMode / thread context
2. `inboundRootId` — the inbound post's `root_id` (always a valid root)
3. `replyToId` — agent/directive-supplied (may be non-root; last resort)

## Reproduction

1. DM the bot with a top-level message (post A)
2. Bot replies in thread (post B, `root_id=A`)
3. User replies in thread (post C, `root_id=A`)
4. Core dispatcher sets `payload.replyToId = C` (non-root post)
5. `resolveMattermostReplyRootId` falls through to `replyToId = C` → **400 Bad Request**

With this fix, step 5 resolves to `inboundRootId = A` (the valid thread root).

## Test plan

- [x] Added regression test: `inboundRootId` takes priority over non-root `replyToId` when `threadRootId` is absent
- [x] Added test: `threadRootId` still takes priority over `inboundRootId`
- [x] Added test: falls back to `replyToId` when both are absent (top-level message)
- [x] Existing tests pass unchanged
- [x] All 3 call sites updated to pass `inboundRootId`

Closes #30977

🤖 Generated with [Claude Code](https://claude.com/claude-code)