### PR TITLE
fix(signal): pass reply/quote context to inbound handler

### DIFF
--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -394,6 +394,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         mediaType: undefined,
         mediaPaths: undefined,
         mediaTypes: undefined,
+        replyToId: undefined,
+        replyToBody: undefined,
+        replyToSender: undefined,
+        replyToIsQuote: undefined,
       });
     },
     onError: (err) => {
@@ -870,8 +874,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
-      replyToId:
-        dataMessage?.quote?.id != null ? String(dataMessage.quote.id) : undefined,
+      replyToId: visibleQuoteText && dataMessage?.quote?.id != null
+        ? String(dataMessage.quote.id)
+        : undefined,
       replyToBody: visibleQuoteText || undefined,
       replyToSender: visibleQuoteSender,
       replyToIsQuote: visibleQuoteText ? true : undefined,

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -217,6 +217,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       Provider: "signal" as const,
       Surface: "signal" as const,
       MessageSid: entry.messageId,
+      ReplyToId: entry.replyToId,
       ReplyToBody: entry.replyToBody,
       ReplyToSender: entry.replyToSender,
       ReplyToIsQuote: entry.replyToIsQuote,
@@ -229,10 +230,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       MediaTypes: entry.mediaTypes,
       WasMentioned: entry.isGroup ? entry.wasMentioned === true : undefined,
       CommandAuthorized: entry.commandAuthorized,
-      ReplyToId: entry.replyToId,
-      ReplyToBody: entry.replyToBody,
-      ReplyToSender: entry.replyToSender,
-      ReplyToIsQuote: entry.replyToBody ? true : undefined,
       OriginatingChannel: "signal" as const,
       OriginatingTo: signalTo,
     });

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -122,6 +122,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     mediaTypes?: string[];
     commandAuthorized: boolean;
     wasMentioned?: boolean;
+    replyToId?: string;
     replyToBody?: string;
     replyToSender?: string;
     replyToIsQuote?: boolean;
@@ -228,6 +229,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       MediaTypes: entry.mediaTypes,
       WasMentioned: entry.isGroup ? entry.wasMentioned === true : undefined,
       CommandAuthorized: entry.commandAuthorized,
+      ReplyToId: entry.replyToId,
+      ReplyToBody: entry.replyToBody,
+      ReplyToSender: entry.replyToSender,
+      ReplyToIsQuote: entry.replyToBody ? true : undefined,
       OriginatingChannel: "signal" as const,
       OriginatingTo: signalTo,
     });
@@ -868,6 +873,8 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
+      replyToId:
+        dataMessage?.quote?.id != null ? String(dataMessage.quote.id) : undefined,
       replyToBody: visibleQuoteText || undefined,
       replyToSender: visibleQuoteSender,
       replyToIsQuote: visibleQuoteText ? true : undefined,

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -42,6 +42,7 @@ export type SignalDataMessage = {
     text?: string | null;
     author?: string | null;
     authorUuid?: string | null;
+    authorNumber?: string | null;
   } | null;
   reaction?: SignalReactionMessage | null;
 };

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -38,6 +38,7 @@ export type SignalDataMessage = {
     groupName?: string | null;
   } | null;
   quote?: {
+    id?: number | null;
     text?: string | null;
     author?: string | null;
     authorUuid?: string | null;

--- a/extensions/signal/src/monitor/inbound-context.ts
+++ b/extensions/signal/src/monitor/inbound-context.ts
@@ -33,8 +33,8 @@ export function resolveSignalQuoteContext(params: {
   });
   const quoteText = normalizeOptionalString(params.dataMessage?.quote?.text) ?? "";
   const quoteSender = resolveSignalSender({
-    sourceNumber: params.dataMessage?.quote?.author ?? null,
-    sourceUuid: params.dataMessage?.quote?.authorUuid ?? null,
+    sourceNumber: params.dataMessage?.quote?.authorNumber ?? null,
+    sourceUuid: params.dataMessage?.quote?.authorUuid ?? params.dataMessage?.quote?.author ?? null,
   });
   const quoteSenderAllowed =
     !params.isGroup || params.effectiveGroupAllow.length === 0

--- a/extensions/signal/src/monitor/inbound-context.ts
+++ b/extensions/signal/src/monitor/inbound-context.ts
@@ -7,6 +7,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import {
   formatSignalSenderDisplay,
   isSignalSenderAllowed,
+  looksLikeUuid,
   resolveSignalSender,
 } from "../identity.js";
 import type { SignalDataMessage } from "./event-handler.types.js";
@@ -32,9 +33,10 @@ export function resolveSignalQuoteContext(params: {
     accountId: params.accountId,
   });
   const quoteText = normalizeOptionalString(params.dataMessage?.quote?.text) ?? "";
+  const quoteAuthor = params.dataMessage?.quote?.author ?? null;
   const quoteSender = resolveSignalSender({
-    sourceNumber: params.dataMessage?.quote?.authorNumber ?? null,
-    sourceUuid: params.dataMessage?.quote?.authorUuid ?? params.dataMessage?.quote?.author ?? null,
+    sourceNumber: params.dataMessage?.quote?.authorNumber ?? (quoteAuthor && !looksLikeUuid(quoteAuthor) ? quoteAuthor : null),
+    sourceUuid: params.dataMessage?.quote?.authorUuid ?? (quoteAuthor && looksLikeUuid(quoteAuthor) ? quoteAuthor : null),
   });
   const quoteSenderAllowed =
     !params.isGroup || params.effectiveGroupAllow.length === 0


### PR DESCRIPTION
## Problem

The Signal adapter reads `dataMessage.quote` from signal-cli JSON-RPC (which contains the id, author, and text of the quoted/replied-to message), but never forwards it as reply context into the inbound processing pipeline.

The Telegram adapter already does this correctly — it populates `ReplyToId`, `ReplyToBody`, and `ReplyToSender` fields. Signal was missing this parity.

## Changes

**`event-handler.types.ts`**
- Extend `SignalDataMessage.quote` to include `id?: number | null` and `author?: string | null` (signal-cli already sends these fields)

**`event-handler.ts`**
- Add `replyToId`, `replyToBody`, `replyToSender` to the internal `SignalInboundEntry` type
- Populate them at `inboundDebouncer.enqueue()` from `dataMessage.quote`
- Forward all four `ReplyTo*` fields (`ReplyToId`, `ReplyToBody`, `ReplyToSender`, `ReplyToIsQuote`) into `finalizeInboundContext()`

## Result

When a user replies to a message in Signal, the agent now receives the original message text, sender, and ID as context — consistent with how the Telegram adapter works.

## Test plan

- [ ] Send a plain Signal message → `ReplyTo*` fields are absent (no regression)
- [ ] Reply to a Signal message → `ReplyToBody` contains quoted text, `ReplyToSender` contains the quoted author, `ReplyToId` contains the timestamp string
- [ ] Reaction messages → unaffected (reaction path is separate)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)