### PR TITLE
fix(mattermost): restore threadRootId priority in thread replies

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -175,7 +175,7 @@ export function resolveMattermostEffectiveReplyToId(params: {
   threadRootId?: string | null;
 }): string | undefined {
   const threadRootId = params.threadRootId?.trim();
-  if (threadRootId && params.replyToMode !== "off") {
+  if (threadRootId) {
     return threadRootId;
   }
   if (params.kind === "direct") {


### PR DESCRIPTION
Fixes #30977

## Root Cause

Commit aaba1ae6 ("honor replyToMode off for threaded messages") added a `replyToMode !== "off"` guard to `resolveMattermostEffectiveReplyToId()`. This conflates session routing (should DM threads fork sessions?) with reply delivery (should the bot reply in the thread?).

Since DMs default to `replyToMode: "off"`, the guard makes `effectiveReplyToId` undefined for all DM thread replies. Downstream call sites lose the thread root, so replies go to the main channel or fail with 400 Invalid RootId.

## Fix

Remove the guard so `threadRootId` always flows through to delivery. `replyToMode` still controls session forking via `resolveMattermostThreadSessionContext` — unchanged.

One-line change.