### PR TITLE
docs(browser): replace legacy extension relay guidance

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -4,6 +4,10 @@
     "target": "OpenClaw"
   },
   {
+    "source": "Chrome extension (legacy relay)",
+    "target": "Chrome 扩展（旧版 relay）"
+  },
+  {
     "source": "Gateway",
     "target": "Gateway 网关"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1125,6 +1125,7 @@
                     "pages": [
                       "tools/browser",
                       "tools/browser-login",
+                      "tools/chrome-extension",
                       "tools/browser-linux-troubleshooting",
                       "tools/browser-wsl2-windows-remote-cdp-troubleshooting"
                     ]

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -305,6 +305,9 @@ OpenClaw can also attach to a running Chromium-based browser profile through the
 official Chrome DevTools MCP server. This reuses the tabs and login state
 already open in that browser profile.
 
+Migrating older extension-relay docs or configs? See
+[Chrome extension (legacy relay)](/tools/chrome-extension).
+
 Official background and setup references:
 
 - [Chrome for Developers: Use Chrome DevTools MCP with your browser session](https://developer.chrome.com/blog/chrome-devtools-mcp-debug-your-browser-session)

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -2,7 +2,7 @@
 summary: "Legacy Chrome extension relay migration notes for current browser setup"
 read_when:
   - You found older docs or config that mention a Chrome extension relay
-  - You are migrating `browser.profiles.*.driver: \"extension\"`
+  - 'You are migrating `browser.profiles.*.driver: "extension"`'
   - You want to use your real signed-in Chrome tabs with current OpenClaw releases
 title: "Chrome extension (legacy relay)"
 ---

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -1,0 +1,87 @@
+---
+summary: "Legacy Chrome extension relay migration notes for current browser setup"
+read_when:
+  - You found older docs or config that mention a Chrome extension relay
+  - You are migrating `browser.profiles.*.driver: \"extension\"`
+  - You want to use your real signed-in Chrome tabs with current OpenClaw releases
+title: "Chrome extension (legacy relay)"
+---
+
+# Chrome extension (legacy relay)
+
+Older OpenClaw docs and configs described a **Chrome extension relay** flow for
+controlling your existing Chrome tabs. That is **not** the current browser setup
+for host-local browser attachment.
+
+Current releases use the built-in `user` profile, or your own
+`driver: "existing-session"` profile, to attach through **Chrome DevTools MCP**
+instead of the removed extension driver path.
+
+Use this page as a migration note if you still see references to:
+
+- `browser.profiles.*.driver: "extension"`
+- a built-in `chrome` profile for browser relay
+- a dedicated relay server config such as `browser.relayBindHost`
+
+## Current path
+
+Use one of these instead:
+
+- built-in `user` profile
+- custom profile with `driver: "existing-session"`
+
+Examples:
+
+```bash
+openclaw browser --browser-profile user tabs
+openclaw browser create-profile --name chrome-live --driver existing-session
+openclaw browser create-profile --name brave-live --driver existing-session --user-data-dir "~/Library/Application Support/BraveSoftware/Brave-Browser"
+```
+
+```json5
+{
+  browser: {
+    defaultProfile: "user",
+    profiles: {
+      user: {
+        driver: "existing-session",
+        attachOnly: true,
+        color: "#00AA00",
+      },
+      brave: {
+        driver: "existing-session",
+        attachOnly: true,
+        userDataDir: "~/Library/Application Support/BraveSoftware/Brave-Browser",
+        color: "#FB542B",
+      },
+    },
+  },
+}
+```
+
+## What changed
+
+- `driver: "extension"` was replaced by `driver: "existing-session"`
+- the old relay-specific config path is no longer the normal browser attach path
+- the built-in attach profile is `user`, not `chrome`
+
+OpenClaw doctor can normalize older browser configs:
+
+- `browser.profiles.*.driver: "extension"` becomes `"existing-session"`
+- `browser.relayBindHost` is removed
+
+## When to use `user` vs `openclaw`
+
+- Use `openclaw` when you want an isolated, OpenClaw-managed browser profile
+- Use `user` when you need the browser tabs and login state already open in your
+  local Chromium-based browser
+
+The `user` / `existing-session` path is **host-local**. For Docker, remote
+gateways, or hosted browsers, use a node host or a remote CDP profile instead.
+
+## Related docs
+
+- [Browser tool](/tools/browser)
+- [browser CLI](/cli/browser)
+- [Gateway doctor](/gateway/doctor)
+- [Gateway configuration reference](/gateway/configuration-reference)


### PR DESCRIPTION
## Summary
- add an English docs page at `/tools/chrome-extension` that explains the current browser attach model
- point legacy extension-relay readers to the built-in `user` profile and `driver: "existing-session"`
- link the migration note from the main browser docs in the existing-session section

Fixes #55162.

## Why
The current browser docs describe host-local Chrome attachment through Chrome DevTools MCP, but older extension-relay guidance still points readers at a removed `driver: "extension"` / built-in `chrome` profile flow. This patch gives that old path a clear migration target instead of leaving stale guidance in circulation.

## Validation
- docs-only change; no code paths changed
- verified against current browser docs and doctor/config reference language around `existing-session` and extension-driver migration