### PR TITLE
fix(plugins): fix regression where cwd source checkout overrides installed plugin root

### DIFF
--- a/src/plugins/bundled-dir.test.ts
+++ b/src/plugins/bundled-dir.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import * as openclawRoot from "../infra/openclaw-root.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
 
 const tempDirs: string[] = [];
@@ -42,7 +43,12 @@ describe("resolveBundledPluginsDir", () => {
       "utf8",
     );
 
-    vi.spyOn(process, "cwd").mockReturnValue(repoRoot);
+    vi.spyOn(openclawRoot, "resolveOpenClawPackageRootSync").mockImplementation((opts) => {
+      if (opts.moduleUrl) {
+        return repoRoot;
+      }
+      return null;
+    });
 
     expect(fs.realpathSync(resolveBundledPluginsDir() ?? "")).toBe(
       fs.realpathSync(path.join(repoRoot, "dist-runtime", "extensions")),
@@ -58,7 +64,12 @@ describe("resolveBundledPluginsDir", () => {
       "utf8",
     );
 
-    vi.spyOn(process, "cwd").mockReturnValue(repoRoot);
+    vi.spyOn(openclawRoot, "resolveOpenClawPackageRootSync").mockImplementation((opts) => {
+      if (opts.moduleUrl) {
+        return repoRoot;
+      }
+      return null;
+    });
 
     expect(fs.realpathSync(resolveBundledPluginsDir() ?? "")).toBe(
       fs.realpathSync(path.join(repoRoot, "dist", "extensions")),
@@ -76,7 +87,12 @@ describe("resolveBundledPluginsDir", () => {
       "utf8",
     );
 
-    vi.spyOn(process, "cwd").mockReturnValue(repoRoot);
+    vi.spyOn(openclawRoot, "resolveOpenClawPackageRootSync").mockImplementation((opts) => {
+      if (opts.moduleUrl) {
+        return repoRoot;
+      }
+      return null;
+    });
     process.env.VITEST = "true";
 
     expect(fs.realpathSync(resolveBundledPluginsDir() ?? "")).toBe(
@@ -97,11 +113,51 @@ describe("resolveBundledPluginsDir", () => {
       "utf8",
     );
 
-    vi.spyOn(process, "cwd").mockReturnValue(repoRoot);
+    vi.spyOn(openclawRoot, "resolveOpenClawPackageRootSync").mockImplementation((opts) => {
+      if (opts.moduleUrl) {
+        return repoRoot;
+      }
+      return null;
+    });
     delete process.env.VITEST;
 
     expect(fs.realpathSync(resolveBundledPluginsDir() ?? "")).toBe(
       fs.realpathSync(path.join(repoRoot, "extensions")),
+    );
+  });
+
+  it("does not let a cwd source checkout override an installed package root", () => {
+    const installedRoot = makeRepoRoot("openclaw-bundled-dir-installed-");
+    fs.mkdirSync(path.join(installedRoot, "dist", "extensions"), { recursive: true });
+    fs.writeFileSync(
+      path.join(installedRoot, "package.json"),
+      `${JSON.stringify({ name: "openclaw" }, null, 2)}\n`,
+      "utf8",
+    );
+
+    const sourceRoot = makeRepoRoot("openclaw-bundled-dir-source-");
+    fs.mkdirSync(path.join(sourceRoot, "extensions"), { recursive: true });
+    fs.mkdirSync(path.join(sourceRoot, "src"), { recursive: true });
+    fs.writeFileSync(path.join(sourceRoot, ".git"), "gitdir: /tmp/fake.git\n", "utf8");
+    fs.writeFileSync(
+      path.join(sourceRoot, "package.json"),
+      `${JSON.stringify({ name: "openclaw" }, null, 2)}\n`,
+      "utf8",
+    );
+
+    vi.spyOn(openclawRoot, "resolveOpenClawPackageRootSync").mockImplementation((opts) => {
+      if (opts.moduleUrl) {
+        return installedRoot;
+      }
+      if (opts.cwd) {
+        return sourceRoot;
+      }
+      return null;
+    });
+    delete process.env.VITEST;
+
+    expect(fs.realpathSync(resolveBundledPluginsDir() ?? "")).toBe(
+      fs.realpathSync(path.join(installedRoot, "dist", "extensions")),
     );
   });
 });

--- a/src/plugins/bundled-dir.ts
+++ b/src/plugins/bundled-dir.ts
@@ -12,6 +12,31 @@ function isSourceCheckoutRoot(packageRoot: string): boolean {
   );
 }
 
+function resolveExtensionsDirForPackageRoot(
+  packageRoot: string,
+  preferSourceCheckout: boolean,
+): string | undefined {
+  const sourceExtensionsDir = path.join(packageRoot, "extensions");
+  const builtExtensionsDir = path.join(packageRoot, "dist", "extensions");
+  if (
+    (preferSourceCheckout || isSourceCheckoutRoot(packageRoot)) &&
+    fs.existsSync(sourceExtensionsDir)
+  ) {
+    return sourceExtensionsDir;
+  }
+  // Local source checkouts stage a runtime-complete bundled plugin tree under
+  // dist-runtime/. Prefer that over source extensions only when the paired
+  // dist/ tree exists; otherwise wrappers can drift ahead of the last build.
+  const runtimeExtensionsDir = path.join(packageRoot, "dist-runtime", "extensions");
+  if (fs.existsSync(runtimeExtensionsDir) && fs.existsSync(builtExtensionsDir)) {
+    return runtimeExtensionsDir;
+  }
+  if (fs.existsSync(builtExtensionsDir)) {
+    return builtExtensionsDir;
+  }
+  return undefined;
+}
+
 export function resolveBundledPluginsDir(env: NodeJS.ProcessEnv = process.env): string | undefined {
   const override = env.OPENCLAW_BUNDLED_PLUGINS_DIR?.trim();
   if (override) {
@@ -21,30 +46,19 @@ export function resolveBundledPluginsDir(env: NodeJS.ProcessEnv = process.env): 
   const preferSourceCheckout = Boolean(env.VITEST);
 
   try {
-    const packageRoots = [
-      resolveOpenClawPackageRootSync({ cwd: process.cwd() }),
-      resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url }),
-    ].filter(
-      (entry, index, all): entry is string => Boolean(entry) && all.indexOf(entry) === index,
-    );
-    for (const packageRoot of packageRoots) {
-      const sourceExtensionsDir = path.join(packageRoot, "extensions");
-      const builtExtensionsDir = path.join(packageRoot, "dist", "extensions");
-      if (
-        (preferSourceCheckout || isSourceCheckoutRoot(packageRoot)) &&
-        fs.existsSync(sourceExtensionsDir)
-      ) {
-        return sourceExtensionsDir;
+    const modulePackageRoot = resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url });
+    if (modulePackageRoot) {
+      const resolved = resolveExtensionsDirForPackageRoot(modulePackageRoot, preferSourceCheckout);
+      if (resolved) {
+        return resolved;
       }
-      // Local source checkouts stage a runtime-complete bundled plugin tree under
-      // dist-runtime/. Prefer that over source extensions only when the paired
-      // dist/ tree exists; otherwise wrappers can drift ahead of the last build.
-      const runtimeExtensionsDir = path.join(packageRoot, "dist-runtime", "extensions");
-      if (fs.existsSync(runtimeExtensionsDir) && fs.existsSync(builtExtensionsDir)) {
-        return runtimeExtensionsDir;
-      }
-      if (fs.existsSync(builtExtensionsDir)) {
-        return builtExtensionsDir;
+    }
+
+    const cwdPackageRoot = resolveOpenClawPackageRootSync({ cwd: process.cwd() });
+    if (cwdPackageRoot && cwdPackageRoot !== modulePackageRoot) {
+      const resolved = resolveExtensionsDirForPackageRoot(cwdPackageRoot, preferSourceCheckout);
+      if (resolved) {
+        return resolved;
       }
     }
   } catch {


### PR DESCRIPTION
## Summary

Fix a regression where the installed OpenClaw CLI can load bundled plugins from a cwd source checkout instead of from its own installed package root.

Closes #55193.

## Regression

When the installed CLI is run from inside an OpenClaw source checkout, `resolveBundledPluginsDir()` can pick the checkout's `extensions/` tree before the installed package root.

That regresses normal installed-release behavior by mixing source extensions with the installed runtime and producing misleading failures such as:
- plugin load crashes from `.../extensions/*.ts`
- spurious config validation errors during commands like `openclaw browser status`

## Fix

- resolve the running CLI's module/package root first
- only consider a distinct cwd package root afterward
- keep the existing source-checkout preference for true source/dev runs
- add a regression test covering the installed-package-root vs cwd-checkout case

## Validation

- `bun run test src/plugins/bundled-dir.test.ts`
- `pnpm build`
- `pnpm check`
- `bun run openclaw -- plugins inspect --all` from the repo root is now clean
- `bun run openclaw -- browser status` from the repo root no longer emits the plugin/config failure wall before reaching normal gateway behavior

## AI disclosure

- AI-assisted
- Fully tested for the changed surface locally
- I understand the code and validated the repro and fix directly
