### PR TITLE
Responses: stop client tool loops at handoff

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1036,6 +1036,83 @@ export async function runEmbeddedPiAgent(
             provider,
             model: modelId,
           });
+
+          // Client-hosted tools must short-circuit before later error handling.
+          // The adapter returns a synthetic pending tool result to the model, so
+          // follow-up prompt/overflow branches can otherwise swallow the
+          // side-channel pendingToolCalls metadata and cause `/v1/responses` to
+          // return plain text instead of OpenResponses function_call items.
+          if (attempt.clientToolCalls && attempt.clientToolCalls.length > 0) {
+            const usageMeta = buildUsageAgentMetaFields({
+              usageAccumulator,
+              lastAssistantUsage: lastAssistant?.usage as UsageLike | undefined,
+              lastRunPromptUsage,
+              lastTurnTotal,
+            });
+            const agentMeta: EmbeddedPiAgentMeta = {
+              sessionId: sessionIdUsed,
+              provider: lastAssistant?.provider ?? provider,
+              model: lastAssistant?.model ?? model.id,
+              usage: usageMeta.usage,
+              lastCallUsage: usageMeta.lastCallUsage,
+              promptTokens: usageMeta.promptTokens,
+              compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
+            };
+            const payloads = buildEmbeddedRunPayloads({
+              assistantTexts: attempt.assistantTexts,
+              toolMetas: attempt.toolMetas,
+              lastAssistant: attempt.lastAssistant,
+              lastToolError: attempt.lastToolError,
+              config: params.config,
+              sessionKey: params.sessionKey ?? params.sessionId,
+              provider: activeErrorContext.provider,
+              model: activeErrorContext.model,
+              verboseLevel: params.verboseLevel,
+              reasoningLevel: params.reasoningLevel,
+              toolResultFormat: resolvedToolResultFormat,
+              suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+              inlineToolResultsAllowed: false,
+              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+            });
+
+            if (lastProfileId) {
+              await markAuthProfileGood({
+                store: authStore,
+                provider,
+                profileId: lastProfileId,
+                agentDir: params.agentDir,
+              });
+              await markAuthProfileUsed({
+                store: authStore,
+                profileId: lastProfileId,
+                agentDir: params.agentDir,
+              });
+            }
+
+            return {
+              payloads: payloads.length ? payloads : undefined,
+              meta: {
+                durationMs: Date.now() - started,
+                agentMeta,
+                aborted,
+                systemPromptReport: attempt.systemPromptReport,
+                stopReason: "tool_calls",
+                pendingToolCalls: attempt.clientToolCalls.map((call) => ({
+                  id: randomBytes(5).toString("hex").slice(0, 9),
+                  name: call.name,
+                  arguments: JSON.stringify(call.params),
+                })),
+              },
+              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+              messagingToolSentTexts: attempt.messagingToolSentTexts,
+              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+              messagingToolSentTargets: attempt.messagingToolSentTargets,
+              successfulCronAdds: attempt.successfulCronAdds,
+            };
+          }
+
           const formattedAssistantErrorText = lastAssistant
             ? formatAssistantErrorText(lastAssistant, {
                 cfg: params.config,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import {
@@ -1042,7 +1041,7 @@ export async function runEmbeddedPiAgent(
           // follow-up prompt/overflow branches can otherwise swallow the
           // side-channel pendingToolCalls metadata and cause `/v1/responses` to
           // return plain text instead of OpenResponses function_call items.
-          if (attempt.clientToolCalls && attempt.clientToolCalls.length > 0) {
+          if (attempt.clientToolCall) {
             const usageMeta = buildUsageAgentMetaFields({
               usageAccumulator,
               lastAssistantUsage: lastAssistant?.usage as UsageLike | undefined,
@@ -1098,11 +1097,13 @@ export async function runEmbeddedPiAgent(
                 aborted,
                 systemPromptReport: attempt.systemPromptReport,
                 stopReason: "tool_calls",
-                pendingToolCalls: attempt.clientToolCalls.map((call) => ({
-                  id: randomBytes(5).toString("hex").slice(0, 9),
-                  name: call.name,
-                  arguments: JSON.stringify(call.params),
-                })),
+                pendingToolCalls: [
+                  {
+                    id: attempt.clientToolCall.id,
+                    name: attempt.clientToolCall.name,
+                    arguments: JSON.stringify(attempt.clientToolCall.params),
+                  },
+                ],
               },
               didSendViaMessagingTool: attempt.didSendViaMessagingTool,
               didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
@@ -1894,6 +1895,24 @@ export async function runEmbeddedPiAgent(
               agentDir: params.agentDir,
             });
           }
+          const pendingClientToolCall = attempt.clientToolCall as
+            | { id: string; name: string; params: Record<string, unknown> }
+            | undefined;
+          const stopReason = pendingClientToolCall
+            ? "tool_calls"
+            : attempt.yieldDetected
+              ? "end_turn"
+              : (lastAssistant?.stopReason as string | undefined);
+          let pendingToolCalls: Array<{ id: string; name: string; arguments: string }> | undefined;
+          if (pendingClientToolCall) {
+            pendingToolCalls = [
+              {
+                id: pendingClientToolCall.id,
+                name: pendingClientToolCall.name,
+                arguments: JSON.stringify(pendingClientToolCall.params),
+              },
+            ];
+          }
           return {
             payloads: payloads.length ? payloads : undefined,
             meta: {
@@ -1904,20 +1923,8 @@ export async function runEmbeddedPiAgent(
               // Handle client tool calls (OpenResponses hosted tools)
               // Propagate the LLM stop reason so callers (lifecycle events,
               // ACP bridge) can distinguish end_turn from max_tokens.
-              stopReason: attempt.clientToolCall
-                ? "tool_calls"
-                : attempt.yieldDetected
-                  ? "end_turn"
-                  : (lastAssistant?.stopReason as string | undefined),
-              pendingToolCalls: attempt.clientToolCall
-                ? [
-                    {
-                      id: randomBytes(5).toString("hex").slice(0, 9),
-                      name: attempt.clientToolCall.name,
-                      arguments: JSON.stringify(attempt.clientToolCall.params),
-                    },
-                  ]
-                : undefined,
+              stopReason,
+              pendingToolCalls,
             },
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
             didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -175,6 +175,7 @@ type PromptBuildHookRunner = {
 
 const SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE = "openclaw.sessions_yield_interrupt";
 const SESSIONS_YIELD_CONTEXT_CUSTOM_TYPE = "openclaw.sessions_yield";
+const CLIENT_TOOL_INTERRUPT_REASON = "client_tool";
 const SESSIONS_YIELD_ABORT_SETTLE_TIMEOUT_MS = process.env.OPENCLAW_TEST_FAST === "1" ? 250 : 2_000;
 
 // Persist a hidden context reminder so the next turn knows why the runner stopped.
@@ -374,6 +375,85 @@ export function stripSessionsYieldArtifacts(activeSession: {
     const isYieldInterruptMessage =
       last.type === "custom_message" && last.customType === SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE;
     if (!isYieldAbortAssistant && !isYieldInterruptMessage) {
+      break;
+    }
+    fileEntries.pop();
+    if (last.id) {
+      byId.delete(last.id);
+    }
+    sessionManager.leafId = last.parentId ?? null;
+    changed = true;
+  }
+  if (changed) {
+    sessionManager._rewriteFile?.();
+  }
+}
+
+function stripClientToolArtifacts(
+  activeSession: {
+    messages: AgentMessage[];
+    agent: { replaceMessages: (messages: AgentMessage[]) => void };
+    sessionManager?: unknown;
+  },
+  toolCallId: string,
+) {
+  if (!toolCallId) {
+    return;
+  }
+
+  const strippedMessages = activeSession.messages.slice();
+  while (strippedMessages.length > 0) {
+    const last = strippedMessages.at(-1) as
+      | AgentMessage
+      | { role?: string; stopReason?: string; toolCallId?: string };
+    if (last?.role === "assistant" && "stopReason" in last && last.stopReason === "aborted") {
+      strippedMessages.pop();
+      continue;
+    }
+    if (last?.role === "toolResult" && last.toolCallId === toolCallId) {
+      strippedMessages.pop();
+      continue;
+    }
+    break;
+  }
+  if (strippedMessages.length !== activeSession.messages.length) {
+    activeSession.agent.replaceMessages(strippedMessages);
+  }
+
+  const sessionManager = activeSession.sessionManager as
+    | {
+        fileEntries?: Array<{
+          type?: string;
+          id?: string;
+          parentId?: string | null;
+          message?: { role?: string; stopReason?: string; toolCallId?: string };
+        }>;
+        byId?: Map<string, { id: string }>;
+        leafId?: string | null;
+        _rewriteFile?: () => void;
+      }
+    | undefined;
+  const fileEntries = sessionManager?.fileEntries;
+  const byId = sessionManager?.byId;
+  if (!fileEntries || !byId) {
+    return;
+  }
+
+  let changed = false;
+  while (fileEntries.length > 1) {
+    const last = fileEntries.at(-1);
+    if (!last || last.type === "session") {
+      break;
+    }
+    const isClientAbortAssistant =
+      last.type === "message" &&
+      last.message?.role === "assistant" &&
+      last.message?.stopReason === "aborted";
+    const isClientToolResult =
+      last.type === "message" &&
+      last.message?.role === "toolResult" &&
+      last.message?.toolCallId === toolCallId;
+    if (!isClientAbortAssistant && !isClientToolResult) {
       break;
     }
     fileEntries.pop();
@@ -2156,16 +2236,23 @@ export async function runEmbeddedAttempt(
       });
 
       // Add client tools (OpenResponses hosted tools) to customTools
-      let clientToolCallDetected: { name: string; params: Record<string, unknown> } | null = null;
+      let clientToolCallDetected: {
+        id: string;
+        name: string;
+        params: Record<string, unknown>;
+      } | null = null;
       const clientToolLoopDetection = resolveToolLoopDetectionConfig({
         cfg: params.config,
         agentId: sessionAgentId,
       });
+      let interruptForClientTool:
+        | ((toolCallId: string, toolName: string, toolParams: Record<string, unknown>) => void)
+        | undefined;
       const clientToolDefs = clientTools
         ? toClientToolDefinitions(
             clientTools,
-            (toolName, toolParams) => {
-              clientToolCallDetected = { name: toolName, params: toolParams };
+            (toolCallId, toolName, toolParams) => {
+              interruptForClientTool?.(toolCallId, toolName, toolParams);
             },
             {
               agentId: sessionAgentId,
@@ -2517,6 +2604,7 @@ export async function runEmbeddedAttempt(
       }
 
       let aborted = Boolean(params.abortSignal?.aborted);
+      let clientToolInterrupted = false;
       let yieldAborted = false;
       let timedOut = false;
       let timedOutDuringCompaction = false;
@@ -2559,6 +2647,12 @@ export async function runEmbeddedAttempt(
         }
         abortCompaction();
         void activeSession.abort();
+      };
+      interruptForClientTool = (toolCallId, toolName, toolParams) => {
+        clientToolCallDetected = { id: toolCallId, name: toolName, params: toolParams };
+        if (!runAbortController.signal.aborted) {
+          abortRun(false, CLIENT_TOOL_INTERRUPT_REASON);
+        }
       };
       const abortable = <T>(promise: Promise<T>): Promise<T> => {
         const signal = runAbortController.signal;
@@ -2910,6 +3004,11 @@ export async function runEmbeddedAttempt(
             isRunnerAbortError(err) &&
             err instanceof Error &&
             err.cause === "sessions_yield";
+          clientToolInterrupted =
+            !!clientToolCallDetected &&
+            isRunnerAbortError(err) &&
+            err instanceof Error &&
+            err.cause === CLIENT_TOOL_INTERRUPT_REASON;
           if (yieldAborted) {
             aborted = false;
             // Ensure the session abort has mostly settled before proceeding, but
@@ -2923,6 +3022,14 @@ export async function runEmbeddedAttempt(
             if (yieldMessage) {
               await persistSessionsYieldContextMessage(activeSession, yieldMessage);
             }
+          } else if (clientToolInterrupted && clientToolCallDetected) {
+            aborted = false;
+            const interruptedClientToolCall = clientToolCallDetected as {
+              id: string;
+              name: string;
+              params: Record<string, unknown>;
+            };
+            stripClientToolArtifacts(activeSession, interruptedClientToolCall.id);
           } else {
             promptError = err;
             promptErrorSource = "prompt";
@@ -2955,14 +3062,15 @@ export async function runEmbeddedAttempt(
 
           // Skip compaction wait when yield aborted the run — the signal is
           // already tripped and abortable() would immediately reject.
-          const compactionRetryWait = yieldAborted
-            ? { timedOut: false }
-            : await waitForCompactionRetryWithAggregateTimeout({
-                waitForCompactionRetry,
-                abortable,
-                aggregateTimeoutMs: COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS,
-                isCompactionStillInFlight: isCompactionInFlight,
-              });
+          const compactionRetryWait =
+            yieldAborted || clientToolInterrupted
+              ? { timedOut: false }
+              : await waitForCompactionRetryWithAggregateTimeout({
+                  waitForCompactionRetry,
+                  abortable,
+                  aggregateTimeoutMs: COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS,
+                  isCompactionStillInFlight: isCompactionInFlight,
+                });
           if (compactionRetryWait.timedOut) {
             timedOutDuringCompaction = true;
             if (!isProbeSession) {

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -63,7 +63,7 @@ export type EmbeddedRunAttemptResult = {
   attemptUsage?: NormalizedUsage;
   compactionCount?: number;
   /** Client tool call detected (OpenResponses hosted tools). */
-  clientToolCall?: { name: string; params: Record<string, unknown> };
+  clientToolCall?: { id: string; name: string; params: Record<string, unknown> };
   /** True when sessions_yield tool was called during this attempt. */
   yieldDetected?: boolean;
 };

--- a/src/agents/pi-embedded-runner/sessions-yield.orchestration.test.ts
+++ b/src/agents/pi-embedded-runner/sessions-yield.orchestration.test.ts
@@ -62,7 +62,7 @@ describe("sessions_yield orchestration", () => {
       makeAttemptResult({
         promptError: null,
         yieldDetected: true,
-        clientToolCall: { name: "hosted_tool", params: { arg: "value" } },
+        clientToolCall: { id: "call_1", name: "hosted_tool", params: { arg: "value" } },
       }),
     );
 
@@ -75,13 +75,14 @@ describe("sessions_yield orchestration", () => {
     expect(result.meta.stopReason).toBe("tool_calls");
     expect(result.meta.pendingToolCalls).toHaveLength(1);
     expect(result.meta.pendingToolCalls![0].name).toBe("hosted_tool");
+    expect(result.meta.pendingToolCalls![0].id).toBe("call_1");
   });
 
   it("clientToolCalls takes precedence over promptError", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         promptError: new Error("request_too_large: Request size exceeds model context window"),
-        clientToolCalls: [{ name: "hosted_tool", params: { arg: "value" } }],
+        clientToolCall: { id: "call_2", name: "hosted_tool", params: { arg: "value" } },
       }),
     );
 
@@ -93,6 +94,7 @@ describe("sessions_yield orchestration", () => {
     expect(result.meta.stopReason).toBe("tool_calls");
     expect(result.meta.pendingToolCalls).toHaveLength(1);
     expect(result.meta.pendingToolCalls![0].name).toBe("hosted_tool");
+    expect(result.meta.pendingToolCalls![0].id).toBe("call_2");
   });
 
   it("normal attempt without yield has no stopReason override", async () => {

--- a/src/agents/pi-embedded-runner/sessions-yield.orchestration.test.ts
+++ b/src/agents/pi-embedded-runner/sessions-yield.orchestration.test.ts
@@ -77,6 +77,24 @@ describe("sessions_yield orchestration", () => {
     expect(result.meta.pendingToolCalls![0].name).toBe("hosted_tool");
   });
 
+  it("clientToolCalls takes precedence over promptError", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: new Error("request_too_large: Request size exceeds model context window"),
+        clientToolCalls: [{ name: "hosted_tool", params: { arg: "value" } }],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-client-tool-vs-prompt-error",
+    });
+
+    expect(result.meta.stopReason).toBe("tool_calls");
+    expect(result.meta.pendingToolCalls).toHaveLength(1);
+    expect(result.meta.pendingToolCalls![0].name).toBe("hosted_tool");
+  });
+
   it("normal attempt without yield has no stopReason override", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
 

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -176,7 +176,11 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
 // These tools are intercepted to return a "pending" result instead of executing
 export function toClientToolDefinitions(
   tools: ClientToolDefinition[],
-  onClientToolCall?: (toolName: string, params: Record<string, unknown>) => void,
+  onClientToolCall?: (
+    toolCallId: string,
+    toolName: string,
+    params: Record<string, unknown>,
+  ) => void,
   hookContext?: HookContext,
 ): ToolDefinition[] {
   return tools.map((tool) => {
@@ -201,7 +205,7 @@ export function toClientToolDefinitions(
         const paramsRecord = isPlainObject(adjustedParams) ? adjustedParams : {};
         // Notify handler that a client tool was called
         if (onClientToolCall) {
-          onClientToolCall(func.name, paramsRecord);
+          onClientToolCall(toolCallId, func.name, paramsRecord);
         }
         // Return a pending result - the client will execute this tool
         return jsonResult({

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -345,7 +345,7 @@ describe("before_tool_call hook integration for client tools", () => {
     const extensionContext = {} as Parameters<typeof tool.execute>[4];
     await tool.execute("client-call-1", { value: "ok" }, undefined, undefined, extensionContext);
 
-    expect(onClientToolCall).toHaveBeenCalledWith("client_tool", {
+    expect(onClientToolCall).toHaveBeenCalledWith("client-call-1", "client_tool", {
       value: "ok",
       extra: true,
     });


### PR DESCRIPTION
## Summary

- Problem: client-hosted tools in `/v1/responses` were still returned into model context as a synthetic pending tool result before the caller could answer with `function_call_output`.
- Why it matters: the model could keep looping within the same turn and issue extra hosted tool calls instead of cleanly handing off to the caller.
- What changed: client tool hits now interrupt the current embedded run immediately, preserve the original tool call id, and strip the synthetic pending tool-result artifacts before returning `tool_calls`.
- What did NOT change (scope boundary): the external `/v1/responses` continuation contract still uses `previous_response_id` + `function_call_output`; this PR does not add a long-lived in-request pause/resume mechanism.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: client-hosted tools were wrapped as a normal pending tool result, and the embedded run only converted them into `tool_calls` at the end of a successful attempt. If the turn continued or hit an early-exit path, the model saw the pending result and kept calling more tools.
- Missing detection / guardrail: no handoff-specific interrupt path existed for client tools, and no regression test asserted that client tool delegation must win over prompt-error/overflow paths.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this sat in the OpenResponses hosted-tool adapter / embedded run bridge.
- Why this regressed now: the earlier fix to preserve hosted tool calls on early exit made the underlying behavior visible, but the handoff semantics were still wrong.
- If unknown, what was ruled out: ruled out `/v1/responses` packaging bugs; the loop started earlier in the embedded run/tool adapter path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/pi-tools.before-tool-call.integration.e2e.test.ts`
  - `src/agents/pi-embedded-runner/sessions-yield.orchestration.test.ts`
  - `src/gateway/openresponses-http.test.ts`
- Scenario the test should lock in: hosted tool delegation preserves the original `call_id`, interrupts the current run immediately, and still produces a clean OpenResponses `function_call` handoff.
- Why this is the smallest reliable guardrail: the bug spans adapter -> embedded run -> HTTP packaging, so a single-layer unit test is not enough.
- Existing test that already covers this (if any): `openresponses-http.test.ts` already covers function_call packaging; this PR extends the lower-layer handoff coverage.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `/v1/responses` hosted/client tools now hand off immediately instead of feeding a synthetic pending tool result back into the model.
- Returned `function_call.call_id` now preserves the original tool call id generated by the model/runtime.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm dev env
- Model/provider: embedded runner + OpenResponses hosted tools
- Integration/channel (if any): `/v1/responses`
- Relevant config (redacted): default local gateway config

### Steps

1. Call `POST /v1/responses` with a client-hosted tool.
2. Have the model decide to call that hosted tool.
3. Observe the returned response items and continue with `function_call_output`.

### Expected

- The first hosted tool call ends the current turn as `tool_calls`.
- The caller receives a `function_call` item with the original `call_id`.
- The model does not continue looping inside the same turn on synthetic pending tool results.

### Actual

- Before this fix, the model could see a synthetic pending tool result and keep issuing more hosted/status tool calls in the same round.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - targeted hosted-tool handoff regression tests pass
  - `/v1/responses` hosted function-call packaging tests still pass
- Edge cases checked:
  - hosted tool call wins over prompt-error path
  - hook-adjusted client tool params still reach the callback
  - original `call_id` is preserved
- What you did **not** verify:
  - real external client integration end-to-end outside the local test harness

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `d65a3f1253`
- Files/config to restore:
  - `src/agents/pi-tool-definition-adapter.ts`
  - `src/agents/pi-embedded-runner/run/attempt.ts`
  - `src/agents/pi-embedded-runner/run.ts`
- Known bad symptoms reviewers should watch for:
  - hosted tools stop producing `function_call` output items
  - call ids change unexpectedly across handoff
  - synthetic pending tool results remain in context and tool loops reappear

## Risks and Mitigations

- Risk: immediate handoff could leave stray synthetic tool-result artifacts in the session transcript.
  - Mitigation: strip the trailing pending tool-result and aborted assistant artifacts from both in-memory session state and session file state before returning.
- Risk: changing handoff timing could break existing hosted-tool packaging.
  - Mitigation: keep the existing `/v1/responses` packaging tests green and preserve the original `call_id` in the returned `function_call` item.
