### PR TITLE
fix: clean up saved media when ensureMediaHosted fails after save

### DIFF
--- a/src/media/host.test.ts
+++ b/src/media/host.test.ts
@@ -27,61 +27,74 @@ vi.mock("../logger.js", async () => {
 const { ensureMediaHosted } = await import("./host.js");
 const { PortInUseError } = await import("../infra/ports.js");
 
+type CleanupCase = {
+  name: string;
+  filePath: string;
+  savedMedia: { id: string; size: number };
+  tailnetHostname?: string;
+  tailnetError?: Error;
+  port?: number;
+  startServer: boolean;
+  ensurePortError?: Error;
+  startServerError?: Error;
+  expectedError: RegExp | Error;
+  expectedCleanupPath: string;
+};
+
+type SuccessCase = {
+  name: string;
+  filePath: string;
+  savedMedia: { id: string; size: number };
+  tailnetHostname: string;
+  port: number;
+  startServer: boolean;
+  ensurePortError?: Error;
+  expectedUrl: string;
+  expectServerStart: boolean;
+};
+
+type HostedMediaCase = CleanupCase | SuccessCase;
+
 describe("ensureMediaHosted", () => {
-  function mockSavedMedia(id: string, size: number) {
+  function mockSavedMedia(id: string, size: number, path = `/tmp/${id}`) {
     saveMediaSource.mockResolvedValue({
       id,
-      path: `/tmp/${id}`,
+      path,
       size,
     });
   }
 
-  async function expectHostedMediaCase(
-    params:
-      | {
-          filePath: string;
-          savedMedia: { id: string; size: number };
-          tailnetHostname: string;
-          startServer: boolean;
-          expectedError: RegExp;
-          expectedCleanupPath: string;
-        }
-      | {
-          filePath: string;
-          savedMedia: { id: string; size: number };
-          tailnetHostname: string;
-          port: number;
-          startServer: boolean;
-          ensurePortError?: Error;
-          expectedUrl: string;
-          expectServerStart: boolean;
-        },
-  ) {
-    getTailnetHostname.mockResolvedValue(params.tailnetHostname);
-    if ("expectedError" in params) {
-      saveMediaSource.mockResolvedValue({
-        id: params.savedMedia.id,
-        path: params.filePath,
-        size: params.savedMedia.size,
-      });
+  async function expectHostedMediaCase(params: HostedMediaCase) {
+    mockSavedMedia(params.savedMedia.id, params.savedMedia.size, params.filePath);
+    if ("tailnetError" in params && params.tailnetError) {
+      getTailnetHostname.mockRejectedValue(params.tailnetError);
+    } else {
+      getTailnetHostname.mockResolvedValue(params.tailnetHostname);
+    }
+
+    if (params.ensurePortError) {
+      ensurePortAvailable.mockRejectedValue(params.ensurePortError);
+    } else {
       ensurePortAvailable.mockResolvedValue(undefined);
+    }
+
+    if ("expectedError" in params) {
+      if (params.startServerError) {
+        startMediaServer.mockRejectedValue(params.startServerError);
+      } else {
+        startMediaServer.mockResolvedValue({ unref: vi.fn() } as unknown as Server);
+      }
       const rmSpy = vi.spyOn(fs, "rm").mockResolvedValue(undefined);
 
       await expect(
-        ensureMediaHosted(params.filePath, { startServer: params.startServer }),
+        ensureMediaHosted(params.filePath, { startServer: params.startServer, port: params.port }),
       ).rejects.toThrow(params.expectedError);
       expect(rmSpy).toHaveBeenCalledWith(params.expectedCleanupPath);
       rmSpy.mockRestore();
       return;
     }
 
-    mockSavedMedia(params.savedMedia.id, params.savedMedia.size);
-    if (params.ensurePortError) {
-      ensurePortAvailable.mockRejectedValue(params.ensurePortError);
-    } else {
-      ensurePortAvailable.mockResolvedValue(undefined);
-      startMediaServer.mockResolvedValue({ unref: vi.fn() } as unknown as Server);
-    }
+    startMediaServer.mockResolvedValue({ unref: vi.fn() } as unknown as Server);
 
     const result = await ensureMediaHosted(params.filePath, {
       startServer: params.startServer,
@@ -120,6 +133,36 @@ describe("ensureMediaHosted", () => {
       expectedCleanupPath: "/tmp/file1",
     },
     {
+      name: "cleans up when hostname lookup fails after save",
+      filePath: "/tmp/file-hostname",
+      savedMedia: { id: "id-hostname", size: 5 },
+      tailnetError: new Error("hostname lookup failed"),
+      startServer: false,
+      expectedError: /hostname lookup failed/,
+      expectedCleanupPath: "/tmp/file-hostname",
+    },
+    {
+      name: "cleans up when port check fails unexpectedly",
+      filePath: "/tmp/file-port",
+      savedMedia: { id: "id-port", size: 5 },
+      tailnetHostname: "tail.net",
+      startServer: false,
+      ensurePortError: new Error("port check failed"),
+      expectedError: /port check failed/,
+      expectedCleanupPath: "/tmp/file-port",
+    },
+    {
+      name: "cleans up when media server startup fails",
+      filePath: "/tmp/file-start",
+      savedMedia: { id: "id-start", size: 9 },
+      tailnetHostname: "tail.net",
+      port: 1234,
+      startServer: true,
+      startServerError: new Error("startup failed"),
+      expectedError: /startup failed/,
+      expectedCleanupPath: "/tmp/file-start",
+    },
+    {
       name: "starts media server when allowed",
       filePath: "/tmp/id2",
       savedMedia: { id: "id2", size: 9 },
@@ -140,7 +183,7 @@ describe("ensureMediaHosted", () => {
       expectedUrl: "https://tail.net/media/id3",
       expectServerStart: false,
     },
-  ] as const)("$name", async (testCase) => {
+  ] satisfies HostedMediaCase[])("$name", async (testCase) => {
     await expectHostedMediaCase(testCase);
   });
 });

--- a/src/media/host.ts
+++ b/src/media/host.ts
@@ -30,29 +30,33 @@ export async function ensureMediaHosted(
   const runtime = opts.runtime ?? defaultRuntime;
 
   const saved = await saveMediaSource(source);
-  const hostname = await getTailnetHostname();
+  try {
+    const hostname = await getTailnetHostname();
 
-  // Decide whether we must start a media server.
-  const needsServerStart = await isPortFree(port);
-  if (needsServerStart && !opts.startServer) {
-    await fs.rm(saved.path).catch(() => {});
-    throw new Error(
-      `Media hosting requires the webhook/Funnel server. Start \`${formatCliCommand("openclaw webhook")}\`/\`${formatCliCommand("openclaw up")}\` or re-run with --serve-media.`,
-    );
-  }
-  if (needsServerStart && opts.startServer) {
-    if (!mediaServer) {
-      mediaServer = await startMediaServer(port, TTL_MS, runtime);
-      logInfo(
-        `🦞 Started temporary media host on http://localhost:${port}/media/:id (TTL ${TTL_MS / 1000}s)`,
-        runtime,
+    // Decide whether we must start a media server.
+    const needsServerStart = await isPortFree(port);
+    if (needsServerStart && !opts.startServer) {
+      throw new Error(
+        `Media hosting requires the webhook/Funnel server. Start \`${formatCliCommand("openclaw webhook")}\`/\`${formatCliCommand("openclaw up")}\` or re-run with --serve-media.`,
       );
-      mediaServer.unref?.();
     }
-  }
+    if (needsServerStart && opts.startServer) {
+      if (!mediaServer) {
+        mediaServer = await startMediaServer(port, TTL_MS, runtime);
+        logInfo(
+          `🦞 Started temporary media host on http://localhost:${port}/media/:id (TTL ${TTL_MS / 1000}s)`,
+          runtime,
+        );
+        mediaServer.unref?.();
+      }
+    }
 
-  const url = `https://${hostname}/media/${saved.id}`;
-  return { url, id: saved.id, size: saved.size };
+    const url = `https://${hostname}/media/${saved.id}`;
+    return { url, id: saved.id, size: saved.size };
+  } catch (error) {
+    await fs.rm(saved.path).catch(() => {});
+    throw error;
+  }
 }
 
 async function isPortFree(port: number) {


### PR DESCRIPTION
Summary
clean up saved media when hosting setup fails after save

Problem
`ensureMediaHosted()` currently saves media to disk first and only cleans it up in one failure branch.

If a later setup step fails — such as hostname lookup, an unexpected port check failure, or media server startup — the saved media file is left behind on disk.

Root cause
The setup flow calls:

`saveMediaSource(source)`

before the rest of the hosting setup, but cleanup is only performed in the specific branch where a server is required and `startServer` is false.

Other failure paths do not share a common cleanup path.

What changed
- wrap the post-save hosting setup flow in a shared failure cleanup path
- remove the saved media file when a later setup step throws
- keep the success path unchanged
- add regression tests for hostname lookup failure, unexpected port-check failure, and media server startup failure

Before / After
Before
- `ensureMediaHosted()` saved media first
- cleanup only happened in the “server required but not allowed to start” branch
- later failures could leave orphaned media files on disk

After
- any failure after `saveMediaSource()` now triggers best-effort cleanup of the saved file
- success behavior is unchanged
- regression tests cover the previously missing failure paths

Scope boundary
This PR only fixes post-save cleanup inside `ensureMediaHosted()`.

It does not:
- change successful media hosting behavior
- change URL generation
- change media retention policy
- refactor broader media lifecycle handling

Validation
- `pnpm vitest run src/media/host.test.ts`
- `pnpm vitest run src/media/host.test.ts src/media/store.test.ts`
- verified cleanup on:
  - hostname lookup failure
  - unexpected port-check failure
  - media server startup failure
- verified the existing success path test still passes

Not verified
I did not run an end-to-end media hosting flow against a live webhook/Funnel server in this environment.

User impact
Users are less likely to accumulate orphaned media files when media hosting setup fails after the file has already been saved.

Risks and mitigations
Risk: cleanup could accidentally affect successful hosting flows
Mitigation: the change is limited to exceptions thrown after `saveMediaSource()` succeeds, and the success path remains unchanged

Risk: cleanup failure could hide the original error
Mitigation: cleanup remains best-effort via `fs.rm(...).catch(() => {})`, so the original error is still surfaced

Compatibility / migration
backward compatible: yes
migration required: no

Failure recovery
rerun the original action that triggered `ensureMediaHosted()`
remove any previously orphaned files manually if they were created before this fix landed
