### PR TITLE
feat(whatsapp): add allowOutboundTo config for separate outbound target authorization

### DIFF
--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -24,6 +24,7 @@ export type ResolvedWhatsAppAccount = {
   isLegacyAuthDir: boolean;
   selfChatMode?: boolean;
   allowFrom?: string[];
+  allowOutboundTo?: string[];
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
   dmPolicy?: DmPolicy;
@@ -147,6 +148,7 @@ export function resolveWhatsAppAccount(params: {
     selfChatMode: merged.selfChatMode,
     dmPolicy: merged.dmPolicy,
     allowFrom: merged.allowFrom,
+    allowOutboundTo: (merged as Record<string, unknown>).allowOutboundTo as string[] | undefined,
     groupAllowFrom: merged.groupAllowFrom,
     groupPolicy: merged.groupPolicy,
     textChunkLimit: merged.textChunkLimit,

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -17,6 +17,7 @@ import {
   resolveWhatsAppGroupToolPolicy,
 } from "./group-policy.js";
 import { looksLikeWhatsAppTargetId, normalizeWhatsAppMessagingTarget } from "./normalize.js";
+import { resolveAllowOutboundTo } from "./resolve-allow-outbound.js";
 import {
   createActionGate,
   createWhatsAppOutboundBase,
@@ -71,8 +72,13 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
         sendPollWhatsApp: async (...args) =>
           await getWhatsAppRuntime().channel.whatsapp.sendPollWhatsApp(...args),
         shouldLogVerbose: () => getWhatsAppRuntime().logging.shouldLogVerbose(),
-        resolveTarget: ({ to, allowFrom, mode }) =>
-          resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+        resolveTarget: ({ to, allowFrom, cfg, accountId, mode }) =>
+          resolveWhatsAppOutboundTarget({
+            to,
+            allowFrom,
+            allowOutboundTo: resolveAllowOutboundTo(cfg, accountId),
+            mode,
+          }),
       }),
       normalizePayload: ({ payload }) => ({
         ...payload,

--- a/extensions/whatsapp/src/outbound-adapter.ts
+++ b/extensions/whatsapp/src/outbound-adapter.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import { chunkText } from "openclaw/plugin-sdk/reply-runtime";
 import { shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { resolveAllowOutboundTo } from "./resolve-allow-outbound.js";
 import { resolveWhatsAppOutboundTarget } from "./runtime-api.js";
 import { sendMessageWhatsApp, sendPollWhatsApp } from "./send.js";
 
@@ -23,8 +24,13 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
   chunkerMode: "text",
   textChunkLimit: 4000,
   pollMaxOptions: 12,
-  resolveTarget: ({ to, allowFrom, mode }) =>
-    resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+  resolveTarget: ({ to, allowFrom, cfg, accountId, mode }) =>
+    resolveWhatsAppOutboundTarget({
+      to,
+      allowFrom,
+      allowOutboundTo: resolveAllowOutboundTo(cfg, accountId),
+      mode,
+    }),
   sendPayload: async (ctx) => {
     const text = trimLeadingWhitespace(ctx.payload.text);
     const hasMedia = resolveSendableOutboundReplyParts(ctx.payload).hasMedia;

--- a/extensions/whatsapp/src/resolve-allow-outbound.ts
+++ b/extensions/whatsapp/src/resolve-allow-outbound.ts
@@ -1,0 +1,32 @@
+import {
+  resolveMergedAccountConfig,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/account-resolution";
+import { resolveDefaultWhatsAppAccountId } from "./accounts.js";
+import type { WhatsAppAccountConfig } from "./runtime-api.js";
+
+/**
+ * Resolve the `allowOutboundTo` list from the WhatsApp channel config.
+ * This list permits outbound sends to targets that may not be in `allowFrom`,
+ * keeping inbound DM gating separate from outbound message permissions.
+ */
+export function resolveAllowOutboundTo(
+  cfg: OpenClawConfig | undefined,
+  accountId?: string | null,
+): string[] | undefined {
+  if (!cfg) {
+    return undefined;
+  }
+  const rootCfg = cfg.channels?.whatsapp;
+  if (!rootCfg) {
+    return undefined;
+  }
+  const effectiveAccountId = accountId?.trim() || resolveDefaultWhatsAppAccountId(cfg);
+  const merged = resolveMergedAccountConfig<WhatsAppAccountConfig>({
+    channelConfig: rootCfg as WhatsAppAccountConfig | undefined,
+    accounts: rootCfg?.accounts as Record<string, Partial<WhatsAppAccountConfig>> | undefined,
+    accountId: effectiveAccountId,
+    omitKeys: ["defaultAccount"],
+  });
+  return (merged as Record<string, unknown>).allowOutboundTo as string[] | undefined;
+}

--- a/extensions/whatsapp/src/resolve-outbound-target.test.ts
+++ b/extensions/whatsapp/src/resolve-outbound-target.test.ts
@@ -203,6 +203,72 @@ describe("resolveWhatsAppOutboundTarget", () => {
     });
   });
 
+  describe("allowOutboundTo list", () => {
+    it("allows message when target is in allowOutboundTo but not in allowFrom", () => {
+      // normalizeWhatsAppTarget calls: 1. allowFrom entry (SECONDARY), 2. allowOutboundTo entry (PRIMARY), 3. to (PRIMARY)
+      vi.mocked(normalize.normalizeWhatsAppTarget)
+        .mockReturnValueOnce(SECONDARY_TARGET) // allowFrom[0]
+        .mockReturnValueOnce(PRIMARY_TARGET) // allowOutboundTo[0]
+        .mockReturnValueOnce(PRIMARY_TARGET); // to
+      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
+
+      expectResolutionOk(
+        {
+          to: PRIMARY_TARGET,
+          allowFrom: [SECONDARY_TARGET],
+          allowOutboundTo: [PRIMARY_TARGET],
+          mode: "explicit",
+        },
+        PRIMARY_TARGET,
+      );
+    });
+
+    it("allows message when allowOutboundTo has wildcard", () => {
+      // normalizeWhatsAppTarget calls: 1. allowFrom entry (SECONDARY), 2. to (PRIMARY)
+      vi.mocked(normalize.normalizeWhatsAppTarget)
+        .mockReturnValueOnce(SECONDARY_TARGET) // allowFrom[0]
+        .mockReturnValueOnce(PRIMARY_TARGET); // to
+      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
+
+      expectResolutionOk(
+        {
+          to: PRIMARY_TARGET,
+          allowFrom: [SECONDARY_TARGET],
+          allowOutboundTo: ["*"],
+          mode: "explicit",
+        },
+        PRIMARY_TARGET,
+      );
+    });
+
+    it("still denies when target is in neither allowFrom nor allowOutboundTo", () => {
+      const THIRD_TARGET = "+15550001111";
+      // normalizeWhatsAppTarget calls: 1. allowFrom entry (SECONDARY), 2. allowOutboundTo entry (THIRD), 3. to (PRIMARY)
+      vi.mocked(normalize.normalizeWhatsAppTarget)
+        .mockReturnValueOnce(SECONDARY_TARGET) // allowFrom[0]
+        .mockReturnValueOnce(THIRD_TARGET) // allowOutboundTo[0]
+        .mockReturnValueOnce(PRIMARY_TARGET); // to
+      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
+
+      expectResolutionError({
+        to: PRIMARY_TARGET,
+        allowFrom: [SECONDARY_TARGET],
+        allowOutboundTo: [THIRD_TARGET],
+        mode: "explicit",
+      });
+    });
+
+    it("allowOutboundTo is optional and defaults to empty", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
+
+      expectResolutionError({
+        to: PRIMARY_TARGET,
+        allowFrom: [SECONDARY_TARGET],
+        mode: "explicit",
+      });
+    });
+  });
+
   describe("whitespace handling", () => {
     it("trims whitespace from to parameter", () => {
       mockNormalizedDirectMessage(PRIMARY_TARGET);

--- a/extensions/whatsapp/src/resolve-outbound-target.ts
+++ b/extensions/whatsapp/src/resolve-outbound-target.ts
@@ -8,6 +8,7 @@ export type WhatsAppOutboundTargetResolution =
 export function resolveWhatsAppOutboundTarget(params: {
   to: string | null | undefined;
   allowFrom: Array<string | number> | null | undefined;
+  allowOutboundTo?: Array<string | number> | null | undefined;
   mode: string | null | undefined;
 }): WhatsAppOutboundTargetResolution {
   const trimmed = params.to?.trim() ?? "";
@@ -16,6 +17,17 @@ export function resolveWhatsAppOutboundTarget(params: {
     .filter(Boolean);
   const hasWildcard = allowListRaw.includes("*");
   const allowList = allowListRaw
+    .filter((entry) => entry !== "*")
+    .map((entry) => normalizeWhatsAppTarget(entry))
+    .filter((entry): entry is string => Boolean(entry));
+
+  // Separate outbound allowlist: when configured, permits sending to targets
+  // that are not in allowFrom (e.g. proactive messages to third parties).
+  const outboundListRaw = (params.allowOutboundTo ?? [])
+    .map((entry) => String(entry).trim())
+    .filter(Boolean);
+  const hasOutboundWildcard = outboundListRaw.includes("*");
+  const outboundList = outboundListRaw
     .filter((entry) => entry !== "*")
     .map((entry) => normalizeWhatsAppTarget(entry))
     .filter((entry): entry is string => Boolean(entry));
@@ -31,10 +43,10 @@ export function resolveWhatsAppOutboundTarget(params: {
     if (isWhatsAppGroupJid(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }
-    if (hasWildcard || allowList.length === 0) {
+    if (hasWildcard || hasOutboundWildcard || allowList.length === 0) {
       return { ok: true, to: normalizedTo };
     }
-    if (allowList.includes(normalizedTo)) {
+    if (allowList.includes(normalizedTo) || outboundList.includes(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }
     return {

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -47,6 +47,8 @@ type WhatsAppSharedConfig = {
   selfChatMode?: boolean;
   /** Optional allowlist for WhatsApp direct chats (E.164). */
   allowFrom?: string[];
+  /** Optional allowlist for outbound message targets (E.164 or group JID). When set, outbound sends are allowed to these targets even if they are not in allowFrom. Use "*" to allow all outbound targets. */
+  allowOutboundTo?: string[];
   /** Default delivery target for CLI `--deliver` when no explicit `--reply-to` is provided (E.164 or group JID). */
   defaultTo?: string;
   /** Optional allowlist for WhatsApp group senders (E.164). */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -45,6 +45,7 @@ const WhatsAppSharedSchema = z.object({
   dmPolicy: DmPolicySchema.optional().default("pairing"),
   selfChatMode: z.boolean().optional(),
   allowFrom: z.array(z.string()).optional(),
+  allowOutboundTo: z.array(z.string()).optional(),
   defaultTo: z.string().optional(),
   groupAllowFrom: z.array(z.string()).optional(),
   groupPolicy: GroupPolicySchema.optional().default("allowlist"),


### PR DESCRIPTION
## Summary

Adds a new `allowOutboundTo` config field for WhatsApp channels that permits outbound sends to targets not in `allowFrom`. This separates inbound DM gating (who can message the bot) from outbound permissions (who the bot can message).

## Problem

Previously, the only way to send proactive messages to numbers not in `allowFrom` was to add them there, which also allowed those numbers to initiate conversations with the bot.

## Solution

New optional config field `channels.whatsapp.allowOutboundTo` (string array):
- Supports E.164 numbers and group JIDs
- Supports `*` wildcard for unrestricted outbound
- Works at account level (multi-account) via config merge
- No changes to inbound access control behavior

### Config example

```json
{
  "channels": {
    "whatsapp": {
      "dmPolicy": "allowlist",
      "allowFrom": ["+15551234567"],
      "allowOutboundTo": ["*"]
    }
  }
}
```

## Changes

- `src/config/types.whatsapp.ts`: Added `allowOutboundTo` to `WhatsAppSharedConfig`
- `src/config/zod-schema.providers-whatsapp.ts`: Added zod validation
- `extensions/whatsapp/src/accounts.ts`: Added to `ResolvedWhatsAppAccount`
- `extensions/whatsapp/src/resolve-allow-outbound.ts`: New helper to resolve config
- `extensions/whatsapp/src/resolve-outbound-target.ts`: Check outbound list in target resolution
- `extensions/whatsapp/src/channel.ts` + `outbound-adapter.ts`: Wire through resolveTarget
- `extensions/whatsapp/src/resolve-outbound-target.test.ts`: 4 new tests (25 total pass)

## Testing

- `pnpm build` ✅
- `pnpm check` (format, lint, type-check, boundary checks) ✅
- All 25 tests pass ✅
- Manually verified: outbound sends work with `allowOutboundTo: ["*"]` while `allowFrom` stays restricted