### PR TITLE
Tests: cover custom local auth marker handling

### DIFF
--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -5,7 +5,9 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import { withEnvAsync } from "../test-utils/env.js";
 import { ensureAuthProfileStore } from "./auth-profiles.js";
+import { CUSTOM_LOCAL_AUTH_MARKER } from "./model-auth-markers.js";
 import {
+  applyLocalNoAuthHeaderOverride,
   getApiKeyForModel,
   hasAvailableAuthForProvider,
   resolveApiKeyForProvider,
@@ -350,6 +352,51 @@ describe("getApiKeyForModel", () => {
       });
       expect(resolved.apiKey).toBe("gateway-test-key");
       expect(resolved.source).toContain("AI_GATEWAY_API_KEY");
+    });
+  });
+
+  it("synthesizes auth for custom local OpenAI-compatible providers without api keys", async () => {
+    const cfg = {
+      models: {
+        providers: {
+          localai: {
+            api: "openai-completions",
+            baseUrl: "http://127.0.0.1:8080/v1",
+            models: [{ id: "llama", name: "Llama" }],
+          },
+        },
+      },
+    } as const;
+
+    const resolved = await resolveApiKeyForProvider({
+      provider: "localai",
+      store: { version: 1, profiles: {} },
+      cfg: cfg as never,
+    });
+    expect(resolved.apiKey).toBe(CUSTOM_LOCAL_AUTH_MARKER);
+    expect(resolved.source).toContain("synthetic local key");
+  });
+
+  it("clears Authorization for synthetic local OpenAI-compatible auth", () => {
+    const model = {
+      id: "local-model",
+      provider: "localai",
+      api: "openai-completions",
+      headers: {
+        Authorization: "Bearer placeholder",
+        "x-test": "keep",
+      },
+    } as unknown as Model<Api>;
+
+    const patched = applyLocalNoAuthHeaderOverride(model, {
+      apiKey: CUSTOM_LOCAL_AUTH_MARKER,
+      source: "synthetic",
+      mode: "api-key",
+    });
+
+    expect(patched.headers).toMatchObject({
+      Authorization: null,
+      "x-test": "keep",
     });
   });
 


### PR DESCRIPTION
## Summary
- supersede #55278 with a fresh branch based directly on `upstream/main`
- add regression coverage for custom local OpenAI-compatible providers that rely on the synthetic `custom-local` auth marker
- verify that `applyLocalNoAuthHeaderOverride(...)` clears the Authorization header for those synthetic local-auth cases

## Why This PR Is Small
#55278 was opened from the wrong ancestry and pulled in unrelated fork history, which made it `DIRTY`/`CONFLICTING` despite the intended Lane 2 scope being much smaller.

After replaying that work onto a fresh `upstream/main`, current upstream already contained the gateway/ingress/runtime changes from the earlier subset. The remaining clean delta was the missing regression coverage in `src/agents/model-auth.profiles.test.ts`.

## Validation
- `OPENCLAW_TEST_PROFILE=low timeout 120s pnpm vitest run --maxWorkers=1 src/agents/model-auth.profiles.test.ts`
  - pass: `30/30`
- `pnpm build`
  - pass
  - local config warning remains:
    - `browser.profiles.chrome.driver` invalid value in `/home/spryguy/.openclaw/openclaw.json`
    - `gateway.providerConcurrency` unrecognized in `/home/spryguy/.openclaw/openclaw.json`

## Deferred
- The broader embedded runner context/lifecycle reconciliation remains in the approved Lane 2b plan.
- This replacement PR does not include the oversized `run/attempt.ts` or context-engine lifecycle work.
