### PR TITLE
fix: use active channel registry version for channel loader cache invalidation

### DIFF
--- a/src/channels/plugins/plugins-core.test.ts
+++ b/src/channels/plugins/plugins-core.test.ts
@@ -29,7 +29,11 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { LineProbeResult } from "../../plugin-sdk/line.js";
 import { clearPluginDiscoveryCache } from "../../plugins/discovery.js";
 import { clearPluginManifestRegistryCache } from "../../plugins/manifest-registry.js";
-import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  pinActivePluginChannelRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
   createMSTeamsTestPluginBase,
@@ -615,10 +619,12 @@ async function expectDirectoryIds(
 
 describe("channel plugin loader", () => {
   beforeEach(() => {
+    resetPluginRuntimeStateForTest();
     setActivePluginRegistry(emptyRegistry);
   });
 
   afterEach(() => {
+    resetPluginRuntimeStateForTest();
     setActivePluginRegistry(emptyRegistry);
     clearPluginDiscoveryCache();
     clearPluginManifestRegistryCache();
@@ -650,7 +656,34 @@ describe("channel plugin loader", () => {
     expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutboundV2);
   });
 
+  it("refreshes cached plugin values when the channel registry is re-pinned", async () => {
+    setActivePluginRegistry(registryWithMSTeams);
+    pinActivePluginChannelRegistry(registryWithMSTeams);
+    expect(await loadChannelPlugin("msteams")).toBe(msteamsPlugin);
+
+    setActivePluginRegistry(registryWithMSTeamsV2);
+    expect(await loadChannelPlugin("msteams")).toBe(msteamsPlugin);
+
+    pinActivePluginChannelRegistry(registryWithMSTeamsV2);
+    expect(await loadChannelPlugin("msteams")).toBe(msteamsPluginV2);
+  });
+
+  it("refreshes cached outbound values when the channel registry is re-pinned", async () => {
+    setActivePluginRegistry(registryWithMSTeams);
+    pinActivePluginChannelRegistry(registryWithMSTeams);
+    expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutbound);
+
+    setActivePluginRegistry(registryWithMSTeamsV2);
+    expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutbound);
+
+    pinActivePluginChannelRegistry(registryWithMSTeamsV2);
+    expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutboundV2);
+  });
+
   it("returns undefined when plugin has no outbound adapter", async () => {
+    setActivePluginRegistry(emptyRegistry);
+    expect(await loadChannelOutboundAdapter("msteams")).toBeUndefined();
+
     setActivePluginRegistry(registryWithMSTeamsNoOutbound);
     expect(await loadChannelOutboundAdapter("msteams")).toBeUndefined();
   });

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -1,5 +1,8 @@
-import type { PluginChannelRegistration, PluginRegistry } from "../../plugins/registry.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import type { PluginChannelRegistration } from "../../plugins/registry.js";
+import {
+  getActivePluginChannelRegistryVersion,
+  requireActivePluginChannelRegistry,
+} from "../../plugins/runtime.js";
 import type { ChannelId } from "./types.js";
 
 type ChannelRegistryValueResolver<TValue> = (
@@ -10,13 +13,14 @@ export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
 ): (id: ChannelId) => Promise<TValue | undefined> {
   const cache = new Map<ChannelId, TValue>();
-  let lastRegistry: PluginRegistry | null = null;
+  let lastRegistryVersion = -1;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
-    const registry = getActivePluginRegistry();
-    if (registry !== lastRegistry) {
+    const registry = requireActivePluginChannelRegistry();
+    const registryVersion = getActivePluginChannelRegistryVersion();
+    if (registryVersion !== lastRegistryVersion) {
       cache.clear();
-      lastRegistry = registry;
+      lastRegistryVersion = registryVersion;
     }
     const cached = cache.get(id);
     if (cached) {


### PR DESCRIPTION
Summary
use active channel registry version for channel loader cache invalidation

Problem
`loadChannelPlugin()` and `loadChannelOutboundAdapter()` currently cache against the generic active plugin registry object identity.

That can diverge from the channel plugin system’s actual source of truth when the active channel registry is pinned or re-pinned. In those cases, the loader can keep serving stale channel plugin or outbound adapter snapshots.

Root cause
`createChannelRegistryLoader()` in:

`src/channels/plugins/registry-loader.ts`

still uses the generic plugin registry path and object-reference comparison for cache invalidation.

But the main channel plugin lookup path already uses:
- `requireActivePluginChannelRegistry()`
- `getActivePluginChannelRegistryVersion()`

So the loader and the main channel lookup path are keyed off different registry-version sources.

What changed
- switch `createChannelRegistryLoader()` to read from the active channel registry path
- use active channel registry version for cache invalidation instead of generic plugin registry object identity
- add regression tests for channel plugin and outbound adapter reloads when the active channel registry is re-pinned
- tighten test isolation by resetting plugin runtime state in the relevant loader test block

Before / After
Before
- channel loader cache invalidation depended on generic plugin registry object identity
- pinned / re-pinned channel registry scenarios could diverge from the main channel lookup path
- loader calls could return stale channel plugin or outbound adapter snapshots

After
- channel loader cache invalidation follows the active channel registry version
- loader behavior matches the main channel plugin lookup path
- re-pinned channel registry snapshots correctly invalidate cached loader results

Scope boundary
This PR only fixes the registry version source mismatch in channel loader caching.

It does not:
- refactor the broader channel registry architecture
- change non-channel plugin loader behavior
- change channel plugin ordering or catalog behavior
- redesign caching beyond this specific invalidation source

Validation
- `pnpm vitest run src/channels/plugins/plugins-core.test.ts src/plugins/runtime.channel-pin.test.ts`
- verified new regression coverage for:
  - cached plugin values refreshing when the channel registry is re-pinned
  - cached outbound adapter values refreshing when the channel registry is re-pinned
- verified related runtime channel pin tests still pass

Not verified
I did not run a full end-to-end channel startup flow against live channel integrations in this environment.

User impact
Channel plugin loader calls are less likely to return stale plugin or outbound adapter snapshots after channel registry pinning or re-pinning.

Risks and mitigations
Risk: cache invalidation may happen more often than before
Mitigation: the new invalidation source matches the channel system’s existing source of truth, prioritizing correctness over stale cache reuse

Risk: the change could affect tests or flows that relied on stale cached values
Mitigation: regression tests now explicitly cover re-pin behavior, and the change is limited to the channel loader path

Compatibility / migration
backward compatible: yes
migration required: no

Failure recovery
revert the PR or restore the previous loader behavior if any unexpected cache invalidation regression appears
