### PR TITLE
fix(feishu): read full CardKit streaming card content via raw_card_content param

### DIFF
--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -129,6 +129,110 @@ describe("getMessageFeishu", () => {
     });
     expect(mockConvertMarkdownTables).toHaveBeenCalledWith("hello", "preserve");
     expect(result).toEqual({ messageId: "om_send", chatId: "oc_send" });
+
+  it("passes card_msg_content_type param to message.get", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_param",
+            chat_id: "oc_param",
+            msg_type: "text",
+            body: { content: JSON.stringify({ text: "hi" }) },
+          },
+        ],
+      },
+    });
+
+    await getMessageFeishu({ cfg: {} as ClawdbotConfig, messageId: "om_param" });
+
+    expect(mockClientGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { card_msg_content_type: "raw_card_content" },
+      }),
+    );
+  });
+
+  it("extracts content from CardKit json_card format (streaming card)", async () => {
+    const jsonCard = {
+      config: { summary: { content: "Summary text from streaming card" } },
+      body: {
+        elements: [
+          {
+            tag: "column_set",
+            columns: [
+              {
+                elements: [{ tag: "plain_text", property: { content: "Column text" } }],
+              },
+            ],
+          },
+          { tag: "markdown", content: "Body markdown" },
+        ],
+      },
+    };
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_jsoncard",
+            chat_id: "oc_jsoncard",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({ json_card: JSON.stringify(jsonCard) }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_jsoncard",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_jsoncard",
+        contentType: "interactive",
+        content: "Summary text from streaming card\nColumn text\nBody markdown",
+      }),
+    );
+  });
+
+  it("falls back to legacy elements when json_card parsing fails", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_fallback",
+            chat_id: "oc_fallback",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                json_card: "not valid json{{{",
+                elements: [{ tag: "markdown", content: "fallback content" }],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_fallback",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_fallback",
+        contentType: "interactive",
+        content: "fallback content",
+      }),
+    );
   });
 
   it("extracts text content from interactive card elements", async () => {

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -129,6 +129,7 @@ describe("getMessageFeishu", () => {
     });
     expect(mockConvertMarkdownTables).toHaveBeenCalledWith("hello", "preserve");
     expect(result).toEqual({ messageId: "om_send", chatId: "oc_send" });
+  });
 
   it("passes card_msg_content_type param to message.get", async () => {
     mockClientGet.mockResolvedValueOnce({

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -185,7 +185,9 @@ async function sendReplyOrFallbackDirect(
 function extractJsonCardTexts(elements: unknown[]): string[] {
   const texts: string[] = [];
   for (const el of elements) {
-    if (!el || typeof el !== "object") { continue; }
+    if (!el || typeof el !== "object") {
+      continue;
+    }
     const node = el as {
       tag?: string;
       property?: { content?: string };
@@ -241,7 +243,7 @@ function parseInteractiveCardContent(parsed: unknown): string {
 
       // Also extract text from body elements (schema 2.0: body.elements)
       if (Array.isArray(jsonCard.body?.elements)) {
-        parts.push(...extractJsonCardTexts(jsonCard.body!.elements));
+        parts.push(...extractJsonCardTexts(jsonCard.body.elements));
       }
       // Schema 1.0: top-level elements
       if (Array.isArray(jsonCard.elements)) {
@@ -249,7 +251,9 @@ function parseInteractiveCardContent(parsed: unknown): string {
       }
 
       const result = parts.join("\n").trim();
-      if (result) { return result; }
+      if (result) {
+        return result;
+      }
     } catch {
       // Fall through to legacy element parsing
     }

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -179,9 +179,76 @@ async function sendReplyOrFallbackDirect(
   return toFeishuSendResult(response, params.directParams.receiveId);
 }
 
+/**
+ * Recursively extract plain_text content from CardKit json_card body elements.
+ */
+function extractJsonCardTexts(elements: unknown[]): string[] {
+  const texts: string[] = [];
+  for (const el of elements) {
+    if (!el || typeof el !== "object") continue;
+    const node = el as {
+      tag?: string;
+      property?: { content?: string };
+      elements?: unknown[];
+      columns?: unknown[];
+      rows?: unknown[];
+    };
+    if (node.tag === "plain_text" && typeof node.property?.content === "string") {
+      texts.push(node.property.content);
+    }
+    if (node.tag === "markdown" && typeof (node as { content?: string }).content === "string") {
+      texts.push((node as { content?: string }).content!);
+    }
+    // Recurse into nested structures (column_set columns, form elements, etc.)
+    if (Array.isArray(node.elements)) {
+      texts.push(...extractJsonCardTexts(node.elements));
+    }
+    if (Array.isArray(node.columns)) {
+      for (const col of node.columns) {
+        if (
+          col &&
+          typeof col === "object" &&
+          Array.isArray((col as { elements?: unknown[] }).elements)
+        ) {
+          texts.push(...extractJsonCardTexts((col as { elements: unknown[] }).elements));
+        }
+      }
+    }
+  }
+  return texts;
+}
+
 function parseInteractiveCardContent(parsed: unknown): string {
   if (!parsed || typeof parsed !== "object") {
     return "[Interactive Card]";
+  }
+
+  // CardKit streaming cards: the raw_card_content param returns a `json_card` field
+  // containing the full card structure as a JSON string.
+  const jsonCardStr = (parsed as { json_card?: unknown }).json_card;
+  if (typeof jsonCardStr === "string") {
+    try {
+      const jsonCard = JSON.parse(jsonCardStr) as {
+        config?: { summary?: { content?: string } };
+        body?: { elements?: unknown[] };
+      };
+      const parts: string[] = [];
+
+      // summary.content is the streaming card's summary (often the full reply text prefix)
+      if (typeof jsonCard.config?.summary?.content === "string") {
+        parts.push(jsonCard.config.summary.content);
+      }
+
+      // Also extract text from body elements
+      if (Array.isArray(jsonCard.body?.elements)) {
+        parts.push(...extractJsonCardTexts(jsonCard.body!.elements));
+      }
+
+      const result = parts.join("\n").trim();
+      if (result) return result;
+    } catch {
+      // Fall through to legacy element parsing
+    }
   }
 
   // Support both schema 1.0 (top-level `elements`) and 2.0 (`body.elements`).
@@ -301,6 +368,9 @@ export async function getMessageFeishu(params: {
   try {
     const response = (await client.im.message.get({
       path: { message_id: messageId },
+      // Undocumented in the SDK types but supported by the API: when set, interactive
+      // messages return the full json_card structure instead of fallback screenshot content.
+      params: { card_msg_content_type: "raw_card_content" } as Record<string, string>,
     })) as FeishuGetMessageResponse;
 
     if (response.code !== 0) {
@@ -355,15 +425,19 @@ export async function listFeishuThreadMessages(params: {
 
   const client = createFeishuClient(account);
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- card_msg_content_type is not in the SDK types yet
+  const listParams: any = {
+    container_id_type: "thread",
+    container_id: threadId,
+    // Fetch newest messages first so long threads keep the most recent turns.
+    // Results are reversed below to restore chronological order.
+    sort_type: "ByCreateTimeDesc",
+    page_size: Math.min(limit + 1, 50),
+    // See comment in getMessageFeishu – retrieve full card content.
+    card_msg_content_type: "raw_card_content",
+  };
   const response = (await client.im.message.list({
-    params: {
-      container_id_type: "thread",
-      container_id: threadId,
-      // Fetch newest messages first so long threads keep the most recent turns.
-      // Results are reversed below to restore chronological order.
-      sort_type: "ByCreateTimeDesc",
-      page_size: Math.min(limit + 1, 50),
-    },
+    params: listParams,
   })) as {
     code?: number;
     msg?: string;

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -185,7 +185,7 @@ async function sendReplyOrFallbackDirect(
 function extractJsonCardTexts(elements: unknown[]): string[] {
   const texts: string[] = [];
   for (const el of elements) {
-    if (!el || typeof el !== "object") continue;
+    if (!el || typeof el !== "object") { continue; }
     const node = el as {
       tag?: string;
       property?: { content?: string };
@@ -249,7 +249,7 @@ function parseInteractiveCardContent(parsed: unknown): string {
       }
 
       const result = parts.join("\n").trim();
-      if (result) return result;
+      if (result) { return result; }
     } catch {
       // Fall through to legacy element parsing
     }

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -191,7 +191,6 @@ function extractJsonCardTexts(elements: unknown[]): string[] {
       property?: { content?: string };
       elements?: unknown[];
       columns?: unknown[];
-      rows?: unknown[];
     };
     if (node.tag === "plain_text" && typeof node.property?.content === "string") {
       texts.push(node.property.content);
@@ -425,19 +424,18 @@ export async function listFeishuThreadMessages(params: {
 
   const client = createFeishuClient(account);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- card_msg_content_type is not in the SDK types yet
-  const listParams: any = {
-    container_id_type: "thread",
+  const listParams = {
+    container_id_type: "thread" as const,
     container_id: threadId,
     // Fetch newest messages first so long threads keep the most recent turns.
     // Results are reversed below to restore chronological order.
-    sort_type: "ByCreateTimeDesc",
+    sort_type: "ByCreateTimeDesc" as const,
     page_size: Math.min(limit + 1, 50),
     // See comment in getMessageFeishu – retrieve full card content.
     card_msg_content_type: "raw_card_content",
   };
   const response = (await client.im.message.list({
-    params: listParams,
+    params: listParams as typeof listParams & { card_msg_content_type?: string },
   })) as {
     code?: number;
     msg?: string;

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -230,6 +230,7 @@ function parseInteractiveCardContent(parsed: unknown): string {
       const jsonCard = JSON.parse(jsonCardStr) as {
         config?: { summary?: { content?: string } };
         body?: { elements?: unknown[] };
+        elements?: unknown[];
       };
       const parts: string[] = [];
 
@@ -238,9 +239,13 @@ function parseInteractiveCardContent(parsed: unknown): string {
         parts.push(jsonCard.config.summary.content);
       }
 
-      // Also extract text from body elements
+      // Also extract text from body elements (schema 2.0: body.elements)
       if (Array.isArray(jsonCard.body?.elements)) {
         parts.push(...extractJsonCardTexts(jsonCard.body!.elements));
+      }
+      // Schema 1.0: top-level elements
+      if (Array.isArray(jsonCard.elements)) {
+        parts.push(...extractJsonCardTexts(jsonCard.elements));
       }
 
       const result = parts.join("\n").trim();


### PR DESCRIPTION
## Problem

When reading messages that were sent as CardKit streaming cards (created via `POST /cardkit/v1/cards`), the IM API (`GET /im/v1/messages/{message_id}`) returns fallback content (a screenshot image + placeholder text like `[Interactive Card]`) instead of the actual card text content. This makes it impossible to retrieve the full text of bot replies that use streaming cards.

## Root Cause

CardKit streaming cards are referenced by `card_id` in the message body (`{"type":"card","data":{"card_id":"xxx"}}`). The CardKit API only provides write endpoints — there is no read API to fetch card content by `card_id`. However, the IM message read API supports an undocumented query parameter `card_msg_content_type=raw_card_content` that instructs the API to inline the full card structure as a `json_card` field in the response content.

## Fix

### 1. Pass `card_msg_content_type` parameter

Add `card_msg_content_type: "raw_card_content"` to both:
- `client.im.message.get()` — used by `getMessageFeishu()` for single message reads
- `client.im.message.list()` — used by `listFeishuThreadMessages()` for thread history

### 2. Parse `json_card` format in `parseInteractiveCardContent`

Before the existing element-based parsing, check for the `json_card` field (a JSON string) and extract text from:
- `config.summary.content` — the card summary (streaming cards write the full reply text here)
- `body.elements` — recursively extract `plain_text` and `markdown` nodes, including nested structures like `column_set`

Falls through to the existing `elements` / `body.elements` parsing if `json_card` is absent or unparseable.

### 3. Tests

Added 3 new test cases:
- Verifies `card_msg_content_type` param is passed to `message.get`
- Verifies `json_card` format is correctly parsed (summary + nested body elements)
- Verifies fallback to legacy elements when `json_card` contains invalid JSON

## Related Issues

- Relates to #54972 (CardKit streaming card content not readable)
- Relates to #48281 (Interactive card message parsing)
- Relates to #32930 (Message content retrieval improvements)

## References

- The official Lark plugin ([larksuite/openclaw-lark](https://github.com/nicepkg/openclaw-lark)) uses the same `card_msg_content_type=raw_card_content` parameter in its `fetchCardContent` function (`src/messaging/inbound/parse-io.ts`).