### PR TITLE
fix: auto-retry GatewayDrainingError instead of surfacing to user (#55412)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -178,6 +178,7 @@ export async function runAgentTurnWithFallback(params: {
   let fallbackAttempts: RuntimeFallbackAttempt[] = [];
   let didResetAfterCompactionFailure = false;
   let didRetryTransientHttpError = false;
+  let didRetryGatewayDrainingError = false;
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.getActiveSessionEntry()?.systemPromptReport,
   );
@@ -693,6 +694,24 @@ export async function runAgentTurnWithFallback(params: {
         );
         await new Promise<void>((resolve) => {
           setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
+        });
+        continue;
+      }
+
+      // Auto-retry on GatewayDrainingError — this is always transient
+      // (gateway is restarting and will be back in seconds). (#55412)
+      const isGatewayDraining =
+        !didRetryGatewayDrainingError &&
+        (message.includes("Gateway is draining") ||
+          (err instanceof Error && err.name === "GatewayDrainingError"));
+      if (isGatewayDraining) {
+        didRetryGatewayDrainingError = true;
+        const GATEWAY_DRAINING_RETRY_DELAY_MS = 15_000;
+        defaultRuntime.error(
+          `Gateway draining during agent run. Waiting ${GATEWAY_DRAINING_RETRY_DELAY_MS}ms for restart, then retrying.`,
+        );
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, GATEWAY_DRAINING_RETRY_DELAY_MS);
         });
         continue;
       }


### PR DESCRIPTION
## Summary

When the gateway restarts (e.g., after `config.patch`), in-flight agent runs that trigger new commands during the drain window get `GatewayDrainingError`. This falls through to the generic error handler and surfaces to users as:

```
⚠️ Agent failed before reply: Gateway is draining for restart; new tasks are not accepted.
Logs: openclaw logs --follow
```

This is a **transient error** — the gateway comes back up seconds later. But the user sees an error and thinks something is broken.

## Fix

Adds a check for `GatewayDrainingError` before the generic error handler in the agent-runner error handling chain. When detected:
1. Wait 15 seconds for the gateway restart to complete
2. Retry the run (same pattern as existing transient HTTP error handling)

The check matches both the error message string (`Gateway is draining`) and the error class name (`GatewayDrainingError`), using a `didRetryGatewayDrainingError` flag to prevent infinite retry loops.

## Why 15 seconds?

Gateway restarts typically complete within 5-10 seconds, but the delay accounts for slower systems. The existing transient HTTP retry uses 2.5 seconds since those are usually immediate provider hiccups. Gateway restarts need more time for the process to fully stop and restart.

Fixes #55412