### PR TITLE
fix: initialize globalVersion to 1 so skills snapshot refreshes after gateway restart

### DIFF
--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -24,7 +24,12 @@ const log = createSubsystemLogger("gateway/skills");
 const listeners = new Set<(event: SkillsChangeEvent) => void>();
 const workspaceVersions = new Map<string, number>();
 const watchers = new Map<string, SkillsWatchState>();
-let globalVersion = 0;
+// Start at 1 so that sessions persisted with version 0 (the default) are
+// always refreshed on the first turn after a gateway restart.  Without this,
+// a restart resets the in-memory counter to 0 and the comparison
+// `snapshotVersion > 0 && stored < snapshotVersion` is always false, leaving
+// long-lived sessions stuck with a stale skills snapshot indefinitely.
+let globalVersion = 1;
 
 export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.git([\\/]|$)/,


### PR DESCRIPTION
## Problem

Long-lived sessions store a `skillsSnapshot` with `version: 0`. After a gateway restart, the in-memory `globalVersion` resets to `0`, so the refresh check:

```typescript
const shouldRefreshSnapshot = snapshotVersion > 0 
    && (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion;
```

always evaluates to `false` (`0 > 0` is false). The snapshot is never rebuilt, and skills that were added, renamed, or deleted between restarts remain stale in the agent prompt indefinitely.

## Fix

Initialize `globalVersion` to `1` instead of `0` in `src/agents/skills/refresh.ts`.

This ensures that after any gateway restart, sessions with the default version (`0`) trigger `shouldRefreshSnapshot = true` on their first turn, causing a single `buildWorkspaceSkillSnapshot()` call that picks up the current state of skills on disk.

## Verified

Reproduced and fixed on a live system:

**Before fix:** Main Telegram session showed `amazon-shop` and `walmart-shop` (deleted days ago), missing `online-shop` (the replacement). Multiple gateway restarts did not help. Snapshot version stuck at 0.

**After fix:** Gateway restart → main session rebuilt snapshot on first turn → all stale entries removed, all current entries present, version bumped to 1.

## Side effects

The only change: every session rebuilds its skill snapshot **once** on the first turn after each gateway restart (stored version 0 < globalVersion 1). This is:

- **Cheap**: `buildWorkspaceSkillSnapshot` reads SKILL.md frontmatter from ~20 files
- **Once per session per restart**, not every turn (subsequent turns see version 1 = 1, no refresh)
- **No impact on watcher**: `bumpVersion` still returns `Date.now()` since `Date.now() > 1`
- **No race conditions**: `updateSessionStore` uses async lock

Fixes #55489