### PR TITLE
fix(threading): populate currentThreadTs in buildToolContext fallback

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -175,7 +175,7 @@ describe("agent-runner-utils", () => {
     expect(resolved.embeddedContext.messageTo).toBe("268300329");
   });
 
-  it("uses OriginatingTo for telegram native command tool context without implicit thread state", () => {
+  it("uses OriginatingTo for telegram native command tool context with thread state from MessageThreadId", () => {
     const context = buildThreadingToolContext({
       sessionCtx: {
         Provider: "telegram",
@@ -193,7 +193,7 @@ describe("agent-runner-utils", () => {
       currentChannelId: "telegram:-1003841603622",
       currentMessageId: "2284",
     });
-    expect(context.currentThreadTs).toBeUndefined();
+    expect(context.currentThreadTs).toBe("928");
   });
 
   it("uses OriginatingTo for threading tool context on discord native commands", () => {

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -51,6 +51,7 @@ export function buildThreadingToolContext(params: {
     return {
       currentChannelId: originTo?.trim() || undefined,
       currentChannelProvider: provider ?? (rawProvider as ChannelId),
+      currentThreadTs: sessionCtx.MessageThreadId != null ? String(sessionCtx.MessageThreadId) : undefined,
       currentMessageId,
       hasRepliedRef,
     };


### PR DESCRIPTION
## Summary

Channels without a custom `buildToolContext` on their threading adapter (e.g. Telegram) hit the fallback path in `buildThreadingToolContext()`, which returned context **without `currentThreadTs`**. This caused `resolveAutoThreadId()` to always return `undefined` for these channels, so media/file sends via the message tool lost their thread context.

**Result:** Files sent via the message tool in Telegram forum topics went to user DMs instead of staying in the topic.

## Root Cause

In `src/auto-reply/reply/agent-runner-utils.ts`, the fallback for channels without `buildToolContext`:

```typescript
if (!threading?.buildToolContext) {
    return {
      currentChannelId: originTo?.trim() || undefined,
      currentChannelProvider: provider ?? (rawProvider as ChannelId),
      currentMessageId,
      hasRepliedRef,
      // currentThreadTs was MISSING
    };
}
```

Text replies work because they use `routeThreadId` from `ctx.MessageThreadId` directly in the delivery path, bypassing the tool context chain. The message tool path depends on `currentThreadTs` being set in the tool context.

## Fix

Add `currentThreadTs: sessionCtx.MessageThreadId != null ? String(sessionCtx.MessageThreadId) : undefined` to the fallback return.

This makes thread-aware routing work for **all channels** by default — not just those with custom `buildToolContext` implementations. Channels that already have `buildToolContext` (Slack, Matrix, MSTeams, BlueBubbles) are completely unaffected.

## Which channels benefit

| Channel | Has buildToolContext | Fixed by this PR |
|---------|---------------------|-----------------|
| Telegram | ❌ No | ✅ Yes |
| Discord | ❌ No | ✅ Yes |
| Any future plugin | ❌ No | ✅ Yes |
| Slack | ✅ Yes | Unaffected |
| Matrix | ✅ Yes | Unaffected |
| MSTeams | ✅ Yes | Unaffected |
| BlueBubbles | ✅ Yes | Unaffected |

## Risk

Low — this is an additive change that populates a field that was previously `undefined`. No protocol or behavioral changes for channels with custom `buildToolContext`.

Fixes #52286
Related: #38409, #31368