### PR TITLE
feat(docker): add OPENCLAW_SKIP_ONBOARDING env to skip onboarding during Docker setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Channels: add Yuanbao channel docs entrance so the Tencent Yuanbao bot appears in the channel listing and sidebar navigation. (#73443) Thanks @loongfay.
 - Active Memory: add optional per-conversation `allowedChatIds` and `deniedChatIds` filters so operators can enable recall only for selected direct, group, or channel conversations while keeping broad sessions skipped. (#67977) Thanks @quengh.
 - Active Memory: return bounded partial recall summaries when the hidden memory sub-agent times out, including the default temporary-transcript path, so useful recovered context is not discarded. (#73219) Thanks @joeykrug.
+- Docker setup: add `OPENCLAW_SKIP_ONBOARDING` so automated Docker installs can skip the interactive onboarding step while still applying gateway defaults. (#55518) Thanks @jinjimz.
 
 ### Fixes
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -131,6 +131,7 @@ The setup script accepts these optional environment variables:
 | `OPENCLAW_HOME_VOLUME`                     | Persist `/home/node` in a named Docker volume                   |
 | `OPENCLAW_PLUGIN_STAGE_DIR`                | Container path for generated bundled plugin deps and mirrors    |
 | `OPENCLAW_SANDBOX`                         | Opt in to sandbox bootstrap (`1`, `true`, `yes`, `on`)          |
+| `OPENCLAW_SKIP_ONBOARDING`                 | Skip the interactive onboarding step (`1`, `true`, `yes`, `on`) |
 | `OPENCLAW_DOCKER_SOCKET`                   | Override Docker socket path                                     |
 | `OPENCLAW_DISABLE_BONJOUR`                 | Disable Bonjour/mDNS advertising (defaults to `1` for Docker)   |
 | `OPENCLAW_DISABLE_BUNDLED_SOURCE_OVERLAYS` | Disable bundled plugin source bind-mount overlays               |

--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -12,6 +12,8 @@ RAW_SANDBOX_SETTING="${OPENCLAW_SANDBOX:-}"
 SANDBOX_ENABLED=""
 DOCKER_SOCKET_PATH="${OPENCLAW_DOCKER_SOCKET:-}"
 TIMEZONE="${OPENCLAW_TZ:-}"
+RAW_SKIP_ONBOARDING="${OPENCLAW_SKIP_ONBOARDING:-}"
+SKIP_ONBOARDING=""
 
 fail() {
   echo "ERROR: $*" >&2
@@ -232,6 +234,9 @@ fi
 if is_truthy_value "$RAW_SANDBOX_SETTING"; then
   SANDBOX_ENABLED="1"
 fi
+if is_truthy_value "$RAW_SKIP_ONBOARDING"; then
+  SKIP_ONBOARDING="1"
+fi
 
 OPENCLAW_CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$HOME/.openclaw}"
 OPENCLAW_WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
@@ -295,6 +300,7 @@ export OTEL_EXPORTER_OTLP_PROTOCOL="${OTEL_EXPORTER_OTLP_PROTOCOL:-}"
 export OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-}"
 export OTEL_SEMCONV_STABILITY_OPT_IN="${OTEL_SEMCONV_STABILITY_OPT_IN:-}"
 export OPENCLAW_OTEL_PRELOADED="${OPENCLAW_OTEL_PRELOADED:-}"
+export OPENCLAW_SKIP_ONBOARDING="$SKIP_ONBOARDING"
 
 # Detect Docker socket GID for sandbox group_add.
 DOCKER_GID=""
@@ -489,7 +495,8 @@ upsert_env "$ENV_FILE" \
   OTEL_EXPORTER_OTLP_PROTOCOL \
   OTEL_SERVICE_NAME \
   OTEL_SEMCONV_STABILITY_OPT_IN \
-  OPENCLAW_OTEL_PRELOADED
+  OPENCLAW_OTEL_PRELOADED \
+  OPENCLAW_SKIP_ONBOARDING
 
 if [[ "$IMAGE_NAME" == "openclaw:local" ]]; then
   echo "==> Building Docker image: $IMAGE_NAME"
@@ -525,22 +532,26 @@ run_prestart_gateway --user root --entrypoint sh openclaw-gateway -c \
    [ -d /home/node/.openclaw/workspace/.openclaw ] && chown -R node:node /home/node/.openclaw/workspace/.openclaw || true'
 
 echo ""
-echo "==> Onboarding (interactive)"
-echo "Docker setup pins Gateway mode to local."
-echo "Gateway runtime bind comes from OPENCLAW_GATEWAY_BIND (default: lan)."
-echo "Current runtime bind: $OPENCLAW_GATEWAY_BIND"
-if is_truthy_value "$OPENCLAW_DISABLE_BONJOUR"; then
-  echo "Bonjour/mDNS advertising: force disabled (OPENCLAW_DISABLE_BONJOUR=$OPENCLAW_DISABLE_BONJOUR)."
-elif [[ -z "$OPENCLAW_DISABLE_BONJOUR" ]]; then
-  echo "Bonjour/mDNS advertising: auto (disabled inside the Gateway container unless explicitly enabled)."
+if [[ -n "$SKIP_ONBOARDING" ]]; then
+  echo "==> Skipping onboarding (OPENCLAW_SKIP_ONBOARDING is set)"
 else
-  echo "Bonjour/mDNS advertising: explicitly enabled (OPENCLAW_DISABLE_BONJOUR=$OPENCLAW_DISABLE_BONJOUR)."
+  echo "==> Onboarding (interactive)"
+  echo "Docker setup pins Gateway mode to local."
+  echo "Gateway runtime bind comes from OPENCLAW_GATEWAY_BIND (default: lan)."
+  echo "Current runtime bind: $OPENCLAW_GATEWAY_BIND"
+  if is_truthy_value "$OPENCLAW_DISABLE_BONJOUR"; then
+    echo "Bonjour/mDNS advertising: force disabled (OPENCLAW_DISABLE_BONJOUR=$OPENCLAW_DISABLE_BONJOUR)."
+  elif [[ -z "$OPENCLAW_DISABLE_BONJOUR" ]]; then
+    echo "Bonjour/mDNS advertising: auto (disabled inside the Gateway container unless explicitly enabled)."
+  else
+    echo "Bonjour/mDNS advertising: explicitly enabled (OPENCLAW_DISABLE_BONJOUR=$OPENCLAW_DISABLE_BONJOUR)."
+  fi
+  echo "Gateway token: $OPENCLAW_GATEWAY_TOKEN"
+  echo "Tailscale exposure: Off (use host-level tailnet/Tailscale setup separately)."
+  echo "Install Gateway daemon: No (managed by Docker Compose)"
+  echo ""
+  run_prestart_cli onboard --mode local --no-install-daemon
 fi
-echo "Gateway token: $OPENCLAW_GATEWAY_TOKEN"
-echo "Tailscale exposure: Off (use host-level tailnet/Tailscale setup separately)."
-echo "Install Gateway daemon: No (managed by Docker Compose)"
-echo ""
-run_prestart_cli onboard --mode local --no-install-daemon
 
 echo ""
 echo "==> Docker gateway defaults"

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -520,6 +520,39 @@ describe("scripts/docker/setup.sh", () => {
     expect(result.stderr).toContain("OPENCLAW_TZ must match a timezone in /usr/share/zoneinfo");
   });
 
+  it("skips onboarding when OPENCLAW_SKIP_ONBOARDING is set", async () => {
+    const activeSandbox = requireSandbox(sandbox);
+    await resetDockerLog(activeSandbox);
+
+    const result = runDockerSetup(activeSandbox, {
+      OPENCLAW_SKIP_ONBOARDING: "1",
+    });
+
+    expect(result.status).toBe(0);
+    const log = await readDockerLog(activeSandbox);
+    expect(log).not.toContain("onboard");
+    // Gateway defaults (config set) and control UI allowlist should still run.
+    expect(log).toContain("config set gateway.mode local");
+    expect(log).toContain("config set gateway.bind lan");
+    const envFile = await readFile(join(activeSandbox.rootDir, ".env"), "utf8");
+    expect(envFile).toContain("OPENCLAW_SKIP_ONBOARDING=1");
+  });
+
+  it("treats OPENCLAW_SKIP_ONBOARDING=0 as disabled and runs onboarding", async () => {
+    const activeSandbox = requireSandbox(sandbox);
+    await resetDockerLog(activeSandbox);
+
+    const result = runDockerSetup(activeSandbox, {
+      OPENCLAW_SKIP_ONBOARDING: "0",
+    });
+
+    expect(result.status).toBe(0);
+    const log = await readDockerLog(activeSandbox);
+    expect(log).toContain("onboard --mode local --no-install-daemon");
+    const envFile = await readFile(join(activeSandbox.rootDir, ".env"), "utf8");
+    expect(envFile).toContain("OPENCLAW_SKIP_ONBOARDING=");
+  });
+
   it("avoids associative arrays so the script remains Bash 3.2-compatible", async () => {
     const script = await readFile(join(repoRoot, "scripts", "docker", "setup.sh"), "utf8");
     expect(script).not.toMatch(/^\s*declare -A\b/m);

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -550,7 +550,7 @@ describe("scripts/docker/setup.sh", () => {
     const log = await readDockerLog(activeSandbox);
     expect(log).toContain("onboard --mode local --no-install-daemon");
     const envFile = await readFile(join(activeSandbox.rootDir, ".env"), "utf8");
-    expect(envFile).toContain("OPENCLAW_SKIP_ONBOARDING=");
+    expect(envFile).toMatch(/OPENCLAW_SKIP_ONBOARDING=\n/);
   });
 
   it("avoids associative arrays so the script remains Bash 3.2-compatible", async () => {

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -532,8 +532,9 @@ describe("scripts/docker/setup.sh", () => {
     const log = await readDockerLog(activeSandbox);
     expect(log).not.toContain("onboard");
     // Gateway defaults (config set) and control UI allowlist should still run.
-    expect(log).toContain("config set gateway.mode local");
-    expect(log).toContain("config set gateway.bind lan");
+    expect(log).toContain("config set --batch-json");
+    expect(log).toContain('"path":"gateway.mode","value":"local"');
+    expect(log).toContain('"path":"gateway.bind","value":"lan"');
     const envFile = await readFile(join(activeSandbox.rootDir, ".env"), "utf8");
     expect(envFile).toContain("OPENCLAW_SKIP_ONBOARDING=1");
   });


### PR DESCRIPTION
Add support for OPENCLAW_SKIP_ONBOARDING environment variable in Docker setup script. When set to a truthy value (1, true, yes), the interactive onboarding step is skipped during container setup. Gateway defaults and control UI allowlist still run as usual.

This is useful for automated/CI deployments where interactive onboarding is not needed.

Includes e2e tests for both enabled and disabled cases.

## Summary

- **Problem:** Docker setup script always runs interactive onboarding (`openclaw onboard`), which blocks automated/CI deployments that don't need or can't handle interactive prompts.
- **Why it matters:** Users running Docker setup in headless/CI environments have no way to skip the onboarding step, causing the setup to hang or require manual intervention.
- **What changed:** Added `OPENCLAW_SKIP_ONBOARDING` environment variable support. When set to a truthy value (`1`, `true`, `yes`), the onboarding step is skipped. The variable is normalized via the existing `is_truthy_value` helper, exported, and persisted to `.env`. Added two e2e tests covering enabled and disabled cases.
- **What did NOT change (scope boundary):** Gateway defaults (`config set gateway.mode`, `config set gateway.bind`) and control UI allowlist setup still run regardless of this flag. No changes to the onboarding command itself.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- N/A
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/docker-setup.e2e.test.ts`
- **Scenario the test should lock in:**
  1. `OPENCLAW_SKIP_ONBOARDING=1` → onboarding is skipped, `onboard` does not appear in log, `.env` contains `OPENCLAW_SKIP_ONBOARDING=1`, gateway config commands still run.
  2. `OPENCLAW_SKIP_ONBOARDING=0` → onboarding runs normally, `onboard --mode local --no-install-daemon` appears in log.
- **Why this is the smallest reliable guardrail:** The Docker setup script is only exercised via the e2e sandbox harness; unit tests cannot cover the shell script behavior.
- **Existing test that already covers this (if any):** None — this is a new feature.

## User-visible / Behavior Changes

- New environment variable `OPENCLAW_SKIP_ONBOARDING`. When set to a truthy value, Docker setup skips the interactive onboarding step and prints `==> Skipping onboarding (OPENCLAW_SKIP_ONBOARDING is set)` instead.
- Default behavior (variable unset or falsy) is unchanged — onboarding runs as before.

## Diagram (if applicable)

```text
Before:
docker setup -> ... -> onboard --mode local --no-install-daemon (always)

After:
docker setup -> ... -> OPENCLAW_SKIP_ONBOARDING set?
                         ├─ yes -> "Skipping onboarding" (skip)
                         └─ no  -> onboard --mode local --no-install-daemon (unchanged)
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin)
- Runtime/container: Docker
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: `OPENCLAW_SKIP_ONBOARDING=1`

### Steps

1. Set `OPENCLAW_SKIP_ONBOARDING=1` in your environment
2. Run `./docker-setup.sh` (or `scripts/docker/setup.sh`)
3. Observe that onboarding is skipped

### Expected

- Console prints `==> Skipping onboarding (OPENCLAW_SKIP_ONBOARDING is set)` and proceeds directly to gateway defaults.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Two new e2e tests added and passing in `src/docker-setup.e2e.test.ts`.

## Human Verification (required)

- **Verified scenarios:** `OPENCLAW_SKIP_ONBOARDING=1` skips onboarding; unset/`0` runs onboarding as before.
- **Edge cases checked:** Falsy values (`0`, `false`, `no`, empty string) all correctly fall through to onboarding.
- **What you did not verify:** Full Docker image build + runtime with a real container (verified via e2e sandbox harness only).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — default behavior is unchanged when variable is unset.
- Config/env changes? `Yes` — new optional env var `OPENCLAW_SKIP_ONBOARDING`.
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** Users who set `OPENCLAW_SKIP_ONBOARDING=1` on first-ever setup may miss required onboarding configuration.
  - **Mitigation:** Gateway defaults (`gateway.mode`, `gateway.bind`) and control UI allowlist are applied regardless of this flag, so core configuration is still set. Only the interactive `openclaw onboard` wizard is skipped.
