### PR TITLE
feishu: stop contributing top-level card schema to shared message tool

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -135,13 +135,7 @@ function describeFeishuMessageTool({
     return {
       actions: [],
       capabilities: enabled ? ["cards"] : [],
-      schema: enabled
-        ? {
-            properties: {
-              card: createMessageToolCardSchema(),
-            },
-          }
-        : null,
+      schema: null,
     };
   }
   const actions = new Set<ChannelMessageActionName>([
@@ -163,13 +157,7 @@ function describeFeishuMessageTool({
   return {
     actions: Array.from(actions),
     capabilities: enabled ? ["cards"] : [],
-    schema: enabled
-      ? {
-          properties: {
-            card: createMessageToolCardSchema(),
-          },
-        }
-      : null,
+    schema: null,
   };
 }
 

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
-import { __setModelCatalogImportForTest, loadModelCatalog } from "./model-catalog.js";
+import { __setModelCatalogImportForTest, __testing as modelCatalogTesting, loadModelCatalog } from "./model-catalog.js";
 import {
   installModelCatalogTestHooks,
   mockCatalogImportFailThenRecover,
@@ -351,5 +351,43 @@ describe("loadModelCatalog", () => {
     );
     expect(matches).toHaveLength(1);
     expect(matches[0]?.name).toBe("Kilo Auto");
+  });
+  it("overrides existing rightcode catalog input capability from configured model input", () => {
+    const models = [
+      {
+        id: "rightcode/v1",
+        provider: "rightcode",
+        name: "RightCode V1",
+        input: ["text"],
+      },
+    ];
+
+    modelCatalogTesting.mergeConfiguredOptInProviderModels({
+      config: {
+        models: {
+          providers: {
+            rightcode: {
+              baseUrl: "https://api.rightcode.ai/v1",
+              api: "openai-completions",
+              models: [
+                {
+                  id: "rightcode/v1",
+                  name: "Configured RightCode V1",
+                  input: ["image"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 8192,
+                },
+              ],
+            },
+          },
+        },
+      } as OpenClawConfig,
+      models,
+    });
+
+    expect(models).toHaveLength(1);
+    expect(models[0]?.name).toBe("RightCode V1");
+    expect(models[0]?.input).toEqual(["image"]);
   });
 });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -34,7 +34,9 @@ const defaultImportPiSdk = () => import("./pi-model-discovery-runtime.js");
 let importPiSdk = defaultImportPiSdk;
 let modelSuppressionPromise: Promise<typeof import("./model-suppression.runtime.js")> | undefined;
 
-const NON_PI_NATIVE_MODEL_PROVIDERS = new Set(["deepseek", "kilocode"]);
+// Allow configured catalog entries to declare capabilities for custom providers
+// whose discovered `/models` payloads omit image/document support metadata.
+const NON_PI_NATIVE_MODEL_PROVIDERS = new Set(["deepseek", "kilocode", "rightcode"]);
 
 function shouldLogModelCatalogTiming(): boolean {
   return process.env.OPENCLAW_DEBUG_INGRESS_TIMING === "1";
@@ -112,21 +114,30 @@ function mergeConfiguredOptInProviderModels(params: {
     return;
   }
 
-  const seen = new Set(
-    params.models.map(
-      (entry) => `${entry.provider.toLowerCase().trim()}::${entry.id.toLowerCase().trim()}`,
-    ),
+  const seen = new Map(
+    params.models.map((entry, index) => [
+      `${entry.provider.toLowerCase().trim()}::${entry.id.toLowerCase().trim()}`,
+      index,
+    ]),
   );
 
   for (const entry of configured) {
     const key = `${entry.provider.toLowerCase().trim()}::${entry.id.toLowerCase().trim()}`;
-    if (seen.has(key)) {
+    const existingIndex = seen.get(key);
+    if (existingIndex !== undefined) {
+      if (entry.input) {
+        params.models[existingIndex] = { ...params.models[existingIndex], input: entry.input };
+      }
       continue;
     }
     params.models.push(entry);
-    seen.add(key);
+    seen.set(key, params.models.length - 1);
   }
 }
+
+export const __testing = {
+  mergeConfiguredOptInProviderModels,
+};
 
 export function resetModelCatalogCacheForTest() {
   modelCatalogPromise = null;

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -546,6 +546,62 @@ describe("message tool schema scoping", () => {
     expect(schema.required ?? []).not.toContain("buttons");
   });
 
+  it("does not expose top-level card schema for feishu shared sends", () => {
+    const feishuPlugin = createChannelPlugin({
+      id: "feishu",
+      label: "Feishu",
+      docsPath: "/channels/feishu",
+      blurb: "Feishu test plugin.",
+      actions: ["send"],
+      capabilities: ["cards"],
+    });
+
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "feishu", source: "test", plugin: feishuPlugin }]),
+    );
+
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "feishu",
+    });
+    const schema = tool.parameters as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+
+    expect(schema.properties?.card).toBeUndefined();
+    expect(schema.required ?? []).not.toContain("card");
+  });
+
+  it("allows feishu plain send params without card when sending path", async () => {
+    mockSendResult({ channel: "feishu", to: "user:open_id" });
+    const feishuPlugin = createChannelPlugin({
+      id: "feishu",
+      label: "Feishu",
+      docsPath: "/channels/feishu",
+      blurb: "Feishu test plugin.",
+      actions: ["send"],
+      capabilities: ["cards"],
+    });
+
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "feishu", source: "test", plugin: feishuPlugin }]),
+    );
+
+    const call = await executeSend({
+      action: {
+        channel: "feishu",
+        path: "C:/tmp/test.png",
+      },
+      toolOptions: {
+        currentChannelProvider: "feishu",
+      },
+    });
+
+    expect(call?.params?.path).toBe("C:/tmp/test.png");
+    expect(call?.params?.card).toBeUndefined();
+  });
+
   it("hides telegram poll extras when telegram polls are disabled in scoped mode", () => {
     const telegramPluginWithConfig = createChannelPlugin({
       id: "telegram",


### PR DESCRIPTION
Title feishu: stop contributing top-level card schema to shared message tool

Summary Feishu currently contributes a top-level card schema to the shared message tool via describeFeishuMessageTool(). In practice, this can block normal file/image sends at tool-schema validation with an error like:

card: must have required property 'card'

Feishu runtime already treats cards as a special path and explicitly rejects card + media, so exposing card on the shared top-level send schema is both unnecessary and fragile.

What this changes

Keep Feishu cards capability metadata
Stop contributing top-level card schema from describeFeishuMessageTool()
Leave Feishu runtime send behavior unchanged
Why

Restores normal file/image sends through the shared message tool
Avoids polluting the shared send schema with a Feishu-specific structured payload path
Matches existing intent that provider-added card schemas remain optional
Evidence

src/plugin-sdk/channel-actions.ts defines createMessageToolCardSchema() as optional
src/agents/tools/message-tool.test.ts already asserts that merged card schema should not be required
Feishu runtime still explicitly rejects card + media in extensions/feishu/src/channel.ts
Manual verification

Build patched OpenClaw dist
Restart gateway / create a fresh session so tool schema is rebuilt
Send an image via Feishu message tool
Send a markdown file via Feishu message tool
Confirm both succeed without requiring card
Notes A live validation issue may persist inside already-running sessions because tool schemas are created with the agent/tool instance and are not refreshed mid-session. Restarting the gateway or starting a fresh session picks up the new schema.