### PR TITLE
fix(ui): exec approval modal closes without submitting decision

### DIFF
--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -334,7 +334,10 @@ export type AppViewState = {
     handleNostrProfileSave: () => Promise<void>;
     handleNostrProfileImport: () => Promise<void>;
     handleNostrProfileToggleAdvanced: () => void;
-    handleExecApprovalDecision: (decision: "allow-once" | "allow-always" | "deny") => Promise<void>;
+    handleExecApprovalDecision: (
+      decision: "allow-once" | "allow-always" | "deny",
+      approvalId?: string,
+    ) => Promise<void>;
     handleGatewayUrlConfirm: () => void;
     handleGatewayUrlCancel: () => void;
     handleConfigLoad: () => Promise<void>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -682,20 +682,24 @@ export class OpenClawApp extends LitElement {
     handleNostrProfileToggleAdvancedInternal(this);
   }
 
-  async handleExecApprovalDecision(decision: "allow-once" | "allow-always" | "deny") {
-    const active = this.execApprovalQueue[0];
-    if (!active || !this.client || this.execApprovalBusy) {
+  async handleExecApprovalDecision(
+    decision: "allow-once" | "allow-always" | "deny",
+    approvalId?: string,
+  ) {
+    const id = approvalId ?? this.execApprovalQueue[0]?.id;
+    if (!id || !this.client || this.execApprovalBusy) {
       return;
     }
     this.execApprovalBusy = true;
     this.execApprovalError = null;
     try {
-      const method = active.kind === "plugin" ? "plugin.approval.resolve" : "exec.approval.resolve";
+      const active = this.execApprovalQueue.find((entry) => entry.id === id);
+      const method = active?.kind === "plugin" ? "plugin.approval.resolve" : "exec.approval.resolve";
       await this.client.request(method, {
-        id: active.id,
+        id,
         decision,
       });
-      this.execApprovalQueue = this.execApprovalQueue.filter((entry) => entry.id !== active.id);
+      this.execApprovalQueue = this.execApprovalQueue.filter((entry) => entry.id !== id);
     } catch (err) {
       this.execApprovalError = `Approval failed: ${String(err)}`;
     } finally {

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -86,21 +86,21 @@ export function renderExecApprovalPrompt(state: AppViewState) {
           <button
             class="btn primary"
             ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("allow-once")}
+            @click=${() => state.handleExecApprovalDecision("allow-once", active.id)}
           >
             Allow once
           </button>
           <button
             class="btn"
             ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("allow-always")}
+            @click=${() => state.handleExecApprovalDecision("allow-always", active.id)}
           >
             Always allow
           </button>
           <button
             class="btn danger"
             ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("deny")}
+            @click=${() => state.handleExecApprovalDecision("deny", active.id)}
           >
             Deny
           </button>


### PR DESCRIPTION
## Summary

- Problem: Clicking "Allow once" (or any decision button) in the exec approval modal closes the modal but silently fails to submit the approval to the backend. The command stays stuck at "Approval required" indefinitely.
- Why it matters: Users lose the ability to approve tool executions through the Control UI, forcing them to use CLI workarounds.
- What changed: The approval buttons now pass the active approval ID directly to the handler via the click closure, instead of the handler reading from `execApprovalQueue[0]` at call time.
- What did NOT change (scope boundary): No backend changes, no new state, no new dependencies. The handler signature adds an optional parameter with full backward compat.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #55251
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Race condition between the expiry cleanup timer and the button click handler. When `exec.approval.requested` arrives, the event handler sets a `setTimeout` to auto-remove the entry from `execApprovalQueue` after expiry. If this timer fires between the last Lit render and the user's click, the handler reads `this.execApprovalQueue[0]` as `undefined` and returns silently — no request is sent, but the modal disappears on the next render cycle because the queue is now empty.
- Missing detection / guardrail: The handler had no fallback for the case where the queue entry was already pruned but the button DOM was still visible.
- Prior context: The expiry timer was added to clean up stale approval entries, but the handler was written assuming the queue would always be in sync with the rendered DOM at click time.
- Why this regressed now: Likely more noticeable in environments with clock skew between gateway and client (e.g., VM port-forwarding setups where the gateway clock and browser clock diverge), which shortens the effective timer delay.
- If unknown, what was ruled out: Backend approval logic is correct — `exec.approval.resolve` properly validates and resolves pending IDs.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `ui/src/ui/views/exec-approval.ts` render output
- Scenario the test should lock in: Button click handler passes the approval ID from the rendered entry, not from live queue state.
- Why this is the smallest reliable guardrail: The race only manifests when the queue state diverges from the rendered DOM, which a unit test can simulate by clearing the queue before invoking the handler.
- If no new test is added, why not: The existing test infrastructure for the approval modal does not cover click handler arguments. Adding a targeted test for this would require mocking the Lit render cycle, which is out of scope for this fix.

## User-visible / Behavior Changes

The approval modal buttons now reliably submit the decision to the backend, even if the approval entry expires from the queue between render and click.

## Diagram (if applicable)

```text
Before:
[user clicks Allow once] -> handler reads queue[0] -> undefined (timer cleared it) -> silent return -> modal disappears -> command stuck

After:
[user clicks Allow once] -> handler receives approval ID from closure -> sends resolve request -> command proceeds
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node 22+, npm global install
- Model/provider: any
- Integration/channel (if any): Control UI (webchat)
- Relevant config (redacted): `tools.elevated.enabled: true`

### Steps

1. Trigger any command that requires exec approval
2. Wait for the approval modal to appear in Control UI
3. Click "Allow once"

### Expected

- Approval is submitted, command proceeds

### Actual (before fix)

- Modal closes, no request sent, command stuck at "Approval required"

## Evidence

- [x] Trace/log snippets — verified that `exec.approval.resolve` request is now sent via WebSocket after clicking "Allow once", confirmed via browser DevTools WS frame inspector

## Human Verification (required)

- Verified scenarios: Read through the full approval flow from button click → handler → WebSocket request → backend resolve → broadcast event. Confirmed the fix correctly passes the ID from the render-time closure.
- Edge cases checked: Handler still works without the optional parameter (backward compat). Handler still correctly handles expired/unknown IDs (backend returns error, catch block displays it).
- What you did **not** verify: Did not test in the exact VM port-forwarding topology described in the issue (host browser → forwarded port → guest gateway).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: None — the optional parameter defaults to existing behavior when not provided.