### PR TITLE
fix: report correct Telegram bot health status (#55482)

### DIFF
--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -623,3 +623,67 @@ describe("telegramPlugin outbound sendPayload forceDocument", () => {
     );
   });
 });
+
+// Regression: https://github.com/openclaw/openclaw/pull/55482
+// The health endpoint builds a minimal snapshot without `running` or
+// `tokenSource`. buildChannelSummary must derive those from the account
+// and probe result so the health response is accurate.
+describe("telegramPlugin buildChannelSummary health fallbacks", () => {
+  it("derives running and tokenSource from account when snapshot omits them", () => {
+    const account = resolveAccount(
+      {
+        channels: { telegram: { botToken: "tok" } },
+      } as OpenClawConfig,
+      "default",
+    );
+
+    // Minimal snapshot like the health endpoint produces: configured but
+    // no running/tokenSource fields, with a successful probe.
+    const snapshot = {
+      accountId: "default",
+      configured: true,
+      probe: { ok: true, bot: { username: "testbot" }, elapsedMs: 1 },
+    };
+
+    const summary = telegramPlugin.status!.buildChannelSummary!({
+      account,
+      cfg: {} as OpenClawConfig,
+      defaultAccountId: "default",
+      snapshot,
+    });
+
+    expect(summary).toMatchObject({
+      configured: true,
+      running: true,
+      tokenSource: account.tokenSource,
+    });
+  });
+
+  it("reports running=false when probe fails", () => {
+    const account = resolveAccount(
+      {
+        channels: { telegram: { botToken: "tok" } },
+      } as OpenClawConfig,
+      "default",
+    );
+
+    const snapshot = {
+      accountId: "default",
+      configured: true,
+      probe: { ok: false, elapsedMs: 1 },
+    };
+
+    const summary = telegramPlugin.status!.buildChannelSummary!({
+      account,
+      cfg: {} as OpenClawConfig,
+      defaultAccountId: "default",
+      snapshot,
+    });
+
+    expect(summary).toMatchObject({
+      configured: true,
+      running: false,
+      tokenSource: account.tokenSource,
+    });
+  });
+});

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -413,7 +413,17 @@ export const telegramPlugin = createChatChannelPlugin({
     status: createComputedAccountStatusAdapter<ResolvedTelegramAccount, TelegramProbe, unknown>({
       defaultRuntime: createDefaultChannelRuntimeState(DEFAULT_ACCOUNT_ID),
       collectStatusIssues: collectTelegramStatusIssues,
-      buildChannelSummary: ({ snapshot }) => buildTokenChannelStatusSummary(snapshot),
+      buildChannelSummary: ({ account, snapshot }) => {
+        // The health endpoint builds a minimal snapshot without tokenSource
+        // or running. Fill them from the resolved account and probe result
+        // so the health response accurately reflects the bot's state.
+        const probeOk = !!(snapshot.probe as { ok?: boolean } | undefined)?.ok;
+        return buildTokenChannelStatusSummary({
+          ...snapshot,
+          tokenSource: snapshot.tokenSource ?? account.tokenSource,
+          running: snapshot.running ?? (snapshot.configured !== false && probeOk),
+        });
+      },
       probeAccount: async ({ account, timeoutMs }) =>
         probeTelegram(account.token, timeoutMs, {
           accountId: account.accountId,


### PR DESCRIPTION
## Summary
- Fixes #55482
- Telegram health endpoint incorrectly reported `running: false` and `tokenSource: none`
- Fixed health check to accurately reflect the bot's operational state

## Test plan
- Start Telegram bot integration
- Check health endpoint and verify it shows `running: true` when bot is active