### PR TITLE
feat(slack): add ignoreOtherMentions channel option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Changes
+
+- Slack/monitor: add `ignoreOtherMentions` channel option to skip messages that mention other users or bots without mentioning the configured bot, reducing noise in busy channels. (#55570) Thanks @pingren.
+
 ### Fixes
 
 - Providers/Anthropic: skip `service_tier` injection for OAuth-authenticated stream wrapper requests so Claude OAuth requests stop failing with HTTP 401. (#60356) thanks @openperf.

--- a/extensions/slack/src/monitor/channel-config.ts
+++ b/extensions/slack/src/monitor/channel-config.ts
@@ -11,6 +11,7 @@ import { allowListMatches, normalizeAllowListLower, normalizeSlackSlug } from ".
 export type SlackChannelConfigResolved = {
   allowed: boolean;
   requireMention: boolean;
+  ignoreOtherMentions?: boolean;
   allowBots?: boolean;
   users?: Array<string | number>;
   skills?: string[];
@@ -22,6 +23,7 @@ export type SlackChannelConfigResolved = {
 export type SlackChannelConfigEntry = {
   enabled?: boolean;
   requireMention?: boolean;
+  ignoreOtherMentions?: boolean;
   allowBots?: boolean;
   users?: Array<string | number>;
   skills?: string[];
@@ -138,6 +140,10 @@ export function resolveSlackChannelConfig(params: {
   const requireMention =
     firstDefined(resolved.requireMention, fallback?.requireMention, requireMentionDefault) ??
     requireMentionDefault;
+  const ignoreOtherMentions = firstDefined(
+    resolved.ignoreOtherMentions,
+    fallback?.ignoreOtherMentions,
+  );
   const allowBots = firstDefined(resolved.allowBots, fallback?.allowBots);
   const users = firstDefined(resolved.users, fallback?.users);
   const skills = firstDefined(resolved.skills, fallback?.skills);
@@ -145,6 +151,7 @@ export function resolveSlackChannelConfig(params: {
   const result: SlackChannelConfigResolved = {
     allowed,
     requireMention,
+    ignoreOtherMentions,
     allowBots,
     users,
     skills,

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -700,6 +700,89 @@ describe("prepareSlackMessage sender prefix", () => {
     expect(body).toContain("Alice (U1): <@BOT> hello");
   });
 
+  it("drops channel message mentioning another user when ignoreOtherMentions is true", async () => {
+    const ctx = createInboundSlackTestContext({
+      cfg: {
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+      defaultRequireMention: false,
+      channelsConfig: { C123: { ignoreOtherMentions: true } },
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    ctx.resolveUserName = async () => ({ name: "Alice" }) as any;
+    const message = {
+      channel: "C123",
+      channel_type: "channel",
+      user: "U1",
+      text: "<@U_OTHER> do something",
+      ts: "1.000",
+    } as SlackMessageEvent;
+
+    const result = await prepareSlackMessage({
+      ctx,
+      account: createSlackTestAccount(),
+      message,
+      opts: { source: "message" },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("does not drop channel message when bot is also mentioned with ignoreOtherMentions", async () => {
+    const ctx = createInboundSlackTestContext({
+      cfg: {
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+      defaultRequireMention: false,
+      channelsConfig: { C123: { ignoreOtherMentions: true } },
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    ctx.resolveUserName = async () => ({ name: "Alice" }) as any;
+    const message = {
+      channel: "C123",
+      channel_type: "channel",
+      user: "U1",
+      text: "<@B1> <@U_OTHER> do something",
+      ts: "1.000",
+    } as SlackMessageEvent;
+
+    const result = await prepareSlackMessage({
+      ctx,
+      account: createSlackTestAccount(),
+      message,
+      opts: { source: "message" },
+    });
+
+    expect(result).not.toBeNull();
+  });
+
+  it("does not apply ignoreOtherMentions in DMs", async () => {
+    const ctx = createInboundSlackTestContext({
+      cfg: {
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+      channelsConfig: { D123: { ignoreOtherMentions: true } },
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    ctx.resolveUserName = async () => ({ name: "Alice" }) as any;
+    const message = {
+      channel: "D123",
+      channel_type: "im",
+      user: "U1",
+      text: "<@U_OTHER> hello",
+      ts: "1.000",
+    } as SlackMessageEvent;
+
+    const result = await prepareSlackMessage({
+      ctx,
+      account: createSlackTestAccount(),
+      message,
+      opts: { source: "message" },
+    });
+
+    expect(result).not.toBeNull();
+  });
+
   it("detects /new as control command when prefixed with Slack mention", async () => {
     const ctx = createSenderPrefixCtx({
       channels: { dm: { enabled: true, policy: "open", allowFrom: ["*"] } },

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -529,8 +529,16 @@ export async function prepareSlackMessage(params: {
   }
 
   // Drop messages that mention other users/bots but not this bot (parity with Discord).
+  // Guard on canDetectMention so we don't false-drop when bot ID resolution failed.
   const ignoreOtherMentions = channelConfig?.ignoreOtherMentions ?? false;
-  if (isRoom && ignoreOtherMentions && hasAnyMention && !wasMentioned && !implicitMention) {
+  if (
+    isRoom &&
+    ignoreOtherMentions &&
+    canDetectMention &&
+    hasAnyMention &&
+    !wasMentioned &&
+    !implicitMention
+  ) {
     logInboundDrop({
       log: logVerbose,
       channel: "slack",

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -537,6 +537,20 @@ export async function prepareSlackMessage(params: {
       reason: "other user/bot mentioned (ignoreOtherMentions)",
       target: senderId,
     });
+    const pendingText = (message.text ?? "").trim();
+    recordPendingHistoryEntryIfEnabled({
+      historyMap: ctx.channelHistories,
+      historyKey,
+      limit: ctx.historyLimit,
+      entry: pendingText
+        ? {
+            sender: await resolveSenderName(),
+            body: pendingText,
+            timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
+            messageId: message.ts,
+          }
+        : null,
+    });
     return null;
   }
 

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -528,6 +528,18 @@ export async function prepareSlackMessage(params: {
     return null;
   }
 
+  // Drop messages that mention other users/bots but not this bot (parity with Discord).
+  const ignoreOtherMentions = channelConfig?.ignoreOtherMentions ?? false;
+  if (isRoom && ignoreOtherMentions && hasAnyMention && !wasMentioned && !implicitMention) {
+    logInboundDrop({
+      log: logVerbose,
+      channel: "slack",
+      reason: "other user/bot mentioned (ignoreOtherMentions)",
+      target: senderId,
+    });
+    return null;
+  }
+
   const threadStarter =
     isThreadReply && threadTs
       ? await resolveSlackThreadStarter({

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -33,6 +33,8 @@ export type SlackChannelConfig = {
   enabled?: boolean;
   /** Require mentioning the bot to trigger replies. */
   requireMention?: boolean;
+  /** Drop messages that mention other users/bots but not this bot (default: false). */
+  ignoreOtherMentions?: boolean;
   /** Optional tool policy overrides for this channel. */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -851,6 +851,7 @@ export const SlackChannelSchema = z
   .object({
     enabled: z.boolean().optional(),
     requireMention: z.boolean().optional(),
+    ignoreOtherMentions: z.boolean().optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     allowBots: z.boolean().optional(),


### PR DESCRIPTION
## Problem

When multiple bots coexist in the same Slack channel, the bot responds to messages that `@mention` other bots. Discord already has `ignoreOtherMentions` to handle this — Slack does not.

## Solution

Add `ignoreOtherMentions` support to Slack channel config, matching the existing Discord implementation.

When enabled, messages that mention other users/bots but not this bot are silently dropped in channel contexts.

### Config example

```json
{
  "channels": {
    "slack": {
      "accounts": {
        "default": {
          "channels": {
            "C0ABC12345": {
              "ignoreOtherMentions": true
            }
          }
        }
      }
    }
  }
}
```

### Changes

- `SlackChannelSchema`: add `ignoreOtherMentions: z.boolean().optional()`
- `SlackChannelConfigEntry` / `SlackChannelConfigResolved` types: add the field
- `resolveSlackChannelConfig`: resolve from channel entry with wildcard fallback
- Message handler `prepare.ts`: add drop check after mention gate (mirrors Discord `message-handler.preflight.ts` L823-835)

### Testing

- All 244 existing Slack monitor tests pass
- Logic mirrors the proven Discord implementation