### PR TITLE
docs: remove GitHub Discussion guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Welcome to the lobster tank! 🦞
 ## How to Contribute
 
 1. **Bugs & small fixes** → Open a PR!
-2. **New features / architecture** → Start a [GitHub Discussion](https://github.com/openclaw/openclaw/discussions) or ask in Discord first
+2. **New features / architecture** → Ask in Discord first
 3. **Refactor-only PRs** → Don't open a PR. We are not accepting refactor-only changes unless a maintainer explicitly asks for them as part of a concrete fix.
 4. **Test/CI-only PRs for known `main` failures** → Don't open a PR. The Maintainer team is already tracking those failures, and PRs that only tweak tests or CI to chase them will be closed unless they are required to validate a new fix.
 5. **Questions** → Discord [#help](https://discord.com/channels/1456350064065904867/1459642797895319552) / [#users-helping-users](https://discord.com/channels/1456350064065904867/1459007081603403828)


### PR DESCRIPTION
## Context
- remove the outdated GitHub Discussion guidance from `CONTRIBUTING.md`
- keep contributor routing for larger proposals pointed at Discord

## Testing
- [x] `git diff --check`
- [x] searched `CONTRIBUTING.md` to confirm the stale discussion wording was removed
- [ ] full test suite not run (docs-only change)
