### PR TITLE
docs(plugins): add ExperienceEngine to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -46,6 +46,17 @@ file messages via any DingTalk client.
 openclaw plugins install @largezhou/ddingtalk
 ```
 
+### ExperienceEngine
+
+Experience intervention layer for coding agents that learns reusable task guidance and injects it across OpenClaw, Claude Code, and Codex.
+
+- **npm:** `@alan512/experienceengine`
+- **repo:** [github.com/Alan-512/ExperienceEngine](https://github.com/Alan-512/ExperienceEngine)
+
+```bash
+openclaw plugins install @alan512/experienceengine
+```
+
 ### Lossless Claw (LCM)
 
 Lossless Context Management plugin for OpenClaw. DAG-based conversation


### PR DESCRIPTION
Adds ExperienceEngine to the Community Plugins page with npm package, repo URL, one-line description, and install command.\n\nPlugin details:\n- npm: @alan512/experienceengine\n- repo: https://github.com/Alan-512/ExperienceEngine\n- install: openclaw plugins install @alan512/experienceengine\n\nThis follows the submission fields listed on the same page.