### PR TITLE
fix: suppress duplicate 'New session' verbose notice after /new reset

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -85,6 +85,7 @@ export async function runReplyAgent(params: {
   agentCfgContextTokens?: number;
   resolvedVerboseLevel: VerboseLevel;
   isNewSession: boolean;
+  resetNoticeSent?: boolean;
   blockStreamingEnabled: boolean;
   blockReplyChunking?: {
     minChars: number;
@@ -669,7 +670,7 @@ export async function runReplyAgent(params: {
     let finalPayloads = guardedReplyPayloads;
     const verboseNotices: ReplyPayload[] = [];
 
-    if (verboseEnabled && activeIsNewSession) {
+    if (verboseEnabled && activeIsNewSession && !params.resetNoticeSent) {
       verboseNotices.push({ text: `🧭 New session: ${followupRun.run.sessionId}` });
     }
 

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -126,13 +126,13 @@ async function sendResetSessionNotice(params: {
   model: string;
   defaultProvider: string;
   defaultModel: string;
-}): Promise<void> {
+}): Promise<boolean> {
   const route = resolveResetSessionNoticeRoute({
     ctx: params.ctx,
     command: params.command,
   });
   if (!route) {
-    return;
+    return false;
   }
   const { routeReply } = await loadRouteReplyRuntime();
   await routeReply({
@@ -151,6 +151,7 @@ async function sendResetSessionNotice(params: {
     threadId: params.threadId,
     cfg: params.cfg,
   });
+  return true;
 }
 
 type RunPreparedReplyParams = {
@@ -453,8 +454,9 @@ export async function runPreparedReply(
       }
     }
   }
+  let resetNoticeSent = false;
   if (resetTriggered && command.isAuthorizedSender) {
-    await sendResetSessionNotice({
+    resetNoticeSent = await sendResetSessionNotice({
       ctx,
       command,
       sessionKey,
@@ -605,7 +607,7 @@ export async function runPreparedReply(
     agentCfgContextTokens: agentCfg?.contextTokens,
     resolvedVerboseLevel: resolvedVerboseLevel ?? "off",
     isNewSession,
-    resetNoticeSent: resetTriggered && command.isAuthorizedSender,
+    resetNoticeSent,
     blockStreamingEnabled,
     blockReplyChunking,
     resolvedBlockStreamingBreak,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -605,6 +605,7 @@ export async function runPreparedReply(
     agentCfgContextTokens: agentCfg?.contextTokens,
     resolvedVerboseLevel: resolvedVerboseLevel ?? "off",
     isNewSession,
+    resetNoticeSent: resetTriggered && command.isAuthorizedSender,
     blockStreamingEnabled,
     blockReplyChunking,
     resolvedBlockStreamingBreak,


### PR DESCRIPTION
## Summary
Fix duplicate "New session" notifications when verbose mode is enabled and user runs `/new`.

## Problem
Two separate notices are sent:
1. `✅ New session started · model: xxx` from `sendResetSessionNotice` in `get-reply-run.ts`
2. `🧭 New session: <id>` from verbose notices in `agent-runner.ts`

The second notice is redundant and can confuse the agent into responding twice to the "new session" event.

## Changes
- Add `resetNoticeSent` optional param to `runReplyAgent`
- Pass `resetTriggered && command.isAuthorizedSender` from `get-reply-run.ts`
- Skip verbose new-session notice when reset notice was already sent

## Files Changed
- `src/auto-reply/reply/agent-runner.ts` — add param, guard verbose notice
- `src/auto-reply/reply/get-reply-run.ts` — pass `resetNoticeSent` flag

Fixes #55515