### PR TITLE
fix(hooks): enforce allowedAgentIds for implicit routing

### DIFF
--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -177,14 +177,14 @@ describe("gateway hooks helpers", () => {
 
   test("isHookAgentAllowed honors hooks.allowedAgentIds for explicit routing", () => {
     const resolved = resolveHooksConfigOrThrow(buildHookAgentConfig(["hooks"]));
-    expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
+    expect(isHookAgentAllowed(resolved, undefined)).toBe(false);
     expect(isHookAgentAllowed(resolved, "hooks")).toBe(true);
     expect(isHookAgentAllowed(resolved, "missing-agent")).toBe(false);
   });
 
   test("isHookAgentAllowed treats empty allowlist as deny-all for explicit agentId", () => {
     const resolved = resolveHooksConfigOrThrow(buildHookAgentConfig([]));
-    expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
+    expect(isHookAgentAllowed(resolved, undefined)).toBe(false);
     expect(isHookAgentAllowed(resolved, "hooks")).toBe(false);
     expect(isHookAgentAllowed(resolved, "main")).toBe(false);
   });
@@ -194,6 +194,13 @@ describe("gateway hooks helpers", () => {
     expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
     expect(isHookAgentAllowed(resolved, "hooks")).toBe(true);
     expect(isHookAgentAllowed(resolved, "missing-agent")).toBe(true);
+  });
+
+  test("isHookAgentAllowed allows implicit routing when default agent is allowlisted", () => {
+    const resolved = resolveHooksConfigOrThrow(buildHookAgentConfig(["main"]));
+    expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
+    expect(isHookAgentAllowed(resolved, "hooks")).toBe(false);
+    expect(isHookAgentAllowed(resolved, "main")).toBe(true);
   });
 
   test("resolveHookSessionKey disables request sessionKey by default", () => {

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -175,16 +175,16 @@ describe("gateway hooks helpers", () => {
     expect(resolveHookTargetAgentId(resolved, undefined)).toBeUndefined();
   });
 
-  test("isHookAgentAllowed honors hooks.allowedAgentIds for explicit routing", () => {
+  test("isHookAgentAllowed only enforces hooks.allowedAgentIds for explicit routing", () => {
     const resolved = resolveHooksConfigOrThrow(buildHookAgentConfig(["hooks"]));
-    expect(isHookAgentAllowed(resolved, undefined)).toBe(false);
+    expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
     expect(isHookAgentAllowed(resolved, "hooks")).toBe(true);
     expect(isHookAgentAllowed(resolved, "missing-agent")).toBe(false);
   });
 
   test("isHookAgentAllowed treats empty allowlist as deny-all for explicit agentId", () => {
     const resolved = resolveHooksConfigOrThrow(buildHookAgentConfig([]));
-    expect(isHookAgentAllowed(resolved, undefined)).toBe(false);
+    expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
     expect(isHookAgentAllowed(resolved, "hooks")).toBe(false);
     expect(isHookAgentAllowed(resolved, "main")).toBe(false);
   });
@@ -196,7 +196,7 @@ describe("gateway hooks helpers", () => {
     expect(isHookAgentAllowed(resolved, "missing-agent")).toBe(true);
   });
 
-  test("isHookAgentAllowed allows implicit routing when default agent is allowlisted", () => {
+  test("isHookAgentAllowed keeps implicit routing compatible regardless of allowlist", () => {
     const resolved = resolveHooksConfigOrThrow(buildHookAgentConfig(["main"]));
     expect(isHookAgentAllowed(resolved, undefined)).toBe(true);
     expect(isHookAgentAllowed(resolved, "hooks")).toBe(false);

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -286,14 +286,13 @@ export function isHookAgentAllowed(
   hooksConfig: HooksConfigResolved,
   agentId: string | undefined,
 ): boolean {
-  // Keep backwards compatibility for callers that omit agentId.
-  const raw = agentId?.trim();
-  if (!raw) {
-    return true;
-  }
   const allowed = hooksConfig.agentPolicy.allowedAgentIds;
   if (allowed === undefined) {
     return true;
+  }
+  const raw = agentId?.trim();
+  if (!raw) {
+    return allowed.has(hooksConfig.agentPolicy.defaultAgentId);
   }
   const resolved = resolveHookTargetAgentId(hooksConfig, raw);
   return resolved ? allowed.has(resolved) : false;

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -286,13 +286,15 @@ export function isHookAgentAllowed(
   hooksConfig: HooksConfigResolved,
   agentId: string | undefined,
 ): boolean {
+  // Preserve backwards compatibility for callers that omit agentId. The
+  // allowlist is meant to constrain explicit routing requests.
+  const raw = agentId?.trim();
+  if (!raw) {
+    return true;
+  }
   const allowed = hooksConfig.agentPolicy.allowedAgentIds;
   if (allowed === undefined) {
     return true;
-  }
-  const raw = agentId?.trim();
-  if (!raw) {
-    return allowed.has(hooksConfig.agentPolicy.defaultAgentId);
   }
   const resolved = resolveHookTargetAgentId(hooksConfig, raw);
   return resolved ? allowed.has(resolved) : false;

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -462,15 +462,11 @@ describe("gateway server hooks", () => {
     };
     setMainAndHooksAgents();
     await withGatewayServer(async ({ port }) => {
-      mockIsolatedRunOkOnce();
       const resNoAgent = await postHook(port, "/hooks/agent", { message: "No explicit agent" });
-      expect(resNoAgent.status).toBe(200);
-      await waitForSystemEvent();
-      const noAgentCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
-        job?: { agentId?: string };
-      };
-      expect(noAgentCall?.job?.agentId).toBeUndefined();
-      drainSystemEvents(resolveMainKey());
+      expect(resNoAgent.status).toBe(400);
+      const noAgentBody = (await resNoAgent.json()) as { error?: string };
+      expect(noAgentBody.error).toContain("hooks.allowedAgentIds");
+      expect(cronIsolatedRun).not.toHaveBeenCalled();
 
       mockIsolatedRunOkOnce();
       const resAllowed = await postHook(port, "/hooks/agent", {
@@ -511,6 +507,13 @@ describe("gateway server hooks", () => {
       list: [{ id: "main", default: true }, { id: "hooks" }],
     };
     await withGatewayServer(async ({ port }) => {
+      const resImplicitDenied = await postHook(port, "/hooks/agent", {
+        message: "Implicit denied",
+      });
+      expect(resImplicitDenied.status).toBe(400);
+      const implicitDeniedBody = (await resImplicitDenied.json()) as { error?: string };
+      expect(implicitDeniedBody.error).toContain("hooks.allowedAgentIds");
+
       const resDenied = await postHook(port, "/hooks/agent", {
         message: "Denied",
         agentId: "hooks",

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -462,11 +462,16 @@ describe("gateway server hooks", () => {
     };
     setMainAndHooksAgents();
     await withGatewayServer(async ({ port }) => {
+      mockIsolatedRunOkOnce();
       const resNoAgent = await postHook(port, "/hooks/agent", { message: "No explicit agent" });
-      expect(resNoAgent.status).toBe(400);
-      const noAgentBody = (await resNoAgent.json()) as { error?: string };
-      expect(noAgentBody.error).toContain("hooks.allowedAgentIds");
-      expect(cronIsolatedRun).not.toHaveBeenCalled();
+      expect(resNoAgent.status).toBe(200);
+      await waitForSystemEvent();
+      const implicitCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
+        | { job?: { agentId?: string } }
+        | undefined;
+      expect(implicitCall?.job?.agentId).toBeUndefined();
+      expect(peekSystemEvents(resolveMainKey()).length).toBeGreaterThan(0);
+      drainSystemEvents(resolveMainKey());
 
       mockIsolatedRunOkOnce();
       const resAllowed = await postHook(port, "/hooks/agent", {
@@ -507,12 +512,18 @@ describe("gateway server hooks", () => {
       list: [{ id: "main", default: true }, { id: "hooks" }],
     };
     await withGatewayServer(async ({ port }) => {
-      const resImplicitDenied = await postHook(port, "/hooks/agent", {
-        message: "Implicit denied",
+      mockIsolatedRunOkOnce();
+      const resImplicitAllowed = await postHook(port, "/hooks/agent", {
+        message: "Implicit allowed",
       });
-      expect(resImplicitDenied.status).toBe(400);
-      const implicitDeniedBody = (await resImplicitDenied.json()) as { error?: string };
-      expect(implicitDeniedBody.error).toContain("hooks.allowedAgentIds");
+      expect(resImplicitAllowed.status).toBe(200);
+      await waitForSystemEvent();
+      const implicitCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
+        | { job?: { agentId?: string } }
+        | undefined;
+      expect(implicitCall?.job?.agentId).toBeUndefined();
+      expect(peekSystemEvents(resolveMainKey()).length).toBeGreaterThan(0);
+      drainSystemEvents(resolveMainKey());
 
       const resDenied = await postHook(port, "/hooks/agent", {
         message: "Denied",


### PR DESCRIPTION
## Summary
- apply hooks.allowedAgentIds to implicit /hooks/agent routing instead of only explicit agentId overrides
- deny implicit routing when the default agent is not allowlisted
- add helper and integration coverage for implicit default-agent enforcement

## Testing
- ./node_modules/.bin/vitest run src/gateway/hooks.test.ts src/gateway/server.hooks.test.ts