### PR TITLE
feat(tts): add Xiaomi MiMo-V2-TTS as speech provider

### DIFF
--- a/extensions/xiaomi/index.ts
+++ b/extensions/xiaomi/index.ts
@@ -2,6 +2,7 @@ import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-en
 import { PROVIDER_LABELS } from "openclaw/plugin-sdk/provider-usage";
 import { applyXiaomiConfig, XIAOMI_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildXiaomiProvider } from "./provider-catalog.js";
+import { buildMimoSpeechProvider } from "./speech-provider.js";
 
 const PROVIDER_ID = "xiaomi";
 
@@ -39,5 +40,8 @@ export default defineSingleProviderPluginEntry({
       displayName: PROVIDER_LABELS.xiaomi,
       windows: [],
     }),
+  },
+  register(api) {
+    api.registerSpeechProvider(buildMimoSpeechProvider());
   },
 });

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -2,6 +2,7 @@
   "id": "xiaomi",
   "enabledByDefault": true,
   "providers": ["xiaomi"],
+  "speechProviders": ["mimo"],
   "providerAuthEnvVars": {
     "xiaomi": ["XIAOMI_API_KEY"]
   },

--- a/extensions/xiaomi/openclaw.plugin.json
+++ b/extensions/xiaomi/openclaw.plugin.json
@@ -2,7 +2,9 @@
   "id": "xiaomi",
   "enabledByDefault": true,
   "providers": ["xiaomi"],
-  "speechProviders": ["mimo"],
+  "contracts": {
+    "speechProviders": ["mimo"]
+  },
   "providerAuthEnvVars": {
     "xiaomi": ["XIAOMI_API_KEY"]
   },

--- a/extensions/xiaomi/speech-provider.ts
+++ b/extensions/xiaomi/speech-provider.ts
@@ -1,0 +1,152 @@
+import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import type {
+  SpeechProviderConfig,
+  SpeechProviderPlugin,
+  SpeechVoiceOption,
+} from "openclaw/plugin-sdk/speech-core";
+
+const MIMO_TTS_MODELS = ["mimo-v2-tts"] as const;
+
+const DEFAULT_MIMO_BASE_URL = "https://api.xiaomimimo.com/v1";
+const DEFAULT_MIMO_MODEL = "mimo-v2-tts";
+const DEFAULT_MIMO_VOICE = "mimo_default";
+
+function trimToUndefined(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function normalizeMimoBaseUrl(baseUrl: string | undefined): string {
+  const trimmed = baseUrl?.trim();
+  return trimmed?.replace(/\/+$/, "") || DEFAULT_MIMO_BASE_URL;
+}
+
+type MimoProviderConfig = {
+  apiKey?: string;
+  baseUrl: string;
+  model: string;
+  voice: string;
+  style?: string;
+};
+
+function readMimoProviderConfig(providerConfig: SpeechProviderConfig): MimoProviderConfig {
+  const raw = asObject(providerConfig);
+  return {
+    apiKey: normalizeResolvedSecretInputString({
+      value: raw?.apiKey,
+      path: "messages.tts.providers.mimo.apiKey",
+    }),
+    baseUrl: normalizeMimoBaseUrl(trimToUndefined(raw?.baseUrl)),
+    model: trimToUndefined(raw?.model) ?? DEFAULT_MIMO_MODEL,
+    voice: trimToUndefined(raw?.voice) ?? DEFAULT_MIMO_VOICE,
+    style: trimToUndefined(raw?.style),
+  };
+}
+
+export async function mimoTTS(params: {
+  text: string;
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  voice: string;
+  style?: string;
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const { text, apiKey, baseUrl, model, voice, style, timeoutMs } = params;
+
+  let assistantContent = text;
+  if (style) {
+    assistantContent = `<style>${style}</style>${text}`;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "api-key": apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "assistant", content: assistantContent }],
+        audio: {
+          format: "wav",
+          voice,
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const error = await response.text().catch(() => "Unknown error");
+      throw new Error(`MiMo TTS API error (${response.status}): ${error}`);
+    }
+
+    const data = await response.json();
+    const audioData = data?.choices?.[0]?.message?.audio?.data;
+    if (!audioData) {
+      throw new Error("MiMo TTS API returned no audio data");
+    }
+
+    return Buffer.from(audioData, "base64");
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function listMimoVoices(): Promise<SpeechVoiceOption[]> {
+  return [
+    { id: "mimo_default", name: "Default (Chinese)", locale: "zh-CN" },
+    { id: "default_zh", name: "Chinese", locale: "zh-CN" },
+    { id: "default_en", name: "English", locale: "en-US" },
+  ];
+}
+
+export function buildMimoSpeechProvider(): SpeechProviderPlugin {
+  return {
+    id: "mimo",
+    label: "Xiaomi MiMo TTS",
+    aliases: ["xiaomi", "mimo"],
+    models: MIMO_TTS_MODELS,
+
+    isConfigured: ({ providerConfig }) =>
+      Boolean(readMimoProviderConfig(providerConfig).apiKey || process.env.MIMO_API_KEY),
+
+    synthesize: async (req) => {
+      const config = readMimoProviderConfig(req.providerConfig);
+      const apiKey = config.apiKey || process.env.MIMO_API_KEY;
+      if (!apiKey) {
+        throw new Error("MiMo API key missing");
+      }
+
+      const audioBuffer = await mimoTTS({
+        text: req.text,
+        apiKey,
+        baseUrl: config.baseUrl,
+        model: config.model,
+        voice: config.voice,
+        style: config.style,
+        timeoutMs: req.timeoutMs,
+      });
+
+      return {
+        audioBuffer,
+        outputFormat: "wav",
+        fileExtension: "wav",
+        voiceCompatible: req.target === "voice-note",
+      };
+    },
+
+    listVoices: async () => {
+      return listMimoVoices();
+    },
+  };
+}

--- a/extensions/xiaomi/speech-provider.ts
+++ b/extensions/xiaomi/speech-provider.ts
@@ -120,14 +120,13 @@ export function buildMimoSpeechProvider(): SpeechProviderPlugin {
     isConfigured: ({ providerConfig }) =>
       Boolean(
         readMimoProviderConfig(providerConfig).apiKey ||
-          process.env.MIMO_API_KEY ||
-          process.env.XIAOMI_API_KEY
+        process.env.MIMO_API_KEY ||
+        process.env.XIAOMI_API_KEY,
       ),
 
     synthesize: async (req) => {
       const config = readMimoProviderConfig(req.providerConfig);
-      const apiKey =
-        config.apiKey || process.env.MIMO_API_KEY || process.env.XIAOMI_API_KEY;
+      const apiKey = config.apiKey || process.env.MIMO_API_KEY || process.env.XIAOMI_API_KEY;
       if (!apiKey) {
         throw new Error("MiMo API key missing");
       }

--- a/extensions/xiaomi/speech-provider.ts
+++ b/extensions/xiaomi/speech-provider.ts
@@ -118,11 +118,16 @@ export function buildMimoSpeechProvider(): SpeechProviderPlugin {
     models: MIMO_TTS_MODELS,
 
     isConfigured: ({ providerConfig }) =>
-      Boolean(readMimoProviderConfig(providerConfig).apiKey || process.env.MIMO_API_KEY),
+      Boolean(
+        readMimoProviderConfig(providerConfig).apiKey ||
+          process.env.MIMO_API_KEY ||
+          process.env.XIAOMI_API_KEY
+      ),
 
     synthesize: async (req) => {
       const config = readMimoProviderConfig(req.providerConfig);
-      const apiKey = config.apiKey || process.env.MIMO_API_KEY;
+      const apiKey =
+        config.apiKey || process.env.MIMO_API_KEY || process.env.XIAOMI_API_KEY;
       if (!apiKey) {
         throw new Error("MiMo API key missing");
       }

--- a/extensions/xiaomi/speech-provider.ts
+++ b/extensions/xiaomi/speech-provider.ts
@@ -141,7 +141,7 @@ export function buildMimoSpeechProvider(): SpeechProviderPlugin {
         audioBuffer,
         outputFormat: "wav",
         fileExtension: ".wav",
-        voiceCompatible: req.target === "voice-note",
+        voiceCompatible: false,
       };
     },
 

--- a/extensions/xiaomi/speech-provider.ts
+++ b/extensions/xiaomi/speech-provider.ts
@@ -78,7 +78,7 @@ export async function mimoTTS(params: {
         model,
         messages: [{ role: "assistant", content: assistantContent }],
         audio: {
-          format: "wav",
+          format: "mp3",
           voice,
         },
       }),
@@ -139,8 +139,8 @@ export function buildMimoSpeechProvider(): SpeechProviderPlugin {
 
       return {
         audioBuffer,
-        outputFormat: "wav",
-        fileExtension: ".wav",
+        outputFormat: "mp3",
+        fileExtension: ".mp3",
         voiceCompatible: false,
       };
     },

--- a/extensions/xiaomi/speech-provider.ts
+++ b/extensions/xiaomi/speech-provider.ts
@@ -140,7 +140,7 @@ export function buildMimoSpeechProvider(): SpeechProviderPlugin {
       return {
         audioBuffer,
         outputFormat: "wav",
-        fileExtension: "wav",
+        fileExtension: ".wav",
         voiceCompatible: req.target === "voice-note",
       };
     },


### PR DESCRIPTION
## Summary

Add Xiaomi MiMo-V2-TTS as a new speech synthesis provider in the existing Xiaomi extension.

Closes #52376

## Motivation

MiMo-V2-TTS provides high-quality Chinese TTS with unique capabilities:
- **Natural language style control** — describe voice style in plain text
- **Dialect support** — Northeastern, Sichuan, Cantonese, Taiwanese
- **Character voices** — Sun Wukong, Lin Daiyu, etc.
- **Singing synthesis** — same model, no mode switch
- **Free** — currently the only free API on the MiMo platform

## Implementation

Uses the existing Xiaomi extension. MiMo TTS uses a non-standard API:
- **Endpoint**: POST `/v1/chat/completions` (not `/v1/audio/speech`)
- **Auth**: `api-key` header (not `Authorization: Bearer`)
- **Audio**: `message.audio.data` base64, 24kHz 16bit mono MP3

## Configuration

```json5
{
  messages: {
    tts: {
      provider: "mimo",
      providers: {
        mimo: {
          apiKey: "sk-xxx",  // or MIMO_API_KEY env var
          voice: "mimo_default",
          style: "Happy"
        }
      }
    }
  }
}
```

## Files Changed

| File | Change |
|------|--------|
| `extensions/xiaomi/speech-provider.ts` | New — 150 lines |
| `extensions/xiaomi/index.ts` | +2 lines |
| `extensions/xiaomi/openclaw.plugin.json` | +1 line |

## Testing

- ✅ `pnpm build` passes
- ✅ TTS tests 26/26 pass
- ✅ Real API: Chinese, English, style control, error handling, long text

---

_AI-assisted (OpenClaw + GitHub Copilot). Fully tested._