### PR TITLE
fix(skills): preserve high-priority skills when truncating prompt

### DIFF
--- a/src/agents/skills/compact-format.test.ts
+++ b/src/agents/skills/compact-format.test.ts
@@ -112,7 +112,9 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     const prompt = buildPrompt(skills, { maxChars: 2000 });
     expect(prompt).toContain("compact format, descriptions omitted");
     expect(prompt).not.toContain("<description>");
-    expect(prompt).toContain("skill-0");
+    // High-priority skills (tail) are preserved; low-priority (head) are dropped.
+    expect(prompt).toContain("skill-99");
+    expect(prompt).not.toContain("skill-0");
     const match = prompt.match(/included (\d+) of (\d+)/);
     expect(match).toBeTruthy();
     expect(Number(match![1])).toBeLessThan(Number(match![2]));
@@ -136,9 +138,9 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
   it("count truncation + compact: shows included X of Y with compact note", () => {
     // 30 skills but maxCount=10, and full format of 10 exceeds budget
     const skills = Array.from({ length: 30 }, (_, i) => makeSkill(`skill-${i}`, "A".repeat(200)));
-    const tenSkills = skills.slice(0, 10);
-    const fullLen = formatSkillsForPrompt(tenSkills).length;
-    const compactLen = formatSkillsCompact(tenSkills).length;
+    const keptSkills = skills.slice(skills.length - 10);
+    const fullLen = formatSkillsForPrompt(keptSkills).length;
+    const compactLen = formatSkillsCompact(keptSkills).length;
     const budget = compactLen + 200;
     // Verify precondition: full format of 10 skills exceeds budget
     expect(fullLen).toBeGreaterThan(budget);
@@ -165,6 +167,30 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     expect(prompt).toContain("included 5 of 20");
     expect(prompt).not.toContain("compact");
     expect(prompt).toContain("<description>");
+    // Highest-priority skills (tail) are kept
+    expect(prompt).toContain("skill-19");
+    expect(prompt).not.toContain("skill-0");
+  });
+
+  it("truncation preserves high-priority (workspace) skills over low-priority (bundled)", () => {
+    const bundled = Array.from({ length: 10 }, (_, i) =>
+      makeSkill(`bundled-${i}`, "A bundled skill"),
+    );
+    const workspace = Array.from({ length: 3 }, (_, i) =>
+      makeSkill(`workspace-${i}`, "A workspace skill"),
+    );
+    // Simulate merged order: bundled (low priority) first, workspace (high priority) last
+    const all = [...bundled, ...workspace];
+    const prompt = buildPrompt(all, { maxChars: 50_000, maxCount: 5 });
+    expect(prompt).toContain("included 5 of 13");
+    // All 3 workspace skills must survive
+    expect(prompt).toContain("workspace-0");
+    expect(prompt).toContain("workspace-1");
+    expect(prompt).toContain("workspace-2");
+    // Only 2 bundled skills fit (highest-indexed = latest in bundled batch)
+    expect(prompt).toContain("bundled-9");
+    expect(prompt).toContain("bundled-8");
+    expect(prompt).not.toContain("bundled-0");
   });
 
   it("compact budget reserves space for the warning line", () => {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -571,7 +571,11 @@ function applySkillsPromptLimits(params: { skills: Skill[]; config?: OpenClawCon
 } {
   const limits = resolveSkillsLimits(params.config);
   const total = params.skills.length;
-  const byCount = params.skills.slice(0, Math.max(0, limits.maxSkillsInPrompt));
+
+  // Skills arrive in priority order (low → high) from the merged Map.
+  // When truncating by count, keep the highest-priority skills (the tail).
+  const countLimit = Math.max(0, limits.maxSkillsInPrompt);
+  const byCount = total > countLimit ? params.skills.slice(total - countLimit) : params.skills;
 
   let skillsForPrompt = byCount;
   let truncated = total > byCount.length;
@@ -592,19 +596,20 @@ function applySkillsPromptLimits(params: { skills: Skill[]; config?: OpenClawCon
       compact = true;
       // No skills dropped — only format downgraded. Preserve existing truncated state.
     } else {
-      // Compact still too large — binary search the largest prefix that fits.
+      // Compact still too large — binary search the largest suffix that fits.
+      // Drop low-priority skills (from the start) first to preserve high-priority ones.
       compact = true;
       let lo = 0;
       let hi = skillsForPrompt.length;
       while (lo < hi) {
         const mid = Math.ceil((lo + hi) / 2);
-        if (fitsCompact(skillsForPrompt.slice(0, mid))) {
+        if (fitsCompact(skillsForPrompt.slice(skillsForPrompt.length - mid))) {
           lo = mid;
         } else {
           hi = mid - 1;
         }
       }
-      skillsForPrompt = skillsForPrompt.slice(0, lo);
+      skillsForPrompt = skillsForPrompt.slice(skillsForPrompt.length - lo);
       truncated = true;
     }
   }


### PR DESCRIPTION
## Summary

- When the skills prompt exceeds the character budget, truncation now drops **low-priority** skills (bundled, extra) first and preserves **high-priority** skills (workspace, project agents).

## Problem

Skills are merged into a Map in priority order: extra → bundled → managed → personal-agents → project-agents → workspace. When the prompt budget is exceeded, the truncation logic took a **prefix** of this list, keeping low-priority skills and dropping high-priority ones from the tail. This meant user-installed workspace skills were the first to be truncated — the opposite of the intended behavior.

## Fix

Changed `applySkillsPromptLimits` to take a **suffix** instead of a prefix when truncating:
- Count-based truncation (`maxSkillsInPrompt`): keeps the last N skills (highest priority)
- Char-based truncation (binary search): searches for the largest suffix that fits within budget

## Testing

- Updated existing truncation tests to assert the new drop order
- Added a dedicated test: `truncation preserves high-priority (workspace) skills over low-priority (bundled)`
- All 16 tests in `compact-format.test.ts` pass
- `pnpm check` passes