### PR TITLE
fix(feishu): exponential backoff + PingInterval guard for WS reconnect

### DIFF
--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -53,12 +53,14 @@ function applyFeishuSDKReconnectPatch(): void {
     (proto as unknown as Record<string, unknown>).handleControlData = async function (
       data: { headers: Array<{ key: string; value: string }>; payload?: Uint8Array },
     ) {
+      const self = this as unknown as Record<string, unknown>;
       try {
         return await origHandleControlData.call(this, data);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         if (msg.includes("PingInterval")) {
-          this.logger?.warn?.(
+          (self.logger as Record<string, Function> | undefined)?.warn?.call(
+            self.logger,
             "[feishu-ws-patch]",
             "swallowed PingInterval error in pong handler (Feishu system_busy?)",
           );
@@ -73,19 +75,22 @@ function applyFeishuSDKReconnectPatch(): void {
   const origReConnect = proto.reConnect as ((isStart?: boolean) => Promise<void>) | undefined;
   if (origReConnect) {
     (proto as unknown as Record<string, unknown>).reConnect = async function (isStart = false) {
+      const self = this as unknown as Record<string, unknown>;
       if (isStart) {
         // Reset backoff counter on a fresh start
-        (this as unknown as Record<string, unknown>)._feishuReconnectCount = 0;
+        self._feishuReconnectCount = 0;
       }
       if (!isStart) {
         // Exponential backoff: doubles each retry, capped at MAX_RECONNECT_BACKOFF_MS
         // Add ±20% jitter to avoid synchronized retries across multiple clients
-        (this as unknown as Record<string, unknown>)._feishuReconnectCount = ((this as unknown as Record<string, unknown>)._feishuReconnectCount as number) + 1 || 1;
-        const count = (this as unknown as Record<string, unknown>)._feishuReconnectCount as number;
-        const { reconnectInterval = DEFAULT_RECONNECT_INTERVAL_MS } = this.wsConfig?.getWS?.() ?? {};
+        self._feishuReconnectCount = ((self._feishuReconnectCount as number) || 0) + 1;
+        const count = self._feishuReconnectCount as number;
+        const wsConfig = self.wsConfig as { getWS?: () => { reconnectInterval?: number } } | undefined;
+        const { reconnectInterval = DEFAULT_RECONNECT_INTERVAL_MS } = wsConfig?.getWS?.() ?? {};
         const jitter = 1 + (Math.random() - 0.5) * 0.4; // ±20%
         const backoff = Math.min(reconnectInterval * Math.pow(2, count - 1) * jitter, MAX_RECONNECT_BACKOFF_MS);
-        this.logger?.info?.(
+        (self.logger as Record<string, Function> | undefined)?.info?.call(
+          self.logger,
           "[feishu-ws-patch]",
           `reconnect backoff: ${Math.round(backoff / 1000)}s (attempt ${count}, jitter ${Math.round((jitter - 1) * 100)}%)`,
         );

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -57,7 +57,7 @@ function applyFeishuSDKReconnectPatch(): void {
         return await origHandleControlData.call(this, data);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("PingInterval") || msg.includes("undefined")) {
+        if (msg.includes("PingInterval")) {
           this.logger?.warn?.(
             "[feishu-ws-patch]",
             "swallowed PingInterval error in pong handler (Feishu system_busy?)",
@@ -73,6 +73,10 @@ function applyFeishuSDKReconnectPatch(): void {
   const origReConnect = proto.reConnect as ((isStart?: boolean) => Promise<void>) | undefined;
   if (origReConnect) {
     (proto as Record<string, unknown>).reConnect = async function (isStart = false) {
+      if (isStart) {
+        // Reset backoff counter on a fresh start
+        (this as Record<string, unknown>)._feishuReconnectCount = 0;
+      }
       if (!isStart) {
         // Exponential backoff: doubles each retry, capped at MAX_RECONNECT_BACKOFF_MS
         this._feishuReconnectCount = ((this as Record<string, unknown>)._feishuReconnectCount as number) + 1 || 1;

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -43,15 +43,14 @@ function applyFeishuSDKReconnectPatch(): void {
   const WSClient = defaultFeishuClientSdk.WSClient;
   if (!WSClient?.prototype) return;
 
-  const proto = WSClient.prototype;
+  const proto = WSClient.prototype as Record<string, unknown>;
 
   // --- Fix 1: Guard PingInterval in handleControlData (pong handler) ---
-  const origHandleControlData = proto.handleControlData as
+  const origHandleControlData = proto["handleControlData"] as
     | ((data: { headers: Array<{ key: string; value: string }>; payload?: Uint8Array }) => Promise<void>)
     | undefined;
   if (origHandleControlData) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (proto as unknown as { handleControlData: typeof origHandleControlData }).handleControlData = async function (
+    proto["handleControlData"] = async function (
       data: { headers: Array<{ key: string; value: string }>; payload?: Uint8Array },
     ) {
       const self = this as unknown as Record<string, unknown>;
@@ -73,10 +72,9 @@ function applyFeishuSDKReconnectPatch(): void {
   }
 
   // --- Fix 2: Exponential backoff on reConnect ---
-  const origReConnect = proto.reConnect as ((isStart?: boolean) => Promise<void>) | undefined;
+  const origReConnect = proto["reConnect"] as ((isStart?: boolean) => Promise<void>) | undefined;
   if (origReConnect) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (proto as unknown as { reConnect: typeof origReConnect }).reConnect = async function (isStart = false) {
+    proto["reConnect"] = async function (isStart = false) {
       const self = this as unknown as Record<string, unknown>;
       if (isStart) {
         // Reset backoff counter on a fresh start

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -50,7 +50,7 @@ function applyFeishuSDKReconnectPatch(): void {
     | ((data: { headers: Array<{ key: string; value: string }>; payload?: Uint8Array }) => Promise<void>)
     | undefined;
   if (origHandleControlData) {
-    (proto as unknown as Record<string, unknown>).handleControlData = async function (
+    (proto as any).handleControlData = async function (
       data: { headers: Array<{ key: string; value: string }>; payload?: Uint8Array },
     ) {
       const self = this as unknown as Record<string, unknown>;
@@ -74,7 +74,7 @@ function applyFeishuSDKReconnectPatch(): void {
   // --- Fix 2: Exponential backoff on reConnect ---
   const origReConnect = proto.reConnect as ((isStart?: boolean) => Promise<void>) | undefined;
   if (origReConnect) {
-    (proto as unknown as Record<string, unknown>).reConnect = async function (isStart = false) {
+    (proto as any).reConnect = async function (isStart = false) {
       const self = this as unknown as Record<string, unknown>;
       if (isStart) {
         // Reset backoff counter on a fresh start

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -50,7 +50,8 @@ function applyFeishuSDKReconnectPatch(): void {
     | ((data: { headers: Array<{ key: string; value: string }>; payload?: Uint8Array }) => Promise<void>)
     | undefined;
   if (origHandleControlData) {
-    (proto as any).handleControlData = async function (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (proto as unknown as { handleControlData: typeof origHandleControlData }).handleControlData = async function (
       data: { headers: Array<{ key: string; value: string }>; payload?: Uint8Array },
     ) {
       const self = this as unknown as Record<string, unknown>;
@@ -74,7 +75,8 @@ function applyFeishuSDKReconnectPatch(): void {
   // --- Fix 2: Exponential backoff on reConnect ---
   const origReConnect = proto.reConnect as ((isStart?: boolean) => Promise<void>) | undefined;
   if (origReConnect) {
-    (proto as any).reConnect = async function (isStart = false) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (proto as unknown as { reConnect: typeof origReConnect }).reConnect = async function (isStart = false) {
       const self = this as unknown as Record<string, unknown>;
       if (isStart) {
         // Reset backoff counter on a fresh start

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -26,6 +26,73 @@ const defaultFeishuClientSdk: FeishuClientSdk = {
 let feishuClientSdk: FeishuClientSdk = defaultFeishuClientSdk;
 let httpsProxyAgentCtor: typeof HttpsProxyAgent = HttpsProxyAgent;
 
+/** Default reconnect interval for Feishu WebSocket (in ms). */
+const DEFAULT_RECONNECT_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
+
+/** Maximum reconnect backoff for Feishu WebSocket (in ms). */
+const MAX_RECONNECT_BACKOFF_MS = 15 * 60 * 1000; // 15 minutes
+
+/**
+ * Applies monkey-patches to the Lark WSClient prototype to fix two bugs:
+ * 1. PingInterval may be undefined on system_busy responses, causing a crash
+ * 2. Reconnect uses a fixed interval instead of exponential backoff
+ *
+ * This is applied once at module load time so all WSClient instances are fixed.
+ */
+function applyFeishuSDKReconnectPatch(): void {
+  const WSClient = defaultFeishuClientSdk.WSClient;
+  if (!WSClient?.prototype) return;
+
+  const proto = WSClient.prototype;
+
+  // --- Fix 1: Guard PingInterval in handleControlData (pong handler) ---
+  const origHandleControlData = proto.handleControlData as
+    | ((data: { headers: Array<{ key: string; value: string }>; payload?: Uint8Array }) => Promise<void>)
+    | undefined;
+  if (origHandleControlData) {
+    (proto as Record<string, unknown>).handleControlData = async function (
+      data: { headers: Array<{ key: string; value: string }>; payload?: Uint8Array },
+    ) {
+      try {
+        return await origHandleControlData.call(this, data);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("PingInterval") || msg.includes("undefined")) {
+          this.logger?.warn?.(
+            "[feishu-ws-patch]",
+            "swallowed PingInterval error in pong handler (Feishu system_busy?)",
+          );
+          return; // swallow — Feishu returns no Pong on system_busy
+        }
+        throw err;
+      }
+    };
+  }
+
+  // --- Fix 2: Exponential backoff on reConnect ---
+  const origReConnect = proto.reConnect as ((isStart?: boolean) => Promise<void>) | undefined;
+  if (origReConnect) {
+    (proto as Record<string, unknown>).reConnect = async function (isStart = false) {
+      if (!isStart) {
+        // Exponential backoff: doubles each retry, capped at MAX_RECONNECT_BACKOFF_MS
+        this._feishuReconnectCount = ((this as Record<string, unknown>)._feishuReconnectCount as number) + 1 || 1;
+        const count = (this as Record<string, unknown>)._feishuReconnectCount as number;
+        const { reconnectInterval = DEFAULT_RECONNECT_INTERVAL_MS } = this.wsConfig?.getWS?.() ?? {};
+        const backoff = Math.min(reconnectInterval * Math.pow(2, count - 1), MAX_RECONNECT_BACKOFF_MS);
+        this.logger?.info?.(
+          "[feishu-ws-patch]",
+          `reconnect backoff: ${Math.round(backoff / 1000)}s (attempt ${count})`,
+        );
+        await new Promise<void>((resolve) => setTimeout(resolve, backoff));
+      }
+      return origReConnect.call(this, isStart);
+    };
+  }
+}
+
+// Apply patch once at module load
+applyFeishuSDKReconnectPatch();
+
 /** Default HTTP timeout for Feishu API requests (30 seconds). */
 export const FEISHU_HTTP_TIMEOUT_MS = 30_000;
 export const FEISHU_HTTP_TIMEOUT_MAX_MS = 300_000;

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -50,7 +50,7 @@ function applyFeishuSDKReconnectPatch(): void {
     | ((data: { headers: Array<{ key: string; value: string }>; payload?: Uint8Array }) => Promise<void>)
     | undefined;
   if (origHandleControlData) {
-    (proto as Record<string, unknown>).handleControlData = async function (
+    (proto as unknown as Record<string, unknown>).handleControlData = async function (
       data: { headers: Array<{ key: string; value: string }>; payload?: Uint8Array },
     ) {
       try {
@@ -72,16 +72,16 @@ function applyFeishuSDKReconnectPatch(): void {
   // --- Fix 2: Exponential backoff on reConnect ---
   const origReConnect = proto.reConnect as ((isStart?: boolean) => Promise<void>) | undefined;
   if (origReConnect) {
-    (proto as Record<string, unknown>).reConnect = async function (isStart = false) {
+    (proto as unknown as Record<string, unknown>).reConnect = async function (isStart = false) {
       if (isStart) {
         // Reset backoff counter on a fresh start
-        (this as Record<string, unknown>)._feishuReconnectCount = 0;
+        (this as unknown as Record<string, unknown>)._feishuReconnectCount = 0;
       }
       if (!isStart) {
         // Exponential backoff: doubles each retry, capped at MAX_RECONNECT_BACKOFF_MS
         // Add ±20% jitter to avoid synchronized retries across multiple clients
-        this._feishuReconnectCount = ((this as Record<string, unknown>)._feishuReconnectCount as number) + 1 || 1;
-        const count = (this as Record<string, unknown>)._feishuReconnectCount as number;
+        (this as unknown as Record<string, unknown>)._feishuReconnectCount = ((this as unknown as Record<string, unknown>)._feishuReconnectCount as number) + 1 || 1;
+        const count = (this as unknown as Record<string, unknown>)._feishuReconnectCount as number;
         const { reconnectInterval = DEFAULT_RECONNECT_INTERVAL_MS } = this.wsConfig?.getWS?.() ?? {};
         const jitter = 1 + (Math.random() - 0.5) * 0.4; // ±20%
         const backoff = Math.min(reconnectInterval * Math.pow(2, count - 1) * jitter, MAX_RECONNECT_BACKOFF_MS);

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -79,13 +79,15 @@ function applyFeishuSDKReconnectPatch(): void {
       }
       if (!isStart) {
         // Exponential backoff: doubles each retry, capped at MAX_RECONNECT_BACKOFF_MS
+        // Add ±20% jitter to avoid synchronized retries across multiple clients
         this._feishuReconnectCount = ((this as Record<string, unknown>)._feishuReconnectCount as number) + 1 || 1;
         const count = (this as Record<string, unknown>)._feishuReconnectCount as number;
         const { reconnectInterval = DEFAULT_RECONNECT_INTERVAL_MS } = this.wsConfig?.getWS?.() ?? {};
-        const backoff = Math.min(reconnectInterval * Math.pow(2, count - 1), MAX_RECONNECT_BACKOFF_MS);
+        const jitter = 1 + (Math.random() - 0.5) * 0.4; // ±20%
+        const backoff = Math.min(reconnectInterval * Math.pow(2, count - 1) * jitter, MAX_RECONNECT_BACKOFF_MS);
         this.logger?.info?.(
           "[feishu-ws-patch]",
-          `reconnect backoff: ${Math.round(backoff / 1000)}s (attempt ${count})`,
+          `reconnect backoff: ${Math.round(backoff / 1000)}s (attempt ${count}, jitter ${Math.round((jitter - 1) * 100)}%)`,
         );
         await new Promise<void>((resolve) => setTimeout(resolve, backoff));
       }


### PR DESCRIPTION
## Summary

Fix two bugs in the Feishu WebSocket reconnect logic that cause extended outages during Feishu rate-limiting events.

### Bug 1: PingInterval undefined crash

When Feishu returns `system busy` (error code 1000040345), the server does not send a Pong frame with `PingInterval`. The Lark SDK crashes with:

```
Cannot read properties of undefined (reading 'PingInterval')
```

**Fix:** Wrap `handleControlData` in a try/catch that silently swallows this specific error.

### Bug 2: Fixed reconnect interval amplifies rate limiting

The Lark SDK reconnects at a fixed interval (default 120s) with no backoff. During a Feishu rate-limit event, this creates a tight loop of failed reconnects.

**Fix:** Added exponential backoff on non-start reconnects: 2min → 4min → 8min → 15min (capped).

### P1 fixes (per greptile review)

- Narrow error filter from `msg.includes("PingInterval") || msg.includes("undefined")` to `msg.includes("PingInterval")` only — avoids swallowing unrelated errors
- Reset `_feishuReconnectCount` to 0 on successful (`isStart=true`) connection — so future failures start fresh at 2min instead of jumping to 16min

### Testing

- [x] PingInterval crash no longer appears in logs after patch
- [x] Reconnect backoff visible in logs as: `[feishu-ws-patch] reconnect backoff: Xs (attempt N)`
- [x] Counter resets correctly after successful reconnect

### Issue

Fixes #55532