### PR TITLE
  fix(webchat): fix real-time updates for sessionKey aliases

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -65,6 +65,69 @@ describe("handleChatEvent", () => {
     expect(handleChatEvent(state, payload)).toBe(null);
   });
 
+  it("accepts canonical default main session key for main alias", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Working...",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Done" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Done" }],
+      },
+    ]);
+  });
+
+  it("accepts main alias for canonical default main session key", () => {
+    const state = createState({
+      sessionKey: "agent:main:main",
+      chatRunId: "run-1",
+      chatStream: "Working...",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Done" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Done" }],
+      },
+    ]);
+  });
+
+  it("does not match a different canonical session key", () => {
+    const state = createState({ sessionKey: "main" });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "agent:other:main",
+      state: "final",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe(null);
+  });
+
   it("returns null for delta from another run", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -128,6 +128,17 @@ describe("handleChatEvent", () => {
     expect(handleChatEvent(state, payload)).toBe(null);
   });
 
+  it("keeps exact sessionKey matching case-sensitive outside the alias pair", () => {
+    const state = createState({ sessionKey: "Work" });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "work",
+      state: "final",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe(null);
+  });
+
   it("returns null for delta from another run", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -14,10 +14,13 @@ const DEFAULT_MAIN_SESSION_ALIAS = "main";
 const DEFAULT_MAIN_SESSION_KEY = "agent:main:main";
 
 function normalizeSessionKey(sessionKey: string | undefined | null): string {
-  return (sessionKey ?? "").trim().toLowerCase();
+  return (sessionKey ?? "").trim();
 }
 
-function matchesSessionKey(current: string | undefined | null, incoming: string | undefined | null): boolean {
+function matchesSessionKey(
+  current: string | undefined | null,
+  incoming: string | undefined | null,
+): boolean {
   const currentNormalized = normalizeSessionKey(current);
   const incomingNormalized = normalizeSessionKey(incoming);
   if (!currentNormalized || !incomingNormalized) {
@@ -26,11 +29,13 @@ function matchesSessionKey(current: string | undefined | null, incoming: string 
   if (currentNormalized === incomingNormalized) {
     return true;
   }
+  const currentAliasKey = currentNormalized.toLowerCase();
+  const incomingAliasKey = incomingNormalized.toLowerCase();
   return (
-    (currentNormalized === DEFAULT_MAIN_SESSION_ALIAS &&
-      incomingNormalized === DEFAULT_MAIN_SESSION_KEY) ||
-    (currentNormalized === DEFAULT_MAIN_SESSION_KEY &&
-      incomingNormalized === DEFAULT_MAIN_SESSION_ALIAS)
+    (currentAliasKey === DEFAULT_MAIN_SESSION_ALIAS &&
+      incomingAliasKey === DEFAULT_MAIN_SESSION_KEY) ||
+    (currentAliasKey === DEFAULT_MAIN_SESSION_KEY &&
+      incomingAliasKey === DEFAULT_MAIN_SESSION_ALIAS)
   );
 }
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -10,6 +10,29 @@ import {
 } from "./scope-errors.ts";
 
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
+const DEFAULT_MAIN_SESSION_ALIAS = "main";
+const DEFAULT_MAIN_SESSION_KEY = "agent:main:main";
+
+function normalizeSessionKey(sessionKey: string | undefined | null): string {
+  return (sessionKey ?? "").trim().toLowerCase();
+}
+
+function matchesSessionKey(current: string | undefined | null, incoming: string | undefined | null): boolean {
+  const currentNormalized = normalizeSessionKey(current);
+  const incomingNormalized = normalizeSessionKey(incoming);
+  if (!currentNormalized || !incomingNormalized) {
+    return false;
+  }
+  if (currentNormalized === incomingNormalized) {
+    return true;
+  }
+  return (
+    (currentNormalized === DEFAULT_MAIN_SESSION_ALIAS &&
+      incomingNormalized === DEFAULT_MAIN_SESSION_KEY) ||
+    (currentNormalized === DEFAULT_MAIN_SESSION_KEY &&
+      incomingNormalized === DEFAULT_MAIN_SESSION_ALIAS)
+  );
+}
 
 function isSilentReplyStream(text: string): boolean {
   return SILENT_REPLY_PATTERN.test(text);
@@ -274,7 +297,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (!payload) {
     return null;
   }
-  if (payload.sessionKey !== state.sessionKey) {
+  if (!matchesSessionKey(state.sessionKey, payload.sessionKey)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

  - Fix WebChat real-time updates when the UI uses `main` and incoming chat events use `agent:main:main`.
  - Replace strict sessionKey equality in the chat event handler with alias-aware matching for the default main session.
  - Add regression tests for alias/canonical matching and non-matching sessions.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] UI / DX

  ## Linked Issue/PR

  - Closes #51851
  - [x] This PR fixes a bug or regression

  ## Root Cause / Regression History (if applicable)

  - Root cause: the WebChat controller used strict sessionKey equality even when `main` and `agent:main:main` referred to the same session.
  - Missing detection / guardrail: no regression test covered alias/canonical matching in `handleChatEvent()`.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
  - Target test or file: `ui/src/ui/controllers/chat.test.ts`
  - Scenario the test should lock in: accept `main` ↔ `agent:main:main` and reject unrelated session keys.

  ## User-visible / Behavior Changes

  - WebChat replies now appear in real time for the default main session alias/canonical mismatch case.

  ## Diagram (if applicable)

  N/A

  ## Security Impact (required)

  - New permissions/capabilities? (`No`)
  - Secrets/tokens handling changed? (`No`)
  - New/changed network calls? (`No`)
  - Command/tool execution surface changed? (`No`)
  - Data access scope changed? (`No`)

  ## Repro + Verification

  ### Steps

  1. Open WebChat in the default main session.
  2. Send a message without refreshing the page.
  3. Verify the reply appears immediately.

  ### Expected

  - The reply appears in real time without a manual refresh.

  ## Evidence

  - [x] Failing test/log before + passing after

  ## Human Verification (required)

  - Verified scenarios: ran `ui/src/ui/controllers/chat.test.ts`, including the new alias/canonical cases.
  - Edge cases checked: unrelated session keys are still rejected.
  - What you did **not** verify: full deployed browser verification.

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? (`Yes`)
  - Config/env changes? (`No`)
  - Migration needed? (`No`)

  ## Risks and Mitigations

  - Risk: alias matching could become too broad.
    - Mitigation: the change is limited to `main` ↔ `agent:main:main` and covered by tests.