### PR TITLE
fix: discord OOM, OpenAI tool adjacency, subagent fallback, auth cache

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.reconnect.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.reconnect.ts
@@ -301,7 +301,10 @@ export function createDiscordGatewayReconnectController(params: {
   const onGatewayDebug = (msg: unknown) => {
     const message = String(msg);
     const at = Date.now();
-    params.pushStatus({ lastEventAt: at });
+    // Only update lastEventAt for meaningful connection state changes (open/close),
+    // not every debug message (heartbeat ACKs, shard chatter). Blanket updates
+    // inflate lastEventAt with noise, masking stale-socket detection on quiet
+    // servers and causing unnecessary restart loops that leak memory. (#55606)
     if (message.includes("WebSocket connection closed")) {
       if (params.gateway?.isConnected) {
         resetHelloStallCounter();

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -771,6 +771,7 @@ async function agentCommandInternal(
             workspaceDir,
             body,
             isFallbackRetry,
+            isNewSession,
             resolvedThinkLevel,
             timeoutMs,
             runId,

--- a/src/agents/auth-profiles.runtime-snapshot-save.test.ts
+++ b/src/agents/auth-profiles.runtime-snapshot-save.test.ts
@@ -8,6 +8,7 @@ import {
   prepareSecretsRuntimeSnapshot,
 } from "../secrets/runtime.js";
 import { ensureAuthProfileStore, markAuthProfileUsed } from "./auth-profiles.js";
+import { updateAuthProfileStoreWithLock } from "./auth-profiles/store.js";
 
 describe("auth profile runtime snapshot persistence", () => {
   it("does not write resolved plaintext keys during usage updates", async () => {
@@ -64,6 +65,60 @@ describe("auth profile runtime snapshot persistence", () => {
         provider: "default",
         id: "OPENAI_API_KEY",
       });
+    } finally {
+      clearSecretsRuntimeSnapshot();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("updateAuthProfileStoreWithLock updates runtime cache after save (#55562)", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-cache-update-"));
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const authPath = path.join(agentDir, "auth-profiles.json");
+    try {
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        authPath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "openai:default": {
+                type: "api_key",
+                provider: "openai",
+                key: "sk-disk-key",
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const snapshot = await prepareSecretsRuntimeSnapshot({
+        config: {},
+        env: {},
+        agentDirs: [agentDir],
+      });
+      activateSecretsRuntimeSnapshot(snapshot);
+
+      // Runtime cache should have the disk profile
+      const before = ensureAuthProfileStore(agentDir);
+      expect(before.profiles["openai:default"]?.provider).toBe("openai");
+
+      // Mutate via locked updater (adds usageStats)
+      await updateAuthProfileStoreWithLock({
+        agentDir,
+        updater: (store) => {
+          store.usageStats = { "openai:default": { lastUsed: 123 } };
+          return true;
+        },
+      });
+
+      // Subsequent non-locked read should see the mutation in the cache
+      const after = ensureAuthProfileStore(agentDir);
+      expect(after.usageStats?.["openai:default"]?.lastUsed).toBe(123);
     } finally {
       clearSecretsRuntimeSnapshot();
       await fs.rm(stateDir, { recursive: true, force: true });

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -141,7 +141,7 @@ export async function updateAuthProfileStoreWithLock(params: {
         // ensureAuthProfileStore() see the freshly persisted state
         // instead of returning stale per-agent keys. (#55562)
         const cacheKey = resolveRuntimeStoreKey(params.agentDir);
-        if (runtimeAuthStoreSnapshots.size > 0) {
+        if (runtimeAuthStoreSnapshots.size > 0 && runtimeAuthStoreSnapshots.has(cacheKey)) {
           runtimeAuthStoreSnapshots.set(cacheKey, cloneAuthProfileStore(store));
         }
       }

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -137,6 +137,13 @@ export async function updateAuthProfileStoreWithLock(params: {
       const shouldSave = params.updater(store);
       if (shouldSave) {
         saveAuthProfileStore(store, params.agentDir);
+        // Update runtime cache so subsequent non-locked reads via
+        // ensureAuthProfileStore() see the freshly persisted state
+        // instead of returning stale per-agent keys. (#55562)
+        const cacheKey = resolveRuntimeStoreKey(params.agentDir);
+        if (runtimeAuthStoreSnapshots.size > 0) {
+          runtimeAuthStoreSnapshots.set(cacheKey, cloneAuthProfileStore(store));
+        }
       }
       return store;
     });

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -54,8 +54,12 @@ export async function persistSessionEntry(params: PersistSessionEntryParams): Pr
 export function resolveFallbackRetryPrompt(params: {
   body: string;
   isFallbackRetry: boolean;
+  isNewSession: boolean;
 }): string {
-  if (!params.isFallbackRetry) {
+  // On new sessions (including subagent spawns), always preserve the original
+  // body: the transcript is empty so the recovery message has no prior context
+  // to "continue" from, and the fallback model needs the original task. (#55581)
+  if (!params.isFallbackRetry || params.isNewSession) {
     return params.body;
   }
   return "Continue where you left off. The previous model attempt failed or timed out.";
@@ -242,6 +246,7 @@ export function runAgentAttempt(params: {
   workspaceDir: string;
   body: string;
   isFallbackRetry: boolean;
+  isNewSession: boolean;
   resolvedThinkLevel: ThinkLevel;
   timeoutMs: number;
   runId: string;
@@ -261,6 +266,7 @@ export function runAgentAttempt(params: {
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
     isFallbackRetry: params.isFallbackRetry,
+    isNewSession: params.isNewSession,
   });
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,

--- a/src/agents/pi-embedded-helpers.validate-turns.test.ts
+++ b/src/agents/pi-embedded-helpers.validate-turns.test.ts
@@ -511,4 +511,50 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
     const result = validateAnthropicTurns(msgs);
     expect(result).toHaveLength(3);
   });
+
+  it("skips user-turn merging when transcript has string-form content", () => {
+    // openai-completions providers that are not Anthropic-compatible may
+    // use plain string content.  Merging would convert to block-form arrays
+    // that downstream providers cannot interpret.
+    const msgs = asMessages([
+      { role: "user", content: "First question" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Answer" }],
+      },
+      { role: "user", content: "Follow-up" },
+      { role: "user", content: "Another follow-up" },
+    ]);
+
+    const result = validateAnthropicTurns(msgs);
+
+    // Consecutive user messages should NOT be merged when content is string-form
+    expect(result).toHaveLength(4);
+    // Content must remain as plain strings, not converted to block arrays
+    expect((result[2] as { content: unknown }).content).toBe("Follow-up");
+    expect((result[3] as { content: unknown }).content).toBe("Another follow-up");
+  });
+
+  it("still strips dangling tool_use blocks with string-form user content", () => {
+    // Even when user messages are string-form, dangling tool_use blocks in
+    // assistant messages should still be stripped.
+    const msgs = [
+      { role: "user", content: "Use tool" },
+      {
+        role: "assistant",
+        content: [
+          { type: "toolUse", id: "tool-1", name: "test", input: {} },
+          { type: "text", text: "I'll check that" },
+        ],
+      },
+      { role: "user", content: "Hello" },
+    ] as unknown as AgentMessage[];
+
+    const result = validateAnthropicTurns(msgs);
+
+    expect(result).toHaveLength(3);
+    // The dangling tool_use should be stripped even with string-form user content
+    const assistantContent = (result[1] as { content?: unknown[] }).content;
+    expect(assistantContent).toEqual([{ type: "text", text: "I'll check that" }]);
+  });
 });

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -171,10 +171,16 @@ export function mergeConsecutiveUserTurns(
   previous: Extract<AgentMessage, { role: "user" }>,
   current: Extract<AgentMessage, { role: "user" }>,
 ): Extract<AgentMessage, { role: "user" }> {
-  const mergedContent = [
-    ...(Array.isArray(previous.content) ? previous.content : []),
-    ...(Array.isArray(current.content) ? current.content : []),
-  ];
+  const toBlocks = (content: unknown): AnthropicContentBlock[] => {
+    if (Array.isArray(content)) {
+      return content;
+    }
+    if (typeof content === "string" && content.length > 0) {
+      return [{ type: "text", text: content }];
+    }
+    return [];
+  };
+  const mergedContent = [...toBlocks(previous.content), ...toBlocks(current.content)];
 
   return {
     ...current,

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -1,12 +1,38 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
-type AnthropicContentBlock = {
-  type: "text" | "toolUse" | "toolResult";
+type AnthropicTextBlock = {
+  type: "text";
   text?: string;
+};
+
+type AnthropicImageBlock = {
+  type: "image";
+  url?: string;
+  mediaType?: string;
+  data?: string;
+};
+
+type AnthropicToolUseBlock = {
+  type: "toolUse";
   id?: string;
   name?: string;
-  toolUseId?: string;
+  input?: unknown;
 };
+
+type AnthropicToolResultBlock = {
+  type: "toolResult";
+  toolUseId?: string;
+  content?: unknown;
+  isError?: boolean;
+};
+
+type AnthropicContentBlock =
+  | AnthropicTextBlock
+  | AnthropicImageBlock
+  | AnthropicToolUseBlock
+  | AnthropicToolResultBlock;
+
+type UserAgentMessage = Extract<AgentMessage, { role: "user" }>;
 
 /**
  * Strips dangling tool_use blocks from assistant messages when the immediately
@@ -89,20 +115,23 @@ function stripDanglingAnthropicToolUses(messages: AgentMessage[]): AgentMessage[
   return result;
 }
 
-function validateTurnsWithConsecutiveMerge<TRole extends "assistant" | "user">(params: {
-  messages: AgentMessage[];
+function validateTurnsWithConsecutiveMerge<
+  TMessage extends AgentMessage,
+  TRole extends "assistant" | "user",
+>(params: {
+  messages: TMessage[];
   role: TRole;
   merge: (
-    previous: Extract<AgentMessage, { role: TRole }>,
-    current: Extract<AgentMessage, { role: TRole }>,
-  ) => Extract<AgentMessage, { role: TRole }>;
-}): AgentMessage[] {
+    previous: Extract<TMessage, { role: TRole }>,
+    current: Extract<TMessage, { role: TRole }>,
+  ) => Extract<TMessage, { role: TRole }>;
+}): TMessage[] {
   const { messages, role, merge } = params;
   if (!Array.isArray(messages) || messages.length === 0) {
     return messages;
   }
 
-  const result: AgentMessage[] = [];
+  const result: TMessage[] = [];
   let lastRole: string | undefined;
 
   for (const msg of messages) {
@@ -119,10 +148,10 @@ function validateTurnsWithConsecutiveMerge<TRole extends "assistant" | "user">(p
 
     if (msgRole === lastRole && lastRole === role) {
       const lastMsg = result[result.length - 1];
-      const currentMsg = msg as Extract<AgentMessage, { role: TRole }>;
+      const currentMsg = msg as Extract<TMessage, { role: TRole }>;
 
       if (lastMsg && typeof lastMsg === "object") {
-        const lastTyped = lastMsg as Extract<AgentMessage, { role: TRole }>;
+        const lastTyped = lastMsg as Extract<TMessage, { role: TRole }>;
         result[result.length - 1] = merge(lastTyped, currentMsg);
         continue;
       }
@@ -168,9 +197,9 @@ export function validateGeminiTurns(messages: AgentMessage[]): AgentMessage[] {
 }
 
 export function mergeConsecutiveUserTurns(
-  previous: Extract<AgentMessage, { role: "user" }>,
-  current: Extract<AgentMessage, { role: "user" }>,
-): Extract<AgentMessage, { role: "user" }> {
+  previous: UserAgentMessage,
+  current: UserAgentMessage,
+): UserAgentMessage {
   const toBlocks = (content: unknown): AnthropicContentBlock[] => {
     if (Array.isArray(content)) {
       return content;
@@ -184,7 +213,10 @@ export function mergeConsecutiveUserTurns(
 
   return {
     ...current,
-    content: mergedContent,
+    // validateAnthropicTurns only merges block-form transcripts, but the
+    // shared AgentMessage type still models user content as string/text/image.
+    // Cast back here so the runtime-safe Anthropic block merge remains local.
+    content: mergedContent as UserAgentMessage["content"],
     timestamp: current.timestamp ?? previous.timestamp,
   };
 }

--- a/src/agents/pi-embedded-helpers/turns.ts
+++ b/src/agents/pi-embedded-helpers/turns.ts
@@ -190,14 +190,49 @@ export function mergeConsecutiveUserTurns(
 }
 
 /**
+ * Returns true when every user message in the transcript uses block-form
+ * (array) `content`.  When any user message carries a plain string, the
+ * transcript is considered "string-form" and consecutive-user merging must
+ * be skipped — merging would convert the content to an array of Anthropic
+ * content blocks that non-Anthropic providers cannot interpret.
+ */
+function transcriptUsesBlockFormContent(messages: AgentMessage[]): boolean {
+  for (const msg of messages) {
+    if (
+      msg &&
+      typeof msg === "object" &&
+      (msg as { role?: string }).role === "user" &&
+      !Array.isArray((msg as { content?: unknown }).content)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Validates and fixes conversation turn sequences for Anthropic API.
  * Anthropic requires strict alternating user→assistant pattern.
  * Merges consecutive user messages together.
  * Also strips dangling tool_use blocks that lack corresponding tool_result blocks.
+ *
+ * When the transcript contains string-form user content (plain strings rather
+ * than Anthropic content-block arrays), consecutive-user merging is skipped to
+ * avoid converting content into a format that non-Anthropic providers cannot
+ * consume.  Dangling tool_use stripping still runs unconditionally.
  */
 export function validateAnthropicTurns(messages: AgentMessage[]): AgentMessage[] {
   // First, strip dangling tool_use blocks from assistant messages
   const stripped = stripDanglingAnthropicToolUses(messages);
+
+  // Only merge consecutive user turns when the transcript uses block-form
+  // content.  String-form transcripts (from openai-completions providers that
+  // are not strictly Anthropic-compatible) would have their content silently
+  // converted to Anthropic content-block arrays, which downstream providers
+  // cannot interpret.  (#55670)
+  if (!transcriptUsesBlockFormContent(stripped)) {
+    return stripped;
+  }
 
   return validateTurnsWithConsecutiveMerge({
     messages: stripped,

--- a/src/agents/transcript-policy.policy.test.ts
+++ b/src/agents/transcript-policy.policy.test.ts
@@ -13,6 +13,24 @@ describe("resolveTranscriptPolicy e2e smoke", () => {
     expect(policy.toolCallIdMode).toBeUndefined();
   });
 
+  it("enables validateAnthropicTurns for all openai-completions providers", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openrouter",
+      modelId: "deepseek-chat",
+      modelApi: "openai-completions",
+    });
+    expect(policy.validateAnthropicTurns).toBe(true);
+  });
+
+  it("enables validateAnthropicTurns for openai-completions with a non-strict provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "opencode",
+      modelId: "deepseek-chat",
+      modelApi: "openai-completions",
+    });
+    expect(policy.validateAnthropicTurns).toBe(true);
+  });
+
   it("uses strict9 tool-call sanitization for Mistral-family models", () => {
     const policy = resolveTranscriptPolicy({
       provider: "mistral",

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -180,7 +180,7 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.validateAnthropicTurns).toBe(true);
   });
 
-  it("keeps OpenRouter on its existing turn-validation path", () => {
+  it("enables dangling-tool-use stripping for OpenRouter openai-completions", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openrouter",
       modelId: "openai/gpt-4.1",
@@ -188,7 +188,10 @@ describe("resolveTranscriptPolicy", () => {
     });
     expect(policy.applyGoogleTurnOrdering).toBe(false);
     expect(policy.validateGeminiTurns).toBe(false);
-    expect(policy.validateAnthropicTurns).toBe(false);
+    // validateAnthropicTurns is enabled for all openai-completions providers
+    // to strip dangling tool_use blocks; user-turn merging is gated at
+    // runtime by a block-form content check so string transcripts are safe.
+    expect(policy.validateAnthropicTurns).toBe(true);
   });
 
   it.each([

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -121,7 +121,11 @@ export function resolveTranscriptPolicy(params: {
     dropThinkingBlocks,
     applyGoogleTurnOrdering: !isOpenAi && (isGoogle || isStrictOpenAiCompatible),
     validateGeminiTurns: !isOpenAi && (isGoogle || isStrictOpenAiCompatible),
-    validateAnthropicTurns: !isOpenAi && (isAnthropic || isStrictOpenAiCompatible),
+    // Strip dangling tool_calls for all openai-completions providers, not just
+    // strictly compatible ones. Session resets can leave orphaned tool_calls in
+    // history that violate OpenAI's adjacency requirement. (#55544)
+    validateAnthropicTurns:
+      !isOpenAi && (isAnthropic || isStrictOpenAiCompatible || params.modelApi === "openai-completions"),
     allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
   };
 }

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -125,7 +125,8 @@ export function resolveTranscriptPolicy(params: {
     // strictly compatible ones. Session resets can leave orphaned tool_calls in
     // history that violate OpenAI's adjacency requirement. (#55544)
     validateAnthropicTurns:
-      !isOpenAi && (isAnthropic || isStrictOpenAiCompatible || params.modelApi === "openai-completions"),
+      !isOpenAi &&
+      (isAnthropic || isStrictOpenAiCompatible || params.modelApi === "openai-completions"),
     allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
   };
 }

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -181,6 +181,48 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
 
+  it("treats a quiet connected server as healthy when lastEventAt equals lastConnectedAt", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 50_000,
+        lastEventAt: 55_000,
+        lastConnectedAt: 55_000,
+      },
+      {
+        channelId: "discord",
+        now: 200_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("detects stale-socket when real events arrived after connection then went silent", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 50_000,
+        lastEventAt: 60_000,
+        lastConnectedAt: 55_000,
+      },
+      {
+        channelId: "discord",
+        now: 200_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
+  });
+
   it("does not flag stale sockets without an active connected socket", () => {
     const evaluation = evaluateDiscordHealth(
       {

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -11,6 +11,7 @@ export type ChannelHealthSnapshot = {
   lastRunActivityAt?: number | null;
   lastEventAt?: number | null;
   lastStartAt?: number | null;
+  lastConnectedAt?: number | null;
   reconnectAttempts?: number;
   mode?: string;
 };
@@ -116,6 +117,17 @@ export function evaluateChannelHealth(
     snapshot.connected === true &&
     snapshot.lastEventAt != null
   ) {
+    // When the only recorded event is the connection itself (lastEventAt
+    // matches lastConnectedAt), the server is quiet — not half-dead.
+    // Skip stale-socket detection so quiet servers don't trigger
+    // unnecessary restart loops that leak memory. (#55606)
+    const lastConnectedAt =
+      typeof snapshot.lastConnectedAt === "number" && Number.isFinite(snapshot.lastConnectedAt)
+        ? snapshot.lastConnectedAt
+        : null;
+    if (lastConnectedAt != null && snapshot.lastEventAt <= lastConnectedAt) {
+      return { healthy: true, reason: "healthy" };
+    }
     if (lastStartAt != null && snapshot.lastEventAt < lastStartAt) {
       const lifecycleEventGap = Math.max(0, policy.now - lastStartAt);
       if (lifecycleEventGap <= policy.staleEventThresholdMs) {


### PR DESCRIPTION
## Summary

Fixes four independent high-impact bugs:

- **#55606** — Discord health-monitor triggers excessive stale-socket reconnects on quiet servers, leaking memory until OOM. Removed blanket `lastEventAt` inflation from debug messages and added a quiet-server guard using `lastConnectedAt` so connected channels with no real events aren't treated as stale.

- **#55544** — Session reset prompt (`/new`, `/reset`) breaks tool_call adjacency for custom OpenAI-compatible providers (HTTP 400). Enabled `validateAnthropicTurns` for all `openai-completions` providers so orphaned tool_calls from prior sessions are stripped before sending.

- **#55581** — Subagent loses its original task when model fallback triggers, receiving a generic "Continue where you left off" recovery message instead. Now preserves the original body when `isNewSession` is true since the transcript is empty and the fallback model needs the actual task.

- **#55562** — Gateway in-memory auth cache overwrites per-agent API keys on disk during usage/cooldown updates. Added runtime cache write-through after locked saves so subsequent reads via `ensureAuthProfileStore()` return fresh data.

## Test plan

- [x] `pnpm vitest run src/gateway/channel-health-policy.test.ts` — 16 tests pass (2 new)
- [x] `pnpm vitest run src/agents/transcript-policy.policy.test.ts` — 4 tests pass (2 new)
- [x] `pnpm vitest run src/agents/auth-profiles.runtime-snapshot-save.test.ts` — 2 tests pass (1 new)
- [x] `pnpm tsc --noEmit` — clean