### PR TITLE
feat(config): improve error messages for groupPolicy and dmPolicy

### DIFF
--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -100,7 +100,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         dmPolicy: {
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -130,7 +129,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         groupPolicy: {
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         enrichGroupParticipantsFromContacts: {
           default: true,
@@ -308,7 +306,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -338,7 +335,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               groupPolicy: {
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               enrichGroupParticipantsFromContacts: {
                 default: true,
@@ -654,7 +650,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         groupPolicy: {
           default: "allowlist",
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         historyLimit: {
           type: "integer",
@@ -879,7 +874,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         dmPolicy: {
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -905,7 +899,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             },
             policy: {
               type: "string",
-              enum: ["pairing", "allowlist", "open", "disabled"],
             },
             allowFrom: {
               type: "array",
@@ -1862,7 +1855,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               historyLimit: {
                 type: "integer",
@@ -2087,7 +2079,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -2113,7 +2104,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   },
                   policy: {
                     type: "string",
-                    enum: ["pairing", "allowlist", "open", "disabled"],
                   },
                   allowFrom: {
                     type: "array",
@@ -4279,7 +4269,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         groupPolicy: {
           default: "allowlist",
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         groupAllowFrom: {
           type: "array",
@@ -4591,7 +4580,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             policy: {
               default: "pairing",
               type: "string",
-              enum: ["pairing", "allowlist", "open", "disabled"],
             },
             allowFrom: {
               type: "array",
@@ -4661,7 +4649,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               groupAllowFrom: {
                 type: "array",
@@ -4973,7 +4960,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   policy: {
                     default: "pairing",
                     type: "string",
-                    enum: ["pairing", "allowlist", "open", "disabled"],
                   },
                   allowFrom: {
                     type: "array",
@@ -5086,7 +5072,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -5120,7 +5105,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         groupPolicy: {
           default: "allowlist",
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         historyLimit: {
           type: "integer",
@@ -5362,7 +5346,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -5396,7 +5379,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               historyLimit: {
                 type: "integer",
@@ -5676,7 +5658,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -5694,7 +5675,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         groupPolicy: {
           default: "allowlist",
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         groupAllowFrom: {
           type: "array",
@@ -5962,7 +5942,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -5980,7 +5959,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               groupAllowFrom: {
                 type: "array",
@@ -6609,7 +6587,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         groupPolicy: {
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         replyToMode: {
           type: "string",
@@ -6711,7 +6688,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             },
             policy: {
               type: "string",
-              enum: ["pairing", "allowlist", "open", "disabled"],
             },
             allowFrom: {
               type: "array",
@@ -7040,7 +7016,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -7071,7 +7046,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         groupPolicy: {
           default: "allowlist",
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         textChunkLimit: {
           type: "integer",
@@ -7321,7 +7295,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -7352,7 +7325,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               textChunkLimit: {
                 type: "integer",
@@ -7617,7 +7589,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -7637,7 +7608,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         groupPolicy: {
           default: "allowlist",
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         textChunkLimit: {
           type: "integer",
@@ -8105,7 +8075,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         webhookPort: {
           type: "integer",
@@ -8136,7 +8105,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         groupPolicy: {
           default: "allowlist",
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         rooms: {
           type: "object",
@@ -8436,7 +8404,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               webhookPort: {
                 type: "integer",
@@ -8467,7 +8434,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               rooms: {
                 type: "object",
@@ -8648,7 +8614,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         dmPolicy: {
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -8789,7 +8754,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -8823,7 +8787,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         groupPolicy: {
           default: "allowlist",
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         groups: {
           type: "object",
@@ -9101,7 +9064,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -9135,7 +9097,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               groups: {
                 type: "object",
@@ -9723,7 +9684,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         groupPolicy: {
           default: "allowlist",
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         historyLimit: {
           type: "integer",
@@ -9962,7 +9922,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         dmPolicy: {
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -9988,7 +9947,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             },
             policy: {
               type: "string",
-              enum: ["pairing", "allowlist", "open", "disabled"],
             },
             allowFrom: {
               type: "array",
@@ -10531,7 +10489,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               groupPolicy: {
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               historyLimit: {
                 type: "integer",
@@ -10770,7 +10727,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -10796,7 +10752,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   },
                   policy: {
                     type: "string",
-                    enum: ["pairing", "allowlist", "open", "disabled"],
                   },
                   allowFrom: {
                     type: "array",
@@ -11218,7 +11173,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         botToken: {
           anyOf: [
@@ -11321,7 +11275,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               groupPolicy: {
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               tools: {
                 type: "object",
@@ -11418,7 +11371,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                     },
                     groupPolicy: {
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     skills: {
                       type: "array",
@@ -11495,7 +11447,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         groupPolicy: {
           default: "allowlist",
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         historyLimit: {
           type: "integer",
@@ -11534,7 +11485,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             properties: {
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               tools: {
                 type: "object",
@@ -11631,7 +11581,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                     },
                     groupPolicy: {
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     skills: {
                       type: "array",
@@ -12169,7 +12118,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               botToken: {
                 anyOf: [
@@ -12272,7 +12220,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                     },
                     groupPolicy: {
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     tools: {
                       type: "object",
@@ -12369,7 +12316,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                           },
                           groupPolicy: {
                             type: "string",
-                            enum: ["open", "disabled", "allowlist"],
                           },
                           skills: {
                             type: "array",
@@ -12446,7 +12392,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               historyLimit: {
                 type: "integer",
@@ -12485,7 +12430,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                   properties: {
                     dmPolicy: {
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     tools: {
                       type: "object",
@@ -12582,7 +12526,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                           },
                           groupPolicy: {
                             type: "string",
-                            enum: ["open", "disabled", "allowlist"],
                           },
                           skills: {
                             type: "array",
@@ -13533,7 +13476,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         dmPolicy: {
           default: "pairing",
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         selfChatMode: {
           type: "boolean",
@@ -13556,7 +13498,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         groupPolicy: {
           default: "allowlist",
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         historyLimit: {
           type: "integer",
@@ -13778,7 +13719,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               selfChatMode: {
                 type: "boolean",
@@ -13801,7 +13741,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               historyLimit: {
                 type: "integer",
@@ -14216,7 +14155,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         dmPolicy: {
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -14233,7 +14171,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         groupPolicy: {
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         groupAllowFrom: {
           type: "array",
@@ -14422,7 +14359,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -14439,7 +14375,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               groupPolicy: {
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               groupAllowFrom: {
                 type: "array",
@@ -14507,7 +14442,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         dmPolicy: {
           type: "string",
-          enum: ["pairing", "allowlist", "open", "disabled"],
         },
         allowFrom: {
           type: "array",
@@ -14543,7 +14477,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         groupPolicy: {
           default: "allowlist",
           type: "string",
-          enum: ["open", "disabled", "allowlist"],
         },
         groups: {
           type: "object",
@@ -14624,7 +14557,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -14660,7 +14592,6 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               groups: {
                 type: "object",

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -332,9 +332,25 @@ export const TypingModeSchema = z.union([
 // Used with .default("allowlist").optional() pattern:
 //   - .optional() allows field omission in input config
 //   - .default("allowlist") ensures runtime always resolves to "allowlist" if not provided
-export const GroupPolicySchema = z.enum(["open", "disabled", "allowlist"]);
+export const GroupPolicySchema = z.enum(["open", "disabled", "allowlist"], {
+  errorMap: (issue, ctx) => {
+    if (issue.code === "invalid_enum_value") {
+      return { message: "Invalid groupPolicy: expected 'open', 'disabled', or 'allowlist'" };
+    }
+    return { message: ctx.defaultError };
+  },
+});
 
-export const DmPolicySchema = z.enum(["pairing", "allowlist", "open", "disabled"]);
+export const DmPolicySchema = z.enum(["pairing", "allowlist", "open", "disabled"], {
+  errorMap: (issue, ctx) => {
+    if (issue.code === "invalid_enum_value") {
+      return {
+        message: "Invalid dmPolicy: expected 'pairing', 'allowlist', 'open', or 'disabled'",
+      };
+    }
+    return { message: ctx.defaultError };
+  },
+});
 
 export const BlockStreamingCoalesceSchema = z
   .object({

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -332,25 +332,25 @@ export const TypingModeSchema = z.union([
 // Used with .default("allowlist").optional() pattern:
 //   - .optional() allows field omission in input config
 //   - .default("allowlist") ensures runtime always resolves to "allowlist" if not provided
-export const GroupPolicySchema = z.enum(["open", "disabled", "allowlist"], {
-  errorMap: (issue, ctx) => {
-    if (issue.code === "invalid_enum_value") {
-      return { message: "Invalid groupPolicy: expected 'open', 'disabled', or 'allowlist'" };
-    }
-    return { message: ctx.defaultError };
-  },
-});
+export const GroupPolicySchema = z.string().superRefine((val, ctx) => {
+  const options = ["open", "disabled", "allowlist"];
+  if (!options.includes(val)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Invalid groupPolicy: expected 'open', 'disabled', or 'allowlist'`,
+    });
+  }
+}) as unknown as z.ZodSchema<"open" | "disabled" | "allowlist">;
 
-export const DmPolicySchema = z.enum(["pairing", "allowlist", "open", "disabled"], {
-  errorMap: (issue, ctx) => {
-    if (issue.code === "invalid_enum_value") {
-      return {
-        message: "Invalid dmPolicy: expected 'pairing', 'allowlist', 'open', or 'disabled'",
-      };
-    }
-    return { message: ctx.defaultError };
-  },
-});
+export const DmPolicySchema = z.string().superRefine((val, ctx) => {
+  const options = ["pairing", "allowlist", "open", "disabled"];
+  if (!options.includes(val)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Invalid dmPolicy: expected 'pairing', 'allowlist', 'open', or 'disabled'`,
+    });
+  }
+}) as unknown as z.ZodSchema<"pairing" | "allowlist" | "open" | "disabled">;
 
 export const BlockStreamingCoalesceSchema = z
   .object({

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -358,7 +358,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -388,7 +387,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               },
               groupPolicy: {
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               enrichGroupParticipantsFromContacts: {
                 default: true,
@@ -566,7 +564,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     },
                     dmPolicy: {
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     allowFrom: {
                       type: "array",
@@ -596,7 +593,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     },
                     groupPolicy: {
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     enrichGroupParticipantsFromContacts: {
                       default: true,
@@ -1489,7 +1485,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               historyLimit: {
                 type: "integer",
@@ -1714,7 +1709,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -1740,7 +1734,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                   },
                   policy: {
                     type: "string",
-                    enum: ["pairing", "allowlist", "open", "disabled"],
                   },
                   allowFrom: {
                     type: "array",
@@ -2697,7 +2690,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     groupPolicy: {
                       default: "allowlist",
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     historyLimit: {
                       type: "integer",
@@ -2922,7 +2914,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     },
                     dmPolicy: {
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     allowFrom: {
                       type: "array",
@@ -2948,7 +2939,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                         },
                         policy: {
                           type: "string",
-                          enum: ["pairing", "allowlist", "open", "disabled"],
                         },
                         allowFrom: {
                           type: "array",
@@ -5544,7 +5534,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               groupAllowFrom: {
                 type: "array",
@@ -5856,7 +5845,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                   policy: {
                     default: "pairing",
                     type: "string",
-                    enum: ["pairing", "allowlist", "open", "disabled"],
                   },
                   allowFrom: {
                     type: "array",
@@ -5926,7 +5914,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     groupPolicy: {
                       default: "allowlist",
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     groupAllowFrom: {
                       type: "array",
@@ -6238,7 +6225,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                         policy: {
                           default: "pairing",
                           type: "string",
-                          enum: ["pairing", "allowlist", "open", "disabled"],
                         },
                         allowFrom: {
                           type: "array",
@@ -6457,7 +6443,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -6491,7 +6476,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               historyLimit: {
                 type: "integer",
@@ -6733,7 +6717,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     dmPolicy: {
                       default: "pairing",
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     allowFrom: {
                       type: "array",
@@ -6767,7 +6750,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     groupPolicy: {
                       default: "allowlist",
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     historyLimit: {
                       type: "integer",
@@ -7088,7 +7070,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -7106,7 +7087,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               groupAllowFrom: {
                 type: "array",
@@ -7374,7 +7354,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     dmPolicy: {
                       default: "pairing",
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     allowFrom: {
                       type: "array",
@@ -7392,7 +7371,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     groupPolicy: {
                       default: "allowlist",
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     groupAllowFrom: {
                       type: "array",
@@ -8264,7 +8242,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               },
               groupPolicy: {
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               replyToMode: {
                 type: "string",
@@ -8366,7 +8343,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                   },
                   policy: {
                     type: "string",
-                    enum: ["pairing", "allowlist", "open", "disabled"],
                   },
                   allowFrom: {
                     type: "array",
@@ -8738,7 +8714,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -8769,7 +8744,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               textChunkLimit: {
                 type: "integer",
@@ -9019,7 +8993,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     dmPolicy: {
                       default: "pairing",
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     allowFrom: {
                       type: "array",
@@ -9050,7 +9023,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     groupPolicy: {
                       default: "allowlist",
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     textChunkLimit: {
                       type: "integer",
@@ -9862,7 +9834,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -9882,7 +9853,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               textChunkLimit: {
                 type: "integer",
@@ -10395,7 +10365,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               webhookPort: {
                 type: "integer",
@@ -10426,7 +10395,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               rooms: {
                 type: "object",
@@ -10726,7 +10694,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     dmPolicy: {
                       default: "pairing",
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     webhookPort: {
                       type: "integer",
@@ -10757,7 +10724,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     groupPolicy: {
                       default: "allowlist",
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     rooms: {
                       type: "object",
@@ -10982,7 +10948,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -11702,7 +11667,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -11736,7 +11700,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               groups: {
                 type: "object",
@@ -12014,7 +11977,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     dmPolicy: {
                       default: "pairing",
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     allowFrom: {
                       type: "array",
@@ -12048,7 +12010,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     groupPolicy: {
                       default: "allowlist",
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     groups: {
                       type: "object",
@@ -12674,7 +12635,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               historyLimit: {
                 type: "integer",
@@ -12913,7 +12873,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -12939,7 +12898,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                   },
                   policy: {
                     type: "string",
-                    enum: ["pairing", "allowlist", "open", "disabled"],
                   },
                   allowFrom: {
                     type: "array",
@@ -13482,7 +13440,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     },
                     groupPolicy: {
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     historyLimit: {
                       type: "integer",
@@ -13721,7 +13678,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     },
                     dmPolicy: {
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     allowFrom: {
                       type: "array",
@@ -13747,7 +13703,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                         },
                         policy: {
                           type: "string",
-                          enum: ["pairing", "allowlist", "open", "disabled"],
                         },
                         allowFrom: {
                           type: "array",
@@ -14346,7 +14301,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               botToken: {
                 anyOf: [
@@ -14449,7 +14403,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     },
                     groupPolicy: {
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     tools: {
                       type: "object",
@@ -14546,7 +14499,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                           },
                           groupPolicy: {
                             type: "string",
-                            enum: ["open", "disabled", "allowlist"],
                           },
                           skills: {
                             type: "array",
@@ -14623,7 +14575,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               historyLimit: {
                 type: "integer",
@@ -14662,7 +14613,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                   properties: {
                     dmPolicy: {
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     tools: {
                       type: "object",
@@ -14759,7 +14709,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                           },
                           groupPolicy: {
                             type: "string",
-                            enum: ["open", "disabled", "allowlist"],
                           },
                           skills: {
                             type: "array",
@@ -15297,7 +15246,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     dmPolicy: {
                       default: "pairing",
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     botToken: {
                       anyOf: [
@@ -15400,7 +15348,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                           },
                           groupPolicy: {
                             type: "string",
-                            enum: ["open", "disabled", "allowlist"],
                           },
                           tools: {
                             type: "object",
@@ -15497,7 +15444,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                                 },
                                 groupPolicy: {
                                   type: "string",
-                                  enum: ["open", "disabled", "allowlist"],
                                 },
                                 skills: {
                                   type: "array",
@@ -15574,7 +15520,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     groupPolicy: {
                       default: "allowlist",
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     historyLimit: {
                       type: "integer",
@@ -15613,7 +15558,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                         properties: {
                           dmPolicy: {
                             type: "string",
-                            enum: ["pairing", "allowlist", "open", "disabled"],
                           },
                           tools: {
                             type: "object",
@@ -15710,7 +15654,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                                 },
                                 groupPolicy: {
                                   type: "string",
-                                  enum: ["open", "disabled", "allowlist"],
                                 },
                                 skills: {
                                   type: "array",
@@ -17614,7 +17557,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               dmPolicy: {
                 default: "pairing",
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               selfChatMode: {
                 type: "boolean",
@@ -17637,7 +17579,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               historyLimit: {
                 type: "integer",
@@ -17859,7 +17800,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     dmPolicy: {
                       default: "pairing",
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     selfChatMode: {
                       type: "boolean",
@@ -17882,7 +17822,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     groupPolicy: {
                       default: "allowlist",
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     historyLimit: {
                       type: "integer",
@@ -18558,7 +18497,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -18575,7 +18513,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               },
               groupPolicy: {
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               groupAllowFrom: {
                 type: "array",
@@ -18764,7 +18701,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     },
                     dmPolicy: {
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     allowFrom: {
                       type: "array",
@@ -18781,7 +18717,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     },
                     groupPolicy: {
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     groupAllowFrom: {
                       type: "array",
@@ -18894,7 +18829,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               },
               dmPolicy: {
                 type: "string",
-                enum: ["pairing", "allowlist", "open", "disabled"],
               },
               allowFrom: {
                 type: "array",
@@ -18930,7 +18864,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
               groupPolicy: {
                 default: "allowlist",
                 type: "string",
-                enum: ["open", "disabled", "allowlist"],
               },
               groups: {
                 type: "object",
@@ -19011,7 +18944,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     },
                     dmPolicy: {
                       type: "string",
-                      enum: ["pairing", "allowlist", "open", "disabled"],
                     },
                     allowFrom: {
                       type: "array",
@@ -19047,7 +18979,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
                     groupPolicy: {
                       default: "allowlist",
                       type: "string",
-                      enum: ["open", "disabled", "allowlist"],
                     },
                     groups: {
                       type: "object",


### PR DESCRIPTION
Description:
Currently, providing an invalid value for groupPolicy or dmPolicy (e.g., using "all" instead of "open") results in a generic Zod validation error that doesn't explicitly list the valid options. This can be confusing for users configuring Discord or WhatsApp channels for the first time.
>
This PR adds a custom errorMap to both GroupPolicySchema and DmPolicySchema to provide clear, actionable error messages:
Group Policy: Invalid groupPolicy: expected 'open', 'disabled', or 'allowlist'
DM Policy: Invalid dmPolicy: expected 'pairing', 'allowlist', 'open', or 'disabled'
>
Motivation
Improves the developer/user experience by reducing friction during initial channel configuration and troubleshooting.
>
Validation
Verified the schema change locally using openclaw doctor with invalid configuration values to trigger the new error messages.

---