### PR TITLE
fix(gateway): avoid discord stale-socket reconnect thrash on idle accounts

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2602,7 +2602,7 @@ See [Plugins](/tools/plugin).
 - `OPENCLAW_APNS_RELAY_BASE_URL` / `OPENCLAW_APNS_RELAY_TIMEOUT_MS`: temporary env overrides for the relay config above.
 - `OPENCLAW_APNS_RELAY_ALLOW_HTTP=true`: development-only escape hatch for loopback HTTP relay URLs. Production relay URLs should stay on HTTPS.
 - `gateway.channelHealthCheckMinutes`: channel health-monitor interval in minutes. Set `0` to disable health-monitor restarts globally. Default: `5`.
-- `gateway.channelStaleEventThresholdMinutes`: stale-socket threshold in minutes. Keep this greater than or equal to `gateway.channelHealthCheckMinutes`. Default: `30`.
+- `gateway.channelStaleEventThresholdMinutes`: stale-socket threshold in minutes. Keep this greater than or equal to `gateway.channelHealthCheckMinutes`. Default: `30`. This stale-socket heuristic currently applies to channels other than Discord, Telegram, and webhook-mode channels.
 - `gateway.channelMaxRestartsPerHour`: maximum health-monitor restarts per channel/account in a rolling hour. Default: `10`.
 - `channels.<provider>.healthMonitor.enabled`: per-channel opt-out for health-monitor restarts while keeping the global monitor enabled.
 - `channels.<provider>.accounts.<accountId>.healthMonitor.enabled`: per-account override for multi-account channels. When set, it takes precedence over the channel-level override.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -200,6 +200,7 @@ When validation fails:
 
     - Set `gateway.channelHealthCheckMinutes: 0` to disable health-monitor restarts globally.
     - `channelStaleEventThresholdMinutes` should be greater than or equal to the check interval.
+    - The stale-socket idle-event heuristic currently applies to channels other than Discord, Telegram, and webhook-mode channels.
     - Use `channels.<provider>.healthMonitor.enabled` or `channels.<provider>.accounts.<id>.healthMonitor.enabled` to disable auto-restarts for one channel or account without disabling the global monitor.
     - See [Health Checks](/gateway/health) for operational debugging and the [full reference](/gateway/configuration-reference#gateway) for all fields.
 

--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -27,7 +27,7 @@ Short guide to verify channel connectivity without guessing.
 ## Health monitor config
 
 - `gateway.channelHealthCheckMinutes`: how often the gateway checks channel health. Default: `5`. Set `0` to disable health-monitor restarts globally.
-- `gateway.channelStaleEventThresholdMinutes`: how long a connected channel can stay idle before the health monitor treats it as stale and restarts it. Default: `30`. Keep this greater than or equal to `gateway.channelHealthCheckMinutes`.
+- `gateway.channelStaleEventThresholdMinutes`: how long a connected channel can stay idle before the health monitor treats it as stale and restarts it. Default: `30`. Keep this greater than or equal to `gateway.channelHealthCheckMinutes`. This stale-socket heuristic currently applies to channels other than Discord, Telegram, and webhook-mode channels.
 - `gateway.channelMaxRestartsPerHour`: rolling one-hour cap for health-monitor restarts per channel/account. Default: `10`.
 - `channels.<provider>.healthMonitor.enabled`: disable health-monitor restarts for a specific channel while leaving global monitoring enabled.
 - `channels.<provider>.accounts.<accountId>.healthMonitor.enabled`: multi-account override that wins over the channel-level setting.

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -557,6 +557,23 @@ describe("channel-health-monitor", () => {
       await expectNoRestart(manager);
     });
 
+    it("skips stale-socket restarts for discord idle channels", async () => {
+      const now = Date.now();
+      const manager = createSnapshotManager({
+        discord: {
+          default: {
+            running: true,
+            connected: true,
+            enabled: true,
+            configured: true,
+            lastStartAt: now - STALE_THRESHOLD - 60_000,
+            lastEventAt: now - STALE_THRESHOLD - 30_000,
+          },
+        },
+      });
+      await expectNoRestart(manager);
+    });
+
     it("respects custom staleEventThresholdMs", async () => {
       const customThreshold = 10 * 60_000;
       const now = Date.now();

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -127,7 +127,7 @@ describe("evaluateChannelHealth", () => {
         lastEventAt: 0,
       },
       {
-        channelId: "discord",
+        channelId: "slack",
         now: 100_000,
         channelConnectGraceMs: 10_000,
         staleEventThresholdMs: 30_000,
@@ -153,6 +153,18 @@ describe("evaluateChannelHealth", () => {
         staleEventThresholdMs: 30_000,
       },
     );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("skips stale-socket detection for discord idle channels", () => {
+    const evaluation = evaluateDiscordHealth({
+      running: true,
+      connected: true,
+      enabled: true,
+      configured: true,
+      lastStartAt: 0,
+      lastEventAt: 0,
+    });
     expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
 

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -48,6 +48,13 @@ function isManagedAccount(snapshot: ChannelHealthSnapshot): boolean {
   return snapshot.enabled !== false && snapshot.configured !== false;
 }
 
+function shouldSkipStaleSocketDetection(
+  channelId: ChannelId,
+  snapshot: ChannelHealthSnapshot,
+): boolean {
+  return channelId === "discord" || channelId === "telegram" || snapshot.mode === "webhook";
+}
+
 const BUSY_ACTIVITY_STALE_THRESHOLD_MS = 25 * 60_000;
 // Keep these shared between the background health monitor and on-demand readiness
 // probes so both surfaces evaluate channel lifecycle windows consistently.
@@ -106,13 +113,11 @@ export function evaluateChannelHealth(
   if (snapshot.connected === false) {
     return { healthy: false, reason: "disconnected" };
   }
-  // Skip stale-socket check for Telegram (long-polling mode) and any channel
-  // explicitly operating in webhook mode. In these cases, there is no persistent
-  // outgoing socket that can go half-dead, so the lack of incoming events
-  // does not necessarily indicate a connection failure.
+  // Skip stale-socket check for Discord and Telegram plus webhook-mode channels.
+  // Discord can remain healthy with low traffic for extended periods, so event
+  // idleness alone is not a reliable socket liveness signal.
   if (
-    policy.channelId !== "telegram" &&
-    snapshot.mode !== "webhook" &&
+    !shouldSkipStaleSocketDetection(policy.channelId, snapshot) &&
     snapshot.connected === true &&
     snapshot.lastEventAt != null
   ) {


### PR DESCRIPTION

### Linked Issue

- Closes #55606
- Issue URL: `https://github.com/openclaw/openclaw/issues/55606`

### Summary

- Disable stale-socket idle-event restart heuristics for Discord in shared channel health evaluation.
- Keep stale-socket behavior for channels where event-idle remains a reliable liveness signal.
- Add tests to prevent regressions and document the channel-specific stale-socket behavior.

### What Changed

1. `src/gateway/channel-health-policy.ts`
   - Added channel-aware stale-socket skip helper.
   - Skip stale-socket classification for:
     - `discord`
     - `telegram`
     - channels in `webhook` mode
2. `src/gateway/channel-health-policy.test.ts`
   - Existing stale-socket threshold case now validates on `slack` (to preserve stale logic coverage).
   - Added Discord idle scenario asserting `healthy` (no stale-socket reason).
3. `src/gateway/channel-health-monitor.test.ts`
   - Added monitor-level regression test ensuring Discord idle accounts are not restarted for stale-socket.
4. Docs updates:
   - `docs/gateway/health.md`
   - `docs/gateway/configuration.md`
   - `docs/gateway/configuration-reference.md`
   - Clarified stale-socket idle-event heuristic currently applies to channels other than Discord, Telegram, and webhook-mode channels.

### User-visible Behavior Change

- Discord accounts should no longer be restarted by health monitor solely due to long event-idle periods.
- This reduces repeated `stale-socket` restart cycles in low-traffic Discord environments.

### Test Plan

- Targeted tests intended:
  - `pnpm test -- src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts src/gateway/server/readiness.test.ts`
- Current environment status:
  - Blocked by lockfile/dependency state (`ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` and missing `@anthropic-ai/vertex-sdk` import resolution), so test execution could not complete in this workspace snapshot.

### Risks / Notes

- Main tradeoff: Discord stale-socket auto-recovery from idle-event detection is intentionally reduced.
- Existing disconnected/not-running/stuck paths remain active and continue to recover unhealthy providers.
