### PR TITLE
fix(plugin-sdk): route attempt runner telegram helpers through sdk barrel

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -7,10 +7,6 @@ import {
   DefaultResourceLoader,
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
-import {
-  resolveTelegramInlineButtonsScope,
-  resolveTelegramReactionLevel,
-} from "../../../../extensions/telegram/api.js";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
@@ -26,6 +22,10 @@ import {
   wrapOllamaCompatNumCtx,
 } from "../../../plugin-sdk/ollama.js";
 import { resolveSignalReactionLevel } from "../../../plugin-sdk/signal.js";
+import {
+  resolveTelegramInlineButtonsScope,
+  resolveTelegramReactionLevel,
+} from "../../../plugin-sdk/telegram.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { buildTtsSystemPromptHint } from "../../../tts/tts.js";


### PR DESCRIPTION
## Summary
- switch the embedded attempt runner off the Telegram extension private API path
- import the Telegram helpers through `plugin-sdk/telegram` like other approved public seams
- keep the latest-main delta to the remaining non-test code fix only

## Testing
- `pnpm exec vitest run src/plugin-sdk/channel-import-guardrails.test.ts`
- `pnpm exec vitest run src/agents/pi-embedded-runner/run/attempt.test.ts -t "isOllamaCompatProvider"`