### PR TITLE
fix(agents): correct ClawHub URL in system prompt (clawhub.com → clawhub.ai)

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -356,6 +356,16 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
+  it("points to clawhub.ai (not clawhub.com) for skills discovery", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      docsPath: "/tmp/openclaw/docs",
+    });
+
+    expect(prompt).toContain("https://clawhub.ai");
+    expect(prompt).not.toContain("https://clawhub.com");
+  });
+
   it("includes workspace notes when provided", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -166,7 +166,7 @@ function buildDocsSection(params: { docsPath?: string; isMinimal: boolean; readT
     "Mirror: https://docs.openclaw.ai",
     "Source: https://github.com/openclaw/openclaw",
     "Community: https://discord.com/invite/clawd",
-    "Find new skills: https://clawhub.com",
+    "Find new skills: https://clawhub.ai",
     "For OpenClaw behavior, commands, config, or architecture: consult local docs first.",
     "When diagnosing issues, run `openclaw status` yourself when possible; only ask the user if you lack access (e.g., sandboxed).",
     "",


### PR DESCRIPTION
## Summary
- Fixed hardcoded `clawhub.com` URL in system prompt to `clawhub.ai`
- The incorrect URL in `src/agents/system-prompt.ts` directed users to the wrong domain for skills discovery

## Root cause
`src/agents/system-prompt.ts:169` — `https://clawhub.com` should be `https://clawhub.ai`.

## Test plan
- [x] Added regression test: `"points to clawhub.ai (not clawhub.com) for skills discovery"`
- [x] Asserts correct URL present and wrong URL absent
- [x] All 45 existing tests pass

Closes #54154

🤖 Generated with [Claude Code](https://claude.com/claude-code)