### PR TITLE
docs: add Mattermost to reaction-capable platforms

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -105,7 +105,7 @@ Participate, don't dominate.
 
 ### 😊 React Like a Human!
 
-On platforms that support reactions (Discord, Slack), use emoji reactions naturally:
+On platforms that support reactions (Discord, Slack, Mattermost), use emoji reactions naturally:
 
 **React when:**
 

--- a/docs/tools/reactions.md
+++ b/docs/tools/reactions.md
@@ -48,6 +48,11 @@ tool with the `react` action. Reaction behavior varies by channel.
     - `remove: true` maps to empty emoji internally (still requires `emoji` in the tool call).
   </Accordion>
 
+  <Accordion title="Mattermost">
+    - Uses Mattermost emoji names (e.g. `thumbsup`, `heart`), not Unicode.
+    - `remove: true` removes the specified emoji reaction.
+  </Accordion>
+
   <Accordion title="Zalo Personal (zalouser)">
     - Requires non-empty `emoji`.
     - `remove: true` removes that specific emoji reaction.


### PR DESCRIPTION
## Summary

- Add Mattermost to the list of reaction-capable platforms in the `AGENTS.md` workspace template
- Add Mattermost accordion section to `docs/tools/reactions.md` channel behavior docs

The Mattermost plugin fully supports emoji reactions (`capabilities.reactions: true`) and implements `addMattermostReaction`/`removeMattermostReaction` via the Mattermost API, but it was missing from both the agent workspace template and the reactions documentation. This caused the agent to not use reactions on Mattermost since it didn't know the platform supported them.

## Note

The `zh-CN` translations (`docs/zh-CN/reference/templates/AGENTS.md` and `docs/zh-CN/tools/reactions.md`) likely need the same update — leaving that to maintainers.

## Test plan

- [ ] Verify agent uses emoji reactions on Mattermost after workspace re-scaffolding
- [ ] Confirm `react` action works via `openclaw message send --action react`

🤖 Generated with [Claude Code](https://claude.com/claude-code)