### PR TITLE
feat(skills): add simple operations skills for backup, status, update, and remote checks

### DIFF
--- a/skills/ai-observability-audit/SKILL.md
+++ b/skills/ai-observability-audit/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: ai-observability-audit
+description: Create auditable AI operation summaries with run metadata, decision traces, and anomaly signals. Use when users ask for AI observability, periodic audit reports, incident reconstruction, or compliance-style activity tracking.
+---
+
+# AI Observability & Audit
+
+Produce concise, consistent operational audit outputs.
+
+## Core audit fields
+
+For each meaningful run/event, capture:
+
+- timestamp
+- actor/session
+- task intent
+- tools/actions executed
+- result status (success/failure/partial)
+- risk level
+
+Never include secrets/tokens in logs.
+
+## Decision trace summary
+
+When relevant, include:
+
+- key decisions made
+- why a path was chosen
+- alternatives rejected (brief)
+- approvals requested/granted/denied
+
+Keep traces concise and human-readable.
+
+## Anomaly checks
+
+Flag unusual patterns such as:
+
+- repeated failures of same command
+- sudden spike in privileged/destructive actions
+- routing to unusual devices/nodes
+- unexpected external-action attempts
+
+## Audit cadence
+
+Support periodic reports (daily/weekly) with:
+
+- counts by action type
+- high-risk actions summary
+- failure clusters and top causes
+- remediation recommendations
+
+## Incident reconstruction
+
+For incidents, provide a timeline:
+
+1. trigger event
+2. sequence of actions
+3. impact
+4. recovery steps
+5. preventive controls
+
+## Guardrails
+
+- Prefer structured summaries over raw log dumps.
+- Redact sensitive identifiers when sharing broadly.
+- Never claim certainty when evidence is incomplete.

--- a/skills/github-pr-ready-check/SKILL.md
+++ b/skills/github-pr-ready-check/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: github-pr-ready-check
+description: Run a quick GitHub PR readiness checklist via gh CLI. Use when users ask if a PR is ready to merge, want a pre-review sanity pass, or need CI/review blockers summarized.
+---
+
+# GitHub PR Ready Check
+
+Run a lightweight readiness pass before merge/review.
+
+## Core checks
+
+Given `<repo>` and `<pr-number>`:
+
+```bash
+gh pr view <pr-number> --repo <owner/repo>
+gh pr checks <pr-number> --repo <owner/repo>
+```
+
+Optional structured output:
+
+```bash
+gh pr view <pr-number> --repo <owner/repo> --json title,body,author,mergeStateStatus,reviewDecision,isDraft
+```
+
+## Readiness checklist
+
+1. PR is not draft.
+2. CI checks are passing.
+3. No unresolved blocking review comments.
+4. Merge state is clean.
+5. Title/body are clear enough for maintainers.
+
+## Output format
+
+Return:
+
+- merge readiness verdict (ready / needs fixes)
+- blockers (if any)
+- exact next step command(s)
+
+## Guardrails
+
+- Do not merge automatically unless explicitly asked.
+- Keep feedback concise and objective.

--- a/skills/github-pr-ready-check/SKILL.md
+++ b/skills/github-pr-ready-check/SKILL.md
@@ -32,7 +32,7 @@ gh pr view <pr-number> --repo <owner/repo> --json title,body,author,mergeStateSt
 
 ## Output format
 
-Return:
+Respond with:
 
 - merge readiness verdict (ready / needs fixes)
 - blockers (if any)

--- a/skills/human-in-the-loop-workflows/SKILL.md
+++ b/skills/human-in-the-loop-workflows/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: human-in-the-loop-workflows
+description: Implement approval-gated workflows for risky or irreversible actions. Use when users need plan-preview-approve execution, escalation on ambiguity, and clear checkpoints before changes are applied.
+---
+
+# Human-in-the-Loop Workflows
+
+Use explicit approval gates for sensitive actions.
+
+## Standard HITL pattern
+
+Run this sequence:
+
+1. Plan
+2. Preview impact
+3. Request approval
+4. Execute approved step
+5. Verify outcome
+6. Summarize results
+
+## Require approvals for
+
+- destructive file/system changes
+- external communications/actions
+- privilege/access changes
+- cost-impacting operations
+- policy/security changes
+
+## Approval request format
+
+Keep approvals easy to answer:
+
+- action
+- exact command(s)
+- expected impact
+- rollback option
+- reply choices (Approve / Revise / Cancel)
+
+## Ambiguity handling
+
+If user intent is unclear:
+
+- pause execution
+- ask one focused clarification
+- do not guess on high-risk actions
+
+## Batch approvals
+
+For multiple related steps:
+
+- group low-risk steps together
+- isolate high-risk steps into separate approvals
+- include checkpoint after each high-risk step
+
+## Verification
+
+After execution, report:
+
+- what changed
+- what was skipped
+- evidence of success/failure
+- recommended next step
+
+## Guardrails
+
+- No approval bypass.
+- No hidden side-effects outside approved scope.
+- Stop immediately on unexpected output and re-confirm.

--- a/skills/mesh-policy-enforcer/SKILL.md
+++ b/skills/mesh-policy-enforcer/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: mesh-policy-enforcer
+description: Enforce trust, routing, and tool-usage policy in multi-device OpenClaw setups. Use when users need per-device guardrails, sensitive-task pinning, emergency isolation, or policy-driven task placement.
+---
+
+# Mesh Policy Enforcer
+
+Apply explicit policy controls to multi-device orchestration.
+
+## Define policy profile
+
+Capture policy as simple rules:
+
+- trusted devices list
+- disallowed devices for sensitive tasks
+- allowed tools per device class
+- escalation targets for policy violations
+
+## Policy checks before execution
+
+Before dispatching a task, verify:
+
+1. destination device trust level
+2. task sensitivity label
+3. required tools allowed on destination
+4. channel/session exposure constraints
+
+If any check fails, block dispatch and report the reason.
+
+## Sensitive-task pinning
+
+Pin high-sensitivity operations to approved nodes only.
+
+Examples:
+
+- credentials/secrets operations
+- finance/payment actions
+- external messaging actions
+
+## Emergency isolation
+
+When a node is suspicious/unhealthy:
+
+1. stop routing new tasks to it
+2. revoke or rotate related access if applicable
+3. route pending work to fallback nodes
+4. notify user with impact summary
+
+## Audit output
+
+For each blocked/rerouted task, record:
+
+- policy rule triggered
+- original destination
+- final action (blocked/rerouted)
+- user-visible next step
+
+## Guardrails
+
+- Favor deny-by-default for unknown devices.
+- Do not silently downgrade policy strictness.
+- Require explicit approval for permanent policy changes.

--- a/skills/multi-device-agentic-mesh/SKILL.md
+++ b/skills/multi-device-agentic-mesh/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: multi-device-agentic-mesh
+description: Coordinate OpenClaw tasks across multiple devices/nodes with deterministic routing, failover, and handoff rules. Use when users run OpenClaw on laptop/desktop/VPS combinations and need resilient cross-device execution.
+---
+
+# Multi-Device Agentic Mesh
+
+Coordinate work across multiple OpenClaw nodes safely.
+
+## Baseline discovery
+
+Start with node and session visibility checks:
+
+```bash
+openclaw status
+openclaw nodes list
+openclaw sessions list
+```
+
+If a command is unavailable in a deployment, use the nearest supported status/list command.
+
+## Build a routing table
+
+Classify each node/device by:
+
+- trust level (high/medium/low)
+- latency/availability
+- tool access and capabilities
+- data sensitivity suitability
+
+Use this table to route tasks to the best node.
+
+## Routing policy
+
+Apply these defaults:
+
+1. Send sensitive tasks to highest-trust local node.
+2. Send long-running/background tasks to stable always-on node.
+3. Keep user-facing replies near the active user channel/session.
+
+## Failover
+
+If a primary node fails:
+
+1. retry once
+2. reroute to secondary node
+3. report failover event and degraded mode
+
+Never hide failover from the user.
+
+## Session handoff
+
+When moving work across devices:
+
+- summarize current state
+- include pending actions
+- include exact next command/message
+- confirm handoff destination
+
+## Guardrails
+
+- Do not route sensitive data to untrusted nodes.
+- Ask before changing long-lived routing defaults.
+- Keep decisions auditable (what was routed where and why).

--- a/skills/openclaw-backup-verify/SKILL.md
+++ b/skills/openclaw-backup-verify/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: openclaw-backup-verify
+description: Validate OpenClaw backup archives and restore readiness with repeatable checks. Use when users ask to confirm backup integrity, test migration safety, or verify that a backup file is usable before moving systems.
+---
+
+# OpenClaw Backup Verify
+
+Verify backup files and confirm restore readiness.
+
+## Run verification
+
+Use:
+
+```bash
+openclaw backup verify <archive-path>
+```
+
+For structured output:
+
+```bash
+openclaw backup verify <archive-path> --json
+```
+
+## Basic checklist
+
+1. Confirm file exists and is readable.
+2. Run `openclaw backup verify`.
+3. Confirm result indicates a valid manifest/payload.
+4. Record archive timestamp, size, and checksum.
+
+## Optional integrity checks
+
+Use a checksum before transfer and after transfer:
+
+```bash
+# Linux/macOS
+sha256sum <archive-path>
+
+# PowerShell
+Get-FileHash <archive-path> -Algorithm SHA256
+```
+
+## Migration readiness report
+
+Return a short report with:
+
+- archive path
+- verification result (pass/fail)
+- checksum value (if computed)
+- restore confidence summary
+- next step recommendation
+
+## Failure handling
+
+If verification fails, report:
+
+- exact command and error
+- likely cause (corruption, incomplete transfer, wrong file)
+- minimal next fix (recreate backup, re-copy archive, retry verify)
+
+Never claim restore readiness when verification fails.

--- a/skills/openclaw-cron-hygiene/SKILL.md
+++ b/skills/openclaw-cron-hygiene/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: openclaw-cron-hygiene
+description: Audit and tidy OpenClaw cron schedules for duplicate jobs, conflicting times, and unclear naming. Use when users ask to review existing automations, reduce noisy schedules, or standardize cron job setup.
+---
+
+# OpenClaw Cron Hygiene
+
+Review scheduler health and recommend cleanups.
+
+## Baseline commands
+
+Run:
+
+```bash
+openclaw cron list
+```
+
+For specific jobs:
+
+```bash
+openclaw cron runs <job-id>
+```
+
+## Hygiene checklist
+
+1. Detect duplicate jobs with same purpose.
+2. Detect conflicting/overlapping run times.
+3. Flag disabled jobs that should be removed.
+4. Check naming consistency and clarity.
+5. Check delivery mode consistency (announce/webhook/none).
+
+## Recommendations
+
+Provide:
+
+- keep/merge/remove suggestion per duplicate group
+- proposed naming convention
+- cadence tuning suggestions (reduce noise)
+- retention or summary guidance when jobs are chatty
+
+## Safe execution rule
+
+Do not edit/remove jobs without explicit approval.
+
+When approved, apply minimal change commands and confirm result with `openclaw cron list`.

--- a/skills/openclaw-logs-snapshot/SKILL.md
+++ b/skills/openclaw-logs-snapshot/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: openclaw-logs-snapshot
+description: Capture and summarize recent OpenClaw logs for incident triage. Use when users ask what failed recently, need quick error context, or want a concise failure summary with next actions.
+---
+
+# OpenClaw Logs Snapshot
+
+Collect recent logs and return an actionable summary.
+
+## Collect logs
+
+Start with:
+
+```bash
+openclaw logs
+```
+
+If available in environment, scope to recent window and relevant service output.
+
+## Snapshot workflow
+
+1. Capture recent error/warn entries.
+2. Identify repeating error signatures.
+3. Correlate with gateway/channel status checks.
+4. Produce top 1-3 probable causes.
+
+## Suggested companion checks
+
+```bash
+openclaw status
+openclaw health --json
+openclaw gateway status
+```
+
+## Output format
+
+Return:
+
+- time window reviewed
+- top error signatures (bullet list)
+- probable cause per signature
+- next command to validate/fix each cause
+
+## Guardrails
+
+- Redact secrets/tokens from pasted log lines.
+- Do not spam raw logs unless explicitly requested.
+- Prioritize concise summary over long transcript dumps.

--- a/skills/openclaw-logs-snapshot/SKILL.md
+++ b/skills/openclaw-logs-snapshot/SKILL.md
@@ -34,7 +34,7 @@ openclaw gateway status
 
 ## Output format
 
-Return:
+Respond with:
 
 - time window reviewed
 - top error signatures (bullet list)

--- a/skills/openclaw-status-triage/SKILL.md
+++ b/skills/openclaw-status-triage/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: openclaw-status-triage
+description: Quick triage workflow for OpenClaw runtime health using `openclaw status`, `openclaw health`, and gateway checks. Use when users report that OpenClaw is down, stuck, disconnected, or behaving unexpectedly.
+---
+
+# OpenClaw Status Triage
+
+Run a fast, repeatable first-response diagnostic.
+
+## Core commands
+
+Run in order:
+
+```bash
+openclaw status
+openclaw health --json
+openclaw gateway status
+```
+
+If needed:
+
+```bash
+openclaw doctor
+```
+
+## Triage flow
+
+1. Check whether gateway is running.
+2. Check health output for failing components.
+3. Identify channel/connectivity failures.
+4. Classify issue: service down, auth/session issue, network issue, or config issue.
+5. Propose the smallest safe next step.
+
+## Common next actions
+
+- Service down: `openclaw gateway start`
+- Hung service: `openclaw gateway restart`
+- Config drift: review with `openclaw config validate`
+- Channel issue: inspect with `openclaw channels ...` commands relevant to provider
+
+## Reporting format
+
+Return:
+
+- current status summary (1-3 bullets)
+- probable root cause
+- exact next command
+- what to run next if the first fix fails
+
+## Guardrails
+
+- Prefer read-only diagnostics first.
+- Ask before disruptive actions (`restart`, `reset`, relogin).
+- Do not claim recovery until a follow-up status check passes.

--- a/skills/openclaw-status-triage/SKILL.md
+++ b/skills/openclaw-status-triage/SKILL.md
@@ -13,6 +13,7 @@ Run in order:
 
 ```bash
 openclaw status
+openclaw status --deep
 openclaw health --json
 openclaw gateway status
 ```

--- a/skills/openclaw-update-checker/SKILL.md
+++ b/skills/openclaw-update-checker/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: openclaw-update-checker
+description: Evaluate OpenClaw version/update posture and recommend safe upgrade timing. Use when users ask whether they are up to date, what changed in newer versions, or when to upgrade with minimal disruption.
+---
+
+# OpenClaw Update Checker
+
+Assess update status and provide action-oriented guidance.
+
+## Check current posture
+
+Run:
+
+```bash
+openclaw update status
+openclaw --version
+```
+
+## Evaluate upgrade urgency
+
+Classify as:
+
+1. Up to date
+2. Update available (non-urgent)
+3. Update recommended soon (stability/security reasons)
+
+## Recommended output
+
+Return a concise summary with:
+
+- current version
+- update channel/status
+- whether update is available
+- recommended action now vs later
+
+## Safe upgrade suggestion
+
+Before upgrade, recommend:
+
+1. create verified backup
+2. choose a low-traffic window
+3. restart gateway and re-check status after update
+
+## Minimal commands to include
+
+```bash
+openclaw backup create --verify --output <backup-dir>
+openclaw update status
+openclaw gateway restart
+openclaw status
+```
+
+## Guardrails
+
+- Do not force upgrades.
+- Keep advice environment-aware (dev vs production-like node).
+- If status output is unclear, ask for command output rather than guessing.

--- a/skills/rclone-remote-check/SKILL.md
+++ b/skills/rclone-remote-check/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: rclone-remote-check
+description: Validate rclone remote configuration and run safe connectivity checks for cloud/NAS targets. Use when users ask to confirm Google Drive/S3/OneDrive/WebDAV remotes, troubleshoot upload failures, or validate backup destination access.
+---
+
+# Rclone Remote Check
+
+Confirm remotes are configured and usable.
+
+## Prerequisites
+
+Run:
+
+```bash
+rclone version
+rclone listremotes
+```
+
+If no remotes exist, stop and ask user to run `rclone config`.
+
+## Validate a specific remote
+
+Given `<remote>`:
+
+```bash
+rclone about <remote>:
+rclone lsd <remote>:
+```
+
+For path-level checks:
+
+```bash
+rclone lsf <remote>:<path>
+```
+
+## Optional write test (with approval)
+
+Use only after explicit approval:
+
+```bash
+echo test > /tmp/rclone-test.txt
+rclone copy /tmp/rclone-test.txt <remote>:<path>
+rclone lsf <remote>:<path> --include "rclone-test.txt"
+rclone delete <remote>:<path>/rclone-test.txt
+```
+
+On Windows, use a temp file path under `%TEMP%`.
+
+## Reporting
+
+Return:
+
+- remote name
+- auth/connectivity status
+- list/read test result
+- write/delete test result (if run)
+- exact failing command if broken
+
+## Failure handling
+
+Map failures to likely causes:
+
+- auth/token expired
+- wrong remote name/path
+- permission denied on destination
+- network/proxy/firewall issue
+
+Provide the smallest corrective step first.

--- a/skills/rclone-remote-check/SKILL.md
+++ b/skills/rclone-remote-check/SKILL.md
@@ -35,7 +35,9 @@ rclone lsf <remote>:<path>
 
 ## Optional write test (with approval)
 
-Use only after explicit approval:
+Use only after explicit approval.
+
+Linux/macOS:
 
 ```bash
 echo test > /tmp/rclone-test.txt
@@ -44,7 +46,16 @@ rclone lsf <remote>:<path> --include "rclone-test.txt"
 rclone delete <remote>:<path>/rclone-test.txt
 ```
 
-On Windows, use a temp file path under `%TEMP%`.
+Windows (PowerShell):
+
+```powershell
+$test = Join-Path $env:TEMP "rclone-test.txt"
+"test" | Set-Content -Path $test
+rclone copy $test <remote>:<path>
+rclone lsf <remote>:<path> --include "rclone-test.txt"
+rclone delete <remote>:<path>/rclone-test.txt
+Remove-Item $test -ErrorAction SilentlyContinue
+```
 
 ## Reporting
 

--- a/skills/workspace-cleanup-safe/SKILL.md
+++ b/skills/workspace-cleanup-safe/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: workspace-cleanup-safe
+description: Perform safe, non-destructive workspace cleanup planning and execution. Use when users ask to tidy disk usage, remove stale artifacts, or clean project directories without risking data loss.
+---
+
+# Workspace Cleanup Safe
+
+Clean workspaces with preview-first behavior.
+
+## Audit first (read-only)
+
+Start with a size/age audit:
+
+- large files/directories
+- stale build artifacts
+- temporary caches
+- duplicate archives/log bundles
+
+## Plan format
+
+Return a cleanup plan with groups:
+
+1. Safe to delete now (re-creatable artifacts)
+2. Review before delete (old logs/backups)
+3. Keep (source, configs, credentials)
+
+## Execution rule
+
+Require explicit approval before deletion.
+
+Prefer reversible deletion when possible (trash/recycle bin) over permanent delete.
+
+## Verification
+
+After cleanup, report:
+
+- items removed
+- space reclaimed
+- items skipped intentionally
+
+## Guardrails
+
+- Never delete credentials, config files, or user documents by default.
+- Never run destructive recursive deletes without explicit, scoped confirmation.
+- If scope is ambiguous, stop and ask.


### PR DESCRIPTION
## Summary\nAdd four low-complexity, operations-focused skills that are easy to adopt and review:\n\n- openclaw-backup-verify\n- openclaw-status-triage\n- openclaw-update-checker\n- clone-remote-check\n\n## Why\nThese cover frequent support/ops requests with concise, repeatable runbooks and conservative defaults.\n\n## Notes\n- command examples are intentionally minimal and practical\n- guidance emphasizes read-only diagnostics first and explicit approval for disruptive or write actions\n\n## Testing\n- manual content review for frontmatter quality and clarity\n- verified skill folder naming and placement under skills/\n