### PR TITLE
fix(gateway): enforce owner-only tools in invoke API

### DIFF
--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -115,6 +115,12 @@ vi.mock("../agents/openclaw-tools.js", () => {
       },
     },
     {
+      name: "nodes",
+      ownerOnly: true,
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ ok: true, result: ["node-1"] }),
+    },
+    {
       name: "tools_invoke_test",
       parameters: {
         type: "object",
@@ -570,7 +576,25 @@ describe("POST /tools/invoke", () => {
     expect(res.status).toBe(404);
   });
 
-  it("allows gateway tool via HTTP when explicitly enabled in gateway.tools.allow", async () => {
+  it("denies ownerOnly tools via HTTP even when allowlisted", async () => {
+    setMainAllowedTools({ allow: ["nodes"] });
+
+    const res = await invokeToolAuthed({
+      tool: "nodes",
+      sessionKey: "main",
+    });
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        type: "not_found",
+        message: "Tool not available: nodes",
+      },
+    });
+  });
+
+  it("does not let gateway.tools.allow bypass ownerOnly HTTP restrictions", async () => {
     setMainAllowedTools({ allow: ["gateway"], gatewayAllow: ["gateway"] });
 
     const res = await invokeToolAuthed({
@@ -578,11 +602,14 @@ describe("POST /tools/invoke", () => {
       sessionKey: "main",
     });
 
-    // Ensure we didn't hit the HTTP deny list (404). Invalid args should map to 400.
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.ok).toBe(false);
-    expect(body.error?.type).toBe("tool_error");
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        type: "not_found",
+        message: "Tool not available: gateway",
+      },
+    });
   });
 
   it("treats gateway.tools.deny as higher priority than gateway.tools.allow", async () => {

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -12,6 +12,7 @@ import {
   buildDefaultToolPolicyPipelineSteps,
 } from "../agents/tool-policy-pipeline.js";
 import {
+  applyOwnerOnlyToolPolicy,
   collectExplicitAllowlist,
   mergeAlsoAllowPolicy,
   resolveToolProfilePolicy,
@@ -303,8 +304,9 @@ export async function handleToolsInvokeHttpRequest(
   );
   const gatewayDenySet = new Set(gatewayDenyNames);
   const gatewayFiltered = subagentFiltered.filter((t) => !gatewayDenySet.has(t.name));
+  const ownerAuthorizedTools = applyOwnerOnlyToolPolicy(gatewayFiltered, false);
 
-  const tool = gatewayFiltered.find((t) => t.name === toolName);
+  const tool = ownerAuthorizedTools.find((t) => t.name === toolName);
   if (!tool) {
     sendJson(res, 404, {
       ok: false,


### PR DESCRIPTION
## Summary
- apply `ownerOnly` filtering to the HTTP `/tools/invoke` surface after the normal tool-policy pipeline
- treat authenticated HTTP callers as non-owner contexts so owner-only tools stay unavailable even if separately allowlisted
- add gateway HTTP regression coverage for `nodes` and for `gateway.tools.allow` not bypassing owner-only restrictions

## Testing
- pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/tools-invoke-http.test.ts