### PR TITLE
feat: security audit dmScope check + configurable circuit breaker

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -7470,6 +7470,26 @@
       "hasChildren": false
     },
     {
+      "path": "auth.cooldowns.transientCooldownMinutes",
+      "kind": "core",
+      "type": "number",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "auth.cooldowns.transientFailureThreshold",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "auth.order",
       "kind": "core",
       "type": "object",

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5532}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5534}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -664,6 +664,8 @@
 {"recordType":"path","path":"auth.cooldowns.billingBackoffHoursByProvider.*","kind":"core","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"auth.cooldowns.billingMaxHours","kind":"core","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":["access","auth","performance"],"label":"Billing Backoff Cap (hours)","help":"Cap (hours) for billing backoff (default: 24).","hasChildren":false}
 {"recordType":"path","path":"auth.cooldowns.failureWindowHours","kind":"core","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":["access","auth"],"label":"Failover Window (hours)","help":"Failure window (hours) for backoff counters (default: 24).","hasChildren":false}
+{"recordType":"path","path":"auth.cooldowns.transientCooldownMinutes","kind":"core","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"auth.cooldowns.transientFailureThreshold","kind":"core","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"auth.order","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["access","auth"],"label":"Auth Profile Order","help":"Ordered auth profile IDs per provider (used for automatic failover).","hasChildren":true}
 {"recordType":"path","path":"auth.order.*","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"auth.order.*.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}

--- a/src/agents/auth-profiles.markauthprofilefailure.test.ts
+++ b/src/agents/auth-profiles.markauthprofilefailure.test.ts
@@ -343,4 +343,21 @@ describe("calculateAuthProfileCooldownMs", () => {
     expect(calculateAuthProfileCooldownMs(4)).toBe(5 * 60_000); // 5 minutes (cap)
     expect(calculateAuthProfileCooldownMs(5)).toBe(5 * 60_000); // 5 minutes (cap)
   });
+
+  it("respects custom transientFailureThreshold", () => {
+    const config = { transientFailureThreshold: 5 };
+    expect(calculateAuthProfileCooldownMs(1, config)).toBe(30_000); // always 30s
+    expect(calculateAuthProfileCooldownMs(2, config)).toBe(60_000); // below threshold
+    expect(calculateAuthProfileCooldownMs(4, config)).toBe(60_000); // still below 5
+    expect(calculateAuthProfileCooldownMs(5, config)).toBe(5 * 60_000); // at threshold
+    expect(calculateAuthProfileCooldownMs(6, config)).toBe(5 * 60_000); // above threshold
+  });
+
+  it("respects custom transientCooldownMinutes", () => {
+    const config = { transientCooldownMinutes: 30 };
+    expect(calculateAuthProfileCooldownMs(1, config)).toBe(30_000); // always 30s
+    expect(calculateAuthProfileCooldownMs(2, config)).toBe(60_000); // 1 min
+    expect(calculateAuthProfileCooldownMs(3, config)).toBe(30 * 60_000); // 30 min at threshold
+    expect(calculateAuthProfileCooldownMs(10, config)).toBe(30 * 60_000); // stays at 30 min
+  });
 });

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -321,21 +321,28 @@ export async function markAuthProfileUsed(params: {
   authProfileUsageDeps.saveAuthProfileStore(store, agentDir);
 }
 
-export function calculateAuthProfileCooldownMs(errorCount: number): number {
+export function calculateAuthProfileCooldownMs(
+  errorCount: number,
+  config?: { transientFailureThreshold?: number; transientCooldownMinutes?: number },
+): number {
+  const threshold = config?.transientFailureThreshold ?? 3;
+  const maxCooldownMs = (config?.transientCooldownMinutes ?? 5) * 60_000;
   const normalized = Math.max(1, errorCount);
   if (normalized <= 1) {
-    return 30_000; // 30 seconds
+    return 30_000; // 30 seconds — first failure is always short
   }
-  if (normalized <= 2) {
-    return 60_000; // 1 minute
+  if (normalized < threshold) {
+    return 60_000; // 1 minute — still below threshold
   }
-  return 5 * 60_000; // 5 minutes max
+  return maxCooldownMs; // At or above threshold — max cooldown
 }
 
 type ResolvedAuthCooldownConfig = {
   billingBackoffMs: number;
   billingMaxMs: number;
   failureWindowMs: number;
+  transientFailureThreshold?: number;
+  transientCooldownMinutes?: number;
 };
 
 function resolveAuthCooldownConfig(params: {
@@ -379,6 +386,8 @@ function resolveAuthCooldownConfig(params: {
     billingBackoffMs: billingBackoffHours * 60 * 60 * 1000,
     billingMaxMs: billingMaxHours * 60 * 60 * 1000,
     failureWindowMs: failureWindowHours * 60 * 60 * 1000,
+    transientFailureThreshold: cooldowns?.transientFailureThreshold,
+    transientCooldownMinutes: cooldowns?.transientCooldownMinutes,
   };
 }
 
@@ -497,7 +506,10 @@ function computeNextProfileUsageStats(params: {
     });
     updatedStats.disabledReason = params.reason;
   } else {
-    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
+    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount, {
+      transientFailureThreshold: params.cfgResolved.transientFailureThreshold,
+      transientCooldownMinutes: params.cfgResolved.transientCooldownMinutes,
+    });
     // Keep active cooldown windows immutable so retries within the window
     // cannot push recovery further out.
     updatedStats.cooldownUntil = keepActiveWindowOrRecompute({

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -386,8 +386,18 @@ function resolveAuthCooldownConfig(params: {
     billingBackoffMs: billingBackoffHours * 60 * 60 * 1000,
     billingMaxMs: billingMaxHours * 60 * 60 * 1000,
     failureWindowMs: failureWindowHours * 60 * 60 * 1000,
-    transientFailureThreshold: cooldowns?.transientFailureThreshold,
-    transientCooldownMinutes: cooldowns?.transientCooldownMinutes,
+    transientFailureThreshold:
+      typeof cooldowns?.transientFailureThreshold === "number" &&
+      Number.isFinite(cooldowns.transientFailureThreshold) &&
+      cooldowns.transientFailureThreshold >= 2
+        ? cooldowns.transientFailureThreshold
+        : undefined,
+    transientCooldownMinutes:
+      typeof cooldowns?.transientCooldownMinutes === "number" &&
+      Number.isFinite(cooldowns.transientCooldownMinutes) &&
+      cooldowns.transientCooldownMinutes > 0
+        ? cooldowns.transientCooldownMinutes
+        : undefined,
   };
 }
 

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -791,7 +791,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
               },
               transientFailureThreshold: {
                 type: "integer",
-                minimum: 1,
+                minimum: 2,
               },
               transientCooldownMinutes: {
                 type: "number",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -792,6 +792,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
               transientFailureThreshold: {
                 type: "integer",
                 minimum: 2,
+                maximum: 9007199254740991,
               },
               transientCooldownMinutes: {
                 type: "number",
@@ -13664,16 +13665,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
       label: "Failover Window (hours)",
       help: "Failure window (hours) for backoff counters (default: 24).",
       tags: ["auth", "access"],
-    },
-    "auth.cooldowns.transientFailureThreshold": {
-      label: "Transient Failure Threshold",
-      help: "Consecutive transient failures before applying max cooldown (default: 3).",
-      tags: ["auth", "access", "performance"],
-    },
-    "auth.cooldowns.transientCooldownMinutes": {
-      label: "Transient Cooldown (minutes)",
-      help: "Max cooldown duration in minutes once failure threshold is reached (default: 5).",
-      tags: ["auth", "access", "performance"],
     },
     "agents.defaults.models": {
       label: "Models",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -789,6 +789,14 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                 type: "number",
                 exclusiveMinimum: 0,
               },
+              transientFailureThreshold: {
+                type: "integer",
+                minimum: 1,
+              },
+              transientCooldownMinutes: {
+                type: "number",
+                exclusiveMinimum: 0,
+              },
             },
             additionalProperties: false,
           },
@@ -13656,6 +13664,16 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
       label: "Failover Window (hours)",
       help: "Failure window (hours) for backoff counters (default: 24).",
       tags: ["auth", "access"],
+    },
+    "auth.cooldowns.transientFailureThreshold": {
+      label: "Transient Failure Threshold",
+      help: "Consecutive transient failures before applying max cooldown (default: 3).",
+      tags: ["auth", "access", "performance"],
+    },
+    "auth.cooldowns.transientCooldownMinutes": {
+      label: "Transient Cooldown (minutes)",
+      help: "Max cooldown duration in minutes once failure threshold is reached (default: 5).",
+      tags: ["auth", "access", "performance"],
     },
     "agents.defaults.models": {
       label: "Models",

--- a/src/config/types.auth.ts
+++ b/src/config/types.auth.ts
@@ -28,7 +28,9 @@ export type AuthConfig = {
     failureWindowHours?: number;
     /**
      * Number of consecutive transient failures (rate_limit, timeout, overloaded)
-     * before applying the maximum cooldown duration. Default: 3.
+     * before applying the maximum cooldown duration. Default: 3, minimum: 2.
+     * Backoff progression: 30s (1st failure) -> 60s (below threshold) -> max
+     * cooldown (at threshold). The 60s step only applies when threshold >= 3.
      */
     transientFailureThreshold?: number;
     /**

--- a/src/config/types.auth.ts
+++ b/src/config/types.auth.ts
@@ -26,5 +26,15 @@ export type AuthConfig = {
      * this window, counters reset. Default: 24.
      */
     failureWindowHours?: number;
+    /**
+     * Number of consecutive transient failures (rate_limit, timeout, overloaded)
+     * before applying the maximum cooldown duration. Default: 3.
+     */
+    transientFailureThreshold?: number;
+    /**
+     * Maximum cooldown duration (minutes) applied once the transient failure
+     * threshold is reached. Default: 5.
+     */
+    transientCooldownMinutes?: number;
   };
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -443,6 +443,8 @@ export const OpenClawSchema = z
             billingBackoffHoursByProvider: z.record(z.string(), z.number().positive()).optional(),
             billingMaxHours: z.number().positive().optional(),
             failureWindowHours: z.number().positive().optional(),
+            transientFailureThreshold: z.number().int().min(2).optional(),
+            transientCooldownMinutes: z.number().positive().optional(),
           })
           .strict()
           .optional(),

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1328,6 +1328,33 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
   return findings;
 }
 
+export function collectDmScopeFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+  const findings: SecurityAuditFinding[] = [];
+  const dmScope = cfg.session?.dmScope ?? "main";
+  if (dmScope !== "main") {
+    return findings;
+  }
+  // Only warn when multi-user DM ingress is plausible.
+  const signals = listPotentialMultiUserSignals(cfg);
+  if (signals.length === 0) {
+    return findings;
+  }
+  findings.push({
+    checkId: "session.dm_scope_main",
+    severity: "warn",
+    title: 'DM sessions share the main context (dmScope="main")',
+    detail:
+      'session.dmScope is set to "main" (the default). When multi-user DM channels ' +
+      "are enabled, different DM senders share the same conversation context, which can " +
+      "leak private data across users and enable cross-user prompt injection.",
+    remediation:
+      'Set session.dmScope to "per-channel-peer" or "per-account-channel-peer" to ' +
+      "isolate DM sessions per sender. Run: " +
+      formatCliCommand('openclaw config set session.dmScope "per-channel-peer"'),
+  });
+  return findings;
+}
+
 export function collectLikelyMultiUserSetupFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
   const signals = listPotentialMultiUserSignals(cfg);

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1336,10 +1336,11 @@ export function collectDmScopeFindings(cfg: OpenClawConfig): SecurityAuditFindin
   }
   // Only warn when multi-user DM ingress is plausible — filter out
   // group-only signals (groupPolicy, groupAllowFrom) since dmScope
-  // only affects DM sessions, not group chats.
+  // only affects DM sessions, not group chats.  Also match the
+  // legacy "dm.policy" key form emitted for older channel configs.
   const signals = listPotentialMultiUserSignals(cfg);
   const dmSignals = signals.filter(
-    (s) => s.includes("dmPolicy") || s.includes(".allowFrom"),
+    (s) => s.includes("dmPolicy") || s.includes("dm.policy") || s.includes(".allowFrom"),
   );
   if (dmSignals.length === 0) {
     return findings;

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1334,9 +1334,14 @@ export function collectDmScopeFindings(cfg: OpenClawConfig): SecurityAuditFindin
   if (dmScope !== "main") {
     return findings;
   }
-  // Only warn when multi-user DM ingress is plausible.
+  // Only warn when multi-user DM ingress is plausible — filter out
+  // group-only signals (groupPolicy, groupAllowFrom) since dmScope
+  // only affects DM sessions, not group chats.
   const signals = listPotentialMultiUserSignals(cfg);
-  if (signals.length === 0) {
+  const dmSignals = signals.filter(
+    (s) => s.includes("dmPolicy") || s.includes(".allowFrom"),
+  );
+  if (dmSignals.length === 0) {
     return findings;
   }
   findings.push({

--- a/src/security/audit-extra.ts
+++ b/src/security/audit-extra.ts
@@ -14,6 +14,7 @@ export {
   collectGatewayHttpNoAuthFindings,
   collectGatewayHttpSessionKeyOverrideFindings,
   collectHooksHardeningFindings,
+  collectDmScopeFindings,
   collectLikelyMultiUserSetupFindings,
   collectMinimalProfileOverrideFindings,
   collectModelHygieneFindings,

--- a/src/security/audit.nondeep.runtime.ts
+++ b/src/security/audit.nondeep.runtime.ts
@@ -4,6 +4,7 @@ export {
   collectGatewayHttpNoAuthFindings,
   collectGatewayHttpSessionKeyOverrideFindings,
   collectHooksHardeningFindings,
+  collectDmScopeFindings,
   collectLikelyMultiUserSetupFindings,
   collectMinimalProfileOverrideFindings,
   collectModelHygieneFindings,

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -1399,6 +1399,7 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   findings.push(...auditNonDeep.collectSmallModelRiskFindings({ cfg, env }));
   findings.push(...auditNonDeep.collectExposureMatrixFindings(cfg));
   findings.push(...auditNonDeep.collectLikelyMultiUserSetupFindings(cfg));
+  findings.push(...auditNonDeep.collectDmScopeFindings(cfg));
 
   if (context.includeFilesystem) {
     findings.push(


### PR DESCRIPTION
## Summary

- **#55578** — `security audit` now warns when `session.dmScope="main"` with multi-user DM channels enabled. Detects the cross-user context leak risk that was previously only flagged in per-channel checks, and provides actionable remediation (`openclaw config set session.dmScope "per-channel-peer"`).

- **#55536** — Exposes two new config options under `auth.cooldowns` to make the transient failure circuit breaker configurable:
  - `transientFailureThreshold` (default: 3) — consecutive failures before max cooldown kicks in
  - `transientCooldownMinutes` (default: 5) — max cooldown duration once threshold is reached
  
  The existing stepped backoff (30s / 1m / 5m) is preserved as the default. Users can now tune these for their deployment (e.g., `{ transientFailureThreshold: 5, transientCooldownMinutes: 30 }` for longer cooldowns after more tolerance).

## Test plan

- [x] `pnpm vitest run src/agents/auth-profiles.markauthprofilefailure.test.ts` — 12 tests pass (2 new for custom thresholds)
- [x] `pnpm tsc --noEmit` — clean
- [ ] Manual: run `openclaw security audit` with `session.dmScope="main"` and a channel enabled — should emit `session.dm_scope_main` warning
- [ ] Manual: set `auth.cooldowns.transientCooldownMinutes: 30` and trigger 3+ failures — cooldown should be 30 minutes