### PR TITLE
fix(plugins): clean up channel config during plugin uninstall

### DIFF
--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -626,10 +626,10 @@ export function registerPluginsCli(program: Command) {
       if (cfg.plugins?.slots?.memory === pluginId) {
         preview.push(`memory slot (will reset to "memory-core")`);
       }
-      const channelIds = plugin?.channelIds ?? [];
-      const channelKeysToRemove = channelIds.length > 0 ? channelIds : [pluginId];
+      const channelIds = plugin?.channelIds;
+      const channelKeysToRemove = channelIds !== undefined ? channelIds : [pluginId];
       const channelConfigKeys = channelKeysToRemove.filter((ch) => ch in (cfg.channels ?? {}));
-      if (channelConfigKeys.length > 0) {
+      if (hasInstall && channelConfigKeys.length > 0) {
         preview.push(`channel config (${channelConfigKeys.join(", ")})`);
       }
       const deleteTarget = !keepFiles

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -626,6 +626,12 @@ export function registerPluginsCli(program: Command) {
       if (cfg.plugins?.slots?.memory === pluginId) {
         preview.push(`memory slot (will reset to "memory-core")`);
       }
+      const channelIds = plugin?.channelIds ?? [];
+      const channelKeysToRemove = channelIds.length > 0 ? channelIds : [pluginId];
+      const channelConfigKeys = channelKeysToRemove.filter((ch) => ch in (cfg.channels ?? {}));
+      if (channelConfigKeys.length > 0) {
+        preview.push(`channel config (${channelConfigKeys.join(", ")})`);
+      }
       const deleteTarget = !keepFiles
         ? resolveUninstallDirectoryTarget({
             pluginId,
@@ -660,6 +666,7 @@ export function registerPluginsCli(program: Command) {
       const result = await uninstallPlugin({
         config: cfg,
         pluginId,
+        channelIds: plugin?.channelIds,
         deleteFiles: !keepFiles,
         extensionsDir,
       });
@@ -689,6 +696,9 @@ export function registerPluginsCli(program: Command) {
       }
       if (result.actions.memorySlot) {
         removed.push("memory slot");
+      }
+      if (result.actions.channelConfig) {
+        removed.push("channel config");
       }
       if (result.actions.directory) {
         removed.push("directory");

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -292,6 +292,136 @@ describe("removePluginFromConfig", () => {
     expect(result.plugins?.entries).toBeUndefined();
   });
 
+  it("removes channel config for plugin's channel ids", () => {
+    const config: OpenClawConfig = {
+      channels: {
+        "my-channel": { enabled: true },
+        telegram: { enabled: true },
+      },
+      plugins: {
+        entries: {
+          "my-plugin": { enabled: true },
+        },
+        installs: {
+          "my-plugin": { source: "npm", spec: "my-plugin@1.0.0" },
+        },
+      },
+    };
+
+    const { config: result, actions } = removePluginFromConfig(config, "my-plugin", ["my-channel"]);
+
+    expect(result.channels).toEqual({ telegram: { enabled: true } });
+    expect(actions.channelConfig).toBe(true);
+  });
+
+  it("removes channel config using pluginId as fallback when no channelIds provided", () => {
+    const config: OpenClawConfig = {
+      channels: {
+        "my-plugin": { enabled: true },
+        telegram: { enabled: true },
+      },
+      plugins: {
+        entries: {
+          "my-plugin": { enabled: true },
+        },
+        installs: {
+          "my-plugin": { source: "npm", spec: "my-plugin@1.0.0" },
+        },
+      },
+    };
+
+    const { config: result, actions } = removePluginFromConfig(config, "my-plugin");
+
+    expect(result.channels).toEqual({ telegram: { enabled: true } });
+    expect(actions.channelConfig).toBe(true);
+  });
+
+  it("removes channels config entirely when last channel entry is removed", () => {
+    const config: OpenClawConfig = {
+      channels: {
+        "my-plugin": { enabled: true },
+      },
+      plugins: {
+        entries: {
+          "my-plugin": { enabled: true },
+        },
+        installs: {
+          "my-plugin": { source: "npm", spec: "my-plugin@1.0.0" },
+        },
+      },
+    };
+
+    const { config: result, actions } = removePluginFromConfig(config, "my-plugin");
+
+    expect(result.channels).toBeUndefined();
+    expect(actions.channelConfig).toBe(true);
+  });
+
+  it("does not remove channel config for built-in plugin without install record", () => {
+    const config: OpenClawConfig = {
+      channels: {
+        telegram: { enabled: true, botToken: "tok" },
+      },
+      plugins: {
+        entries: {
+          telegram: { enabled: true },
+        },
+      },
+    };
+
+    const { config: result, actions } = removePluginFromConfig(config, "telegram");
+
+    expect((result.channels as Record<string, unknown>)?.telegram).toEqual({
+      enabled: true,
+      botToken: "tok",
+    });
+    expect(actions.channelConfig).toBe(false);
+  });
+
+  it("preserves shared channel keys (defaults, modelByChannel)", () => {
+    const config: OpenClawConfig = {
+      channels: {
+        defaults: { groupPolicy: "opt-in" },
+        modelByChannel: { "my-plugin": "gpt-5.4" } as Record<string, string>,
+        "my-plugin": { enabled: true },
+      } as unknown as OpenClawConfig["channels"],
+      plugins: {
+        entries: {
+          "my-plugin": { enabled: true },
+        },
+        installs: {
+          "my-plugin": { source: "npm", spec: "my-plugin@1.0.0" },
+        },
+      },
+    };
+
+    const { config: result, actions } = removePluginFromConfig(config, "my-plugin");
+
+    const ch = result.channels as Record<string, unknown> | undefined;
+    expect(ch?.["my-plugin"]).toBeUndefined();
+    expect(ch?.defaults).toEqual({ groupPolicy: "opt-in" });
+    expect(ch?.modelByChannel).toEqual({ "my-plugin": "gpt-5.4" });
+    expect(actions.channelConfig).toBe(true);
+  });
+
+  it("does not modify channels when plugin has no matching channel config", () => {
+    const config: OpenClawConfig = {
+      channels: {
+        telegram: { enabled: true },
+      },
+      plugins: {
+        entries: {
+          "my-plugin": { enabled: true },
+        },
+      },
+    };
+
+    const { config: result, actions } = removePluginFromConfig(config, "my-plugin");
+
+    expect(result.channels).toEqual({ telegram: { enabled: true } });
+    expect(actions.channelConfig).toBe(false);
+  });
+
   it("preserves other config values", () => {
     const config: OpenClawConfig = {
       plugins: {

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -404,6 +404,27 @@ describe("removePluginFromConfig", () => {
     expect(actions.channelConfig).toBe(true);
   });
 
+  it("skips channel cleanup when channelIds is empty array (non-channel plugin)", () => {
+    const config: OpenClawConfig = {
+      channels: {
+        "my-plugin": { enabled: true },
+      },
+      plugins: {
+        entries: {
+          "my-plugin": { enabled: true },
+        },
+        installs: {
+          "my-plugin": { source: "npm", spec: "my-plugin@1.0.0" },
+        },
+      },
+    };
+
+    const { config: result, actions } = removePluginFromConfig(config, "my-plugin", []);
+
+    expect((result.channels as Record<string, unknown>)?.["my-plugin"]).toEqual({ enabled: true });
+    expect(actions.channelConfig).toBe(false);
+  });
+
   it("does not modify channels when plugin has no matching channel config", () => {
     const config: OpenClawConfig = {
       channels: {

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -139,7 +139,7 @@ export function removePluginFromConfig(
   const hasInstallRecord = pluginId in (cfg.plugins?.installs ?? {});
   let channels = cfg.channels as Record<string, unknown> | undefined;
   if (hasInstallRecord && channels) {
-    const keysToRemove = channelIds && channelIds.length > 0 ? channelIds : [pluginId];
+    const keysToRemove = channelIds !== undefined ? channelIds : [pluginId];
     for (const key of keysToRemove) {
       if (channels && key in channels && !CHANNELS_SHARED_KEYS.has(key)) {
         const { [key]: _, ...rest } = channels;

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -11,6 +11,7 @@ export type UninstallActions = {
   allowlist: boolean;
   loadPath: boolean;
   memorySlot: boolean;
+  channelConfig: boolean;
   directory: boolean;
 };
 
@@ -65,6 +66,7 @@ export function resolveUninstallDirectoryTarget(params: {
 export function removePluginFromConfig(
   cfg: OpenClawConfig,
   pluginId: string,
+  channelIds?: string[],
 ): { config: OpenClawConfig; actions: Omit<UninstallActions, "directory"> } {
   const actions: Omit<UninstallActions, "directory"> = {
     entry: false,
@@ -72,6 +74,7 @@ export function removePluginFromConfig(
     allowlist: false,
     loadPath: false,
     memorySlot: false,
+    channelConfig: false,
   };
 
   const pluginsConfig = cfg.plugins ?? {};
@@ -128,6 +131,24 @@ export function removePluginFromConfig(
     slots = undefined;
   }
 
+  // Remove channel config owned by this plugin.
+  // Only clean up channels for plugins that have an install record (i.e. third-party plugins).
+  // Built-in channel plugins (no install record) should keep their channel config intact.
+  // Skip shared config keys that are not actual channel ids.
+  const CHANNELS_SHARED_KEYS = new Set(["defaults", "modelByChannel"]);
+  const hasInstallRecord = pluginId in (cfg.plugins?.installs ?? {});
+  let channels = cfg.channels as Record<string, unknown> | undefined;
+  if (hasInstallRecord && channels) {
+    const keysToRemove = channelIds && channelIds.length > 0 ? channelIds : [pluginId];
+    for (const key of keysToRemove) {
+      if (channels && key in channels && !CHANNELS_SHARED_KEYS.has(key)) {
+        const { [key]: _, ...rest } = channels;
+        channels = Object.keys(rest).length > 0 ? rest : undefined;
+        actions.channelConfig = true;
+      }
+    }
+  }
+
   const newPlugins = {
     ...pluginsConfig,
     entries,
@@ -157,6 +178,7 @@ export function removePluginFromConfig(
 
   const config: OpenClawConfig = {
     ...cfg,
+    channels: channels as OpenClawConfig["channels"],
     plugins: Object.keys(cleanedPlugins).length > 0 ? cleanedPlugins : undefined,
   };
 
@@ -166,6 +188,7 @@ export function removePluginFromConfig(
 export type UninstallPluginParams = {
   config: OpenClawConfig;
   pluginId: string;
+  channelIds?: string[];
   deleteFiles?: boolean;
   extensionsDir?: string;
 };
@@ -177,7 +200,7 @@ export type UninstallPluginParams = {
 export async function uninstallPlugin(
   params: UninstallPluginParams,
 ): Promise<UninstallPluginResult> {
-  const { config, pluginId, deleteFiles = true, extensionsDir } = params;
+  const { config, pluginId, channelIds, deleteFiles = true, extensionsDir } = params;
 
   // Validate plugin exists
   const hasEntry = pluginId in (config.plugins?.entries ?? {});
@@ -191,7 +214,11 @@ export async function uninstallPlugin(
   const isLinked = installRecord?.source === "path";
 
   // Remove from config
-  const { config: newConfig, actions: configActions } = removePluginFromConfig(config, pluginId);
+  const { config: newConfig, actions: configActions } = removePluginFromConfig(
+    config,
+    pluginId,
+    channelIds,
+  );
 
   const actions: UninstallActions = {
     ...configActions,


### PR DESCRIPTION
When uninstalling a channel plugin, removePluginFromConfig now also strips the corresponding channels.<channelId> section. Previously the orphaned channel config caused a validation error on config write ("unknown channel id") because the plugin was no longer registered.

Safety guards:
- Only removes channel config for plugins with an install record (built-in channel plugins are not affected)
- Preserves shared config keys (defaults, modelByChannel)
- Accepts explicit channelIds from plugin registry, falls back to pluginId when unavailable

Closes #39878

## Summary

- **Problem:** `openclaw plugins uninstall <channel-plugin>` removes plugin entries/installs/allowlist but leaves the `channels.<pluginId>` config section intact. On next CLI invocation, config validation fails with `unknown channel id` because the plugin that owned that channel is gone.
- **Why it matters:** Users cannot uninstall channel plugins cleanly; the orphaned config blocks all subsequent CLI commands (including `plugins list`), requiring manual JSON editing to recover.
- **What changed:** `removePluginFromConfig` now also removes `channels.<channelId>` entries owned by the uninstalled plugin. The CLI preview and result summary reflect the channel config removal. Six new tests cover the behavior.
- **What did NOT change (scope boundary):** Config validation strictness is unchanged. No config-guard bypass or loadConfig fallback was added; the fix is purely in the uninstall cleanup path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39878
- Related #39931 (closed, same issue, incomplete fix)
- Related #35915 (open, similar fix, lacks some guards present here)
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `removePluginFromConfig` was never designed to touch the `channels` config section. When channel plugins were introduced, the uninstall path was not updated to clean up their config.
- Missing detection / guardrail: No test verified that channel config is removed on uninstall.
- Prior context: #39931 and #35915 attempted the same fix. #39931 was closed due to CI failures. #35915 is open but does not guard against built-in channel collision.
- Why this regressed now: Not a regression; this was always missing since channel plugins were introduced.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/uninstall.test.ts`
- Scenario the test should lock in: Uninstalling a plugin with an install record removes its `channels.<id>` entry; built-in plugins without install records are not affected; shared keys (`defaults`, `modelByChannel`) are preserved.
- Why this is the smallest reliable guardrail: Pure config mutation function, fully testable without I/O.
- Existing test that already covers this (if any): None before this PR.
- If no new test is added, why not: Six new tests added.

## User-visible / Behavior Changes

- `openclaw plugins uninstall <channel-plugin>` now shows `channel config (<id>)` in the "Will remove" preview and removes it from the config file.
- After uninstall, `openclaw plugins list` and other CLI commands no longer fail with `unknown channel id`.

## Diagram (if applicable)

```text
Before:
uninstall plugin -> remove entries/installs/allowlist -> write config
                    (channels.<id> remains) -> next CLI run -> VALIDATION ERROR

After:
uninstall plugin -> remove entries/installs/allowlist/channels.<id> -> write config
                    -> next CLI run -> OK
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 24.6.0 (Darwin)
- Runtime/container: Node 22.17.0
- Model/provider: N/A
- Integration/channel: openclaw-weixin (@tencent-weixin/openclaw-weixin@2.0.1)
- Relevant config: `channels.openclaw-weixin`, `plugins.entries.openclaw-weixin`, `plugins.installs.openclaw-weixin`

### Steps

1. `npx -y @tencent-weixin/openclaw-weixin-cli@latest install` (install + scan QR)
2. `openclaw plugins uninstall openclaw-weixin --force`
3. `openclaw plugins list`

### Expected

- Step 2 removes all config entries including `channels.openclaw-weixin`
- Step 3 runs without errors

### Actual

- Step 2 shows `Will remove: config entry, install record, channel config (openclaw-weixin), directory`
- Step 3 shows clean plugin list, no validation errors

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

29 unit tests pass (6 new), covering: channel config removal for installed plugins, pluginId fallback, empty channels cleanup, built-in plugin guard, shared key preservation, no-op when no channel config exists.

## Human Verification (required)

- Verified scenarios: Full end-to-end cycle (`npx install` -> scan QR -> `uninstall` -> `plugins list`) on globally installed openclaw built from this branch. Confirmed `channels.openclaw-weixin`, `plugins.entries.openclaw-weixin`, `plugins.installs.openclaw-weixin` are all cleaned after uninstall.
- Edge cases checked: Uninstalling a plugin with no channel config (no-op). Built-in channel plugin without install record (channel config preserved). Shared keys `defaults`/`modelByChannel` not removed.
- What you did **not** verify: Plugin with channelId different from pluginId (tested in unit tests only, no real plugin available). Multi-channel plugin (tested in unit tests only).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: A third-party plugin declares a channelId that collides with a shared key name (e.g. `defaults`).
  - Mitigation: `CHANNELS_SHARED_KEYS` guard explicitly blocks removal of `defaults` and `modelByChannel`.
- Risk: Plugin loaded but channelIds unavailable at uninstall time (plugin failed to load).
  - Mitigation: Falls back to `[pluginId]` as channel key, which covers the common case where channelId === pluginId.

🤖 Generated with [Claude Code](https://claude.com/claude-code)