### PR TITLE
fix(hooks): rebind routed session keys to target agent

### DIFF
--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -290,13 +290,13 @@ describe("gateway hooks helpers", () => {
     ).toBe("slack:channel:c123");
   });
 
-  test("normalizeHookDispatchSessionKey preserves non-target agent scoped keys", () => {
+  test("normalizeHookDispatchSessionKey rebinds non-target agent scoped keys to the target agent", () => {
     expect(
       normalizeHookDispatchSessionKey({
         sessionKey: "agent:main:slack:channel:c123",
         targetAgentId: "hooks",
       }),
-    ).toBe("agent:main:slack:channel:c123");
+    ).toBe("slack:channel:c123");
   });
 
   test("resolveHooksConfig validates defaultSessionKey and generated fallback against prefixes", () => {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -348,10 +348,6 @@ export function normalizeHookDispatchSessionKey(params: {
   if (!parsed) {
     return trimmed;
   }
-  const targetAgentId = normalizeAgentId(params.targetAgentId);
-  if (parsed.agentId !== targetAgentId) {
-    return parsed.rest;
-  }
   return parsed.rest;
 }
 

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -350,7 +350,7 @@ export function normalizeHookDispatchSessionKey(params: {
   }
   const targetAgentId = normalizeAgentId(params.targetAgentId);
   if (parsed.agentId !== targetAgentId) {
-    return `agent:${parsed.agentId}:${parsed.rest}`;
+    return parsed.rest;
   }
   return parsed.rest;
 }

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -357,6 +357,35 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("rebinds foreign agent-scoped session keys to the routed hook agent before isolated dispatch", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:"],
+    };
+    setMainAndHooksAgents();
+    await withGatewayServer(async ({ port }) => {
+      mockIsolatedRunOkOnce();
+
+      const resAgent = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        name: "Email",
+        agentId: "hooks",
+        sessionKey: "agent:main:slack:channel:c123",
+      });
+      expect(resAgent.status).toBe(200);
+      await waitForSystemEvent();
+
+      const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
+        | { sessionKey?: string; job?: { agentId?: string } }
+        | undefined;
+      expect(routedCall?.job?.agentId).toBe("hooks");
+      expect(routedCall?.sessionKey).toBe("slack:channel:c123");
+      drainSystemEvents(resolveMainKey());
+    });
+  });
+
   test("dedupes repeated /hooks/agent deliveries by idempotency key", async () => {
     testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
     await withGatewayServer(async ({ port }) => {


### PR DESCRIPTION
## Summary
- strip foreign `agent:<id>:` prefixes when dispatching a hook into a routed target agent
- keep only the session rest so isolated cron rebases the session under the routed agent
- add regression coverage for non-target agent-scoped hook session keys

## Testing
- pnpm exec vitest run src/gateway/hooks.test.ts src/gateway/server.hooks.test.ts src/cron/isolated-agent/run.session-key.test.ts