### PR TITLE
fix(utils): handle null/undefined in resolveUserPath

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -282,7 +282,10 @@ export function truncateUtf16Safe(input: string, maxLen: number): string {
   return sliceUtf16Safe(input, 0, limit);
 }
 
-export function resolveUserPath(input: string): string {
+export function resolveUserPath(input: string | null | undefined): string {
+  if (input == null) {
+    return "";
+  }
   if (!input) {
     return "";
   }


### PR DESCRIPTION
Update resolveUserPath to properly handle null and undefined inputs by updating the type signature and adding explicit null check.

This fixes an issue where resolveUserPath would fail when passed null/undefined even though the tests expect it to handle these cases gracefully.