### PR TITLE
fix(browser): require admin scope for browser.request

### DIFF
--- a/extensions/browser/index.test.ts
+++ b/extensions/browser/index.test.ts
@@ -56,7 +56,7 @@ describe("browser plugin", () => {
     expect(registerGatewayMethod).toHaveBeenCalledWith(
       "browser.request",
       runtimeApiMocks.handleBrowserGatewayRequest,
-      { scope: "operator.write" },
+      { scope: "operator.admin" },
     );
     expect(runtimeApiMocks.createBrowserPluginService).toHaveBeenCalledTimes(1);
     expect(registerService).toHaveBeenCalledWith(

--- a/extensions/browser/index.ts
+++ b/extensions/browser/index.ts
@@ -21,7 +21,7 @@ export default definePluginEntry({
       })) as OpenClawPluginToolFactory);
     api.registerCli(({ program }) => registerBrowserCli(program), { commands: ["browser"] });
     api.registerGatewayMethod("browser.request", handleBrowserGatewayRequest, {
-      scope: "operator.write",
+      scope: "operator.admin",
     });
     api.registerService(createBrowserPluginService());
   },

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -41,12 +41,12 @@ describe("method scope resolution", () => {
   it("reads plugin-registered gateway method scopes from the active plugin registry", () => {
     const registry = createEmptyPluginRegistry();
     registry.gatewayMethodScopes = {
-      "browser.request": "operator.write",
+      "browser.request": "operator.admin",
     };
     setActivePluginRegistry(registry);
 
     expect(resolveLeastPrivilegeOperatorScopesForMethod("browser.request")).toEqual([
-      "operator.write",
+      "operator.admin",
     ]);
   });
 });
@@ -65,6 +65,16 @@ describe("operator scope authorization", () => {
     expect(authorizeOperatorScopesForMethod("send", ["operator.read"])).toEqual({
       allowed: false,
       missingScope: "operator.write",
+    });
+  });
+
+  it("requires admin for browser.request", () => {
+    expect(authorizeOperatorScopesForMethod("browser.request", ["operator.write"])).toEqual({
+      allowed: false,
+      missingScope: "operator.admin",
+    });
+    expect(authorizeOperatorScopesForMethod("browser.request", ["operator.admin"])).toEqual({
+      allowed: true,
     });
   });
 


### PR DESCRIPTION
## Summary
- raise the bundled browser plugin gateway method `browser.request` from `operator.write` to `operator.admin`
- update plugin registration and method-scope tests to enforce the tighter boundary

## Why
`browser.request` can directly drive the host browser control service or a browser-capable node proxy. Requiring only `operator.write` made this surface reachable to non-admin gateway clients even though the equivalent browser-control capability is effectively an elevated operator action.

## Testing
- pnpm exec vitest run extensions/browser/index.test.ts src/gateway/method-scopes.test.ts src/gateway/server-plugin-bootstrap.browser-plugin.integration.test.ts