### PR TITLE
feat(cli): add agent-id to system event wake

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -696,18 +696,22 @@ public struct AgentWaitParams: Codable, Sendable {
 public struct WakeParams: Codable, Sendable {
     public let mode: AnyCodable
     public let text: String
+    public let agentid: String?
 
     public init(
         mode: AnyCodable,
-        text: String)
+        text: String,
+        agentid: String?)
     {
         self.mode = mode
         self.text = text
+        self.agentid = agentid
     }
 
     private enum CodingKeys: String, CodingKey {
         case mode
         case text
+        case agentid = "agentId"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -696,18 +696,22 @@ public struct AgentWaitParams: Codable, Sendable {
 public struct WakeParams: Codable, Sendable {
     public let mode: AnyCodable
     public let text: String
+    public let agentid: String?
 
     public init(
         mode: AnyCodable,
-        text: String)
+        text: String,
+        agentid: String?)
     {
         self.mode = mode
         self.text = text
+        self.agentid = agentid
     }
 
     private enum CodingKeys: String, CodingKey {
         case mode
         case text
+        case agentid = "agentId"
     }
 }
 

--- a/src/cli/system-cli.test.ts
+++ b/src/cli/system-cli.test.ts
@@ -61,6 +61,17 @@ describe("system-cli", () => {
     expect(runtimeLogs).toEqual([JSON.stringify({ id: "wake-1" }, null, 2)]);
   });
 
+  it("passes --agent-id to gateway params", async () => {
+    await runCli(["system", "event", "--text", "hello", "--agent-id", "my-agent"]);
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "wake",
+      expect.objectContaining({ text: "hello", agentId: "my-agent" }),
+      { mode: "next-heartbeat", text: "hello", agentId: "my-agent" },
+      { expectFinal: false },
+    );
+  });
+
   it("handles invalid wake mode as runtime error", async () => {
     await runCli(["system", "event", "--text", "hello", "--mode", "later"]);
 

--- a/src/cli/system-cli.ts
+++ b/src/cli/system-cli.ts
@@ -6,7 +6,12 @@ import { theme } from "../terminal/theme.js";
 import type { GatewayRpcOpts } from "./gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "./gateway-rpc.js";
 
-type SystemEventOpts = GatewayRpcOpts & { text?: string; mode?: string; json?: boolean };
+type SystemEventOpts = GatewayRpcOpts & {
+  text?: string;
+  mode?: string;
+  agentId?: string;
+  json?: boolean;
+};
 type SystemGatewayOpts = GatewayRpcOpts & { json?: boolean };
 
 const normalizeWakeMode = (raw: unknown) => {
@@ -54,6 +59,7 @@ export function registerSystemCli(program: Command) {
       .description("Enqueue a system event and optionally trigger a heartbeat")
       .requiredOption("--text <text>", "System event text")
       .option("--mode <mode>", "Wake mode (now|next-heartbeat)", "next-heartbeat")
+      .option("--agent-id <agentId>", "Target agent id")
       .option("--json", "Output JSON", false),
   ).action(async (opts: SystemEventOpts) => {
     await runSystemGatewayCommand(
@@ -64,7 +70,14 @@ export function registerSystemCli(program: Command) {
           throw new Error("--text is required");
         }
         const mode = normalizeWakeMode(opts.mode);
-        return await callGatewayFromCli("wake", opts, { mode, text }, { expectFinal: false });
+        const agentId =
+          typeof opts.agentId === "string" ? opts.agentId.trim() || undefined : undefined;
+        return await callGatewayFromCli(
+          "wake",
+          opts,
+          { mode, text, ...(agentId ? { agentId } : {}) },
+          { expectFinal: false },
+        );
       },
       "ok",
     );

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -54,7 +54,7 @@ export class CronService {
     return this.state.store?.jobs.find((job) => job.id === id);
   }
 
-  wake(opts: { mode: "now" | "next-heartbeat"; text: string }) {
+  wake(opts: { mode: "now" | "next-heartbeat"; text: string; agentId?: string }) {
     return ops.wakeNow(this.state, opts);
   }
 }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -594,7 +594,7 @@ export async function enqueueRun(state: CronServiceState, id: string, mode?: "du
 
 export function wakeNow(
   state: CronServiceState,
-  opts: { mode: "now" | "next-heartbeat"; text: string },
+  opts: { mode: "now" | "next-heartbeat"; text: string; agentId?: string },
 ) {
   return wake(state, opts);
 }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1234,15 +1234,15 @@ function emitJobFinished(
 
 export function wake(
   state: CronServiceState,
-  opts: { mode: "now" | "next-heartbeat"; text: string },
+  opts: { mode: "now" | "next-heartbeat"; text: string; agentId?: string },
 ) {
   const text = opts.text.trim();
   if (!text) {
     return { ok: false } as const;
   }
-  state.deps.enqueueSystemEvent(text);
+  state.deps.enqueueSystemEvent(text, opts.agentId ? { agentId: opts.agentId } : undefined);
   if (opts.mode === "now") {
-    state.deps.requestHeartbeatNow({ reason: "wake" });
+    state.deps.requestHeartbeatNow({ reason: "wake", agentId: opts.agentId });
   }
   return { ok: true } as const;
 }

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -39,7 +39,7 @@ export const SendParamsSchema = Type.Object(
     channel: Type.Optional(Type.String()),
     accountId: Type.Optional(Type.String()),
     /** Optional agent id for per-agent media root resolution on gateway sends. */
-    agentId: Type.Optional(Type.String()),
+    agentId: Type.Optional(NonEmptyString),
     /** Thread id (channel-specific meaning, e.g. Telegram forum topic id). */
     threadId: Type.Optional(Type.String()),
     /** Optional session key for mirroring delivered output back into the transcript. */

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -134,6 +134,7 @@ export const WakeParamsSchema = Type.Object(
   {
     mode: Type.Union([Type.Literal("now"), Type.Literal("next-heartbeat")]),
     text: NonEmptyString,
+    agentId: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -37,8 +37,9 @@ export const cronHandlers: GatewayRequestHandlers = {
     const p = params as {
       mode: "now" | "next-heartbeat";
       text: string;
+      agentId?: string;
     };
-    const result = context.cron.wake({ mode: p.mode, text: p.text });
+    const result = context.cron.wake({ mode: p.mode, text: p.text, agentId: p.agentId });
     respond(true, result, undefined);
   },
   "cron.list": async ({ params, respond, context }) => {


### PR DESCRIPTION
## Summary

Adds `--agent-id <agentId>` to `openclaw system event` so a system event wake can target a specific agent instead of always falling back to the default/main agent.

This threads `agentId` through the full wake path:
- CLI flag parsing
- gateway wake param validation
- cron wake handler
- system event enqueue
- immediate heartbeat wake targeting

## Why

On multi-agent setups, `openclaw system event --mode now` could not explicitly target a non-default agent. That made it hard to wake a specific agent session, even when the intended recipient was known.

With this change, commands like:

```bash
openclaw system event --text "Reply exactly: SECRET-CODE-123" --agent-id coding --mode now
```

can wake the `coding` agent directly.

## Changes

- add `--agent-id <agentId>` to `openclaw system event`
- include `agentId` in the wake RPC payload when provided
- extend `WakeParamsSchema` to accept optional `agentId`
- propagate `agentId` through gateway wake handling into `context.cron.wake(...)`
- update cron wake logic so both:
  - `enqueueSystemEvent(...)`, and
  - `requestHeartbeatNow(...)`
  receive the targeted `agentId`
- add CLI test coverage for forwarding `agentId`

## Testing

### Automated

- `pnpm vitest run src/cli/system-cli.test.ts`
- `pnpm vitest run src/cron/`

### Manual

Validated end-to-end on a local multi-agent install by:

```bash
openclaw gateway restart
openclaw system event --text "Reply with exactly SECRET-CODE-123" --agent-id coding --mode now --json
```

Confirmed that:
- the command accepted `--agent-id`
- the wake request was accepted by the gateway
- the `coding` agent, not `main`, handled the event
- the targeted agent produced the expected visible reply

## Notes

This is intentionally minimal and scoped to the existing wake/system-event path. It does not change isolated session behavior; it only makes the existing agent-targeted wake flow explicit and usable from the CLI.
