### PR TITLE
fix: strip orphaned OpenAI reasoning blocks before responses API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Control UI/cron: keep the runtime-only `last` delivery sentinel from being materialized into persisted cron delivery and failure-alert channel configs when jobs are created or edited. (#68829) Thanks @tianhaocui.
+- OpenAI/Responses: strip orphaned reasoning blocks before outbound Responses API calls so compacted or restored histories no longer fail on standalone reasoning items. (#55787) Thanks @suboss87.
 
 ## 2026.4.19-beta.2
 
@@ -28,7 +29,6 @@ Docs: https://docs.openclaw.ai
 - Browser/CDP: allow the selected remote CDP profile host for CDP health and control checks without widening browser navigation SSRF policy, so WSL-to-Windows Chrome endpoints no longer appear offline under strict defaults. Fixes #68108. (#68207) Thanks @Mlightsnow.
 - Codex: stop cumulative app-server token totals from being treated as fresh context usage, so session status no longer reports inflated context percentages after long Codex threads. (#64669) Thanks @cyrusaf.
 - Browser/CDP: add phase-specific CDP readiness diagnostics and normalize loopback WebSocket host aliases, so Windows browser startup failures surface whether HTTP discovery, WebSocket discovery, SSRF validation, or the `Browser.getVersion` health check failed.
-- OpenAI/Responses: strip orphaned reasoning blocks before outbound Responses API calls so compacted or restored histories no longer fail on standalone reasoning items. (#55787) Thanks @suboss87.
 
 ## 2026.4.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Browser/CDP: allow the selected remote CDP profile host for CDP health and control checks without widening browser navigation SSRF policy, so WSL-to-Windows Chrome endpoints no longer appear offline under strict defaults. Fixes #68108. (#68207) Thanks @Mlightsnow.
 - Codex: stop cumulative app-server token totals from being treated as fresh context usage, so session status no longer reports inflated context percentages after long Codex threads. (#64669) Thanks @cyrusaf.
 - Browser/CDP: add phase-specific CDP readiness diagnostics and normalize loopback WebSocket host aliases, so Windows browser startup failures surface whether HTTP discovery, WebSocket discovery, SSRF validation, or the `Browser.getVersion` health check failed.
+- OpenAI/Responses: strip orphaned reasoning blocks before outbound Responses API calls so compacted or restored histories no longer fail on standalone reasoning items. (#55787) Thanks @suboss87.
 
 ## 2026.4.18
 

--- a/src/agents/pi-embedded-helpers/openai.ts
+++ b/src/agents/pi-embedded-helpers/openai.ts
@@ -207,6 +207,7 @@ export function downgradeOpenAIFunctionCallReasoningPairs(
  * is incomplete, drop the block to keep history usable.
  */
 export function downgradeOpenAIReasoningBlocks(messages: AgentMessage[]): AgentMessage[] {
+  let anyChanged = false;
   const out: AgentMessage[] = [];
 
   for (const msg of messages) {
@@ -259,6 +260,7 @@ export function downgradeOpenAIReasoningBlocks(messages: AgentMessage[]): AgentM
       continue;
     }
 
+    anyChanged = true;
     if (nextContent.length === 0) {
       continue;
     }
@@ -266,5 +268,5 @@ export function downgradeOpenAIReasoningBlocks(messages: AgentMessage[]): AgentM
     out.push({ ...assistantMsg, content: nextContent } as AgentMessage);
   }
 
-  return out;
+  return anyChanged ? out : messages;
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1368,12 +1368,10 @@ export async function runEmbeddedAttempt(
           if (!Array.isArray(messages)) {
             return inner(model, context, options);
           }
-          const pairSanitized = downgradeOpenAIFunctionCallReasoningPairs(
-            messages as AgentMessage[],
-          );
-          // Also strip orphaned reasoning blocks that lack a required following
-          // content item — OpenAI rejects these with a 400 error.
-          const sanitized = downgradeOpenAIReasoningBlocks(pairSanitized);
+          // Strip orphaned reasoning blocks first, then fix function-call
+          // pairing — matches the call order in google.ts.
+          const reasoningSanitized = downgradeOpenAIReasoningBlocks(messages as AgentMessage[]);
+          const sanitized = downgradeOpenAIFunctionCallReasoningPairs(reasoningSanitized);
           if (sanitized === messages) {
             return inner(model, context, options);
           }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -72,6 +72,7 @@ import {
 import type { EmbeddedContextFile } from "../../pi-embedded-helpers.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
+  downgradeOpenAIReasoningBlocks,
   isCloudCodeAssistFormatError,
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
@@ -1367,7 +1368,12 @@ export async function runEmbeddedAttempt(
           if (!Array.isArray(messages)) {
             return inner(model, context, options);
           }
-          const sanitized = downgradeOpenAIFunctionCallReasoningPairs(messages as AgentMessage[]);
+          const pairSanitized = downgradeOpenAIFunctionCallReasoningPairs(
+            messages as AgentMessage[],
+          );
+          // Also strip orphaned reasoning blocks that lack a required following
+          // content item — OpenAI rejects these with a 400 error.
+          const sanitized = downgradeOpenAIReasoningBlocks(pairSanitized);
           if (sanitized === messages) {
             return inner(model, context, options);
           }


### PR DESCRIPTION
## Summary

- Wire `downgradeOpenAIReasoningBlocks()` into the `openai-responses` / `openai-codex-responses` stream wrapper in `attempt.ts`
- Prevents 400 errors when conversation history contains orphaned reasoning items

## Root cause

OpenAI's Responses API requires every `reasoning` item to be immediately followed by a non-thinking content item (text or tool_call). After compaction, error recovery, or session restore, the conversation history can end up with orphaned reasoning blocks that lack their required following content. The API rejects these with:

> 400 Item 'rs_...' of type 'reasoning' was provided without its required following item.

`downgradeOpenAIReasoningBlocks()` already existed and was well-tested (5 unit tests) — it strips orphaned reasoning blocks from message history. However, it was only wired into the **Google provider** path (`google.ts:641`), not the **OpenAI responses** path. This fix adds it to the OpenAI path alongside the existing `downgradeOpenAIFunctionCallReasoningPairs()` call.

## Changes

**`src/agents/pi-embedded-runner/run/attempt.ts`** — 2 changes:
1. Import `downgradeOpenAIReasoningBlocks` (line 62)
2. Chain it after `downgradeOpenAIFunctionCallReasoningPairs` in the responses API wrapper (line 1000)

## Test plan

- [x] All 5 existing `downgradeOpenAIReasoningBlocks` tests pass
- [x] `pnpm check` passes (lint, format, types, boundaries)
- [ ] Verify with gpt-5.2-chat or gpt-5.4-chat that tool calls no longer produce 400 errors after session history grows

Fixes #54534.

🤖 Generated with [Claude Code](https://claude.com/claude-code)