### PR TITLE
Fix/OpenAI codex audio media understanding

### DIFF
--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -175,7 +175,7 @@ describe("openai plugin", () => {
       "openai-codex",
       "media provider",
     );
-    expect(codexMediaProvider.capabilities).toEqual(["image"]);
+    expect(codexMediaProvider.capabilities).toEqual(["image", "audio"]);
     expect(imageProviders).toHaveLength(1);
   });
 

--- a/extensions/openai/index.test.ts
+++ b/extensions/openai/index.test.ts
@@ -176,6 +176,7 @@ describe("openai plugin", () => {
       "media provider",
     );
     expect(codexMediaProvider.capabilities).toEqual(["image", "audio"]);
+    expect(codexMediaProvider.transcribeAudio).toBeDefined();
     expect(imageProviders).toHaveLength(1);
   });
 

--- a/extensions/openai/media-understanding-provider.ts
+++ b/extensions/openai/media-understanding-provider.ts
@@ -27,7 +27,8 @@ export const openaiMediaUnderstandingProvider: MediaUnderstandingProvider = {
 
 export const openaiCodexMediaUnderstandingProvider: MediaUnderstandingProvider = {
   id: "openai-codex",
-  capabilities: ["image"],
+  capabilities: ["image", "audio"],
   describeImage: describeImageWithModel,
   describeImages: describeImagesWithModel,
+  transcribeAudio: transcribeOpenAiAudio,
 };

--- a/extensions/openai/media-understanding-provider.ts
+++ b/extensions/openai/media-understanding-provider.ts
@@ -25,10 +25,17 @@ export const openaiMediaUnderstandingProvider: MediaUnderstandingProvider = {
   transcribeAudio: transcribeOpenAiAudio,
 };
 
+async function transcribeOpenAiCodexAudio(params: AudioTranscriptionRequest) {
+  return await transcribeOpenAiAudio({
+    ...params,
+    baseUrl: undefined, // force fallback to DEFAULT_OPENAI_AUDIO_BASE_URL
+  });
+}
+
 export const openaiCodexMediaUnderstandingProvider: MediaUnderstandingProvider = {
   id: "openai-codex",
   capabilities: ["image", "audio"],
   describeImage: describeImageWithModel,
   describeImages: describeImagesWithModel,
-  transcribeAudio: transcribeOpenAiAudio,
+  transcribeAudio: transcribeOpenAiCodexAudio,
 };

--- a/src/media-understanding/defaults.ts
+++ b/src/media-understanding/defaults.ts
@@ -30,6 +30,7 @@ export const DEFAULT_VIDEO_MAX_BASE64_BYTES = 70 * MB;
 export const DEFAULT_AUDIO_MODELS: Record<string, string> = {
   groq: "whisper-large-v3-turbo",
   openai: "gpt-4o-mini-transcribe",
+  "openai-codex": "gpt-4o-mini-transcribe",
   deepgram: "nova-3",
   mistral: "voxtral-mini-latest",
 };


### PR DESCRIPTION
 The openai-codex provider (OAuth) was missing the audio capability and                    
  transcribeAudio handler, so Pro plan users could not use audio transcription.
  Add both to match the regular openai provider, reusing the same Whisper API               
  function.                                                                                 
   
  Closes #55237
  Related #55052                                                                              
                                                            
  ## Summary

  - Problem: `openai-codex` media understanding provider only registered `["image"]`        
  capability, missing `"audio"` and `transcribeAudio` handler
  - Why it matters: OpenAI Pro plan (OAuth) users cannot transcribe audio — forced to use   
  API key provider or skip transcription entirely                                           
  - What changed: Added `"audio"` to capabilities and `transcribeAudio:
  transcribeOpenAiAudio` to the codex provider; updated test assertion                      
  - What did NOT change: No new functions — reuses the existing `transcribeOpenAiAudio` that
   calls `/v1/audio/transcriptions`                                                         
                                                            
  ## Change Type (select all)                                                               
                                                            
  - [x] Bug fix                                                                             
  
  ## Scope (select all touched areas)                                                       
                                                            
  - [x] Integrations

  ## Linked Issue/PR

  - Closes #55237
  - [x] This PR fixes a bug or regression

  ## Root Cause / Regression History (if applicable)                                        
  
  - Root cause: `openaiCodexMediaUnderstandingProvider` was defined with `capabilities:     
  ["image"]` only and no `transcribeAudio` handler          
  - Missing detection / guardrail: No test asserted audio capability for codex provider     
  - Prior context: The codex media provider was likely added with image-only initially and  
  audio was never wired up                                                                  
  - Why this regressed now: Not a regression — audio was never supported for `openai-codex` 
                                                                                            
  ## Regression Test Plan (if applicable)                   
                                                                                            
  - [x] Existing coverage already sufficient                
  - Target test or file: `extensions/openai/index.test.ts`
  - Scenario the test should lock in: Codex media provider registers `["image", "audio"]`   
  capabilities                                                                              
  - Existing test that already covers this: Updated existing assertion at line 196          
                                                                                            
  ## User-visible / Behavior Changes                        
                                                                                            
  - `openai-codex` provider now supports audio transcription via Whisper API                
   
  ## Diagram (if applicable)                                                                
                                                            
  N/A

  ## Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No — same Whisper endpoint, just now reachable via codex
  provider                                                                                  
  - Command/tool execution surface changed? No
  - Data access scope changed? No                                                           
                                                            
  ## Repro + Verification

  ### Environment

  - OS: macOS 15.x (arm64)                                                                  
  - Runtime/container: Node 24
  - Model/provider: openai-codex                                                            
                                                                                            
  ### Steps
                                                                                            
  1. Configure `openai-codex` as provider with audio enabled                                
  2. Send audio attachment through any channel
                                                                                            
  ### Expected                                              

  - Audio is transcribed via Whisper API                                                    
   
  ### Actual (before fix)                                                                   
                                                            
  - Audio transcription skipped — codex provider had no audio capability                    
   
  ## Evidence                                                                               
                                                            
  - [x] Failing test/log before + passing after

  ## Human Verification (required)

  - Verified scenarios: Unit tests pass, format check passes                                
  - Edge cases checked: Provider normalization preserves `openai-codex` ID correctly
  - What you did **not** verify: Live audio transcription with real OAuth credentials       
                                                            
  ## Review Conversations                                                                   
                                                            
  - [x] I replied to or resolved every bot review conversation I addressed in this PR.      
  - [x] I left unresolved only the conversations that still need reviewer or maintainer
  judgment.                                                                                 
                                                            
  ## Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No                                                                    
   
  ## Risks and Mitigations                                                                  
                                                            
  None