### PR TITLE
Build: fall back on Windows symlink errors

### DIFF
--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -34,8 +34,46 @@ function ensureSymlink(targetValue, targetPath, type) {
   fs.symlinkSync(targetValue, targetPath, type);
 }
 
+function tryFallbackCopyFileOnWindows(sourcePath, targetPath, type, error) {
+  if (process.platform !== "win32") {
+    throw error;
+  }
+  if (type === "dir" || type === "junction") {
+    throw error;
+  }
+  if (error?.code !== "EPERM" && error?.code !== "EACCES") {
+    throw error;
+  }
+
+  let sourceStat;
+  try {
+    sourceStat = fs.statSync(sourcePath);
+  } catch {
+    throw error;
+  }
+  if (!sourceStat.isFile()) {
+    throw error;
+  }
+
+  removePathIfExists(targetPath);
+  fs.copyFileSync(sourcePath, targetPath);
+}
+
+function ensureSymlinkOrCopyFile(sourcePath, targetValue, targetPath, type) {
+  try {
+    ensureSymlink(targetValue, targetPath, type);
+  } catch (error) {
+    tryFallbackCopyFileOnWindows(sourcePath, targetPath, type, error);
+  }
+}
+
 function symlinkPath(sourcePath, targetPath, type) {
-  ensureSymlink(relativeSymlinkTarget(sourcePath, targetPath), targetPath, type);
+  ensureSymlinkOrCopyFile(
+    sourcePath,
+    relativeSymlinkTarget(sourcePath, targetPath),
+    targetPath,
+    type,
+  );
 }
 
 function shouldWrapRuntimeJsFile(sourcePath) {
@@ -85,7 +123,7 @@ function stagePluginRuntimeOverlay(sourceDir, targetDir) {
     }
 
     if (dirent.isSymbolicLink()) {
-      ensureSymlink(fs.readlinkSync(sourcePath), targetPath);
+      ensureSymlinkOrCopyFile(sourcePath, fs.readlinkSync(sourcePath), targetPath);
       continue;
     }
 

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -16,6 +16,7 @@ function makeRepoRoot(prefix: string): string {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const dir of tempDirs.splice(0, tempDirs.length)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -259,6 +260,49 @@ describe("stageBundledPluginRuntime", () => {
     expect(fs.lstatSync(runtimeManifestPath).isSymbolicLink()).toBe(false);
     expect(fs.readFileSync(runtimeManifestPath, "utf8")).toBe("{}\n");
     expect(fs.lstatSync(runtimeAssetPath).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(runtimeAssetPath, "utf8")).toBe("ok\n");
+  });
+
+  it("copies file artifacts when Windows denies runtime file symlinks", () => {
+    const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-assets-win-");
+    const distPluginDir = path.join(repoRoot, "dist", "extensions", "diffs");
+    const runtimeAssetPath = path.join(
+      repoRoot,
+      "dist-runtime",
+      "extensions",
+      "diffs",
+      "assets",
+      "info.txt",
+    );
+    fs.mkdirSync(path.join(distPluginDir, "assets"), { recursive: true });
+    fs.writeFileSync(
+      path.join(distPluginDir, "package.json"),
+      JSON.stringify(
+        { name: "@openclaw/diffs", openclaw: { extensions: ["./index.js"] } },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    fs.writeFileSync(path.join(distPluginDir, "openclaw.plugin.json"), "{}\n", "utf8");
+    fs.writeFileSync(path.join(distPluginDir, "assets", "info.txt"), "ok\n", "utf8");
+
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const originalSymlinkSync = fs.symlinkSync.bind(fs);
+    vi.spyOn(fs, "symlinkSync").mockImplementation((target, pathLike, type) => {
+      if (String(pathLike) === runtimeAssetPath) {
+        const error = new Error("symlink denied");
+        Object.assign(error, { code: "EPERM" });
+        throw error;
+      }
+      return originalSymlinkSync(target, pathLike, type);
+    });
+
+    stageBundledPluginRuntime({ repoRoot });
+
+    expect(platformSpy).toBeDefined();
+    expect(fs.existsSync(runtimeAssetPath)).toBe(true);
+    expect(fs.lstatSync(runtimeAssetPath).isSymbolicLink()).toBe(false);
     expect(fs.readFileSync(runtimeAssetPath, "utf8")).toBe("ok\n");
   });
 

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -300,7 +300,7 @@ describe("stageBundledPluginRuntime", () => {
 
     stageBundledPluginRuntime({ repoRoot });
 
-    expect(platformSpy).toBeDefined();
+    expect(platformSpy).toHaveBeenCalled();
     expect(fs.existsSync(runtimeAssetPath)).toBe(true);
     expect(fs.lstatSync(runtimeAssetPath).isSymbolicLink()).toBe(false);
     expect(fs.readFileSync(runtimeAssetPath, "utf8")).toBe("ok\n");


### PR DESCRIPTION
## Summary

- Problem: Windows source builds can fail in `runtime-postbuild` when `dist-runtime` tries to create file symlinks without Developer Mode / symlink privileges.
- Why it matters: affected Windows contributors cannot complete a source build even though the staged runtime artifacts are otherwise valid.
- What changed: kept symlink-first behavior, but added a Windows-only fallback that copies file artifacts when file symlink creation fails with `EPERM` / `EACCES`; added a focused regression test that simulates the Windows permission failure.
- What did NOT change (scope boundary): no changes to directory/node_modules linking behavior, no broader packaging changes, and no UI/runtime loading changes outside `runtime-postbuild` staging.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #55454
- Related #

## User-visible / Behavior Changes

- On Windows machines where file symlink creation is blocked, `runtime-postbuild` now falls back to copying staged plugin file artifacts instead of aborting the build.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: source checkout
- Model/provider: not applicable
- Integration/channel (if any): none
- Relevant config (redacted): none

### Steps

1. Run `runtime-postbuild` staging for bundled plugin artifacts on Windows.
2. Simulate a file symlink failure with `EPERM` for a staged runtime asset.
3. Inspect the staged runtime artifact under `dist-runtime`.

### Expected

- The staged file still exists and contains the original contents.
- The build does not abort just because the file symlink was denied.

### Actual

- Before this change, `ensureSymlink(...)` only handled `EEXIST`, so `EPERM` / `EACCES` bubbled out and failed the build.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- src/plugins/stage-bundled-plugin-runtime.test.ts` passes, including the new simulated Windows `EPERM` fallback case; `pnpm exec oxfmt --check scripts/stage-bundled-plugin-runtime.mjs src/plugins/stage-bundled-plugin-runtime.test.ts` passes; `git diff --check` passes.
- Edge cases checked: directory/node_modules symlink behavior is unchanged; only file symlink permission failures on Windows fall back to copying.
- What you did **not** verify: a real Windows machine with Developer Mode disabled reproducing the exact `EPERM` path outside the simulated test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `0a1c3f3e4d`
- Files/config to restore: `scripts/stage-bundled-plugin-runtime.mjs`, `src/plugins/stage-bundled-plugin-runtime.test.ts`
- Known bad symptoms reviewers should watch for: runtime file artifacts unexpectedly becoming copied on non-Windows platforms or directory/node_modules links losing symlink behavior.

## Risks and Mitigations

- Risk: a Windows symlink failure outside the intended file-artifact path could get masked incorrectly.
  - Mitigation: the fallback is gated to `win32`, only for `EPERM` / `EACCES`, and only when the staged source resolves to a regular file; directory/junction links still rethrow.
- Risk: copied artifacts could diverge from the original symlinked behavior for file assets.
  - Mitigation: this only applies when symlinks are unavailable, and the copied file preserves the same contents needed at runtime.
