### PR TITLE
fix: count Discord ACP block deliveries as visible text

### DIFF
--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -39,7 +39,8 @@ function shouldTreatDeliveredTextAsVisible(params: {
   if (params.kind === "final") {
     return true;
   }
-  return normalizeDeliveryChannel(params.channel) === "telegram";
+  const ch = normalizeDeliveryChannel(params.channel);
+  return ch === "telegram" || ch === "discord";
 }
 
 type AcpDispatchDeliveryState = {


### PR DESCRIPTION
Fixes #55568

ACP-bound Discord channels deliver every response twice identical content, a few seconds apart.

The bug is in `shouldTreatDeliveredTextAsVisible` in `dispatch-acp-delivery.ts`. Block deliveries are only counted as "visible" for Telegram. Discord blocks get delivered fine, but the delivery coordinator doesn't know that, so `finalizeAcpTurnOutput` sees `hasDeliveredVisibleText() === false` and sends the whole thing again as a final reply.

One-line fix: also return `true` when the channel is `discord`.

Tested with a Discord ACP binding (Claude Code, persistent mode) duplicates gone, single delivery confirmed.