### PR TITLE
feat: configurable exec obfuscation command-length threshold

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -46,6 +46,41 @@ const {
   };
 });
 
+vi.mock("openclaw/plugin-sdk/runtime-env", () => {
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => logger,
+  };
+  return {
+    createSubsystemLogger: () => logger,
+    createSubsystemRuntime: () => ({ log: () => {}, error: () => {}, exit: () => {} }),
+    createNonExitingRuntime: () => ({ log: () => {}, error: () => {} }),
+    defaultRuntime: { log: () => {}, error: () => {}, exit: () => {} },
+    danger: (value: unknown) => String(value),
+    info: () => {},
+    success: () => {},
+    warn: () => {},
+    logVerbose: () => {},
+    logVerboseConsole: () => {},
+    shouldLogVerbose: () => false,
+    isVerbose: () => false,
+    setVerbose: () => {},
+    isYes: () => false,
+    setYes: () => {},
+    getChildLogger: () => logger,
+    getLogger: () => logger,
+    resetLogger: () => {},
+    setLoggerOverride: () => {},
+    toPinoLikeLogger: () => logger,
+    runtimeForLogger: () => ({ log: () => {}, error: () => {} }),
+    waitForAbortSignal: async () => {},
+    registerUnhandledRejectionHandler: () => {},
+  };
+});
+
 vi.mock("../gateway-logging.js", () => ({
   attachDiscordGatewayLogging: attachDiscordGatewayLoggingMock,
 }));

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -5,10 +5,16 @@ import type { LineAccountConfig } from "./types.js";
 
 // Avoid pulling in globals/pairing/media dependencies; this suite only asserts
 // allowlist/groupPolicy gating and message-context wiring.
-vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+vi.mock("openclaw/plugin-sdk/runtime-env", () => {
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => logger,
+  };
   return {
-    ...actual,
+    createSubsystemLogger: () => logger,
     danger: (text: string) => text,
     logVerbose: () => {},
     shouldLogVerbose: () => false,

--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -22,10 +22,17 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
   dispatchReplyWithBufferedBlockDispatcher: vi.fn(),
 }));
 
-vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+vi.mock("openclaw/plugin-sdk/runtime-env", () => {
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => logger,
+  };
   return {
-    ...actual,
+    createSubsystemLogger: () => logger,
+    createNonExitingRuntime: () => ({ log: () => {}, error: () => {} }),
     danger: (value: unknown) => String(value),
     logVerbose: vi.fn(),
     waitForAbortSignal: vi.fn(),

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -63,10 +63,17 @@ vi.mock("openclaw/plugin-sdk/channel-runtime", () => ({
   recordChannelActivity: recordChannelActivityMock,
 }));
 
-vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+vi.mock("openclaw/plugin-sdk/runtime-env", () => {
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => logger,
+  };
   return {
-    ...actual,
+    createSubsystemLogger: () => logger,
+    danger: (value: unknown) => String(value),
     logVerbose: logVerboseMock,
   };
 });

--- a/extensions/line/src/setup-surface.test.ts
+++ b/extensions/line/src/setup-surface.test.ts
@@ -22,21 +22,6 @@ const { getBotInfoMock, MessagingApiClientMock } = vi.hoisted(() => {
   return { getBotInfoMock, MessagingApiClientMock };
 });
 
-vi.mock("openclaw/plugin-sdk/runtime-env", () => {
-  const logger = {
-    debug: () => {},
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-    child: () => logger,
-  };
-  return {
-    createSubsystemLogger: () => logger,
-    danger: (value: unknown) => String(value),
-    logVerbose: vi.fn(),
-  };
-});
-
 vi.mock("@line/bot-sdk", () => ({
   messagingApi: { MessagingApiClient: MessagingApiClientMock },
 }));

--- a/extensions/line/src/setup-surface.test.ts
+++ b/extensions/line/src/setup-surface.test.ts
@@ -22,6 +22,21 @@ const { getBotInfoMock, MessagingApiClientMock } = vi.hoisted(() => {
   return { getBotInfoMock, MessagingApiClientMock };
 });
 
+vi.mock("openclaw/plugin-sdk/runtime-env", () => {
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => logger,
+  };
+  return {
+    createSubsystemLogger: () => logger,
+    danger: (value: unknown) => String(value),
+    logVerbose: vi.fn(),
+  };
+});
+
 vi.mock("@line/bot-sdk", () => ({
   messagingApi: { MessagingApiClient: MessagingApiClientMock },
 }));

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -20,6 +20,21 @@ vi.mock("./mattermost/send.js", () => ({
   sendMessageMattermost: sendMessageMattermostMock,
 }));
 
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => logger,
+  };
+  return {
+    ...actual,
+    createSubsystemLogger: () => logger,
+  };
+});
+
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   const original = (await importOriginal()) as Record<string, unknown>;
   return { ...original, fetchWithSsrFGuard: mockFetchGuard };

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -15,6 +15,22 @@ vi.mock("./bot-message-dispatch.js", () => ({
   dispatchTelegramMessage,
 }));
 
+vi.mock("openclaw/plugin-sdk/runtime-env", () => {
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => logger,
+  };
+  return {
+    createSubsystemLogger: () => logger,
+    danger: (value: unknown) => String(value),
+    logVerbose: vi.fn(),
+    shouldLogVerbose: () => false,
+  };
+});
+
 let createTelegramMessageProcessor: typeof import("./bot-message.js").createTelegramMessageProcessor;
 
 describe("telegram bot message processor", () => {

--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -288,10 +288,18 @@ vi.mock("@grammyjs/runner", () => ({
 
 vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => logger,
+  };
   return {
     ...actual,
     computeBackoff,
     sleepWithAbort,
+    createSubsystemLogger: () => logger,
     registerUnhandledRejectionHandler: registerUnhandledRejectionHandlerMock,
   };
 });

--- a/extensions/telegram/src/target-writeback.test-shared.ts
+++ b/extensions/telegram/src/target-writeback.test-shared.ts
@@ -7,6 +7,21 @@ export const loadCronStore = vi.fn();
 export const resolveCronStorePath = vi.fn();
 export const saveCronStore = vi.fn();
 
+vi.mock("openclaw/plugin-sdk/runtime-env", () => {
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => logger,
+  };
+  return {
+    createSubsystemLogger: () => logger,
+    danger: (value: unknown) => String(value),
+    logVerbose: vi.fn(),
+  };
+});
+
 vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
   return {

--- a/extensions/telegram/src/target-writeback.test-shared.ts
+++ b/extensions/telegram/src/target-writeback.test-shared.ts
@@ -7,21 +7,6 @@ export const loadCronStore = vi.fn();
 export const resolveCronStorePath = vi.fn();
 export const saveCronStore = vi.fn();
 
-vi.mock("openclaw/plugin-sdk/runtime-env", () => {
-  const logger = {
-    debug: () => {},
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-    child: () => logger,
-  };
-  return {
-    createSubsystemLogger: () => logger,
-    danger: (value: unknown) => String(value),
-    logVerbose: vi.fn(),
-  };
-});
-
 vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
   return {

--- a/extensions/whatsapp/src/inbound/media.node.test.ts
+++ b/extensions/whatsapp/src/inbound/media.node.test.ts
@@ -13,21 +13,6 @@ const { normalizeMessageContent, downloadMediaMessage } = vi.hoisted(() => ({
   downloadMediaMessage: vi.fn().mockResolvedValue(Buffer.from("fake-media-data")),
 }));
 
-vi.mock("openclaw/plugin-sdk/runtime-env", () => {
-  const logger = {
-    debug: () => {},
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-    child: () => logger,
-  };
-  return {
-    createSubsystemLogger: () => logger,
-    danger: (value: unknown) => String(value),
-    logVerbose: vi.fn(),
-  };
-});
-
 vi.mock("@whiskeysockets/baileys", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@whiskeysockets/baileys")>();
   return {

--- a/extensions/whatsapp/src/inbound/media.node.test.ts
+++ b/extensions/whatsapp/src/inbound/media.node.test.ts
@@ -13,6 +13,21 @@ const { normalizeMessageContent, downloadMediaMessage } = vi.hoisted(() => ({
   downloadMediaMessage: vi.fn().mockResolvedValue(Buffer.from("fake-media-data")),
 }));
 
+vi.mock("openclaw/plugin-sdk/runtime-env", () => {
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => logger,
+  };
+  return {
+    createSubsystemLogger: () => logger,
+    danger: (value: unknown) => String(value),
+    logVerbose: vi.fn(),
+  };
+});
+
 vi.mock("@whiskeysockets/baileys", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@whiskeysockets/baileys")>();
   return {

--- a/extensions/whatsapp/src/resolve-target.test.ts
+++ b/extensions/whatsapp/src/resolve-target.test.ts
@@ -6,6 +6,21 @@ import {
   normalizeWhatsAppTarget,
 } from "./normalize-target.js";
 
+vi.mock("openclaw/plugin-sdk/runtime-env", () => {
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => logger,
+  };
+  return {
+    createSubsystemLogger: () => logger,
+    danger: (value: unknown) => String(value),
+    logVerbose: vi.fn(),
+  };
+});
+
 vi.mock("./runtime-api.js", async () => {
   const actual = await vi.importActual<typeof import("./runtime-api.js")>("./runtime-api.js");
   const normalizeWhatsAppTarget = (value: string) => {

--- a/extensions/whatsapp/src/resolve-target.test.ts
+++ b/extensions/whatsapp/src/resolve-target.test.ts
@@ -6,21 +6,6 @@ import {
   normalizeWhatsAppTarget,
 } from "./normalize-target.js";
 
-vi.mock("openclaw/plugin-sdk/runtime-env", () => {
-  const logger = {
-    debug: () => {},
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-    child: () => logger,
-  };
-  return {
-    createSubsystemLogger: () => logger,
-    danger: (value: unknown) => String(value),
-    logVerbose: vi.fn(),
-  };
-});
-
 vi.mock("./runtime-api.js", async () => {
   const actual = await vi.importActual<typeof import("./runtime-api.js")>("./runtime-api.js");
   const normalizeWhatsAppTarget = (value: string) => {

--- a/extensions/whatsapp/src/session.test.ts
+++ b/extensions/whatsapp/src/session.test.ts
@@ -5,6 +5,41 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetLogger, setLoggerOverride } from "../../../src/logging.js";
 import { baileys, getLastSocket, resetBaileysMocks, resetLoadConfigMock } from "./test-helpers.js";
 
+vi.mock("openclaw/plugin-sdk/runtime-env", () => {
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    child: () => logger,
+  };
+  return {
+    createSubsystemLogger: () => logger,
+    createSubsystemRuntime: () => ({ log: () => {}, error: () => {}, exit: () => {} }),
+    createNonExitingRuntime: () => ({ log: () => {}, error: () => {} }),
+    defaultRuntime: { log: () => {}, error: () => {}, exit: () => {} },
+    danger: (value: unknown) => String(value),
+    info: (value: unknown) => String(value),
+    success: (value: unknown) => String(value),
+    warn: () => {},
+    logVerbose: () => {},
+    logVerboseConsole: () => {},
+    shouldLogVerbose: () => false,
+    isVerbose: () => false,
+    setVerbose: () => {},
+    isYes: () => false,
+    setYes: () => {},
+    getChildLogger: () => logger,
+    getLogger: () => logger,
+    resetLogger: () => {},
+    setLoggerOverride: () => {},
+    toPinoLikeLogger: (_base: unknown, level = "silent") => ({ ...logger, level, trace: () => {} }),
+    runtimeForLogger: () => ({ log: () => {}, error: () => {} }),
+    waitForAbortSignal: async () => {},
+    registerUnhandledRejectionHandler: () => {},
+  };
+});
+
 const useMultiFileAuthStateMock = vi.mocked(baileys.useMultiFileAuthState);
 
 let createWaSocket: typeof import("./session.js").createWaSocket;

--- a/extensions/xai/code-execution.ts
+++ b/extensions/xai/code-execution.ts
@@ -23,11 +23,16 @@ type XaiPluginConfig = NonNullable<
   ? Config
   : undefined;
 
-type CodeExecutionConfig = XaiPluginConfig extends infer Config
-  ? Config extends { codeExecution?: infer CodeExecution }
-    ? CodeExecution
-    : undefined
-  : undefined;
+// The fields accessed at runtime on the codeExecution sub-object.
+// Previously inferred via conditional types from OpenClawConfig, but
+// that chain resolves to `undefined` when the xai plugin entry isn't
+// fully declared in the config schema — causing TS2339 on .enabled
+// and .timeoutSeconds. A concrete interface avoids the inference gap.
+interface CodeExecutionConfig {
+  enabled?: boolean;
+  timeoutSeconds?: number;
+  maxTurns?: number;
+}
 
 function readLegacyGrokApiKey(cfg?: OpenClawConfig): string | undefined {
   const search = cfg?.tools?.web?.search;

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -67,6 +67,8 @@ export type ProcessGatewayAllowlistParams = {
   maxOutput: number;
   pendingMaxOutput: number;
   trustedSafeBinDirs?: ReadonlySet<string>;
+  /** Max command length before obfuscation detection triggers. 0 disables. */
+  maxCommandChars?: number;
 };
 
 export type ProcessGatewayAllowlistResult = {
@@ -124,7 +126,9 @@ export async function processGatewayAllowlist(
     }
     enforcedCommand = enforced.command;
   }
-  const obfuscation = detectCommandObfuscation(params.command);
+  const obfuscation = detectCommandObfuscation(params.command, {
+    maxCommandChars: params.maxCommandChars,
+  });
   if (obfuscation.detected) {
     logInfo(`exec: obfuscation detected (gateway): ${obfuscation.reasons.join(", ")}`);
     params.warnings.push(`⚠️ Obfuscated command detected: ${obfuscation.reasons.join("; ")}`);

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -53,6 +53,8 @@ export type ExecuteNodeHostCommandParams = {
   warnings: string[];
   notifySessionKey?: string;
   trustedSafeBinDirs?: ReadonlySet<string>;
+  /** Max command length before obfuscation detection triggers. 0 disables. */
+  maxCommandChars?: number;
 };
 
 export async function executeNodeHostCommand(
@@ -183,7 +185,9 @@ export async function executeNodeHostCommand(
       // Fall back to requiring approval if node approvals cannot be fetched.
     }
   }
-  const obfuscation = detectCommandObfuscation(params.command);
+  const obfuscation = detectCommandObfuscation(params.command, {
+    maxCommandChars: params.maxCommandChars,
+  });
   if (obfuscation.detected) {
     logInfo(
       `exec: obfuscation detected (node=${nodeQuery ?? "default"}): ${obfuscation.reasons.join(", ")}`,

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -28,6 +28,11 @@ export type ExecToolDefaults = {
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   cwd?: string;
+  /**
+   * Max command length (characters) before obfuscation detection triggers.
+   * Set to 0 to disable the length check. Default: 10000.
+   */
+  maxCommandChars?: number;
 };
 
 export type ExecElevatedDefaults = {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -215,6 +215,7 @@ export function createExecTool(
       `exec: interpreter/runtime binaries in safeBins (${unprofiledInterpreterSafeBins.join(", ")}) are unsafe without explicit hardened profiles; prefer allowlist entries`,
     );
   }
+  const maxCommandChars = defaults?.maxCommandChars;
   const notifyOnExit = defaults?.notifyOnExit !== false;
   const notifyOnExitEmptySuccess = defaults?.notifyOnExitEmptySuccess === true;
   const notifySessionKey = defaults?.sessionKey?.trim() || undefined;
@@ -481,6 +482,7 @@ export function createExecTool(
           warnings,
           notifySessionKey,
           trustedSafeBinDirs,
+          maxCommandChars,
         });
       }
 
@@ -511,6 +513,7 @@ export function createExecTool(
           maxOutput,
           pendingMaxOutput,
           trustedSafeBinDirs,
+          maxCommandChars,
         });
         if (gatewayResult.pendingResult) {
           return gatewayResult.pendingResult;

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -1669,6 +1669,134 @@ describe("compaction-safeguard extension model fallback", () => {
   });
 });
 
+describe("compaction-safeguard request auth header merging", () => {
+  const structuredSummary = [
+    "## Decisions",
+    "Used approach A.",
+    "## Open TODOs",
+    "None.",
+    "## Constraints/Rules",
+    "None.",
+    "## Pending user asks",
+    "None.",
+    "## Exact identifiers",
+    "None.",
+  ].join("\n");
+
+  function createHeaderTestEvent(tokensBefore = 10_000) {
+    // Need enough messages to exceed the default recentTurnsPreserve (3 turns)
+    // so that some messages are actually sent to summarizeInStages.
+    const messagesToSummarize = Array.from({ length: 8 }, (_unused, i) => ({
+      role: i % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      content: `message ${i} ${"x".repeat(500)}`,
+      timestamp: i + 1,
+    })) as AgentMessage[];
+    return {
+      preparation: {
+        messagesToSummarize,
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4000 },
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+  }
+
+  it("proceeds with headers-only auth when no apiKey is returned", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(structuredSummary);
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyAndHeadersMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, headers: { Authorization: "Bearer resolved-token" } });
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyAndHeadersMock,
+    });
+    const event = createHeaderTestEvent();
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary: string };
+    };
+
+    expect(result.cancel).not.toBe(true);
+    expect(mockSummarizeInStages).toHaveBeenCalled();
+    expect(mockSummarizeInStages.mock.calls[0]?.[0]?.headers).toEqual({
+      Authorization: "Bearer resolved-token",
+    });
+  });
+
+  it("merges resolved headers with model.headers, resolved taking precedence", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(structuredSummary);
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture({
+      headers: { "X-Custom": "model-value", Authorization: "Bearer model-token" },
+    });
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyAndHeadersMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, headers: { Authorization: "Bearer resolved-token" } });
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyAndHeadersMock,
+    });
+    const event = createHeaderTestEvent();
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary: string };
+    };
+
+    expect(result.cancel).not.toBe(true);
+    expect(mockSummarizeInStages).toHaveBeenCalled();
+    expect(mockSummarizeInStages.mock.calls[0]?.[0]?.headers).toEqual({
+      "X-Custom": "model-value",
+      Authorization: "Bearer resolved-token",
+    });
+  });
+
+  it("falls back to model.headers when resolved headers are undefined", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(structuredSummary);
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture({
+      headers: { "X-Custom": "model-value" },
+    });
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyAndHeadersMock = vi.fn().mockResolvedValue({ ok: true, apiKey: "sk-test" }); // pragma: allowlist secret
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyAndHeadersMock,
+    });
+    const event = createHeaderTestEvent();
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary: string };
+    };
+
+    expect(result.cancel).not.toBe(true);
+    expect(mockSummarizeInStages).toHaveBeenCalled();
+    expect(mockSummarizeInStages.mock.calls[0]?.[0]?.headers).toEqual({
+      "X-Custom": "model-value",
+    });
+  });
+});
+
 describe("compaction-safeguard double-compaction guard", () => {
   it("cancels compaction when there are no real messages to summarize", async () => {
     const sessionManager = stubSessionManager();

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -132,21 +132,13 @@ const createCompactionEvent = (params: { messageText: string; tokensBefore: numb
 const createCompactionContext = (params: {
   sessionManager: ExtensionContext["sessionManager"];
   getApiKeyAndHeadersMock?: ReturnType<typeof vi.fn>;
-  getApiKeyMock?: ReturnType<typeof vi.fn>;
 }) =>
   ({
     model: undefined,
     sessionManager: params.sessionManager,
     modelRegistry: {
       getApiKeyAndHeaders:
-        params.getApiKeyAndHeadersMock ??
-        vi.fn(async (model) => {
-          const legacyGetApiKey = params.getApiKeyMock as
-            | undefined
-            | ((model: NonNullable<ExtensionContext["model"]>) => Promise<string | undefined>);
-          const apiKey = await legacyGetApiKey?.(model);
-          return apiKey !== undefined ? { ok: true, apiKey } : { ok: false, error: "missing auth" };
-        }),
+        params.getApiKeyAndHeadersMock ?? vi.fn(async () => ({ ok: true, apiKey: "test-key" })),
     },
   }) as unknown as Partial<ExtensionContext>;
 
@@ -1237,10 +1229,8 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
 
     const compactionHandler = createCompactionHandler();
-    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
     const mockContext = createCompactionContext({
       sessionManager,
-      getApiKeyMock,
     });
     const messagesToSummarize: AgentMessage[] = Array.from({ length: 4 }, (_unused, index) => ({
       role: "user",
@@ -1293,10 +1283,8 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
 
     const compactionHandler = createCompactionHandler();
-    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
     const mockContext = createCompactionContext({
       sessionManager,
-      getApiKeyMock,
     });
     const event = {
       preparation: {
@@ -1358,10 +1346,8 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
 
     const compactionHandler = createCompactionHandler();
-    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
     const mockContext = createCompactionContext({
       sessionManager,
-      getApiKeyMock,
     });
     const event = {
       preparation: {
@@ -1461,10 +1447,8 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
 
     const compactionHandler = createCompactionHandler();
-    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
     const mockContext = createCompactionContext({
       sessionManager,
-      getApiKeyMock,
     });
     const event = {
       preparation: {
@@ -1524,10 +1508,8 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
 
     const compactionHandler = createCompactionHandler();
-    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
     const mockContext = createCompactionContext({
       sessionManager,
-      getApiKeyMock,
     });
     const event = {
       preparation: {
@@ -1587,10 +1569,8 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
 
     const compactionHandler = createCompactionHandler();
-    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
     const mockContext = createCompactionContext({
       sessionManager,
-      getApiKeyMock,
     });
     const event = {
       preparation: {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -660,7 +660,10 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       return { cancel: true };
     }
     const apiKey = requestAuth.apiKey;
-    const headers = requestAuth.headers;
+    const headers =
+      requestAuth.headers || model.headers
+        ? { ...model.headers, ...requestAuth.headers }
+        : undefined;
     if (!apiKey && !headers) {
       log.warn(
         "Compaction safeguard: no request credentials available; cancelling compaction to preserve history.",

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -152,6 +152,7 @@ function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
     notifyOnExitEmptySuccess:
       agentExec?.notifyOnExitEmptySuccess ?? globalExec?.notifyOnExitEmptySuccess,
     applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
+    maxCommandChars: agentExec?.maxCommandChars ?? globalExec?.maxCommandChars,
   };
 }
 
@@ -438,6 +439,7 @@ export function createOpenClawCodingTools(options?: {
     notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
     notifyOnExitEmptySuccess:
       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
+    maxCommandChars: options?.exec?.maxCommandChars ?? execConfig.maxCommandChars,
     sandbox: sandbox
       ? {
           containerName: sandbox.containerName,

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -791,3 +791,186 @@ describe("buildSubagentSystemPrompt", () => {
     }
   });
 });
+
+/**
+ * MODELSELFAWARE-01: Dedicated model identity line in the system prompt.
+ *
+ * The OpenClaw system prompt carries model information in two places:
+ *   1. A dedicated "**Your model identity**" line — prominent, unambiguous,
+ *      designed for the model to self-report accurately when asked "what model
+ *      are you?"
+ *   2. The pipe-delimited `## Runtime` metadata line (`model=X`) — a compact
+ *      machine-readable summary that models may not reliably parse.
+ *
+ * These tests verify that:
+ *   - The dedicated line appears when runtimeInfo.model is set and is absent
+ *     when it is not.
+ *   - The dedicated line appears BEFORE the ## Runtime section (ordering
+ *     matters because models weight earlier prompt content more heavily).
+ *   - The Runtime line still carries its own `model=` field independently.
+ *   - When autoroute switches the running model away from the default_model,
+ *     both values are present and distinct.
+ */
+describe("MODELSELFAWARE-01 — model identity line", () => {
+  // Helper: build a prompt with the given runtimeInfo for reuse across tests.
+  const buildWithModel = (model?: string, defaultModel?: string) =>
+    buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      runtimeInfo: {
+        agentId: "work",
+        host: "host",
+        os: "macOS",
+        arch: "arm64",
+        node: "v20",
+        ...(model ? { model } : {}),
+        ...(defaultModel ? { defaultModel } : {}),
+      },
+    });
+
+  it("includes the dedicated model identity line when runtimeInfo.model is set", () => {
+    // When runtimeInfo.model is provided, the prompt must contain a
+    // human-readable identity statement so the agent can answer "what model
+    // are you?" without parsing the pipe-delimited Runtime line.
+    const prompt = buildWithModel("anthropic/claude-sonnet-4");
+
+    expect(prompt).toContain(
+      "**Your model identity**: You are running as `anthropic/claude-sonnet-4`.",
+    );
+    expect(prompt).toContain("This is your actual model");
+  });
+
+  it("omits the dedicated model identity line when runtimeInfo.model is absent", () => {
+    // When no model is known at runtime (e.g. early bootstrap or missing
+    // config), the identity line must not appear — avoids a confusing
+    // "running as `undefined`" in the prompt.
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      runtimeInfo: {
+        agentId: "work",
+        host: "host",
+        os: "macOS",
+        arch: "arm64",
+        node: "v20",
+        // model intentionally omitted
+      },
+    });
+
+    expect(prompt).not.toContain("**Your model identity**");
+    expect(prompt).not.toContain("This is your actual model");
+  });
+
+  it("omits the dedicated model identity line when runtimeInfo is entirely absent", () => {
+    // Edge case: no runtimeInfo at all. The identity line must not appear.
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).not.toContain("**Your model identity**");
+  });
+
+  it("places the model identity line BEFORE the ## Runtime section", () => {
+    // Ordering matters for prompt parsing: the dedicated identity line must
+    // come before ## Runtime so models encounter the unambiguous statement
+    // first, before the dense pipe-delimited metadata.
+    const prompt = buildWithModel("anthropic/claude-sonnet-4");
+
+    const identityIndex = prompt.indexOf("**Your model identity**");
+    const runtimeIndex = prompt.indexOf("## Runtime");
+
+    // Both must be present
+    expect(identityIndex).toBeGreaterThan(-1);
+    expect(runtimeIndex).toBeGreaterThan(-1);
+
+    // Identity line must appear earlier in the prompt than ## Runtime
+    expect(identityIndex).toBeLessThan(runtimeIndex);
+  });
+
+  it("does not duplicate model info — identity line and Runtime line each state it once", () => {
+    // The dedicated identity line and the Runtime metadata line both mention
+    // the model, but in different formats. Neither should cause the other to
+    // appear twice. We verify each format appears exactly once.
+    const model = "anthropic/claude-sonnet-4";
+    const prompt = buildWithModel(model);
+
+    // The dedicated identity statement (backtick-wrapped model name)
+    const identityPattern = `running as \`${model}\``;
+    const identityMatches = prompt.split(identityPattern).length - 1;
+    expect(identityMatches).toBe(1);
+
+    // The Runtime pipe-delimited field
+    const runtimePattern = `model=${model}`;
+    const runtimeMatches = prompt.split(runtimePattern).length - 1;
+    expect(runtimeMatches).toBe(1);
+  });
+
+  it("shows both model and default_model when autoroute switches the running model", () => {
+    // AUTOROUTE scenario: the running model differs from the tenant's
+    // default_model. The identity line should reflect the actual running
+    // model, while the Runtime line carries both model= and default_model=
+    // so the agent (and operators) can see the distinction.
+    const runningModel = "google/gemini-2.5-pro";
+    const defaultModel = "anthropic/claude-opus-4-5";
+    const prompt = buildWithModel(runningModel, defaultModel);
+
+    // Dedicated identity line shows the actual running model
+    expect(prompt).toContain(`**Your model identity**: You are running as \`${runningModel}\`.`);
+
+    // Runtime line carries both values
+    expect(prompt).toContain(`model=${runningModel}`);
+    expect(prompt).toContain(`default_model=${defaultModel}`);
+
+    // The identity line should NOT mention the default model — it's purely
+    // about what the agent IS, not what it was configured as.
+    const identityLine = prompt
+      .split("\n")
+      .find((line) => line.includes("**Your model identity**"));
+    expect(identityLine).toBeDefined();
+    expect(identityLine).not.toContain(defaultModel);
+  });
+
+  it("buildRuntimeLine independently carries model= regardless of the identity line", () => {
+    // Unit test for buildRuntimeLine: the pipe-delimited Runtime metadata
+    // must include model= when runtimeInfo.model is set, independent of
+    // whatever the full prompt does with the identity line.
+    const line = buildRuntimeLine(
+      {
+        agentId: "work",
+        host: "host",
+        os: "macOS",
+        arch: "arm64",
+        node: "v20",
+        model: "openai/gpt-4.1",
+        defaultModel: "anthropic/claude-opus-4-5",
+      },
+      "telegram",
+      ["inlineButtons"],
+      "low",
+    );
+
+    expect(line).toContain("model=openai/gpt-4.1");
+    expect(line).toContain("default_model=anthropic/claude-opus-4-5");
+    // The Runtime line should NOT contain the identity statement format
+    expect(line).not.toContain("**Your model identity**");
+  });
+
+  it("buildRuntimeLine omits model= when runtimeInfo.model is absent", () => {
+    // When no model is set, the Runtime line should not include a bare
+    // "model=" field that could confuse parsers.
+    const line = buildRuntimeLine(
+      {
+        agentId: "work",
+        host: "host",
+        os: "macOS",
+        arch: "arm64",
+        node: "v20",
+        // model intentionally omitted
+      },
+      "telegram",
+      [],
+      "off",
+    );
+
+    expect(line).not.toContain("model=");
+    expect(line).toContain("agent=work");
+  });
+});

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -655,6 +655,17 @@ export function buildAgentSystemPrompt(params: {
     );
   }
 
+  // MODELSELFAWARE-01: Dedicated model identity statement. This is separate
+  // from the pipe-delimited Runtime metadata line below, which models may
+  // not reliably parse. This prominent, unambiguous statement ensures the
+  // agent can accurately self-report its model, even after mid-session
+  // switches across providers (e.g. Anthropic → Google → OpenAI).
+  if (runtimeInfo?.model) {
+    lines.push(
+      `**Your model identity**: You are running as \`${runtimeInfo.model}\`. This is your actual model — use this when asked what model you are.`,
+    );
+  }
+
   lines.push(
     "## Runtime",
     buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities, params.defaultThinkLevel),

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -335,10 +335,12 @@ export async function handleBashChatCommand(params: {
     const timeoutSec = params.cfg.tools?.exec?.timeoutSec;
     const notifyOnExit = params.cfg.tools?.exec?.notifyOnExit;
     const notifyOnExitEmptySuccess = params.cfg.tools?.exec?.notifyOnExitEmptySuccess;
+    const maxCommandChars = params.cfg.tools?.exec?.maxCommandChars;
     const execTool = createExecTool({
       scopeKey: CHAT_BASH_SCOPE_KEY,
       allowBackground: true,
       timeoutSec,
+      maxCommandChars,
       sessionKey: params.sessionKey,
       notifyOnExit,
       notifyOnExitEmptySuccess,

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4676,6 +4676,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                         notifyOnExitEmptySuccess: {
                           type: "boolean",
                         },
+                        maxCommandChars: {
+                          type: "integer",
+                          minimum: 0,
+                          maximum: 9007199254740991,
+                        },
                         applyPatch: {
                           type: "object",
                           properties: {
@@ -7257,6 +7262,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
               },
               notifyOnExitEmptySuccess: {
                 type: "boolean",
+              },
+              maxCommandChars: {
+                type: "integer",
+                minimum: 0,
+                maximum: 9007199254740991,
               },
               applyPatch: {
                 type: "object",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -262,6 +262,19 @@ export type ExecToolConfig = {
    * Default false to reduce context noise.
    */
   notifyOnExitEmptySuccess?: boolean;
+  /**
+   * Max command length (characters) before obfuscation detection flags the
+   * command as "too long". Commands exceeding this threshold are blocked before
+   * any regex pattern scanning runs.
+   *
+   * Useful for automated workflows on chat surfaces (Discord, Telegram) where
+   * legitimate generated commands may exceed the default 10,000-character limit
+   * and no approval UI is available.
+   *
+   * Set to 0 to disable the length check entirely (regex pattern scanning
+   * still applies). Default: 10000.
+   */
+  maxCommandChars?: number;
   /** apply_patch subtool configuration. */
   applyPatch?: {
     /** Enable apply_patch for OpenAI models (default: true; set false to disable). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -446,6 +446,7 @@ const ToolExecBaseShape = {
   cleanupMs: z.number().int().positive().optional(),
   notifyOnExit: z.boolean().optional(),
   notifyOnExitEmptySuccess: z.boolean().optional(),
+  maxCommandChars: z.number().int().nonnegative().optional(),
   applyPatch: ToolExecApplyPatchSchema,
 } as const;
 

--- a/src/infra/exec-obfuscation-detect.test.ts
+++ b/src/infra/exec-obfuscation-detect.test.ts
@@ -203,6 +203,27 @@ describe("detectCommandObfuscation", () => {
       expect(result.matchedPatterns).toContain("command-too-long");
     });
 
+    it("respects a custom maxCommandChars threshold", () => {
+      // A command that is under the default 10k limit but over a custom 100-char limit.
+      const command = "echo " + "x".repeat(200);
+      const defaultResult = detectCommandObfuscation(command);
+      expect(defaultResult.matchedPatterns).not.toContain("command-too-long");
+
+      const customResult = detectCommandObfuscation(command, { maxCommandChars: 100 });
+      expect(customResult.detected).toBe(true);
+      expect(customResult.matchedPatterns).toContain("command-too-long");
+    });
+
+    it("disables the length check when maxCommandChars is 0", () => {
+      // A command well over the default 10k limit should pass when the check is disabled.
+      const command = `a=${"x".repeat(20_000)};b=y;END`;
+      const defaultResult = detectCommandObfuscation(command);
+      expect(defaultResult.matchedPatterns).toContain("command-too-long");
+
+      const disabledResult = detectCommandObfuscation(command, { maxCommandChars: 0 });
+      expect(disabledResult.matchedPatterns).not.toContain("command-too-long");
+    });
+
     it("returns no detection for empty input", () => {
       const result = detectCommandObfuscation("");
       expect(result.detected).toBe(false);

--- a/src/infra/exec-obfuscation-detect.test.ts
+++ b/src/infra/exec-obfuscation-detect.test.ts
@@ -221,6 +221,7 @@ describe("detectCommandObfuscation", () => {
       expect(defaultResult.matchedPatterns).toContain("command-too-long");
 
       const disabledResult = detectCommandObfuscation(command, { maxCommandChars: 0 });
+      expect(disabledResult.detected).toBe(false);
       expect(disabledResult.matchedPatterns).not.toContain("command-too-long");
     });
 

--- a/src/infra/exec-obfuscation-detect.ts
+++ b/src/infra/exec-obfuscation-detect.ts
@@ -17,7 +17,15 @@ type ObfuscationPattern = {
   regex: RegExp;
 };
 
-const MAX_COMMAND_CHARS = 10_000;
+/**
+ * Default character limit for commands before they are flagged as potentially
+ * obfuscated. Operators can override this via `tools.exec.maxCommandChars` in
+ * openclaw.json — useful for automated workflows on chat surfaces (Discord,
+ * Telegram) that lack exec approval UIs.
+ *
+ * Set to 0 to disable the length check entirely.
+ */
+const DEFAULT_MAX_COMMAND_CHARS = 10_000;
 
 const INVISIBLE_UNICODE_CODE_POINTS = new Set<number>([
   0x00ad,
@@ -214,11 +222,26 @@ function shouldSuppressCurlPipeShell(command: string): boolean {
   );
 }
 
-export function detectCommandObfuscation(command: string): ObfuscationDetection {
+export type ObfuscationDetectOptions = {
+  /**
+   * Override the maximum command length threshold.
+   * Commands longer than this are flagged as potentially obfuscated before any
+   * regex pattern scanning runs. Set to 0 to disable the length check.
+   *
+   * Default: 10,000 characters.
+   */
+  maxCommandChars?: number;
+};
+
+export function detectCommandObfuscation(
+  command: string,
+  options?: ObfuscationDetectOptions,
+): ObfuscationDetection {
   if (!command || !command.trim()) {
     return { detected: false, reasons: [], matchedPatterns: [] };
   }
-  if (command.length > MAX_COMMAND_CHARS) {
+  const maxChars = options?.maxCommandChars ?? DEFAULT_MAX_COMMAND_CHARS;
+  if (maxChars > 0 && command.length > maxChars) {
     return {
       detected: true,
       reasons: ["Command too long; potential obfuscation"],


### PR DESCRIPTION
## Summary

- Adds `tools.exec.maxCommandChars` config option to control the character limit that triggers the "command too long" obfuscation detection flag
- Supports per-agent override via `agents[].tools.exec.maxCommandChars`
- Default remains 10,000 characters (no behavior change for existing users)
- Setting to `0` disables the length check entirely while preserving all regex-based pattern detection

## Motivation

Closes #55802. Automated workflows on chat surfaces (Discord, Telegram) that lack exec approval UIs get unconditionally blocked when generated commands exceed 10k characters. This gives operators a config knob to tune the threshold for their use case.

## Changes

| File | Change |
|------|--------|
| `src/infra/exec-obfuscation-detect.ts` | Accept optional `maxCommandChars` via options parameter |
| `src/config/types.tools.ts` | Add `maxCommandChars` to `ExecToolConfig` type |
| `src/config/zod-schema.agent-runtime.ts` | Add Zod validator for `maxCommandChars` |
| `src/agents/bash-tools.exec-types.ts` | Add `maxCommandChars` to `ExecToolDefaults` |
| `src/agents/pi-tools.ts` | Wire config resolution (agent → global fallback) |
| `src/agents/bash-tools.exec.ts` | Thread value to both exec host implementations |
| `src/agents/bash-tools.exec-host-gateway.ts` | Pass option to `detectCommandObfuscation` |
| `src/agents/bash-tools.exec-host-node.ts` | Pass option to `detectCommandObfuscation` |
| `src/infra/exec-obfuscation-detect.test.ts` | Tests for custom threshold + disabled check |
| `src/config/schema.base.generated.ts` | Regenerated |

## Config example

```yaml
# openclaw.json
{
  "tools": {
    "exec": {
      "maxCommandChars": 50000
    }
  }
}
```

Or per-agent:
```yaml
{
  "agents": [
    {
      "id": "builder",
      "tools": {
        "exec": {
          "maxCommandChars": 0
        }
      }
    }
  ]
}
```

## Test plan

- [x] Existing obfuscation detection tests pass (33 tests)
- [x] New test: custom threshold correctly lowers the limit
- [x] New test: `maxCommandChars: 0` disables the length check
- [x] Approval ID tests pass (16 tests)
- [x] All pre-commit checks pass (lint, format, schema gen, boundary checks)