### PR TITLE
feat: plugin load status and startup summary logging

### DIFF
--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -55,6 +55,65 @@ function logGatewayPluginDiagnostics(params: {
   }
 }
 
+/**
+ * Emit per-plugin load status and a consolidated startup summary.
+ *
+ * Addresses https://github.com/openclaw/openclaw/issues/55803 — plugin
+ * load/health status was previously invisible in logs unless an error occurred.
+ * This function logs every plugin's outcome (loaded, disabled, error) so
+ * operators can quickly verify which plugins are active after startup or
+ * a config reload.
+ */
+function logPluginLoadSummary(params: {
+  plugins: PluginRegistry["plugins"];
+  log: Pick<GatewayPluginBootstrapLog, "info" | "warn">;
+}) {
+  let loaded = 0;
+  let disabled = 0;
+  let errored = 0;
+
+  for (const plugin of params.plugins) {
+    const toolCount = plugin.toolNames.length;
+    const hookCount = plugin.hookCount;
+    const channelCount = plugin.channelIds.length;
+
+    // Build a compact capability summary for loaded plugins.
+    const capabilities: string[] = [];
+    if (toolCount > 0) {
+      capabilities.push(`${toolCount} tools`);
+    }
+    if (hookCount > 0) {
+      capabilities.push(`${hookCount} hooks`);
+    }
+    if (channelCount > 0) {
+      capabilities.push(`${channelCount} channels`);
+    }
+    if (plugin.providerIds.length > 0) {
+      capabilities.push(`${plugin.providerIds.length} providers`);
+    }
+
+    const capSuffix = capabilities.length > 0 ? ` (${capabilities.join(", ")})` : "";
+
+    if (plugin.status === "loaded") {
+      loaded++;
+      params.log.info(`[plugins] load: ${plugin.id} status=loaded enabled=true${capSuffix}`);
+    } else if (plugin.status === "disabled") {
+      disabled++;
+      params.log.info(`[plugins] load: ${plugin.id} status=disabled enabled=false`);
+    } else {
+      errored++;
+      params.log.warn(
+        `[plugins] load: ${plugin.id} status=error error=${plugin.error ?? "unknown"}`,
+      );
+    }
+  }
+
+  // Consolidated summary line for quick health assessment.
+  params.log.info(
+    `[plugins] summary: ${params.plugins.length} total, ${loaded} loaded, ${disabled} disabled, ${errored} errored`,
+  );
+}
+
 export function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
   installGatewayPluginRuntimeEnvironment(params.cfg);
   const loaded = loadGatewayPlugins({
@@ -70,6 +129,13 @@ export function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
   if ((params.logDiagnostics ?? true) && loaded.pluginRegistry.diagnostics.length > 0) {
     logGatewayPluginDiagnostics({
       diagnostics: loaded.pluginRegistry.diagnostics,
+      log: params.log,
+    });
+  }
+  // Per-plugin load status and consolidated summary (see #55803).
+  if (loaded.pluginRegistry.plugins.length > 0) {
+    logPluginLoadSummary({
+      plugins: loaded.pluginRegistry.plugins,
       log: params.log,
     });
   }

--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -103,7 +103,7 @@ function logPluginLoadSummary(params: {
     } else {
       errored++;
       params.log.warn(
-        `[plugins] load: ${plugin.id} status=error error=${plugin.error ?? "unknown"}`,
+        `[plugins] load: ${plugin.id} status=error error="${plugin.error ?? "unknown"}"`,
       );
     }
   }
@@ -133,7 +133,7 @@ export function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
     });
   }
   // Per-plugin load status and consolidated summary (see #55803).
-  if (loaded.pluginRegistry.plugins.length > 0) {
+  if ((params.logDiagnostics ?? true) && loaded.pluginRegistry.plugins.length > 0) {
     logPluginLoadSummary({
       plugins: loaded.pluginRegistry.plugins,
       log: params.log,


### PR DESCRIPTION
## Summary

Adds per-plugin load status and a consolidated startup summary to gateway logs. Previously, plugin lifecycle events were only logged on error — success was silent, making it impossible to verify which plugins are active after startup.

## New log output

```
[plugins] load: brave status=loaded enabled=true (2 tools, 1 hooks)
[plugins] load: memory status=loaded enabled=true (4 tools)
[plugins] load: discord status=loaded enabled=true (1 channels)
[plugins] load: unused-plugin status=disabled enabled=false
[plugins] summary: 4 total, 3 loaded, 1 disabled, 0 errored
```

Each loaded plugin shows a compact capability summary (tools, hooks, channels, providers). Disabled plugins confirm they were intentionally skipped. Errored plugins are logged at WARN level with the error message.

The summary line gives operators an instant health check:
- `errored > 0` → something needs attention
- `loaded < expected` → plugin may be misconfigured or missing

## Changes

| File | Change |
|------|--------|
| `src/gateway/server-plugin-bootstrap.ts` | Add `logPluginLoadSummary()` function, wire into `prepareGatewayPluginLoad()` |

## Motivation

Closes #55803. Fleet operators running multi-agent deployments with custom plugins need to quickly verify plugin health after gateway startup or config reload. The current silent-on-success behavior forces operators to check `openclaw plugins list` manually or wait for a tool call to fail before discovering a broken plugin.

## Test plan

- [x] Existing integration tests pass (2 tests)
- [x] All pre-commit checks pass (lint, format, schema, boundary checks)
- [x] Log format is structured and grep-friendly (`[plugins] load: <id> status=<status>`)
- [x] Runs on both startup and config reload paths (both use `prepareGatewayPluginLoad`)