### PR TITLE
fix(ui): clear stale sessions result when API returns empty

### DIFF
--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -62,12 +62,10 @@ export async function loadSessions(
       params.limit = limit;
     }
     const res = await state.client.request<SessionsListResult | undefined>("sessions.list", params);
-    if (res) {
-      state.sessionsResult = res;
-    }
+    state.sessionsResult = res ?? null;
   } catch (err) {
+    state.sessionsResult = null;
     if (isMissingOperatorReadScopeError(err)) {
-      state.sessionsResult = null;
       state.sessionsError = formatMissingOperatorReadScopeMessage("sessions");
     } else {
       state.sessionsError = String(err);


### PR DESCRIPTION
## Summary

- Problem: Control UI dashboard shows phantom session/subagent count (e.g. 14) when the backend actually has none.
- Why it matters: The stale count misleads users into thinking sessions are active when they are not.
- What changed: `loadSessions()` now unconditionally assigns the API response (with `?? null` fallback) instead of only updating on truthy values.
- What did NOT change: No changes to the backend `sessions.list` handler, no changes to the UI rendering logic.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #55705
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `loadSessions()` in `ui/src/ui/controllers/sessions.ts` only updated `state.sessionsResult` inside an `if (res)` guard. When `sessions.list` returned `undefined`, the previous cached result was never cleared.
- Missing detection / guardrail: No test covering the "API returns undefined" path.
- Prior context: The conditional pattern has been present since the sessions controller was introduced.
- Why this regressed now: Likely surfaced by WebSocket reconnect behavior or gateway state changes in 2026.3.24.
- If unknown, what was ruled out: Backend `sessions.list` handler returns correct data when called directly via CLI.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `ui/src/ui/controllers/sessions.ts`
- Scenario the test should lock in: When `client.request("sessions.list")` resolves to `undefined`, `sessionsResult` must be reset to `null`.
- If no new test is added, why not: The fix is a single-line defensive change; happy to add a unit test if maintainers prefer.

## User-visible / Behavior Changes

- Dashboard "Sessions" card now shows "N/A" instead of a stale count when the API returns no data.

## Diagram (if applicable)

```text
Before:
[sessions.list → undefined] → sessionsResult unchanged → dashboard shows stale "14"

After:
[sessions.list → undefined] → sessionsResult = null → dashboard shows "N/A"