### PR TITLE
fix(telegram): backoff for transient network errors in sendChatAction

### DIFF
--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -101,13 +101,14 @@ describe("createTelegramSendChatActionHandler", () => {
     expect(logger).toHaveBeenCalledWith(expect.stringContaining("recovered"));
   });
 
-  it("does not count non-401 errors toward suspension", async () => {
+  it("does not count non-401 non-transient errors toward suspension", async () => {
     const fn = vi.fn().mockRejectedValue(make500Error());
     const logger = vi.fn();
     const handler = createTelegramSendChatActionHandler({
       sendChatActionFn: fn,
       logger,
       maxConsecutive401: 2,
+      maxConsecutiveTransient: 2,
     });
 
     await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("500");
@@ -115,6 +116,64 @@ describe("createTelegramSendChatActionHandler", () => {
     await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("500");
 
     expect(handler.isSuspended()).toBe(false);
+  });
+
+  it("applies backoff and swallows transient network errors", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("Network request for 'sendChatAction' failed!"));
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutiveTransient: 3,
+    });
+
+    // Transient errors are swallowed (not re-thrown)
+    await handler.sendChatAction(123, "typing");
+    expect(logger).toHaveBeenCalledWith(expect.stringContaining("transient network error"));
+
+    // Second call should trigger backoff
+    await handler.sendChatAction(123, "typing");
+    expect(mocks.sleepWithAbort).toHaveBeenCalled();
+  });
+
+  it("suspends after maxConsecutiveTransient network failures", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("Network request for 'sendChatAction' failed!"));
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutiveTransient: 2,
+    });
+
+    await handler.sendChatAction(123, "typing");
+    await handler.sendChatAction(123, "typing");
+
+    expect(handler.isSuspended()).toBe(true);
+    expect(logger).toHaveBeenCalledWith(expect.stringContaining("suspended"));
+  });
+
+  it("resets transient failure counter on success", async () => {
+    let callCount = 0;
+    const fn = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount <= 2) {
+        throw new Error("Network request for 'sendChatAction' failed!");
+      }
+      return Promise.resolve(true);
+    });
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+      maxConsecutiveTransient: 5,
+    });
+
+    await handler.sendChatAction(123, "typing");
+    await handler.sendChatAction(123, "typing");
+    await handler.sendChatAction(123, "typing");
+
+    expect(handler.isSuspended()).toBe(false);
+    expect(logger).toHaveBeenCalledWith(expect.stringContaining("recovered"));
   });
 
   it("reset() clears suspension", async () => {

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -43,6 +43,8 @@ export type CreateTelegramSendChatActionHandlerParams = {
   sendChatActionFn: SendChatActionFn;
   logger: TelegramSendChatActionLogger;
   maxConsecutive401?: number;
+  /** Max consecutive transient network errors before suspending (default: 5). */
+  maxConsecutiveTransient?: number;
 };
 
 const BACKOFF_POLICY: BackoffPolicy = {
@@ -60,6 +62,22 @@ function is401Error(error: unknown): boolean {
   return message.includes("401") || message.toLowerCase().includes("unauthorized");
 }
 
+function isTransientNetworkError(error: unknown): boolean {
+  if (!error) {
+    return false;
+  }
+  const message = error instanceof Error ? error.message : JSON.stringify(error);
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("network request") ||
+    lower.includes("econnreset") ||
+    lower.includes("econnrefused") ||
+    lower.includes("etimedout") ||
+    lower.includes("fetch failed") ||
+    lower.includes("socket hang up")
+  );
+}
+
 /**
  * Creates a GLOBAL (per-account) handler for sendChatAction that tracks 401 errors
  * across all message contexts. This prevents the infinite loop that caused Telegram
@@ -73,12 +91,15 @@ export function createTelegramSendChatActionHandler({
   sendChatActionFn,
   logger,
   maxConsecutive401 = 10,
+  maxConsecutiveTransient = 5,
 }: CreateTelegramSendChatActionHandlerParams): TelegramSendChatActionHandler {
   let consecutive401Failures = 0;
+  let consecutiveTransientFailures = 0;
   let suspended = false;
 
   const reset = () => {
     consecutive401Failures = 0;
+    consecutiveTransientFailures = 0;
     suspended = false;
   };
 
@@ -91,25 +112,33 @@ export function createTelegramSendChatActionHandler({
       return;
     }
 
-    if (consecutive401Failures > 0) {
-      const backoffMs = computeBackoff(BACKOFF_POLICY, consecutive401Failures);
+    const totalFailures = consecutive401Failures + consecutiveTransientFailures;
+    if (totalFailures > 0) {
+      const backoffMs = computeBackoff(BACKOFF_POLICY, totalFailures);
       logger(
         `sendChatAction backoff: waiting ${backoffMs}ms before retry ` +
-          `(failure ${consecutive401Failures}/${maxConsecutive401})`,
+          `(failure ${totalFailures})`,
       );
       await sleepWithAbort(backoffMs);
     }
 
     try {
       await sendChatActionFn(chatId, action, threadParams);
-      // Success: reset failure counter
+      // Success: reset all failure counters
       if (consecutive401Failures > 0) {
         logger(`sendChatAction recovered after ${consecutive401Failures} consecutive 401 failures`);
-        consecutive401Failures = 0;
       }
+      if (consecutiveTransientFailures > 0) {
+        logger(
+          `sendChatAction recovered after ${consecutiveTransientFailures} consecutive network failures`,
+        );
+      }
+      consecutive401Failures = 0;
+      consecutiveTransientFailures = 0;
     } catch (error) {
       if (is401Error(error)) {
         consecutive401Failures++;
+        consecutiveTransientFailures = 0;
 
         if (consecutive401Failures >= maxConsecutive401) {
           suspended = true;
@@ -124,6 +153,22 @@ export function createTelegramSendChatActionHandler({
               `Retrying with exponential backoff.`,
           );
         }
+      } else if (isTransientNetworkError(error)) {
+        consecutiveTransientFailures++;
+        consecutive401Failures = 0;
+
+        if (consecutiveTransientFailures >= maxConsecutiveTransient) {
+          suspended = true;
+          logger(
+            `sendChatAction suspended after ${consecutiveTransientFailures} consecutive network failures. ` +
+              `Will resume on reset.`,
+          );
+        } else if (consecutiveTransientFailures === 1) {
+          // Log only on first transient failure to avoid spam
+          logger(`sendChatAction transient network error, retrying with backoff`);
+        }
+        // Swallow transient errors — sendChatAction is best-effort
+        return;
       }
       throw error;
     }

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -69,7 +69,7 @@ function isTransientNetworkError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : JSON.stringify(error);
   const lower = message.toLowerCase();
   return (
-    lower.includes("network request") ||
+    lower.includes("network request for") ||
     lower.includes("econnreset") ||
     lower.includes("econnrefused") ||
     lower.includes("etimedout") ||
@@ -117,7 +117,7 @@ export function createTelegramSendChatActionHandler({
       const backoffMs = computeBackoff(BACKOFF_POLICY, totalFailures);
       logger(
         `sendChatAction backoff: waiting ${backoffMs}ms before retry ` +
-          `(failure ${totalFailures})`,
+          `(failure ${totalFailures}/${consecutive401Failures > 0 ? maxConsecutive401 : maxConsecutiveTransient})`,
       );
       await sleepWithAbort(backoffMs);
     }


### PR DESCRIPTION
## Summary

- Adds exponential backoff for transient network errors (connection reset, timeout, fetch failures) in the `sendChatAction` handler
- Swallows transient errors instead of re-throwing (sendChatAction is best-effort)
- Logs only on first transient failure to prevent log spam
- Suspends after 5 consecutive transient failures (configurable via `maxConsecutiveTransient`)
- Resets counters on success

Closes #55811

## Test plan

- [x] 10 tests pass including 4 new transient error tests
- [x] `pnpm check` passes