### PR TITLE
fix: inject context.agentId into tool-call dispatch for built-in tools

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -704,6 +704,12 @@ export async function compactEmbeddedPiSessionDirect(
       const { builtInTools, customTools } = splitSdkTools({
         tools: effectiveTools,
         sandboxEnabled: !!sandbox?.enabled,
+        hookContext: {
+          agentId: sessionAgentId,
+          sessionKey: sandboxSessionKey,
+          sessionId: params.sessionId,
+          runId,
+        },
       });
 
       const { session } = await createAgentSession({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -763,6 +763,12 @@ export async function runEmbeddedAttempt(
       const { builtInTools, customTools } = splitSdkTools({
         tools: effectiveTools,
         sandboxEnabled: !!sandbox?.enabled,
+        hookContext: {
+          agentId: sessionAgentId,
+          sessionKey: sandboxSessionKey,
+          sessionId: params.sessionId,
+          runId: params.runId,
+        },
       });
 
       // Add client tools (OpenResponses hosted tools) to customTools

--- a/src/agents/pi-embedded-runner/tool-split.ts
+++ b/src/agents/pi-embedded-runner/tool-split.ts
@@ -1,17 +1,22 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
+import type { HookContext } from "../pi-tools.before-tool-call.js";
 import { toToolDefinitions } from "../pi-tool-definition-adapter.js";
 
 // We always pass tools via `customTools` so our policy filtering, sandbox integration,
 // and extended toolset remain consistent across providers.
 type AnyAgentTool = AgentTool;
 
-export function splitSdkTools(options: { tools: AnyAgentTool[]; sandboxEnabled: boolean }): {
+export function splitSdkTools(options: {
+  tools: AnyAgentTool[];
+  sandboxEnabled: boolean;
+  hookContext?: HookContext;
+}): {
   builtInTools: AnyAgentTool[];
   customTools: ReturnType<typeof toToolDefinitions>;
 } {
-  const { tools } = options;
+  const { tools, hookContext } = options;
   return {
     builtInTools: [],
-    customTools: toToolDefinitions(tools),
+    customTools: toToolDefinitions(tools, hookContext),
   };
 }

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -114,7 +114,10 @@ function splitToolExecuteArgs(args: ToolExecuteArgsAny): {
   };
 }
 
-export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
+export function toToolDefinitions(
+  tools: AnyAgentTool[],
+  hookContext?: HookContext,
+): ToolDefinition[] {
   return tools.map((tool) => {
     const name = tool.name || "tool";
     const normalizedName = normalizeToolName(name);
@@ -133,6 +136,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
               toolName: name,
               params,
               toolCallId,
+              ctx: hookContext,
             });
             if (hookOutcome.blocked) {
               throw new Error(hookOutcome.reason);


### PR DESCRIPTION
## Problem

The plugin hook system has two tool dispatch paths:

1. **Client tools** (`toClientToolDefinitions`) — correctly pass `HookContext` with `agentId` to `runBeforeToolCallHook()` ✅
2. **Built-in tools** (`toToolDefinitions` → `splitSdkTools`) — call `runBeforeToolCallHook()` **without `ctx`**, so `before_tool_call` hooks never receive `agentId` ❌

This means plugins that need to know which agent is making a tool call (e.g., for audit logging, per-agent rate limiting, or access control) get `agentId=undefined` for all built-in tools.

The `after_tool_call` path already wires `agentId` correctly via `pi-embedded-subscribe.handlers.tools.ts` — this fix closes the gap on the `before_tool_call` side.

## Fix

Thread `HookContext` through the built-in tool path (4 files, +25/-4 lines):

| File | Change |
|------|--------|
| `pi-tool-definition-adapter.ts` | Add optional `hookContext` param to `toToolDefinitions()`, pass as `ctx` to `runBeforeToolCallHook()` |
| `tool-split.ts` | Add optional `hookContext` param to `splitSdkTools()`, forward to `toToolDefinitions()` |
| `run/attempt.ts` | Pass `{agentId, sessionKey, sessionId, runId}` to `splitSdkTools()` |
| `compact.ts` | Same context pass-through for the compaction code path |

## Backward Compatibility

`hookContext` is optional at every level. Existing callers without context continue to work — hooks receive `agentId=undefined`, identical to current behavior. No breaking changes.

## Verification

- `tsc --noEmit` passes with zero errors
- Existing `wired-hooks-after-tool-call.e2e.test.ts` validates the after_tool_call path with agentId