### PR TITLE
feat: INFO-level tool call observability with duration and redacted args

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -330,8 +330,11 @@ async function emitToolResultOutput(params: {
 
 /**
  * Build a compact, redacted summary of tool call arguments for log output.
- * Truncates long values to keep log lines readable while still providing
- * enough context to diagnose tool call issues.
+ * Truncates the raw serialized form *before* redaction so that large tool
+ * inputs (e.g. write/edit calls carrying full file contents) don't incur
+ * full JSON allocation + regex redaction cost for a 200-char preview.
+ * A 2× preview buffer is kept before redaction so that secret patterns
+ * straddling the boundary are still caught by `redactSensitiveText`.
  */
 function buildSanitizedArgSummary(args: unknown, maxLen = 200): string {
   if (args == null) {
@@ -339,7 +342,10 @@ function buildSanitizedArgSummary(args: unknown, maxLen = 200): string {
   }
   try {
     const raw = typeof args === "string" ? args : JSON.stringify(args);
-    const redacted = redactSensitiveText(raw);
+    // Truncate to bounded window before running regex-heavy redaction.
+    const previewWindow = maxLen * 2;
+    const bounded = raw.length > previewWindow ? raw.slice(0, previewWindow) : raw;
+    const redacted = redactSensitiveText(bounded);
     return redacted.length > maxLen ? `${redacted.slice(0, maxLen)}…` : redacted;
   } catch {
     return "[unserializable]";

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -4,6 +4,8 @@ import {
   buildExecApprovalPendingReplyPayload,
   buildExecApprovalUnavailableReplyPayload,
 } from "../infra/exec-approval-reply.js";
+import { logInfo } from "../logger.js";
+import { redactSensitiveText } from "../logging/redact.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
@@ -326,6 +328,24 @@ async function emitToolResultOutput(params: {
   });
 }
 
+/**
+ * Build a compact, redacted summary of tool call arguments for log output.
+ * Truncates long values to keep log lines readable while still providing
+ * enough context to diagnose tool call issues.
+ */
+function buildSanitizedArgSummary(args: unknown, maxLen = 200): string {
+  if (args == null) {
+    return "";
+  }
+  try {
+    const raw = typeof args === "string" ? args : JSON.stringify(args);
+    const redacted = redactSensitiveText(raw);
+    return redacted.length > maxLen ? `${redacted.slice(0, maxLen)}…` : redacted;
+  } catch {
+    return "[unserializable]";
+  }
+}
+
 export async function handleToolExecutionStart(
   ctx: ToolHandlerContext,
   evt: AgentEvent & { toolName: string; toolCallId: string; args: unknown },
@@ -367,6 +387,9 @@ export async function handleToolExecutionStart(
   ctx.log.debug(
     `embedded run tool start: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
+  // INFO-level observability for tool calls (see #55806).
+  const argSummary = buildSanitizedArgSummary(args);
+  logInfo(`tool-call: start tool=${toolName}${argSummary ? ` args=${argSummary}` : ""}`);
 
   const shouldEmitToolEvents = ctx.shouldEmitToolResult();
   emitAgentEvent({
@@ -575,13 +598,32 @@ export async function handleToolExecutionEnd(
   ctx.log.debug(
     `embedded run tool end: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
+  // INFO-level observability for tool results (see #55806).
+  const durationMs = startData?.startTime != null ? Date.now() - startData.startTime : undefined;
+  {
+    const parts = [`tool-call: end tool=${toolName}`];
+    if (durationMs != null) {
+      parts.push(`duration=${durationMs}ms`);
+    }
+    if (isToolError) {
+      const errorMessage = extractToolErrorMessage(sanitizedResult);
+      parts.push("status=error");
+      if (errorMessage) {
+        const truncated =
+          errorMessage.length > 200 ? `${errorMessage.slice(0, 200)}…` : errorMessage;
+        parts.push(`error=${truncated}`);
+      }
+    } else {
+      parts.push("status=ok");
+    }
+    logInfo(parts.join(" "));
+  }
 
   await emitToolResultOutput({ ctx, toolName, meta, isToolError, result, sanitizedResult });
 
   // Run after_tool_call plugin hook (fire-and-forget)
   const hookRunnerAfter = ctx.hookRunner ?? getGlobalHookRunner();
   if (hookRunnerAfter?.hasHooks("after_tool_call")) {
-    const durationMs = startData?.startTime != null ? Date.now() - startData.startTime : undefined;
     const hookEvent: PluginHookAfterToolCallEvent = {
       toolName,
       params: afterToolCallArgs,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -390,7 +390,7 @@ export async function handleToolExecutionStart(
   // INFO-level observability for tool calls (see #55806).
   const argSummary = buildSanitizedArgSummary(args);
   logInfo(
-    `tool-call: start runId=${runId} toolCallId=${toolCallId} tool=${toolName}${argSummary ? ` args="${argSummary}"` : ""}`,
+    `tool-call: start runId=${runId} toolCallId=${toolCallId} tool=${toolName}${argSummary ? ` args=${JSON.stringify(argSummary)}` : ""}`,
   );
 
   const shouldEmitToolEvents = ctx.shouldEmitToolResult();
@@ -608,13 +608,16 @@ export async function handleToolExecutionEnd(
       parts.push(`duration=${durationMs}ms`);
     }
     if (isToolError) {
-      const rawError = extractToolErrorMessage(sanitizedResult);
+      // extractToolErrorMessage handles object payloads; fall back to string results directly.
+      const rawError =
+        extractToolErrorMessage(sanitizedResult) ??
+        (typeof sanitizedResult === "string" ? sanitizedResult : undefined);
       const errorMessage = rawError ? redactSensitiveText(rawError) : undefined;
       parts.push("status=error");
       if (errorMessage) {
         const truncated =
           errorMessage.length > 200 ? `${errorMessage.slice(0, 200)}…` : errorMessage;
-        parts.push(`error="${truncated}"`);
+        parts.push(`error=${JSON.stringify(truncated)}`);
       }
     } else {
       parts.push("status=ok");
@@ -627,6 +630,10 @@ export async function handleToolExecutionEnd(
   // Run after_tool_call plugin hook (fire-and-forget)
   const hookRunnerAfter = ctx.hookRunner ?? getGlobalHookRunner();
   if (hookRunnerAfter?.hasHooks("after_tool_call")) {
+    // Compute duration after emitToolResultOutput so hook consumers get total
+    // wall-clock time (including output emission), preserving original semantics.
+    const hookDurationMs =
+      startData?.startTime != null ? Date.now() - startData.startTime : undefined;
     const hookEvent: PluginHookAfterToolCallEvent = {
       toolName,
       params: afterToolCallArgs,
@@ -634,7 +641,7 @@ export async function handleToolExecutionEnd(
       toolCallId,
       result: sanitizedResult,
       error: isToolError ? extractToolErrorMessage(sanitizedResult) : undefined,
-      durationMs,
+      durationMs: hookDurationMs,
     };
     void hookRunnerAfter
       .runAfterToolCall(hookEvent, {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -389,7 +389,9 @@ export async function handleToolExecutionStart(
   );
   // INFO-level observability for tool calls (see #55806).
   const argSummary = buildSanitizedArgSummary(args);
-  logInfo(`tool-call: start tool=${toolName}${argSummary ? ` args=${argSummary}` : ""}`);
+  logInfo(
+    `tool-call: start runId=${runId} toolCallId=${toolCallId} tool=${toolName}${argSummary ? ` args="${argSummary}"` : ""}`,
+  );
 
   const shouldEmitToolEvents = ctx.shouldEmitToolResult();
   emitAgentEvent({
@@ -601,17 +603,18 @@ export async function handleToolExecutionEnd(
   // INFO-level observability for tool results (see #55806).
   const durationMs = startData?.startTime != null ? Date.now() - startData.startTime : undefined;
   {
-    const parts = [`tool-call: end tool=${toolName}`];
+    const parts = [`tool-call: end runId=${runId} toolCallId=${toolCallId} tool=${toolName}`];
     if (durationMs != null) {
       parts.push(`duration=${durationMs}ms`);
     }
     if (isToolError) {
-      const errorMessage = extractToolErrorMessage(sanitizedResult);
+      const rawError = extractToolErrorMessage(sanitizedResult);
+      const errorMessage = rawError ? redactSensitiveText(rawError) : undefined;
       parts.push("status=error");
       if (errorMessage) {
         const truncated =
           errorMessage.length > 200 ? `${errorMessage.slice(0, 200)}…` : errorMessage;
-        parts.push(`error=${truncated}`);
+        parts.push(`error="${truncated}"`);
       }
     } else {
       parts.push("status=ok");


### PR DESCRIPTION
## Summary

Adds structured INFO-level log entries for tool call start and end events, making tool execution visible in default log configurations. Previously, tool execution events were only logged at DEBUG level, invisible in production.

## New log output

```
tool-call: start tool=exec args={"command":"npm test","workdir":"/app"}
tool-call: end tool=exec duration=1523ms status=ok

tool-call: start tool=read args={"path":"/etc/hosts"}
tool-call: end tool=read duration=12ms status=error error=ENOENT: no such file or directory
```

### Start event
- Tool name
- Sanitized argument summary (secrets redacted via `redactSensitiveText`, truncated to 200 chars)

### End event
- Tool name
- Execution duration in milliseconds
- Structured status: `ok` or `error`
- Truncated error message when status is error

## Changes

| File | Change |
|------|--------|
| `src/agents/pi-embedded-subscribe.handlers.tools.ts` | Add `logInfo` + `redactSensitiveText` imports, `buildSanitizedArgSummary()` helper, INFO log lines at start/end |

## Motivation

Closes #55806. Fleet operators need tool call observability at INFO level to diagnose agent behavior without enabling DEBUG logging. Three gaps addressed: sanitized input logging, error categorization, and duration tracking.

## Test plan

- [x] Existing tool handler tests pass (29 tests)
- [x] All pre-commit checks pass