### PR TITLE
Fix duplicate /new reset hook emissions

### DIFF
--- a/src/auto-reply/reply/commands-core.test.ts
+++ b/src/auto-reply/reply/commands-core.test.ts
@@ -2,9 +2,30 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HookRunner } from "../../plugins/hooks.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
+const internalHookMocks = vi.hoisted(() => ({
+  triggerInternalHook: vi.fn(),
+}));
+
 const hookRunnerMocks = vi.hoisted(() => ({
   hasHooks: vi.fn<HookRunner["hasHooks"]>(),
   runBeforeReset: vi.fn<HookRunner["runBeforeReset"]>(),
+}));
+
+vi.mock("../../hooks/internal-hooks.js", () => ({
+  createInternalHookEvent: (
+    _type: string,
+    action: string,
+    sessionKey: string,
+    context: unknown,
+  ) => ({
+    type: "command",
+    action,
+    sessionKey,
+    context,
+    timestamp: new Date("2026-01-01T00:00:00.000Z"),
+    messages: [],
+  }),
+  triggerInternalHook: (...args: unknown[]) => internalHookMocks.triggerInternalHook(...args),
 }));
 
 vi.mock("../../plugins/hook-runner-global.js", () => ({
@@ -15,7 +36,8 @@ vi.mock("../../plugins/hook-runner-global.js", () => ({
     }) as unknown as HookRunner,
 }));
 
-const { emitResetCommandHooks } = await import("./commands-core.js");
+const { emitResetCommandHooks, resetRecentResetHookEmissionsForTest } =
+  await import("./commands-core.js");
 
 describe("emitResetCommandHooks", () => {
   async function runBeforeResetContext(sessionKey?: string) {
@@ -46,6 +68,9 @@ describe("emitResetCommandHooks", () => {
   }
 
   beforeEach(() => {
+    resetRecentResetHookEmissionsForTest();
+    internalHookMocks.triggerInternalHook.mockReset();
+    internalHookMocks.triggerInternalHook.mockResolvedValue(undefined);
     hookRunnerMocks.hasHooks.mockReset();
     hookRunnerMocks.runBeforeReset.mockReset();
     hookRunnerMocks.hasHooks.mockImplementation((hookName) => hookName === "before_reset");
@@ -84,5 +109,80 @@ describe("emitResetCommandHooks", () => {
       sessionId: "prev-session",
       workspaceDir: "/tmp/openclaw-workspace",
     });
+  });
+
+  it("dedupes repeated reset-hook emission for the same prior session", async () => {
+    const command = {
+      surface: "discord",
+      senderId: "rai",
+      channel: "discord",
+      from: "discord:rai",
+      to: "discord:bot",
+      resetHookTriggered: false,
+    } as HandleCommandsParams["command"];
+
+    const baseParams = {
+      action: "new" as const,
+      ctx: {} as HandleCommandsParams["ctx"],
+      cfg: {} as HandleCommandsParams["cfg"],
+      command,
+      sessionKey: "agent:main:discord:direct:123",
+      previousSessionEntry: {
+        sessionId: "prior-session-1",
+      } as HandleCommandsParams["previousSessionEntry"],
+      workspaceDir: "/tmp/openclaw-workspace",
+    };
+
+    await emitResetCommandHooks(baseParams);
+    await emitResetCommandHooks({
+      ...baseParams,
+      command: { ...command, resetHookTriggered: false } as HandleCommandsParams["command"],
+    });
+
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1));
+  });
+
+  it("allows reset-hook emission again when prior session changes", async () => {
+    await emitResetCommandHooks({
+      action: "new",
+      ctx: {} as HandleCommandsParams["ctx"],
+      cfg: {} as HandleCommandsParams["cfg"],
+      command: {
+        surface: "discord",
+        senderId: "rai",
+        channel: "discord",
+        from: "discord:rai",
+        to: "discord:bot",
+        resetHookTriggered: false,
+      } as HandleCommandsParams["command"],
+      sessionKey: "agent:main:discord:direct:123",
+      previousSessionEntry: {
+        sessionId: "prior-session-1",
+      } as HandleCommandsParams["previousSessionEntry"],
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    await emitResetCommandHooks({
+      action: "new",
+      ctx: {} as HandleCommandsParams["ctx"],
+      cfg: {} as HandleCommandsParams["cfg"],
+      command: {
+        surface: "discord",
+        senderId: "rai",
+        channel: "discord",
+        from: "discord:rai",
+        to: "discord:bot",
+        resetHookTriggered: false,
+      } as HandleCommandsParams["command"],
+      sessionKey: "agent:main:discord:direct:123",
+      previousSessionEntry: {
+        sessionId: "prior-session-2",
+      } as HandleCommandsParams["previousSessionEntry"],
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(2));
   });
 });

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -31,6 +31,44 @@ let HANDLERS: CommandHandler[] | null = null;
 
 export type ResetCommandAction = "new" | "reset";
 
+const RECENT_RESET_HOOK_EMISSION_MAX = 512;
+const recentResetHookEmissions = new Set<string>();
+
+function normalizeResetHookSessionKey(sessionKey?: string): string {
+  const normalized = sessionKey?.trim().toLowerCase();
+  return normalized && normalized.length > 0 ? normalized : "<none>";
+}
+
+function buildResetHookDedupKey(params: {
+  action: ResetCommandAction;
+  sessionKey?: string;
+  previousSessionId?: string;
+}): string | null {
+  const previousSessionId = params.previousSessionId?.trim();
+  if (!previousSessionId) {
+    return null;
+  }
+  return `${params.action}|${normalizeResetHookSessionKey(params.sessionKey)}|${previousSessionId}`;
+}
+
+function markResetHookEmissionSeen(key: string): void {
+  if (recentResetHookEmissions.has(key)) {
+    return;
+  }
+  recentResetHookEmissions.add(key);
+  if (recentResetHookEmissions.size <= RECENT_RESET_HOOK_EMISSION_MAX) {
+    return;
+  }
+  const oldestKey = recentResetHookEmissions.values().next().value;
+  if (oldestKey) {
+    recentResetHookEmissions.delete(oldestKey);
+  }
+}
+
+export function resetRecentResetHookEmissionsForTest(): void {
+  recentResetHookEmissions.clear();
+}
+
 export async function emitResetCommandHooks(params: {
   action: ResetCommandAction;
   ctx: HandleCommandsParams["ctx"];
@@ -44,6 +82,19 @@ export async function emitResetCommandHooks(params: {
   previousSessionEntry?: HandleCommandsParams["previousSessionEntry"];
   workspaceDir: string;
 }): Promise<void> {
+  const dedupKey = buildResetHookDedupKey({
+    action: params.action,
+    sessionKey: params.sessionKey,
+    previousSessionId: params.previousSessionEntry?.sessionId,
+  });
+  if (dedupKey && recentResetHookEmissions.has(dedupKey)) {
+    params.command.resetHookTriggered = true;
+    logVerbose(
+      `Skipping duplicate ${params.action} reset hook emission for prior session ${params.previousSessionEntry?.sessionId ?? "<none>"}`,
+    );
+    return;
+  }
+
   const hookEvent = createInternalHookEvent("command", params.action, params.sessionKey ?? "", {
     sessionEntry: params.sessionEntry,
     previousSessionEntry: params.previousSessionEntry,
@@ -53,6 +104,9 @@ export async function emitResetCommandHooks(params: {
     cfg: params.cfg, // Pass config for LLM slug generation
   });
   await triggerInternalHook(hookEvent);
+  if (dedupKey) {
+    markResetHookEmissionSeen(dedupKey);
+  }
   params.command.resetHookTriggered = true;
 
   // Send hook messages immediately if present


### PR DESCRIPTION
## Summary
- dedupe reset-hook emission for the same `/new`/`/reset` source session inside `emitResetCommandHooks`
- keep the dedupe bounded and mark duplicate attempts as already triggered to block fallback re-emission
- add focused tests for duplicate suppression and for allowing a new prior session through

## Root cause
A single `/new` could re-enter the reset-hook path multiple times for the same `previousSessionEntry.sessionId` (including fallback paths), which let `command:new` hooks like `memory-reflection` run repeatedly for the same original session. That produced multiple reflection files and kept the session looking active for too long.

## Testing
- Added focused tests in `src/auto-reply/reply/commands-core.test.ts`
- Attempted to run targeted tests locally, but this temp environment does not have installable dependencies available:
  - `node_modules` was absent
  - install/test attempts were blocked by sandbox/network/store restrictions
