### PR TITLE
fix: suppress Discord ACP thread relay chatter

### DIFF
--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -159,6 +159,50 @@ describe("startAcpSpawnParentStreamRelay", () => {
     relay.dispose();
   });
 
+  it("suppresses intermediate relay events for visible Discord thread sessions", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-2b",
+      parentSessionKey: "agent:main:discord:channel:thread-1",
+      childSessionKey: "agent:codex:acp:child-2b",
+      agentId: "codex",
+      streamFlushMs: 1,
+      noOutputNoticeMs: 1_000,
+      noOutputPollMs: 250,
+      suppressIntermediateEvents: true,
+    });
+
+    vi.advanceTimersByTime(1_500);
+    expect(collectedTexts().some((text) => text.includes("has produced no output for 1s"))).toBe(
+      false,
+    );
+
+    emitAgentEvent({
+      runId: "run-2b",
+      stream: "assistant",
+      data: {
+        delta: "resumed output",
+      },
+    });
+    vi.advanceTimersByTime(5);
+
+    const texts = collectedTexts();
+    expect(texts.some((text) => text.includes("Started codex session"))).toBe(true);
+    expect(texts.some((text) => text.includes("resumed output."))).toBe(false);
+    expect(texts.some((text) => text.includes("codex: resumed output"))).toBe(false);
+
+    emitAgentEvent({
+      runId: "run-2b",
+      stream: "lifecycle",
+      data: {
+        phase: "end",
+        startedAt: 1_000,
+        endedAt: 3_100,
+      },
+    });
+    expect(collectedTexts().some((text) => text.includes("codex run completed in 2s"))).toBe(true);
+    relay.dispose();
+  });
+
   it("auto-disposes stale relays after max lifetime timeout", () => {
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-3",

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -13,6 +13,7 @@ const DEFAULT_NO_OUTPUT_POLL_MS = 15_000;
 const DEFAULT_MAX_RELAY_LIFETIME_MS = 6 * 60 * 60 * 1000;
 const STREAM_BUFFER_MAX_CHARS = 4_000;
 const STREAM_SNIPPET_MAX_CHARS = 220;
+const SUPPRESSED_INTERMEDIATE_EVENT_SUFFIXES = [":progress", ":stall", ":resumed"] as const;
 
 function compactWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
@@ -84,6 +85,7 @@ export function startAcpSpawnParentStreamRelay(params: {
   noOutputPollMs?: number;
   maxRelayLifetimeMs?: number;
   emitStartNotice?: boolean;
+  suppressIntermediateEvents?: boolean;
 }): AcpSpawnParentRelayHandle {
   const runId = params.runId.trim();
   const parentSessionKey = params.parentSessionKey.trim();
@@ -114,6 +116,7 @@ export function startAcpSpawnParentStreamRelay(params: {
   const relayLabel = truncate(compactWhitespace(params.agentId), 40) || "ACP child";
   const contextPrefix = `acp-spawn:${runId}`;
   const logPath = toTrimmedString(params.logPath);
+  const suppressIntermediateEvents = params.suppressIntermediateEvents === true;
   let logDirReady = false;
   let pendingLogLines = "";
   let logFlushScheduled = false;
@@ -185,12 +188,18 @@ export function startAcpSpawnParentStreamRelay(params: {
       }),
     );
   };
+  const shouldSuppressSystemEvent = (contextKey: string) =>
+    suppressIntermediateEvents &&
+    SUPPRESSED_INTERMEDIATE_EVENT_SUFFIXES.some((suffix) => contextKey.endsWith(suffix));
   const emit = (text: string, contextKey: string) => {
     const cleaned = text.trim();
     if (!cleaned) {
       return;
     }
     logEvent("system_event", { contextKey, text: cleaned });
+    if (shouldSuppressSystemEvent(contextKey)) {
+      return;
+    }
     enqueueSystemEvent(cleaned, { sessionKey: parentSessionKey, contextKey });
     wake();
   };

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -775,6 +775,61 @@ describe("spawnAcpDirect", () => {
     expect(secondHandle.notifyStarted).toHaveBeenCalledTimes(1);
   });
 
+  it("suppresses intermediate relay events when streaming to a Discord thread parent", async () => {
+    const relayHandle = createRelayHandle();
+    hoisted.startAcpSpawnParentStreamRelayMock.mockReset().mockReturnValue(relayHandle);
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        streamTo: "parent",
+      },
+      {
+        agentSessionKey: "agent:main:discord:channel:parent-channel:thread:worker-thread",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+        agentThreadId: "worker-thread",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.startAcpSpawnParentStreamRelayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentSessionKey: "agent:main:discord:channel:parent-channel:thread:worker-thread",
+        suppressIntermediateEvents: true,
+      }),
+    );
+  });
+
+  it("suppresses intermediate relay events for Discord thread parent session keys without thread context", async () => {
+    const relayHandle = createRelayHandle();
+    hoisted.startAcpSpawnParentStreamRelayMock.mockReset().mockReturnValue(relayHandle);
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        streamTo: "parent",
+      },
+      {
+        agentSessionKey: "agent:main:discord:channel:parent-channel:thread:worker-thread",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(hoisted.startAcpSpawnParentStreamRelayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentSessionKey: "agent:main:discord:channel:parent-channel:thread:worker-thread",
+        suppressIntermediateEvents: true,
+      }),
+    );
+  });
+
   it("implicitly streams mode=run ACP spawns for subagent requester sessions", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -40,6 +40,7 @@ import {
   isSubagentSessionKey,
   normalizeAgentId,
   parseAgentSessionKey,
+  resolveThreadParentSessionKey,
 } from "../routing/session-key.js";
 import {
   deliveryContextFromSession,
@@ -852,6 +853,10 @@ export async function spawnAcpDirect(
           childSessionKey: sessionKey,
         })
       : undefined;
+  const parentSessionIsThreadBound = Boolean(resolveThreadParentSessionKey(parentSessionKey));
+  const suppressIntermediateRelayEvents =
+    ctx.agentChannel === "discord" &&
+    (requesterState.hasThreadContext || parentSessionIsThreadBound);
   let parentRelay: AcpSpawnParentRelayHandle | undefined;
   if (effectiveStreamToParent && parentSessionKey) {
     // Register relay before dispatch so fast lifecycle failures are not missed.
@@ -862,6 +867,7 @@ export async function spawnAcpDirect(
       agentId: targetAgentId,
       logPath: streamLogPath,
       emitStartNotice: false,
+      suppressIntermediateEvents: suppressIntermediateRelayEvents,
     });
   }
   try {
@@ -909,6 +915,7 @@ export async function spawnAcpDirect(
         agentId: targetAgentId,
         logPath: streamLogPath,
         emitStartNotice: false,
+        suppressIntermediateEvents: suppressIntermediateRelayEvents,
       });
     }
     parentRelay?.notifyStarted();

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -8,6 +8,7 @@ export {
   isAcpSessionKey,
   isSubagentSessionKey,
   parseAgentSessionKey,
+  resolveThreadParentSessionKey,
   type ParsedAgentSessionKey,
 } from "../sessions/session-key-utils.js";
 export {


### PR DESCRIPTION
## Summary

- Problem: visible Discord ACP threads render parent relay `progress`, `stall`, and `resumed` system events as normal chat messages.
- Why it matters: thread-bound ACP runs look noisy and duplicate-like, which makes the real assistant result harder to follow.
- What changed: ACP parent relays now suppress only those intermediate system events for visible Discord thread parent sessions, while keeping relay logging and terminal lifecycle notices intact.
- What did NOT change (scope boundary): no changes to non-Discord channels, non-thread sessions, or completion/error/timeout notices.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55807
- Related #55807
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `src/agents/acp-spawn-parent-stream.ts` unconditionally enqueued `:progress`, `:stall`, and `:resumed` relay events into the parent session, and visible Discord thread parents render those system events as normal thread messages.
- Missing detection / guardrail: there was no channel/thread-specific suppression path for intermediate ACP relay events, and no regression test covering Discord thread parent sessions.
- Prior context (`git blame`, prior PR, issue, or refactor if known): current ACP relay behavior is present in the existing parent-stream relay implementation; exact introducing commit was not traced in this PR.
- Why this regressed now: Discord thread-bound ACP makes those parent session system events user-visible, so relay chatter now shows up directly in the thread UX.
- If unknown, what was ruled out: this PR does not change webhook delivery, child run dispatch, or final lifecycle notices.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/acp-spawn-parent-stream.test.ts`
  - `src/agents/acp-spawn.test.ts`
- Scenario the test should lock in: Discord thread parent sessions should suppress relay `progress`, `stall`, and `resumed` system events, including the case where the parent session key is thread-bound but the current turn does not carry explicit thread context.
- Why this is the smallest reliable guardrail: the bug lives in the ACP relay + spawn wiring, so targeted unit coverage on those two seams catches the behavior without requiring a live Discord environment.
- Existing test that already covers this (if any): none for this exact Discord thread relay suppression behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Discord thread-bound ACP parent sessions no longer show intermediate relay chatter (`progress`, `stall`, `resumed`) as visible thread messages.
- Start, completion, error, and timeout notices still appear.

## Diagram (if applicable)

```text
Before:
Discord thread-bound ACP run -> parent relay enqueues progress/stall/resumed -> Discord thread shows intermediate chatter

After:
Discord thread-bound ACP run -> parent relay logs intermediate events but suppresses visible enqueue -> Discord thread shows only start/final lifecycle notices
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm test environment
- Model/provider: N/A for local regression tests
- Integration/channel (if any): Discord thread-bound ACP relay path
- Relevant config (redacted): thread-bound Discord ACP parent session with `streamTo="parent"`

### Steps

1. Start an ACP parent relay for a Discord thread parent session.
2. Emit assistant delta / no-output / resumed events through the relay.
3. Finish the run through lifecycle end/error paths.

### Expected

- Intermediate relay chatter is suppressed for visible Discord thread parents.
- Final lifecycle notices still reach the parent session.

### Actual

- Verified by targeted tests in the touched relay + spawn seams.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Ran `pnpm test -- src/agents/acp-spawn-parent-stream.test.ts src/agents/acp-spawn.test.ts`
  - Ran `pnpm check`
  - Added and verified a regression case where the parent session key is already thread-bound even when the current call has no explicit thread context
- Edge cases checked:
  - Intermediate relay suppression stays limited to `progress`, `stall`, and `resumed`
  - `start`, `done`, `error`, and `timeout` notices still flow
  - Non-thread/session-local relay logging remains intact
- What you did **not** verify:
  - No live Discord manual smoke test in a real thread-bound ACP session

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: suppressing intermediate relay events too broadly could hide useful chatter outside the affected Discord thread UX.
  - Mitigation: suppression is scoped to Discord parent sessions that are thread-bound by current context or parent session key, and final lifecycle notices are still preserved.

## AI Assistance

- [x] AI-assisted
- Testing: fully tested for the touched relay/spawn surfaces, not manually smoke-tested in live Discord
