### PR TITLE
fix(gateway): deny nodes over HTTP tools invoke

### DIFF
--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -49,8 +49,8 @@ vi.mock("../config/sessions.js", () => ({
   },
 }));
 
-vi.mock("./auth.js", () => ({
-  authorizeHttpGatewayConnect: async () => ({ ok: true }),
+vi.mock("./http-auth-helpers.js", () => ({
+  authorizeGatewayBearerRequestOrReply: async () => true,
 }));
 
 vi.mock("../logger.js", () => ({
@@ -113,6 +113,12 @@ vi.mock("../agents/openclaw-tools.js", () => {
       execute: async () => {
         throw toolInputError("invalid args");
       },
+    },
+    {
+      name: "nodes",
+      ownerOnly: true,
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ ok: true, ownerOnly: true }),
     },
     {
       name: "tools_invoke_test",
@@ -568,6 +574,18 @@ describe("POST /tools/invoke", () => {
     });
 
     expect(res.status).toBe(404);
+  });
+
+  it("denies owner-only nodes tool via HTTP even when agent policy allows it", async () => {
+    setMainAllowedTools({ allow: ["nodes"] });
+
+    const res = await invokeToolAuthed({
+      tool: "nodes",
+      sessionKey: "main",
+    });
+
+    expect(res.status).toBe(404);
+    expect(hookMocks.runBeforeToolCallHook).not.toHaveBeenCalled();
   });
 
   it("allows gateway tool via HTTP when explicitly enabled in gateway.tools.allow", async () => {

--- a/src/security/dangerous-tools.ts
+++ b/src/security/dangerous-tools.ts
@@ -15,6 +15,8 @@ export const DEFAULT_GATEWAY_HTTP_TOOL_DENY = [
   "cron",
   // Gateway control plane — prevents gateway reconfiguration via HTTP
   "gateway",
+  // Paired device control plane — prevents remote node/device control via HTTP by default
+  "nodes",
   // Interactive setup — requires terminal QR scan, hangs on HTTP
   "whatsapp_login",
 ] as const;


### PR DESCRIPTION
## Summary
- add `nodes` to the default `/tools/invoke` HTTP deny list so paired device control is not exposed over HTTP by default
- keep the existing explicit `gateway.tools.allow` opt-in behavior for dangerous HTTP tools unchanged
- add a regression test showing `nodes` stays unavailable over HTTP even when an agent allowlist includes it

## Testing
- pnpm exec vitest run src/gateway/tools-invoke-http.test.ts src/gateway/tools-invoke-http.cron-regression.test.ts