### PR TITLE
fix(cli): pass agentId in message send to enable transcript writes

### DIFF
--- a/src/commands/message.test.ts
+++ b/src/commands/message.test.ts
@@ -70,6 +70,34 @@ vi.mock("../../extensions/whatsapp/runtime-api.js", () => ({
   handleWhatsAppAction,
 }));
 
+const runMessageActionSpy = vi.hoisted(() =>
+  vi.fn(async () => ({
+    kind: "send" as const,
+    channel: "telegram",
+    action: "send" as const,
+    to: "123456",
+    handledBy: "plugin" as const,
+    payload: { ok: true },
+    dryRun: false,
+  })),
+);
+
+// Lazy-ref so we can swap between spy and real implementation per test.
+let useRunMessageActionSpy = false;
+vi.mock("../infra/outbound/message-action-runner.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../infra/outbound/message-action-runner.js")>();
+  return {
+    ...actual,
+    runMessageAction: (...args: unknown[]) => {
+      if (useRunMessageActionSpy) {
+        return (runMessageActionSpy as (...a: unknown[]) => unknown)(...args);
+      }
+      return (actual.runMessageAction as (...a: unknown[]) => unknown)(...args);
+    },
+  };
+});
+
 import { messageCommand } from "./message.js";
 
 let envSnapshot: ReturnType<typeof captureEnv>;
@@ -80,6 +108,7 @@ beforeEach(() => {
   process.env.TELEGRAM_BOT_TOKEN = "";
   process.env.DISCORD_BOT_TOKEN = "";
   testConfig = {};
+  useRunMessageActionSpy = false;
   setActivePluginRegistry(EMPTY_TEST_REGISTRY);
   callGatewayMock.mockClear();
   webAuthExists.mockClear().mockResolvedValue(false);
@@ -87,6 +116,7 @@ beforeEach(() => {
   handleSlackAction.mockClear();
   handleTelegramAction.mockClear();
   handleWhatsAppAction.mockClear();
+  runMessageActionSpy.mockClear();
   resolveCommandSecretRefsViaGateway.mockClear();
 });
 
@@ -507,5 +537,65 @@ describe("messageCommand", () => {
       }),
       expect.any(Object),
     );
+  });
+
+  it("passes default agentId to runMessageAction for transcript writes", async () => {
+    useRunMessageActionSpy = true;
+    const deps = makeDeps();
+    await messageCommand(
+      {
+        action: "send",
+        channel: "telegram",
+        target: "123456",
+        message: "hi",
+      },
+      deps,
+      runtime,
+    );
+    expect(runMessageActionSpy).toHaveBeenCalledTimes(1);
+    // Default agent id is "main" when no agents config is present.
+    expect(runMessageActionSpy).toHaveBeenCalledWith(expect.objectContaining({ agentId: "main" }));
+  });
+
+  it("passes explicit --agent to runMessageAction", async () => {
+    useRunMessageActionSpy = true;
+    const deps = makeDeps();
+    await messageCommand(
+      {
+        action: "send",
+        channel: "telegram",
+        target: "123456",
+        message: "hi",
+        agent: "custom-agent",
+      },
+      deps,
+      runtime,
+    );
+    expect(runMessageActionSpy).toHaveBeenCalledTimes(1);
+    expect(runMessageActionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "custom-agent" }),
+    );
+  });
+
+  it("resolves agentId from agents config when no explicit --agent", async () => {
+    useRunMessageActionSpy = true;
+    testConfig = {
+      agents: {
+        list: [{ id: "mybot", default: true }],
+      },
+    };
+    const deps = makeDeps();
+    await messageCommand(
+      {
+        action: "send",
+        channel: "telegram",
+        target: "123456",
+        message: "hi",
+      },
+      deps,
+      runtime,
+    );
+    expect(runMessageActionSpy).toHaveBeenCalledTimes(1);
+    expect(runMessageActionSpy).toHaveBeenCalledWith(expect.objectContaining({ agentId: "mybot" }));
   });
 });

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -1,3 +1,4 @@
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
   CHANNEL_MESSAGE_ACTION_NAMES,
   type ChannelMessageActionName,
@@ -10,6 +11,7 @@ import { withProgress } from "../cli/progress.js";
 import { loadConfig } from "../config/config.js";
 import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
 import { runMessageAction } from "../infra/outbound/message-action-runner.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { buildMessageCliJson, formatMessageCliText } from "./message-format.js";
@@ -52,12 +54,18 @@ export async function messageCommand(
 
   const outboundDeps: OutboundSendDeps = createOutboundSendDeps(deps);
 
+  // Resolve agentId so the outbound runner can find the active session and
+  // write to the JSONL transcript (mirrors the agent tool code path).
+  const agentId =
+    typeof opts.agent === "string" ? normalizeAgentId(opts.agent) : resolveDefaultAgentId(cfg);
+
   const run = async () =>
     await runMessageAction({
       cfg,
       action,
       params: opts,
       deps: outboundDeps,
+      agentId,
       gateway: {
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,


### PR DESCRIPTION
## Summary
- `openclaw message send` CLI command did not write to session transcript because `agentId` was missing from the `runMessageAction()` call
- Added `agentId` resolution from `--agent` flag or `resolveDefaultAgentId()` (defaults to `"main"`)

## Root cause
`src/commands/message.ts:56` called `runMessageAction()` without `agentId`. In `src/infra/outbound/message-action-runner.ts:675`, `resolvedAgentId` falls through to `undefined` when neither `agentId` nor `sessionKey` is provided. The session route resolution is gated on `agentId && !dryRun`, so no transcript write occurs. The agent tool path (`src/agents/tools/message-tool.ts`) already passes `agentId` correctly — only the CLI path was missing it.

## Test plan
- [x] Test: default `agentId: "main"` is passed when no agents config is present
- [x] Test: explicit `--agent` flag value is passed through
- [x] Test: `agentId` is resolved from agents config when a default agent is configured
- [x] `pnpm check` passes

Closes #54186

🤖 Generated with [Claude Code](https://claude.com/claude-code)