### PR TITLE
fix(docker): add pnpm store cache mount to prune step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,8 @@ RUN pnpm ui:build
 # Prune dev dependencies and strip build-only metadata before copying
 # runtime assets into the final image.
 FROM build AS runtime-assets
-RUN CI=true pnpm prune --prod && \
+RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
+    CI=true pnpm prune --prod && \
     find dist -type f \( -name '*.d.ts' -o -name '*.d.mts' -o -name '*.d.cts' -o -name '*.map' \) -delete
 
 # ── Runtime base images ─────────────────────────────────────────


### PR DESCRIPTION
## Problem

The `runtime-assets` stage runs `pnpm prune --prod` without a pnpm store
cache mount. With `node-linker=hoisted` (set in `.npmrc`), pnpm prune does
not simply delete devDependency directories — it re-resolves the prod
dependency tree and re-links `node_modules`. Without the store available,
pnpm falls back to downloading prod packages from the npm registry, making
every image build slower and network-dependent.

## Fix

Add the same `--mount=type=cache` directive used in the `pnpm install` step
to the `pnpm prune --prod` step, sharing the same cache id
(`openclaw-pnpm-store`). The store is already populated by the `build` stage,
so the prune step reads from cache rather than re-downloading.

## Test plan

- [x] Build the Docker image locally and confirm no package downloads during
  the `pnpm prune` step (`docker build --progress=plain .`)
- [x] Verify the final image runs correctly (`docker compose up`)
