### PR TITLE
Add @moltenbot/openclaw-plugin-statocyst to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -82,7 +82,6 @@ and files.
 
 ```bash
 openclaw plugins install @sliverp/qqbot
-```
 
 
 ### Statocyst

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -84,6 +84,18 @@ and files.
 openclaw plugins install @sliverp/qqbot
 ```
 
+
+### Statocyst
+
+OpenClaw plugin for realtime Statocyst skill request/result messaging.
+
+- **npm:** `@moltenbot/openclaw-plugin-statocyst`
+- **repo:** [github.com/Molten-Bot/statocyst](https://github.com/Molten-Bot/statocyst)
+
+```bash
+openclaw plugins install @moltenbot/openclaw-plugin-statocyst
+```
+
 ### wecom
 
 OpenClaw Enterprise WeCom Channel Plugin.

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -82,7 +82,7 @@ and files.
 
 ```bash
 openclaw plugins install @sliverp/qqbot
-
+```
 
 ### Statocyst
 


### PR DESCRIPTION
Adds the Statocyst plugin to the OpenClaw Community Plugins page.

Plugin details:
- npm: @moltenbot/openclaw-plugin-statocyst
- repo: github.com/Molten-Bot/statocyst  
- description: OpenClaw plugin for realtime Statocyst skill request/result messaging.

Install command:
```bash
openclaw plugins install @moltenbot/openclaw-plugin-statocyst
```

Note: Placed in alphabetical order (after QQbot, before wecom).