### PR TITLE
Add OpenRouter audio transcription support

### DIFF
--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -18,6 +18,21 @@ title: "Audio and Voice Notes"
 - **Command parsing**: When transcription succeeds, `CommandBody`/`RawBody` are set to the transcript so slash commands still work.
 - **Verbose logging**: In `--verbose`, we log when transcription runs and when it replaces the body.
 
+## What changed for external models
+
+Previously, external chat-model routes such as `openrouter/...` could not receive audio
+attachments as audio input for transcription. In practice, that meant:
+
+- OpenClaw could transcribe audio with local CLIs or providers that expose dedicated STT APIs.
+- But simply selecting an external model like `openrouter/google/gemini-3-flash-preview`
+  did **not** make audio transcription work, because the model was never sent an audio payload.
+
+OpenClaw now supports an explicit OpenRouter audio-transcription path for `tools.media.audio`
+using multimodal `chat/completions` requests with `input_audio`.
+
+That means you can now use external multimodal models, for example OpenRouter Gemini Flash,
+as the backend that turns inbound voice notes into text.
+
 ## Auto-detection (default)
 
 If you **don’t configure models** and `tools.media.audio.enabled` is **not** set to `false`,
@@ -109,6 +124,27 @@ Note: Binary detection is best-effort across macOS/Linux/Windows; ensure the CLI
 }
 ```
 
+### Provider-only (OpenRouter Gemini)
+
+```json5
+{
+  tools: {
+    media: {
+      audio: {
+        enabled: true,
+        models: [{ provider: "openrouter", model: "google/gemini-3-flash-preview" }],
+      },
+    },
+  },
+}
+```
+
+This is useful when, for example, a Telegram voice note is downloaded by OpenClaw and you want
+the transcript to come from an external multimodal model instead of Whisper/OpenAI/Deepgram.
+With the config above, the voice note enters the normal `tools.media.audio` pipeline and
+OpenClaw sends the audio bytes to OpenRouter using `input_audio`, then injects the returned
+transcript back into the inbound message context.
+
 ### Echo transcript to chat (opt-in)
 
 ```json5
@@ -132,6 +168,7 @@ Note: Binary detection is best-effort across macOS/Linux/Windows; ensure the CLI
 - Deepgram picks up `DEEPGRAM_API_KEY` when `provider: "deepgram"` is used.
 - Deepgram setup details: [Deepgram (audio transcription)](/providers/deepgram).
 - Mistral setup details: [Mistral](/providers/mistral).
+- OpenRouter audio via multimodal chat-completions is supported when you explicitly configure `provider: "openrouter"` in `tools.media.audio.models`.
 - Audio providers can override `baseUrl`, `headers`, and `providerOptions` via `tools.media.audio`.
 - Default size cap is 20MB (`tools.media.audio.maxBytes`). Oversize audio is skipped for that model and the next entry is tried.
 - Tiny/empty audio files below 1024 bytes are skipped before provider/CLI transcription.

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -54,7 +54,14 @@ describe("openrouter plugin", () => {
       ),
     ).toEqual(["openrouter"]);
     expect(speechProviders).toHaveLength(0);
-    expect(mediaProviders).toHaveLength(0);
+    expect(mediaProviders).toHaveLength(1);
+    expect(
+      mediaProviders.map(
+        (provider) =>
+          // oxlint-disable-next-line typescript/no-explicit-any
+          (provider as any).id,
+      ),
+    ).toEqual(["openrouter"]);
     expect(imageProviders).toHaveLength(0);
   });
 });

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -13,6 +13,7 @@ import {
   createOpenRouterWrapper,
   isProxyReasoningUnsupported,
 } from "openclaw/plugin-sdk/provider-stream";
+import { openrouterMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { applyOpenrouterConfig, OPENROUTER_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildOpenrouterProvider } from "./provider-catalog.js";
 
@@ -154,5 +155,6 @@ export default definePluginEntry({
       },
       isCacheTtlEligible: (ctx) => isOpenRouterCacheTtlModel(ctx.modelId),
     });
+    api.registerMediaUnderstandingProvider(openrouterMediaUnderstandingProvider);
   },
 });

--- a/extensions/openrouter/media-understanding-provider.test.ts
+++ b/extensions/openrouter/media-understanding-provider.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  createRequestCaptureJsonFetch,
+  installPinnedHostnameTestHooks,
+} from "../../src/media-understanding/audio.test-helpers.js";
+import {
+  openrouterMediaUnderstandingProvider,
+  transcribeOpenRouterAudio,
+} from "./media-understanding-provider.js";
+
+installPinnedHostnameTestHooks();
+
+describe("openrouterMediaUnderstandingProvider", () => {
+  it("has expected provider metadata", () => {
+    expect(openrouterMediaUnderstandingProvider.id).toBe("openrouter");
+    expect(openrouterMediaUnderstandingProvider.capabilities).toEqual(["audio"]);
+    expect(openrouterMediaUnderstandingProvider.transcribeAudio).toBeDefined();
+  });
+
+  it("uses OpenRouter chat completions with input_audio by default", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({
+      choices: [{ message: { content: "hello from audio" } }],
+    });
+
+    const result = await transcribeOpenRouterAudio({
+      buffer: Buffer.from("audio-bytes"),
+      fileName: "voice.ogg",
+      mime: "audio/ogg",
+      apiKey: "test-openrouter-key", // pragma: allowlist secret
+      timeoutMs: 5000,
+      fetchFn,
+    });
+
+    const request = getRequest();
+    expect(request.url).toBe("https://openrouter.ai/api/v1/chat/completions");
+    const headers = new Headers(request.init?.headers);
+    expect(headers.get("authorization")).toBe("Bearer test-openrouter-key");
+
+    const body = JSON.parse(String(request.init?.body)) as {
+      model: string;
+      messages: Array<{
+        role: string;
+        content: Array<
+          | { type: "text"; text: string }
+          | { type: "input_audio"; input_audio: { data: string; format: string } }
+        >;
+      }>;
+    };
+    expect(body.model).toBe("google/gemini-3-flash-preview");
+    expect(body.messages[0]?.content[0]).toEqual({
+      type: "text",
+      text: "Please transcribe this audio file.",
+    });
+    expect(body.messages[0]?.content[1]).toEqual({
+      type: "input_audio",
+      input_audio: {
+        data: Buffer.from("audio-bytes").toString("base64"),
+        format: "ogg",
+      },
+    });
+    expect(result).toEqual({
+      text: "hello from audio",
+      model: "google/gemini-3-flash-preview",
+    });
+  });
+
+  it("allows overriding baseUrl, model, prompt, and language hint", async () => {
+    const { fetchFn, getRequest } = createRequestCaptureJsonFetch({
+      choices: [{ message: { content: [{ type: "text", text: "bonjour" }] } }],
+    });
+
+    await transcribeOpenRouterAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "note.mp3",
+      mime: "audio/mpeg",
+      apiKey: "key", // pragma: allowlist secret
+      timeoutMs: 1000,
+      baseUrl: "https://openrouter-proxy.example/v1",
+      model: "google/gemini-3-flash",
+      prompt: "Return only the transcript.",
+      language: "fr",
+      fetchFn,
+    });
+
+    const request = getRequest();
+    expect(request.url).toBe("https://openrouter-proxy.example/v1/chat/completions");
+    const body = JSON.parse(String(request.init?.body)) as {
+      model: string;
+      messages: Array<{
+        content: Array<
+          { type: "text"; text: string } | { type: "input_audio"; input_audio: { format: string } }
+        >;
+      }>;
+    };
+    expect(body.model).toBe("google/gemini-3-flash");
+    expect(body.messages[0]?.content[0]).toEqual({
+      type: "text",
+      text: "Return only the transcript.\nExpected language: fr.",
+    });
+    expect(body.messages[0]?.content[1]).toEqual({
+      type: "input_audio",
+      input_audio: {
+        data: Buffer.from("audio").toString("base64"),
+        format: "mp3",
+      },
+    });
+  });
+});

--- a/extensions/openrouter/media-understanding-provider.ts
+++ b/extensions/openrouter/media-understanding-provider.ts
@@ -1,0 +1,173 @@
+import path from "node:path";
+import {
+  assertOkOrThrowHttpError,
+  normalizeBaseUrl,
+  postJsonRequest,
+  type AudioTranscriptionRequest,
+  type AudioTranscriptionResult,
+  type MediaUnderstandingProvider,
+} from "openclaw/plugin-sdk/media-understanding";
+
+export const DEFAULT_OPENROUTER_AUDIO_BASE_URL = "https://openrouter.ai/api/v1";
+const DEFAULT_OPENROUTER_AUDIO_MODEL = "google/gemini-3-flash-preview";
+const DEFAULT_OPENROUTER_AUDIO_PROMPT = "Please transcribe this audio file.";
+
+type OpenRouterChatCompletionPayload = {
+  choices?: Array<{
+    message?: {
+      content?: string | Array<{ type?: string; text?: string }>;
+    };
+  }>;
+};
+
+function resolveAudioFormat(params: { mime?: string; fileName?: string }): string {
+  const mime = params.mime?.trim().toLowerCase();
+  if (mime === "audio/mpeg") {
+    return "mp3";
+  }
+  if (
+    mime === "audio/mp4" ||
+    mime === "audio/x-m4a" ||
+    mime === "audio/m4a" ||
+    mime === "audio/aac"
+  ) {
+    return mime === "audio/aac" ? "aac" : "m4a";
+  }
+  if (mime === "audio/flac") {
+    return "flac";
+  }
+  if (mime === "audio/ogg" || mime === "audio/opus") {
+    return "ogg";
+  }
+  if (mime === "audio/wav" || mime === "audio/x-wav" || mime === "audio/wave") {
+    return "wav";
+  }
+  if (mime === "audio/aiff" || mime === "audio/x-aiff") {
+    return "aiff";
+  }
+
+  const ext = path
+    .extname(params.fileName ?? "")
+    .replace(/^\./, "")
+    .trim()
+    .toLowerCase();
+  if (ext === "mp3") {
+    return "mp3";
+  }
+  if (ext === "m4a" || ext === "mp4") {
+    return "m4a";
+  }
+  if (ext === "aac") {
+    return "aac";
+  }
+  if (ext === "flac") {
+    return "flac";
+  }
+  if (ext === "ogg" || ext === "oga" || ext === "opus") {
+    return "ogg";
+  }
+  if (ext === "wav" || ext === "wave") {
+    return "wav";
+  }
+  if (ext === "aiff" || ext === "aif") {
+    return "aiff";
+  }
+  return "wav";
+}
+
+function resolvePrompt(params: { prompt?: string; language?: string }): string {
+  const trimmedPrompt = params.prompt?.trim();
+  const trimmedLanguage = params.language?.trim();
+  if (trimmedPrompt && trimmedLanguage) {
+    return `${trimmedPrompt}\nExpected language: ${trimmedLanguage}.`;
+  }
+  if (trimmedPrompt) {
+    return trimmedPrompt;
+  }
+  if (trimmedLanguage) {
+    return `${DEFAULT_OPENROUTER_AUDIO_PROMPT}\nExpected language: ${trimmedLanguage}.`;
+  }
+  return DEFAULT_OPENROUTER_AUDIO_PROMPT;
+}
+
+function coerceOpenRouterText(payload: OpenRouterChatCompletionPayload): string | null {
+  const content = payload.choices?.[0]?.message?.content;
+  if (typeof content === "string") {
+    const trimmed = content.trim();
+    return trimmed || null;
+  }
+  if (Array.isArray(content)) {
+    const text = content
+      .map((part) => (typeof part.text === "string" ? part.text.trim() : ""))
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+    return text || null;
+  }
+  return null;
+}
+
+export async function transcribeOpenRouterAudio(
+  params: AudioTranscriptionRequest,
+): Promise<AudioTranscriptionResult> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const baseUrl = normalizeBaseUrl(params.baseUrl, DEFAULT_OPENROUTER_AUDIO_BASE_URL);
+  const allowPrivate = Boolean(params.baseUrl?.trim());
+  const model = params.model?.trim() || DEFAULT_OPENROUTER_AUDIO_MODEL;
+  const url = `${baseUrl}/chat/completions`;
+
+  const headers = new Headers(params.headers);
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "application/json");
+  }
+  if (!headers.has("authorization")) {
+    headers.set("authorization", `Bearer ${params.apiKey}`);
+  }
+
+  const body = {
+    model,
+    stream: false,
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: resolvePrompt(params) },
+          {
+            type: "input_audio",
+            input_audio: {
+              data: params.buffer.toString("base64"),
+              format: resolveAudioFormat(params),
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  const { response: res, release } = await postJsonRequest({
+    url,
+    headers,
+    body,
+    timeoutMs: params.timeoutMs,
+    fetchFn,
+    allowPrivateNetwork: allowPrivate,
+  });
+
+  try {
+    await assertOkOrThrowHttpError(res, "Audio transcription failed");
+    const payload = (await res.json()) as OpenRouterChatCompletionPayload;
+    const text = coerceOpenRouterText(payload);
+    if (!text) {
+      throw new Error("Audio transcription response missing text");
+    }
+    return { text, model };
+  } finally {
+    await release();
+  }
+}
+
+export const openrouterMediaUnderstandingProvider: MediaUnderstandingProvider = {
+  id: "openrouter",
+  capabilities: ["audio"],
+  transcribeAudio: transcribeOpenRouterAudio,
+};


### PR DESCRIPTION
## Summary

- Problem: External multimodal models routed through `openrouter/...` could not be used for inbound audio transcription, because OpenClaw had no OpenRouter media-understanding provider and never sent audio payloads to OpenRouter for STT.
- Why it matters: Voice notes from channels like Telegram could only be transcribed via local CLIs or dedicated STT providers; selecting an external model like `openrouter/google/gemini-3-flash-preview` did not actually enable audio transcription.
- What changed: Added an OpenRouter audio media-understanding provider that sends `input_audio` via `chat/completions`, registered it in the OpenRouter plugin, added focused tests, and documented the config and behavior.
- What did NOT change (scope boundary): No auto-detection changes, no Telegram-specific routing changes, no generic “all external models can now take audio in the main chat pipeline” change; this is only for `tools.media.audio` transcription.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: OpenRouter on `main` registered only a text-model provider and no media-understanding provider, so `tools.media.audio.models: [{ provider: "openrouter", ... }]` had no valid provider path for transcription. Also, the existing shared audio helper targets OpenAI-style `/audio/transcriptions`, while OpenRouter multimodal audio uses `chat/completions` with `input_audio`.
- Missing detection / guardrail: No provider registration test asserted that OpenRouter exposes a media-understanding surface, and no provider-level test covered audio transcription request shape for OpenRouter.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Existing audio provider patterns already existed for OpenAI, Groq, Deepgram, and Mistral, but OpenRouter had not been wired into that layer on `main`.
- Why this regressed now: Not a recent regression in code behavior; it was a functional gap that became visible once we tried to use OpenRouter Gemini as the transcription backend.
- If unknown, what was ruled out: Ruled out config-only fixes; the missing piece was runtime provider support, not just docs or config schema.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/openrouter/media-understanding-provider.test.ts`
  - `extensions/openrouter/index.test.ts`
- Scenario the test should lock in:
  - OpenRouter registers a media-understanding provider.
  - Audio transcription uses `https://openrouter.ai/api/v1/chat/completions`.
  - Request body includes `input_audio`.
  - Configured model like `google/gemini-3-flash-preview` is passed through.
- Why this is the smallest reliable guardrail: The failure was at provider registration and provider request-shape level; unit/seam coverage there catches the bug without needing a full channel e2e.
- Existing test that already covers this (if any): None before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- OpenClaw can now transcribe inbound audio via OpenRouter when explicitly configured in `tools.media.audio.models`.
- Example supported config:
  - `{ provider: "openrouter", model: "google/gemini-3-flash-preview" }`
- Documentation now explains that external `openrouter/...` model refs previously did not receive audio input for transcription, and that this PR adds a dedicated media-transcription path for them.
- Auto-detection behavior is unchanged.

## Diagram (if applicable)

```text
Before:
[Telegram voice note] -> [tools.media.audio] -> [no OpenRouter media provider] -> [cannot transcribe via openrouter/gemini]

After:
[Telegram voice note] -> [tools.media.audio]
  -> [provider=openrouter, model=google/gemini-3-flash-preview]
  -> [OpenRouter chat/completions + input_audio]
  -> [transcript]
  -> [inbound message context]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): Yes
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation:
  - This adds a new outbound audio-transcription capability via OpenRouter for users who explicitly configure `provider: "openrouter"` under `tools.media.audio.models`.
  - Risk: audio bytes may now be sent to OpenRouter when that provider is selected.
  - Mitigation: behavior is opt-in only, uses the existing `tools.media.audio` path, respects existing size/time limits, reuses standard provider auth, and does not change auto-detection defaults.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm repo workflow
- Model/provider: OpenRouter, example model `google/gemini-3-flash-preview`
- Integration/channel (if any): generic `tools.media.audio` pipeline; applicable to Telegram voice-note ingestion once configured
- Relevant config (redacted):

```json5
{
  tools: {
    media: {
      audio: {
        enabled: true,
        models: [{ provider: "openrouter", model: "google/gemini-3-flash-preview" }],
      },
    },
  },
}
```

### Steps

1. Configure `tools.media.audio.models` with `provider: "openrouter"` and an OpenRouter multimodal model such as `google/gemini-3-flash-preview`.
2. Send or process an inbound audio attachment through the normal media-audio pipeline.
3. Observe that OpenClaw uses the OpenRouter media-understanding provider and submits audio through `chat/completions` with `input_audio`.

### Expected

- Audio is transcribed through OpenRouter and the transcript is returned to the media-understanding pipeline.

### Actual

- After this PR, that path works; before this PR, OpenRouter had no media-understanding transcription path and could not be used for this purpose.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test -- extensions/openrouter/media-understanding-provider.test.ts`
  - `pnpm test -- extensions/openrouter/index.test.ts`
  - `pnpm check:bundled-plugin-metadata`
  - `pnpm plugin-sdk:check-exports`
  - `pnpm exec oxfmt --check docs/nodes/audio.md extensions/openrouter/index.test.ts extensions/openrouter/index.ts extensions/openrouter/media-understanding-provider.test.ts extensions/openrouter/media-understanding-provider.ts`
- Edge cases checked:
  - default OpenRouter endpoint/model
  - explicit base URL override
  - explicit model override
  - prompt + language hint composition
  - request contains `input_audio` with expected format mapping
- What you did **not** verify:
  - live OpenRouter transcription against a real account/model
  - end-to-end Telegram voice-note flow on a deployed environment

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:
  - N/A

## Risks and Mitigations

- Risk: Some OpenRouter models may reject `input_audio` even if a user selects them for transcription.
  - Mitigation: This path is explicit/opt-in; users choose the model in `tools.media.audio.models`, and failures stay within the existing per-model fallback behavior of the audio pipeline.
- Risk: OpenRouter request/response shape could differ for some vendors/models.
  - Mitigation: Added focused request-shape tests and kept implementation isolated to a dedicated OpenRouter media provider, making future adjustments local.
- Risk: Reviewers may assume this changes generic main-chat multimodal audio support.
  - Mitigation: Docs and summary explicitly scope this to `tools.media.audio` transcription only.