### PR TITLE
fix(config): Prevent UI save crashes by correctly un-redacting Secret…

### DIFF
--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -602,6 +602,29 @@ function restoreGuessingArray(
 }
 
 /**
+ * Attempts to re-map a SecretRef shape safely from original.
+ */
+function tryRestoreSecretRef(
+  incoming: unknown,
+  orig: Record<string, unknown>,
+  prefix: string,
+): Record<string, unknown> | undefined {
+  if (isSecretRefShape(incoming as Record<string, unknown>)) {
+    const incomingRef = incoming as Record<string, unknown>;
+    if (incomingRef.id === REDACTED_SENTINEL) {
+      if (!("id" in orig)) {
+        throw new RedactionError(prefix ? `${prefix}.id` : "id");
+      }
+      return {
+        ...incomingRef,
+        id: orig.id,
+      };
+    }
+  }
+  return undefined;
+}
+
+/**
  * Worker for restoreRedactedValues().
  * Used when there are ConfigUiHints available.
  */
@@ -644,6 +667,10 @@ function restoreRedactedValuesWithLookup(
     });
   }
   const orig = toObjectRecord(original);
+
+  const restoredSecretRef = tryRestoreSecretRef(incoming, orig, prefix);
+  if (restoredSecretRef) return restoredSecretRef;
+
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(incoming as Record<string, unknown>)) {
     result[key] = value;
@@ -704,6 +731,10 @@ function restoreRedactedValuesGuessing(
     return restoreGuessingArray(incomingArray, original, path, hints);
   }
   const orig = toObjectRecord(original);
+
+  const restoredSecretRef = tryRestoreSecretRef(incoming, orig, prefix);
+  if (restoredSecretRef) return restoredSecretRef;
+
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(incoming as Record<string, unknown>)) {
     const path = prefix ? `${prefix}.${key}` : key;


### PR DESCRIPTION
Fixes a consistent crash that prevented users from saving settings via the OpenClaw Web UI.

When attempting to save the configuration, the gateway would throw the following validation error: GatewayRequestError: invalid config: gateway.auth.token.id: Env secret reference id must match /^[A-Z][A-Z0-9_]{0,127}$/

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

Problem: Saving configurations via the OpenClaw Web UI crashes explicitly with invalid config: gateway.auth.token.id: Env secret reference id must match /^[A-Z][A-Z0-9_]{0,127}$/ when a SecretRef is present.

Why it matters: Users are completely blocked from updating their settings via the interface since standard secret masking behavior triggers a hard validation loop crash.

What changed: Added [tryRestoreSecretRef](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [redact-snapshot.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to intercept SecretRef shapes during inbound un-redaction. It detects __OPENCLAW_REDACTED__ ids and safely maps them back to their initial un-redacted state.

What did NOT change (scope boundary): Did not alter standard primitive masking, did not remove the strict Zod regex guardrails for SecretRef configurations.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The UI dynamically posts back masked objects where passwords and [SecretRef.id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) fields are rewritten as __OPENCLAW_REDACTED__. The backend un-redaction sweep failed to identify SecretRef objects in its loop correctly, skipping the un-redaction step. Consequently, Zod evaluated the raw __OPENCLAW_REDACTED__ literal string against its strict environment variable Regex pattern, causing an immediate drop.
- Missing detection / guardrail: [restoreRedactedValues](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) test coverage lacked an inbound round-trip serialization edge-case for nested SecretRef objects simulating the UI response format.
- Prior context (`git blame`, prior PR, issue, or refactor if known):
- Why this regressed now:
- If unknown, what was ruled out:

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

Users can now successfully save and update configs in the Web UI, even if they have active environment secret references (e.g., gateway.auth.token).

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[UI Save] -> payload with {id: "__OPENCLAW_REDACTED__"} -> [Un-masking misses SecretRefs] -> [Zod Regex Fails] -> Crash

After:
[UI Save] -> payload with {id: "__OPENCLAW_REDACTED__"} -> [tryRestoreSecretRef hooks object] -> {id: "ORIGINAL_ENV_VAR"} -> [Zod Regex Passes] -> Config Saved```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

Explicitly modified how secret shapes are decoded upon inbound gateway requests. The risk of exposing secrets is mitigated because we are specifically taking the [REDACTED_SENTINEL](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) payload from the user and safely translating it to the server's existing state mapping ([orig.id](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) rather than executing arbitrary values.

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1. Bind a SecretRef inside openclaw.yaml config (e.g., an auth token matching standard regex bounds).
2. Start the gateway and navigate to the Web UI Settings tab.
3. Attempt to save the settings without making credential changes.


### Expected

- Configuration persists smoothly without breaking or dropping user state.

### Actual

-

## Evidence

Throws: GatewayRequestError: invalid config: gateway.auth.token.id: Env secret reference id must match /^[A-Z][A-Z0-9_]{0,127}$/

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Broadly un-redacting items incorrectly formatted or impersonating a Secret Reference shape.
  - Mitigation: Logic relies on strict [isSecretRefShape](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) guarding. Re-mapping extracts exclusively from the [orig](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) dictionary which acts as the trusted backend source of truth, keeping client-driven modifications bounded manipulation impossible.
