### PR TITLE
fix(voice-call): read telnyx transcription_data fields

### DIFF
--- a/extensions/voice-call/src/providers/telnyx.test.ts
+++ b/extensions/voice-call/src/providers/telnyx.test.ts
@@ -185,4 +185,42 @@ describe("TelnyxProvider.parseWebhookEvent", () => {
     }
     expect(event.dedupeKey).toBe("telnyx:req:abc");
   });
+
+  it("maps transcription_data payloads into call.speech events", () => {
+    const provider = new TelnyxProvider({
+      apiKey: "KEY123",
+      connectionId: "CONN456",
+      publicKey: undefined,
+    });
+    const result = provider.parseWebhookEvent(
+      createCtx({
+        rawBody: JSON.stringify({
+          data: {
+            id: "evt-tx",
+            event_type: "call.transcription",
+            payload: {
+              call_control_id: "call-2",
+              transcription_data: {
+                transcript: "pineapple",
+                is_final: true,
+                confidence: 0.286865,
+              },
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(result.events).toHaveLength(1);
+    const event = result.events[0];
+    expect(event).toMatchObject({
+      id: "evt-tx",
+      type: "call.speech",
+      callId: "call-2",
+      providerCallId: "call-2",
+      transcript: "pineapple",
+      isFinal: true,
+      confidence: 0.286865,
+    });
+  });
 });

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -166,12 +166,13 @@ export class TelnyxProvider implements VoiceCallProvider {
         };
 
       case "call.transcription":
+        const transcriptionData = data.payload?.transcription_data;
         return {
           ...baseEvent,
           type: "call.speech",
-          transcript: data.payload?.transcription || "",
-          isFinal: data.payload?.is_final ?? true,
-          confidence: data.payload?.confidence,
+          transcript: transcriptionData?.transcript || data.payload?.transcription || "",
+          isFinal: transcriptionData?.is_final ?? data.payload?.is_final ?? true,
+          confidence: transcriptionData?.confidence ?? data.payload?.confidence,
         };
 
       case "call.hangup":
@@ -340,6 +341,12 @@ interface TelnyxEvent {
     transcription?: string;
     is_final?: boolean;
     confidence?: number;
+    transcription_data?: {
+      transcript?: string;
+      is_final?: boolean;
+      confidence?: number;
+      [key: string]: unknown;
+    };
     hangup_cause?: string;
     digit?: string;
     [key: string]: unknown;

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -165,7 +165,7 @@ export class TelnyxProvider implements VoiceCallProvider {
           text: data.payload?.text || "",
         };
 
-      case "call.transcription":
+      case "call.transcription": {
         const transcriptionData = data.payload?.transcription_data;
         return {
           ...baseEvent,
@@ -174,6 +174,7 @@ export class TelnyxProvider implements VoiceCallProvider {
           isFinal: transcriptionData?.is_final ?? data.payload?.is_final ?? true,
           confidence: transcriptionData?.confidence ?? data.payload?.confidence,
         };
+      }
 
       case "call.hangup":
         return {


### PR DESCRIPTION
## Summary
- read Telnyx transcription fields from `payload.transcription_data` when handling `call.transcription` events
- keep compatibility with older flat payload fields as a fallback
- add a regression test that proves a valid nested Telnyx payload produces a populated `call.speech`

## Root Cause
The provider mapped transcript fields from the top-level payload, but Telnyx sends them inside `transcription_data`. That left valid transcription events with empty transcript content.

## Scope
- changes only the Telnyx transcription-event mapper and its provider test coverage
- does not change webhook verification, other providers, or speech event semantics outside this payload mapping fix

## Testing
- `pnpm exec vitest run extensions/voice-call/src/providers/telnyx.test.ts`
- `pnpm build`
- `pnpm check`
- `pnpm test`

## Screenshots
- Not applicable

Resubmission of #56018 after reducing the active PR queue. No code changes from the original submission.

Closes #55956
