### PR TITLE
fix(plugins): fall back to npm on clawhub request failures

### DIFF
--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -117,6 +117,7 @@ vi.mock("../hooks/installs.js", () => ({
 vi.mock("../plugins/clawhub.js", () => ({
   CLAWHUB_INSTALL_ERROR_CODE: {
     PACKAGE_NOT_FOUND: "package_not_found",
+    REQUEST_FAILED: "request_failed",
     VERSION_NOT_FOUND: "version_not_found",
   },
   installPluginFromClawHub: (...args: unknown[]) => installPluginFromClawHub(...args),

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -346,6 +346,52 @@ describe("plugins cli install", () => {
     );
   });
 
+  it("falls back to npm when ClawHub request resolution fails before install", async () => {
+    const cfg = {
+      plugins: {
+        entries: {},
+      },
+    } as OpenClawConfig;
+    const enabledCfg = createEnabledPluginConfig("demo");
+
+    loadConfig.mockReturnValue(cfg);
+    installPluginFromClawHub.mockResolvedValue({
+      ok: false,
+      error: "fetch failed",
+      code: "request_failed",
+    });
+    installPluginFromNpmSpec.mockResolvedValue({
+      ok: true,
+      pluginId: "demo",
+      targetDir: "/tmp/openclaw-state/extensions/demo",
+      version: "1.2.3",
+      npmResolution: {
+        packageName: "demo",
+        resolvedVersion: "1.2.3",
+        tarballUrl: "https://registry.npmjs.org/demo/-/demo-1.2.3.tgz",
+      },
+    });
+    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
+    recordPluginInstall.mockReturnValue(enabledCfg);
+    applyExclusiveSlotSelection.mockReturnValue({
+      config: enabledCfg,
+      warnings: [],
+    });
+
+    await runPluginsCommand(["plugins", "install", "demo"]);
+
+    expect(installPluginFromClawHub).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "clawhub:demo",
+      }),
+    );
+    expect(installPluginFromNpmSpec).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "demo",
+      }),
+    );
+  });
+
   it("does not fall back to npm when ClawHub rejects a real package", async () => {
     installPluginFromClawHub.mockResolvedValue({
       ok: false,

--- a/src/cli/plugins-command-helpers.ts
+++ b/src/cli/plugins-command-helpers.ts
@@ -165,6 +165,7 @@ export function decidePreferredClawHubFallback(params: {
   code?: string;
 }): PreferredClawHubFallbackDecision {
   if (
+    params.code === CLAWHUB_INSTALL_ERROR_CODE.REQUEST_FAILED ||
     params.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
     params.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND
   ) {

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -197,4 +197,15 @@ describe("installPluginFromClawHub", () => {
       error: "Version not found on ClawHub: demo@9.9.9.",
     });
   });
+
+  it("returns typed request failures for package resolution errors", async () => {
+    expect(CLAWHUB_INSTALL_ERROR_CODE.REQUEST_FAILED).toBe("request_failed");
+    fetchClawHubPackageDetailMock.mockRejectedValueOnce(new Error("fetch failed"));
+
+    await expect(installPluginFromClawHub({ spec: "clawhub:demo" })).resolves.toMatchObject({
+      ok: false,
+      code: CLAWHUB_INSTALL_ERROR_CODE.REQUEST_FAILED,
+      error: "fetch failed",
+    });
+  });
 });

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -21,6 +21,7 @@ export const CLAWHUB_INSTALL_ERROR_CODE = {
   INVALID_SPEC: "invalid_spec",
   PACKAGE_NOT_FOUND: "package_not_found",
   VERSION_NOT_FOUND: "version_not_found",
+  REQUEST_FAILED: "request_failed",
   NO_INSTALLABLE_VERSION: "no_installable_version",
   SKILL_PACKAGE: "skill_package",
   UNSUPPORTED_FAMILY: "unsupported_family",
@@ -82,7 +83,10 @@ function mapClawHubRequestError(
       CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND,
     );
   }
-  return buildClawHubInstallFailure(error instanceof Error ? error.message : String(error));
+  return buildClawHubInstallFailure(
+    error instanceof Error ? error.message : String(error),
+    CLAWHUB_INSTALL_ERROR_CODE.REQUEST_FAILED,
+  );
 }
 
 function resolveRequestedVersion(params: {


### PR DESCRIPTION
## Summary
- classify non-404 ClawHub request failures as a retryable lookup failure
- fall back to npm when the ClawHub-first resolution path fails during package or version lookup
- add regression coverage for both the ClawHub error mapping and the CLI fallback behavior

## Root Cause
The documented install flow is ClawHub first and npm second, but request-stage failures during ClawHub package resolution were surfaced as hard errors instead of a fallback signal. That prevented npm fallback for transient or transport-level failures.

## Scope
- changes only ClawHub error classification, fallback selection, and related test coverage
- does not change explicit `clawhub:` installs or later-stage install failures after a package has already been selected

## Testing
- `pnpm exec vitest run src/plugins/clawhub.test.ts src/cli/plugins-cli.install.test.ts`
- `pnpm build`
- `pnpm check`
- `pnpm test`

## Screenshots
- Not applicable

Resubmission of #56020 after reducing the active PR queue. No code changes from the original submission.

Closes #55805
