### PR TITLE
fix(discord): restore uploadUrlRequest arg to RateLimitError in voice-message

### DIFF
--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -639,6 +639,7 @@ describe("monitorDiscordProvider", () => {
         retry_after: 193.632,
         global: false,
       },
+      request,
     );
     rateLimitError.discordCode = 30034;
     clientHandleDeployRequestMock.mockRejectedValueOnce(rateLimitError);

--- a/extensions/discord/src/send.creates-thread.test.ts
+++ b/extensions/discord/src/send.creates-thread.test.ts
@@ -427,7 +427,7 @@ function createMockRateLimitError(retryAfter = 0.001): RateLimitError {
     message: "You are being rate limited.",
     retry_after: retryAfter,
     global: false,
-  });
+  }, request);
 }
 
 describe("retry rate limits", () => {

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -283,11 +283,15 @@ export async function sendDiscordVoiceMessage(
           retry_after?: number;
           global?: boolean;
         };
-        throw new RateLimitError(res, {
-          message: retryData.message ?? "You are being rate limited.",
-          retry_after: retryData.retry_after ?? 1,
-          global: retryData.global ?? false,
-        });
+        throw new RateLimitError(
+          res,
+          {
+            message: retryData.message ?? "You are being rate limited.",
+            retry_after: retryData.retry_after ?? 1,
+            global: retryData.global ?? false,
+          },
+          uploadUrlRequest,
+        );
       }
       const errorBody = (await res.json().catch(() => null)) as {
         code?: number;


### PR DESCRIPTION
## Summary
Restores the dropped `uploadUrlRequest` argument to `RateLimitError` in the Discord voice-message upload path, and updates the matching Discord tests to use the current constructor signature.

## What changes
- `extensions/discord/src/voice-message.ts`: pass `uploadUrlRequest` as the third `RateLimitError` argument
- `extensions/discord/src/monitor/provider.test.ts`: pass the request object when constructing `RateLimitError`
- `extensions/discord/src/send.creates-thread.test.ts`: pass the request object when constructing `RateLimitError`

## Why
A regression removed the request argument from these callsites. That leaves `upstream/main` red on the Discord rate-limit path and breaks the affected tests/typecheck.

## Scope
Discord only. No behavior change beyond restoring the intended `RateLimitError` construction.

## Verification
- `pnpm test -- --run extensions/discord/src/voice-message.test.ts extensions/discord/src/monitor/provider.test.ts extensions/discord/src/send.creates-thread.test.ts`

## Notes
`upstream/main` still has unrelated TypeScript failures outside this change, including `src/agents/skills/source.ts`. Those are out of scope here.
