### PR TITLE
docs(nextcloud-talk): document required response feature

### DIFF
--- a/docs/channels/nextcloud-talk.md
+++ b/docs/channels/nextcloud-talk.md
@@ -36,7 +36,7 @@ Details: [Plugins](/tools/plugin)
 2. On your Nextcloud server, create a bot:
 
    ```bash
-   ./occ talk:bot:install "OpenClaw" "<shared-secret>" "<webhook-url>" --feature reaction
+   ./occ talk:bot:install "OpenClaw" "<shared-secret>" "<webhook-url>" --feature webhook --feature response --feature reaction
    ```
 
 3. Enable the bot in the target room settings.
@@ -63,6 +63,7 @@ Minimal config:
 ## Notes
 
 - Bots cannot initiate DMs. The user must message the bot first.
+- If inbound webhooks work but every reply fails with HTTP 401, re-register the bot with `--feature response`. Without it, Nextcloud accepts the webhook but rejects outbound bot messages.
 - Webhook URL must be reachable by the Gateway; set `webhookPublicUrl` if behind a proxy.
 - Media uploads are not supported by the bot API; media is sent as URLs.
 - The webhook payload does not distinguish DMs vs rooms; set `apiUser` + `apiPassword` to enable room-type lookups (otherwise DMs are treated as rooms).

--- a/docs/zh-CN/channels/nextcloud-talk.md
+++ b/docs/zh-CN/channels/nextcloud-talk.md
@@ -42,7 +42,7 @@ OpenClaw 将自动提供本地安装路径。
 1. 安装 Nextcloud Talk 插件。
 2. 在你的 Nextcloud 服务器上创建机器人：
    ```bash
-   ./occ talk:bot:install "OpenClaw" "<shared-secret>" "<webhook-url>" --feature reaction
+   ./occ talk:bot:install "OpenClaw" "<shared-secret>" "<webhook-url>" --feature webhook --feature response --feature reaction
    ```
 3. 在目标房间设置中启用机器人。
 4. 配置 OpenClaw：
@@ -68,6 +68,7 @@ OpenClaw 将自动提供本地安装路径。
 ## 注意事项
 
 - 机器人无法主动发起私信。用户必须先向机器人发送消息。
+- 如果入站 webhook 正常，但每次回复都返回 HTTP 401，请用 `--feature response` 重新注册机器人。缺少这个能力时，Nextcloud 会接收 webhook，但拒绝机器人向会话回消息。
 - Webhook URL 必须可被 Gateway 网关访问；如果在代理后面，请设置 `webhookPublicUrl`。
 - 机器人 API 不支持媒体上传；媒体以 URL 形式发送。
 - Webhook 载荷无法区分私信和房间；设置 `apiUser` + `apiPassword` 以启用房间类型查询（否则私信将被视为房间）。


### PR DESCRIPTION
## Summary
- update the Nextcloud Talk bot install command to include `--feature webhook --feature response --feature reaction`
- add a short troubleshooting note for the common HTTP 401 case when the bot was registered without `--feature response`
- AI-assisted

## Test plan
- [x] `oxfmt --check docs/channels/nextcloud-talk.md docs/zh-CN/channels/nextcloud-talk.md`
- [x] `pnpm dlx markdownlint-cli2 docs/channels/nextcloud-talk.md docs/zh-CN/channels/nextcloud-talk.md`
- [x] manually reviewed the English and zh-CN setup steps for consistency
- [x] `node scripts/docs-link-audit.mjs` still reports pre-existing unrelated broken links in other zh-CN docs

References #53982

Made with [Cursor](https://cursor.com)