### PR TITLE
fix: use American English spelling in code comments

### DIFF
--- a/extensions/browser/src/browser/cdp-proxy-bypass.ts
+++ b/extensions/browser/src/browser/cdp-proxy-bypass.ts
@@ -19,7 +19,7 @@ const directHttpsAgent = new https.Agent();
 /**
  * Returns a plain (non-proxy) agent for WebSocket or HTTP connections
  * when the target is a loopback address. Returns `undefined` otherwise
- * so callers fall through to their default behaviour.
+ * so callers fall through to their default behavior.
  */
 export function getDirectAgentForCdp(url: string): http.Agent | https.Agent | undefined {
   try {

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -162,7 +162,7 @@ async function writeCachedCommandHash(
     await fs.writeFile(filePath, hash, "utf-8");
   } catch {
     // Best-effort: failing to cache the hash just means the next restart
-    // will sync commands again, which is the pre-fix behaviour.
+    // will sync commands again, which is the pre-fix behavior.
   }
 }
 

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -62,7 +62,7 @@ export function formatDuplicateTelegramTokenReason(params: {
  * block channel-level fallthrough for the given accountId.  This mirrors the
  * guard in `token.ts` so that status-check functions (`isConfigured`,
  * `unconfiguredReason`, `describeAccount`) stay consistent with the gateway
- * runtime behaviour.
+ * runtime behavior.
  *
  * The guard fires when:
  *   1. The accountId is not the default account, AND

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -4,7 +4,7 @@
  * Wraps `OpenAIWebSocketManager` in a `StreamFn` that can be plugged into the
  * pi-embedded-runner agent in place of the default `streamSimple` HTTP function.
  *
- * Key behaviours:
+ * Key behaviors:
  *  - Per-session `OpenAIWebSocketManager` (keyed by sessionId)
  *  - Tracks `previous_response_id` to send only incremental tool-result inputs
  *  - Falls back to `streamSimple` (HTTP) if the WebSocket connection fails

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -306,7 +306,7 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
           // Flat-params recovery: non-frontier models (e.g. Grok) sometimes flatten
           // job properties to the top level alongside `action` instead of nesting
           // them inside `job`. When `params.job` is missing or empty, reconstruct
-          // a synthetic job object from any recognised top-level job fields.
+          // a synthetic job object from any recognized top-level job fields.
           // See: https://github.com/openclaw/openclaw/issues/11310
           if (
             !params.job ||

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -79,7 +79,7 @@ function contentTypeForExt(ext: string): string {
 }
 
 /**
- * Extensions recognised as static assets.  Missing files with these extensions
+ * Extensions recognized as static assets.  Missing files with these extensions
  * return 404 instead of the SPA index.html fallback.  `.html` is intentionally
  * excluded — actual HTML files on disk are served earlier, and missing `.html`
  * paths should fall through to the SPA router (client-side routers may use


### PR DESCRIPTION
## Summary

- **Problem:** Several code comments use British English spelling (`behaviour`, `recognised`) which violates the repo's American English style guide.
- **Why it matters:** Consistent spelling across the codebase per the documented style guide (`CONTRIBUTING.md`, `AGENTS.md`).
- **What changed:** 6 comment-only edits: `behaviour` → `behavior` (4 files), `recognised` → `recognized` (2 files).
- **What did NOT change (scope boundary):** No logic, no runtime behavior, no tests, no user-facing strings.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: N/A (comment-only changes)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Search for `behaviour` and `recognised` in `src/` and `extensions/` production `.ts` files
2. Verify all matches are in comments/docstrings only
3. Replace with American English equivalents (`behavior`, `recognized`)

### Expected

- No British spellings of `behaviour` or `recognised` in production source comments

### Actual

- 6 instances found and fixed across 6 files

## Evidence

- [x] Trace/log snippets

Files changed (comment-only, no logic):
- `src/agents/openai-ws-stream.ts:7` — `behaviours` → `behaviors`
- `src/gateway/control-ui.ts:82` — `recognised` → `recognized`
- `src/agents/tools/cron-tool.ts:309` — `recognised` → `recognized`
- `extensions/telegram/src/shared.ts:65` — `behaviour` → `behavior`
- `extensions/telegram/src/bot-native-command-menu.ts:165` — `behaviour` → `behavior`
- `extensions/browser/src/browser/cdp-proxy-bypass.ts:22` — `behaviour` → `behavior`

## Human Verification (required)

- Verified scenarios: Searched all `.ts` files in `src/` and `extensions/` for `behaviour` and `recognised`; confirmed all 6 hits are in comments/docstrings only.
- Edge cases checked: Verified no runtime strings, variable names, or test assertions use these spellings.
- What you did **not** verify: Did not run full test suite (changes are comment-only with zero runtime impact).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None.