### PR TITLE
fix(memory-lancedb): add missing radix to parseInt call

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -506,7 +506,7 @@ export default definePluginEntry({
           .option("--limit <n>", "Max results", "5")
           .action(async (query, opts) => {
             const vector = await embeddings.embed(query);
-            const results = await db.search(vector, parseInt(opts.limit), 0.3);
+            const results = await db.search(vector, Number.parseInt(opts.limit, 10), 0.3);
             // Strip vectors for output
             const output = results.map((r) => ({
               id: r.entry.id,


### PR DESCRIPTION
## Summary

- **Problem:** `extensions/memory-lancedb/index.ts` uses bare `parseInt(opts.limit)` without a radix, which can misparse inputs with leading zeros or unexpected prefixes.
- **Why it matters:** Every other `parseInt` call site in the repo (30+) uses `Number.parseInt(..., 10)` with an explicit radix. This is the only outlier, and omitting the radix is a known source of subtle parsing bugs.
- **What changed:** Replaced `parseInt(opts.limit)` with `Number.parseInt(opts.limit, 10)` to match repo convention and ensure base-10 parsing.
- **What did NOT change (scope boundary):** No logic, no new dependencies, no other files touched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Original code used bare `parseInt()` without a radix parameter.
- Missing detection / guardrail: No lint rule enforcing `radix` for `parseInt` calls in this extension.
- Prior context: The file was added without the radix; rest of the repo already follows the `Number.parseInt(..., 10)` convention.
- Why this regressed now: It didn't regress — it was always missing.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- If no new test is added, why not: The fix is a one-token change (`parseInt` → `Number.parseInt` + radix). The CLI option has a hardcoded default of `"5"`, so the only way to trigger misparsing would be a user passing an unusual string like `"010"`. A test would be disproportionate to the risk.

## User-visible / Behavior Changes

None under normal usage. Edge case: if a user passed `--limit 010`, `parseInt` without radix would return `10` in modern engines (but `8` in legacy octal mode). With the fix it always returns `10`.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / Bun
- Model/provider: N/A
- Integration/channel (if any): memory-lancedb plugin
- Relevant config (redacted): N/A

### Steps

1. Open `extensions/memory-lancedb/index.ts`
2. Search for `parseInt` — line 509 is the only call without a radix
3. Compare with the 30+ other `Number.parseInt(..., 10)` calls across the repo

### Expected

- All `parseInt` calls use an explicit radix and `Number.parseInt` form

### Actual

- Line 509 used bare `parseInt(opts.limit)` without radix — now fixed

## Evidence

- [x] Trace/log snippets

```bash
# Before (only match without radix in the entire repo):
rg 'parseInt\([^,)]+\)' --type ts --glob '!*.test.ts'
# extensions/memory-lancedb/index.ts:509:  const results = await db.search(vector, parseInt(opts.limit), 0.3);

# After: no matches