### PR TITLE
Fix #55802 and #55849: exec obfuscation config and sessionKey in transcript header

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -67,6 +67,8 @@ export type ProcessGatewayAllowlistParams = {
   maxOutput: number;
   pendingMaxOutput: number;
   trustedSafeBinDirs?: ReadonlySet<string>;
+  /** Maximum command length before triggering obfuscation detection. Default: 10000. */
+  maxCommandChars?: number;
 };
 
 export type ProcessGatewayAllowlistResult = {
@@ -124,7 +126,9 @@ export async function processGatewayAllowlist(
     }
     enforcedCommand = enforced.command;
   }
-  const obfuscation = detectCommandObfuscation(params.command);
+  const obfuscation = detectCommandObfuscation(params.command, {
+    maxCommandChars: params.maxCommandChars,
+  });
   if (obfuscation.detected) {
     logInfo(`exec: obfuscation detected (gateway): ${obfuscation.reasons.join(", ")}`);
     params.warnings.push(`⚠️ Obfuscated command detected: ${obfuscation.reasons.join("; ")}`);

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -53,6 +53,8 @@ export type ExecuteNodeHostCommandParams = {
   warnings: string[];
   notifySessionKey?: string;
   trustedSafeBinDirs?: ReadonlySet<string>;
+  /** Maximum command length before triggering obfuscation detection. Default: 10000. */
+  maxCommandChars?: number;
 };
 
 export async function executeNodeHostCommand(
@@ -183,7 +185,9 @@ export async function executeNodeHostCommand(
       // Fall back to requiring approval if node approvals cannot be fetched.
     }
   }
-  const obfuscation = detectCommandObfuscation(params.command);
+  const obfuscation = detectCommandObfuscation(params.command, {
+    maxCommandChars: params.maxCommandChars,
+  });
   if (obfuscation.detected) {
     logInfo(
       `exec: obfuscation detected (node=${nodeQuery ?? "default"}): ${obfuscation.reasons.join(", ")}`,

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -28,6 +28,8 @@ export type ExecToolDefaults = {
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   cwd?: string;
+  /** Maximum command length before triggering obfuscation detection. Default: 10000. Set to 0 or negative to disable. */
+  maxCommandChars?: number;
 };
 
 export type ExecElevatedDefaults = {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -481,6 +481,7 @@ export function createExecTool(
           warnings,
           notifySessionKey,
           trustedSafeBinDirs,
+          maxCommandChars: defaults?.maxCommandChars,
         });
       }
 
@@ -511,6 +512,7 @@ export function createExecTool(
           maxOutput,
           pendingMaxOutput,
           trustedSafeBinDirs,
+          maxCommandChars: defaults?.maxCommandChars,
         });
         if (gatewayResult.pendingResult) {
           return gatewayResult.pendingResult;

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -175,6 +175,8 @@ export async function ensureSessionHeader(params: {
   sessionFile: string;
   sessionId: string;
   cwd: string;
+  sessionKey?: string;
+  agentId?: string;
 }) {
   const file = params.sessionFile;
   try {
@@ -185,13 +187,19 @@ export async function ensureSessionHeader(params: {
   }
   await fs.mkdir(path.dirname(file), { recursive: true });
   const sessionVersion = 2;
-  const entry = {
+  const entry: Record<string, unknown> = {
     type: "session",
     version: sessionVersion,
     id: params.sessionId,
     timestamp: new Date().toISOString(),
     cwd: params.cwd,
   };
+  if (params.sessionKey) {
+    entry.sessionKey = params.sessionKey;
+  }
+  if (params.agentId) {
+    entry.agentId = params.agentId;
+  }
   await fs.writeFile(file, `${JSON.stringify(entry)}\n`, "utf-8");
 }
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -398,10 +398,16 @@ export async function compactEmbeddedPiSessionDirect(
       : sandbox.workspaceDir
     : resolvedWorkspace;
   await fs.mkdir(effectiveWorkspace, { recursive: true });
+  const { sessionAgentId } = resolveSessionAgentIds({
+    sessionKey: params.sessionKey,
+    config: params.config,
+  });
   await ensureSessionHeader({
     sessionFile: params.sessionFile,
     sessionId: params.sessionId,
     cwd: effectiveWorkspace,
+    sessionKey: params.sessionKey,
+    agentId: sessionAgentId,
   });
 
   let restoreSkillEnv: (() => void) | undefined;

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4694,6 +4694,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                           },
                           additionalProperties: false,
                         },
+                        maxCommandChars: {
+                          type: "integer",
+                          minimum: -9007199254740991,
+                          maximum: 9007199254740991,
+                        },
                         approvalRunningNoticeMs: {
                           type: "integer",
                           minimum: 0,
@@ -7180,6 +7185,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                   },
                 },
                 additionalProperties: false,
+              },
+              maxCommandChars: {
+                type: "integer",
+                minimum: -9007199254740991,
+                maximum: 9007199254740991,
               },
             },
             additionalProperties: false,
@@ -12507,6 +12517,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
       label: "Exec Approval Running Notice (ms)",
       help: "Delay in milliseconds before showing an in-progress notice after an exec approval is granted. Increase to reduce flicker for fast commands, or lower for quicker operator feedback.",
       tags: ["tools"],
+    },
+    "tools.exec.maxCommandChars": {
+      label: "Exec Max Command Chars",
+      help: "Maximum command length (in characters) before triggering obfuscation detection. Commands longer than this threshold are flagged as potentially obfuscated and require approval. Set to 0 or negative to disable the length check. Default: 10000.",
+      tags: ["performance", "tools"],
     },
     "tools.exec.host": {
       label: "Exec Host",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -578,6 +578,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Per-agent provider-specific tool policy overrides for channel-scoped capability control. Use this when a single agent needs tighter restrictions on one provider than others.",
   "tools.exec.approvalRunningNoticeMs":
     "Delay in milliseconds before showing an in-progress notice after an exec approval is granted. Increase to reduce flicker for fast commands, or lower for quicker operator feedback.",
+  "tools.exec.maxCommandChars":
+    "Maximum command length (in characters) before triggering obfuscation detection. Commands longer than this threshold are flagged as potentially obfuscated and require approval. Set to 0 or negative to disable the length check. Default: 10000.",
   "tools.links.enabled":
     "Enable automatic link understanding pre-processing so URLs can be summarized before agent reasoning. Keep enabled for richer context, and disable when strict minimal processing is required.",
   "tools.links.maxLinks":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -180,6 +180,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.exec.notifyOnExit": "Exec Notify On Exit",
   "tools.exec.notifyOnExitEmptySuccess": "Exec Notify On Empty Success",
   "tools.exec.approvalRunningNoticeMs": "Exec Approval Running Notice (ms)",
+  "tools.exec.maxCommandChars": "Exec Max Command Chars",
   "tools.exec.host": "Exec Host",
   "tools.exec.security": "Exec Security",
   "tools.exec.ask": "Exec Ask",

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -67,18 +67,26 @@ export function resolveMirroredTranscriptText(params: {
 async function ensureSessionHeader(params: {
   sessionFile: string;
   sessionId: string;
+  sessionKey?: string;
+  agentId?: string;
 }): Promise<void> {
   if (fs.existsSync(params.sessionFile)) {
     return;
   }
   await fs.promises.mkdir(path.dirname(params.sessionFile), { recursive: true });
-  const header = {
+  const header: Record<string, unknown> = {
     type: "session",
     version: CURRENT_SESSION_VERSION,
     id: params.sessionId,
     timestamp: new Date().toISOString(),
     cwd: process.cwd(),
   };
+  if (params.sessionKey) {
+    header.sessionKey = params.sessionKey;
+  }
+  if (params.agentId) {
+    header.agentId = params.agentId;
+  }
   await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
     encoding: "utf-8",
     mode: 0o600,
@@ -179,7 +187,12 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     };
   }
 
-  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
+  await ensureSessionHeader({
+    sessionFile,
+    sessionId: entry.sessionId,
+    sessionKey,
+    agentId: params.agentId,
+  });
 
   const existingMessageId = params.idempotencyKey
     ? await transcriptHasIdempotencyKey(sessionFile, params.idempotencyKey)

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -277,6 +277,13 @@ export type ExecToolConfig = {
      */
     allowModels?: string[];
   };
+  /**
+   * Maximum command length (in characters) before triggering obfuscation detection.
+   * Commands longer than this threshold will be flagged as potentially obfuscated
+   * and require approval. Set to 0 or negative to disable the length check.
+   * Default: 10000
+   */
+  maxCommandChars?: number;
 };
 
 export type FsToolsConfig = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -433,6 +433,8 @@ const ToolExecBaseShape = {
   notifyOnExit: z.boolean().optional(),
   notifyOnExitEmptySuccess: z.boolean().optional(),
   applyPatch: ToolExecApplyPatchSchema,
+  /** Maximum command length (in characters) before triggering obfuscation detection. Default: 10000. Set to 0 or negative to disable. */
+  maxCommandChars: z.number().int().optional(),
 } as const;
 
 const AgentToolExecSchema = z

--- a/src/infra/exec-obfuscation-detect.test.ts
+++ b/src/infra/exec-obfuscation-detect.test.ts
@@ -203,6 +203,30 @@ describe("detectCommandObfuscation", () => {
       expect(result.matchedPatterns).toContain("command-too-long");
     });
 
+    it("respects custom maxCommandChars threshold", () => {
+      const longCommand = `a=${"x".repeat(100)};b=y;END`;
+      // With default threshold (10000), this should not be flagged
+      expect(detectCommandObfuscation(longCommand).detected).toBe(false);
+      // With custom threshold (50), this should be flagged
+      const result = detectCommandObfuscation(longCommand, { maxCommandChars: 50 });
+      expect(result.detected).toBe(true);
+      expect(result.matchedPatterns).toContain("command-too-long");
+    });
+
+    it("disables length check when maxCommandChars is 0", () => {
+      const veryLongCommand = `a=${"x".repeat(20_000)};b=y;END`;
+      // With threshold 0, length check is disabled
+      const result = detectCommandObfuscation(veryLongCommand, { maxCommandChars: 0 });
+      expect(result.matchedPatterns).not.toContain("command-too-long");
+    });
+
+    it("disables length check when maxCommandChars is negative", () => {
+      const veryLongCommand = `a=${"x".repeat(20_000)};b=y;END`;
+      // With negative threshold, length check is disabled
+      const result = detectCommandObfuscation(veryLongCommand, { maxCommandChars: -1 });
+      expect(result.matchedPatterns).not.toContain("command-too-long");
+    });
+
     it("returns no detection for empty input", () => {
       const result = detectCommandObfuscation("");
       expect(result.detected).toBe(false);

--- a/src/infra/exec-obfuscation-detect.ts
+++ b/src/infra/exec-obfuscation-detect.ts
@@ -17,7 +17,7 @@ type ObfuscationPattern = {
   regex: RegExp;
 };
 
-const MAX_COMMAND_CHARS = 10_000;
+const DEFAULT_MAX_COMMAND_CHARS = 10_000;
 
 const INVISIBLE_UNICODE_CODE_POINTS = new Set<number>([
   0x00ad,
@@ -214,11 +214,21 @@ function shouldSuppressCurlPipeShell(command: string): boolean {
   );
 }
 
-export function detectCommandObfuscation(command: string): ObfuscationDetection {
+export type DetectCommandObfuscationOptions = {
+  /** Maximum command length before triggering obfuscation detection. Default: 10000. Set to 0 or negative to disable. */
+  maxCommandChars?: number;
+};
+
+export function detectCommandObfuscation(
+  command: string,
+  options?: DetectCommandObfuscationOptions,
+): ObfuscationDetection {
   if (!command || !command.trim()) {
     return { detected: false, reasons: [], matchedPatterns: [] };
   }
-  if (command.length > MAX_COMMAND_CHARS) {
+
+  const maxCommandChars = options?.maxCommandChars ?? DEFAULT_MAX_COMMAND_CHARS;
+  if (maxCommandChars > 0 && command.length > maxCommandChars) {
     return {
       detected: true,
       reasons: ["Command too long; potential obfuscation"],


### PR DESCRIPTION
## Summary

This PR fixes two issues:
- **#55802**: Make exec obfuscation command length threshold configurable
- **#55849**: Add sessionKey and agentId to session transcript headers

## Changes

### #55802 - exec obfuscation config
- Add `tools.exec.maxCommandChars` configuration option (default: 10000)
- Allows users to customize the command length threshold for obfuscation detection
- Set to 0 or negative to disable the length check
- Updated types, zod schema, help text, and labels

**Usage:**
```json
{
  "tools": {
    "exec": {
      "maxCommandChars": 50000
    }
  }
}
```

### #55849 - sessionKey in transcript header
- Add `sessionKey` and `agentId` to session transcript headers
- Enables post-reset recovery of orphaned transcript files
- Supports session audit and compaction resilience

**Example header:**
```json
{
  "type": "session",
  "version": 2,
  "id": "...",
  "sessionKey": "agent:main:my-project",
  "agentId": "main",
  "timestamp": "...",
  "cwd": "..."
}
```

## Test Plan
- [x] `pnpm test -- src/infra/exec-obfuscation-detect.test.ts` passes
- [x] `pnpm tsgo` type-check passes
- [x] `pnpm lint` passes
- [x] `pnpm check` passes