### PR TITLE
fix(hooks): load bundled hooks when hooks.internal.enabled is undefined

### DIFF
--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -137,6 +137,30 @@ describe("loader", () => {
       }
     });
 
+    it("loads bundled hooks when hooks.internal.enabled is undefined (#55929)", async () => {
+      // Regression: when enabled is undefined (not explicitly set), bundled hooks
+      // with defaultEnableMode "default-on" should still load.  The old guard
+      // `if (!cfg.hooks?.internal?.enabled)` treated undefined as falsy and
+      // skipped ALL hooks, including bundled ones.
+      const bundledDir = path.join(tmpDir, "bundled-hooks");
+      await writeDiscoveredHook({
+        sourceDir: bundledDir,
+        hookName: "session-memory",
+        handlerCode:
+          'export default async function(event) { event.messages.push("bundled-loaded"); }\n',
+      });
+
+      // No `enabled` field at all — simulates fresh install default
+      const cfg: OpenClawConfig = {};
+
+      const count = await loadInternalHooks(cfg, tmpDir, { bundledHooksDir: bundledDir });
+      expect(count).toBe(1);
+
+      const event = createInternalHookEvent("command", "new", "test-session");
+      await triggerInternalHook(event);
+      expect(event.messages).toContain("bundled-loaded");
+    });
+
     it("should load a handler from a module", async () => {
       // Create a test handler module
       const handlerCode = `

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -121,20 +121,26 @@ describe("loader", () => {
       expect(getRegisteredEventKeys()).not.toContain("command:new");
     };
 
-    it("should return 0 when hooks are disabled or missing", async () => {
-      for (const cfg of [
-        {
-          hooks: {
-            internal: {
-              enabled: false,
-            },
+    it("should return 0 when hooks are explicitly disabled", async () => {
+      const cfg: OpenClawConfig = {
+        hooks: {
+          internal: {
+            enabled: false,
           },
-        } satisfies OpenClawConfig,
-        {} satisfies OpenClawConfig,
-      ]) {
-        const count = await loadInternalHooks(cfg, tmpDir);
-        expect(count).toBe(0);
-      }
+        },
+      };
+      const count = await loadInternalHooks(cfg, tmpDir);
+      expect(count).toBe(0);
+    });
+
+    it("should return 0 when config is empty and no hooks are discoverable", async () => {
+      // An empty config no longer means hooks are disabled — it means
+      // "proceed to discovery".  This test verifies that the loader
+      // returns 0 when there are simply no hooks to find (the bundled
+      // dir env var is pointed at a non-existent path in beforeEach).
+      const cfg: OpenClawConfig = {};
+      const count = await loadInternalHooks(cfg, tmpDir);
+      expect(count).toBe(0);
     });
 
     it("loads bundled hooks when hooks.internal.enabled is undefined (#55929)", async () => {

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -65,8 +65,12 @@ export async function loadInternalHooks(
     bundledHooksDir?: string;
   },
 ): Promise<number> {
-  // Check if hooks are enabled
-  if (!cfg.hooks?.internal?.enabled) {
+  // Check if hooks are explicitly disabled.
+  // When `enabled` is undefined (default), allow loading so that bundled
+  // hooks (source: "openclaw-bundled") can be discovered — their per-hook
+  // policy already defaults them to "default-on".  Only block when the
+  // user has explicitly set `hooks.internal.enabled` to `false`.
+  if (cfg.hooks?.internal?.enabled === false) {
     return 0;
   }
 
@@ -153,7 +157,7 @@ export async function loadInternalHooks(
   }
 
   // 2. Load legacy config handlers (backwards compatibility)
-  const handlers = cfg.hooks.internal.handlers ?? [];
+  const handlers = cfg.hooks?.internal?.handlers ?? [];
   for (const handlerConfig of handlers) {
     try {
       // Legacy handler paths: keep them workspace-relative.


### PR DESCRIPTION
## Summary

Fixes #55929

`loadInternalHooks()` has a top-level guard `if (!cfg.hooks?.internal?.enabled)` that returns early when the field is `undefined` — its default value on a fresh install. This prevents **all** hooks from loading, including bundled ones like `session-memory` that have `defaultEnableMode: "default-on"` in their source policy.

The per-hook policy system (`policy.ts`) already correctly treats bundled hooks as enabled by default, but it was never reached because of the early return.

## Changes

**`src/hooks/loader.ts`**
- Changed the guard from `!cfg.hooks?.internal?.enabled` (falsy check) to `cfg.hooks?.internal?.enabled === false` (strict equality). Now `undefined` (default) proceeds to hook discovery, and only an explicit `false` disables all hooks.
- Added optional chaining on `cfg.hooks?.internal?.handlers` (line 160) to prevent `TypeError` when `cfg.hooks` is entirely absent.

**`src/hooks/loader.test.ts`**
- Added regression test: creates a bundled hook directory, passes an empty config `{}`, and verifies the hook loads and fires correctly.

## Testing

- All 15 loader tests pass (including the new regression test)
- All 173 hooks tests pass across 20 test files
- No TypeScript errors in changed files