### PR TITLE
docs(cli): fix incorrect config filename in hooks documentation

### DIFF
--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -125,7 +125,7 @@ Not ready: 0
 openclaw hooks enable <name>
 ```
 
-Enable a specific hook by adding it to your config (`~/.openclaw/config.json`).
+Enable a specific hook by adding it to your config (`~/.openclaw/openclaw.json`).
 
 **Note:** Workspace hooks are disabled by default until enabled here or in config. Hooks managed by plugins show `plugin:<id>` in `openclaw hooks list` and can’t be enabled/disabled here. Enable/disable the plugin instead.
 

--- a/docs/zh-CN/cli/hooks.md
+++ b/docs/zh-CN/cli/hooks.md
@@ -131,7 +131,7 @@ Not ready: 0
 openclaw hooks enable <name>
 ```
 
-通过将特定钩子添加到配置（`~/.openclaw/config.json`）来启用它。
+通过将特定钩子添加到配置（`~/.openclaw/openclaw.json`）来启用它。
 
 **注意：** 由插件管理的钩子在 `openclaw hooks list` 中显示 `plugin:<id>`，
 无法在此处启用/禁用。请改为启用/禁用该插件。


### PR DESCRIPTION
## Summary

- **Problem:** `docs/cli/hooks.md` and `docs/zh-CN/cli/hooks.md` reference `~/.openclaw/config.json` as the config file path.
- **Why it matters:** The actual config file is `~/.openclaw/openclaw.json`. Users following the docs would look for the wrong file.
- **What changed:** Corrected the config filename from `config.json` to `openclaw.json` in both English and Chinese hooks docs.
- **What did NOT change (scope boundary):** No code, logic, or other documentation changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

Docs now point to the correct config file path (`~/.openclaw/openclaw.json`).

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.3.0)

### Steps

1. Open `docs/cli/hooks.md` line 128
2. Observe it references `~/.openclaw/config.json`
3. Cross-check with source code (`src/config/io.owner-display-secret.test.ts`, `src/wizard/setup.test.ts`) — actual file is `openclaw.json`

### Expected

- Docs reference `~/.openclaw/openclaw.json`

### Actual

- Before: `~/.openclaw/config.json`
- After: `~/.openclaw/openclaw.json`

## Evidence

- [x] Verified against test fixtures (`src/config/io.owner-display-secret.test.ts:38`, `src/wizard/setup.test.ts:92`) confirming `openclaw.json` is the correct filename

## Human Verification (required)

- Verified scenarios: grep'd codebase for `openclaw.json` — consistently used as the config filename
- Edge cases checked: both English and Chinese docs updated
- What you did **not** verify: other docs that might reference the config path (grep showed only these two files use `config.json`)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

None