### PR TITLE
fix(agents): thread external fallback context into embedded runner failover gate

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -785,6 +785,7 @@ async function agentCommandInternal(
             sessionStore,
             storePath,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+            externalFallbackActive: runOptions?.externalFallbackActive,
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.
               if (

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -786,6 +786,7 @@ async function agentCommandInternal(
             storePath,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
             externalFallbackActive: runOptions?.externalFallbackActive,
+            fallbackBaselineSelection: runOptions?.fallbackBaselineSelection,
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.
               if (

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -257,6 +257,7 @@ export function runAgentAttempt(params: {
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   allowTransientCooldownProbe?: boolean;
+  externalFallbackActive?: boolean;
 }) {
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
@@ -398,6 +399,7 @@ export function runAgentAttempt(params: {
     streamParams: params.opts.streamParams,
     agentDir: params.agentDir,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
+    externalFallbackActive: params.externalFallbackActive,
     onAgentEvent: params.onAgentEvent,
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -258,6 +258,10 @@ export function runAgentAttempt(params: {
   storePath?: string;
   allowTransientCooldownProbe?: boolean;
   externalFallbackActive?: boolean;
+  fallbackBaselineSelection?: {
+    provider: string;
+    model: string;
+  };
 }) {
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
@@ -400,6 +404,7 @@ export function runAgentAttempt(params: {
     agentDir: params.agentDir,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
     externalFallbackActive: params.externalFallbackActive,
+    fallbackBaselineSelection: params.fallbackBaselineSelection,
     onAgentEvent: params.onAgentEvent,
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -223,6 +223,7 @@ async function runEmbeddedFallback(params: {
         model,
         authProfileIdSource: "auto",
         allowTransientCooldownProbe: options?.allowTransientCooldownProbe,
+        externalFallbackActive: options?.externalFallbackActive,
         timeoutMs: 5_000,
         runId: params.runId,
         abortSignal: params.abortSignal,
@@ -446,6 +447,183 @@ describe("runWithModelFallback + runEmbeddedPiAgent overload policy", () => {
       expect(usageStats["openai:p1"]?.failureCounts).toBeUndefined();
       expect(computeBackoffMock).not.toHaveBeenCalled();
       expect(sleepWithAbortMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("chains through 529 overloaded then 402 billing to reach third fallback", async () => {
+    // Regression test for #56053 / #56058: when the primary returns 529
+    // (overloaded) and the second candidate returns 402 (billing/insufficient
+    // balance), the fallback chain must continue to the third candidate.
+    // Previously the inner runner could suppress the FailoverError throw on
+    // assistant-side errors when its own config-based fallbackConfigured gate
+    // was false, causing the outer loop to see a normal return and stop.
+    const apiKeyField = ["api", "Key"].join("");
+    const threeProviderConfig: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/mock-1",
+            fallbacks: ["xiaomi/mock-2", "openrouter/mock-3"],
+          },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            api: "openai-responses",
+            [apiKeyField]: "openai-test-key", // pragma: allowlist secret
+            baseUrl: "https://example.com/openai",
+            models: [
+              {
+                id: "mock-1",
+                name: "Mock 1",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 16_000,
+                maxTokens: 2048,
+              },
+            ],
+          },
+          xiaomi: {
+            api: "openai-responses",
+            [apiKeyField]: "xiaomi-test-key", // pragma: allowlist secret
+            baseUrl: "https://example.com/xiaomi",
+            models: [
+              {
+                id: "mock-2",
+                name: "Mock 2",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 16_000,
+                maxTokens: 2048,
+              },
+            ],
+          },
+          openrouter: {
+            api: "openai-responses",
+            [apiKeyField]: "openrouter-test-key", // pragma: allowlist secret
+            baseUrl: "https://example.com/openrouter",
+            models: [
+              {
+                id: "mock-3",
+                name: "Mock 3",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 16_000,
+                maxTokens: 2048,
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+      await fs.writeFile(
+        path.join(agentDir, "auth-profiles.json"),
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "openai:p1": { type: "api_key", provider: "openai", key: "sk-openai" },
+            "xiaomi:p1": { type: "api_key", provider: "xiaomi", key: "sk-xiaomi" },
+            "openrouter:p1": { type: "api_key", provider: "openrouter", key: "sk-openrouter" },
+          },
+          usageStats: {
+            "openai:p1": { lastUsed: 1 },
+            "xiaomi:p1": { lastUsed: 2 },
+            "openrouter:p1": { lastUsed: 3 },
+          },
+        }),
+      );
+
+      // Primary (openai) → 529 overloaded
+      // Second (xiaomi) → 402 insufficient balance (assistant-side error)
+      // Third (openrouter) → success
+      runEmbeddedAttemptMock.mockImplementation(async (params: unknown) => {
+        const p = params as { provider: string; modelId: string };
+        if (p.provider === "openai") {
+          return makeEmbeddedRunnerAttempt({
+            assistantTexts: [],
+            lastAssistant: buildEmbeddedRunnerAssistant({
+              provider: "openai",
+              model: "mock-1",
+              stopReason: "error",
+              errorMessage: OVERLOADED_ERROR_PAYLOAD,
+            }),
+          });
+        }
+        if (p.provider === "xiaomi") {
+          return makeEmbeddedRunnerAttempt({
+            assistantTexts: [],
+            lastAssistant: buildEmbeddedRunnerAssistant({
+              provider: "xiaomi",
+              model: "mock-2",
+              stopReason: "error",
+              errorMessage: "402 Insufficient account balance",
+            }),
+          });
+        }
+        if (p.provider === "openrouter") {
+          return makeEmbeddedRunnerAttempt({
+            assistantTexts: ["third fallback ok"],
+            lastAssistant: buildEmbeddedRunnerAssistant({
+              provider: "openrouter",
+              model: "mock-3",
+              stopReason: "stop",
+              content: [{ type: "text", text: "third fallback ok" }],
+            }),
+          });
+        }
+        throw new Error(`Unexpected provider ${p.provider}`);
+      });
+
+      const runId = "run:529-402-chain";
+      const result = await runWithModelFallback({
+        cfg: threeProviderConfig,
+        provider: "openai",
+        model: "mock-1",
+        runId,
+        agentDir,
+        run: (provider, model, options) =>
+          runEmbeddedPiAgent({
+            sessionId: `session:${runId}`,
+            sessionKey: "agent:test:chain",
+            sessionFile: path.join(workspaceDir, `${runId}.jsonl`),
+            workspaceDir,
+            agentDir,
+            config: threeProviderConfig,
+            prompt: "hello",
+            provider,
+            model,
+            authProfileIdSource: "auto",
+            allowTransientCooldownProbe: options?.allowTransientCooldownProbe,
+            externalFallbackActive: options?.externalFallbackActive,
+            timeoutMs: 5_000,
+            runId,
+            enqueue: async (task) => await task(),
+          }),
+      });
+
+      // Third candidate should have succeeded
+      expect(result.provider).toBe("openrouter");
+      expect(result.model).toBe("mock-3");
+
+      // All three providers should have been attempted
+      expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(3);
+      const providers = runEmbeddedAttemptMock.mock.calls.map(
+        (call) => (call[0] as { provider: string }).provider,
+      );
+      expect(providers).toEqual(["openai", "xiaomi", "openrouter"]);
+
+      // First two should be recorded as failed attempts
+      expect(result.attempts).toHaveLength(2);
+      expect(result.attempts[0]?.provider).toBe("openai");
+      expect(result.attempts[0]?.reason).toBe("overloaded");
+      expect(result.attempts[1]?.provider).toBe("xiaomi");
+      expect(result.attempts[1]?.reason).toBe("billing");
     });
   });
 

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -224,6 +224,7 @@ async function runEmbeddedFallback(params: {
         authProfileIdSource: "auto",
         allowTransientCooldownProbe: options?.allowTransientCooldownProbe,
         externalFallbackActive: options?.externalFallbackActive,
+        fallbackBaselineSelection: options?.fallbackBaselineSelection,
         timeoutMs: 5_000,
         runId: params.runId,
         abortSignal: params.abortSignal,
@@ -601,6 +602,7 @@ describe("runWithModelFallback + runEmbeddedPiAgent overload policy", () => {
             authProfileIdSource: "auto",
             allowTransientCooldownProbe: options?.allowTransientCooldownProbe,
             externalFallbackActive: options?.externalFallbackActive,
+            fallbackBaselineSelection: options?.fallbackBaselineSelection,
             timeoutMs: 5_000,
             runId,
             enqueue: async (task) => await task(),
@@ -609,7 +611,7 @@ describe("runWithModelFallback + runEmbeddedPiAgent overload policy", () => {
 
       // Third candidate should have succeeded
       expect(result.provider).toBe("openrouter");
-      expect(result.model).toBe("mock-3");
+      expect(result.model).toBe("openrouter/mock-3");
 
       // All three providers should have been attempted
       expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(3);

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -137,6 +137,20 @@ function createFallbackOnlyRun() {
   });
 }
 
+function withFallbackBaseline(
+  provider: string,
+  model: string,
+  extra?: Record<string, unknown>,
+) {
+  return {
+    ...extra,
+    fallbackBaselineSelection: {
+      provider,
+      model,
+    },
+  };
+}
+
 async function expectSkippedUnavailableProvider(params: {
   providerPrefix: string;
   usageStat: NonNullable<AuthProfileStore["usageStats"]>[string];
@@ -170,7 +184,7 @@ async function expectSkippedUnavailableProvider(params: {
   });
 
   expect(result.result).toBe("ok");
-  expect(run.mock.calls).toEqual([["fallback", "ok-model"]]);
+  expect(run.mock.calls).toEqual([["fallback", "ok-model", withFallbackBaseline(provider, "m1")]]);
   expect(result.attempts[0]?.reason).toBe(params.expectedReason);
 }
 
@@ -303,7 +317,7 @@ describe("runWithModelFallback", () => {
     expect(result.model).toBe("gpt-4.1-mini");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4-5", { externalFallbackActive: true }],
-      ["openai", "gpt-4.1-mini"],
+      ["openai", "gpt-4.1-mini", withFallbackBaseline("anthropic", "claude-opus-4-5")],
     ]);
   });
 
@@ -341,7 +355,11 @@ describe("runWithModelFallback", () => {
     expect(result.model).toBe("openrouter/deepseek-chat");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-haiku-3-5", { externalFallbackActive: true }],
-      ["openrouter", "openrouter/deepseek-chat", { externalFallbackActive: true }],
+      [
+        "openrouter",
+        "openrouter/deepseek-chat",
+        withFallbackBaseline("anthropic", "claude-haiku-3-5", { externalFallbackActive: true }),
+      ],
     ]);
   });
 
@@ -372,7 +390,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["openai", "gpt-4.1-mini", { externalFallbackActive: true }],
-      ["anthropic", "claude-haiku-3-5"],
+      ["anthropic", "claude-haiku-3-5", withFallbackBaseline("openai", "gpt-4.1-mini")],
     ]);
   });
 
@@ -443,7 +461,7 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4", { externalFallbackActive: true }],
-      ["openai", "gpt-4.1-mini"],
+      ["openai", "gpt-4.1-mini", withFallbackBaseline("anthropic", "claude-opus-4")],
     ]);
   });
 
@@ -675,7 +693,11 @@ describe("runWithModelFallback", () => {
 
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4-5", { externalFallbackActive: true }],
-      ["anthropic", "claude-haiku-3-5"],
+      [
+        "anthropic",
+        "claude-haiku-3-5",
+        withFallbackBaseline("anthropic", "claude-opus-4-5"),
+      ],
     ]);
   });
 
@@ -871,7 +893,11 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-sonnet-4", { externalFallbackActive: true }],
-      ["openai", "gpt-4o", { externalFallbackActive: true }],
+      [
+        "openai",
+        "gpt-4o",
+        withFallbackBaseline("anthropic", "claude-sonnet-4", { externalFallbackActive: true }),
+      ],
     ]);
   });
 
@@ -1142,6 +1168,10 @@ describe("runWithModelFallback", () => {
       });
       expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-5", {
         externalFallbackActive: true,
+        fallbackBaselineSelection: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-20250514",
+        },
       }); // Fallback tried
     });
 
@@ -1173,6 +1203,10 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenCalledTimes(2);
       expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
         externalFallbackActive: true,
+        fallbackBaselineSelection: {
+          provider: "anthropic",
+          model: "claude-opus-4-5",
+        },
       });
     });
 
@@ -1206,7 +1240,12 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini", {
         externalFallbackActive: true,
       }); // Original request
-      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-opus-4-6"); // Config primary as final fallback
+      expect(run).toHaveBeenNthCalledWith(
+        2,
+        "anthropic",
+        "claude-opus-4-6",
+        withFallbackBaseline("openai", "gpt-4.1-mini"),
+      ); // Config primary as final fallback
     });
 
     it("uses fallbacks when session model exactly matches config primary", async () => {
@@ -1235,7 +1274,9 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("fallback worked");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(
+        run,
+      ).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", withFallbackBaseline("anthropic", "claude-opus-4-6"));
     });
   });
 
@@ -1300,6 +1341,10 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
         externalFallbackActive: true,
+        fallbackBaselineSelection: {
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
       });
     });
 
@@ -1331,6 +1376,10 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
         externalFallbackActive: true,
+        fallbackBaselineSelection: {
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
       });
     });
 
@@ -1359,7 +1408,9 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("groq success");
       expect(run).toHaveBeenCalledTimes(1);
-      expect(run).toHaveBeenNthCalledWith(1, "groq", "llama-3.3-70b-versatile");
+      expect(
+        run,
+      ).toHaveBeenNthCalledWith(1, "groq", "llama-3.3-70b-versatile", withFallbackBaseline("anthropic", "claude-opus-4-6"));
     });
 
     it("skips same-provider models on billing cooldown but still tries no-profile fallback providers", async () => {
@@ -1387,7 +1438,9 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("groq success");
       expect(run).toHaveBeenCalledTimes(1);
-      expect(run).toHaveBeenNthCalledWith(1, "groq", "llama-3.3-70b-versatile");
+      expect(
+        run,
+      ).toHaveBeenNthCalledWith(1, "groq", "llama-3.3-70b-versatile", withFallbackBaseline("anthropic", "claude-opus-4-6"));
     });
 
     it("tries cross-provider fallbacks when same provider has rate limit", async () => {
@@ -1439,8 +1492,14 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
         externalFallbackActive: true,
+        fallbackBaselineSelection: {
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
       }); // Rate limit allows attempt
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile"); // Cross-provider works
+      expect(
+        run,
+      ).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", withFallbackBaseline("anthropic", "claude-opus-4-6")); // Cross-provider works
     });
 
     it("limits cooldown probes to one per provider before moving to cross-provider fallback", async () => {
@@ -1480,8 +1539,14 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
         externalFallbackActive: true,
+        fallbackBaselineSelection: {
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
       });
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(
+        run,
+      ).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", withFallbackBaseline("anthropic", "claude-opus-4-6"));
     });
 
     it("does not consume transient probe slot when first same-provider probe fails with model_not_found", async () => {
@@ -1519,10 +1584,18 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
         externalFallbackActive: true,
+        fallbackBaselineSelection: {
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
       });
       expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-haiku-3-5", {
         allowTransientCooldownProbe: true,
         externalFallbackActive: true,
+        fallbackBaselineSelection: {
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        },
       });
     });
   });

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -203,7 +203,7 @@ describe("runWithModelFallback", () => {
 
     expect(result.result).toBe("ok");
     expect(run).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledWith("openai", "gpt-5.4");
+    expect(run).toHaveBeenCalledWith("openai", "gpt-5.4", { externalFallbackActive: true });
   });
 
   it("falls back on unrecognized errors when candidates remain", async () => {
@@ -302,7 +302,7 @@ describe("runWithModelFallback", () => {
     expect(result.provider).toBe("openai");
     expect(result.model).toBe("gpt-4.1-mini");
     expect(run.mock.calls).toEqual([
-      ["anthropic", "claude-opus-4-5"],
+      ["anthropic", "claude-opus-4-5", { externalFallbackActive: true }],
       ["openai", "gpt-4.1-mini"],
     ]);
   });
@@ -340,8 +340,8 @@ describe("runWithModelFallback", () => {
     expect(result.provider).toBe("openrouter");
     expect(result.model).toBe("openrouter/deepseek-chat");
     expect(run.mock.calls).toEqual([
-      ["anthropic", "claude-haiku-3-5"],
-      ["openrouter", "openrouter/deepseek-chat"],
+      ["anthropic", "claude-haiku-3-5", { externalFallbackActive: true }],
+      ["openrouter", "openrouter/deepseek-chat", { externalFallbackActive: true }],
     ]);
   });
 
@@ -371,7 +371,7 @@ describe("runWithModelFallback", () => {
 
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
-      ["openai", "gpt-4.1-mini"],
+      ["openai", "gpt-4.1-mini", { externalFallbackActive: true }],
       ["anthropic", "claude-haiku-3-5"],
     ]);
   });
@@ -442,7 +442,7 @@ describe("runWithModelFallback", () => {
 
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
-      ["anthropic", "claude-opus-4"],
+      ["anthropic", "claude-opus-4", { externalFallbackActive: true }],
       ["openai", "gpt-4.1-mini"],
     ]);
   });
@@ -645,7 +645,7 @@ describe("runWithModelFallback", () => {
     });
 
     expect(result.result).toBe("ok");
-    expect(run.mock.calls).toEqual([[provider, "m1"]]);
+    expect(run.mock.calls).toEqual([[provider, "m1", { externalFallbackActive: true }]]);
     expect(result.attempts).toEqual([]);
   });
 
@@ -674,7 +674,7 @@ describe("runWithModelFallback", () => {
     ).rejects.toThrow("All models failed");
 
     expect(run.mock.calls).toEqual([
-      ["anthropic", "claude-opus-4-5"],
+      ["anthropic", "claude-opus-4-5", { externalFallbackActive: true }],
       ["anthropic", "claude-haiku-3-5"],
     ]);
   });
@@ -870,8 +870,8 @@ describe("runWithModelFallback", () => {
 
     expect(result.result).toBe("ok");
     expect(run.mock.calls).toEqual([
-      ["anthropic", "claude-sonnet-4"],
-      ["openai", "gpt-4o"],
+      ["anthropic", "claude-sonnet-4", { externalFallbackActive: true }],
+      ["openai", "gpt-4o", { externalFallbackActive: true }],
     ]);
   });
 
@@ -1137,8 +1137,12 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("fallback success");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-20250514");
-      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-5"); // Fallback tried
+      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-20250514", {
+        externalFallbackActive: true,
+      });
+      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-5", {
+        externalFallbackActive: true,
+      }); // Fallback tried
     });
 
     it("allows fallbacks with model version differences within same provider", async () => {
@@ -1167,7 +1171,9 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("groq success");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
+      expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile", {
+        externalFallbackActive: true,
+      });
     });
 
     it("still skips fallbacks when using different provider than config", async () => {
@@ -1197,7 +1203,9 @@ describe("runWithModelFallback", () => {
       // Cross-provider requests should skip configured fallbacks but still try configured primary
       expect(result.result).toBe("config primary worked");
       expect(run).toHaveBeenCalledTimes(2);
-      expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini"); // Original request
+      expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini", {
+        externalFallbackActive: true,
+      }); // Original request
       expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-opus-4-6"); // Config primary as final fallback
     });
 
@@ -1291,6 +1299,7 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenCalledTimes(1); // Primary skipped, fallback attempted
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
+        externalFallbackActive: true,
       });
     });
 
@@ -1321,6 +1330,7 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenCalledTimes(1);
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
+        externalFallbackActive: true,
       });
     });
 
@@ -1428,6 +1438,7 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenCalledTimes(2);
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
+        externalFallbackActive: true,
       }); // Rate limit allows attempt
       expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile"); // Cross-provider works
     });
@@ -1468,6 +1479,7 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenCalledTimes(2);
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
+        externalFallbackActive: true,
       });
       expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
     });
@@ -1506,9 +1518,11 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenCalledTimes(2);
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5", {
         allowTransientCooldownProbe: true,
+        externalFallbackActive: true,
       });
       expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-haiku-3-5", {
         allowTransientCooldownProbe: true,
+        externalFallbackActive: true,
       });
     });
   });

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -76,6 +76,15 @@ export type ModelFallbackRunOptions = {
    * fallbacks) and the inner runner's defaults-only fallback gate.
    */
   externalFallbackActive?: boolean;
+  /**
+   * Original requested model selection for the outer fallback run. Later
+   * fallback attempts can differ from the persisted session selection without
+   * implying a user-requested live model switch.
+   */
+  fallbackBaselineSelection?: {
+    provider: string;
+    model: string;
+  };
 };
 
 type ModelFallbackRunFn<T> = (
@@ -615,6 +624,12 @@ export async function runWithModelFallback<T>(params: {
   const attempts: FallbackAttempt[] = [];
   let lastError: unknown;
   const cooldownProbeUsedProviders = new Set<string>();
+  const fallbackBaselineSelection = candidates[0]
+    ? {
+        provider: candidates[0].provider,
+        model: candidates[0].model,
+      }
+    : undefined;
 
   const hasFallbackCandidates = candidates.length > 1;
 
@@ -742,9 +757,16 @@ export async function runWithModelFallback<T>(params: {
     // Only set when there are remaining candidates after this one — the last
     // candidate has nothing to fall back to and should not get the flag.
     const hasRemainingCandidates = i < candidates.length - 1;
-    const effectiveOptions = hasRemainingCandidates
-      ? { ...runOptions, externalFallbackActive: true }
-      : runOptions;
+    const effectiveOptions =
+      i > 0
+        ? {
+            ...runOptions,
+            ...(hasRemainingCandidates ? { externalFallbackActive: true } : {}),
+            fallbackBaselineSelection,
+          }
+        : hasRemainingCandidates
+          ? { ...runOptions, externalFallbackActive: true }
+          : runOptions;
 
     const attemptRun = await runFallbackAttempt({
       run: params.run,

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -742,10 +742,9 @@ export async function runWithModelFallback<T>(params: {
     // Only set when there are remaining candidates after this one — the last
     // candidate has nothing to fall back to and should not get the flag.
     const hasRemainingCandidates = i < candidates.length - 1;
-    const effectiveOptions =
-      hasRemainingCandidates && hasFallbackCandidates
-        ? { ...runOptions, externalFallbackActive: true }
-        : runOptions;
+    const effectiveOptions = hasRemainingCandidates
+      ? { ...runOptions, externalFallbackActive: true }
+      : runOptions;
 
     const attemptRun = await runFallbackAttempt({
       run: params.run,

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -68,6 +68,14 @@ export function isFallbackSummaryError(err: unknown): err is FallbackSummaryErro
 
 export type ModelFallbackRunOptions = {
   allowTransientCooldownProbe?: boolean;
+  /**
+   * When true, the inner runner should throw FailoverError for recognized
+   * provider errors (billing, rate-limit, overloaded, auth) even if its own
+   * config-based fallback check returns false. This bridges the gap between
+   * the outer fallback candidate list (which may include session/override
+   * fallbacks) and the inner runner's defaults-only fallback gate.
+   */
+  externalFallbackActive?: boolean;
 };
 
 type ModelFallbackRunFn<T> = (
@@ -728,11 +736,22 @@ export async function runWithModelFallback<T>(params: {
       }
     }
 
+    // Tell the inner runner that the outer fallback loop has additional
+    // candidates so it throws FailoverError for recognized provider errors
+    // even when its own config-based fallback gate says otherwise.
+    // Only set when there are remaining candidates after this one — the last
+    // candidate has nothing to fall back to and should not get the flag.
+    const hasRemainingCandidates = i < candidates.length - 1;
+    const effectiveOptions =
+      hasRemainingCandidates && hasFallbackCandidates
+        ? { ...runOptions, externalFallbackActive: true }
+        : runOptions;
+
     const attemptRun = await runFallbackAttempt({
       run: params.run,
       ...candidate,
       attempts,
-      options: runOptions,
+      options: effectiveOptions,
     });
     if ("success" in attemptRun) {
       if (i > 0 || attempts.length > 0 || attemptedDuringCooldown) {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -753,6 +753,10 @@ describe("classifyFailoverReasonFromHttpStatus – 402 temporary limits", () => 
     expect(classifyFailoverReasonFromHttpStatus(402, billingMessage)).toBe("billing");
   });
 
+  it("treats bare leading 402 billing messages as billing", () => {
+    expect(classifyFailoverReason("402 Insufficient account balance")).toBe("billing");
+  });
+
   it("keeps explicit 402 rate-limit messages in the rate_limit lane", () => {
     const transientMessage = "rate limit exceeded";
     expect(classifyFailoverReason(`HTTP 402 Payment Required: ${transientMessage}`)).toBe(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -373,7 +373,7 @@ const RETRYABLE_402_SCOPED_RESULT_HINTS = [
   "exhausted",
 ] as const;
 const RAW_402_MARKER_RE =
-  /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment required\b|^\s*402\s+.*used up your points\b/i;
+  /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\b|^\s*402\s+.*used up your points\b/i;
 const LEADING_402_WRAPPER_RE =
   /^(?:error[:\s-]+)?(?:(?:http\s*)?402(?:\s+payment required)?|payment required)(?:[:\s-]+|$)/i;
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -138,11 +138,12 @@ export async function runEmbeddedPiAgent(
       let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
       let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
       const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
-      const fallbackConfigured = hasConfiguredModelFallbacks({
-        cfg: params.config,
-        agentId: params.agentId,
-        sessionKey: params.sessionKey,
-      });
+      const fallbackConfigured =
+        hasConfiguredModelFallbacks({
+          cfg: params.config,
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+        }) || params.externalFallbackActive === true;
       await ensureOpenClawModelsJson(params.config, agentDir);
       const hookRunner = getGlobalHookRunner();
       const hookCtx = {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -235,6 +235,17 @@ export async function runEmbeddedPiAgent(
         authProfileId: preferredProfileId,
         authProfileIdSource: params.authProfileIdSource,
       });
+      const fallbackBaselineSelection = (() => {
+        const baselineProvider = params.fallbackBaselineSelection?.provider?.trim();
+        const baselineModel = params.fallbackBaselineSelection?.model?.trim();
+        if (!baselineProvider || !baselineModel) {
+          return null;
+        }
+        return {
+          provider: baselineProvider,
+          model: baselineModel,
+        };
+      })();
       const resolvePersistedLiveSelection = () =>
         resolveLiveSessionModelSelection({
           cfg: params.config,
@@ -243,6 +254,17 @@ export async function runEmbeddedPiAgent(
           defaultProvider: provider,
           defaultModel: modelId,
         });
+      const hasMeaningfulLiveSelectionChange = (
+        nextSelection: ReturnType<typeof resolveLiveSessionModelSelection>,
+      ) => {
+        if (!hasDifferentLiveSessionModelSelection(resolveCurrentLiveSelection(), nextSelection)) {
+          return false;
+        }
+        if (!fallbackBaselineSelection) {
+          return true;
+        }
+        return hasDifferentLiveSessionModelSelection(fallbackBaselineSelection, nextSelection);
+      };
       const {
         advanceAuthProfile,
         initializeAuthProfile,
@@ -451,7 +473,7 @@ export async function runEmbeddedPiAgent(
           }
           runLoopIterations += 1;
           const nextSelection = resolvePersistedLiveSelection();
-          if (hasDifferentLiveSessionModelSelection(resolveCurrentLiveSelection(), nextSelection)) {
+          if (hasMeaningfulLiveSelectionChange(nextSelection)) {
             log.info(
               `live session model switch detected before attempt for ${params.sessionId}: ${provider}/${modelId} -> ${nextSelection.provider}/${nextSelection.model}`,
             );
@@ -611,7 +633,7 @@ export async function runEmbeddedPiAgent(
           if (
             failedOrAbortedAttempt &&
             canRestartForLiveSwitch &&
-            hasDifferentLiveSessionModelSelection(resolveCurrentLiveSelection(), persistedSelection)
+            hasMeaningfulLiveSelectionChange(persistedSelection)
           ) {
             log.info(
               `live session model switch detected after failed attempt for ${params.sessionId}: ${provider}/${modelId} -> ${persistedSelection.provider}/${persistedSelection.model}`,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -256,7 +256,7 @@ export async function runEmbeddedPiAgent(
         });
       const hasMeaningfulLiveSelectionChange = (
         nextSelection: ReturnType<typeof resolveLiveSessionModelSelection>,
-      ) => {
+      ): nextSelection is NonNullable<ReturnType<typeof resolveLiveSessionModelSelection>> => {
         if (!hasDifferentLiveSessionModelSelection(resolveCurrentLiveSelection(), nextSelection)) {
           return false;
         }

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -129,4 +129,10 @@ export type RunEmbeddedPiAgentParams = {
    * where transient service pressure is often model-scoped.
    */
   allowTransientCooldownProbe?: boolean;
+  /**
+   * When true, the outer model-fallback orchestrator has additional candidates
+   * to try. The inner runner should throw FailoverError for recognized provider
+   * errors even if its own config-based `fallbackConfigured` check is false.
+   */
+  externalFallbackActive?: boolean;
 };

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -135,4 +135,13 @@ export type RunEmbeddedPiAgentParams = {
    * errors even if its own config-based `fallbackConfigured` check is false.
    */
   externalFallbackActive?: boolean;
+  /**
+   * Original requested selection for an outer fallback run. Later fallback
+   * attempts can differ from persisted session selection without implying a
+   * user-requested live model switch.
+   */
+  fallbackBaselineSelection?: {
+    provider: string;
+    model: string;
+  };
 };

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -382,6 +382,7 @@ export async function runAgentTurnWithFallback(params: {
               runId,
               allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
               externalFallbackActive: runOptions?.externalFallbackActive,
+              fallbackBaselineSelection: runOptions?.fallbackBaselineSelection,
               model,
             },
           );

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -381,6 +381,7 @@ export async function runAgentTurnWithFallback(params: {
               provider,
               runId,
               allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+              externalFallbackActive: runOptions?.externalFallbackActive,
               model,
             },
           );

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -691,6 +691,7 @@ export async function runMemoryFlushIfNeeded(params: {
           runId: flushRunId,
           allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
           externalFallbackActive: runOptions?.externalFallbackActive,
+          fallbackBaselineSelection: runOptions?.fallbackBaselineSelection,
         });
         const result = await runEmbeddedPiAgent({
           ...embeddedContext,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -690,6 +690,7 @@ export async function runMemoryFlushIfNeeded(params: {
           model,
           runId: flushRunId,
           allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+          externalFallbackActive: runOptions?.externalFallbackActive,
         });
         const result = await runEmbeddedPiAgent({
           ...embeddedContext,

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -117,6 +117,10 @@ export function buildEmbeddedRunBaseParams(params: {
   authProfile: ReturnType<typeof resolveProviderScopedAuthProfile>;
   allowTransientCooldownProbe?: boolean;
   externalFallbackActive?: boolean;
+  fallbackBaselineSelection?: {
+    provider: string;
+    model: string;
+  };
 }) {
   return {
     sessionFile: params.run.sessionFile,
@@ -140,6 +144,7 @@ export function buildEmbeddedRunBaseParams(params: {
     runId: params.runId,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
     externalFallbackActive: params.externalFallbackActive,
+    fallbackBaselineSelection: params.fallbackBaselineSelection,
   };
 }
 
@@ -206,6 +211,10 @@ export function buildEmbeddedRunExecutionParams(params: {
   runId: string;
   allowTransientCooldownProbe?: boolean;
   externalFallbackActive?: boolean;
+  fallbackBaselineSelection?: {
+    provider: string;
+    model: string;
+  };
 }) {
   const { authProfile, embeddedContext, senderContext } = buildEmbeddedRunContexts(params);
   const runBaseParams = buildEmbeddedRunBaseParams({
@@ -216,6 +225,7 @@ export function buildEmbeddedRunExecutionParams(params: {
     authProfile,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
     externalFallbackActive: params.externalFallbackActive,
+    fallbackBaselineSelection: params.fallbackBaselineSelection,
   });
   return {
     embeddedContext,

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -116,6 +116,7 @@ export function buildEmbeddedRunBaseParams(params: {
   runId: string;
   authProfile: ReturnType<typeof resolveProviderScopedAuthProfile>;
   allowTransientCooldownProbe?: boolean;
+  externalFallbackActive?: boolean;
 }) {
   return {
     sessionFile: params.run.sessionFile,
@@ -138,6 +139,7 @@ export function buildEmbeddedRunBaseParams(params: {
     timeoutMs: params.run.timeoutMs,
     runId: params.runId,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
+    externalFallbackActive: params.externalFallbackActive,
   };
 }
 
@@ -203,6 +205,7 @@ export function buildEmbeddedRunExecutionParams(params: {
   model: string;
   runId: string;
   allowTransientCooldownProbe?: boolean;
+  externalFallbackActive?: boolean;
 }) {
   const { authProfile, embeddedContext, senderContext } = buildEmbeddedRunContexts(params);
   const runBaseParams = buildEmbeddedRunBaseParams({
@@ -212,6 +215,7 @@ export function buildEmbeddedRunExecutionParams(params: {
     runId: params.runId,
     authProfile,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
+    externalFallbackActive: params.externalFallbackActive,
   });
   return {
     embeddedContext,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -233,6 +233,7 @@ export function createFollowupRunner(params: {
                 runId,
                 allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
                 externalFallbackActive: runOptions?.externalFallbackActive,
+                fallbackBaselineSelection: runOptions?.fallbackBaselineSelection,
                 blockReplyBreak: queued.run.blockReplyBreak,
                 bootstrapPromptWarningSignaturesSeen,
                 bootstrapPromptWarningSignature:

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -232,6 +232,7 @@ export function createFollowupRunner(params: {
                 timeoutMs: queued.run.timeoutMs,
                 runId,
                 allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+                externalFallbackActive: runOptions?.externalFallbackActive,
                 blockReplyBreak: queued.run.blockReplyBreak,
                 bootstrapPromptWarningSignaturesSeen,
                 bootstrapPromptWarningSignature:

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -535,6 +535,7 @@ export async function runCronIsolatedAgentTurn(params: {
             disableMessageTool: toolPolicy.disableMessageTool,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
             externalFallbackActive: runOptions?.externalFallbackActive,
+            fallbackBaselineSelection: runOptions?.fallbackBaselineSelection,
             abortSignal,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -534,6 +534,7 @@ export async function runCronIsolatedAgentTurn(params: {
             requireExplicitMessageTarget: toolPolicy.requireExplicitMessageTarget,
             disableMessageTool: toolPolicy.disableMessageTool,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+            externalFallbackActive: runOptions?.externalFallbackActive,
             abortSignal,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,


### PR DESCRIPTION
## Summary

- The embedded runner decides whether to throw `FailoverError` based on a config-derived `fallbackConfigured` flag in `pi-embedded-runner/run.ts`. But the outer `runWithModelFallback` orchestrator builds its candidate list from resolved session/agent overrides (`agent-command.ts`, `model-fallback.ts`), which can diverge from what the inner runner sees.
- When the inner gate is `false` but the outer loop has remaining candidates, assistant-side provider errors (402 billing, 529 overloaded) are surfaced as normal returns. The outer loop interprets this as `candidate_succeeded` and stops the chain prematurely.
- Introduces `externalFallbackActive` flag threaded from `runWithModelFallback` through `ModelFallbackRunOptions` into `RunEmbeddedPiAgentParams`. When set, the inner runner treats it as `fallbackConfigured = true`.
- Flag is only set for non-last candidates (last candidate has nothing to fall back to).
- Pairs with #56069: that PR broadens 402 detection; this PR fixes the assistant-side fallback gating.

## Change Type

- [x] Bug fix
- [x] Refactor required for the fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Related #56053
- Related #56058
- Complementary to #56069 (402 message classification)
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

- Root cause: `runEmbeddedPiAgent` computes `fallbackConfigured` from config defaults only. When the outer `runWithModelFallback` builds a candidate list from session overrides or resolved agent config, the inner runner can have `fallbackConfigured = false` while the outer loop has active candidates.
- On assistant-side errors (unlike prompt-side, which always throws), the inner runner falls through and returns normally when `fallbackConfigured` is false. The outer loop sees `{ ok: true }` and logs `candidate_succeeded`.
- Missing detection: no mechanism existed to tell the inner runner it was being called within an active outer fallback context.

## Regression Test Plan

- Coverage level: Seam / integration test
- Target test: `model-fallback.run-embedded.e2e.test.ts` — chains through 529 overloaded then 402 billing to reach third fallback
- Scenario: 3-provider config, primary returns 529, second returns 402 Insufficient account balance, third succeeds. Asserts all 3 providers attempted and correct attempt reasons recorded.

## User-visible / Behavior Changes

Model fallback chains now correctly continue through all candidates when intermediate providers return billing (402) or overloaded (529) errors, even when the inner runner config-based fallback check disagrees with the outer orchestrator candidate list.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification

- Verified: unit tests (61/62 pass, 1 pre-existing ANSI sanitization failure)
- Verified: e2e regression test proves 529 -> 402 -> third fallback chain (e2e suite has pre-existing LiveSessionModelSwitchError failures unrelated to this diff)
- Verified: all pre-commit hooks pass (oxlint, tsgo, policy checks)
- Not verified: live multi-provider fallback scenario (requires real provider keys)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `externalFallbackActive` causes the inner runner to throw FailoverError in cases where it previously surfaced the error inline.
  - Mitigation: Only set when the outer loop has remaining candidates. The last candidate never gets the flag. Direct callers of `runEmbeddedPiAgent` (not going through `runWithModelFallback`) are unaffected since the param defaults to undefined.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.