### PR TITLE
Fix stale sessionFile reuse across heartbeat rollovers

### DIFF
--- a/src/config/sessions/session-file.ts
+++ b/src/config/sessions/session-file.ts
@@ -14,13 +14,17 @@ export async function resolveAndPersistSessionFile(params: {
   activeSessionKey?: string;
 }): Promise<{ sessionFile: string; sessionEntry: SessionEntry }> {
   const { sessionId, sessionKey, sessionStore, storePath } = params;
+  const storeEntry = sessionStore[sessionKey];
   const baseEntry = params.sessionEntry ??
-    sessionStore[sessionKey] ?? { sessionId, updatedAt: Date.now() };
+    storeEntry ?? { sessionId, updatedAt: Date.now() };
   const fallbackSessionFile = params.fallbackSessionFile?.trim();
+  const preserveExistingSessionFile = (storeEntry?.sessionId ?? baseEntry.sessionId) === sessionId;
   const entryForResolve =
-    !baseEntry.sessionFile && fallbackSessionFile
-      ? { ...baseEntry, sessionFile: fallbackSessionFile }
-      : baseEntry;
+    !preserveExistingSessionFile && baseEntry.sessionFile
+      ? { ...baseEntry, sessionFile: undefined }
+      : !baseEntry.sessionFile && fallbackSessionFile
+        ? { ...baseEntry, sessionFile: fallbackSessionFile }
+        : baseEntry;
   const sessionFile = resolveSessionFilePath(sessionId, entryForResolve, {
     agentId: params.agentId,
     sessionsDir: params.sessionsDir,

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -632,4 +632,42 @@ describe("resolveAndPersistSessionFile", () => {
     const saved = loadSessionStore(fixture.storePath(), { skipCache: true });
     expect(saved[sessionKey]?.sessionFile).toBe(fallbackSessionFile);
   });
+
+  it("re-derives the transcript path when a new sessionId inherits a stale sessionFile", async () => {
+    const previousSessionId = "old-session-id";
+    const sessionId = "fresh-session-id";
+    const sessionKey = "agent:main:heartbeat";
+    const staleSessionFile = resolveSessionTranscriptPathInDir(previousSessionId, fixture.sessionsDir());
+    fs.writeFileSync(
+      fixture.storePath(),
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: previousSessionId,
+          updatedAt: Date.now(),
+          sessionFile: staleSessionFile,
+        },
+      }),
+      "utf-8",
+    );
+    const sessionStore = loadSessionStore(fixture.storePath(), { skipCache: true });
+
+    const result = await resolveAndPersistSessionFile({
+      sessionId,
+      sessionKey,
+      sessionStore,
+      storePath: fixture.storePath(),
+      sessionEntry: {
+        ...sessionStore[sessionKey],
+        sessionId,
+      },
+      agentId: "main",
+      sessionsDir: fixture.sessionsDir(),
+    });
+
+    const expectedSessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    expect(result.sessionFile).toBe(expectedSessionFile);
+
+    const saved = loadSessionStore(fixture.storePath(), { skipCache: true });
+    expect(saved[sessionKey]?.sessionFile).toBe(expectedSessionFile);
+  });
 });

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -144,6 +144,7 @@ describe("resolveCronSession", () => {
         entry: {
           sessionId: "existing-session-id-456",
           updatedAt: NOW_MS - 1000,
+          sessionFile: "/tmp/existing-session-id-456.jsonl",
           systemSent: true,
           modelOverride: "sonnet-4",
           providerOverride: "anthropic",
@@ -158,6 +159,23 @@ describe("resolveCronSession", () => {
       expect(result.sessionEntry.modelOverride).toBe("sonnet-4");
       expect(result.sessionEntry.providerOverride).toBe("anthropic");
       expect(clearBootstrapSnapshot).toHaveBeenCalledWith("webhook:stable-key");
+    });
+
+    it("clears inherited sessionFile when forceNew creates a fresh session", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id-456",
+          updatedAt: NOW_MS - 1000,
+          sessionFile: "/tmp/existing-session-id-456.jsonl",
+          systemSent: true,
+        },
+        fresh: true,
+        forceNew: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.sessionId).not.toBe("existing-session-id-456");
+      expect(result.sessionEntry.sessionFile).toBeUndefined();
     });
 
     it("clears delivery routing metadata and deliveryContext when forceNew is true", () => {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -67,6 +67,9 @@ export function resolveCronSession(params: {
   const sessionEntry: SessionEntry = {
     // Preserve existing per-session overrides even when rolling to a new sessionId.
     ...entry,
+    ...(isNewSession && {
+      sessionFile: undefined,
+    }),
     // Always update these core fields
     sessionId,
     updatedAt: params.nowMs,


### PR DESCRIPTION
## Summary
- stop heartbeat/cron fresh sessions from inheriting a stale `sessionFile`
- re-derive the transcript path whenever a new `sessionId` rolls over from an older stored entry
- add regression coverage for both session-file persistence and cron isolated-session rollover

## Problem
Heartbeat/cron runs can rotate to a fresh `sessionId` while keeping the previous transcript pointer in `sessions.json`. That leaves the store pointing at an older `.jsonl` file even though the current run is writing to a new transcript. Downstream symptoms include stale heartbeat history, cleanup false positives, and replaying old breaker/auth context from the wrong transcript.

## Root cause
There were two independent carry-over paths:
- `src/cron/isolated-agent/session.ts` preserved `...entry` during `forceNew` / fresh rollover and therefore carried the old `sessionFile` into the new session entry.
- `src/config/sessions/session-file.ts` reused `baseEntry.sessionFile` even when the store had already rotated to a different `sessionId`.

## Fix
- clear inherited `sessionFile` in `resolveCronSession()` whenever a fresh session is created
- in `resolveAndPersistSessionFile()`, only preserve an existing `sessionFile` when the stored `sessionId` still matches the target `sessionId`
- otherwise re-derive the transcript path from the fresh session id

## Tests
- added a regression test for `resolveAndPersistSessionFile()` to ensure a fresh `sessionId` does not keep a stale transcript path
- added a regression test for `resolveCronSession()` to ensure `forceNew` clears inherited `sessionFile`

## Validation
Ran:
```bash
pnpm exec vitest run --config vitest.unit.config.ts \
  src/config/sessions/sessions.test.ts \
  src/cron/isolated-agent/session.test.ts
```
