### PR TITLE
fix(cli-runner): classify 'No conversation found with session ID' as session_expired

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -928,3 +928,27 @@ describe("classifyFailoverReason", () => {
     ).toBe("auth_permanent");
   });
 });
+
+describe("classifyFailoverReason – session_expired via Claude CLI error JSON", () => {
+  // Claude CLI outputs `{"type":"result","subtype":"error_during_execution","is_error":true,
+  // "errors":["No conversation found with session ID: <uuid>"]}` when --resume targets a
+  // missing transcript. The phrase is "no conversation found" (not "conversation not found"),
+  // so it must be matched as its own entry in isCliSessionExpiredErrorMessage.
+  it("classifies Claude CLI 'No conversation found with session ID' as session_expired", () => {
+    const cliErrorJson = JSON.stringify({
+      type: "result",
+      subtype: "error_during_execution",
+      is_error: true,
+      errors: ["No conversation found with session ID: a5bb1e59-66b8-4a97-8465-304a4397b92c"],
+    });
+    expect(classifyFailoverReason(cliErrorJson)).toBe("session_expired");
+  });
+
+  it("classifies plain 'No conversation found with session ID' string as session_expired", () => {
+    expect(
+      classifyFailoverReason(
+        "No conversation found with session ID: a5bb1e59-66b8-4a97-8465-304a4397b92c",
+      ),
+    ).toBe("session_expired");
+  });
+});

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -950,6 +950,7 @@ function isCliSessionExpiredErrorMessage(raw: string): boolean {
     lower.includes("session expired") ||
     lower.includes("session invalid") ||
     lower.includes("conversation not found") ||
+    lower.includes("no conversation found") ||
     lower.includes("conversation does not exist") ||
     lower.includes("conversation expired") ||
     lower.includes("conversation invalid") ||


### PR DESCRIPTION
## Summary

- Problem: When Claude CLI is invoked with `--resume <session-id>` and the transcript file no longer exists, it exits with a non-zero code and outputs `No conversation found with session ID: <uuid>`. This error string is not recognized by `isCliSessionExpiredErrorMessage`, so `classifyFailoverReason` returns `"unknown"` instead of `"session_expired"`.
- Why it matters: With `reason === "unknown"`, the session-expired recovery path in `cli-runner.ts` and `attempt-execution.ts` is never triggered. The stale `claudeCliSessionId` remains in `sessions.json` and every subsequent message fails with the same error in a permanent loop.
- What changed: Added `"no conversation found"` to the match list in `isCliSessionExpiredErrorMessage`. The phrase `"No conversation found with session ID"` is distinct from the already-covered `"conversation not found"` (reversed word order), so it requires its own entry.
- What did NOT change (scope boundary): No behavior change for any other error path; only the missing pattern match is added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #50817
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `isCliSessionExpiredErrorMessage` checks for `"conversation not found"` but Claude CLI emits `"No conversation found with session ID: <uuid>"` — the word order differs, so `String.includes("conversation not found")` does not match.
- Missing detection / guardrail: Unit test for this specific Claude CLI error JSON shape.
- Prior context: The `session_expired` recovery path (`attempt-execution.ts:303`, `cli-runner.ts:60`) already correctly clears the stale session ID and retries without `--resume`; it just never fired for this error message.
- Why this regressed now: The pattern was always missing; the Claude CLI error message format was not anticipated when the classifier was written.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- Scenario the test should lock in: `classifyFailoverReason` returns `"session_expired"` for the exact Claude CLI error JSON shape and for the plain error string.
- Why this is the smallest reliable guardrail: The classifier is a pure function; a unit test directly on the input/output is sufficient and faster than an integration test.
- Existing test that already covers this (if any): None — the session_expired pattern was not tested.
- If no new test is added, why not: A test is added.

## User-visible / Behavior Changes

When a CLI session transcript is missing, OpenClaw now automatically clears the stale session ID and retries as a fresh session instead of failing permanently with `"No conversation found with session ID"`.

## Diagram (if applicable)

```text
Before:
[message] -> [--resume <stale-id>] -> CLI exits non-zero
          -> classifyFailoverReason -> "unknown"
          -> FailoverError(unknown)  -> permanent failure (stale ID stays)

After:
[message] -> [--resume <stale-id>] -> CLI exits non-zero
          -> classifyFailoverReason -> "session_expired"
          -> clear stale ID from sessions.json
          -> retry without --resume  -> fresh session, success
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+
- Model/provider: claude-cli / any
- Integration/channel (if any): Any channel using CLI backend with session resume

### Steps

1. Have an active session with `claudeCliSessionId` set in `sessions.json`
2. Delete the corresponding `.jsonl` transcript file from `~/.claude/projects/<workspace>/`
3. Send a new message — observe `No conversation found with session ID` error

### Expected

- Session ID cleared; message succeeds in a fresh session

### Actual (before fix)

- Permanent failure loop: same error on every subsequent message

## Evidence

- [x] Failing test/log before + passing after

Before fix: `classifyFailoverReason('{"type":"result","subtype":"error_during_execution","errors":["No conversation found with session ID: ..."]}')` returns `null` → reason `"unknown"`.

After fix: returns `"session_expired"`. New test in `pi-embedded-helpers.isbillingerrormessage.test.ts` passes.

## Human Verification (required)

- Verified scenarios: Confirmed on Discord that the "No conversation found with session ID" error no longer occurs after applying this fix.
- Edge cases checked: Existing tests (77 total) all pass; no regression in other classifiers.
- What you did **not** verify: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `"no conversation found"` substring could match an unrelated error message that happens to contain that phrase.
  - Mitigation: The phrase is highly specific to session/conversation lookup failures; the risk of false-positive classification as `session_expired` is negligible compared to the current permanent-failure behavior.