### PR TITLE
fix(telegram): add max retries and backoff to sendChatAction

### DIFF
--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -1029,7 +1029,7 @@ export async function sendMessageTelegram(
 }
 
 // Max retry attempts for sendChatAction to prevent infinite loops (issue #56096)
-const MAX_SEND_CHAT_ACTION_RETRIES = 5;
+const MAX_SEND_CHAT_ACTION_ATTEMPTS = 5;
 
 /**
  * Check if an error is recoverable for sendChatAction with stricter rules.
@@ -1061,7 +1061,7 @@ export async function sendTypingTelegram(
   // Use limited retries with exponential backoff for sendChatAction
   // This prevents infinite retry loops (issue #56096)
   const typingRetryConfig: RetryConfig = {
-    attempts: MAX_SEND_CHAT_ACTION_RETRIES,
+    attempts: MAX_SEND_CHAT_ACTION_ATTEMPTS,
     minDelayMs: 1000, // Start with 1s backoff
     maxDelayMs: 30_000, // Cap at 30s
     jitter: 0.2,
@@ -1073,6 +1073,7 @@ export async function sendTypingTelegram(
     retry: typingRetryConfig,
     verbose: opts.verbose,
     shouldRetry: shouldRetrySendChatAction,
+    strictShouldRetry: true,
   });
   const threadParams = buildTypingThreadParams(target.messageThreadId ?? opts.messageThreadId);
 
@@ -1089,11 +1090,9 @@ export async function sendTypingTelegram(
   } catch (err) {
     // Log but don't fail - typing indicator is non-critical
     // This ensures the main message flow continues even if typing fails
-    if (opts.verbose) {
-      sendLogger.warn(
-        `sendTypingTelegram failed after ${MAX_SEND_CHAT_ACTION_RETRIES} retries, continuing: ${formatErrorMessage(err)}`,
-      );
-    }
+    sendLogger.warn(
+      `sendTypingTelegram failed after ${MAX_SEND_CHAT_ACTION_ATTEMPTS} attempts, continuing: ${formatErrorMessage(err)}`,
+    );
     // Return success anyway - typing indicator is best-effort
   }
 

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -1028,6 +1028,22 @@ export async function sendMessageTelegram(
   return textResult;
 }
 
+// Max retry attempts for sendChatAction to prevent infinite loops (issue #56096)
+const MAX_SEND_CHAT_ACTION_RETRIES = 5;
+
+/**
+ * Check if an error is recoverable for sendChatAction with stricter rules.
+ * Avoids retrying on 529 (overloaded) which can cause infinite loops.
+ */
+function shouldRetrySendChatAction(err: unknown): boolean {
+  const errMsg = formatErrorMessage(err).toLowerCase();
+  // Do not retry on 429 (rate limit) or 529 (overloaded) - these can cause infinite loops
+  if (errMsg.includes("429") || errMsg.includes("529") || errMsg.includes("overload")) {
+    return false;
+  }
+  return isRecoverableTelegramNetworkError(err, { context: "send" });
+}
+
 export async function sendTypingTelegram(
   to: string,
   opts: TelegramTypingOpts = {},
@@ -1041,23 +1057,46 @@ export async function sendTypingTelegram(
     persistTarget: to,
     verbose: opts.verbose,
   });
+
+  // Use limited retries with exponential backoff for sendChatAction
+  // This prevents infinite retry loops (issue #56096)
+  const typingRetryConfig: RetryConfig = {
+    attempts: MAX_SEND_CHAT_ACTION_RETRIES,
+    minDelayMs: 1000, // Start with 1s backoff
+    maxDelayMs: 30_000, // Cap at 30s
+    jitter: 0.2,
+  };
+
   const requestWithDiag = createTelegramRequestWithDiag({
     cfg,
     account,
-    retry: opts.retry,
+    retry: typingRetryConfig,
     verbose: opts.verbose,
-    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "send" }),
+    shouldRetry: shouldRetrySendChatAction,
   });
   const threadParams = buildTypingThreadParams(target.messageThreadId ?? opts.messageThreadId);
-  await requestWithDiag(
-    () =>
-      api.sendChatAction(
-        chatId,
-        "typing",
-        threadParams as Parameters<TelegramApi["sendChatAction"]>[2],
-      ),
-    "typing",
-  );
+
+  try {
+    await requestWithDiag(
+      () =>
+        api.sendChatAction(
+          chatId,
+          "typing",
+          threadParams as Parameters<TelegramApi["sendChatAction"]>[2],
+        ),
+      "typing",
+    );
+  } catch (err) {
+    // Log but don't fail - typing indicator is non-critical
+    // This ensures the main message flow continues even if typing fails
+    if (opts.verbose) {
+      sendLogger.warn(
+        `sendTypingTelegram failed after ${MAX_SEND_CHAT_ACTION_RETRIES} retries, continuing: ${formatErrorMessage(err)}`,
+      );
+    }
+    // Return success anyway - typing indicator is best-effort
+  }
+
   return { ok: true };
 }
 

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -61,6 +61,25 @@ function is401Error(error: unknown): boolean {
 }
 
 /**
+ * Check if error is 429 (rate limit) or 529 (overloaded).
+ * These should NOT trigger retries as they cause infinite loops (issue #56096).
+ */
+function is429Or529Error(error: unknown): boolean {
+  if (!error) {
+    return false;
+  }
+  const message = error instanceof Error ? error.message : JSON.stringify(error);
+  const lowerMsg = message.toLowerCase();
+  return (
+    message.includes("429") ||
+    message.includes("529") ||
+    lowerMsg.includes("rate limit") ||
+    lowerMsg.includes("overload") ||
+    lowerMsg.includes("too many requests")
+  );
+}
+
+/**
  * Creates a GLOBAL (per-account) handler for sendChatAction that tracks 401 errors
  * across all message contexts. This prevents the infinite loop that caused Telegram
  * to delete bots (issue #27092).
@@ -108,6 +127,16 @@ export function createTelegramSendChatActionHandler({
         consecutive401Failures = 0;
       }
     } catch (error) {
+      // Issue #56096: Do not retry on 429/529 errors - they cause infinite loops
+      if (is429Or529Error(error)) {
+        logger(
+          `sendChatAction failed with rate limit/overloaded error (429/529). ` +
+            `Not retrying to prevent infinite loop.`,
+        );
+        // Re-throw without incrementing consecutive401Failures
+        throw error;
+      }
+
       if (is401Error(error)) {
         consecutive401Failures++;
 


### PR DESCRIPTION
## Summary
- Add MAX_SEND_CHAT_ACTION_RETRIES (5) to prevent infinite retry loops
- Add shouldRetrySendChatAction() to skip 429 (rate limit) and 529 (overloaded) errors
- Add exponential backoff (1s to 30s) with jitter for sendChatAction
- Make sendTypingTelegram failures non-blocking (best-effort typing indicator)

## Why
Issue #56096 reports that Telegram sendChatAction enters an infinite retry loop when the model returns 529 (overloaded). The bot becomes completely unresponsive. This fix:
1. Limits retry attempts to 5 (instead of infinite)
2. Never retries on 429/529 errors (these cause the loop)
3. Uses exponential backoff with 1s → 2s → 4s → 8s → 16s pattern
4. Even if all retries fail, the typing indicator is non-critical so the main message flow continues

## Testing
- [x] Code compiles without errors
- [x] Logic changes are minimal and focused
- [x] Matches the issue requirements

Fixes #56096