### PR TITLE
fix(feishu): suppress NO_REPLY silent token before Feishu API calls

### DIFF
--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -48,6 +48,74 @@ function resetOutboundMocks() {
   sendMediaFeishuMock.mockResolvedValue({ messageId: "media_msg" });
 }
 
+describe("feishuOutbound NO_REPLY guard", () => {
+  beforeEach(() => {
+    resetOutboundMocks();
+  });
+
+  it("suppresses NO_REPLY text before any Feishu API call", async () => {
+    const result = await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "NO_REPLY",
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({ messageId: "suppressed" }));
+  });
+
+  it("suppresses NO_REPLY with surrounding whitespace", async () => {
+    const result = await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "  NO_REPLY  ",
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({ messageId: "suppressed" }));
+  });
+
+  it("does not suppress substantive text containing NO_REPLY", async () => {
+    await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "This is not a NO_REPLY situation",
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "This is not a NO_REPLY situation",
+      }),
+    );
+  });
+
+  it("suppresses NO_REPLY text caption in sendMedia but still sends media", async () => {
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "NO_REPLY",
+      mediaUrl: "https://example.com/image.png",
+      accountId: "main",
+    });
+
+    // Text should be suppressed
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+    // Media should still be sent
+    expect(sendMediaFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaUrl: "https://example.com/image.png",
+      }),
+    );
+  });
+});
+
 describe("feishuOutbound.sendText local-image auto-convert", () => {
   beforeEach(() => {
     resetOutboundMocks();

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { createAttachedChannelResultAdapter } from "openclaw/plugin-sdk/channel-send-result";
+import { isSilentReplyText } from "openclaw/plugin-sdk/reply-runtime";
 import { chunkTextForOutbound, type ChannelOutboundAdapter } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { sendMediaFeishu } from "./media.js";
@@ -94,6 +95,14 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       mediaLocalRoots,
       identity,
     }) => {
+      // Defense-in-depth: suppress NO_REPLY token before any Feishu API call.
+      // Heartbeat/cron pushes without reply context can bypass the upstream
+      // normalize pipeline, leaking the internal silent token to end users.
+      const trimmedText = text?.trim() ?? "";
+      if (isSilentReplyText(trimmedText)) {
+        return { messageId: "suppressed", chatId: "" };
+      }
+
       const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
       // Scheme A compatibility shim:
       // when upstream accidentally returns a local image path as plain text,
@@ -156,8 +165,8 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       threadId,
     }) => {
       const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
-      // Send text first if provided
-      if (text?.trim()) {
+      // Send text first if provided (suppress NO_REPLY silent token)
+      if (text?.trim() && !isSilentReplyText(text.trim())) {
         await sendOutboundText({
           cfg,
           to,


### PR DESCRIPTION
## Summary

- Add defense-in-depth `NO_REPLY` silent-token guard to `feishuOutbound.sendText` and `feishuOutbound.sendMedia`, matching the existing guard in the Slack plugin (`extensions/slack/src/send.ts`).
- Heartbeat/cron push messages without reply context can bypass the upstream `normalizeReplyPayload` pipeline, leaking the internal `NO_REPLY` token as visible text to end users.
- The `sendText` path now suppresses pure `NO_REPLY` messages before any Feishu API call; the `sendMedia` path strips `NO_REPLY` text captions while still delivering media attachments.

## Changes

- `extensions/feishu/src/outbound.ts`: Import `isSilentReplyText` from `openclaw/plugin-sdk/reply-runtime` and add guards in both `sendText` and `sendMedia` handlers.
- `extensions/feishu/src/outbound.test.ts`: Add 4 test cases covering NO_REPLY suppression (exact match, whitespace-padded, substantive text passthrough, media-with-NO_REPLY-caption).

## Test Plan

- `pnpm test -- extensions/feishu/src/outbound.test.ts` — all 18 tests pass (14 existing + 4 new).

Closes #56117