### PR TITLE
fix(daemon): use detached handoff for macOS launchd self-restart

### DIFF
--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -359,7 +359,6 @@ export function triggerOpenClawRestart(): RestartAttempt {
     const handoff = scheduleDetachedLaunchdRestartHandoff({
       env: process.env,
       mode: "kickstart",
-      waitForPid: process.pid,
     });
     tried.push("scheduleDetachedLaunchdRestartHandoff(mode=kickstart)");
     if (handoff.ok) {

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -6,6 +6,10 @@ import {
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
 } from "../daemon/constants.js";
+import {
+  isCurrentProcessLaunchdServiceLabel,
+  scheduleDetachedLaunchdRestartHandoff,
+} from "../daemon/launchd-restart-handoff.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { cleanStaleGatewayProcessesSync, findGatewayPidsOnPortSync } from "./restart-stale-pids.js";
 import { relaunchGatewayScheduledTask } from "./windows-task-restart.js";
@@ -345,6 +349,31 @@ export function triggerOpenClawRestart(): RestartAttempt {
   const label =
     process.env.OPENCLAW_LAUNCHD_LABEL ||
     resolveGatewayLaunchAgentLabel(process.env.OPENCLAW_PROFILE);
+
+  // When the current process IS the launchd-managed gateway, a synchronous
+  // `launchctl kickstart -k` would bootout (kill) the caller before the restart
+  // completes, leaving the service unloaded. Use a detached handoff script that
+  // outlives this process, waits for it to exit, then performs the kickstart.
+  // This matches the pattern already used by restartLaunchAgent() in launchd.ts.
+  if (isCurrentProcessLaunchdServiceLabel(label)) {
+    const handoff = scheduleDetachedLaunchdRestartHandoff({
+      env: process.env,
+      mode: "kickstart",
+      waitForPid: process.pid,
+    });
+    tried.push("scheduleDetachedLaunchdRestartHandoff(mode=kickstart)");
+    if (handoff.ok) {
+      return { ok: true, method: "launchctl", tried };
+    }
+    return {
+      ok: false,
+      method: "launchctl",
+      detail: handoff.detail ?? "detached restart handoff failed",
+      tried,
+    };
+  }
+
+  // Not running inside the managed service — safe to use synchronous kickstart.
   const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
   const domain = uid !== undefined ? `gui/${uid}` : "gui/501";
   const target = `${domain}/${label}`;


### PR DESCRIPTION
## Summary

When `triggerOpenClawRestart()` is called from within the launchd-managed gateway process on macOS (e.g. via config-change-triggered restart or `!restart` chat command), the synchronous `launchctl kickstart -k` bootouts the calling process before it can complete the restart. The service is left unloaded, and the gateway does not come back.

This PR adds a guard: when `isCurrentProcessLaunchdServiceLabel()` detects the caller IS the managed service, it delegates to `scheduleDetachedLaunchdRestartHandoff()` — the same detached-shell pattern already used by `restartLaunchAgent()` (launchd.ts:569) and `restartGatewayProcessWithFreshPid()` (process-respawn.ts:37). The detached script outlives the dying gateway process, waits for it to exit, then performs the kickstart.

**Root cause evidence** (macOS unified log):
```
launchd: booting out service: caller = launchctl[61349]<-zsh[61348]<-node[55627]
launchd: service inactive: ai.openclaw.gateway
launchd: removing service: ai.openclaw.gateway
```
The gateway (PID 55627) spawns launchctl which bootouts itself — a self-kill race condition.

## Changes

- `src/infra/restart.ts`: In the darwin branch of `triggerOpenClawRestart()`, check `isCurrentProcessLaunchdServiceLabel(label)` and use `scheduleDetachedLaunchdRestartHandoff(mode: "kickstart")` when true. The existing synchronous `kickstart -k` path is preserved for callers that are NOT the managed service.

## Test plan

- [ ] Verified no new TS errors from `pnpm check` (pre-existing failures in telegram extension and media-understanding-core are unrelated)
- [ ] Lint/format passes on the changed file
- [ ] The fix reuses existing tested infrastructure (`scheduleDetachedLaunchdRestartHandoff` has its own test suite in `launchd-restart-handoff.test.ts`)
- [ ] Manually confirmed on macOS: chat messages that trigger config writes no longer kill the gateway

Fixes #41815