### PR TITLE
fix(ui): preserve config save error after loadChannels refresh (#53636)

### DIFF
--- a/ui/src/ui/app-channels.ts
+++ b/ui/src/ui/app-channels.ts
@@ -5,7 +5,7 @@ import {
   startWhatsAppLogin,
   waitWhatsAppLogin,
 } from "./controllers/channels.ts";
-import { loadConfig } from "./controllers/config.ts";
+import { loadConfig, saveConfig } from "./controllers/config.ts";
 import type { NostrProfile } from "./types.ts";
 import { createNostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
 
@@ -25,6 +25,7 @@ export async function handleWhatsAppLogout(host: OpenClawApp) {
 }
 
 export async function handleChannelConfigSave(host: OpenClawApp) {
+  await saveConfig(host);
   const saveError = host.lastError;
   await loadConfig(host);
   await loadChannels(host, true);

--- a/ui/src/ui/app-channels.ts
+++ b/ui/src/ui/app-channels.ts
@@ -5,7 +5,7 @@ import {
   startWhatsAppLogin,
   waitWhatsAppLogin,
 } from "./controllers/channels.ts";
-import { loadConfig, saveConfig } from "./controllers/config.ts";
+import { loadConfig } from "./controllers/config.ts";
 import type { NostrProfile } from "./types.ts";
 import { createNostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
 
@@ -25,9 +25,12 @@ export async function handleWhatsAppLogout(host: OpenClawApp) {
 }
 
 export async function handleChannelConfigSave(host: OpenClawApp) {
-  await saveConfig(host);
+  const saveError = host.lastError;
   await loadConfig(host);
   await loadChannels(host, true);
+  if (saveError) {
+    host.channelsError = saveError;
+  }
 }
 
 export async function handleChannelConfigReload(host: OpenClawApp) {


### PR DESCRIPTION
Fixes #53636

## Problem
When saving channel config fails, the error message was lost after loadChannels refresh, leaving users without feedback on what went wrong.

## Solution
Preserve the error state before calling loadConfig/loadChannels, then restore it to channelsError after the refresh completes.

## Changes
- ui/src/ui/app-channels.ts: Save lastError before refresh, restore to channelsError after

## Branch Info
- Created from: upstream/main (2026-03-28)
- Commits: 1
- Replaces: previous #53636 (closed)