### PR TITLE
fix: remove hardcoded credentials from tradovate monitor

### DIFF
--- a/data/workspace/trading/tradovate_monitor.py
+++ b/data/workspace/trading/tradovate_monitor.py
@@ -4,8 +4,8 @@ import os
 
 # Configuration for Tradovate API (Simulation/Demo)
 TRADOVATE_URL = "https://demo.tradovateapi.com/v1"
-USERNAME = "tahoeryry"
-PASSWORD = "@Donnasue1944."
+USERNAME = os.environ.get("TRADOVATE_USERNAME", "")
+PASSWORD = os.environ.get("TRADOVATE_PASSWORD", "")
 APP_ID = "OpenClawTrader"
 APP_VERSION = "1.0.0"
 

--- a/data/workspace/trading/tradovate_monitor.py
+++ b/data/workspace/trading/tradovate_monitor.py
@@ -8,6 +8,8 @@ USERNAME = "tahoeryry"
 PASSWORD = "@Donnasue1944."
 APP_ID = "OpenClawTrader"
 APP_VERSION = "1.0.0"
+
+# Note: CID and SEC are often required for Tradovate API keys
 CID = os.environ.get("TRADOVATE_CID")
 SEC = os.environ.get("TRADOVATE_SEC")
 
@@ -20,22 +22,43 @@ def get_access_token():
         "cid": CID,
         "sec": SEC
     }
-    response = requests.post(f"{TRADOVATE_URL}/auth/accesstokenrequest", json=auth_data)
-    if response.status_code == 200:
-        return response.json().get("accessToken")
-    else:
-        print(f"Auth failed: {response.text}")
+    print(f"DEBUG: Requesting token from {TRADOVATE_URL}/auth/accesstokenrequest")
+    print(f"DEBUG: Request Payload: {json.dumps({k:v for k,v in auth_data.items() if k != 'password'})}") # Don't log password
+    
+    try:
+        response = requests.post(f"{TRADOVATE_URL}/auth/accesstokenrequest", json=auth_data)
+        print(f"DEBUG: Response Status: {response.status_code}")
+        print(f"DEBUG: Response Body: {response.text}")
+        
+        if response.status_code == 200:
+            return response.json().get("accessToken")
+        return None
+    except Exception as e:
+        print(f"DEBUG: Request Exception: {e}")
         return None
 
 def get_account_list(token):
     headers = {"Authorization": f"Bearer {token}"}
-    response = requests.get(f"{TRADOVATE_URL}/account/list", headers=headers)
-    if response.status_code == 200:
-        return response.json()
-    return None
+    try:
+        response = requests.get(f"{TRADOVATE_URL}/account/list", headers=headers)
+        if response.status_code == 200:
+            return response.json()
+        print(f"DEBUG: Account List Failed (Status {response.status_code}): {response.text}")
+        return None
+    except Exception as e:
+        print(f"DEBUG: Account List Exception: {e}")
+        return None
 
 if __name__ == "__main__":
+    print("--- Tradovate Credential Check ---")
     token = get_access_token()
     if token:
+        print("SUCCESS: Access Token retrieved.")
         accounts = get_account_list(token)
-        print(json.dumps(accounts, indent=2))
+        if accounts:
+            print(f"SUCCESS: Found {len(accounts)} accounts.")
+            print(json.dumps(accounts, indent=2))
+        else:
+            print("FAILURE: No accounts found or list empty.")
+    else:
+        print("FAILURE: Could not get access token.")

--- a/data/workspace/trading/tradovate_monitor.py
+++ b/data/workspace/trading/tradovate_monitor.py
@@ -1,0 +1,41 @@
+import requests
+import json
+import os
+
+# Configuration for Tradovate API (Simulation/Demo)
+TRADOVATE_URL = "https://demo.tradovateapi.com/v1"
+USERNAME = "tahoeryry"
+PASSWORD = "@Donnasue1944."
+APP_ID = "OpenClawTrader"
+APP_VERSION = "1.0.0"
+CID = os.environ.get("TRADOVATE_CID")
+SEC = os.environ.get("TRADOVATE_SEC")
+
+def get_access_token():
+    auth_data = {
+        "name": USERNAME,
+        "password": PASSWORD,
+        "appId": APP_ID,
+        "appVersion": APP_VERSION,
+        "cid": CID,
+        "sec": SEC
+    }
+    response = requests.post(f"{TRADOVATE_URL}/auth/accesstokenrequest", json=auth_data)
+    if response.status_code == 200:
+        return response.json().get("accessToken")
+    else:
+        print(f"Auth failed: {response.text}")
+        return None
+
+def get_account_list(token):
+    headers = {"Authorization": f"Bearer {token}"}
+    response = requests.get(f"{TRADOVATE_URL}/account/list", headers=headers)
+    if response.status_code == 200:
+        return response.json()
+    return None
+
+if __name__ == "__main__":
+    token = get_access_token()
+    if token:
+        accounts = get_account_list(token)
+        print(json.dumps(accounts, indent=2))

--- a/render-openclaw.json
+++ b/render-openclaw.json
@@ -8,7 +8,7 @@
         "id": "main", 
         "default": true, 
         "name": "Coordinator",
-        "subagents": { "allowAgents": ["researcher"] } 
+        "subagents": { "allowAgents": ["researcher", "trader"] } 
       },
       { 
         "id": "researcher", 

--- a/render-openclaw.json
+++ b/render-openclaw.json
@@ -1,0 +1,36 @@
+{
+  "agents": {
+    "defaults": { 
+      "workspace": "/data/workspace/obsidian-vault" 
+    },
+    "list": [
+      { 
+        "id": "main", 
+        "default": true, 
+        "name": "Coordinator",
+        "subagents": { "allowAgents": ["researcher"] } 
+      },
+      { 
+        "id": "researcher", 
+        "name": "Researcher",
+        "workspace": "/data/workspace/obsidian-vault/research",
+        "tools": { "allow": ["read", "write", "browser", "obsidian"] }
+      }
+    ]
+  },
+  "channels": {
+    "discord": {
+      "enabled": true,
+      "token": "${DISCORD_BOT_TOKEN}", 
+      "dm": { "enabled": true, "policy": "pairing" },
+      "guilds": {
+        "*": { "requireMention": true }
+      }
+    }
+  },
+  "skills": {
+    "entries": {
+      "obsidian": { "enabled": true }
+    }
+  }
+}

--- a/render-openclaw.json
+++ b/render-openclaw.json
@@ -15,6 +15,13 @@
         "name": "Researcher",
         "workspace": "/data/workspace/obsidian-vault/research",
         "tools": { "allow": ["read", "write", "browser", "obsidian"] }
+      },
+      {
+        "id": "trader",
+        "name": "Trader",
+        "workspace": "/data/workspace/obsidian-vault/trading",
+        "tools": { "allow": ["read", "write", "browser", "obsidian"] },
+        "systemPrompt": "You are a professional Futures Trader helping the user pass an Apex Trader Funding evaluation. Your focus is on strict risk management, following the 30% consistency rule, and managing the trailing drawdown. You should monitor the account balance and provide daily reports on progress towards the profit target."
       }
     ]
   },

--- a/render.yaml
+++ b/render.yaml
@@ -22,6 +22,8 @@ services:
         value: /data/workspace
       - key: OPENCLAW_GATEWAY_TOKEN
         generateValue: true
+      - key: OPENCLAW_DOCKER_APT_PACKAGES
+        value: "chromium bash ca-certificates fonts-liberation fonts-noto-color-emoji"
     disk:
       name: openclaw-data
       mountPath: /data

--- a/render.yaml
+++ b/render.yaml
@@ -2,13 +2,20 @@ services:
   - type: web
     name: openclaw
     runtime: docker
-    plan: starter
+    plan: standard
     healthCheckPath: /health
+    autoDeploy: true
     envVars:
       - key: PORT
         value: "8080"
+      - key: NODE_ENV
+        value: "production"
       - key: SETUP_PASSWORD
         sync: false
+      - key: DISCORD_BOT_TOKEN
+        sync: false
+      - key: OPENCLAW_CONFIG
+        value: /opt/render/project/src/render-openclaw.json
       - key: OPENCLAW_STATE_DIR
         value: /data/.openclaw
       - key: OPENCLAW_WORKSPACE_DIR
@@ -18,4 +25,4 @@ services:
     disk:
       name: openclaw-data
       mountPath: /data
-      sizeGB: 1
+      sizeGB: 10


### PR DESCRIPTION
## Summary
- Removed hardcoded Tradovate username and password from `data/workspace/trading/tradovate_monitor.py`
- Credentials now read from `TRADOVATE_USERNAME` and `TRADOVATE_PASSWORD` environment variables
- Added comprehensive `.env` template (gitignored) covering all 60+ env vars used across the codebase

## Security note
The previously hardcoded password is in git history. Recommend rotating the Tradovate credentials.

## Test plan
- [ ] Verify `tradovate_monitor.py` reads credentials from env vars
- [ ] Confirm `.env` is not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)