### PR TITLE
fix: include BOOTSTRAP.md template in npm package (#56155)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "assets/",
     "dist/",
     "docs/",
+    "docs/reference/templates/",
     "!docs/.generated/**",
     "!docs/.i18n/zh-CN.tm.jsonl",
     "skills/"


### PR DESCRIPTION
## Summary
- Added `docs/reference/templates/` to package.json `files` array
- Ensures `BOOTSTRAP.md` workspace template is included in the published npm package
- Prevents runtime error "Missing workspace template: BOOTSTRAP.md" when seeding new agent workspaces

## Test plan
- [x] Verified `docs/reference/templates/BOOTSTRAP.md` exists in source
- [x] `npm pack --dry-run` confirms file is included in package output

Closes #56155