### PR TITLE
fix(gateway): preserve operator scopes for shared-auth connections

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -512,7 +512,7 @@ export function attachGatewayWsMessageHandler(params: {
           close(1008, truncateCloseReason(authMessage));
         };
         const clearUnboundScopes = () => {
-          if (scopes.length > 0) {
+          if (scopes.length > 0 && !sharedAuthOk) {
             scopes = [];
             connectParams.scopes = scopes;
           }


### PR DESCRIPTION
## Summary

- Restores the `!sharedAuthOk` guard inside `clearUnboundScopes` that was removed by 3e2b3bd2c5 (#53110), which causes token-authenticated backend clients (e.g. AlphaClaw chat bridge) to have their operator scopes unconditionally stripped during the WS handshake
- All scoped method calls (`chat.history`, etc.) fail with `missing scope: operator.read` even though the connection is properly authenticated

## Root Cause

`clearUnboundScopes` was meant to strip self-declared scopes only for unauthenticated or device-less anonymous connections. The original fix in 9c142993b added `&& !sharedAuthOk` so token/password-authenticated operators keep their scopes. #53110 refactored the call site and removed this guard, regressing the fix.

## Test plan

- [ ] Connect as `gateway-client` / `backend` / `operator` with a valid token and no device identity — scopes should be preserved
- [ ] `chat.history` (requires `operator.read`) succeeds after the handshake
- [ ] Control UI connections without shared auth still have scopes cleared as before

Closes #56194