### PR TITLE
fix(skills): load skill commands regardless of model alias configuration

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -207,10 +207,13 @@ export async function resolveReplyDirectives(params: {
         .filter((alias) => !reservedCommands.has(alias.toLowerCase()))
     : [];
 
-  // Only load workspace skill commands when we actually need them to filter aliases.
-  // This avoids scanning skills for messages that only use plain text with no slash syntax.
+  // Load workspace skill commands when the message contains a slash and text commands are
+  // allowed.  Previously this was also gated on `rawAliases.length > 0`, which meant skill
+  // commands were never loaded (and therefore never transformed) when no model aliases were
+  // configured.  The downstream `handleInlineActions` needs the list to resolve `/skill`
+  // invocations regardless of whether model aliases exist.
   const skillCommands =
-    allowTextCommands && commandTextHasSlash && rawAliases.length > 0
+    allowTextCommands && commandTextHasSlash
       ? (await loadSkillCommands()).listSkillCommandsForWorkspace({
           workspaceDir,
           cfg,

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -8,6 +8,7 @@ import type { TypingController } from "./typing.js";
 
 const handleCommandsMock = vi.fn();
 const getChannelPluginMock = vi.fn();
+const listSkillCommandsForWorkspaceMock = vi.fn();
 
 let handleInlineActions: typeof import("./get-reply-inline-actions.js").handleInlineActions;
 type HandleInlineActionsInput = Parameters<
@@ -27,6 +28,10 @@ async function loadFreshInlineActionsModuleForTest() {
       getChannelPlugin: (...args: unknown[]) => getChannelPluginMock(...args),
     };
   });
+  vi.doMock("../skill-commands.runtime.js", () => ({
+    listSkillCommandsForWorkspace: (...args: unknown[]) =>
+      listSkillCommandsForWorkspaceMock(...args),
+  }));
   ({ handleInlineActions } = await import("./get-reply-inline-actions.js"));
 }
 
@@ -118,6 +123,7 @@ describe("handleInlineActions", () => {
     getChannelPluginMock.mockImplementation((channelId?: string) =>
       channelId === "whatsapp" ? { commands: { skipWhenConfigEmpty: true } } : undefined,
     );
+    listSkillCommandsForWorkspaceMock.mockReset();
     await loadFreshInlineActionsModuleForTest();
   });
 
@@ -292,5 +298,53 @@ describe("handleInlineActions", () => {
         }),
       }),
     );
+  });
+
+  it("falls back to fresh skill command load when upstream passes empty array", async () => {
+    const typing = createTypingController();
+    handleCommandsMock.mockResolvedValue({ shouldContinue: false, reply: { text: "done" } });
+    const freshSkillCommands: SkillCommandSpec[] = [
+      {
+        name: "deploy",
+        skillName: "deploy-helper",
+        description: "Deploy helper",
+        promptTemplate: undefined,
+        sourceFilePath: "/tmp/plugin/commands/deploy.md",
+      },
+    ];
+    listSkillCommandsForWorkspaceMock.mockReturnValue(freshSkillCommands);
+
+    const ctx = buildTestCtx({
+      Body: "/deploy staging",
+      CommandBody: "/deploy staging",
+    });
+
+    const result = await handleInlineActions(
+      createHandleInlineActionsInput({
+        ctx,
+        typing,
+        cleanedBody: "/deploy staging",
+        command: {
+          isAuthorizedSender: true,
+          rawBodyNormalized: "/deploy staging",
+          commandBodyNormalized: "/deploy staging",
+        },
+        overrides: {
+          allowTextCommands: true,
+          cfg: { commands: { text: true } },
+          // Upstream passed empty array (e.g. no model aliases configured),
+          // handleInlineActions should fall back to loading fresh.
+          skillCommands: [],
+        },
+      }),
+    );
+
+    // The fresh load should have been called since upstream passed [].
+    expect(listSkillCommandsForWorkspaceMock).toHaveBeenCalledTimes(1);
+    // Skill command was resolved and body was rewritten.
+    expect(ctx.Body).toBe(
+      'Use the "deploy-helper" skill for this request.\n\nUser input:\nstaging',
+    );
+    expect(result).toEqual({ kind: "reply", reply: { text: "done" } });
   });
 });

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -185,7 +185,7 @@ export async function handleInlineActions(params: {
     // `/skill …` needs the full skill command list.
     (slashCommandName === "skill" || !getBuiltinSlashCommands().has(slashCommandName));
   const skillCommands =
-    shouldLoadSkillCommands && params.skillCommands
+    shouldLoadSkillCommands && params.skillCommands && params.skillCommands.length > 0
       ? params.skillCommands
       : shouldLoadSkillCommands
         ? (await import("../skill-commands.runtime.js")).listSkillCommandsForWorkspace({


### PR DESCRIPTION
## Summary

Fixes #56188

`/skill <name> <input>` was silently skipped (passed as raw text to the agent) when no model aliases were configured in `cfg.agents.defaults.models.*.alias`.

## Root Cause

Two issues in the skill command resolution pipeline:

1. **`resolveReplyDirectives`** (`src/auto-reply/reply/get-reply-directives.ts`): Skill commands were only loaded when `rawAliases.length > 0`, meaning they were never loaded (and never passed downstream) when no model aliases existed.

2. **`handleInlineActions`** (`src/auto-reply/reply/get-reply-inline-actions.ts`): The fallback fresh-load of skill commands was unreachable because `params.skillCommands` (an empty `[]` from issue 1) is truthy in JavaScript, so the ternary always took the first branch returning `[]` instead of falling through to the fresh-load path.

## Fix

1. Remove the `rawAliases.length > 0` gate from skill command loading in `resolveReplyDirectives` — skill commands should be loaded whenever the message contains a slash and text commands are allowed, regardless of model alias configuration.

2. Change the truthy check `params.skillCommands` to `params.skillCommands.length > 0` in `handleInlineActions` so that an empty upstream array correctly falls through to the fresh-load path.

## Test

Added a test case verifying that when `skillCommands` is passed as an empty array (simulating the no-model-aliases scenario), `handleInlineActions` falls back to loading skill commands fresh and correctly rewrites the `/skill` command body.

## Verification

- `pnpm test -- src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts` — 6/6 pass
- `pnpm check` — only pre-existing type errors in unrelated files (`channels.status.test.ts`, `typing-lease.test-support.ts`)