### PR TITLE
fix: generate systemd gateway env files

### DIFF
--- a/extensions/signal/src/runtime-api.ts
+++ b/extensions/signal/src/runtime-api.ts
@@ -27,7 +27,7 @@ export {
   normalizeE164,
   normalizeSignalMessagingTarget,
   resolveChannelMediaMaxBytes,
-} from "openclaw/plugin-sdk/signal-core";
+} from "openclaw/plugin-sdk/signal";
 export { detectBinary, installSignalCli } from "openclaw/plugin-sdk/setup-tools";
 export {
   resolveAllowlistProviderRuntimeGroupPolicy,

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -56,4 +56,5 @@ export type GatewayServiceRenderArgs = {
   programArguments: string[];
   workingDirectory?: string;
   environment?: GatewayServiceEnv;
+  environmentFilePath?: string;
 };

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -35,4 +35,19 @@ describe("buildSystemdUnit", () => {
       }),
     ).toThrow(/CR or LF/);
   });
+
+  it("renders EnvironmentFile when an env file path is provided", () => {
+    const unit = buildSystemdUnit({
+      description: "OpenClaw Gateway",
+      programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+      environment: {
+        OPENCLAW_GATEWAY_TOKEN: "secret",
+      },
+      environmentFilePath: "/home/test/.config/systemd/user/openclaw-gateway.env",
+    });
+    expect(unit).toContain(
+      "EnvironmentFile=/home/test/.config/systemd/user/openclaw-gateway.env",
+    );
+    expect(unit).not.toContain("Environment=OPENCLAW_GATEWAY_TOKEN=secret");
+  });
 });

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -40,6 +40,7 @@ export function buildSystemdUnit({
   programArguments,
   workingDirectory,
   environment,
+  environmentFilePath,
 }: GatewayServiceRenderArgs): string {
   const execStart = programArguments.map(systemdEscapeArg).join(" ");
   const descriptionValue = description?.trim() || "OpenClaw Gateway";
@@ -48,7 +49,9 @@ export function buildSystemdUnit({
   const workingDirLine = workingDirectory
     ? `WorkingDirectory=${systemdEscapeArg(workingDirectory)}`
     : null;
-  const envLines = renderEnvLines(environment);
+  const envLines = environmentFilePath
+    ? [`EnvironmentFile=${systemdEscapeArg(environmentFilePath)}`]
+    : renderEnvLines(environment);
   return [
     "[Unit]",
     descriptionLine,

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -11,6 +11,7 @@ vi.mock("node:child_process", () => ({
 import { splitArgsPreservingQuotes } from "./arg-split.js";
 import { parseSystemdExecStart } from "./systemd-unit.js";
 import {
+  installSystemdService,
   isNonFatalSystemdInstallProbeError,
   isSystemdUserServiceAvailable,
   parseSystemdShow,
@@ -18,6 +19,7 @@ import {
   restartSystemdService,
   resolveSystemdUserUnitPath,
   stopSystemdService,
+  uninstallSystemdService,
 } from "./systemd.js";
 
 type ExecFileError = Error & {
@@ -745,5 +747,93 @@ describe("systemd service control", () => {
         cb(null, "", "");
       });
     await assertRestartSuccess({ USER: "debian" });
+  });
+});
+
+describe("systemd service install rendering", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    execFileMock.mockReset();
+  });
+
+  it("writes an EnvironmentFile-backed unit and env file", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "status");
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "daemon-reload");
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "enable", GATEWAY_SERVICE);
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "restart", GATEWAY_SERVICE);
+        cb(null, "", "");
+      });
+
+    const writeFileSpy = vi.spyOn(fs, "writeFile").mockResolvedValue(undefined);
+    vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    vi.spyOn(fs, "access").mockRejectedValue(Object.assign(new Error("missing"), { code: "ENOENT" }));
+    vi.spyOn(fs, "copyFile").mockResolvedValue(undefined);
+    vi.spyOn(fs, "chmod").mockResolvedValue(undefined);
+    vi.spyOn(fs, "unlink").mockRejectedValue(Object.assign(new Error("missing"), { code: "ENOENT" }));
+
+    await installSystemdService({
+      env: { HOME: TEST_SERVICE_HOME },
+      stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+      programArguments: ["/usr/bin/openclaw", "gateway", "run"],
+      environment: {
+        OPENCLAW_GATEWAY_TOKEN: "env-file-token",
+      },
+      description: "OpenClaw Gateway",
+    });
+
+    expect(writeFileSpy).toHaveBeenCalledTimes(2);
+    expect(writeFileSpy.mock.calls[0]?.[0]).toBe(
+      `${TEST_SERVICE_HOME}/.config/systemd/user/openclaw-gateway.service`,
+    );
+    expect(String(writeFileSpy.mock.calls[0]?.[1])).toContain(
+      `EnvironmentFile=${TEST_SERVICE_HOME}/.config/systemd/user/openclaw-gateway.env`,
+    );
+    expect(writeFileSpy.mock.calls[1]?.[0]).toBe(
+      `${TEST_SERVICE_HOME}/.config/systemd/user/openclaw-gateway.env`,
+    );
+    expect(String(writeFileSpy.mock.calls[1]?.[1])).toContain(
+      'OPENCLAW_GATEWAY_TOKEN="env-file-token"',
+    );
+  });
+
+  it("removes the EnvironmentFile on uninstall", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "status");
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "disable", "--now", GATEWAY_SERVICE);
+        cb(null, "", "");
+      });
+
+    const unlinkSpy = vi.spyOn(fs, "unlink").mockResolvedValue(undefined);
+    const write = vi.fn();
+
+    await uninstallSystemdService({
+      env: { HOME: TEST_SERVICE_HOME },
+      stdout: { write } as unknown as NodeJS.WritableStream,
+    });
+
+    expect(unlinkSpy).toHaveBeenNthCalledWith(
+      1,
+      `${TEST_SERVICE_HOME}/.config/systemd/user/openclaw-gateway.service`,
+    );
+    expect(unlinkSpy).toHaveBeenNthCalledWith(
+      2,
+      `${TEST_SERVICE_HOME}/.config/systemd/user/openclaw-gateway.env`,
+    );
+    expect(String(write.mock.calls[1]?.[0])).toContain("Removed systemd environment");
   });
 });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -55,6 +55,13 @@ function resolveSystemdUnitPath(env: GatewayServiceEnv): string {
   return resolveSystemdUnitPathForName(env, resolveSystemdServiceName(env));
 }
 
+function resolveSystemdEnvironmentFilePath(env: GatewayServiceEnv): string {
+  const unitPath = resolveSystemdUnitPath(env);
+  const unitDir = path.posix.dirname(unitPath);
+  const serviceName = resolveSystemdServiceName(env);
+  return path.posix.join(unitDir, `${serviceName}.env`);
+}
+
 export function resolveSystemdUserUnitPath(env: GatewayServiceEnv): string {
   return resolveSystemdUnitPath(env);
 }
@@ -416,6 +423,25 @@ async function assertSystemdAvailable(env: GatewayServiceEnv = process.env as Ga
   throw new Error(`systemctl --user unavailable: ${detail || "unknown error"}`.trim());
 }
 
+function renderSystemdEnvironmentFileContent(
+  environment: GatewayServiceEnv | undefined,
+): string | null {
+  if (!environment) {
+    return null;
+  }
+  const entries = Object.entries(environment).filter(
+    ([, value]) => typeof value === "string" && value.trim(),
+  );
+  if (entries.length === 0) {
+    return null;
+  }
+  const lines = entries.map(([key, value]) => {
+    const rawValue = value ?? "";
+    return `${key}=${JSON.stringify(rawValue.trim())}`;
+  });
+  return `${lines.join("\n")}\n`;
+}
+
 async function writeSystemdUnit({
   env,
   programArguments,
@@ -426,6 +452,7 @@ async function writeSystemdUnit({
   await assertSystemdAvailable(env);
 
   const unitPath = resolveSystemdUnitPath(env);
+  const environmentFilePath = resolveSystemdEnvironmentFilePath(env);
   await fs.mkdir(path.dirname(unitPath), { recursive: true });
 
   // Preserve user customizations: back up existing unit file before overwriting.
@@ -445,8 +472,21 @@ async function writeSystemdUnit({
     programArguments,
     workingDirectory,
     environment,
+    environmentFilePath:
+      renderSystemdEnvironmentFileContent(environment) !== null ? environmentFilePath : undefined,
   });
   await fs.writeFile(unitPath, unit, "utf8");
+  const environmentFileContent = renderSystemdEnvironmentFileContent(environment);
+  if (environmentFileContent === null) {
+    try {
+      await fs.unlink(environmentFilePath);
+    } catch {
+      // No environment file to remove.
+    }
+  } else {
+    await fs.writeFile(environmentFilePath, environmentFileContent, { encoding: "utf8", mode: 0o600 });
+    await fs.chmod(environmentFilePath, 0o600);
+  }
   return { unitPath, backedUp };
 }
 
@@ -531,11 +571,18 @@ export async function uninstallSystemdService({
   await execSystemctlUser(env, ["disable", "--now", unitName]);
 
   const unitPath = resolveSystemdUnitPath(env);
+  const environmentFilePath = resolveSystemdEnvironmentFilePath(env);
   try {
     await fs.unlink(unitPath);
     stdout.write(`${formatLine("Removed systemd service", unitPath)}\n`);
   } catch {
     stdout.write(`Systemd service not found at ${unitPath}\n`);
+  }
+  try {
+    await fs.unlink(environmentFilePath);
+    stdout.write(`${formatLine("Removed systemd environment", environmentFilePath)}\n`);
+  } catch {
+    // Environment file is optional.
   }
 }
 


### PR DESCRIPTION
## Summary
- generate systemd gateway units with `EnvironmentFile=` instead of inline `Environment=` entries
- write the gateway env file alongside the managed user unit and remove it on uninstall
- add tests covering env-file unit rendering plus install/uninstall behavior

## Verification
- isolated Vitest check passed for the new env-file install/uninstall behavior
- note: the repo's normal Vitest harness is currently blocked in this checkout by an unrelated `openclaw/plugin-sdk/signal-core` module-resolution issue