### PR TITLE
docs(cron): clarify CLI JSON output shapes

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -39,6 +39,14 @@ top-level delivery fields, payload `provider` delivery aliases) and migrates sim
 `notify: true` webhook fallback jobs to explicit webhook delivery when `cron.webhook` is
 configured.
 
+## JSON output
+
+Use these shapes when you script against the CLI:
+
+- `openclaw cron list --json` returns `{ "jobs": [...] }`
+- `openclaw cron runs --id <job-id> --json` returns `{ "entries": [...] }`
+- `openclaw cron run --json` returns `{ ok: true, enqueued: true, runId }` when the manual run is queued successfully
+
 ## Common edits
 
 Update delivery settings without changing the message:

--- a/docs/zh-CN/cli/cron.md
+++ b/docs/zh-CN/cli/cron.md
@@ -28,6 +28,14 @@ x-i18n:
 
 说明：一次性（`--at`）任务成功后默认删除。使用 `--keep-after-run` 保留。
 
+## JSON 输出
+
+如果你要把 CLI 输出接进脚本，返回结构如下：
+
+- `openclaw cron list --json` 返回 `{ "jobs": [...] }`
+- `openclaw cron runs --id <job-id> --json` 返回 `{ "entries": [...] }`
+- `openclaw cron run --json` 在手动执行成功入队时返回 `{ ok: true, enqueued: true, runId }`
+
 ## 常见编辑
 
 更新投递设置而不更改消息：


### PR DESCRIPTION
## Summary
- document the top-level JSON wrappers returned by `openclaw cron list --json` and `openclaw cron runs --id <job-id> --json`
- point out that `openclaw cron run --json` returns the queued run shape documented elsewhere on the page
- keep the change scoped to the CLI reference and sync the zh-CN page
- resubmitted after reducing active PR count
- AI-assisted

## Test plan
- [x] `/home/ubuntu/openclaw/node_modules/.bin/oxfmt --check docs/cli/cron.md docs/zh-CN/cli/cron.md`
- [x] `pnpm dlx markdownlint-cli2 docs/cli/cron.md docs/zh-CN/cli/cron.md`
- [x] pre-commit hook ran `pnpm check`
- [x] manually reviewed the new JSON output section against the existing `cron run` note on the page

References #41372

Made with [Cursor](https://cursor.com)