### PR TITLE
UI: add Control UI chat session actions

### DIFF
--- a/src/config/bundled-channel-config-runtime.test.ts
+++ b/src/config/bundled-channel-config-runtime.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockedBundledPluginsState = vi.hoisted(() => ({
+  plugins: undefined as unknown,
+  runtimeSchema: {
+    safeParse: vi.fn((value: unknown) => ({ success: true, data: value })),
+  },
+}));
+
+vi.mock("../channels/plugins/bundled.js", () => {
+  const mockedExports: Record<string, unknown> = {};
+  Object.defineProperty(mockedExports, "bundledChannelPlugins", {
+    enumerable: true,
+    get: () => mockedBundledPluginsState.plugins,
+  });
+  return mockedExports;
+});
+
+vi.mock("../plugins/bundled-plugin-metadata.js", () => ({
+  BUNDLED_PLUGIN_METADATA: [],
+}));
+
+describe("bundled channel config runtime", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockedBundledPluginsState.plugins = undefined;
+    mockedBundledPluginsState.runtimeSchema.safeParse.mockClear();
+  });
+
+  it("rehydrates bundled channel maps after bundled plugins finish initializing", async () => {
+    const runtime = await import("./bundled-channel-config-runtime.js");
+
+    const initialSchemaMap = runtime.getBundledChannelConfigSchemaMap();
+    expect(initialSchemaMap.has("slack")).toBe(false);
+    expect(initialSchemaMap.has("msteams")).toBe(true);
+
+    const slackConfigSchema = {
+      schema: {
+        type: "object",
+        properties: {
+          botToken: { type: "string" },
+        },
+      },
+      runtime: mockedBundledPluginsState.runtimeSchema,
+    };
+    mockedBundledPluginsState.plugins = [
+      {
+        id: "slack",
+        configSchema: slackConfigSchema,
+      },
+    ];
+
+    const hydratedSchemaMap = runtime.getBundledChannelConfigSchemaMap();
+    expect(hydratedSchemaMap.get("slack")).toEqual(slackConfigSchema);
+    expect(runtime.getBundledChannelRuntimeMap().get("slack")).toBe(
+      mockedBundledPluginsState.runtimeSchema,
+    );
+  });
+});

--- a/src/config/bundled-channel-config-runtime.ts
+++ b/src/config/bundled-channel-config-runtime.ts
@@ -11,50 +11,86 @@ import { WhatsAppConfigSchema } from "./zod-schema.providers-whatsapp.js";
 type BundledChannelRuntimeMap = ReadonlyMap<string, ChannelConfigRuntimeSchema>;
 type BundledChannelConfigSchemaMap = ReadonlyMap<string, ChannelConfigSchema>;
 
-const bundledChannelRuntimeMap = new Map<string, ChannelConfigRuntimeSchema>();
-const bundledChannelConfigSchemaMap = new Map<string, ChannelConfigSchema>();
 const staticBundledChannelSchemas = new Map<string, ChannelConfigSchema>([
   ["msteams", buildChannelConfigSchema(MSTeamsConfigSchema)],
   ["whatsapp", buildChannelConfigSchema(WhatsAppConfigSchema)],
 ]);
-for (const plugin of bundledChannelPlugins) {
-  const channelSchema = plugin.configSchema;
-  if (!channelSchema) {
-    continue;
-  }
-  bundledChannelConfigSchemaMap.set(plugin.id, channelSchema);
-  if (channelSchema.runtime) {
-    bundledChannelRuntimeMap.set(plugin.id, channelSchema.runtime);
-  }
-}
-for (const entry of BUNDLED_PLUGIN_METADATA) {
-  const channelConfigs = entry.manifest.channelConfigs;
-  if (!channelConfigs) {
-    continue;
-  }
-  for (const [channelId, channelConfig] of Object.entries(channelConfigs)) {
-    const channelSchema = channelConfig?.schema as Record<string, unknown> | undefined;
+type BundledChannelConfigRuntimeState = {
+  configSchemaMap: BundledChannelConfigSchemaMap;
+  runtimeMap: BundledChannelRuntimeMap;
+  hydratedBundledPlugins: boolean;
+};
+
+let bundledChannelConfigRuntimeState: BundledChannelConfigRuntimeState | null = null;
+
+function buildBundledChannelConfigRuntimeState(): BundledChannelConfigRuntimeState {
+  const runtimeMap = new Map<string, ChannelConfigRuntimeSchema>();
+  const configSchemaMap = new Map<string, ChannelConfigSchema>();
+  const hydratedBundledPlugins = Array.isArray(bundledChannelPlugins);
+  const channelPlugins = hydratedBundledPlugins ? bundledChannelPlugins : [];
+
+  for (const plugin of channelPlugins) {
+    const channelSchema = plugin.configSchema;
     if (!channelSchema) {
       continue;
     }
-    if (!bundledChannelConfigSchemaMap.has(channelId)) {
-      bundledChannelConfigSchemaMap.set(channelId, { schema: channelSchema });
+    configSchemaMap.set(plugin.id, channelSchema);
+    if (channelSchema.runtime) {
+      runtimeMap.set(plugin.id, channelSchema.runtime);
     }
   }
+
+  for (const entry of BUNDLED_PLUGIN_METADATA) {
+    const channelConfigs = entry.manifest.channelConfigs;
+    if (!channelConfigs) {
+      continue;
+    }
+    for (const [channelId, channelConfig] of Object.entries(channelConfigs)) {
+      const channelSchema = channelConfig?.schema as Record<string, unknown> | undefined;
+      if (!channelSchema) {
+        continue;
+      }
+      if (!configSchemaMap.has(channelId)) {
+        configSchemaMap.set(channelId, { schema: channelSchema });
+      }
+    }
+  }
+
+  for (const [channelId, channelSchema] of staticBundledChannelSchemas) {
+    if (!configSchemaMap.has(channelId)) {
+      configSchemaMap.set(channelId, channelSchema);
+    }
+    if (channelSchema.runtime && !runtimeMap.has(channelId)) {
+      runtimeMap.set(channelId, channelSchema.runtime);
+    }
+  }
+
+  return {
+    configSchemaMap,
+    runtimeMap,
+    hydratedBundledPlugins,
+  };
 }
-for (const [channelId, channelSchema] of staticBundledChannelSchemas) {
-  if (!bundledChannelConfigSchemaMap.has(channelId)) {
-    bundledChannelConfigSchemaMap.set(channelId, channelSchema);
+
+function ensureBundledChannelConfigRuntimeState(): BundledChannelConfigRuntimeState {
+  // Generated bundled channel entries can import config validation during their own
+  // module initialization, so this state must be built lazily and retried once the
+  // bundled plugin list finishes hydrating.
+  if (
+    bundledChannelConfigRuntimeState &&
+    (bundledChannelConfigRuntimeState.hydratedBundledPlugins ||
+      !Array.isArray(bundledChannelPlugins))
+  ) {
+    return bundledChannelConfigRuntimeState;
   }
-  if (channelSchema.runtime && !bundledChannelRuntimeMap.has(channelId)) {
-    bundledChannelRuntimeMap.set(channelId, channelSchema.runtime);
-  }
+  bundledChannelConfigRuntimeState = buildBundledChannelConfigRuntimeState();
+  return bundledChannelConfigRuntimeState;
 }
 
 export function getBundledChannelRuntimeMap(): BundledChannelRuntimeMap {
-  return bundledChannelRuntimeMap;
+  return ensureBundledChannelConfigRuntimeState().runtimeMap;
 }
 
 export function getBundledChannelConfigSchemaMap(): BundledChannelConfigSchemaMap {
-  return bundledChannelConfigSchemaMap;
+  return ensureBundledChannelConfigRuntimeState().configSchemaMap;
 }

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -14,6 +14,8 @@ export const de: TranslationMap = {
     na: "k. A.",
     docs: "Dokumentation",
     resources: "Ressourcen",
+    newChat: "Neuer Chat",
+    renameChat: "Chat umbenennen",
   },
   nav: {
     chat: "Chat",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -16,6 +16,8 @@ export const en: TranslationMap = {
     theme: "Theme",
     resources: "Resources",
     search: "Search",
+    newChat: "New chat",
+    renameChat: "Rename chat",
   },
   nav: {
     chat: "Chat",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -14,6 +14,8 @@ export const es: TranslationMap = {
     na: "n/a",
     docs: "Docs",
     resources: "Recursos",
+    newChat: "Nuevo chat",
+    renameChat: "Renombrar chat",
   },
   nav: {
     chat: "Chat",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -15,6 +15,8 @@ export const pt_BR: TranslationMap = {
     docs: "Docs",
     resources: "Recursos",
     search: "Pesquisar",
+    newChat: "Novo chat",
+    renameChat: "Renomear chat",
   },
   nav: {
     chat: "Chat",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -15,6 +15,8 @@ export const zh_CN: TranslationMap = {
     docs: "文档",
     resources: "资源",
     search: "搜索",
+    newChat: "新聊天",
+    renameChat: "重命名聊天",
   },
   nav: {
     chat: "聊天",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -15,6 +15,8 @@ export const zh_TW: TranslationMap = {
     docs: "文檔",
     resources: "資源",
     search: "搜尋",
+    newChat: "新增聊天",
+    renameChat: "重新命名聊天",
   },
   nav: {
     chat: "聊天",

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -759,6 +759,10 @@
   max-width: 320px;
 }
 
+.chat-controls__session-action {
+  flex-shrink: 0;
+}
+
 .chat-controls__thinking {
   display: flex;
   align-items: center;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -571,6 +571,11 @@
     transform var(--duration-fast) ease;
 }
 
+button.nav-item {
+  width: 100%;
+  font: inherit;
+}
+
 .nav-item__icon {
   width: 16px;
   height: 16px;
@@ -611,6 +616,18 @@
   opacity: 1;
 }
 
+.nav-item:disabled {
+  cursor: not-allowed;
+  opacity: 0.64;
+  transform: none;
+}
+
+.nav-item:disabled:hover {
+  color: var(--muted);
+  background: transparent;
+  border-color: transparent;
+}
+
 .nav-item.active,
 .nav-item--active {
   color: var(--text-strong);
@@ -625,6 +642,48 @@
 .nav-item--active .nav-item__icon {
   opacity: 1;
   color: var(--accent);
+}
+
+.nav-item--action {
+  color: var(--text-strong);
+  background: color-mix(in srgb, var(--accent-subtle) 82%, var(--bg-elevated) 18%);
+  border-color: color-mix(in srgb, var(--accent) 22%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 10%, transparent);
+}
+
+.nav-item--action .nav-item__icon {
+  opacity: 1;
+  color: var(--accent);
+}
+
+.nav-item--action:hover {
+  color: var(--text-strong);
+  background: color-mix(in srgb, var(--accent-subtle) 92%, var(--bg-elevated) 8%);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+  transform: translateY(-1px);
+}
+
+.nav-item--action:disabled,
+.nav-item--action:disabled:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent-subtle) 58%, var(--bg-elevated) 42%);
+  border-color: color-mix(in srgb, var(--accent) 14%, transparent);
+  box-shadow: none;
+}
+
+.nav-item--action:disabled .nav-item__icon,
+.nav-item--action:disabled:hover .nav-item__icon {
+  color: var(--accent);
+}
+
+.sidebar-chat-actions {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.sidebar-chat-action {
+  width: 100%;
 }
 
 .sidebar--collapsed .sidebar-shell {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -130,9 +130,13 @@ function renderCronFilterIcon(hiddenCount: number) {
   `;
 }
 
-export function renderChatSessionSelect(state: AppViewState) {
+export function renderChatSessionSelect(
+  state: AppViewState,
+  opts?: { onRenameSession?: () => void },
+) {
   const sessionGroups = resolveSessionOptionGroups(state, state.sessionKey, state.sessionsResult);
   const modelSelect = renderChatModelSelect(state);
+  const canRenameSession = Boolean(opts?.onRenameSession);
   return html`
     <div class="chat-controls__session-row">
       <label class="field chat-controls__session">
@@ -163,6 +167,20 @@ export function renderChatSessionSelect(state: AppViewState) {
         </select>
       </label>
       ${modelSelect}
+      ${canRenameSession
+        ? html`
+            <button
+              type="button"
+              class="btn btn--sm btn--icon chat-controls__session-action"
+              title=${t("common.renameChat")}
+              aria-label=${t("common.renameChat")}
+              ?disabled=${!state.connected || !state.client}
+              @click=${() => opts?.onRenameSession?.()}
+            >
+              ${icons.penLine}
+            </button>
+          `
+        : nothing}
     </div>
   `;
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -84,7 +84,6 @@ import {
   deleteSessionsAndRefresh,
   loadSessions,
   patchSession,
-  resolveNewControlUiSessionLabel,
 } from "./controllers/sessions.ts";
 import {
   installSkill,
@@ -404,30 +403,29 @@ export function renderApp(state: AppViewState) {
       return;
     }
     const now = new Date();
-    const nextLabel = resolveNewControlUiSessionLabel(
-      window.prompt("New chat title:", createDefaultControlUiSessionLabel(now)),
-      now,
-    );
-    if (!nextLabel) {
-      return;
-    }
+    const nextLabel = createDefaultControlUiSessionLabel(now);
     state.lastError = null;
     const result = await createControlUiSession(state, {
       agentId: activeSessionAgentId,
       label: nextLabel,
+      now,
     });
     if (!result?.key) {
       state.lastError = state.sessionsError ?? "Failed to create chat";
       return;
     }
     switchChatSession(state, result.key);
+    if (state.tab !== "chat") {
+      state.setTab("chat" as import("./navigation.ts").Tab);
+    }
+    state.navDrawerOpen = false;
   };
   const handleRenameChatSession = async () => {
     if (!state.client || !state.connected) {
       return;
     }
     const currentLabel = currentSessionRow?.label?.trim() || "";
-    const promptValue = window.prompt("Rename chat:", currentLabel);
+    const promptValue = window.prompt(t("common.renameChat"), currentLabel);
     if (promptValue === null) {
       return;
     }
@@ -551,6 +549,21 @@ export function renderApp(state: AppViewState) {
               </button>
             </div>
             <div class="sidebar-shell__body">
+              <div class="sidebar-chat-actions">
+                <button
+                  type="button"
+                  class="nav-item nav-item--action sidebar-chat-action"
+                  title=${t("common.newChat")}
+                  aria-label=${t("common.newChat")}
+                  ?disabled=${!state.client || !state.connected}
+                  @click=${() => void handleCreateChatSession()}
+                >
+                  <span class="nav-item__icon" aria-hidden="true">${icons.edit}</span>
+                  ${!navCollapsed
+                    ? html`<span class="nav-item__text">${t("common.newChat")}</span>`
+                    : nothing}
+                </button>
+              </div>
               <nav class="sidebar-nav">
                 ${TAB_GROUPS.map((group) => {
                   const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
@@ -662,7 +675,9 @@ export function renderApp(state: AppViewState) {
           : html`<section class="content-header">
               <div>
                 ${isChat
-                  ? renderChatSessionSelect(state)
+                  ? renderChatSessionSelect(state, {
+                      onRenameSession: () => void handleRenameChatSession(),
+                    })
                   : html`<div class="page-title">${titleForTab(state.tab)}</div>`}
                 ${isChat ? nothing : html`<div class="page-sub">${subtitleForTab(state.tab)}</div>`}
               </div>
@@ -1522,7 +1537,7 @@ export function renderApp(state: AppViewState) {
               onAbort: () => void state.handleAbortChat(),
               onQueueRemove: (id) => state.removeQueuedMessage(id),
               onNewSession: () => void handleCreateChatSession(),
-              onRenameSession: () => void handleRenameChatSession(),
+              onRenameSession: undefined,
               onClearHistory: async () => {
                 if (!state.client || !state.connected) {
                   return;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -78,7 +78,14 @@ import {
 import { loadLogs } from "./controllers/logs.ts";
 import { loadNodes } from "./controllers/nodes.ts";
 import { loadPresence } from "./controllers/presence.ts";
-import { deleteSessionsAndRefresh, loadSessions, patchSession } from "./controllers/sessions.ts";
+import {
+  createControlUiSession,
+  createDefaultControlUiSessionLabel,
+  deleteSessionsAndRefresh,
+  loadSessions,
+  patchSession,
+  resolveNewControlUiSessionLabel,
+} from "./controllers/sessions.ts";
 import {
   installSkill,
   loadSkills,
@@ -329,6 +336,8 @@ export function renderApp(state: AppViewState) {
     state.agentsList?.agents?.[0]?.id ??
     null;
   const activeSessionAgentId = resolveAgentIdFromSessionKey(state.sessionKey);
+  const currentSessionRow =
+    state.sessionsResult?.sessions?.find((row) => row.key === state.sessionKey) ?? null;
   const toolsPanelUsesActiveSession = Boolean(
     resolvedAgentId && activeSessionAgentId && resolvedAgentId === activeSessionAgentId,
   );
@@ -390,6 +399,48 @@ export function renderApp(state: AppViewState) {
     state.cronForm.deliveryMode === "webhook"
       ? rawDeliveryToSuggestions.filter((value) => isHttpUrl(value))
       : rawDeliveryToSuggestions;
+  const handleCreateChatSession = async () => {
+    if (!state.client || !state.connected) {
+      return;
+    }
+    const now = new Date();
+    const nextLabel = resolveNewControlUiSessionLabel(
+      window.prompt("New chat title:", createDefaultControlUiSessionLabel(now)),
+      now,
+    );
+    if (!nextLabel) {
+      return;
+    }
+    state.lastError = null;
+    const result = await createControlUiSession(state, {
+      agentId: activeSessionAgentId,
+      label: nextLabel,
+    });
+    if (!result?.key) {
+      state.lastError = state.sessionsError ?? "Failed to create chat";
+      return;
+    }
+    switchChatSession(state, result.key);
+  };
+  const handleRenameChatSession = async () => {
+    if (!state.client || !state.connected) {
+      return;
+    }
+    const currentLabel = currentSessionRow?.label?.trim() || "";
+    const promptValue = window.prompt("Rename chat:", currentLabel);
+    if (promptValue === null) {
+      return;
+    }
+    const nextLabel = promptValue.trim();
+    if (!nextLabel || nextLabel === currentLabel) {
+      return;
+    }
+    state.lastError = null;
+    const result = await patchSession(state, state.sessionKey, { label: nextLabel });
+    if (!result) {
+      state.lastError = state.sessionsError ?? "Failed to rename chat";
+    }
+  };
 
   return html`
     ${renderCommandPalette({
@@ -1470,7 +1521,8 @@ export function renderApp(state: AppViewState) {
               canAbort: Boolean(state.chatRunId),
               onAbort: () => void state.handleAbortChat(),
               onQueueRemove: (id) => state.removeQueuedMessage(id),
-              onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
+              onNewSession: () => void handleCreateChatSession(),
+              onRenameSession: () => void handleRenameChatSession(),
               onClearHistory: async () => {
                 if (!state.client || !state.connected) {
                   return;

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { deleteSessionsAndRefresh, subscribeSessions, type SessionsState } from "./sessions.ts";
+import {
+  buildControlUiSessionKey,
+  createControlUiSession,
+  createDefaultControlUiSessionLabel,
+  deleteSessionsAndRefresh,
+  patchSession,
+  resolveNewControlUiSessionLabel,
+  subscribeSessions,
+  type SessionsState,
+} from "./sessions.ts";
 
 type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
 
@@ -39,6 +48,112 @@ describe("subscribeSessions", () => {
 
     expect(request).toHaveBeenCalledWith("sessions.subscribe", {});
     expect(state.sessionsError).toBeNull();
+  });
+});
+
+describe("buildControlUiSessionKey", () => {
+  it("builds a deterministic agent-scoped UI session key from the title", () => {
+    const now = new Date(2026, 2, 27, 18, 42);
+    const key = buildControlUiSessionKey({
+      agentId: "Ops Agent",
+      label: "Planning / Roadmap",
+      now,
+      randomSuffix: "a1b2",
+    });
+
+    expect(key).toBe("agent:ops-agent:ui:20260327-1842-planning-roadmap-a1b2");
+  });
+});
+
+describe("createDefaultControlUiSessionLabel", () => {
+  it("formats a stable fallback chat label", () => {
+    expect(createDefaultControlUiSessionLabel(new Date(2026, 2, 27, 18, 42))).toBe(
+      "Chat 2026-03-27 18:42",
+    );
+  });
+});
+
+describe("resolveNewControlUiSessionLabel", () => {
+  it("returns null when the prompt is canceled", () => {
+    expect(resolveNewControlUiSessionLabel(null)).toBeNull();
+  });
+
+  it("falls back to the generated chat label when the prompt is blank", () => {
+    expect(resolveNewControlUiSessionLabel("   ", new Date(2026, 2, 27, 18, 42))).toBe(
+      "Chat 2026-03-27 18:42",
+    );
+  });
+});
+
+describe("patchSession", () => {
+  it("returns the patch result and refreshes sessions", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.patch") {
+        return {
+          ok: true,
+          path: "",
+          key: "agent:main:ui:20260327-1842-planning-a1b2",
+          entry: { sessionId: "session-1" },
+        };
+      }
+      if (method === "sessions.list") {
+        return undefined;
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const state = createState(request);
+
+    const result = await patchSession(state, "agent:main:ui:20260327-1842-planning-a1b2", {
+      label: "Planning",
+    });
+
+    expect(result?.key).toBe("agent:main:ui:20260327-1842-planning-a1b2");
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.patch", {
+      key: "agent:main:ui:20260327-1842-planning-a1b2",
+      label: "Planning",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
+      includeGlobal: true,
+      includeUnknown: true,
+    });
+  });
+});
+
+describe("createControlUiSession", () => {
+  it("creates a labeled UI session and refreshes the session list", async () => {
+    const now = new Date(2026, 2, 27, 18, 42);
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.patch") {
+        return {
+          ok: true,
+          path: "",
+          key: "agent:main:ui:20260327-1842-planning-roadmap-a1b2",
+          entry: { sessionId: "session-1" },
+        };
+      }
+      if (method === "sessions.list") {
+        return undefined;
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const state = createState(request);
+
+    const result = await createControlUiSession(state, {
+      agentId: "main",
+      label: "Planning Roadmap",
+      now,
+      randomSuffix: "a1b2",
+    });
+
+    expect(result?.key).toBe("agent:main:ui:20260327-1842-planning-roadmap-a1b2");
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.patch", {
+      key: "agent:main:ui:20260327-1842-planning-roadmap-a1b2",
+      label: "Planning Roadmap",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
+      includeGlobal: true,
+      includeUnknown: true,
+    });
   });
 });
 

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -1,6 +1,7 @@
+import { normalizeAgentId } from "../../../../src/routing/session-key.js";
 import { toNumber } from "../format.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
-import type { SessionsListResult } from "../types.ts";
+import type { SessionsListResult, SessionsPatchResult } from "../types.ts";
 import {
   formatMissingOperatorReadScopeMessage,
   isMissingOperatorReadScopeError,
@@ -17,6 +18,77 @@ export type SessionsState = {
   sessionsIncludeGlobal: boolean;
   sessionsIncludeUnknown: boolean;
 };
+
+const CONTROL_UI_SESSION_SLUG_MAX = 32;
+
+function pad2(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function createControlUiSessionRandomSuffix(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID().replaceAll("-", "").slice(0, 4);
+  }
+  if (typeof globalThis.crypto?.getRandomValues === "function") {
+    const array = new Uint8Array(2);
+    globalThis.crypto.getRandomValues(array);
+    return Array.from(array, (value) => value.toString(16).padStart(2, "0"))
+      .join("")
+      .slice(0, 4);
+  }
+  return Math.random().toString(16).slice(2, 6).padEnd(4, "0");
+}
+
+function formatControlUiSessionTimestamp(now: Date): string {
+  return (
+    [now.getFullYear(), pad2(now.getMonth() + 1), pad2(now.getDate())].join("") +
+    `-${pad2(now.getHours())}${pad2(now.getMinutes())}`
+  );
+}
+
+function formatControlUiSessionLabelTimestamp(now: Date): string {
+  return `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(now.getDate())} ${pad2(now.getHours())}:${pad2(now.getMinutes())}`;
+}
+
+function slugifyControlUiSessionLabel(label: string): string {
+  return (
+    label
+      .trim()
+      .toLowerCase()
+      .replace(/['’"]/g, "")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, CONTROL_UI_SESSION_SLUG_MAX) || "chat"
+  );
+}
+
+export function buildControlUiSessionKey(params: {
+  agentId: string;
+  label: string;
+  now?: Date;
+  randomSuffix?: string;
+}): string {
+  const now = params.now ?? new Date();
+  const suffix = (params.randomSuffix ?? createControlUiSessionRandomSuffix()).trim().toLowerCase();
+  const safeSuffix = suffix || createControlUiSessionRandomSuffix();
+  const slug = slugifyControlUiSessionLabel(params.label);
+  return `agent:${normalizeAgentId(params.agentId)}:ui:${formatControlUiSessionTimestamp(now)}-${slug}-${safeSuffix}`;
+}
+
+export function createDefaultControlUiSessionLabel(now: Date = new Date()): string {
+  return `Chat ${formatControlUiSessionLabelTimestamp(now)}`;
+}
+
+export function resolveNewControlUiSessionLabel(
+  input: string | null | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (input === null) {
+    return null;
+  }
+  const trimmed = typeof input === "string" ? input.trim() : "";
+  return trimmed || createDefaultControlUiSessionLabel(now);
+}
 
 export async function subscribeSessions(state: SessionsState) {
   if (!state.client || !state.connected) {
@@ -87,9 +159,9 @@ export async function patchSession(
     verboseLevel?: string | null;
     reasoningLevel?: string | null;
   },
-) {
+): Promise<SessionsPatchResult | null> {
   if (!state.client || !state.connected) {
-    return;
+    return null;
   }
   const params: Record<string, unknown> = { key };
   if ("label" in patch) {
@@ -108,11 +180,27 @@ export async function patchSession(
     params.reasoningLevel = patch.reasoningLevel;
   }
   try {
-    await state.client.request("sessions.patch", params);
+    const result = await state.client.request<SessionsPatchResult>("sessions.patch", params);
     await loadSessions(state);
+    return result ?? null;
   } catch (err) {
     state.sessionsError = String(err);
+    return null;
   }
+}
+
+export async function createControlUiSession(
+  state: SessionsState,
+  params: {
+    agentId: string;
+    label: string;
+    now?: Date;
+    randomSuffix?: string;
+  },
+): Promise<SessionsPatchResult | null> {
+  const label = params.label.trim();
+  const key = buildControlUiSessionKey({ ...params, label });
+  return patchSession(state, key, { label });
 }
 
 export async function deleteSessionsAndRefresh(

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -107,6 +107,24 @@ describe("control UI routing", () => {
     expect(app.querySelector(".sidebar-brand__copy")).not.toBeNull();
   });
 
+  it("keeps the new chat action at the top of the sidebar and collapses it to an icon", async () => {
+    const app = mountApp("/chat");
+    await app.updateComplete;
+
+    const action = app.querySelector<HTMLButtonElement>("button.sidebar-chat-action");
+    expect(action).not.toBeNull();
+    expect(action?.title).toBe("New chat");
+    expect(action?.querySelector(".nav-item__text")?.textContent?.trim()).toBe("New chat");
+
+    app.applySettings({ ...app.settings, navCollapsed: true });
+    await app.updateComplete;
+
+    const collapsedAction = app.querySelector<HTMLButtonElement>("button.sidebar-chat-action");
+    expect(collapsedAction).not.toBeNull();
+    expect(collapsedAction?.title).toBe("New chat");
+    expect(collapsedAction?.querySelector(".nav-item__text")).toBeNull();
+  });
+
   it("does not render a desktop sidebar resizer or inject a custom nav width", async () => {
     const app = mountApp("/chat");
     await app.updateComplete;

--- a/ui/src/ui/views/chat.browser.test.ts
+++ b/ui/src/ui/views/chat.browser.test.ts
@@ -1,5 +1,5 @@
 import { render } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import "../../styles.css";
 import { renderChat, type ChatProps } from "./chat.ts";
 
@@ -126,26 +126,13 @@ describe("chat context notice", () => {
     expect(icon.getBoundingClientRect().width).toBeLessThan(24);
   });
 
-  it("fires the new chat and rename chat toolbar actions", async () => {
-    const onNewSession = vi.fn();
-    const onRenameSession = vi.fn();
+  it("does not render session actions in the composer toolbar", async () => {
     const container = document.createElement("div");
     document.body.append(container);
-    render(
-      renderChat(
-        createProps({
-          onNewSession,
-          onRenameSession,
-        }),
-      ),
-      container,
-    );
+    render(renderChat(createProps({})), container);
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
-    container.querySelector<HTMLButtonElement>('button[title="New chat"]')?.click();
-    container.querySelector<HTMLButtonElement>('button[title="Rename chat"]')?.click();
-
-    expect(onNewSession).toHaveBeenCalledTimes(1);
-    expect(onRenameSession).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('button[title="New chat"]')).toBeNull();
+    expect(container.querySelector('button[title="Rename chat"]')).toBeNull();
   });
 });

--- a/ui/src/ui/views/chat.browser.test.ts
+++ b/ui/src/ui/views/chat.browser.test.ts
@@ -1,5 +1,5 @@
 import { render } from "lit";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import "../../styles.css";
 import { renderChat, type ChatProps } from "./chat.ts";
 
@@ -68,6 +68,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     onSend: () => undefined,
     onQueueRemove: () => undefined,
     onNewSession: () => undefined,
+    onRenameSession: () => undefined,
     agentsList: null,
     currentAgentId: "",
     onAgentChange: () => undefined,
@@ -123,5 +124,28 @@ describe("chat context notice", () => {
     expect(iconStyle.width).toBe("16px");
     expect(iconStyle.height).toBe("16px");
     expect(icon.getBoundingClientRect().width).toBeLessThan(24);
+  });
+
+  it("fires the new chat and rename chat toolbar actions", async () => {
+    const onNewSession = vi.fn();
+    const onRenameSession = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(
+      renderChat(
+        createProps({
+          onNewSession,
+          onRenameSession,
+        }),
+      ),
+      container,
+    );
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    container.querySelector<HTMLButtonElement>('button[title="New chat"]')?.click();
+    container.querySelector<HTMLButtonElement>('button[title="Rename chat"]')?.click();
+
+    expect(onNewSession).toHaveBeenCalledTimes(1);
+    expect(onRenameSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -185,6 +185,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     onSend: () => undefined,
     onQueueRemove: () => undefined,
     onNewSession: () => undefined,
+    onRenameSession: () => undefined,
     agentsList: null,
     currentAgentId: "",
     onAgentChange: () => undefined,
@@ -637,28 +638,33 @@ describe("chat view", () => {
     expect(stopButton).not.toBeUndefined();
     stopButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(onAbort).toHaveBeenCalledTimes(1);
-    expect(container.textContent).not.toContain("New session");
+    expect(container.querySelector('button[title="New chat"]')).toBeNull();
+    expect(container.querySelector('button[title="Rename chat"]')).toBeNull();
   });
 
-  it("shows a new session button when aborting is unavailable", () => {
+  it("shows new chat and rename actions when aborting is unavailable", () => {
     const container = document.createElement("div");
     const onNewSession = vi.fn();
+    const onRenameSession = vi.fn();
     render(
       renderChat(
         createProps({
           canAbort: false,
           onNewSession,
+          onRenameSession,
         }),
       ),
       container,
     );
 
-    const newSessionButton = container.querySelector<HTMLButtonElement>(
-      'button[title="New session"]',
-    );
+    const newSessionButton = container.querySelector<HTMLButtonElement>('button[title="New chat"]');
+    const renameButton = container.querySelector<HTMLButtonElement>('button[title="Rename chat"]');
     expect(newSessionButton).not.toBeUndefined();
+    expect(renameButton).not.toBeUndefined();
     newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    renameButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(onNewSession).toHaveBeenCalledTimes(1);
+    expect(onRenameSession).toHaveBeenCalledTimes(1);
     expect(container.textContent).not.toContain("Stop");
   });
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -642,29 +642,19 @@ describe("chat view", () => {
     expect(container.querySelector('button[title="Rename chat"]')).toBeNull();
   });
 
-  it("shows new chat and rename actions when aborting is unavailable", () => {
+  it("keeps session actions out of the composer toolbar", () => {
     const container = document.createElement("div");
-    const onNewSession = vi.fn();
-    const onRenameSession = vi.fn();
     render(
       renderChat(
         createProps({
           canAbort: false,
-          onNewSession,
-          onRenameSession,
         }),
       ),
       container,
     );
 
-    const newSessionButton = container.querySelector<HTMLButtonElement>('button[title="New chat"]');
-    const renameButton = container.querySelector<HTMLButtonElement>('button[title="Rename chat"]');
-    expect(newSessionButton).not.toBeUndefined();
-    expect(renameButton).not.toBeUndefined();
-    newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    renameButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(onNewSession).toHaveBeenCalledTimes(1);
-    expect(onRenameSession).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('button[title="New chat"]')).toBeNull();
+    expect(container.querySelector('button[title="Rename chat"]')).toBeNull();
     expect(container.textContent).not.toContain("Stop");
   });
 
@@ -823,6 +813,20 @@ describe("chat view", () => {
     expect(state.sessionsResult?.sessions[0]?.model).toBe("gpt-5-mini");
     expect(state.sessionsResult?.sessions[0]?.modelProvider).toBe("openai");
     vi.unstubAllGlobals();
+  });
+
+  it("renders a rename action in the chat header session row", () => {
+    const { state } = createChatHeaderState();
+    const onRenameSession = vi.fn();
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state, { onRenameSession }), container);
+
+    const renameButton = container.querySelector<HTMLButtonElement>('button[title="Rename chat"]');
+    expect(renameButton).not.toBeNull();
+    expect(renameButton?.disabled).toBe(false);
+
+    renameButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onRenameSession).toHaveBeenCalledTimes(1);
   });
 
   it("reloads effective tools after a chat-header model switch for the active tools panel", async () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -95,6 +95,7 @@ export type ChatProps = {
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
   onNewSession: () => void;
+  onRenameSession?: () => void;
   onClearHistory?: () => void;
   agentsList: {
     agents: Array<{ id: string; name?: string; identity?: { name?: string; avatarUrl?: string } }>;
@@ -1354,10 +1355,20 @@ export function renderChat(props: ChatProps) {
                   <button
                     class="btn btn--ghost"
                     @click=${props.onNewSession}
-                    title="New session"
-                    aria-label="New session"
+                    title="New chat"
+                    aria-label="New chat"
+                    ?disabled=${!props.connected}
                   >
                     ${icons.plus}
+                  </button>
+                  <button
+                    class="btn btn--ghost"
+                    @click=${props.onRenameSession}
+                    title="Rename chat"
+                    aria-label="Rename chat"
+                    ?disabled=${!props.connected}
+                  >
+                    ${icons.penLine}
                   </button>
                 `}
             <button

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1349,28 +1349,6 @@ export function renderChat(props: ChatProps) {
 
           <div class="agent-chat__toolbar-right">
             ${nothing /* search hidden for now */}
-            ${canAbort
-              ? nothing
-              : html`
-                  <button
-                    class="btn btn--ghost"
-                    @click=${props.onNewSession}
-                    title="New chat"
-                    aria-label="New chat"
-                    ?disabled=${!props.connected}
-                  >
-                    ${icons.plus}
-                  </button>
-                  <button
-                    class="btn btn--ghost"
-                    @click=${props.onRenameSession}
-                    title="Rename chat"
-                    aria-label="Rename chat"
-                    ?disabled=${!props.connected}
-                  >
-                    ${icons.penLine}
-                  </button>
-                `}
             <button
               class="btn btn--ghost"
               @click=${() => exportMarkdown(props)}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `New chat` lived in the composer row, which made it read like an input affordance next to `Attach file` instead of a chat/session navigation action.
- Why it matters: Control UI needs a ChatGPT/Gemini-style way to start parallel sessions quickly, including an obvious affordance in both the expanded sidebar and the collapsed rail.
- What changed: moved `New chat` into the left sidebar as the primary session action; the expanded sidebar shows the `New chat` label, the collapsed rail shows an icon-only affordance; moved `Rename chat` into the chat header session controls; clicking `New chat` now creates a fresh `agent:<agentId>:ui:<YYYYMMDD-HHmm>-chat-<rand4>` session immediately with the generated default label and switches to it.
- Reliability hardening: lazily hydrate bundled channel schema/runtime maps so generated bundled-channel entries can finish initializing before config validation iterates them; this avoids the `bundledChannelPlugins is not iterable` import-time crash that showed up in `extension-fast` CI lanes.
- What did NOT change (scope boundary): `/new` semantics stay unchanged, and this PR does not revive the broader tabs/history/theme work from #29417.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29563
- Related #29417
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the session-management actions were placed in the composer controls instead of the navigation/session surfaces where users expect chat-level actions to live.
- Missing detection / guardrail: there was no UI regression coverage asserting the placement of `New chat` in the sidebar or the collapsed-rail affordance, and no focused regression test covering the import-order hazard in bundled channel config runtime hydration.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #29563 requested the narrow session-management flow in Control UI; #29417 attempted a much broader UI rewrite that drifted from `main`.
- Why this regressed now: N/A
- If unknown, what was ruled out: local repros of the extension lanes passed once the runtime maps were hydrated lazily, which points to an import-order failure rather than an extension-specific functional regression.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/views/chat.test.ts`, `ui/src/ui/views/chat.browser.test.ts`, `ui/src/ui/navigation.browser.test.ts`, `src/config/bundled-channel-config-runtime.test.ts`
- Scenario the test should lock in: `New chat` renders in the sidebar, remains available in the collapsed rail as an icon-only action, is removed from the composer row, still creates/switches to a fresh Control UI session immediately, and bundled channel config/runtime maps can be imported before bundled channel entries finish hydrating without crashing.
- Why this is the smallest reliable guardrail: the behavior spans shared layout rendering plus chat view wiring, and the CI failure surface was isolated to one import-order seam in config runtime initialization.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- The left sidebar now shows `New chat` as the primary action instead of placing it beside the composer controls.
- The expanded sidebar shows the text label, and the collapsed rail keeps a matching icon-only action.
- `Rename chat` moved out of the composer row and into the chat header session controls.
- `New chat` no longer prompts first; it creates a fresh session immediately with the generated default label and switches into it.
- The composer row is reserved for message actions such as attachments and send-state controls.

## Diagram (if applicable)

```text
Before:
[left sidebar] -> [session list only]
[composer row] -> [Attach file] [New chat] [Rename chat] [Send]

After:
[left sidebar] -> [New chat] [session list]
[collapsed rail] -> [new chat icon]
[chat header] -> [session/model controls] [Rename chat]
[composer row] -> [Attach file] [message actions]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 + Bun/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Control UI (web)
- Relevant config (redacted): local gateway Control UI served at `http://127.0.0.1:18789`

### Steps

1. Open Control UI Chat with a connected local gateway.
2. Confirm `New chat` appears at the top of the left sidebar.
3. Collapse the sidebar and confirm the icon-only `New chat` affordance remains visible.
4. Click `New chat` and confirm the URL/session switches immediately without a title prompt.
5. Confirm `Rename chat` remains available in the chat header controls and the composer no longer shows session actions.
6. Run representative extension lanes that were red in CI and confirm they no longer trip `bundledChannelPlugins is not iterable` during config runtime import.

### Expected

- `New chat` is visually grouped with chat/session navigation, not composer input actions.
- Expanded and collapsed sidebar states both expose the action clearly.
- Clicking `New chat` creates a distinct `agent:<agentId>:ui:...` session key and switches into it immediately.
- `Rename chat` still updates the visible label for the current session.
- Representative extension lanes boot their config runtime without the bundled-channel import-order crash.

### Actual

- Verified locally: the sidebar/rail affordances rendered correctly, `New chat` created and switched to a new session key immediately, the composer no longer showed `New chat` / `Rename chat`, and representative `extension-fast` lanes passed after the lazy hydration change.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands and live result:
- `pnpm test -- ui/src/ui/views/chat.test.ts`
- `pnpm --dir ui test src/ui/views/chat.browser.test.ts src/ui/navigation.browser.test.ts`
- `pnpm test -- src/config/bundled-channel-config-runtime.test.ts`
- `pnpm test:extension google`
- `pnpm test:extension telegram`
- live Control UI smoke at `http://127.0.0.1:18789/chat`: verified the sidebar action, collapsed icon, immediate session switch, and composer cleanup
- CI failure signature observed before the hardening: `TypeError: bundledChannelPlugins is not iterable` from `src/config/bundled-channel-config-runtime.ts:20`

### Screenshots

Expanded sidebar:

![Expanded sidebar New chat](https://github.com/user-attachments/assets/2b1bbfd8-6d80-4a60-bcfd-19c793565d1d)

Collapsed rail:

![Collapsed rail New chat](https://github.com/user-attachments/assets/c1410da3-0c67-4881-bcba-99d99fbe9cd0)

## Human Verification (required)

- Verified scenarios: created a new chat from the sidebar, observed the page switch to a new session key, collapsed the rail and confirmed the icon-only affordance, confirmed `Rename chat` moved to the header while the composer no longer showed session actions, and reran representative extension lanes that were red in CI.
- Edge cases checked: `New chat` uses the generated default label without prompting; repeated creation keeps generating distinct session keys; unchanged or blank rename input remains a no-op.
- What you did **not** verify: the full local `pnpm build` in this dirty working tree is not a trustworthy signal because unrelated local dependency/worktree drift outside this PR changes the toolchain surface; I used focused verification plus PR CI for the touched paths.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: users may miss the action if the collapsed state loses the label.
  - Mitigation: the collapsed rail keeps a dedicated icon-only affordance in the same primary position.
- Risk: moving actions across surfaces can break muscle memory or tests.
  - Mitigation: the PR updates focused UI/browser coverage and keeps rename available in the header session controls.
- Risk: eager bundled-channel schema hydration can race generated entry initialization under some import orders.
  - Mitigation: the config/runtime maps now hydrate lazily and retry once bundled channel entries are available.
- Risk: users may expect `/new` to match the new sidebar behavior.
  - Mitigation: this PR keeps `/new` unchanged explicitly and makes the dedicated sidebar action the primary session-creation path.
