### PR TITLE
fix: guard against duplicate Feishu tool registration on config hot-reload

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -9,6 +9,8 @@ import { setFeishuRuntime } from "./src/runtime.js";
 import { registerFeishuSubagentHooks } from "./src/subagent-hooks.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
+let feishuToolsRegistered = false;
+
 export { feishuPlugin } from "./src/channel.js";
 export { setFeishuRuntime } from "./src/runtime.js";
 export {
@@ -68,6 +70,8 @@ export default defineChannelPluginEntry({
   plugin: feishuPlugin,
   setRuntime: setFeishuRuntime,
   registerFull(api) {
+    if (feishuToolsRegistered) return;
+    feishuToolsRegistered = true;
     registerFeishuSubagentHooks(api);
     registerFeishuDocTools(api);
     registerFeishuChatTools(api);

--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -9,7 +9,7 @@ import { setFeishuRuntime } from "./src/runtime.js";
 import { registerFeishuSubagentHooks } from "./src/subagent-hooks.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
-let feishuToolsRegistered = false;
+let registeredRegistry: object | null = null;
 
 export { feishuPlugin } from "./src/channel.js";
 export { setFeishuRuntime } from "./src/runtime.js";
@@ -70,8 +70,10 @@ export default defineChannelPluginEntry({
   plugin: feishuPlugin,
   setRuntime: setFeishuRuntime,
   registerFull(api) {
-    if (feishuToolsRegistered) return;
-    feishuToolsRegistered = true;
+    // Registry-bound guard: re-register when a new registry instance is
+    // created (e.g. during in-process gateway restarts).
+    if (registeredRegistry === api.registry) return;
+    registeredRegistry = api.registry;
     registerFeishuSubagentHooks(api);
     registerFeishuDocTools(api);
     registerFeishuChatTools(api);


### PR DESCRIPTION
## Problem

Feishu plugin tools re-register repeatedly on config hot-reload (#56114). Every time the config changes and triggers a gateway reload, `registerFull()` is called again, causing all 7 `registerFeishu*Tools()` functions to execute repeatedly and register duplicate tools.

## Root Cause

In `extensions/feishu/index.ts`, the `registerFull()` callback has no deduplication protection. The plugin system re-invokes each plugin's `register()` on config hot-reload, and `registerFull` blindly re-registers all tools every time.

## Fix

Added a module-level `feishuToolsRegistered` boolean guard in `extensions/feishu/index.ts`. On first call, `registerFull()` executes normally and sets the flag to `true`. Subsequent calls return immediately. `setRuntime` and `registerChannel` are unaffected.

Changes: 1 file, 4 lines added.

## Testing

Manual verification: config hot-reload no longer triggers duplicate tool registration.

Fixes #56114
