### PR TITLE
fix: correct Telnyx transcription field mapping to use transcription_data

### DIFF
--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -169,9 +169,9 @@ export class TelnyxProvider implements VoiceCallProvider {
         return {
           ...baseEvent,
           type: "call.speech",
-          transcript: data.payload?.transcription || "",
-          isFinal: data.payload?.is_final ?? true,
-          confidence: data.payload?.confidence,
+          transcript: data.payload?.transcription_data?.transcript || "",
+          isFinal: data.payload?.transcription_data?.is_final ?? true,
+          confidence: data.payload?.transcription_data?.confidence,
         };
 
       case "call.hangup":

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -338,6 +338,11 @@ interface TelnyxEvent {
     client_state?: string;
     text?: string;
     transcription?: string;
+    transcription_data?: {
+      transcript?: string;
+      is_final?: boolean;
+      confidence?: number;
+    };
     is_final?: boolean;
     confidence?: number;
     hangup_cause?: string;


### PR DESCRIPTION
## Problem

Voice Call Plugin: Telnyx transcription field mapping is wrong (#55956). The plugin reads transcription from `data.payload.transcription`, but Telnyx actually sends it at `data.payload.transcription_data.transcript`. Same issue affects `is_final` and `confidence` fields.

This causes every transcript to resolve as an empty string, making conversation mode completely unable to hear the caller.

## Root Cause

In `extensions/voice-call/src/providers/telnyx.ts`, the `call.transcription` event handler reads fields from the wrong path in the payload. Telnyx nests these under `transcription_data`:
```json
{
  "data": {
    "payload": {
      "transcription_data": {
        "transcript": "...",
        "is_final": true,
        "confidence": 0.28
      }
    }
  }
}
```

## Fix

Updated the field paths in the `call.transcription` case:
- `data.payload?.transcription` -> `data.payload?.transcription_data?.transcript`
- `data.payload?.is_final` -> `data.payload?.transcription_data?.is_final`
- `data.payload?.confidence` -> `data.payload?.transcription_data?.confidence`

Changes: 1 file, 3 lines changed.

## Testing

- Telnyx transcription events now correctly extract transcript text, is_final flag, and confidence score from the nested `transcription_data` object.

Fixes #55956
