### PR TITLE
fix(security): extend audit to flag dmPolicy=open and session.dmScope=main

### DIFF
--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -86,7 +86,6 @@ describe("collectExposureMatrixFindings - dmPolicy parity (#55612)", () => {
     };
     const findings = collectExposureMatrixFindings(cfg);
     const ids = findings.map((f) => f.checkId);
-    expect(ids).toContain("security.exposure.open_channels_with_elevated");
     expect(ids).toContain("security.exposure.open_dms_with_elevated");
     expect(
       findings.find((f) => f.checkId === "security.exposure.open_dms_with_elevated")?.severity,
@@ -124,7 +123,6 @@ describe("collectExposureMatrixFindings - dmPolicy parity (#55612)", () => {
     const ids = findings.map((f) => f.checkId);
     expect(ids).toContain("security.exposure.open_groups_with_elevated");
     expect(ids).toContain("security.exposure.open_dms_with_elevated");
-    expect(ids).toContain("security.exposure.open_channels_with_elevated");
   });
 
   it("preserves existing groupPolicy='open' behavior unchanged", () => {

--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   collectAttackSurfaceSummaryFindings,
+  collectExposureMatrixFindings,
+  collectLikelyMultiUserSetupFindings,
   collectSmallModelRiskFindings,
 } from "./audit-extra.sync.js";
 import { safeEqualSecret } from "./secret-equal.js";
@@ -73,5 +75,151 @@ describe("collectSmallModelRiskFindings", () => {
     expect(finding?.detail).toContain("ollama/mistral-8b");
     expect(finding?.detail).toContain("web=[off]");
     expect(finding?.detail).toContain("No web/browser tools detected");
+  });
+});
+
+describe("collectExposureMatrixFindings - dmPolicy parity (#55612)", () => {
+  it("flags dmPolicy='open' with elevated tools enabled", () => {
+    const cfg: OpenClawConfig = {
+      tools: { elevated: { enabled: true, allowFrom: { whatsapp: ["+1"] } } },
+      channels: { whatsapp: { dmPolicy: "open" } },
+    };
+    const findings = collectExposureMatrixFindings(cfg);
+    const ids = findings.map((f) => f.checkId);
+    expect(ids).toContain("security.exposure.open_channels_with_elevated");
+    expect(ids).toContain("security.exposure.open_dms_with_elevated");
+    expect(
+      findings.find((f) => f.checkId === "security.exposure.open_dms_with_elevated")?.severity,
+    ).toBe("critical");
+  });
+
+  it("flags dmPolicy='open' with runtime/fs tools exposed", () => {
+    const cfg: OpenClawConfig = {
+      channels: { whatsapp: { dmPolicy: "open" } },
+      tools: { elevated: { enabled: false } },
+    };
+    const findings = collectExposureMatrixFindings(cfg);
+    const ids = findings.map((f) => f.checkId);
+    expect(ids).toContain("security.exposure.open_dms_with_runtime_or_fs");
+  });
+
+  it("does not flag dmPolicy runtime/fs when sandbox=all", () => {
+    const cfg: OpenClawConfig = {
+      channels: { whatsapp: { dmPolicy: "open" } },
+      tools: { elevated: { enabled: false }, profile: "coding" },
+      agents: { defaults: { sandbox: { mode: "all" } } },
+    };
+    const findings = collectExposureMatrixFindings(cfg);
+    expect(
+      findings.some((f) => f.checkId === "security.exposure.open_dms_with_runtime_or_fs"),
+    ).toBe(false);
+  });
+
+  it("emits both group and dm findings when both policies are open", () => {
+    const cfg: OpenClawConfig = {
+      tools: { elevated: { enabled: true, allowFrom: { whatsapp: ["+1"] } } },
+      channels: { whatsapp: { groupPolicy: "open", dmPolicy: "open" } },
+    };
+    const findings = collectExposureMatrixFindings(cfg);
+    const ids = findings.map((f) => f.checkId);
+    expect(ids).toContain("security.exposure.open_groups_with_elevated");
+    expect(ids).toContain("security.exposure.open_dms_with_elevated");
+    expect(ids).toContain("security.exposure.open_channels_with_elevated");
+  });
+
+  it("preserves existing groupPolicy='open' behavior unchanged", () => {
+    const cfg: OpenClawConfig = {
+      tools: { elevated: { enabled: true, allowFrom: { whatsapp: ["+1"] } } },
+      channels: { whatsapp: { groupPolicy: "open" } },
+    };
+    const findings = collectExposureMatrixFindings(cfg);
+    expect(findings.some((f) => f.checkId === "security.exposure.open_groups_with_elevated")).toBe(
+      true,
+    );
+    expect(findings.some((f) => f.checkId === "security.exposure.open_dms_with_elevated")).toBe(
+      false,
+    );
+  });
+
+  it("returns empty when no open policies exist", () => {
+    const cfg: OpenClawConfig = {
+      channels: { whatsapp: { groupPolicy: "allowlist", dmPolicy: "pairing" } },
+    };
+    const findings = collectExposureMatrixFindings(cfg);
+    expect(findings.length).toBe(0);
+  });
+
+  it("detects account-level dmPolicy='open'", () => {
+    const cfg: OpenClawConfig = {
+      tools: { elevated: { enabled: true, allowFrom: { whatsapp: ["+1"] } } },
+      channels: { whatsapp: { accounts: { myAccount: { dmPolicy: "open" } } } },
+    };
+    const findings = collectExposureMatrixFindings(cfg);
+    const dm = findings.find((f) => f.checkId === "security.exposure.open_dms_with_elevated");
+    expect(dm).toBeDefined();
+    expect(dm?.detail).toContain("channels.whatsapp.accounts.myAccount.dmPolicy");
+  });
+});
+
+describe("collectLikelyMultiUserSetupFindings - dmScope check (#55578)", () => {
+  it("flags dmScope='main' when multi-user signals exist", () => {
+    const cfg: OpenClawConfig = {
+      session: { dmScope: "main" },
+      channels: { whatsapp: { dmPolicy: "open" } },
+    };
+    const findings = collectLikelyMultiUserSetupFindings(cfg);
+    const dmScopeFinding = findings.find(
+      (f) => f.checkId === "security.trust_model.dm_scope_main_multi_user",
+    );
+    expect(dmScopeFinding).toBeDefined();
+    expect(dmScopeFinding?.severity).toBe("critical");
+    expect(dmScopeFinding?.detail).toContain("session.dmScope");
+    expect(dmScopeFinding?.remediation).toContain("per-channel-peer");
+  });
+
+  it("flags default dmScope (unset) when multi-user signals exist", () => {
+    const cfg: OpenClawConfig = {
+      channels: { whatsapp: { dmPolicy: "open" } },
+    };
+    const findings = collectLikelyMultiUserSetupFindings(cfg);
+    expect(
+      findings.some((f) => f.checkId === "security.trust_model.dm_scope_main_multi_user"),
+    ).toBe(true);
+  });
+
+  it("does not flag when dmScope is per-channel-peer", () => {
+    const cfg: OpenClawConfig = {
+      session: { dmScope: "per-channel-peer" },
+      channels: { whatsapp: { dmPolicy: "open" } },
+    };
+    const findings = collectLikelyMultiUserSetupFindings(cfg);
+    expect(
+      findings.some((f) => f.checkId === "security.trust_model.dm_scope_main_multi_user"),
+    ).toBe(false);
+  });
+
+  it("does not flag dmScope when no multi-user signals", () => {
+    const cfg: OpenClawConfig = {
+      session: { dmScope: "main" },
+      channels: { whatsapp: {} },
+    };
+    const findings = collectLikelyMultiUserSetupFindings(cfg);
+    expect(
+      findings.some((f) => f.checkId === "security.trust_model.dm_scope_main_multi_user"),
+    ).toBe(false);
+  });
+
+  it("still emits multi_user_heuristic alongside dmScope finding", () => {
+    const cfg: OpenClawConfig = {
+      session: { dmScope: "main" },
+      channels: { whatsapp: { dmPolicy: "open" } },
+    };
+    const findings = collectLikelyMultiUserSetupFindings(cfg);
+    expect(findings.some((f) => f.checkId === "security.trust_model.multi_user_heuristic")).toBe(
+      true,
+    );
+    expect(
+      findings.some((f) => f.checkId === "security.trust_model.dm_scope_main_multi_user"),
+    ).toBe(true);
   });
 });

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -357,7 +357,7 @@ function isBrowserEnabled(cfg: OpenClawConfig): boolean {
   }
 }
 
-function listGroupPolicyOpen(cfg: OpenClawConfig): string[] {
+function listPolicyOpen(cfg: OpenClawConfig, policyKey: "groupPolicy" | "dmPolicy"): string[] {
   const out: string[] = [];
   const channels = cfg.channels as Record<string, unknown> | undefined;
   if (!channels || typeof channels !== "object") {
@@ -368,8 +368,8 @@ function listGroupPolicyOpen(cfg: OpenClawConfig): string[] {
       continue;
     }
     const section = value as Record<string, unknown>;
-    if (section.groupPolicy === "open") {
-      out.push(`channels.${channelId}.groupPolicy`);
+    if (section[policyKey] === "open") {
+      out.push(`channels.${channelId}.${policyKey}`);
     }
     const accounts = section.accounts;
     if (accounts && typeof accounts === "object") {
@@ -378,13 +378,21 @@ function listGroupPolicyOpen(cfg: OpenClawConfig): string[] {
           continue;
         }
         const acc = accountVal as Record<string, unknown>;
-        if (acc.groupPolicy === "open") {
-          out.push(`channels.${channelId}.accounts.${accountId}.groupPolicy`);
+        if (acc[policyKey] === "open") {
+          out.push(`channels.${channelId}.accounts.${accountId}.${policyKey}`);
         }
       }
     }
   }
   return out;
+}
+
+function listGroupPolicyOpen(cfg: OpenClawConfig): string[] {
+  return listPolicyOpen(cfg, "groupPolicy");
+}
+
+function listDmPolicyOpen(cfg: OpenClawConfig): string[] {
+  return listPolicyOpen(cfg, "dmPolicy");
 }
 
 function hasConfiguredGroupTargets(section: Record<string, unknown>): boolean {
@@ -1290,37 +1298,79 @@ export function collectSmallModelRiskFindings(params: {
 export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
   const openGroups = listGroupPolicyOpen(cfg);
-  if (openGroups.length === 0) {
+  const openDms = listDmPolicyOpen(cfg);
+  const allOpenPaths = [...openGroups, ...openDms];
+  if (allOpenPaths.length === 0) {
     return findings;
   }
 
   const elevatedEnabled = cfg.tools?.elevated?.enabled !== false;
   if (elevatedEnabled) {
     findings.push({
-      checkId: "security.exposure.open_groups_with_elevated",
+      checkId: "security.exposure.open_channels_with_elevated",
       severity: "critical",
-      title: "Open groupPolicy with elevated tools enabled",
+      title: "Open groupPolicy/dmPolicy with elevated tools enabled",
       detail:
-        `Found groupPolicy="open" at:\n${openGroups.map((p) => `- ${p}`).join("\n")}\n` +
-        "With tools.elevated enabled, a prompt injection in those rooms can become a high-impact incident.",
-      remediation: `Set groupPolicy="allowlist" and keep elevated allowlists extremely tight.`,
+        `Found open policy at:\n${allOpenPaths.map((p) => `- ${p}`).join("\n")}\n` +
+        "With tools.elevated enabled, a prompt injection from these channels can become a high-impact incident.",
+      remediation: `Set groupPolicy/dmPolicy to "allowlist" or "pairing" and keep elevated allowlists extremely tight.`,
     });
+
+    if (openGroups.length > 0) {
+      findings.push({
+        checkId: "security.exposure.open_groups_with_elevated",
+        severity: "critical",
+        title: "Open groupPolicy with elevated tools enabled",
+        detail:
+          `Found groupPolicy="open" at:\n${openGroups.map((p) => `- ${p}`).join("\n")}\n` +
+          "With tools.elevated enabled, a prompt injection in those rooms can become a high-impact incident.",
+        remediation: `Set groupPolicy="allowlist" and keep elevated allowlists extremely tight.`,
+      });
+    }
+
+    if (openDms.length > 0) {
+      findings.push({
+        checkId: "security.exposure.open_dms_with_elevated",
+        severity: "critical",
+        title: "Open dmPolicy with elevated tools enabled",
+        detail:
+          `Found dmPolicy="open" at:\n${openDms.map((p) => `- ${p}`).join("\n")}\n` +
+          "With tools.elevated enabled, an untrusted DM sender can trigger elevated tool execution.",
+        remediation: `Set dmPolicy="pairing" (recommended) or "allowlist" and keep elevated allowlists extremely tight.`,
+      });
+    }
   }
 
   const { riskyContexts, hasRuntimeRisk } = collectRiskyToolExposureContexts(cfg);
 
   if (riskyContexts.length > 0) {
-    findings.push({
-      checkId: "security.exposure.open_groups_with_runtime_or_fs",
-      severity: hasRuntimeRisk ? "critical" : "warn",
-      title: "Open groupPolicy with runtime/filesystem tools exposed",
-      detail:
-        `Found groupPolicy="open" at:\n${openGroups.map((p) => `- ${p}`).join("\n")}\n` +
-        `Risky tool exposure contexts:\n${riskyContexts.map((line) => `- ${line}`).join("\n")}\n` +
-        "Prompt injection in open groups can trigger command/file actions in these contexts.",
-      remediation:
-        'For open groups, prefer tools.profile="messaging" (or deny group:runtime/group:fs), set tools.fs.workspaceOnly=true, and use agents.defaults.sandbox.mode="all" for exposed agents.',
-    });
+    if (openGroups.length > 0) {
+      findings.push({
+        checkId: "security.exposure.open_groups_with_runtime_or_fs",
+        severity: hasRuntimeRisk ? "critical" : "warn",
+        title: "Open groupPolicy with runtime/filesystem tools exposed",
+        detail:
+          `Found groupPolicy="open" at:\n${openGroups.map((p) => `- ${p}`).join("\n")}\n` +
+          `Risky tool exposure contexts:\n${riskyContexts.map((line) => `- ${line}`).join("\n")}\n` +
+          "Prompt injection in open groups can trigger command/file actions in these contexts.",
+        remediation:
+          'For open groups, prefer tools.profile="messaging" (or deny group:runtime/group:fs), set tools.fs.workspaceOnly=true, and use agents.defaults.sandbox.mode="all" for exposed agents.',
+      });
+    }
+
+    if (openDms.length > 0) {
+      findings.push({
+        checkId: "security.exposure.open_dms_with_runtime_or_fs",
+        severity: hasRuntimeRisk ? "critical" : "warn",
+        title: "Open dmPolicy with runtime/filesystem tools exposed",
+        detail:
+          `Found dmPolicy="open" at:\n${openDms.map((p) => `- ${p}`).join("\n")}\n` +
+          `Risky tool exposure contexts:\n${riskyContexts.map((line) => `- ${line}`).join("\n")}\n` +
+          "An untrusted DM sender can trigger command/file actions in these contexts.",
+        remediation:
+          'For open DMs, prefer tools.profile="messaging" (or deny group:runtime/group:fs), set tools.fs.workspaceOnly=true, and use agents.defaults.sandbox.mode="all" for exposed agents.',
+      });
+    }
   }
 
   return findings;
@@ -1354,6 +1404,22 @@ export function collectLikelyMultiUserSetupFindings(cfg: OpenClawConfig): Securi
     remediation:
       'If users may be mutually untrusted, split trust boundaries (separate gateways + credentials, ideally separate OS users/hosts). If you intentionally run shared-user access, set agents.defaults.sandbox.mode="all", keep tools.fs.workspaceOnly=true, deny runtime/fs/web tools unless required, and keep personal/private identities + credentials off that runtime.',
   });
+
+  const dmScope = cfg.session?.dmScope ?? "main";
+  if (dmScope === "main") {
+    findings.push({
+      checkId: "security.trust_model.dm_scope_main_multi_user",
+      severity: "critical",
+      title: 'session.dmScope="main" leaks context across DM senders',
+      detail:
+        'Multi-user heuristics detected and session.dmScope is "main" (or unset, defaulting to "main"). ' +
+        "All DM senders share the same main session, which means conversation context, tool outputs, " +
+        "and potentially sensitive data from one user's DM is visible to subsequent DM senders.",
+      remediation:
+        'Set session.dmScope="per-channel-peer" (recommended) or "per-account-channel-peer" to isolate DM sessions per sender. ' +
+        'Run: openclaw config set session.dmScope "per-channel-peer"',
+    });
+  }
 
   return findings;
 }

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1306,16 +1306,6 @@ export function collectExposureMatrixFindings(cfg: OpenClawConfig): SecurityAudi
 
   const elevatedEnabled = cfg.tools?.elevated?.enabled !== false;
   if (elevatedEnabled) {
-    findings.push({
-      checkId: "security.exposure.open_channels_with_elevated",
-      severity: "critical",
-      title: "Open groupPolicy/dmPolicy with elevated tools enabled",
-      detail:
-        `Found open policy at:\n${allOpenPaths.map((p) => `- ${p}`).join("\n")}\n` +
-        "With tools.elevated enabled, a prompt injection from these channels can become a high-impact incident.",
-      remediation: `Set groupPolicy/dmPolicy to "allowlist" or "pairing" and keep elevated allowlists extremely tight.`,
-    });
-
     if (openGroups.length > 0) {
       findings.push({
         checkId: "security.exposure.open_groups_with_elevated",
@@ -1405,8 +1395,11 @@ export function collectLikelyMultiUserSetupFindings(cfg: OpenClawConfig): Securi
       'If users may be mutually untrusted, split trust boundaries (separate gateways + credentials, ideally separate OS users/hosts). If you intentionally run shared-user access, set agents.defaults.sandbox.mode="all", keep tools.fs.workspaceOnly=true, deny runtime/fs/web tools unless required, and keep personal/private identities + credentials off that runtime.',
   });
 
+  const hasDmSignal = signals.some(
+    (s) => s.includes("dmPolicy") || s.includes(".dm.policy") || s.includes(".dm.allowFrom"),
+  );
   const dmScope = cfg.session?.dmScope ?? "main";
-  if (dmScope === "main") {
+  if (dmScope === "main" && hasDmSignal) {
     findings.push({
       checkId: "security.trust_model.dm_scope_main_multi_user",
       severity: "critical",

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -3819,6 +3819,84 @@ description: test skill
     );
   });
 
+  it("flags open dmPolicy with elevated tools enabled", async () => {
+    const res = await audit({
+      tools: { elevated: { enabled: true, allowFrom: { whatsapp: ["+1"] } } },
+      channels: { whatsapp: { dmPolicy: "open" } },
+    });
+    expectFinding(res, "security.exposure.open_channels_with_elevated", "critical");
+    expectFinding(res, "security.exposure.open_dms_with_elevated", "critical");
+  });
+
+  it("flags open dmPolicy with runtime/filesystem tools exposed without guards", async () => {
+    const res = await audit({
+      channels: { whatsapp: { dmPolicy: "open" } },
+      tools: { elevated: { enabled: false } },
+    });
+    expectFinding(res, "security.exposure.open_dms_with_runtime_or_fs", "critical");
+  });
+
+  it("does not flag dmPolicy runtime/fs exposure when sandbox mode is all", async () => {
+    const res = await audit({
+      channels: { whatsapp: { dmPolicy: "open" } },
+      tools: {
+        elevated: { enabled: false },
+        profile: "coding",
+      },
+      agents: {
+        defaults: {
+          sandbox: { mode: "all" },
+        },
+      },
+    });
+    expectNoFinding(res, "security.exposure.open_dms_with_runtime_or_fs");
+  });
+
+  it("emits both group and dm findings when both policies are open", async () => {
+    const res = await audit({
+      channels: { whatsapp: { groupPolicy: "open", dmPolicy: "open" } },
+      tools: { elevated: { enabled: true, allowFrom: { whatsapp: ["+1"] } } },
+    });
+    expectFinding(res, "security.exposure.open_groups_with_elevated", "critical");
+    expectFinding(res, "security.exposure.open_dms_with_elevated", "critical");
+    expectFinding(res, "security.exposure.open_channels_with_elevated", "critical");
+  });
+
+  it("flags session.dmScope=main when multi-user signals are detected", async () => {
+    const res = await audit({
+      session: { dmScope: "main" },
+      channels: { whatsapp: { dmPolicy: "open" } },
+      tools: { elevated: { enabled: false } },
+    });
+    expectFinding(res, "security.trust_model.dm_scope_main_multi_user", "critical");
+  });
+
+  it("flags default dmScope (unset) when multi-user signals are detected", async () => {
+    const res = await audit({
+      channels: { whatsapp: { dmPolicy: "open" } },
+      tools: { elevated: { enabled: false } },
+    });
+    expectFinding(res, "security.trust_model.dm_scope_main_multi_user", "critical");
+  });
+
+  it("does not flag dmScope when set to per-channel-peer", async () => {
+    const res = await audit({
+      session: { dmScope: "per-channel-peer" },
+      channels: { whatsapp: { dmPolicy: "open" } },
+      tools: { elevated: { enabled: false } },
+    });
+    expectNoFinding(res, "security.trust_model.dm_scope_main_multi_user");
+  });
+
+  it("does not flag dmScope=main when no multi-user signals exist", async () => {
+    const res = await audit({
+      session: { dmScope: "main" },
+      channels: { whatsapp: {} },
+      tools: { elevated: { enabled: false } },
+    });
+    expectNoFinding(res, "security.trust_model.dm_scope_main_multi_user");
+  });
+
   describe("maybeProbeGateway auth selection", () => {
     const makeProbeCapture = () => {
       let capturedAuth: { token?: string; password?: string } | undefined;

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -3824,7 +3824,6 @@ description: test skill
       tools: { elevated: { enabled: true, allowFrom: { whatsapp: ["+1"] } } },
       channels: { whatsapp: { dmPolicy: "open" } },
     });
-    expectFinding(res, "security.exposure.open_channels_with_elevated", "critical");
     expectFinding(res, "security.exposure.open_dms_with_elevated", "critical");
   });
 
@@ -3859,7 +3858,6 @@ description: test skill
     });
     expectFinding(res, "security.exposure.open_groups_with_elevated", "critical");
     expectFinding(res, "security.exposure.open_dms_with_elevated", "critical");
-    expectFinding(res, "security.exposure.open_channels_with_elevated", "critical");
   });
 
   it("flags session.dmScope=main when multi-user signals are detected", async () => {


### PR DESCRIPTION
## Summary

- **`dmPolicy="open"` parity**: `groupPolicy="open"` triggers CRITICAL findings for elevated tools and runtime/fs exposure, but `dmPolicy="open"` did not — now it does
- **`session.dmScope="main"` detection**: when `dmScope` is `"main"` alongside multi-user signals, cross-user context leakage is flagged as CRITICAL
- Refactored `listGroupPolicyOpen` into generic `listPolicyOpen(cfg, policyKey)` to eliminate duplication

## Change Type

- [x] Bug fix
- [x] Security hardening

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

Closes #55612
Closes #55578

## Root Cause / Regression History

**Root cause:** `collectExposureMatrixFindings` and `collectLikelyMultiUserSetupFindings` only inspected `groupPolicy` — `dmPolicy` was never checked despite having the same security implications.

**Missing detection / guardrail:** No rule existed for `dmPolicy="open"` exposure or `session.dmScope="main"` in multi-user setups.

**Prior context:** The exposure matrix rules were added when groups were the primary multi-user surface. DM policy support was added later but the audit rules were not updated.

## Regression Test Plan

- [x] Unit test

**Target test or file:** `src/security/audit-extra.sync.test.ts` (unit) + `src/security/audit.test.ts` (integration)

**Scenario the test should lock in:**
1. `dmPolicy="open"` + elevated tools → CRITICAL `open_dms_with_elevated`
2. `dmPolicy="open"` + runtime/fs tools → CRITICAL `open_dms_with_runtime_or_fs`
3. `session.dmScope="main"` + multi-user signals → CRITICAL `dm_scope_main_multi_user`
4. `dmPolicy="pairing"` (safe) → no findings

## New findings

| Check ID | Severity | Trigger |
|---|---|---|
| `security.exposure.open_dms_with_elevated` | CRITICAL | `dmPolicy="open"` + elevated tools enabled |
| `security.exposure.open_dms_with_runtime_or_fs` | CRITICAL | `dmPolicy="open"` + runtime/fs tools |
| `security.trust_model.dm_scope_main_multi_user` | CRITICAL | `session.dmScope="main"` + multi-user signals |

## User-visible / Behavior Changes

- `openclaw security audit` now reports three additional findings when DM policies are misconfigured

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification

- Verified: all new test cases pass expected findings with correct severity and check IDs
- Verified: existing tests remain unchanged
- Edge cases: `dmPolicy="pairing"` produces no findings; nested account-level policies are detected

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None — additive detection rules only.

> Made with AI assistance (Cursor). All logic reviewed and verified manually.