### PR TITLE
Add TouchBridge skill — phone biometric auth for sudo on Mac

### DIFF
--- a/skills/touchbridge/SKILL.md
+++ b/skills/touchbridge/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: touchbridge
+description: Authenticate sudo and macOS system prompts using your phone's biometric (Face ID/fingerprint) instead of typing passwords. Perfect for Mac Mini, Mac Studio, Mac Pro, and MacBook Neo base users without Touch ID.
+homepage: https://github.com/HMAKT99/UnTouchID
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🔐",
+        "requires": { "bins": ["touchbridged", "touchbridge-test"] },
+        "install":
+          [
+            {
+              "id": "pkg",
+              "kind": "pkg",
+              "url": "https://github.com/HMAKT99/UnTouchID/releases/download/v0.1.0-alpha/TouchBridge-0.1.0.pkg",
+              "bins": ["touchbridged", "touchbridge-test"],
+              "label": "Install TouchBridge (.pkg)",
+            },
+          ],
+      },
+  }
+---
+
+# TouchBridge
+
+Use your phone's fingerprint or Face ID to authenticate `sudo`, screensaver unlock, and other macOS auth prompts — instead of typing your password.
+
+Free, open source alternative to Apple's $199 Touch ID keyboard. Works with iPhone, Android, Apple Watch, Wear OS, or any browser.
+
+## References
+
+- `references/setup.md` (install + pairing + testing)
+
+## Workflow
+
+1. Check if TouchBridge is installed: `which touchbridged`.
+2. If not installed: download and run the .pkg installer from the GitHub release.
+3. Check daemon status: `ls ~/Library/Application\ Support/TouchBridge/daemon.sock`.
+4. If daemon not running: `touchbridged serve --simulator` (for testing) or `touchbridged serve --web` (for phone auth).
+
+### For sudo commands
+
+TouchBridge automatically handles `sudo` authentication when installed. The PAM module intercepts the auth request and routes it to the daemon, which prompts the user's phone.
+
+If the phone is unreachable, sudo falls through to the normal password prompt — the user is never locked out.
+
+### Modes
+
+- `touchbridged serve --simulator` — auto-approve (testing, no phone needed)
+- `touchbridged serve --web` — any phone via browser URL (no app install)
+- `touchbridged serve --interactive` — approve/deny in terminal
+- `touchbridged serve` — production mode with paired iPhone/Android via BLE
+
+### Configuration
+
+```bash
+touchbridge-test config show              # view policy
+touchbridge-test config set --timeout 20  # change auth timeout
+touchbridge-test logs                     # view recent auth events
+touchbridge-test list-devices             # show paired devices
+```
+
+## Guardrails
+
+- Never type or log the user's macOS password — TouchBridge replaces password entry entirely.
+- If `touchbridged` is not running, sudo falls through to password — never block the user.
+- The simulator mode (`--simulator`) is for testing only — remind the user to switch to phone auth for real security.
+- Never modify `/etc/pam.d/sudo` directly — use the install script which creates backups.

--- a/skills/touchbridge/SKILL.md
+++ b/skills/touchbridge/SKILL.md
@@ -11,11 +11,19 @@ metadata:
         "install":
           [
             {
+              "id": "source",
+              "kind": "shell",
+              "command": "git clone https://github.com/HMAKT99/UnTouchID.git /tmp/touchbridge-install && cd /tmp/touchbridge-install && cd daemon && swift build -c release && cd .. && make -C pam && sudo bash scripts/install.sh",
+              "bins": ["touchbridged", "touchbridge-test"],
+              "label": "Build and install from source (recommended)",
+            },
+            {
               "id": "pkg",
               "kind": "pkg",
               "url": "https://github.com/HMAKT99/UnTouchID/releases/download/v0.1.0-alpha/TouchBridge-0.1.0.pkg",
+              "sha256": "370b8f0ab32c23216f16de19c8487633301be2810b9fa8793e3ac093f7699f9e",
               "bins": ["touchbridged", "touchbridge-test"],
-              "label": "Install TouchBridge (.pkg)",
+              "label": "Install TouchBridge (.pkg) — verify with: shasum -a 256 TouchBridge-0.1.0.pkg",
             },
           ],
       },
@@ -35,9 +43,25 @@ Free, open source alternative to Apple's $199 Touch ID keyboard. Works with iPho
 ## Workflow
 
 1. Check if TouchBridge is installed: `which touchbridged`.
-2. If not installed: download and run the .pkg installer from the GitHub release.
+2. If not installed: **build from source** (recommended — user can audit the code):
+   ```bash
+   git clone https://github.com/HMAKT99/UnTouchID.git
+   cd UnTouchID && cd daemon && swift build -c release && cd ..
+   make -C pam
+   sudo bash scripts/install.sh
+   ```
+   Alternatively, download the .pkg from the GitHub release and verify its checksum:
+   ```bash
+   shasum -a 256 TouchBridge-0.1.0.pkg
+   # Expected: 370b8f0ab32c23216f16de19c8487633301be2810b9fa8793e3ac093f7699f9e
+   spctl -a -t install TouchBridge-0.1.0.pkg  # verify notarisation
+   ```
 3. Check daemon status: `ls ~/Library/Application\ Support/TouchBridge/daemon.sock`.
-4. If daemon not running: `touchbridged serve --simulator` (for testing) or `touchbridged serve --web` (for phone auth).
+4. Start the daemon:
+   - **Production** (requires paired phone): `touchbridged serve` or `touchbridged serve --web`
+   - **Testing only** — ⚠️ REQUIRES EXPLICIT USER CONFIRMATION before running:
+     `touchbridged serve --simulator`
+     This mode auto-approves ALL sudo requests with no biometric check. Never use in production. Always ask the user before enabling this mode.
 
 ### For sudo commands
 
@@ -47,10 +71,10 @@ If the phone is unreachable, sudo falls through to the normal password prompt �
 
 ### Modes
 
-- `touchbridged serve --simulator` — auto-approve (testing, no phone needed)
-- `touchbridged serve --web` — any phone via browser URL (no app install)
-- `touchbridged serve --interactive` — approve/deny in terminal
 - `touchbridged serve` — production mode with paired iPhone/Android via BLE
+- `touchbridged serve --web` — any phone via browser URL (no app install needed)
+- `touchbridged serve --interactive` — approve/deny in terminal
+- `touchbridged serve --simulator` — ⚠️ TESTING ONLY — auto-approves all sudo. Never enable without explicit user consent.
 
 ### Configuration
 
@@ -63,7 +87,9 @@ touchbridge-test list-devices             # show paired devices
 
 ## Guardrails
 
+- **Never enable `--simulator` mode without explicit user confirmation.** This mode auto-approves all sudo requests and is a critical security risk if left running in production.
 - Never type or log the user's macOS password — TouchBridge replaces password entry entirely.
 - If `touchbridged` is not running, sudo falls through to password — never block the user.
-- The simulator mode (`--simulator`) is for testing only — remind the user to switch to phone auth for real security.
 - Never modify `/etc/pam.d/sudo` directly — use the install script which creates backups.
+- When installing via .pkg, always verify the SHA-256 checksum before running.
+- The build-from-source path is the recommended install method — users can audit the code before running it.

--- a/skills/touchbridge/references/setup.md
+++ b/skills/touchbridge/references/setup.md
@@ -1,44 +1,70 @@
 # TouchBridge Setup Reference
 
-## Quick Install
+## Install from Source (Recommended)
 
-Download and run the .pkg installer:
-```bash
-# Download from GitHub Release
-curl -L -o /tmp/TouchBridge.pkg https://github.com/HMAKT99/UnTouchID/releases/download/v0.1.0-alpha/TouchBridge-0.1.0.pkg
-open /tmp/TouchBridge.pkg
-```
+Building from source lets you audit the code before running it.
 
-Or build from source:
 ```bash
 git clone https://github.com/HMAKT99/UnTouchID.git
 cd UnTouchID
+
+# Review the install script before running:
+cat scripts/install.sh
+
+# Build
 cd daemon && swift build -c release && cd ..
 make -C pam
+
+# Install (will ask for admin password, shows diff before patching PAM)
 sudo bash scripts/install.sh
 ```
 
-## Test (no phone needed)
+## Install from .pkg (Alternative)
+
+If you prefer the pre-built installer, **verify the checksum first**:
 
 ```bash
-# Terminal 1
-touchbridged serve --simulator
+# Download
+curl -L -o /tmp/TouchBridge.pkg https://github.com/HMAKT99/UnTouchID/releases/download/v0.1.0-alpha/TouchBridge-0.1.0.pkg
 
-# Terminal 2
-sudo echo 'TouchBridge works!'
-# → Auto-approved, no password prompt
+# Verify integrity — must match this hash:
+shasum -a 256 /tmp/TouchBridge.pkg
+# Expected: 370b8f0ab32c23216f16de19c8487633301be2810b9fa8793e3ac093f7699f9e
+
+# Verify code signing (if notarised):
+spctl -a -t install /tmp/TouchBridge.pkg
+
+# Install
+open /tmp/TouchBridge.pkg
 ```
 
-## Use with any phone (no app install)
+## Production Use — Phone Auth
 
 ```bash
-# Terminal 1
+# Option A: Any phone via browser (no app install)
 touchbridged serve --web
 
-# Terminal 2
+# Option B: Paired iPhone/Android via BLE
+touchbridged serve
+```
+
+```bash
+# Test sudo
 sudo echo test
-# → Shows a URL in Terminal 1
-# → Open URL on any phone → tap Approve
+# → Phone prompts biometric → approve → sudo succeeds
+```
+
+## Testing Only — Simulator
+
+⚠️ **WARNING: Simulator mode auto-approves ALL sudo requests without any biometric check. Never use in production. Only use for testing in a controlled environment.**
+
+```bash
+# Only for testing — requires explicit user consent
+touchbridged serve --simulator
+
+# In another terminal
+sudo echo 'TouchBridge works!'
+# → Auto-approved, no phone needed
 ```
 
 ## Pair iPhone or Android

--- a/skills/touchbridge/references/setup.md
+++ b/skills/touchbridge/references/setup.md
@@ -1,0 +1,63 @@
+# TouchBridge Setup Reference
+
+## Quick Install
+
+Download and run the .pkg installer:
+```bash
+# Download from GitHub Release
+curl -L -o /tmp/TouchBridge.pkg https://github.com/HMAKT99/UnTouchID/releases/download/v0.1.0-alpha/TouchBridge-0.1.0.pkg
+open /tmp/TouchBridge.pkg
+```
+
+Or build from source:
+```bash
+git clone https://github.com/HMAKT99/UnTouchID.git
+cd UnTouchID
+cd daemon && swift build -c release && cd ..
+make -C pam
+sudo bash scripts/install.sh
+```
+
+## Test (no phone needed)
+
+```bash
+# Terminal 1
+touchbridged serve --simulator
+
+# Terminal 2
+sudo echo 'TouchBridge works!'
+# → Auto-approved, no password prompt
+```
+
+## Use with any phone (no app install)
+
+```bash
+# Terminal 1
+touchbridged serve --web
+
+# Terminal 2
+sudo echo test
+# → Shows a URL in Terminal 1
+# → Open URL on any phone → tap Approve
+```
+
+## Pair iPhone or Android
+
+```bash
+touchbridge-test pair
+# Shows pairing JSON → enter in companion app
+```
+
+## View auth history
+
+```bash
+touchbridge-test logs
+touchbridge-test logs --surface pam_sudo --count 20
+```
+
+## Uninstall
+
+```bash
+sudo bash scripts/uninstall.sh
+# Restores original PAM config, removes daemon
+```


### PR DESCRIPTION
## TouchBridge Skill

Authenticate `sudo` and macOS system prompts using your phone's biometric (Face ID / fingerprint) instead of typing passwords.

### Why this skill?

Many OpenClaw users run on **Mac Mini** — which has no Touch ID. When the agent or user needs `sudo`, they currently type their password. TouchBridge lets the phone handle it instead.

### What it does

- Intercepts `sudo` auth via PAM module → routes to phone biometric
- Supports: iPhone, Android, Apple Watch, Wear OS, any browser
- Falls through to password if phone is unreachable
- No cloud — local BLE only

### Modes

- `touchbridged serve --simulator` — auto-approve (testing)
- `touchbridged serve --web` — any phone via browser URL
- `touchbridged serve` — production BLE with paired phone

### Install

One-click .pkg installer available: [TouchBridge-0.1.0.pkg](https://github.com/HMAKT99/UnTouchID/releases/download/v0.1.0-alpha/TouchBridge-0.1.0.pkg)

### References

- Issue: #56259
- Repo: https://github.com/HMAKT99/UnTouchID
- Listed in awesome-mac (68k stars): merged