### PR TITLE
fix(cli): infer skills workspace from cwd

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -111,10 +111,11 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
-  resolveDefaultAgentId: (...args: unknown[]) => mocks.resolveDefaultAgentIdMock(...args),
-  resolveAgentWorkspaceDir: (...args: unknown[]) => mocks.resolveAgentWorkspaceDirMock(...args),
-  resolveAgentIdByWorkspacePath: (...args: unknown[]) =>
-    mocks.resolveAgentIdByWorkspacePathMock(...args),
+  resolveDefaultAgentId: (config: unknown) => mocks.resolveDefaultAgentIdMock(config),
+  resolveAgentWorkspaceDir: (config: unknown, agentId: unknown) =>
+    mocks.resolveAgentWorkspaceDirMock(config, agentId),
+  resolveAgentIdByWorkspacePath: (config: unknown, workspacePath: unknown) =>
+    mocks.resolveAgentIdByWorkspacePathMock(config, workspacePath),
 }));
 
 vi.mock("../agents/skills-clawhub.js", () => ({

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -71,6 +71,7 @@ const mocks = vi.hoisted(() => {
     loadConfigMock: vi.fn(() => ({})),
     resolveDefaultAgentIdMock: vi.fn(() => "main"),
     resolveAgentWorkspaceDirMock: vi.fn(() => "/tmp/workspace"),
+    resolveAgentIdByWorkspacePathMock: vi.fn(),
     searchSkillsFromClawHubMock: vi.fn(),
     installSkillFromClawHubMock: vi.fn(),
     updateSkillsFromClawHubMock: vi.fn(),
@@ -88,6 +89,7 @@ const {
   loadConfigMock,
   resolveDefaultAgentIdMock,
   resolveAgentWorkspaceDirMock,
+  resolveAgentIdByWorkspacePathMock,
   searchSkillsFromClawHubMock,
   installSkillFromClawHubMock,
   updateSkillsFromClawHubMock,
@@ -109,8 +111,10 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
-  resolveDefaultAgentId: () => mocks.resolveDefaultAgentIdMock(),
-  resolveAgentWorkspaceDir: () => mocks.resolveAgentWorkspaceDirMock(),
+  resolveDefaultAgentId: (...args: unknown[]) => mocks.resolveDefaultAgentIdMock(...args),
+  resolveAgentWorkspaceDir: (...args: unknown[]) => mocks.resolveAgentWorkspaceDirMock(...args),
+  resolveAgentIdByWorkspacePath: (...args: unknown[]) =>
+    mocks.resolveAgentIdByWorkspacePathMock(...args),
 }));
 
 vi.mock("../agents/skills-clawhub.js", () => ({
@@ -143,6 +147,7 @@ describe("skills cli commands", () => {
     loadConfigMock.mockReset();
     resolveDefaultAgentIdMock.mockReset();
     resolveAgentWorkspaceDirMock.mockReset();
+    resolveAgentIdByWorkspacePathMock.mockReset();
     searchSkillsFromClawHubMock.mockReset();
     installSkillFromClawHubMock.mockReset();
     updateSkillsFromClawHubMock.mockReset();
@@ -152,6 +157,7 @@ describe("skills cli commands", () => {
     loadConfigMock.mockReturnValue({});
     resolveDefaultAgentIdMock.mockReturnValue("main");
     resolveAgentWorkspaceDirMock.mockReturnValue("/tmp/workspace");
+    resolveAgentIdByWorkspacePathMock.mockReturnValue(undefined);
     searchSkillsFromClawHubMock.mockResolvedValue([]);
     installSkillFromClawHubMock.mockResolvedValue({
       ok: false,
@@ -210,6 +216,31 @@ describe("skills cli commands", () => {
     ).toBe(true);
   });
 
+  it("installs into the workspace inferred from cwd before falling back to the default agent", async () => {
+    resolveAgentIdByWorkspacePathMock.mockReturnValue("writer");
+    resolveAgentWorkspaceDirMock.mockImplementation((...args: unknown[]) => {
+      const agentId = args[1];
+      return `/tmp/workspace-${String(agentId)}`;
+    });
+    installSkillFromClawHubMock.mockResolvedValue({
+      ok: true,
+      slug: "content-writer",
+      version: "1.0.0",
+      targetDir: "/tmp/workspace-writer/skills/content-writer",
+    });
+
+    await runCommand(["skills", "install", "content-writer"]);
+
+    expect(resolveAgentIdByWorkspacePathMock).toHaveBeenCalledWith({}, process.cwd());
+    expect(installSkillFromClawHubMock).toHaveBeenCalledWith({
+      workspaceDir: "/tmp/workspace-writer",
+      slug: "content-writer",
+      version: undefined,
+      force: false,
+      logger: expect.any(Object),
+    });
+  });
+
   it("updates all tracked ClawHub skills", async () => {
     readTrackedClawHubSkillSlugsMock.mockResolvedValue(["calendar"]);
     updateSkillsFromClawHubMock.mockResolvedValue([
@@ -235,6 +266,35 @@ describe("skills cli commands", () => {
       true,
     );
     expect(runtimeErrors).toEqual([]);
+  });
+
+  it("updates tracked skills in the workspace inferred from cwd before falling back to the default agent", async () => {
+    resolveAgentIdByWorkspacePathMock.mockReturnValue("writer");
+    resolveAgentWorkspaceDirMock.mockImplementation((...args: unknown[]) => {
+      const agentId = args[1];
+      return `/tmp/workspace-${String(agentId)}`;
+    });
+    readTrackedClawHubSkillSlugsMock.mockResolvedValue(["content-writer"]);
+    updateSkillsFromClawHubMock.mockResolvedValue([
+      {
+        ok: true,
+        slug: "content-writer",
+        previousVersion: "0.9.0",
+        version: "1.0.0",
+        changed: true,
+        targetDir: "/tmp/workspace-writer/skills/content-writer",
+      },
+    ]);
+
+    await runCommand(["skills", "update", "--all"]);
+
+    expect(resolveAgentIdByWorkspacePathMock).toHaveBeenCalledWith({}, process.cwd());
+    expect(readTrackedClawHubSkillSlugsMock).toHaveBeenCalledWith("/tmp/workspace-writer");
+    expect(updateSkillsFromClawHubMock).toHaveBeenCalledWith({
+      workspaceDir: "/tmp/workspace-writer",
+      slug: undefined,
+      logger: expect.any(Object),
+    });
   });
 
   it.each([
@@ -280,6 +340,21 @@ describe("skills cli commands", () => {
 
     const payload = JSON.parse(runtimeStdout.at(-1) ?? "{}") as Record<string, unknown>;
     assert(payload);
+  });
+
+  it("loads skills status from the workspace inferred from cwd", async () => {
+    resolveAgentIdByWorkspacePathMock.mockReturnValue("writer");
+    resolveAgentWorkspaceDirMock.mockImplementation((...args: unknown[]) => {
+      const agentId = args[1];
+      return `/tmp/workspace-${String(agentId)}`;
+    });
+
+    await runCommand(["skills", "list", "--json"]);
+
+    expect(resolveAgentIdByWorkspacePathMock).toHaveBeenCalledWith({}, process.cwd());
+    expect(buildWorkspaceSkillStatusMock).toHaveBeenCalledWith("/tmp/workspace-writer", {
+      config: {},
+    });
   });
 
   it("keeps non-JSON skills list output on stdout with human-readable formatting", async () => {

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -69,9 +69,22 @@ const mocks = vi.hoisted(() => {
   });
   return {
     loadConfigMock: vi.fn(() => ({})),
-    resolveDefaultAgentIdMock: vi.fn(() => "main"),
-    resolveAgentWorkspaceDirMock: vi.fn(() => "/tmp/workspace"),
-    resolveAgentIdByWorkspacePathMock: vi.fn(),
+    resolveDefaultAgentIdMock: vi.fn((config: unknown) => {
+      void config;
+      return "main";
+    }),
+    resolveAgentWorkspaceDirMock: vi.fn((config: unknown, agentId: unknown) => {
+      void config;
+      void agentId;
+      return "/tmp/workspace";
+    }),
+    resolveAgentIdByWorkspacePathMock: vi.fn<
+      (config: unknown, workspacePath: unknown) => string | undefined
+    >((config: unknown, workspacePath: unknown) => {
+      void config;
+      void workspacePath;
+      return undefined;
+    }),
     searchSkillsFromClawHubMock: vi.fn(),
     installSkillFromClawHubMock: vi.fn(),
     updateSkillsFromClawHubMock: vi.fn(),

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentIdByWorkspacePath,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
 import {
   installSkillFromClawHub,
   readTrackedClawHubSkillSlugs,
@@ -24,9 +28,13 @@ type SkillStatusReport = Awaited<
   ReturnType<(typeof import("../agents/skills-status.js"))["buildWorkspaceSkillStatus"]>
 >;
 
+function resolveActiveAgentId(config: ReturnType<typeof loadConfig>): string {
+  return resolveAgentIdByWorkspacePath(config, process.cwd()) ?? resolveDefaultAgentId(config);
+}
+
 async function loadSkillsStatusReport(): Promise<SkillStatusReport> {
   const config = loadConfig();
-  const workspaceDir = resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+  const workspaceDir = resolveAgentWorkspaceDir(config, resolveActiveAgentId(config));
   const { buildWorkspaceSkillStatus } = await import("../agents/skills-status.js");
   return buildWorkspaceSkillStatus(workspaceDir, { config });
 }
@@ -43,7 +51,7 @@ async function runSkillsAction(render: (report: SkillStatusReport) => string): P
 
 function resolveActiveWorkspaceDir(): string {
   const config = loadConfig();
-  return resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+  return resolveAgentWorkspaceDir(config, resolveActiveAgentId(config));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Problem: the skills CLI resolved the default agent workspace too aggressively, so running skills commands inside a sub-agent workspace could read or write the wrong workspace.
- Why it matters: multi-agent setups lose workspace isolation and skills can appear to install into one workspace while `skills list` still reads another.
- What changed: infer the active agent from `process.cwd()` via `resolveAgentIdByWorkspacePath(...)` before falling back to `resolveDefaultAgentId(...)`, and use that shared resolution for both install/update and list/info/check.
- Scope boundary: no ClawHub API changes, no payload format changes, no broader workspace-resolution behavior outside the skills CLI.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #56161
- [x] This PR fixes a bug or regression

## Root Cause

- `src/cli/skills-cli.ts` previously resolved the workspace from `resolveDefaultAgentId(config)` alone.
- That meant commands launched from a sub-agent workspace ignored `process.cwd()` even when the workspace path mapped to a configured agent.
- The original PR also left `loadSkillsStatusReport()` on the default workspace path, which made `skills list` / `skills info` / `skills check` inconsistent with `skills install` / `skills update`.

## Regression Test Plan

- [x] Unit test
- Target file: `src/cli/skills-cli.commands.test.ts`
- Scenarios locked in:
  - install uses the cwd-inferred workspace
  - update uses the cwd-inferred workspace
  - list/info/check load status from the cwd-inferred workspace
  - fallback still uses the default workspace when cwd does not map to an agent

## User-visible Changes

- `openclaw skills install`
- `openclaw skills update`
- `openclaw skills list`
- `openclaw skills info`
- `openclaw skills check`

All now prefer the workspace inferred from the current working directory before falling back to the default agent workspace.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Verification

- `pnpm test -- src/cli/skills-cli.commands.test.ts`

## Human Verification

- Re-landed this as a clean latest-`main` PR with only the skills CLI change.
- Verified the cwd-inferred workspace path is used consistently for both write actions and status-report reads in the command tests.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: commands launched from unrelated directories must still fall back cleanly.
- Mitigation: the shared resolver still falls back to `resolveDefaultAgentId(...)` when cwd inference returns nothing.