### PR TITLE
feat: add compliance-audit skill (EU AI Act, SOX, HIPAA)

### DIFF
--- a/skills/compliance-audit/SKILL.md
+++ b/skills/compliance-audit/SKILL.md
@@ -1,25 +1,7 @@
 ---
 name: compliance-audit
 description: 'Audit files for regulatory compliance (EU AI Act, SOX, HIPAA, GDPR, NIST). Use when: checking AI content meets transparency requirements, preparing files for external sharing, or the user mentions compliance or regulations. Stamps files with provenance metadata. Requires akf CLI.'
-homepage: https://akf.dev
-metadata:
-  {
-    "openclaw":
-      {
-        "emoji": "🛡️",
-        "requires": { "bins": ["akf"] },
-        "install":
-          [
-            {
-              "id": "uv-akf",
-              "kind": "uv",
-              "package": "akf",
-              "bins": ["akf"],
-              "label": "Install AKF — the AI native file format (uv)",
-            },
-          ],
-      },
-  }
+metadata: { "openclaw": { "emoji": "🛡️", "homepage": "https://akf.dev", "requires": { "bins": ["akf"] }, "install": [{ "id": "uv-akf", "kind": "uv", "package": "akf", "bins": ["akf"], "label": "Install AKF — the AI native file format (uv)" }] } }
 ---
 
 # Compliance Audit

--- a/skills/compliance-audit/SKILL.md
+++ b/skills/compliance-audit/SKILL.md
@@ -1,18 +1,25 @@
 ---
 name: compliance-audit
 description: 'Audit files for regulatory compliance (EU AI Act, SOX, HIPAA, GDPR, NIST). Use when: checking AI content meets transparency requirements, preparing files for external sharing, or the user mentions compliance or regulations. Stamps files with provenance metadata. Requires akf CLI.'
+homepage: https://akf.dev
 metadata:
-  openclaw:
-    emoji: "🛡️"
-    requires:
-      bins:
-        - akf
-    install:
-      - id: pip-akf
-        kind: pip
-        package: akf
-        bins: [akf]
-        label: "Install AKF — the AI native file format (pip)"
+  {
+    "openclaw":
+      {
+        "emoji": "🛡️",
+        "requires": { "bins": ["akf"] },
+        "install":
+          [
+            {
+              "id": "uv-akf",
+              "kind": "uv",
+              "package": "akf",
+              "bins": ["akf"],
+              "label": "Install AKF — the AI native file format (uv)",
+            },
+          ],
+      },
+  }
 ---
 
 # Compliance Audit

--- a/skills/compliance-audit/SKILL.md
+++ b/skills/compliance-audit/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: compliance-audit
+description: 'Audit files for regulatory compliance (EU AI Act, SOX, HIPAA, GDPR, NIST). Use when: checking AI content meets transparency requirements, preparing files for external sharing, or the user mentions compliance or regulations. Stamps files with provenance metadata. Requires akf CLI.'
+metadata:
+  openclaw:
+    emoji: "🛡️"
+    requires:
+      bins:
+        - akf
+    install:
+      - id: pip-akf
+        kind: pip
+        package: akf
+        bins: [akf]
+        label: "Install AKF — the AI native file format (pip)"
+---
+
+# Compliance Audit
+
+Audit files for regulatory compliance and stamp AI-generated content with provenance.
+
+## When to use
+
+- Before sharing AI-generated documents externally
+- When the user asks about compliance, EU AI Act, or regulations
+- To verify files meet transparency requirements
+
+## Commands
+
+### Audit a file
+
+```bash
+akf audit <file> --regulation eu_ai_act
+akf audit <file> --regulation hipaa
+akf audit <file> --regulation sox
+```
+
+### Stamp provenance
+
+```bash
+akf stamp <file> --agent openclaw --evidence "<what was done>"
+```
+
+### Check existing metadata
+
+```bash
+akf read <file>
+akf inspect <file>
+```
+
+### Scan a directory
+
+```bash
+akf scan <directory>
+```
+
+## Why
+
+EU AI Act Article 50 takes effect August 2, 2026. AI-generated content must carry transparency metadata. This skill helps OpenClaw users stay compliant.


### PR DESCRIPTION
## What

Adds a `compliance-audit` skill that lets OpenClaw agents audit files for regulatory compliance and stamp AI-generated content with provenance metadata.

## Why

OpenClaw agents generate content across 25+ channels — WhatsApp, Slack, Discord, email. None of that content currently carries provenance metadata. Recipients have no way to know:

- Was this message/file AI-generated?
- What model produced it?
- Has it been human-reviewed?
- Does it meet regulatory requirements?

EU AI Act Article 50 takes effect **August 2, 2026** — AI-generated content published for public interest must carry transparency metadata. Penalties up to EUR 35M / 7% of global turnover.

## What the skill does

```bash
# Audit a file against a regulation
akf audit report.pdf --regulation eu_ai_act

# Stamp an agent's output with provenance
akf stamp output.md --agent openclaw --evidence "generated from user request"

# Scan a directory for trust report
akf scan ./outputs
```

Supports EU AI Act, SOX, HIPAA, GDPR, NIST AI RMF, ISO 42001.

## How it fits

- Uses the standard skill format (single `SKILL.md`)
- Installs via `pip install akf` (auto-install gated in metadata)
- No changes to core OpenClaw code
- The `akf` CLI is MIT-licensed, open spec: https://akf.dev

## Testing

```bash
pip install akf
akf quickstart  # 10-second demo
```