### PR TITLE
web_search: add optional Baidu provider via qianfan

### DIFF
--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -36,6 +36,7 @@ Scope intent:
 - `plugins.entries.xai.config.webSearch.apiKey`
 - `plugins.entries.moonshot.config.webSearch.apiKey`
 - `plugins.entries.perplexity.config.webSearch.apiKey`
+- `plugins.entries.qianfan.config.webSearch.apiKey`
 - `plugins.entries.firecrawl.config.webSearch.apiKey`
 - `plugins.entries.tavily.config.webSearch.apiKey`
 - `tools.web.search.apiKey`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -474,6 +474,13 @@
       "optIn": true
     },
     {
+      "id": "plugins.entries.qianfan.config.webSearch.apiKey",
+      "configFile": "openclaw.json",
+      "path": "plugins.entries.qianfan.config.webSearch.apiKey",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "plugins.entries.tavily.config.webSearch.apiKey",
       "configFile": "openclaw.json",
       "path": "plugins.entries.tavily.config.webSearch.apiKey",

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -1,5 +1,5 @@
 ---
-summary: "web_search tool -- search the web with Brave, Firecrawl, Gemini, Grok, Kimi, Perplexity, or Tavily"
+summary: "web_search tool -- search the web with Baidu, Brave, Firecrawl, Gemini, Grok, Kimi, Perplexity, or Tavily"
 read_when:
   - You want to enable or configure web_search
   - You need to choose a search provider
@@ -46,6 +46,9 @@ returns results. Results are cached by query for 15 minutes (configurable).
 ## Choosing a provider
 
 <CardGroup cols={2}>
+  <Card title="Baidu Search" icon="globe" href="/tools/web">
+    Chinese-first web search via Qianfan. Supports direct structured results and smart AI-synthesized answers.
+  </Card>
   <Card title="Brave Search" icon="shield" href="/tools/brave-search">
     Structured results with snippets. Supports `llm-context` mode, country/language filters. Free tier available.
   </Card>
@@ -77,17 +80,18 @@ returns results. Results are cached by query for 15 minutes (configurable).
 
 ### Provider comparison
 
-| Provider                               | Result style               | Filters                                          | API key                                     |
-| -------------------------------------- | -------------------------- | ------------------------------------------------ | ------------------------------------------- |
-| [Brave](/tools/brave-search)           | Structured snippets        | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                             |
-| [DuckDuckGo](/tools/duckduckgo-search) | Structured snippets        | --                                               | None (key-free)                             |
-| [Exa](/tools/exa-search)               | Structured + extracted     | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                               |
-| [Firecrawl](/tools/firecrawl)          | Structured snippets        | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                         |
-| [Gemini](/tools/gemini-search)         | AI-synthesized + citations | --                                               | `GEMINI_API_KEY`                            |
-| [Grok](/tools/grok-search)             | AI-synthesized + citations | --                                               | `XAI_API_KEY`                               |
-| [Kimi](/tools/kimi-search)             | AI-synthesized + citations | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`         |
-| [Perplexity](/tools/perplexity-search) | Structured snippets        | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` |
-| [Tavily](/tools/tavily)                | Structured snippets        | Via `tavily_search` tool                         | `TAVILY_API_KEY`                            |
+| Provider                               | Result style                 | Filters                                          | API key                                     |
+| -------------------------------------- | ---------------------------- | ------------------------------------------------ | ------------------------------------------- |
+| Baidu                                  | Structured or AI + citations | --                                               | `QIANFAN_API_KEY`                           |
+| [Brave](/tools/brave-search)           | Structured snippets          | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                             |
+| [DuckDuckGo](/tools/duckduckgo-search) | Structured snippets          | --                                               | None (key-free)                             |
+| [Exa](/tools/exa-search)               | Structured + extracted       | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                               |
+| [Firecrawl](/tools/firecrawl)          | Structured snippets          | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                         |
+| [Gemini](/tools/gemini-search)         | AI-synthesized + citations   | --                                               | `GEMINI_API_KEY`                            |
+| [Grok](/tools/grok-search)             | AI-synthesized + citations   | --                                               | `XAI_API_KEY`                               |
+| [Kimi](/tools/kimi-search)             | AI-synthesized + citations   | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`         |
+| [Perplexity](/tools/perplexity-search) | Structured snippets          | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` |
+| [Tavily](/tools/tavily)                | Structured snippets          | Via `tavily_search` tool                         | `TAVILY_API_KEY`                            |
 
 ## Auto-detection
 
@@ -102,8 +106,9 @@ the first one found:
 3. **Grok** -- `XAI_API_KEY` or `plugins.entries.xai.config.webSearch.apiKey`
 4. **Kimi** -- `KIMI_API_KEY` / `MOONSHOT_API_KEY` or `plugins.entries.moonshot.config.webSearch.apiKey`
 5. **Perplexity** -- `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey`
-6. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey`
-7. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey`
+6. **Baidu** -- `QIANFAN_API_KEY` or `plugins.entries.qianfan.config.webSearch.apiKey`
+7. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey`
+8. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey`
 
 If no keys are found, it falls back to Brave (you will get a missing-key error
 prompting you to configure one).

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -46,7 +46,7 @@ returns results. Results are cached by query for 15 minutes (configurable).
 ## Choosing a provider
 
 <CardGroup cols={2}>
-  <Card title="Baidu Search" icon="globe" href="/tools/web">
+  <Card title="Baidu Search" icon="globe">
     Chinese-first web search via Qianfan. Supports direct structured results and smart AI-synthesized answers.
   </Card>
   <Card title="Brave Search" icon="shield" href="/tools/brave-search">

--- a/extensions/qianfan/bundled-web-search.contract.test.ts
+++ b/extensions/qianfan/bundled-web-search.contract.test.ts
@@ -1,0 +1,3 @@
+import { describeBundledWebSearchFastPathContract } from "../../test/helpers/extensions/bundled-web-search-fast-path-contract.js";
+
+describeBundledWebSearchFastPathContract("qianfan");

--- a/extensions/qianfan/index.ts
+++ b/extensions/qianfan/index.ts
@@ -1,6 +1,7 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applyQianfanConfig, QIANFAN_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildQianfanProvider } from "./provider-catalog.js";
+import { createBaiduWebSearchProvider } from "./src/baidu-web-search-provider.js";
 
 const PROVIDER_ID = "qianfan";
 
@@ -27,5 +28,8 @@ export default defineSingleProviderPluginEntry({
     catalog: {
       buildProvider: buildQianfanProvider,
     },
+  },
+  register(api) {
+    api.registerWebSearchProvider(createBaiduWebSearchProvider());
   },
 });

--- a/extensions/qianfan/openclaw.plugin.json
+++ b/extensions/qianfan/openclaw.plugin.json
@@ -5,6 +5,22 @@
   "providerAuthEnvVars": {
     "qianfan": ["QIANFAN_API_KEY"]
   },
+  "uiHints": {
+    "webSearch.apiKey": {
+      "label": "Baidu Search API Key",
+      "help": "Qianfan API key for Baidu web search (fallback: QIANFAN_API_KEY env var).",
+      "sensitive": true,
+      "placeholder": "bce-v3/..."
+    },
+    "webSearch.mode": {
+      "label": "Baidu Search Mode",
+      "help": "Use direct structured search or smart AI-synthesized search."
+    },
+    "webSearch.model": {
+      "label": "Baidu Smart Search Model",
+      "help": "Model override used only for smart mode."
+    }
+  },
   "providerAuthChoices": [
     {
       "provider": "qianfan",
@@ -20,9 +36,29 @@
       "cliDescription": "QIANFAN API key"
     }
   ],
+  "contracts": {
+    "webSearchProviders": ["baidu"]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "webSearch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": {
+            "type": ["string", "object"]
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["direct", "smart"]
+          },
+          "model": {
+            "type": "string"
+          }
+        }
+      }
+    }
   }
 }

--- a/extensions/qianfan/plugin-registration.contract.test.ts
+++ b/extensions/qianfan/plugin-registration.contract.test.ts
@@ -1,0 +1,7 @@
+import { describePluginRegistrationContract } from "../../test/helpers/extensions/plugin-registration-contract.js";
+
+describePluginRegistrationContract({
+  pluginId: "qianfan",
+  providerIds: ["qianfan"],
+  webSearchProviderIds: ["baidu"],
+});

--- a/extensions/qianfan/src/baidu-web-search-provider.test.ts
+++ b/extensions/qianfan/src/baidu-web-search-provider.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import plugin from "../index.js";
+import { __testing, createBaiduWebSearchProvider } from "./baidu-web-search-provider.js";
+
+describe("baidu web search provider", () => {
+  const priorFetch = global.fetch;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    global.fetch = priorFetch;
+  });
+
+  it("registers the Baidu web search provider from the Qianfan plugin", () => {
+    const registrations: { providers: unknown[] } = { providers: [] };
+
+    plugin.register({
+      registerProvider() {},
+      registerWebSearchProvider(provider: unknown) {
+        registrations.providers.push(provider);
+      },
+      config: {},
+    } as never);
+
+    expect(plugin.id).toBe("qianfan");
+    expect(registrations.providers).toHaveLength(1);
+
+    const provider = registrations.providers[0] as Record<string, unknown>;
+    expect(provider.id).toBe("baidu");
+    expect(provider.autoDetectOrder).toBe(55);
+    expect(provider.envVars).toEqual(["QIANFAN_API_KEY"]);
+  });
+
+  it("exposes the expected metadata and selection wiring", () => {
+    const provider = createBaiduWebSearchProvider();
+    if (!provider.applySelectionConfig) {
+      throw new Error("Expected applySelectionConfig to be defined");
+    }
+    const applied = provider.applySelectionConfig({});
+
+    expect(provider.id).toBe("baidu");
+    expect(provider.credentialPath).toBe("plugins.entries.qianfan.config.webSearch.apiKey");
+    expect(applied.plugins?.entries?.qianfan?.enabled).toBe(true);
+  });
+
+  it("prefers scoped configured API keys over environment fallbacks", () => {
+    expect(__testing.resolveBaiduApiKey({ apiKey: "bce-v3/configured" })).toBe("bce-v3/configured");
+  });
+
+  it("defaults to direct mode and the documented smart-search model", () => {
+    expect(__testing.resolveBaiduMode()).toBe("direct");
+    expect(__testing.resolveBaiduMode({ mode: "smart" })).toBe("smart");
+    expect(__testing.resolveBaiduSmartModel()).toBe("ernie-4.5-turbo-32k");
+  });
+
+  it("maps direct search references into structured results", async () => {
+    vi.stubEnv("QIANFAN_API_KEY", "bce-v3/test-key");
+    const mockFetch = vi.fn(async (_input?: unknown, init?: unknown) => {
+      return {
+        ok: true,
+        text: async () =>
+          JSON.stringify({
+            request_id: "req-1",
+            references: [
+              {
+                title: "北京旅游攻略",
+                url: "https://example.com/beijing",
+                snippet: "故宫、长城、颐和园",
+                date: "2026-03-28 10:00:00",
+                website: "example.com",
+                type: "web",
+              },
+            ],
+          }),
+      } as Response;
+    });
+    global.fetch = mockFetch as typeof global.fetch;
+
+    const provider = createBaiduWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: {
+        baidu: { apiKey: "bce-v3/configured" },
+      },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const result = await tool.execute({
+      query: "北京景点",
+      count: 3,
+    });
+
+    expect(result).toMatchObject({
+      provider: "baidu",
+      mode: "direct",
+      results: [
+        {
+          url: "https://example.com/beijing",
+          published: "2026-03-28 10:00:00",
+          siteName: "example.com",
+        },
+      ],
+    });
+
+    const requestInit = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    const body = JSON.parse(String(requestInit?.body));
+    expect(body).toMatchObject({
+      search_source: "baidu_search_v2",
+      search_mode: "required",
+      stream: false,
+      resource_type_filter: [{ type: "web", top_k: 3 }],
+    });
+    expect(requestInit?.headers).toMatchObject({
+      "X-Appbuilder-Authorization": "Bearer bce-v3/configured",
+    });
+  });
+
+  it("maps smart search responses into wrapped content with citations", async () => {
+    vi.stubEnv("QIANFAN_API_KEY", "bce-v3/test-key");
+    const mockFetch = vi.fn(async (_input?: unknown, init?: unknown) => {
+      return {
+        ok: true,
+        text: async () =>
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  role: "assistant",
+                  content: "北京推荐故宫、长城和颐和园。",
+                },
+              },
+            ],
+            references: [
+              {
+                title: "故宫博物院",
+                url: "https://example.com/gugong",
+                content: "故宫简介",
+                website: "example.com",
+                type: "web",
+              },
+            ],
+          }),
+      } as Response;
+    });
+    global.fetch = mockFetch as typeof global.fetch;
+
+    const provider = createBaiduWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: {
+        baidu: { apiKey: "bce-v3/configured", mode: "smart", model: "ernie-4.5-turbo-32k" },
+      },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const result = await tool.execute({
+      query: "北京景点",
+      count: 2,
+    });
+
+    expect(result).toMatchObject({
+      provider: "baidu",
+      mode: "smart",
+      model: "ernie-4.5-turbo-32k",
+      citations: [{ url: "https://example.com/gugong", title: "故宫博物院" }],
+    });
+
+    const requestInit = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    const body = JSON.parse(String(requestInit?.body));
+    expect(body).toMatchObject({
+      model: "ernie-4.5-turbo-32k",
+      search_mode: "required",
+      enable_reasoning: false,
+      enable_deep_search: false,
+      resource_type_filter: [{ type: "web", top_k: 2 }],
+    });
+  });
+
+  it("returns a missing-key payload when no Qianfan key is available", async () => {
+    const provider = createBaiduWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: {
+        baidu: {},
+      },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const result = await tool.execute({ query: "北京景点" });
+
+    expect(result).toMatchObject({
+      error: "missing_baidu_api_key",
+    });
+  });
+
+  it("rejects unsupported generic web filters", async () => {
+    const provider = createBaiduWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: {
+        baidu: { apiKey: "bce-v3/configured" },
+      },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const result = await tool.execute({
+      query: "北京景点",
+      freshness: "week",
+    });
+
+    expect(result).toMatchObject({
+      error: "unsupported_freshness",
+    });
+  });
+});

--- a/extensions/qianfan/src/baidu-web-search-provider.ts
+++ b/extensions/qianfan/src/baidu-web-search-provider.ts
@@ -1,0 +1,429 @@
+import { Type } from "@sinclair/typebox";
+import {
+  DEFAULT_SEARCH_COUNT,
+  MAX_SEARCH_COUNT,
+  buildSearchCacheKey,
+  buildUnsupportedSearchFilterResponse,
+  enablePluginInConfig,
+  getScopedCredentialValue,
+  mergeScopedSearchConfig,
+  readCachedSearchPayload,
+  readConfiguredSecretString,
+  readNumberParam,
+  readProviderEnvValue,
+  readStringParam,
+  resolveProviderWebSearchPluginConfig,
+  resolveSearchCacheTtlMs,
+  resolveSearchCount,
+  resolveSearchTimeoutSeconds,
+  resolveSiteName,
+  setProviderWebSearchPluginConfigValue,
+  setScopedCredentialValue,
+  type SearchConfigRecord,
+  type WebSearchProviderPlugin,
+  type WebSearchProviderToolDefinition,
+  withTrustedWebSearchEndpoint,
+  wrapWebContent,
+  writeCachedSearchPayload,
+} from "openclaw/plugin-sdk/provider-web-search";
+
+const BAIDU_SEARCH_ENDPOINT = "https://qianfan.baidubce.com/v2/ai_search/chat/completions";
+const BAIDU_DIRECT_MODE = "direct";
+const BAIDU_SMART_MODE = "smart";
+const DEFAULT_BAIDU_SMART_MODEL = "ernie-4.5-turbo-32k";
+const BAIDU_SEARCH_SOURCE = "baidu_search_v2";
+const BAIDU_API_ENV_VARS = ["QIANFAN_API_KEY"] as const;
+
+type BaiduMode = typeof BAIDU_DIRECT_MODE | typeof BAIDU_SMART_MODE;
+
+type BaiduConfig = {
+  apiKey?: string;
+  mode?: string;
+  model?: string;
+};
+
+type BaiduReference = {
+  url?: string;
+  title?: string;
+  date?: string;
+  content?: string;
+  snippet?: string;
+  website?: string;
+  type?: string;
+};
+
+type BaiduSmartResponse = {
+  choices?: Array<{
+    message?: {
+      content?: string;
+      role?: string;
+    };
+  }>;
+  references?: BaiduReference[];
+  error?: {
+    code?: number;
+    message?: string;
+  };
+};
+
+type BaiduDirectResponse = {
+  references?: BaiduReference[];
+  error?: {
+    code?: number;
+    message?: string;
+  };
+};
+
+type BaiduSearchResult = {
+  title: string;
+  url: string;
+  description: string;
+  published?: string;
+  siteName?: string;
+};
+
+function resolveBaiduConfig(searchConfig?: SearchConfigRecord): BaiduConfig {
+  const baidu = searchConfig?.baidu;
+  return baidu && typeof baidu === "object" && !Array.isArray(baidu) ? (baidu as BaiduConfig) : {};
+}
+
+function resolveBaiduApiKey(baidu?: BaiduConfig): string | undefined {
+  return (
+    readConfiguredSecretString(baidu?.apiKey, "tools.web.search.baidu.apiKey") ??
+    readProviderEnvValue([...BAIDU_API_ENV_VARS])
+  );
+}
+
+function resolveBaiduMode(baidu?: BaiduConfig): BaiduMode {
+  return baidu?.mode === BAIDU_SMART_MODE ? BAIDU_SMART_MODE : BAIDU_DIRECT_MODE;
+}
+
+function resolveBaiduSmartModel(baidu?: BaiduConfig): string {
+  const model = typeof baidu?.model === "string" ? baidu.model.trim() : "";
+  return model || DEFAULT_BAIDU_SMART_MODEL;
+}
+
+function normalizeBaiduReferences(data: { references?: BaiduReference[] }): BaiduReference[] {
+  return Array.isArray(data.references)
+    ? data.references.filter((entry): entry is BaiduReference =>
+        Boolean(entry && typeof entry === "object" && !Array.isArray(entry)),
+      )
+    : [];
+}
+
+function mapBaiduReferencesToResults(references: BaiduReference[]): BaiduSearchResult[] {
+  return references.flatMap((entry) => {
+    const url = typeof entry.url === "string" ? entry.url.trim() : "";
+    if (!url) {
+      return [];
+    }
+    const title = typeof entry.title === "string" ? entry.title.trim() : "";
+    const description =
+      typeof entry.snippet === "string" && entry.snippet.trim()
+        ? entry.snippet.trim()
+        : typeof entry.content === "string"
+          ? entry.content.trim()
+          : "";
+    const published = typeof entry.date === "string" ? entry.date.trim() : "";
+    const siteName =
+      typeof entry.website === "string" && entry.website.trim()
+        ? entry.website.trim()
+        : resolveSiteName(url) || undefined;
+    return [
+      {
+        title: title ? wrapWebContent(title, "web_search") : "",
+        url,
+        description: description ? wrapWebContent(description, "web_search") : "",
+        published: published || undefined,
+        siteName,
+      },
+    ];
+  });
+}
+
+function mapBaiduReferencesToCitations(
+  references: BaiduReference[],
+): Array<{ url: string; title?: string }> {
+  const seen = new Set<string>();
+  const citations: Array<{ url: string; title?: string }> = [];
+  for (const entry of references) {
+    const url = typeof entry.url === "string" ? entry.url.trim() : "";
+    if (!url || seen.has(url)) {
+      continue;
+    }
+    seen.add(url);
+    const title = typeof entry.title === "string" ? entry.title.trim() : "";
+    citations.push({
+      url,
+      ...(title ? { title } : {}),
+    });
+  }
+  return citations;
+}
+
+async function parseBaiduResponseJson<T extends { error?: { code?: number; message?: string } }>(
+  res: Response,
+  label: string,
+): Promise<T> {
+  const bodyText = await res.text();
+  if (!res.ok) {
+    throw new Error(`${label} error (${res.status}): ${bodyText || res.statusText}`);
+  }
+
+  let data: T;
+  try {
+    data = JSON.parse(bodyText) as T;
+  } catch (error) {
+    throw new Error(`${label} returned invalid JSON: ${String(error)}`, { cause: error });
+  }
+
+  if (data.error) {
+    const code = data.error.code ?? res.status;
+    const message = data.error.message?.trim() || "unknown error";
+    throw new Error(`${label} error (${code}): ${message}`);
+  }
+
+  return data;
+}
+
+async function runBaiduDirectSearch(params: {
+  query: string;
+  count: number;
+  apiKey: string;
+  timeoutSeconds: number;
+}): Promise<Array<Record<string, unknown>>> {
+  return await withTrustedWebSearchEndpoint(
+    {
+      url: BAIDU_SEARCH_ENDPOINT,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Appbuilder-Authorization": `Bearer ${params.apiKey}`,
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: params.query }],
+          search_source: BAIDU_SEARCH_SOURCE,
+          resource_type_filter: [{ type: "web", top_k: params.count }],
+          stream: false,
+          search_mode: "required",
+        }),
+      },
+    },
+    async (res) => {
+      const data = await parseBaiduResponseJson<BaiduDirectResponse>(res, "Baidu Search API");
+      return mapBaiduReferencesToResults(normalizeBaiduReferences(data));
+    },
+  );
+}
+
+async function runBaiduSmartSearch(params: {
+  query: string;
+  count: number;
+  apiKey: string;
+  model: string;
+  timeoutSeconds: number;
+}): Promise<{ content: string; citations: Array<{ url: string; title?: string }> }> {
+  return await withTrustedWebSearchEndpoint(
+    {
+      url: BAIDU_SEARCH_ENDPOINT,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Appbuilder-Authorization": `Bearer ${params.apiKey}`,
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: params.query }],
+          search_source: BAIDU_SEARCH_SOURCE,
+          resource_type_filter: [{ type: "web", top_k: params.count }],
+          stream: false,
+          model: params.model,
+          search_mode: "required",
+          enable_reasoning: false,
+          enable_deep_search: false,
+        }),
+      },
+    },
+    async (res) => {
+      const data = await parseBaiduResponseJson<BaiduSmartResponse>(res, "Baidu Smart Search API");
+      const references = normalizeBaiduReferences(data);
+      return {
+        content: data.choices?.[0]?.message?.content?.trim() || "No response",
+        citations: mapBaiduReferencesToCitations(references),
+      };
+    },
+  );
+}
+
+function createBaiduSchema() {
+  return Type.Object(
+    {
+      query: Type.String({ description: "Search query string." }),
+      count: Type.Optional(
+        Type.Number({
+          description: "Number of results to return (1-10).",
+          minimum: 1,
+          maximum: MAX_SEARCH_COUNT,
+        }),
+      ),
+      country: Type.Optional(Type.String({ description: "Not supported by Baidu web search." })),
+      language: Type.Optional(Type.String({ description: "Not supported by Baidu web search." })),
+      freshness: Type.Optional(Type.String({ description: "Not supported by Baidu web search." })),
+      date_after: Type.Optional(Type.String({ description: "Not supported by Baidu web search." })),
+      date_before: Type.Optional(
+        Type.String({ description: "Not supported by Baidu web search." }),
+      ),
+    },
+    { additionalProperties: false },
+  );
+}
+
+function missingBaiduKeyPayload() {
+  return {
+    error: "missing_baidu_api_key",
+    message:
+      "web_search (baidu) needs a Qianfan API key. Set QIANFAN_API_KEY in the Gateway environment, or configure plugins.entries.qianfan.config.webSearch.apiKey.",
+    docs: "https://docs.openclaw.ai/tools/web",
+  };
+}
+
+function createBaiduToolDefinition(
+  searchConfig?: SearchConfigRecord,
+): WebSearchProviderToolDefinition {
+  const baiduConfig = resolveBaiduConfig(searchConfig);
+  const mode = resolveBaiduMode(baiduConfig);
+
+  return {
+    description:
+      mode === BAIDU_SMART_MODE
+        ? "Search the web using Baidu smart search via Qianfan. Returns AI-synthesized answers with citations from Baidu Search."
+        : "Search the web using Baidu direct search via Qianfan. Returns structured titles, URLs, and snippets with strong Chinese-language coverage.",
+    parameters: createBaiduSchema(),
+    execute: async (args) => {
+      const params = args as Record<string, unknown>;
+      const unsupportedResponse = buildUnsupportedSearchFilterResponse(params, "baidu");
+      if (unsupportedResponse) {
+        return unsupportedResponse;
+      }
+
+      const apiKey = resolveBaiduApiKey(baiduConfig);
+      if (!apiKey) {
+        return missingBaiduKeyPayload();
+      }
+
+      const query = readStringParam(params, "query", { required: true });
+      const count =
+        readNumberParam(params, "count", { integer: true }) ??
+        searchConfig?.maxResults ??
+        undefined;
+      const resolvedCount = resolveSearchCount(count, DEFAULT_SEARCH_COUNT);
+      const smartModel = mode === BAIDU_SMART_MODE ? resolveBaiduSmartModel(baiduConfig) : "";
+      const cacheKey = buildSearchCacheKey(
+        mode === BAIDU_SMART_MODE
+          ? ["baidu", mode, query, resolvedCount, smartModel]
+          : ["baidu", mode, query, resolvedCount],
+      );
+      const cached = readCachedSearchPayload(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      const start = Date.now();
+      if (mode === BAIDU_SMART_MODE) {
+        const result = await runBaiduSmartSearch({
+          query,
+          count: resolvedCount,
+          apiKey,
+          model: smartModel,
+          timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
+        });
+        const payload = {
+          query,
+          provider: "baidu",
+          mode,
+          model: smartModel,
+          tookMs: Date.now() - start,
+          externalContent: {
+            untrusted: true,
+            source: "web_search",
+            provider: "baidu",
+            wrapped: true,
+          },
+          content: wrapWebContent(result.content),
+          citations: result.citations,
+        };
+        writeCachedSearchPayload(cacheKey, payload, resolveSearchCacheTtlMs(searchConfig));
+        return payload;
+      }
+
+      const results = await runBaiduDirectSearch({
+        query,
+        count: resolvedCount,
+        apiKey,
+        timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
+      });
+      const payload = {
+        query,
+        provider: "baidu",
+        mode,
+        count: results.length,
+        tookMs: Date.now() - start,
+        externalContent: {
+          untrusted: true,
+          source: "web_search",
+          provider: "baidu",
+          wrapped: true,
+        },
+        results,
+      };
+      writeCachedSearchPayload(cacheKey, payload, resolveSearchCacheTtlMs(searchConfig));
+      return payload;
+    },
+  };
+}
+
+export function createBaiduWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    id: "baidu",
+    label: "Baidu Search",
+    hint: "Chinese-first web search via Qianfan · direct or AI-synthesized modes",
+    onboardingScopes: ["text-inference"],
+    credentialLabel: "Baidu / Qianfan API key",
+    envVars: [...BAIDU_API_ENV_VARS],
+    placeholder: "bce-v3/...",
+    signupUrl: "https://console.bce.baidu.com/qianfan/ais/console/apiKey",
+    docsUrl: "https://docs.openclaw.ai/tools/web",
+    autoDetectOrder: 55,
+    credentialPath: "plugins.entries.qianfan.config.webSearch.apiKey",
+    inactiveSecretPaths: ["plugins.entries.qianfan.config.webSearch.apiKey"],
+    getCredentialValue: (searchConfig) => getScopedCredentialValue(searchConfig, "baidu"),
+    setCredentialValue: (searchConfigTarget, value) =>
+      setScopedCredentialValue(searchConfigTarget, "baidu", value),
+    getConfiguredCredentialValue: (config) =>
+      resolveProviderWebSearchPluginConfig(config, "qianfan")?.apiKey,
+    setConfiguredCredentialValue: (configTarget, value) => {
+      setProviderWebSearchPluginConfigValue(configTarget, "qianfan", "apiKey", value);
+    },
+    applySelectionConfig: (config) => enablePluginInConfig(config, "qianfan").config,
+    createTool: (ctx) =>
+      createBaiduToolDefinition(
+        mergeScopedSearchConfig(
+          ctx.searchConfig as SearchConfigRecord | undefined,
+          "baidu",
+          resolveProviderWebSearchPluginConfig(ctx.config, "qianfan"),
+        ) as SearchConfigRecord | undefined,
+      ),
+  };
+}
+
+export const __testing = {
+  resolveBaiduApiKey,
+  resolveBaiduConfig,
+  resolveBaiduMode,
+  resolveBaiduSmartModel,
+  mapBaiduReferencesToResults,
+  mapBaiduReferencesToCitations,
+} as const;

--- a/extensions/qianfan/web-search-provider.contract.test.ts
+++ b/extensions/qianfan/web-search-provider.contract.test.ts
@@ -1,0 +1,3 @@
+import { describeWebSearchProviderContracts } from "../../test/helpers/extensions/web-search-provider-contract.js";
+
+describeWebSearchProviderContracts("qianfan");

--- a/extensions/qianfan/web-search-provider.ts
+++ b/extensions/qianfan/web-search-provider.ts
@@ -1,0 +1,1 @@
+export { __testing, createBaiduWebSearchProvider } from "./src/baidu-web-search-provider.js";

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -13,6 +13,7 @@ const runtime: RuntimeEnv = {
 };
 
 const SEARCH_PROVIDER_ENV_VARS = [
+  "QIANFAN_API_KEY",
   "BRAVE_API_KEY",
   "FIRECRAWL_API_KEY",
   "GEMINI_API_KEY",
@@ -188,6 +189,24 @@ describe("setupSearch", () => {
     expect(result.tools?.web?.search?.enabled).toBe(true);
     expect(pluginWebSearchApiKey(result, "brave")).toBe("BSA-test-key");
     expect(result.plugins?.entries?.brave?.enabled).toBe(true);
+  });
+
+  it("sets provider and key for baidu via the qianfan plugin", async () => {
+    const cfg: OpenClawConfig = {};
+    const { prompter } = createPrompter({
+      selectValue: "baidu",
+      textValue: "bce-v3/test-key",
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search?.provider).toBe("baidu");
+    expect(result.tools?.web?.search?.enabled).toBe(true);
+    expect(pluginWebSearchApiKey(result, "qianfan")).toBe("bce-v3/test-key");
+    expect(result.plugins?.entries?.qianfan?.enabled).toBe(true);
+    expect(prompter.text).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Baidu / Qianfan API key",
+      }),
+    );
   });
 
   it("sets provider and key for gemini", async () => {

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -17,7 +17,16 @@ const getConfiguredPluginWebSearchCredential =
 
 const mockWebSearchProviders = [
   {
+    id: "baidu",
+    autoDetectOrder: 55,
+    envVars: ["QIANFAN_API_KEY"],
+    credentialPath: "plugins.entries.qianfan.config.webSearch.apiKey",
+    getCredentialValue: getScopedWebSearchCredential("baidu"),
+    getConfiguredCredentialValue: getConfiguredPluginWebSearchCredential("qianfan"),
+  },
+  {
     id: "brave",
+    autoDetectOrder: 10,
     envVars: ["BRAVE_API_KEY"],
     credentialPath: "plugins.entries.brave.config.webSearch.apiKey",
     getCredentialValue: (search?: Record<string, unknown>) => search?.apiKey,
@@ -25,6 +34,7 @@ const mockWebSearchProviders = [
   },
   {
     id: "firecrawl",
+    autoDetectOrder: 60,
     envVars: ["FIRECRAWL_API_KEY"],
     credentialPath: "plugins.entries.firecrawl.config.webSearch.apiKey",
     getCredentialValue: getScopedWebSearchCredential("firecrawl"),
@@ -32,6 +42,7 @@ const mockWebSearchProviders = [
   },
   {
     id: "gemini",
+    autoDetectOrder: 20,
     envVars: ["GEMINI_API_KEY"],
     credentialPath: "plugins.entries.google.config.webSearch.apiKey",
     getCredentialValue: getScopedWebSearchCredential("gemini"),
@@ -39,6 +50,7 @@ const mockWebSearchProviders = [
   },
   {
     id: "grok",
+    autoDetectOrder: 30,
     envVars: ["XAI_API_KEY"],
     credentialPath: "plugins.entries.xai.config.webSearch.apiKey",
     getCredentialValue: getScopedWebSearchCredential("grok"),
@@ -46,6 +58,7 @@ const mockWebSearchProviders = [
   },
   {
     id: "kimi",
+    autoDetectOrder: 40,
     envVars: ["KIMI_API_KEY", "MOONSHOT_API_KEY"],
     credentialPath: "plugins.entries.moonshot.config.webSearch.apiKey",
     getCredentialValue: getScopedWebSearchCredential("kimi"),
@@ -53,6 +66,7 @@ const mockWebSearchProviders = [
   },
   {
     id: "perplexity",
+    autoDetectOrder: 50,
     envVars: ["PERPLEXITY_API_KEY", "OPENROUTER_API_KEY"],
     credentialPath: "plugins.entries.perplexity.config.webSearch.apiKey",
     getCredentialValue: getScopedWebSearchCredential("perplexity"),
@@ -60,6 +74,7 @@ const mockWebSearchProviders = [
   },
   {
     id: "tavily",
+    autoDetectOrder: 70,
     envVars: ["TAVILY_API_KEY"],
     credentialPath: "plugins.entries.tavily.config.webSearch.apiKey",
     getCredentialValue: getScopedWebSearchCredential("tavily"),
@@ -150,6 +165,22 @@ describe("web search provider config", () => {
         providerConfig: {
           apiKey: "test-key", // pragma: allowlist secret
           model: "gemini-2.5-flash",
+        },
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts baidu provider and config", () => {
+    const res = validateConfigObjectWithPlugins(
+      buildWebSearchProviderConfig({
+        enabled: true,
+        provider: "baidu",
+        providerConfig: {
+          apiKey: "bce-v3/test-key", // pragma: allowlist secret
+          mode: "smart",
+          model: "ernie-4.5-turbo-32k",
         },
       }),
     );
@@ -257,6 +288,7 @@ describe("web search provider auto-detection", () => {
   const savedEnv = { ...process.env };
 
   beforeEach(() => {
+    delete process.env.QIANFAN_API_KEY;
     delete process.env.BRAVE_API_KEY;
     delete process.env.FIRECRAWL_API_KEY;
     delete process.env.GEMINI_API_KEY;
@@ -287,6 +319,11 @@ describe("web search provider auto-detection", () => {
   it("auto-detects gemini when only GEMINI_API_KEY is set", () => {
     process.env.GEMINI_API_KEY = "test-gemini-key"; // pragma: allowlist secret
     expect(resolveSearchProvider({})).toBe("gemini");
+  });
+
+  it("auto-detects baidu when only QIANFAN_API_KEY is set", () => {
+    process.env.QIANFAN_API_KEY = "bce-v3/test-baidu-key"; // pragma: allowlist secret
+    expect(resolveSearchProvider({})).toBe("baidu");
   });
 
   it("auto-detects tavily when only TAVILY_API_KEY is set", () => {
@@ -329,7 +366,7 @@ describe("web search provider auto-detection", () => {
     expect(resolveSearchProvider({})).toBe("kimi");
   });
 
-  it("follows alphabetical order — brave wins when multiple keys available", () => {
+  it("follows auto-detect priority — brave wins when multiple keys available", () => {
     process.env.BRAVE_API_KEY = "test-brave-key"; // pragma: allowlist secret
     process.env.GEMINI_API_KEY = "test-gemini-key"; // pragma: allowlist secret
     process.env.PERPLEXITY_API_KEY = "test-perplexity-key"; // pragma: allowlist secret
@@ -337,14 +374,14 @@ describe("web search provider auto-detection", () => {
     expect(resolveSearchProvider({})).toBe("brave");
   });
 
-  it("gemini wins over grok, kimi, and perplexity when brave unavailable", () => {
+  it("gemini wins over lower-priority providers when brave unavailable", () => {
     process.env.GEMINI_API_KEY = "test-gemini-key"; // pragma: allowlist secret
     process.env.PERPLEXITY_API_KEY = "test-perplexity-key"; // pragma: allowlist secret
     process.env.XAI_API_KEY = "test-xai-key"; // pragma: allowlist secret
     expect(resolveSearchProvider({})).toBe("gemini");
   });
 
-  it("grok wins over kimi and perplexity when brave and gemini unavailable", () => {
+  it("grok wins over lower-priority providers when brave and gemini unavailable", () => {
     process.env.XAI_API_KEY = "test-xai-key"; // pragma: allowlist secret
     process.env.KIMI_API_KEY = "test-kimi-key"; // pragma: allowlist secret
     process.env.PERPLEXITY_API_KEY = "test-perplexity-key"; // pragma: allowlist secret

--- a/src/config/test-helpers.ts
+++ b/src/config/test-helpers.ts
@@ -88,7 +88,9 @@ export function buildWebSearchProviderConfig(params: {
         ? "xai"
         : params.provider === "kimi"
           ? "moonshot"
-          : params.provider;
+          : params.provider === "baidu"
+            ? "qianfan"
+            : params.provider;
   return {
     tools: {
       web: {

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -11829,7 +11829,12 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
       source: "./index.ts",
       built: "index.js",
     },
-    publicSurfaceArtifacts: ["api.js", "onboard.js", "provider-catalog.js"],
+    publicSurfaceArtifacts: [
+      "api.js",
+      "onboard.js",
+      "provider-catalog.js",
+      "web-search-provider.js",
+    ],
     packageName: "@openclaw/qianfan-provider",
     packageVersion: "2026.3.27",
     packageDescription: "OpenClaw Qianfan provider plugin",
@@ -11841,7 +11846,24 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
       configSchema: {
         type: "object",
         additionalProperties: false,
-        properties: {},
+        properties: {
+          webSearch: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              apiKey: {
+                type: ["string", "object"],
+              },
+              mode: {
+                type: "string",
+                enum: ["direct", "smart"],
+              },
+              model: {
+                type: "string",
+              },
+            },
+          },
+        },
       },
       enabledByDefault: true,
       providers: ["qianfan"],
@@ -11863,6 +11885,25 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "QIANFAN API key",
         },
       ],
+      uiHints: {
+        "webSearch.apiKey": {
+          label: "Baidu Search API Key",
+          help: "Qianfan API key for Baidu web search (fallback: QIANFAN_API_KEY env var).",
+          sensitive: true,
+          placeholder: "bce-v3/...",
+        },
+        "webSearch.mode": {
+          label: "Baidu Search Mode",
+          help: "Use direct structured search or smart AI-synthesized search.",
+        },
+        "webSearch.model": {
+          label: "Baidu Smart Search Model",
+          help: "Model override used only for smart mode.",
+        },
+      },
+      contracts: {
+        webSearchProviders: ["baidu"],
+      },
     },
   },
   {

--- a/src/plugins/web-search-providers.runtime.test.ts
+++ b/src/plugins/web-search-providers.runtime.test.ts
@@ -8,6 +8,7 @@ type PluginAutoEnableModule = typeof import("../config/plugin-auto-enable.js");
 type WebSearchProvidersSharedModule = typeof import("./web-search-providers.shared.js");
 
 const BUNDLED_WEB_SEARCH_PROVIDERS = [
+  { pluginId: "qianfan", id: "baidu", order: 55 },
   { pluginId: "brave", id: "brave", order: 10 },
   { pluginId: "google", id: "gemini", order: 20 },
   { pluginId: "xai", id: "grok", order: 30 },
@@ -34,6 +35,7 @@ let webSearchProvidersSharedModule: WebSearchProvidersSharedModule;
 
 const DEFAULT_WEB_SEARCH_WORKSPACE = "/tmp/workspace";
 const EXPECTED_BUNDLED_RUNTIME_WEB_SEARCH_PROVIDER_KEYS = [
+  "qianfan:baidu",
   "brave:brave",
   "duckduckgo:duckduckgo",
   "exa:exa",

--- a/src/plugins/web-search-providers.test.ts
+++ b/src/plugins/web-search-providers.test.ts
@@ -3,6 +3,7 @@ import { resolveBundledPluginWebSearchProviders } from "./web-search-providers.j
 
 const WEB_SEARCH_PROVIDER_TEST_TIMEOUT_MS = 300_000;
 const EXPECTED_BUNDLED_WEB_SEARCH_PROVIDER_KEYS = [
+  "qianfan:baidu",
   "brave:brave",
   "duckduckgo:duckduckgo",
   "exa:exa",
@@ -14,6 +15,7 @@ const EXPECTED_BUNDLED_WEB_SEARCH_PROVIDER_KEYS = [
   "tavily:tavily",
 ] as const;
 const EXPECTED_BUNDLED_WEB_SEARCH_PROVIDER_PLUGIN_IDS = [
+  "qianfan",
   "brave",
   "duckduckgo",
   "exa",
@@ -25,6 +27,7 @@ const EXPECTED_BUNDLED_WEB_SEARCH_PROVIDER_PLUGIN_IDS = [
   "tavily",
 ] as const;
 const EXPECTED_BUNDLED_WEB_SEARCH_CREDENTIAL_PATHS = [
+  "plugins.entries.qianfan.config.webSearch.apiKey",
   "plugins.entries.brave.config.webSearch.apiKey",
   "",
   "plugins.entries.exa.config.webSearch.apiKey",

--- a/src/secrets/runtime.coverage.test.ts
+++ b/src/secrets/runtime.coverage.test.ts
@@ -30,7 +30,7 @@ vi.mock("../plugins/web-search-providers.runtime.js", () => ({
 }));
 
 function createTestProvider(params: {
-  id: "brave" | "gemini" | "grok" | "kimi" | "perplexity" | "firecrawl" | "tavily";
+  id: "baidu" | "brave" | "gemini" | "grok" | "kimi" | "perplexity" | "firecrawl" | "tavily";
   pluginId: string;
   order: number;
 }): PluginWebSearchProviderEntry {
@@ -84,6 +84,7 @@ function createTestProvider(params: {
 
 function buildTestWebSearchProviders(): PluginWebSearchProviderEntry[] {
   return [
+    createTestProvider({ id: "baidu", pluginId: "qianfan", order: 55 }),
     createTestProvider({ id: "brave", pluginId: "brave", order: 10 }),
     createTestProvider({ id: "gemini", pluginId: "google", order: 20 }),
     createTestProvider({ id: "grok", pluginId: "xai", order: 30 }),
@@ -174,6 +175,9 @@ function buildConfigForOpenClawTarget(entry: SecretRegistryEntry, envId: string)
       ["channels", "feishu", "accounts", "sample", "connectionMode"],
       "webhook",
     );
+  }
+  if (entry.id === "plugins.entries.qianfan.config.webSearch.apiKey") {
+    setPathCreateStrict(config, ["tools", "web", "search", "provider"], "baidu");
   }
   if (entry.id === "plugins.entries.brave.config.webSearch.apiKey") {
     setPathCreateStrict(config, ["tools", "web", "search", "provider"], "brave");

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -726,6 +726,17 @@ const SECRET_TARGET_REGISTRY: SecretTargetRegistryEntry[] = [
     includeInAudit: true,
   },
   {
+    id: "plugins.entries.qianfan.config.webSearch.apiKey",
+    targetType: "plugins.entries.qianfan.config.webSearch.apiKey",
+    configFile: "openclaw.json",
+    pathPattern: "plugins.entries.qianfan.config.webSearch.apiKey",
+    secretShape: SECRET_INPUT_SHAPE,
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+  {
     id: "plugins.entries.brave.config.webSearch.apiKey",
     targetType: "plugins.entries.brave.config.webSearch.apiKey",
     configFile: "openclaw.json",


### PR DESCRIPTION
## Summary

This PR adds a bundled `baidu` `web_search` provider via the existing
`qianfan` plugin.

It supports two modes:

- `direct`: structured search results
- `smart`: AI-synthesized answer with citations

Refs #56304

## Motivation

This is intended to improve zh-CN retrieval coverage by adding a
Chinese-first search backend with strong mainland Chinese web coverage,
while keeping the implementation small and maintainer-friendly.

Why Baidu:

- Baidu remains the largest search backend in China
- it covers a distinct Chinese-local content ecosystem
- Qianfan already exposes both direct search and AI search generation APIs
- those two API shapes map cleanly onto OpenClaw's existing `web_search`
  output patterns

## Scope

Included in this PR:

- add bundled `baidu` web-search provider ownership under `qianfan`
- add minimal Qianfan-owned web search config:
  - `plugins.entries.qianfan.config.webSearch.apiKey`
  - `plugins.entries.qianfan.config.webSearch.mode`
  - `plugins.entries.qianfan.config.webSearch.model`
- support `QIANFAN_API_KEY` as env fallback
- normalize direct responses into structured `results[]`
- normalize smart responses into `content + citations`
- add targeted tests, contract tests, metadata sync, and docs

Not included:

- fallback / provider rotation
- provider ranking redesign
- query rewriting
- plugin architecture refactors
- unrelated UI or infra changes

## Implementation Notes

- provider id: `baidu`
- plugin owner: `qianfan`
- default mode: `direct`
- smart mode default model: `ernie-4.5-turbo-32k`
- auto-detect order: `55`
- shared `QIANFAN_API_KEY` web-search auto-detect behavior is intentional and
  follows the existing shared-key pattern already used by Gemini for LLM +
  web search

## Follow-up

After initial review, I pushed `6a145ae488` to keep the PR narrowly scoped
while addressing the remaining docs / contract sync gaps:

- synced the SecretRef docs baseline for
  `plugins.entries.qianfan.config.webSearch.apiKey`
- added the missing Qianfan web-search credential to the canonical SecretRef
  surface page
- removed the Baidu card self-link in `docs/tools/web.md`

## Test Plan

Ran:

- `COREPACK_HOME=/tmp/corepack corepack pnpm exec vitest run --config vitest.unit.config.ts extensions/qianfan/src/baidu-web-search-provider.test.ts src/config/config.web-search-provider.test.ts src/plugins/web-search-providers.test.ts src/plugins/web-search-providers.runtime.test.ts src/commands/onboard-search.test.ts src/secrets/runtime.coverage.test.ts`
- `COREPACK_HOME=/tmp/corepack corepack pnpm exec vitest run --config vitest.extensions.config.ts extensions/qianfan/src/baidu-web-search-provider.test.ts extensions/qianfan/web-search-provider.contract.test.ts extensions/qianfan/bundled-web-search.contract.test.ts extensions/qianfan/plugin-registration.contract.test.ts`
- `PATH=/tmp/corepack-bin:$PATH COREPACK_HOME=/tmp/corepack corepack pnpm exec vitest run --config vitest.unit.config.ts src/secrets/target-registry.test.ts`
- `PATH=/tmp/corepack-bin:$PATH COREPACK_HOME=/tmp/corepack corepack pnpm exec vitest run --config vitest.unit.config.ts src/secrets/runtime.coverage.test.ts`
- `COREPACK_HOME=/tmp/corepack corepack pnpm check:bundled-plugin-metadata`
- `PATH=/tmp/corepack-bin:$PATH COREPACK_HOME=/tmp/corepack corepack pnpm check`
- `PATH=/tmp/corepack-bin:$PATH COREPACK_HOME=/tmp/corepack corepack pnpm check:docs`

Manual / live validation performed locally against the Baidu Qianfan endpoint:

- direct search request/response shape
- smart search request/response shape

## Current CI Status

On the latest PR head `6a145ae488`, the Baidu-related regressions that had
shown up in:

- `checks-node-test-3`
- `checks-windows-node-test-5`

are resolved.

The remaining failing checks are currently outside the touched Baidu /
Qianfan / web-search surface:

- `src/plugins/contracts/tts.contract.test.ts`
- `extensions/matrix/src/matrix/monitor/index.test.ts`
- `src/process/exec.test.ts`

Recent `main` CI runs have also been unstable, so these remaining failures
may need reruns once the base-branch noise settles.

## Known Verification Gap

Full `pnpm build` in this environment is currently blocked by a repo-level
postbuild step while staging bundled runtime deps for `slack`
(`npm install failed` in `scripts/runtime-postbuild.mjs`).

I was able to verify:

- targeted unit coverage
- extension/provider tests
- contract tests
- bundled metadata sync
- SecretRef baseline sync
- `pnpm check`
- `pnpm check:docs`

## AI-assisted Disclosure

This PR was implemented with AI assistance, then reviewed locally with the
scope intentionally kept to a small provider addition under the existing
Qianfan plugin.
