### PR TITLE
Fix sessions_spawn for subagent runtime with ACP-only fields

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -200,18 +200,22 @@ describe("sessions_spawn tool", () => {
     );
   });
 
-  it("rejects resumeSessionId without runtime=acp", async () => {
+  it("ignores resumeSessionId for subagent runtime and still spawns", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
 
-    const result = await tool.execute("call-guard", {
+    await tool.execute("call-guard", {
       task: "resume prior work",
       resumeSessionId: "7f4a78e0-f6be-43fe-855c-c1c4fd229bc4",
     });
 
-    expect(JSON.stringify(result)).toContain("resumeSessionId is only supported for runtime=acp");
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "resume prior work",
+      }),
+      expect.any(Object),
+    );
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
   });
 
@@ -239,24 +243,24 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
-  it('rejects streamTo when runtime is not "acp"', async () => {
+  it("ignores streamTo for subagent runtime and still spawns", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
 
-    const result = await tool.execute("call-3b", {
+    await tool.execute("call-3b", {
       runtime: "subagent",
       task: "analyze file",
       streamTo: "parent",
     });
 
-    expect(result.details).toMatchObject({
-      status: "error",
-    });
-    const details = result.details as { error?: string };
-    expect(details.error).toContain("streamTo is only supported for runtime=acp");
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "analyze file",
+      }),
+      expect.any(Object),
+    );
   });
 
   it("keeps attachment content schema unconstrained for llama.cpp grammar safety", () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -127,19 +127,11 @@ export function createSessionsSpawnTool(
           }>)
         : undefined;
 
-      if (streamTo && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `streamTo is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
-
-      if (resumeSessionId && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `resumeSessionId is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
+      // Be forgiving for schema-following models: ACP-only fields may be emitted
+      // even when the caller intends runtime="subagent". Ignore those fields here
+      // instead of rejecting the entire spawn request.
+      const effectiveResumeSessionId = runtime === "acp" ? resumeSessionId : undefined;
+      const effectiveStreamTo = runtime === "acp" ? streamTo : undefined;
 
       if (runtime === "acp") {
         if (Array.isArray(attachments) && attachments.length > 0) {
@@ -154,12 +146,12 @@ export function createSessionsSpawnTool(
             task,
             label: label || undefined,
             agentId: requestedAgentId,
-            resumeSessionId,
+            resumeSessionId: effectiveResumeSessionId,
             cwd,
             mode: mode && ACP_SPAWN_MODES.includes(mode) ? mode : undefined,
             thread,
             sandbox,
-            streamTo,
+            streamTo: effectiveStreamTo,
           },
           {
             agentSessionKey: opts?.agentSessionKey,


### PR DESCRIPTION
## Summary

- Problem: sessions_spawn exposes ACP-only fields (streamTo, resumeSessionId) even when callers intend runtime="subagent".
- Why it matters: schema-following models may emit those ACP-only fields, causing valid subagent spawns to fail before dispatch.
- What changed: ignore ACP-only fields for non-ACP runtime instead of rejecting the request; update tests to lock in the forgiving subagent behavior.
- What did NOT change (scope boundary): ACP runtime behavior, schema shape, or any other spawn semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #56326
- Related #43556
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: a mixed public sessions_spawn schema exposes ACP-only fields to tool-calling models, while execution rejects those same fields for runtime="subagent" before dispatch.
- Missing detection / guardrail: no forgiving strip/ignore layer for ACP-only fields on the subagent path.
- Prior context: community reports already describe the streamTo is only supported for runtime=acp failure on subagent spawns.
- Why this regressed now: schema-following models are more likely to emit optional fields that appear in the public schema.
- If unknown, what was ruled out: ruled out allowlist/config mistakes and subagent runtime implementation itself.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: src/agents/tools/sessions-spawn-tool.test.ts
- Scenario the test should lock in: runtime="subagent" should ignore streamTo / resumeSessionId and still call spawnSubagentDirect(...).
- Why this is the smallest reliable guardrail: the failure happens in the tool dispatch guard before runtime execution, so a focused unit test covers the exact breakage point.
- Existing test that already covers this (if any): existing sessions_spawn tool tests covered the prior reject behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Subagent spawns become more robust when models include ACP-only fields that are irrelevant to runtime="subagent".

## Diagram (if applicable)

Before:
LLM tool call -> sessions_spawn(runtime=subagent, streamTo=parent) -> guard rejects -> no spawn

After:
LLM tool call -> sessions_spawn(runtime=subagent, streamTo=parent) -> ACP-only fields ignored -> spawnSubagentDirect(...) -> success

## Security Impact (required)

- New permissions/capabilities? (Yes/No) No
- Secrets/tokens handling changed? (Yes/No) No
- New/changed network calls? (Yes/No) No
- Command/tool execution surface changed? (Yes/No) No
- Data access scope changed? (Yes/No) No
- If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime/container: local host runtime
- Model/provider: schema-following tool-call model behavior
- Integration/channel (if any): N/A
- Relevant config (redacted): sessions_spawn(runtime="subagent")

### Steps

1. Call sessions_spawn with runtime="subagent".
2. Include streamTo: "parent" or resumeSessionId in the tool args.
3. Observe pre-dispatch failure.

### Expected

- ACP-only fields are ignored for subagent runtime.
- The request still reaches spawnSubagentDirect(...).

### Actual

- The request was rejected with streamTo is only supported for runtime=acp or resumeSessionId is only supported for runtime=acp.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced failing subagent spawn locally, applied equivalent workaround, confirmed subagent runs succeeded afterward; ran pnpm exec vitest run src/agents/tools/sessions-spawn-tool.test.ts and got 9/9 passing.
- Edge cases checked: streamTo on subagent path; resumeSessionId on subagent path; ACP path left unchanged in code.
- What you did **not** verify: full end-to-end hosted CI matrix.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes/No) Yes
- Config/env changes? (Yes/No) No
- Migration needed? (Yes/No) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: silently ignoring ACP-only fields could mask caller mistakes.
  - Mitigation: the ignored fields are already invalid for subagent runtime and currently hard-fail valid multi-agent use cases; ACP behavior remains unchanged.