### PR TITLE
fix(plugins): gateway-bindable registry satisfies default requests in agent_end hooks

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -319,9 +319,22 @@ function getCompatibleActivePluginRegistry(
   if (!activeCacheKey) {
     return undefined;
   }
-  return resolvePluginLoadCacheContext(options).cacheKey === activeCacheKey
-    ? activeRegistry
-    : undefined;
+  const requestedMode = resolveRuntimeSubagentMode(options.runtimeOptions);
+  const requestCacheKey = resolvePluginLoadCacheContext(options).cacheKey;
+  if (requestCacheKey === activeCacheKey) {
+    return activeRegistry;
+  }
+  // "gateway-bindable" is a superset of "default": if the active registry was
+  // loaded with gateway-bindable subagent access, it satisfies any "default"
+  // mode request without reloading. Reloading would downgrade api.runtime.subagent
+  // from a live proxy to an unavailable stub, breaking hooks like agent_end.
+  // Note: we only check the mode segment of the cacheKey, not the full key,
+  // because gateway startup passes extra params (coreGatewayHandlers) that
+  // differ from runtime calls but don't affect plugin registration correctness.
+  if (requestedMode === "default" && activeCacheKey.includes("::gateway-bindable::")) {
+    return activeRegistry;
+  }
+  return undefined;
 }
 
 export function resolveRuntimePluginRegistry(


### PR DESCRIPTION
## Summary

- **Problem:** After `c0d4c07b88` added `coreGatewayMethodNames` to the plugin registry cache key, the key generated at gateway startup (`gateway-bindable` mode, includes gateway method names) no longer matched the key generated during `agent_end` hook dispatch (`default` mode, no gateway methods). This caused the loader to reload plugins from scratch on every `agent_end` call, downgrading `api.runtime.subagent` from a live gateway proxy to an unavailable stub.
- **Why it matters:** Any plugin relying on `api.runtime.subagent.run()` inside `agent_end` (e.g. loop-watchdog) silently fails with `TypeError: Cannot read properties of undefined`. The hook fires but cannot perform its intended action.
- **What changed:** `getCompatibleActivePluginRegistry` now recognizes that a `gateway-bindable` registry is a superset of `default`. If the active registry was loaded with gateway-bindable subagent access, it is returned as-is for any `default`-mode request, skipping the reload.
- **What did NOT change (scope boundary):** No changes to cache key structure, plugin loading paths, gateway startup, or any other hook context. The full cacheKey match path is preserved; only a new fallback path is added for this specific mode mismatch.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** `c0d4c07b88` added `coreGatewayMethodNames` to the plugin registry cache key so that registries loaded with different gateway method sets are not incorrectly shared. This is correct for most cases, but it caused a false mismatch between the gateway-startup registry (which includes `coreGatewayHandlers`) and hook-dispatch calls (which do not pass `coreGatewayHandlers`), triggering an unnecessary reload that stripped subagent capability.
- **Missing detection / guardrail:** No test covered the case where a plugin hook fires in `agent_end` context and attempts to use `api.runtime.subagent` — the reload path and capability downgrade were undetected.
- **Prior context:** `c0d4c07b88` (`fix(regression): scope plugin registry reuse by gateway methods`) introduced the regression on 2026-03-27.
- **Why this regressed now:** The gateway method scoping was a correctness fix for a different issue, but it did not account for the asymmetry between gateway-startup load options and hook-dispatch load options.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** loader seam test for `getCompatibleActivePluginRegistry`
- **Scenario the test should lock in:** When `agent_end` hook fires after a gateway-startup plugin load, `getCompatibleActivePluginRegistry` must return the existing registry (not `undefined`), and `api.runtime.subagent` must remain a live proxy.
- **Why this is the smallest reliable guardrail:** The mode-mismatch logic is entirely within `getCompatibleActivePluginRegistry`; a unit test with a `gateway-bindable` active key and a `default` request key is sufficient.
- **If no new test is added, why not:** Test infrastructure for this path requires gateway context seam mocks; left for follow-up to keep this fix minimal.

## User-visible / Behavior Changes

Plugins that use `api.runtime.subagent.run()` inside `agent_end` hooks now work correctly. Previously they silently failed to execute their intended action after each agent turn.

## Diagram (if applicable)

```text
Before (regression):
[agent_end fires] -> getCompatibleActivePluginRegistry(default mode)
  -> cacheKey(default) != cacheKey(gateway-bindable+methods) -> reload plugins
  -> api.runtime.subagent = unavailable stub -> subagent.run() throws

After:
[agent_end fires] -> getCompatibleActivePluginRegistry(default mode)
  -> cacheKey mismatch detected -> check: active is gateway-bindable, request is default
  -> gateway-bindable ⊇ default -> return existing registry
  -> api.runtime.subagent = live proxy -> subagent.run() works
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux 6.17.0-19-generic (x64)
- Runtime/container: Node v25.8.2, OpenClaw 2026.3.27
- Model/provider: cursor2api/anthropic/claude-sonnet-4.6
- Integration/channel: webchat (direct)
- Relevant config: loop-watchdog plugin installed

### Steps

1. Install a plugin that calls `api.runtime.subagent.run()` in its `agent_end` hook (e.g. `@abwuge/openclaw-loop-watchdog`)
2. Complete an agent turn (let `agent_end` fire)
3. Observe whether the subagent action executes or throws

### Expected

- `agent_end` hook completes successfully; subagent action fires; wake message enqueued

### Actual (before fix)

- `agent_end` hook fires but silently fails: `TypeError: Cannot read properties of undefined` or `Plugin runtime subagent methods are only available during a gateway request`

## Evidence

- [x] Trace/log snippets

Gateway log before fix:
```
[loop-watchdog] agent_end entered sk=<session>
[loop-watchdog] readFlag result: found
[loop-watchdog] Failed to send wake message: TypeError: Cannot read properties of undefined
```

Gateway log after fix:
```
[loop-watchdog] agent_end entered sk=<session>
[loop-watchdog] readFlag result: found
[loop-watchdog] enqueueSystemEvent result: true
```

## Human Verification (required)

- **Verified scenarios:** gateway restart triggers orphan scan and wake via `gateway_start`; `agent_end` fires and successfully enqueues wake message; system prompt delivered to session
- **Edge cases checked:** gateway restart mid-turn; multiple consecutive agent turns; plugin loaded before and after gateway restart
- **What you did not verify:** behavior when `coreGatewayHandlers` set differs between two concurrent gateway instances

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** A `gateway-bindable` registry loaded with one set of gateway methods could be reused for a request that expects a different set, bypassing the scoping introduced in `c0d4c07b88`.
  - **Mitigation:** The fallback only triggers when `requestedMode === "default"` — i.e. hook-dispatch contexts that do not pass `coreGatewayHandlers` at all. Gateway-to-gateway reuse (both `gateway-bindable`) still requires full cacheKey match.