### PR TITLE
fix(heartbeat): prevent subagent announcements from re-triggering heartbeat cascade

### DIFF
--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -283,6 +283,64 @@ describe("heartbeat-wake", () => {
     });
   });
 
+  it("suppresses rapid subagent stream wakes within cooldown (issue #56049)", async () => {
+    vi.useFakeTimers();
+    const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handler);
+
+    // First subagent stream wake should fire normally
+    requestHeartbeatNow({
+      reason: "acp:spawn:stream",
+      sessionKey: "agent:main:telegram:group:-1001",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Second subagent stream wake within cooldown should be suppressed
+    requestHeartbeatNow({
+      reason: "acp:spawn:stream",
+      sessionKey: "agent:main:telegram:group:-1001",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(1); // still 1 — suppressed
+
+    // Non-subagent wake for same target should still fire
+    requestHeartbeatNow({
+      reason: "exec-event",
+      sessionKey: "agent:main:telegram:group:-1001",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows subagent stream wake after cooldown expires", async () => {
+    vi.useFakeTimers();
+    const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handler);
+
+    requestHeartbeatNow({
+      reason: "acp:spawn:stream",
+      sessionKey: "agent:main:discord:channel:alerts",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Advance past the 60s cooldown
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    requestHeartbeatNow({
+      reason: "acp:spawn:stream",
+      sessionKey: "agent:main:discord:channel:alerts",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
   it("executes distinct targeted wakes queued in the same coalescing window", async () => {
     vi.useFakeTimers();
     const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -178,8 +178,12 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
             sessionKey: pendingWake.sessionKey,
           });
           const lastRan = lastRanAtByTarget.get(targetKey);
-          if (lastRan != null && Date.now() - lastRan < SUBAGENT_WAKE_COOLDOWN_MS) {
-            continue;
+          if (lastRan != null) {
+            if (Date.now() - lastRan < SUBAGENT_WAKE_COOLDOWN_MS) {
+              continue; // still within cooldown, suppress
+            }
+            // Expired — evict the stale entry immediately
+            lastRanAtByTarget.delete(targetKey);
           }
         }
 
@@ -252,6 +256,9 @@ export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () =
     // `scheduled === true` can cause spurious immediate re-runs.
     running = false;
     scheduled = false;
+    // Clear subagent cooldown state so wakes are not suppressed in the new
+    // lifecycle based on activity from before the handler was replaced.
+    lastRanAtByTarget.clear();
   }
   if (handler && pendingWakes.size > 0) {
     schedule(DEFAULT_COALESCE_MS, "normal");

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -45,6 +45,14 @@ let timerKind: WakeTimerKind | null = null;
 
 const DEFAULT_COALESCE_MS = 250;
 const DEFAULT_RETRY_MS = 1_000;
+/**
+ * Cooldown period for subagent stream wakes (acp:spawn:*). After a handler
+ * fires for a given wake target, subsequent subagent wakes within this window
+ * are dropped to prevent cascading heartbeat polls when multiple subagent
+ * completions arrive in quick succession.
+ */
+const SUBAGENT_WAKE_COOLDOWN_MS = 60_000;
+const lastRanAtByTarget = new Map<string, number>();
 const REASON_PRIORITY = {
   RETRY: 0,
   INTERVAL: 1,
@@ -64,6 +72,10 @@ function resolveReasonPriority(reason: string): number {
     return REASON_PRIORITY.ACTION;
   }
   return REASON_PRIORITY.DEFAULT;
+}
+
+function isSubagentStreamWake(reason: string): boolean {
+  return reason.startsWith("acp:spawn:");
 }
 
 function normalizeWakeReason(reason?: string): string {
@@ -157,12 +169,33 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
     running = true;
     try {
       for (const pendingWake of pendingBatch) {
+        // Subagent stream wakes (acp:spawn:*) are subject to a cooldown to
+        // prevent cascading heartbeat polls when multiple subagent completions
+        // fire in rapid succession (issue #56049).
+        if (isSubagentStreamWake(pendingWake.reason)) {
+          const targetKey = getWakeTargetKey({
+            agentId: pendingWake.agentId,
+            sessionKey: pendingWake.sessionKey,
+          });
+          const lastRan = lastRanAtByTarget.get(targetKey);
+          if (lastRan != null && Date.now() - lastRan < SUBAGENT_WAKE_COOLDOWN_MS) {
+            continue;
+          }
+        }
+
         const wakeOpts = {
           reason: pendingWake.reason ?? undefined,
           ...(pendingWake.agentId ? { agentId: pendingWake.agentId } : {}),
           ...(pendingWake.sessionKey ? { sessionKey: pendingWake.sessionKey } : {}),
         };
         const res = await active(wakeOpts);
+        if (res.status === "ran") {
+          const targetKey = getWakeTargetKey({
+            agentId: pendingWake.agentId,
+            sessionKey: pendingWake.sessionKey,
+          });
+          lastRanAtByTarget.set(targetKey, Date.now());
+        }
         if (res.status === "skipped" && res.reason === "requests-in-flight") {
           // The main lane is busy; retry this wake target soon.
           queuePendingWakeReason({
@@ -265,6 +298,7 @@ export function resetHeartbeatWakeStateForTests() {
   timerDueAt = null;
   timerKind = null;
   pendingWakes.clear();
+  lastRanAtByTarget.clear();
   scheduled = false;
   running = false;
   handlerGeneration += 1;


### PR DESCRIPTION
## Summary

When subagent sessions complete with auto-announce enabled, the result messages insert into the main session's message queue. Each insertion calls `requestHeartbeatNow()` which re-triggers the heartbeat handler, causing heartbeat polls to fire in rapid succession (~18s apart) instead of at the configured interval.

## Changes

- Added a 60-second cooldown for subagent stream wakes (`acp:spawn:*`) per wake target in `heartbeat-wake.ts`
- After the heartbeat handler fires for a given target, subsequent subagent wakes within the cooldown window are suppressed
- Non-subagent wakes (exec events, hooks, etc.) are unaffected
- Added tests for cooldown suppression and expiry
- Reset state is cleared in `resetHeartbeatWakeStateForTests()`

## Files Changed

- `src/infra/heartbeat-wake.ts` — cooldown logic for subagent stream wakes
- `src/infra/heartbeat-wake.test.ts` — tests for cooldown behavior

Fixes #56049