### PR TITLE
fix(plugins): deduplicate tool registration on config hot-reload

### DIFF
--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -291,20 +291,35 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       names.push(tool.name);
     }
 
-    const normalized = names.map((name) => name.trim()).filter(Boolean);
+    let normalized = names.map((name) => name.trim()).filter(Boolean);
 
-    // Deduplicate: skip if the same plugin already registered a tool with any
-    // of the same names.  This prevents duplicate entries when a plugin's
-    // registerFull() callback is invoked multiple times during config
-    // hot-reload cycles (see #56114).
+    // Deduplicate: filter out names already registered by this plugin.
+    // This prevents duplicate entries when a plugin's registerFull() callback
+    // is invoked multiple times during config hot-reload cycles (see #56114).
     if (normalized.length > 0) {
-      const alreadyRegistered = registry.tools.some(
+      const registeredNames = new Set(
+        registry.tools.filter((t) => t.pluginId === record.id).flatMap((t) => t.names),
+      );
+      const newNames = normalized.filter((n) => !registeredNames.has(n));
+
+      if (newNames.length === 0) {
+        return; // nothing genuinely new — skip
+      }
+
+      // Use only the new names from here on
+      normalized = newNames;
+    }
+
+    // For nameless tools, also check for duplicates by factory reference
+    if (normalized.length === 0) {
+      const alreadyRegisteredFactory = registry.tools.some(
         (existing) =>
           existing.pluginId === record.id &&
-          existing.names.some((n) => normalized.includes(n)),
+          existing.names.length === 0 &&
+          existing.factory === factory,
       );
-      if (alreadyRegistered) {
-        return;
+      if (alreadyRegisteredFactory) {
+        return; // skip duplicate nameless factory
       }
     }
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -292,6 +292,22 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
 
     const normalized = names.map((name) => name.trim()).filter(Boolean);
+
+    // Deduplicate: skip if the same plugin already registered a tool with any
+    // of the same names.  This prevents duplicate entries when a plugin's
+    // registerFull() callback is invoked multiple times during config
+    // hot-reload cycles (see #56114).
+    if (normalized.length > 0) {
+      const alreadyRegistered = registry.tools.some(
+        (existing) =>
+          existing.pluginId === record.id &&
+          existing.names.some((n) => normalized.includes(n)),
+      );
+      if (alreadyRegistered) {
+        return;
+      }
+    }
+
     if (normalized.length > 0) {
       record.toolNames.push(...normalized);
     }


### PR DESCRIPTION
## Summary

Feishu plugin (and potentially other plugins using `registerFull()`) re-registers all tools on every config hot-reload/session restart, causing:
- Log spam: 490+ duplicate entries/day
- Performance waste from redundant tool entries
- Potential memory leak from accumulating tool factory references

## Root Cause

`registerTool()` in the plugin registry unconditionally pushes to `registry.tools` without checking if the same plugin has already registered a tool with the same name. During config hot-reload, `defineChannelPluginEntry`'s `register()` callback calls `registerFull(api)` again, re-registering all tools.

## Changes

- Added deduplication guard in `registerTool()`: if the same pluginId has already registered a tool with any of the same names, skip the registration
- This is a generic fix that protects all plugins, not just Feishu

## Files Changed

- `src/plugins/registry.ts` — added deduplication check in `registerTool()`

Fixes #56114