### PR TITLE
fix(subagents): inherit originating channel for completion announce delivery

### DIFF
--- a/.last-pr-check.json
+++ b/.last-pr-check.json
@@ -1,0 +1,65 @@
+{
+  "lastCheck": "2026-03-30T08:09:00.000Z",
+  "openPRs": [
+    {
+      "number": 57445,
+      "title": "fix(memory): include reset and deleted session files in indexer",
+      "lastCommentAt": "2026-03-30T04:31:24Z",
+      "status": "implemented_better_solution"
+    },
+    {
+      "number": 56671,
+      "title": "fix(config): deduplicate clobbered config snapshots in-process",
+      "lastCommentAt": "2026-03-29T11:06:07Z",
+      "status": "responded_to_maintainer"
+    },
+    {
+      "number": 56669,
+      "title": "fix(tools): preserve Optional annotation when merging anyOf variants",
+      "lastCommentAt": "2026-03-30T04:32:40Z",
+      "status": "added_regression_tests"
+    },
+    {
+      "number": 56664,
+      "title": "fix(discord): handle reconnect-exhausted gracefully",
+      "lastCommentAt": "2026-03-29T13:34:59Z",
+      "status": "addressed_maintainer_feedback"
+    },
+    {
+      "number": 56660,
+      "title": "fix(compaction): use model override in overflow and timeout recovery paths",
+      "lastCommentAt": "2026-03-29T00:22:46Z",
+      "status": "fixed_auth_profile_issue"
+    },
+    {
+      "number": 56362,
+      "title": "fix(discord): ensure resetTriggers rotate sessionId and clear history",
+      "lastCommentAt": "2026-03-30T06:29:20Z",
+      "status": "addressed_codex_feedback"
+    },
+    {
+      "number": 56360,
+      "title": "fix(subagents): inherit originating channel for completion announce delivery",
+      "lastCommentAt": "2026-03-28T13:13:31Z",
+      "status": "reviewed_by_maintainer"
+    },
+    {
+      "number": 56358,
+      "title": "fix(plugins): deduplicate tool registration on config hot-reload",
+      "lastCommentAt": "2026-03-29T08:52:45Z",
+      "status": "fixed_over_eager_guard"
+    },
+    {
+      "number": 56357,
+      "title": "fix(control-ui): restore header logo and favicon display",
+      "lastCommentAt": "2026-03-30T06:29:21Z",
+      "status": "addressed_codex_csp_feedback"
+    },
+    {
+      "number": 56356,
+      "title": "fix(heartbeat): prevent subagent announcements from re-triggering heartbeat cascade",
+      "lastCommentAt": "2026-03-29T00:22:35Z",
+      "status": "fixed_p1_handler_registration_issue"
+    }
+  ]
+}

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -522,9 +522,16 @@ async function sendSubagentAnnounceDirectly(params: {
     const completionDirectOrigin = normalizeDeliveryContext(params.completionDirectOrigin);
     const directOrigin = normalizeDeliveryContext(params.directOrigin);
     const requesterSessionOrigin = normalizeDeliveryContext(params.requesterSessionOrigin);
+    
+    // Merge completionDirectOrigin with directOrigin so that missing fields
+    // (channel, to, accountId) fall back to the originating session's
+    // lastChannel / lastTo.  Without this merge, a completion origin that
+    // carries a channel but not a `to` (e.g. from a bound route with an
+    // incomplete target) would prevent external delivery because
+    // `hasDeliverableDirectTarget` requires both channel and to.
     const effectiveDirectOrigin =
       params.expectsCompletionMessage && completionDirectOrigin
-        ? completionDirectOrigin
+        ? mergeDeliveryContext(completionDirectOrigin, directOrigin)
         : directOrigin;
     const sessionOnlyOrigin = effectiveDirectOrigin?.channel
       ? effectiveDirectOrigin

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -259,6 +259,47 @@ describe("subagent announce seam flow", () => {
     expect(agentSpy).not.toHaveBeenCalled();
   });
 
+  it("inherits session lastChannel/lastTo for completion announce when requesterOrigin lacks to", async () => {
+    loadSessionStoreMock.mockImplementation(() => ({
+      "agent:main:main": {
+        sessionId: "session-tg-group",
+        updatedAt: Date.now(),
+        lastChannel: "telegram",
+        lastTo: "-1001234567890",
+        lastAccountId: "bot:123",
+      },
+    }));
+
+    ({ runSubagentAnnounceFlow } = await import("./subagent-announce.js"));
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:tg",
+      childRunId: "run-tg-group-completion",
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: { channel: "telegram" },
+      requesterDisplayKey: "main",
+      task: "telegram group task",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "task done",
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const agentCall = agentSpy.mock.calls[0]?.[0];
+    expect(agentCall?.params).toEqual(
+      expect.objectContaining({
+        deliver: true,
+        channel: "telegram",
+        to: "-1001234567890",
+      }),
+    );
+  });
+
   it("keeps completion direct announce session-only when requester origin is webchat", async () => {
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:webchat",
@@ -334,4 +375,5 @@ describe("subagent announce seam flow", () => {
     expect(params.accountId).toBeUndefined();
     expect(params.threadId).toBeUndefined();
   });
+
 });

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -270,8 +270,8 @@ describe("subagent announce seam flow", () => {
       },
     }));
 
-    ({ runSubagentAnnounceFlow } = await import("./subagent-announce.js"));
-    const didAnnounce = await runSubagentAnnounceFlow({
+    const { runSubagentAnnounceFlow: reloadedFlow } = await import("./subagent-announce.js");
+    const didAnnounce = await reloadedFlow({
       childSessionKey: "agent:main:subagent:tg",
       childRunId: "run-tg-group-completion",
       requesterSessionKey: "agent:main:main",


### PR DESCRIPTION
## Summary

When a subagent completes a task and the main agent session composes a reply for a Telegram group chat, the reply is silently dropped with error `Outbound not configured for channel: telegram`. Direct replies to inbound messages work fine — only the subagent completion announce path is broken.

## Root Cause

In `sendSubagentAnnounceDirectly()`, `completionDirectOrigin` was used as-is without falling back to `directOrigin` for missing fields. When the completion origin carried a `channel` but not a `to` (chat ID), `hasDeliverableDirectTarget` failed because it requires both channel and to for external delivery.

## Changes

- Use `mergeDeliveryContext(completionDirectOrigin, directOrigin)` instead of using `completionDirectOrigin` alone, so missing fields (channel, to, accountId) fall back to the originating session's `lastChannel`/`lastTo`
- Added test verifying Telegram group completion announce inherits session routing

## Files Changed

- `src/agents/subagent-announce-delivery.ts` — merge delivery contexts
- `src/agents/subagent-announce.test.ts` — test for inherited routing

Fixes #56032