### PR TITLE
fix: support canonical skill source field

### DIFF
--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -15,6 +15,7 @@ import {
   type SkillInstallSpec,
   type SkillsInstallPreferences,
 } from "./skills.js";
+import { getSkillSource } from "./skills/types.js";
 
 export type SkillInstallRequest = {
   workspaceDir: string;
@@ -440,7 +441,7 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
 
   const spec = findInstallSpec(entry, params.installId);
   const warnings = await collectSkillInstallScanWarnings(entry);
-  const skillSource = entry.skill.sourceInfo?.source?.trim() || "unknown";
+  const skillSource = getSkillSource(entry.skill) ?? "unknown";
 
   // Warn when install is triggered from a non-bundled source.
   // Workspace/project/personal agent skills can contain attacker-controlled metadata.

--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -17,6 +17,7 @@ import {
   type SkillsInstallPreferences,
 } from "./skills.js";
 import { resolveBundledSkillsContext } from "./skills/bundled-context.js";
+import { getSkillSource } from "./skills/types.js";
 
 export type SkillStatusConfigCheck = RequirementConfigCheck;
 
@@ -186,7 +187,7 @@ function buildSkillStatus(
       (skillConfig?.apiKey && entry.metadata?.primaryEnv === envName),
     );
   const isConfigSatisfied = (pathStr: string) => isConfigPathTruthy(config, pathStr);
-  const skillSource = entry.skill.sourceInfo?.source?.trim() || "unknown";
+  const skillSource = getSkillSource(entry.skill) ?? "unknown";
   const bundled =
     skillSource === "openclaw-bundled" ||
     (skillSource === "unknown" && bundledNames?.has(entry.skill.name) === true);

--- a/src/agents/skills.test-helpers.ts
+++ b/src/agents/skills.test-helpers.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { createSyntheticSourceInfo, type Skill } from "@mariozechner/pi-coding-agent";
+import type { Skill } from "@mariozechner/pi-coding-agent";
 
 export async function writeSkill(params: {
   dir: string;
@@ -37,10 +37,7 @@ export function createCanonicalFixtureSkill(params: {
     description: params.description,
     filePath: params.filePath,
     baseDir: params.baseDir,
-    sourceInfo: createSyntheticSourceInfo(params.filePath, {
-      source: params.source,
-      baseDir: params.baseDir,
-    }),
+    source: params.source,
     disableModelInvocation: params.disableModelInvocation ?? false,
   };
 }

--- a/src/agents/skills.test-helpers.ts
+++ b/src/agents/skills.test-helpers.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { Skill } from "@mariozechner/pi-coding-agent";
+import { createSyntheticSourceInfo, type Skill } from "@mariozechner/pi-coding-agent";
 
 export async function writeSkill(params: {
   dir: string;
@@ -37,7 +37,11 @@ export function createCanonicalFixtureSkill(params: {
     description: params.description,
     filePath: params.filePath,
     baseDir: params.baseDir,
+    sourceInfo: createSyntheticSourceInfo(params.filePath, {
+      source: params.source,
+      baseDir: params.baseDir,
+    }),
     source: params.source,
     disableModelInvocation: params.disableModelInvocation ?? false,
-  };
+  } as Skill;
 }

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -21,8 +21,10 @@ export type {
   SkillEntry,
   SkillInstallSpec,
   SkillSnapshot,
+  SkillSourceCompat,
   SkillsInstallPreferences,
 } from "./skills/types.js";
+export { getSkillSource } from "./skills/types.js";
 export {
   buildWorkspaceSkillSnapshot,
   buildWorkspaceSkillsPrompt,

--- a/src/agents/skills/compact-format.test.ts
+++ b/src/agents/skills/compact-format.test.ts
@@ -1,5 +1,9 @@
 import os from "node:os";
-import { formatSkillsForPrompt, type Skill } from "@mariozechner/pi-coding-agent";
+import {
+  createSyntheticSourceInfo,
+  formatSkillsForPrompt,
+  type Skill,
+} from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SkillEntry } from "./types.js";
@@ -15,9 +19,13 @@ function makeSkill(name: string, desc = "A skill", filePath = `/skills/${name}/S
     description: desc,
     filePath,
     baseDir: `/skills/${name}`,
+    sourceInfo: createSyntheticSourceInfo(filePath, {
+      source: "workspace",
+      baseDir: `/skills/${name}`,
+    }),
     source: "workspace",
     disableModelInvocation: false,
-  };
+  } as Skill;
 }
 
 function makeEntry(skill: Skill): SkillEntry {

--- a/src/agents/skills/compact-format.test.ts
+++ b/src/agents/skills/compact-format.test.ts
@@ -1,9 +1,5 @@
 import os from "node:os";
-import {
-  createSyntheticSourceInfo,
-  formatSkillsForPrompt,
-  type Skill,
-} from "@mariozechner/pi-coding-agent";
+import { formatSkillsForPrompt, type Skill } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SkillEntry } from "./types.js";
@@ -19,10 +15,7 @@ function makeSkill(name: string, desc = "A skill", filePath = `/skills/${name}/S
     description: desc,
     filePath,
     baseDir: `/skills/${name}`,
-    sourceInfo: createSyntheticSourceInfo(filePath, {
-      source: "workspace",
-      baseDir: `/skills/${name}`,
-    }),
+    source: "workspace",
     disableModelInvocation: false,
   };
 }

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -8,7 +8,7 @@ import {
 } from "../../shared/config-eval.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import { resolveSkillKey } from "./frontmatter.js";
-import type { SkillEligibilityContext, SkillEntry } from "./types.js";
+import { getSkillSource, type SkillEligibilityContext, type SkillEntry } from "./types.js";
 
 const DEFAULT_CONFIG_VALUES: Record<string, boolean> = {
   "browser.enabled": true,
@@ -50,7 +50,7 @@ function normalizeAllowlist(input: unknown): string[] | undefined {
 const BUNDLED_SOURCES = new Set(["openclaw-bundled"]);
 
 function isBundledSkill(entry: SkillEntry): boolean {
-  return BUNDLED_SOURCES.has(entry.skill.sourceInfo?.source ?? "");
+  return BUNDLED_SOURCES.has(getSkillSource(entry.skill) ?? "");
 }
 
 export function resolveBundledAllowlist(config?: OpenClawConfig): string[] | undefined {

--- a/src/agents/skills/source.test.ts
+++ b/src/agents/skills/source.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { SkillSourceCompat } from "./types.js";
+import { getSkillSource } from "./types.js";
+
+function makeSkill(partial: Partial<SkillSourceCompat>): SkillSourceCompat {
+  return {
+    name: "demo",
+    description: "demo",
+    filePath: "/tmp/demo/SKILL.md",
+    baseDir: "/tmp/demo",
+    source: "openclaw-workspace",
+    disableModelInvocation: false,
+    ...partial,
+  } as SkillSourceCompat;
+}
+
+describe("getSkillSource", () => {
+  it("prefers the canonical top-level source field", () => {
+    expect(
+      getSkillSource(
+        makeSkill({
+          source: "openclaw-bundled",
+          sourceInfo: { source: "openclaw-workspace" },
+        }),
+      ),
+    ).toBe("openclaw-bundled");
+  });
+
+  it("falls back to legacy sourceInfo.source when source is absent", () => {
+    expect(
+      getSkillSource(
+        makeSkill({
+          source: undefined,
+          sourceInfo: { source: "openclaw-bundled" },
+        }),
+      ),
+    ).toBe("openclaw-bundled");
+  });
+
+  it("returns undefined when neither source shape is populated", () => {
+    expect(
+      getSkillSource(
+        makeSkill({
+          source: "",
+          sourceInfo: {},
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -1,5 +1,10 @@
 import type { Skill } from "@mariozechner/pi-coding-agent";
 
+export type SkillSourceCompat = Skill & {
+  source?: string;
+  sourceInfo?: { source?: string };
+};
+
 export type SkillInstallSpec = {
   id?: string;
   kind: "brew" | "node" | "go" | "uv" | "download";
@@ -91,3 +96,13 @@ export type SkillSnapshot = {
   resolvedSkills?: Skill[];
   version?: number;
 };
+
+export function getSkillSource(skill: SkillSourceCompat): string | undefined {
+  const directSource = typeof skill.source === "string" ? skill.source.trim() : "";
+  if (directSource) {
+    return directSource;
+  }
+  const legacySource =
+    typeof skill.sourceInfo?.source === "string" ? skill.sourceInfo.source.trim() : "";
+  return legacySource || undefined;
+}

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -1,8 +1,8 @@
 import type { Skill } from "@mariozechner/pi-coding-agent";
 
-export type SkillSourceCompat = Skill & {
+export type SkillSourceCompat = Omit<Skill, "sourceInfo"> & {
   source?: string;
-  sourceInfo?: { source?: string };
+  sourceInfo?: Partial<Skill["sourceInfo"]>;
 };
 
 export type SkillInstallSpec = {

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -11,6 +11,7 @@ import { SANDBOX_BROWSER_SECURITY_HASH_EPOCH } from "../agents/sandbox/constants
 import { execDockerRaw, type ExecDockerRawResult } from "../agents/sandbox/docker.js";
 import { resolveSandboxToolPolicyForAgent } from "../agents/sandbox/tool-policy.js";
 import type { SandboxToolPolicy } from "../agents/sandbox/types.js";
+import { getSkillSource } from "../agents/skills.js";
 import { isToolAllowedByPolicies } from "../agents/tool-policy-match.js";
 import { resolveToolProfilePolicy } from "../agents/tool-policy.js";
 import { listAgentWorkspaceDirs } from "../agents/workspace-dirs.js";
@@ -1261,7 +1262,7 @@ export async function collectInstalledSkillsCodeSafetyFindings(params: {
   for (const workspaceDir of workspaceDirs) {
     const entries = loadWorkspaceSkillEntries(workspaceDir, { config: params.cfg });
     for (const entry of entries) {
-      if (entry.skill.sourceInfo?.source === "openclaw-bundled") {
+      if (getSkillSource(entry.skill) === "openclaw-bundled") {
         continue;
       }
 


### PR DESCRIPTION
## Summary
- read skill provenance from the canonical top-level `skill.source` field
- fall back to legacy `skill.sourceInfo.source` when older fixtures or persisted data still use it
- update skill test fixtures to match the current upstream `Skill` shape

## Why
Recent upstream `@mariozechner/pi-coding-agent` builds expose skill provenance on `Skill.source`, while several OpenClaw call sites and tests still assume `sourceInfo.source`. That drift breaks skills-related flows and local validation.

This PR keeps the compatibility surface narrow by centralizing source resolution in a helper and reusing it across the affected call sites.

## Verification
- `pnpm vitest --run src/agents/skills/source.test.ts src/agents/skills.buildworkspaceskillstatus.test.ts src/agents/skills-status.test.ts src/agents/skills/compact-format.test.ts`
- `pnpm exec tsc -p tsconfig.plugin-sdk.dts.json --pretty false`
- `git commit` hook passed (`pnpm check` + lint gates)

## Notes
- `CI=true pnpm build` still hits the known bundled runtime dependency staging failure for `diffs` on current `main`; that issue appears orthogonal to this skills API compatibility fix.
