### PR TITLE
fix(delivery): move permanently failing messages (HTTP 4xx) to failed/ immediately

### DIFF
--- a/src/infra/outbound/delivery-queue-policy.ts
+++ b/src/infra/outbound/delivery-queue-policy.ts
@@ -1,0 +1,31 @@
+/**
+ * Permanent delivery error detection policy.
+ * Lives in its own module to avoid circular imports between
+ * delivery-queue-storage.ts and delivery-queue-recovery.ts.
+ */
+
+const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
+  /no conversation reference found/i,
+  /chat not found/i,
+  /user not found/i,
+  /bot.*not.*member/i,
+  /bot was blocked by the user/i,
+  /forbidden: bot was kicked/i,
+  /chat_id is empty/i,
+  /recipient is not a valid/i,
+  /outbound not configured for channel/i,
+  /ambiguous .* recipient/i,
+  /User .* not in room/i,
+  // HTTP 4xx client errors — the request itself is invalid and will never succeed on retry.
+  // Requires status-code context (e.g. "403 Forbidden", "404: Not Found") to avoid
+  // false positives from transient messages that incidentally contain these numbers
+  // (e.g. "429 Too Many Requests: retry after 400"). Excludes 429 (rate-limiting).
+  /\b(?:400|403|404|405|410|413|415|422)(?::\s|\s+[A-Za-z])/,
+  /message is too long/i,
+  /request entity too large/i,
+  /bad request:/i,
+];
+
+export function isPermanentDeliveryError(error: string): boolean {
+  return PERMANENT_ERROR_PATTERNS.some((re) => re.test(error));
+}

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/config.js";
+import { isPermanentDeliveryError } from "./delivery-queue-policy.js";
 import {
   ackDelivery,
   failDelivery,
@@ -7,6 +8,9 @@ import {
   type QueuedDelivery,
   type QueuedDeliveryPayload,
 } from "./delivery-queue-storage.js";
+
+// Re-export so the barrel (delivery-queue.ts) and external callers keep working.
+export { isPermanentDeliveryError };
 
 export type RecoverySummary = {
   recovered: number;
@@ -39,19 +43,6 @@ const BACKOFF_MS: readonly number[] = [
   600_000, // retry 4: 10m
 ];
 
-const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
-  /no conversation reference found/i,
-  /chat not found/i,
-  /user not found/i,
-  /bot.*not.*member/i,
-  /bot was blocked by the user/i,
-  /forbidden: bot was kicked/i,
-  /chat_id is empty/i,
-  /recipient is not a valid/i,
-  /outbound not configured for channel/i,
-  /ambiguous .* recipient/i,
-  /User .* not in room/i,
-];
 
 function createEmptyRecoverySummary(): RecoverySummary {
   return {
@@ -138,9 +129,6 @@ export function isEntryEligibleForRecoveryRetry(
   return { eligible: false, remainingBackoffMs: nextEligibleAt - now };
 }
 
-export function isPermanentDeliveryError(error: string): boolean {
-  return PERMANENT_ERROR_PATTERNS.some((re) => re.test(error));
-}
 
 /**
  * On gateway startup, scan the delivery queue and retry any pending entries.

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { resolveStateDir } from "../../config/paths.js";
 import { generateSecureUuid } from "../secure-random.js";
+import { isPermanentDeliveryError } from "./delivery-queue-policy.js";
 import type { OutboundMirror } from "./mirror.js";
 import type { OutboundChannel } from "./targets.js";
 
@@ -178,8 +179,24 @@ export async function ackDelivery(id: string, stateDir?: string): Promise<void> 
   await unlinkBestEffort(deliveredPath);
 }
 
-/** Update a queue entry after a failed delivery attempt. */
+/** Update a queue entry after a failed delivery attempt.
+ * If the error matches a known permanent failure pattern (e.g. HTTP 4xx),
+ * the entry is moved to failed/ immediately instead of being retried.
+ */
 export async function failDelivery(id: string, error: string, stateDir?: string): Promise<void> {
+  if (isPermanentDeliveryError(error)) {
+    const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
+    try {
+      const entry = await readQueueEntry(filePath);
+      entry.lastError = error;
+      entry.lastAttemptAt = Date.now();
+      await writeQueueEntry(filePath, entry);
+    } catch {
+      // best-effort — proceed with move even if stamp fails
+    }
+    await moveToFailed(id, stateDir);
+    return;
+  }
   const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
   const entry = await readQueueEntry(filePath);
   entry.retryCount += 1;

--- a/src/infra/outbound/delivery-queue.policy.test.ts
+++ b/src/infra/outbound/delivery-queue.policy.test.ts
@@ -17,6 +17,13 @@ describe("delivery-queue policy", () => {
       "chat_id is empty",
       "Outbound not configured for channel: demo-channel",
       "MatrixError: [403] User @bot:matrix.example.com not in room !mixedCase:matrix.example.com",
+      "400: Bad Request: message is too long",
+      "Request to sendMessage API failed. (413: Request Entity Too Large)",
+      "bad request: can't parse entities",
+      "403 Forbidden",
+      "404 Not Found",
+      "message is too long",
+      "request entity too large",
     ])("returns true for permanent error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(true);
     });
@@ -27,6 +34,8 @@ describe("delivery-queue policy", () => {
       "socket hang up",
       "rate limited",
       "500 Internal Server Error",
+      "429 Too Many Requests",
+      "429 Too Many Requests: retry after 400",
     ])("returns false for transient error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(false);
     });

--- a/src/infra/outbound/delivery-queue.storage.test.ts
+++ b/src/infra/outbound/delivery-queue.storage.test.ts
@@ -121,6 +121,22 @@ describe("delivery-queue storage", () => {
       expect((entry.lastAttemptAt as number) > 0).toBe(true);
       expect(entry.lastError).toBe("connection refused");
     });
+
+    it("moves entry to failed/ immediately for permanent errors", async () => {
+      const id = await enqueueDelivery(
+        {
+          channel: "telegram",
+          to: "123",
+          payloads: [{ text: "x".repeat(5000) }],
+        },
+        tmpDir(),
+      );
+
+      await failDelivery(id, "400: Bad Request: message is too long", tmpDir());
+
+      expect(fs.existsSync(path.join(queueDir(), `${id}.json`))).toBe(false);
+      expect(fs.existsSync(path.join(queueDir(), "failed", `${id}.json`))).toBe(true);
+    });
   });
 
   describe("moveToFailed", () => {


### PR DESCRIPTION
Rebased version of #33414 (upstream split `delivery-queue.ts` into `delivery-queue-storage.ts` and `delivery-queue-recovery.ts`).

## Summary

- `failDelivery` now checks `isPermanentDeliveryError` and moves permanent failures to `failed/` immediately
- Added HTTP 4xx patterns (400, 403, 404, 405, 410, 413, 415, 422) and message-level errors to `PERMANENT_ERROR_PATTERNS`
- 429 (rate-limiting) correctly excluded as transient

## Linked Issue/PR

- Closes #33403
- Supersedes #33414

## Test plan

- [x] New test: permanent error moves entry to `failed/` immediately
- [x] New pattern tests for HTTP 4xx, `message is too long`, etc.
- [x] 429 correctly returns false (transient)
- [x] `pnpm check` + scoped tests pass (41/41)