### PR TITLE
fix(clawhub): append login hint to 429 rate-limit errors when unauthenticated (#56368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ClawHub: show a login hint on unauthenticated 429 rate-limit errors during ClawHub search/install/archive fetches, and keep the regression tests guarded against silently passing. Fixes #56368; carries forward #56394. Thanks @Talegqz.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -4,11 +4,13 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
+  ClawHubRequestError,
   downloadClawHubPackageArchive,
   downloadClawHubSkillArchive,
   normalizeClawHubSha256Integrity,
   normalizeClawHubSha256Hex,
   parseClawHubPluginSpec,
+  RATE_LIMIT_LOGIN_HINT,
   resolveClawHubAuthToken,
   resolveLatestVersionFromPackage,
   satisfiesGatewayMinimum,
@@ -221,6 +223,60 @@ describe("clawhub helpers", () => {
 
     await expect(searchClawHubSkills({ query: "calendar", fetchImpl })).resolves.toEqual([]);
   });
+
+  it("appends login hint to 429 errors when unauthenticated", async () => {
+    delete process.env.OPENCLAW_CLAWHUB_TOKEN;
+    delete process.env.CLAWHUB_TOKEN;
+    delete process.env.CLAWHUB_AUTH_TOKEN;
+    process.env.OPENCLAW_CLAWHUB_CONFIG_PATH = "/nonexistent/config.json";
+
+    const fetchImpl = async () => new Response("Rate limit exceeded", { status: 429 });
+
+    const result = searchClawHubSkills({ query: "weather", fetchImpl });
+    await expect(result).rejects.toThrow(ClawHubRequestError);
+    const err = await result.catch((error: unknown) => error);
+
+    expect(err).toBeInstanceOf(ClawHubRequestError);
+    const error = err as ClawHubRequestError;
+    expect(error.status).toBe(429);
+    expect(error.message).toContain("Rate limit exceeded");
+    expect(error.message).toContain(RATE_LIMIT_LOGIN_HINT);
+  });
+
+  it("does not append login hint to 429 errors when authenticated", async () => {
+    process.env.OPENCLAW_CLAWHUB_TOKEN = "valid-token";
+
+    const fetchImpl = async () => new Response("Rate limit exceeded", { status: 429 });
+
+    const result = searchClawHubSkills({ query: "weather", fetchImpl });
+    await expect(result).rejects.toThrow(ClawHubRequestError);
+    const err = await result.catch((error: unknown) => error);
+
+    expect(err).toBeInstanceOf(ClawHubRequestError);
+    const error = err as ClawHubRequestError;
+    expect(error.status).toBe(429);
+    expect(error.message).toContain("Rate limit exceeded");
+    expect(error.message).not.toContain(RATE_LIMIT_LOGIN_HINT);
+  });
+
+  it("does not append login hint to non-429 errors", async () => {
+    delete process.env.OPENCLAW_CLAWHUB_TOKEN;
+    delete process.env.CLAWHUB_TOKEN;
+    delete process.env.CLAWHUB_AUTH_TOKEN;
+    process.env.OPENCLAW_CLAWHUB_CONFIG_PATH = "/nonexistent/config.json";
+
+    const fetchImpl = async () => new Response("Internal Server Error", { status: 500 });
+
+    const result = searchClawHubSkills({ query: "weather", fetchImpl });
+    await expect(result).rejects.toThrow(ClawHubRequestError);
+    const err = await result.catch((error: unknown) => error);
+
+    expect(err).toBeInstanceOf(ClawHubRequestError);
+    const error = err as ClawHubRequestError;
+    expect(error.status).toBe(500);
+    expect(error.message).not.toContain(RATE_LIMIT_LOGIN_HINT);
+  });
+
   it("downloads package archives to sanitized temp paths and cleans them up", async () => {
     const archive = await downloadClawHubPackageArchive({
       name: "@hyf/zai-external-alpha",

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -18,6 +18,13 @@ import {
   searchClawHubSkills,
 } from "./clawhub.js";
 
+async function expectClawHubRequestError(result: Promise<unknown>): Promise<ClawHubRequestError> {
+  await expect(result).rejects.toThrow(ClawHubRequestError);
+  const err = await result.catch((error: unknown) => error);
+  expect(err).toBeInstanceOf(ClawHubRequestError);
+  return err as ClawHubRequestError;
+}
+
 describe("clawhub helpers", () => {
   const originalHome = process.env.HOME;
 
@@ -233,11 +240,7 @@ describe("clawhub helpers", () => {
     const fetchImpl = async () => new Response("Rate limit exceeded", { status: 429 });
 
     const result = searchClawHubSkills({ query: "weather", fetchImpl });
-    await expect(result).rejects.toThrow(ClawHubRequestError);
-    const err = await result.catch((error: unknown) => error);
-
-    expect(err).toBeInstanceOf(ClawHubRequestError);
-    const error = err as ClawHubRequestError;
+    const error = await expectClawHubRequestError(result);
     expect(error.status).toBe(429);
     expect(error.message).toContain("Rate limit exceeded");
     expect(error.message).toContain(RATE_LIMIT_LOGIN_HINT);
@@ -249,11 +252,7 @@ describe("clawhub helpers", () => {
     const fetchImpl = async () => new Response("Rate limit exceeded", { status: 429 });
 
     const result = searchClawHubSkills({ query: "weather", fetchImpl });
-    await expect(result).rejects.toThrow(ClawHubRequestError);
-    const err = await result.catch((error: unknown) => error);
-
-    expect(err).toBeInstanceOf(ClawHubRequestError);
-    const error = err as ClawHubRequestError;
+    const error = await expectClawHubRequestError(result);
     expect(error.status).toBe(429);
     expect(error.message).toContain("Rate limit exceeded");
     expect(error.message).not.toContain(RATE_LIMIT_LOGIN_HINT);
@@ -268,11 +267,7 @@ describe("clawhub helpers", () => {
     const fetchImpl = async () => new Response("Internal Server Error", { status: 500 });
 
     const result = searchClawHubSkills({ query: "weather", fetchImpl });
-    await expect(result).rejects.toThrow(ClawHubRequestError);
-    const err = await result.catch((error: unknown) => error);
-
-    expect(err).toBeInstanceOf(ClawHubRequestError);
-    const error = err as ClawHubRequestError;
+    const error = await expectClawHubRequestError(result);
     expect(error.status).toBe(500);
     expect(error.message).not.toContain(RATE_LIMIT_LOGIN_HINT);
   });

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -378,9 +378,10 @@ function buildUrl(params: Pick<ClawHubRequestParams, "baseUrl" | "path" | "searc
 
 async function clawhubRequest(
   params: ClawHubRequestParams,
-): Promise<{ response: Response; url: URL }> {
+): Promise<{ response: Response; url: URL; authenticated: boolean }> {
   const url = buildUrl(params);
   const token = normalizeOptionalString(params.token) || (await resolveClawHubAuthToken());
+  const authenticated = Boolean(token);
   const controller = new AbortController();
   const timeout = setTimeout(
     () =>
@@ -396,7 +397,7 @@ async function clawhubRequest(
       headers: token ? { Authorization: `Bearer ${token}` } : undefined,
       signal: controller.signal,
     });
-    return { response, url };
+    return { response, url, authenticated };
   } finally {
     clearTimeout(timeout);
   }
@@ -411,13 +412,24 @@ async function readErrorBody(response: Response): Promise<string> {
   }
 }
 
+export const RATE_LIMIT_LOGIN_HINT =
+  "Tip: You are not logged in to ClawHub. Run `npx clawhub login` to authenticate and get a higher rate limit.";
+
+function appendRateLimitHint(body: string, status: number, authenticated: boolean): string {
+  if (status !== 429 || authenticated) {
+    return body;
+  }
+  return `${body}\n\n${RATE_LIMIT_LOGIN_HINT}`;
+}
+
 async function fetchJson<T>(params: ClawHubRequestParams): Promise<T> {
-  const { response, url } = await clawhubRequest(params);
+  const { response, url, authenticated } = await clawhubRequest(params);
   if (!response.ok) {
+    const body = await readErrorBody(response);
     throw new ClawHubRequestError({
       path: url.pathname,
       status: response.status,
-      body: await readErrorBody(response),
+      body: appendRateLimitHint(body, response.status, authenticated),
     });
   }
   return (await response.json()) as T;
@@ -597,7 +609,7 @@ export async function downloadClawHubPackageArchive(params: {
     : params.tag
       ? { tag: params.tag }
       : undefined;
-  const { response, url } = await clawhubRequest({
+  const { response, url, authenticated } = await clawhubRequest({
     baseUrl: params.baseUrl,
     path: `/api/v1/packages/${encodeURIComponent(params.name)}/download`,
     search,
@@ -606,10 +618,11 @@ export async function downloadClawHubPackageArchive(params: {
     fetchImpl: params.fetchImpl,
   });
   if (!response.ok) {
+    const body = await readErrorBody(response);
     throw new ClawHubRequestError({
       path: url.pathname,
       status: response.status,
-      body: await readErrorBody(response),
+      body: appendRateLimitHint(body, response.status, authenticated),
     });
   }
   const bytes = new Uint8Array(await response.arrayBuffer());
@@ -635,7 +648,7 @@ export async function downloadClawHubSkillArchive(params: {
   timeoutMs?: number;
   fetchImpl?: FetchLike;
 }): Promise<ClawHubDownloadResult> {
-  const { response, url } = await clawhubRequest({
+  const { response, url, authenticated } = await clawhubRequest({
     baseUrl: params.baseUrl,
     path: "/api/v1/download",
     token: params.token,
@@ -648,10 +661,11 @@ export async function downloadClawHubSkillArchive(params: {
     },
   });
   if (!response.ok) {
+    const body = await readErrorBody(response);
     throw new ClawHubRequestError({
       path: url.pathname,
       status: response.status,
-      body: await readErrorBody(response),
+      body: appendRateLimitHint(body, response.status, authenticated),
     });
   }
   const bytes = new Uint8Array(await response.arrayBuffer());


### PR DESCRIPTION
## Summary

When `openclaw skills install` or `openclaw skills search` hits a 429 rate limit while unauthenticated, the error message now includes a helpful hint telling the user to log in:

```
ClawHub /api/v1/skills/weather failed (429): Rate limit exceeded

Tip: You are not logged in to ClawHub. Run `npx clawhub login` to authenticate and get a higher rate limit.
```

Previously the error was just the raw 429 message with no guidance, causing users to assume ClawHub was down.

## Changes

- `src/infra/clawhub.ts` — Added `appendRateLimitHint()` helper that appends a login hint when status is 429 and no auth token was resolved. Applied to all three error-throwing sites: `fetchJson()`, `downloadClawHubPackageArchive()`, and `downloadClawHubSkillArchive()`. Also tracks whether the request was authenticated via the `clawhubRequest()` return value.
- `src/infra/clawhub.test.ts` — Added three test cases: hint appears on unauthenticated 429, hint is suppressed when authenticated, and hint is suppressed on non-429 errors.

## Verification

- `pnpm check` passes (type-check + lint + format)
- `pnpm test -- src/infra/clawhub.test.ts` — 10 passed, 2 skipped (macOS-only)
- `pnpm test -- src/plugins/clawhub.test.ts` — 6 passed
- `pnpm test -- src/cli/skills-cli.commands.test.ts` — 3 passed

Fixes #56368