### PR TITLE
feat: add Cursor Agent CLI backend extension

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -219,6 +219,17 @@ The bundled Google plugin also registers a default for `google-gemini-cli`:
 - `sessionMode: "existing"`
 - `sessionIdFields: ["session_id", "sessionId"]`
 
+The bundled Cursor Agent plugin registers a default for `cursor-agent`:
+
+- `command: "agent"`
+- `args: ["-p", "--trust"]`
+- `output: "text"`
+- `modelArg: "--model"`
+- `sessionMode: "none"`
+
+Cursor Agent authenticates via browser login (`agent login`), no API key needed.
+Use `cursor-agent/<model>` model refs (e.g. `cursor-agent/claude-4.6-opus-high`).
+
 Override only if needed (common: absolute `command` path).
 
 ## Plugin-owned defaults

--- a/extensions/cursor-agent/cli-backend.ts
+++ b/extensions/cursor-agent/cli-backend.ts
@@ -1,0 +1,26 @@
+import type { CliBackendPlugin } from "openclaw/plugin-sdk/cli-backend";
+import {
+  CLI_FRESH_WATCHDOG_DEFAULTS,
+  CLI_RESUME_WATCHDOG_DEFAULTS,
+} from "openclaw/plugin-sdk/cli-backend";
+
+export function buildCursorAgentCliBackend(): CliBackendPlugin {
+  return {
+    id: "cursor-agent",
+    config: {
+      command: "agent",
+      args: ["-p", "--trust"],
+      output: "text",
+      input: "arg",
+      modelArg: "--model",
+      sessionMode: "none",
+      reliability: {
+        watchdog: {
+          fresh: { ...CLI_FRESH_WATCHDOG_DEFAULTS },
+          resume: { ...CLI_RESUME_WATCHDOG_DEFAULTS },
+        },
+      },
+      serialize: true,
+    },
+  };
+}

--- a/extensions/cursor-agent/index.ts
+++ b/extensions/cursor-agent/index.ts
@@ -1,0 +1,11 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { buildCursorAgentCliBackend } from "./cli-backend.js";
+
+export default definePluginEntry({
+  id: "cursor-agent",
+  name: "Cursor Agent CLI Backend",
+  description: "CLI backend for Cursor Agent (non-interactive mode)",
+  register(api) {
+    api.registerCliBackend(buildCursorAgentCliBackend());
+  },
+});

--- a/extensions/cursor-agent/openclaw.plugin.json
+++ b/extensions/cursor-agent/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "cursor-agent",
+  "enabledByDefault": true,
+  "cliBackends": ["cursor-agent"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/cursor-agent/package.json
+++ b/extensions/cursor-agent/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/cursor-agent",
+  "version": "2026.3.27",
+  "private": true,
+  "description": "OpenClaw Cursor Agent CLI backend",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}


### PR DESCRIPTION
Adds `cursor-agent` as a supported CLI backend in OpenClaw, following the same pattern as the existing Claude Code, Codex, and Gemini CLI backends.

## What this adds

A new extension at `extensions/cursor-agent/` that registers the Cursor Agent CLI (`agent` binary) as an OpenClaw CLI backend.

## How to use

Install the Cursor CLI:
```
curl https://cursor.com/install -fsS | bash
```

Authenticate once:
```
agent login
```

Then use `cursor-agent` as your agent in OpenClaw config:
```
model: cursor-agent/claude-4.6-opus-high
```

Supported models: any model available in your Cursor subscription. Run `agent models` to list them.

## Key facts about the Cursor CLI

- Binary: `agent`
- Non-interactive mode: `agent -p --trust "task"`
- Model selection: `--model <id>` (e.g. `claude-4.6-opus-high`)
- Auth: browser login via `agent login`, stored locally — no API key needed
- Credits: flat ~2 credits/task regardless of token usage (Cursor subscription)

## Origin

This contribution was built by running Cursor Agent (Opus 4.6 1m) against the OpenClaw repo, using the following prompt:

> I want to contribute a Cursor Agent integration to the OpenClaw project. OpenClaw is an open-source AI assistant platform at https://github.com/openclaw/openclaw.

Task: Explore the repo, understand how existing ACP agents are registered (look at how Claude Code or Codex are wired), then open a PR that adds cursor-agent as a supported ACP agent using the agent CLI binary.

Key facts about the Cursor CLI:

• Binary: agent
• Non-interactive mode: agent -p --trust "task"
• Model selection: --model <id> (e.g. claude-4.6-opus-high)
• Auth: browser login via agent login, stored locally
• No API key needed

Follow whatever patterns/schema OpenClaw uses for registering agents. Keep the PR minimal and focused — just the integration, no extras. Write a clear PR description explaining what it adds and how to use it.


---

## Summary

- **Problem:** No way to use Cursor Agent as an OpenClaw CLI backend despite it supporting a non-interactive `-p --trust` mode compatible with the existing CLI backend interface
- **Why it matters:** Cursor Agent provides access to frontier models (Opus, GPT-5.x, Gemini, etc.) at flat credit cost rather than per-token API pricing — useful for token-heavy tasks
- **What changed:** New extension `extensions/cursor-agent/` with `cli-backend.ts`, `index.ts`, `package.json`, `openclaw.plugin.json` + docs update in `docs/gateway/cli-backends.md`
- **What did NOT change:** No existing backends, gateway logic, or config contracts touched

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History

N/A — this is a new feature addition, not a bug fix.

## Regression Test Plan

N/A — new extension, no existing behavior changed.

- [ ] If no new test is added, why not: Pure CLI backend registration following identical pattern to existing backends (Claude Code, Codex, Gemini). No new logic paths introduced.

## User-visible / Behavior Changes

New option: users can configure `cursor-agent/<model>` as their agent backend. No changes to existing behavior or defaults.

## Diagram

N/A — additive extension, no flow changes.

Before:
```
[user] -> [openclaw] -> [claude/codex/gemini CLI backends]
```

After:
```
[user] -> [openclaw] -> [claude/codex/gemini/cursor-agent CLI backends]
```

## Security Impact

- New permissions/capabilities? Yes — executes the `agent` binary
- Secrets/tokens handling changed? No — Cursor auth is managed entirely by the `agent` CLI itself (stored in `~/.cursor/`), OpenClaw does not handle or store any Cursor credentials
- New/changed network calls? No — all network calls made by the `agent` binary, not OpenClaw
- Command/tool execution surface changed? Yes — adds `agent` as an executable OpenClaw can invoke
- Data access scope changed? No
- Risk: Same as any other CLI backend — OpenClaw invokes an external binary with user-provided prompts. Mitigation: identical to existing Claude Code / Codex backends; no elevated permissions.

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime: Node + local agent binary
- Model: `claude-4.6-opus-high` via Cursor subscription

### Steps

1. Install Cursor CLI: `curl https://cursor.com/install -fsS | bash`
2. Authenticate: `agent login`
3. Configure OpenClaw to use `cursor-agent/claude-4.6-opus-high`
4. Run a task

### Expected

- OpenClaw invokes `agent -p --trust --model claude-4.6-opus-high "<task>"`
- Response returned as text

### Actual

- Works as expected. Tested locally on macOS arm64.

## Evidence

- Manually verified: `agent -p --trust "Say hello in one sentence"` returns expected output
- Extension structure verified against `extensions/anthropic/`, `extensions/deepseek/`, and Gemini CLI backend patterns

## Human Verification

- Verified the extension loads following the same registration pattern as existing CLI backends
- Verified `agent -p --trust --model <id>` works end-to-end locally
- Did not verify: Windows/Linux environments, all available model IDs

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `agent` binary not in PATH on some systems
  - Mitigation: Same as Claude Code / Codex — user is responsible for installing the CLI. Error message from OpenClaw will indicate binary not found.
- Risk: Cursor changes CLI flags in future versions
  - Mitigation: Extension is minimal and easy to update. `-p --trust` flags are documented in Cursor's official CLI docs.
