### PR TITLE
fix(agents): webchat-aware exec approval follow-up and pending copy

### DIFF
--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -71,10 +71,11 @@ export async function sendExecApprovalFollowup(
   // Webchat (internal channel) has no outbound delivery route — the gateway
   // would try to remap it to a configured external channel and fail.  Skip
   // `deliver` for internal channels and explicitly route the agent run to
-  // INTERNAL_MESSAGE_CHANNEL.  For external channels, keep `deliver: true`
-  // even when an explicit `to` is missing so the gateway can fall back to
-  // session-level implicit routing (last channel / default target).
-  const hasExternalDeliveryPair = deliveryTarget.deliver && !isInternal;
+  // INTERNAL_MESSAGE_CHANNEL.  For external channels, only request delivery
+  // when a concrete deliverable route was resolved (channel + target); when
+  // the route is incomplete or the origin channel is unknown, stay
+  // session-only so the gateway does not fall back to an unrelated default.
+  const deliver = deliveryTarget.deliver && !isInternal;
 
   await callGatewayTool(
     "agent",
@@ -82,16 +83,12 @@ export async function sendExecApprovalFollowup(
     {
       sessionKey,
       message: buildExecApprovalFollowupPrompt(resultText),
-      deliver: hasExternalDeliveryPair,
-      ...(hasExternalDeliveryPair ? { bestEffortDeliver: true as const } : {}),
-      channel: hasExternalDeliveryPair
-        ? deliveryTarget.channel
-        : isInternal
-          ? INTERNAL_MESSAGE_CHANNEL
-          : undefined,
-      to: hasExternalDeliveryPair ? deliveryTarget.to : undefined,
-      accountId: hasExternalDeliveryPair ? deliveryTarget.accountId : undefined,
-      threadId: hasExternalDeliveryPair ? deliveryTarget.threadId : undefined,
+      deliver,
+      ...(deliver ? { bestEffortDeliver: true as const } : {}),
+      channel: deliver ? deliveryTarget.channel : isInternal ? INTERNAL_MESSAGE_CHANNEL : undefined,
+      to: deliver ? deliveryTarget.to : undefined,
+      accountId: deliver ? deliveryTarget.accountId : undefined,
+      threadId: deliver ? deliveryTarget.threadId : undefined,
       idempotencyKey: `exec-approval-followup:${params.approvalId}`,
     },
     { expectFinal: true },

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -1,5 +1,9 @@
 import { resolveExternalBestEffortDeliveryTarget } from "../infra/outbound/best-effort-delivery.js";
-import { isGatewayMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  isInternalMessageChannel,
+  normalizeMessageChannel,
+} from "../utils/message-channel.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 type ExecApprovalFollowupParams = {
@@ -62,10 +66,15 @@ export async function sendExecApprovalFollowup(
     threadId: params.turnSourceThreadId,
   });
   const normalizedTurnSourceChannel = normalizeMessageChannel(params.turnSourceChannel);
-  const sessionOnlyOriginChannel =
-    normalizedTurnSourceChannel && isGatewayMessageChannel(normalizedTurnSourceChannel)
-      ? normalizedTurnSourceChannel
-      : undefined;
+  const isInternal = isInternalMessageChannel(normalizedTurnSourceChannel);
+
+  // Webchat (internal channel) has no outbound delivery route — the gateway
+  // would try to remap it to a configured external channel and fail.  Skip
+  // `deliver` for internal channels and explicitly route the agent run to
+  // INTERNAL_MESSAGE_CHANNEL.  For external channels, keep `deliver: true`
+  // even when an explicit `to` is missing so the gateway can fall back to
+  // session-level implicit routing (last channel / default target).
+  const hasExternalDeliveryPair = deliveryTarget.deliver && !isInternal;
 
   await callGatewayTool(
     "agent",
@@ -73,24 +82,16 @@ export async function sendExecApprovalFollowup(
     {
       sessionKey,
       message: buildExecApprovalFollowupPrompt(resultText),
-      deliver: deliveryTarget.deliver,
-      ...(deliveryTarget.deliver ? { bestEffortDeliver: true as const } : {}),
-      channel: deliveryTarget.deliver ? deliveryTarget.channel : sessionOnlyOriginChannel,
-      to: deliveryTarget.deliver
-        ? deliveryTarget.to
-        : sessionOnlyOriginChannel
-          ? params.turnSourceTo
+      deliver: hasExternalDeliveryPair,
+      ...(hasExternalDeliveryPair ? { bestEffortDeliver: true as const } : {}),
+      channel: hasExternalDeliveryPair
+        ? deliveryTarget.channel
+        : isInternal
+          ? INTERNAL_MESSAGE_CHANNEL
           : undefined,
-      accountId: deliveryTarget.deliver
-        ? deliveryTarget.accountId
-        : sessionOnlyOriginChannel
-          ? params.turnSourceAccountId
-          : undefined,
-      threadId: deliveryTarget.deliver
-        ? deliveryTarget.threadId
-        : sessionOnlyOriginChannel
-          ? params.turnSourceThreadId
-          : undefined,
+      to: hasExternalDeliveryPair ? deliveryTarget.to : undefined,
+      accountId: hasExternalDeliveryPair ? deliveryTarget.accountId : undefined,
+      threadId: hasExternalDeliveryPair ? deliveryTarget.threadId : undefined,
       idempotencyKey: `exec-approval-followup:${params.approvalId}`,
     },
     { expectFinal: true },

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -336,6 +336,7 @@ export async function processGatewayAllowlist(
         initiatingSurface,
         sentApproverDms,
         unavailableReason,
+        turnSourceChannel: params.turnSourceChannel,
       }),
     };
   }

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -374,6 +374,7 @@ export async function executeNodeHostCommand(
       sentApproverDms,
       unavailableReason,
       nodeId,
+      turnSourceChannel: params.turnSourceChannel,
     });
   }
 

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -374,6 +374,7 @@ export function buildExecApprovalPendingToolResult(params: {
   sentApproverDms: boolean;
   unavailableReason: ExecApprovalUnavailableReason | null;
   nodeId?: string;
+  turnSourceChannel?: string;
 }): AgentToolResult<ExecToolDetails> {
   return {
     content: [
@@ -395,6 +396,7 @@ export function buildExecApprovalPendingToolResult(params: {
                 cwd: params.cwd,
                 host: params.host,
                 nodeId: params.nodeId,
+                turnSourceChannel: params.turnSourceChannel,
               }),
       },
     ],

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -340,6 +340,7 @@ export function buildApprovalPendingMessage(params: {
   cwd: string;
   host: "gateway" | "node";
   nodeId?: string;
+  turnSourceChannel?: string;
 }) {
   let fence = "```";
   while (params.command.includes(fence)) {
@@ -361,7 +362,14 @@ export function buildApprovalPendingMessage(params: {
   lines.push(commandBlock);
   lines.push("Mode: foreground (interactive approvals available).");
   lines.push("Background mode requires pre-approved policy (allow-always or ask=off).");
-  lines.push(`Reply with: /approve ${params.approvalSlug} allow-once|allow-always|deny`);
+  if (params.turnSourceChannel === "webchat") {
+    lines.push(
+      "Use the exec approval buttons (Allow once, Always allow, or Deny) in the Control UI.",
+    );
+    lines.push(`Alternatively: /approve ${params.approvalSlug} allow-once|allow-always|deny`);
+  } else {
+    lines.push(`Reply with: /approve ${params.approvalSlug} allow-once|allow-always|deny`);
+  }
   lines.push("If the short code is ambiguous, use the full id in /approve.");
   return lines.join("\n");
 }

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -11,6 +11,7 @@ import { isDangerousHostEnvVarName } from "../infra/host-env-security.js";
 import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { isInternalMessageChannel } from "../utils/message-channel.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -362,7 +363,7 @@ export function buildApprovalPendingMessage(params: {
   lines.push(commandBlock);
   lines.push("Mode: foreground (interactive approvals available).");
   lines.push("Background mode requires pre-approved policy (allow-always or ask=off).");
-  if (params.turnSourceChannel === "webchat") {
+  if (isInternalMessageChannel(params.turnSourceChannel)) {
     lines.push(
       "Use the exec approval buttons (Allow once, Always allow, or Deny) in the Control UI.",
     );

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -488,6 +488,7 @@ describe("exec approvals", () => {
       ask: "always",
       approvalRunningNoticeMs: 0,
       sessionKey: "agent:main:main",
+      messageProvider: "webchat",
       elevated: { enabled: true, allowed: true, defaultLevel: "ask" },
     });
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -450,7 +450,7 @@ export function buildAgentSystemPrompt(params: {
     "Keep narration brief and value-dense; avoid repeating obvious steps.",
     "Use plain human language for narration unless in a technical context.",
     "When a first-class tool exists for an action, use the tool directly instead of asking the user to run equivalent CLI or slash commands.",
-    "When exec returns approval-pending, include the concrete /approve command from tool output (with allow-once|allow-always|deny) as plain chat text for the user, and do not ask for a different or rotated code.",
+    "When exec returns approval-pending, include the approval instructions from tool output (Control UI buttons when available, or the /approve command with allow-once|allow-always|deny) as plain chat text for the user, and do not ask for a different or rotated code.",
     "Never execute /approve through exec or any other shell/tool path; /approve is a user-facing approval command, not a shell command.",
     "Treat allow-once as single-command only: if another elevated command needs approval, request a fresh /approve and do not claim prior approval covered it.",
     "When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) so the user can approve what will actually run.",


### PR DESCRIPTION
fix(agents): webchat-aware exec approval follow-up and pending copy

## Summary

- Problem: When an exec approval originated from webchat (an internal message channel), the follow-up delivery after approval completion failed. The gateway tried to remap the internal channel to a configured external channel and couldn't find a delivery route. Additionally, the approval-pending message always showed the `/approve` CLI command, which is not the primary interaction model for webchat/Control UI users.
- Why it matters: Webchat operators never received the follow-up result after approving or denying a tool execution, making the approval flow feel broken. The CLI-centric approval instructions were confusing for Control UI users who have dedicated approval buttons.
- What changed:
  - **Followup delivery**: `sendExecApprovalFollowup` now detects internal channels via `isInternalMessageChannel()` and skips the outbound `deliver` flag. Instead, it explicitly routes the agent run back to `INTERNAL_MESSAGE_CHANNEL` so the result appears in the webchat session.
  - **Approval UX**: The `turnSourceChannel` is now threaded through the exec host (gateway and node), shared pending-result builder, and into the approval-pending message builder. When the source channel is `webchat`, the message shows Control UI button instructions first, with the `/approve` command as a fallback.
  - **System prompt**: The agent instruction for approval-pending responses was updated to mention Control UI buttons alongside the `/approve` command.
- What did NOT change (scope boundary): External channel delivery (Telegram, Discord, Slack, etc.) is unaffected. The approval manager, timeout logic, and two-phase gating (Patch 1) are not modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related # (Patch 1: two-phase approval gating PR)
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `sendExecApprovalFollowup` unconditionally set `deliver: true`, which tells the gateway to remap the channel to an external delivery route. Internal channels (webchat) have no such route, so the follow-up silently failed. The approval-pending message was also hardcoded to show only the `/approve` CLI command regardless of channel.
- Missing detection / guardrail: No check for internal vs external channel before setting the `deliver` flag. No channel-aware branching in the approval-pending message builder.
- Prior context (`git blame`, prior PR, issue, or refactor if known): The follow-up delivery was originally built for external channels only. Webchat approval support was added later without updating the follow-up path.
- Why this regressed now: The two-phase approval gating fix (Patch 1) made webchat approvals actually reachable, surfacing the pre-existing follow-up delivery gap.
- If unknown, what was ruled out: N/A — root cause is identified.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/bash-tools.exec.approval-id.test.ts`
- Scenario the test should lock in: When the follow-up fires for a webchat-originated approval, `deliver` must be `false` (not `true`).
- Why this is the smallest reliable guardrail: The unit test directly asserts the `deliver` flag value in the agent call payload, which is the exact field that caused the silent failure.
- Existing test that already covers this (if any): The existing follow-up test was updated — it previously asserted `deliver: true` and now asserts `deliver: false` for the webchat path.
- If no new test is added, why not: Existing test was updated to cover the fix.

## User-visible / Behavior Changes

- Webchat users now receive the follow-up result after approving or denying an exec operation (previously silent failure).
- Webchat approval-pending messages now show Control UI button instructions first, with `/approve` as a fallback. External channel users see the same `/approve` message as before.

## Diagram (if applicable)

```text
Before:
[webchat approval completes] -> deliver: true -> [gateway remaps channel] -> [no external route] -> silent failure

After:
[webchat approval completes] -> deliver: false -> [route to INTERNAL_MESSAGE_CHANNEL] -> [result in webchat session]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime/container: Node 22+
- Model/provider: Any
- Integration/channel (if any): Webchat / Control UI
- Relevant config (redacted): No external messaging channels configured

### Steps

1. Start gateway with no external channels configured (webchat only).
2. Trigger an elevated exec command that requires approval.
3. Approve via Control UI buttons or `/approve` command.

### Expected

- Follow-up result appears in the webchat session after approval.
- Approval-pending message shows Control UI button instructions (with `/approve` fallback).

### Actual

- (Before fix) Follow-up silently fails; webchat user never sees the result.
- (Before fix) Approval-pending message shows only `/approve` CLI command.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Test: `pnpm test -- src/agents/bash-tools.exec.approval-id.test.ts` — passes with `deliver: false` assertion.

## Human Verification (required)

- Verified scenarios: Scoped test passes with updated assertion (`deliver: false` for webchat follow-up).
- Edge cases checked: External channel delivery path unchanged (still `deliver: true` when channel+to are present and external).
- What you did **not** verify: Live end-to-end webchat approval flow with a running gateway.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: If `isInternalMessageChannel()` returns a false positive for a non-internal channel, the follow-up would skip external delivery.
  - Mitigation: `isInternalMessageChannel()` checks against a known constant (`INTERNAL_MESSAGE_CHANNEL`); false positives are unlikely. External channel paths are unchanged and tested separately.

### Files Changed

| File                                              | Change                                                          |
|---------------------------------------------------|-----------------------------------------------------------------|
| `src/agents/bash-tools.exec-approval-followup.ts` | Skip `deliver` for webchat; route to `INTERNAL_MESSAGE_CHANNEL` |
| `src/agents/bash-tools.exec-host-gateway.ts`      | Pass `turnSourceChannel` to pending result builder              |
| `src/agents/bash-tools.exec-host-node.ts`         | Pass `turnSourceChannel` to pending result builder              |
| `src/agents/bash-tools.exec-host-shared.ts`       | Accept `turnSourceChannel` param, forward to message builder    |
| `src/agents/bash-tools.exec-runtime.ts`           | Webchat-aware approval copy (Control UI buttons first)          |
| `src/agents/system-prompt.ts`                     | Updated approval-pending agent instruction                      |
| `src/agents/bash-tools.exec.approval-id.test.ts`  | Updated follow-up test: `deliver: false` for webchat            |
