### PR TITLE
fix(agent): respect configured default agent for --to sessions

### DIFF
--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -21,7 +21,7 @@ import {
 } from "../../config/sessions.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { resolvePreferredSessionKeyForSessionIdMatches } from "../../sessions/session-id-resolution.js";
-import { listAgentIds } from "../agent-scope.js";
+import { listAgentIds, resolveDefaultAgentId } from "../agent-scope.js";
 import { clearBootstrapSnapshotOnSessionRollover } from "../bootstrap-cache.js";
 
 export type SessionResolution = {
@@ -51,21 +51,23 @@ export function resolveSessionKeyForRequest(opts: {
   const sessionCfg = opts.cfg.session;
   const scope = sessionCfg?.scope ?? "per-sender";
   const mainKey = normalizeMainKey(sessionCfg?.mainKey);
+  const defaultAgentId = resolveDefaultAgentId(opts.cfg);
   const explicitSessionKey =
     opts.sessionKey?.trim() ||
     resolveExplicitAgentSessionKey({
       cfg: opts.cfg,
       agentId: opts.agentId,
     });
-  const storeAgentId = resolveAgentIdFromSessionKey(explicitSessionKey);
+
+  const ctx: MsgContext | undefined = opts.to?.trim() ? { From: opts.to } : undefined;
+  let sessionKey: string | undefined =
+    explicitSessionKey ??
+    (ctx ? resolveSessionKey(scope, ctx, mainKey, defaultAgentId) : undefined);
+  const storeAgentId = resolveAgentIdFromSessionKey(sessionKey);
   const storePath = resolveStorePath(sessionCfg?.store, {
     agentId: storeAgentId,
   });
   const sessionStore = loadSessionStore(storePath);
-
-  const ctx: MsgContext | undefined = opts.to?.trim() ? { From: opts.to } : undefined;
-  let sessionKey: string | undefined =
-    explicitSessionKey ?? (ctx ? resolveSessionKey(scope, ctx, mainKey) : undefined);
 
   // If a session id was provided, prefer to re-use its entry (by id) even when no key was derived.
   // When duplicates exist across agent stores, pick the same deterministic best match used by the

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -1068,6 +1068,25 @@ describe("agentCommand", () => {
     });
   });
 
+  it("uses the configured default agent when deriving a session from --to", async () => {
+    await withTempHome(async (home) => {
+      const storePattern = path.join(home, "sessions", "{agentId}", "sessions.json");
+      const cfg = mockConfig(home, storePattern, undefined, undefined, [
+        { id: "main" },
+        { id: "steward", default: true },
+      ]);
+
+      const stewardStore = path.join(home, "sessions", "steward", "sessions.json");
+      const resolution = resolveSession({ cfg, to: "+1555" });
+
+      expect(resolution.sessionKey).toBe("agent:steward:main");
+      expect(resolution.storePath).toBe(stewardStore);
+      expect(resolveSessionAgentId({ sessionKey: resolution.sessionKey, config: cfg })).toBe(
+        "steward",
+      );
+    });
+  });
+
   it("rejects unknown agent overrides", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");

--- a/src/commands/agent/session.test.ts
+++ b/src/commands/agent/session.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   loadSessionStore: vi.fn(),
   resolveStorePath: vi.fn(),
   listAgentIds: vi.fn(),
+  resolveDefaultAgentId: vi.fn(),
 }));
 
 vi.mock("../../config/sessions.js", async () => {
@@ -20,6 +21,7 @@ vi.mock("../../config/sessions.js", async () => {
 
 vi.mock("../../agents/agent-scope.js", () => ({
   listAgentIds: mocks.listAgentIds,
+  resolveDefaultAgentId: mocks.resolveDefaultAgentId,
 }));
 
 let resolveSessionKeyForRequest: typeof import("./session.js").resolveSessionKeyForRequest;
@@ -54,6 +56,7 @@ describe("resolveSessionKeyForRequest", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.listAgentIds.mockReturnValue(["main"]);
+    mocks.resolveDefaultAgentId.mockReturnValue("main");
   });
 
   const baseCfg: OpenClawConfig = {};
@@ -69,6 +72,33 @@ describe("resolveSessionKeyForRequest", () => {
       to: "+15551234567",
     });
     expect(result.sessionKey).toBe("agent:main:main");
+  });
+
+  it("uses the configured default agent store when --to derives a session key", async () => {
+    mocks.listAgentIds.mockReturnValue(["main", "steward"]);
+    mocks.resolveDefaultAgentId.mockReturnValue("steward");
+    mocks.resolveStorePath.mockImplementation(
+      (_store: string | undefined, opts?: { agentId?: string }) => {
+        if (opts?.agentId === "steward") {
+          return MYBOT_STORE_PATH;
+        }
+        return MAIN_STORE_PATH;
+      },
+    );
+    mockStoresByPath({
+      [MYBOT_STORE_PATH]: {
+        "agent:steward:main": { sessionId: "sess-steward", updatedAt: 0 },
+      },
+    });
+
+    const result = resolveSessionKeyForRequest({
+      cfg: baseCfg,
+      to: "+15551234567",
+    });
+
+    expect(result.sessionKey).toBe("agent:steward:main");
+    expect(result.storePath).toBe(MYBOT_STORE_PATH);
+    expect(result.sessionStore["agent:steward:main"]?.sessionId).toBe("sess-steward");
   });
 
   it("finds session by sessionId via reverse lookup in primary store", async () => {

--- a/src/config/sessions/session-key.test.ts
+++ b/src/config/sessions/session-key.test.ts
@@ -73,4 +73,20 @@ describe("resolveSessionKey", () => {
       expect(resolveSessionKey("per-sender", ctx)).toBe("discord:direct:123456");
     });
   });
+
+  it("uses the provided default agent id for direct chats", () => {
+    const ctx = makeCtx({
+      From: "+15551234567",
+    });
+    expect(resolveSessionKey("per-sender", ctx, "main", "steward")).toBe("agent:steward:main");
+  });
+
+  it("uses the provided default agent id for group chats", () => {
+    const ctx = makeCtx({
+      From: "12345-678@g.us",
+    });
+    expect(resolveSessionKey("per-sender", ctx, "main", "steward")).toBe(
+      "agent:steward:whatsapp:group:12345-678@g.us",
+    );
+  });
 });

--- a/src/config/sessions/session-key.ts
+++ b/src/config/sessions/session-key.ts
@@ -2,6 +2,7 @@ import type { MsgContext } from "../../auto-reply/templating.js";
 import {
   buildAgentMainSessionKey,
   DEFAULT_AGENT_ID,
+  normalizeAgentId,
   normalizeMainKey,
 } from "../../routing/session-key.js";
 import { normalizeE164 } from "../../utils.js";
@@ -26,7 +27,12 @@ export function deriveSessionKey(scope: SessionScope, ctx: MsgContext) {
  * Resolve the session key with a canonical direct-chat bucket (default: "main").
  * All non-group direct chats collapse to this bucket; groups stay isolated.
  */
-export function resolveSessionKey(scope: SessionScope, ctx: MsgContext, mainKey?: string) {
+export function resolveSessionKey(
+  scope: SessionScope,
+  ctx: MsgContext,
+  mainKey?: string,
+  agentId?: string,
+) {
   const explicit = ctx.SessionKey?.trim();
   if (explicit) {
     return normalizeExplicitSessionKey(explicit, ctx);
@@ -36,13 +42,14 @@ export function resolveSessionKey(scope: SessionScope, ctx: MsgContext, mainKey?
     return raw;
   }
   const canonicalMainKey = normalizeMainKey(mainKey);
+  const canonicalAgentId = normalizeAgentId(agentId || DEFAULT_AGENT_ID);
   const canonical = buildAgentMainSessionKey({
-    agentId: DEFAULT_AGENT_ID,
+    agentId: canonicalAgentId,
     mainKey: canonicalMainKey,
   });
   const isGroup = raw.includes(":group:") || raw.includes(":channel:");
   if (!isGroup) {
     return canonical;
   }
-  return `agent:${DEFAULT_AGENT_ID}:${raw}`;
+  return `agent:${canonicalAgentId}:${raw}`;
 }


### PR DESCRIPTION
## Summary

  - Problem: `openclaw agent --to ...` derived `main`-scoped sessions when
  `--agent` was omitted, even when config selected a different default agent
  such as `steward`.
  - Why it matters: the command behaved differently depending on whether
  `--agent` was passed explicitly, so default-agent routing and session
  persistence became inconsistent.
  - What changed: session-key derivation now uses the configured default agent,
  and session-store resolution now follows the derived session key instead of
  preselecting the `main` store.
  - What did NOT change (scope boundary): explicit `--agent`, explicit
  `--session-key`, and existing cross-store `sessionId` lookup behavior remain
  unchanged.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [x] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #56370
  - Related #
  - [x] This PR fixes a bug or regression

  ## Root Cause / Regression History (if applicable)

  - Root cause: direct-session key derivation hardcoded the agent segment to
  `main`, and session-store selection happened before the derived key was
  available, so `--to` requests always opened the `main` store first.
  - Missing detection / guardrail: there was no regression test covering `--to`
  with a configured default agent other than `main`.
  - Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
  - Why this regressed now: the code path still assumed `main` as the implicit
  agent even after default-agent configuration became a supported behavior.
  - If unknown, what was ruled out: routing bindings and explicit `--agent`
  handling were ruled out; the mismatch was isolated to implicit session
  derivation.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
    - [x] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file: `src/config/sessions/session-key.test.ts`, `src/
  commands/agent/session.test.ts`, `src/commands/agent.test.ts`
  - Scenario the test should lock in: when config sets `steward` as the default
  agent, `openclaw agent --to ...` should resolve `agent:steward:main` and use
  the `steward` session store.
  - Why this is the smallest reliable guardrail: it covers both the session-key
  builder and the command-side session resolution path without requiring live
  model auth or external integrations.
  - Existing test that already covers this (if any): none for the non-`main`
  default-agent path.
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  `openclaw agent --to ...` now respects the configured default agent when
  `--agent` is omitted, including both session-key derivation and session-store
  selection.

  ## Diagram (if applicable)

  ```text
  Before:
  openclaw agent --to ... -> derive session key as agent:main:main -> open main
  store

  After:
  openclaw agent --to ... -> resolve configured default agent -> derive
  agent:<default>:main -> open that agent's store

  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No) No
  - Secrets/tokens handling changed? (Yes/No) No
  - New/changed network calls? (Yes/No) No
  - Command/tool execution surface changed? (Yes/No) No
  - Data access scope changed? (Yes/No) No
  - If any Yes, explain risk + mitigation:

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: Node 22 + pnpm
  - Model/provider: N/A for the regression tests
  - Integration/channel (if any): N/A
  - Relevant config (redacted): agents.list with steward marked default: true

  ### Steps

  1. Configure multiple agents and mark steward as the default agent.
  2. Run openclaw agent --to <target> --message "..." without --agent.
  3. Inspect the resolved session key and backing session store.

  ### Expected

  - The command uses the configured default agent, for example
    agent:steward:main, and persists state in the steward session store.

  ### Actual

  - Before this fix, the command resolved to agent:main:main and used the main
    session store.

  ## Evidence

  Attach at least one:

  - [x] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  - Verified scenarios: verified direct session-key derivation, command-side
    session resolution, and store-path selection for a non-main default agent.
  - Edge cases checked: group-chat key derivation still follows the resolved
    default agent; explicit agent/session-key paths remain unchanged.
  - What you did not verify: full live CLI execution against a real provider/
    model runtime.

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in
    this PR.
  - [x] I left unresolved only the conversations that still need reviewer or
    maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No) Yes
  - Config/env changes? (Yes/No) No
  - Migration needed? (Yes/No) No
  - If yes, exact upgrade steps:

  ## Risks and Mitigations

  - Risk: a caller that relied on the buggy implicit main behavior could now
    resolve to a different agent store.
      - Mitigation: explicit --agent behavior is unchanged, and the new tests
        lock the intended default-agent semantics in place.