### PR TITLE
fix: make image tool timeout configurable

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -1876,6 +1876,20 @@
       "hasChildren": false
     },
     {
+      "path": "agents.defaults.imageTimeoutSeconds",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "media",
+        "performance"
+      ],
+      "label": "Image Timeout (sec)",
+      "hasChildren": false
+    },
+    {
       "path": "agents.defaults.maxConcurrent",
       "kind": "core",
       "type": "integer",
@@ -21600,7 +21614,10 @@
     {
       "path": "channels.matrix.accessToken",
       "kind": "channel",
-      "type": "string",
+      "type": [
+        "object",
+        "string"
+      ],
       "required": false,
       "deprecated": false,
       "sensitive": true,
@@ -21611,6 +21628,36 @@
         "network",
         "security"
       ],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.matrix.accessToken.id",
+      "kind": "channel",
+      "type": "string",
+      "required": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.matrix.accessToken.provider",
+      "kind": "channel",
+      "type": "string",
+      "required": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.matrix.accessToken.source",
+      "kind": "channel",
+      "type": "string",
+      "required": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
       "hasChildren": false
     },
     {
@@ -23862,6 +23909,16 @@
       "kind": "channel",
       "type": "string",
       "required": true,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.msteams.blockStreaming",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
       "deprecated": false,
       "sensitive": false,
       "tags": [],
@@ -44763,6 +44820,26 @@
     },
     {
       "path": "models.providers.*.models.*.compat.toolSchemaProfile",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "models.providers.*.models.*.compat.unsupportedToolSchemaKeywords",
+      "kind": "core",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "models.providers.*.models.*.compat.unsupportedToolSchemaKeywords.*",
       "kind": "core",
       "type": "string",
       "required": false,

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5554}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5561}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -159,6 +159,7 @@
 {"recordType":"path","path":"agents.defaults.imageModel.fallbacks","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["media","models","reliability"],"label":"Image Model Fallbacks","help":"Ordered fallback image models (provider/model).","hasChildren":true}
 {"recordType":"path","path":"agents.defaults.imageModel.fallbacks.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"agents.defaults.imageModel.primary","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["media","models"],"label":"Image Model","help":"Optional image model (provider/model) used when the primary model lacks image input.","hasChildren":false}
+{"recordType":"path","path":"agents.defaults.imageTimeoutSeconds","kind":"core","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":["media","performance"],"label":"Image Timeout (sec)","hasChildren":false}
 {"recordType":"path","path":"agents.defaults.maxConcurrent","kind":"core","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"agents.defaults.mediaMaxMb","kind":"core","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"agents.defaults.memorySearch","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"Memory Search","help":"Vector search over MEMORY.md and memory/*.md (per-agent overrides supported).","hasChildren":true}
@@ -1921,7 +1922,10 @@
 {"recordType":"path","path":"channels.line.tokenFile","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.line.webhookPath","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Matrix","help":"open protocol; install the plugin to enable.","hasChildren":true}
-{"recordType":"path","path":"channels.matrix.accessToken","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":true,"tags":["access","auth","channels","network","security"],"hasChildren":false}
+{"recordType":"path","path":"channels.matrix.accessToken","kind":"channel","type":["object","string"],"required":false,"deprecated":false,"sensitive":true,"tags":["access","auth","channels","network","security"],"hasChildren":true}
+{"recordType":"path","path":"channels.matrix.accessToken.id","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.matrix.accessToken.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.matrix.accessToken.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.matrix.accounts.*","kind":"channel","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.matrix.ackReaction","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2127,6 +2131,7 @@
 {"recordType":"path","path":"channels.msteams.appPassword.id","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.appPassword.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.appPassword.source","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.msteams.blockStreaming","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.blockStreamingCoalesce","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.msteams.blockStreamingCoalesce.idleMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.msteams.blockStreamingCoalesce.maxChars","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3950,6 +3955,8 @@
 {"recordType":"path","path":"models.providers.*.models.*.compat.thinkingFormat","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"models.providers.*.models.*.compat.toolCallArgumentsEncoding","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"models.providers.*.models.*.compat.toolSchemaProfile","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"models.providers.*.models.*.compat.unsupportedToolSchemaKeywords","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"models.providers.*.models.*.compat.unsupportedToolSchemaKeywords.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"models.providers.*.models.*.contextWindow","kind":"core","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"models.providers.*.models.*.cost","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"models.providers.*.models.*.cost.cacheRead","kind":"core","type":"number","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -674,6 +674,47 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("passes configured image timeout to the provider runtime", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("MINIMAX_API_KEY", "minimax-test");
+      let observedTimeoutMs: number | undefined;
+      installImageUnderstandingProviderStubs({
+        id: "minimax",
+        capabilities: ["image"],
+        describeImage: async (params: ImageDescriptionRequest) => {
+          observedTimeoutMs = params.timeoutMs;
+          return { text: "ok", model: "MiniMax-VL-01" };
+        },
+      } satisfies MediaUnderstandingProvider);
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "minimax/MiniMax-M2.7" },
+            imageModel: { primary: "minimax/MiniMax-VL-01" },
+            imageTimeoutSeconds: 90,
+          },
+        },
+        plugins: {
+          entries: {
+            minimax: { enabled: true },
+          },
+        },
+      };
+
+      const tool = requireImageTool(createImageTool({ config: cfg, agentDir }));
+      const result = await tool.execute("t1", {
+        prompt: "Describe the image.",
+        image: `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+      });
+
+      expect(observedTimeoutMs).toBe(90_000);
+      expect(result.content).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: "text", text: "ok" })]),
+      );
+    });
+  });
+
   it("sends moonshot image requests with user+image payloads only", async () => {
     await withTempAgentDir(async (agentDir) => {
       vi.stubEnv("MOONSHOT_API_KEY", "moonshot-test");
@@ -1286,5 +1327,23 @@ describe("image tool response validation", () => {
       } as never,
     });
     expect(text).toBe("hello");
+  });
+});
+
+describe("image tool timeout config", () => {
+  it("uses the default image timeout when config is unset", () => {
+    expect(__testing.resolveImageToolTimeoutMs(undefined)).toBe(30_000);
+    expect(__testing.resolveImageToolTimeoutMs({ agents: { defaults: {} } })).toBe(30_000);
+  });
+
+  it("converts agents.defaults.imageTimeoutSeconds to milliseconds", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          imageTimeoutSeconds: 90,
+        },
+      },
+    };
+    expect(__testing.resolveImageToolTimeoutMs(cfg)).toBe(90_000);
   });
 });

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -1346,4 +1346,15 @@ describe("image tool timeout config", () => {
     };
     expect(__testing.resolveImageToolTimeoutMs(cfg)).toBe(90_000);
   });
+
+  it("clamps image timeout to the maximum safe Node timer delay", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          imageTimeoutSeconds: 3_000_000,
+        },
+      },
+    };
+    expect(__testing.resolveImageToolTimeoutMs(cfg)).toBe(2_147_483_647);
+  });
 });

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -42,6 +42,7 @@ const DEFAULT_PROMPT = "Describe the image.";
 const ANTHROPIC_IMAGE_PRIMARY = "anthropic/claude-opus-4-6";
 const ANTHROPIC_IMAGE_FALLBACK = "anthropic/claude-opus-4-5";
 const DEFAULT_MAX_IMAGES = 20;
+const DEFAULT_IMAGE_TIMEOUT_MS = 30_000;
 
 const imageToolProviderDeps = {
   buildProviderRegistry,
@@ -52,6 +53,7 @@ export const __testing = {
   decodeDataUrl,
   coerceImageAssistantText,
   resolveImageToolMaxTokens,
+  resolveImageToolTimeoutMs,
   setProviderDepsForTest(overrides?: {
     buildProviderRegistry?: typeof buildProviderRegistry;
     getMediaUnderstandingProvider?: typeof getMediaUnderstandingProvider;
@@ -72,6 +74,14 @@ function resolveImageToolMaxTokens(modelMaxTokens: number | undefined, requested
     return requestedMaxTokens;
   }
   return Math.min(requestedMaxTokens, modelMaxTokens);
+}
+
+function resolveImageToolTimeoutMs(cfg?: OpenClawConfig): number {
+  const seconds = cfg?.agents?.defaults?.imageTimeoutSeconds;
+  if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds <= 0) {
+    return DEFAULT_IMAGE_TIMEOUT_MS;
+  }
+  return Math.floor(seconds * 1000);
 }
 
 /**
@@ -159,6 +169,7 @@ async function runImagePrompt(params: {
   const effectiveCfg = applyImageModelConfigDefaults(params.cfg, params.imageModelConfig);
   const providerCfg: OpenClawConfig = effectiveCfg ?? {};
   const providerRegistry = imageToolProviderDeps.buildProviderRegistry(undefined, providerCfg);
+  const timeoutMs = resolveImageToolTimeoutMs(providerCfg);
 
   const result = await runWithImageModelFallback({
     cfg: effectiveCfg,
@@ -183,7 +194,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: params.prompt,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });
@@ -200,7 +211,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: params.prompt,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });
@@ -217,7 +228,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: `${params.prompt}\n\nDescribe image ${index + 1} of ${params.images.length}.`,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -43,6 +43,7 @@ const ANTHROPIC_IMAGE_PRIMARY = "anthropic/claude-opus-4-6";
 const ANTHROPIC_IMAGE_FALLBACK = "anthropic/claude-opus-4-5";
 const DEFAULT_MAX_IMAGES = 20;
 const DEFAULT_IMAGE_TIMEOUT_MS = 30_000;
+const MAX_SET_TIMEOUT_MS = 2_147_483_647;
 
 const imageToolProviderDeps = {
   buildProviderRegistry,
@@ -81,7 +82,7 @@ function resolveImageToolTimeoutMs(cfg?: OpenClawConfig): number {
   if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds <= 0) {
     return DEFAULT_IMAGE_TIMEOUT_MS;
   }
-  return Math.floor(seconds * 1000);
+  return Math.min(Math.floor(seconds * 1000), MAX_SET_TIMEOUT_MS);
 }
 
 /**

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -1405,6 +1405,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                   },
                 ],
               },
+              imageTimeoutSeconds: {
+                type: "integer",
+                exclusiveMinimum: 0,
+                maximum: 9007199254740991,
+              },
               imageGenerationModel: {
                 anyOf: [
                   {
@@ -13804,6 +13809,10 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
       label: "Image Model Fallbacks",
       help: "Ordered fallback image models (provider/model).",
       tags: ["reliability", "models", "media"],
+    },
+    "agents.defaults.imageTimeoutSeconds": {
+      label: "Image Timeout (sec)",
+      tags: ["performance", "media"],
     },
     "agents.defaults.imageGenerationModel.primary": {
       label: "Image Generation Model",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -13812,6 +13812,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
     },
     "agents.defaults.imageTimeoutSeconds": {
       label: "Image Timeout (sec)",
+      help: "Timeout in seconds for image-tool analysis requests before OpenClaw aborts the provider call (default: 30). Raise this for slower image-analysis providers while leaving the field unset to keep existing behavior.",
       tags: ["performance", "media"],
     },
     "agents.defaults.imageGenerationModel.primary": {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1020,6 +1020,8 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.imageModel.primary":
     "Optional image model (provider/model) used when the primary model lacks image input.",
   "agents.defaults.imageModel.fallbacks": "Ordered fallback image models (provider/model).",
+  "agents.defaults.imageTimeoutSeconds":
+    "Timeout in seconds for image-tool analysis requests before OpenClaw aborts the provider call (default: 30). Raise this for slower image-analysis providers while leaving the field unset to keep existing behavior.",
   "agents.defaults.imageGenerationModel.primary":
     "Optional image-generation model (provider/model) used by the shared image generation capability.",
   "agents.defaults.imageGenerationModel.fallbacks":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -454,6 +454,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.model.fallbacks": "Model Fallbacks",
   "agents.defaults.imageModel.primary": "Image Model",
   "agents.defaults.imageModel.fallbacks": "Image Model Fallbacks",
+  "agents.defaults.imageTimeoutSeconds": "Image Timeout (sec)",
   "agents.defaults.imageGenerationModel.primary": "Image Generation Model",
   "agents.defaults.imageGenerationModel.fallbacks": "Image Generation Model Fallbacks",
   "agents.defaults.pdfModel.primary": "PDF Model",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -122,6 +122,8 @@ export type AgentDefaultsConfig = {
   model?: AgentModelConfig;
   /** Optional image-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   imageModel?: AgentModelConfig;
+  /** Timeout in seconds for image-tool analysis requests before OpenClaw aborts the provider call (default: 30). */
+  imageTimeoutSeconds?: number;
   /** Optional image-generation model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   imageGenerationModel?: AgentModelConfig;
   /** Optional PDF-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -11,4 +11,12 @@ describe("agent defaults schema", () => {
       }),
     ).not.toThrow();
   });
+
+  it("accepts imageTimeoutSeconds as a positive integer", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({
+        imageTimeoutSeconds: 90,
+      }),
+    ).not.toThrow();
+  });
 });

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -18,6 +18,7 @@ export const AgentDefaultsSchema = z
   .object({
     model: AgentModelSchema.optional(),
     imageModel: AgentModelSchema.optional(),
+    imageTimeoutSeconds: z.number().int().positive().optional(),
     imageGenerationModel: AgentModelSchema.optional(),
     pdfModel: AgentModelSchema.optional(),
     pdfMaxBytesMb: z.number().positive().optional(),


### PR DESCRIPTION
## Summary

This PR addresses a follow-up image-tool bug tracked in #56419.

The shared `image` tool currently hardcodes `timeoutMs: 30_000` before delegating to the media-understanding runtime. That means slow but otherwise valid image-analysis requests can be aborted by OpenClaw itself via `AbortController`.

This patch keeps the current default behavior, but exposes the timeout as agent config:

- `agents.defaults.imageTimeoutSeconds`

## Change Type

- [x] Bug fix
- [x] Behavior/config surface change required to fix the bug
- [ ] Refactor only
- [ ] Test-only

## Scope

Focused to the shared image-tool timeout path only.

Included:
- agent defaults type/schema for `imageTimeoutSeconds`
- base config schema output
- image tool timeout resolution
- focused tests for schema parsing and timeout propagation

Not changed:
- image provider selection
- media-understanding provider registry
- provider-specific image payload behavior
- default timeout value (still 30 seconds)

## Linked Issue/PR

- Fixes #56419
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

The current shared image-tool path injects a fixed `timeoutMs: 30_000` in `src/agents/tools/image-tool.ts`, and the shared image runtime in `src/media-understanding/image.ts` actively aborts requests with `AbortController` when that timeout is exceeded.

That makes slow image-analysis providers fail with `This operation was aborted`, even when the underlying request path is otherwise valid.

## What Changed

- Added `agents.defaults.imageTimeoutSeconds` to agent defaults types/schema
- Regenerated `src/config/schema.base.generated.ts`
- Added a small helper in `image-tool.ts` to resolve the configured timeout while preserving the current `30_000ms` default
- Replaced the three hardcoded `30_000` image timeout call sites with the resolved config value
- Added focused tests for:
  - schema acceptance
  - default timeout behavior
  - conversion from seconds to milliseconds
  - propagation of the configured timeout into the provider runtime

## User-visible / Behavior Changes

No behavior change for existing configs.

If `agents.defaults.imageTimeoutSeconds` is unset, the image tool still uses the current 30-second timeout.

Operators can now explicitly raise that timeout for slower image-analysis providers.

## Repro + Verification

### Problem evidence

Current source before this patch:
- `src/agents/tools/image-tool.ts` passes `timeoutMs: 30_000`
- `src/media-understanding/image.ts` creates an `AbortController` and aborts when that timeout is exceeded

That is the behavior reported in #56419.

### Focused validation run

Passed:
- `corepack pnpm test -- src/config/zod-schema.agent-defaults.test.ts --reporter=verbose`
- `./node_modules/.bin/vitest run src/agents/tools/image-tool.test.ts -t "passes configured image timeout|uses the default image timeout when config is unset|converts agents.defaults.imageTimeoutSeconds to milliseconds" --reporter=verbose`
- `corepack pnpm check:base-config-schema`

### Full-file note

I also ran the full file:
- `corepack pnpm test -- src/agents/tools/image-tool.test.ts --reporter=verbose`

It is currently red on this branch, but the same four failures also reproduce on a clean, unmodified latest `upstream/main` baseline:
- three existing timeout failures in generic runtime fallback tests
- one existing fetch call-count mismatch in `allows local image paths outside default media roots when workspaceOnly is off`

So the current full-file failures do not appear to be introduced by this patch.

## Human Verification

- Verified the new config field parses through `AgentDefaultsSchema`
- Verified timeout defaults remain `30_000ms` when unset
- Verified a configured `imageTimeoutSeconds: 90` reaches the provider runtime as `90_000ms`
- Verified generated base schema updated cleanly

## Failure Recovery

Low-risk rollback:
- revert this PR to restore the previous hardcoded 30-second timeout path

## Risks and Mitigations

### Risk

Adding a new config field increases config surface.

### Mitigation

- default behavior is unchanged when the field is unset
- patch is narrowly scoped to the shared image-tool timeout only
- tests cover parsing and propagation behavior directly

## AI assistance

AI-assisted: drafted and implemented with Codex, then locally reviewed and tested by me.

Testing level: lightly tested / focused tests passed.
