### PR TITLE
fix: handle wildcard (*) in plugin API version range checks

### DIFF
--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -80,6 +80,12 @@ describe("clawhub helpers", () => {
     expect(satisfiesPluginApiRange("2026.3.22", ">=2026.3.22")).toBe(true);
     expect(satisfiesPluginApiRange("2026.3.21", ">=2026.3.22")).toBe(false);
     expect(satisfiesPluginApiRange("invalid", "^1.2.0")).toBe(false);
+
+    // Wildcard ranges should match any version (#56446)
+    expect(satisfiesPluginApiRange("2026.3.24", "*")).toBe(true);
+    expect(satisfiesPluginApiRange("1.0.0", "*")).toBe(true);
+    expect(satisfiesPluginApiRange("2026.3.24", "x")).toBe(true);
+    expect(satisfiesPluginApiRange("2026.3.24", "X")).toBe(true);
   });
 
   it("checks min gateway versions with loose host labels", () => {

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -295,6 +295,10 @@ function satisfiesComparator(version: string, token: string): boolean {
   if (!trimmed) {
     return true;
   }
+  // Wildcard ranges match any version (standard semver behavior)
+  if (trimmed === "*" || trimmed === "x" || trimmed === "X") {
+    return true;
+  }
   if (trimmed.startsWith("^")) {
     const base = trimmed.slice(1).trim();
     const upperBound = upperBoundForCaret(base);


### PR DESCRIPTION
## Problem

Fixes #56446

`openclaw plugins install` rejects plugins that declare `peerDependencies: { "openclaw": "*" }` with:

```
Plugin "@byterover/byterover" requires plugin API *, but this OpenClaw runtime exposes 2026.3.24.
```

The wildcard `*` is a standard semver range meaning "any version," but the hand-rolled semver parser in `satisfiesComparator()` doesn't recognize it. The `*` token falls through to the regex comparator which tries to parse it as a semver string, fails, and returns `false`.

## Fix

Added an early return in `satisfiesComparator()` for standard semver wildcard tokens (`*`, `x`, `X`) so they correctly match any version. This is consistent with the npm/node-semver specification where these tokens represent "any version."

## Tests

Added 4 test cases to the existing `satisfiesPluginApiRange` test covering `*`, `x`, and `X` wildcards against both calver (`2026.3.24`) and standard semver (`1.0.0`) versions. All pass.