### PR TITLE
fix(discord): prevent false stale-socket detection during connection idle periods

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -53,6 +53,16 @@ export async function runDiscordGatewayLifecycle(params: {
   const onGatewayDebug = reconnectController.onGatewayDebug;
   gatewayEmitter?.on("debug", onGatewayDebug);
 
+  // Update lastEventAt on gateway metrics (emitted every 60s by Carbon's ConnectionMonitor)
+  // Only update when the gateway is actually connected — the metrics interval keeps firing
+  // even after disconnect (during resume attempts), which would mask real stale-socket events.
+  const onGatewayMetrics = () => {
+    if (lifecycleStopping) return;
+    if (!gateway?.isConnected) return;
+    pushStatus({ lastEventAt: Date.now() });
+  };
+  gatewayEmitter?.on("metrics", onGatewayMetrics);
+
   let sawDisallowedIntents = false;
   const handleGatewayEvent = (event: DiscordGatewayEvent): "continue" | "stop" => {
     if (event.type === "disallowed-intents") {
@@ -132,6 +142,7 @@ export async function runDiscordGatewayLifecycle(params: {
     stopGatewayLogging();
     reconnectController.dispose();
     gatewayEmitter?.removeListener("debug", onGatewayDebug);
+    gatewayEmitter?.removeListener("metrics", onGatewayMetrics);
     if (params.voiceManager) {
       await params.voiceManager.destroy();
       params.voiceManagerRef.current = null;


### PR DESCRIPTION
## Summary

Fix Discord gateway false positive stale-socket restarts that caused ~35-minute crash cycles.

## Root Cause

The Discord gateway health monitor tracks `lastEventAt` to detect stale connections. This timestamp was only updated on WebSocket **debug** events (open/close). During normal operation, Discord sends heartbeat ACKs every ~41 seconds, but these do NOT emit debug events.

After 30 minutes of idle time (below the `staleEventThresholdMs` default), `lastEventAt` becomes stale, triggering a false positive stale-socket restart. The restart sets `maxAttempts: 0` before calling `gateway.disconnect()`, causing Carbon to throw an uncaught "Max reconnect attempts (0)" exception that kills the entire gateway process.

## Fix

**Part 1: Close event handler sets `connected = false`**

The close debug event immediately sets `connected = false`, which short-circuits the health check:

```typescript
if (message.includes("WebSocket connection closed")) {
  pushStatus({ connected: false, ... });
  return;
}
```

This is the primary mechanism preventing false positives: `connected === false` returns unhealthy immediately without checking `lastEventAt`.

**Part 2: `onGatewayMetrics` guard prevents edge case**

Carbon's `ConnectionMonitor` emits `metrics` events every 60 seconds whenever the connection is healthy. We listen to these events and refresh `lastEventAt`:

```typescript
const onGatewayMetrics = () => {
  if (lifecycleStopping) return;
  if (!gateway?.isConnected) return;
  pushStatus({ lastEventAt: Date.now() });
};
gatewayEmitter?.on("metrics", onGatewayMetrics);
```

The `!gateway?.isConnected` guard addresses an edge case: if the close debug event does not fire (e.g., network drop without clean close), `connected` would stay `true` and `lastEventAt` would keep getting refreshed by metrics during the resume window. Only after `disconnect()` is called does `gateway.isConnected` become `false`, at which point the guard prevents further refreshes — allowing the stale check to finally trigger after the threshold.

## Testing

Ran the fix for 1 day in production. No false stale-socket restarts observed during extended idle periods. Real WebSocket disconnects (code 1005, ~hourly) are still correctly detected and recovered.

## Related

Fixes #56399