### PR TITLE
fix(whatsapp): prevent unsolicited pairing codes during reconnect cycles

### DIFF
--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -49,6 +49,11 @@ export async function checkInboundAccessControl(params: {
   messageTimestampMs?: number;
   connectedAtMs?: number;
   pairingGraceMs?: number;
+  /** True when processing a Baileys "append" upsert (history/offline catch-up).
+   *  Pairing challenges must never fire for append messages — they are replays,
+   *  not real-time inbound DMs. Without this guard, reconnect loops cause
+   *  unsolicited pairing codes to be sent to contacts (#56448). */
+  isAppend?: boolean;
   sock: {
     sendMessage: (jid: string, content: { text: string }) => Promise<unknown>;
   };
@@ -79,9 +84,13 @@ export async function checkInboundAccessControl(params: {
       ? params.pairingGraceMs
       : PAIRING_REPLY_HISTORY_GRACE_MS;
   const suppressPairingReply =
-    typeof params.connectedAtMs === "number" &&
+    // Suppress for append (history/offline) messages — these are replays from
+    // Baileys, not real-time DMs. Sending pairing codes for replayed messages
+    // during reconnect cycles sends unsolicited messages to contacts (#56448).
+    params.isAppend === true ||
+    (typeof params.connectedAtMs === "number" &&
     typeof params.messageTimestampMs === "number" &&
-    params.messageTimestampMs < params.connectedAtMs - pairingGraceMs;
+    params.messageTimestampMs < params.connectedAtMs - pairingGraceMs);
 
   // Group policy filtering:
   // - "open": groups bypass allowFrom, only mention-gating applies

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -207,6 +207,7 @@ export async function monitorWebInbox(options: {
 
   const normalizeInboundMessage = async (
     msg: WAMessage,
+    opts?: { isAppend?: boolean },
   ): Promise<NormalizedInboundMessage | null> => {
     const id = msg.key?.id ?? undefined;
     const remoteJid = msg.key?.remoteJid;
@@ -271,6 +272,7 @@ export async function monitorWebInbox(options: {
       isFromMe: Boolean(msg.key?.fromMe),
       messageTimestampMs,
       connectedAtMs,
+      isAppend: opts?.isAppend,
       sock: { sendMessage: (jid, content) => sendTrackedMessage(jid, content) },
       remoteJid,
     });
@@ -463,21 +465,19 @@ export async function monitorWebInbox(options: {
     if (upsert.type !== "notify" && upsert.type !== "append") {
       return;
     }
+    const isAppend = upsert.type === "append";
     for (const msg of upsert.messages ?? []) {
       recordChannelActivity({
         channel: "whatsapp",
         accountId: options.accountId,
         direction: "inbound",
       });
-      const inbound = await normalizeInboundMessage(msg);
-      if (!inbound) {
-        continue;
-      }
 
-      await maybeMarkInboundAsRead(inbound);
-
-      // If this is history/offline catch-up, mark read above but skip auto-reply.
-      if (upsert.type === "append") {
+      // Skip old history BEFORE access control to prevent pairing challenges
+      // from firing on replayed messages during reconnect cycles (#56448).
+      // Without this guard, 408 reconnect loops cause unsolicited pairing
+      // codes to be sent to the user's contacts.
+      if (isAppend) {
         const APPEND_RECENT_GRACE_MS = 60_000;
         const msgTsRaw = msg.messageTimestamp;
         const msgTsNum = msgTsRaw != null ? Number(msgTsRaw) : NaN;
@@ -486,6 +486,13 @@ export async function monitorWebInbox(options: {
           continue;
         }
       }
+
+      const inbound = await normalizeInboundMessage(msg, { isAppend });
+      if (!inbound) {
+        continue;
+      }
+
+      await maybeMarkInboundAsRead(inbound);
 
       const enriched = await enrichInboundMessage(msg);
       if (!enriched) {


### PR DESCRIPTION
## Problem

Fixes #56448 (beta-blocker)

When the WhatsApp connection experiences repeated 408 timeouts (~every 15 min), Baileys replays recent messages as `type: "append"` upserts on each reconnect. The code sends pairing codes to contacts BEFORE checking if the message is a historical replay, causing unsolicited messages from the user's personal WhatsApp account to their contacts without consent.

This is a privacy/trust violation. The user's contacts receive messages containing "OpenClaw" branding and pairing codes they never requested.

## Root Cause

In `handleMessagesUpsert` (monitor.ts), the execution order is:

```
1. normalizeInboundMessage(msg)    ← calls checkInboundAccessControl
   └─ checkInboundAccessControl    ← triggers pairing challenge (SENDS MESSAGE)
2. maybeMarkInboundAsRead(inbound)
3. if (upsert.type === "append")   ← skip auto-reply for history
   └─ continue                     ← TOO LATE, pairing code already sent
```

The existing `suppressPairingReply` guard (access-control.ts:81-84) only catches messages timestamped >30s before `connectedAtMs`. But during a 408 reconnect, `connectedAtMs` resets to `Date.now()`, so messages from the disconnect window appear "recent" and pass through the guard.

## Fix

Two-layer defense-in-depth:

**Layer 1 — Structural reorder (monitor.ts):** Move the `append` age filter BEFORE `normalizeInboundMessage`, so replayed messages never reach access control or the pairing flow:

```
1. if (isAppend && old) continue   ← FILTER FIRST
2. normalizeInboundMessage(msg)    ← safe: only real-time messages reach here
3. maybeMarkInboundAsRead(inbound)
4. enrichInboundMessage / enqueue
```

**Layer 2 — Explicit suppress flag (access-control.ts):** Pass `isAppend` through the call chain and add it to `suppressPairingReply`. Even if Layer 1 is somehow bypassed, pairing challenges are explicitly suppressed for ALL append messages:

```ts
const suppressPairingReply =
  params.isAppend === true ||  // NEW: never pair for replayed messages
  (params.messageTimestampMs < params.connectedAtMs - pairingGraceMs);
```

## Why two layers?

This is a privacy bug. A messaging system must NEVER send unsolicited messages. Belt and suspenders: if the structural reorder somehow fails (e.g., future refactor moves the check), the explicit `isAppend` flag in access control still prevents the pairing flow from firing on replayed messages.

## Files Changed

- `extensions/whatsapp/src/inbound/monitor.ts` — reorder append filter, thread `isAppend` param
- `extensions/whatsapp/src/inbound/access-control.ts` — add `isAppend` param, suppress pairing for append