### PR TITLE
fix: resolve Windows exec Chinese character garbling issue

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -102,14 +102,15 @@ export async function runExec(
   args: string[],
   opts: number | { timeoutMs?: number; maxBuffer?: number; cwd?: string } = 10_000,
 ): Promise<{ stdout: string; stderr: string }> {
+  const defaultEncoding = process.platform === "win32" ? "gbk" : "utf8";
   const options =
     typeof opts === "number"
-      ? { timeout: opts, encoding: "utf8" as const }
+      ? { timeout: opts, encoding: defaultEncoding as const }
       : {
           timeout: opts.timeoutMs,
           maxBuffer: opts.maxBuffer,
           cwd: opts.cwd,
-          encoding: "utf8" as const,
+          encoding: defaultEncoding as const,
         };
   try {
     const argv = [command, ...args];
@@ -303,11 +304,13 @@ export async function runCommandWithTimeout(
     }
 
     child.stdout?.on("data", (d) => {
-      stdout += d.toString();
+      const defaultEncoding = process.platform === "win32" ? "gbk" : "utf8";
+      stdout += d.toString(defaultEncoding);
       armNoOutputTimer();
     });
     child.stderr?.on("data", (d) => {
-      stderr += d.toString();
+      const defaultEncoding = process.platform === "win32" ? "gbk" : "utf8";
+      stderr += d.toString(defaultEncoding);
       armNoOutputTimer();
     });
     child.on("error", (err) => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -2,7 +2,7 @@ import { execFile, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { promisify } from "node:util";
+import { promisify, TextDecoder } from "node:util";
 import { danger, shouldLogVerbose } from "../globals.js";
 import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
 import { logDebug, logError } from "../logger.js";
@@ -102,15 +102,14 @@ export async function runExec(
   args: string[],
   opts: number | { timeoutMs?: number; maxBuffer?: number; cwd?: string } = 10_000,
 ): Promise<{ stdout: string; stderr: string }> {
-  const defaultEncoding = process.platform === "win32" ? "gbk" : "utf8";
   const options =
     typeof opts === "number"
-      ? { timeout: opts, encoding: defaultEncoding as const }
+      ? { timeout: opts, encoding: "buffer" as const }
       : {
           timeout: opts.timeoutMs,
           maxBuffer: opts.maxBuffer,
           cwd: opts.cwd,
-          encoding: defaultEncoding as const,
+          encoding: "buffer" as const,
         };
   try {
     const argv = [command, ...args];
@@ -130,13 +129,19 @@ export async function runExec(
       execArgs = args;
     }
     const useCmdWrapper = isWindowsBatchCommand(execCommand);
-    const { stdout, stderr } = useCmdWrapper
+    const { stdout: stdoutBuffer, stderr: stderrBuffer } = useCmdWrapper
       ? await execFileAsync(
           process.env.ComSpec ?? "cmd.exe",
           ["/d", "/s", "/c", buildCmdExeCommandLine(execCommand, execArgs)],
           { ...options, windowsVerbatimArguments: true },
         )
       : await execFileAsync(execCommand, execArgs, options);
+    
+    // Decode buffers with platform-specific encoding
+    const decoder = new TextDecoder(process.platform === "win32" ? "gbk" : "utf-8");
+    const stdout = decoder.decode(stdoutBuffer);
+    const stderr = decoder.decode(stderrBuffer);
+    
     if (shouldLogVerbose()) {
       if (stdout.trim()) {
         logDebug(stdout.trim());
@@ -245,6 +250,11 @@ export async function runCommandWithTimeout(
   );
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {
+    // Create TextDecoder once outside stream callbacks
+    const encoding = process.platform === "win32" ? "gbk" : "utf-8";
+    const stdoutDecoder = new TextDecoder(encoding);
+    const stderrDecoder = new TextDecoder(encoding);
+    
     let stdout = "";
     let stderr = "";
     let settled = false;
@@ -304,14 +314,22 @@ export async function runCommandWithTimeout(
     }
 
     child.stdout?.on("data", (d) => {
-      const defaultEncoding = process.platform === "win32" ? "gbk" : "utf8";
-      stdout += d.toString(defaultEncoding);
+      // Stream decoding with { stream: true } to handle multi-byte characters
+      stdout += stdoutDecoder.decode(d, { stream: true });
       armNoOutputTimer();
     });
     child.stderr?.on("data", (d) => {
-      const defaultEncoding = process.platform === "win32" ? "gbk" : "utf8";
-      stderr += d.toString(defaultEncoding);
+      // Stream decoding with { stream: true } to handle multi-byte characters
+      stderr += stderrDecoder.decode(d, { stream: true });
       armNoOutputTimer();
+    });
+    child.stdout?.on("end", () => {
+      // Final decode to flush any remaining bytes
+      stdout += stdoutDecoder.decode();
+    });
+    child.stderr?.on("end", () => {
+      // Final decode to flush any remaining bytes
+      stderr += stderrDecoder.decode();
     });
     child.on("error", (err) => {
       if (settled) {


### PR DESCRIPTION
### Summary
Fixes the Windows exec tool garbled Chinese characters issue (#56462). The problem was that the exec tool hardcoded "utf8" encoding on Windows, but Windows cmd.exe/PowerShell outputs in GBK/CP936 encoding by default.

### Changes
1. **Auto-detect encoding**: Use GBK on Windows, UTF-8 on other platforms
2. **Fix `runExec()`**: Use platform-specific default encoding instead of hardcoding UTF-8
3. **Fix `runCommandWithTimeout()`**: Decode Buffer with correct platform-specific encoding

### Testing
- Tested on Windows 11 with PowerShell 7.6.0
- Verified Chinese output displays correctly: `Write-Output "这是中文测试"` now works properly
- Verified backwards compatibility: UTF-8 still works on non-Windows platforms

### Related Issues
Closes #56462
Closes #50519 (duplicate)