### PR TITLE
fix(slack): match channel-prefixed allowlist keys

### DIFF
--- a/extensions/slack/src/monitor/channel-config.ts
+++ b/extensions/slack/src/monitor/channel-config.ts
@@ -111,10 +111,16 @@ export function resolveSlackChannelConfig(params: {
   // entry-scan. buildChannelKeyCandidates deduplicates identical keys.
   const channelIdLower = channelId.toLowerCase();
   const channelIdUpper = channelId.toUpperCase();
+  const channelTarget = `channel:${channelId}`;
+  const channelTargetLower = `channel:${channelIdLower}`;
+  const channelTargetUpper = `channel:${channelIdUpper}`;
   const candidates = buildChannelKeyCandidates(
     channelId,
     channelIdLower !== channelId ? channelIdLower : undefined,
     channelIdUpper !== channelId ? channelIdUpper : undefined,
+    channelTarget,
+    channelTargetLower !== channelTarget ? channelTargetLower : undefined,
+    channelTargetUpper !== channelTarget ? channelTargetUpper : undefined,
     allowNameMatching ? (channelName ? `#${directName}` : undefined) : undefined,
     allowNameMatching ? directName : undefined,
     allowNameMatching ? normalizedName : undefined,

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -82,6 +82,31 @@ describe("resolveSlackChannelConfig", () => {
     expect(res).toMatchObject({ allowed: true, requireMention: false });
   });
 
+  it("matches channel config keys prefixed with channel: when runtime passes a bare Slack channel id", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C0AJYR3BVTJ",
+      channels: { "channel:C0AJYR3BVTJ": { allow: true, requireMention: false } },
+      defaultRequireMention: true,
+    });
+    expect(res).toMatchObject({
+      allowed: true,
+      requireMention: false,
+      matchKey: "channel:C0AJYR3BVTJ",
+    });
+  });
+
+  it("matches lowercase channel:-prefixed config keys when Slack delivers uppercase channel IDs", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C0AJYR3BVTJ",
+      channels: { "channel:c0ajyr3bvtj": { allow: true, requireMention: false } },
+      defaultRequireMention: true,
+    });
+    expect(res).toMatchObject({
+      allowed: true,
+      requireMention: false,
+    });
+  });
+
   it("blocks channel-name route matches by default", () => {
     const res = resolveSlackChannelConfig({
       channelId: "C1",


### PR DESCRIPTION
## Summary

- Problem: Slack public-channel allowlist entries configured as `channel:<CHANNEL_ID>` were not matched by the runtime channel resolver, so valid allowed channels like `#general` could be treated as `channel-not-allowed`.
- Why it matters: `@CEO` mentions in allowed Slack public channels could reach the provider but still die in authorization before routing and reply, which made the channel appear broken even though membership, history access, and app delivery were otherwise working.
- What changed: add `channel:${channelId}` plus lowercase/uppercase channel-prefixed variants to the candidate keys in `resolveSlackChannelConfig(...)`, and add regression coverage for those key shapes.
- What did NOT change (scope boundary): this PR does not change mention routing, session persistence, provider setup, or Slack message/app_mention race handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41264
- Related #41582
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Slack runtime channel matching only tried bare channel IDs and optional channel names, while the real config used allowlist keys in the form `channel:<CHANNEL_ID>`.
- Missing detection / guardrail: there was no regression test covering `channel:`-prefixed Slack channel keys against runtime bare channel IDs.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #41582 was a prior attempt in the same issue area, but it focused on session-route persistence rather than the earlier channel allowlist match failure.
- Why this regressed now: the deployed config used `channel:C...` keys, but the runtime matcher never considered that key shape.
- If unknown, what was ruled out: ruled out channel membership, Slack history visibility, missing provider ingress, and initial public-channel event delivery failure.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/slack/src/monitor/monitor.test.ts`
- Scenario the test should lock in: a Slack allowlist entry stored as `channel:C0AJYR3BVTJ` (and lowercase variant) must match a runtime event carrying bare channel ID `C0AJYR3BVTJ`.
- Why this is the smallest reliable guardrail: the bug is a pure config-key matching bug in `resolveSlackChannelConfig(...)`; no larger integration setup is required to prove it.
- Existing test that already covers this (if any): existing tests already covered bare uppercase/lowercase channel IDs, but not the `channel:`-prefixed key form.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Slack public channels already listed in config with `channel:<CHANNEL_ID>` keys are now treated as allowed at runtime.
- This restores reply handling for affected Slack public-channel mentions without requiring users to rewrite existing channel keys.

## Diagram (if applicable)

```text
Before:
[user mentions @CEO in #general] -> runtime sees C0AJYR3BVTJ -> no match for channel:C0AJYR3BVTJ -> channel-not-allowed -> no reply

After:
[user mentions @CEO in #general] -> runtime sees C0AJYR3BVTJ -> matches channel:C0AJYR3BVTJ -> authorize -> route -> reply
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Debian/Linux
- Runtime/container: local OpenClaw gateway service
- Model/provider: Slack channel integration with multiple Slack accounts
- Integration/channel (if any): Slack `#general`
- Relevant config (redacted): Slack allowlist configured with `channel:C0AJYR3BVTJ` and `requireMention: true`

### Steps

1. Configure Slack public-channel allowlist entries using `channel:<CHANNEL_ID>` keys.
2. Send `@CEO` in `#general`.
3. Observe authorization/result before and after patch.

### Expected

- The configured public channel is recognized as allowed and the mention can continue through authorization and reply handling.

### Actual

- Before the fix, the channel was treated as `channel-not-allowed` even though the exact `channel:C...` key existed in config.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: traced the live Slack `#general` path on a running instance; before the fix `@CEO` died at `reason=channel-not-allowed`; after applying the same minimal fix on the server, the `ceo` path reached `stage=ready`, dispatched, and replied in-channel.
- Edge cases checked: verified both `channel:C...` and `channel:c...` key forms in unit tests.
- What you did **not** verify: did not fully clean up every unrelated Slack runtime/config issue discovered during investigation; this PR stays scoped to channel key matching only.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: matching additional `channel:`-prefixed key variants could affect Slack configs that intentionally relied on bare IDs not matching those keys.
  - Mitigation: the change is limited to explicit `channel:` key forms already present in user config, and existing bare-ID/name matching behavior is unchanged.
