### PR TITLE
fix: keep xai fast reasoning model ids stable

### DIFF
--- a/extensions/xai/model-id.ts
+++ b/extensions/xai/model-id.ts
@@ -1,10 +1,4 @@
 export function normalizeXaiModelId(id: string): string {
-  if (id === "grok-4-fast-reasoning") {
-    return "grok-4-fast";
-  }
-  if (id === "grok-4-1-fast-reasoning") {
-    return "grok-4-1-fast";
-  }
   if (id === "grok-4.20-experimental-beta-0304-reasoning") {
     return "grok-4.20-beta-latest-reasoning";
   }

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -70,7 +70,7 @@ describe("xai web search config resolution", () => {
 
     expect(resolveXaiWebSearchCredential(searchConfig)).toBe("plugin-key");
     expect(resolveXaiInlineCitations(searchConfig)).toBe(true);
-    expect(resolveXaiWebSearchModel(searchConfig)).toBe("grok-4-fast");
+    expect(resolveXaiWebSearchModel(searchConfig)).toBe("grok-4-fast-reasoning");
   });
 
   it("treats unresolved non-env SecretRefs as missing credentials instead of throwing", async () => {
@@ -114,7 +114,7 @@ describe("xai web search config resolution", () => {
 
   it("uses config model when provided", () => {
     expect(resolveXaiWebSearchModel({ grok: { model: "grok-4-fast-reasoning" } })).toBe(
-      "grok-4-fast",
+      "grok-4-fast-reasoning",
     );
   });
 

--- a/src/agents/model-id-normalization.test.ts
+++ b/src/agents/model-id-normalization.test.ts
@@ -11,9 +11,7 @@ describe("normalizeXaiModelId", () => {
     );
   });
 
-  it("maps older fast and 4.20 ids to the current Pi-backed ids", () => {
-    expect(normalizeXaiModelId("grok-4-fast-reasoning")).toBe("grok-4-fast");
-    expect(normalizeXaiModelId("grok-4-1-fast-reasoning")).toBe("grok-4-1-fast");
+  it("maps older 4.20 ids to the current Pi-backed ids", () => {
     expect(normalizeXaiModelId("grok-4.20-reasoning")).toBe("grok-4.20-beta-latest-reasoning");
     expect(normalizeXaiModelId("grok-4.20-non-reasoning")).toBe(
       "grok-4.20-beta-latest-non-reasoning",
@@ -21,6 +19,8 @@ describe("normalizeXaiModelId", () => {
   });
 
   it("leaves current xai model ids unchanged", () => {
+    expect(normalizeXaiModelId("grok-4-fast-reasoning")).toBe("grok-4-fast-reasoning");
+    expect(normalizeXaiModelId("grok-4-1-fast-reasoning")).toBe("grok-4-1-fast-reasoning");
     expect(normalizeXaiModelId("grok-4.20-beta-latest-reasoning")).toBe(
       "grok-4.20-beta-latest-reasoning",
     );


### PR DESCRIPTION
## Summary

Fix a bug where OpenClaw silently rewrites current xAI fast reasoning model ids to different ids during normalization.

Closes #56531.

## Regression

OpenClaw currently advertises these as current bundled xAI model ids:
- `grok-4-fast-reasoning`
- `grok-4-1-fast-reasoning`

But `normalizeXaiModelId()` was still rewriting them to:
- `grok-4-fast`
- `grok-4-1-fast`

That breaks the contract between the bundled model catalog/docs and the effective runtime model selection.

In practice this shows up immediately in config-driven flows such as `openclaw models status`, where a user-configured default like `xai/grok-4-1-fast-reasoning` resolves to a different effective model than the one declared in config.

## Fix

- stop normalizing `grok-4-fast-reasoning` to `grok-4-fast`
- stop normalizing `grok-4-1-fast-reasoning` to `grok-4-1-fast`
- keep the existing legacy 4.20 alias normalization intact
- update normalization tests so current fast reasoning ids stay unchanged
- update xAI web-search tests so configured fast reasoning ids remain canonical there too

## Why This Fix

This keeps normalization aligned with the bundled xAI catalog and docs instead of silently downgrading currently supported ids.

It is intentionally narrow:
- it fixes the current fast reasoning ids that should already be stable
- it preserves the existing older 4.20 compatibility mappings
- it updates only the affected expectations on the xAI surface

## Validation

- `pnpm test:extension xai`
- `pnpm build`
- `pnpm check`
- `pnpm test`

## AI disclosure

- AI-assisted
- Fully tested for the changed surface locally
- I understand the code and validated the repro and fix directly
- I attempted `codex review --base upstream/main` per CONTRIBUTING, but the local Codex CLI failed in this environment during startup / network initialization before producing review output

## Screenshots

- Not applicable; this is a model-id normalization/runtime selection fix, not a UI change