### PR TITLE
fix: preserve image/video file paths when media understanding succeeds

### DIFF
--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -27,10 +27,10 @@ describe("buildInboundMediaNote", () => {
     );
   });
 
-  it("skips media notes for attachments with understanding output", () => {
+  it("skips media notes for audio attachments with understanding output", () => {
     const note = buildInboundMediaNote({
-      MediaPaths: ["/tmp/a.png", "/tmp/b.png"],
-      MediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+      MediaPaths: ["/tmp/a.ogg", "/tmp/b.png"],
+      MediaUrls: ["https://example.com/a.ogg", "https://example.com/b.png"],
       MediaUnderstanding: [
         {
           kind: "audio.transcription",
@@ -41,6 +41,29 @@ describe("buildInboundMediaNote", () => {
       ],
     });
     expect(note).toBe("[media attached: /tmp/b.png | https://example.com/b.png]");
+  });
+
+  it("keeps image paths when image understanding output exists", () => {
+    const note = buildInboundMediaNote({
+      MediaPaths: ["/tmp/photo.jpg", "/tmp/doc.pdf"],
+      MediaUrls: ["https://example.com/photo.jpg", "https://example.com/doc.pdf"],
+      MediaUnderstanding: [
+        {
+          kind: "image.description",
+          attachmentIndex: 0,
+          text: "A kitchen counter with items",
+          provider: "openai",
+        },
+      ],
+    });
+    // Image paths preserved so agent can access files on disk
+    expect(note).toBe(
+      [
+        "[media attached: 2 files]",
+        "[media attached 1/2: /tmp/photo.jpg | https://example.com/photo.jpg]",
+        "[media attached 2/2: /tmp/doc.pdf | https://example.com/doc.pdf]",
+      ].join("\n"),
+    );
   });
 
   it("only suppresses attachments when media understanding succeeded", () => {
@@ -75,7 +98,7 @@ describe("buildInboundMediaNote", () => {
     );
   });
 
-  it("suppresses attachments when media understanding succeeds via decisions", () => {
+  it("keeps image paths when media understanding succeeds via decisions", () => {
     const note = buildInboundMediaNote({
       MediaPaths: ["/tmp/a.png", "/tmp/b.png"],
       MediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
@@ -85,7 +108,14 @@ describe("buildInboundMediaNote", () => {
         >[number],
       ],
     });
-    expect(note).toBe("[media attached: /tmp/b.png | https://example.com/b.png]");
+    // Image paths are preserved so the agent can access files on disk (e.g. photolog)
+    expect(note).toBe(
+      [
+        "[media attached: 2 files]",
+        "[media attached 1/2: /tmp/a.png | https://example.com/a.png]",
+        "[media attached 2/2: /tmp/b.png | https://example.com/b.png]",
+      ].join("\n"),
+    );
   });
 
   it("strips audio attachments when transcription succeeded via MediaUnderstanding (issue #4197)", () => {

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -48,12 +48,14 @@ function isAudioPath(path: string | undefined): boolean {
 
 export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
   // Attachment indices follow MediaPaths/MediaUrls ordering as supplied by the channel.
+  // Only suppress audio attachments (transcript replaces the file).
+  // Image/video paths are kept so the agent can access the file on disk (e.g. photolog).
   const suppressed = new Set<number>();
   const transcribedAudioIndices = new Set<number>();
   if (Array.isArray(ctx.MediaUnderstanding)) {
     for (const output of ctx.MediaUnderstanding) {
-      suppressed.add(output.attachmentIndex);
       if (output.kind === "audio.transcription") {
+        suppressed.add(output.attachmentIndex);
         transcribedAudioIndices.add(output.attachmentIndex);
       }
     }
@@ -65,8 +67,8 @@ export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
       }
       for (const attachment of decision.attachments) {
         if (attachment.chosen?.outcome === "success") {
-          suppressed.add(attachment.attachmentIndex);
           if (decision.capability === "audio") {
+            suppressed.add(attachment.attachmentIndex);
             transcribedAudioIndices.add(attachment.attachmentIndex);
           }
         }


### PR DESCRIPTION
## Summary

When media understanding (vision model) successfully describes an image, `buildInboundMediaNote()` suppresses the `[media attached: /path/...]` line entirely. This means the agent gets the description but has no way to locate the actual file on disk — breaking any skill or workflow that needs to copy, read EXIF metadata from, or otherwise access the image file.

This PR changes the suppression logic so that only **audio** attachments are suppressed when transcription succeeds (the transcript fully replaces the audio file). Image and video file paths are always preserved in the media note, so the agent receives both the description and the file path.

## Changes

- `src/auto-reply/media-note.ts`: Only add audio attachment indices to the `suppressed` set, not image/video
- `src/auto-reply/media-note.test.ts`: Updated existing tests and added a new test for image path preservation

## Test plan

- [x] Existing audio suppression tests still pass (transcribed audio files are still stripped)
- [x] New test verifies image paths are preserved when `image.description` understanding exists
- [x] Updated decision-based test verifies image paths preserved via `MediaUnderstandingDecisions`
- [x] `pnpm check` passes