### PR TITLE
fix(slack): enable preview streaming in flat DMs (replyToMode: off)

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
@@ -61,16 +61,16 @@ describe("slack preview streaming eligibility", () => {
     ).toBe(true);
   });
 
-  it("stays off for top-level DMs without a reply thread", () => {
+  it("stays on for top-level DMs without a reply thread", () => {
     expect(
       shouldEnableSlackPreviewStreaming({
         mode: "partial",
         isDirectMessage: true,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  it("allows DM preview when the reply is threaded", () => {
+  it("stays on for DMs with a reply thread", () => {
     expect(
       shouldEnableSlackPreviewStreaming({
         mode: "partial",
@@ -80,7 +80,7 @@ describe("slack preview streaming eligibility", () => {
     ).toBe(true);
   });
 
-  it("keeps top-level DMs off even when replyToMode would create a reply thread", () => {
+  it("stays on for top-level DMs when replyToMode would create a reply thread", () => {
     const streamThreadHint = resolveSlackStreamingThreadHint({
       replyToMode: "all",
       incomingThreadTs: undefined,
@@ -94,7 +94,7 @@ describe("slack preview streaming eligibility", () => {
         isDirectMessage: true,
         threadTs: undefined,
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(streamThreadHint).toBe("1000.4");
   });
 });

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -58,10 +58,12 @@ export function shouldEnableSlackPreviewStreaming(params: {
   if (params.mode === "off") {
     return false;
   }
-  if (!params.isDirectMessage) {
-    return true;
-  }
-  return Boolean(params.threadTs);
+  // Enable preview streaming for all modes in both channels and DMs.
+  // Previously, DMs without an existing threadTs were excluded to avoid
+  // orphaned drafts, but createSlackDraftStream() posts directly to the
+  // DM target and does not require a pre-existing thread. This blocked
+  // post-and-edit streaming in flat (replyToMode: off) DM conversations.
+  return true;
 }
 
 export function shouldInitializeSlackDraftStream(params: {


### PR DESCRIPTION
## Problem

`shouldEnableSlackPreviewStreaming()` required a `threadTs` to be present for DM messages, causing it to return `false` for top-level (non-threaded) DM replies. This blocked post-and-edit (draft preview) streaming in flat DM conversations — i.e. when `replyToMode` is `off` or unset.

```
// Before
if (!params.isDirectMessage) return true;
return Boolean(params.threadTs); // ← always false in flat DMs
```

## Root Cause

The `threadTs` gate was added to prevent orphaned draft messages before a thread exists. However, `createSlackDraftStream()` posts directly to the DM target channel (using `channel` only, with optional `threadTs`), so it does not require a pre-existing thread. The guard was overly conservative.

## Fix

Remove the DM-specific branch and return `true` for all non-`off` modes, in both channels and DMs.

```ts
// After
if (params.mode === 'off') return false;
return true;
```

## Testing

- Updated all three affected test cases in `dispatch.streaming.test.ts` to assert `true` for DM scenarios
- Locally verified: with `streaming: partial` and `replyToMode: off`, DM replies now show `(edited)` post-and-edit streaming
- Confirmed channels unaffected (already returned `true`, behavior unchanged)

Fixes #56480