### PR TITLE
fix(web-fetch): enable env proxy routing for fake-ip compatibility

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,7 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
-import { hasEnvHttpProxyConfigured } from "../../infra/net/proxy-env.js";
 import { SsrFBlockedError } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import type { RuntimeWebFetchFirecrawlMetadata } from "../../secrets/runtime-web-tools.js";
@@ -544,23 +543,20 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   let release: (() => Promise<void>) | null = null;
   let finalUrl = params.url;
   try {
-    // Detect proxy based on the request URL protocol to match EnvHttpProxyAgent semantics.
-    // For http:// URLs, only HTTP_PROXY matters; for https:// URLs, HTTPS_PROXY takes precedence.
-    const parsedUrl = new URL(params.url);
-    const protocol = parsedUrl.protocol.replace(":", "") as "http" | "https";
-    const envProxyConfigured = hasEnvHttpProxyConfigured(protocol);
-    const allowRfc2544 = envProxyConfigured || params.allowFakeIp;
+    // Only relax SSRF guard when user explicitly enables allowFakeIp config.
+    // We no longer auto-detect proxy env vars because:
+    // 1. NO_PROXY exclusions mean some URLs bypass the proxy but SSRF is still relaxed
+    // 2. Users who need proxy + fake-ip should set allowFakeIp: true explicitly
+    // This keeps the security model simple: SSRF relaxation requires explicit opt-in.
+    const allowRfc2544 = params.allowFakeIp;
     const result = await fetchWithWebToolsNetworkGuard({
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
-      // When a proxy is configured (e.g. Clash fake-ip mode), enable env proxy
-      // routing and allow the RFC 2544 benchmark range (198.18.0.0/15) in the
-      // SSRF guard. Without useEnvProxy, requests stay in STRICT mode and
-      // direct-connect to the fake-ip address instead of going through the proxy.
-      // When tools.web.fetch.allowFakeIp is true, also allow the RFC 2544 range
-      // for users who use TUN mode proxies without setting HTTP_PROXY env vars.
-      useEnvProxy: envProxyConfigured,
+      // When tools.web.fetch.allowFakeIp is true, allow the RFC 2544 range
+      // (198.18.0.0/15) in the SSRF guard for proxy fake-ip compatibility
+      // (e.g., Clash TUN mode). Users must explicitly enable this config option.
+      useEnvProxy: true,
       policy: allowRfc2544 ? { allowRfc2544BenchmarkRange: true } : undefined,
       init: {
         headers: {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -520,8 +520,11 @@ async function maybeFetchFirecrawlWebFetchPayload(
 }
 
 async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
+  // Include allowFakeIp in cache key to partition by security mode.
+  // Without this, content fetched with allowFakeIp=true could be replayed
+  // to later calls with allowFakeIp=false, bypassing stricter SSRF policy.
   const cacheKey = normalizeCacheKey(
-    `fetch:${params.url}:${params.extractMode}:${params.maxChars}`,
+    `fetch:${params.url}:${params.extractMode}:${params.maxChars}:${params.allowFakeIp}`,
   );
   const cached = readCache(FETCH_CACHE, cacheKey);
   if (cached) {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -543,11 +543,13 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   let release: (() => Promise<void>) | null = null;
   let finalUrl = params.url;
   try {
-    // Only relax SSRF guard when user explicitly enables allowFakeIp config.
-    // We no longer auto-detect proxy env vars because:
+    // Only relax SSRF guard and enable trusted proxy mode when user explicitly
+    // enables allowFakeIp config. We no longer auto-detect proxy env vars because:
     // 1. NO_PROXY exclusions mean some URLs bypass the proxy but SSRF is still relaxed
-    // 2. Users who need proxy + fake-ip should set allowFakeIp: true explicitly
-    // This keeps the security model simple: SSRF relaxation requires explicit opt-in.
+    // 2. Protocol-changing redirects keep SSRF relaxed after proxy stops
+    // 3. trusted_env_proxy mode trusts proxy-side DNS, weakening SSRF for normal fetches
+    // This keeps the security model simple: both SSRF relaxation and trusted proxy mode
+    // require explicit opt-in via allowFakeIp: true.
     const allowRfc2544 = params.allowFakeIp;
     const result = await fetchWithWebToolsNetworkGuard({
       url: params.url,
@@ -556,7 +558,9 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       // When tools.web.fetch.allowFakeIp is true, allow the RFC 2544 range
       // (198.18.0.0/15) in the SSRF guard for proxy fake-ip compatibility
       // (e.g., Clash TUN mode). Users must explicitly enable this config option.
-      useEnvProxy: true,
+      // Also enable trusted_env_proxy mode only when allowFakeIp is true,
+      // to avoid weakening SSRF for normal untrusted fetches.
+      useEnvProxy: allowRfc2544,
       policy: allowRfc2544 ? { allowRfc2544BenchmarkRange: true } : undefined,
       init: {
         headers: {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,8 +1,8 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
-import { SsrFBlockedError } from "../../infra/net/ssrf.js";
 import { hasEnvHttpProxyConfigured } from "../../infra/net/proxy-env.js";
+import { SsrFBlockedError } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import type { RuntimeWebFetchFirecrawlMetadata } from "../../secrets/runtime-web-tools.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
@@ -102,6 +102,13 @@ function resolveFetchReadabilityEnabled(fetch?: WebFetchConfig): boolean {
     return fetch.readability;
   }
   return true;
+}
+
+function resolveFetchAllowFakeIp(fetch?: WebFetchConfig): boolean {
+  if (typeof fetch?.allowFakeIp === "boolean") {
+    return fetch.allowFakeIp;
+  }
+  return false;
 }
 
 function resolveFetchMaxCharsCap(fetch?: WebFetchConfig): number {
@@ -459,6 +466,7 @@ type WebFetchRuntimeParams = FirecrawlRuntimeParams & {
   cacheTtlMs: number;
   userAgent: string;
   readabilityEnabled: boolean;
+  allowFakeIp: boolean;
 };
 
 function toFirecrawlContentParams(
@@ -536,7 +544,8 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   let release: (() => Promise<void>) | null = null;
   let finalUrl = params.url;
   try {
-    const useProxy = hasEnvHttpProxyConfigured();
+    const envProxyConfigured = hasEnvHttpProxyConfigured();
+    const allowRfc2544 = envProxyConfigured || params.allowFakeIp;
     const result = await fetchWithWebToolsNetworkGuard({
       url: params.url,
       maxRedirects: params.maxRedirects,
@@ -545,8 +554,10 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       // routing and allow the RFC 2544 benchmark range (198.18.0.0/15) in the
       // SSRF guard. Without useEnvProxy, requests stay in STRICT mode and
       // direct-connect to the fake-ip address instead of going through the proxy.
-      useEnvProxy: useProxy,
-      policy: useProxy ? { allowRfc2544BenchmarkRange: true } : undefined,
+      // When tools.web.fetch.allowFakeIp is true, also allow the RFC 2544 range
+      // for users who use TUN mode proxies without setting HTTP_PROXY env vars.
+      useEnvProxy: envProxyConfigured,
+      policy: allowRfc2544 ? { allowRfc2544BenchmarkRange: true } : undefined,
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
@@ -795,6 +806,7 @@ export function createWebFetchTool(options?: {
         cacheTtlMs: resolveCacheTtlMs(fetch?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
         userAgent,
         readabilityEnabled,
+        allowFakeIp: resolveFetchAllowFakeIp(fetch),
         firecrawlEnabled,
         firecrawlApiKey,
         firecrawlBaseUrl,

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -544,7 +544,11 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   let release: (() => Promise<void>) | null = null;
   let finalUrl = params.url;
   try {
-    const envProxyConfigured = hasEnvHttpProxyConfigured();
+    // Detect proxy based on the request URL protocol to match EnvHttpProxyAgent semantics.
+    // For http:// URLs, only HTTP_PROXY matters; for https:// URLs, HTTPS_PROXY takes precedence.
+    const parsedUrl = new URL(params.url);
+    const protocol = parsedUrl.protocol.replace(":", "") as "http" | "https";
+    const envProxyConfigured = hasEnvHttpProxyConfigured(protocol);
     const allowRfc2544 = envProxyConfigured || params.allowFakeIp;
     const result = await fetchWithWebToolsNetworkGuard({
       url: params.url,

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
 import { SsrFBlockedError } from "../../infra/net/ssrf.js";
+import { hasEnvHttpProxyConfigured } from "../../infra/net/proxy-env.js";
 import { logDebug } from "../../logger.js";
 import type { RuntimeWebFetchFirecrawlMetadata } from "../../secrets/runtime-web-tools.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
@@ -535,10 +536,17 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
   let release: (() => Promise<void>) | null = null;
   let finalUrl = params.url;
   try {
+    const useProxy = hasEnvHttpProxyConfigured();
     const result = await fetchWithWebToolsNetworkGuard({
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
+      // When a proxy is configured (e.g. Clash fake-ip mode), enable env proxy
+      // routing and allow the RFC 2544 benchmark range (198.18.0.0/15) in the
+      // SSRF guard. Without useEnvProxy, requests stay in STRICT mode and
+      // direct-connect to the fake-ip address instead of going through the proxy.
+      useEnvProxy: useProxy,
+      policy: useProxy ? { allowRfc2544BenchmarkRange: true } : undefined,
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -5542,6 +5542,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                   readability: {
                     type: "boolean",
                   },
+                  allowFakeIp: {
+                    type: "boolean",
+                  },
                   firecrawl: {
                     type: "object",
                     properties: {
@@ -12906,6 +12909,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
     "tools.web.fetch.readability": {
       label: "Web Fetch Readability Extraction",
       help: "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
+      tags: ["tools"],
+    },
+    "tools.web.fetch.allowFakeIp": {
+      label: "Allow Fake IP",
+      help: "Allow RFC 2544 benchmark range (198.18.0.0/15) in SSRF guard for proxy fake-ip compatibility (e.g., Clash TUN mode). Enable this if you use a proxy with fake-ip DNS without setting HTTP_PROXY/HTTPS_PROXY environment variables.",
       tags: ["tools"],
     },
     "tools.web.fetch.firecrawl.enabled": {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -705,6 +705,8 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.userAgent": "Override User-Agent header for web_fetch requests.",
   "tools.web.fetch.readability":
     "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
+  "tools.web.fetch.allowFakeIp":
+    "Allow RFC 2544 benchmark range (198.18.0.0/15) in SSRF guard for proxy fake-ip compatibility (e.g., Clash TUN mode). Enable this if you use a proxy with fake-ip DNS without setting HTTP_PROXY/HTTPS_PROXY environment variables.",
   "tools.web.fetch.firecrawl.enabled": "Enable Firecrawl fallback for web_fetch (if configured).",
   "tools.web.fetch.firecrawl.apiKey": "Firecrawl API key (fallback: FIRECRAWL_API_KEY env var).",
   "tools.web.fetch.firecrawl.baseUrl":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -533,6 +533,12 @@ export type ToolsConfig = {
       userAgent?: string;
       /** Use Readability to extract main content (default: true). */
       readability?: boolean;
+      /**
+       * Allow RFC 2544 benchmark range (198.18.0.0/15) in SSRF guard for proxy fake-ip
+       * compatibility (e.g., Clash TUN mode). Enable this if you use a proxy with fake-ip
+       * DNS without setting HTTP_PROXY/HTTPS_PROXY environment variables.
+       */
+      allowFakeIp?: boolean;
       firecrawl?: {
         /** Enable Firecrawl fallback (default: true when apiKey is set). */
         enabled?: boolean;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -333,6 +333,7 @@ export const ToolsWebFetchSchema = z
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
     readability: z.boolean().optional(),
+    allowFakeIp: z.boolean().optional(),
     firecrawl: z
       .object({
         enabled: z.boolean().optional(),

--- a/test-pr.ps1
+++ b/test-pr.ps1
@@ -1,0 +1,32 @@
+# test-pr.ps1 - 测试 PR #41113
+
+Write-Host "🧪 测试 PR #41113 (RFC2544 bypass with proxy detection)" -ForegroundColor Green
+
+# 检查构建
+if (-not (Test-Path "dist\index.js")) {
+    Write-Host "❌ 需要先构建项目" -ForegroundColor Red
+    Write-Host "运行: pnpm run build:docker" -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "✅ 构建文件存在" -ForegroundColor Green
+
+# 停止当前 gateway
+Write-Host "`n🛑 停止当前 gateway..." -ForegroundColor Yellow
+$currentGateway = Get-Process -Id (Get-NetTCPConnection -LocalPort 18789 -ErrorAction SilentlyContinue).OwningProcess -ErrorAction SilentlyContinue | Where-Object {$_.ProcessName -eq "node"}
+if ($currentGateway) {
+    Stop-Process -Id $currentGateway.Id -Force
+    Write-Host "✅ 已停止" -ForegroundColor Green
+} else {
+    Write-Host "ℹ️  没有运行中的 gateway" -ForegroundColor Gray
+}
+
+# 使用本地版本启动
+Write-Host "`n🚀 使用 PR 版本启动 gateway..." -ForegroundColor Cyan
+Write-Host "提示: 这会使用当前目录的 openclaw 版本" -ForegroundColor Gray
+Write-Host "`n请在新的 terminal 窗口中运行:" -ForegroundColor Yellow
+Write-Host "  cd C:\Users\sunki\openclaw-pr" -ForegroundColor White
+Write-Host "  .\node_modules\.bin\openclaw gateway start" -ForegroundColor White
+
+Write-Host "`n或者直接运行:" -ForegroundColor Yellow
+Write-Host "  node .\dist\cli.js gateway start" -ForegroundColor White


### PR DESCRIPTION
Problem

“00:16:53+08:00 [security] blocked URL fetch (url-fetch) target=https://www.cnn.com/2026/03/28/world/live-news/iran-war-us-israel-trump reason=Blocked: resolves to private/internal/special-use IP address
00:16:53+08:00 [tools] web_fetch failed: Blocked: resolves to private/internal/special-use IP address
00:16:55+08:00 [security] blocked URL fetch (url-fetch) target=https://www.foxnews.com/live-news/us-israel-iran-war-strait-hormuz-updates-march-26 reason=Blocked: resolves to private/internal/special-use IP address
00:16:55+08:00 [tools] web_fetch failed: Blocked: resolves to private/internal/special-use IP address”

web_fetch fails when using proxy software with fake-ip mode (Clash, Surge, etc.) because DNS resolves to 198.18.0.0/15 which is blocked by the SSRF guard. Even though fetchWithWebToolsNetworkGuard has useEnvProxy support, runWebFetch() never passes it, so requests stay in STRICT mode and direct-connect to the fake-ip address instead of routing through the proxy.

Fix
When a proxy env var is detected:
 - Pass useEnvProxy: true to switch to TRUSTED_ENV_PROXY mode, which uses EnvHttpProxyAgent
 - Pass policy: { allowRfc2544BenchmarkRange: true } to unblock the SSRF guard for the fake-ip range

Testing
Tested locally with Clash fake-ip mode enabled — web_fetch works correctly.

Related: #31176