### PR TITLE
fix(discord): harden reconnect shutdown and idle health

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.reconnect.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.reconnect.ts
@@ -49,6 +49,7 @@ export function createDiscordGatewayReconnectController(params: {
   abortSignal?: AbortSignal;
   pushStatus: (patch: Parameters<DiscordMonitorStatusSink>[0]) => void;
   isLifecycleStopping: () => boolean;
+  signalLifecycleStopping?: () => void;
   drainPendingGatewayErrors: () => "continue" | "stop";
 }) {
   let forceStopHandler: ((err: unknown) => void) | undefined;
@@ -57,6 +58,7 @@ export function createDiscordGatewayReconnectController(params: {
   let helloConnectedPollId: ReturnType<typeof setInterval> | undefined;
   let reconnectInFlight: Promise<void> | undefined;
   let consecutiveHelloStalls = 0;
+  let waitForStopActive = false;
 
   const shouldStop = () => params.isLifecycleStopping() || params.abortSignal?.aborted;
   const resetHelloStallCounter = () => {
@@ -394,6 +396,12 @@ export function createDiscordGatewayReconnectController(params: {
       })();
     }, DISCORD_GATEWAY_HELLO_TIMEOUT_MS);
   };
+  const onGatewayMetrics = () => {
+    if (!params.gateway?.isConnected || shouldStop()) {
+      return;
+    }
+    params.pushStatus({ lastEventAt: Date.now() });
+  };
   const onAbort = () => {
     reconnectStallWatchdog.disarm();
     const at = Date.now();
@@ -401,7 +409,11 @@ export function createDiscordGatewayReconnectController(params: {
     if (!params.gateway) {
       return;
     }
+    params.signalLifecycleStopping?.();
     params.gateway.options.reconnect = { maxAttempts: 0 };
+    if (waitForStopActive) {
+      return;
+    }
     params.gateway.disconnect();
   };
   const ensureStartupReady = async () => {
@@ -479,8 +491,10 @@ export function createDiscordGatewayReconnectController(params: {
     ensureStartupReady,
     onAbort,
     onGatewayDebug,
+    onGatewayMetrics,
     clearHelloWatch,
     registerForceStop: (handler: (err: unknown) => void) => {
+      waitForStopActive = true;
       forceStopHandler = handler;
       if (queuedForceStopError !== undefined) {
         const queued = queuedForceStopError;
@@ -489,6 +503,7 @@ export function createDiscordGatewayReconnectController(params: {
       }
     },
     dispose: () => {
+      waitForStopActive = false;
       reconnectStallWatchdog.stop();
       clearHelloWatch();
       params.abortSignal?.removeEventListener("abort", onAbort);

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -849,10 +849,120 @@ describe("runDiscordGatewayLifecycle", () => {
     abortController.abort();
 
     await expect(lifecyclePromise).resolves.toBeUndefined();
-    expect(runtimeLog).not.toHaveBeenCalledWith(
+    expect(runtimeLog).toHaveBeenCalledWith(
       expect.stringContaining("ignoring expected reconnect-exhausted during shutdown"),
     );
-    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("Max reconnect attempts"));
+    expect(runtimeError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Max reconnect attempts"),
+    );
+  });
+
+  it("suppresses reconnect-exhausted emitted during abort-driven disconnect", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    let lifecycleHandler: ((event: DiscordGatewayEvent) => void) | undefined;
+    let signalWaitReady: (() => void) | undefined;
+    const waitReady = new Promise<void>((resolve) => {
+      signalWaitReady = resolve;
+    });
+
+    waitForDiscordGatewayStopMock.mockImplementationOnce(
+      (waitParams: WaitForDiscordGatewayStopParams) =>
+        new Promise<void>((resolve, reject) => {
+          let settled = false;
+          const cleanup = () => {
+            waitParams.abortSignal?.removeEventListener("abort", onAbort);
+            waitParams.gatewaySupervisor?.detachLifecycle();
+          };
+          const finishResolve = () => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            try {
+              waitParams.gateway?.disconnect?.();
+            } finally {
+              cleanup();
+              resolve();
+            }
+          };
+          const finishReject = (err: unknown) => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            try {
+              waitParams.gateway?.disconnect?.();
+            } finally {
+              cleanup();
+              reject(err);
+            }
+          };
+          const onAbort = () => {
+            finishResolve();
+          };
+
+          if (waitParams.abortSignal?.aborted) {
+            finishResolve();
+            return;
+          }
+
+          waitParams.abortSignal?.addEventListener("abort", onAbort, { once: true });
+          waitParams.gatewaySupervisor?.attachLifecycle((event) => {
+            const shouldStop = (waitParams.onGatewayEvent?.(event) ?? "stop") === "stop";
+            if (shouldStop) {
+              finishReject(event.err);
+            }
+          });
+          signalWaitReady?.();
+          waitParams.registerForceStop?.((err) => {
+            finishReject(err);
+          });
+        }),
+    );
+
+    const emitter = new EventEmitter();
+    const gateway: MockGateway = {
+      isConnected: true,
+      options: { intents: 0, reconnect: { maxAttempts: 50 } } as GatewayPlugin["options"],
+      disconnect: vi.fn(() => {
+        lifecycleHandler?.(
+          createGatewayEvent(
+            "reconnect-exhausted",
+            "Max reconnect attempts (0) reached after code 1005",
+          ),
+        );
+      }),
+      connect: vi.fn(),
+      emitter,
+    };
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    const abortController = new AbortController();
+    const { lifecycleParams, gatewaySupervisor, runtimeError, runtimeLog } = createLifecycleHarness(
+      {
+        gateway,
+      },
+    );
+    lifecycleParams.abortSignal = abortController.signal;
+    gatewaySupervisor.attachLifecycle.mockImplementation((handler) => {
+      lifecycleHandler = handler;
+    });
+    gatewaySupervisor.detachLifecycle.mockImplementation(() => {
+      lifecycleHandler = undefined;
+    });
+
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+    await waitReady;
+    abortController.abort();
+
+    await expect(lifecyclePromise).resolves.toBeUndefined();
+    expect(gateway.disconnect).toHaveBeenCalledTimes(1);
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("ignoring expected reconnect-exhausted during shutdown"),
+    );
+    expect(runtimeError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Max reconnect attempts"),
+    );
   });
 
   it("rejects reconnect-exhausted queued before startup when shutdown has not begun", async () => {
@@ -884,6 +994,55 @@ describe("runDiscordGatewayLifecycle", () => {
     await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow(
       "Max reconnect attempts",
     );
+  });
+
+  it("updates lastEventAt from metrics only while connected", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const { emitter, gateway } = createGatewayHarness();
+      gateway.isConnected = true;
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+      let resolveWait: (() => void) | undefined;
+      waitForDiscordGatewayStopMock.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveWait = resolve;
+          }),
+      );
+
+      const statusUpdates: Array<Record<string, unknown>> = [];
+      const { lifecycleParams } = createLifecycleHarness({ gateway });
+      lifecycleParams.statusSink = vi.fn((patch) => {
+        statusUpdates.push({ ...patch });
+      });
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const beforeMetrics = statusUpdates.filter((patch) => "lastEventAt" in patch).length;
+      await vi.advanceTimersByTimeAsync(60_000);
+      emitter.emit("metrics");
+
+      const afterConnectedMetrics = statusUpdates.filter((patch) => "lastEventAt" in patch).length;
+      expect(afterConnectedMetrics).toBe(beforeMetrics + 1);
+      expect(statusUpdates.at(-1)).toEqual({ lastEventAt: Date.now() });
+
+      gateway.isConnected = false;
+      await vi.advanceTimersByTimeAsync(60_000);
+      emitter.emit("metrics");
+
+      const afterDisconnectedMetrics = statusUpdates.filter(
+        (patch) => "lastEventAt" in patch,
+      ).length;
+      expect(afterDisconnectedMetrics).toBe(afterConnectedMetrics);
+
+      resolveWait?.();
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not push connected: true when abortSignal is already aborted", async () => {

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -48,10 +48,15 @@ export async function runDiscordGatewayLifecycle(params: {
     abortSignal: params.abortSignal,
     pushStatus,
     isLifecycleStopping: () => lifecycleStopping,
+    signalLifecycleStopping: () => {
+      lifecycleStopping = true;
+    },
     drainPendingGatewayErrors: () => drainPendingGatewayErrors(),
   });
   const onGatewayDebug = reconnectController.onGatewayDebug;
+  const onGatewayMetrics = reconnectController.onGatewayMetrics;
   gatewayEmitter?.on("debug", onGatewayDebug);
+  gatewayEmitter?.on("metrics", onGatewayMetrics);
 
   let sawDisallowedIntents = false;
   const handleGatewayEvent = (event: DiscordGatewayEvent): "continue" | "stop" => {
@@ -132,6 +137,7 @@ export async function runDiscordGatewayLifecycle(params: {
     stopGatewayLogging();
     reconnectController.dispose();
     gatewayEmitter?.removeListener("debug", onGatewayDebug);
+    gatewayEmitter?.removeListener("metrics", onGatewayMetrics);
     if (params.voiceManager) {
       await params.voiceManager.destroy();
       params.voiceManagerRef.current = null;


### PR DESCRIPTION
## Summary
- prevent stale-socket shutdown from racing an extra disconnect before `waitForDiscordGatewayStop()` owns teardown
- mark lifecycle shutdown before abort-driven disconnects so expected `reconnect-exhausted` events stay informational
- refresh `lastEventAt` from gateway `metrics` only while the socket is still connected
- add regressions for queued shutdown errors, active abort disconnects, and idle metrics refresh

## Why
This consolidates the Discord crash-resilience cluster at the root-cause layer. The crash path came from the reconnect controller calling `disconnect()` during abort while the lifecycle wait loop had not settled yet. That let a synchronous `reconnect-exhausted` event surface on the active lifecycle path. Healthy idle periods also looked stale because `lastEventAt` only moved on debug events.

## Validation
- `./node_modules/.bin/vitest run --config vitest.config.ts --pool=threads --maxWorkers=1 extensions/discord/src/monitor/provider.lifecycle.test.ts`
- `./node_modules/.bin/vitest run --config vitest.config.ts --pool=threads --maxWorkers=1 extensions/discord/src/monitor.gateway.test.ts`
- pre-commit `pnpm check`

Fixes #56339
Fixes #56399
Fixes #56274

Supersedes #56486
Supersedes #56493
