### PR TITLE
fix: show success confirmation after Discord model override (#56093)

### DIFF
--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -28,7 +28,6 @@ import {
 import type { OpenClawConfig, loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
-import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { chunkItems, withTimeout } from "openclaw/plugin-sdk/text-runtime";
 import { resolveDiscordChannelConfigWithFallback, resolveDiscordGuildEntry } from "./allow-list.js";
 import { resolveDiscordChannelInfo } from "./message-utils.js";
@@ -804,36 +803,20 @@ export async function handleDiscordModelPickerInteraction(params: {
       return;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 250));
-
-    const effectiveModelRef = resolveDiscordModelPickerCurrentModel({
-      cfg: ctx.cfg,
-      route,
-      data: pickerData,
-    });
-    const persisted = effectiveModelRef === resolvedModelRef;
-
-    if (!persisted) {
-      logVerbose(
-        `discord: model picker override mismatch — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${route.sessionKey}`,
-      );
-    }
-
-    if (persisted) {
-      await recordDiscordModelPickerRecentModel({
-        scope: preferenceScope,
-        modelRef: resolvedModelRef,
-        limit: 5,
-      }).catch(() => undefined);
-    }
+    // The dispatch completed successfully — the override is applied.
+    // Record the model as recently used and confirm to the user.
+    // Note: reading the session store back to verify can false-negative when the
+    // picker route session key differs from the dispatch session key (e.g. in
+    // server channels), so we trust the successful dispatch result.
+    await recordDiscordModelPickerRecentModel({
+      scope: preferenceScope,
+      modelRef: resolvedModelRef,
+      limit: 5,
+    }).catch(() => undefined);
 
     await params.safeInteractionCall("model picker follow-up", () =>
       interaction.followUp({
-        ...buildDiscordModelPickerNoticePayload(
-          persisted
-            ? `✅ Model set to ${resolvedModelRef}.`
-            : `⚠️ Tried to set ${resolvedModelRef}, but current model is ${effectiveModelRef}.`,
-        ),
+        ...buildDiscordModelPickerNoticePayload(`✅ Model set to ${resolvedModelRef}.`),
         ephemeral: true,
       }),
     );

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -8,7 +8,6 @@ import type {
 import type { ModelsProviderData } from "../../../../src/auto-reply/reply/commands-models.js";
 import * as dispatcherModule from "../../../../src/auto-reply/reply/provider-dispatcher.js";
 import type { OpenClawConfig } from "../../../../src/config/config.js";
-import * as globalsModule from "../../../../src/globals.js";
 import * as timeoutModule from "../../../../src/utils/with-timeout.js";
 import * as modelPickerPreferencesModule from "./model-picker-preferences.js";
 import * as modelPickerModule from "./model-picker.js";
@@ -425,7 +424,7 @@ describe("Discord model picker interactions", () => {
     expectDispatchedModelSelection({ dispatchSpy, model: "openai/gpt-4o" });
   });
 
-  it("verifies model state against the bound thread session", async () => {
+  it("shows success confirmation for bound thread session model switch", async () => {
     const context = createModelPickerContext();
     context.threadBindings = createBoundThreadBindingManager({
       accountId: "default",
@@ -439,7 +438,6 @@ describe("Discord model picker interactions", () => {
     vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
     mockModelCommandPipeline(modelCommand);
     createDispatchSpy();
-    const verboseSpy = vi.spyOn(globalsModule, "logVerbose").mockImplementation(() => {});
 
     const select = createDiscordModelPickerFallbackSelect(context);
     const selectInteraction = createInteraction({
@@ -463,10 +461,14 @@ describe("Discord model picker interactions", () => {
 
     await button.run(submitInteraction as unknown as PickerButtonInteraction, submitData);
 
-    const mismatchLog = verboseSpy.mock.calls.find((call) =>
-      String(call[0] ?? "").includes("model picker override mismatch"),
-    )?.[0];
-    expect(mismatchLog).toContain("session key agent:worker:subagent:bound");
+    // After a successful dispatch, the picker should confirm success without
+    // a misleading mismatch warning (the picker route session key can differ
+    // from the dispatch session key in server channels).
+    const followUpCalls = (submitInteraction.followUp as ReturnType<typeof vi.fn>).mock.calls;
+    const successCall = followUpCalls.find((call) =>
+      String(call[0]?.content ?? "").includes("Model set to"),
+    );
+    expect(successCall).toBeDefined();
   });
 
   it("loads model picker data from the effective bound route", async () => {


### PR DESCRIPTION
## Summary
- Discord `/model` picker showed misleading "Tried to set X, but current model is Y" warning even when the override succeeded
- Root cause: post-dispatch session store read-back used a different session key than the dispatch pipeline, so `resolveStoredModelOverride` returned null and fell back to the agent default
- Fix: remove the racy read-back verification; since `dispatchCommandInteraction` is fully awaited, always show the success confirmation after a successful dispatch
- Error and timeout paths remain unchanged

## Test plan
- [x] Updated existing test to verify success confirmation instead of mismatch log
- [ ] Manual: run `/model` in a Discord guild channel, verify success message appears

Closes #56093