### PR TITLE
fix(clawhub): reject malformed trailing-at plugin specs

### DIFF
--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -33,10 +33,15 @@ describe("clawhub helpers", () => {
     expect(parseClawHubPluginSpec("clawhub:demo")).toEqual({
       name: "demo",
     });
+    expect(parseClawHubPluginSpec("clawhub:@scope/pkg")).toEqual({
+      name: "@scope/pkg",
+    });
     expect(parseClawHubPluginSpec("clawhub:demo@1.2.3")).toEqual({
       name: "demo",
       version: "1.2.3",
     });
+    expect(parseClawHubPluginSpec("clawhub:demo@")).toBeNull();
+    expect(parseClawHubPluginSpec("clawhub:@scope/pkg@")).toBeNull();
     expect(parseClawHubPluginSpec("@scope/pkg")).toBeNull();
   });
 

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -40,6 +40,10 @@ describe("clawhub helpers", () => {
       name: "demo",
       version: "1.2.3",
     });
+    expect(parseClawHubPluginSpec("clawhub:@scope/pkg@1.2.3")).toEqual({
+      name: "@scope/pkg",
+      version: "1.2.3",
+    });
     expect(parseClawHubPluginSpec("clawhub:demo@")).toBeNull();
     expect(parseClawHubPluginSpec("clawhub:@scope/pkg@")).toBeNull();
     expect(parseClawHubPluginSpec("@scope/pkg")).toBeNull();

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -424,12 +424,20 @@ export function parseClawHubPluginSpec(raw: string): {
     return null;
   }
   const atIndex = spec.lastIndexOf("@");
-  if (atIndex <= 0 || atIndex >= spec.length - 1) {
+  if (atIndex <= 0) {
     return { name: spec };
   }
+  if (atIndex >= spec.length - 1) {
+    return null;
+  }
+  const name = spec.slice(0, atIndex).trim();
+  const version = spec.slice(atIndex + 1).trim();
+  if (!name || !version) {
+    return null;
+  }
   return {
-    name: spec.slice(0, atIndex).trim(),
-    version: spec.slice(atIndex + 1).trim() || undefined,
+    name,
+    version,
   };
 }
 


### PR DESCRIPTION
## Summary
- reject malformed ClawHub specs that end with a trailing `@` in `parseClawHubPluginSpec`
- preserve valid scoped package parsing (`clawhub:@scope/name`)
- add regression tests for trailing-`@` malformed inputs

## Problem
Malformed inputs like `clawhub:demo@` were parsed as `{ name: "demo@" }`, then failed later as package lookup errors (`package_not_found`) instead of being rejected as invalid spec.

## Changes
- `src/infra/clawhub.ts`
  - return `null` when an explicit `@` is present but no version follows
  - keep existing valid paths for no-version and scoped names
- `src/infra/clawhub.test.ts`
  - add coverage for:
    - `clawhub:@scope/pkg` (valid)
    - `clawhub:demo@` (invalid)
    - `clawhub:@scope/pkg@` (invalid)

## Validation
- `pnpm exec vitest run src/infra/clawhub.test.ts --config vitest.config.ts`

Closes #56579