### PR TITLE
fix(agent): tune overload failover backoff ceiling and config

### DIFF
--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -151,7 +151,9 @@ Think of the suites as “increasing realism” (and increasing flakiness/cost):
   - Not CI-stable by design (real networks, real provider policies, quotas, outages)
   - Costs money / uses rate limits
   - Prefer running narrowed subsets instead of “everything”
-- Live runs will source `~/.profile` to pick up missing API keys
+- Live runs source `~/.profile` to pick up missing API keys.
+- By default, live runs still isolate `HOME` and copy config/auth material into a temp test home so unit fixtures cannot mutate your real `~/.openclaw`.
+- Set `OPENCLAW_LIVE_USE_REAL_HOME=1` only when you intentionally need live tests to use your real home directory.
 - `pnpm test:live` now defaults to a quieter mode: it keeps `[live] ...` progress output, but suppresses the extra `~/.profile` notice and mutes gateway bootstrap logs/Bonjour chatter. Set `OPENCLAW_LIVE_TEST_QUIET=0` if you want the full startup logs back.
 - API key rotation (provider-specific): set `*_API_KEYS` with comma/semicolon format or `*_API_KEY_1`, `*_API_KEY_2` (for example `OPENAI_API_KEYS`, `ANTHROPIC_API_KEYS`, `GEMINI_API_KEYS`) or per-live override via `OPENCLAW_LIVE_*_KEY`; tests retry on rate limit responses.
 - Progress/heartbeat output:
@@ -452,6 +454,7 @@ Live tests discover credentials the same way the CLI does. Practical implication
 
 - Profile store: `~/.openclaw/credentials/` (preferred; what “profile keys” means in the tests)
 - Config: `~/.openclaw/openclaw.json` (or `OPENCLAW_CONFIG_PATH`)
+- Live local runs copy the active config plus auth stores into a temp test home by default; `agents.*.workspace` / `agentDir` path overrides are stripped in that staged copy so probes stay off your real host workspace.
 
 If you want to rely on env keys (e.g. exported in your `~/.profile`), run local tests after `source ~/.profile`, or use the Docker runners below (they can mount `~/.profile` into the container).
 

--- a/src/agents/pi-embedded-runner/run.overload-backoff.test.ts
+++ b/src/agents/pi-embedded-runner/run.overload-backoff.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { computeBackoff } from "../../infra/backoff.js";
+import {
+  DEFAULT_OVERLOAD_FAILOVER_BACKOFF_MAX_MS,
+  OVERLOAD_FAILOVER_BACKOFF_INITIAL_MS,
+  resolveOverloadFailoverBackoffPolicy,
+} from "./run/helpers.js";
+
+describe("resolveOverloadFailoverBackoffPolicy", () => {
+  it("defaults the ceiling to 30s", () => {
+    const policy = {
+      ...resolveOverloadFailoverBackoffPolicy(),
+      jitter: 0,
+    };
+
+    expect(policy.maxMs).toBe(DEFAULT_OVERLOAD_FAILOVER_BACKOFF_MAX_MS);
+    expect(computeBackoff(policy, 8)).toBe(DEFAULT_OVERLOAD_FAILOVER_BACKOFF_MAX_MS);
+  });
+
+  it("respects a configured ceiling override", () => {
+    const policy = {
+      ...resolveOverloadFailoverBackoffPolicy(500),
+      jitter: 0,
+    };
+
+    expect(policy.maxMs).toBe(500);
+    expect(computeBackoff(policy, 2)).toBe(500);
+    expect(computeBackoff(policy, 10)).toBe(500);
+  });
+
+  it("clamps invalid or undersized values to the initial delay floor", () => {
+    expect(resolveOverloadFailoverBackoffPolicy(Number.NaN).maxMs).toBe(
+      DEFAULT_OVERLOAD_FAILOVER_BACKOFF_MAX_MS,
+    );
+    expect(resolveOverloadFailoverBackoffPolicy(-1).maxMs).toBe(
+      OVERLOAD_FAILOVER_BACKOFF_INITIAL_MS,
+    );
+    expect(resolveOverloadFailoverBackoffPolicy(10).maxMs).toBe(
+      OVERLOAD_FAILOVER_BACKOFF_INITIAL_MS,
+    );
+  });
+});

--- a/src/agents/pi-embedded-runner/run.overload-backoff.test.ts
+++ b/src/agents/pi-embedded-runner/run.overload-backoff.test.ts
@@ -28,10 +28,13 @@ describe("resolveOverloadFailoverBackoffPolicy", () => {
     expect(computeBackoff(policy, 10)).toBe(500);
   });
 
-  it("clamps invalid or undersized values to the initial delay floor", () => {
+  it("treats NaN as unset and applies the default ceiling", () => {
     expect(resolveOverloadFailoverBackoffPolicy(Number.NaN).maxMs).toBe(
       DEFAULT_OVERLOAD_FAILOVER_BACKOFF_MAX_MS,
     );
+  });
+
+  it("clamps negative or undersized values to the initial delay floor", () => {
     expect(resolveOverloadFailoverBackoffPolicy(-1).maxMs).toBe(
       OVERLOAD_FAILOVER_BACKOFF_INITIAL_MS,
     );

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -73,8 +73,8 @@ import {
   buildErrorAgentMeta,
   buildUsageAgentMetaFields,
   createCompactionDiagId,
-  OVERLOAD_FAILOVER_BACKOFF_POLICY,
   resolveActiveErrorContext,
+  resolveOverloadFailoverBackoffPolicy,
   resolveMaxRunRetryIterations,
   type RuntimeAuthState,
   scrubAnthropicRefusalMagic,
@@ -311,6 +311,9 @@ export async function runEmbeddedPiAgent(
       let runLoopIterations = 0;
       let overloadFailoverAttempts = 0;
       let timeoutCompactionAttempts = 0;
+      const overloadFailoverBackoffPolicy = resolveOverloadFailoverBackoffPolicy(
+        params.config?.agents?.defaults?.embeddedPi?.overloadBackoffMaxMs,
+      );
       const maybeMarkAuthProfileFailure = async (failure: {
         profileId?: string;
         reason?: AuthProfileFailureReason | null;
@@ -347,7 +350,7 @@ export async function runEmbeddedPiAgent(
           return;
         }
         overloadFailoverAttempts += 1;
-        const delayMs = computeBackoff(OVERLOAD_FAILOVER_BACKOFF_POLICY, overloadFailoverAttempts);
+        const delayMs = computeBackoff(overloadFailoverBackoffPolicy, overloadFailoverAttempts);
         log.warn(
           `overload backoff before failover for ${provider}/${modelId}: attempt=${overloadFailoverAttempts} delayMs=${delayMs}`,
         );

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -25,14 +25,23 @@ export const RUNTIME_AUTH_REFRESH_MARGIN_MS = 5 * 60 * 1000;
 export const RUNTIME_AUTH_REFRESH_RETRY_MS = 60 * 1000;
 export const RUNTIME_AUTH_REFRESH_MIN_DELAY_MS = 5 * 1000;
 
+export const OVERLOAD_FAILOVER_BACKOFF_INITIAL_MS = 250;
+export const DEFAULT_OVERLOAD_FAILOVER_BACKOFF_MAX_MS = 30_000;
+
 // Keep overload pacing noticeable enough to avoid tight retry bursts, but short
 // enough that fallback still feels responsive within a single turn.
-export const OVERLOAD_FAILOVER_BACKOFF_POLICY: BackoffPolicy = {
-  initialMs: 250,
-  maxMs: 1_500,
-  factor: 2,
-  jitter: 0.2,
-};
+export function resolveOverloadFailoverBackoffPolicy(maxMs?: number): BackoffPolicy {
+  const normalizedMaxMs =
+    typeof maxMs === "number" && Number.isFinite(maxMs)
+      ? Math.max(OVERLOAD_FAILOVER_BACKOFF_INITIAL_MS, Math.floor(maxMs))
+      : DEFAULT_OVERLOAD_FAILOVER_BACKOFF_MAX_MS;
+  return {
+    initialMs: OVERLOAD_FAILOVER_BACKOFF_INITIAL_MS,
+    maxMs: normalizedMaxMs,
+    factor: 2,
+    jitter: 0.2,
+  };
+}
 
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
 const ANTHROPIC_MAGIC_STRING_REPLACEMENT = "ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)";

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -2433,6 +2433,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                       },
                     ],
                   },
+                  overloadBackoffMaxMs: {
+                    type: "integer",
+                    minimum: 0,
+                    maximum: 9007199254740991,
+                  },
                 },
                 additionalProperties: false,
               },
@@ -13984,6 +13989,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
       label: "Embedded Pi Project Settings Policy",
       help: 'How embedded Pi handles workspace-local `.pi/config/settings.json`: "sanitize" (default) strips shellPath/shellCommandPrefix, "ignore" disables project settings entirely, and "trusted" applies project settings as-is.',
       tags: ["access"],
+    },
+    "agents.defaults.embeddedPi.overloadBackoffMaxMs": {
+      label: "Embedded Pi Overload Backoff Max (ms)",
+      help: "Maximum delay in ms for embedded Pi overload failover retries. Increase this to slow repeated overload fallback churn; values below the initial retry delay clamp up automatically.",
+      tags: ["reliability", "performance"],
     },
     "agents.defaults.heartbeat.directPolicy": {
       label: "Heartbeat Direct Policy",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -13993,7 +13993,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
     "agents.defaults.embeddedPi.overloadBackoffMaxMs": {
       label: "Embedded Pi Overload Backoff Max (ms)",
       help: "Maximum delay in ms for embedded Pi overload failover retries. Increase this to slow repeated overload fallback churn; values below the initial retry delay clamp up automatically.",
-      tags: ["reliability", "performance"],
+      tags: ["reliability", "performance", "storage"],
     },
     "agents.defaults.heartbeat.directPolicy": {
       label: "Heartbeat Direct Policy",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1084,6 +1084,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Embedded Pi runner hardening controls for how workspace-local Pi settings are trusted and applied in OpenClaw sessions.",
   "agents.defaults.embeddedPi.projectSettingsPolicy":
     'How embedded Pi handles workspace-local `.pi/config/settings.json`: "sanitize" (default) strips shellPath/shellCommandPrefix, "ignore" disables project settings entirely, and "trusted" applies project settings as-is.',
+  "agents.defaults.embeddedPi.overloadBackoffMaxMs":
+    "Maximum delay in ms for embedded Pi overload failover retries. Increase this to slow repeated overload fallback churn; values below the initial retry delay clamp up automatically.",
   "agents.defaults.humanDelay.mode": 'Delay style for block replies ("off", "natural", "custom").',
   "agents.defaults.humanDelay.minMs": "Minimum delay in ms for custom humanDelay (default: 800).",
   "agents.defaults.humanDelay.maxMs": "Maximum delay in ms for custom humanDelay (default: 2500).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -492,6 +492,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.memoryFlush.systemPrompt": "Compaction Memory Flush System Prompt",
   "agents.defaults.embeddedPi": "Embedded Pi",
   "agents.defaults.embeddedPi.projectSettingsPolicy": "Embedded Pi Project Settings Policy",
+  "agents.defaults.embeddedPi.overloadBackoffMaxMs": "Embedded Pi Overload Backoff Max (ms)",
   "agents.defaults.heartbeat.directPolicy": "Heartbeat Direct Policy",
   "agents.list.*.heartbeat.directPolicy": "Heartbeat Direct Policy",
   "agents.defaults.heartbeat.suppressToolErrorWarnings": "Heartbeat Suppress Tool Error Warnings",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -182,6 +182,8 @@ export type AgentDefaultsConfig = {
      * - trusted: trust project settings as-is
      */
     projectSettingsPolicy?: "trusted" | "sanitize" | "ignore";
+    /** Maximum delay in ms for exponential overload failover backoff (default: 30000). */
+    overloadBackoffMaxMs?: number;
   };
   /** Vector memory search configuration (per-agent overrides supported). */
   memorySearch?: MemorySearchConfig;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -182,7 +182,7 @@ export type AgentDefaultsConfig = {
      * - trusted: trust project settings as-is
      */
     projectSettingsPolicy?: "trusted" | "sanitize" | "ignore";
-    /** Maximum delay in ms for exponential overload failover backoff (default: 30000). */
+    /** Maximum delay in ms for exponential overload failover backoff (default: 30000). Must be a whole-number value; fractional ms are floored at runtime. */
     overloadBackoffMaxMs?: number;
   };
   /** Vector memory search configuration (per-agent overrides supported). */

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -11,4 +11,14 @@ describe("agent defaults schema", () => {
       }),
     ).not.toThrow();
   });
+
+  it("accepts embeddedPi overloadBackoffMaxMs as a non-negative integer", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({
+        embeddedPi: {
+          overloadBackoffMaxMs: 500,
+        },
+      }),
+    ).not.toThrow();
+  });
 });

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -134,6 +134,7 @@ export const AgentDefaultsSchema = z
         projectSettingsPolicy: z
           .union([z.literal("trusted"), z.literal("sanitize"), z.literal("ignore")])
           .optional(),
+        overloadBackoffMaxMs: z.number().int().nonnegative().optional(),
       })
       .strict()
       .optional(),

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -1,0 +1,139 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { installTestEnv } from "./test-env.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+const tempDirs = new Set<string>();
+const cleanupFns: Array<() => void> = [];
+
+function restoreProcessEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) {
+      delete process.env[key];
+    }
+  }
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function writeFile(targetPath: string, content: string): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fs.writeFileSync(targetPath, content, "utf8");
+}
+
+function createTempHome(): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-env-real-home-"));
+  tempDirs.add(tempDir);
+  return tempDir;
+}
+
+afterEach(() => {
+  while (cleanupFns.length > 0) {
+    cleanupFns.pop()?.();
+  }
+  restoreProcessEnv();
+  for (const tempDir of tempDirs) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+describe("installTestEnv", () => {
+  it("keeps live tests on a temp HOME while copying config and auth state", () => {
+    const realHome = createTempHome();
+    writeFile(path.join(realHome, ".profile"), "export TEST_PROFILE_ONLY=from-profile\n");
+    writeFile(
+      path.join(realHome, "custom-openclaw.json5"),
+      `{
+        // Preserve provider config, strip host-bound paths.
+        agents: {
+          defaults: {
+            workspace: "/Users/peter/Projects",
+            agentDir: "/Users/peter/.openclaw/agents/main/agent",
+          },
+          list: [
+            {
+              id: "dev",
+              workspace: "/Users/peter/dev-workspace",
+              agentDir: "/Users/peter/.openclaw/agents/dev/agent",
+            },
+          ],
+        },
+        models: {
+          providers: {
+            custom: { baseUrl: "https://example.test/v1" },
+          },
+        },
+      }`,
+    );
+    writeFile(path.join(realHome, ".openclaw", "credentials", "token.txt"), "secret\n");
+    writeFile(
+      path.join(realHome, ".openclaw", "agents", "main", "agent", "auth-profiles.json"),
+      JSON.stringify({ version: 1, profiles: { default: { provider: "openai" } } }, null, 2),
+    );
+    writeFile(path.join(realHome, ".claude", ".credentials.json"), '{"accessToken":"token"}\n');
+
+    process.env.HOME = realHome;
+    process.env.USERPROFILE = realHome;
+    process.env.OPENCLAW_LIVE_TEST = "1";
+    process.env.OPENCLAW_LIVE_TEST_QUIET = "1";
+    process.env.OPENCLAW_CONFIG_PATH = "~/custom-openclaw.json5";
+
+    const testEnv = installTestEnv();
+    cleanupFns.push(testEnv.cleanup);
+
+    expect(testEnv.tempHome).not.toBe(realHome);
+    expect(process.env.HOME).toBe(testEnv.tempHome);
+    expect(process.env.OPENCLAW_TEST_HOME).toBe(testEnv.tempHome);
+    expect(process.env.TEST_PROFILE_ONLY).toBe("from-profile");
+
+    const copiedConfigPath = path.join(testEnv.tempHome, ".openclaw", "openclaw.json");
+    const copiedConfig = JSON.parse(fs.readFileSync(copiedConfigPath, "utf8")) as {
+      agents?: {
+        defaults?: Record<string, unknown>;
+        list?: Array<Record<string, unknown>>;
+      };
+      models?: { providers?: Record<string, unknown> };
+    };
+    expect(copiedConfig.models?.providers?.custom).toEqual({ baseUrl: "https://example.test/v1" });
+    expect(copiedConfig.agents?.defaults?.workspace).toBeUndefined();
+    expect(copiedConfig.agents?.defaults?.agentDir).toBeUndefined();
+    expect(copiedConfig.agents?.list?.[0]?.workspace).toBeUndefined();
+    expect(copiedConfig.agents?.list?.[0]?.agentDir).toBeUndefined();
+
+    expect(
+      fs.existsSync(path.join(testEnv.tempHome, ".openclaw", "credentials", "token.txt")),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(testEnv.tempHome, ".openclaw", "agents", "main", "agent", "auth-profiles.json"),
+      ),
+    ).toBe(true);
+    expect(fs.existsSync(path.join(testEnv.tempHome, ".claude", ".credentials.json"))).toBe(true);
+  });
+
+  it("allows explicit live runs against the real HOME", () => {
+    const realHome = createTempHome();
+    writeFile(path.join(realHome, ".profile"), "export TEST_PROFILE_ONLY=from-profile\n");
+
+    process.env.HOME = realHome;
+    process.env.USERPROFILE = realHome;
+    process.env.OPENCLAW_LIVE_TEST = "1";
+    process.env.OPENCLAW_LIVE_USE_REAL_HOME = "1";
+    process.env.OPENCLAW_LIVE_TEST_QUIET = "1";
+
+    const testEnv = installTestEnv();
+
+    expect(testEnv.tempHome).toBe(realHome);
+    expect(process.env.HOME).toBe(realHome);
+    expect(process.env.TEST_PROFILE_ONLY).toBe("from-profile");
+  });
+});

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { installTestEnv } from "./test-env.js";
+import { __testing, installTestEnv } from "./test-env.js";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -135,5 +135,22 @@ describe("installTestEnv", () => {
     expect(testEnv.tempHome).toBe(realHome);
     expect(process.env.HOME).toBe(realHome);
     expect(process.env.TEST_PROFILE_ONLY).toBe("from-profile");
+  });
+
+  it("parses simple exported profile vars without relying on bash", () => {
+    expect(
+      __testing.parseSimpleProfileEnv(
+        [
+          "# comment",
+          "export TEST_PROFILE_ONLY=from-profile",
+          "QUOTED_VALUE='hello world'",
+          'DOUBLE_QUOTED="quoted"',
+        ].join("\n"),
+      ),
+    ).toEqual([
+      { key: "TEST_PROFILE_ONLY", value: "from-profile" },
+      { key: "QUOTED_VALUE", value: "hello world" },
+      { key: "DOUBLE_QUOTED", value: "quoted" },
+    ]);
   });
 });

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -2,8 +2,11 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import JSON5 from "json5";
 
 type RestoreEntry = { key: string; value: string | undefined };
+
+const LIVE_EXTERNAL_AUTH_DIRS = [".claude", ".codex", ".minimax"] as const;
 
 function isTruthyEnvValue(value: string | undefined): boolean {
   if (!value) {
@@ -31,8 +34,19 @@ function restoreEnv(entries: RestoreEntry[]): void {
   }
 }
 
-function loadProfileEnv(): void {
-  const profilePath = path.join(os.homedir(), ".profile");
+function resolveHomeRelativePath(input: string, homeDir: string): string {
+  const trimmed = input.trim();
+  if (trimmed === "~") {
+    return homeDir;
+  }
+  if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+    return path.join(homeDir, trimmed.slice(2));
+  }
+  return path.resolve(trimmed);
+}
+
+function loadProfileEnv(homeDir = os.homedir()): void {
+  const profilePath = path.join(homeDir, ".profile");
   if (!fs.existsSync(profilePath)) {
     return;
   }
@@ -67,20 +81,8 @@ function loadProfileEnv(): void {
   }
 }
 
-export function installTestEnv(): { cleanup: () => void; tempHome: string } {
-  const live =
-    process.env.LIVE === "1" ||
-    process.env.OPENCLAW_LIVE_TEST === "1" ||
-    process.env.OPENCLAW_LIVE_GATEWAY === "1";
-
-  // Live tests must use the real user environment (keys, profiles, config).
-  // The default test env isolates HOME to avoid touching real state.
-  if (live) {
-    loadProfileEnv();
-    return { cleanup: () => {}, tempHome: process.env.HOME ?? "" };
-  }
-
-  const restore: RestoreEntry[] = [
+function resolveRestoreEntries(): RestoreEntry[] {
+  return [
     { key: "OPENCLAW_TEST_FAST", value: process.env.OPENCLAW_TEST_FAST },
     { key: "HOME", value: process.env.HOME },
     { key: "USERPROFILE", value: process.env.USERPROFILE },
@@ -96,6 +98,8 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
     { key: "OPENCLAW_BRIDGE_PORT", value: process.env.OPENCLAW_BRIDGE_PORT },
     { key: "OPENCLAW_CANVAS_HOST_PORT", value: process.env.OPENCLAW_CANVAS_HOST_PORT },
     { key: "OPENCLAW_TEST_HOME", value: process.env.OPENCLAW_TEST_HOME },
+    { key: "OPENCLAW_AGENT_DIR", value: process.env.OPENCLAW_AGENT_DIR },
+    { key: "PI_CODING_AGENT_DIR", value: process.env.PI_CODING_AGENT_DIR },
     { key: "TELEGRAM_BOT_TOKEN", value: process.env.TELEGRAM_BOT_TOKEN },
     { key: "DISCORD_BOT_TOKEN", value: process.env.DISCORD_BOT_TOKEN },
     { key: "SLACK_BOT_TOKEN", value: process.env.SLACK_BOT_TOKEN },
@@ -106,7 +110,12 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
     { key: "GITHUB_TOKEN", value: process.env.GITHUB_TOKEN },
     { key: "NODE_OPTIONS", value: process.env.NODE_OPTIONS },
   ];
+}
 
+function createIsolatedTestHome(restore: RestoreEntry[]): {
+  cleanup: () => void;
+  tempHome: string;
+} {
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-home-"));
 
   process.env.HOME = tempHome;
@@ -118,6 +127,8 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
   delete process.env.OPENCLAW_CONFIG_PATH;
   // Prefer deriving state dir from HOME so nested tests that change HOME also isolate correctly.
   delete process.env.OPENCLAW_STATE_DIR;
+  delete process.env.OPENCLAW_AGENT_DIR;
+  delete process.env.PI_CODING_AGENT_DIR;
   // Prefer test-controlled ports over developer overrides (avoid port collisions across tests/workers).
   delete process.env.OPENCLAW_GATEWAY_PORT;
   delete process.env.OPENCLAW_BRIDGE_ENABLED;
@@ -156,6 +167,132 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
   };
 
   return { cleanup, tempHome };
+}
+
+function ensureParentDir(targetPath: string): void {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+}
+
+function copyDirIfExists(sourcePath: string, targetPath: string): void {
+  if (!fs.existsSync(sourcePath)) {
+    return;
+  }
+  fs.mkdirSync(targetPath, { recursive: true });
+  fs.cpSync(sourcePath, targetPath, {
+    recursive: true,
+    force: true,
+  });
+}
+
+function copyFileIfExists(sourcePath: string, targetPath: string): void {
+  if (!fs.existsSync(sourcePath)) {
+    return;
+  }
+  ensureParentDir(targetPath);
+  fs.copyFileSync(sourcePath, targetPath);
+}
+
+function sanitizeLiveConfig(raw: string): string {
+  try {
+    const parsed = JSON5.parse(raw) as {
+      agents?: {
+        defaults?: Record<string, unknown>;
+        list?: Array<Record<string, unknown>>;
+      };
+    };
+    if (!parsed || typeof parsed !== "object") {
+      return raw;
+    }
+    if (parsed.agents?.defaults && typeof parsed.agents.defaults === "object") {
+      delete parsed.agents.defaults.workspace;
+      delete parsed.agents.defaults.agentDir;
+    }
+    if (Array.isArray(parsed.agents?.list)) {
+      parsed.agents.list = parsed.agents.list.map((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return entry;
+        }
+        const nextEntry = { ...entry };
+        delete nextEntry.workspace;
+        delete nextEntry.agentDir;
+        return nextEntry;
+      });
+    }
+    return `${JSON.stringify(parsed, null, 2)}\n`;
+  } catch {
+    return raw;
+  }
+}
+
+function copyLiveAuthProfiles(realStateDir: string, tempStateDir: string): void {
+  const agentsDir = path.join(realStateDir, "agents");
+  if (!fs.existsSync(agentsDir)) {
+    return;
+  }
+  for (const entry of fs.readdirSync(agentsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const sourcePath = path.join(agentsDir, entry.name, "agent", "auth-profiles.json");
+    const targetPath = path.join(tempStateDir, "agents", entry.name, "agent", "auth-profiles.json");
+    copyFileIfExists(sourcePath, targetPath);
+  }
+}
+
+function stageLiveTestState(params: {
+  env: NodeJS.ProcessEnv;
+  realHome: string;
+  tempHome: string;
+}): void {
+  const realStateDir = params.env.OPENCLAW_STATE_DIR?.trim()
+    ? resolveHomeRelativePath(params.env.OPENCLAW_STATE_DIR, params.realHome)
+    : path.join(params.realHome, ".openclaw");
+  const tempStateDir = path.join(params.tempHome, ".openclaw");
+  fs.mkdirSync(tempStateDir, { recursive: true });
+
+  const realConfigPath = params.env.OPENCLAW_CONFIG_PATH?.trim()
+    ? resolveHomeRelativePath(params.env.OPENCLAW_CONFIG_PATH, params.realHome)
+    : path.join(realStateDir, "openclaw.json");
+  if (fs.existsSync(realConfigPath)) {
+    const rawConfig = fs.readFileSync(realConfigPath, "utf8");
+    fs.writeFileSync(
+      path.join(tempStateDir, "openclaw.json"),
+      sanitizeLiveConfig(rawConfig),
+      "utf8",
+    );
+  }
+
+  copyDirIfExists(path.join(realStateDir, "credentials"), path.join(tempStateDir, "credentials"));
+  copyLiveAuthProfiles(realStateDir, tempStateDir);
+
+  for (const authDir of LIVE_EXTERNAL_AUTH_DIRS) {
+    copyDirIfExists(path.join(params.realHome, authDir), path.join(params.tempHome, authDir));
+  }
+}
+
+export function installTestEnv(): { cleanup: () => void; tempHome: string } {
+  const live =
+    process.env.LIVE === "1" ||
+    process.env.OPENCLAW_LIVE_TEST === "1" ||
+    process.env.OPENCLAW_LIVE_GATEWAY === "1";
+  const allowRealHome = isTruthyEnvValue(process.env.OPENCLAW_LIVE_USE_REAL_HOME);
+  const realHome = process.env.HOME ?? os.homedir();
+  const liveEnvSnapshot = { ...process.env };
+
+  loadProfileEnv(realHome);
+
+  if (live && allowRealHome) {
+    return { cleanup: () => {}, tempHome: realHome };
+  }
+
+  const restore = resolveRestoreEntries();
+  const testEnv = createIsolatedTestHome(restore);
+
+  if (live) {
+    stageLiveTestState({ env: liveEnvSnapshot, realHome, tempHome: testEnv.tempHome });
+  }
+
+  return testEnv;
 }
 
 export function withIsolatedTestHome(): { cleanup: () => void; tempHome: string } {

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import JSON5 from "json5";
 
 type RestoreEntry = { key: string; value: string | undefined };
+type ProfileEnvEntry = { key: string; value: string };
 
 const LIVE_EXTERNAL_AUTH_DIRS = [".claude", ".codex", ".minimax"] as const;
 
@@ -45,41 +46,96 @@ function resolveHomeRelativePath(input: string, homeDir: string): string {
   return path.resolve(trimmed);
 }
 
+function stripWrappingQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === '"' || first === "'") && first === last) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
+
+function applyProfileEnvEntries(entries: Iterable<ProfileEnvEntry>): number {
+  let applied = 0;
+  for (const entry of entries) {
+    if (!entry.key || (process.env[entry.key] ?? "") !== "") {
+      continue;
+    }
+    process.env[entry.key] = entry.value;
+    applied += 1;
+  }
+  return applied;
+}
+
+function parseSimpleProfileEnv(content: string): ProfileEnvEntry[] {
+  const entries: ProfileEnvEntry[] = [];
+  for (const rawLine of content.split(/\r?\n/u)) {
+    const trimmed = rawLine.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/u.exec(trimmed);
+    if (!match) {
+      continue;
+    }
+    const [, key, rawValue] = match;
+    entries.push({ key, value: stripWrappingQuotes(rawValue) });
+  }
+  return entries;
+}
+
 function loadProfileEnv(homeDir = os.homedir()): void {
   const profilePath = path.join(homeDir, ".profile");
   if (!fs.existsSync(profilePath)) {
     return;
   }
+  let applied = 0;
+  let loadedFromShell = false;
   try {
-    const output = execFileSync(
-      "/bin/bash",
-      ["-lc", `set -a; source "${profilePath}" >/dev/null 2>&1; env -0`],
-      { encoding: "utf8" },
-    );
-    const entries = output.split("\0");
-    let applied = 0;
-    for (const entry of entries) {
-      if (!entry) {
+    const shellCandidates =
+      process.platform === "win32" ? ["bash", "/bin/bash"] : ["/bin/bash", "bash"];
+    for (const shellCommand of shellCandidates) {
+      try {
+        const output = execFileSync(
+          shellCommand,
+          ["-lc", `set -a; source "${profilePath}" >/dev/null 2>&1; env -0`],
+          { encoding: "utf8" },
+        );
+        const entries: ProfileEnvEntry[] = [];
+        for (const entry of output.split("\0")) {
+          if (!entry) {
+            continue;
+          }
+          const idx = entry.indexOf("=");
+          if (idx <= 0) {
+            continue;
+          }
+          entries.push({ key: entry.slice(0, idx), value: entry.slice(idx + 1) });
+        }
+        applied = applyProfileEnvEntries(entries);
+        loadedFromShell = true;
+        break;
+      } catch {
         continue;
       }
-      const idx = entry.indexOf("=");
-      if (idx <= 0) {
-        continue;
-      }
-      const key = entry.slice(0, idx);
-      if (!key || (process.env[key] ?? "") !== "") {
-        continue;
-      }
-      process.env[key] = entry.slice(idx + 1);
-      applied += 1;
     }
-    if (applied > 0 && !isTruthyEnvValue(process.env.OPENCLAW_LIVE_TEST_QUIET)) {
-      console.log(`[live] loaded ${applied} env vars from ~/.profile`);
+    if (!loadedFromShell) {
+      applied = applyProfileEnvEntries(parseSimpleProfileEnv(fs.readFileSync(profilePath, "utf8")));
     }
   } catch {
     // ignore profile load failures
   }
+  if (applied > 0 && !isTruthyEnvValue(process.env.OPENCLAW_LIVE_TEST_QUIET)) {
+    console.log(`[live] loaded ${applied} env vars from ~/.profile`);
+  }
 }
+
+export const __testing = {
+  parseSimpleProfileEnv,
+};
 
 function resolveRestoreEntries(): RestoreEntry[] {
   return [


### PR DESCRIPTION
## Summary
- raise embedded Pi overload failover ceiling from 1.5s to 30s by default
- centralize overload backoff policy resolution and support config override
- wire config types, labels, help, and generated schema for `agents.defaults.embeddedPi.overloadBackoffMaxMs`
- add regression tests for default, override, and clamped values

## Context
- complements #56107
- consolidates #56529
