### PR TITLE
fix(mistral): onboarding-generated configs trigger 422 responses

### DIFF
--- a/extensions/mistral/onboard.test.ts
+++ b/extensions/mistral/onboard.test.ts
@@ -8,6 +8,7 @@ import {
   createLegacyProviderConfig,
   EXPECTED_FALLBACKS,
 } from "../../test/helpers/extensions/onboard-config.js";
+import { applyMistralModelCompat } from "./api.js";
 import { buildMistralModelDefinition as buildBundledMistralModelDefinition } from "./model-definitions.js";
 import {
   applyMistralConfig,
@@ -51,8 +52,8 @@ describe("mistral onboard", () => {
     expect(mistralDefault?.maxTokens).toBe(16384);
   });
 
-  it("uses the bundled mistral default model definition", () => {
-    const bundled = buildBundledMistralModelDefinition();
+  it("uses the bundled mistral default model definition with the Mistral compat patch", () => {
+    const bundled = applyMistralModelCompat(buildBundledMistralModelDefinition());
     const cfg = applyMistralProviderConfig({});
     const defaultModel = cfg.models?.providers?.mistral?.models.find(
       (model) => model.id === bundled.id,
@@ -62,6 +63,11 @@ describe("mistral onboard", () => {
       id: bundled.id,
       contextWindow: bundled.contextWindow,
       maxTokens: bundled.maxTokens,
+      compat: {
+        supportsStore: false,
+        supportsReasoningEffort: false,
+        maxTokensField: "max_tokens",
+      },
     });
   });
 

--- a/extensions/mistral/onboard.ts
+++ b/extensions/mistral/onboard.ts
@@ -2,6 +2,7 @@ import {
   createDefaultModelPresetAppliers,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
+import { applyMistralModelCompat } from "./api.js";
 import {
   buildMistralModelDefinition,
   MISTRAL_BASE_URL,
@@ -16,7 +17,7 @@ const mistralPresetAppliers = createDefaultModelPresetAppliers({
     providerId: "mistral",
     api: "openai-completions",
     baseUrl: MISTRAL_BASE_URL,
-    defaultModel: buildMistralModelDefinition(),
+    defaultModel: applyMistralModelCompat(buildMistralModelDefinition()),
     defaultModelId: MISTRAL_DEFAULT_MODEL_ID,
     aliases: [{ modelRef: MISTRAL_DEFAULT_MODEL_REF, alias: "Mistral" }],
   }),


### PR DESCRIPTION
## Summary

Mistral onboarding currently writes a provider config that routes through `openai-completions` without the Mistral request-shape compat patch. Fresh onboarding-generated configs can then send fields like `store` and `max_completion_tokens`, which Mistral rejects with 422 responses.

This change keeps the onboarding scope narrow: when the Mistral provider preset generates its default model, it applies the existing Mistral compat patch so newly generated configs use the correct request-shape hints from the start.

## Changes

- apply `applyMistralModelCompat()` to the default model generated by Mistral onboarding
- extend Mistral onboarding tests to assert the bundled default model carries the compat patch

## Testing

- `pnpm exec vitest run extensions/mistral/api.test.ts extensions/mistral/onboard.test.ts src/commands/onboard-non-interactive.provider-auth.test.ts`
- commit hook checks during `git commit`

Fixes #56546