### PR TITLE
fix(slack): process thread_broadcast as regular inbound messages

### DIFF
--- a/extensions/slack/src/monitor/events/message-subtype-handlers.test.ts
+++ b/extensions/slack/src/monitor/events/message-subtype-handlers.test.ts
@@ -41,7 +41,7 @@ describe("resolveSlackMessageSubtypeHandler", () => {
     expect(handler?.describe("general")).toContain("deleted");
   });
 
-  it("resolves thread_broadcast metadata and identifiers", () => {
+  it("returns undefined for thread_broadcast (now processed as regular message)", () => {
     const event = {
       type: "message",
       subtype: "thread_broadcast",
@@ -51,13 +51,7 @@ describe("resolveSlackMessageSubtypeHandler", () => {
       user: "U1",
     } as unknown as SlackMessageEvent;
 
-    const handler = resolveSlackMessageSubtypeHandler(event);
-    expect(handler?.eventKind).toBe("thread_broadcast");
-    expect(handler?.resolveSenderId(event)).toBe("U1");
-    expect(handler?.resolveChannelId(event)).toBe("C1");
-    expect(handler?.resolveChannelType(event)).toBeUndefined();
-    expect(handler?.contextKey(event)).toBe("slack:thread:broadcast:C1:123.456");
-    expect(handler?.describe("general")).toContain("broadcast");
+    expect(resolveSlackMessageSubtypeHandler(event)).toBeUndefined();
   });
 
   it("returns undefined for regular messages", () => {

--- a/extensions/slack/src/monitor/events/message-subtype-handlers.ts
+++ b/extensions/slack/src/monitor/events/message-subtype-handlers.ts
@@ -1,11 +1,7 @@
 import type { SlackMessageEvent } from "../../types.js";
-import type {
-  SlackMessageChangedEvent,
-  SlackMessageDeletedEvent,
-  SlackThreadBroadcastEvent,
-} from "../types.js";
+import type { SlackMessageChangedEvent, SlackMessageDeletedEvent } from "../types.js";
 
-type SupportedSubtype = "message_changed" | "message_deleted" | "thread_broadcast";
+type SupportedSubtype = "message_changed" | "message_deleted";
 
 export type SlackMessageSubtypeHandler = {
   subtype: SupportedSubtype;
@@ -59,39 +55,16 @@ const deletedHandler: SlackMessageSubtypeHandler = {
   resolveChannelType: () => undefined,
 };
 
-const threadBroadcastHandler: SlackMessageSubtypeHandler = {
-  subtype: "thread_broadcast",
-  eventKind: "thread_broadcast",
-  describe: (channelLabel) => `Slack thread reply broadcast in ${channelLabel}.`,
-  contextKey: (event) => {
-    const thread = event as SlackThreadBroadcastEvent;
-    const channelId = thread.channel ?? "unknown";
-    const messageId = thread.message?.ts ?? thread.event_ts ?? "unknown";
-    return `slack:thread:broadcast:${channelId}:${messageId}`;
-  },
-  resolveSenderId: (event) => {
-    const thread = event as SlackThreadBroadcastEvent;
-    return thread.user ?? thread.message?.user ?? thread.message?.bot_id;
-  },
-  resolveChannelId: (event) => (event as SlackThreadBroadcastEvent).channel,
-  resolveChannelType: () => undefined,
-};
-
 const SUBTYPE_HANDLER_REGISTRY: Record<SupportedSubtype, SlackMessageSubtypeHandler> = {
   message_changed: changedHandler,
   message_deleted: deletedHandler,
-  thread_broadcast: threadBroadcastHandler,
 };
 
 export function resolveSlackMessageSubtypeHandler(
   event: SlackMessageEvent,
 ): SlackMessageSubtypeHandler | undefined {
   const subtype = event.subtype;
-  if (
-    subtype !== "message_changed" &&
-    subtype !== "message_deleted" &&
-    subtype !== "thread_broadcast"
-  ) {
+  if (subtype !== "message_changed" && subtype !== "message_deleted") {
     return undefined;
   }
   return SUBTYPE_HANDLER_REGISTRY[subtype];

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -177,14 +177,10 @@ describe("registerSlackMessageEvents", () => {
       calls: 0,
     },
     {
-      name: "blocks thread_broadcast system events without an authenticated sender",
+      name: "does not emit system events for thread_broadcast (processed as regular message)",
       input: {
         overrides: { dmPolicy: "open" },
-        event: {
-          ...makeThreadBroadcastEvent(),
-          user: undefined,
-          message: { ts: "123.456" },
-        },
+        event: makeThreadBroadcastEvent(),
       },
       calls: 0,
     },
@@ -192,6 +188,17 @@ describe("registerSlackMessageEvents", () => {
   it.each(cases)("$name", async ({ input, calls }) => {
     await runMessageCase(input);
     expect(messageQueueMock).toHaveBeenCalledTimes(calls);
+  });
+
+  it("routes thread_broadcast messages to the message handler instead of system events", async () => {
+    const { handleSlackMessage } = await invokeRegisteredHandler({
+      eventName: "message",
+      overrides: { dmPolicy: "open" },
+      event: makeThreadBroadcastEvent(),
+    });
+
+    expect(handleSlackMessage).toHaveBeenCalledTimes(1);
+    expect(messageQueueMock).not.toHaveBeenCalled();
   });
 
   it("passes regular message events to the message handler", async () => {

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -214,7 +214,8 @@ export function createSlackMessageHandler(params: {
       opts.source === "message" &&
       message.subtype &&
       message.subtype !== "file_share" &&
-      message.subtype !== "bot_message"
+      message.subtype !== "bot_message" &&
+      message.subtype !== "thread_broadcast"
     ) {
       return;
     }


### PR DESCRIPTION
## Summary

Fixes Slack thread replies that are sent with **"Also send to #channel"** (subtype `thread_broadcast`) being dropped before they reach agent message handling.

Today, these events are treated as metadata-only system events and return early, so user text is never processed. This PR routes them through the normal message pipeline.

Closes #56605.

## Root cause

`thread_broadcast` was blocked at two layers:

1. **Subtype system-event registry** (`extensions/slack/src/monitor/events/message-subtype-handlers.ts`)
   - Included `thread_broadcast`, causing early return in `registerSlackMessageEvents`
2. **Inbound subtype filter** (`extensions/slack/src/monitor/message-handler.ts`)
   - Dropped all subtypes except `file_share` and `bot_message`

This combination guaranteed `thread_broadcast` payloads never reached `prepareSlackMessage`/dispatch.

## What changed

### 1) Stop treating `thread_broadcast` as system-event-only
- Removed `thread_broadcast` from `SupportedSubtype` registry
- Removed dedicated `threadBroadcastHandler`
- `resolveSlackMessageSubtypeHandler()` now returns `undefined` for `thread_broadcast`

### 2) Allow `thread_broadcast` in normal inbound message filtering
- Added `message.subtype !== "thread_broadcast"` exemption in `createSlackMessageHandler`

### 3) Tests updated
- `message-subtype-handlers.test.ts`:
  - now asserts `thread_broadcast` is **not** resolved as subtype system event
- `messages.test.ts`:
  - adds explicit test that `thread_broadcast` routes to `handleSlackMessage`
  - keeps assertion that no system event is enqueued for this subtype

## Why this approach

- Aligns with Slack/Bolt precedent: `thread_broadcast` should be processable as user message content
- Preserves existing security checks on true system-event subtypes (`message_changed`, `message_deleted`)
- Lets existing dedupe (`markMessageSeen(channel, ts)`) handle duplicate deliveries if Slack emits equivalent events

## Scope

Only Slack monitor routing behavior for `thread_broadcast` changed.
No changes to other channels or subtype system-event behavior.

## Notes

I could not run local vitest in this environment because the workspace is missing `pnpm` and a transitive module needed by test bootstrap (`discord-api-types/v10`). The changed tests are included and CI should validate in the repo environment.
