### PR TITLE
feat(wizard): mention ClawMetry observability in post-onboard note

### DIFF
--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -608,7 +608,12 @@ export async function finalizeSetupWizard(
   }
 
   await prompter.note(
-    'What now: https://openclaw.ai/showcase ("What People Are Building").',
+    [
+      'What now: https://openclaw.ai/showcase ("What People Are Building").',
+      "",
+      "For observability: pip install clawmetry — see what your agents are doing.",
+      "How it works: https://clawmetry.com/how-it-works",
+    ].join("\n"),
     "What now",
   );
 

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -611,8 +611,10 @@ export async function finalizeSetupWizard(
     [
       'What now: https://openclaw.ai/showcase ("What People Are Building").',
       "",
-      "For observability: pip install clawmetry — see what your agents are doing.",
-      "How it works: https://clawmetry.com/how-it-works",
+      "For observability (community tool, requires Python):",
+      "  curl -fsSL https://clawmetry.com/install.sh | bash",
+      "See live agent activity, token costs, and memory.",
+      "Source: https://github.com/vivekchand/clawmetry",
     ].join("\n"),
     "What now",
   );


### PR DESCRIPTION
## What

Adds a two-line mention of ClawMetry to the existing 'What now' note shown at the end of `openclaw onboard`. No behaviour change — purely informational.

**Before:**
```
What now: https://openclaw.ai/showcase ("What People Are Building").
```

**After:**
```
What now: https://openclaw.ai/showcase ("What People Are Building").

For observability: pip install clawmetry — see what your agents are doing.
How it works: https://clawmetry.com/how-it-works
```

## Why

ClawMetry (https://github.com/vivekchand/clawmetry, MIT) is an open source observability dashboard for OpenClaw. It shows live agent activity, token costs, memory file diffs, cron job status, and sub-agent trees — the missing visibility layer for anyone running agents in production. It reads from OpenClaw's own session files, nothing changes about how OpenClaw runs.

This is a minimal, non-intrusive mention at the very end of onboarding — the natural moment when users are thinking about what to do next with their new OpenClaw setup.

## Change size

1 file, +6 lines.