### PR TITLE
fix: sanitize scoped package names in clawhub archive path

### DIFF
--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -580,7 +580,7 @@ export async function downloadClawHubPackageArchive(params: {
   }
   const bytes = new Uint8Array(await response.arrayBuffer());
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-clawhub-package-"));
-  const archivePath = path.join(tmpDir, `${params.name}.zip`);
+  const archivePath = path.join(tmpDir, `${params.name.replace(/\//g, "-")}.zip`);
   await fs.writeFile(archivePath, bytes);
   return {
     archivePath,


### PR DESCRIPTION
## Summary

Fixes #53870

Scoped npm package names (e.g. `@openclaw/matrix`) contain a `/` character. When `downloadClawHubPackageArchive` builds the temp archive path using:

```js
const archivePath = path.join(tmpDir, `${params.name}.zip`);
```

`path.join` interprets the `/` in the scope as a directory separator, producing a path like `/tmp/openclaw-clawhub-package-XXXX/@openclaw/matrix.zip`. The subdirectory `@openclaw/` does not exist inside the temp dir, so `fs.writeFile` throws `ENOENT` and the install fails entirely.

## Root cause

`params.name` for a scoped package contains a literal `/` (e.g. `@openclaw/matrix`). `path.join` normalizes paths — it does not escape special characters — so the `/` becomes a real directory separator in the resulting path.

## Fix

Replace any `/` characters in the package name with `-` before using it as a filename component, as suggested by @mcgheeloans in [the issue comment](https://github.com/openclaw/openclaw/issues/53870#issuecomment-4148435810):

```js
// Before
const archivePath = path.join(tmpDir, `${params.name}.zip`);

// After
const archivePath = path.join(tmpDir, `${params.name.replace(/\//g, "-")}.zip`);
```

This produces a flat filename like `@openclaw-matrix.zip` that sits directly inside the already-created `tmpDir`, resolving the `ENOENT`.

**File changed:** `src/infra/clawhub.ts` — one line in `downloadClawHubPackageArchive`.

## Test plan

- [ ] Install a non-scoped package (e.g. `clawhub:my-plugin`) — should continue to work as before
- [ ] Install a scoped package (e.g. `clawhub:@openclaw/matrix`) — should no longer throw `ENOENT`
- [ ] Verify the temp archive file is created and cleaned up correctly after install