### PR TITLE
fix(tts): add verbose logging for TTS provider fallback debugging

### DIFF
--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -20,7 +20,7 @@ import type {
 } from "openclaw/plugin-sdk/config-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { isVerbose, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/sandbox";
 import { CONFIG_DIR, resolveUserPath, stripMarkdown } from "openclaw/plugin-sdk/text-runtime";
 import {
@@ -665,6 +665,10 @@ export async function synthesizeSpeech(params: {
   const target = channelId && OPUS_CHANNELS.has(channelId) ? "voice-note" : "audio-file";
 
   const errors: string[] = [];
+  const primaryProvider = providers[0];
+  logVerbose(
+    `TTS: starting with provider ${primaryProvider}, fallbacks: ${providers.slice(1).join(", ") || "none"}`,
+  );
 
   for (const provider of providers) {
     const providerStart = Date.now();
@@ -676,6 +680,7 @@ export async function synthesizeSpeech(params: {
         errors,
       });
       if (!resolvedProvider) {
+        logVerbose(`TTS: provider ${provider} skipped (${errors[errors.length - 1]})`);
         continue;
       }
       const synthesis = await resolvedProvider.synthesize({
@@ -696,7 +701,17 @@ export async function synthesizeSpeech(params: {
         fileExtension: synthesis.fileExtension,
       };
     } catch (err) {
-      errors.push(formatTtsProviderError(provider, err));
+      const errorMsg = formatTtsProviderError(provider, err);
+      errors.push(errorMsg);
+      const rawError = err instanceof Error ? err.message : String(err);
+      if (provider === primaryProvider) {
+        const hasFallbacks = providers.length > 1;
+        logVerbose(
+          `TTS: primary provider ${provider} failed (${rawError})${hasFallbacks ? "; trying fallback providers." : "; no fallback providers configured."}`,
+        );
+      } else {
+        logVerbose(`TTS: ${provider} failed (${rawError}); trying next provider.`);
+      }
     }
   }
 
@@ -814,6 +829,16 @@ export async function maybeApplyTtsToPayload(params: {
   });
   if (directives.warnings.length > 0) {
     logVerbose(`TTS: ignored directive overrides (${directives.warnings.join("; ")})`);
+  }
+
+  if (isVerbose()) {
+    const effectiveProvider = directives.overrides?.provider
+      ? (canonicalizeSpeechProviderId(directives.overrides.provider, params.cfg) ??
+        getTtsProvider(config, prefsPath))
+      : getTtsProvider(config, prefsPath);
+    logVerbose(
+      `TTS: auto mode enabled (${autoMode}), channel=${params.channel}, selected provider=${effectiveProvider}, config.provider=${config.provider}, config.providerSource=${config.providerSource}`,
+    );
   }
 
   const cleanedText = directives.cleanedText;


### PR DESCRIPTION
## Summary

When Discord auto TTS is configured with ElevenLabs, it silently falls back to Edge TTS without any error message. This adds verbose logging to help diagnose TTS provider selection and fallback issues.

This is a reworked version of #46042 that addresses all review feedback:

- **Fixed dead `else if` condition**: The original PR had `else if (errors.length > 0)` which was always true because `errors.push()` ran before the check. Now uses a clean `if (provider === primaryProvider)` / `else` pattern to distinguish primary vs fallback failure messages.
- **Fixed double disk read**: `getTtsProvider()` does a synchronous file read internally. The original PR called it unconditionally in `maybeApplyTtsToPayload` for logging, then it was called again inside `textToSpeech`. Now wrapped in an `isVerbose()` guard so the extra call is skipped when verbose logging is disabled.
- **Fixed wrong provider logged**: The original PR logged the provider selection *before* `parseTtsDirectives()` ran, so directive overrides were not reflected. Now the log is emitted *after* directives are parsed, and if there's a provider override directive, it reports that provider instead.

With verbose logging enabled (`-v` flag), users will see:
- `TTS: auto mode enabled (always), channel=discord, selected provider=elevenlabs, ...`
- `TTS: starting with provider elevenlabs, fallbacks: openai, edge`
- `TTS: primary provider elevenlabs failed (elevenlabs: no API key); trying fallback providers.`

## Test plan

- [x] Run with `-v` flag and `messages.tts.provider: elevenlabs` configured — verify correct provider name appears in logs
- [x] Verify primary provider failure shows "primary provider ... failed" message
- [x] Verify fallback provider failure shows "trying next provider" message
- [x] Verify without `-v` flag, no extra disk reads occur (no `getTtsProvider` call in `maybeApplyTtsToPayload`)
- [x] Verify with a TTS directive override, the log reflects the override provider, not the config provider

Fixes: #46015
Supersedes: #46042