### PR TITLE
fix: use pinned channel registry in outbound adapter loader

### DIFF
--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -1,5 +1,5 @@
 import type { PluginChannelRegistration, PluginRegistry } from "../../plugins/registry.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import { requireActivePluginChannelRegistry } from "../../plugins/runtime.js";
 import type { ChannelId } from "./types.js";
 
 type ChannelRegistryValueResolver<TValue> = (
@@ -13,7 +13,7 @@ export function createChannelRegistryLoader<TValue>(
   let lastRegistry: PluginRegistry | null = null;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
-    const registry = getActivePluginRegistry();
+    const registry = requireActivePluginChannelRegistry();
     if (registry !== lastRegistry) {
       cache.clear();
       lastRegistry = registry;


### PR DESCRIPTION
## Summary

`createChannelRegistryLoader` (`src/channels/plugins/registry-loader.ts`) used `getActivePluginRegistry()` to look up channel outbound adapters. The active registry can be silently replaced at runtime — for example, when `resolvePluginCapabilityProviders` reloads plugins to search for media-understanding providers upon receiving an inbound media message.

The sibling `getChannelPlugin()` (used for channel resolution checks) already reads from the **pinned** channel registry via `requireActivePluginChannelRegistry()`, which is specifically designed to survive such reloads (see the docstring on `pinActivePluginChannelRegistry` in `src/plugins/runtime.ts`).

This mismatch caused `loadChannelOutboundAdapter` to fail with **"Outbound not configured for channel: telegram"** during agent turns dispatched via the gateway WebSocket RPC (`method: "agent"` with `deliver: true`). The active registry lost the channel plugin entries after a media message triggered a capability-provider reload, while the pinned registry still had them.

**Fix:** switch `createChannelRegistryLoader` from `getActivePluginRegistry()` to `requireActivePluginChannelRegistry()`, making the outbound adapter loader consistent with `getChannelPlugin()`.

## Steps to reproduce

1. Configure a gateway with two agents — one bound to a Telegram group, another to Max/Telegram DM
2. Set a primary model with an expired OAuth token so model fallback is triggered
3. Send a media message (image/file) to one of the agents
4. Trigger an agent turn to the Telegram-bound agent via WS RPC (`method: "agent"`, `deliver: true`)
5. The agent's response fails to deliver with: `Error: Outbound not configured for channel: telegram`

## Test plan

- [ ] Verify `getChannelPlugin("telegram")` and `loadChannelOutboundAdapter("telegram")` return consistent results after a capability-provider reload
- [ ] Verify agent turn delivery to Telegram groups works after inbound media messages
- [ ] Existing channel registry pin tests in `runtime.channel-pin.test.ts` still pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)