### PR TITLE
fix(tools): preserve Optional annotation when merging anyOf variants in normalizeToolParameters

### DIFF
--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it, vi } from "vitest";
 import { normalizeToolParameters } from "./pi-tools.schema.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 
+// Helper function to create enum types for test cases
+const stringEnum = (values: string[]) => Type.Union(values.map((v) => Type.Literal(v)));
+
 describe("normalizeToolParameters", () => {
   it("injects properties:{} for type:object schemas missing properties (MCP no-param tools)", () => {
     const tool: AnyAgentTool = {
@@ -82,5 +85,52 @@ describe("normalizeToolParameters", () => {
     expect(parameters.properties?.count.type).toBe("integer");
     expect(parameters.properties?.query.minLength).toBeUndefined();
     expect(parameters.properties?.query.type).toBe("string");
+  });
+
+  it("excludes TypeBox-Optional properties from merged required when flattening anyOf variants", () => {
+    const buttonSchema = Type.Optional(Type.Array(Type.String()));
+    const variantA = Type.Object({ action: stringEnum(["send"]), buttons: buttonSchema });
+    const variantB = Type.Object({ action: stringEnum(["delete"]), buttons: buttonSchema });
+    const tool: AnyAgentTool = {
+      name: "demo",
+      label: "demo",
+      description: "demo",
+      parameters: Type.Union([variantA, variantB]),
+      execute: vi.fn(),
+    };
+
+    const normalized = normalizeToolParameters(tool);
+    const parameters = normalized.parameters as { required?: string[] };
+
+    expect(parameters.required).not.toContain("buttons");
+    expect(parameters.required).toContain("action"); // required in both variants, not Optional
+  });
+
+  it("handles enum-plus-Optional edge case when merging properties", () => {
+    // Create an Optional enum property that will be merged
+    const optionalEnumProp = Type.Optional(Type.Union([Type.Literal("a"), Type.Literal("b")]));
+    const variantA = Type.Object({
+      action: stringEnum(["send"]),
+      mode: optionalEnumProp,
+    });
+    const variantB = Type.Object({
+      action: stringEnum(["delete"]),
+      mode: optionalEnumProp,
+    });
+    const tool: AnyAgentTool = {
+      name: "demo",
+      label: "demo",
+      description: "demo",
+      parameters: Type.Union([variantA, variantB]),
+      execute: vi.fn(),
+    };
+
+    const normalized = normalizeToolParameters(tool);
+    const parameters = normalized.parameters as { required?: string[] };
+
+    // Even though enum merging might lose the Optional symbol,
+    // the property should still be excluded from required
+    expect(parameters.required).not.toContain("mode");
+    expect(parameters.required).toContain("action");
   });
 });

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -170,13 +170,30 @@ export function normalizeToolParameterSchema(
   const baseRequired = Array.isArray(schemaRecord.required)
     ? schemaRecord.required.filter((key) => typeof key === "string")
     : undefined;
+  // When computing merged required, exclude properties that carry a TypeBox
+  // Optional annotation (Symbol.for("TypeBox.Optional")) in their merged
+  // schema. normalizeToolParameters flattens anyOf variants into a single
+  // object, and during that merge the Optional marker on properties like
+  // `buttons` can be preserved in the schema value but lost from the
+  // per-variant `required` arrays — causing them to resurface as required
+  // in the merged output.
+  const typeboxOptionalSymbol = Symbol.for("TypeBox.Optional");
+  const isPropertyOptional = (key: string): boolean => {
+    const prop = mergedProperties[key];
+    if (!prop || typeof prop !== "object") {
+      return false;
+    }
+    const record = prop as Record<string | symbol, unknown>;
+    return record[typeboxOptionalSymbol] === "Optional";
+  };
   const mergedRequired =
     baseRequired && baseRequired.length > 0
-      ? baseRequired
+      ? baseRequired.filter((key) => !isPropertyOptional(key))
       : objectVariants > 0
         ? Array.from(requiredCounts.entries())
             .filter(([, count]) => count === objectVariants)
             .map(([key]) => key)
+            .filter((key) => !isPropertyOptional(key))
         : undefined;
 
   const nextSchema: Record<string, unknown> = { ...schemaRecord };


### PR DESCRIPTION
## Summary

The `message` tool schema declares `buttons` as a required parameter (`required: ["action", "buttons"]`), causing all non-send actions (react, delete, edit, poll) to fail with validation error unless an empty `buttons: []` array is passed.

## Root Cause

`normalizeToolParameters()` in `src/agents/pi-tools.schema.ts` flattens `anyOf` variants into a merged `Type.Object`. During that merge, the TypeBox `Optional` annotation (`Symbol.for('TypeBox.Optional')`) on properties like `buttons` is preserved in the property schema value but not consulted when computing the merged `required` array. Since `buttons` appears in every variant's required list (after the Optional marker is stripped by the variant extraction), it resurfaces as required in the merged output.

## Changes

Added a check in the merged required computation to inspect each property for the TypeBox Optional symbol. Properties annotated as Optional are now excluded from the required array, matching the original schema intent.

## Files Changed

- `src/agents/pi-tools.schema.ts` — filter Optional-annotated properties from merged required

Fixes #56496