### PR TITLE
fix(config): deduplicate clobbered config snapshots in-process

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1217,6 +1217,14 @@ function sameFingerprint(
   );
 }
 
+// In-process dedup for clobbered config snapshots. When writeConfigHealthState
+// fails silently (e.g. during doctor --fix migration), the on-disk
+// lastObservedSuspiciousSignature is never persisted, causing every subsequent
+// readConfigFile to generate a new timestamped .clobbered.* backup file.
+// This Set tracks signatures already observed in the current process lifetime,
+// covering both the async and sync code paths.
+const observedSuspiciousSignatures = new Set<string>();
+
 async function observeConfigSnapshot(
   deps: Required<ConfigIoDeps>,
   snapshot: ConfigFileSnapshot,
@@ -1273,6 +1281,13 @@ async function observeConfigSnapshot(
   if (entry.lastObservedSuspiciousSignature === suspiciousSignature) {
     return;
   }
+  // In-process dedup: if we already observed this signature in this process
+  // (writeConfigHealthState may have failed silently), skip the snapshot.
+  const dedupKey = `${snapshot.path}:${suspiciousSignature}`;
+  if (observedSuspiciousSignatures.has(dedupKey)) {
+    return;
+  }
+  observedSuspiciousSignatures.add(dedupKey);
 
   const backup =
     (backupBaseline?.hash ? backupBaseline : null) ??
@@ -1401,6 +1416,12 @@ function observeConfigSnapshotSync(
   if (entry.lastObservedSuspiciousSignature === suspiciousSignature) {
     return;
   }
+  // In-process dedup (sync path): same guard as the async path above.
+  const dedupKey = `${snapshot.path}:${suspiciousSignature}`;
+  if (observedSuspiciousSignatures.has(dedupKey)) {
+    return;
+  }
+  observedSuspiciousSignatures.add(dedupKey);
 
   const backup =
     (backupBaseline?.hash ? backupBaseline : null) ??


### PR DESCRIPTION
## Summary

`openclaw doctor --fix` generates **thousands** of timestamped `.clobbered.*` backup files instead of one, filling up the config directory.

## Root Cause

Confirmed by @martingarramon in #56450:

`writeConfigHealthState` in `src/config/io.ts` is wrapped in a silent `catch {}`. When the health state file can't be written during the config directory migration that `doctor --fix` triggers, the dedup signature (`lastObservedSuspiciousSignature`) is never persisted to disk. Every subsequent `readConfigFile` call sees no prior signature and calls `persistClobberedConfigSnapshot` unconditionally, generating one timestamped file per read.

## Changes

Added an in-process `Set<string>` (`observedSuspiciousSignatures`) that tracks config anomaly signatures within the current process lifecycle. Both code paths now check this Set before writing a clobbered snapshot:

- **Async path** (`observeConfigSnapshot`): dedup check added before `persistClobberedConfigSnapshot`
- **Sync path** (`observeConfigSnapshotSync`): same dedup check added

This ensures that even when the on-disk health state fails to persist, the same signature is only processed once per process.

## Files Changed

- `src/config/io.ts`

Fixes #56450