### PR TITLE
fix: normalize openai-codex and github-copilot provider IDs for media-understanding

### DIFF
--- a/src/media-understanding/provider-id.ts
+++ b/src/media-understanding/provider-id.ts
@@ -1,9 +1,23 @@
 import { normalizeProviderId } from "../agents/provider-id.js";
 
+/**
+ * Normalize a provider ID for media-understanding registry lookups.
+ *
+ * Provider variants that share the same underlying API and model catalog
+ * are collapsed to their base provider so a single media-understanding
+ * adapter can serve all of them:
+ *
+ * - `"gemini"` → `"google"`
+ * - `"openai-codex"` → `"openai"` (Codex OAuth uses the same OpenAI vision models)
+ * - `"github-copilot"` → `"openai"` (Copilot routes through OpenAI models)
+ */
 export function normalizeMediaProviderId(id: string): string {
   const normalized = normalizeProviderId(id);
   if (normalized === "gemini") {
     return "google";
+  }
+  if (normalized === "openai-codex" || normalized === "github-copilot") {
+    return "openai";
   }
   return normalized;
 }

--- a/src/media-understanding/provider-registry.test.ts
+++ b/src/media-understanding/provider-registry.test.ts
@@ -160,4 +160,47 @@ describe("media-understanding provider registry", () => {
 
     expect(getMediaUnderstandingProvider("avOnly", registry)).toBeUndefined();
   });
+
+  it("normalizes openai-codex to openai for media-understanding lookup", () => {
+    const pluginRegistry = createEmptyPluginRegistry();
+    pluginRegistry.mediaUnderstandingProviders.push({
+      pluginId: "openai",
+      pluginName: "OpenAI Plugin",
+      source: "test",
+      provider: {
+        id: "openai",
+        capabilities: ["image", "audio"],
+        describeImage: async () => ({ text: "openai image" }),
+      },
+    });
+    setActivePluginRegistry(pluginRegistry);
+
+    const registry = buildMediaUnderstandingRegistry();
+    const provider = getMediaUnderstandingProvider("openai-codex", registry);
+
+    expect(provider).toBeDefined();
+    expect(provider?.id).toBe("openai");
+    expect(provider?.capabilities).toContain("image");
+  });
+
+  it("normalizes github-copilot to openai for media-understanding lookup", () => {
+    const pluginRegistry = createEmptyPluginRegistry();
+    pluginRegistry.mediaUnderstandingProviders.push({
+      pluginId: "openai",
+      pluginName: "OpenAI Plugin",
+      source: "test",
+      provider: {
+        id: "openai",
+        capabilities: ["image", "audio"],
+        describeImage: async () => ({ text: "openai image" }),
+      },
+    });
+    setActivePluginRegistry(pluginRegistry);
+
+    const registry = buildMediaUnderstandingRegistry();
+    const provider = getMediaUnderstandingProvider("github-copilot", registry);
+
+    expect(provider).toBeDefined();
+    expect(provider?.id).toBe("openai")
+  });
 });


### PR DESCRIPTION
## Summary

When using `openai-codex` (Codex OAuth) or `github-copilot` as a provider, the image/media-understanding tool fails with:

> No media-understanding provider registered for openai-codex

Both providers route through OpenAI models that fully support vision, but `normalizeMediaProviderId()` did not map them to `"openai"`, so the registry lookup couldn't find the OpenAI media-understanding adapter.

## Changes

- **`src/media-understanding/provider-id.ts`** — Added normalization rules: `openai-codex → openai` and `github-copilot → openai`, matching the existing `gemini → google` pattern.
- **`src/media-understanding/provider-registry.test.ts`** — Added two tests confirming both provider variants resolve to the `openai` media-understanding provider.

## Test plan

- [x] All 5 existing + new media-understanding tests pass (`pnpm vitest src/media-understanding`)
- [x] Pre-commit hooks (lint, typecheck) pass
- [ ] Manual verification: configure `openai-codex` as primary provider → image tool should work without fallback