### PR TITLE
Fix 401/403 auth failures being misclassified as rate limits in embedded runtime

### DIFF
--- a/extensions/google/image-generation-provider.test.ts
+++ b/extensions/google/image-generation-provider.test.ts
@@ -3,6 +3,32 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildGoogleImageGenerationProvider } from "./image-generation-provider.js";
 import { __testing as geminiWebSearchTesting } from "./src/gemini-web-search-provider.js";
 
+vi.mock("openclaw/plugin-sdk/provider-http", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/provider-http")>();
+  return {
+    ...actual,
+    postJsonRequest: async (params: {
+      url: string;
+      headers: Headers;
+      body: unknown;
+      timeoutMs: number;
+      fetchFn: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+      allowPrivateNetwork?: boolean;
+    }) => {
+      const response = await params.fetchFn(params.url, {
+        method: "POST",
+        headers: params.headers,
+        body: JSON.stringify(params.body),
+      });
+      return {
+        response,
+        finalUrl: params.url,
+        release: async () => {},
+      };
+    },
+  };
+});
+
 function mockGoogleApiKeyAuth() {
   vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
     apiKey: "google-test-key",

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -5,7 +5,7 @@ vi.mock("../../src/infra/wsl.js", () => ({
   isWSL2Sync: () => false,
 }));
 
-vi.mock("../../src/infra/net/fetch-guard.js", () => ({
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: async (params: {
     url: string;
     init?: RequestInit;

--- a/src/agents/auth-profiles.markauthprofilefailure.test.ts
+++ b/src/agents/auth-profiles.markauthprofilefailure.test.ts
@@ -215,6 +215,23 @@ describe("markAuthProfileFailure", () => {
       expect(stats?.cooldownUntil).toBeUndefined();
     });
   });
+  it("disables auth failures without using cooldown escalation", async () => {
+    await withAuthProfileStore(async ({ agentDir, store }) => {
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "auth",
+        agentDir,
+      });
+
+      const stats = store.usageStats?.["anthropic:default"];
+      expect(typeof stats?.disabledUntil).toBe("number");
+      expect(stats?.disabledReason).toBe("auth");
+      expect(stats?.cooldownUntil).toBeUndefined();
+      expect(stats?.failureCounts?.auth).toBe(1);
+      expect(stats?.failureCounts?.rate_limit).toBeUndefined();
+    });
+  });
   it("resets backoff counters outside the failure window", async () => {
     const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
     try {

--- a/src/agents/auth-profiles/state-observation.ts
+++ b/src/agents/auth-profiles/state-observation.ts
@@ -15,7 +15,9 @@ export function logAuthProfileFailureStateChange(params: {
   now: number;
 }): void {
   const windowType =
-    params.reason === "billing" || params.reason === "auth_permanent" ? "disabled" : "cooldown";
+    params.reason === "billing" || params.reason === "auth" || params.reason === "auth_permanent"
+      ? "disabled"
+      : "cooldown";
   const previousCooldownUntil = params.previous?.cooldownUntil;
   const previousDisabledUntil = params.previous?.disabledUntil;
   // Active cooldown/disable windows are intentionally immutable; log whether this

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -667,9 +667,9 @@ function computeNextProfileUsageStats(params: {
     params.reason === "auth" ||
     params.reason === "auth_permanent"
   ) {
-    const billingCount = failureCounts[params.reason] ?? 1;
+    const disabledFailureCount = failureCounts[params.reason] ?? 1;
     const backoffMs = calculateAuthProfileBillingDisableMsWithConfig({
-      errorCount: billingCount,
+      errorCount: disabledFailureCount,
       baseMs: params.cfgResolved.billingBackoffMs,
       maxMs: params.cfgResolved.billingMaxMs,
     });
@@ -734,9 +734,9 @@ function computeNextProfileUsageStats(params: {
 }
 
 /**
- * Mark a profile as failed for a specific reason. Billing and permanent-auth
- * failures are treated as "disabled" (longer backoff) vs the regular cooldown
- * window.
+ * Mark a profile as failed for a specific reason. Billing, auth, and
+ * permanent-auth failures are treated as "disabled" (longer backoff) vs the
+ * regular cooldown window.
  */
 export async function markAuthProfileFailure(params: {
   store: AuthProfileStore;

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -662,7 +662,11 @@ function computeNextProfileUsageStats(params: {
     lastFailureAt: params.now,
   };
 
-  if (params.reason === "billing" || params.reason === "auth_permanent") {
+  if (
+    params.reason === "billing" ||
+    params.reason === "auth" ||
+    params.reason === "auth_permanent"
+  ) {
     const billingCount = failureCounts[params.reason] ?? 1;
     const backoffMs = calculateAuthProfileBillingDisableMsWithConfig({
       errorCount: billingCount,

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -532,6 +532,10 @@ describe("classifyFailoverReasonFromHttpStatus", () => {
     expect(classifyFailoverReasonFromHttpStatus(401, "invalid_api_key")).toBe("auth_permanent");
   });
 
+  it("keeps explicit HTTP 429 in the rate_limit lane even when auth keywords appear", () => {
+    expect(classifyFailoverReasonFromHttpStatus(429, "invalid api key")).toBe("rate_limit");
+  });
+
   it("treats HTTP 422 as format error", () => {
     expect(classifyFailoverReasonFromHttpStatus(422)).toBe("format");
     expect(classifyFailoverReasonFromHttpStatus(422, "check open ai req parameter error")).toBe(
@@ -833,6 +837,14 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("invalid api key")).toBe("auth");
     expect(classifyFailoverReason("no credentials found")).toBe("auth");
     expect(classifyFailoverReason("no api key found")).toBe("auth");
+    expect(classifyFailoverReason("HTTP 429 invalid api key")).toBe("rate_limit");
+    expect(
+      classifyFailoverReason("HTTP 401 rate limit exceeded while validating credentials"),
+    ).toBe("auth");
+    expect(classifyFailoverReason("HTTP 401 insufficient quota")).toBe("auth");
+    expect(classifyFailoverReason("403 quota exceeded: access denied for this API key")).toBe(
+      "auth",
+    );
     expect(
       classifyFailoverReason(
         'No API key found for provider "openai". Auth store: /tmp/openclaw-agent-abc/auth-profiles.json (agentDir: /tmp/openclaw-agent-abc).',
@@ -894,6 +906,12 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("You have hit your ChatGPT usage limit (plus plan)")).toBe(
       "rate_limit",
     );
+  });
+
+  it("keeps message-only classification behavior when no explicit HTTP status is present", () => {
+    expect(classifyFailoverReason("rate limit exceeded")).toBe("rate_limit");
+    expect(classifyFailoverReason("quota exceeded")).toBe("rate_limit");
+    expect(classifyFailoverReason("access denied")).toBe("auth");
   });
   it("classifies AWS Bedrock too-many-tokens-per-day errors as rate_limit", () => {
     expect(

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -842,6 +842,7 @@ describe("classifyFailoverReason", () => {
       classifyFailoverReason("HTTP 401 rate limit exceeded while validating credentials"),
     ).toBe("auth");
     expect(classifyFailoverReason("HTTP 401 insufficient quota")).toBe("auth");
+    expect(classifyFailoverReason("401 session expired")).toBe("auth");
     expect(classifyFailoverReason("403 quota exceeded: access denied for this API key")).toBe(
       "auth",
     );

--- a/src/tasks/task-owner-access.test.ts
+++ b/src/tasks/task-owner-access.test.ts
@@ -13,6 +13,7 @@ const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
 
 afterEach(() => {
   resetTaskRegistryForTests({ persist: false });
+  resetTaskFlowRegistryForTests();
   if (ORIGINAL_STATE_DIR == null) {
     delete process.env.OPENCLAW_STATE_DIR;
   } else {

--- a/src/tasks/task-owner-access.test.ts
+++ b/src/tasks/task-owner-access.test.ts
@@ -6,6 +6,7 @@ import {
   getTaskByIdForOwner,
   resolveTaskForLookupTokenForOwner,
 } from "./task-owner-access.js";
+import { resetTaskFlowRegistryForTests } from "./task-flow-registry.js";
 import { createTaskRecord, resetTaskRegistryForTests } from "./task-registry.js";
 
 const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
@@ -24,10 +25,12 @@ async function withTaskRegistryTempDir<T>(run: () => Promise<T> | T): Promise<T>
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
     process.env.OPENCLAW_STATE_DIR = root;
     resetTaskRegistryForTests({ persist: false });
+    resetTaskFlowRegistryForTests();
     try {
       return await run();
     } finally {
       resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests();
       if (previousStateDir == null) {
         delete process.env.OPENCLAW_STATE_DIR;
       } else {


### PR DESCRIPTION
Fixes #47720.

Rebased this PR onto the latest upstream main and force-updated the branch so the PR now reflects only the intended auth/rate-limit fix on a clean history.

This patch fixes the main embedded/runtime failover path where some HTTP `401/403` auth failures could be misclassified as `rate_limit`.

In those cases, auth profile state could incorrectly enter the rate-limit cooldown lane and surface misleading rate-limit state and messaging.
This patch fixes the main embedded/runtime failover path where some HTTP `401/403` auth failures could be misclassified as `rate_limit`.

In those cases, auth profile state could incorrectly enter the rate-limit cooldown lane and surface misleading rate-limit state and messaging.

**What changes**
- Prefer an explicit leading HTTP status over ambiguous message keywords in `classifyFailoverReason()`
- Keep message-keyword heuristics as fallback for message-only inputs
- Route auth failures into the existing disabled lane in auth profile state instead of the cooldown lane
- Keep `429` behavior unchanged

**Behavioral boundary**
- If a leading HTTP status is present, classification now prefers that explicit status over message keywords
- `401/403` are no longer overridden by rate limit / quota wording in the message body
- `429` still maps to `rate_limit`
- Message-only inputs keep their previous heuristic behavior
- In auth profile state, `auth` now follows the existing `disabledUntil` lane rather than `cooldownUntil`
- This does not introduce permanent disablement; profiles become eligible again after the existing disabled window expires
- This patch does not redesign auth-specific disable durations or the broader failover taxonomy

**Scope**
- No new CLI commands
- No `doctor --fix` changes
- No unrelated provider refactors
- Focused on the main embedded/runtime classification path and auth profile state alignment

**Added regression coverage for**
- `HTTP 401 ... insufficient quota -> auth`
- `HTTP 403 ... access denied -> auth`
- `HTTP 429 ... invalid api key -> rate_limit`
- Message-only inputs keep prior heuristic behavior

**Targeted tests**
- `corepack pnpm vitest run --config vitest.config.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- `corepack pnpm vitest run --config vitest.config.ts src/agents/auth-profiles.markauthprofilefailure.test.ts`
- `corepack pnpm vitest run --config vitest.config.ts src/agents/auth-profiles/state-observation.test.ts`
