### PR TITLE
docs: fix subagent context file list and coding profile description

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -102,7 +102,7 @@ Per-agent override: `agents.list[].tools.profile`.
 | Profile     | What it includes                            |
 | ----------- | ------------------------------------------- |
 | `full`      | All tools (default)                         |
-| `coding`    | File I/O, runtime, sessions, memory, image  |
+| `coding`    | File I/O, runtime, web, sessions, memory, image |
 | `messaging` | Messaging, session list/history/send/status |
 | `minimal`   | `session_status` only                       |
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -290,6 +290,6 @@ Sub-agents use a dedicated in-process queue lane:
 - Sub-agent announce is **best-effort**. If the gateway restarts, pending "announce back" work is lost.
 - Sub-agents still share the same gateway process resources; treat `maxConcurrent` as a safety valve.
 - `sessions_spawn` is always non-blocking: it returns `{ status: "accepted", runId, childSessionKey }` immediately.
-- Sub-agent context only injects `AGENTS.md` + `TOOLS.md` (no `SOUL.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, or `BOOTSTRAP.md`).
+- Sub-agent context injects `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, and `USER.md` (no `HEARTBEAT.md`, `BOOTSTRAP.md`, or `MEMORY.md`). See `MINIMAL_BOOTSTRAP_ALLOWLIST` in `src/agents/workspace.ts`.
 - Maximum nesting depth is 5 (`maxSpawnDepth` range: 1–5). Depth 2 is recommended for most use cases.
 - `maxChildrenPerAgent` caps active children per session (default: 5, range: 1–20).


### PR DESCRIPTION
## Summary

- **Problem:** `docs/tools/subagents.md` states sub-agents only receive `AGENTS.md` + `TOOLS.md`, but the source code (`MINIMAL_BOOTSTRAP_ALLOWLIST` in `src/agents/workspace.ts`) and tests (`workspace.test.ts`) show they receive 5 files: `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`.
- **Why it matters:** Users and agents relying on the docs will incorrectly believe sub-agent workspaces should only contain `AGENTS.md` + `TOOLS.md`, missing the opportunity to provide identity/personality/user context to sub-agents.
- **What changed:** Fixed the context file list in `subagents.md` L293 to match source. Added "web" to the `coding` profile description in `index.md` (`web_search`/`web_fetch` are in the coding profile per `tool-catalog.ts`).
- **What did NOT change:** No code changes. Docs only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A — docs-only fix, no associated issue.
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** The docs were likely written before `SOUL.md`, `IDENTITY.md`, and `USER.md` were added to the `MINIMAL_BOOTSTRAP_ALLOWLIST`, and were not updated when the allowlist was expanded.
- **Missing detection / guardrail:** No automated check that docs match source constants.
- **Prior context:** `MINIMAL_BOOTSTRAP_ALLOWLIST` in `src/agents/workspace.ts` includes 5 files. The `expectSubagentAllowedBootstrapNames` test helper in `workspace.test.ts` explicitly asserts all 5.
- **Why this regressed now:** N/A — the docs were always inaccurate relative to the current source.
- **If unknown, what was ruled out:** N/A

## Regression Test Plan (if applicable)

N/A — docs-only change. Existing `workspace.test.ts` already validates the correct behavior.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/agents/workspace.test.ts` — `filterBootstrapFilesForSession` tests
- If no new test is added, why not: Existing tests already assert the 5-file allowlist. This is a docs-only fix.

## User-visible / Behavior Changes

None — docs correction only.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

N/A — docs-only.

### Steps

1. Read `docs/tools/subagents.md` L293
2. Compare with `MINIMAL_BOOTSTRAP_ALLOWLIST` in `src/agents/workspace.ts`
3. Compare with `expectSubagentAllowedBootstrapNames` in `src/agents/workspace.test.ts`

### Expected

Docs match source code.

### Actual

Before: docs claim only 2 files. Source and tests confirm 5.

## Evidence

- [x] Source: `MINIMAL_BOOTSTRAP_ALLOWLIST` = `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`
- [x] Test: `expectSubagentAllowedBootstrapNames` asserts all 5 present, and `HEARTBEAT.md`, `BOOTSTRAP.md`, `MEMORY.md` absent

## Human Verification (required)

- Verified: `grep` confirmed source constants, test assertions, and doc text
- Edge cases: Also verified `coding` profile in `tool-catalog.ts` includes `web_search`/`web_fetch`
- Not verified: No build/runtime verification needed (docs only)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None — docs-only correction to match existing source behavior.