### PR TITLE
fix: check all accepted parameter names for read tool path validation

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -352,7 +352,11 @@ export async function handleToolExecutionStart(
         ? record.path
         : typeof record.file_path === "string"
           ? record.file_path
-          : "";
+          : typeof record.file === "string"
+            ? record.file
+            : typeof record.filePath === "string"
+              ? record.filePath
+              : "";
     const filePath = filePathValue.trim();
     if (!filePath) {
       const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;


### PR DESCRIPTION
## Summary

Fixes #56694.

The `read` tool schema accepts four parameter names for the file path: `path`, `file_path`, `file`, and `filePath`. However, the path validation check in `handleToolExecutionStart` only tested `record.path` and `record.file_path`, causing a false-positive warning when the model used `file` or `filePath`.

## Changes

- `src/agents/pi-embedded-subscribe.handlers.tools.ts`: Extend the path extraction chain to also check `record.file` and `record.filePath` before treating the path as missing.

## Before

```js
const filePathValue =
  typeof record.path === "string"
    ? record.path
    : typeof record.file_path === "string"
      ? record.file_path
      : "";
```

## After

```js
const filePathValue =
  typeof record.path === "string"
    ? record.path
    : typeof record.file_path === "string"
      ? record.file_path
      : typeof record.file === "string"
        ? record.file
        : typeof record.filePath === "string"
          ? record.filePath
          : "";
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)