### PR TITLE
fix: deduplicate bootstrap files by path to prevent accumulation on restart

### DIFF
--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -31,6 +31,7 @@ function sanitizeBootstrapFiles(
   warn?: (message: string) => void,
 ): WorkspaceBootstrapFile[] {
   const sanitized: WorkspaceBootstrapFile[] = [];
+  const seenPaths = new Set<string>();
   for (const file of files) {
     const pathValue = typeof file.path === "string" ? file.path.trim() : "";
     if (!pathValue) {
@@ -39,6 +40,10 @@ function sanitizeBootstrapFiles(
       );
       continue;
     }
+    if (seenPaths.has(pathValue)) {
+      continue;
+    }
+    seenPaths.add(pathValue);
     sanitized.push({ ...file, path: pathValue });
   }
   return sanitized;


### PR DESCRIPTION
## Summary

Fixes #56698.

Hook bootstrap virtual files pushed via `event.context.bootstrapFiles.push()` were never deduplicated at the framework level. On every gateway restart, the same virtual file (e.g. `SELF_IMPROVEMENT_REMINDER.md`) would be appended again, wasting thousands of context characters per session.

## Changes

- `src/agents/bootstrap-files.ts`: Add a `seenPaths` set in `sanitizeBootstrapFiles` to skip duplicate path entries. First occurrence wins (preserving hook insertion order).

## Before / After

Before: after 40 restarts, a virtual file could appear 80 times consuming ~49,000 chars of context.

After: each unique path appears at most once regardless of how many times hooks have pushed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)