### PR TITLE
fix: restore --exclude-labels SPAM,TRASH,DRAFT,SENT in Gmail watcher

### DIFF
--- a/src/hooks/gmail.ts
+++ b/src/hooks/gmail.ts
@@ -241,6 +241,7 @@ export function buildGogWatchServeArgs(cfg: GmailHookRuntimeConfig): string[] {
     "--hook-token",
     cfg.hookToken,
   ];
+  args.push("--exclude-labels", "SPAM,TRASH,DRAFT,SENT");
   if (cfg.includeBody) {
     args.push("--include-body");
   }


### PR DESCRIPTION
## Summary

Fixes #56635.

The `--exclude-labels SPAM,TRASH,DRAFT,SENT` flag was passed to `gog gmail watch serve` in 2026.2.24 but was accidentally dropped in 2026.3.24. Without it only SPAM and TRASH are excluded by the `gog` CLI defaults, causing sent mail and draft saves to trigger webhook notifications and the agent to process the user's own outbound email.

## Changes

- `src/hooks/gmail.ts`: Restore the `--exclude-labels SPAM,TRASH,DRAFT,SENT` argument in `buildGogWatchServeArgs()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)