### PR TITLE
fix(tts): skip directives inside code blocks

### DIFF
--- a/src/plugins/contracts/tts.contract.test.ts
+++ b/src/plugins/contracts/tts.contract.test.ts
@@ -469,6 +469,219 @@ describe("tts", () => {
       expect(openaiOverrides?.voice).toBeUndefined();
       expect(result.warnings).toContain('invalid OpenAI voice "kokoro-chinese"');
     });
+
+    it("ignores TTS directives inside inline code", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "Use `[[tts:voice=Audrey]]` to change the voice.";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+      expect(result.overrides.provider).toBeUndefined();
+    });
+
+    it("ignores TTS directives inside fenced code blocks", () => {
+      const policy = resolveModelOverridePolicy({
+        enabled: true,
+        allowProvider: true,
+        allowText: true,
+      });
+      const input =
+        "Here is an example:\n\n" +
+        "```\n[[tts:text]]hello[[/tts:text]]\n[[tts:provider=elevenlabs]]\n```\n\n" +
+        "That was just an example.";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+      expect(result.overrides.provider).toBeUndefined();
+      expect(result.ttsText).toBeUndefined();
+    });
+
+    it("preserves original code in ttsText without placeholder leakage", () => {
+      const policy = resolveModelOverridePolicy({
+        enabled: true,
+        allowProvider: true,
+        allowText: true,
+      });
+      const input = "[[tts:text]]Use `const x = 1;` in your code[[/tts:text]]";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(true);
+      expect(result.ttsText).toBe("Use `const x = 1;` in your code");
+      expect(result.ttsText).not.toContain("\uFDD0");
+    });
+
+    it("preserves inline and fenced code inside tts:text blocks in ttsText", () => {
+      const policy = resolveModelOverridePolicy({
+        enabled: true,
+        allowText: true,
+      });
+      const input =
+        "[[tts:text]]" +
+        "Here is some `inline code` and a fenced block:\n" +
+        "```ts\n" +
+        "const x = 1;\n" +
+        "console.log(x);\n" +
+        "```\n" +
+        "[[/tts:text]]";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(true);
+      const expectedTtsText =
+        "Here is some `inline code` and a fenced block:\n" +
+        "```ts\n" +
+        "const x = 1;\n" +
+        "console.log(x);\n" +
+        "```";
+      expect(result.ttsText).toBe(expectedTtsText);
+      expect(result.ttsText).not.toContain("\uFDD0");
+    });
+
+    it("ignores TTS directives inside double-backtick code spans", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "Use ``[[tts:voice=Audrey]]`` to change the voice.";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+      expect(result.overrides.provider).toBeUndefined();
+    });
+
+    it("ignores TTS directives inside multi-backtick code spans containing backticks", () => {
+      const policy = resolveModelOverridePolicy({
+        enabled: true,
+        allowProvider: true,
+        allowText: true,
+      });
+      const input = "Example `` `code` [[tts:provider=elevenlabs]] `` done.";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+      expect(result.overrides.provider).toBeUndefined();
+      expect(result.ttsText).toBeUndefined();
+    });
+
+    it("processes directives outside code but preserves code blocks", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "Say hello [[tts:provider=elevenlabs]] with `some code` here.";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(true);
+      expect(result.overrides.provider).toBe("elevenlabs");
+      expect(result.cleanedText).toContain("`some code`");
+      expect(result.cleanedText).not.toContain("[[tts:");
+    });
+
+    it("ignores TTS directives inside 4-backtick fenced code blocks", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "````\ninside ``` nested\n[[tts:provider=elevenlabs]]\n````\nafter";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+    });
+
+    it("ignores TTS directives inside tilde-fenced code blocks", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "~~~\n[[tts:provider=elevenlabs]]\n~~~\nafter";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+    });
+
+    it("ignores TTS directives inside fenced code blocks with CRLF line endings", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "```\r\n[[tts:voice=Audrey]]\r\n```\r\nafter";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+    });
+
+    it("ignores TTS directives inside CommonMark-indented fenced code blocks", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "1. item\n   ```\n   [[tts:voice=Audrey]]\n   ```\nafter";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+    });
+
+    it("ignores TTS directives inside triple-backtick inline code spans", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "Use ``` [[tts:voice=Audrey]] ``` in your text";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+    });
+
+    it("does not mask directives when backtick run lengths differ", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "``[[tts:provider=elevenlabs]]```";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(true);
+      expect(result.overrides.provider).toBe("elevenlabs");
+    });
+
+    it("ignores TTS directives inside multiline inline code spans", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "`line1\n[[tts:provider=elevenlabs]]\nline2`";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+    });
+
+    it("does not mask across paragraph breaks in inline code spans", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "`line1\n\n[[tts:provider=elevenlabs]]\nline2`";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(true);
+      expect(result.overrides.provider).toBe("elevenlabs");
+    });
+
+    it("ignores TTS directives in fenced blocks with trailing whitespace on closing fence", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "```\n[[tts:voice=Audrey]]\n```   \nafter";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+    });
+
+    it("ignores TTS directives inside unclosed fenced code blocks", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "```\n[[tts:provider=elevenlabs]]";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+    });
+
+    it("does not treat backticks in info string as a fence opener", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      // Invalid fence (backtick in info string) → ``` acts as inline code delimiters,
+      // so the directive is inside a code span per CommonMark and should be ignored.
+      const input = "```js`demo\n[[tts:voice=Audrey]]\n```\nafter";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+    });
+
+    it("ignores TTS directives when closing fence is longer than opener", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true, allowProvider: true });
+      const input = "```\n[[tts:provider=elevenlabs]]\n`````\nafter";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+    });
   });
 
   describe("summarizeText", () => {

--- a/src/tts/directives.ts
+++ b/src/tts/directives.ts
@@ -37,6 +37,65 @@ function resolveDirectiveProviderConfig(
   return options?.providerConfigs?.[provider.id];
 }
 
+// U+FDD0 is a Unicode non-character reserved for internal use and unlikely to
+// appear in user-supplied text, making it a practical sentinel for placeholders.
+const PLACEHOLDER_SENTINEL = "\uFDD0";
+
+// CommonMark fenced code block (backticks): line-anchored, 0–3 spaces indent,
+// closing fence must be at least as long as the opener, backtick info strings
+// reject backticks per spec, unclosed fences extend to EOF.
+const BACKTICK_FENCE =
+  "(?<=^|\\n) {0,3}(?<btick>`{3,})[^\\n`]*\\r?\\n[\\s\\S]*?(?:\\r?\\n {0,3}\\k<btick>`*[ \\t]*(?=\\r?\\n|$)|$)";
+
+// CommonMark fenced code block (tildes): same structure, tildes allow any info string.
+const TILDE_FENCE =
+  "(?<=^|\\n) {0,3}(?<tilde>~{3,})[^\\n]*\\r?\\n[\\s\\S]*?(?:\\r?\\n {0,3}\\k<tilde>~*[ \\t]*(?=\\r?\\n|$)|$)";
+
+// Inline code span: named backreference matches any delimiter length (`, ``, ```, …).
+// Allows single newlines (CommonMark treats them as spaces in code spans) but
+// stops at paragraph breaks (\n\n) to prevent over-masking across blocks.
+// Negative lookaround enforces maximal backtick runs per CommonMark §6.1.
+const INLINE_CODE = "(?<!`)(?<code>`+)(?!`)(?:[^\\n]|\\n(?!\\n))*?(?<!`)\\k<code>(?!`)";
+
+const CODE_BLOCK_PATTERN = new RegExp(`${BACKTICK_FENCE}|${TILDE_FENCE}|${INLINE_CODE}`, "g");
+
+/**
+ * Temporarily replace fenced code blocks and inline code spans with inert
+ * placeholders so that literal TTS directive examples inside code are not
+ * interpreted as active directives.
+ *
+ * Returns the masked text and a `restore` function that reverses the masking.
+ * Each call generates a unique nonce via `crypto.randomUUID()` to prevent
+ * placeholder collisions across concurrent or nested invocations.
+ */
+function maskCodeBlocks(text: string): { masked: string; restore: (s: string) => string } {
+  const identity = (s: string): string => s;
+  if (!text.includes("`") && !text.includes("~")) {
+    return { masked: text, restore: identity };
+  }
+
+  const nonce = crypto.randomUUID().replace(/-/g, "");
+  const placeholders: string[] = [];
+
+  const masked = text.replace(CODE_BLOCK_PATTERN, (match) => {
+    const index = placeholders.length;
+    placeholders.push(match);
+    return `${PLACEHOLDER_SENTINEL}${nonce}${index}${PLACEHOLDER_SENTINEL}`;
+  });
+
+  const placeholderPattern = new RegExp(
+    `${PLACEHOLDER_SENTINEL}${nonce}(\\d+)${PLACEHOLDER_SENTINEL}`,
+    "g",
+  );
+  const restore = (s: string): string =>
+    s.replace(
+      placeholderPattern,
+      (original, index: string) => placeholders[Number(index)] ?? original,
+    );
+
+  return { masked, restore };
+}
+
 export function parseTtsDirectives(
   text: string,
   policy: SpeechModelOverridePolicy,
@@ -49,14 +108,15 @@ export function parseTtsDirectives(
   const providers = resolveDirectiveProviders(options);
   const overrides: TtsDirectiveOverrides = {};
   const warnings: string[] = [];
-  let cleanedText = text;
+  const { masked, restore } = maskCodeBlocks(text);
+  let cleanedText = masked;
   let hasDirective = false;
 
   const blockRegex = /\[\[tts:text\]\]([\s\S]*?)\[\[\/tts:text\]\]/gi;
   cleanedText = cleanedText.replace(blockRegex, (_match, inner: string) => {
     hasDirective = true;
     if (policy.allowText && overrides.ttsText == null) {
-      overrides.ttsText = inner.trim();
+      overrides.ttsText = restore(inner.trim());
     }
     return "";
   });
@@ -124,7 +184,7 @@ export function parseTtsDirectives(
   });
 
   return {
-    cleanedText,
+    cleanedText: restore(cleanedText),
     ttsText: overrides.ttsText,
     hasDirective,
     overrides,


### PR DESCRIPTION
## Summary

Fixes #56680

`parseTtsDirectives()` previously matched `[[tts:...]]` patterns even inside inline code and fenced code blocks, causing literal examples to be treated as active TTS directives.

## Changes

### `src/tts/directives.ts`
- Add `maskCodeBlocks()` — replaces Markdown code regions with inert placeholders before directive parsing, then restores original content afterward
- Integrate masking into `parseTtsDirectives()`: restore applied to both `cleanedText` and `ttsText`
- Regex patterns extracted as named constants (`BACKTICK_FENCE`, `TILDE_FENCE`, `INLINE_CODE`) for maintainability

### `src/plugins/contracts/tts.contract.test.ts`
- 21 new test cases (54 total) covering:
  - Inline code (single, double, triple+ backticks)
  - Fenced blocks (backticks, tildes, 4+ backtick nesting)
  - CommonMark edge cases (0–3 indent, CRLF, trailing whitespace, unclosed fences)
  - Backtick rejection in info strings
  - Longer closing fence than opener
  - Multiline inline code spans (within paragraph boundaries)
  - Paragraph break boundary (no over-masking)
  - Maximal backtick run enforcement for inline code spans
  - Placeholder leakage prevention in `ttsText`
  - Mixed scenarios (directives in prose + code blocks in same input)

### CommonMark compliance
The code-block regex follows the CommonMark spec:
- Fenced blocks: line-anchored, 0–3 spaces indent, backreference closers, CRLF, trailing whitespace
- Unclosed fences extend to end-of-input
- Backtick info strings reject backticks per spec
- Inline spans: named backreference delimiter matching, single newlines allowed, paragraph breaks stop matching