### PR TITLE
fix(logging): guard readLoggingConfig() against re-entrant console.warn (fixes #56715)

### DIFF
--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -72,14 +72,14 @@ function resolveConsoleSettings(): ConsoleSettings {
   }
 
   let cfg: OpenClawConfig["logging"] | undefined =
-    (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
+    (loggingState.overrideSettings as LoggerSettings | null) ?? undefined;
   if (!cfg && !shouldSkipMutatingLoggingConfigRead()) {
     if (loggingState.resolvingConsoleSettings) {
       cfg = undefined;
     } else {
       loggingState.resolvingConsoleSettings = true;
       try {
-        cfg = loadConfigFallback();
+        cfg = readLoggingConfig() ?? loadConfigFallback();
       } finally {
         loggingState.resolvingConsoleSettings = false;
       }


### PR DESCRIPTION
## Summary

Fixes #56715 — `RangeError: Maximum call stack size exceeded` when a plugin is in `plugins.entries` but disabled and absent from `plugins.allow`.

**Root cause:** `readLoggingConfig()` was called on line 75 of `console.ts` *outside* the `resolvingConsoleSettings` re-entrancy guard. The call chain was:

```
loadConfig() → config warning → console.warn
  → resolveConsoleSettings() → readLoggingConfig() → loadConfig() → [infinite loop]
```

The existing guard only protected `loadConfigFallback()` but not `readLoggingConfig()`.

**Fix:** Move `readLoggingConfig()` inside the existing `resolvingConsoleSettings` re-entrancy guard. When called re-entrantly, `cfg` is left `undefined` and the recursion breaks.

## Test plan

- [x] All 81 existing logging unit tests pass
- [x] TypeScript type-check passes
- [x] Manual: configure a plugin in `plugins.entries` with `enabled: false` and absent from `plugins.allow`, restart gateway — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)