### PR TITLE
fix(feishu): downgrade tool registration logs from info to debug (fixes #56695)

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -729,5 +729,5 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     },
   });
 
-  api.logger.info?.("feishu_bitable: Registered bitable tools");
+  api.logger.debug?.("feishu_bitable: Registered bitable tools");
 }

--- a/extensions/feishu/src/chat.ts
+++ b/extensions/feishu/src/chat.ts
@@ -188,5 +188,5 @@ export function registerFeishuChatTools(api: OpenClawPluginApi) {
     { name: "feishu_chat" },
   );
 
-  api.logger.info?.("feishu_chat: Registered feishu_chat tool");
+  api.logger.debug?.("feishu_chat: Registered feishu_chat tool");
 }

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -1575,6 +1575,6 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
   }
 
   if (registered.length > 0) {
-    api.logger.info?.(`feishu_doc: Registered ${registered.join(", ")}`);
+    api.logger.debug?.(`feishu_doc: Registered ${registered.join(", ")}`);
   }
 }

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -239,5 +239,5 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
     { name: "feishu_drive" },
   );
 
-  api.logger.info?.(`feishu_drive: Registered feishu_drive tool`);
+  api.logger.debug?.(`feishu_drive: Registered feishu_drive tool`);
 }

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -171,5 +171,5 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
     { name: "feishu_perm" },
   );
 
-  api.logger.info?.(`feishu_perm: Registered feishu_perm tool`);
+  api.logger.debug?.(`feishu_perm: Registered feishu_perm tool`);
 }

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -228,5 +228,5 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
     { name: "feishu_wiki" },
   );
 
-  api.logger.info?.(`feishu_wiki: Registered feishu_wiki tool`);
+  api.logger.debug?.(`feishu_wiki: Registered feishu_wiki tool`);
 }


### PR DESCRIPTION
## Summary

Fixes #56695 — Feishu plugin tools (`feishu_doc`, `feishu_chat`, `feishu_wiki`, `feishu_drive`, `feishu_perm`, `feishu_bitable`) were logging at `info` level on every agent dispatch, producing 4-5 log lines per message in multi-agent setups.

**Root cause:** The plugin registry can be re-evaluated on each agent dispatch. When `registerFeishuXxxTools()` is called, it always emits `api.logger.info?.("... Registered ...")`. In one production instance, this produced `feishu_doc` appearing 421 times in a single day's logs.

**Fix:** Change all 6 Feishu tool registration log calls from `info` to `debug`. Registration is an internal lifecycle event not relevant to end users at normal log levels, but still accessible to developers with `debug` logging enabled.

## Test plan

- [x] 525 of 526 Feishu extension tests pass (1 pre-existing flaky network test: `monitor.webhook-security.test.ts` fails with `ECONNRESET` independently of these changes)
- [x] TypeScript type-check passes
- [x] Manual: gateway logs should no longer show `Registered feishu_X tool` at `info` level

🤖 Generated with [Claude Code](https://claude.com/claude-code)