### PR TITLE
fix(slack): wake interaction system events

### DIFF
--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -1,6 +1,6 @@
 import type { SlackActionMiddlewareArgs } from "@slack/bolt";
 import type { Block, KnownBlock } from "@slack/web-api";
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/channel-runtime";
+import { enqueueSystemEvent, requestHeartbeatNow } from "openclaw/plugin-sdk/channel-runtime";
 import {
   buildPluginBindingResolvedText,
   parsePluginBindingApprovalCustomId,
@@ -629,10 +629,13 @@ function enqueueSlackBlockActionEvent(params: {
     params.parsed.messageTs,
     params.parsed.actionId,
   ].filter(Boolean);
-  enqueueSystemEvent(params.formatSystemEvent(eventPayload), {
+  const queued = enqueueSystemEvent(params.formatSystemEvent(eventPayload), {
     sessionKey,
     contextKey: contextParts.join(":"),
   });
+  if (queued) {
+    requestHeartbeatNow({ reason: "exec-event", sessionKey });
+  }
 }
 
 function buildSlackConfirmationBlocks(params: {

--- a/extensions/slack/src/monitor/events/interactions.modal.ts
+++ b/extensions/slack/src/monitor/events/interactions.modal.ts
@@ -1,4 +1,4 @@
-import { enqueueSystemEvent } from "openclaw/plugin-sdk/channel-runtime";
+import { enqueueSystemEvent, requestHeartbeatNow } from "openclaw/plugin-sdk/channel-runtime";
 import { parseSlackModalPrivateMetadata } from "../../modal-metadata.js";
 import { authorizeSlackSystemEventSender } from "../auth.js";
 import type { SlackMonitorContext } from "../context.js";
@@ -227,10 +227,13 @@ export async function emitSlackModalLifecycleEvent(params: {
     return;
   }
 
-  enqueueSystemEvent(params.formatSystemEvent(eventPayload), {
+  const queued = enqueueSystemEvent(params.formatSystemEvent(eventPayload), {
     sessionKey: sessionRouting.sessionKey,
     contextKey: [params.contextPrefix, callbackId, viewId, userId].filter(Boolean).join(":"),
   });
+  if (queued) {
+    requestHeartbeatNow({ reason: "exec-event", sessionKey: sessionRouting.sessionKey });
+  }
 }
 
 export function registerModalLifecycleHandler(params: {

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
+const requestHeartbeatNowMock = vi.hoisted(() => vi.fn());
 const dispatchPluginInteractiveHandlerMock = vi.hoisted(() =>
   vi.fn(async () => ({
     matched: false,
@@ -13,6 +14,7 @@ const buildPluginBindingResolvedTextMock = vi.hoisted(() => vi.fn(() => "Binding
 
 let registerSlackInteractionEvents: typeof import("./interactions.js").registerSlackInteractionEvents;
 let enqueueSystemEventSpy: ReturnType<typeof vi.spyOn>;
+let requestHeartbeatNowSpy: ReturnType<typeof vi.spyOn>;
 let dispatchPluginInteractiveHandlerSpy: ReturnType<typeof vi.spyOn>;
 let resolvePluginConversationBindingApprovalSpy: ReturnType<typeof vi.spyOn>;
 let buildPluginBindingResolvedTextSpy: ReturnType<typeof vi.spyOn>;
@@ -176,6 +178,12 @@ describe("registerSlackInteractionEvents", () => {
         (enqueueSystemEventMock as (...innerArgs: unknown[]) => boolean)(
           ...args,
         )) as typeof channelRuntime.enqueueSystemEvent);
+    requestHeartbeatNowSpy = vi
+      .spyOn(channelRuntime, "requestHeartbeatNow")
+      .mockImplementation(((...args: Parameters<typeof channelRuntime.requestHeartbeatNow>) =>
+        (requestHeartbeatNowMock as (...innerArgs: unknown[]) => void)(
+          ...args,
+        )) as typeof channelRuntime.requestHeartbeatNow);
     dispatchPluginInteractiveHandlerSpy = vi
       .spyOn(pluginRuntime, "dispatchPluginInteractiveHandler")
       .mockImplementation(((
@@ -207,10 +215,13 @@ describe("registerSlackInteractionEvents", () => {
 
   beforeEach(() => {
     enqueueSystemEventSpy.mockClear();
+    requestHeartbeatNowSpy.mockClear();
     dispatchPluginInteractiveHandlerSpy.mockClear();
     resolvePluginConversationBindingApprovalSpy.mockClear();
     buildPluginBindingResolvedTextSpy.mockClear();
     enqueueSystemEventMock.mockClear();
+    enqueueSystemEventMock.mockReturnValue(true);
+    requestHeartbeatNowMock.mockClear();
     dispatchPluginInteractiveHandlerMock.mockClear();
     resolvePluginConversationBindingApprovalMock.mockClear();
     resolvePluginConversationBindingApprovalMock.mockResolvedValue({ status: "expired" });
@@ -295,6 +306,10 @@ describe("registerSlackInteractionEvents", () => {
       channelId: "C1",
       channelType: "channel",
       senderId: "U123",
+    });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:ops:slack:channel:C1",
     });
     expect(app.client.chat.update).toHaveBeenCalledTimes(1);
   });
@@ -743,6 +758,7 @@ describe("registerSlackInteractionEvents", () => {
 
     expect(ack).toHaveBeenCalled();
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
     expect(app.client.chat.update).not.toHaveBeenCalled();
     expect(respond).toHaveBeenCalledWith({
       text: "You are not authorized to use this control.",
@@ -1336,6 +1352,10 @@ describe("registerSlackInteractionEvents", () => {
         expect.objectContaining({ actionId: "notes_input", inputValue: "ship now" }),
       ]),
     );
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:ops:slack:channel:C1",
+    });
   });
 
   it("blocks modal events when private metadata userId does not match submitter", async () => {
@@ -1363,6 +1383,7 @@ describe("registerSlackInteractionEvents", () => {
 
     expect(ack).toHaveBeenCalled();
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
   });
 
   it("blocks modal events when private metadata is missing userId", async () => {
@@ -1739,6 +1760,10 @@ describe("registerSlackInteractionEvents", () => {
       ]),
     );
     expect(options.sessionKey).toBe("agent:main:slack:channel:C99");
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:main:slack:channel:C99",
+    });
   });
 
   it("defaults modal close isCleared to false when Slack omits the flag", async () => {

--- a/src/plugin-sdk/channel-runtime.ts
+++ b/src/plugin-sdk/channel-runtime.ts
@@ -12,6 +12,7 @@ export * from "../channels/plugins/outbound/interactive.js";
 export * from "../channels/plugins/whatsapp-heartbeat.js";
 export * from "../polls.js";
 export { enqueueSystemEvent, resetSystemEventsForTest } from "../infra/system-events.js";
+export { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 export { recordChannelActivity } from "../infra/channel-activity.js";
 export * from "../infra/heartbeat-events.ts";
 export * from "../infra/heartbeat-visibility.ts";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Slack block actions and modal lifecycle handlers enqueue system events but never request a heartbeat for the routed session.
- Why it matters: the queued interaction event can sit idle until some unrelated inbound message or manual wake happens, so approval buttons and modal submissions can become dead letters.
- What changed: Slack interaction handlers now request an `exec-event` heartbeat for the same session key after a system event is successfully queued, and the interaction regression tests now assert that wake behavior.
- What did NOT change (scope boundary): this does not change Slack auth checks, message update behavior, non-interaction Slack event sources, or general heartbeat scheduling rules outside these interaction paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #28047
- Related #28047
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the Slack interaction paths stopped at `enqueueSystemEvent(...)`, so they never triggered the heartbeat wake that actually consumes the queued event.
- Missing detection / guardrail: the interaction regression tests asserted enqueue behavior, but they did not assert that the routed session was woken after the enqueue.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #28047 documented the missing wake after successful Slack Block Kit callbacks; the same gap also existed for modal submit/close lifecycle events.
- Why this regressed now: interaction handlers were wired as system-event producers, but unlike inbound messages they did not also request the follow-up turn needed to process those events.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/slack/src/monitor/events/interactions.test.ts`
- Scenario the test should lock in: successful block actions, modal submissions, and modal closes enqueue the system event and then request an `exec-event` heartbeat for the same routed session key.
- Why this is the smallest reliable guardrail: the bug is inside the interaction event handler contract itself, so the direct interaction unit test can assert both the enqueue and wake steps without broader Slack/network setup.
- Existing test that already covers this (if any): existing interaction tests already covered enqueue + auth behavior; this PR extends those assertions to cover the missing wake.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Slack Block Kit buttons and Slack modal submit/close events now trigger the routed agent session promptly after the interaction is acknowledged, instead of waiting for an unrelated later turn.

## Diagram (if applicable)

```text
Before:
[Slack button/modal] -> [enqueue system event] -> [session stays idle] -> [event waits for unrelated wake]

After:
[Slack button/modal] -> [enqueue system event] -> [request exec-event heartbeat] -> [same session processes interaction]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 via `pnpm`
- Model/provider: N/A
- Integration/channel (if any): Slack Socket Mode interaction handlers
- Relevant config (redacted): Slack account with channel bindings routing system events to agent sessions

### Steps

1. Trigger a Slack block action or modal submit/close that routes through `registerSlackInteractionEvents`.
2. Observe the handler ack, authorize, and enqueue the interaction system event.
3. Confirm the same routed session receives an immediate `exec-event` heartbeat request after the enqueue succeeds.

### Expected

- The queued interaction event triggers a prompt session turn for the routed session.

### Actual

- Before this fix, the event could remain queued until a different message or manual wake happened.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Slack interaction regression suite passes for block actions, modal submissions, and modal close events; `pnpm check` passes; `pnpm build` passes.
- Edge cases checked: unauthorized block actions and mismatched modal submitters still do not enqueue or wake; wakes are only requested when `enqueueSystemEvent(...)` reports that the event was queued.
- What you did **not** verify: live Slack end-to-end behavior against a real workspace.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: waking the wrong session would make Slack interaction events show up in the wrong agent turn.
  - Mitigation: reuse the same routed `sessionKey` that the interaction path already computed for `enqueueSystemEvent(...)`, and cover block + modal routes in tests.
- Risk: unnecessary extra heartbeat churn for duplicate interaction events.
  - Mitigation: request the wake only when `enqueueSystemEvent(...)` returns `true`, so deduped/skipped enqueues do not force another turn.
