### PR TITLE
fix(telegram): resolve env SecretRef bot tokens before startup

### DIFF
--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -41,6 +41,11 @@ const { initSpy, runSpy, loadConfig } = vi.hoisted(() => ({
     channels: { telegram: {} },
   })),
 }));
+const { resolveConfiguredSecretInputStringMock } = vi.hoisted(() => ({
+  resolveConfiguredSecretInputStringMock: vi.fn(async ({ value }: { value: unknown }) => ({
+    value: typeof value === "string" ? value.trim() || undefined : undefined,
+  })),
+}));
 
 const { registerUnhandledRejectionHandlerMock, emitUnhandledRejection, resetUnhandledRejection } =
   vi.hoisted(() => {
@@ -246,6 +251,7 @@ vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
   return {
     ...actual,
     loadConfig,
+    resolveConfiguredSecretInputString: resolveConfiguredSecretInputStringMock,
   };
 });
 
@@ -338,6 +344,11 @@ describe("monitorTelegramProvider (grammY)", () => {
       agents: { defaults: { maxConcurrent: 2 } },
       channels: { telegram: {} },
     });
+    resolveConfiguredSecretInputStringMock
+      .mockReset()
+      .mockImplementation(async ({ value }: { value: unknown }) => ({
+        value: typeof value === "string" ? value.trim() || undefined : undefined,
+      }));
     initSpy.mockClear();
     readTelegramUpdateOffsetSpy.mockReset().mockResolvedValue(null);
     api.getUpdates.mockReset().mockResolvedValue([]);
@@ -405,6 +416,28 @@ describe("monitorTelegramProvider (grammY)", () => {
           maxRetryTime: 60 * 60 * 1000,
           retryInterval: "exponential",
         }),
+      }),
+    );
+  });
+
+  it("resolves env SecretRef token before starting the provider", async () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "op://secrets/telegram/credential");
+    resolveConfiguredSecretInputStringMock.mockResolvedValueOnce({
+      value: "resolved-telegram-token",
+    });
+    const abort = new AbortController();
+    mockRunOnceAndAbort(abort);
+    await monitorTelegramProvider({ abortSignal: abort.signal });
+
+    expect(resolveConfiguredSecretInputStringMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: "op://secrets/telegram/credential",
+        path: "TELEGRAM_BOT_TOKEN",
+      }),
+    );
+    expect(readTelegramUpdateOffsetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        botToken: "resolved-telegram-token",
       }),
     );
   });

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -2,6 +2,7 @@ import type { RunOptions } from "@grammyjs/runner";
 import { resolveAgentMaxConcurrent } from "openclaw/plugin-sdk/config-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
+import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/config-runtime";
 import { waitForAbortSignal } from "openclaw/plugin-sdk/runtime-env";
 import { registerUnhandledRejectionHandler } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -75,6 +76,55 @@ const isGrammyHttpError = (err: unknown): boolean => {
   return (err as { name?: string }).name === "HttpError";
 };
 
+async function resolveMonitorTelegramToken(params: {
+  cfg: OpenClawConfig;
+  explicitToken?: string;
+  resolvedAccountToken: string;
+  resolvedAccountTokenSource: "env" | "tokenFile" | "config" | "none";
+}): Promise<string> {
+  const explicitToken = params.explicitToken?.trim();
+  if (explicitToken) {
+    const resolved = await resolveConfiguredSecretInputString({
+      config: params.cfg,
+      env: process.env,
+      value: explicitToken,
+      path: "telegram.monitor.token",
+    });
+    if (resolved.value) {
+      return resolved.value;
+    }
+    if (explicitToken === params.resolvedAccountToken) {
+      throw new Error(
+        `Telegram bot token unavailable: ${resolved.unresolvedRefReason ?? "explicit token SecretRef is unresolved."}`,
+      );
+    }
+    return explicitToken;
+  }
+
+  if (params.resolvedAccountTokenSource === "env") {
+    const envToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+    if (envToken) {
+      const resolved = await resolveConfiguredSecretInputString({
+        config: params.cfg,
+        env: process.env,
+        value: envToken,
+        path: "TELEGRAM_BOT_TOKEN",
+      });
+      if (resolved.value) {
+        return resolved.value;
+      }
+      if (envToken === params.resolvedAccountToken) {
+        throw new Error(
+          `Telegram bot token unavailable: ${resolved.unresolvedRefReason ?? "TELEGRAM_BOT_TOKEN SecretRef is unresolved."}`,
+        );
+      }
+      return envToken;
+    }
+  }
+
+  return params.resolvedAccountToken.trim();
+}
+
 export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
   const log = opts.runtime?.error ?? console.error;
   let pollingSession: TelegramPollingSession | undefined;
@@ -110,7 +160,12 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       cfg,
       accountId: opts.accountId,
     });
-    const token = opts.token?.trim() || account.token;
+    const token = await resolveMonitorTelegramToken({
+      cfg,
+      explicitToken: opts.token,
+      resolvedAccountToken: account.token,
+      resolvedAccountTokenSource: account.tokenSource,
+    });
     if (!token) {
       throw new Error(
         `Telegram bot token missing for account "${account.accountId}" (set channels.telegram.accounts.${account.accountId}.botToken/tokenFile or TELEGRAM_BOT_TOKEN for default).`,


### PR DESCRIPTION
# OpenClaw Upstream PR Draft - Telegram SecretRef

## Why this PR matters

This is a small but meaningful community contribution.

- It fixes a real runtime failure
- It improves SecretRef-first deployments
- It helps users who avoid plaintext secrets in env/service configs
- It adds regression coverage

## Recommended PR title

`fix(telegram): resolve env SecretRef bot tokens before provider startup`

Alternative:

`fix(telegram): support SecretRef-style TELEGRAM_BOT_TOKEN during monitor startup`

## Suggested PR body

```md
## Summary

This fixes a Telegram startup failure when `TELEGRAM_BOT_TOKEN` is provided as a SecretRef-style env value (for example `op://...`) instead of a plaintext token.

Before this change, the Telegram monitor path could treat the unresolved env string as the actual bot token and pass it directly into Telegram API calls. In practice that caused startup failures such as:

- `deleteWebhook failed`
- `deleteMyCommands failed`
- `setMyCommands failed`
- `404 Not Found`

## Root cause

`monitorTelegramProvider` relied on the env/config-resolved token path, but if the token source was `env`, the runtime could still use `process.env.TELEGRAM_BOT_TOKEN` as-is during startup.

That works for plaintext env tokens, but not for SecretRef-style values.

## What this changes

- adds a SecretRef-aware token resolution step before Telegram provider startup
- resolves explicit/env token inputs through the configured secret-input runtime path
- fails explicitly when the SecretRef is unavailable instead of passing `op://...` to Telegram
- keeps existing plaintext-token behavior unchanged

## Test coverage

Adds a regression test covering the case where:

- `TELEGRAM_BOT_TOKEN` is set to a SecretRef-style value
- runtime secret resolution returns a plaintext token
- Telegram monitor startup uses the resolved plaintext token

## Why this matters

This helps OpenClaw behave more consistently in SecretRef-first setups, especially for service/daemon environments where users want to avoid plaintext secrets in `.env`, launchd, or systemd configuration.
```

## Short issue-style summary

If you want a short companion issue or note first:

```md
Telegram startup can fail when `TELEGRAM_BOT_TOKEN` is supplied as a SecretRef-style env value (for example `op://...`).

The bot token itself may still be valid, but the runtime path can pass the unresolved env string into Telegram API calls, producing `deleteWebhook` / command-sync failures with `404 Not Found`.

I have a small fix + regression test prepared and can open a PR.
```

## Suggested submission flow

1. Create a branch in the upstream clone
2. Commit only the 2 Telegram source files
3. Open a small PR with the body above
4. If maintainers want more context, add the reproduction notes in a comment

## Scope to include

Include:

- `extensions/telegram/src/monitor.ts`
- `extensions/telegram/src/monitor.test.ts`

Do not include:

- local service plist edits
- local `.env` edits
- local `dist/` patching for live recovery
- workspace / personal runbook files

## Confidence note

Good to mention if asked:

- targeted Telegram monitor test passes
- root cause was locally reproduced and traced
- the fix is intentionally narrow
