### PR TITLE
fix(acp): treat block deliveries as visible text on all channels

### DIFF
--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -122,16 +122,15 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     expect(coordinator.hasFailedVisibleTextDelivery()).toBe(false);
   });
 
-  it("does not treat non-telegram direct block text as visible", async () => {
+  it("treats non-telegram direct block text as visible", async () => {
     const coordinator = createCoordinator();
 
     await coordinator.deliver("block", { text: "hello" }, { skipTts: true });
     await coordinator.settleVisibleText();
 
     expect(coordinator.hasDeliveredFinalReply()).toBe(false);
-    expect(coordinator.hasDeliveredVisibleText()).toBe(false);
+    expect(coordinator.hasDeliveredVisibleText()).toBe(true);
     expect(coordinator.hasFailedVisibleTextDelivery()).toBe(false);
-    expect(coordinator.getRoutedCounts().block).toBe(0);
   });
 
   it("tracks failed visible telegram block delivery separately", async () => {

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -39,6 +39,9 @@ function shouldTreatDeliveredTextAsVisible(params: {
   if (params.kind === "final") {
     return true;
   }
+  if (params.kind === "block") {
+    return true;
+  }
   return normalizeDeliveryChannel(params.channel) === "telegram";
 }
 


### PR DESCRIPTION
## Summary

Fix duplicate message delivery for ACP sessions on Discord (and all non-Telegram channels).

## Problem

Every ACP session response in a Discord thread is delivered **twice** — first as streamed block chunks, then again as a full "final" reply with identical content.

**Affects:** Discord, WhatsApp, Slack, and all non-Telegram channels using ACP thread-bound or binding-based sessions with streaming.

**Related issue:** #55595

## Root Cause

`shouldTreatDeliveredTextAsVisible()` in `dispatch-acp-delivery.ts` only returned `true` for block deliveries on Telegram:

```typescript
// Before (broken)
if (params.kind === "final") return true;
return normalizeDeliveryChannel(params.channel) === "telegram";
```

This meant that when ACP block chunks were streamed to a Discord thread via `routeReply()`, they were **not tracked as visible text**. When `finalizeAcpTurnOutput()` ran after the turn completed, it checked:

```
!hasDeliveredVisibleText() || hasFailedVisibleTextDelivery()
```

Since `deliveredVisibleText` was `false` (blocks weren't counted), the guard evaluated `true` and the system re-sent the full accumulated block text as a "final" delivery — duplicating the content.

## Fix

Return `true` for `kind === "block"` on all channels, matching the existing behavior for `kind === "final"`:

```typescript
// After (fixed)
if (params.kind === "final") return true;
if (params.kind === "block") return true;
return normalizeDeliveryChannel(params.channel) === "telegram";
```

## Changes

- `src/auto-reply/reply/dispatch-acp-delivery.ts`: Add `block` to visible text tracking
- `src/auto-reply/reply/dispatch-acp-delivery.test.ts`: Update test to expect block text is visible on all channels

## Testing

- Verified locally: Discord ACP thread sessions now deliver responses exactly once
- Tested with both `deliveryMode: "live"` and `deliveryMode: "final_only"`
- Both modes now produce a single message instead of duplicate