### PR TITLE
Agents: flatten text-only user content for OpenAI completions

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -25,6 +25,7 @@ import {
 } from "./moonshot-stream-wrappers.js";
 import {
   createOpenAIFastModeWrapper,
+  createOpenAiCompletionsPlainTextUserContentWrapper,
   createOpenAIResponsesContextManagementWrapper,
   createOpenAIServiceTierWrapper,
   resolveOpenAIFastMode,
@@ -294,6 +295,8 @@ export function applyExtraParamsToAgent(
     agent.streamFn,
     effectiveExtraParams,
   );
+
+  agent.streamFn = createOpenAiCompletionsPlainTextUserContentWrapper(agent.streamFn);
 
   const rawParallelToolCalls = resolveAliasedParamValue(
     [resolvedExtraParams, override],

--- a/src/agents/pi-embedded-runner/openai-completions-plaintext-user-content.test.ts
+++ b/src/agents/pi-embedded-runner/openai-completions-plaintext-user-content.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { flattenOpenAiCompletionsTextOnlyUserContentInPayload } from "./openai-completions-plaintext-user-content.js";
+
+describe("flattenOpenAiCompletionsTextOnlyUserContentInPayload", () => {
+  it("flattens single text part to string for text-only openai-completions models", () => {
+    const payload = {
+      model: "m",
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+        },
+      ],
+    };
+    flattenOpenAiCompletionsTextOnlyUserContentInPayload(payload, {
+      api: "openai-completions",
+      input: ["text"],
+      provider: "local",
+      id: "qwen",
+    });
+    expect(payload.messages[0]).toEqual({ role: "user", content: "hello" });
+  });
+
+  it("joins multiple text parts with newlines", () => {
+    const payload = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "a" },
+            { type: "text", text: "b" },
+          ],
+        },
+      ],
+    };
+    flattenOpenAiCompletionsTextOnlyUserContentInPayload(payload, {
+      api: "openai-completions",
+      input: ["text"],
+      provider: "local",
+      id: "qwen",
+    });
+    expect((payload.messages[0] as unknown as { content: string }).content).toBe("a\nb");
+  });
+
+  it("skips when model declares image input", () => {
+    const payload = {
+      messages: [{ role: "user", content: [{ type: "text", text: "x" }] }],
+    };
+    flattenOpenAiCompletionsTextOnlyUserContentInPayload(payload, {
+      api: "openai-completions",
+      input: ["text", "image"],
+      provider: "openai",
+      id: "gpt-5",
+    });
+    expect((payload.messages[0] as { content: unknown[] }).content).toEqual([
+      { type: "text", text: "x" },
+    ]);
+  });
+
+  it("skips openrouter anthropic routes", () => {
+    const payload = {
+      messages: [{ role: "user", content: [{ type: "text", text: "x" }] }],
+    };
+    flattenOpenAiCompletionsTextOnlyUserContentInPayload(payload, {
+      api: "openai-completions",
+      input: ["text"],
+      provider: "openrouter",
+      id: "anthropic/claude-3.5-sonnet",
+    });
+    expect((payload.messages[0] as { content: unknown[] }).content).toEqual([
+      { type: "text", text: "x" },
+    ]);
+  });
+
+  it("does not change non-openai-completions APIs", () => {
+    const payload = {
+      messages: [{ role: "user", content: [{ type: "text", text: "x" }] }],
+    };
+    flattenOpenAiCompletionsTextOnlyUserContentInPayload(payload, {
+      api: "anthropic-messages",
+      input: ["text"],
+      provider: "anthropic",
+      id: "claude",
+    });
+    expect((payload.messages[0] as { content: unknown[] }).content).toEqual([
+      { type: "text", text: "x" },
+    ]);
+  });
+
+  it("leaves multimodal user content unchanged", () => {
+    const payload = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "see" },
+            { type: "image_url", image_url: { url: "data:image/png;base64,abc" } },
+          ],
+        },
+      ],
+    };
+    flattenOpenAiCompletionsTextOnlyUserContentInPayload(payload, {
+      api: "openai-completions",
+      input: ["text", "image"],
+      provider: "openai",
+      id: "gpt-5",
+    });
+    expect(payload.messages[0]).toEqual({
+      role: "user",
+      content: [
+        { type: "text", text: "see" },
+        { type: "image_url", image_url: { url: "data:image/png;base64,abc" } },
+      ],
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/openai-completions-plaintext-user-content.ts
+++ b/src/agents/pi-embedded-runner/openai-completions-plaintext-user-content.ts
@@ -1,0 +1,73 @@
+/**
+ * Some OpenAI-compatible chat backends (e.g. strict text-only gateways) reject
+ * user messages whose `content` is a multimodal array like
+ * `[{ type: "text", text: "..." }]` and only accept a plain string. Pi's
+ * openai-completions adapter always uses the array form when the in-memory
+ * user message uses structured parts.
+ *
+ * When the configured model does not declare image input, flatten those
+ * payloads to a single string before the HTTP request.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/38902
+ */
+export function flattenOpenAiCompletionsTextOnlyUserContentInPayload(
+  payload: Record<string, unknown>,
+  model: {
+    api?: unknown;
+    input?: unknown;
+    provider?: unknown;
+    id?: unknown;
+  },
+): void {
+  if (model.api !== "openai-completions") {
+    return;
+  }
+  const input = model.input;
+  if (Array.isArray(input) && input.includes("image")) {
+    return;
+  }
+  // OpenRouter Anthropic routes rely on per-part cache_control breakpoints; keep arrays.
+  if (
+    model.provider === "openrouter" &&
+    typeof model.id === "string" &&
+    model.id.startsWith("anthropic/")
+  ) {
+    return;
+  }
+
+  const messages = payload.messages;
+  if (!Array.isArray(messages)) {
+    return;
+  }
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      continue;
+    }
+    const role = (msg as { role?: unknown }).role;
+    if (role !== "user") {
+      continue;
+    }
+    const content = (msg as { content?: unknown }).content;
+    if (!Array.isArray(content) || content.length === 0) {
+      continue;
+    }
+    const textPieces: string[] = [];
+    for (const part of content) {
+      if (!part || typeof part !== "object") {
+        textPieces.length = 0;
+        break;
+      }
+      const p = part as { type?: unknown; text?: unknown };
+      if (p.type !== "text" || typeof p.text !== "string") {
+        textPieces.length = 0;
+        break;
+      }
+      textPieces.push(p.text);
+    }
+    if (textPieces.length === 0) {
+      continue;
+    }
+    (msg as { content: unknown }).content = textPieces.join("\n");
+  }
+}

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -3,6 +3,7 @@ import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
 import { resolveProviderAttributionHeaders } from "../provider-attribution.js";
 import { log } from "./logger.js";
+import { flattenOpenAiCompletionsTextOnlyUserContentInPayload } from "./openai-completions-plaintext-user-content.js";
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 
 type OpenAIServiceTier = "auto" | "default" | "flex" | "priority";
@@ -375,6 +376,21 @@ export function createCodexDefaultTransportWrapper(baseStreamFn: StreamFn | unde
     underlying(model, context, {
       ...options,
       transport: options?.transport ?? "auto",
+    });
+}
+
+/**
+ * Strict OpenAI-compatible servers may reject user `content` sent as a
+ * single-element `[{ type: "text", text }]` array. Flatten to a string when
+ * the model is configured for text input only.
+ */
+export function createOpenAiCompletionsPlainTextUserContentWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) =>
+    streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
+      flattenOpenAiCompletionsTextOnlyUserContentInPayload(payloadObj, model);
     });
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: some OpenAI-compatible gateways reject user `content` sent as `[{"type":"text"}]` and return 422, while the same payload works when user content is plain text.
- Why it matters: embedded runs can fail with opaque 422 errors on strict providers even for plain-text prompts.
- What changed: OpenAI-completions payloads now flatten text-only user messages to plain strings for text-only models, while preserving multimodal and OpenRouter Anthropic array semantics.
- What did NOT change (scope boundary): no provider-specific retry logic or broad 422 recovery flow was added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38902
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: OpenAI-completions requests carried user text inside content-part arrays even for text-only model paths; some providers accept only plain string `content` for user roles.
- Missing detection / guardrail: no normalization layer in embedded OpenAI-completions payload assembly for text-only compatibility.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #38902 reports strict gateway/provider compatibility with 422 responses.
- Why this regressed now: provider compatibility variance surfaced as integrations tightened payload validation.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/openai-completions-plaintext-user-content.test.ts`
- Scenario the test should lock in: text-only user content is flattened to string only where safe; multimodal and OpenRouter Anthropic paths stay unchanged.
- Why this is the smallest reliable guardrail: the regression is in request-shaping behavior before outbound transport.
- Existing test that already covers this (if any): none for this compatibility edge.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Embedded runs against strict OpenAI-compatible endpoints avoid a class of 422 errors for plain-text prompts.

## Diagram (if applicable)

```text
Before:
[user text] -> content array -> strict gateway rejects (422)

After:
[user text] -> flattened string content -> gateway accepts
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev)
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: OpenAI-compatible text-only provider path
- Integration/channel (if any): embedded agent run path
- Relevant config (redacted): default embedded OpenAI-completions flow

### Steps

1. Run embedded flow with text-only model against strict OpenAI-compatible endpoint.
2. Inspect outbound message payload shape.
3. Confirm text-only user messages are sent as strings and request succeeds.

### Expected

- No 422 due to user-content array shape in text-only path.

### Actual

- Payload normalization now flattens text-only user content where appropriate.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- `pnpm test -- src/agents/pi-embedded-runner/openai-completions-plaintext-user-content.test.ts`
- `pnpm tsgo`

## Human Verification (required)

- Verified scenarios: text-only flattening applies only in compatible paths.
- Edge cases checked: OpenRouter Anthropic route preservation; multimodal messages not flattened.
- What you did **not** verify: full live-provider matrix beyond targeted compatibility path.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: over-flattening could alter semantics for non-text payloads.
  - Mitigation: guard conditions restrict flattening to text-only safe paths and tests cover preservation cases.

Made with [Cursor](https://cursor.com)