### PR TITLE
docs: clarify browser plugin setup

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -39,14 +39,17 @@ openclaw browser --browser-profile openclaw open https://example.com
 openclaw browser --browser-profile openclaw snapshot
 ```
 
+Before using the managed browser, enable browser config and the bundled
+`browser` plugin in `~/.openclaw/openclaw.json` (see configuration below).
+After changing either setting, restart the Gateway and verify with the above commands.
+
 If you get “Browser disabled”, enable it in config (see below) and restart the
 Gateway.
 
 ## Plugin control
 
-The default `browser` tool is now a bundled plugin that ships enabled by
-default. That means you can disable or replace it without removing the rest of
-OpenClaw's plugin system:
+The default `browser` tool is a bundled plugin. That means you can disable or
+replace it without removing the rest of OpenClaw's plugin system:
 
 ```json5
 {
@@ -133,6 +136,13 @@ Browser settings live in `~/.openclaw/openclaw.json`.
         color: "#FB542B",
       },
       remote: { cdpUrl: "http://10.0.0.42:9222", color: "#00AA00" },
+    },
+  },
+  plugins: {
+    entries: {
+      browser: {
+        enabled: true,
+      },
     },
   },
 }
@@ -748,6 +758,29 @@ Strict-mode example (block private/internal destinations by default):
 ```
 
 ## Troubleshooting
+
+### Problem: `unknown method: browser.request`
+
+This usually means the Gateway does not currently have the bundled browser tool
+registered, so `openclaw browser` cannot reach the managed browser service.
+
+Check these first:
+
+1. Confirm the managed browser is enabled in `~/.openclaw/openclaw.json`.
+2. Confirm the bundled browser plugin is explicitly enabled in config.
+3. Restart the Gateway after changing either setting.
+
+Verify the fix:
+
+```bash
+openclaw browser status
+```
+
+Success looks like:
+
+- `openclaw browser status` returns browser info instead of `unknown method: browser.request`
+- Gateway logs show `Browser control listening on http://127.0.0.1:<gateway+2>/`
+- `running: false` is still healthy until you start the browser or open a page
 
 For Linux-specific issues (especially snap Chromium), see
 [Browser troubleshooting](/tools/browser-linux-troubleshooting).


### PR DESCRIPTION

## Summary

- Problem: The managed browser docs did not clearly say that the bundled `browser` plugin must be enabled alongside `browser.enabled`, which can surface as `unknown method: browser.request`.
- Why it matters: Users can follow the docs, restart Gateway, and still get a confusing startup failure.
- What changed: Updated the main config example, added a setup note, and added troubleshooting for `unknown method: browser.request`.
- What did NOT change (scope boundary): No runtime behavior changed; this is a docs-only clarification.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The `browser` plugin is marked `enabledByDefault`, but Gateway startup only includes bundled sidecar plugins when they are explicitly selected for startup. In practice, `browser.enabled` alone did not register `browser.request`.
- Missing detection / guardrail: The docs did not show explicit bundled browser plugin enablement and did not mention `unknown method: browser.request`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Reproduced locally with `openclaw browser status`; no linked issue or prior PR was used for this docs change.
- Why this regressed now: Unknown.
- If unknown, what was ruled out: Not caused by invalid config syntax or a missing Gateway restart.

## Regression Test Plan (if applicable)

N/A (docs-only PR; no runtime or test-surface changes in this PR)

## User-visible / Behavior Changes

- The browser docs now tell users to enable both browser config and the bundled `browser` plugin for the standard managed-browser setup.
- The main browser configuration example now includes `plugins.entries.browser.enabled: true`.
- The troubleshooting section now covers `unknown method: browser.request` and how to verify the fix.

## Diagram (if applicable)

```text
Before:
[user follows browser docs] -> [browser.enabled set] -> [gateway starts without usable browser.request] -> [confusing failure]

After:
[user follows updated browser docs] -> [browser.enabled + bundled browser plugin enabled] -> [gateway exposes browser.request] -> [managed browser commands work]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Local OpenClaw CLI + Gateway instance
- Model/provider: N/A
- Integration/channel (if any): Managed browser / Gateway
- Relevant config (redacted): `browser.enabled: true`; working setup also required `plugins.entries.browser.enabled: true`

### Steps

1. Configure the managed browser with `browser.enabled: true` and restart the Gateway.
2. Run `openclaw browser status`.
3. Observe `unknown method: browser.request`, then add `plugins.entries.browser.enabled: true`, restart again, and rerun `openclaw browser status`.

Before:
<img width="773" height="113" alt="Screenshot 2026-03-28 at 10 43 38 PM" src="https://github.com/user-attachments/assets/daca5f91-6576-4bf9-9ffd-8adc7d3bffbc" />

After:
<img width="654" height="246" alt="Screenshot 2026-03-28 at 10 44 12 PM" src="https://github.com/user-attachments/assets/b5e3c16c-2eee-4f7f-81af-ae6a3252f138" />



### Expected

- The docs should show the working managed-browser setup clearly.
- `openclaw browser status` should succeed once the documented setup is applied.

### Actual

- With browser config alone, `openclaw browser status` failed with `unknown method: browser.request`.
- After explicit bundled browser plugin enablement, `openclaw browser status` succeeded.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Reproduced the failure locally and confirmed the documented config fixes it.
- Edge cases checked: Confirmed `running: false` can still be healthy before launch; confirmed a bad `browser.executablePath` is a separate issue.
- What you did **not** verify: None

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None, doc changes only.

AI-assisted: Yes
Testing: Lightly tested (manual local reproduction and verification on a macOS OpenClaw instance)
