### PR TITLE
Discord: treat empty component specs as absent instead of throwing

### DIFF
--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -67,6 +67,42 @@ describe("discord components", () => {
     ).toThrow("options");
   });
 
+  it("returns null for empty LLM-default component specs", () => {
+    // LLMs often fill every tool parameter with empty/zero defaults.
+    // This must return null so the send falls through to plain-text.
+    const spec = readDiscordComponentSpec({
+      text: "",
+      reusable: false,
+      container: { accentColor: "", spoiler: false },
+      blocks: [],
+      modal: { title: "", triggerLabel: "", triggerStyle: "primary", fields: [] },
+    });
+    expect(spec).toBeNull();
+  });
+
+  it("returns null for component spec with only empty blocks", () => {
+    expect(readDiscordComponentSpec({ blocks: [] })).toBeNull();
+  });
+
+  it("returns null for component spec with only empty text", () => {
+    expect(readDiscordComponentSpec({ text: "" })).toBeNull();
+  });
+
+  it("returns null for component spec with empty modal and no other content", () => {
+    expect(readDiscordComponentSpec({ modal: { fields: [] } })).toBeNull();
+  });
+
+  it("returns spec when modal has actual fields", () => {
+    const spec = readDiscordComponentSpec({
+      modal: {
+        title: "Test",
+        fields: [{ type: "text", label: "Name" }],
+      },
+    });
+    expect(spec).not.toBeNull();
+    expect(spec?.modal?.fields).toHaveLength(1);
+  });
+
   it("requires attachment references for file blocks", () => {
     expect(() =>
       readDiscordComponentSpec({

--- a/extensions/discord/src/components.ts
+++ b/extensions/discord/src/components.ts
@@ -585,35 +585,46 @@ export function readDiscordComponentSpec(raw: unknown): DiscordComponentMessageS
   }
   const obj = requireObject(raw, "components");
   const blocksRaw = obj.blocks;
-  const blocks = Array.isArray(blocksRaw)
-    ? blocksRaw.map((entry, idx) => parseComponentBlock(entry, `components.blocks[${idx}]`))
-    : undefined;
+  const blocks =
+    Array.isArray(blocksRaw) && blocksRaw.length > 0
+      ? blocksRaw.map((entry, idx) => parseComponentBlock(entry, `components.blocks[${idx}]`))
+      : undefined;
   const modalRaw = obj.modal;
   const reusable = typeof obj.reusable === "boolean" ? obj.reusable : undefined;
   let modal: DiscordModalSpec | undefined;
-  if (modalRaw !== undefined) {
+  if (modalRaw !== undefined && modalRaw !== null) {
     const modalObj = requireObject(modalRaw, "components.modal");
     const fieldsRaw = modalObj.fields;
-    if (!Array.isArray(fieldsRaw) || fieldsRaw.length === 0) {
-      throw new Error("components.modal.fields must be a non-empty array");
+    // Treat empty modal (no fields) as absent — LLMs often fill in all tool
+    // parameters with empty defaults which produces an empty modal spec.
+    if (Array.isArray(fieldsRaw) && fieldsRaw.length > 0) {
+      if (fieldsRaw.length > 5) {
+        throw new Error("components.modal.fields supports up to 5 inputs");
+      }
+      const fields = fieldsRaw.map((entry, idx) =>
+        parseModalField(entry, `components.modal.fields[${idx}]`, idx),
+      );
+      modal = {
+        title: readString(modalObj.title, "components.modal.title"),
+        callbackData: readOptionalString(modalObj.callbackData),
+        triggerLabel: readOptionalString(modalObj.triggerLabel),
+        triggerStyle: readOptionalString(modalObj.triggerStyle) as DiscordComponentButtonStyle,
+        allowedUsers: readOptionalStringArray(
+          modalObj.allowedUsers,
+          "components.modal.allowedUsers",
+        ),
+        fields,
+      };
     }
-    if (fieldsRaw.length > 5) {
-      throw new Error("components.modal.fields supports up to 5 inputs");
-    }
-    const fields = fieldsRaw.map((entry, idx) =>
-      parseModalField(entry, `components.modal.fields[${idx}]`, idx),
-    );
-    modal = {
-      title: readString(modalObj.title, "components.modal.title"),
-      callbackData: readOptionalString(modalObj.callbackData),
-      triggerLabel: readOptionalString(modalObj.triggerLabel),
-      triggerStyle: readOptionalString(modalObj.triggerStyle) as DiscordComponentButtonStyle,
-      allowedUsers: readOptionalStringArray(modalObj.allowedUsers, "components.modal.allowedUsers"),
-      fields,
-    };
+  }
+  const text = readOptionalString(obj.text);
+  // If spec has no meaningful content (no text, blocks, or modal), treat as absent.
+  // This handles LLMs that fill in every tool parameter with empty defaults.
+  if (!text && !blocks?.length && !modal) {
+    return null;
   }
   return {
-    text: readOptionalString(obj.text),
+    text,
     reusable,
     container:
       typeof obj.container === "object" && obj.container && !Array.isArray(obj.container)


### PR DESCRIPTION
## Summary

- LLMs often fill every tool parameter with empty/zero defaults, producing a `components` object like `{blocks: [], modal: {fields: []}, text: ""}`.
- `readDiscordComponentSpec` threw `"components.modal.fields must be a non-empty array"` on the empty modal, killing the entire Discord send instead of falling through to plain-text delivery.
- Fix: treat empty modal (no fields) as absent; return `null` when the spec has no meaningful content (no text, blocks, or modal).

### Root cause

The existing `hasDiscordComponentObjectKeys` guard only checks `Object.keys(value).length > 0`, which passes for empty-default objects. Once inside `readDiscordComponentSpec`, the empty `fields: []` triggers the validation throw at line 581. Every subsequent send attempt hits the same error.

### Changes

- `extensions/discord/src/components.ts`: Skip empty modal fields instead of throwing; skip empty blocks arrays; return `null` for specs with no meaningful content
- `extensions/discord/src/components.test.ts`: 5 regression tests covering all empty-default patterns (full LLM default object, empty blocks only, empty text only, empty modal only, valid modal with fields)

## Test plan

- [x] All 10 component tests pass (`pnpm test -- extensions/discord/src/components.test.ts`)
- [x] Pre-commit hooks pass (lint, typecheck, format)
- [x] Verified fix in production: messages that previously failed with "Message failed" now deliver as plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)