### PR TITLE
fix(discord): use listener-stripping disconnect in abort handler to prevent crash

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.reconnect.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.reconnect.ts
@@ -401,8 +401,13 @@ export function createDiscordGatewayReconnectController(params: {
     if (!params.gateway) {
       return;
     }
-    params.gateway.options.reconnect = { maxAttempts: 0 };
-    params.gateway.disconnect();
+    // Use the listener-stripping disconnect to avoid Carbon's automatic
+    // reconnection path. Previously we set maxAttempts=0 and called
+    // gateway.disconnect(), but Carbon's handleReconnectionAttempt treats
+    // 0 >= 0 as "exhausted" and emits a crash-level error before the
+    // lifecycle sets lifecycleStopping=true. Stripping the socket close
+    // listeners first prevents the reconnection handler from firing at all.
+    void disconnectGatewaySocketWithoutAutoReconnect();
   };
   const ensureStartupReady = async () => {
     if (!params.gateway || params.gateway.isConnected || shouldStop()) {


### PR DESCRIPTION
## Summary

Fix `SafeGatewayPlugin` crash when `abortSignal` fires — the process crashes with `Error: Max reconnect attempts (0) reached after code 1005` instead of exiting cleanly.

## Problem

When `abortSignal` fires, `onAbort()` in `provider.lifecycle.reconnect.ts` sets `maxAttempts=0` as a sentinel to disable reconnection, then calls `gateway.disconnect()`. Carbon's internal reconnection handler evaluates `this.reconnectAttempts >= maxAttempts` → `0 >= 0 = true`, emitting a crash-level error.

This error races the lifecycle's `finally` block which sets `lifecycleStopping = true`. Since `lifecycleStopping` is still `false` when the error is drained, `handleGatewayEvent` does not suppress it, and `drainPendingGatewayErrors` throws — crashing the monitor.

## Fix

Replace the `maxAttempts=0` + `disconnect()` pattern with the existing `disconnectGatewaySocketWithoutAutoReconnect()` helper. This function strips Carbon's close/error listeners from the WebSocket before closing it, preventing the reconnection handler from firing at all. The gateway shuts down cleanly without the `0 >= 0` sentinel collision.

## Changes

- `extensions/discord/src/monitor/provider.lifecycle.reconnect.ts`: replace `maxAttempts=0` sentinel in `onAbort()` with `disconnectGatewaySocketWithoutAutoReconnect()`

Fixes #56833