### PR TITLE
fix(agents): add "terminated" to timeout ERROR_PATTERNS for model fallback

### DIFF
--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -20,6 +20,7 @@ const ERROR_PATTERNS = {
     "high demand",
   ],
   timeout: [
+    "terminated",
     "timeout",
     "timed out",
     "deadline exceeded",


### PR DESCRIPTION
## Summary

- `rawError=\"terminated\"` was not matched by any entry in `ERROR_PATTERNS.timeout`
- `classifyFailoverReason(\"terminated\")` returned `null`, so the fallback chain was never triggered
- Added `\"terminated\"` to the timeout pattern list — consistent with existing `\"socket hang up\"` and `ECONNRESET` handling

## Root Cause

In `src/agents/pi-embedded-helpers/failover-matches.ts`, `ERROR_PATTERNS.timeout` covers connection-closure errors like `\"socket hang up\"`, `ECONNREFUSED`, and `ECONNRESET`, but omits `\"terminated\"` — the raw error string emitted when an upstream proxy (NVIDIA NIM, Cloudflare AI Gateway, Azure API Management) aborts a TCP stream mid-response.

When the primary model returns `error=terminated`, the gateway called `classifyFailoverReason(\"terminated\")`, which returned `null`. The fallback chain was skipped entirely; the primary model retried 4× on itself before surfacing the error to the user.

## Change

`src/agents/pi-embedded-helpers/failover-matches.ts`:
- Before: `\"terminated\"` not in `ERROR_PATTERNS.timeout`
- After: `\"terminated\"` added as the first entry in `ERROR_PATTERNS.timeout`

This is a one-line addition consistent with PR #19077 (which added `ENETUNREACH`/`ECONNREFUSED`) and the existing treatment of `\"socket hang up\"`.

## Test plan

- [ ] Configure a provider behind a proxy that can terminate connections (e.g. NVIDIA inference API)
- [ ] Trigger a `terminated` error from the primary model
- [ ] Verify the fallback chain (Gemini → GPT → Sonnet) is now invoked
- [ ] Verify normal requests (no error) are unaffected

Fixes #56875