### PR TITLE
fix(acp): avoid final text replay after visible ACP text delivery

### DIFF
--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -122,16 +122,37 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     expect(coordinator.hasFailedVisibleTextDelivery()).toBe(false);
   });
 
-  it("does not treat non-telegram direct block text as visible", async () => {
+  it("treats non-tool direct block text as visible on non-telegram channels", async () => {
     const coordinator = createCoordinator();
 
     await coordinator.deliver("block", { text: "hello" }, { skipTts: true });
     await coordinator.settleVisibleText();
 
     expect(coordinator.hasDeliveredFinalReply()).toBe(false);
-    expect(coordinator.hasDeliveredVisibleText()).toBe(false);
+    expect(coordinator.hasDeliveredVisibleText()).toBe(true);
     expect(coordinator.hasFailedVisibleTextDelivery()).toBe(false);
     expect(coordinator.getRoutedCounts().block).toBe(0);
+  });
+
+  it("preserves visible direct tool text behavior for telegram delivery", async () => {
+    const coordinator = createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "telegram",
+        Surface: "telegram",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher: createDispatcher(),
+      inboundAudio: false,
+      shouldRouteToOriginating: false,
+    });
+
+    await coordinator.deliver("tool", { text: "tool summary" }, { skipTts: true });
+    await coordinator.settleVisibleText();
+
+    expect(coordinator.hasDeliveredVisibleText()).toBe(true);
+    expect(coordinator.hasFailedVisibleTextDelivery()).toBe(false);
+    expect(coordinator.getRoutedCounts().tool).toBe(0);
   });
 
   it("tracks failed visible telegram block delivery separately", async () => {

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -36,10 +36,10 @@ function shouldTreatDeliveredTextAsVisible(params: {
   if (!params.text?.trim()) {
     return false;
   }
-  if (params.kind === "final") {
-    return true;
+  if (params.kind === "tool") {
+    return normalizeDeliveryChannel(params.channel) === "telegram";
   }
-  return normalizeDeliveryChannel(params.channel) === "telegram";
+  return true;
 }
 
 type AcpDispatchDeliveryState = {

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -107,6 +107,8 @@ async function runDispatch(params: {
   cfg?: OpenClawConfig;
   dispatcher?: ReplyDispatcher;
   shouldRouteToOriginating?: boolean;
+  originatingChannel?: string;
+  originatingTo?: string;
   onReplyStart?: () => void;
   ctxOverrides?: Record<string, unknown>;
   sessionKeyOverride?: string;
@@ -126,7 +128,10 @@ async function runDispatch(params: {
     inboundAudio: false,
     shouldRouteToOriginating: params.shouldRouteToOriginating ?? false,
     ...(params.shouldRouteToOriginating
-      ? { originatingChannel: "telegram", originatingTo: "telegram:thread-1" }
+      ? {
+          originatingChannel: params.originatingChannel ?? "telegram",
+          originatingTo: params.originatingTo ?? "telegram:thread-1",
+        }
       : {}),
     shouldSendToolSummaries: true,
     bypassForCommand: false,
@@ -206,6 +211,8 @@ async function runRoutedAcpTextTurn(text: string) {
     bodyForAgent: "run acp",
     dispatcher,
     shouldRouteToOriginating: true,
+    originatingChannel: "discord",
+    originatingTo: "discord:thread-1",
   });
   return { result };
 }
@@ -820,6 +827,12 @@ describe("tryDispatchAcpReply", () => {
     expect(result?.counts.block).toBe(1);
     expect(result?.counts.final).toBe(0);
     expect(routeMocks.routeReply).toHaveBeenCalledTimes(1);
+    expect(routeMocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "discord",
+        to: "discord:thread-1",
+      }),
+    );
   });
 
   it("does not deliver final fallback text when direct block text was already visible", async () => {
@@ -871,7 +884,7 @@ describe("tryDispatchAcpReply", () => {
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
-  it("preserves final fallback when direct block text is filtered by non-telegram channels", async () => {
+  it("does not deliver final fallback text when direct discord block text was already visible", async () => {
     setReadyAcpResolution();
     ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
     queueTtsReplies({ text: "CODEX_OK" }, {} as ReturnType<typeof ttsMocks.maybeApplyTtsToPayload>);
@@ -890,9 +903,7 @@ describe("tryDispatchAcpReply", () => {
     expect(dispatcher.sendBlockReply).toHaveBeenCalledWith(
       expect.objectContaining({ text: "CODEX_OK" }),
     );
-    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "CODEX_OK" }),
-    );
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
   it("falls back to final text when a later telegram ACP block delivery fails", async () => {


### PR DESCRIPTION
## Problem
ACP turns could deliver visible block text during the turn and then replay the same accumulated text again as final fallback at turn end. The duplicate was reproducible on non-Telegram channels such as Discord, and it was not limited to the routed path.

## Root Cause
`src/auto-reply/reply/dispatch-acp-delivery.ts` only treated ACP text as visible when it was a `final` reply or a Telegram-visible direct delivery. That meant successful non-tool `block` delivery on other channels could leave `deliveredVisibleText` false, so fallback logic in `src/auto-reply/reply/dispatch-acp.ts` could replay accumulated text.

## Strategy
Treat delivered ACP text as visible for all non-tool replies, while preserving the existing Telegram direct tool behavior.

## Code Changes
1. `src/auto-reply/reply/dispatch-acp-delivery.ts`
- treat all non-tool ACP text as visible
- preserve existing Telegram direct `tool` visibility behavior

2. `src/auto-reply/reply/dispatch-acp.test.ts`
- add routed Discord regression coverage for no final replay after visible block delivery
- update direct Discord regression coverage to ensure visible block delivery suppresses final fallback

3. `src/auto-reply/reply/dispatch-acp-delivery.test.ts`
- assert non-tool direct block delivery is visible on non-Telegram channels
- preserve Telegram direct tool visibility semantics

## Scope / Risk
- no config/schema changes
- no user-facing command changes
- no docs/dist changes
- low risk: one visibility-classification adjustment plus focused ACP regression coverage

## Validation
- `pnpm test -- src/auto-reply/reply/dispatch-acp.test.ts src/auto-reply/reply/dispatch-acp-delivery.test.ts`
- local commit hook passed (`pnpm check` + lint gates)
