### PR TITLE
fix(security): include dangerous commands in known commands list

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -219,6 +219,13 @@ function listKnownNodeCommands(cfg: OpenClawConfig): Set<string> {
       }
     }
   }
+  // Also include known dangerous commands, which are valid but restricted
+  for (const cmd of DEFAULT_DANGEROUS_NODE_COMMANDS) {
+    const normalized = normalizeNodeCommand(cmd);
+    if (normalized) {
+      out.add(normalized);
+    }
+  }
   return out;
 }
 


### PR DESCRIPTION
## Summary

- Problem: `openclaw security audit` reports valid dangerous commands like `camera.snap` and `sms.send` as "unknown" when put in `denyCommands`.
- Why it matters: Users get warnings for doing the right thing.
- What changed: Added dangerous commands to the known list.
- What did NOT change: Everything else.

## Change Type

- [x] Bug fix

## Scope

(Internal security audit fix)

## Linked Issue/PR

- [x] This PR fixes a bug

## Root Cause

`listKnownNodeCommands()` only checked allowlist, not dangerous commands list.

## User-visible / Behavior Changes

False "unknown command" warnings gone.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None.