### PR TITLE
fix(ui): prevent overview access grid layout overlap on resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: keep assistant tool calls and displaced tool results in the same compaction chunk so strict summarization providers stop rejecting orphaned tool pairs. (#58849) Thanks @openperf.
 - Outbound/sanitizer: strip leaked `<tool_call>`, `<function_calls>`, and model special tokens from shared user-visible assistant text, including truncated tool-call streams, so internal scaffolding no longer bleeds into replies across surfaces. (#60619) Thanks @oliviareid-svg.
 - Control UI/avatar: honor `ui.assistant.avatar` when serving `/avatar/:agentId` so Appearance UI avatar paths stop falling back to initials placeholders. (#60778) Thanks @hannasdev.
+- Control UI/Overview: prevent gateway access token/password visibility toggle buttons from overlapping their inputs at narrow widths. (#56924) Thanks @bbddbb1.
 
 ## 2026.4.2
 

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -221,11 +221,11 @@ export function renderOverview(props: OverviewProps) {
             : html`
                 <label class="field">
                   <span>${t("overview.access.token")}</span>
-                  <div style="display: flex; align-items: center; gap: 8px;">
+                  <div style="display: flex; align-items: center; gap: 8px; min-width: 0;">
                     <input
                       type=${props.showGatewayToken ? "text" : "password"}
                       autocomplete="off"
-                      style="flex: 1;"
+                      style="flex: 1 1 0%; min-width: 0; width: 100%; box-sizing: border-box;"
                       .value=${props.settings.token}
                       @input=${(e: Event) => {
                         const v = (e.target as HTMLInputElement).value;
@@ -236,7 +236,7 @@ export function renderOverview(props: OverviewProps) {
                     <button
                       type="button"
                       class="btn btn--icon ${props.showGatewayToken ? "active" : ""}"
-                      style="width: 36px; height: 36px;"
+                      style="flex-shrink: 0; width: 36px; height: 36px; box-sizing: border-box;"
                       title=${props.showGatewayToken ? "Hide token" : "Show token"}
                       aria-label="Toggle token visibility"
                       aria-pressed=${props.showGatewayToken}
@@ -248,11 +248,11 @@ export function renderOverview(props: OverviewProps) {
                 </label>
                 <label class="field">
                   <span>${t("overview.access.password")}</span>
-                  <div style="display: flex; align-items: center; gap: 8px;">
+                  <div style="display: flex; align-items: center; gap: 8px; min-width: 0;">
                     <input
                       type=${props.showGatewayPassword ? "text" : "password"}
                       autocomplete="off"
-                      style="flex: 1;"
+                      style="flex: 1 1 0%; min-width: 0; width: 100%; box-sizing: border-box;"
                       .value=${props.password}
                       @input=${(e: Event) => {
                         const v = (e.target as HTMLInputElement).value;
@@ -263,7 +263,7 @@ export function renderOverview(props: OverviewProps) {
                     <button
                       type="button"
                       class="btn btn--icon ${props.showGatewayPassword ? "active" : ""}"
-                      style="width: 36px; height: 36px;"
+                      style="flex-shrink: 0; width: 36px; height: 36px; box-sizing: border-box;"
                       title=${props.showGatewayPassword ? "Hide password" : "Show password"}
                       aria-label="Toggle password visibility"
                       aria-pressed=${props.showGatewayPassword}

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -225,7 +225,7 @@ export function renderOverview(props: OverviewProps) {
                     <input
                       type=${props.showGatewayToken ? "text" : "password"}
                       autocomplete="off"
-                      style="flex: 1 1 0%; min-width: 0; width: 100%; box-sizing: border-box;"
+                      style="flex: 1 1 0%; min-width: 0; box-sizing: border-box;"
                       .value=${props.settings.token}
                       @input=${(e: Event) => {
                         const v = (e.target as HTMLInputElement).value;


### PR DESCRIPTION
## Summary

- Problem: Token/password visibility toggle buttons overlap with their input fields in the Overview page when the browser window is narrowed
- Why it matters: Poor UX on smaller screens or narrow browser windows prevents users from interacting with these fields properly
- What changed: Added explicit box-sizing, flex-shrink, and min-width properties to the visibility toggle buttons and their flex containers to ensure proper flex behavior at any width
- What did NOT change: No behavioral changes to the visibility toggling functionality itself

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #56921 
- Related 
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

- Root cause: The inline `width: 36px` on `.btn--icon` buttons without explicit `box-sizing: border-box` caused the flex container's `gap: 8px` and input's `flex: 1` to calculate incorrectly at narrow widths, resulting in overlap
- Missing detection/guardrail: No CSS constraint prevented the button from exceeding its intended visual width
- Prior context: This is a layout issue in the overview access section that appears at specific viewport widths

## Regression Test Plan

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test (visual/browser testing)
  - [ ] Existing coverage already sufficient
- Target test or file: Browser E2E tests for overview page responsiveness
- Scenario the test should lock in: Verify no layout overlap at 400px viewport width
- Why this is the smallest reliable guardrail: Visual/responsive testing is needed to catch CSS layout issues
- Existing test that already covers this (if any): None found
- If no new test is added, why not: CSS layout issues require browser-based visual testing which is covered by manual verification

## User-visible / Behavior Changes

- Token and password visibility toggle buttons no longer overlap with their input fields at any browser width
- No functional changes to visibility toggling behavior

## Diagram
Before (narrow width):
<img width="910" height="83" alt="image" src="https://github.com/user-attachments/assets/4cdc0ae3-d157-41a4-8b3f-851f80be1bb0" />
After (narrow width):
<img width="919" height="82" alt="image" src="https://github.com/user-attachments/assets/53e7310d-ccc0-4f3a-b346-385d3af04452" />

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Development
- Model/provider: N/A
- Integration/channel (if any): Control UI

### Steps

1. Start gateway on port 18789
2. Start UI dev server on port 5173
3. Open http://localhost:5173/?gatewayUrl=ws://127.0.0.1:18789
4. Navigate to Overview page
5. Resize browser window to narrow widths (400px, 500px, 600px)
6. Observe token and password visibility toggle buttons

### Expected

No overlap between input fields and their visibility toggle buttons at any width

### Actual

Buttons overlap at narrow widths (before fix)

## Human Verification

- Verified scenarios: Tested at 400px, 500px, 800px, 1200px viewport widths
- Edge cases checked: Toggle state (show/hide), different input content lengths
- What I did **not** verify: Browser-specific rendering differences

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- None: This is a pure CSS layout fix with no functional changes

