### PR TITLE
fix: include sessionFile in sessions_list tool response

### DIFF
--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -85,6 +85,7 @@ export type SessionListRow = {
   lastChannel?: string;
   lastTo?: string;
   lastAccountId?: string;
+  sessionFile?: string;
   transcriptPath?: string;
   messages?: unknown[];
 };

--- a/src/agents/tools/sessions-list-tool.test.ts
+++ b/src/agents/tools/sessions-list-tool.test.ts
@@ -160,6 +160,63 @@ describe("sessions-list-tool", () => {
     });
   });
 
+  it("includes sessionFile field in sessions_list results when present", async () => {
+    const gatewayCallMock = vi.fn(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [
+            {
+              key: "agent:main:main",
+              kind: "direct",
+              sessionId: "sess-abc",
+              sessionFile: "/home/user/.openclaw/agents/main/sessions/sess-abc.jsonl",
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    vi.doMock("../../gateway/call.js", () => ({
+      callGateway: gatewayCallMock,
+    }));
+    vi.doMock("./sessions-helpers.js", async () => {
+      const actual =
+        await vi.importActual<typeof import("./sessions-helpers.js")>("./sessions-helpers.js");
+      return {
+        ...actual,
+        createAgentToAgentPolicy: () => ({}),
+        createSessionVisibilityGuard: async () => ({
+          check: () => ({ allowed: true }),
+        }),
+        resolveEffectiveSessionToolsVisibility: () => "all",
+        resolveSandboxedSessionToolContext: () => ({
+          mainKey: "main",
+          alias: "main",
+          requesterInternalKey: undefined,
+          restrictToSpawned: false,
+        }),
+      };
+    });
+
+    const { createSessionsListTool } = await import("./sessions-list-tool.js");
+    const tool = createSessionsListTool({ config: {} as never });
+
+    const result = await tool.execute("call-sf", {});
+    const details = result.details as {
+      sessions?: Array<{
+        sessionId?: string;
+        sessionFile?: string;
+      }>;
+    };
+
+    expect(details.sessions?.[0]?.sessionFile).toBe(
+      "/home/user/.openclaw/agents/main/sessions/sess-abc.jsonl",
+    );
+  });
+
   it("keeps live session setting metadata in sessions_list results", async () => {
     const gatewayCallMock = vi.fn(async (opts: unknown) => {
       const request = opts as { method?: string };

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -243,6 +243,7 @@ export function createSessionsListTool(opts?: {
               : undefined,
           updatedAt: typeof entry.updatedAt === "number" ? entry.updatedAt : undefined,
           sessionId,
+          sessionFile,
           model: typeof entry.model === "string" ? entry.model : undefined,
           contextTokens: typeof entry.contextTokens === "number" ? entry.contextTokens : undefined,
           totalTokens: typeof entry.totalTokens === "number" ? entry.totalTokens : undefined,


### PR DESCRIPTION
## Summary

The `sessions_list` tool was not returning the `sessionFile` field from session records, causing the Control UI to derive an incorrect transcript path — especially for multi-agent setups where `sessionId` and `sessionFile` point to different locations.

## Root Cause

In `sessions-list-tool.ts`, the `sessionFile` field was already being read from the gateway response and used to compute `transcriptPath`, but it was never included in the returned `row` object. This meant the Control UI could not access the raw `sessionFile` path directly.

## Changes

- Added `sessionFile?: string` to the `SessionListRow` type in `sessions-helpers.ts`
- Added `sessionFile` to the `row` object returned by `sessions-list-tool.ts`
- Added a test case in `sessions-list-tool.test.ts` verifying `sessionFile` is present in the tool output

## Testing

Existing tests pass. Added test for `sessionFile` field presence.

Fixes openclaw/openclaw#56925