### PR TITLE
tui: improve /sessions search coverage for named sessions

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createCommandHandlers } from "./tui-command-handlers.js";
+import { buildSessionPickerSearchText, createCommandHandlers } from "./tui-command-handlers.js";
 
 type LoadHistoryMock = ReturnType<typeof vi.fn> & (() => Promise<void>);
 type SetActivityStatusMock = ReturnType<typeof vi.fn> & ((text: string) => void);
@@ -81,6 +81,28 @@ function createHarness(params?: {
     state,
   };
 }
+
+describe("buildSessionPickerSearchText", () => {
+  it("includes named main session fragments and derived metadata", () => {
+    const searchText = buildSessionPickerSearchText({
+      formattedKey: "main:alpha",
+      session: {
+        key: "agent:main:main:alpha",
+        displayName: "Sprint Inbox",
+        label: "alpha",
+        subject: "Roadmap",
+        sessionId: "sess-123",
+        derivedTitle: "Alpha planning",
+        lastMessagePreview: "Let's ship this",
+      },
+    });
+
+    expect(searchText).toContain("main:alpha");
+    expect(searchText).toContain("agent:main:main:alpha");
+    expect(searchText).toContain("alpha");
+    expect(searchText).toContain("Alpha planning");
+  });
+});
 
 describe("tui command handlers", () => {
   it("renders the sending indicator before chat.send resolves", async () => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -67,8 +67,7 @@ export function buildSessionPickerSearchText(params: {
   formattedKey: string;
 }): string {
   const parsed = parseAgentSessionKey(params.session.key);
-  const restKey = parsed?.rest;
-  const tailKey = restKey?.split(":").filter(Boolean).at(-1);
+  const tailKey = parsed?.rest?.split(":").filter(Boolean).at(-1);
   return [
     params.formattedKey,
     params.session.displayName,
@@ -77,7 +76,6 @@ export function buildSessionPickerSearchText(params: {
     params.session.derivedTitle,
     params.session.sessionId,
     params.session.key,
-    restKey,
     tailKey,
     params.session.lastMessagePreview,
   ]

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -8,7 +8,7 @@ import {
 } from "../auto-reply/thinking.js";
 import type { SessionsPatchResult } from "../gateway/protocol/index.js";
 import { formatRelativeTimestamp } from "../infra/format-time/format-relative.ts";
-import { normalizeAgentId } from "../routing/session-key.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { helpText, parseCommand } from "./commands.js";
 import type { ChatLog } from "./components/chat-log.js";
 import {
@@ -52,6 +52,37 @@ type CommandHandlerContext = {
 
 function isBtwCommand(text: string): boolean {
   return /^\/btw(?::|\s|$)/i.test(text.trim());
+}
+
+export function buildSessionPickerSearchText(params: {
+  session: {
+    key: string;
+    displayName?: string;
+    label?: string;
+    subject?: string;
+    sessionId?: string;
+    lastMessagePreview?: string;
+    derivedTitle?: string;
+  };
+  formattedKey: string;
+}): string {
+  const parsed = parseAgentSessionKey(params.session.key);
+  const restKey = parsed?.rest;
+  const tailKey = restKey?.split(":").filter(Boolean).at(-1);
+  return [
+    params.formattedKey,
+    params.session.displayName,
+    params.session.label,
+    params.session.subject,
+    params.session.derivedTitle,
+    params.session.sessionId,
+    params.session.key,
+    restKey,
+    tailKey,
+    params.session.lastMessagePreview,
+  ]
+    .filter(Boolean)
+    .join(" ");
 }
 
 export function createCommandHandlers(context: CommandHandlerContext) {
@@ -182,16 +213,10 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           value: session.key,
           label,
           description,
-          searchText: [
-            session.displayName,
-            session.label,
-            session.subject,
-            session.sessionId,
-            session.key,
-            session.lastMessagePreview,
-          ]
-            .filter(Boolean)
-            .join(" "),
+          searchText: buildSessionPickerSearchText({
+            session,
+            formattedKey,
+          }),
         };
       });
       const selector = createFilterableSelectList(items, 9);


### PR DESCRIPTION
## Summary
This PR improves the TUI `/sessions` picker search so named sessions (including named main-style keys) are easier to find from the top filter input.

## Changes
- add `buildSessionPickerSearchText()` in `src/tui/tui-command-handlers.ts`
- include additional search terms in picker filtering:
  - formatted key (`parsed.rest`)
  - `derivedTitle`
  - parsed key fragments (`rest` and tail segment)
  - existing metadata fields (display name, label, subject, sessionId, raw key, last preview)
- add unit test coverage in `src/tui/tui-command-handlers.test.ts` for named-main key fragments and derived metadata

## Validation
Attempted local run:
- `timeout 60s node ./node_modules/vitest/vitest.mjs run src/tui/tui-command-handlers.test.ts -t "includes named main session fragments and derived metadata"`

In this environment Vitest timed out (exit 124) after printing only the RUN header, so full local test confirmation was not possible here.
