### PR TITLE
fix: restore exec tool command argument validation (fixes #56916)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/exec: fix exec tool validation failure (`command: must have required property 'command'`) that occurred for Kimi (Anthropic-compatible) providers in 2026.3.28 — the Kimi tool-call argument repair path incorrectly cleared valid streamed arguments back to `{}` when the final `}` delta triggered a repair check on already-complete JSON. Fixes #56916. (#54491)
 - ACP/sessions_spawn: register ACP child runs for completion tracking and lifecycle cleanup, and make registration-failure cleanup explicitly best-effort so callers do not assume an already-started ACP turn was fully aborted. (#40885) Thanks @xaeon2026 and @vincentkoc.
 - ACPX/runtime: derive the bundled ACPX expected version from the extension package metadata instead of hardcoding a separate literal, so plugin-local ACPX installs stop drifting out of health-check parity after version bumps. (#49089) Thanks @jiejiesks and @vincentkoc.
 - Gateway/auth: make local-direct `trusted-proxy` fallback require the configured shared token instead of silently authenticating same-host callers, while keeping same-host reverse proxy identity-header flows on the normal trusted-proxy path. Thanks @zhangning-agent and @vincentkoc.


### PR DESCRIPTION
## Summary

Fixes the exec tool validation failure where command property was missing despite the model sending correct arguments.

## Root Cause

The bug affected Kimi (Anthropic-compatible API) provider users in 2026.3.28. The Kimi tool-call argument repair path incorrectly cleared valid streamed arguments back to {} when the final } delta triggered a repair check on already-complete JSON. This was already fixed by commits a2e4707cf and ec7f19e2e. This PR adds a changelog entry documenting the fix for issue #56916.

Fixes openclaw/openclaw#56916