### PR TITLE
feat(slack): enable inline buttons by default

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -576,6 +576,17 @@ export async function compactEmbeddedPiSessionDirect(
         runtimeCapabilities.push(capability);
       }
     }
+    // Slack: enable inline buttons by default (Block Kit is always available)
+    if (runtimeChannel === "slack") {
+      if (!runtimeCapabilities) {
+        runtimeCapabilities = [];
+      }
+      if (
+        !runtimeCapabilities.some((cap) => String(cap).trim().toLowerCase() === "inlinebuttons")
+      ) {
+        runtimeCapabilities.push("inlineButtons");
+      }
+    }
     const reactionGuidance =
       runtimeChannel && params.config
         ? resolveChannelReactionGuidance({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -594,6 +594,17 @@ export async function runEmbeddedAttempt(
         runtimeCapabilities.push(capability);
       }
     }
+    // Slack: enable inline buttons by default (Block Kit is always available)
+    if (runtimeChannel === "slack") {
+      if (!runtimeCapabilities) {
+        runtimeCapabilities = [];
+      }
+      if (
+        !runtimeCapabilities.some((cap) => String(cap).trim().toLowerCase() === "inlinebuttons")
+      ) {
+        runtimeCapabilities.push("inlineButtons");
+      }
+    }
     const reactionGuidance =
       runtimeChannel && params.config
         ? resolveChannelReactionGuidance({


### PR DESCRIPTION
## Summary

Enable Slack inline buttons (Block Kit) by default, without requiring explicit `capabilities.inlineButtons` config.

## Changes

Added Slack-specific logic in both `compact.ts` and `attempt.ts` (the two runtime entry points) to auto-inject `"inlineButtons"` into `runtimeCapabilities` when the channel is `slack`. This mirrors the existing Telegram pattern that already does this.

**Before:** Slack users had to manually add `slack.capabilities.inlineButtons: "all"` to their config to use interactive buttons.

**After:** Inline buttons are enabled by default for Slack. Block Kit is always available in Slack, so there's no downside.

## Files Changed

- `src/agents/pi-embedded-runner/compact.ts` — +11 lines
- `src/agents/pi-embedded-runner/run/attempt.ts` — +11 lines

Fixes #56951