### PR TITLE
fix(security): warn about insecure session.dmScope in multi-user setups

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1355,5 +1355,27 @@ export function collectLikelyMultiUserSetupFindings(cfg: OpenClawConfig): Securi
       'If users may be mutually untrusted, split trust boundaries (separate gateways + credentials, ideally separate OS users/hosts). If you intentionally run shared-user access, set agents.defaults.sandbox.mode="all", keep tools.fs.workspaceOnly=true, deny runtime/fs/web tools unless required, and keep personal/private identities + credentials off that runtime.',
   });
 
+  // When multi-user signals are present and session.dmScope is still the
+  // insecure default ("main"), DM conversations from different users share
+  // the same session context — leaking private messages between users.
+  const dmScope = cfg.session?.dmScope ?? "main";
+  if (dmScope === "main") {
+    findings.push({
+      checkId: "security.session.dm_scope_main_multi_user",
+      severity: "critical",
+      title: 'DM sessions share context across users (session.dmScope is "main")',
+      detail:
+        'Multi-user signals are present but session.dmScope is "main" (the default). ' +
+        "All DM users share the same conversation context, which leaks private messages, " +
+        "tool outputs, and sensitive data between unrelated users. " +
+        "This is the most common privacy vulnerability in multi-user OpenClaw deployments.",
+      remediation:
+        "Run: " +
+        formatCliCommand('openclaw config set session.dmScope "per-channel-peer"') +
+        " to isolate DM sessions per sender. " +
+        'For multi-account channels, use "per-account-channel-peer" instead.',
+    });
+  }
+
   return findings;
 }

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -3819,6 +3819,31 @@ description: test skill
     );
   });
 
+  it("warns about dmScope=main when multi-user signals present", async () => {
+    const cfg = {
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+      tools: { elevated: { enabled: false } },
+    } satisfies OpenClawConfig;
+    const res = await audit(cfg);
+    const finding = res.findings.find(
+      (f) => f.checkId === "security.session.dm_scope_main_multi_user",
+    );
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe("critical");
+    expect(finding?.detail).toContain("session.dmScope");
+    expect(finding?.remediation).toContain("per-channel-peer");
+  });
+
+  it("does not warn about dmScope when already set to per-channel-peer", async () => {
+    const cfg = {
+      session: { dmScope: "per-channel-peer" },
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+      tools: { elevated: { enabled: false } },
+    } satisfies OpenClawConfig;
+    const res = await audit(cfg);
+    expectNoFinding(res, "security.session.dm_scope_main_multi_user");
+  });
+
   describe("maybeProbeGateway auth selection", () => {
     const makeProbeCapture = () => {
       let capturedAuth: { token?: string; password?: string } | undefined;


### PR DESCRIPTION
## Summary

- Add a critical security finding when multi-user signals are detected but `session.dmScope` is still `"main"` (the insecure default)
- All DM users sharing the same session context = private messages leak between users

## Root cause

The existing channel-level dmScope check in `audit-channel.ts` only fires when `isMultiUserDm=true` — meaning multiple users must already be in the allowlist. This misses the most dangerous case: `dmPolicy="open"` with no allowlist, where ANY user can DM the bot and share context with every other user.

## Fix

Add a proactive global-level check in `collectLikelyMultiUserSetupFindings()` (`audit-extra.sync.ts`) that fires when:
1. Multi-user signals are present (open DM policy, wildcard allowFrom, group targets)
2. `session.dmScope` is still `"main"`

Emits a **critical** finding with actionable remediation: `openclaw config set session.dmScope "per-channel-peer"`.

## Test plan

- [x] 2 new tests in `audit.test.ts`:
  - Warns when dmScope=main with multi-user signals
  - Does NOT warn when dmScope=per-channel-peer
- [x] Format and lint clean (pre-existing `no-unnecessary-type-assertion` errors on main, not from this change)

Fixes #55578.