### PR TITLE
fix(whatsapp): exclude DM allowFrom from group policy sender bypass

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/group-activation.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-activation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock the SDK runtime so we can unit-test resolveGroupPolicyFor
+// without needing the full runtime.
+vi.mock("openclaw/plugin-sdk/config-runtime", () => ({
+  resolveGroupSessionKey: vi.fn(({ From }: { From: string }) => ({ id: From })),
+  resolveChannelGroupPolicy: vi.fn(
+    (params: { hasGroupAllowFrom?: boolean; groupId?: string }) => params,
+  ),
+  resolveChannelGroupRequireMention: vi.fn(),
+  loadSessionStore: vi.fn(),
+  resolveStorePath: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
+  normalizeGroupActivation: vi.fn(),
+}));
+
+import { resolveChannelGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
+import { resolveGroupPolicyFor } from "./group-activation.js";
+
+describe("resolveGroupPolicyFor", () => {
+  it("does not set hasGroupAllowFrom when only DM allowFrom is configured", () => {
+    // Regression: DM allowFrom entries (added by pairing) were incorrectly
+    // treated as group-level sender filtering, causing groupPolicy=allowlist
+    // with no groups to auto-reply to ALL groups instead of blocking them.
+    const cfg = {
+      channels: {
+        whatsapp: {
+          allowFrom: ["+1234567890"],
+        },
+      },
+    } as never;
+
+    resolveGroupPolicyFor(cfg, "group@g.us");
+
+    expect(resolveChannelGroupPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({ hasGroupAllowFrom: false }),
+    );
+  });
+
+  it("sets hasGroupAllowFrom when groupAllowFrom is configured", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupAllowFrom: ["+1234567890"],
+        },
+      },
+    } as never;
+
+    resolveGroupPolicyFor(cfg, "group@g.us");
+
+    expect(resolveChannelGroupPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({ hasGroupAllowFrom: true }),
+    );
+  });
+
+  it("does not set hasGroupAllowFrom when both allowFrom and empty groupAllowFrom are present", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          allowFrom: ["+1234567890"],
+          groupAllowFrom: [],
+        },
+      },
+    } as never;
+
+    resolveGroupPolicyFor(cfg, "group@g.us");
+
+    expect(resolveChannelGroupPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({ hasGroupAllowFrom: false }),
+    );
+  });
+});

--- a/extensions/whatsapp/src/auto-reply/monitor/group-activation.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-activation.ts
@@ -18,9 +18,9 @@ export function resolveGroupPolicyFor(cfg: ReturnType<LoadConfigFn>, conversatio
   const whatsappCfg = cfg.channels?.whatsapp as
     | { groupAllowFrom?: string[]; allowFrom?: string[] }
     | undefined;
-  const hasGroupAllowFrom = Boolean(
-    whatsappCfg?.groupAllowFrom?.length || whatsappCfg?.allowFrom?.length,
-  );
+  // Only check groupAllowFrom — DM allowFrom entries (from pairing) should
+  // not grant group access or bypass the group allowlist gate.
+  const hasGroupAllowFrom = Boolean(whatsappCfg?.groupAllowFrom?.length);
   return resolveChannelGroupPolicy({
     cfg,
     channel: "whatsapp",


### PR DESCRIPTION
## Summary

- Fix security regression where `groupPolicy: "allowlist"` with no groups defined auto-replies to ALL groups instead of fail-closed blocking them

## Root cause

`resolveGroupPolicyFor()` in `extensions/whatsapp/src/auto-reply/monitor/group-activation.ts` computes `hasGroupAllowFrom` by checking BOTH `groupAllowFrom` AND `allowFrom`:

```typescript
const hasGroupAllowFrom = Boolean(
  whatsappCfg?.groupAllowFrom?.length || whatsappCfg?.allowFrom?.length,
);
```

`allowFrom` is the DM allowlist populated by pairing. When a user pairs via DM, their ID enters `allowFrom`, which makes `hasGroupAllowFrom` true, triggering the `senderFilterBypass` in `group-policy.ts:347` — allowing ALL groups through the allowlist gate.

## Fix

Only check `groupAllowFrom` (intentional group-level sender filtering), not `allowFrom` (DM pairing entries).

## Test plan

- [x] Existing `group-policy.test.ts` tests pass (the core logic is correct)
- [x] `pnpm format` clean
- [ ] Verify: `groupPolicy: "allowlist"` with no groups + DM-paired users → groups blocked
- [ ] Verify: `groupPolicy: "allowlist"` with `groupAllowFrom` configured → groups allowed with sender filtering

Fixes #56957.