### PR TITLE
fix: multiple bug fixes (Mistral onboarding, Matrix DM, tool schema, cron)

### DIFF
--- a/extensions/matrix/src/matrix/direct-room.ts
+++ b/extensions/matrix/src/matrix/direct-room.ts
@@ -21,10 +21,28 @@ export function isStrictDirectMembership(params: {
   selfUserId?: string | null;
   remoteUserId?: string | null;
   joinedMembers?: readonly string[] | null;
+  isDirectFlag?: boolean | null;
 }): boolean {
   const selfUserId = trimMaybeString(params.selfUserId);
   const remoteUserId = trimMaybeString(params.remoteUserId);
   const joinedMembers = params.joinedMembers ?? [];
+
+  // Priority 1: is_direct flag is authoritative (Matrix protocol standard)
+  if (params.isDirectFlag === true) {
+    return Boolean(
+      selfUserId &&
+      remoteUserId &&
+      joinedMembers.includes(selfUserId) &&
+      joinedMembers.includes(remoteUserId),
+    );
+  }
+
+  // Priority 2: explicit is_direct=false means not a DM
+  if (params.isDirectFlag === false) {
+    return false;
+  }
+
+  // Priority 3: fallback to 2-member check only when is_direct is unavailable
   return Boolean(
     selfUserId &&
     remoteUserId &&

--- a/extensions/matrix/src/matrix/direct-room.ts
+++ b/extensions/matrix/src/matrix/direct-room.ts
@@ -67,16 +67,25 @@ export async function hasDirectMatrixMemberFlag(
   client: MatrixClient,
   roomId: string,
   userId?: string | null,
-): Promise<boolean> {
+): Promise<boolean | null> {
   const normalizedUserId = trimMaybeString(userId);
   if (!normalizedUserId) {
-    return false;
+    return null;
   }
   try {
     const state = await client.getRoomStateEvent(roomId, "m.room.member", normalizedUserId);
-    return state?.is_direct === true;
+    // Return true if is_direct is explicitly true, false if explicitly false, null if absent
+    if (state?.is_direct === true) {
+      return true;
+    }
+    if (state?.is_direct === false) {
+      return false;
+    }
+    // is_direct field is absent from the membership event
+    return null;
   } catch {
-    return false;
+    // API/network error - treat as unavailable
+    return null;
   }
 }
 
@@ -113,8 +122,9 @@ export async function inspectMatrixDirectRoomEvidence(params: {
     joinedMembers,
     strict,
     viaMemberState:
-      (await hasDirectMatrixMemberFlag(params.client, params.roomId, params.remoteUserId)) ||
-      (await hasDirectMatrixMemberFlag(params.client, params.roomId, selfUserId)),
+      (await hasDirectMatrixMemberFlag(params.client, params.roomId, params.remoteUserId)) ===
+        true ||
+      (await hasDirectMatrixMemberFlag(params.client, params.roomId, selfUserId)) === true,
   };
 }
 

--- a/extensions/matrix/src/matrix/direct-room.ts
+++ b/extensions/matrix/src/matrix/direct-room.ts
@@ -28,10 +28,12 @@ export function isStrictDirectMembership(params: {
   const joinedMembers = params.joinedMembers ?? [];
 
   // Priority 1: is_direct flag is authoritative (Matrix protocol standard)
+  // Still require exactly 2 members to avoid misclassifying shared rooms as DMs
   if (params.isDirectFlag === true) {
     return Boolean(
       selfUserId &&
       remoteUserId &&
+      joinedMembers.length === 2 &&
       joinedMembers.includes(selfUserId) &&
       joinedMembers.includes(remoteUserId),
     );

--- a/extensions/matrix/src/matrix/monitor/direct.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.ts
@@ -113,10 +113,23 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
       const { roomId, senderId } = params;
       const selfUserId = params.selfUserId ?? (await ensureSelfUserId());
       const joinedMembers = await resolveJoinedMembers(roomId);
+
+      // Check is_direct flag first (authoritative Matrix protocol signal)
+      const directViaSender = await resolveDirectMemberFlag(roomId, senderId);
+      const directViaSelf = await resolveDirectMemberFlag(roomId, selfUserId);
+      // Preserve explicit false: if both lookups resolved and both are false, forward false
+      const isDirectFlag: boolean | null =
+        directViaSender || directViaSelf
+          ? true
+          : directViaSender === false && directViaSelf === false
+            ? false
+            : null;
+
       const strictDirectMembership = isStrictDirectMembership({
         selfUserId,
         remoteUserId: senderId,
         joinedMembers,
+        isDirectFlag,
       });
 
       try {

--- a/extensions/matrix/src/matrix/monitor/direct.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.ts
@@ -82,10 +82,10 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
   const resolveDirectMemberFlag = async (
     roomId: string,
     userId?: string | null,
-  ): Promise<boolean> => {
+  ): Promise<boolean | null> => {
     const normalizedUserId = userId?.trim();
     if (!normalizedUserId) {
-      return false;
+      return null;
     }
     const cacheKey = `${roomId}\n${normalizedUserId}`;
     const cached = directMemberFlagCache.get(cacheKey);
@@ -117,9 +117,9 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
       // Check is_direct flag first (authoritative Matrix protocol signal)
       const directViaSender = await resolveDirectMemberFlag(roomId, senderId);
       const directViaSelf = await resolveDirectMemberFlag(roomId, selfUserId);
-      // Preserve explicit false: if both lookups resolved and both are false, forward false
+      // Priority: true > null > false. Any true makes it true, both false makes it false, otherwise null
       const isDirectFlag: boolean | null =
-        directViaSender || directViaSelf
+        directViaSender === true || directViaSelf === true
           ? true
           : directViaSender === false && directViaSelf === false
             ? false

--- a/extensions/matrix/src/matrix/monitor/direct.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.ts
@@ -117,13 +117,15 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
       // Check is_direct flag first (authoritative Matrix protocol signal)
       const directViaSender = await resolveDirectMemberFlag(roomId, senderId);
       const directViaSelf = await resolveDirectMemberFlag(roomId, selfUserId);
-      // Priority: true > null > false. Any true makes it true, both false makes it false, otherwise null
+      // Priority: true > false > null. Any true makes it true (authoritative DM),
+      // any explicit false makes it false (authoritative non-DM),
+      // only both null returns null (unavailable, fallback to 2-member check)
       const isDirectFlag: boolean | null =
         directViaSender === true || directViaSelf === true
           ? true
-          : directViaSender === false && directViaSelf === false
+          : directViaSender === false || directViaSelf === false
             ? false
-            : null;
+            : null; // both null
 
       const strictDirectMembership = isStrictDirectMembership({
         selfUserId,

--- a/extensions/mistral/api.ts
+++ b/extensions/mistral/api.ts
@@ -4,40 +4,9 @@ export {
   MISTRAL_BASE_URL,
   MISTRAL_DEFAULT_MODEL_ID,
 } from "./model-definitions.js";
+export { applyMistralModelCompat, MISTRAL_MODEL_COMPAT_PATCH } from "./model-compat.js";
 export {
   applyMistralConfig,
   applyMistralProviderConfig,
   MISTRAL_DEFAULT_MODEL_REF,
 } from "./onboard.js";
-
-const MISTRAL_MAX_TOKENS_FIELD = "max_tokens";
-
-export const MISTRAL_MODEL_COMPAT_PATCH = {
-  supportsStore: false,
-  supportsReasoningEffort: false,
-  maxTokensField: MISTRAL_MAX_TOKENS_FIELD,
-} as const satisfies {
-  supportsStore: boolean;
-  supportsReasoningEffort: boolean;
-  maxTokensField: "max_tokens";
-};
-
-export function applyMistralModelCompat<T extends { compat?: unknown }>(model: T): T {
-  const compat =
-    model.compat && typeof model.compat === "object"
-      ? (model.compat as Record<string, unknown>)
-      : undefined;
-  if (
-    compat &&
-    Object.entries(MISTRAL_MODEL_COMPAT_PATCH).every(([key, value]) => compat[key] === value)
-  ) {
-    return model;
-  }
-  return {
-    ...model,
-    compat: {
-      ...compat,
-      ...MISTRAL_MODEL_COMPAT_PATCH,
-    } as T extends { compat?: infer TCompat } ? TCompat : never,
-  } as T;
-}

--- a/extensions/mistral/model-compat.ts
+++ b/extensions/mistral/model-compat.ts
@@ -1,0 +1,31 @@
+const MISTRAL_MAX_TOKENS_FIELD = "max_tokens";
+
+export const MISTRAL_MODEL_COMPAT_PATCH = {
+  supportsStore: false,
+  supportsReasoningEffort: false,
+  maxTokensField: MISTRAL_MAX_TOKENS_FIELD,
+} as const satisfies {
+  supportsStore: boolean;
+  supportsReasoningEffort: boolean;
+  maxTokensField: "max_tokens";
+};
+
+export function applyMistralModelCompat<T extends { compat?: unknown }>(model: T): T {
+  const compat =
+    model.compat && typeof model.compat === "object"
+      ? (model.compat as Record<string, unknown>)
+      : undefined;
+  if (
+    compat &&
+    Object.entries(MISTRAL_MODEL_COMPAT_PATCH).every(([key, value]) => compat[key] === value)
+  ) {
+    return model;
+  }
+  return {
+    ...model,
+    compat: {
+      ...compat,
+      ...MISTRAL_MODEL_COMPAT_PATCH,
+    } as T extends { compat?: infer TCompat } ? TCompat : never,
+  } as T;
+}

--- a/extensions/mistral/onboard.ts
+++ b/extensions/mistral/onboard.ts
@@ -2,6 +2,7 @@ import {
   createDefaultModelPresetAppliers,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
+import { applyMistralModelCompat } from "./model-compat.js";
 import {
   buildMistralModelDefinition,
   MISTRAL_BASE_URL,
@@ -16,7 +17,7 @@ const mistralPresetAppliers = createDefaultModelPresetAppliers({
     providerId: "mistral",
     api: "openai-completions",
     baseUrl: MISTRAL_BASE_URL,
-    defaultModel: buildMistralModelDefinition(),
+    defaultModel: applyMistralModelCompat(buildMistralModelDefinition()),
     defaultModelId: MISTRAL_DEFAULT_MODEL_ID,
     aliases: [{ modelRef: MISTRAL_DEFAULT_MODEL_REF, alias: "Mistral" }],
   }),

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -64,7 +64,17 @@ function mergePropertySchemas(existing: unknown, incoming: unknown): unknown {
     return merged;
   }
 
-  return existing;
+  // Preserve Optional annotation when merging schemas
+  const existingRecord = existing as Record<string, unknown>;
+  const incomingRecord = incoming as Record<string, unknown>;
+  const merged: Record<string, unknown> = { ...existingRecord };
+
+  // If either schema has optional=true, the merged schema should be optional
+  if (incomingRecord.optional === true || existingRecord.optional === true) {
+    merged.optional = true;
+  }
+
+  return merged;
 }
 
 export function normalizeToolParameters(

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -26,6 +26,12 @@ import {
 } from "./subagent-followup.js";
 
 function normalizeDeliveryTarget(channel: string, to: string): string {
+  // Defensive: ensure channel and to are strings (TypeScript type narrowing)
+  if (typeof channel !== "string" || typeof to !== "string") {
+    throw new Error(
+      `normalizeDeliveryTarget: channel and to must be strings, got channel=${typeof channel}, to=${typeof to}`,
+    );
+  }
   const channelLower = channel.trim().toLowerCase();
   const toTrimmed = to.trim();
   if (channelLower === "feishu" || channelLower === "lark") {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -378,11 +378,12 @@ export async function dispatchCronDelivery(
     options?: { retryTransient?: boolean },
   ): Promise<RunCronAgentTurnResult | null> => {
     const identity = resolveAgentOutboundIdentity(params.cfgWithAgentDefaults, params.agentId);
-    const deliveryIdempotencyKey = buildDirectCronDeliveryIdempotencyKey({
-      runSessionId: params.runSessionId,
-      delivery,
-    });
     try {
+      // Validate delivery target early and include in try/catch to avoid uncaught exceptions
+      const deliveryIdempotencyKey = buildDirectCronDeliveryIdempotencyKey({
+        runSessionId: params.runSessionId,
+        delivery,
+      });
       const payloadsForDelivery =
         deliveryPayloads.length > 0
           ? deliveryPayloads


### PR DESCRIPTION
# Summary

Fixes 6 bugs across Mistral provider onboarding, Matrix DM room classification, tool schema validation, and cron delivery handling. Includes security hardening for cron delivery exception handling and Matrix DM classification logic.

## Changes

### 1. Mistral onboarding 422 errors (#56546)

**Problem:** Mistral provider onboarding failed with 422 errors due to missing compatibility settings for model parameters.

**Root Cause:** Mistral API requires `max_tokens` field (not `max_completion_tokens`) and does not support the `store` parameter.

**Fix:** 
- Extract `applyMistralModelCompat()` into new `extensions/mistral/model-compat.ts`
- Apply compat patch during onboarding to set `supportsStore: false` and `maxTokensField: max_tokens`
- Re-export from `api.ts` to avoid circular imports

### 2. Message tool buttons parameter validation (#56496)

**Problem:** Tool actions without buttons (react/delete/edit/poll) failed schema validation because `buttons` was incorrectly required.

**Root Cause:** `mergePropertySchemas()` did not preserve the `optional: true` annotation when merging schema variants.

**Fix:**
- `mergePropertySchemas()` now preserves `optional: true` annotation from either schema variant
- Allows tool button actions to omit the `buttons` parameter when not applicable

### 3. Matrix rooms misclassified as DM (#56599)

**Problem:** Matrix DM classification logic had multiple issues:
1. Unreachable code branch when `is_direct` flag was absent (returned `false` instead of `null`)
2. When `is_direct: true`, the code skipped the 2-member check, causing shared rooms to be misclassified as DMs after additional members joined
3. **Security finding:** Explicit `is_direct: false` was ignored when the other side returned `null`, potentially misclassifying non-DM rooms

**Fix:**
- `hasDirectMatrixMemberFlag()` returns `boolean | null` to distinguish absent vs explicit false
- `isStrictDirectMembership()` uses three-tier classification:
  - **Priority 1:** `is_direct: true` → DM (authoritative, but still requires exactly 2 members)
  - **Priority 2:** `is_direct: false` → not DM (explicit negative)
  - **Priority 3:** fallback to 2-member check when `is_direct` is absent
- `isDirectMessage()` properly aggregates flags with three-valued logic
- **Security fix:** Changed priority from `true > null > false` to `true > false > null` so explicit `false` is never ignored
- **Key insight:** A room can start as direct chat but later become shared; we must keep the 2-member guard even when `is_direct=true`

### 4. Cron delivery type guard

**Problem:** `normalizeDeliveryTarget()` threw silent TypeError when channel/to were non-strings.

**Fix:**
- Add runtime `typeof` guard at function entry
- Throw descriptive error for invalid types

### 5. Security Hardening (Aisle Review)

**5.1 Cron delivery exception handling**
- **Problem:** `normalizeDeliveryTarget()` throw was outside `try/catch` in `deliverViaDirect()`, causing uncaught exceptions on malformed delivery targets
- **Fix:** Move idempotency key construction inside the `try` block so all delivery-target errors are caught and handled

**5.2 Matrix DM flag priority**
- **Problem:** When one side had `is_direct: false` and the other returned `null`, the combiner returned `null` instead of `false`
- **Fix:** Changed logic to `true > false > null` priority so explicit `false` is authoritative

## Files Changed

| File | Change |
|------|--------|
| `extensions/mistral/model-compat.ts` | new - extracted compat logic |
| `extensions/mistral/api.ts` | re-export from model-compat.ts |
| `extensions/mistral/onboard.ts` | apply compat during onboarding |
| `extensions/matrix/src/matrix/direct-room.ts` | three-tier classification + nullable return + keep 2-member guard |
| `extensions/matrix/src/matrix/monitor/direct.ts` | proper isDirectFlag aggregation + fix false/null priority |
| `src/agents/pi-tools.schema.ts` | optional annotation propagation |
| `src/cron/isolated-agent/delivery-dispatch.ts` | runtime type guard + move idempotency key inside try/catch |

## Testing

All checks pass:
- ✅ check
- ✅ check-additional  
- ✅ build-smoke
- ✅ lint
- ✅ Greptile Review
- ✅ Aisle Security (addressed findings)

## Related Issues

- Closes #56546 (Mistral onboarding 422)
- Closes #56496 (Message tool buttons validation)
- Closes #56599 (Matrix DM classification)
