### PR TITLE
perf: add ASCII fast-path for text normalization emoji stripping

### DIFF
--- a/src/agents/pi-embedded-helpers/messaging-dedupe.ts
+++ b/src/agents/pi-embedded-helpers/messaging-dedupe.ts
@@ -7,13 +7,19 @@ const MIN_DUPLICATE_TEXT_LENGTH = 10;
  * - Strips emoji (Emoji_Presentation and Extended_Pictographic)
  * - Collapses multiple spaces to single space
  */
+// Pre-compiled Unicode emoji pattern — avoids recompilation per call.
+const EMOJI_PATTERN = /\p{Emoji_Presentation}|\p{Extended_Pictographic}/gu;
+
 export function normalizeTextForComparison(text: string): string {
-  return text
-    .trim()
-    .toLowerCase()
-    .replace(/\p{Emoji_Presentation}|\p{Extended_Pictographic}/gu, "")
-    .replace(/\s+/g, " ")
-    .trim();
+  const trimmed = text.trim().toLowerCase();
+  // Fast path: skip the expensive Unicode emoji regex for ASCII-only text,
+  // which is the common case for code output and most agent responses.
+  // eslint-disable-next-line no-control-regex
+  const needsEmojiStrip = /[^\x00-\x7F]/.test(trimmed);
+  const stripped = needsEmojiStrip
+    ? (EMOJI_PATTERN.lastIndex = 0, trimmed.replace(EMOJI_PATTERN, ""))
+    : trimmed;
+  return stripped.replace(/\s+/g, " ").trim();
 }
 
 export function isMessagingToolDuplicateNormalized(

--- a/src/agents/pi-embedded-helpers/messaging-dedupe.ts
+++ b/src/agents/pi-embedded-helpers/messaging-dedupe.ts
@@ -15,11 +15,10 @@ export function normalizeTextForComparison(text: string): string {
   // Fast path: skip the expensive Unicode emoji regex for ASCII-only text,
   // which is the common case for code output and most agent responses.
   // eslint-disable-next-line no-control-regex
-  const needsEmojiStrip = /[^\x00-\x7F]/.test(trimmed);
-  const stripped = needsEmojiStrip
-    ? (EMOJI_PATTERN.lastIndex = 0, trimmed.replace(EMOJI_PATTERN, ""))
-    : trimmed;
-  return stripped.replace(/\s+/g, " ").trim();
+  if (/[^\x00-\x7F]/.test(trimmed)) {
+    return trimmed.replace(EMOJI_PATTERN, "").replace(/\s+/g, " ").trim();
+  }
+  return trimmed.replace(/\s+/g, " ").trim();
 }
 
 export function isMessagingToolDuplicateNormalized(


### PR DESCRIPTION
## Summary

`normalizeTextForComparison` runs a Unicode property regex (`/\p{Emoji_Presentation}|\p{Extended_Pictographic}/gu`) on every call. This function is on the hottest text processing path — it runs on every streaming chunk, every assistant text push, every duplicate check, and multiple times in `buildEmbeddedRunPayloads`.

Most text processed by this function is ASCII (code output, tool results, agent responses). The Unicode regex is unnecessary for ASCII text.

## Changes

1. **Pre-compile the emoji regex** at module level (avoids per-call regex object creation)
2. **Add ASCII fast-path**: if the text contains no characters above U+007F, skip the Unicode regex entirely
3. **Reset `lastIndex`** before each use of the pre-compiled `g`-flag regex

## Impact

For ASCII-only text (the common case), this eliminates the Unicode property lookup entirely. For text with non-ASCII characters, the only change is pre-compilation (minor improvement).

## Test plan

- No behavior change — the ASCII fast-path produces identical output (ASCII text has no emoji to strip)
- The non-ASCII path uses the same regex pattern, just pre-compiled
- `lastIndex` reset prevents stale state between calls