### PR TITLE
fix(xai): polish auth reuse and configure UX

### DIFF
--- a/extensions/xai/code-execution.test.ts
+++ b/extensions/xai/code-execution.test.ts
@@ -1,4 +1,11 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  upsertAuthProfile,
+} from "../../src/agents/auth-profiles.js";
 import { withFetchPreconnect } from "../../test/helpers/plugins/fetch-mock.js";
 import { createCodeExecutionTool } from "./code-execution.js";
 
@@ -41,6 +48,7 @@ function parseFirstRequestBody(mockFetch: ReturnType<typeof installCodeExecution
 }
 
 afterEach(() => {
+  clearRuntimeAuthProfileStoreSnapshots();
   vi.restoreAllMocks();
 });
 
@@ -155,5 +163,37 @@ describe("xai code_execution tool", () => {
     expect((request?.headers as Record<string, string> | undefined)?.Authorization).toBe(
       "Bearer xai-legacy-key",
     );
+  });
+
+  it("reuses xAI auth profile keys for code_execution requests", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-code-execution-"));
+    try {
+      upsertAuthProfile({
+        profileId: "xai:default",
+        agentDir,
+        credential: {
+          type: "api_key",
+          provider: "xai",
+          key: "xai-profile-key",
+        },
+      });
+      const mockFetch = installCodeExecutionFetch();
+      const tool = createCodeExecutionTool({
+        config: {},
+        agentDir,
+      });
+
+      expect(tool?.name).toBe("code_execution");
+      await tool?.execute?.("code-execution:profile-key", {
+        task: "Summarize the median of [1, 2, 3]",
+      });
+
+      const request = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((request?.headers as Record<string, string> | undefined)?.Authorization).toBe(
+        "Bearer xai-profile-key",
+      );
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
   });
 });

--- a/extensions/xai/code-execution.ts
+++ b/extensions/xai/code-execution.ts
@@ -1,13 +1,12 @@
 import { Type } from "@sinclair/typebox";
 import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/config-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
+import { jsonResult, readStringParam } from "openclaw/plugin-sdk/provider-web-search";
 import {
-  jsonResult,
-  readConfiguredSecretString,
-  readProviderEnvValue,
-  readStringParam,
-  resolveProviderWebSearchPluginConfig,
-} from "openclaw/plugin-sdk/provider-web-search";
+  hasXaiProfileCredential,
+  resolveConfiguredXaiApiKey,
+  resolveXaiApiKey,
+} from "./src/auth-shared.js";
 import {
   buildXaiCodeExecutionPayload,
   requestXaiCodeExecution,
@@ -36,18 +35,6 @@ function readCodeExecutionConfigRecord(
   return config && typeof config === "object" ? (config as Record<string, unknown>) : undefined;
 }
 
-function readLegacyGrokApiKey(cfg?: OpenClawConfig): string | undefined {
-  const search = cfg?.tools?.web?.search;
-  if (!search || typeof search !== "object") {
-    return undefined;
-  }
-  const grok = (search as Record<string, unknown>).grok;
-  return readConfiguredSecretString(
-    grok && typeof grok === "object" ? (grok as Record<string, unknown>).apiKey : undefined,
-    "tools.web.search.grok.apiKey",
-  );
-}
-
 function readPluginCodeExecutionConfig(cfg?: OpenClawConfig): CodeExecutionConfig | undefined {
   const entries = cfg?.plugins?.entries;
   if (!entries || typeof entries !== "object") {
@@ -68,34 +55,26 @@ function readPluginCodeExecutionConfig(cfg?: OpenClawConfig): CodeExecutionConfi
   return codeExecution as CodeExecutionConfig;
 }
 
-function resolveFallbackXaiApiKey(cfg?: OpenClawConfig): string | undefined {
-  return (
-    readConfiguredSecretString(
-      resolveProviderWebSearchPluginConfig(cfg as Record<string, unknown> | undefined, "xai")
-        ?.apiKey,
-      "plugins.entries.xai.config.webSearch.apiKey",
-    ) ?? readLegacyGrokApiKey(cfg)
-  );
-}
-
 function resolveCodeExecutionEnabled(params: {
   sourceConfig?: OpenClawConfig;
   runtimeConfig?: OpenClawConfig;
   config?: CodeExecutionConfig;
+  agentDir?: string;
 }): boolean {
   if (readCodeExecutionConfigRecord(params.config)?.enabled === false) {
     return false;
   }
   return Boolean(
-    resolveFallbackXaiApiKey(params.runtimeConfig) ??
-    resolveFallbackXaiApiKey(params.sourceConfig) ??
-    readProviderEnvValue(["XAI_API_KEY"]),
+    resolveConfiguredXaiApiKey(params.runtimeConfig) ??
+    resolveConfiguredXaiApiKey(params.sourceConfig) ??
+    hasXaiProfileCredential(params.agentDir),
   );
 }
 
 export function createCodeExecutionTool(options?: {
   config?: OpenClawConfig;
   runtimeConfig?: OpenClawConfig | null;
+  agentDir?: string;
 }) {
   const runtimeConfig = options?.runtimeConfig ?? getRuntimeConfigSnapshot();
   const codeExecutionConfig =
@@ -106,6 +85,7 @@ export function createCodeExecutionTool(options?: {
       sourceConfig: options?.config,
       runtimeConfig: runtimeConfig ?? undefined,
       config: codeExecutionConfig,
+      agentDir: options?.agentDir,
     })
   ) {
     return null;
@@ -115,7 +95,7 @@ export function createCodeExecutionTool(options?: {
     label: "Code Execution",
     name: "code_execution",
     description:
-      "Run sandboxed Python analysis with xAI. Use for calculations, tabulation, summaries, and chart-style analysis without local machine access.",
+      "Run sandboxed Python analysis with xAI. Use for calculations, tabulation, summaries, and chart-style analysis without local machine access. If this tool is available, it is configured enough to try instead of claiming remote analysis is unavailable.",
     parameters: Type.Object({
       task: Type.String({
         description:
@@ -123,10 +103,11 @@ export function createCodeExecutionTool(options?: {
       }),
     }),
     execute: async (_toolCallId: string, args: Record<string, unknown>) => {
-      const apiKey =
-        resolveFallbackXaiApiKey(runtimeConfig ?? undefined) ??
-        resolveFallbackXaiApiKey(options?.config) ??
-        readProviderEnvValue(["XAI_API_KEY"]);
+      const apiKey = await resolveXaiApiKey({
+        sourceConfig: options?.config,
+        runtimeConfig: runtimeConfig ?? undefined,
+        agentDir: options?.agentDir,
+      });
       if (!apiKey) {
         return jsonResult({
           error: "missing_xai_api_key",

--- a/extensions/xai/code-execution.ts
+++ b/extensions/xai/code-execution.ts
@@ -112,7 +112,7 @@ export function createCodeExecutionTool(options?: {
         return jsonResult({
           error: "missing_xai_api_key",
           message:
-            "code_execution needs an xAI API key. Set XAI_API_KEY in the Gateway environment, or configure plugins.entries.xai.config.webSearch.apiKey.",
+            "code_execution needs xAI auth. If Grok is already your active model, this tool should reuse the same xAI auth profile after a gateway restart or re-running configure. Otherwise set XAI_API_KEY in the Gateway environment, or configure plugins.entries.xai.config.webSearch.apiKey.",
           docs: "https://docs.openclaw.ai/tools/code-execution",
         });
       }

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -153,6 +153,7 @@ export default defineSingleProviderPluginEntry({
         createCodeExecutionTool({
           config: ctx.config,
           runtimeConfig: ctx.runtimeConfig,
+          agentDir: ctx.agentDir,
         }),
       { name: "code_execution" },
     );
@@ -161,6 +162,7 @@ export default defineSingleProviderPluginEntry({
         createXSearchTool({
           config: ctx.config,
           runtimeConfig: ctx.runtimeConfig,
+          agentDir: ctx.agentDir,
         }),
       { name: "x_search" },
     );

--- a/extensions/xai/src/auth-shared.ts
+++ b/extensions/xai/src/auth-shared.ts
@@ -1,0 +1,80 @@
+import {
+  ensureAuthProfileStore,
+  listProfilesForProvider,
+  resolveApiKeyForProfile,
+} from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  readConfiguredSecretString,
+  readProviderEnvValue,
+  resolveProviderWebSearchPluginConfig,
+} from "openclaw/plugin-sdk/provider-web-search";
+
+export function readLegacyGrokApiKey(cfg?: OpenClawConfig): string | undefined {
+  const search = cfg?.tools?.web?.search;
+  if (!search || typeof search !== "object") {
+    return undefined;
+  }
+  const grok = (search as Record<string, unknown>).grok;
+  return readConfiguredSecretString(
+    grok && typeof grok === "object" ? (grok as Record<string, unknown>).apiKey : undefined,
+    "tools.web.search.grok.apiKey",
+  );
+}
+
+export function readPluginXaiWebSearchApiKey(cfg?: OpenClawConfig): string | undefined {
+  return readConfiguredSecretString(
+    resolveProviderWebSearchPluginConfig(cfg as Record<string, unknown> | undefined, "xai")?.apiKey,
+    "plugins.entries.xai.config.webSearch.apiKey",
+  );
+}
+
+export function resolveConfiguredXaiApiKey(cfg?: OpenClawConfig): string | undefined {
+  return readPluginXaiWebSearchApiKey(cfg) ?? readLegacyGrokApiKey(cfg);
+}
+
+export function hasXaiProfileCredential(agentDir?: string): boolean {
+  const store = ensureAuthProfileStore(agentDir, {
+    allowKeychainPrompt: false,
+  });
+  return listProfilesForProvider(store, "xai").length > 0;
+}
+
+export async function resolveXaiApiKeyFromProfiles(params: {
+  config?: OpenClawConfig;
+  agentDir?: string;
+}): Promise<string | undefined> {
+  const store = ensureAuthProfileStore(params.agentDir, {
+    allowKeychainPrompt: false,
+  });
+  const profileIds = listProfilesForProvider(store, "xai");
+  for (const profileId of profileIds) {
+    const resolved = await resolveApiKeyForProfile({
+      cfg: params.config,
+      store,
+      profileId,
+      agentDir: params.agentDir,
+    });
+    const apiKey = resolved?.apiKey?.trim();
+    if (apiKey) {
+      return apiKey;
+    }
+  }
+  return undefined;
+}
+
+export async function resolveXaiApiKey(params: {
+  sourceConfig?: OpenClawConfig;
+  runtimeConfig?: OpenClawConfig;
+  agentDir?: string;
+}): Promise<string | undefined> {
+  return (
+    resolveConfiguredXaiApiKey(params.runtimeConfig) ??
+    resolveConfiguredXaiApiKey(params.sourceConfig) ??
+    readProviderEnvValue(["XAI_API_KEY"]) ??
+    (await resolveXaiApiKeyFromProfiles({
+      config: params.runtimeConfig ?? params.sourceConfig,
+      agentDir: params.agentDir,
+    }))
+  );
+}

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -1,8 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  upsertAuthProfile,
+} from "../../src/agents/auth-profiles.js";
 import { NON_ENV_SECRETREF_MARKER } from "../../src/agents/model-auth-markers.js";
 import { capturePluginRegistration } from "../../src/plugins/captured-registration.js";
 import { createNonExitingRuntime } from "../../src/runtime.js";
 import { withEnv } from "../../test/helpers/plugins/env.js";
+import { withFetchPreconnect } from "../../test/helpers/plugins/fetch-mock.js";
 import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
 import xaiPlugin from "./index.js";
 import { resolveXaiCatalogEntry } from "./model-definitions.js";
@@ -16,6 +24,39 @@ const {
   resolveXaiWebSearchCredential,
   resolveXaiWebSearchModel,
 } = __testing;
+
+function installWebSearchFetch(payload?: Record<string, unknown>) {
+  const mockFetch = vi.fn((_input?: unknown, _init?: unknown) =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve(
+          payload ?? {
+            output: [
+              {
+                type: "message",
+                content: [
+                  {
+                    type: "output_text",
+                    text: "Found matching posts",
+                    annotations: [{ type: "url_citation", url: "https://x.com/openclaw/status/1" }],
+                  },
+                ],
+              },
+            ],
+            citations: ["https://x.com/openclaw/status/1"],
+          },
+        ),
+    } as Response),
+  );
+  global.fetch = withFetchPreconnect(mockFetch);
+  return mockFetch;
+}
+
+afterEach(() => {
+  clearRuntimeAuthProfileStoreSnapshots();
+  vi.restoreAllMocks();
+});
 
 describe("xai web search config resolution", () => {
   it("prefers configured api keys and resolves grok scoped defaults", () => {
@@ -34,6 +75,37 @@ describe("xai web search config resolution", () => {
     withEnv({ XAI_API_KEY: undefined }, () => {
       expect(resolveXaiWebSearchCredential({})).toBeUndefined();
     });
+  });
+
+  it("uses xAI auth profiles as a fallback credential source", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-xai-web-search-"));
+    try {
+      upsertAuthProfile({
+        profileId: "xai:default",
+        agentDir,
+        credential: {
+          type: "api_key",
+          provider: "xai",
+          key: "xai-profile-key",
+        },
+      });
+      const mockFetch = installWebSearchFetch();
+      const provider = createXaiWebSearchProvider();
+      expect(provider.hasCredential?.({ config: {}, agentDir })).toBe(true);
+
+      const tool = provider.createTool({
+        config: {},
+        agentDir,
+      });
+      await tool?.execute({ query: "latest OpenClaw announcements" });
+
+      const request = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((request?.headers as Record<string, string> | undefined)?.Authorization).toBe(
+        "Bearer xai-profile-key",
+      );
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
   });
 
   it("resolves env SecretRefs without requiring a runtime snapshot", () => {

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -180,6 +180,7 @@ describe("xai web search config resolution", () => {
 
       await expect(maybeTool.execute({ query: "OpenClaw" })).resolves.toMatchObject({
         error: "missing_xai_api_key",
+        message: expect.stringContaining("If Grok is already your active model"),
       });
     });
   });

--- a/extensions/xai/web-search.ts
+++ b/extensions/xai/web-search.ts
@@ -20,6 +20,7 @@ import {
   type WebSearchProviderPlugin,
   writeCache,
 } from "openclaw/plugin-sdk/provider-web-search";
+import { hasXaiProfileCredential, resolveXaiApiKey } from "./src/auth-shared.js";
 import {
   buildXaiWebSearchPayload,
   extractXaiWebSearchContent,
@@ -225,11 +226,14 @@ export function createXaiWebSearchProvider(): WebSearchProviderPlugin {
       setProviderWebSearchPluginConfigValue(configTarget, "xai", "apiKey", value);
     },
     runSetup: runXaiSearchProviderSetup,
+    hasCredential: (ctx) =>
+      Boolean(resolveXaiWebSearchCredential(resolveXaiToolSearchConfig(ctx))) ||
+      hasXaiProfileCredential(ctx.agentDir),
     createTool: (ctx) => {
       const searchConfig = resolveXaiToolSearchConfig(ctx);
       return {
         description:
-          "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search.",
+          "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search. If this tool is available, it is configured enough to try and should be used instead of telling the user web search is unavailable.",
         parameters: Type.Object({
           query: Type.String({ description: "Search query string." }),
           count: Type.Optional(
@@ -241,7 +245,12 @@ export function createXaiWebSearchProvider(): WebSearchProviderPlugin {
           ),
         }),
         execute: async (args: Record<string, unknown>) => {
-          const apiKey = resolveXaiWebSearchCredential(searchConfig);
+          const apiKey =
+            resolveXaiWebSearchCredential(searchConfig) ??
+            (await resolveXaiApiKey({
+              sourceConfig: ctx.config,
+              agentDir: ctx.agentDir,
+            }));
 
           if (!apiKey) {
             return {

--- a/extensions/xai/web-search.ts
+++ b/extensions/xai/web-search.ts
@@ -256,7 +256,7 @@ export function createXaiWebSearchProvider(): WebSearchProviderPlugin {
             return {
               error: "missing_xai_api_key",
               message:
-                "web_search (grok) needs an xAI API key. Set XAI_API_KEY in the Gateway environment, or configure plugins.entries.xai.config.webSearch.apiKey.",
+                "web_search (grok) needs xAI auth. If Grok is already your active model, this tool should reuse the same xAI auth profile after a gateway restart or re-running configure. Otherwise set XAI_API_KEY in the Gateway environment, or configure plugins.entries.xai.config.webSearch.apiKey.",
               docs: "https://docs.openclaw.ai/tools/web",
             };
           }

--- a/extensions/xai/x-search.test.ts
+++ b/extensions/xai/x-search.test.ts
@@ -1,4 +1,11 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  upsertAuthProfile,
+} from "../../src/agents/auth-profiles.js";
 import { withFetchPreconnect } from "../../test/helpers/plugins/fetch-mock.js";
 import { createXSearchTool } from "./x-search.js";
 
@@ -40,6 +47,7 @@ function parseFirstRequestBody(mockFetch: ReturnType<typeof installXSearchFetch>
 }
 
 afterEach(() => {
+  clearRuntimeAuthProfileStoreSnapshots();
   vi.restoreAllMocks();
 });
 
@@ -152,6 +160,38 @@ describe("xai x_search tool", () => {
     expect((request?.headers as Record<string, string> | undefined)?.Authorization).toBe(
       "Bearer xai-plugin-key",
     );
+  });
+
+  it("reuses xAI auth profile keys for x_search requests", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-x-search-"));
+    try {
+      upsertAuthProfile({
+        profileId: "xai:default",
+        agentDir,
+        credential: {
+          type: "api_key",
+          provider: "xai",
+          key: "xai-profile-key",
+        },
+      });
+      const mockFetch = installXSearchFetch();
+      const tool = createXSearchTool({
+        config: {},
+        agentDir,
+      });
+
+      expect(tool?.name).toBe("x_search");
+      await tool?.execute?.("x-search:profile-key", {
+        query: "latest post from huntharo",
+      });
+
+      const request = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+      expect((request?.headers as Record<string, string> | undefined)?.Authorization).toBe(
+        "Bearer xai-profile-key",
+      );
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
   });
 
   it("prefers the active runtime config for SecretRef-backed x_search keys", async () => {

--- a/extensions/xai/x-search.ts
+++ b/extensions/xai/x-search.ts
@@ -9,10 +9,14 @@ import {
   readStringArrayParam,
   readStringParam,
   resolveCacheTtlMs,
-  resolveProviderWebSearchPluginConfig,
   resolveTimeoutSeconds,
   writeCache,
 } from "openclaw/plugin-sdk/provider-web-search";
+import {
+  hasXaiProfileCredential,
+  resolveConfiguredXaiApiKey,
+  resolveXaiApiKey,
+} from "./src/auth-shared.js";
 import {
   buildXaiXSearchPayload,
   requestXaiXSearch,
@@ -56,29 +60,6 @@ function getSharedXSearchCache(): Map<string, XSearchCacheEntry> {
 
 const X_SEARCH_CACHE = getSharedXSearchCache();
 
-function readLegacyGrokApiKey(cfg?: OpenClawConfig): string | undefined {
-  const search = cfg?.tools?.web?.search;
-  if (!search || typeof search !== "object") {
-    return undefined;
-  }
-  const grok = (search as Record<string, unknown>).grok;
-  return readConfiguredSecretString(
-    grok && typeof grok === "object" ? (grok as Record<string, unknown>).apiKey : undefined,
-    "tools.web.search.grok.apiKey",
-  );
-}
-
-function readPluginXaiWebSearchApiKey(cfg?: OpenClawConfig): string | undefined {
-  return readConfiguredSecretString(
-    resolveProviderWebSearchPluginConfig(cfg as Record<string, unknown> | undefined, "xai")?.apiKey,
-    "plugins.entries.xai.config.webSearch.apiKey",
-  );
-}
-
-function resolveFallbackXaiApiKey(cfg?: OpenClawConfig): string | undefined {
-  return readPluginXaiWebSearchApiKey(cfg) ?? readLegacyGrokApiKey(cfg);
-}
-
 function resolveXSearchConfig(cfg?: OpenClawConfig): XSearchConfig {
   const xSearch = cfg?.tools?.web?.x_search;
   if (!xSearch || typeof xSearch !== "object") {
@@ -91,6 +72,7 @@ function resolveXSearchEnabled(params: {
   cfg?: OpenClawConfig;
   config?: XSearchConfig;
   runtimeConfig?: OpenClawConfig;
+  agentDir?: string;
 }): boolean {
   if (params.config?.enabled === false) {
     return false;
@@ -101,7 +83,7 @@ function resolveXSearchEnabled(params: {
       : undefined;
   if (
     readConfiguredSecretString(runtimeXSearchConfig?.apiKey, "tools.web.x_search.apiKey") ||
-    resolveFallbackXaiApiKey(params.runtimeConfig)
+    resolveConfiguredXaiApiKey(params.runtimeConfig)
   ) {
     return true;
   }
@@ -111,26 +93,9 @@ function resolveXSearchEnabled(params: {
   );
   return Boolean(
     configuredApiKey ||
-    resolveFallbackXaiApiKey(params.cfg) ||
+    resolveConfiguredXaiApiKey(params.cfg) ||
+    hasXaiProfileCredential(params.agentDir) ||
     readProviderEnvValue(["XAI_API_KEY"]),
-  );
-}
-
-function resolveXSearchApiKey(params: {
-  sourceConfig?: OpenClawConfig;
-  runtimeConfig?: OpenClawConfig;
-}): string | undefined {
-  const sourceXSearchConfig = resolveXSearchConfig(params.sourceConfig);
-  const runtimeXSearchConfig =
-    params.runtimeConfig && params.runtimeConfig !== params.sourceConfig
-      ? resolveXSearchConfig(params.runtimeConfig)
-      : undefined;
-  return (
-    readConfiguredSecretString(runtimeXSearchConfig?.apiKey, "tools.web.x_search.apiKey") ??
-    readConfiguredSecretString(sourceXSearchConfig?.apiKey, "tools.web.x_search.apiKey") ??
-    resolveFallbackXaiApiKey(params.runtimeConfig) ??
-    resolveFallbackXaiApiKey(params.sourceConfig) ??
-    readProviderEnvValue(["XAI_API_KEY"])
   );
 }
 
@@ -182,6 +147,7 @@ function buildXSearchCacheKey(params: {
 export function createXSearchTool(options?: {
   config?: OpenClawConfig;
   runtimeConfig?: OpenClawConfig | null;
+  agentDir?: string;
 }) {
   const xSearchConfig = resolveXSearchConfig(options?.config);
   const runtimeConfig = options?.runtimeConfig ?? getRuntimeConfigSnapshot();
@@ -190,6 +156,7 @@ export function createXSearchTool(options?: {
       cfg: options?.config,
       config: xSearchConfig,
       runtimeConfig: runtimeConfig ?? undefined,
+      agentDir: options?.agentDir,
     })
   ) {
     return null;
@@ -199,7 +166,7 @@ export function createXSearchTool(options?: {
     label: "X Search",
     name: "x_search",
     description:
-      "Search X (formerly Twitter) using xAI, including targeted post or thread lookups. For per-post stats like reposts, replies, bookmarks, or views, prefer the exact post URL or status ID.",
+      "Search X (formerly Twitter) using xAI, including targeted post or thread lookups. If this tool is available, it is configured enough to try and should be used for X/Twitter requests instead of claiming search is unavailable. For per-post stats like reposts, replies, bookmarks, or views, prefer the exact post URL or status ID, and include the post text and direct post URL in the final answer when available.",
     parameters: Type.Object({
       query: Type.String({ description: "X search query string." }),
       allowed_x_handles: Type.Optional(
@@ -226,10 +193,19 @@ export function createXSearchTool(options?: {
       ),
     }),
     execute: async (_toolCallId: string, args: Record<string, unknown>) => {
-      const apiKey = resolveXSearchApiKey({
-        sourceConfig: options?.config,
-        runtimeConfig: runtimeConfig ?? undefined,
-      });
+      const sourceXSearchConfig = resolveXSearchConfig(options?.config);
+      const runtimeXSearchConfig =
+        runtimeConfig && runtimeConfig !== options?.config
+          ? resolveXSearchConfig(runtimeConfig)
+          : undefined;
+      const apiKey =
+        readConfiguredSecretString(runtimeXSearchConfig?.apiKey, "tools.web.x_search.apiKey") ??
+        readConfiguredSecretString(sourceXSearchConfig?.apiKey, "tools.web.x_search.apiKey") ??
+        (await resolveXaiApiKey({
+          sourceConfig: options?.config,
+          runtimeConfig: runtimeConfig ?? undefined,
+          agentDir: options?.agentDir,
+        }));
       if (!apiKey) {
         return jsonResult({
           error: "missing_xai_api_key",

--- a/extensions/xai/x-search.ts
+++ b/extensions/xai/x-search.ts
@@ -210,7 +210,7 @@ export function createXSearchTool(options?: {
         return jsonResult({
           error: "missing_xai_api_key",
           message:
-            "x_search needs an xAI API key. Set XAI_API_KEY in the Gateway environment, or configure tools.web.x_search.apiKey or plugins.entries.xai.config.webSearch.apiKey.",
+            "x_search needs xAI auth. If Grok is already your active model, this tool should reuse the same xAI auth profile after a gateway restart or re-running configure. Otherwise set XAI_API_KEY in the Gateway environment, or configure tools.web.x_search.apiKey or plugins.entries.xai.config.webSearch.apiKey.",
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -158,6 +158,7 @@ export function createOpenClawTools(
     config: options?.config,
     sandboxed: options?.sandboxed,
     runtimeWebSearch: runtimeWebTools?.search,
+    agentDir: options?.agentDir,
   });
   const webFetchTool = createWebFetchTool({
     config: options?.config,

--- a/src/agents/pi-embedded-runner/run/auth-controller.ts
+++ b/src/agents/pi-embedded-runner/run/auth-controller.ts
@@ -4,6 +4,7 @@ import { prepareProviderRuntimeAuth } from "../../../plugins/provider-runtime.js
 import {
   type AuthProfileStore,
   isProfileInCooldown,
+  resolveAuthStorePathForDisplay,
   resolveProfilesUnavailableReason,
 } from "../../auth-profiles.js";
 import { FailoverError, resolveFailoverStatus } from "../../failover-error.js";
@@ -15,7 +16,11 @@ import {
   type FailoverReason,
 } from "../../pi-embedded-helpers.js";
 import { clampRuntimeAuthRefreshDelayMs } from "../../runtime-auth-refresh.js";
-import { shouldTraceProviderAuth, summarizeProviderAuthKey } from "../../xai-auth-trace.js";
+import {
+  shouldLogProviderAuthSummaryOnce,
+  shouldTraceProviderAuth,
+  summarizeProviderAuthKey,
+} from "../../xai-auth-trace.js";
 import { describeUnknownError } from "../utils.js";
 import {
   RUNTIME_AUTH_REFRESH_MARGIN_MS,
@@ -357,6 +362,20 @@ export function createEmbeddedRunAuthController(params: {
         );
       }
       params.setRuntimeAuthState(null);
+    }
+    const authSummarySource = apiKeyInfo.profileId
+      ? `auth profile ${apiKeyInfo.profileId} (${resolveAuthStorePathForDisplay(params.agentDir)})`
+      : apiKeyInfo.source;
+    const runtimeMode = preparedAuth?.apiKey ? "prepared runtime auth" : "direct runtime key";
+    if (
+      shouldLogProviderAuthSummaryOnce(
+        runtimeModel.provider,
+        `${apiKeyInfo.profileId ?? apiKeyInfo.source}:${runtimeMode}:${runtimeModel.baseUrl ?? "default"}`,
+      )
+    ) {
+      params.log.info(
+        `[xai-auth] using ${authSummarySource}; mode=${apiKeyInfo.mode}; transport=${runtimeModel.api}; runtime=${runtimeMode}. Set OPENCLAW_DEBUG_XAI_AUTH=1 for per-request traces.`,
+      );
     }
     params.setLastProfileId(apiKeyInfo.profileId);
   };

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -233,8 +233,11 @@ export function buildAgentSystemPrompt(params: {
     ls: "List directory contents",
     exec: "Run shell commands (pty available for TTY-required CLIs)",
     process: "Manage background exec sessions",
-    web_search: "Search the web",
+    web_search:
+      "Search the web. If this tool is available, it is configured enough to try; use it instead of claiming web search is unavailable.",
     web_fetch: "Fetch and extract readable content from a URL",
+    x_search:
+      "Search X posts. If this tool is available, use it by default for X/Twitter requests instead of claiming X search is unavailable. For specific post stats, prefer the exact post URL or status ID and include the post text plus direct post URL in the final answer when available.",
     // Channel docking: add login tools here when a channel needs interactive linking.
     browser: "Control web browser",
     canvas: "Present/eval/snapshot the Canvas",
@@ -270,6 +273,7 @@ export function buildAgentSystemPrompt(params: {
     "process",
     "code_execution",
     "web_search",
+    "x_search",
     "web_fetch",
     "browser",
     "canvas",

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -13,6 +13,7 @@ export function createWebSearchTool(options?: {
   config?: OpenClawConfig;
   sandboxed?: boolean;
   runtimeWebSearch?: RuntimeWebSearchMetadata;
+  agentDir?: string;
 }): AnyAgentTool | null {
   const runtimeProviderId =
     options?.runtimeWebSearch?.selectedProvider ?? options?.runtimeWebSearch?.providerConfigured;

--- a/src/agents/xai-auth-trace.test.ts
+++ b/src/agents/xai-auth-trace.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { shouldLogProviderAuthSummaryOnce, shouldTraceProviderAuth } from "./xai-auth-trace.js";
+
+describe("xai auth trace helpers", () => {
+  it("only enables verbose xai auth tracing when the debug env var is set", () => {
+    expect(shouldTraceProviderAuth("xai", {} as NodeJS.ProcessEnv)).toBe(false);
+    expect(
+      shouldTraceProviderAuth("xai", { OPENCLAW_DEBUG_XAI_AUTH: "1" } as NodeJS.ProcessEnv),
+    ).toBe(true);
+    expect(
+      shouldTraceProviderAuth("openai", { OPENCLAW_DEBUG_XAI_AUTH: "1" } as NodeJS.ProcessEnv),
+    ).toBe(false);
+  });
+
+  it("logs the xai auth summary only once per summary key", () => {
+    const key = `unit-${Date.now()}`;
+    expect(shouldLogProviderAuthSummaryOnce("xai", key)).toBe(true);
+    expect(shouldLogProviderAuthSummaryOnce("xai", key)).toBe(false);
+    expect(shouldLogProviderAuthSummaryOnce("openai", `${key}-other`)).toBe(false);
+  });
+});

--- a/src/agents/xai-auth-trace.ts
+++ b/src/agents/xai-auth-trace.ts
@@ -1,6 +1,7 @@
 import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 
 const DEFAULT_KEY_PREVIEW = { head: 4, tail: 4 };
+const loggedProviderAuthSummaries = new Set<string>();
 
 function formatApiKeyPreview(raw: string): string {
   const trimmed = raw.trim();
@@ -19,8 +20,23 @@ function formatApiKeyPreview(raw: string): string {
   return `${trimmed.slice(0, head)}…${trimmed.slice(-tail)}`;
 }
 
-export function shouldTraceProviderAuth(provider: string): boolean {
-  return provider.trim().toLowerCase() === "xai";
+export function shouldTraceProviderAuth(
+  provider: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return provider.trim().toLowerCase() === "xai" && env.OPENCLAW_DEBUG_XAI_AUTH === "1";
+}
+
+export function shouldLogProviderAuthSummaryOnce(provider: string, summaryKey: string): boolean {
+  if (provider.trim().toLowerCase() !== "xai") {
+    return false;
+  }
+  const key = `${provider.trim().toLowerCase()}:${summaryKey}`;
+  if (loggedProviderAuthSummaries.has(key)) {
+    return false;
+  }
+  loggedProviderAuthSummaries.add(key);
+  return true;
 }
 
 export function summarizeProviderAuthKey(apiKey: string | undefined): string {

--- a/src/commands/auth-choice.apply-helpers.test.ts
+++ b/src/commands/auth-choice.apply-helpers.test.ts
@@ -1,4 +1,11 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  upsertAuthProfile,
+} from "../agents/auth-profiles.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import {
   ensureApiKeyFromOptionEnvOrPrompt,
@@ -194,6 +201,7 @@ async function ensureWithOptionEnvOrPrompt(params: {
 
 afterEach(() => {
   restoreMinimaxEnv();
+  clearRuntimeAuthProfileStoreSnapshots();
   vi.restoreAllMocks();
 });
 
@@ -254,8 +262,126 @@ describe("ensureApiKeyFromEnvOrPrompt", () => {
     expect(text).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "Enter key",
+        secret: true,
       }),
     );
+  });
+
+  it("keeps the stored profile api key when the prompt is left blank", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-minimax-auth-choice-"));
+    try {
+      upsertAuthProfile({
+        profileId: "minimax:default",
+        agentDir,
+        credential: {
+          type: "api_key",
+          provider: "minimax",
+          key: "stored-key",
+        },
+      });
+
+      const { confirm, text, setCredential } = createPromptAndCredentialSpies({
+        confirmResult: false,
+        textResult: "   ",
+      });
+
+      const result = await ensureApiKeyFromEnvOrPrompt({
+        config: {
+          auth: {
+            profiles: {
+              "minimax:default": {
+                provider: "minimax",
+                mode: "api_key",
+              },
+            },
+          },
+        },
+        agentDir,
+        profileIds: ["minimax:default"],
+        provider: "minimax",
+        envLabel: "MINIMAX_API_KEY",
+        promptMessage: "Enter key",
+        normalize: (value) => value.trim(),
+        validate: () => undefined,
+        prompter: createPrompter({
+          confirm,
+          text,
+        }),
+        setCredential,
+      });
+
+      expect(result).toBe("stored-key");
+      expect(setCredential).toHaveBeenCalledWith("stored-key", "plaintext");
+      expect(text).toHaveBeenCalledWith(
+        expect.objectContaining({
+          placeholder: expect.stringContaining("st…ey"),
+          secret: true,
+        }),
+      );
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves an existing secret ref when keeping the current key", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-minimax-auth-choice-"));
+    try {
+      upsertAuthProfile({
+        profileId: "minimax:default",
+        agentDir,
+        credential: {
+          type: "api_key",
+          provider: "minimax",
+          keyRef: { source: "env", provider: "default", id: "MINIMAX_API_KEY" },
+        },
+      });
+
+      const env = { MINIMAX_API_KEY: "stored-ref-key" } as NodeJS.ProcessEnv;
+      const { confirm, text, setCredential } = createPromptAndCredentialSpies({
+        confirmResult: false,
+        textResult: "",
+      });
+
+      const result = await ensureApiKeyFromEnvOrPrompt({
+        config: {
+          auth: {
+            profiles: {
+              "minimax:default": {
+                provider: "minimax",
+                mode: "api_key",
+              },
+            },
+          },
+        },
+        env,
+        agentDir,
+        profileIds: ["minimax:default"],
+        provider: "minimax",
+        envLabel: "MINIMAX_API_KEY",
+        promptMessage: "Enter key",
+        normalize: (value) => value.trim(),
+        validate: () => undefined,
+        prompter: createPrompter({
+          confirm,
+          text,
+        }),
+        setCredential,
+      });
+
+      expect(result).toBe("stored-ref-key");
+      expect(setCredential).toHaveBeenCalledWith(
+        { source: "env", provider: "default", id: "MINIMAX_API_KEY" },
+        "plaintext",
+      );
+      expect(text).toHaveBeenCalledWith(
+        expect.objectContaining({
+          placeholder: expect.stringContaining("stor…-key"),
+          secret: true,
+        }),
+      );
+    } finally {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    }
   });
 
   it("uses explicit inline env ref when secret-input-mode=ref selects existing env key", async () => {

--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -104,6 +104,7 @@ function createApplyAuthChoiceConfig(includeMinimaxProvider = false) {
 async function runPromptAuthConfigWithAllowlist(includeMinimaxProvider = false) {
   mocks.promptAuthChoiceGrouped.mockResolvedValue("kilocode-api-key");
   mocks.applyAuthChoice.mockResolvedValue(createApplyAuthChoiceConfig(includeMinimaxProvider));
+  mocks.promptDefaultModel.mockResolvedValue({});
   mocks.promptModelAllowlist.mockResolvedValue({
     models: ["kilocode/kilo/auto"],
   });
@@ -114,6 +115,56 @@ async function runPromptAuthConfigWithAllowlist(includeMinimaxProvider = false) 
 }
 
 describe("promptAuthConfig", () => {
+  it("prompts for the default model after a provider auth choice and applies it", async () => {
+    mocks.promptAuthChoiceGrouped.mockResolvedValue("xai-api-key");
+    mocks.resolvePreferredProviderForAuthChoice.mockResolvedValue("xai");
+    mocks.applyAuthChoice.mockResolvedValue({
+      config: {
+        agents: {
+          defaults: {
+            model: { primary: "xai/grok-4" },
+          },
+        },
+        models: {
+          providers: {
+            xai: {
+              baseUrl: "https://api.x.ai/v1",
+              api: "openai-responses",
+              models: [
+                { id: "grok-4", name: "Grok 4" },
+                {
+                  id: "grok-4.20-beta-latest-reasoning",
+                  name: "Grok 4.20 Beta Latest (Reasoning)",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    mocks.promptDefaultModel.mockResolvedValue({
+      model: "xai/grok-4.20-beta-latest-reasoning",
+    });
+    mocks.promptModelAllowlist.mockResolvedValue({
+      models: ["xai/grok-4.20-beta-latest-reasoning"],
+    });
+
+    const result = await promptAuthConfig({}, makeRuntime(), noopPrompter);
+
+    expect(mocks.promptDefaultModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preferredProvider: "xai",
+        ignoreAllowlist: true,
+      }),
+    );
+    expect(result.agents?.defaults?.model).toEqual({
+      primary: "xai/grok-4.20-beta-latest-reasoning",
+    });
+    expect(Object.keys(result.agents?.defaults?.models ?? {})).toEqual([
+      "xai/grok-4.20-beta-latest-reasoning",
+    ]);
+  });
+
   it("keeps Kilo provider models while applying allowlist defaults", async () => {
     const result = await runPromptAuthConfigWithAllowlist();
     expect(result.models?.providers?.kilocode?.models?.map((model) => model.id)).toEqual([

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -129,6 +129,23 @@ export async function promptAuthConfig(
       setDefaultModel: true,
     });
     next = applied.config;
+
+    const modelSelection = await promptDefaultModel({
+      config: next,
+      prompter,
+      allowKeep: true,
+      ignoreAllowlist: true,
+      includeProviderPluginSetups: true,
+      preferredProvider,
+      workspaceDir: resolveDefaultAgentWorkspaceDir(),
+      runtime,
+    });
+    if (modelSelection.config) {
+      next = modelSelection.config;
+    }
+    if (modelSelection.model) {
+      next = applyPrimaryModel(next, modelSelection.model);
+    }
   } else {
     const modelSelection = await promptDefaultModel({
       config: next,

--- a/src/plugins/provider-api-key-auth.ts
+++ b/src/plugins/provider-api-key-auth.ts
@@ -112,6 +112,8 @@ export function createProviderApiKeyAuthMethod(
             : ctx.secretInputMode,
         config: ctx.config,
         env: ctx.env,
+        agentDir: ctx.agentDir,
+        profileIds: resolveProfileIds(params),
         expectedProviders: params.expectedProviders ?? [params.providerId],
         provider: params.providerId,
         envLabel: params.envVar,

--- a/src/plugins/provider-auth-input.ts
+++ b/src/plugins/provider-auth-input.ts
@@ -1,3 +1,4 @@
+import { ensureAuthProfileStore, resolveApiKeyForProfile } from "../agents/auth-profiles.js";
 import { resolveEnvApiKey } from "../agents/model-auth-env.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { SecretInput } from "../config/types.secrets.js";
@@ -26,6 +27,11 @@ export {
 } from "./provider-auth-mode.js";
 
 const DEFAULT_KEY_PREVIEW = { head: 4, tail: 4 };
+
+type ExistingStoredApiKey = {
+  credentialInput: SecretInput;
+  resolvedApiKey: string;
+};
 
 export function normalizeApiKeyInput(raw: string): string {
   const trimmed = String(raw ?? "").trim();
@@ -94,6 +100,56 @@ export function normalizeSecretInputModeInput(
   return undefined;
 }
 
+async function resolveExistingStoredApiKey(params: {
+  config: OpenClawConfig;
+  agentDir?: string;
+  profileIds?: string[];
+}): Promise<ExistingStoredApiKey | undefined> {
+  const profileIds = (params.profileIds ?? []).map((value) => value.trim()).filter(Boolean);
+  if (profileIds.length === 0) {
+    return undefined;
+  }
+
+  const store = ensureAuthProfileStore(params.agentDir, {
+    allowKeychainPrompt: false,
+  });
+
+  for (const profileId of profileIds) {
+    const credential = store.profiles[profileId];
+    if (!credential) {
+      continue;
+    }
+
+    const credentialInput =
+      credential.type === "api_key"
+        ? (credential.keyRef ?? credential.key)
+        : credential.type === "token"
+          ? (credential.tokenRef ?? credential.token)
+          : undefined;
+    if (!credentialInput) {
+      continue;
+    }
+
+    const resolved = await resolveApiKeyForProfile({
+      cfg: params.config,
+      store,
+      profileId,
+      agentDir: params.agentDir,
+    });
+    const resolvedApiKey = resolved?.apiKey?.trim();
+    if (!resolvedApiKey) {
+      continue;
+    }
+
+    return {
+      credentialInput,
+      resolvedApiKey,
+    };
+  }
+
+  return undefined;
+}
+
 export async function maybeApplyApiKeyFromOption(params: {
   token: string | undefined;
   tokenProvider: string | undefined;
@@ -120,6 +176,8 @@ export async function ensureApiKeyFromOptionEnvOrPrompt(params: {
   secretInputMode?: SecretInputMode;
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  agentDir?: string;
+  profileIds?: string[];
   expectedProviders: string[];
   provider: string;
   envLabel: string;
@@ -150,6 +208,8 @@ export async function ensureApiKeyFromOptionEnvOrPrompt(params: {
   return await ensureApiKeyFromEnvOrPrompt({
     config: params.config,
     env: params.env,
+    agentDir: params.agentDir,
+    profileIds: params.profileIds,
     provider: params.provider,
     envLabel: params.envLabel,
     promptMessage: params.promptMessage,
@@ -164,6 +224,8 @@ export async function ensureApiKeyFromOptionEnvOrPrompt(params: {
 export async function ensureApiKeyFromEnvOrPrompt(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  agentDir?: string;
+  profileIds?: string[];
   provider: string;
   envLabel: string;
   promptMessage: string;
@@ -213,11 +275,45 @@ export async function ensureApiKeyFromEnvOrPrompt(params: {
     }
   }
 
+  const existingStoredApiKey =
+    selectedMode === "plaintext"
+      ? await resolveExistingStoredApiKey({
+          config: params.config,
+          agentDir: params.agentDir,
+          profileIds: params.profileIds,
+        })
+      : undefined;
+  const existingPreview = existingStoredApiKey
+    ? formatApiKeyPreview(existingStoredApiKey.resolvedApiKey)
+    : undefined;
+
   const key = await params.prompter.text({
     message: params.promptMessage,
-    validate: params.validate,
+    ...(existingPreview
+      ? {
+          placeholder: `Press Enter to keep current (${existingPreview})`,
+        }
+      : {}),
+    secret: true,
+    validate: (value) => {
+      const normalized = params.normalize(String(value ?? ""));
+      if (!normalized && existingStoredApiKey) {
+        return undefined;
+      }
+      return params.validate(value);
+    },
   });
-  const apiKey = params.normalize(String(key ?? ""));
-  await params.setCredential(apiKey, selectedMode);
-  return apiKey;
+  const normalizedInput = params.normalize(String(key ?? ""));
+  const credentialInput: SecretInput = (() => {
+    if (!normalizedInput && existingStoredApiKey) {
+      return existingStoredApiKey.credentialInput;
+    }
+    return normalizedInput;
+  })();
+  await params.setCredential(credentialInput, selectedMode);
+  return selectedMode === "plaintext" && existingStoredApiKey && !normalizedInput
+    ? existingStoredApiKey.resolvedApiKey
+    : typeof credentialInput === "string"
+      ? params.normalize(credentialInput)
+      : "";
 }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1189,6 +1189,7 @@ export type WebSearchProviderContext = {
   config?: OpenClawConfig;
   searchConfig?: Record<string, unknown>;
   runtimeMetadata?: RuntimeWebSearchMetadata;
+  agentDir?: string;
 };
 
 export type WebSearchCredentialResolutionSource = "config" | "secretRef" | "env" | "missing";
@@ -1240,6 +1241,7 @@ export type WebSearchProviderPlugin = {
   setConfiguredCredentialValue?: (configTarget: OpenClawConfig, value: unknown) => void;
   applySelectionConfig?: (config: OpenClawConfig) => OpenClawConfig;
   runSetup?: (ctx: WebSearchProviderSetupContext) => OpenClawConfig | Promise<OpenClawConfig>;
+  hasCredential?: (ctx: WebSearchProviderContext) => boolean;
   resolveRuntimeMetadata?: (
     ctx: WebSearchRuntimeMetadataContext,
   ) => Partial<RuntimeWebSearchMetadata> | Promise<Partial<RuntimeWebSearchMetadata>>;

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -31,6 +31,7 @@ function createProvider(params: {
   credentialPath: string;
   autoDetectOrder?: number;
   requiresCredential?: boolean;
+  hasCredential?: PluginWebSearchProviderEntry["hasCredential"];
   getCredentialValue?: PluginWebSearchProviderEntry["getCredentialValue"];
   getConfiguredCredentialValue?: PluginWebSearchProviderEntry["getConfiguredCredentialValue"];
   createTool?: PluginWebSearchProviderEntry["createTool"];
@@ -46,6 +47,7 @@ function createProvider(params: {
     credentialPath: params.credentialPath,
     autoDetectOrder: params.autoDetectOrder,
     requiresCredential: params.requiresCredential,
+    hasCredential: params.hasCredential,
     getCredentialValue: params.getCredentialValue ?? (() => undefined),
     setCredentialValue: () => {},
     getConfiguredCredentialValue: params.getConfiguredCredentialValue,
@@ -145,6 +147,34 @@ describe("web search runtime", () => {
     await expect(
       runWebSearch({
         config,
+        args: { query: "hello" },
+      }),
+    ).resolves.toEqual({
+      provider: "custom",
+      result: { query: "hello", ok: true },
+    });
+  });
+
+  it("auto-detects a provider from provider-owned credential hooks", async () => {
+    const provider = createProvider({
+      pluginId: "custom-search",
+      id: "custom",
+      credentialPath: "plugins.entries.custom-search.config.webSearch.apiKey",
+      autoDetectOrder: 1,
+      hasCredential: () => true,
+      createTool: () => ({
+        description: "custom",
+        parameters: {},
+        execute: async (args) => ({ ...args, ok: true }),
+      }),
+    });
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([provider]);
+    resolveBundledPluginWebSearchProvidersMock.mockReturnValue([provider]);
+
+    await expect(
+      runWebSearch({
+        config: {},
+        agentDir: "/tmp/openclaw-agent",
         args: { query: "hello" },
       }),
     ).resolves.toEqual({

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -25,6 +25,7 @@ export type ResolveWebSearchDefinitionParams = {
   runtimeWebSearch?: RuntimeWebSearchMetadata;
   providerId?: string;
   preferRuntimeProviders?: boolean;
+  agentDir?: string;
 };
 
 export type RunWebSearchParams = ResolveWebSearchDefinitionParams & {
@@ -75,12 +76,23 @@ function hasEntryCredential(
     | "envVars"
     | "getConfiguredCredentialValue"
     | "getCredentialValue"
+    | "hasCredential"
     | "requiresCredential"
   >,
   config: OpenClawConfig | undefined,
   search: WebSearchConfig | undefined,
+  agentDir?: string,
 ): boolean {
   if (!providerRequiresCredential(provider)) {
+    return true;
+  }
+  if (
+    provider.hasCredential?.({
+      config,
+      searchConfig: search as Record<string, unknown> | undefined,
+      agentDir,
+    })
+  ) {
     return true;
   }
   const rawValue =
@@ -123,6 +135,7 @@ export function resolveWebSearchProviderId(params: {
   search?: WebSearchConfig;
   config?: OpenClawConfig;
   providers?: PluginWebSearchProviderEntry[];
+  agentDir?: string;
 }): string {
   const providers = sortWebSearchProvidersForAutoDetect(
     params.providers ??
@@ -150,7 +163,7 @@ export function resolveWebSearchProviderId(params: {
         keylessFallbackProviderId ||= provider.id;
         continue;
       }
-      if (!hasEntryCredential(provider, params.config, params.search)) {
+      if (!hasEntryCredential(provider, params.config, params.search, params.agentDir)) {
         continue;
       }
       logVerbose(
@@ -197,12 +210,23 @@ export function resolveWebSearchDefinition(
     options?.providerId ??
     runtimeWebSearch?.selectedProvider ??
     runtimeWebSearch?.providerConfigured ??
-    resolveWebSearchProviderId({ config: options?.config, search, providers });
+    resolveWebSearchProviderId({
+      config: options?.config,
+      search,
+      providers,
+      agentDir: options?.agentDir,
+    });
   const provider =
     providers.find((entry) => entry.id === providerId) ??
     providers.find(
       (entry) =>
-        entry.id === resolveWebSearchProviderId({ config: options?.config, search, providers }),
+        entry.id ===
+        resolveWebSearchProviderId({
+          config: options?.config,
+          search,
+          providers,
+          agentDir: options?.agentDir,
+        }),
     ) ??
     providers[0];
   if (!provider) {
@@ -213,6 +237,7 @@ export function resolveWebSearchDefinition(
     config: options?.config,
     searchConfig: search as Record<string, unknown> | undefined,
     runtimeMetadata: runtimeWebSearch,
+    agentDir: options?.agentDir,
   });
   if (!definition) {
     return null;

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -7,6 +7,7 @@ import {
   multiselect,
   type Option,
   outro,
+  password,
   select,
   spinner,
   text,
@@ -100,8 +101,9 @@ export function createClackPrompter(): WizardPrompter {
     },
     text: async (params) => {
       const validate = params.validate;
+      const promptFn = params.secret ? password : text;
       return guardCancel(
-        await text({
+        await promptFn({
           message: stylePromptMessage(params.message),
           initialValue: params.initialValue,
           placeholder: params.placeholder,

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -21,6 +21,7 @@ export type WizardTextParams = {
   message: string;
   initialValue?: string;
   placeholder?: string;
+  secret?: boolean;
   validate?: (value: string) => string | undefined;
 };
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: xAI follow-up UX around `configure`, auth reuse, and xAI-backed search tools was still rough even after the main Responses/x_search work landed. On a fresh machine, `openclaw configure` could save the xAI auth profile but still leave the agent on `xai/grok-4`, the `/model` picker could miss the model I picked, provider API key prompts always forced re-entry in plaintext, and `web_search` / `x_search` / `code_execution` could tell me to configure a second xAI key even when Grok auth was already working.
- Why it matters: this makes Grok feel half-configured, pushes people toward redundant key storage, and undermines trust in the built-in xAI tools right after onboarding.
- What changed: I made `configure` persist the selected provider model, taught provider API key prompts to reuse stored keys with masked input, reduced the noisy per-request xAI auth trace logs, and let the xAI search/code tools reuse auth profiles plus give honest fallback guidance when auth is still missing.
- What did NOT change (scope boundary): I did not change the core xAI Responses transport, the underlying xAI tool request shapes, or the already-landed x_search/code_execution plugin moves.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #6872
- Related #26286
- Related #21599
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the xAI follow-up surfaces were each carrying a slightly different assumption about where xAI auth lived. The model runtime was already happy with auth profiles, but configure/model persistence and the xAI-backed tools still acted like separate plugin key config was the primary source of truth.
- Missing detection / guardrail: we did not have coverage for “pick a provider model during configure and make sure it becomes the saved default/allowlist entry,” and we also did not have coverage that xAI-backed tools should treat auth profiles as valid credentials instead of surfacing misleading missing-key guidance.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this is follow-up polish after the xAI Responses and native tool work discussed in #6872 and related PRs. The main functionality worked, but these onboarding/auth seams were still inconsistent.
- Why this regressed now: the xAI feature set expanded faster than the configure/auth UX was normalized around the auth-profile path.
- If unknown, what was ruled out: I verified this was not a raw xAI API auth failure. The logs showed the auth profile was already being resolved correctly for the Grok model path.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/configure.gateway-auth.prompt-auth-config.test.ts`, `src/commands/auth-choice.apply-helpers.test.ts`, `src/web-search/runtime.test.ts`, `extensions/xai/web-search.test.ts`, `extensions/xai/x-search.test.ts`, `extensions/xai/code-execution.test.ts`, `src/agents/xai-auth-trace.test.ts`
- Scenario the test should lock in: picking an xAI provider model during configure should persist it; stored provider API keys should be reusable without re-entry; xAI-backed tools should detect auth profiles as configured credentials and should not steer users toward redundant xAI key setup.
- Why this is the smallest reliable guardrail: these are seam-level failures across configure, auth resolution, and plugin tool enablement, so isolated pure unit tests would miss the actual integration points.
- Existing test that already covers this (if any): the new and updated tests above are the intended guardrails for this branch.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- `openclaw configure` now preserves the xAI model I picked instead of silently leaving the gateway on `xai/grok-4`.
- Provider API key prompts now let me press Enter to keep an already-stored key and mask pasted input instead of echoing it in plaintext.
- xAI auth trace logging is no longer noisy on every request by default.
- If Grok is already the active model, `web_search`, `x_search`, and `code_execution` now reuse the same xAI auth profile path and give better guidance instead of insisting on a second plugin key.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[configure xAI + pick Grok 4.20 reasoning]
  -> [xAI auth profile saved]
  -> [default model can stay on xai/grok-4]
  -> [xAI tools may say "configure another xAI key"]

After:
[configure xAI + pick Grok 4.20 reasoning]
  -> [xAI auth profile saved]
  -> [selected Grok model persisted]
  -> [xAI tools reuse the same auth profile]
  -> [fallback message points to restart/reconfigure before asking for another key]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this branch broadens legitimate xAI auth reuse from the existing auth-profile store into the xAI-backed search/code tools and improves provider API key reuse during configure. The mitigation is that it still stays within existing xAI credential sources, keeps prompt input masked, and preserves secret refs instead of rewriting them into plaintext.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local gateway
- Model/provider: `xai/grok-4.20-beta-latest-reasoning`
- Integration/channel (if any): Telegram
- Relevant config (redacted): xAI auth stored in `xai:default` auth profile; xAI provider models configured in `openclaw.json`

### Steps

1. Run `openclaw configure`, choose xAI, provide an xAI API key, and pick `grok-4.20-beta-latest-reasoning`.
2. Start the gateway and check the active model plus `/model` picker behavior.
3. Ask Grok-backed `web_search` / `x_search` requests without adding a second xAI plugin key.

### Expected

- The selected Grok model stays selected, `/model` reflects it, and the xAI tools reuse the existing xAI auth instead of claiming they are unconfigured.

### Actual

- Before this branch, the selected model could collapse back to `xai/grok-4`, the picker could miss the chosen model, provider API key prompts always re-asked in plaintext, and xAI tools could tell me to configure another xAI key.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I verified end to end that Grok works as the active OpenClaw model, that X search works in Telegram, and that the xAI-backed tools can reuse the active Grok auth path instead of requiring a separate plugin key. I also verified the failure mode on another machine where `openclaw configure` saved xAI auth but left the gateway on `xai/grok-4`, which this branch fixes.
- Edge cases checked: I checked stored provider API key reuse, masked prompt input, xAI auth-profile fallback for `web_search`, `x_search`, and `code_execution`, and the quieter default xAI auth logging behavior.
- What you did **not** verify: I did not run a full remote multi-machine E2E matrix for every channel on this follow-up branch.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the new auth-profile reuse path could make xAI-backed tools appear configured in cases where the stored auth profile is stale.
  - Mitigation: the tools still fail safely, and the fallback guidance now points the user toward restart/reconfigure instead of telling them to create redundant config.
- Risk: provider API key prompt reuse touches shared configure/auth code, so another provider’s prompt flow could be affected.
  - Mitigation: I kept the change inside the shared provider API-key path and added regression coverage around the helper flow that preserves stored credentials.
