### PR TITLE
feat(skills): add deepsleep — two-phase daily memory persistence

### DIFF
--- a/skills/deepsleep/SKILL.md
+++ b/skills/deepsleep/SKILL.md
@@ -17,19 +17,19 @@ Activate when user mentions daily summary, memory persistence, sleep cycle, cros
 
 ### Phase 1: Deep Sleep Pack (23:40)
 
-1. **Auto-discover sessions** — Use `sessions_list(kinds=['group'], activeMinutes=1440)` to find all active groups and DMs from the past 24 hours. New groups are automatically included.
+1. **Auto-discover sessions** — Use `sessions_list(kinds=['group', 'main'], activeMinutes=1440)` to find all active groups AND direct messages from the past 24 hours. New groups are automatically included.
 2. **Pull conversation history** — For each active session, use `sessions_history(sessionKey=<key>, limit=100)`.
 3. **Filter and summarize** — Apply filtering criteria to generate concise summaries:
    - Keep: Decisions, Lessons, Preferences, Relationships, Milestones
    - Skip: Transient (heartbeats, weather), Already captured in MEMORY.md
 4. **Schedule future items** — Extract future-dated reminders and write to `memory/schedule.md` with trigger dates.
-5. **Write daily file** — Append to `memory/YYYY-MM-DD.md` with sections: per-group summaries, Open Questions, Tomorrow actions, and Todos.
-6. **Update long-term memory** — Merge-update `MEMORY.md` (update in place, don't append duplicates; remove outdated info).
+5. **Write daily file (idempotent)** — Write the `## Daily Summary (DeepSleep)` section to `memory/YYYY-MM-DD.md`. Before writing, check if a `## Daily Summary (DeepSleep)` header already exists for today — if so, replace it instead of appending a duplicate. This ensures retries and re-runs produce the same result.
+6. **Update long-term memory (privacy-safe)** — Merge-update `MEMORY.md` (update in place, don't append duplicates; remove outdated info). **Important:** Do NOT copy private MEMORY.md content into the daily summary file. The daily file may be broadcast to groups in Phase 2 — only include information that originated from those groups' own conversations.
 
 ### Phase 2: Morning Dispatch (00:10)
 
 1. **Read yesterday's summary** — Load `memory/YYYY-MM-DD.md` from the previous day.
-2. **Send per-group briefs** — For each group with content, send a personalized morning recap via `message(action='send', target='chat:<id>')`.
+2. **Send per-group briefs** — For each group with content, send a personalized morning recap via `message(action='send', target='chat:<id>')`. Only include information from that specific group's summary — never cross-leak content between groups or from MEMORY.md.
 3. **Include reminders** — Attach any schedule items due today.
 4. **Track open questions** — Include relevant Open Questions for continuity.
 
@@ -69,13 +69,13 @@ File: `memory/schedule.md`
 ### 1. Create cron jobs
 
 ```bash
-# Phase 1: Pack
+# Phase 1: Pack (adjust timeout for your session count; ~30s per active session)
 openclaw cron add \
   --name "deepsleep-pack" \
   --cron "40 23 * * *" \
   --tz "Your/Timezone" \
   --system-event "Execute DeepSleep Phase 1. Read the deepsleep skill and follow the pack process." \
-  --timeout-seconds 180
+  --timeout-seconds 300
 
 # Phase 2: Dispatch
 openclaw cron add \
@@ -85,6 +85,8 @@ openclaw cron add \
   --system-event "Execute DeepSleep Phase 2. Read the deepsleep skill and follow the dispatch process." \
   --timeout-seconds 120
 ```
+
+**Timeout guidance:** Phase 1 needs ~30 seconds per active session for history pull + summarization. Default 300s covers ~10 sessions comfortably. For larger deployments, increase to 600s or more.
 
 ### 2. Enable cross-session visibility
 
@@ -101,6 +103,12 @@ Create `memory/schedule.md` with the table header above.
 
 - OpenClaw with `tools.sessions.visibility` set to `all`
 - Cron jobs using `systemEvent` mode (main session access)
+
+## Privacy Notes
+
+- Phase 1 writes a daily summary that Phase 2 broadcasts to groups. Never include private MEMORY.md content in the daily summary.
+- Each group only receives its own summary in the morning dispatch — no cross-group content leakage.
+- MEMORY.md is updated separately and stays in the main session context only.
 
 ## Inspirations
 

--- a/skills/deepsleep/SKILL.md
+++ b/skills/deepsleep/SKILL.md
@@ -104,11 +104,32 @@ Create `memory/schedule.md` with the table header above.
 - OpenClaw with `tools.sessions.visibility` set to `all`
 - Cron jobs using `systemEvent` mode (main session access)
 
+## Phase 3: Session Memory Restore (on demand)
+
+The most critical piece — when the agent receives a message in a group session:
+
+1. Check if `memory/groups/<chat_id>.md` exists
+2. If yes, read it to restore context about recent discussions, open questions, and todos
+3. This is configured in `AGENTS.md` under "群 Session 记忆恢复"
+
+Without this step, Phases 1-2 only help the human (morning brief), but the agent itself still wakes up with no memory.
+
+### File structure
+```
+memory/groups/
+├── oc_abc123.md    # Group A: recent 3-day summary + open questions
+├── oc_def456.md    # Group B: recent 3-day summary + open questions
+└── ...
+```
+
+Phase 2 generates/updates these files each morning. They are compact (< 2KB each) and designed for fast loading.
+
 ## Privacy Notes
 
 - Phase 1 writes a daily summary that Phase 2 broadcasts to groups. Never include private MEMORY.md content in the daily summary.
 - Each group only receives its own summary in the morning dispatch — no cross-group content leakage.
 - MEMORY.md is updated separately and stays in the main session context only.
+- Per-group memory snapshots only contain that group's own conversation summaries.
 
 ## Inspirations
 

--- a/skills/deepsleep/SKILL.md
+++ b/skills/deepsleep/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: deepsleep
+description: Two-phase daily memory persistence for AI agents. Nightly pack at 23:40 plus morning dispatch at 00:10. Auto-discovers sessions, filters by importance, tracks open questions, and delivers per-group morning briefs.
+---
+
+# DeepSleep
+
+Two-phase daily memory persistence for AI agents.
+
+Like humans need sleep for memory consolidation, AI agents need DeepSleep to persist context across sessions.
+
+## When to Activate
+
+Activate when user mentions daily summary, memory persistence, sleep cycle, cross-session memory, morning brief, or nightly pack.
+
+## Phases
+
+### Phase 1: Deep Sleep Pack (23:40)
+
+1. **Auto-discover sessions** — Use `sessions_list(kinds=['group'], activeMinutes=1440)` to find all active groups and DMs from the past 24 hours. New groups are automatically included.
+2. **Pull conversation history** — For each active session, use `sessions_history(sessionKey=<key>, limit=100)`.
+3. **Filter and summarize** — Apply filtering criteria to generate concise summaries:
+   - Keep: Decisions, Lessons, Preferences, Relationships, Milestones
+   - Skip: Transient (heartbeats, weather), Already captured in MEMORY.md
+4. **Schedule future items** — Extract future-dated reminders and write to `memory/schedule.md` with trigger dates.
+5. **Write daily file** — Append to `memory/YYYY-MM-DD.md` with sections: per-group summaries, Open Questions, Tomorrow actions, and Todos.
+6. **Update long-term memory** — Merge-update `MEMORY.md` (update in place, don't append duplicates; remove outdated info).
+
+### Phase 2: Morning Dispatch (00:10)
+
+1. **Read yesterday's summary** — Load `memory/YYYY-MM-DD.md` from the previous day.
+2. **Send per-group briefs** — For each group with content, send a personalized morning recap via `message(action='send', target='chat:<id>')`.
+3. **Include reminders** — Attach any schedule items due today.
+4. **Track open questions** — Include relevant Open Questions for continuity.
+
+## Daily Summary Template
+
+```markdown
+## Daily Summary (DeepSleep)
+
+### [Group Name]
+- Concise summary of key discussions and decisions
+
+### Direct Messages
+- (DM content if any)
+
+### Open Questions
+- Unresolved questions, tracked across days
+
+### Tomorrow
+- Actionable next steps
+
+### Todo
+- [ ] Immediate action items
+```
+
+## Schedule File Format
+
+File: `memory/schedule.md`
+
+```markdown
+| Date | Source | Item | Status |
+|------|--------|------|--------|
+| YYYY-MM-DD | Group/DM | Description | pending/done |
+```
+
+## Setup
+
+### 1. Create cron jobs
+
+```bash
+# Phase 1: Pack
+openclaw cron add \
+  --name "deepsleep-pack" \
+  --cron "40 23 * * *" \
+  --tz "Your/Timezone" \
+  --system-event "Execute DeepSleep Phase 1. Read the deepsleep skill and follow the pack process." \
+  --timeout-seconds 180
+
+# Phase 2: Dispatch
+openclaw cron add \
+  --name "deepsleep-dispatch" \
+  --cron "10 0 * * *" \
+  --tz "Your/Timezone" \
+  --system-event "Execute DeepSleep Phase 2. Read the deepsleep skill and follow the dispatch process." \
+  --timeout-seconds 120
+```
+
+### 2. Enable cross-session visibility
+
+```bash
+openclaw config set tools.sessions.visibility all
+openclaw gateway restart
+```
+
+### 3. Initialize schedule
+
+Create `memory/schedule.md` with the table header above.
+
+## Requirements
+
+- OpenClaw with `tools.sessions.visibility` set to `all`
+- Cron jobs using `systemEvent` mode (main session access)
+
+## Inspirations
+
+Built with insights from the community: agent-sleep (multi-level sleep), memory-reflect (filtering criteria), jarvis-memory-architecture (cron inbox), memory-curator (open questions).


### PR DESCRIPTION
## What

Adds **DeepSleep** — a two-phase daily memory persistence skill for AI agents.

## Why

AI agents lose all context between sessions. DeepSleep solves this with a nightly consolidation cycle inspired by how human sleep consolidates memories.

## How it works

### Phase 1: Deep Sleep Pack (23:40)
- Auto-discovers all active sessions (groups + DMs + new groups)
- Pulls conversation history via `sessions_history`
- Filters by importance: keeps decisions, lessons, preferences, relationships, milestones; skips noise
- Extracts future-dated reminders to `schedule.md`
- Writes daily summary with Open Questions + Tomorrow sections
- Merge-updates `MEMORY.md` long-term memory (update in place, not append)

### Phase 2: Morning Dispatch (00:10)
- Reads yesterday's packed summary
- Sends personalized morning briefs to each group
- Includes schedule due-date alerts and open question tracking

## Key features
- **Auto-discovery**: No hardcoded group lists — uses `sessions_list` to find active sessions
- **Smart filtering**: Inspired by memory-reflect's filtering criteria
- **Schedule memory**: Future-dated reminders with auto alerts
- **Open Questions**: Cross-day question tracking for continuity
- **Merge, not append**: Keeps long-term memory lean

## Community credits
Built with insights from: agent-sleep, memory-reflect, jarvis-memory-architecture, memory-curator

## Also available
- **ClawHub**: `clawhub install deepsleep`
- **GitHub**: https://github.com/JeffChang2024/deepsleep

## Testing
- [x] Tested with 7 Feishu group chats + DM sessions
- [x] Both phases verified (pack + dispatch)
- [x] Cross-session history access confirmed
- [x] AI-assisted (marked as such)