### PR TITLE
fix: include paired users from credentials store in command authoriza…

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -2,6 +2,7 @@ import { getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.
 import type { ChannelId, ChannelPlugin } from "../channels/plugins/types.js";
 import { normalizeAnyChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { readChannelAllowFromStoreSync } from "../pairing/pairing-store.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
@@ -386,12 +387,36 @@ function resolveFallbackAllowFrom(params: {
   const accountCfg =
     resolveFallbackAccountConfig(channelCfg?.accounts, params.accountId) ??
     resolveFallbackDefaultAccountConfig(channelCfg);
-  const allowFrom =
+  const configAllowFrom =
     accountCfg?.allowFrom ??
     accountCfg?.dm?.allowFrom ??
     channelCfg?.allowFrom ??
     channelCfg?.dm?.allowFrom;
-  return Array.isArray(allowFrom) ? allowFrom : [];
+  const configList = Array.isArray(configAllowFrom) ? configAllowFrom : [];
+
+  // Also include paired users from the credentials store so that
+  // successfully paired senders are recognized for group commands
+  // even when config-level allowFrom is not explicitly set.
+  try {
+    const pairedUsers = readChannelAllowFromStoreSync(
+      providerId as "telegram" | "discord",
+      undefined,
+      params.accountId?.trim() || undefined,
+    );
+    if (pairedUsers.length > 0) {
+      const merged = [...configList];
+      for (const user of pairedUsers) {
+        if (!merged.includes(user)) {
+          merged.push(user);
+        }
+      }
+      return merged;
+    }
+  } catch {
+    // Credentials store unavailable — fall back to config only
+  }
+
+  return configList;
 }
 
 function resolveFallbackAccountConfig(


### PR DESCRIPTION
 ## Summary

  - Fixes #56966
  - When a user completes Telegram pairing, their ID is stored in `credentials/telegram-{account}-allowFrom.json` but not in the config-level
  `channels.telegram.accounts.{account}.allowFrom`
  - This causes group commands like `/activation` to reject the paired user with "You are not authorized to use this command"
  - This fix merges the credentials pairing store entries into the fallback `allowFrom` list in `resolveFallbackAllowFrom()` so that successfully
  paired users are recognized for command authorization

  ## Changes

  - `src/auto-reply/command-auth.ts`: Import `readChannelAllowFromStoreSync` from pairing store and merge paired user IDs into the fallback
  allowFrom list

  ## Test plan

  - [ ] Set up a fresh Telegram bot with `dmPolicy: "pairing"`
  - [ ] Complete pairing via `openclaw pairing approve telegram <CODE>`
  - [ ] Verify DM works normally
  - [ ] Add bot to a Telegram group
  - [ ] Run `/activation always` in the group
  - [ ] Verify the command succeeds (previously returned "You are not authorized")
  - [ ] Verify that users NOT in the pairing store are still rejected