### PR TITLE
fix: serialize Paperclip runtime auth env injection

### DIFF
--- a/extensions/microsoft/speech-provider.test.ts
+++ b/extensions/microsoft/speech-provider.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { listMicrosoftVoices } from "./speech-provider.js";
 
+const asFetch = <T extends typeof fetch>(fn: T): typeof fetch => fn as unknown as typeof fetch;
+
 describe("listMicrosoftVoices", () => {
   const originalFetch = globalThis.fetch;
 
@@ -10,23 +12,25 @@ describe("listMicrosoftVoices", () => {
   });
 
   it("maps Microsoft voice metadata into speech voice options", async () => {
-    globalThis.fetch = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify([
-          {
-            ShortName: "en-US-AvaNeural",
-            FriendlyName: "Microsoft Ava Online (Natural) - English (United States)",
-            Locale: "en-US",
-            Gender: "Female",
-            VoiceTag: {
-              ContentCategories: ["General"],
-              VoicePersonalities: ["Friendly", "Positive"],
+    globalThis.fetch = asFetch(
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify([
+            {
+              ShortName: "en-US-AvaNeural",
+              FriendlyName: "Microsoft Ava Online (Natural) - English (United States)",
+              Locale: "en-US",
+              Gender: "Female",
+              VoiceTag: {
+                ContentCategories: ["General"],
+                VoicePersonalities: ["Friendly", "Positive"],
+              },
             },
-          },
-        ]),
-        { status: 200 },
-      ),
-    ) as typeof globalThis.fetch;
+          ]),
+          { status: 200 },
+        ),
+      ) as unknown as typeof globalThis.fetch,
+    );
 
     const voices = await listMicrosoftVoices();
 
@@ -54,9 +58,13 @@ describe("listMicrosoftVoices", () => {
   });
 
   it("throws on Microsoft voice list failures", async () => {
-    globalThis.fetch = vi
-      .fn()
-      .mockResolvedValue(new Response("nope", { status: 503 })) as typeof globalThis.fetch;
+    globalThis.fetch = asFetch(
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response("nope", { status: 503 }),
+        ) as unknown as typeof globalThis.fetch,
+    );
 
     await expect(listMicrosoftVoices()).rejects.toThrow("Microsoft voices API error (503)");
   });

--- a/extensions/msteams/src/graph.test.ts
+++ b/extensions/msteams/src/graph.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const asFetch = <T extends typeof fetch>(fn: T): typeof fetch => fn as unknown as typeof fetch;
+
 const {
   loadMSTeamsSdkWithAuthMock,
   createMSTeamsTokenProviderMock,
@@ -54,12 +56,14 @@ describe("msteams graph helpers", () => {
   });
 
   it("fetches Graph JSON and surfaces Graph errors with response text", async () => {
-    globalThis.fetch = vi.fn(async () => {
-      return new Response(JSON.stringify({ value: [{ id: "group-1" }] }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    }) as typeof fetch;
+    globalThis.fetch = asFetch(
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ value: [{ id: "group-1" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }) as unknown as typeof fetch,
+    );
 
     await expect(
       fetchGraphJson<{ value: Array<{ id: string }> }>({
@@ -79,9 +83,11 @@ describe("msteams graph helpers", () => {
       },
     );
 
-    globalThis.fetch = vi.fn(async () => {
-      return new Response("forbidden", { status: 403 });
-    }) as typeof fetch;
+    globalThis.fetch = asFetch(
+      vi.fn(async () => {
+        return new Response("forbidden", { status: 403 });
+      }) as unknown as typeof fetch,
+    );
 
     await expect(
       fetchGraphJson({
@@ -132,22 +138,24 @@ describe("msteams graph helpers", () => {
   });
 
   it("builds encoded Graph paths for teams and channels", async () => {
-    globalThis.fetch = vi.fn(async (input) => {
-      const url = typeof input === "string" ? input : String(input);
-      if (url.includes("/groups?")) {
-        return new Response(JSON.stringify({ value: [{ id: "team-1", displayName: "Ops" }] }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        });
-      }
-      return new Response(
-        JSON.stringify({ value: [{ id: "chan-1", displayName: "Deployments" }] }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        },
-      );
-    }) as typeof fetch;
+    globalThis.fetch = asFetch(
+      vi.fn(async (input) => {
+        const url = typeof input === "string" ? input : String(input);
+        if (url.includes("/groups?")) {
+          return new Response(JSON.stringify({ value: [{ id: "team-1", displayName: "Ops" }] }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(
+          JSON.stringify({ value: [{ id: "chan-1", displayName: "Deployments" }] }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      }) as unknown as typeof fetch,
+    );
 
     await expect(listTeamsByName("graph-token", "Bob's Team")).resolves.toEqual([
       { id: "team-1", displayName: "Ops" },

--- a/extensions/voice-call/src/providers/twilio/api.test.ts
+++ b/extensions/voice-call/src/providers/twilio/api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { twilioApiRequest } from "./api.js";
 
 const originalFetch = globalThis.fetch;
+const asFetch = <T extends typeof fetch>(fn: T): typeof fetch => fn as unknown as typeof fetch;
 
 describe("twilioApiRequest", () => {
   afterEach(() => {
@@ -9,9 +10,11 @@ describe("twilioApiRequest", () => {
   });
 
   it("posts form bodies with basic auth and parses json", async () => {
-    globalThis.fetch = vi.fn(async () => {
-      return new Response(JSON.stringify({ sid: "CA123" }), { status: 200 });
-    }) as typeof fetch;
+    globalThis.fetch = asFetch(
+      vi.fn(async () => {
+        return new Response(JSON.stringify({ sid: "CA123" }), { status: 200 });
+      }) as unknown as typeof fetch,
+    );
 
     await expect(
       twilioApiRequest({
@@ -47,7 +50,7 @@ describe("twilioApiRequest", () => {
       new Response(null, { status: 204 }),
       new Response("missing", { status: 404 }),
     ];
-    globalThis.fetch = vi.fn(async () => responses.shift()!) as typeof fetch;
+    globalThis.fetch = asFetch(vi.fn(async () => responses.shift()!) as unknown as typeof fetch);
 
     await expect(
       twilioApiRequest({
@@ -72,9 +75,9 @@ describe("twilioApiRequest", () => {
   });
 
   it("throws twilio api errors for non-ok responses", async () => {
-    globalThis.fetch = vi.fn(
-      async () => new Response("bad request", { status: 400 }),
-    ) as typeof fetch;
+    globalThis.fetch = asFetch(
+      vi.fn(async () => new Response("bad request", { status: 400 })) as unknown as typeof fetch,
+    );
 
     await expect(
       twilioApiRequest({

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -101,6 +101,7 @@ let registerLogTransportFn: typeof import("../logging/logger.js").registerLogTra
 let resetLoggerFn: typeof import("../logging/logger.js").resetLogger;
 let setLoggerOverrideFn: typeof import("../logging/logger.js").setLoggerOverride;
 const originalFetch = globalThis.fetch;
+const asFetch = <T extends typeof fetch>(fn: T): typeof fetch => fn as unknown as typeof fetch;
 
 beforeAll(async () => {
   vi.resetModules();
@@ -132,10 +133,12 @@ beforeEach(() => {
   resolveCopilotApiTokenMock.mockImplementation(async () => {
     throw new Error("unexpected extra Copilot token refresh");
   });
-  globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-    throw new Error(`Unexpected fetch in test: ${url}`);
-  }) as typeof fetch;
+  globalThis.fetch = asFetch(
+    vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      throw new Error(`Unexpected fetch in test: ${url}`);
+    }) as unknown as typeof fetch,
+  );
   computeBackoffMock.mockClear();
   sleepWithAbortMock.mockClear();
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -135,6 +135,122 @@ const RUN_RETRY_ITERATIONS_PER_PROFILE = 8;
 const MIN_RUN_RETRY_ITERATIONS = 32;
 const MAX_RUN_RETRY_ITERATIONS = 160;
 
+const PAPERCLIP_RUNTIME_ENV_KEYS = [
+  "PAPERCLIP_API_URL",
+  "PAPERCLIP_RUN_ID",
+  "PAPERCLIP_AGENT_ID",
+  "PAPERCLIP_COMPANY_ID",
+  "PAPERCLIP_API_KEY",
+  "PAPERCLIP_AUTH_HEADER",
+] as const;
+
+let paperclipRuntimeEnvLock: Promise<void> = Promise.resolve();
+
+async function withPaperclipRuntimeEnvLock<T>(
+  params: Pick<
+    RunEmbeddedPiAgentParams,
+    "paperclipRuntimeAuth" | "runId" | "sessionId" | "sessionKey"
+  >,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!params.paperclipRuntimeAuth) {
+    return fn();
+  }
+
+  const previousLock = paperclipRuntimeEnvLock;
+  let release!: () => void;
+  paperclipRuntimeEnvLock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  await previousLock;
+  log.debug(
+    `[paperclip-runtime-auth-lock] acquired run=${params.runId} session=${redactRunIdentifier(params.sessionId)} sessionKey=${redactRunIdentifier(params.sessionKey)}`,
+  );
+  try {
+    return await fn();
+  } finally {
+    release();
+    log.debug(
+      `[paperclip-runtime-auth-lock] released run=${params.runId} session=${redactRunIdentifier(params.sessionId)} sessionKey=${redactRunIdentifier(params.sessionKey)}`,
+    );
+  }
+}
+
+function applyPaperclipRuntimeAuthEnv(
+  params: Pick<RunEmbeddedPiAgentParams, "paperclipRuntimeAuth">,
+): () => void {
+  const previous = new Map<string, string | undefined>();
+  for (const key of PAPERCLIP_RUNTIME_ENV_KEYS) {
+    previous.set(key, process.env[key]);
+  }
+
+  const auth = params.paperclipRuntimeAuth;
+  if (!auth) {
+    return () => {
+      for (const key of PAPERCLIP_RUNTIME_ENV_KEYS) {
+        const value = previous.get(key);
+        if (typeof value === "string") {
+          process.env[key] = value;
+        } else {
+          delete process.env[key];
+        }
+      }
+    };
+  }
+  const authToken = auth.authToken?.trim();
+  const authScheme = auth.authScheme?.trim().toLowerCase();
+  const apiUrl = auth.apiUrl?.trim();
+  const runId = auth.runId?.trim();
+  const agentId = auth.agentId?.trim();
+  const companyId = auth.companyId?.trim();
+
+  if (apiUrl) {
+    process.env.PAPERCLIP_API_URL = apiUrl;
+  } else {
+    delete process.env.PAPERCLIP_API_URL;
+  }
+  if (runId) {
+    process.env.PAPERCLIP_RUN_ID = runId;
+  } else {
+    delete process.env.PAPERCLIP_RUN_ID;
+  }
+  if (agentId) {
+    process.env.PAPERCLIP_AGENT_ID = agentId;
+  } else {
+    delete process.env.PAPERCLIP_AGENT_ID;
+  }
+  if (companyId) {
+    process.env.PAPERCLIP_COMPANY_ID = companyId;
+  } else {
+    delete process.env.PAPERCLIP_COMPANY_ID;
+  }
+  if (authToken) {
+    process.env.PAPERCLIP_API_KEY = authToken;
+    const scheme = authScheme && authScheme.length > 0 ? authScheme : "bearer";
+    process.env.PAPERCLIP_AUTH_HEADER = `${scheme} ${authToken}`;
+  } else {
+    delete process.env.PAPERCLIP_API_KEY;
+    delete process.env.PAPERCLIP_AUTH_HEADER;
+  }
+
+  return () => {
+    for (const key of PAPERCLIP_RUNTIME_ENV_KEYS) {
+      const value = previous.get(key);
+      if (typeof value === "string") {
+        process.env[key] = value;
+      } else {
+        delete process.env[key];
+      }
+    }
+  };
+}
+
+export const __paperclipAuthEnvTestUtils = {
+  applyPaperclipRuntimeAuthEnv,
+  PAPERCLIP_RUNTIME_ENV_KEYS,
+};
+
 function resolveMaxRunRetryIterations(profileCandidateCount: number): number {
   const scaled =
     BASE_RUN_RETRY_ITERATIONS +
@@ -228,1427 +344,1457 @@ export async function runEmbeddedPiAgent(
   const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
 
   return enqueueSession(() =>
-    enqueueGlobal(async () => {
-      const started = Date.now();
-      const workspaceResolution = resolveRunWorkspaceDir({
-        workspaceDir: params.workspaceDir,
-        sessionKey: params.sessionKey,
-        agentId: params.agentId,
-        config: params.config,
-      });
-      const resolvedWorkspace = workspaceResolution.workspaceDir;
-      const redactedSessionId = redactRunIdentifier(params.sessionId);
-      const redactedSessionKey = redactRunIdentifier(params.sessionKey);
-      const redactedWorkspace = redactRunIdentifier(resolvedWorkspace);
-      if (workspaceResolution.usedFallback) {
-        log.warn(
-          `[workspace-fallback] caller=runEmbeddedPiAgent reason=${workspaceResolution.fallbackReason} run=${params.runId} session=${redactedSessionId} sessionKey=${redactedSessionKey} agent=${workspaceResolution.agentId} workspace=${redactedWorkspace}`,
-        );
-      }
-      ensureRuntimePluginsLoaded({
-        config: params.config,
-        workspaceDir: resolvedWorkspace,
-        allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-      });
-
-      let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
-      let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
-      const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
-      const fallbackConfigured = hasConfiguredModelFallbacks({
-        cfg: params.config,
-        agentId: params.agentId,
-        sessionKey: params.sessionKey,
-      });
-      await ensureOpenClawModelsJson(params.config, agentDir);
-
-      // Run before_model_resolve hooks early so plugins can override the
-      // provider/model before resolveModel().
-      //
-      // Legacy compatibility: before_agent_start is also checked for override
-      // fields if present. New hook takes precedence when both are set.
-      let modelResolveOverride: { providerOverride?: string; modelOverride?: string } | undefined;
-      let legacyBeforeAgentStartResult: PluginHookBeforeAgentStartResult | undefined;
-      const hookRunner = getGlobalHookRunner();
-      const hookCtx = {
-        agentId: workspaceResolution.agentId,
-        sessionKey: params.sessionKey,
-        sessionId: params.sessionId,
-        workspaceDir: resolvedWorkspace,
-        messageProvider: params.messageProvider ?? undefined,
-        trigger: params.trigger,
-        channelId: params.messageChannel ?? params.messageProvider ?? undefined,
-      };
-      if (hookRunner?.hasHooks("before_model_resolve")) {
+    enqueueGlobal(async () =>
+      withPaperclipRuntimeEnvLock(params, async () => {
+        const restorePaperclipRuntimeEnv = applyPaperclipRuntimeAuthEnv(params);
         try {
-          modelResolveOverride = await hookRunner.runBeforeModelResolve(
-            { prompt: params.prompt },
-            hookCtx,
-          );
-        } catch (hookErr) {
-          log.warn(`before_model_resolve hook failed: ${String(hookErr)}`);
-        }
-      }
-      if (hookRunner?.hasHooks("before_agent_start")) {
-        try {
-          legacyBeforeAgentStartResult = await hookRunner.runBeforeAgentStart(
-            { prompt: params.prompt },
-            hookCtx,
-          );
-          modelResolveOverride = {
-            providerOverride:
-              modelResolveOverride?.providerOverride ??
-              legacyBeforeAgentStartResult?.providerOverride,
-            modelOverride:
-              modelResolveOverride?.modelOverride ?? legacyBeforeAgentStartResult?.modelOverride,
-          };
-        } catch (hookErr) {
-          log.warn(
-            `before_agent_start hook (legacy model resolve path) failed: ${String(hookErr)}`,
-          );
-        }
-      }
-      if (modelResolveOverride?.providerOverride) {
-        provider = modelResolveOverride.providerOverride;
-        log.info(`[hooks] provider overridden to ${provider}`);
-      }
-      if (modelResolveOverride?.modelOverride) {
-        modelId = modelResolveOverride.modelOverride;
-        log.info(`[hooks] model overridden to ${modelId}`);
-      }
-
-      const { model, error, authStorage, modelRegistry } = await resolveModelAsync(
-        provider,
-        modelId,
-        agentDir,
-        params.config,
-      );
-      if (!model) {
-        throw new FailoverError(error ?? `Unknown model: ${provider}/${modelId}`, {
-          reason: "model_not_found",
-          provider,
-          model: modelId,
-        });
-      }
-      let runtimeModel = model;
-
-      const ctxInfo = resolveContextWindowInfo({
-        cfg: params.config,
-        provider,
-        modelId,
-        modelContextWindow: runtimeModel.contextWindow,
-        defaultTokens: DEFAULT_CONTEXT_TOKENS,
-      });
-      // Apply contextTokens cap to model so pi-coding-agent's auto-compaction
-      // threshold uses the effective limit, not the native context window.
-      let effectiveModel =
-        ctxInfo.tokens < (runtimeModel.contextWindow ?? Infinity)
-          ? { ...runtimeModel, contextWindow: ctxInfo.tokens }
-          : runtimeModel;
-      const ctxGuard = evaluateContextWindowGuard({
-        info: ctxInfo,
-        warnBelowTokens: CONTEXT_WINDOW_WARN_BELOW_TOKENS,
-        hardMinTokens: CONTEXT_WINDOW_HARD_MIN_TOKENS,
-      });
-      if (ctxGuard.shouldWarn) {
-        log.warn(
-          `low context window: ${provider}/${modelId} ctx=${ctxGuard.tokens} (warn<${CONTEXT_WINDOW_WARN_BELOW_TOKENS}) source=${ctxGuard.source}`,
-        );
-      }
-      if (ctxGuard.shouldBlock) {
-        log.error(
-          `blocked model (context window too small): ${provider}/${modelId} ctx=${ctxGuard.tokens} (min=${CONTEXT_WINDOW_HARD_MIN_TOKENS}) source=${ctxGuard.source}`,
-        );
-        throw new FailoverError(
-          `Model context window too small (${ctxGuard.tokens} tokens). Minimum is ${CONTEXT_WINDOW_HARD_MIN_TOKENS}.`,
-          { reason: "unknown", provider, model: modelId },
-        );
-      }
-
-      const authStore = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
-      const preferredProfileId = params.authProfileId?.trim();
-      let lockedProfileId = params.authProfileIdSource === "user" ? preferredProfileId : undefined;
-      if (lockedProfileId) {
-        const lockedProfile = authStore.profiles[lockedProfileId];
-        if (
-          !lockedProfile ||
-          normalizeProviderId(lockedProfile.provider) !== normalizeProviderId(provider)
-        ) {
-          lockedProfileId = undefined;
-        }
-      }
-      const profileOrder = resolveAuthProfileOrder({
-        cfg: params.config,
-        store: authStore,
-        provider,
-        preferredProfile: preferredProfileId,
-      });
-      if (lockedProfileId && !profileOrder.includes(lockedProfileId)) {
-        throw new Error(`Auth profile "${lockedProfileId}" is not configured for ${provider}.`);
-      }
-      const profileCandidates = lockedProfileId
-        ? [lockedProfileId]
-        : profileOrder.length > 0
-          ? profileOrder
-          : [undefined];
-      let profileIndex = 0;
-
-      const initialThinkLevel = params.thinkLevel ?? "off";
-      let thinkLevel = initialThinkLevel;
-      const attemptedThinking = new Set<ThinkLevel>();
-      let apiKeyInfo: ApiKeyInfo | null = null;
-      let lastProfileId: string | undefined;
-      let runtimeAuthState: RuntimeAuthState | null = null;
-      let runtimeAuthRefreshCancelled = false;
-      const hasRefreshableRuntimeAuth = () => Boolean(runtimeAuthState?.sourceApiKey.trim());
-
-      const clearRuntimeAuthRefreshTimer = () => {
-        if (!runtimeAuthState?.refreshTimer) {
-          return;
-        }
-        clearTimeout(runtimeAuthState.refreshTimer);
-        runtimeAuthState.refreshTimer = undefined;
-      };
-
-      const stopRuntimeAuthRefreshTimer = () => {
-        if (!runtimeAuthState) {
-          return;
-        }
-        runtimeAuthRefreshCancelled = true;
-        clearRuntimeAuthRefreshTimer();
-      };
-
-      const refreshRuntimeAuth = async (reason: string): Promise<void> => {
-        if (!runtimeAuthState) {
-          return;
-        }
-        if (runtimeAuthState.refreshInFlight) {
-          await runtimeAuthState.refreshInFlight;
-          return;
-        }
-        runtimeAuthState.refreshInFlight = (async () => {
-          const sourceApiKey = runtimeAuthState?.sourceApiKey.trim() ?? "";
-          if (!sourceApiKey) {
-            throw new Error(`Runtime auth refresh requires a source credential.`);
+          const started = Date.now();
+          const workspaceResolution = resolveRunWorkspaceDir({
+            workspaceDir: params.workspaceDir,
+            sessionKey: params.sessionKey,
+            agentId: params.agentId,
+            config: params.config,
+          });
+          const resolvedWorkspace = workspaceResolution.workspaceDir;
+          const redactedSessionId = redactRunIdentifier(params.sessionId);
+          const redactedSessionKey = redactRunIdentifier(params.sessionKey);
+          const redactedWorkspace = redactRunIdentifier(resolvedWorkspace);
+          if (workspaceResolution.usedFallback) {
+            log.warn(
+              `[workspace-fallback] caller=runEmbeddedPiAgent reason=${workspaceResolution.fallbackReason} run=${params.runId} session=${redactedSessionId} sessionKey=${redactedSessionKey} agent=${workspaceResolution.agentId} workspace=${redactedWorkspace}`,
+            );
           }
-          log.debug(`Refreshing runtime auth for ${runtimeModel.provider} (${reason})...`);
-          const preparedAuth = await prepareProviderRuntimeAuth({
-            provider: runtimeModel.provider,
+          ensureRuntimePluginsLoaded({
             config: params.config,
             workspaceDir: resolvedWorkspace,
-            env: process.env,
-            context: {
-              config: params.config,
-              agentDir,
-              workspaceDir: resolvedWorkspace,
-              env: process.env,
-              provider: runtimeModel.provider,
-              modelId,
-              model: runtimeModel,
-              apiKey: sourceApiKey,
-              authMode: runtimeAuthState?.authMode ?? "unknown",
-              profileId: runtimeAuthState?.profileId,
-            },
+            allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
           });
-          if (!preparedAuth?.apiKey) {
-            throw new Error(
-              `Provider "${runtimeModel.provider}" does not support runtime auth refresh.`,
-            );
-          }
-          authStorage.setRuntimeApiKey(runtimeModel.provider, preparedAuth.apiKey);
-          if (preparedAuth.baseUrl) {
-            runtimeModel = { ...runtimeModel, baseUrl: preparedAuth.baseUrl };
-            effectiveModel = { ...effectiveModel, baseUrl: preparedAuth.baseUrl };
-          }
-          runtimeAuthState = {
-            ...runtimeAuthState,
-            expiresAt: preparedAuth.expiresAt,
-          };
-          if (preparedAuth.expiresAt) {
-            const remaining = preparedAuth.expiresAt - Date.now();
-            log.debug(
-              `Runtime auth refreshed for ${runtimeModel.provider}; expires in ${Math.max(0, Math.floor(remaining / 1000))}s.`,
-            );
-          }
-        })()
-          .catch((err) => {
-            log.warn(
-              `Runtime auth refresh failed for ${runtimeModel.provider}: ${describeUnknownError(err)}`,
-            );
-            throw err;
-          })
-          .finally(() => {
-            if (runtimeAuthState) {
-              runtimeAuthState.refreshInFlight = undefined;
-            }
-          });
-        await runtimeAuthState.refreshInFlight;
-      };
 
-      const scheduleRuntimeAuthRefresh = (): void => {
-        if (!runtimeAuthState || runtimeAuthRefreshCancelled) {
-          return;
-        }
-        if (!hasRefreshableRuntimeAuth()) {
-          log.warn(
-            `Skipping runtime auth refresh scheduling for ${runtimeModel.provider}; source credential missing.`,
-          );
-          return;
-        }
-        if (!runtimeAuthState.expiresAt) {
-          return;
-        }
-        clearRuntimeAuthRefreshTimer();
-        const now = Date.now();
-        const refreshAt = runtimeAuthState.expiresAt - RUNTIME_AUTH_REFRESH_MARGIN_MS;
-        const delayMs = Math.max(RUNTIME_AUTH_REFRESH_MIN_DELAY_MS, refreshAt - now);
-        const timer = setTimeout(() => {
-          if (runtimeAuthRefreshCancelled) {
-            return;
+          let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
+          let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+          const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
+          const fallbackConfigured = hasConfiguredModelFallbacks({
+            cfg: params.config,
+            agentId: params.agentId,
+            sessionKey: params.sessionKey,
+          });
+          await ensureOpenClawModelsJson(params.config, agentDir);
+
+          // Run before_model_resolve hooks early so plugins can override the
+          // provider/model before resolveModel().
+          //
+          // Legacy compatibility: before_agent_start is also checked for override
+          // fields if present. New hook takes precedence when both are set.
+          let modelResolveOverride:
+            | { providerOverride?: string; modelOverride?: string }
+            | undefined;
+          let legacyBeforeAgentStartResult: PluginHookBeforeAgentStartResult | undefined;
+          const hookRunner = getGlobalHookRunner();
+          const hookCtx = {
+            agentId: workspaceResolution.agentId,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+            workspaceDir: resolvedWorkspace,
+            messageProvider: params.messageProvider ?? undefined,
+            trigger: params.trigger,
+            channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+          };
+          if (hookRunner?.hasHooks("before_model_resolve")) {
+            try {
+              modelResolveOverride = await hookRunner.runBeforeModelResolve(
+                { prompt: params.prompt },
+                hookCtx,
+              );
+            } catch (hookErr) {
+              log.warn(`before_model_resolve hook failed: ${String(hookErr)}`);
+            }
           }
-          refreshRuntimeAuth("scheduled")
-            .then(() => scheduleRuntimeAuthRefresh())
-            .catch(() => {
+          if (hookRunner?.hasHooks("before_agent_start")) {
+            try {
+              legacyBeforeAgentStartResult = await hookRunner.runBeforeAgentStart(
+                { prompt: params.prompt },
+                hookCtx,
+              );
+              modelResolveOverride = {
+                providerOverride:
+                  modelResolveOverride?.providerOverride ??
+                  legacyBeforeAgentStartResult?.providerOverride,
+                modelOverride:
+                  modelResolveOverride?.modelOverride ??
+                  legacyBeforeAgentStartResult?.modelOverride,
+              };
+            } catch (hookErr) {
+              log.warn(
+                `before_agent_start hook (legacy model resolve path) failed: ${String(hookErr)}`,
+              );
+            }
+          }
+          if (modelResolveOverride?.providerOverride) {
+            provider = modelResolveOverride.providerOverride;
+            log.info(`[hooks] provider overridden to ${provider}`);
+          }
+          if (modelResolveOverride?.modelOverride) {
+            modelId = modelResolveOverride.modelOverride;
+            log.info(`[hooks] model overridden to ${modelId}`);
+          }
+
+          const { model, error, authStorage, modelRegistry } = await resolveModelAsync(
+            provider,
+            modelId,
+            agentDir,
+            params.config,
+          );
+          if (!model) {
+            throw new FailoverError(error ?? `Unknown model: ${provider}/${modelId}`, {
+              reason: "model_not_found",
+              provider,
+              model: modelId,
+            });
+          }
+          let runtimeModel = model;
+
+          const ctxInfo = resolveContextWindowInfo({
+            cfg: params.config,
+            provider,
+            modelId,
+            modelContextWindow: runtimeModel.contextWindow,
+            defaultTokens: DEFAULT_CONTEXT_TOKENS,
+          });
+          // Apply contextTokens cap to model so pi-coding-agent's auto-compaction
+          // threshold uses the effective limit, not the native context window.
+          let effectiveModel =
+            ctxInfo.tokens < (runtimeModel.contextWindow ?? Infinity)
+              ? { ...runtimeModel, contextWindow: ctxInfo.tokens }
+              : runtimeModel;
+          const ctxGuard = evaluateContextWindowGuard({
+            info: ctxInfo,
+            warnBelowTokens: CONTEXT_WINDOW_WARN_BELOW_TOKENS,
+            hardMinTokens: CONTEXT_WINDOW_HARD_MIN_TOKENS,
+          });
+          if (ctxGuard.shouldWarn) {
+            log.warn(
+              `low context window: ${provider}/${modelId} ctx=${ctxGuard.tokens} (warn<${CONTEXT_WINDOW_WARN_BELOW_TOKENS}) source=${ctxGuard.source}`,
+            );
+          }
+          if (ctxGuard.shouldBlock) {
+            log.error(
+              `blocked model (context window too small): ${provider}/${modelId} ctx=${ctxGuard.tokens} (min=${CONTEXT_WINDOW_HARD_MIN_TOKENS}) source=${ctxGuard.source}`,
+            );
+            throw new FailoverError(
+              `Model context window too small (${ctxGuard.tokens} tokens). Minimum is ${CONTEXT_WINDOW_HARD_MIN_TOKENS}.`,
+              { reason: "unknown", provider, model: modelId },
+            );
+          }
+
+          const authStore = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+          const preferredProfileId = params.authProfileId?.trim();
+          let lockedProfileId =
+            params.authProfileIdSource === "user" ? preferredProfileId : undefined;
+          if (lockedProfileId) {
+            const lockedProfile = authStore.profiles[lockedProfileId];
+            if (
+              !lockedProfile ||
+              normalizeProviderId(lockedProfile.provider) !== normalizeProviderId(provider)
+            ) {
+              lockedProfileId = undefined;
+            }
+          }
+          const profileOrder = resolveAuthProfileOrder({
+            cfg: params.config,
+            store: authStore,
+            provider,
+            preferredProfile: preferredProfileId,
+          });
+          if (lockedProfileId && !profileOrder.includes(lockedProfileId)) {
+            throw new Error(`Auth profile "${lockedProfileId}" is not configured for ${provider}.`);
+          }
+          const profileCandidates = lockedProfileId
+            ? [lockedProfileId]
+            : profileOrder.length > 0
+              ? profileOrder
+              : [undefined];
+          let profileIndex = 0;
+
+          const initialThinkLevel = params.thinkLevel ?? "off";
+          let thinkLevel = initialThinkLevel;
+          const attemptedThinking = new Set<ThinkLevel>();
+          let apiKeyInfo: ApiKeyInfo | null = null;
+          let lastProfileId: string | undefined;
+          let runtimeAuthState: RuntimeAuthState | null = null;
+          let runtimeAuthRefreshCancelled = false;
+          const hasRefreshableRuntimeAuth = () => Boolean(runtimeAuthState?.sourceApiKey.trim());
+
+          const clearRuntimeAuthRefreshTimer = () => {
+            if (!runtimeAuthState?.refreshTimer) {
+              return;
+            }
+            clearTimeout(runtimeAuthState.refreshTimer);
+            runtimeAuthState.refreshTimer = undefined;
+          };
+
+          const stopRuntimeAuthRefreshTimer = () => {
+            if (!runtimeAuthState) {
+              return;
+            }
+            runtimeAuthRefreshCancelled = true;
+            clearRuntimeAuthRefreshTimer();
+          };
+
+          const refreshRuntimeAuth = async (reason: string): Promise<void> => {
+            if (!runtimeAuthState) {
+              return;
+            }
+            if (runtimeAuthState.refreshInFlight) {
+              await runtimeAuthState.refreshInFlight;
+              return;
+            }
+            runtimeAuthState.refreshInFlight = (async () => {
+              const sourceApiKey = runtimeAuthState?.sourceApiKey.trim() ?? "";
+              if (!sourceApiKey) {
+                throw new Error(`Runtime auth refresh requires a source credential.`);
+              }
+              log.debug(`Refreshing runtime auth for ${runtimeModel.provider} (${reason})...`);
+              const preparedAuth = await prepareProviderRuntimeAuth({
+                provider: runtimeModel.provider,
+                config: params.config,
+                workspaceDir: resolvedWorkspace,
+                env: process.env,
+                context: {
+                  config: params.config,
+                  agentDir,
+                  workspaceDir: resolvedWorkspace,
+                  env: process.env,
+                  provider: runtimeModel.provider,
+                  modelId,
+                  model: runtimeModel,
+                  apiKey: sourceApiKey,
+                  authMode: runtimeAuthState?.authMode ?? "unknown",
+                  profileId: runtimeAuthState?.profileId,
+                },
+              });
+              if (!preparedAuth?.apiKey) {
+                throw new Error(
+                  `Provider "${runtimeModel.provider}" does not support runtime auth refresh.`,
+                );
+              }
+              authStorage.setRuntimeApiKey(runtimeModel.provider, preparedAuth.apiKey);
+              if (preparedAuth.baseUrl) {
+                runtimeModel = { ...runtimeModel, baseUrl: preparedAuth.baseUrl };
+                effectiveModel = { ...effectiveModel, baseUrl: preparedAuth.baseUrl };
+              }
+              runtimeAuthState = {
+                ...runtimeAuthState,
+                expiresAt: preparedAuth.expiresAt,
+              };
+              if (preparedAuth.expiresAt) {
+                const remaining = preparedAuth.expiresAt - Date.now();
+                log.debug(
+                  `Runtime auth refreshed for ${runtimeModel.provider}; expires in ${Math.max(0, Math.floor(remaining / 1000))}s.`,
+                );
+              }
+            })()
+              .catch((err) => {
+                log.warn(
+                  `Runtime auth refresh failed for ${runtimeModel.provider}: ${describeUnknownError(err)}`,
+                );
+                throw err;
+              })
+              .finally(() => {
+                if (runtimeAuthState) {
+                  runtimeAuthState.refreshInFlight = undefined;
+                }
+              });
+            await runtimeAuthState.refreshInFlight;
+          };
+
+          const scheduleRuntimeAuthRefresh = (): void => {
+            if (!runtimeAuthState || runtimeAuthRefreshCancelled) {
+              return;
+            }
+            if (!hasRefreshableRuntimeAuth()) {
+              log.warn(
+                `Skipping runtime auth refresh scheduling for ${runtimeModel.provider}; source credential missing.`,
+              );
+              return;
+            }
+            if (!runtimeAuthState.expiresAt) {
+              return;
+            }
+            clearRuntimeAuthRefreshTimer();
+            const now = Date.now();
+            const refreshAt = runtimeAuthState.expiresAt - RUNTIME_AUTH_REFRESH_MARGIN_MS;
+            const delayMs = Math.max(RUNTIME_AUTH_REFRESH_MIN_DELAY_MS, refreshAt - now);
+            const timer = setTimeout(() => {
               if (runtimeAuthRefreshCancelled) {
                 return;
               }
-              const retryTimer = setTimeout(() => {
-                if (runtimeAuthRefreshCancelled) {
-                  return;
-                }
-                refreshRuntimeAuth("scheduled-retry")
-                  .then(() => scheduleRuntimeAuthRefresh())
-                  .catch(() => undefined);
-              }, RUNTIME_AUTH_REFRESH_RETRY_MS);
-              const activeRuntimeAuthState = runtimeAuthState;
-              if (activeRuntimeAuthState) {
-                activeRuntimeAuthState.refreshTimer = retryTimer;
-              }
-              if (runtimeAuthRefreshCancelled && activeRuntimeAuthState) {
-                clearTimeout(retryTimer);
-                activeRuntimeAuthState.refreshTimer = undefined;
-              }
-            });
-        }, delayMs);
-        runtimeAuthState.refreshTimer = timer;
-        if (runtimeAuthRefreshCancelled) {
-          clearTimeout(timer);
-          runtimeAuthState.refreshTimer = undefined;
-        }
-      };
-
-      const resolveAuthProfileFailoverReason = (params: {
-        allInCooldown: boolean;
-        message: string;
-        profileIds?: Array<string | undefined>;
-      }): FailoverReason => {
-        if (params.allInCooldown) {
-          const profileIds = (params.profileIds ?? profileCandidates).filter(
-            (id): id is string => typeof id === "string" && id.length > 0,
-          );
-          return (
-            resolveProfilesUnavailableReason({
-              store: authStore,
-              profileIds,
-            }) ?? "unknown"
-          );
-        }
-        const classified = classifyFailoverReason(params.message);
-        return classified ?? "auth";
-      };
-
-      const throwAuthProfileFailover = (params: {
-        allInCooldown: boolean;
-        message?: string;
-        error?: unknown;
-      }): never => {
-        const fallbackMessage = `No available auth profile for ${provider} (all in cooldown or unavailable).`;
-        const message =
-          params.message?.trim() ||
-          (params.error ? describeUnknownError(params.error).trim() : "") ||
-          fallbackMessage;
-        const reason = resolveAuthProfileFailoverReason({
-          allInCooldown: params.allInCooldown,
-          message,
-          profileIds: profileCandidates,
-        });
-        if (fallbackConfigured) {
-          throw new FailoverError(message, {
-            reason,
-            provider,
-            model: modelId,
-            status: resolveFailoverStatus(reason),
-            cause: params.error,
-          });
-        }
-        if (params.error instanceof Error) {
-          throw params.error;
-        }
-        throw new Error(message);
-      };
-
-      const resolveApiKeyForCandidate = async (candidate?: string) => {
-        return getApiKeyForModel({
-          model: runtimeModel,
-          cfg: params.config,
-          profileId: candidate,
-          store: authStore,
-          agentDir,
-        });
-      };
-
-      const applyApiKeyInfo = async (candidate?: string): Promise<void> => {
-        apiKeyInfo = await resolveApiKeyForCandidate(candidate);
-        const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
-        if (!apiKeyInfo.apiKey) {
-          if (apiKeyInfo.mode !== "aws-sdk") {
-            throw new Error(
-              `No API key resolved for provider "${runtimeModel.provider}" (auth mode: ${apiKeyInfo.mode}).`,
-            );
-          }
-          lastProfileId = resolvedProfileId;
-          return;
-        }
-        let runtimeAuthHandled = false;
-        const preparedAuth = await prepareProviderRuntimeAuth({
-          provider: runtimeModel.provider,
-          config: params.config,
-          workspaceDir: resolvedWorkspace,
-          env: process.env,
-          context: {
-            config: params.config,
-            agentDir,
-            workspaceDir: resolvedWorkspace,
-            env: process.env,
-            provider: runtimeModel.provider,
-            modelId,
-            model: runtimeModel,
-            apiKey: apiKeyInfo.apiKey,
-            authMode: apiKeyInfo.mode,
-            profileId: apiKeyInfo.profileId,
-          },
-        });
-        if (preparedAuth?.baseUrl) {
-          runtimeModel = { ...runtimeModel, baseUrl: preparedAuth.baseUrl };
-          effectiveModel = { ...effectiveModel, baseUrl: preparedAuth.baseUrl };
-        }
-        if (preparedAuth?.apiKey) {
-          authStorage.setRuntimeApiKey(runtimeModel.provider, preparedAuth.apiKey);
-          runtimeAuthState = {
-            sourceApiKey: apiKeyInfo.apiKey,
-            authMode: apiKeyInfo.mode,
-            profileId: apiKeyInfo.profileId,
-            expiresAt: preparedAuth.expiresAt,
-          };
-          if (preparedAuth.expiresAt) {
-            scheduleRuntimeAuthRefresh();
-          }
-          runtimeAuthHandled = true;
-        }
-        if (runtimeAuthHandled) {
-          // Plugin-owned runtime auth already stored the exchanged credential.
-        } else {
-          authStorage.setRuntimeApiKey(runtimeModel.provider, apiKeyInfo.apiKey);
-          runtimeAuthState = null;
-        }
-        lastProfileId = apiKeyInfo.profileId;
-      };
-
-      const advanceAuthProfile = async (): Promise<boolean> => {
-        if (lockedProfileId) {
-          return false;
-        }
-        let nextIndex = profileIndex + 1;
-        while (nextIndex < profileCandidates.length) {
-          const candidate = profileCandidates[nextIndex];
-          if (candidate && isProfileInCooldown(authStore, candidate)) {
-            nextIndex += 1;
-            continue;
-          }
-          try {
-            await applyApiKeyInfo(candidate);
-            profileIndex = nextIndex;
-            thinkLevel = initialThinkLevel;
-            attemptedThinking.clear();
-            return true;
-          } catch (err) {
-            if (candidate && candidate === lockedProfileId) {
-              throw err;
-            }
-            nextIndex += 1;
-          }
-        }
-        return false;
-      };
-
-      try {
-        const autoProfileCandidates = profileCandidates.filter(
-          (candidate): candidate is string =>
-            typeof candidate === "string" && candidate.length > 0 && candidate !== lockedProfileId,
-        );
-        const allAutoProfilesInCooldown =
-          autoProfileCandidates.length > 0 &&
-          autoProfileCandidates.every((candidate) => isProfileInCooldown(authStore, candidate));
-        const unavailableReason = allAutoProfilesInCooldown
-          ? (resolveProfilesUnavailableReason({
-              store: authStore,
-              profileIds: autoProfileCandidates,
-            }) ?? "unknown")
-          : null;
-        const allowTransientCooldownProbe =
-          params.allowTransientCooldownProbe === true &&
-          allAutoProfilesInCooldown &&
-          shouldAllowCooldownProbeForReason(unavailableReason);
-        let didTransientCooldownProbe = false;
-
-        while (profileIndex < profileCandidates.length) {
-          const candidate = profileCandidates[profileIndex];
-          const inCooldown =
-            candidate && candidate !== lockedProfileId && isProfileInCooldown(authStore, candidate);
-          if (inCooldown) {
-            if (allowTransientCooldownProbe && !didTransientCooldownProbe) {
-              didTransientCooldownProbe = true;
-              log.warn(
-                `probing cooldowned auth profile for ${provider}/${modelId} due to ${unavailableReason ?? "transient"} unavailability`,
-              );
-            } else {
-              profileIndex += 1;
-              continue;
-            }
-          }
-          await applyApiKeyInfo(profileCandidates[profileIndex]);
-          break;
-        }
-        if (profileIndex >= profileCandidates.length) {
-          throwAuthProfileFailover({ allInCooldown: true });
-        }
-      } catch (err) {
-        if (err instanceof FailoverError) {
-          throw err;
-        }
-        if (profileCandidates[profileIndex] === lockedProfileId) {
-          throwAuthProfileFailover({ allInCooldown: false, error: err });
-        }
-        const advanced = await advanceAuthProfile();
-        if (!advanced) {
-          throwAuthProfileFailover({ allInCooldown: false, error: err });
-        }
-      }
-
-      const maybeRefreshRuntimeAuthForAuthError = async (
-        errorText: string,
-        retried: boolean,
-      ): Promise<boolean> => {
-        if (!runtimeAuthState || retried) {
-          return false;
-        }
-        if (!isFailoverErrorMessage(errorText)) {
-          return false;
-        }
-        if (classifyFailoverReason(errorText) !== "auth") {
-          return false;
-        }
-        try {
-          await refreshRuntimeAuth("auth-error");
-          scheduleRuntimeAuthRefresh();
-          return true;
-        } catch {
-          return false;
-        }
-      };
-
-      const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
-      const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
-      let overflowCompactionAttempts = 0;
-      let toolResultTruncationAttempted = false;
-      let bootstrapPromptWarningSignaturesSeen =
-        params.bootstrapPromptWarningSignaturesSeen ??
-        (params.bootstrapPromptWarningSignature ? [params.bootstrapPromptWarningSignature] : []);
-      const usageAccumulator = createUsageAccumulator();
-      let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
-      let autoCompactionCount = 0;
-      let runLoopIterations = 0;
-      let overloadFailoverAttempts = 0;
-      const maybeMarkAuthProfileFailure = async (failure: {
-        profileId?: string;
-        reason?: AuthProfileFailureReason | null;
-        config?: RunEmbeddedPiAgentParams["config"];
-        agentDir?: RunEmbeddedPiAgentParams["agentDir"];
-      }) => {
-        const { profileId, reason } = failure;
-        if (!profileId || !reason || reason === "timeout") {
-          return;
-        }
-        await markAuthProfileFailure({
-          store: authStore,
-          profileId,
-          reason,
-          cfg: params.config,
-          agentDir,
-          runId: params.runId,
-        });
-      };
-      const resolveAuthProfileFailureReason = (
-        failoverReason: FailoverReason | null,
-      ): AuthProfileFailureReason | null => {
-        // Timeouts are transport/model-path failures, not auth health signals,
-        // so they should not persist auth-profile failure state.
-        if (!failoverReason || failoverReason === "timeout") {
-          return null;
-        }
-        return failoverReason;
-      };
-      const maybeBackoffBeforeOverloadFailover = async (reason: FailoverReason | null) => {
-        if (reason !== "overloaded") {
-          return;
-        }
-        overloadFailoverAttempts += 1;
-        const delayMs = computeBackoff(OVERLOAD_FAILOVER_BACKOFF_POLICY, overloadFailoverAttempts);
-        log.warn(
-          `overload backoff before failover for ${provider}/${modelId}: attempt=${overloadFailoverAttempts} delayMs=${delayMs}`,
-        );
-        try {
-          await sleepWithAbort(delayMs, params.abortSignal);
-        } catch (err) {
-          if (params.abortSignal?.aborted) {
-            const abortErr = new Error("Operation aborted", { cause: err });
-            abortErr.name = "AbortError";
-            throw abortErr;
-          }
-          throw err;
-        }
-      };
-      // Resolve the context engine once and reuse across retries to avoid
-      // repeated initialization/connection overhead per attempt.
-      ensureContextEnginesInitialized();
-      const contextEngine = await resolveContextEngine(params.config);
-      try {
-        let authRetryPending = false;
-        // Hoisted so the retry-limit error path can use the most recent API total.
-        let lastTurnTotal: number | undefined;
-        while (true) {
-          if (runLoopIterations >= MAX_RUN_LOOP_ITERATIONS) {
-            const message =
-              `Exceeded retry limit after ${runLoopIterations} attempts ` +
-              `(max=${MAX_RUN_LOOP_ITERATIONS}).`;
-            log.error(
-              `[run-retry-limit] sessionKey=${params.sessionKey ?? params.sessionId} ` +
-                `provider=${provider}/${modelId} attempts=${runLoopIterations} ` +
-                `maxAttempts=${MAX_RUN_LOOP_ITERATIONS}`,
-            );
-            return {
-              payloads: [
-                {
-                  text:
-                    "Request failed after repeated internal retries. " +
-                    "Please try again, or use /new to start a fresh session.",
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta: buildErrorAgentMeta({
-                  sessionId: params.sessionId,
-                  provider,
-                  model: model.id,
-                  usageAccumulator,
-                  lastRunPromptUsage,
-                  lastTurnTotal,
-                }),
-                error: { kind: "retry_limit", message },
-              },
-            };
-          }
-          runLoopIterations += 1;
-          const runtimeAuthRetry = authRetryPending;
-          authRetryPending = false;
-          attemptedThinking.add(thinkLevel);
-          await fs.mkdir(resolvedWorkspace, { recursive: true });
-
-          const prompt =
-            provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt;
-
-          const attempt = await runEmbeddedAttempt({
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            trigger: params.trigger,
-            memoryFlushWritePath: params.memoryFlushWritePath,
-            messageChannel: params.messageChannel,
-            messageProvider: params.messageProvider,
-            agentAccountId: params.agentAccountId,
-            messageTo: params.messageTo,
-            messageThreadId: params.messageThreadId,
-            groupId: params.groupId,
-            groupChannel: params.groupChannel,
-            groupSpace: params.groupSpace,
-            spawnedBy: params.spawnedBy,
-            senderId: params.senderId,
-            senderName: params.senderName,
-            senderUsername: params.senderUsername,
-            senderE164: params.senderE164,
-            senderIsOwner: params.senderIsOwner,
-            currentChannelId: params.currentChannelId,
-            currentThreadTs: params.currentThreadTs,
-            currentMessageId: params.currentMessageId,
-            replyToMode: params.replyToMode,
-            hasRepliedRef: params.hasRepliedRef,
-            sessionFile: params.sessionFile,
-            workspaceDir: resolvedWorkspace,
-            agentDir,
-            config: params.config,
-            allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-            contextEngine,
-            contextTokenBudget: ctxInfo.tokens,
-            skillsSnapshot: params.skillsSnapshot,
-            prompt,
-            images: params.images,
-            clientTools: params.clientTools,
-            disableTools: params.disableTools,
-            provider,
-            modelId,
-            model: applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
-            authProfileId: lastProfileId,
-            authProfileIdSource: lockedProfileId ? "user" : "auto",
-            authStorage,
-            modelRegistry,
-            agentId: workspaceResolution.agentId,
-            legacyBeforeAgentStartResult,
-            thinkLevel,
-            fastMode: params.fastMode,
-            verboseLevel: params.verboseLevel,
-            reasoningLevel: params.reasoningLevel,
-            toolResultFormat: resolvedToolResultFormat,
-            execOverrides: params.execOverrides,
-            bashElevated: params.bashElevated,
-            timeoutMs: params.timeoutMs,
-            runId: params.runId,
-            abortSignal: params.abortSignal,
-            shouldEmitToolResult: params.shouldEmitToolResult,
-            shouldEmitToolOutput: params.shouldEmitToolOutput,
-            onPartialReply: params.onPartialReply,
-            onAssistantMessageStart: params.onAssistantMessageStart,
-            onBlockReply: params.onBlockReply,
-            onBlockReplyFlush: params.onBlockReplyFlush,
-            blockReplyBreak: params.blockReplyBreak,
-            blockReplyChunking: params.blockReplyChunking,
-            onReasoningStream: params.onReasoningStream,
-            onReasoningEnd: params.onReasoningEnd,
-            onToolResult: params.onToolResult,
-            onAgentEvent: params.onAgentEvent,
-            extraSystemPrompt: params.extraSystemPrompt,
-            inputProvenance: params.inputProvenance,
-            streamParams: params.streamParams,
-            ownerNumbers: params.ownerNumbers,
-            enforceFinalTag: params.enforceFinalTag,
-            bootstrapPromptWarningSignaturesSeen,
-            bootstrapPromptWarningSignature:
-              bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
-          });
-
-          const {
-            aborted,
-            promptError,
-            timedOut,
-            timedOutDuringCompaction,
-            sessionIdUsed,
-            lastAssistant,
-          } = attempt;
-          bootstrapPromptWarningSignaturesSeen =
-            attempt.bootstrapPromptWarningSignaturesSeen ??
-            (attempt.bootstrapPromptWarningSignature
-              ? Array.from(
-                  new Set([
-                    ...bootstrapPromptWarningSignaturesSeen,
-                    attempt.bootstrapPromptWarningSignature,
-                  ]),
-                )
-              : bootstrapPromptWarningSignaturesSeen);
-          const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
-          const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
-          mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
-          // Keep prompt size from the latest model call so session totalTokens
-          // reflects current context usage, not accumulated tool-loop usage.
-          lastRunPromptUsage = lastAssistantUsage ?? attemptUsage;
-          lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
-          const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
-          autoCompactionCount += attemptCompactionCount;
-          const activeErrorContext = resolveActiveErrorContext({
-            lastAssistant,
-            provider,
-            model: modelId,
-          });
-          const formattedAssistantErrorText = lastAssistant
-            ? formatAssistantErrorText(lastAssistant, {
-                cfg: params.config,
-                sessionKey: params.sessionKey ?? params.sessionId,
-                provider: activeErrorContext.provider,
-                model: activeErrorContext.model,
-              })
-            : undefined;
-          const assistantErrorText =
-            lastAssistant?.stopReason === "error"
-              ? lastAssistant.errorMessage?.trim() || formattedAssistantErrorText
-              : undefined;
-
-          const contextOverflowError = !aborted
-            ? (() => {
-                if (promptError) {
-                  const errorText = describeUnknownError(promptError);
-                  if (isLikelyContextOverflowError(errorText)) {
-                    return { text: errorText, source: "promptError" as const };
+              refreshRuntimeAuth("scheduled")
+                .then(() => scheduleRuntimeAuthRefresh())
+                .catch(() => {
+                  if (runtimeAuthRefreshCancelled) {
+                    return;
                   }
-                  // Prompt submission failed with a non-overflow error. Do not
-                  // inspect prior assistant errors from history for this attempt.
-                  return null;
-                }
-                if (assistantErrorText && isLikelyContextOverflowError(assistantErrorText)) {
-                  return { text: assistantErrorText, source: "assistantError" as const };
-                }
-                return null;
-              })()
-            : null;
-
-          if (contextOverflowError) {
-            const overflowDiagId = createCompactionDiagId();
-            const errorText = contextOverflowError.text;
-            const msgCount = attempt.messagesSnapshot?.length ?? 0;
-            const observedOverflowTokens = extractObservedOverflowTokenCount(errorText);
-            log.warn(
-              `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
-                `provider=${provider}/${modelId} source=${contextOverflowError.source} ` +
-                `messages=${msgCount} sessionFile=${params.sessionFile} ` +
-                `diagId=${overflowDiagId} compactionAttempts=${overflowCompactionAttempts} ` +
-                `observedTokens=${observedOverflowTokens ?? "unknown"} ` +
-                `error=${errorText.slice(0, 200)}`,
-            );
-            const isCompactionFailure = isCompactionFailureError(errorText);
-            const hadAttemptLevelCompaction = attemptCompactionCount > 0;
-            // If this attempt already compacted (SDK auto-compaction), avoid immediately
-            // running another explicit compaction for the same overflow trigger.
-            if (
-              !isCompactionFailure &&
-              hadAttemptLevelCompaction &&
-              overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
-            ) {
-              overflowCompactionAttempts++;
-              log.warn(
-                `context overflow persisted after in-attempt compaction (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); retrying prompt without additional compaction for ${provider}/${modelId}`,
-              );
-              continue;
-            }
-            // Attempt explicit overflow compaction only when this attempt did not
-            // already auto-compact.
-            if (
-              !isCompactionFailure &&
-              !hadAttemptLevelCompaction &&
-              overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
-            ) {
-              if (log.isEnabled("debug")) {
-                log.debug(
-                  `[compaction-diag] decision diagId=${overflowDiagId} branch=compact ` +
-                    `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=unknown ` +
-                    `attempt=${overflowCompactionAttempts + 1} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
-                );
-              }
-              overflowCompactionAttempts++;
-              log.warn(
-                `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
-              );
-              let compactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
-              // When the engine owns compaction, hooks are not fired inside
-              // compactEmbeddedPiSessionDirect (which is bypassed).  Fire them
-              // here so subscribers (memory extensions, usage trackers) are
-              // notified even on overflow-recovery compactions.
-              const overflowEngineOwnsCompaction = contextEngine.info.ownsCompaction === true;
-              const overflowHookRunner = overflowEngineOwnsCompaction ? hookRunner : null;
-              if (overflowHookRunner?.hasHooks("before_compaction")) {
-                try {
-                  await overflowHookRunner.runBeforeCompaction(
-                    { messageCount: -1, sessionFile: params.sessionFile },
-                    hookCtx,
-                  );
-                } catch (hookErr) {
-                  log.warn(
-                    `before_compaction hook failed during overflow recovery: ${String(hookErr)}`,
-                  );
-                }
-              }
-              try {
-                const overflowCompactionRuntimeContext = {
-                  ...buildEmbeddedCompactionRuntimeContext({
-                    sessionKey: params.sessionKey,
-                    messageChannel: params.messageChannel,
-                    messageProvider: params.messageProvider,
-                    agentAccountId: params.agentAccountId,
-                    currentChannelId: params.currentChannelId,
-                    currentThreadTs: params.currentThreadTs,
-                    currentMessageId: params.currentMessageId,
-                    authProfileId: lastProfileId,
-                    workspaceDir: resolvedWorkspace,
-                    agentDir,
-                    config: params.config,
-                    skillsSnapshot: params.skillsSnapshot,
-                    senderIsOwner: params.senderIsOwner,
-                    senderId: params.senderId,
-                    provider,
-                    modelId,
-                    thinkLevel,
-                    reasoningLevel: params.reasoningLevel,
-                    bashElevated: params.bashElevated,
-                    extraSystemPrompt: params.extraSystemPrompt,
-                    ownerNumbers: params.ownerNumbers,
-                  }),
-                  runId: params.runId,
-                  trigger: "overflow",
-                  ...(observedOverflowTokens !== undefined
-                    ? { currentTokenCount: observedOverflowTokens }
-                    : {}),
-                  diagId: overflowDiagId,
-                  attempt: overflowCompactionAttempts,
-                  maxAttempts: MAX_OVERFLOW_COMPACTION_ATTEMPTS,
-                };
-                compactResult = await contextEngine.compact({
-                  sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
-                  sessionFile: params.sessionFile,
-                  tokenBudget: ctxInfo.tokens,
-                  ...(observedOverflowTokens !== undefined
-                    ? { currentTokenCount: observedOverflowTokens }
-                    : {}),
-                  force: true,
-                  compactionTarget: "budget",
-                  runtimeContext: overflowCompactionRuntimeContext,
+                  const retryTimer = setTimeout(() => {
+                    if (runtimeAuthRefreshCancelled) {
+                      return;
+                    }
+                    refreshRuntimeAuth("scheduled-retry")
+                      .then(() => scheduleRuntimeAuthRefresh())
+                      .catch(() => undefined);
+                  }, RUNTIME_AUTH_REFRESH_RETRY_MS);
+                  const activeRuntimeAuthState = runtimeAuthState;
+                  if (activeRuntimeAuthState) {
+                    activeRuntimeAuthState.refreshTimer = retryTimer;
+                  }
+                  if (runtimeAuthRefreshCancelled && activeRuntimeAuthState) {
+                    clearTimeout(retryTimer);
+                    activeRuntimeAuthState.refreshTimer = undefined;
+                  }
                 });
-                if (compactResult.ok && compactResult.compacted) {
-                  await runContextEngineMaintenance({
-                    contextEngine,
-                    sessionId: params.sessionId,
-                    sessionKey: params.sessionKey,
-                    sessionFile: params.sessionFile,
-                    reason: "compaction",
-                    runtimeContext: overflowCompactionRuntimeContext,
-                  });
-                }
-              } catch (compactErr) {
-                log.warn(
-                  `contextEngine.compact() threw during overflow recovery for ${provider}/${modelId}: ${String(compactErr)}`,
+            }, delayMs);
+            runtimeAuthState.refreshTimer = timer;
+            if (runtimeAuthRefreshCancelled) {
+              clearTimeout(timer);
+              runtimeAuthState.refreshTimer = undefined;
+            }
+          };
+
+          const resolveAuthProfileFailoverReason = (params: {
+            allInCooldown: boolean;
+            message: string;
+            profileIds?: Array<string | undefined>;
+          }): FailoverReason => {
+            if (params.allInCooldown) {
+              const profileIds = (params.profileIds ?? profileCandidates).filter(
+                (id): id is string => typeof id === "string" && id.length > 0,
+              );
+              return (
+                resolveProfilesUnavailableReason({
+                  store: authStore,
+                  profileIds,
+                }) ?? "unknown"
+              );
+            }
+            const classified = classifyFailoverReason(params.message);
+            return classified ?? "auth";
+          };
+
+          const throwAuthProfileFailover = (params: {
+            allInCooldown: boolean;
+            message?: string;
+            error?: unknown;
+          }): never => {
+            const fallbackMessage = `No available auth profile for ${provider} (all in cooldown or unavailable).`;
+            const message =
+              params.message?.trim() ||
+              (params.error ? describeUnknownError(params.error).trim() : "") ||
+              fallbackMessage;
+            const reason = resolveAuthProfileFailoverReason({
+              allInCooldown: params.allInCooldown,
+              message,
+              profileIds: profileCandidates,
+            });
+            if (fallbackConfigured) {
+              throw new FailoverError(message, {
+                reason,
+                provider,
+                model: modelId,
+                status: resolveFailoverStatus(reason),
+                cause: params.error,
+              });
+            }
+            if (params.error instanceof Error) {
+              throw params.error;
+            }
+            throw new Error(message);
+          };
+
+          const resolveApiKeyForCandidate = async (candidate?: string) => {
+            return getApiKeyForModel({
+              model: runtimeModel,
+              cfg: params.config,
+              profileId: candidate,
+              store: authStore,
+              agentDir,
+            });
+          };
+
+          const applyApiKeyInfo = async (candidate?: string): Promise<void> => {
+            apiKeyInfo = await resolveApiKeyForCandidate(candidate);
+            const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
+            if (!apiKeyInfo.apiKey) {
+              if (apiKeyInfo.mode !== "aws-sdk") {
+                throw new Error(
+                  `No API key resolved for provider "${runtimeModel.provider}" (auth mode: ${apiKeyInfo.mode}).`,
                 );
-                compactResult = { ok: false, compacted: false, reason: String(compactErr) };
               }
-              if (
-                compactResult.ok &&
-                compactResult.compacted &&
-                overflowHookRunner?.hasHooks("after_compaction")
-              ) {
-                try {
-                  await overflowHookRunner.runAfterCompaction(
-                    {
-                      messageCount: -1,
-                      compactedCount: -1,
-                      tokenCount: compactResult.result?.tokensAfter,
-                      sessionFile: params.sessionFile,
-                    },
-                    hookCtx,
-                  );
-                } catch (hookErr) {
-                  log.warn(
-                    `after_compaction hook failed during overflow recovery: ${String(hookErr)}`,
-                  );
-                }
+              lastProfileId = resolvedProfileId;
+              return;
+            }
+            let runtimeAuthHandled = false;
+            const preparedAuth = await prepareProviderRuntimeAuth({
+              provider: runtimeModel.provider,
+              config: params.config,
+              workspaceDir: resolvedWorkspace,
+              env: process.env,
+              context: {
+                config: params.config,
+                agentDir,
+                workspaceDir: resolvedWorkspace,
+                env: process.env,
+                provider: runtimeModel.provider,
+                modelId,
+                model: runtimeModel,
+                apiKey: apiKeyInfo.apiKey,
+                authMode: apiKeyInfo.mode,
+                profileId: apiKeyInfo.profileId,
+              },
+            });
+            if (preparedAuth?.baseUrl) {
+              runtimeModel = { ...runtimeModel, baseUrl: preparedAuth.baseUrl };
+              effectiveModel = { ...effectiveModel, baseUrl: preparedAuth.baseUrl };
+            }
+            if (preparedAuth?.apiKey) {
+              authStorage.setRuntimeApiKey(runtimeModel.provider, preparedAuth.apiKey);
+              runtimeAuthState = {
+                sourceApiKey: apiKeyInfo.apiKey,
+                authMode: apiKeyInfo.mode,
+                profileId: apiKeyInfo.profileId,
+                expiresAt: preparedAuth.expiresAt,
+              };
+              if (preparedAuth.expiresAt) {
+                scheduleRuntimeAuthRefresh();
               }
-              if (compactResult.compacted) {
-                autoCompactionCount += 1;
-                log.info(`auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`);
+              runtimeAuthHandled = true;
+            }
+            if (runtimeAuthHandled) {
+              // Plugin-owned runtime auth already stored the exchanged credential.
+            } else {
+              authStorage.setRuntimeApiKey(runtimeModel.provider, apiKeyInfo.apiKey);
+              runtimeAuthState = null;
+            }
+            lastProfileId = apiKeyInfo.profileId;
+          };
+
+          const advanceAuthProfile = async (): Promise<boolean> => {
+            if (lockedProfileId) {
+              return false;
+            }
+            let nextIndex = profileIndex + 1;
+            while (nextIndex < profileCandidates.length) {
+              const candidate = profileCandidates[nextIndex];
+              if (candidate && isProfileInCooldown(authStore, candidate)) {
+                nextIndex += 1;
                 continue;
               }
-              log.warn(
-                `auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
-              );
+              try {
+                await applyApiKeyInfo(candidate);
+                profileIndex = nextIndex;
+                thinkLevel = initialThinkLevel;
+                attemptedThinking.clear();
+                return true;
+              } catch (err) {
+                if (candidate && candidate === lockedProfileId) {
+                  throw err;
+                }
+                nextIndex += 1;
+              }
             }
-            // Fallback: try truncating oversized tool results in the session.
-            // This handles the case where a single tool result exceeds the
-            // context window and compaction cannot reduce it further.
-            if (!toolResultTruncationAttempted) {
-              const contextWindowTokens = ctxInfo.tokens;
-              const hasOversized = attempt.messagesSnapshot
-                ? sessionLikelyHasOversizedToolResults({
-                    messages: attempt.messagesSnapshot,
-                    contextWindowTokens,
-                  })
-                : false;
+            return false;
+          };
 
-              if (hasOversized) {
-                if (log.isEnabled("debug")) {
+          try {
+            const autoProfileCandidates = profileCandidates.filter(
+              (candidate): candidate is string =>
+                typeof candidate === "string" &&
+                candidate.length > 0 &&
+                candidate !== lockedProfileId,
+            );
+            const allAutoProfilesInCooldown =
+              autoProfileCandidates.length > 0 &&
+              autoProfileCandidates.every((candidate) => isProfileInCooldown(authStore, candidate));
+            const unavailableReason = allAutoProfilesInCooldown
+              ? (resolveProfilesUnavailableReason({
+                  store: authStore,
+                  profileIds: autoProfileCandidates,
+                }) ?? "unknown")
+              : null;
+            const allowTransientCooldownProbe =
+              params.allowTransientCooldownProbe === true &&
+              allAutoProfilesInCooldown &&
+              shouldAllowCooldownProbeForReason(unavailableReason);
+            let didTransientCooldownProbe = false;
+
+            while (profileIndex < profileCandidates.length) {
+              const candidate = profileCandidates[profileIndex];
+              const inCooldown =
+                candidate &&
+                candidate !== lockedProfileId &&
+                isProfileInCooldown(authStore, candidate);
+              if (inCooldown) {
+                if (allowTransientCooldownProbe && !didTransientCooldownProbe) {
+                  didTransientCooldownProbe = true;
+                  log.warn(
+                    `probing cooldowned auth profile for ${provider}/${modelId} due to ${unavailableReason ?? "transient"} unavailability`,
+                  );
+                } else {
+                  profileIndex += 1;
+                  continue;
+                }
+              }
+              await applyApiKeyInfo(profileCandidates[profileIndex]);
+              break;
+            }
+            if (profileIndex >= profileCandidates.length) {
+              throwAuthProfileFailover({ allInCooldown: true });
+            }
+          } catch (err) {
+            if (err instanceof FailoverError) {
+              throw err;
+            }
+            if (profileCandidates[profileIndex] === lockedProfileId) {
+              throwAuthProfileFailover({ allInCooldown: false, error: err });
+            }
+            const advanced = await advanceAuthProfile();
+            if (!advanced) {
+              throwAuthProfileFailover({ allInCooldown: false, error: err });
+            }
+          }
+
+          const maybeRefreshRuntimeAuthForAuthError = async (
+            errorText: string,
+            retried: boolean,
+          ): Promise<boolean> => {
+            if (!runtimeAuthState || retried) {
+              return false;
+            }
+            if (!isFailoverErrorMessage(errorText)) {
+              return false;
+            }
+            if (classifyFailoverReason(errorText) !== "auth") {
+              return false;
+            }
+            try {
+              await refreshRuntimeAuth("auth-error");
+              scheduleRuntimeAuthRefresh();
+              return true;
+            } catch {
+              return false;
+            }
+          };
+
+          const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
+          const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
+          let overflowCompactionAttempts = 0;
+          let toolResultTruncationAttempted = false;
+          let bootstrapPromptWarningSignaturesSeen =
+            params.bootstrapPromptWarningSignaturesSeen ??
+            (params.bootstrapPromptWarningSignature
+              ? [params.bootstrapPromptWarningSignature]
+              : []);
+          const usageAccumulator = createUsageAccumulator();
+          let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
+          let autoCompactionCount = 0;
+          let runLoopIterations = 0;
+          let overloadFailoverAttempts = 0;
+          const maybeMarkAuthProfileFailure = async (failure: {
+            profileId?: string;
+            reason?: AuthProfileFailureReason | null;
+            config?: RunEmbeddedPiAgentParams["config"];
+            agentDir?: RunEmbeddedPiAgentParams["agentDir"];
+          }) => {
+            const { profileId, reason } = failure;
+            if (!profileId || !reason || reason === "timeout") {
+              return;
+            }
+            await markAuthProfileFailure({
+              store: authStore,
+              profileId,
+              reason,
+              cfg: params.config,
+              agentDir,
+              runId: params.runId,
+            });
+          };
+          const resolveAuthProfileFailureReason = (
+            failoverReason: FailoverReason | null,
+          ): AuthProfileFailureReason | null => {
+            // Timeouts are transport/model-path failures, not auth health signals,
+            // so they should not persist auth-profile failure state.
+            if (!failoverReason || failoverReason === "timeout") {
+              return null;
+            }
+            return failoverReason;
+          };
+          const maybeBackoffBeforeOverloadFailover = async (reason: FailoverReason | null) => {
+            if (reason !== "overloaded") {
+              return;
+            }
+            overloadFailoverAttempts += 1;
+            const delayMs = computeBackoff(
+              OVERLOAD_FAILOVER_BACKOFF_POLICY,
+              overloadFailoverAttempts,
+            );
+            log.warn(
+              `overload backoff before failover for ${provider}/${modelId}: attempt=${overloadFailoverAttempts} delayMs=${delayMs}`,
+            );
+            try {
+              await sleepWithAbort(delayMs, params.abortSignal);
+            } catch (err) {
+              if (params.abortSignal?.aborted) {
+                const abortErr = new Error("Operation aborted", { cause: err });
+                abortErr.name = "AbortError";
+                throw abortErr;
+              }
+              throw err;
+            }
+          };
+          // Resolve the context engine once and reuse across retries to avoid
+          // repeated initialization/connection overhead per attempt.
+          ensureContextEnginesInitialized();
+          const contextEngine = await resolveContextEngine(params.config);
+          try {
+            let authRetryPending = false;
+            // Hoisted so the retry-limit error path can use the most recent API total.
+            let lastTurnTotal: number | undefined;
+            while (true) {
+              if (runLoopIterations >= MAX_RUN_LOOP_ITERATIONS) {
+                const message =
+                  `Exceeded retry limit after ${runLoopIterations} attempts ` +
+                  `(max=${MAX_RUN_LOOP_ITERATIONS}).`;
+                log.error(
+                  `[run-retry-limit] sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                    `provider=${provider}/${modelId} attempts=${runLoopIterations} ` +
+                    `maxAttempts=${MAX_RUN_LOOP_ITERATIONS}`,
+                );
+                return {
+                  payloads: [
+                    {
+                      text:
+                        "Request failed after repeated internal retries. " +
+                        "Please try again, or use /new to start a fresh session.",
+                      isError: true,
+                    },
+                  ],
+                  meta: {
+                    durationMs: Date.now() - started,
+                    agentMeta: buildErrorAgentMeta({
+                      sessionId: params.sessionId,
+                      provider,
+                      model: model.id,
+                      usageAccumulator,
+                      lastRunPromptUsage,
+                      lastTurnTotal,
+                    }),
+                    error: { kind: "retry_limit", message },
+                  },
+                };
+              }
+              runLoopIterations += 1;
+              const runtimeAuthRetry = authRetryPending;
+              authRetryPending = false;
+              attemptedThinking.add(thinkLevel);
+              await fs.mkdir(resolvedWorkspace, { recursive: true });
+
+              const prompt =
+                provider === "anthropic"
+                  ? scrubAnthropicRefusalMagic(params.prompt)
+                  : params.prompt;
+
+              const attempt = await runEmbeddedAttempt({
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                trigger: params.trigger,
+                memoryFlushWritePath: params.memoryFlushWritePath,
+                messageChannel: params.messageChannel,
+                messageProvider: params.messageProvider,
+                agentAccountId: params.agentAccountId,
+                messageTo: params.messageTo,
+                messageThreadId: params.messageThreadId,
+                groupId: params.groupId,
+                groupChannel: params.groupChannel,
+                groupSpace: params.groupSpace,
+                spawnedBy: params.spawnedBy,
+                senderId: params.senderId,
+                senderName: params.senderName,
+                senderUsername: params.senderUsername,
+                senderE164: params.senderE164,
+                senderIsOwner: params.senderIsOwner,
+                currentChannelId: params.currentChannelId,
+                currentThreadTs: params.currentThreadTs,
+                currentMessageId: params.currentMessageId,
+                replyToMode: params.replyToMode,
+                hasRepliedRef: params.hasRepliedRef,
+                sessionFile: params.sessionFile,
+                workspaceDir: resolvedWorkspace,
+                agentDir,
+                config: params.config,
+                allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+                contextEngine,
+                contextTokenBudget: ctxInfo.tokens,
+                skillsSnapshot: params.skillsSnapshot,
+                prompt,
+                images: params.images,
+                clientTools: params.clientTools,
+                disableTools: params.disableTools,
+                provider,
+                modelId,
+                model: applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
+                authProfileId: lastProfileId,
+                authProfileIdSource: lockedProfileId ? "user" : "auto",
+                authStorage,
+                modelRegistry,
+                agentId: workspaceResolution.agentId,
+                legacyBeforeAgentStartResult,
+                thinkLevel,
+                fastMode: params.fastMode,
+                verboseLevel: params.verboseLevel,
+                reasoningLevel: params.reasoningLevel,
+                toolResultFormat: resolvedToolResultFormat,
+                execOverrides: params.execOverrides,
+                bashElevated: params.bashElevated,
+                timeoutMs: params.timeoutMs,
+                runId: params.runId,
+                abortSignal: params.abortSignal,
+                shouldEmitToolResult: params.shouldEmitToolResult,
+                shouldEmitToolOutput: params.shouldEmitToolOutput,
+                onPartialReply: params.onPartialReply,
+                onAssistantMessageStart: params.onAssistantMessageStart,
+                onBlockReply: params.onBlockReply,
+                onBlockReplyFlush: params.onBlockReplyFlush,
+                blockReplyBreak: params.blockReplyBreak,
+                blockReplyChunking: params.blockReplyChunking,
+                onReasoningStream: params.onReasoningStream,
+                onReasoningEnd: params.onReasoningEnd,
+                onToolResult: params.onToolResult,
+                onAgentEvent: params.onAgentEvent,
+                extraSystemPrompt: params.extraSystemPrompt,
+                inputProvenance: params.inputProvenance,
+                streamParams: params.streamParams,
+                ownerNumbers: params.ownerNumbers,
+                enforceFinalTag: params.enforceFinalTag,
+                bootstrapPromptWarningSignaturesSeen,
+                bootstrapPromptWarningSignature:
+                  bootstrapPromptWarningSignaturesSeen[
+                    bootstrapPromptWarningSignaturesSeen.length - 1
+                  ],
+              });
+
+              const {
+                aborted,
+                promptError,
+                timedOut,
+                timedOutDuringCompaction,
+                sessionIdUsed,
+                lastAssistant,
+              } = attempt;
+              bootstrapPromptWarningSignaturesSeen =
+                attempt.bootstrapPromptWarningSignaturesSeen ??
+                (attempt.bootstrapPromptWarningSignature
+                  ? Array.from(
+                      new Set([
+                        ...bootstrapPromptWarningSignaturesSeen,
+                        attempt.bootstrapPromptWarningSignature,
+                      ]),
+                    )
+                  : bootstrapPromptWarningSignaturesSeen);
+              const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
+              const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
+              mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
+              // Keep prompt size from the latest model call so session totalTokens
+              // reflects current context usage, not accumulated tool-loop usage.
+              lastRunPromptUsage = lastAssistantUsage ?? attemptUsage;
+              lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
+              const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
+              autoCompactionCount += attemptCompactionCount;
+              const activeErrorContext = resolveActiveErrorContext({
+                lastAssistant,
+                provider,
+                model: modelId,
+              });
+              const formattedAssistantErrorText = lastAssistant
+                ? formatAssistantErrorText(lastAssistant, {
+                    cfg: params.config,
+                    sessionKey: params.sessionKey ?? params.sessionId,
+                    provider: activeErrorContext.provider,
+                    model: activeErrorContext.model,
+                  })
+                : undefined;
+              const assistantErrorText =
+                lastAssistant?.stopReason === "error"
+                  ? lastAssistant.errorMessage?.trim() || formattedAssistantErrorText
+                  : undefined;
+
+              const contextOverflowError = !aborted
+                ? (() => {
+                    if (promptError) {
+                      const errorText = describeUnknownError(promptError);
+                      if (isLikelyContextOverflowError(errorText)) {
+                        return { text: errorText, source: "promptError" as const };
+                      }
+                      // Prompt submission failed with a non-overflow error. Do not
+                      // inspect prior assistant errors from history for this attempt.
+                      return null;
+                    }
+                    if (assistantErrorText && isLikelyContextOverflowError(assistantErrorText)) {
+                      return { text: assistantErrorText, source: "assistantError" as const };
+                    }
+                    return null;
+                  })()
+                : null;
+
+              if (contextOverflowError) {
+                const overflowDiagId = createCompactionDiagId();
+                const errorText = contextOverflowError.text;
+                const msgCount = attempt.messagesSnapshot?.length ?? 0;
+                const observedOverflowTokens = extractObservedOverflowTokenCount(errorText);
+                log.warn(
+                  `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                    `provider=${provider}/${modelId} source=${contextOverflowError.source} ` +
+                    `messages=${msgCount} sessionFile=${params.sessionFile} ` +
+                    `diagId=${overflowDiagId} compactionAttempts=${overflowCompactionAttempts} ` +
+                    `observedTokens=${observedOverflowTokens ?? "unknown"} ` +
+                    `error=${errorText.slice(0, 200)}`,
+                );
+                const isCompactionFailure = isCompactionFailureError(errorText);
+                const hadAttemptLevelCompaction = attemptCompactionCount > 0;
+                // If this attempt already compacted (SDK auto-compaction), avoid immediately
+                // running another explicit compaction for the same overflow trigger.
+                if (
+                  !isCompactionFailure &&
+                  hadAttemptLevelCompaction &&
+                  overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
+                ) {
+                  overflowCompactionAttempts++;
+                  log.warn(
+                    `context overflow persisted after in-attempt compaction (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); retrying prompt without additional compaction for ${provider}/${modelId}`,
+                  );
+                  continue;
+                }
+                // Attempt explicit overflow compaction only when this attempt did not
+                // already auto-compact.
+                if (
+                  !isCompactionFailure &&
+                  !hadAttemptLevelCompaction &&
+                  overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
+                ) {
+                  if (log.isEnabled("debug")) {
+                    log.debug(
+                      `[compaction-diag] decision diagId=${overflowDiagId} branch=compact ` +
+                        `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=unknown ` +
+                        `attempt=${overflowCompactionAttempts + 1} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
+                    );
+                  }
+                  overflowCompactionAttempts++;
+                  log.warn(
+                    `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
+                  );
+                  let compactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
+                  // When the engine owns compaction, hooks are not fired inside
+                  // compactEmbeddedPiSessionDirect (which is bypassed).  Fire them
+                  // here so subscribers (memory extensions, usage trackers) are
+                  // notified even on overflow-recovery compactions.
+                  const overflowEngineOwnsCompaction = contextEngine.info.ownsCompaction === true;
+                  const overflowHookRunner = overflowEngineOwnsCompaction ? hookRunner : null;
+                  if (overflowHookRunner?.hasHooks("before_compaction")) {
+                    try {
+                      await overflowHookRunner.runBeforeCompaction(
+                        { messageCount: -1, sessionFile: params.sessionFile },
+                        hookCtx,
+                      );
+                    } catch (hookErr) {
+                      log.warn(
+                        `before_compaction hook failed during overflow recovery: ${String(hookErr)}`,
+                      );
+                    }
+                  }
+                  try {
+                    const overflowCompactionRuntimeContext = {
+                      ...buildEmbeddedCompactionRuntimeContext({
+                        sessionKey: params.sessionKey,
+                        messageChannel: params.messageChannel,
+                        messageProvider: params.messageProvider,
+                        agentAccountId: params.agentAccountId,
+                        currentChannelId: params.currentChannelId,
+                        currentThreadTs: params.currentThreadTs,
+                        currentMessageId: params.currentMessageId,
+                        authProfileId: lastProfileId,
+                        workspaceDir: resolvedWorkspace,
+                        agentDir,
+                        config: params.config,
+                        skillsSnapshot: params.skillsSnapshot,
+                        senderIsOwner: params.senderIsOwner,
+                        senderId: params.senderId,
+                        provider,
+                        modelId,
+                        thinkLevel,
+                        reasoningLevel: params.reasoningLevel,
+                        bashElevated: params.bashElevated,
+                        extraSystemPrompt: params.extraSystemPrompt,
+                        ownerNumbers: params.ownerNumbers,
+                      }),
+                      runId: params.runId,
+                      trigger: "overflow",
+                      ...(observedOverflowTokens !== undefined
+                        ? { currentTokenCount: observedOverflowTokens }
+                        : {}),
+                      diagId: overflowDiagId,
+                      attempt: overflowCompactionAttempts,
+                      maxAttempts: MAX_OVERFLOW_COMPACTION_ATTEMPTS,
+                    };
+                    compactResult = await contextEngine.compact({
+                      sessionId: params.sessionId,
+                      sessionKey: params.sessionKey,
+                      sessionFile: params.sessionFile,
+                      tokenBudget: ctxInfo.tokens,
+                      ...(observedOverflowTokens !== undefined
+                        ? { currentTokenCount: observedOverflowTokens }
+                        : {}),
+                      force: true,
+                      compactionTarget: "budget",
+                      runtimeContext: overflowCompactionRuntimeContext,
+                    });
+                    if (compactResult.ok && compactResult.compacted) {
+                      await runContextEngineMaintenance({
+                        contextEngine,
+                        sessionId: params.sessionId,
+                        sessionKey: params.sessionKey,
+                        sessionFile: params.sessionFile,
+                        reason: "compaction",
+                        runtimeContext: overflowCompactionRuntimeContext,
+                      });
+                    }
+                  } catch (compactErr) {
+                    log.warn(
+                      `contextEngine.compact() threw during overflow recovery for ${provider}/${modelId}: ${String(compactErr)}`,
+                    );
+                    compactResult = { ok: false, compacted: false, reason: String(compactErr) };
+                  }
+                  if (
+                    compactResult.ok &&
+                    compactResult.compacted &&
+                    overflowHookRunner?.hasHooks("after_compaction")
+                  ) {
+                    try {
+                      await overflowHookRunner.runAfterCompaction(
+                        {
+                          messageCount: -1,
+                          compactedCount: -1,
+                          tokenCount: compactResult.result?.tokensAfter,
+                          sessionFile: params.sessionFile,
+                        },
+                        hookCtx,
+                      );
+                    } catch (hookErr) {
+                      log.warn(
+                        `after_compaction hook failed during overflow recovery: ${String(hookErr)}`,
+                      );
+                    }
+                  }
+                  if (compactResult.compacted) {
+                    autoCompactionCount += 1;
+                    log.info(
+                      `auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`,
+                    );
+                    continue;
+                  }
+                  log.warn(
+                    `auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
+                  );
+                }
+                // Fallback: try truncating oversized tool results in the session.
+                // This handles the case where a single tool result exceeds the
+                // context window and compaction cannot reduce it further.
+                if (!toolResultTruncationAttempted) {
+                  const contextWindowTokens = ctxInfo.tokens;
+                  const hasOversized = attempt.messagesSnapshot
+                    ? sessionLikelyHasOversizedToolResults({
+                        messages: attempt.messagesSnapshot,
+                        contextWindowTokens,
+                      })
+                    : false;
+
+                  if (hasOversized) {
+                    if (log.isEnabled("debug")) {
+                      log.debug(
+                        `[compaction-diag] decision diagId=${overflowDiagId} branch=truncate_tool_results ` +
+                          `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=${hasOversized} ` +
+                          `attempt=${overflowCompactionAttempts} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
+                      );
+                    }
+                    toolResultTruncationAttempted = true;
+                    log.warn(
+                      `[context-overflow-recovery] Attempting tool result truncation for ${provider}/${modelId} ` +
+                        `(contextWindow=${contextWindowTokens} tokens)`,
+                    );
+                    const truncResult = await truncateOversizedToolResultsInSession({
+                      sessionFile: params.sessionFile,
+                      contextWindowTokens,
+                      sessionId: params.sessionId,
+                      sessionKey: params.sessionKey,
+                    });
+                    if (truncResult.truncated) {
+                      log.info(
+                        `[context-overflow-recovery] Truncated ${truncResult.truncatedCount} tool result(s); retrying prompt`,
+                      );
+                      // Do NOT reset overflowCompactionAttempts here — the global cap must remain
+                      // enforced across all iterations to prevent unbounded compaction cycles (OC-65).
+                      continue;
+                    }
+                    log.warn(
+                      `[context-overflow-recovery] Tool result truncation did not help: ${truncResult.reason ?? "unknown"}`,
+                    );
+                  } else if (log.isEnabled("debug")) {
+                    log.debug(
+                      `[compaction-diag] decision diagId=${overflowDiagId} branch=give_up ` +
+                        `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=${hasOversized} ` +
+                        `attempt=${overflowCompactionAttempts} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
+                    );
+                  }
+                }
+                if (
+                  (isCompactionFailure ||
+                    overflowCompactionAttempts >= MAX_OVERFLOW_COMPACTION_ATTEMPTS ||
+                    toolResultTruncationAttempted) &&
+                  log.isEnabled("debug")
+                ) {
                   log.debug(
-                    `[compaction-diag] decision diagId=${overflowDiagId} branch=truncate_tool_results ` +
-                      `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=${hasOversized} ` +
+                    `[compaction-diag] decision diagId=${overflowDiagId} branch=give_up ` +
+                      `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=unknown ` +
                       `attempt=${overflowCompactionAttempts} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
                   );
                 }
-                toolResultTruncationAttempted = true;
-                log.warn(
-                  `[context-overflow-recovery] Attempting tool result truncation for ${provider}/${modelId} ` +
-                    `(contextWindow=${contextWindowTokens} tokens)`,
-                );
-                const truncResult = await truncateOversizedToolResultsInSession({
-                  sessionFile: params.sessionFile,
-                  contextWindowTokens,
-                  sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
+                const kind = isCompactionFailure ? "compaction_failure" : "context_overflow";
+                return {
+                  payloads: [
+                    {
+                      text:
+                        "Context overflow: prompt too large for the model. " +
+                        "Try /reset (or /new) to start a fresh session, or use a larger-context model.",
+                      isError: true,
+                    },
+                  ],
+                  meta: {
+                    durationMs: Date.now() - started,
+                    agentMeta: buildErrorAgentMeta({
+                      sessionId: sessionIdUsed,
+                      provider,
+                      model: model.id,
+                      usageAccumulator,
+                      lastRunPromptUsage,
+                      lastAssistant,
+                      lastTurnTotal,
+                    }),
+                    systemPromptReport: attempt.systemPromptReport,
+                    error: { kind, message: errorText },
+                  },
+                };
+              }
+
+              if (promptError && !aborted) {
+                // Normalize wrapped errors (e.g. abort-wrapped RESOURCE_EXHAUSTED) into
+                // FailoverError so rate-limit classification works even for nested shapes.
+                const normalizedPromptFailover = coerceToFailoverError(promptError, {
+                  provider: activeErrorContext.provider,
+                  model: activeErrorContext.model,
+                  profileId: lastProfileId,
                 });
-                if (truncResult.truncated) {
-                  log.info(
-                    `[context-overflow-recovery] Truncated ${truncResult.truncatedCount} tool result(s); retrying prompt`,
-                  );
-                  // Do NOT reset overflowCompactionAttempts here — the global cap must remain
-                  // enforced across all iterations to prevent unbounded compaction cycles (OC-65).
+                const promptErrorDetails = normalizedPromptFailover
+                  ? describeFailoverError(normalizedPromptFailover)
+                  : describeFailoverError(promptError);
+                const errorText = promptErrorDetails.message || describeUnknownError(promptError);
+                if (await maybeRefreshRuntimeAuthForAuthError(errorText, runtimeAuthRetry)) {
+                  authRetryPending = true;
                   continue;
                 }
-                log.warn(
-                  `[context-overflow-recovery] Tool result truncation did not help: ${truncResult.reason ?? "unknown"}`,
-                );
-              } else if (log.isEnabled("debug")) {
-                log.debug(
-                  `[compaction-diag] decision diagId=${overflowDiagId} branch=give_up ` +
-                    `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=${hasOversized} ` +
-                    `attempt=${overflowCompactionAttempts} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
-                );
-              }
-            }
-            if (
-              (isCompactionFailure ||
-                overflowCompactionAttempts >= MAX_OVERFLOW_COMPACTION_ATTEMPTS ||
-                toolResultTruncationAttempted) &&
-              log.isEnabled("debug")
-            ) {
-              log.debug(
-                `[compaction-diag] decision diagId=${overflowDiagId} branch=give_up ` +
-                  `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=unknown ` +
-                  `attempt=${overflowCompactionAttempts} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
-              );
-            }
-            const kind = isCompactionFailure ? "compaction_failure" : "context_overflow";
-            return {
-              payloads: [
-                {
-                  text:
-                    "Context overflow: prompt too large for the model. " +
-                    "Try /reset (or /new) to start a fresh session, or use a larger-context model.",
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta: buildErrorAgentMeta({
-                  sessionId: sessionIdUsed,
-                  provider,
-                  model: model.id,
-                  usageAccumulator,
-                  lastRunPromptUsage,
-                  lastAssistant,
-                  lastTurnTotal,
-                }),
-                systemPromptReport: attempt.systemPromptReport,
-                error: { kind, message: errorText },
-              },
-            };
-          }
-
-          if (promptError && !aborted) {
-            // Normalize wrapped errors (e.g. abort-wrapped RESOURCE_EXHAUSTED) into
-            // FailoverError so rate-limit classification works even for nested shapes.
-            const normalizedPromptFailover = coerceToFailoverError(promptError, {
-              provider: activeErrorContext.provider,
-              model: activeErrorContext.model,
-              profileId: lastProfileId,
-            });
-            const promptErrorDetails = normalizedPromptFailover
-              ? describeFailoverError(normalizedPromptFailover)
-              : describeFailoverError(promptError);
-            const errorText = promptErrorDetails.message || describeUnknownError(promptError);
-            if (await maybeRefreshRuntimeAuthForAuthError(errorText, runtimeAuthRetry)) {
-              authRetryPending = true;
-              continue;
-            }
-            // Handle role ordering errors with a user-friendly message
-            if (/incorrect role information|roles must alternate/i.test(errorText)) {
-              return {
-                payloads: [
-                  {
-                    text:
-                      "Message ordering conflict - please try again. " +
-                      "If this persists, use /new to start a fresh session.",
-                    isError: true,
-                  },
-                ],
-                meta: {
-                  durationMs: Date.now() - started,
-                  agentMeta: buildErrorAgentMeta({
-                    sessionId: sessionIdUsed,
-                    provider,
-                    model: model.id,
-                    usageAccumulator,
-                    lastRunPromptUsage,
-                    lastAssistant,
-                    lastTurnTotal,
-                  }),
-                  systemPromptReport: attempt.systemPromptReport,
-                  error: { kind: "role_ordering", message: errorText },
-                },
-              };
-            }
-            // Handle image size errors with a user-friendly message (no retry needed)
-            const imageSizeError = parseImageSizeError(errorText);
-            if (imageSizeError) {
-              const maxMb = imageSizeError.maxMb;
-              const maxMbLabel =
-                typeof maxMb === "number" && Number.isFinite(maxMb) ? `${maxMb}` : null;
-              const maxBytesHint = maxMbLabel ? ` (max ${maxMbLabel}MB)` : "";
-              return {
-                payloads: [
-                  {
-                    text:
-                      `Image too large for the model${maxBytesHint}. ` +
-                      "Please compress or resize the image and try again.",
-                    isError: true,
-                  },
-                ],
-                meta: {
-                  durationMs: Date.now() - started,
-                  agentMeta: buildErrorAgentMeta({
-                    sessionId: sessionIdUsed,
-                    provider,
-                    model: model.id,
-                    usageAccumulator,
-                    lastRunPromptUsage,
-                    lastAssistant,
-                    lastTurnTotal,
-                  }),
-                  systemPromptReport: attempt.systemPromptReport,
-                  error: { kind: "image_size", message: errorText },
-                },
-              };
-            }
-            const promptFailoverReason =
-              promptErrorDetails.reason ?? classifyFailoverReason(errorText);
-            const promptProfileFailureReason =
-              resolveAuthProfileFailureReason(promptFailoverReason);
-            await maybeMarkAuthProfileFailure({
-              profileId: lastProfileId,
-              reason: promptProfileFailureReason,
-            });
-            const promptFailoverFailure =
-              promptFailoverReason !== null || isFailoverErrorMessage(errorText);
-            // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
-            const failedPromptProfileId = lastProfileId;
-            const logPromptFailoverDecision = createFailoverDecisionLogger({
-              stage: "prompt",
-              runId: params.runId,
-              rawError: errorText,
-              failoverReason: promptFailoverReason,
-              profileFailureReason: promptProfileFailureReason,
-              provider,
-              model: modelId,
-              profileId: failedPromptProfileId,
-              fallbackConfigured,
-              aborted,
-            });
-            if (
-              promptFailoverFailure &&
-              promptFailoverReason !== "timeout" &&
-              (await advanceAuthProfile())
-            ) {
-              logPromptFailoverDecision("rotate_profile");
-              await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
-              continue;
-            }
-            const fallbackThinking = pickFallbackThinkingLevel({
-              message: errorText,
-              attempted: attemptedThinking,
-            });
-            if (fallbackThinking) {
-              log.warn(
-                `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
-              );
-              thinkLevel = fallbackThinking;
-              continue;
-            }
-            // Throw FailoverError for prompt-side failover reasons when fallbacks
-            // are configured so outer model fallback can continue on overload,
-            // rate-limit, auth, or billing failures.
-            if (fallbackConfigured && promptFailoverFailure) {
-              const status = resolveFailoverStatus(promptFailoverReason ?? "unknown");
-              logPromptFailoverDecision("fallback_model", { status });
-              await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
-              throw (
-                normalizedPromptFailover ??
-                new FailoverError(errorText, {
-                  reason: promptFailoverReason ?? "unknown",
+                // Handle role ordering errors with a user-friendly message
+                if (/incorrect role information|roles must alternate/i.test(errorText)) {
+                  return {
+                    payloads: [
+                      {
+                        text:
+                          "Message ordering conflict - please try again. " +
+                          "If this persists, use /new to start a fresh session.",
+                        isError: true,
+                      },
+                    ],
+                    meta: {
+                      durationMs: Date.now() - started,
+                      agentMeta: buildErrorAgentMeta({
+                        sessionId: sessionIdUsed,
+                        provider,
+                        model: model.id,
+                        usageAccumulator,
+                        lastRunPromptUsage,
+                        lastAssistant,
+                        lastTurnTotal,
+                      }),
+                      systemPromptReport: attempt.systemPromptReport,
+                      error: { kind: "role_ordering", message: errorText },
+                    },
+                  };
+                }
+                // Handle image size errors with a user-friendly message (no retry needed)
+                const imageSizeError = parseImageSizeError(errorText);
+                if (imageSizeError) {
+                  const maxMb = imageSizeError.maxMb;
+                  const maxMbLabel =
+                    typeof maxMb === "number" && Number.isFinite(maxMb) ? `${maxMb}` : null;
+                  const maxBytesHint = maxMbLabel ? ` (max ${maxMbLabel}MB)` : "";
+                  return {
+                    payloads: [
+                      {
+                        text:
+                          `Image too large for the model${maxBytesHint}. ` +
+                          "Please compress or resize the image and try again.",
+                        isError: true,
+                      },
+                    ],
+                    meta: {
+                      durationMs: Date.now() - started,
+                      agentMeta: buildErrorAgentMeta({
+                        sessionId: sessionIdUsed,
+                        provider,
+                        model: model.id,
+                        usageAccumulator,
+                        lastRunPromptUsage,
+                        lastAssistant,
+                        lastTurnTotal,
+                      }),
+                      systemPromptReport: attempt.systemPromptReport,
+                      error: { kind: "image_size", message: errorText },
+                    },
+                  };
+                }
+                const promptFailoverReason =
+                  promptErrorDetails.reason ?? classifyFailoverReason(errorText);
+                const promptProfileFailureReason =
+                  resolveAuthProfileFailureReason(promptFailoverReason);
+                await maybeMarkAuthProfileFailure({
+                  profileId: lastProfileId,
+                  reason: promptProfileFailureReason,
+                });
+                const promptFailoverFailure =
+                  promptFailoverReason !== null || isFailoverErrorMessage(errorText);
+                // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
+                const failedPromptProfileId = lastProfileId;
+                const logPromptFailoverDecision = createFailoverDecisionLogger({
+                  stage: "prompt",
+                  runId: params.runId,
+                  rawError: errorText,
+                  failoverReason: promptFailoverReason,
+                  profileFailureReason: promptProfileFailureReason,
                   provider,
                   model: modelId,
-                  profileId: lastProfileId,
-                  status: resolveFailoverStatus(promptFailoverReason ?? "unknown"),
-                })
-              );
-            }
-            if (promptFailoverFailure || promptFailoverReason) {
-              logPromptFailoverDecision("surface_error");
-            }
-            throw promptError;
-          }
-
-          const fallbackThinking = pickFallbackThinkingLevel({
-            message: lastAssistant?.errorMessage,
-            attempted: attemptedThinking,
-          });
-          if (fallbackThinking && !aborted) {
-            log.warn(
-              `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
-            );
-            thinkLevel = fallbackThinking;
-            continue;
-          }
-
-          const authFailure = isAuthAssistantError(lastAssistant);
-          const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
-          const billingFailure = isBillingAssistantError(lastAssistant);
-          const failoverFailure = isFailoverAssistantError(lastAssistant);
-          const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
-          const assistantProfileFailureReason =
-            resolveAuthProfileFailureReason(assistantFailoverReason);
-          const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
-          const imageDimensionError = parseImageDimensionError(lastAssistant?.errorMessage ?? "");
-          // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
-          const failedAssistantProfileId = lastProfileId;
-          const logAssistantFailoverDecision = createFailoverDecisionLogger({
-            stage: "assistant",
-            runId: params.runId,
-            rawError: lastAssistant?.errorMessage?.trim(),
-            failoverReason: assistantFailoverReason,
-            profileFailureReason: assistantProfileFailureReason,
-            provider: activeErrorContext.provider,
-            model: activeErrorContext.model,
-            profileId: failedAssistantProfileId,
-            fallbackConfigured,
-            timedOut,
-            aborted,
-          });
-
-          if (
-            authFailure &&
-            (await maybeRefreshRuntimeAuthForAuthError(
-              lastAssistant?.errorMessage ?? "",
-              runtimeAuthRetry,
-            ))
-          ) {
-            authRetryPending = true;
-            continue;
-          }
-          if (imageDimensionError && lastProfileId) {
-            const details = [
-              imageDimensionError.messageIndex !== undefined
-                ? `message=${imageDimensionError.messageIndex}`
-                : null,
-              imageDimensionError.contentIndex !== undefined
-                ? `content=${imageDimensionError.contentIndex}`
-                : null,
-              imageDimensionError.maxDimensionPx !== undefined
-                ? `limit=${imageDimensionError.maxDimensionPx}px`
-                : null,
-            ]
-              .filter(Boolean)
-              .join(" ");
-            log.warn(
-              `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
-            );
-          }
-
-          // Rotate on timeout to try another account/model path in this turn,
-          // but exclude post-prompt compaction timeouts (model succeeded; no profile issue).
-          const shouldRotate =
-            (!aborted && failoverFailure) || (timedOut && !timedOutDuringCompaction);
-
-          if (shouldRotate) {
-            if (lastProfileId) {
-              const reason = timedOut ? "timeout" : assistantProfileFailureReason;
-              // Skip cooldown for timeouts: a timeout is model/network-specific,
-              // not an auth issue. Marking the profile would poison fallback models
-              // on the same provider (e.g. gpt-5.3 timeout blocks gpt-5.2).
-              await maybeMarkAuthProfileFailure({
-                profileId: lastProfileId,
-                reason,
-              });
-              if (timedOut && !isProbeSession) {
-                log.warn(`Profile ${lastProfileId} timed out. Trying next account...`);
-              }
-              if (cloudCodeAssistFormatError) {
-                log.warn(
-                  `Profile ${lastProfileId} hit Cloud Code Assist format error. Tool calls will be sanitized on retry.`,
-                );
-              }
-            }
-
-            const rotated = await advanceAuthProfile();
-            if (rotated) {
-              logAssistantFailoverDecision("rotate_profile");
-              await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
-              continue;
-            }
-
-            if (fallbackConfigured) {
-              await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
-              // Prefer formatted error message (user-friendly) over raw errorMessage
-              const message =
-                (lastAssistant
-                  ? formatAssistantErrorText(lastAssistant, {
-                      cfg: params.config,
-                      sessionKey: params.sessionKey ?? params.sessionId,
-                      provider: activeErrorContext.provider,
-                      model: activeErrorContext.model,
+                  profileId: failedPromptProfileId,
+                  fallbackConfigured,
+                  aborted,
+                });
+                if (
+                  promptFailoverFailure &&
+                  promptFailoverReason !== "timeout" &&
+                  (await advanceAuthProfile())
+                ) {
+                  logPromptFailoverDecision("rotate_profile");
+                  await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
+                  continue;
+                }
+                const fallbackThinking = pickFallbackThinkingLevel({
+                  message: errorText,
+                  attempted: attemptedThinking,
+                });
+                if (fallbackThinking) {
+                  log.warn(
+                    `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+                  );
+                  thinkLevel = fallbackThinking;
+                  continue;
+                }
+                // Throw FailoverError for prompt-side failover reasons when fallbacks
+                // are configured so outer model fallback can continue on overload,
+                // rate-limit, auth, or billing failures.
+                if (fallbackConfigured && promptFailoverFailure) {
+                  const status = resolveFailoverStatus(promptFailoverReason ?? "unknown");
+                  logPromptFailoverDecision("fallback_model", { status });
+                  await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
+                  throw (
+                    normalizedPromptFailover ??
+                    new FailoverError(errorText, {
+                      reason: promptFailoverReason ?? "unknown",
+                      provider,
+                      model: modelId,
+                      profileId: lastProfileId,
+                      status: resolveFailoverStatus(promptFailoverReason ?? "unknown"),
                     })
-                  : undefined) ||
-                lastAssistant?.errorMessage?.trim() ||
-                (timedOut
-                  ? "LLM request timed out."
-                  : rateLimitFailure
-                    ? "LLM request rate limited."
-                    : billingFailure
-                      ? formatBillingErrorMessage(
-                          activeErrorContext.provider,
-                          activeErrorContext.model,
-                        )
-                      : authFailure
-                        ? "LLM request unauthorized."
-                        : "LLM request failed.");
-              const status =
-                resolveFailoverStatus(assistantFailoverReason ?? "unknown") ??
-                (isTimeoutErrorMessage(message) ? 408 : undefined);
-              logAssistantFailoverDecision("fallback_model", { status });
-              throw new FailoverError(message, {
-                reason: assistantFailoverReason ?? "unknown",
+                  );
+                }
+                if (promptFailoverFailure || promptFailoverReason) {
+                  logPromptFailoverDecision("surface_error");
+                }
+                throw promptError;
+              }
+
+              const fallbackThinking = pickFallbackThinkingLevel({
+                message: lastAssistant?.errorMessage,
+                attempted: attemptedThinking,
+              });
+              if (fallbackThinking && !aborted) {
+                log.warn(
+                  `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
+                );
+                thinkLevel = fallbackThinking;
+                continue;
+              }
+
+              const authFailure = isAuthAssistantError(lastAssistant);
+              const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
+              const billingFailure = isBillingAssistantError(lastAssistant);
+              const failoverFailure = isFailoverAssistantError(lastAssistant);
+              const assistantFailoverReason = classifyFailoverReason(
+                lastAssistant?.errorMessage ?? "",
+              );
+              const assistantProfileFailureReason =
+                resolveAuthProfileFailureReason(assistantFailoverReason);
+              const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
+              const imageDimensionError = parseImageDimensionError(
+                lastAssistant?.errorMessage ?? "",
+              );
+              // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
+              const failedAssistantProfileId = lastProfileId;
+              const logAssistantFailoverDecision = createFailoverDecisionLogger({
+                stage: "assistant",
+                runId: params.runId,
+                rawError: lastAssistant?.errorMessage?.trim(),
+                failoverReason: assistantFailoverReason,
+                profileFailureReason: assistantProfileFailureReason,
                 provider: activeErrorContext.provider,
                 model: activeErrorContext.model,
-                profileId: lastProfileId,
-                status,
-              });
-            }
-            logAssistantFailoverDecision("surface_error");
-          }
-
-          const usageMeta = buildUsageAgentMetaFields({
-            usageAccumulator,
-            lastAssistantUsage: lastAssistant?.usage as UsageLike | undefined,
-            lastRunPromptUsage,
-            lastTurnTotal,
-          });
-          const agentMeta: EmbeddedPiAgentMeta = {
-            sessionId: sessionIdUsed,
-            provider: lastAssistant?.provider ?? provider,
-            model: lastAssistant?.model ?? model.id,
-            usage: usageMeta.usage,
-            lastCallUsage: usageMeta.lastCallUsage,
-            promptTokens: usageMeta.promptTokens,
-            compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
-          };
-
-          const payloads = buildEmbeddedRunPayloads({
-            assistantTexts: attempt.assistantTexts,
-            toolMetas: attempt.toolMetas,
-            lastAssistant: attempt.lastAssistant,
-            lastToolError: attempt.lastToolError,
-            config: params.config,
-            sessionKey: params.sessionKey ?? params.sessionId,
-            provider: activeErrorContext.provider,
-            model: activeErrorContext.model,
-            verboseLevel: params.verboseLevel,
-            reasoningLevel: params.reasoningLevel,
-            toolResultFormat: resolvedToolResultFormat,
-            suppressToolErrorWarnings: params.suppressToolErrorWarnings,
-            inlineToolResultsAllowed: false,
-            didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-            didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
-          });
-
-          // Timeout aborts can leave the run without any assistant payloads.
-          // Emit an explicit timeout error instead of silently completing, so
-          // callers do not lose the turn as an orphaned user message.
-          if (timedOut && !timedOutDuringCompaction && payloads.length === 0) {
-            return {
-              payloads: [
-                {
-                  text:
-                    "Request timed out before a response was generated. " +
-                    "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta,
+                profileId: failedAssistantProfileId,
+                fallbackConfigured,
+                timedOut,
                 aborted,
-                systemPromptReport: attempt.systemPromptReport,
-              },
-              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
-              messagingToolSentTexts: attempt.messagingToolSentTexts,
-              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
-              messagingToolSentTargets: attempt.messagingToolSentTargets,
-              successfulCronAdds: attempt.successfulCronAdds,
-            };
-          }
+              });
 
-          log.debug(
-            `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
-          );
-          if (lastProfileId) {
-            await markAuthProfileGood({
-              store: authStore,
-              provider,
-              profileId: lastProfileId,
-              agentDir: params.agentDir,
-            });
-            await markAuthProfileUsed({
-              store: authStore,
-              profileId: lastProfileId,
-              agentDir: params.agentDir,
-            });
-          }
-          return {
-            payloads: payloads.length ? payloads : undefined,
-            meta: {
-              durationMs: Date.now() - started,
-              agentMeta,
-              aborted,
-              systemPromptReport: attempt.systemPromptReport,
-              // Handle client tool calls (OpenResponses hosted tools)
-              // Propagate the LLM stop reason so callers (lifecycle events,
-              // ACP bridge) can distinguish end_turn from max_tokens.
-              stopReason: attempt.clientToolCall
-                ? "tool_calls"
-                : attempt.yieldDetected
-                  ? "end_turn"
-                  : (lastAssistant?.stopReason as string | undefined),
-              pendingToolCalls: attempt.clientToolCall
-                ? [
+              if (
+                authFailure &&
+                (await maybeRefreshRuntimeAuthForAuthError(
+                  lastAssistant?.errorMessage ?? "",
+                  runtimeAuthRetry,
+                ))
+              ) {
+                authRetryPending = true;
+                continue;
+              }
+              if (imageDimensionError && lastProfileId) {
+                const details = [
+                  imageDimensionError.messageIndex !== undefined
+                    ? `message=${imageDimensionError.messageIndex}`
+                    : null,
+                  imageDimensionError.contentIndex !== undefined
+                    ? `content=${imageDimensionError.contentIndex}`
+                    : null,
+                  imageDimensionError.maxDimensionPx !== undefined
+                    ? `limit=${imageDimensionError.maxDimensionPx}px`
+                    : null,
+                ]
+                  .filter(Boolean)
+                  .join(" ");
+                log.warn(
+                  `Profile ${lastProfileId} rejected image payload${details ? ` (${details})` : ""}.`,
+                );
+              }
+
+              // Rotate on timeout to try another account/model path in this turn,
+              // but exclude post-prompt compaction timeouts (model succeeded; no profile issue).
+              const shouldRotate =
+                (!aborted && failoverFailure) || (timedOut && !timedOutDuringCompaction);
+
+              if (shouldRotate) {
+                if (lastProfileId) {
+                  const reason = timedOut ? "timeout" : assistantProfileFailureReason;
+                  // Skip cooldown for timeouts: a timeout is model/network-specific,
+                  // not an auth issue. Marking the profile would poison fallback models
+                  // on the same provider (e.g. gpt-5.3 timeout blocks gpt-5.2).
+                  await maybeMarkAuthProfileFailure({
+                    profileId: lastProfileId,
+                    reason,
+                  });
+                  if (timedOut && !isProbeSession) {
+                    log.warn(`Profile ${lastProfileId} timed out. Trying next account...`);
+                  }
+                  if (cloudCodeAssistFormatError) {
+                    log.warn(
+                      `Profile ${lastProfileId} hit Cloud Code Assist format error. Tool calls will be sanitized on retry.`,
+                    );
+                  }
+                }
+
+                const rotated = await advanceAuthProfile();
+                if (rotated) {
+                  logAssistantFailoverDecision("rotate_profile");
+                  await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
+                  continue;
+                }
+
+                if (fallbackConfigured) {
+                  await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
+                  // Prefer formatted error message (user-friendly) over raw errorMessage
+                  const message =
+                    (lastAssistant
+                      ? formatAssistantErrorText(lastAssistant, {
+                          cfg: params.config,
+                          sessionKey: params.sessionKey ?? params.sessionId,
+                          provider: activeErrorContext.provider,
+                          model: activeErrorContext.model,
+                        })
+                      : undefined) ||
+                    lastAssistant?.errorMessage?.trim() ||
+                    (timedOut
+                      ? "LLM request timed out."
+                      : rateLimitFailure
+                        ? "LLM request rate limited."
+                        : billingFailure
+                          ? formatBillingErrorMessage(
+                              activeErrorContext.provider,
+                              activeErrorContext.model,
+                            )
+                          : authFailure
+                            ? "LLM request unauthorized."
+                            : "LLM request failed.");
+                  const status =
+                    resolveFailoverStatus(assistantFailoverReason ?? "unknown") ??
+                    (isTimeoutErrorMessage(message) ? 408 : undefined);
+                  logAssistantFailoverDecision("fallback_model", { status });
+                  throw new FailoverError(message, {
+                    reason: assistantFailoverReason ?? "unknown",
+                    provider: activeErrorContext.provider,
+                    model: activeErrorContext.model,
+                    profileId: lastProfileId,
+                    status,
+                  });
+                }
+                logAssistantFailoverDecision("surface_error");
+              }
+
+              const usageMeta = buildUsageAgentMetaFields({
+                usageAccumulator,
+                lastAssistantUsage: lastAssistant?.usage as UsageLike | undefined,
+                lastRunPromptUsage,
+                lastTurnTotal,
+              });
+              const agentMeta: EmbeddedPiAgentMeta = {
+                sessionId: sessionIdUsed,
+                provider: lastAssistant?.provider ?? provider,
+                model: lastAssistant?.model ?? model.id,
+                usage: usageMeta.usage,
+                lastCallUsage: usageMeta.lastCallUsage,
+                promptTokens: usageMeta.promptTokens,
+                compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
+              };
+
+              const payloads = buildEmbeddedRunPayloads({
+                assistantTexts: attempt.assistantTexts,
+                toolMetas: attempt.toolMetas,
+                lastAssistant: attempt.lastAssistant,
+                lastToolError: attempt.lastToolError,
+                config: params.config,
+                sessionKey: params.sessionKey ?? params.sessionId,
+                provider: activeErrorContext.provider,
+                model: activeErrorContext.model,
+                verboseLevel: params.verboseLevel,
+                reasoningLevel: params.reasoningLevel,
+                toolResultFormat: resolvedToolResultFormat,
+                suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+                inlineToolResultsAllowed: false,
+                didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+              });
+
+              // Timeout aborts can leave the run without any assistant payloads.
+              // Emit an explicit timeout error instead of silently completing, so
+              // callers do not lose the turn as an orphaned user message.
+              if (timedOut && !timedOutDuringCompaction && payloads.length === 0) {
+                return {
+                  payloads: [
                     {
-                      id: randomBytes(5).toString("hex").slice(0, 9),
-                      name: attempt.clientToolCall.name,
-                      arguments: JSON.stringify(attempt.clientToolCall.params),
+                      text:
+                        "Request timed out before a response was generated. " +
+                        "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
+                      isError: true,
                     },
-                  ]
-                : undefined,
-            },
-            didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-            didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
-            messagingToolSentTexts: attempt.messagingToolSentTexts,
-            messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
-            messagingToolSentTargets: attempt.messagingToolSentTargets,
-            successfulCronAdds: attempt.successfulCronAdds,
-          };
+                  ],
+                  meta: {
+                    durationMs: Date.now() - started,
+                    agentMeta,
+                    aborted,
+                    systemPromptReport: attempt.systemPromptReport,
+                  },
+                  didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                  didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+                  messagingToolSentTexts: attempt.messagingToolSentTexts,
+                  messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+                  messagingToolSentTargets: attempt.messagingToolSentTargets,
+                  successfulCronAdds: attempt.successfulCronAdds,
+                };
+              }
+
+              log.debug(
+                `embedded run done: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - started} aborted=${aborted}`,
+              );
+              if (lastProfileId) {
+                await markAuthProfileGood({
+                  store: authStore,
+                  provider,
+                  profileId: lastProfileId,
+                  agentDir: params.agentDir,
+                });
+                await markAuthProfileUsed({
+                  store: authStore,
+                  profileId: lastProfileId,
+                  agentDir: params.agentDir,
+                });
+              }
+              return {
+                payloads: payloads.length ? payloads : undefined,
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta,
+                  aborted,
+                  systemPromptReport: attempt.systemPromptReport,
+                  // Handle client tool calls (OpenResponses hosted tools)
+                  // Propagate the LLM stop reason so callers (lifecycle events,
+                  // ACP bridge) can distinguish end_turn from max_tokens.
+                  stopReason: attempt.clientToolCall
+                    ? "tool_calls"
+                    : attempt.yieldDetected
+                      ? "end_turn"
+                      : (lastAssistant?.stopReason as string | undefined),
+                  pendingToolCalls: attempt.clientToolCall
+                    ? [
+                        {
+                          id: randomBytes(5).toString("hex").slice(0, 9),
+                          name: attempt.clientToolCall.name,
+                          arguments: JSON.stringify(attempt.clientToolCall.params),
+                        },
+                      ]
+                    : undefined,
+                },
+                didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
+                messagingToolSentTexts: attempt.messagingToolSentTexts,
+                messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+                messagingToolSentTargets: attempt.messagingToolSentTargets,
+                successfulCronAdds: attempt.successfulCronAdds,
+              };
+            }
+          } finally {
+            await contextEngine.dispose?.();
+            stopRuntimeAuthRefreshTimer();
+          }
+        } finally {
+          restorePaperclipRuntimeEnv();
         }
-      } finally {
-        await contextEngine.dispose?.();
-        stopRuntimeAuthRefreshTimer();
-      }
-    }),
+      }),
+    ),
   );
 }

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -152,7 +152,7 @@ describe("clawhub helpers", () => {
 
   it("injects resolved auth token into ClawHub requests", async () => {
     process.env.OPENCLAW_CLAWHUB_TOKEN = "env-token-123";
-    const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
       const url = input instanceof Request ? input.url : String(input);
       expect(url).toContain("/api/v1/search");
       expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer env-token-123");
@@ -160,7 +160,7 @@ describe("clawhub helpers", () => {
         status: 200,
         headers: { "content-type": "application/json" },
       });
-    };
+    }) as unknown as typeof fetch;
 
     await expect(searchClawHubSkills({ query: "calendar", fetchImpl })).resolves.toEqual([]);
   });

--- a/test/pi-embedded-runner.paperclip-auth.test.ts
+++ b/test/pi-embedded-runner.paperclip-auth.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { __paperclipAuthEnvTestUtils } from "../src/agents/pi-embedded-runner/run.js";
+
+describe("applyPaperclipRuntimeAuthEnv", () => {
+  const envKeys = [
+    "PAPERCLIP_API_URL",
+    "PAPERCLIP_RUN_ID",
+    "PAPERCLIP_AGENT_ID",
+    "PAPERCLIP_COMPANY_ID",
+    "PAPERCLIP_API_KEY",
+    "PAPERCLIP_AUTH_HEADER",
+  ] as const;
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      delete process.env[key];
+    }
+  });
+
+  it("overwrites stale PAPERCLIP_AUTH_HEADER for a new run and restores prior env", () => {
+    const previousRunId = process.env.PAPERCLIP_RUN_ID;
+    process.env.PAPERCLIP_AUTH_HEADER = "Bearer stale-content-token";
+    process.env.PAPERCLIP_API_KEY = "stale-content-token";
+    process.env.PAPERCLIP_AGENT_ID = "agent-content";
+
+    const restore = __paperclipAuthEnvTestUtils.applyPaperclipRuntimeAuthEnv({
+      paperclipRuntimeAuth: {
+        apiUrl: "http://127.0.0.1:3100/",
+        runId: "run-research",
+        agentId: "agent-research",
+        companyId: "company-1",
+        authToken: "fresh-research-token",
+        authScheme: "bearer",
+      },
+    });
+
+    expect(process.env.PAPERCLIP_API_KEY).toBe("fresh-research-token");
+    expect(process.env.PAPERCLIP_AUTH_HEADER).toBe("bearer fresh-research-token");
+    expect(process.env.PAPERCLIP_AGENT_ID).toBe("agent-research");
+    expect(process.env.PAPERCLIP_RUN_ID).toBe("run-research");
+
+    restore();
+
+    expect(process.env.PAPERCLIP_API_KEY).toBe("stale-content-token");
+    expect(process.env.PAPERCLIP_AUTH_HEADER).toBe("Bearer stale-content-token");
+    expect(process.env.PAPERCLIP_AGENT_ID).toBe("agent-content");
+    expect(process.env.PAPERCLIP_RUN_ID).toBe(previousRunId);
+  });
+});


### PR DESCRIPTION
## Summary\n- serialize Paperclip runtime auth env injection in pi-embedded-runner to avoid concurrent runs clobbering shared PAPERCLIP_* env vars\n- add coverage around Paperclip auth env application/restore behavior\n- fix fetch mock typing in affected tests so whole-repo TypeScript validation passes\n\n## Validation\n- NODE_OPTIONS=--max-old-space-size=8192 pnpm -C /Users/jaxpkm/moltbot exec tsc -p /Users/jaxpkm/moltbot/tsconfig.json --noEmit\n