### PR TITLE
fix(heartbeat): respect heartbeat.model override — three-location fix

### DIFF
--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -81,10 +81,9 @@ describe("live model switch", () => {
       authProfileId: "profile-gpt",
       authProfileIdSource: "user",
     });
-    expect(state.resolveDefaultModelForAgentMock).toHaveBeenCalledWith({
-      cfg: { session: { store: "/tmp/custom-store.json" } },
-      agentId: "reply",
-    });
+    // When both defaultProvider and defaultModel are provided by the caller,
+    // resolveDefaultModelForAgent is skipped (caller-provided defaults take priority).
+    expect(state.resolveDefaultModelForAgentMock).not.toHaveBeenCalled();
     expect(state.resolveStorePathMock).toHaveBeenCalledWith("/tmp/custom-store.json", {
       agentId: "reply",
     });
@@ -107,6 +106,54 @@ describe("live model switch", () => {
       model: "gpt-5.4",
       authProfileId: "profile-gpt",
     });
+  });
+
+  it("uses caller-provided defaults when both defaultProvider and defaultModel are present", async () => {
+    // This is the heartbeat model override scenario: the caller passes the heartbeat model
+    // as defaultProvider/defaultModel, and we should use those instead of resolveDefaultModelForAgent.
+    state.loadSessionStoreMock.mockReturnValue({});
+
+    const { resolveLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      resolveLiveSessionModelSelection({
+        cfg: { session: { store: "/tmp/store.json" } },
+        sessionKey: "main",
+        agentId: "reply",
+        defaultProvider: "google",
+        defaultModel: "gemini-3.1-pro-preview",
+      }),
+    ).toEqual({
+      provider: "google",
+      model: "gemini-3.1-pro-preview",
+      authProfileId: undefined,
+      authProfileIdSource: undefined,
+    });
+    // resolveDefaultModelForAgent should NOT be called when caller provides both defaults
+    expect(state.resolveDefaultModelForAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to resolveDefaultModelForAgent when caller defaults are missing", async () => {
+    state.loadSessionStoreMock.mockReturnValue({});
+
+    const { resolveLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      resolveLiveSessionModelSelection({
+        cfg: { session: { store: "/tmp/store.json" } },
+        sessionKey: "main",
+        agentId: "reply",
+        defaultProvider: "",
+        defaultModel: "",
+      }),
+    ).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      authProfileId: undefined,
+      authProfileIdSource: undefined,
+    });
+    // Falls back to resolveDefaultModelForAgent when caller defaults are empty
+    expect(state.resolveDefaultModelForAgentMock).toHaveBeenCalled();
   });
 
   it("treats auth-profile-source changes as no-op when no auth profile is selected", async () => {

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -38,12 +38,12 @@ export function resolveLiveSessionModelSelection(params: {
     return null;
   }
   const agentId = params.agentId?.trim();
-  const defaultModelRef = agentId
-    ? resolveDefaultModelForAgent({
-        cfg,
-        agentId,
-      })
-    : { provider: params.defaultProvider, model: params.defaultModel };
+  const defaultModelRef =
+    params.defaultProvider && params.defaultModel
+      ? { provider: params.defaultProvider, model: params.defaultModel }
+      : agentId
+        ? resolveDefaultModelForAgent({ cfg, agentId })
+        : { provider: params.defaultProvider, model: params.defaultModel };
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId,
   });

--- a/src/auto-reply/reply/get-reply.heartbeat-guard.test.ts
+++ b/src/auto-reply/reply/get-reply.heartbeat-guard.test.ts
@@ -1,0 +1,140 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../templating.js";
+import type { ReplyDirectiveContinuation } from "./get-reply-directives.js";
+import "./get-reply.test-runtime-mocks.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveReplyDirectives: vi.fn(),
+  initSessionState: vi.fn(),
+  handleInlineActions: vi.fn(),
+}));
+vi.mock("./directive-handling.defaults.js", () => ({
+  resolveDefaultModel: vi.fn(() => ({
+    defaultProvider: "openai",
+    defaultModel: "gpt-4o-mini",
+    aliasIndex: new Map(),
+  })),
+}));
+vi.mock("./get-reply-directives.js", () => ({
+  resolveReplyDirectives: (...args: unknown[]) => mocks.resolveReplyDirectives(...args),
+}));
+vi.mock("./get-reply-inline-actions.js", () => ({
+  handleInlineActions: (...args: unknown[]) => mocks.handleInlineActions(...args),
+}));
+vi.mock("./session.js", () => ({
+  initSessionState: (...args: unknown[]) => mocks.initSessionState(...args),
+}));
+
+let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
+let loadConfigMock: typeof import("../../config/config.js").loadConfig;
+let resolveModelRefFromStringMock: ReturnType<typeof vi.fn>;
+
+beforeAll(async () => {
+  ({ getReplyFromConfig } = await import("./get-reply.js"));
+  ({ loadConfig: loadConfigMock } = await import("../../config/config.js"));
+  const modelSelection = await import("../../agents/model-selection.js");
+  resolveModelRefFromStringMock = vi.mocked(modelSelection.resolveModelRefFromString);
+});
+
+function buildCtx(overrides: Partial<MsgContext> = {}): MsgContext {
+  return {
+    Provider: "telegram",
+    Surface: "telegram",
+    ChatType: "direct",
+    Body: "hello",
+    BodyForAgent: "hello",
+    RawBody: "hello",
+    CommandBody: "hello",
+    SessionKey: "agent:main:telegram:123",
+    From: "telegram:user:42",
+    To: "telegram:123",
+    Timestamp: 1710000000000,
+    ...overrides,
+  };
+}
+
+describe("getReplyFromConfig heartbeat guard", () => {
+  beforeEach(() => {
+    mocks.resolveReplyDirectives.mockReset();
+    mocks.initSessionState.mockReset();
+    mocks.handleInlineActions.mockReset();
+    vi.mocked(loadConfigMock).mockReset();
+
+    vi.mocked(loadConfigMock).mockReturnValue({});
+    mocks.resolveReplyDirectives.mockResolvedValue({ kind: "reply", reply: { text: "ok" } });
+    mocks.handleInlineActions.mockResolvedValue({ kind: "reply", reply: { text: "ok" } });
+    mocks.initSessionState.mockResolvedValue({
+      sessionCtx: {},
+      sessionEntry: {},
+      previousSessionEntry: {},
+      sessionStore: {},
+      sessionKey: "agent:main:telegram:123",
+      sessionId: "session-1",
+      isNewSession: false,
+      resetTriggered: false,
+      systemSent: false,
+      abortedLastRun: false,
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-chat",
+      groupResolution: undefined,
+      isGroup: false,
+      triggerBodyNormalized: "",
+      bodyStripped: "",
+    });
+  });
+
+  it("preserves heartbeat model override after directive resolution", async () => {
+    // resolveModelRefFromString is mocked to null by default in get-reply.test-mocks.ts;
+    // override it once so the heartbeat ref resolves correctly.
+    resolveModelRefFromStringMock.mockReturnValueOnce({
+      ref: { provider: "minimax", model: "MiniMax-M2.7" },
+    });
+
+    // Simulate resolveReplyDirectives returning a different provider/model (as if a
+    // model directive fired inside the heartbeat turn). The guard in get-reply.ts should
+    // prevent this from overwriting the resolved heartbeat model.
+    mocks.resolveReplyDirectives.mockResolvedValueOnce({
+      kind: "continue",
+      result: {
+        commandSource: "",
+        command: {},
+        allowTextCommands: false,
+        skillCommands: undefined,
+        directives: {},
+        cleanedBody: "",
+        elevatedEnabled: false,
+        elevatedAllowed: false,
+        elevatedFailures: [],
+        defaultActivation: undefined,
+        resolvedThinkLevel: undefined,
+        resolvedFastMode: false,
+        resolvedVerboseLevel: undefined,
+        resolvedReasoningLevel: "default",
+        resolvedElevatedLevel: "default",
+        execOverrides: undefined,
+        blockStreamingEnabled: false,
+        blockReplyChunking: undefined,
+        resolvedBlockStreamingBreak: "message_end",
+        provider: "openai",
+        model: "gpt-4o-mini",
+        modelState: { resolveDefaultThinkingLevel: undefined },
+        contextTokens: 0,
+        inlineStatusRequested: false,
+        directiveAck: undefined,
+        perMessageQueueMode: undefined,
+        perMessageQueueOptions: undefined,
+        messageProviderKey: "",
+      } as unknown as ReplyDirectiveContinuation,
+    });
+
+    await getReplyFromConfig(buildCtx(), {
+      isHeartbeat: true,
+      heartbeatModelOverride: "minimax/MiniMax-M2.7",
+    });
+
+    // The guard must keep the heartbeat model — not the directive-resolved one.
+    expect(mocks.handleInlineActions).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "minimax", model: "MiniMax-M2.7" }),
+    );
+  });
+});

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -345,8 +345,10 @@ export async function getReplyFromConfig(
     perMessageQueueMode,
     perMessageQueueOptions,
   } = directiveResult.result;
-  provider = resolvedProvider;
-  model = resolvedModel;
+  if (!hasResolvedHeartbeatModelOverride) {
+    provider = resolvedProvider;
+    model = resolvedModel;
+  }
 
   const maybeEmitMissingResetHooks = async () => {
     if (!resetTriggered || !command.isAuthorizedSender || command.resetHookTriggered) {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -345,6 +345,11 @@ export async function getReplyFromConfig(
     perMessageQueueMode,
     perMessageQueueOptions,
   } = directiveResult.result;
+  // When a heartbeat model override is active, preserve it after directive resolution.
+  // Heartbeat messages are system-generated and never contain inline model directives,
+  // so resolvedProvider/resolvedModel should match the input values. This outer guard
+  // provides defense-in-depth alongside the skipStoredOverride guard in
+  // createModelSelectionState (model-selection.ts:418).
   if (!hasResolvedHeartbeatModelOverride) {
     provider = resolvedProvider;
     model = resolvedModel;

--- a/src/plugins/runtime/runtime-system.ts
+++ b/src/plugins/runtime/runtime-system.ts
@@ -17,7 +17,7 @@ export function createRuntimeSystem(): PluginRuntime["system"] {
         reason,
         agentId,
         sessionKey,
-        heartbeat: heartbeat ? { target: heartbeat.target } : undefined,
+        heartbeat: heartbeat ? { target: heartbeat.target, model: heartbeat.model } : undefined,
       });
     },
     runCommandWithTimeout,

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -16,7 +16,7 @@ export type RunHeartbeatOnceOptions = {
   agentId?: string;
   sessionKey?: string;
   /** Override heartbeat config (e.g. `{ target: "last" }` to deliver to the last active channel). */
-  heartbeat?: { target?: string };
+  heartbeat?: { target?: string; model?: string };
 };
 
 /** Core runtime helpers exposed to trusted native plugins. */


### PR DESCRIPTION
## Summary

**Problem:** When `agents.defaults.heartbeat.model` is configured, the heartbeat ignores it and falls back to the main session default model. This is a recurring regression (previously reported in #9556, #13009, #14279, #21144, now #56788).

**Why it matters:** Users who want a cheaper or more capable model for autonomous heartbeat tasks cannot override the heartbeat model. The heartbeat always runs with the primary conversation model.

**What changed:** Three fixes across three files, each addresses a different point in the model resolution chain where the heartbeat model override is lost:

1. **`src/plugins/runtime/runtime-system.ts`** — `createRuntimeSystem` was stripping `heartbeat.model` when forwarding to `runHeartbeatOnceInternal`. Added `model` to the passthrough.

2. **`src/agents/live-model-switch.ts`** — `resolveLiveSessionModelSelection` ignored caller-provided `defaultProvider`/`defaultModel` when `agentId` was present. Changed to prefer caller-provided defaults when both are present.

3. **`src/auto-reply/reply/get-reply.ts`** — After `resolveReplyDirectives`, provider/model unconditionally overwrote the heartbeat model. Added guard: `if (!hasResolvedHeartbeatModelOverride)`.

**What did NOT change:** Non-heartbeat conversation flows, cron job model resolution, subagent spawning, `/model` command.

## Coordination with #57094

This PR overlaps with #57094 on `live-model-switch.ts`. @openperf independently found and fixed the same root cause with broader coverage (`model-fallback.ts`, `agent-runner-execution.ts`, retry cap).

**Suggested merge order: #57094 first, then this PR.**

Once #57094 merges, we'll rebase and drop the `live-model-switch.ts` change here. The remaining two fixes (`runtime-system.ts`/`types-core.ts` and `get-reply.ts`) are not covered in #57094 and are needed to close the full upstream call chain — without them, the model override is silently dropped before the live-switch logic is ever reached.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway
- [x] Agents

## Linked Issue

Closes #56788

Related: #9556, #13009, #14279, #21144

## Root Cause / Regression History

This bug has been reported and "fixed" multiple times (#9556, #13009, #14279, #21144). Previous fix attempts (#13016, #9429, #14956) only addressed one of three loss points and were closed without merging.

The heartbeat model is resolved correctly in `getReplyFromConfig`, but lost at three downstream points:
1. Plugin runtime API strips the model field
2. Live session model selection ignores caller defaults
3. Directive resolution overwrites the heartbeat model

## Regression Test Plan

1. Set `agents.defaults.heartbeat.model` to a different model than default
2. Trigger heartbeat via `openclaw system event --text "test" --mode now`
3. Verify no `live session model switch detected` error in logs
4. Verify heartbeat uses configured model
5. Verify normal conversations still use default model

## Security Impact

- Authentication/authorization/secrets: **No**
- Network/sandbox/filesystem: **No**
- Exec/eval/code-gen: **No**
- User input processing: **No**
- Rate limiting/audit: **No**

## Human Verification

Tested on two OpenClaw v2026.3.28 Docker instances. Both showed zero model switch errors after patching, normal conversation routing unaffected.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------| 
| Patch 1 changes defaultModelRef priority for all callers | Only one caller exists, always provides both defaults with already-resolved values |
| Patch 3 skips directive model override during heartbeat | Heartbeat messages are system-generated, never contain inline directives |