### PR TITLE
fix(cli): preload all plugins for status route

### DIFF
--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -66,7 +66,7 @@ function loadPluginRegistryModule() {
 }
 
 function resolvePluginRegistryScope(commandPath: string[]): "channels" | "all" {
-  return commandPath[0] === "status" || commandPath[0] === "health" ? "channels" : "all";
+  return commandPath[0] === "health" ? "channels" : "all";
 }
 
 function shouldLoadPluginsForCommand(commandPath: string[], jsonOutputMode: boolean): boolean {

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -37,9 +37,11 @@ async function prepareRoutedCommand(params: {
     try {
       ensurePluginRegistryLoaded({
         scope:
-          params.commandPath[0] === "status" || params.commandPath[0] === "health"
-            ? "channels"
-            : "all",
+          params.commandPath[0] === "status"
+            ? "all"
+            : params.commandPath[0] === "health"
+              ? "channels"
+              : "all",
       });
     } finally {
       loggingState.forceConsoleToStderr = prev;

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -36,12 +36,7 @@ async function prepareRoutedCommand(params: {
     }
     try {
       ensurePluginRegistryLoaded({
-        scope:
-          params.commandPath[0] === "status"
-            ? "all"
-            : params.commandPath[0] === "health"
-              ? "channels"
-              : "all",
+        scope: params.commandPath[0] === "health" ? "channels" : "all",
       });
     } finally {
       loggingState.forceConsoleToStderr = prev;


### PR DESCRIPTION
## Summary

This PR fixes the `openclaw status` / `openclaw status --deep` regression reported as symptom A in #57011.

On `v2026.3.28`, `status` can traverse config paths that rely on plugin-provided memory embedding adapters. If the CLI preloads only `channels` plugins, the embedding provider registry can remain incomplete and valid multimodal memory configs can fail with:

```text
agents.*.memorySearch.multimodal requires a provider adapter that supports multimodal embeddings for the configured model.
```

This patch makes `status` preload `all` plugins consistently across both CLI execution paths, while keeping `health` on `channels`.

## Root cause

OpenClaw has two relevant CLI execution paths:

1. route-first handling in `src/cli/route.ts`
2. Commander preaction handling in `src/cli/program/preaction.ts`

Originally, both paths treated `status` the same as `health` and resolved plugin scope to `channels`. That is too narrow for `status`, because `status --deep` can touch config paths that depend on non-channel plugins, including memory-related provider adapters.

## Change

Minimal behavior change only:

- `status` now preloads `all`
- `health` remains on `channels`
- the scope decision is now consistent across both CLI paths
- the route-first ternary was simplified to remove the redundant branch

## Why this PR is intentionally narrow

Issue #57011 currently mixes at least two symptoms:

1. `status` / `status --deep` failing on a valid multimodal memory config
2. missing published `memory-tool.runtime-*` artifacts

This PR addresses only symptom 1.

## Repro

1. Use a config with:
   - `memorySearch.enabled=true`
   - multimodal memory enabled
   - a valid plugin-backed provider adapter path available at runtime
2. Run:

```bash
openclaw status --deep
```

Before this patch, `status --deep` can fail during memory config resolution because the required plugin adapters were not always preloaded for the `status` command.

## Verification

I verified the behavior change against a real `v2026.3.28` Docker-based gateway runtime.

Before patch:
- `health --json` passed
- gateway remained healthy
- `status --deep` failed on multimodal memory config resolution

After patch:
- `status --deep` returned `rc=0`
- memory section rendered normally
- gateway health behavior was unchanged

## Scope / risk

Low-risk CLI routing fix:

- two small files changed
- no schema changes
- no runtime behavior changes outside `status`
- no changes to `health`

Refs #57011
