### PR TITLE
docs: document browser.request failures caused by gateway install drift

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -296,7 +296,7 @@ Common signatures:
 
 - `unknown command "browser"` or `unknown command 'browser'` → the bundled browser plugin is excluded by `plugins.allow`.
 - browser tool missing / unavailable while `browser.enabled=true` → `plugins.allow` excludes `browser`, so the plugin never loaded.
-- `GatewayClientRequestError: unknown method: browser.request` together with version mismatch output such as `Config was last written by a newer OpenClaw ... current version is ...` → the installed Gateway service may still be running from an older OpenClaw install/version than the CLI you are invoking. On macOS, prefer `openclaw gateway install --force` (or `openclaw doctor`) to rewrite the LaunchAgent instead of editing the plist manually.
+- `GatewayClientRequestError: unknown method: browser.request` together with version mismatch output such as `Config was last written by a newer OpenClaw ... current version is ...` → the running Gateway process may be coming from an older OpenClaw install/version than the CLI you are invoking. On macOS, prefer restarting/updating the Gateway via the OpenClaw Mac app, or run `openclaw gateway install --force` (or `openclaw doctor`) to repair the install state, instead of editing startup files manually.
 - `Failed to start Chrome CDP on port` → browser process failed to launch.
 - `browser.executablePath not found` → configured path is invalid.
 - `No Chrome tabs found for profile="user"` → the Chrome MCP attach profile has no open local Chrome tabs.

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -296,6 +296,7 @@ Common signatures:
 
 - `unknown command "browser"` or `unknown command 'browser'` → the bundled browser plugin is excluded by `plugins.allow`.
 - browser tool missing / unavailable while `browser.enabled=true` → `plugins.allow` excludes `browser`, so the plugin never loaded.
+- `GatewayClientRequestError: unknown method: browser.request` together with version mismatch output such as `Config was last written by a newer OpenClaw ... current version is ...` → the installed Gateway service may still be running from an older OpenClaw install/version than the CLI you are invoking. On macOS, prefer `openclaw gateway install --force` (or `openclaw doctor`) to rewrite the LaunchAgent instead of editing the plist manually.
 - `Failed to start Chrome CDP on port` → browser process failed to launch.
 - `browser.executablePath not found` → configured path is invalid.
 - `No Chrome tabs found for profile="user"` → the Chrome MCP attach profile has no open local Chrome tabs.

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -283,7 +283,7 @@ flowchart TD
     Common log signatures:
 
     - `unknown command "browser"` or `unknown command 'browser'` → `plugins.allow` is set and does not include `browser`.
-    - `GatewayClientRequestError: unknown method: browser.request` plus a version mismatch like `Config was last written by a newer OpenClaw ... current version is ...` → the Gateway service may still be installed from an older OpenClaw build than the CLI currently on your PATH. Run `openclaw gateway install --force` (or `openclaw doctor`) before editing LaunchAgent files manually.
+    - `GatewayClientRequestError: unknown method: browser.request` plus a version mismatch like `Config was last written by a newer OpenClaw ... current version is ...` → the running Gateway process may be coming from an older OpenClaw build than the CLI currently on your PATH. On macOS, prefer restarting/updating the Gateway via the OpenClaw Mac app, or run `openclaw gateway install --force` (or `openclaw doctor`) to repair the install state, instead of editing startup files manually.
     - `Failed to start Chrome CDP on port` → local browser launch failed.
     - `browser.executablePath not found` → configured binary path is wrong.
     - `No Chrome tabs found for profile="user"` → the Chrome MCP attach profile has no open local Chrome tabs.

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -283,6 +283,7 @@ flowchart TD
     Common log signatures:
 
     - `unknown command "browser"` or `unknown command 'browser'` → `plugins.allow` is set and does not include `browser`.
+    - `GatewayClientRequestError: unknown method: browser.request` plus a version mismatch like `Config was last written by a newer OpenClaw ... current version is ...` → the Gateway service may still be installed from an older OpenClaw build than the CLI currently on your PATH. Run `openclaw gateway install --force` (or `openclaw doctor`) before editing LaunchAgent files manually.
     - `Failed to start Chrome CDP on port` → local browser launch failed.
     - `browser.executablePath not found` → configured binary path is wrong.
     - `No Chrome tabs found for profile="user"` → the Chrome MCP attach profile has no open local Chrome tabs.


### PR DESCRIPTION
## Summary
Adds troubleshooting guidance for a confusing upgrade/drift case on macOS:

- CLI is newer than the installed Gateway service
- `openclaw browser status` fails with `unknown method: browser.request`
- users are tempted to debug browser/plugin config when the real fix is to rewrite the installed service via `openclaw gateway install --force` or `openclaw doctor`

Closes #57079.