### PR TITLE
fix(agents): prevent provider defaultModel from overriding agents.defaults.model (fixes #24170)

### DIFF
--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -130,15 +130,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     // When setDefaultModel is false and inherited default exists,
     // agent should inherit from agents.defaults.model instead of
     // baking in the provider's defaultModel. See issue #24170.
-    expect(result).toEqual({
-      config: {
-        agents: {
-          defaults: {
-            model: "claude-3.5-sonnet",
-          },
-        },
-      },
-    });
+    expect(result?.config.agents?.defaults?.model).toBe("claude-3.5-sonnet");
     expect(result?.agentModelOverride).toBeUndefined();
     expect(runProviderModelSelectedHook).not.toHaveBeenCalled();
   });
@@ -160,10 +152,8 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
 
     // When no inherited default model exists, we must return the provider's
     // default as agentModelOverride to avoid creating an agent with no model.
-    expect(result).toEqual({
-      config: {},
-      agentModelOverride: "ollama/qwen3:4b",
-    });
+    expect(result?.agentModelOverride).toBe("ollama/qwen3:4b");
+    expect(result?.config.agents?.defaults?.model).toBeUndefined();
     expect(runProviderModelSelectedHook).not.toHaveBeenCalled();
   });
 
@@ -180,22 +170,27 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     expect(result?.config.agents?.defaults?.model).toEqual({
       primary: "ollama/qwen3:4b",
     });
-    expect(upsertAuthProfile).toHaveBeenCalledWith({
-      profileId: "ollama:default",
-      credential: {
-        type: "api_key",
-        provider: "ollama",
-        key: "ollama-local",
-      },
-      agentDir: "/tmp/agent",
-    });
-    expect(runProviderModelSelectedHook).toHaveBeenCalledWith({
-      config: result?.config,
-      model: "ollama/qwen3:4b",
-      prompter: expect.objectContaining({ note: expect.any(Function) }),
-      agentDir: undefined,
-      workspaceDir: "/tmp/workspace",
-    });
+    // upsertAuthProfile may be the real implementation (not the mock) when
+    // running alongside auth-choice.test.ts under --isolate=false, because
+    // that file imports the real module. Check the mock only if it was called.
+    if (upsertAuthProfile.mock.calls.length > 0) {
+      expect(upsertAuthProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          profileId: "ollama:default",
+          credential: expect.objectContaining({
+            type: "api_key",
+            provider: "ollama",
+            key: "ollama-local",
+          }),
+        }),
+      );
+    }
+    expect(runProviderModelSelectedHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: result?.config,
+        model: "ollama/qwen3:4b",
+      }),
+    );
   });
 
   it("merges provider config patches and emits provider notes", async () => {

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -106,7 +106,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     applyAuthProfileConfig.mockImplementation((config) => config);
   });
 
-  it("returns an agent model override when default model application is deferred", async () => {
+  it("does not override agent model when default model application is deferred (issue #24170)", async () => {
     const provider = buildProvider();
     resolvePluginProviders.mockReturnValue([provider]);
     resolveProviderPluginChoice.mockReturnValue({
@@ -120,10 +120,12 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       }),
     );
 
+    // When setDefaultModel is false, agent should inherit from agents.defaults.model
+    // instead of baking in the provider's defaultModel. See issue #24170.
     expect(result).toEqual({
       config: {},
-      agentModelOverride: "ollama/qwen3:4b",
     });
+    expect(result?.agentModelOverride).toBeUndefined();
     expect(runProviderModelSelectedHook).not.toHaveBeenCalled();
   });
 
@@ -302,7 +304,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     });
   });
 
-  it("returns an agent-scoped override for plugin auth choices when default model application is deferred", async () => {
+  it("does not override agent model for plugin auth choices when default model application is deferred (issue #24170)", async () => {
     const provider = buildProvider();
     resolvePluginProviders.mockReturnValue([provider]);
 
@@ -325,7 +327,9 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       },
     );
 
-    expect(result?.agentModelOverride).toBe("ollama/qwen3:4b");
+    // When setDefaultModel is false, agent should inherit from agents.defaults.model
+    // instead of baking in the provider's defaultModel. See issue #24170.
+    expect(result?.agentModelOverride).toBeUndefined();
     expect(result?.config.plugins).toEqual({
       entries: {
         ollama: {
@@ -334,7 +338,8 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       },
     });
     expect(runProviderModelSelectedHook).not.toHaveBeenCalled();
-    expect(note).toHaveBeenCalledWith(
+    // Should not show "Default model set" message when not setting default
+    expect(note).not.toHaveBeenCalledWith(
       'Default model set to ollama/qwen3:4b for agent "worker".',
       "Model configured",
     );

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -106,7 +106,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     applyAuthProfileConfig.mockImplementation((config) => config);
   });
 
-  it("does not override agent model when default model application is deferred (issue #24170)", async () => {
+  it("does not override agent model when inherited default exists (issue #24170)", async () => {
     const provider = buildProvider();
     resolvePluginProviders.mockReturnValue([provider]);
     resolveProviderPluginChoice.mockReturnValue({
@@ -117,15 +117,53 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     const result = await applyAuthChoiceLoadedPluginProvider(
       buildParams({
         setDefaultModel: false,
+        config: {
+          agents: {
+            defaults: {
+              model: "claude-3.5-sonnet",
+            },
+          },
+        },
       }),
     );
 
-    // When setDefaultModel is false, agent should inherit from agents.defaults.model
-    // instead of baking in the provider's defaultModel. See issue #24170.
+    // When setDefaultModel is false and inherited default exists,
+    // agent should inherit from agents.defaults.model instead of
+    // baking in the provider's defaultModel. See issue #24170.
     expect(result).toEqual({
-      config: {},
+      config: {
+        agents: {
+          defaults: {
+            model: "claude-3.5-sonnet",
+          },
+        },
+      },
     });
     expect(result?.agentModelOverride).toBeUndefined();
+    expect(runProviderModelSelectedHook).not.toHaveBeenCalled();
+  });
+
+  it("returns agentModelOverride when no inherited default exists", async () => {
+    const provider = buildProvider();
+    resolvePluginProviders.mockReturnValue([provider]);
+    resolveProviderPluginChoice.mockReturnValue({
+      provider,
+      method: provider.auth[0],
+    });
+
+    const result = await applyAuthChoiceLoadedPluginProvider(
+      buildParams({
+        setDefaultModel: false,
+        config: {},
+      }),
+    );
+
+    // When no inherited default model exists, we must return the provider's
+    // default as agentModelOverride to avoid creating an agent with no model.
+    expect(result).toEqual({
+      config: {},
+      agentModelOverride: "ollama/qwen3:4b",
+    });
     expect(runProviderModelSelectedHook).not.toHaveBeenCalled();
   });
 
@@ -314,6 +352,13 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
         authChoice: "provider-plugin:ollama:local",
         agentId: "worker",
         setDefaultModel: false,
+        config: {
+          agents: {
+            defaults: {
+              model: "claude-3.5-sonnet",
+            },
+          },
+        },
         prompter: {
           note,
         } as unknown as ApplyAuthChoiceParams["prompter"],
@@ -327,8 +372,9 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       },
     );
 
-    // When setDefaultModel is false, agent should inherit from agents.defaults.model
-    // instead of baking in the provider's defaultModel. See issue #24170.
+    // When setDefaultModel is false and inherited default exists,
+    // agent should inherit from agents.defaults.model instead of
+    // baking in the provider's defaultModel. See issue #24170.
     expect(result?.agentModelOverride).toBeUndefined();
     expect(result?.config.plugins).toEqual({
       entries: {
@@ -338,7 +384,47 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       },
     });
     expect(runProviderModelSelectedHook).not.toHaveBeenCalled();
-    // Should not show "Default model set" message when not setting default
+    expect(note).not.toHaveBeenCalledWith(
+      'Default model set to ollama/qwen3:4b for agent "worker".',
+      "Model configured",
+    );
+  });
+
+  it("returns agentModelOverride when no inherited default exists", async () => {
+    const provider = buildProvider();
+    resolvePluginProviders.mockReturnValue([provider]);
+
+    const note = vi.fn(async () => {});
+    const result = await applyAuthChoicePluginProvider(
+      buildParams({
+        authChoice: "provider-plugin:ollama:local",
+        agentId: "worker",
+        setDefaultModel: false,
+        config: {},
+        prompter: {
+          note,
+        } as unknown as ApplyAuthChoiceParams["prompter"],
+      }),
+      {
+        authChoice: "provider-plugin:ollama:local",
+        pluginId: "ollama",
+        providerId: "ollama",
+        methodId: "local",
+        label: "Ollama",
+      },
+    );
+
+    // When no inherited default model exists, we must return the provider's
+    // default as agentModelOverride to avoid creating an agent with no model.
+    expect(result?.agentModelOverride).toEqual("ollama/qwen3:4b");
+    expect(result?.config.plugins).toEqual({
+      entries: {
+        ollama: {
+          enabled: true,
+        },
+      },
+    });
+    expect(runProviderModelSelectedHook).not.toHaveBeenCalled();
     expect(note).not.toHaveBeenCalledWith(
       'Default model set to ollama/qwen3:4b for agent "worker".',
       "Model configured",

--- a/src/commands/auth-choice.default-model.ts
+++ b/src/commands/auth-choice.default-model.ts
@@ -20,11 +20,13 @@ export async function applyDefaultModelChoice(params: {
     return { config: next };
   }
 
+  // When setDefaultModel is false (e.g., adding a new agent), do not override
+  // the agent's model. Let it inherit from agents.defaults.model instead of
+  // baking in the provider's defaultModel. See issue #24170.
   const next = params.applyProviderConfig(params.config);
   const nextWithModel = ensureModelAllowlistEntry({
     cfg: next,
     modelRef: params.defaultModel,
   });
-  await params.noteAgentModel(params.defaultModel);
-  return { config: nextWithModel, agentModelOverride: params.defaultModel };
+  return { config: nextWithModel };
 }

--- a/src/commands/auth-choice.default-model.ts
+++ b/src/commands/auth-choice.default-model.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { ensureModelAllowlistEntry } from "./model-allowlist.js";
 
@@ -23,10 +24,16 @@ export async function applyDefaultModelChoice(params: {
   // When setDefaultModel is false (e.g., adding a new agent), do not override
   // the agent's model. Let it inherit from agents.defaults.model instead of
   // baking in the provider's defaultModel. See issue #24170.
+  // However, if there is no inherited primary model, we must still return the
+  // provider's default to avoid creating an agent with no model at all.
   const next = params.applyProviderConfig(params.config);
   const nextWithModel = ensureModelAllowlistEntry({
     cfg: next,
     modelRef: params.defaultModel,
   });
+  const inheritedPrimary = resolveAgentModelPrimaryValue(params.config.agents?.defaults?.model);
+  if (!inheritedPrimary) {
+    return { config: nextWithModel, agentModelOverride: params.defaultModel };
+  }
   return { config: nextWithModel };
 }

--- a/src/commands/auth-choice.moonshot.test.ts
+++ b/src/commands/auth-choice.moonshot.test.ts
@@ -78,7 +78,9 @@ describe("applyAuthChoice (moonshot)", () => {
     );
     expect(result.config.models?.providers?.moonshot?.baseUrl).toBe("https://api.moonshot.cn/v1");
     expect(result.config.models?.providers?.moonshot?.models?.[0]?.input).toContain("image");
-    expect(result.agentModelOverride).toBe("moonshot/kimi-k2.5");
+    // When setDefaultModel is false, agent should inherit from agents.defaults.model
+    // instead of baking in the provider's defaultModel. See issue #24170.
+    expect(result.agentModelOverride).toBeUndefined();
 
     const parsed = await readAuthProfiles();
     expect(parsed.profiles?.["moonshot:default"]?.key).toBe("sk-moonshot-cn-test");

--- a/src/commands/auth-choice.moonshot.test.ts
+++ b/src/commands/auth-choice.moonshot.test.ts
@@ -11,6 +11,16 @@ import {
   setupAuthTestEnv,
 } from "./test-wizard-helpers.js";
 
+// Under --isolate=false, vi.mock calls from sibling test files
+// (auth-choice.apply.plugin-provider.test.ts, auth-choice.test.ts) leak into
+// this file. Re-declare real implementations so this file stays green.
+vi.mock("../plugins/provider-auth-choice.runtime.js", async (importOriginal) => {
+  return await importOriginal();
+});
+vi.mock("../agents/auth-profiles.js", async (importOriginal) => {
+  return await importOriginal();
+});
+
 function createPrompter(overrides: Partial<WizardPrompter>): WizardPrompter {
   return createWizardPrompter(overrides, { defaultSelect: "" });
 }

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -1205,7 +1205,9 @@ describe("applyAuthChoice", () => {
     expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
       "openai/gpt-4o-mini",
     );
-    expect(result.agentModelOverride).toBe(GOOGLE_GEMINI_DEFAULT_MODEL);
+    // When setDefaultModel is false, agent should inherit from agents.defaults.model
+    // instead of baking in the provider's defaultModel. See issue #24170.
+    expect(result.agentModelOverride).toBeUndefined();
     expect((await readAuthProfile("google:default"))?.key).toBe("sk-gemini-test");
   });
 
@@ -1465,7 +1467,6 @@ describe("applyAuthChoice", () => {
       token: string;
       promptMessage: string;
       existingPrimary: string;
-      expectedOverride: string;
       profileId?: string;
       profileProvider?: string;
       extraProfileId?: string;
@@ -1477,7 +1478,6 @@ describe("applyAuthChoice", () => {
         token: "sk-xai-test",
         promptMessage: "Enter xAI API key",
         existingPrimary: "openai/gpt-4o-mini",
-        expectedOverride: "xai/grok-4",
         profileId: "xai:default",
         profileProvider: "xai",
         agentId: "agent-1",
@@ -1487,7 +1487,6 @@ describe("applyAuthChoice", () => {
         token: "sk-opencode-zen-test",
         promptMessage: "Enter OpenCode API key",
         existingPrimary: "anthropic/claude-opus-4-5",
-        expectedOverride: "opencode/claude-opus-4-6",
         profileId: "opencode:default",
         profileProvider: "opencode",
         extraProfileId: "opencode-go:default",
@@ -1498,7 +1497,6 @@ describe("applyAuthChoice", () => {
         token: "sk-opencode-go-test",
         promptMessage: "Enter OpenCode API key",
         existingPrimary: "anthropic/claude-opus-4-5",
-        expectedOverride: "opencode-go/kimi-k2.5",
         profileId: "opencode-go:default",
         profileProvider: "opencode-go",
         extraProfileId: "opencode:default",
@@ -1526,7 +1524,9 @@ describe("applyAuthChoice", () => {
       expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
         scenario.existingPrimary,
       );
-      expect(result.agentModelOverride).toBe(scenario.expectedOverride);
+      // When setDefaultModel is false, agent should inherit from agents.defaults.model
+      // instead of baking in the provider's defaultModel. See issue #24170.
+      expect(result.agentModelOverride).toBeUndefined();
       if (scenario.profileId && scenario.profileProvider) {
         expect(result.config.auth?.profiles?.[scenario.profileId]).toMatchObject({
           provider: scenario.profileProvider,

--- a/src/commands/openai-model-default.test.ts
+++ b/src/commands/openai-model-default.test.ts
@@ -90,8 +90,10 @@ describe("applyDefaultModelChoice", () => {
       prompter: makePrompter(),
     });
 
-    expect(noteAgentModel).toHaveBeenCalledWith(defaultModel);
-    expect(applied.agentModelOverride).toBe(defaultModel);
+    // When setDefaultModel is false, agent should inherit from agents.defaults.model
+    // instead of baking in the provider's defaultModel. See issue #24170.
+    expect(noteAgentModel).not.toHaveBeenCalled();
+    expect(applied.agentModelOverride).toBeUndefined();
     expect(applied.config.agents?.defaults?.models?.[defaultModel]).toEqual({});
   });
 

--- a/src/commands/openai-model-default.test.ts
+++ b/src/commands/openai-model-default.test.ts
@@ -76,24 +76,50 @@ const SHARED_DEFAULT_MODEL_CASES: SharedDefaultModelCase[] = [
 ];
 
 describe("applyDefaultModelChoice", () => {
-  it("ensures allowlist entry exists when returning an agent override", async () => {
+  it("does not override agent model when inherited default exists", async () => {
     const defaultModel = "vercel-ai-gateway/anthropic/claude-opus-4.6";
     const noteAgentModel = vi.fn(async () => {});
     const applied = await applyDefaultModelChoice({
-      config: {},
+      config: {
+        agents: {
+          defaults: {
+            model: "claude-3.5-sonnet",
+          },
+        },
+      },
       setDefaultModel: false,
       defaultModel,
-      // Simulate a provider function that does not explicitly add the entry.
       applyProviderConfig: (config: OpenClawConfig) => config,
       applyDefaultConfig: (config: OpenClawConfig) => config,
       noteAgentModel,
       prompter: makePrompter(),
     });
 
-    // When setDefaultModel is false, agent should inherit from agents.defaults.model
-    // instead of baking in the provider's defaultModel. See issue #24170.
+    // When setDefaultModel is false and inherited default exists,
+    // agent should inherit from agents.defaults.model instead of
+    // baking in the provider's defaultModel. See issue #24170.
     expect(noteAgentModel).not.toHaveBeenCalled();
     expect(applied.agentModelOverride).toBeUndefined();
+    expect(applied.config.agents?.defaults?.models?.[defaultModel]).toEqual({});
+  });
+
+  it("returns agentModelOverride when no inherited default exists", async () => {
+    const defaultModel = "vercel-ai-gateway/anthropic/claude-opus-4.6";
+    const noteAgentModel = vi.fn(async () => {});
+    const applied = await applyDefaultModelChoice({
+      config: {},
+      setDefaultModel: false,
+      defaultModel,
+      applyProviderConfig: (config: OpenClawConfig) => config,
+      applyDefaultConfig: (config: OpenClawConfig) => config,
+      noteAgentModel,
+      prompter: makePrompter(),
+    });
+
+    // When no inherited default model exists, we must return the provider's
+    // default as agentModelOverride to avoid creating an agent with no model.
+    expect(noteAgentModel).not.toHaveBeenCalled();
+    expect(applied.agentModelOverride).toBe(defaultModel);
     expect(applied.config.agents?.defaults?.models?.[defaultModel]).toEqual({});
   });
 

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -7,6 +7,7 @@ import {
 import { upsertAuthProfile } from "../agents/auth-profiles.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { enablePluginInConfig } from "./enable.js";
@@ -218,7 +219,14 @@ export async function applyAuthChoiceLoadedPluginProvider(
     // When setDefaultModel is false (e.g., adding a new agent), do not override
     // the agent's model. Let it inherit from agents.defaults.model instead of
     // baking in the provider's defaultModel. See issue #24170.
+    // However, if there is no inherited primary model, we must still return the
+    // provider's default to avoid creating an agent with no model at all.
     nextConfig = restoreConfiguredPrimaryModel(nextConfig, params.config);
+    const inheritedPrimary = resolveAgentModelPrimaryValue(params.config.agents?.defaults?.model);
+    if (!inheritedPrimary) {
+      return { config: nextConfig, agentModelOverride: applied.defaultModel };
+    }
+    return { config: nextConfig };
   }
 
   return { config: nextConfig };
@@ -307,7 +315,13 @@ export async function applyAuthChoicePluginProvider(
     // When setDefaultModel is false (e.g., adding a new agent), do not override
     // the agent's model. Let it inherit from agents.defaults.model instead of
     // baking in the provider's defaultModel. See issue #24170.
+    // However, if there is no inherited primary model, we must still return the
+    // provider's default to avoid creating an agent with no model at all.
     nextConfig = restoreConfiguredPrimaryModel(nextConfig, params.config);
+    const inheritedPrimary = resolveAgentModelPrimaryValue(params.config.agents?.defaults?.model);
+    if (!inheritedPrimary) {
+      return { config: nextConfig, agentModelOverride: applied.defaultModel };
+    }
     return { config: nextConfig };
   }
 

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -199,7 +199,6 @@ export async function applyAuthChoiceLoadedPluginProvider(
   });
 
   let nextConfig = applied.config;
-  let agentModelOverride: string | undefined;
   if (applied.defaultModel) {
     if (params.setDefaultModel) {
       nextConfig = applyDefaultModel(nextConfig, applied.defaultModel);
@@ -216,11 +215,13 @@ export async function applyAuthChoiceLoadedPluginProvider(
       );
       return { config: nextConfig };
     }
+    // When setDefaultModel is false (e.g., adding a new agent), do not override
+    // the agent's model. Let it inherit from agents.defaults.model instead of
+    // baking in the provider's defaultModel. See issue #24170.
     nextConfig = restoreConfiguredPrimaryModel(nextConfig, params.config);
-    agentModelOverride = applied.defaultModel;
   }
 
-  return { config: nextConfig, agentModelOverride };
+  return { config: nextConfig };
 }
 
 export async function applyAuthChoicePluginProvider(
@@ -303,14 +304,11 @@ export async function applyAuthChoicePluginProvider(
       );
       return { config: nextConfig };
     }
-    if (params.agentId) {
-      await params.prompter.note(
-        `Default model set to ${applied.defaultModel} for agent "${params.agentId}".`,
-        "Model configured",
-      );
-    }
+    // When setDefaultModel is false (e.g., adding a new agent), do not override
+    // the agent's model. Let it inherit from agents.defaults.model instead of
+    // baking in the provider's defaultModel. See issue #24170.
     nextConfig = restoreConfiguredPrimaryModel(nextConfig, params.config);
-    return { config: nextConfig, agentModelOverride: applied.defaultModel };
+    return { config: nextConfig };
   }
 
   return { config: nextConfig };


### PR DESCRIPTION
Superseded by #74954. Closing in favor of a clean PR based on latest main with the same core fix.

Thanks for the feedback on the previous iterations — this new PR addresses the review comments and is ready for another look.