### PR TITLE
ACPX: harden Windows queue-owner failure recovery

### DIFF
--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -12,6 +12,7 @@ import {
   ACPX_PLUGIN_TOOLS_MCP_SERVER_NAME,
   ACPX_PINNED_VERSION,
   createAcpxPluginConfigSchema,
+  resolveDefaultQueueOwnerTtlSeconds,
   resolveAcpxPluginRoot,
   resolveAcpxPluginConfig,
   resolvePluginToolsMcpServerConfig,
@@ -80,6 +81,7 @@ describe("acpx plugin config parsing", () => {
     expect(resolved.pluginToolsMcpBridge).toBe(false);
     expect(resolved.mcpServers).toEqual({});
     expect(resolved.strictWindowsCmdWrapper).toBe(true);
+    expect(resolved.queueOwnerTtlSeconds).toBe(resolveDefaultQueueOwnerTtlSeconds());
   });
 
   it("accepts command override and disables plugin-local auto-install", () => {
@@ -256,6 +258,11 @@ describe("acpx plugin config parsing", () => {
     });
 
     expect(resolved.strictWindowsCmdWrapper).toBe(true);
+  });
+
+  it("uses a higher default queue-owner TTL on Windows", () => {
+    expect(resolveDefaultQueueOwnerTtlSeconds("win32")).toBe(2);
+    expect(resolveDefaultQueueOwnerTtlSeconds("linux")).toBe(0.1);
   });
 
   it("rejects non-boolean strictWindowsCmdWrapper", () => {

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -59,7 +59,9 @@ describe("acpx plugin config parsing", () => {
       fs.writeFileSync(path.join(bundledPluginRoot, "openclaw.plugin.json"), "{}\n", "utf8");
 
       const moduleUrl = pathToFileURL(path.join(bundledPluginRoot, "index.js")).href;
-      expect(resolveAcpxPluginRoot(moduleUrl)).toBe(workspacePluginRoot);
+      expect(path.normalize(resolveAcpxPluginRoot(moduleUrl))).toBe(
+        path.normalize(workspacePluginRoot),
+      );
     } finally {
       fs.rmSync(repoRoot, { recursive: true, force: true });
     }

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -116,8 +116,15 @@ export type ResolvedAcpxPluginConfig = {
 
 const DEFAULT_PERMISSION_MODE: AcpxPermissionMode = "approve-reads";
 const DEFAULT_NON_INTERACTIVE_POLICY: AcpxNonInteractivePermissionPolicy = "fail";
-const DEFAULT_QUEUE_OWNER_TTL_SECONDS = 0.1;
 const DEFAULT_STRICT_WINDOWS_CMD_WRAPPER = true;
+
+export function resolveDefaultQueueOwnerTtlSeconds(
+  platform: NodeJS.Platform = process.platform,
+): number {
+  // Windows spawn/wrapper overhead can make a 100ms owner TTL too aggressive
+  // for medium/complex prompt turns; keep other platforms unchanged.
+  return platform === "win32" ? 2 : 0.1;
+}
 
 type ParseResult =
   | { ok: true; value: AcpxPluginConfig | undefined }
@@ -324,7 +331,8 @@ export function resolveAcpxPluginConfig(params: {
     strictWindowsCmdWrapper:
       normalized.strictWindowsCmdWrapper ?? DEFAULT_STRICT_WINDOWS_CMD_WRAPPER,
     timeoutSeconds: normalized.timeoutSeconds,
-    queueOwnerTtlSeconds: normalized.queueOwnerTtlSeconds ?? DEFAULT_QUEUE_OWNER_TTL_SECONDS,
+    queueOwnerTtlSeconds:
+      normalized.queueOwnerTtlSeconds ?? resolveDefaultQueueOwnerTtlSeconds(),
     mcpServers,
   };
 }

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { runAcpRuntimeAdapterContract } from "openclaw/plugin-sdk/testing";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { resolveAcpxPluginConfig } from "./config.js";
+import { resolveAcpxPluginConfig, resolveDefaultQueueOwnerTtlSeconds } from "./config.js";
 import { AcpxRuntime, decodeAcpxRuntimeHandleState } from "./runtime.js";
 import {
   cleanupMockRuntimeFixtures,
@@ -382,7 +382,7 @@ describe("AcpxRuntime", () => {
     const promptArgs = (prompt?.args as string[]) ?? [];
     const ttlFlagIndex = promptArgs.indexOf("--ttl");
     expect(ttlFlagIndex).toBeGreaterThanOrEqual(0);
-    expect(promptArgs[ttlFlagIndex + 1]).toBe("0.1");
+    expect(promptArgs[ttlFlagIndex + 1]).toBe(String(resolveDefaultQueueOwnerTtlSeconds()));
   });
 
   it("emits done once when ACP stream repeats stop reason responses", async () => {

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -203,7 +203,7 @@ describe("AcpxRuntime", () => {
 
       expect(events).toContainEqual({
         type: "error",
-        message: "acpx exited with signal SIGTERM",
+        message: "acpx exited with code 1",
       });
       expect(events.some((event) => event.type === "done")).toBe(false);
     } finally {
@@ -553,7 +553,7 @@ describe("AcpxRuntime", () => {
 
       await expect(runtime.getStatus({ handle })).rejects.toMatchObject({
         code: "ACP_TURN_FAILED",
-        message: "acpx exited with signal SIGTERM",
+        message: "acpx exited with code 1",
       });
     } finally {
       if (previousSignal === undefined) {

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -203,7 +203,7 @@ describe("AcpxRuntime", () => {
 
       expect(events).toContainEqual({
         type: "error",
-        message: "acpx exited with code 1",
+        message: "acpx exited with signal SIGTERM",
       });
       expect(events.some((event) => event.type === "done")).toBe(false);
     } finally {
@@ -553,7 +553,7 @@ describe("AcpxRuntime", () => {
 
       await expect(runtime.getStatus({ handle })).rejects.toMatchObject({
         code: "ACP_TURN_FAILED",
-        message: "acpx exited with code 1",
+        message: "acpx exited with signal SIGTERM",
       });
     } finally {
       if (previousSignal === undefined) {

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -6,7 +6,11 @@ import {
 } from "openclaw/plugin-sdk/acp-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AcpRuntime, OpenClawPluginServiceContext } from "../runtime-api.js";
-import { ACPX_BUNDLED_BIN, ACPX_PINNED_VERSION } from "./config.js";
+import {
+  ACPX_BUNDLED_BIN,
+  ACPX_PINNED_VERSION,
+  resolveDefaultQueueOwnerTtlSeconds,
+} from "./config.js";
 import { createAcpxRuntimeService } from "./service.js";
 
 const { ensureAcpxSpy } = vi.hoisted(() => ({
@@ -144,7 +148,7 @@ describe("createAcpxRuntimeService", () => {
     );
   });
 
-  it("uses a short default queue-owner TTL", async () => {
+  it("uses the platform default queue-owner TTL", async () => {
     const { runtime } = createRuntimeStub(true);
     const runtimeFactory = vi.fn(() => runtime);
     const service = createAcpxRuntimeService({
@@ -156,7 +160,7 @@ describe("createAcpxRuntimeService", () => {
 
     expect(runtimeFactory).toHaveBeenCalledWith(
       expect.objectContaining({
-        queueOwnerTtlSeconds: 0.1,
+        queueOwnerTtlSeconds: resolveDefaultQueueOwnerTtlSeconds(),
       }),
     );
   });

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -3,7 +3,7 @@ import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import type { ResolvedAcpxPluginConfig } from "../config.js";
-import { ACPX_PINNED_VERSION } from "../config.js";
+import { ACPX_PINNED_VERSION, resolveDefaultQueueOwnerTtlSeconds } from "../config.js";
 import { AcpxRuntime } from "../runtime.js";
 
 export const NOOP_LOGGER = {
@@ -359,7 +359,8 @@ export async function createMockRuntimeFixture(params?: {
     nonInteractivePermissions: "fail",
     pluginToolsMcpBridge: false,
     strictWindowsCmdWrapper: true,
-    queueOwnerTtlSeconds: params?.queueOwnerTtlSeconds ?? 0.1,
+    queueOwnerTtlSeconds:
+      params?.queueOwnerTtlSeconds ?? resolveDefaultQueueOwnerTtlSeconds(),
     mcpServers: params?.mcpServers ?? {},
   };
 

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -862,6 +862,7 @@ export class AcpSessionManager {
               sessionKey,
               error: acpError,
               sawTurnOutput,
+              backend: meta?.backend ?? resolvedMeta.backend,
             });
             if (retryFreshHandle) {
               continue;
@@ -1576,11 +1577,17 @@ export class AcpSessionManager {
     sessionKey: string;
     error: AcpRuntimeError;
     sawTurnOutput: boolean;
+    backend?: string;
   }): boolean {
     if (params.attempt > 0 || params.sawTurnOutput) {
       return false;
     }
-    if (!this.isRecoverableAcpxExitError(params.error.message)) {
+    if (
+      !this.isRetryableAcpxStartupFailure({
+        backend: params.backend,
+        error: params.error,
+      })
+    ) {
       return false;
     }
     this.clearCachedRuntimeState(params.sessionKey);
@@ -1591,9 +1598,21 @@ export class AcpSessionManager {
   }
 
   private isRecoverableAcpxExitError(message: string): boolean {
-    const normalized = message.trim();
+    return /^acpx exited with code \d+/i.test(message.trim());
+  }
+
+  private isRetryableAcpxStartupFailure(params: {
+    backend: string | undefined;
+    error: AcpRuntimeError;
+  }): boolean {
+    const backend = params.backend?.trim().toLowerCase();
+    if (backend !== "acpx" || params.error.code !== "ACP_TURN_FAILED") {
+      return false;
+    }
+    const normalized = params.error.message.trim();
     return (
-      /^acpx exited with (code \d+|signal [a-z0-9]+)/i.test(normalized) ||
+      this.isRecoverableAcpxExitError(normalized) ||
+      /^acpx exited with signal [a-z0-9]+/i.test(normalized) ||
       /\bqueue owner\b.*\bunavailable\b/i.test(normalized)
     );
   }

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -1606,12 +1606,17 @@ export class AcpSessionManager {
     error: AcpRuntimeError;
   }): boolean {
     const backend = params.backend?.trim().toLowerCase();
-    if (backend !== "acpx" || params.error.code !== "ACP_TURN_FAILED") {
+    if (backend !== "acpx") {
       return false;
     }
     const normalized = params.error.message.trim();
+    if (this.isRecoverableAcpxExitError(normalized)) {
+      return true;
+    }
+    if (params.error.code !== "ACP_TURN_FAILED") {
+      return false;
+    }
     return (
-      this.isRecoverableAcpxExitError(normalized) ||
       /^acpx exited with signal [a-z0-9]+/i.test(normalized) ||
       /\bqueue owner\b.*\bunavailable\b/i.test(normalized)
     );

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -773,10 +773,10 @@ export class AcpSessionManager {
                   continue;
                 }
                 if (event.type === "error") {
-                  streamError = new AcpRuntimeError(
-                    normalizeAcpErrorCode(event.code),
-                    event.message?.trim() || "ACP turn failed before completion.",
-                  );
+                  const normalizedCode = normalizeAcpErrorCode(event.code);
+                  const normalizedMessage =
+                    event.message?.trim() || "ACP turn failed before completion.";
+                  streamError = new AcpRuntimeError(normalizedCode, normalizedMessage);
                 } else if (event.type === "text_delta" || event.type === "tool_call") {
                   sawTurnOutput = true;
                   if (event.type === "text_delta" && event.stream !== "thought" && event.text) {
@@ -1616,7 +1616,12 @@ export class AcpSessionManager {
     if (params.error.code !== "ACP_TURN_FAILED") {
       return false;
     }
-    return /\bqueue owner\b.*\bunavailable\b/i.test(normalized);
+    return (
+      /^queue owner unavailable$/i.test(normalized) ||
+      /^queue owner unavailable\b.*\b(start(?:ing|up)?|initializ(?:e|ing|ation)|bootstrap)\b/i.test(
+        normalized,
+      )
+    );
   }
 
   private async evictIdleRuntimeHandles(params: { cfg: OpenClawConfig }): Promise<void> {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -1591,7 +1591,11 @@ export class AcpSessionManager {
   }
 
   private isRecoverableAcpxExitError(message: string): boolean {
-    return /^acpx exited with (code \d+|signal [a-z0-9]+)/i.test(message.trim());
+    const normalized = message.trim();
+    return (
+      /^acpx exited with (code \d+|signal [a-z0-9]+)/i.test(normalized) ||
+      /\bqueue owner\b.*\bunavailable\b/i.test(normalized)
+    );
   }
 
   private async evictIdleRuntimeHandles(params: { cfg: OpenClawConfig }): Promise<void> {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -863,7 +863,6 @@ export class AcpSessionManager {
               backend: meta?.backend ?? resolvedMeta.backend,
               error: acpError,
               sawTurnOutput,
-              backend: meta?.backend ?? resolvedMeta.backend,
             });
             if (retryFreshHandle) {
               continue;
@@ -1579,7 +1578,6 @@ export class AcpSessionManager {
     backend?: string;
     error: AcpRuntimeError;
     sawTurnOutput: boolean;
-    backend?: string;
   }): boolean {
     if (params.attempt > 0 || params.sawTurnOutput) {
       return false;
@@ -1618,28 +1616,7 @@ export class AcpSessionManager {
     if (params.error.code !== "ACP_TURN_FAILED") {
       return false;
     }
-    return /^queue owner unavailable[.!]?$/i.test(normalized);
-  }
-
-  private isRetryableAcpxStartupFailure(params: {
-    backend: string | undefined;
-    error: AcpRuntimeError;
-  }): boolean {
-    const backend = params.backend?.trim().toLowerCase();
-    if (backend !== "acpx") {
-      return false;
-    }
-    const normalized = params.error.message.trim();
-    if (this.isRecoverableAcpxExitError(normalized)) {
-      return true;
-    }
-    if (params.error.code !== "ACP_TURN_FAILED") {
-      return false;
-    }
-    return (
-      /^acpx exited with signal [a-z0-9]+/i.test(normalized) ||
-      /\bqueue owner\b.*\bunavailable\b/i.test(normalized)
-    );
+    return /\bqueue owner\b.*\bunavailable\b/i.test(normalized);
   }
 
   private async evictIdleRuntimeHandles(params: { cfg: OpenClawConfig }): Promise<void> {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -711,6 +711,7 @@ export class AcpSessionManager {
           let onCallerAbort: (() => void) | undefined;
           let activeTurnStarted = false;
           let sawTurnOutput = false;
+          let sawTurnDone = false;
           let retryFreshHandle = false;
           let skipPostTurnCleanup = false;
           try {
@@ -777,6 +778,8 @@ export class AcpSessionManager {
                   const normalizedMessage =
                     event.message?.trim() || "ACP turn failed before completion.";
                   streamError = new AcpRuntimeError(normalizedCode, normalizedMessage);
+                } else if (event.type === "done") {
+                  sawTurnDone = true;
                 } else if (event.type === "text_delta" || event.type === "tool_call") {
                   sawTurnOutput = true;
                   if (event.type === "text_delta" && event.stream !== "thought" && event.text) {
@@ -863,6 +866,7 @@ export class AcpSessionManager {
               backend: meta?.backend ?? resolvedMeta.backend,
               error: acpError,
               sawTurnOutput,
+              sawTurnDone,
             });
             if (retryFreshHandle) {
               continue;
@@ -1578,8 +1582,9 @@ export class AcpSessionManager {
     backend?: string;
     error: AcpRuntimeError;
     sawTurnOutput: boolean;
+    sawTurnDone: boolean;
   }): boolean {
-    if (params.attempt > 0 || params.sawTurnOutput) {
+    if (params.attempt > 0 || params.sawTurnOutput || params.sawTurnDone) {
       return false;
     }
     if (

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -860,6 +860,7 @@ export class AcpSessionManager {
             retryFreshHandle = this.shouldRetryTurnWithFreshHandle({
               attempt,
               sessionKey,
+              backend: meta?.backend ?? resolvedMeta.backend,
               error: acpError,
               sawTurnOutput,
               backend: meta?.backend ?? resolvedMeta.backend,
@@ -1575,6 +1576,7 @@ export class AcpSessionManager {
   private shouldRetryTurnWithFreshHandle(params: {
     attempt: number;
     sessionKey: string;
+    backend?: string;
     error: AcpRuntimeError;
     sawTurnOutput: boolean;
     backend?: string;
@@ -1598,7 +1600,25 @@ export class AcpSessionManager {
   }
 
   private isRecoverableAcpxExitError(message: string): boolean {
-    return /^acpx exited with code \d+/i.test(message.trim());
+    return /^acpx exited with (code \d+|signal [a-z0-9]+)/i.test(message.trim());
+  }
+
+  private isRetryableAcpxStartupFailure(params: {
+    backend: string | undefined;
+    error: AcpRuntimeError;
+  }): boolean {
+    const backend = params.backend?.trim().toLowerCase();
+    if (backend !== "acpx") {
+      return false;
+    }
+    const normalized = params.error.message.trim();
+    if (this.isRecoverableAcpxExitError(normalized)) {
+      return true;
+    }
+    if (params.error.code !== "ACP_TURN_FAILED") {
+      return false;
+    }
+    return /^queue owner unavailable[.!]?$/i.test(normalized);
   }
 
   private isRetryableAcpxStartupFailure(params: {

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1151,6 +1151,67 @@ describe("AcpSessionManager", () => {
     expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
   });
 
+  it("does not treat queue owner unavailable as backend-unavailable during close", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.close.mockRejectedValueOnce(new Error("queue owner unavailable"));
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: {
+          ...readySessionMeta(),
+          runtimeSessionName: `runtime:${sessionKey}`,
+        },
+      };
+    });
+    const limitedCfg = {
+      acp: {
+        ...baseCfg.acp,
+        maxConcurrentSessions: 1,
+      },
+    } as OpenClawConfig;
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: limitedCfg,
+      sessionKey: "agent:codex:acp:session-a",
+      text: "first",
+      mode: "prompt",
+      requestId: "r1",
+    });
+
+    await expect(
+      manager.closeSession({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-a",
+        reason: "manual-close",
+        allowBackendUnavailable: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "ACP_TURN_FAILED",
+      message: "queue owner unavailable",
+    });
+
+    await expect(
+      manager.runTurn({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-b",
+        text: "second",
+        mode: "prompt",
+        requestId: "r2",
+      }),
+    ).rejects.toMatchObject({
+      code: "ACP_SESSION_INIT_FAILED",
+      message: expect.stringContaining("max concurrent sessions"),
+    });
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(1);
+  });
+
   it("evicts idle cached runtimes before enforcing max concurrent limits", async () => {
     vi.useFakeTimers();
     try {
@@ -1583,6 +1644,45 @@ describe("AcpSessionManager", () => {
     expect(states).toContain("running");
     expect(states).toContain("idle");
     expect(states).not.toContain("error");
+  });
+
+  it("does not retry when an early error only contains queue owner unavailable", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+    runtimeState.runTurn.mockImplementationOnce(async function* () {
+      yield {
+        type: "error" as const,
+        message: "tool execution failed: queue owner unavailable while replaying command output",
+      };
+    });
+
+    const manager = new AcpSessionManager();
+    await expect(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-queue-owner-no-retry",
+      }),
+    ).rejects.toMatchObject({
+      code: "ACP_TURN_FAILED",
+      message: "tool execution failed: queue owner unavailable while replaying command output",
+    });
+
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(1);
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+    const states = extractStatesFromUpserts();
+    expect(states).toContain("running");
+    expect(states.at(-1)).toBe("error");
   });
 
   it("persists runtime mode changes through setSessionRuntimeMode", async () => {

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1523,6 +1523,38 @@ describe("AcpSessionManager", () => {
     expect(states.at(-1)).toBe("error");
   });
 
+  it("retries once when runtime ensure sees an early transient acpx exit", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.ensureSession.mockRejectedValueOnce(new Error("acpx exited with code 1"));
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+
+    const manager = new AcpSessionManager();
+    await expect(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-ensure-retry",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+    const states = extractStatesFromUpserts();
+    expect(states).toContain("running");
+    expect(states).toContain("idle");
+    expect(states).not.toContain("error");
+  });
+
   it("retries once with a fresh runtime handle after an early acpx exit", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1544,6 +1544,47 @@ describe("AcpSessionManager", () => {
     expect(states).not.toContain("error");
   });
 
+  it("retries once when acpx reports queue owner unavailable before any turn output", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+    runtimeState.runTurn
+      .mockImplementationOnce(async function* () {
+        yield {
+          type: "error" as const,
+          message: "queue owner unavailable",
+        };
+      })
+      .mockImplementationOnce(async function* () {
+        yield { type: "done" as const };
+      });
+
+    const manager = new AcpSessionManager();
+    await expect(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-queue-owner-retry",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
+    const states = extractStatesFromUpserts();
+    expect(states).toContain("running");
+    expect(states).toContain("idle");
+    expect(states).not.toContain("error");
+  });
+
   it("persists runtime mode changes through setSessionRuntimeMode", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1717,6 +1717,46 @@ describe("AcpSessionManager", () => {
     expect(states.at(-1)).toBe("error");
   });
 
+  it("does not retry when acpx emits done before a bare queue owner unavailable error", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+    runtimeState.runTurn.mockImplementationOnce(async function* () {
+      yield { type: "done" as const };
+      yield {
+        type: "error" as const,
+        message: "queue owner unavailable",
+      };
+    });
+
+    const manager = new AcpSessionManager();
+    await expect(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-queue-owner-done-no-retry",
+      }),
+    ).rejects.toMatchObject({
+      code: "ACP_TURN_FAILED",
+      message: "queue owner unavailable",
+    });
+
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(1);
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+    const states = extractStatesFromUpserts();
+    expect(states).toContain("running");
+    expect(states.at(-1)).toBe("error");
+  });
+
   it("persists runtime mode changes through setSessionRuntimeMode", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({


### PR DESCRIPTION
## Summary
- harden Windows ACPX queue-owner failure recovery by retrying with a fresh runtime handle only for startup-stage failures
- preserve stale-exit recovery during init-stage startup failures
- add regression coverage for Windows queue-owner TTL defaults and startup-only retry matching

Fixes #56345