### PR TITLE
fix(mistral): resolve onboarding 422 errors with model compatibility settings

### DIFF
--- a/extensions/mistral/api.ts
+++ b/extensions/mistral/api.ts
@@ -4,40 +4,9 @@ export {
   MISTRAL_BASE_URL,
   MISTRAL_DEFAULT_MODEL_ID,
 } from "./model-definitions.js";
+export { applyMistralModelCompat, MISTRAL_MODEL_COMPAT_PATCH } from "./model-compat.js";
 export {
   applyMistralConfig,
   applyMistralProviderConfig,
   MISTRAL_DEFAULT_MODEL_REF,
 } from "./onboard.js";
-
-const MISTRAL_MAX_TOKENS_FIELD = "max_tokens";
-
-export const MISTRAL_MODEL_COMPAT_PATCH = {
-  supportsStore: false,
-  supportsReasoningEffort: false,
-  maxTokensField: MISTRAL_MAX_TOKENS_FIELD,
-} as const satisfies {
-  supportsStore: boolean;
-  supportsReasoningEffort: boolean;
-  maxTokensField: "max_tokens";
-};
-
-export function applyMistralModelCompat<T extends { compat?: unknown }>(model: T): T {
-  const compat =
-    model.compat && typeof model.compat === "object"
-      ? (model.compat as Record<string, unknown>)
-      : undefined;
-  if (
-    compat &&
-    Object.entries(MISTRAL_MODEL_COMPAT_PATCH).every(([key, value]) => compat[key] === value)
-  ) {
-    return model;
-  }
-  return {
-    ...model,
-    compat: {
-      ...compat,
-      ...MISTRAL_MODEL_COMPAT_PATCH,
-    } as T extends { compat?: infer TCompat } ? TCompat : never,
-  } as T;
-}

--- a/extensions/mistral/model-compat.ts
+++ b/extensions/mistral/model-compat.ts
@@ -1,0 +1,31 @@
+const MISTRAL_MAX_TOKENS_FIELD = "max_tokens";
+
+export const MISTRAL_MODEL_COMPAT_PATCH = {
+  supportsStore: false,
+  supportsReasoningEffort: false,
+  maxTokensField: MISTRAL_MAX_TOKENS_FIELD,
+} as const satisfies {
+  supportsStore: boolean;
+  supportsReasoningEffort: boolean;
+  maxTokensField: "max_tokens";
+};
+
+export function applyMistralModelCompat<T extends { compat?: unknown }>(model: T): T {
+  const compat =
+    model.compat && typeof model.compat === "object"
+      ? (model.compat as Record<string, unknown>)
+      : undefined;
+  if (
+    compat &&
+    Object.entries(MISTRAL_MODEL_COMPAT_PATCH).every(([key, value]) => compat[key] === value)
+  ) {
+    return model;
+  }
+  return {
+    ...model,
+    compat: {
+      ...compat,
+      ...MISTRAL_MODEL_COMPAT_PATCH,
+    } as T extends { compat?: infer TCompat } ? TCompat : never,
+  } as T;
+}

--- a/extensions/mistral/onboard.test.ts
+++ b/extensions/mistral/onboard.test.ts
@@ -62,6 +62,10 @@ describe("mistral onboard", () => {
       id: bundled.id,
       contextWindow: bundled.contextWindow,
       maxTokens: bundled.maxTokens,
+      compat: {
+        supportsStore: false,
+        maxTokensField: "max_tokens",
+      },
     });
   });
 

--- a/extensions/mistral/onboard.ts
+++ b/extensions/mistral/onboard.ts
@@ -2,6 +2,7 @@ import {
   createDefaultModelPresetAppliers,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
+import { applyMistralModelCompat } from "./model-compat.js";
 import {
   buildMistralModelDefinition,
   MISTRAL_BASE_URL,
@@ -16,7 +17,7 @@ const mistralPresetAppliers = createDefaultModelPresetAppliers({
     providerId: "mistral",
     api: "openai-completions",
     baseUrl: MISTRAL_BASE_URL,
-    defaultModel: buildMistralModelDefinition(),
+    defaultModel: applyMistralModelCompat(buildMistralModelDefinition()),
     defaultModelId: MISTRAL_DEFAULT_MODEL_ID,
     aliases: [{ modelRef: MISTRAL_DEFAULT_MODEL_REF, alias: "Mistral" }],
   }),

--- a/extensions/mistral/provider-catalog.ts
+++ b/extensions/mistral/provider-catalog.ts
@@ -1,10 +1,13 @@
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { applyMistralModelCompat } from "./model-compat.js";
 import { buildMistralCatalogModels, MISTRAL_BASE_URL } from "./model-definitions.js";
 
 export function buildMistralProvider(): ModelProviderConfig {
   return {
     baseUrl: MISTRAL_BASE_URL,
     api: "openai-completions",
-    models: buildMistralCatalogModels(),
+    // Apply compat patch to all catalog models to prevent 422 errors when users
+    // manually select models like codestral-latest or mistral-small-latest
+    models: buildMistralCatalogModels().map((model) => applyMistralModelCompat(model)),
   };
 }


### PR DESCRIPTION
# Problem

Mistral provider onboarding failed with 422 errors due to missing compatibility settings for model parameters.

# Root Cause

Mistral API requires `max_tokens` field (not `max_completion_tokens`) and does not support the `store` parameter.

# Fix

- Extract `applyMistralModelCompat()` into new `extensions/mistral/model-compat.ts`
- Apply compat patch during onboarding to set `supportsStore: false` and `maxTokensField: max_tokens`
- Re-export from `api.ts` to avoid circular imports

# Testing

- ✅ check
- ✅ lint

Closes #56546