### PR TITLE
fix: rewrite sessionFile to match new sessionId on gateway session reset

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -243,7 +243,7 @@ function resolveCompactionSessionFile(params: {
   );
 }
 
-function canonicalizeAbsoluteSessionFilePath(filePath: string): string {
+export function canonicalizeAbsoluteSessionFilePath(filePath: string): string {
   const resolved = path.resolve(filePath);
   try {
     const parentDir = fs.realpathSync(path.dirname(resolved));
@@ -253,7 +253,7 @@ function canonicalizeAbsoluteSessionFilePath(filePath: string): string {
   }
 }
 
-function rewriteSessionFileForNewSessionId(params: {
+export function rewriteSessionFileForNewSessionId(params: {
   sessionFile?: string;
   previousSessionId: string;
   nextSessionId: string;

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1186,6 +1186,60 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
+  test("sessions.reset rewrites sessionFile to match new sessionId", async () => {
+    const { dir, storePath } = await createSessionStoreDir();
+    const oldSessionId = "a0000000-0000-4000-8000-000000000001";
+    const oldSessionFile = path.join(dir, `${oldSessionId}.jsonl`);
+
+    await fs.writeFile(
+      oldSessionFile,
+      `${JSON.stringify({ role: "user", content: "old message" })}\n`,
+      "utf-8",
+    );
+
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: oldSessionId,
+          sessionFile: oldSessionFile,
+          updatedAt: Date.now(),
+        },
+      },
+    });
+
+    const { ws } = await openClient();
+    const reset = await rpcReq<{
+      ok: true;
+      key: string;
+      entry: {
+        sessionId: string;
+        sessionFile?: string;
+      };
+    }>(ws, "sessions.reset", { key: "main" });
+
+    expect(reset.ok).toBe(true);
+
+    const newSessionId = reset.payload?.entry.sessionId;
+    const newSessionFile = reset.payload?.entry.sessionFile;
+
+    expect(newSessionId).not.toBe(oldSessionId);
+    expect(newSessionId).toBeTruthy();
+    expect(newSessionFile).toBeTruthy();
+
+    // The new sessionFile basename must contain the new sessionId, not the old one.
+    expect(path.basename(newSessionFile as string)).toBe(`${newSessionId}.jsonl`);
+    expect(newSessionFile).not.toContain(oldSessionId);
+
+    await expect(fs.stat(newSessionFile as string)).resolves.toBeTruthy();
+
+    // Verify persisted store also has the correct sessionFile.
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(store["agent:main:main"]?.sessionFile).toBe(newSessionFile);
+    expect(store["agent:main:main"]?.sessionId).toBe(newSessionId);
+
+    ws.close();
+  });
+
   test("sessions.reset preserves spawned session ownership metadata", async () => {
     const { storePath } = await createSessionStoreDir();
     const customSessionFile = path.join(

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -8,6 +8,10 @@ import { clearBootstrapSnapshot } from "../agents/bootstrap-cache.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../auto-reply/reply/queue.js";
+import {
+  canonicalizeAbsoluteSessionFilePath,
+  rewriteSessionFileForNewSessionId,
+} from "../auto-reply/reply/session-updates.js";
 import { loadConfig } from "../config/config.js";
 import {
   snapshotSessionOrigin,
@@ -311,9 +315,18 @@ export async function performGatewaySessionReset(params: {
     oldSessionFile = currentEntry?.sessionFile;
     const now = Date.now();
     const nextSessionId = randomUUID();
+    const rewrittenSessionFile = rewriteSessionFileForNewSessionId({
+      sessionFile: currentEntry?.sessionFile,
+      previousSessionId: oldSessionId ?? "",
+      nextSessionId,
+    });
+    const normalizedRewrittenSessionFile =
+      rewrittenSessionFile && path.isAbsolute(rewrittenSessionFile)
+        ? canonicalizeAbsoluteSessionFilePath(rewrittenSessionFile)
+        : rewrittenSessionFile;
     const sessionFile = resolveSessionFilePath(
       nextSessionId,
-      currentEntry?.sessionFile ? { sessionFile: currentEntry.sessionFile } : undefined,
+      normalizedRewrittenSessionFile ? { sessionFile: normalizedRewrittenSessionFile } : undefined,
       resolveSessionFilePathOptions({
         storePath,
         agentId: sessionAgentId,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -320,13 +320,14 @@ export async function performGatewaySessionReset(params: {
       previousSessionId: oldSessionId ?? "",
       nextSessionId,
     });
-    const normalizedRewrittenSessionFile =
-      rewrittenSessionFile && path.isAbsolute(rewrittenSessionFile)
-        ? canonicalizeAbsoluteSessionFilePath(rewrittenSessionFile)
-        : rewrittenSessionFile;
+    const effectiveSessionFile = rewrittenSessionFile ?? currentEntry?.sessionFile;
+    const normalizedSessionFile =
+      effectiveSessionFile && path.isAbsolute(effectiveSessionFile)
+        ? canonicalizeAbsoluteSessionFilePath(effectiveSessionFile)
+        : effectiveSessionFile;
     const sessionFile = resolveSessionFilePath(
       nextSessionId,
-      normalizedRewrittenSessionFile ? { sessionFile: normalizedRewrittenSessionFile } : undefined,
+      normalizedSessionFile ? { sessionFile: normalizedSessionFile } : undefined,
       resolveSessionFilePathOptions({
         storePath,
         agentId: sessionAgentId,


### PR DESCRIPTION
## Summary

- Fixes #57020: gateway session reset creates new `sessionId` but preserves stale `sessionFile`
- The reset service now rewrites the sessionFile path to match the new sessionId, preventing transcript data from persisting across resets

## Problem

`performGatewaySessionReset` was passing the old `sessionFile` (named after the old UUID) directly to `resolveSessionFilePath`, which returned it as-is. This meant the new session entry's `sessionFile` pointed to a file named after the **old** session ID — transcripts never actually reset, and old data persisted under the new session.

## Fix

Apply `rewriteSessionFileForNewSessionId` (already used by the compaction path in `session-updates.ts`) before `resolveSessionFilePath`. This correctly rewrites UUID-based, topic-suffix, and fork-pattern sessionFile names to reference the new sessionId. Custom-named sessionFiles (non-UUID patterns) are preserved as-is.

## Changes

- **`src/auto-reply/reply/session-updates.ts`**: Export `rewriteSessionFileForNewSessionId` and `canonicalizeAbsoluteSessionFilePath` (previously private functions)
- **`src/gateway/session-reset-service.ts`**: Use `rewriteSessionFileForNewSessionId` before `resolveSessionFilePath` in `performGatewaySessionReset`
- **`src/gateway/server.sessions.gateway-server-sessions-a.test.ts`**: Add test verifying sessionFile basename contains the new sessionId after reset

## Test plan

- `pnpm test` — new test verifies the sessionFile is rewritten to match the new sessionId
- `pnpm check` — oxlint passes on all modified files