### PR TITLE
fix(heartbeat): clear sessionFile on new isolated session to prevent context accumulation

### DIFF
--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -83,6 +83,7 @@ export function resolveCronSession(params: {
       lastAccountId: undefined,
       lastThreadId: undefined,
       deliveryContext: undefined,
+      sessionFile: undefined,
     }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };


### PR DESCRIPTION
## Problem

When `isolatedSession: true` is configured for heartbeats, `resolveCronSession` is called with `forceNew: true` and correctly generates a new `sessionId` (UUID) on every heartbeat tick.

However, the new session entry was spread from the prior entry (`...entry`), which **preserved the old `sessionFile` path** from the previous run.

`resolveSessionFilePath` has this logic:
```ts
function resolveSessionFilePath(sessionId, entry, opts) {
  const candidate = entry?.sessionFile?.trim();
  if (candidate) return resolvePathWithinSessionsDir(...);  // prefers entry.sessionFile!
  return resolveSessionTranscriptPathInDir(sessionId, sessionsDir);  // only fallback
}
```

So **every heartbeat continued appending to the same old transcript file**, even though a new `sessionId` was assigned. This caused unbounded context growth that eventually triggered model fallbacks and failed heartbeat runs — despite `isolatedSession: true` being set.

Observed: context grew from ~18K tokens to **190K+ tokens** over 24 hours, causing repeated Gemini API errors and fallback to backup models.

## Fix

Clear `sessionFile` when `isNewSession` is true, so `resolveSessionFilePath` falls through to derive a fresh path from the new `sessionId`.

```ts
...(isNewSession && { sessionFile: undefined }),
```

This is analogous to the existing cleanup of `lastChannel`, `lastTo`, `deliveryContext`, etc. that was already done on new session rollover.

## Testing

- Verified locally with `isolatedSession: true` + 1h heartbeat interval: each heartbeat now creates a new `<uuid>.jsonl` transcript file, starting at ~18K tokens instead of inheriting prior session history.
- Existing session.test.ts passes.

## Related

Fixes #43767