### PR TITLE
Use launchctl stop for gateway stop

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -11,6 +11,7 @@ import {
   repairLaunchAgentBootstrap,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
+  stopLaunchAgent,
 } from "./launchd.js";
 
 const state = vi.hoisted(() => ({
@@ -354,6 +355,27 @@ describe("launchd install", () => {
     expect(state.launchctlCalls).toContainEqual(["kickstart", "-k", serviceId]);
     expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
     expect(state.launchctlCalls.some((call) => call[0] === "bootstrap")).toBe(false);
+  });
+
+  it("stops LaunchAgent without unloading it", async () => {
+    const env = createDefaultLaunchdEnv();
+    const stdout = new PassThrough();
+    let output = "";
+    stdout.on("data", (chunk) => {
+      output += String(chunk);
+    });
+
+    await stopLaunchAgent({
+      env,
+      stdout,
+    });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+
+    expect(state.launchctlCalls).toContainEqual(["stop", `${domain}/${label}`]);
+    expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
+    expect(output).toContain(`Stopped LaunchAgent`);
   });
 
   it("uses the configured gateway port for stale cleanup", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -451,9 +451,9 @@ function isUnsupportedGuiDomain(detail: string): boolean {
 export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
-  const res = await execLaunchctl(["bootout", `${domain}/${label}`]);
+  const res = await execLaunchctl(["stop", `${domain}/${label}`]);
   if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
-    throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
+    throw new Error(`launchctl stop failed: ${res.stderr || res.stdout}`.trim());
   }
   stdout.write(`${formatLine("Stopped LaunchAgent", `${domain}/${label}`)}\n`);
 }


### PR DESCRIPTION
Fixes #57131.

## Summary
- use  for Stopped LaunchAgent: gui/501/ai.openclaw.gateway instead of unloading the LaunchAgent
- keep the existing not-loaded handling intact
- add a regression test asserting stop does not bootout the service

## Verification
- 
 RUN  v4.1.2 /Users/leo/openclaw


 Test Files  1 passed (1)
      Tests  1 passed | 24 skipped (25)
   Start at  11:19:00
   Duration  9.26s (transform 3.38s, setup 9.03s, import 67ms, tests 7ms, environment 0ms)

## Security
- patch only changes launchd service-control behavior and tests
- no config, token, or local user data added to the diff