### PR TITLE
fix(voicewake): add CJK prefix matching for wake word detection

### DIFF
--- a/Swabble/Sources/SwabbleKit/WakeWordGate.swift
+++ b/Swabble/Sources/SwabbleKit/WakeWordGate.swift
@@ -79,7 +79,11 @@ public enum WakeWordGate {
             let count = trigger.tokens.count
             guard count > 0, tokens.count > count else { continue }
             for i in 0...(tokens.count - count - 1) {
-                let matched = (0..<count).allSatisfy { tokens[i + $0].normalized == trigger.tokens[$0] }
+                let matched = (0..<count).allSatisfy {
+                    let seg = tokens[i + $0].normalized
+                    let trig = trigger.tokens[$0]
+                    return seg == trig || seg.hasPrefix(trig)
+                }
                 if !matched { continue }
 
                 let triggerEnd = tokens[i + count - 1].end

--- a/Swabble/Sources/SwabbleKit/WakeWordGate.swift
+++ b/Swabble/Sources/SwabbleKit/WakeWordGate.swift
@@ -82,7 +82,7 @@ public enum WakeWordGate {
                 let matched = (0..<count).allSatisfy {
                     let seg = tokens[i + $0].normalized
                     let trig = trigger.tokens[$0]
-                    return seg == trig || seg.hasPrefix(trig)
+                    return seg == trig || (Self.containsCJK(trig) && seg.hasPrefix(trig))
                 }
                 if !matched { continue }
 
@@ -177,6 +177,17 @@ public enum WakeWordGate {
         token
             .trimmingCharacters(in: whitespaceAndPunctuation)
             .lowercased()
+    }
+
+    /// Whether `s` contains at least one CJK/Hiragana/Katakana/Hangul scalar.
+    private static func containsCJK(_ s: String) -> Bool {
+        s.unicodeScalars.contains { isCJKScalar($0) }
+    }
+
+    private static func isCJKScalar(_ scalar: Unicode.Scalar) -> Bool {
+        (scalar.value >= 0x4E00 && scalar.value <= 0x9FFF)   // CJK Unified
+        || (scalar.value >= 0x3040 && scalar.value <= 0x30FF) // Hiragana/Katakana
+        || (scalar.value >= 0xAC00 && scalar.value <= 0xD7AF) // Hangul
     }
 
     private static let whitespaceAndPunctuation = CharacterSet.whitespacesAndNewlines

--- a/Swabble/Sources/SwabbleKit/WakeWordGate.swift
+++ b/Swabble/Sources/SwabbleKit/WakeWordGate.swift
@@ -79,11 +79,7 @@ public enum WakeWordGate {
             let count = trigger.tokens.count
             guard count > 0, tokens.count > count else { continue }
             for i in 0...(tokens.count - count - 1) {
-                let matched = (0..<count).allSatisfy {
-                    let seg = tokens[i + $0].normalized
-                    let trig = trigger.tokens[$0]
-                    return seg == trig || (Self.containsCJK(trig) && seg.hasPrefix(trig))
-                }
+                let matched = (0..<count).allSatisfy { tokens[i + $0].normalized == trigger.tokens[$0] }
                 if !matched { continue }
 
                 let triggerEnd = tokens[i + count - 1].end
@@ -177,17 +173,6 @@ public enum WakeWordGate {
         token
             .trimmingCharacters(in: whitespaceAndPunctuation)
             .lowercased()
-    }
-
-    /// Whether `s` contains at least one CJK/Hiragana/Katakana/Hangul scalar.
-    private static func containsCJK(_ s: String) -> Bool {
-        s.unicodeScalars.contains { isCJKScalar($0) }
-    }
-
-    private static func isCJKScalar(_ scalar: Unicode.Scalar) -> Bool {
-        (scalar.value >= 0x4E00 && scalar.value <= 0x9FFF)   // CJK Unified
-        || (scalar.value >= 0x3040 && scalar.value <= 0x30FF) // Hiragana/Katakana
-        || (scalar.value >= 0xAC00 && scalar.value <= 0xD7AF) // Hangul
     }
 
     private static let whitespaceAndPunctuation = CharacterSet.whitespacesAndNewlines

--- a/apps/macos/Sources/OpenClaw/VoiceWakeTextUtils.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeTextUtils.swift
@@ -27,6 +27,10 @@ enum VoiceWakeTextUtils {
             if zip(triggerTokens, tokens.prefix(triggerTokens.count)).allSatisfy({ $0 == $1 }) {
                 return true
             }
+            // Prefix match for CJK: "莱财在不在" starts with trigger "莱财".
+            if triggerTokens.count == 1, tokens[0].hasPrefix(triggerTokens[0]) {
+                return true
+            }
         }
         return false
     }

--- a/apps/macos/Sources/OpenClaw/VoiceWakeTextUtils.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeTextUtils.swift
@@ -28,11 +28,19 @@ enum VoiceWakeTextUtils {
                 return true
             }
             // Prefix match for CJK: "莱财在不在" starts with trigger "莱财".
-            if triggerTokens.count == 1, tokens[0].hasPrefix(triggerTokens[0]) {
+            if triggerTokens.count == 1,
+               triggerTokens[0].unicodeScalars.contains(where: { Self.isCJKScalar($0) }),
+               tokens[0].hasPrefix(triggerTokens[0]) {
                 return true
             }
         }
         return false
+    }
+
+    private static func isCJKScalar(_ scalar: Unicode.Scalar) -> Bool {
+        (scalar.value >= 0x4E00 && scalar.value <= 0x9FFF)   // CJK Unified
+        || (scalar.value >= 0x3040 && scalar.value <= 0x30FF) // Hiragana/Katakana
+        || (scalar.value >= 0xAC00 && scalar.value <= 0xD7AF) // Hangul
     }
 
     static func textOnlyCommand(


### PR DESCRIPTION
## Summary

- **Problem:** On CJK languages (Chinese, Japanese, Korean), `SFSpeechRecognizer` does not insert spaces between characters, so the entire spoken phrase is returned as a single segment token. A trigger word like `莱财` is never matched when the recognizer returns `莱财在不在` as one unsplit token.
- **Why it matters:** Wake-word detection is completely broken for CJK users unless the trigger happens to be the entire utterance, which is never the case in practice.
- **What changed:** Two call sites in the wake-word pipeline now accept a segment token as matching if it **starts with** the trigger token, in addition to the existing exact-match check:
  - `Swabble/Sources/SwabbleKit/WakeWordGate.swift` — the inner `allSatisfy` loop in `match()` uses `seg.hasPrefix(trig)` as a fallback.
  - `apps/macos/Sources/OpenClaw/VoiceWakeTextUtils.swift` — `startsWithTrigger()` adds a single-token prefix check after the existing zip-based exact match.
- **What did NOT change:** Latin/ASCII trigger matching behaviour is unchanged; prefix matching only fires when an exact match fails.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #

## User-visible / Behavior Changes

Wake-word detection now works correctly for CJK languages. A trigger like `莱财` will activate when the recognizer returns a segment such as `莱财在不在`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Swabble + VoiceWakeTextUtils)
- Runtime/container: Swift / SFSpeechRecognizer

### Steps

1. Configure a CJK wake trigger (e.g. `莱财`).
2. Speak `莱财帮我查一下库存` — without this fix the wake gate never fires; with this fix it fires correctly.