### PR TITLE
fix: resolveOpenClawPackageRootSync incorrectly resolves dist/ as package root

### DIFF
--- a/src/infra/openclaw-root.test.ts
+++ b/src/infra/openclaw-root.test.ts
@@ -213,6 +213,20 @@ describe("resolveOpenClawPackageRoot", () => {
         expected: null,
       }),
     },
+    {
+      name: "skips dist/ that contains a copy of the root package.json",
+      setup: () => {
+        const pkgRoot = fx("dist-copy");
+        setPackageRoot(pkgRoot);
+        // Simulate the build output: dist/package.json is a copy of root package.json
+        setPackageRoot(path.join(pkgRoot, "dist"));
+        // Module lives inside dist/plugins/ — should resolve to pkgRoot, NOT pkgRoot/dist
+        return {
+          opts: { cwd: path.join(pkgRoot, "dist", "plugins") },
+          expected: pkgRoot,
+        };
+      },
+    },
   ])("$name", async ({ setup }) => {
     const { opts, expected } = setup();
     await expectResolvedPackageRoot(

--- a/src/infra/openclaw-root.ts
+++ b/src/infra/openclaw-root.ts
@@ -30,6 +30,16 @@ async function findPackageRoot(startDir: string, maxDepth = 12): Promise<string 
   for (const current of iterAncestorDirs(startDir, maxDepth)) {
     const name = await readPackageName(current);
     if (name && CORE_PACKAGE_NAMES.has(name)) {
+      // Skip subdirectories that inherit the parent's package name.
+      // The build system copies package.json into dist/, so dist/package.json
+      // has the same "name" as the root. We must prefer the outermost match.
+      const parent = path.dirname(current);
+      if (parent !== current) {
+        const parentName = await readPackageName(parent);
+        if (parentName && parentName === name) {
+          continue;
+        }
+      }
       return current;
     }
   }
@@ -40,6 +50,16 @@ function findPackageRootSync(startDir: string, maxDepth = 12): string | null {
   for (const current of iterAncestorDirs(startDir, maxDepth)) {
     const name = readPackageNameSync(current);
     if (name && CORE_PACKAGE_NAMES.has(name)) {
+      // Skip subdirectories that inherit the parent's package name.
+      // The build system copies package.json into dist/, so dist/package.json
+      // has the same "name" as the root. We must prefer the outermost match.
+      const parent = path.dirname(current);
+      if (parent !== current) {
+        const parentName = readPackageNameSync(parent);
+        if (parentName && parentName === name) {
+          continue;
+        }
+      }
       return current;
     }
   }


### PR DESCRIPTION
## Summary

- `findPackageRootSync` walks up ancestor dirs looking for a `package.json` with `name: "openclaw"`. The build system copies `package.json` into `dist/` for ESM exports resolution, so `dist/package.json` also has `name: "openclaw"`.
- When resolving from `dist/plugins/` (or any dist subdirectory), the walker matches `dist/` **first** (it's closer), returning it as the package root.
- Downstream, `resolvePluginRuntimeModulePath` builds `dist/dist/plugins/runtime/index.js` (double dist/) which doesn't exist → `Unable to resolve plugin runtime module` error.

**Impact**: ALL plugin functionality breaks — memory plugins, announce delivery, subagent results. This affects every npm-installed OpenClaw instance (not source checkouts).

## Fix

In `findPackageRoot` / `findPackageRootSync`: when a candidate directory matches a core package name, check if its parent directory also has the same package name. If so, `continue` to prefer the outermost (true) root.

## Test plan

- [x] Added test case `"skips dist/ that contains a copy of the root package.json"` that simulates the exact scenario
- [x] All existing test cases continue to pass (the fix only changes behavior when a child dir inherits the parent's package name)
- [x] Verified on macOS Intel x86_64 with OpenClaw 2026.3.24 — the symlink workaround at `dist/dist/plugins/runtime/index.js` confirmed the root cause; this PR fixes it properly