### PR TITLE
fix(ios): mark activitykit import as preconcurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 - Agents/silent turns: fail closed on silent memory-flush runs so narrated `NO_REPLY` self-talk cannot stream or finalize into external replies even when block streaming is enabled. (#52593)
 - Browser/plugins: auto-enable the bundled browser plugin when browser config or browser tool policy already references it, and show a clearer CLI error when `plugins.allow` excludes `browser`.
 - Matrix/plugin loading: ship and source-load the crypto bootstrap runtime sidecar correctly so current `main` stops warning about failed Matrix bootstrap loads and `matrix/index` plugin-id mismatches on every invocation. (#53298) thanks @keithce.
+- iOS/Live Activities: mark the `ActivityKit` import in `LiveActivityManager.swift` as `@preconcurrency` so Xcode 26.4 / Swift 6 builds stop failing on strict concurrency checks. (#57180) Thanks @ngutman.
 
 ## 2026.3.28
 

--- a/apps/ios/Sources/LiveActivity/LiveActivityManager.swift
+++ b/apps/ios/Sources/LiveActivity/LiveActivityManager.swift
@@ -1,4 +1,4 @@
-import ActivityKit
+@preconcurrency import ActivityKit
 import Foundation
 import os
 


### PR DESCRIPTION
## Summary

- Problem: `apps/ios/Sources/LiveActivity/LiveActivityManager.swift` failed to compile under Xcode 26.4 / Swift 6 strict concurrency because the plain `ActivityKit` import triggered concurrency diagnostics in this file.
- Why it matters: the latest iOS app could not be built or launched from source on the simulator until this was fixed.
- What changed: switched the import to `@preconcurrency import ActivityKit` in `apps/ios/Sources/LiveActivity/LiveActivityManager.swift`.
- What did NOT change (scope boundary): no runtime logic, entitlements, networking, auth flows, or Live Activity behavior were changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Swift 6 strict concurrency checking now rejects this ActivityKit usage path with a plain import in `apps/ios/Sources/LiveActivity/LiveActivityManager.swift`.
- Missing detection / guardrail: we did not have a current Xcode 26.4 / Swift 6 iOS build gate catching this import-level incompatibility.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: the latest Xcode / Swift toolchain tightened concurrency enforcement on this file.
- If unknown, what was ruled out: the failure reproduced directly in the iOS app build and was resolved by scoping the compatibility fix to the ActivityKit import only.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `apps/ios` simulator build with the `OpenClaw` scheme on current Xcode.
- Scenario the test should lock in: the iOS app builds cleanly on the latest supported Xcode / Swift toolchain.
- Why this is the smallest reliable guardrail: this is a compiler/toolchain compatibility issue rather than a pure logic bug.
- Existing test that already covers this (if any): `xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw ... build`.
- If no new test is added, why not: the right guardrail is the build itself; there is no narrower source-level test that would reliably catch this import compatibility failure.

## User-visible / Behavior Changes

None at runtime. This unblocks building and running the latest iOS app from source.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Xcode 26.4 / iOS 26.4 simulator
- Model/provider: N/A
- Integration/channel (if any): iOS app + gateway pairing flow
- Relevant config (redacted): remote gateway over `wss://<tailnet-host>`

### Steps

1. Build `apps/ios` with `xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -configuration Debug -destination 'id=1D348285-707A-49DD-96D6-63F204DC5798' -derivedDataPath build/SimDerivedData build`.
2. Install and launch the app on the iPhone 17 simulator.
3. Pair/approve the simulator device on the gateway and relaunch to confirm the app connects.

### Expected

- The iOS app builds successfully on the latest Xcode.
- The simulator app launches and connects to the gateway after approval.

### Actual

- Before the fix, the iOS build failed in `LiveActivityManager.swift` under Swift 6 concurrency checks.
- After the fix, the build succeeded and the simulator connected successfully.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before:

```text
apps/ios/Sources/LiveActivity/LiveActivityManager.swift:85:32: error: sending 'activity' risks causing data races
apps/ios/Sources/LiveActivity/LiveActivityManager.swift:95:28: error: sending 'activity' risks causing data races
```

After:

```text
** BUILD SUCCEEDED **
[ai.openclaw.ios:GatewayDiag] operator gateway connected host=gutsy-home.tail06a72.ts.net scheme=wss
[ai.openclaw.ios:GatewayDiag] gateway connected host=gutsy-home.tail06a72.ts.net scheme=wss
```

## Human Verification (required)

- Verified scenarios:
  - rebuilt the iOS app on Xcode 26.4 after rebasing onto latest `origin/main`
  - installed and launched the app on the iPhone 17 simulator
  - approved the pending simulator device on the gateway
  - confirmed operator + node gateway connections in logs
- Edge cases checked:
  - relaunch after approval still reconnects successfully
- What you did **not** verify:
  - full repo-wide `pnpm check` remains red due unrelated TypeScript errors in untouched `src/agents/skills*` files against current `@mariozechner/pi-coding-agent` types

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: `@preconcurrency import ActivityKit` could hide future ActivityKit concurrency issues in this file.
  - Mitigation: scope is limited to a single import in one file, and the build + simulator launch were reverified on latest Xcode.
