### PR TITLE
fix: strip context-1m beta when apiKey is unresolved (OAuth compat)

### DIFF
--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -287,7 +287,9 @@ export function createAnthropicBetaHeadersWrapper(
         : betas;
     if (maybeOauth && requestedContext1m) {
       log.warn(
-        `ignoring context1m for OAuth token auth on ${model.provider}/${model.id}; Anthropic rejects context-1m beta with OAuth auth`,
+        isOauth
+          ? `ignoring context1m for OAuth token auth on ${model.provider}/${model.id}; Anthropic rejects context-1m beta with OAuth auth`
+          : `ignoring context1m for ${model.provider}/${model.id}; apiKey is unresolved (possible OAuth/setup-token), stripping context-1m beta defensively`,
       );
     }
 

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -275,17 +275,25 @@ export function createAnthropicBetaHeadersWrapper(
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     const isOauth = isAnthropicOAuthApiKey(options?.apiKey);
+    // When apiKey is null, the auth controller did not thread the credential
+    // into stream options (regression from the split-auth-controller refactor).
+    // Defensively treat unresolved keys as potentially OAuth so we don't inject
+    // the context-1m beta that Anthropic rejects for OAuth/setup-token auth.
+    const maybeOauth = isOauth || options?.apiKey == null;
     const requestedContext1m = betas.includes(ANTHROPIC_CONTEXT_1M_BETA);
     const effectiveBetas =
-      isOauth && requestedContext1m
+      maybeOauth && requestedContext1m
         ? betas.filter((beta) => beta !== ANTHROPIC_CONTEXT_1M_BETA)
         : betas;
-    if (isOauth && requestedContext1m) {
+    if (maybeOauth && requestedContext1m) {
       log.warn(
         `ignoring context1m for OAuth token auth on ${model.provider}/${model.id}; Anthropic rejects context-1m beta with OAuth auth`,
       );
     }
 
+    // When apiKey is unresolved, pi-ai's createClient() will handle the
+    // correct OAuth vs API-key beta selection at request time.  Use the
+    // default set here to avoid overwriting pi-ai's headers.
     const piAiBetas = isOauth
       ? (PI_AI_OAUTH_ANTHROPIC_BETAS as readonly string[])
       : (PI_AI_DEFAULT_ANTHROPIC_BETAS as readonly string[]);


### PR DESCRIPTION
## Summary

Fixes HTTP 401 `OAuth authentication is currently not supported` when using setup-token auth (`sk-ant-oat01-*`) with `context1m: true` in model params.

This is a regression of the fix for #21011 (closed as dup of #20354), re-introduced by the auth controller refactor (`18dc98b00e`). Also related to #41444.

### Root cause

The auth controller refactor (`18dc98b00e`) broke `apiKey` threading into stream `options`. In `createAnthropicBetaHeadersWrapper`, `options?.apiKey` is always `null`, so `isAnthropicOAuthApiKey()` returns `false`. This means:

1. The `context-1m-2025-08-07` beta is **not stripped** for OAuth tokens (the guard on L277 never fires)
2. Anthropic rejects the request because `context-1m` beta is incompatible with OAuth auth

### Fix

When `options.apiKey` is `null` (unresolved), defensively treat it as potentially OAuth and strip the `context-1m` beta. This is safe:

- **If OAuth**: context-1m correctly stripped, auth works
- **If API key**: apiKey would be non-null (threaded correctly for API keys), so this path isn't hit

pi-ai's `createClient()` independently handles the correct OAuth vs API-key beta selection at request time, so the beta header merge at the wrapper layer doesn't need to add OAuth-specific betas — it just needs to avoid injecting incompatible ones.

### Verified

- Tested with `sk-ant-oat01-*` setup-token + `context1m: true` on v2026.3.28
- Before fix: every Anthropic API call returns 401
- After fix: `openclaw models status --probe` returns `ok`, 1M token budget preserved for LCM

## Test plan

- [ ] `openclaw models status --probe` passes with setup-token auth + `context1m: true`
- [ ] Verify `context-1m` beta is NOT sent in request headers for OAuth tokens
- [ ] Verify `context-1m` beta IS still sent for API key auth (`sk-ant-api-*`)
- [ ] Verify LCM token budget remains 1M when `context1m: true` is in config