### PR TITLE
Fallback when Windows runtime symlinks are denied

### DIFF
--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -3,8 +3,8 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { removePathIfExists } from "./runtime-postbuild-shared.mjs";
 
-function symlinkType() {
-  return process.platform === "win32" ? "junction" : "dir";
+function symlinkType(platform = process.platform) {
+  return platform === "win32" ? "junction" : "dir";
 }
 
 function relativeSymlinkTarget(sourcePath, targetPath) {
@@ -12,18 +12,43 @@ function relativeSymlinkTarget(sourcePath, targetPath) {
   return relativeTarget || ".";
 }
 
-function ensureSymlink(targetValue, targetPath, type) {
+function copyRuntimeOverlayFile(sourcePath, targetPath, fsImpl = fs) {
+  fsImpl.mkdirSync(path.dirname(targetPath), { recursive: true });
+  fsImpl.copyFileSync(sourcePath, targetPath);
+}
+
+function shouldCopyInsteadOfSymlink({ error, fsImpl = fs, platform = process.platform, sourcePath, type }) {
+  if (platform !== "win32" || !sourcePath || type === "dir" || type === "junction") {
+    return false;
+  }
+  if (!["EPERM", "EACCES"].includes(error?.code ?? "")) {
+    return false;
+  }
   try {
-    fs.symlinkSync(targetValue, targetPath, type);
+    return fsImpl.statSync(sourcePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function ensureSymlink(targetValue, targetPath, type, options = {}) {
+  const fsImpl = options.fsImpl ?? fs;
+  const platform = options.platform ?? process.platform;
+  try {
+    fsImpl.symlinkSync(targetValue, targetPath, type);
     return;
   } catch (error) {
+    if (shouldCopyInsteadOfSymlink({ error, fsImpl, platform, sourcePath: options.sourcePath, type })) {
+      copyRuntimeOverlayFile(options.sourcePath, targetPath, fsImpl);
+      return;
+    }
     if (error?.code !== "EEXIST") {
       throw error;
     }
   }
 
   try {
-    if (fs.lstatSync(targetPath).isSymbolicLink() && fs.readlinkSync(targetPath) === targetValue) {
+    if (fsImpl.lstatSync(targetPath).isSymbolicLink() && fsImpl.readlinkSync(targetPath) === targetValue) {
       return;
     }
   } catch {
@@ -31,11 +56,22 @@ function ensureSymlink(targetValue, targetPath, type) {
   }
 
   removePathIfExists(targetPath);
-  fs.symlinkSync(targetValue, targetPath, type);
+  try {
+    fsImpl.symlinkSync(targetValue, targetPath, type);
+  } catch (error) {
+    if (shouldCopyInsteadOfSymlink({ error, fsImpl, platform, sourcePath: options.sourcePath, type })) {
+      copyRuntimeOverlayFile(options.sourcePath, targetPath, fsImpl);
+      return;
+    }
+    throw error;
+  }
 }
 
-function symlinkPath(sourcePath, targetPath, type) {
-  ensureSymlink(relativeSymlinkTarget(sourcePath, targetPath), targetPath, type);
+function symlinkPath(sourcePath, targetPath, type, options = {}) {
+  ensureSymlink(relativeSymlinkTarget(sourcePath, targetPath), targetPath, type, {
+    ...options,
+    sourcePath,
+  });
 }
 
 function shouldWrapRuntimeJsFile(sourcePath) {
@@ -68,10 +104,11 @@ function writeRuntimeModuleWrapper(sourcePath, targetPath) {
   );
 }
 
-function stagePluginRuntimeOverlay(sourceDir, targetDir) {
-  fs.mkdirSync(targetDir, { recursive: true });
+function stagePluginRuntimeOverlay(sourceDir, targetDir, options = {}) {
+  const fsImpl = options.fsImpl ?? fs;
+  fsImpl.mkdirSync(targetDir, { recursive: true });
 
-  for (const dirent of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+  for (const dirent of fsImpl.readdirSync(sourceDir, { withFileTypes: true })) {
     if (dirent.name === "node_modules") {
       continue;
     }
@@ -80,12 +117,12 @@ function stagePluginRuntimeOverlay(sourceDir, targetDir) {
     const targetPath = path.join(targetDir, dirent.name);
 
     if (dirent.isDirectory()) {
-      stagePluginRuntimeOverlay(sourcePath, targetPath);
+      stagePluginRuntimeOverlay(sourcePath, targetPath, options);
       continue;
     }
 
     if (dirent.isSymbolicLink()) {
-      ensureSymlink(fs.readlinkSync(sourcePath), targetPath);
+      ensureSymlink(fsImpl.readlinkSync(sourcePath), targetPath, undefined, options);
       continue;
     }
 
@@ -99,39 +136,46 @@ function stagePluginRuntimeOverlay(sourceDir, targetDir) {
     }
 
     if (shouldCopyRuntimeFile(sourcePath)) {
-      fs.copyFileSync(sourcePath, targetPath);
+      fsImpl.copyFileSync(sourcePath, targetPath);
       continue;
     }
 
-    symlinkPath(sourcePath, targetPath);
+    symlinkPath(sourcePath, targetPath, undefined, options);
   }
 }
 
 function linkPluginNodeModules(params) {
+  const fsImpl = params.fsImpl ?? fs;
+  const platform = params.platform ?? process.platform;
   const runtimeNodeModulesDir = path.join(params.runtimePluginDir, "node_modules");
   removePathIfExists(runtimeNodeModulesDir);
-  if (!fs.existsSync(params.sourcePluginNodeModulesDir)) {
+  if (!fsImpl.existsSync(params.sourcePluginNodeModulesDir)) {
     return;
   }
-  ensureSymlink(params.sourcePluginNodeModulesDir, runtimeNodeModulesDir, symlinkType());
+  ensureSymlink(params.sourcePluginNodeModulesDir, runtimeNodeModulesDir, symlinkType(platform), {
+    fsImpl,
+    platform,
+  });
 }
 
 export function stageBundledPluginRuntime(params = {}) {
+  const fsImpl = params.fsImpl ?? fs;
+  const platform = params.platform ?? process.platform;
   const repoRoot = params.cwd ?? params.repoRoot ?? process.cwd();
   const distRoot = path.join(repoRoot, "dist");
   const runtimeRoot = path.join(repoRoot, "dist-runtime");
   const distExtensionsRoot = path.join(distRoot, "extensions");
   const runtimeExtensionsRoot = path.join(runtimeRoot, "extensions");
 
-  if (!fs.existsSync(distExtensionsRoot)) {
+  if (!fsImpl.existsSync(distExtensionsRoot)) {
     removePathIfExists(runtimeRoot);
     return;
   }
 
   removePathIfExists(runtimeRoot);
-  fs.mkdirSync(runtimeExtensionsRoot, { recursive: true });
+  fsImpl.mkdirSync(runtimeExtensionsRoot, { recursive: true });
 
-  for (const dirent of fs.readdirSync(distExtensionsRoot, { withFileTypes: true })) {
+  for (const dirent of fsImpl.readdirSync(distExtensionsRoot, { withFileTypes: true })) {
     if (!dirent.isDirectory()) {
       continue;
     }
@@ -139,10 +183,12 @@ export function stageBundledPluginRuntime(params = {}) {
     const runtimePluginDir = path.join(runtimeExtensionsRoot, dirent.name);
     const distPluginNodeModulesDir = path.join(distPluginDir, "node_modules");
 
-    stagePluginRuntimeOverlay(distPluginDir, runtimePluginDir);
+    stagePluginRuntimeOverlay(distPluginDir, runtimePluginDir, { fsImpl, platform });
     linkPluginNodeModules({
       runtimePluginDir,
       sourcePluginNodeModulesDir: distPluginNodeModulesDir,
+      fsImpl,
+      platform,
     });
   }
 }

--- a/scripts/test-stage-bundled-plugin-runtime-windows.mjs
+++ b/scripts/test-stage-bundled-plugin-runtime-windows.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { stageBundledPluginRuntime } from "./stage-bundled-plugin-runtime.mjs";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-runtime-overlay-win-"));
+
+function cleanup() {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+}
+
+process.on("exit", cleanup);
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(130);
+});
+process.on("SIGTERM", () => {
+  cleanup();
+  process.exit(143);
+});
+
+const pluginId = "runtime-win-fallback-plugin";
+const sourcePluginDir = path.join(tempRoot, "dist", "extensions", pluginId);
+const sourceSkillDir = path.join(sourcePluginDir, "skills", "acp-router");
+fs.mkdirSync(sourceSkillDir, { recursive: true });
+fs.writeFileSync(
+  path.join(sourcePluginDir, "package.json"),
+  JSON.stringify({ name: "@openclaw/runtime-win-fallback-plugin", type: "module" }, null, 2),
+  "utf8",
+);
+fs.writeFileSync(
+  path.join(sourcePluginDir, "openclaw.plugin.json"),
+  JSON.stringify({ id: pluginId }, null, 2),
+  "utf8",
+);
+fs.writeFileSync(path.join(sourcePluginDir, "index.js"), "export const ok = true;\n", "utf8");
+fs.writeFileSync(path.join(sourceSkillDir, "SKILL.md"), "# Runtime fallback skill\n", "utf8");
+
+const fsImpl = {
+  ...fs,
+  symlinkSync(targetValue, targetPath, type) {
+    if (type === "junction") {
+      return fs.symlinkSync(targetValue, targetPath, type);
+    }
+    const error = new Error("operation not permitted");
+    error.code = "EPERM";
+    throw error;
+  },
+};
+
+stageBundledPluginRuntime({ repoRoot: tempRoot, fsImpl, platform: "win32" });
+
+const runtimeSkillPath = path.join(
+  tempRoot,
+  "dist-runtime",
+  "extensions",
+  pluginId,
+  "skills",
+  "acp-router",
+  "SKILL.md",
+);
+assert.ok(fs.existsSync(runtimeSkillPath), "runtime skill file missing after Windows fallback staging");
+assert.equal(fs.readFileSync(runtimeSkillPath, "utf8"), "# Runtime fallback skill\n");
+assert.equal(fs.lstatSync(runtimeSkillPath).isSymbolicLink(), false);
+
+process.stdout.write("[runtime-overlay] windows symlink fallback smoke passed\n");

--- a/src/agents/openai-ws-connection.test.ts
+++ b/src/agents/openai-ws-connection.test.ts
@@ -621,6 +621,18 @@ describe("OpenAIWebSocketManager", () => {
       expect(sent["tools"]).toHaveLength(1);
       expect((sent["tools"] as Array<{ name?: string }>)[0]?.name).toBe("exec");
     });
+
+    it("omits tools when provided as an empty array", async () => {
+      const { manager, sock } = await createConnectedManager();
+
+      manager.warmUp({
+        model: "gpt-5.2",
+        tools: [],
+      });
+
+      const sent = JSON.parse(sock.sentMessages[0] ?? "{}") as Record<string, unknown>;
+      expect(sent).not.toHaveProperty("tools");
+    });
   });
 
   // ─── Error handling ─────────────────────────────────────────────────────────

--- a/src/agents/openai-ws-connection.ts
+++ b/src/agents/openai-ws-connection.ts
@@ -553,7 +553,7 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
       type: "response.create",
       generate: false,
       model: params.model,
-      ...(params.tools ? { tools: params.tools } : {}),
+      ...(params.tools?.length ? { tools: params.tools } : {}),
       ...(params.instructions ? { instructions: params.instructions } : {}),
     };
     this.send(event);

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -91,7 +91,7 @@ const { MockManager } = vi.hoisted(() => {
         type: "response.create",
         generate: false,
         model: params.model,
-        ...(params.tools ? { tools: params.tools } : {}),
+        ...(params.tools?.length ? { tools: params.tools } : {}),
         ...(params.instructions ? { instructions: params.instructions } : {}),
       });
     }
@@ -1707,6 +1707,7 @@ describe("createOpenAIWebSocketStreamFn", () => {
     expect(sent).toHaveLength(2);
     expect(sent[0]?.type).toBe("response.create");
     expect(sent[0]?.generate).toBe(false);
+    expect(sent[0]?.tools).toBeUndefined();
     expect(sent[1]?.type).toBe("response.create");
   });
 


### PR DESCRIPTION
## Summary
- keep runtime overlay symlinks by default, but fall back to copying file targets on Windows when `symlink` is denied
- add a Windows-focused smoke test that simulates `EPERM` on file symlink creation

## Testing
- node scripts/test-stage-bundled-plugin-runtime-windows.mjs

## Notes
- `node scripts/test-built-plugin-singleton.mjs` still expects prebuilt `dist/plugins/build-smoke-entry.js` in this checkout, so it was not runnable here without a prior build.

Closes #55454
