### PR TITLE
feat(web-search): add SearXNG as a search provider

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -720,12 +720,8 @@ function resolveSearxngConfig(search?: WebSearchConfig): SearxngConfig {
   return searxng as SearxngConfig;
 }
 
-function resolveSearxngBaseUrl(config: SearxngConfig): string {
-  return (
-    config.baseUrl?.trim() ||
-    normalizeSecretInput(process.env.SEARXNG_BASE_URL) ||
-    DEFAULT_SEARXNG_BASE_URL
-  );
+function resolveSearxngBaseUrl(config: SearxngConfig): string | undefined {
+  return config.baseUrl?.trim() || normalizeSecretInput(process.env.SEARXNG_BASE_URL) || undefined;
 }
 
 function resolvePerplexityConfig(search?: WebSearchConfig): PerplexityConfig {
@@ -2077,10 +2073,13 @@ export function createWebSearchTool(options?: {
       // do not touch Perplexity-only credential surfaces during tool construction.
       const perplexityRuntime =
         provider === "perplexity" ? resolvePerplexityTransport(perplexityConfig) : undefined;
-      // SearXNG does not require an API key — only a reachable base URL.
+      // SearXNG uses a base URL instead of an API key. Resolve it early so we
+      // can surface an actionable error when no URL is configured at all.
+      const resolvedSearxngUrl =
+        provider === "searxng" ? resolveSearxngBaseUrl(searxngConfig) : undefined;
       const apiKey =
         provider === "searxng"
-          ? "unused"
+          ? resolvedSearxngUrl || undefined
           : provider === "perplexity"
             ? perplexityRuntime?.apiKey
             : provider === "grok"
@@ -2120,6 +2119,7 @@ export function createWebSearchTool(options?: {
       if (
         language &&
         provider !== "brave" &&
+        provider !== "searxng" &&
         !(provider === "perplexity" && supportsStructuredPerplexityFilters)
       ) {
         return jsonResult({
@@ -2127,7 +2127,7 @@ export function createWebSearchTool(options?: {
           message:
             provider === "perplexity"
               ? "language filtering is only supported by the native Perplexity Search API path. Remove Perplexity baseUrl/model overrides or use a direct PERPLEXITY_API_KEY to enable it."
-              : `language filtering is not supported by the ${provider} provider. Only Brave and Perplexity support language filtering.`,
+              : `language filtering is not supported by the ${provider} provider. Only Brave, Perplexity, and SearXNG support language filtering.`,
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1636,7 +1636,8 @@ async function runSearxngSearch(params: {
   timeoutSeconds: number;
   language?: string;
 }): Promise<Array<{ title: string; url: string; description: string; published?: string }>> {
-  const url = new URL(`${params.baseUrl}/search`);
+  const normalizedBaseUrl = params.baseUrl.replace(/\/+$/, "");
+  const url = new URL(`${normalizedBaseUrl}/search`);
   url.searchParams.set("q", params.query);
   url.searchParams.set("format", "json");
   if (params.language) {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -22,7 +22,7 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity"] as const;
+const SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity", "searxng"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
@@ -43,6 +43,8 @@ const KIMI_WEB_SEARCH_TOOL = {
   type: "builtin_function",
   function: { name: "$web_search" },
 } as const;
+
+const DEFAULT_SEARXNG_BASE_URL = "http://localhost:8888";
 
 const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 const BRAVE_FRESHNESS_SHORTCUTS = new Set(["pd", "pw", "pm", "py"]);
@@ -333,6 +335,10 @@ type KimiConfig = {
   model?: string;
 };
 
+type SearxngConfig = {
+  baseUrl?: string;
+};
+
 type GrokSearchResponse = {
   output?: Array<{
     type?: string;
@@ -593,6 +599,14 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
+  if (provider === "searxng") {
+    return {
+      error: "missing_searxng_base_url",
+      message:
+        "web_search (searxng) needs a SearXNG instance URL. Set SEARXNG_BASE_URL in the Gateway environment, or configure tools.web.search.searxng.baseUrl.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
   return {
     error: "missing_perplexity_api_key",
     message:
@@ -620,6 +634,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   }
   if (raw === "perplexity") {
     return "perplexity";
+  }
+  if (raw === "searxng") {
+    return "searxng";
   }
 
   // Auto-detect provider from available API keys (alphabetical order)
@@ -664,6 +681,14 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
       );
       return "perplexity";
     }
+    // SearXNG (detected via base URL or config, since it needs no API key)
+    const searxngConfig = resolveSearxngConfig(search);
+    if (searxngConfig.baseUrl?.trim() || process.env.SEARXNG_BASE_URL?.trim()) {
+      logVerbose(
+        'web_search: no provider configured, auto-detected "searxng" from SEARXNG_BASE_URL',
+      );
+      return "searxng";
+    }
   }
 
   return "brave";
@@ -682,6 +707,25 @@ function resolveBraveConfig(search?: WebSearchConfig): BraveConfig {
 
 function resolveBraveMode(brave: BraveConfig): "web" | "llm-context" {
   return brave.mode === "llm-context" ? "llm-context" : "web";
+}
+
+function resolveSearxngConfig(search?: WebSearchConfig): SearxngConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const searxng = "searxng" in search ? search.searxng : undefined;
+  if (!searxng || typeof searxng !== "object") {
+    return {};
+  }
+  return searxng as SearxngConfig;
+}
+
+function resolveSearxngBaseUrl(config: SearxngConfig): string {
+  return (
+    config.baseUrl?.trim() ||
+    normalizeSecretInput(process.env.SEARXNG_BASE_URL) ||
+    DEFAULT_SEARXNG_BASE_URL
+  );
 }
 
 function resolvePerplexityConfig(search?: WebSearchConfig): PerplexityConfig {
@@ -1577,6 +1621,60 @@ async function runBraveLlmContextSearch(params: {
   );
 }
 
+type SearxngSearchResult = {
+  url?: string;
+  title?: string;
+  content?: string;
+  publishedDate?: string;
+  engine?: string;
+};
+
+type SearxngSearchResponse = {
+  results?: SearxngSearchResult[];
+};
+
+async function runSearxngSearch(params: {
+  query: string;
+  baseUrl: string;
+  count: number;
+  timeoutSeconds: number;
+  language?: string;
+}): Promise<Array<{ title: string; url: string; description: string; published?: string }>> {
+  const url = new URL(`${params.baseUrl}/search`);
+  url.searchParams.set("q", params.query);
+  url.searchParams.set("format", "json");
+  if (params.language) {
+    url.searchParams.set("language", params.language);
+  }
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: url.toString(),
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "GET",
+        headers: { Accept: "application/json" },
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        const detailResult = await readResponseText(res, { maxBytes: 64_000 });
+        const detail = detailResult.text;
+        throw new Error(`SearXNG error (${res.status}): ${detail || res.statusText}`);
+      }
+
+      const data = (await res.json()) as SearxngSearchResponse;
+      const results = Array.isArray(data.results) ? data.results : [];
+      return results.slice(0, params.count).map((entry) => ({
+        title: entry.title ?? "",
+        url: entry.url ?? "",
+        description: entry.content ?? "",
+        published: entry.publishedDate ?? undefined,
+      }));
+    },
+  );
+}
+
 async function runWebSearch(params: {
   query: string;
   count: number;
@@ -1603,6 +1701,7 @@ async function runWebSearch(params: {
   kimiBaseUrl?: string;
   kimiModel?: string;
   braveMode?: "web" | "llm-context";
+  searxngBaseUrl?: string;
 }): Promise<Record<string, unknown>> {
   const effectiveBraveMode = params.braveMode ?? "web";
   const providerSpecificKey =
@@ -1614,7 +1713,9 @@ async function runWebSearch(params: {
           ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
           : params.provider === "kimi"
             ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
-            : "";
+            : params.provider === "searxng"
+              ? (params.searxngBaseUrl ?? DEFAULT_SEARXNG_BASE_URL)
+              : "";
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"
       ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
@@ -1769,6 +1870,39 @@ async function runWebSearch(params: {
     return payload;
   }
 
+  if (params.provider === "searxng") {
+    const searxngResults = await runSearxngSearch({
+      query: params.query,
+      baseUrl: params.searxngBaseUrl ?? DEFAULT_SEARXNG_BASE_URL,
+      count: params.count,
+      timeoutSeconds: params.timeoutSeconds,
+      language: params.language,
+    });
+
+    const mapped = searxngResults.map((entry) => ({
+      title: entry.title ? wrapWebContent(entry.title, "web_search") : "",
+      url: entry.url,
+      description: entry.description ? wrapWebContent(entry.description, "web_search") : "",
+      published: entry.published || undefined,
+    }));
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      count: mapped.length,
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: params.provider,
+        wrapped: true,
+      },
+      results: mapped,
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
   if (params.provider !== "brave") {
     throw new Error("Unsupported web search provider.");
   }
@@ -1911,21 +2045,24 @@ export function createWebSearchTool(options?: {
   const kimiConfig = resolveKimiConfig(search);
   const braveConfig = resolveBraveConfig(search);
   const braveMode = resolveBraveMode(braveConfig);
+  const searxngConfig = resolveSearxngConfig(search);
 
   const description =
-    provider === "perplexity"
-      ? perplexitySchemaTransportHint === "chat_completions"
-        ? "Search the web using Perplexity Sonar via Perplexity/OpenRouter chat completions. Returns AI-synthesized answers with citations from web-grounded search."
-        : "Search the web using Perplexity. Runtime routing decides between native Search API and Sonar chat-completions compatibility. Structured filters are available on the native Search API path."
-      : provider === "grok"
-        ? "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search."
-        : provider === "kimi"
-          ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
-          : provider === "gemini"
-            ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
-            : braveMode === "llm-context"
-              ? "Search the web using Brave Search LLM Context API. Returns pre-extracted page content (text chunks, tables, code blocks) optimized for LLM grounding."
-              : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+    provider === "searxng"
+      ? "Search the web using a SearXNG instance. Aggregates results from multiple search engines. Returns titles, URLs, and snippets."
+      : provider === "perplexity"
+        ? perplexitySchemaTransportHint === "chat_completions"
+          ? "Search the web using Perplexity Sonar via Perplexity/OpenRouter chat completions. Returns AI-synthesized answers with citations from web-grounded search."
+          : "Search the web using Perplexity. Runtime routing decides between native Search API and Sonar chat-completions compatibility. Structured filters are available on the native Search API path."
+        : provider === "grok"
+          ? "Search the web using xAI Grok. Returns AI-synthesized answers with citations from real-time web search."
+          : provider === "kimi"
+            ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
+            : provider === "gemini"
+              ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
+              : braveMode === "llm-context"
+                ? "Search the web using Brave Search LLM Context API. Returns pre-extracted page content (text chunks, tables, code blocks) optimized for LLM grounding."
+                : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -1940,16 +2077,19 @@ export function createWebSearchTool(options?: {
       // do not touch Perplexity-only credential surfaces during tool construction.
       const perplexityRuntime =
         provider === "perplexity" ? resolvePerplexityTransport(perplexityConfig) : undefined;
+      // SearXNG does not require an API key — only a reachable base URL.
       const apiKey =
-        provider === "perplexity"
-          ? perplexityRuntime?.apiKey
-          : provider === "grok"
-            ? resolveGrokApiKey(grokConfig)
-            : provider === "kimi"
-              ? resolveKimiApiKey(kimiConfig)
-              : provider === "gemini"
-                ? resolveGeminiApiKey(geminiConfig)
-                : resolveSearchApiKey(search);
+        provider === "searxng"
+          ? "unused"
+          : provider === "perplexity"
+            ? perplexityRuntime?.apiKey
+            : provider === "grok"
+              ? resolveGrokApiKey(grokConfig)
+              : provider === "kimi"
+                ? resolveKimiApiKey(kimiConfig)
+                : provider === "gemini"
+                  ? resolveGeminiApiKey(geminiConfig)
+                  : resolveSearchApiKey(search);
 
       if (!apiKey) {
         return jsonResult(missingSearchKeyPayload(provider));
@@ -2186,6 +2326,7 @@ export function createWebSearchTool(options?: {
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
         braveMode,
+        searxngBaseUrl: resolveSearxngBaseUrl(searxngConfig),
       });
       return jsonResult(result);
     },
@@ -2219,4 +2360,6 @@ export const __testing = {
   resolveRedirectUrl: resolveCitationRedirectUrl,
   resolveBraveMode,
   mapBraveLlmContextResults,
+  resolveSearxngBaseUrl,
+  resolveSearxngConfig,
 } as const;

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -10,7 +10,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { SecretInputMode } from "./onboard-types.js";
 
-export type SearchProvider = "brave" | "gemini" | "grok" | "kimi" | "perplexity";
+export type SearchProvider = "brave" | "gemini" | "grok" | "kimi" | "perplexity" | "searxng";
 
 type SearchProviderEntry = {
   value: SearchProvider;
@@ -62,6 +62,14 @@ export const SEARCH_PROVIDER_OPTIONS: readonly SearchProviderEntry[] = [
     placeholder: "pplx-...",
     signupUrl: "https://www.perplexity.ai/settings/api",
   },
+  {
+    value: "searxng",
+    label: "SearXNG",
+    hint: "Self-hosted meta-search · no API key needed",
+    envKeys: ["SEARXNG_BASE_URL"],
+    placeholder: "http://localhost:8888",
+    signupUrl: "https://docs.searxng.org/",
+  },
 ] as const;
 
 export function hasKeyInEnv(entry: SearchProviderEntry): boolean {
@@ -81,6 +89,9 @@ function rawKeyValue(config: OpenClawConfig, provider: SearchProvider): unknown 
       return search?.kimi?.apiKey;
     case "perplexity":
       return search?.perplexity?.apiKey;
+    case "searxng":
+      // SearXNG uses baseUrl instead of apiKey; return it so "configured" checks pass.
+      return search?.searxng?.baseUrl;
   }
 }
 
@@ -143,6 +154,10 @@ export function applySearchKey(
       break;
     case "perplexity":
       search.perplexity = { ...search.perplexity, apiKey: key };
+      break;
+    case "searxng":
+      // key is the base URL for SearXNG, not an API key.
+      search.searxng = { ...search.searxng, baseUrl: typeof key === "string" ? key : undefined };
       break;
   }
   return {
@@ -273,12 +288,14 @@ export async function setupSearch(
     return applySearchKey(config, choice, ref);
   }
 
+  const isSearxng = choice === "searxng";
+  const inputLabel = isSearxng ? "instance URL" : "API key";
   const keyInput = await prompter.text({
     message: keyConfigured
-      ? `${entry.label} API key (leave blank to keep current)`
+      ? `${entry.label} ${inputLabel} (leave blank to keep current)`
       : envAvailable
-        ? `${entry.label} API key (leave blank to use env var)`
-        : `${entry.label} API key`,
+        ? `${entry.label} ${inputLabel} (leave blank to use env var)`
+        : `${entry.label} ${inputLabel}`,
     placeholder: keyConfigured ? "Leave blank to keep current" : entry.placeholder,
   });
 
@@ -298,8 +315,10 @@ export async function setupSearch(
 
   await prompter.note(
     [
-      "No API key stored — web_search won't work until a key is available.",
-      `Get your key at: ${entry.signupUrl}`,
+      isSearxng
+        ? "No instance URL stored — web_search won't work until a SearXNG URL is configured."
+        : "No API key stored — web_search won't work until a key is available.",
+      isSearxng ? `Deploy SearXNG: ${entry.signupUrl}` : `Get your key at: ${entry.signupUrl}`,
       "Docs: https://docs.openclaw.ai/tools/web",
     ].join("\n"),
     "Web search",

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -86,6 +86,7 @@ describe("web search provider auto-detection", () => {
     delete process.env.GEMINI_API_KEY;
     delete process.env.KIMI_API_KEY;
     delete process.env.MOONSHOT_API_KEY;
+    delete process.env.SEARXNG_BASE_URL;
     delete process.env.PERPLEXITY_API_KEY;
     delete process.env.OPENROUTER_API_KEY;
     delete process.env.XAI_API_KEY;
@@ -171,5 +172,49 @@ describe("web search provider auto-detection", () => {
         typeof resolveSearchProvider
       >[0]),
     ).toBe("gemini");
+  });
+
+  it("auto-detects searxng when only SEARXNG_BASE_URL is set", () => {
+    process.env.SEARXNG_BASE_URL = "http://localhost:8888";
+    expect(resolveSearchProvider({})).toBe("searxng");
+  });
+
+  it("explicit searxng provider is resolved correctly", () => {
+    expect(
+      resolveSearchProvider({ provider: "searxng" } as unknown as Parameters<
+        typeof resolveSearchProvider
+      >[0]),
+    ).toBe("searxng");
+  });
+
+  it("searxng loses to providers with API keys in auto-detection", () => {
+    process.env.BRAVE_API_KEY = "test-brave-key"; // pragma: allowlist secret
+    process.env.SEARXNG_BASE_URL = "http://localhost:8888";
+    expect(resolveSearchProvider({})).toBe("brave");
+  });
+});
+
+describe("web search searxng config", () => {
+  it("accepts searxng provider and config", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        provider: "searxng",
+        providerConfig: {
+          baseUrl: "http://localhost:8888",
+        },
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts searxng provider with no extra config", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        provider: "searxng",
+      }),
+    );
+
+    expect(res.ok).toBe(true);
   });
 });

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -441,8 +441,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "gemini", "grok", "kimi", or "perplexity"). */
-      provider?: "brave" | "gemini" | "grok" | "kimi" | "perplexity";
+      /** Search provider ("brave", "gemini", "grok", "kimi", "perplexity", or "searxng"). */
+      provider?: "brave" | "gemini" | "grok" | "kimi" | "perplexity" | "searxng";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: SecretInput;
       /** Default search results count (1-10). */
@@ -489,6 +489,11 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** @deprecated Legacy Sonar/OpenRouter field. Ignored by Search API. */
         model?: string;
+      };
+      /** SearXNG-specific configuration (used when provider="searxng"). */
+      searxng?: {
+        /** Base URL of the SearXNG instance (defaults to SEARXNG_BASE_URL env var or "http://localhost:8888"). */
+        baseUrl?: string;
       };
     };
     fetch?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -269,6 +269,7 @@ export const ToolsWebSearchSchema = z
         z.literal("grok"),
         z.literal("gemini"),
         z.literal("kimi"),
+        z.literal("searxng"),
       ])
       .optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),
@@ -311,6 +312,12 @@ export const ToolsWebSearchSchema = z
     brave: z
       .object({
         mode: z.union([z.literal("web"), z.literal("llm-context")]).optional(),
+      })
+      .strict()
+      .optional(),
+    searxng: z
+      .object({
+        baseUrl: z.string().optional(),
       })
       .strict()
       .optional(),

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -302,6 +302,11 @@ function setResolvedWebSearchApiKey(params: {
     return;
   }
   const providerConfig = ensureObject(search, params.provider);
+  if (params.provider === "searxng") {
+    // SearXNG stores a base URL, not an API key.
+    providerConfig.baseUrl = params.value;
+    return;
+  }
   providerConfig.apiKey = params.value;
 }
 

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -10,7 +10,7 @@ import {
   type SecretDefaults,
 } from "./runtime-shared.js";
 
-const WEB_SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity"] as const;
+const WEB_SEARCH_PROVIDERS = ["brave", "gemini", "grok", "kimi", "perplexity", "searxng"] as const;
 const PERPLEXITY_DIRECT_BASE_URL = "https://api.perplexity.ai";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
 const PERPLEXITY_KEY_PREFIXES = ["pplx-"];
@@ -329,6 +329,9 @@ function envVarsForProvider(provider: WebSearchProvider): string[] {
   if (provider === "kimi") {
     return ["KIMI_API_KEY", "MOONSHOT_API_KEY"];
   }
+  if (provider === "searxng") {
+    return ["SEARXNG_BASE_URL"];
+  }
   return ["PERPLEXITY_API_KEY", "OPENROUTER_API_KEY"];
 }
 
@@ -338,6 +341,15 @@ function resolveProviderKeyValue(
 ): unknown {
   if (provider === "brave") {
     return search.apiKey;
+  }
+  if (provider === "searxng") {
+    // SearXNG uses baseUrl, not apiKey. Return it so secret-resolution still
+    // recognises the provider as "configured".
+    const scoped = search.searxng;
+    if (!isRecord(scoped)) {
+      return undefined;
+    }
+    return scoped.baseUrl;
   }
   const scoped = search[provider];
   if (!isRecord(scoped)) {


### PR DESCRIPTION
## Summary

Adds SearXNG as a first-class `web_search` provider. Been wanting this for a while — SearXNG is self-hosted, free, and doesn't need an API key, which makes it a solid fallback when Brave runs out of credits or you just want something you control end-to-end.

- Plugs into the existing provider pattern alongside Brave, Gemini, Grok, Kimi, and Perplexity
- Auto-detected when `SEARXNG_BASE_URL` is set (lowest auto-detect priority so it doesn't override existing setups)
- Configurable via `tools.web.search.searxng.baseUrl`, env var, or the onboarding wizard
- Results come back in the same `title/url/description` shape as Brave web mode

### Config example

```json5
{
  tools: {
    web: {
      search: {
        provider: "searxng",
        searxng: {
          baseUrl: "http://localhost:8888"
        }
      }
    }
  }
}
```

Or just set `SEARXNG_BASE_URL=http://localhost:8888` and it'll auto-detect.

Closes #2317

## Test plan

- [x] Existing web search provider tests pass (18/18)
- [x] New tests for SearXNG config validation and auto-detection (5 added)
- [x] `tsc --noEmit` clean
- [x] `pnpm check` (lint + format) clean
- [ ] Manual test with a running SearXNG instance