### PR TITLE
fix(lancedb-runtime): resolve extension package.json when dist/package.json is absent

### DIFF
--- a/extensions/memory-lancedb/lancedb-runtime.test.ts
+++ b/extensions/memory-lancedb/lancedb-runtime.test.ts
@@ -71,6 +71,28 @@ describe("resolveLanceDbDependencySpec", () => {
     expect(resolveLanceDbDependencySpec(modulePath, readPackageJson)).toBe("0.27.2");
   });
 
+  it("resolves lancedb spec when dist/package.json is absent (post-v2026.3.28 npm layout)", () => {
+    const modulePath = path.join(
+      "/usr/lib/node_modules/openclaw/dist",
+      "lancedb-runtime-3m75WU-W.js",
+    );
+    const extensionPackagePath = path.join(
+      "/usr/lib/node_modules/openclaw/dist/extensions/memory-lancedb",
+      "package.json",
+    );
+    // dist/package.json was removed; only the extension's own package.json exists
+    const readPackageJson = mapReader([
+      [
+        extensionPackagePath,
+        {
+          dependencies: { "@lancedb/lancedb": "^0.27.1" },
+        },
+      ],
+    ]);
+
+    expect(resolveLanceDbDependencySpec(modulePath, readPackageJson)).toBe("^0.27.1");
+  });
+
   it("throws when no candidate package manifest declares @lancedb/lancedb", () => {
     const modulePath = path.join(
       "/usr/lib/node_modules/openclaw/dist",

--- a/extensions/memory-lancedb/lancedb-runtime.ts
+++ b/extensions/memory-lancedb/lancedb-runtime.ts
@@ -52,16 +52,21 @@ function defaultReadPackageJson(manifestPath: string): PackageJsonWithDependenci
 function buildMemoryLanceDbManifestCandidates(modulePath: string): string[] {
   const moduleDir = path.dirname(modulePath);
   const candidates = new Set<string>();
+  // In the bundled (npm) layout the module lives under dist/, and the
+  // extension's own package.json is at dist/extensions/memory-lancedb/package.json.
+  // List this path FIRST so the bundler does not dead-code-eliminate it in
+  // favour of the sibling dist/package.json (which was removed in v2026.3.28).
+  candidates.add(path.join(moduleDir, "extensions", "memory-lancedb", "package.json"));
   candidates.add(path.join(moduleDir, "package.json"));
 
   let cursor = moduleDir;
   while (true) {
-    candidates.add(path.join(cursor, "extensions", "memory-lancedb", "package.json"));
     const parent = path.dirname(cursor);
     if (parent === cursor) {
       break;
     }
     cursor = parent;
+    candidates.add(path.join(cursor, "extensions", "memory-lancedb", "package.json"));
   }
 
   return [...candidates];


### PR DESCRIPTION
## Summary

v2026.3.28 removed `dist/package.json` to fix `findPackageRootSync` incorrectly resolving `dist/` as the package root (PR #57170). However, the bundler (esbuild/tsdown) had already dead-code-eliminated the multi-candidate fallback in `resolveLanceDbDependencySpec`, replacing it with a single `new URL("./package.json", import.meta.url)` read. When `dist/package.json` was removed, this caused `memory-lancedb` to fail with:

```
ENOENT: no such file or directory, open '.../dist/package.json'
```

**Root cause**: `buildMemoryLanceDbManifestCandidates` listed the sibling `package.json` first. At build time, `dist/package.json` existed and satisfied the search, so the bundler inlined only that one read and eliminated the `extensions/memory-lancedb/package.json` fallback as dead code.

## Fix

Reorder `buildMemoryLanceDbManifestCandidates` to list `extensions/memory-lancedb/package.json` **first**. This file is always present in the npm package (copied by `copy-bundled-plugin-metadata`), so the bundler will inline this read instead.

## Test plan

- [x] Added test: `"resolves lancedb spec when dist/package.json is absent (post-v2026.3.28 npm layout)"` — verifies the exact scenario
- [x] All existing tests continue to pass (source layout still resolves correctly)
- [x] Verified on macOS Intel x86_64 with OpenClaw 2026.3.28 — manually created `dist/package.json` as workaround, confirming the root cause

## Relationship to #57170

This is a follow-up to #57170. That PR fixed `findPackageRootSync` in `src/infra/openclaw-root.ts`. This PR fixes the downstream effect of that change on `memory-lancedb` loading.