### PR TITLE
Agents: preserve fallback candidates against pinned session model

### DIFF
--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { updateSessionStore } from "../config/sessions.js";
 import type { AuthProfileFailureReason } from "./auth-profiles.js";
 import { runWithModelFallback } from "./model-fallback.js";
 import type { EmbeddedRunAttemptResult } from "./pi-embedded-runner/run/types.js";
@@ -95,9 +96,10 @@ beforeEach(() => {
 const OVERLOADED_ERROR_PAYLOAD =
   '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}';
 
-function makeConfig(): OpenClawConfig {
+function makeConfig(sessionStorePath?: string): OpenClawConfig {
   const apiKeyField = ["api", "Key"].join("");
   return {
+    ...(sessionStorePath ? { session: { store: sessionStorePath } } : {}),
     agents: {
       defaults: {
         model: {
@@ -202,8 +204,9 @@ async function runEmbeddedFallback(params: {
   sessionKey: string;
   runId: string;
   abortSignal?: AbortSignal;
+  cfg?: OpenClawConfig;
 }) {
-  const cfg = makeConfig();
+  const cfg = params.cfg ?? makeConfig();
   return await runWithModelFallback({
     cfg,
     provider: "openai",
@@ -223,6 +226,7 @@ async function runEmbeddedFallback(params: {
         model,
         authProfileIdSource: "auto",
         allowTransientCooldownProbe: options?.allowTransientCooldownProbe,
+        ignorePersistedLiveModelSelection: options?.ignorePersistedLiveModelSelection,
         timeoutMs: 5_000,
         runId: params.runId,
         abortSignal: params.abortSignal,
@@ -323,6 +327,35 @@ describe("runWithModelFallback + runEmbeddedPiAgent overload policy", () => {
       expectOpenAiThenGroqAttemptOrder();
       expect(computeBackoffMock).toHaveBeenCalledTimes(1);
       expect(sleepWithAbortMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("keeps the fallback candidate active when the session store is pinned to the primary model", async () => {
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+      await writeAuthStore(agentDir);
+      const sessionStorePath = path.join(workspaceDir, "sessions.json");
+      const cfg = makeConfig(sessionStorePath);
+      const sessionKey = "agent:test:pinned-primary";
+      await updateSessionStore(sessionStorePath, (store) => {
+        store[sessionKey] = {
+          providerOverride: "openai",
+          modelOverride: "mock-1",
+        } as never;
+      });
+      mockPrimaryOverloadedThenFallbackSuccess();
+
+      const result = await runEmbeddedFallback({
+        agentDir,
+        workspaceDir,
+        sessionKey,
+        runId: "run:pinned-primary-fallback",
+        cfg,
+      });
+
+      expect(result.provider).toBe("groq");
+      expect(result.model).toBe("mock-2");
+      expect(result.result.payloads?.[0]?.text ?? "").toContain("fallback ok");
+      expectOpenAiThenGroqAttemptOrder();
     });
   });
 

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -68,6 +68,7 @@ export function isFallbackSummaryError(err: unknown): err is FallbackSummaryErro
 
 export type ModelFallbackRunOptions = {
   allowTransientCooldownProbe?: boolean;
+  ignorePersistedLiveModelSelection?: boolean;
 };
 
 type ModelFallbackRunFn<T> = (
@@ -703,7 +704,10 @@ export async function runWithModelFallback<T>(params: {
             });
             continue;
           }
-          runOptions = { allowTransientCooldownProbe: true };
+          runOptions = {
+            allowTransientCooldownProbe: true,
+            ignorePersistedLiveModelSelection: !isPrimary,
+          };
           if (isTransientCooldownReason) {
             transientProbeProviderForAttempt = candidate.provider;
           }
@@ -728,11 +732,18 @@ export async function runWithModelFallback<T>(params: {
       }
     }
 
+    const mergedRunOptions: ModelFallbackRunOptions | undefined = isPrimary
+      ? runOptions
+      : {
+          ...runOptions,
+          ignorePersistedLiveModelSelection: true,
+        };
+
     const attemptRun = await runFallbackAttempt({
       run: params.run,
       ...candidate,
       attempts,
-      options: runOptions,
+      options: mergedRunOptions,
     });
     if ("success" in attemptRun) {
       if (i > 0 || attempts.length > 0 || attemptedDuringCooldown) {

--- a/src/agents/openai-ws-connection.test.ts
+++ b/src/agents/openai-ws-connection.test.ts
@@ -621,6 +621,18 @@ describe("OpenAIWebSocketManager", () => {
       expect(sent["tools"]).toHaveLength(1);
       expect((sent["tools"] as Array<{ name?: string }>)[0]?.name).toBe("exec");
     });
+
+    it("omits tools when provided as an empty array", async () => {
+      const { manager, sock } = await createConnectedManager();
+
+      manager.warmUp({
+        model: "gpt-5.2",
+        tools: [],
+      });
+
+      const sent = JSON.parse(sock.sentMessages[0] ?? "{}") as Record<string, unknown>;
+      expect(sent).not.toHaveProperty("tools");
+    });
   });
 
   // ─── Error handling ─────────────────────────────────────────────────────────

--- a/src/agents/openai-ws-connection.ts
+++ b/src/agents/openai-ws-connection.ts
@@ -553,7 +553,7 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
       type: "response.create",
       generate: false,
       model: params.model,
-      ...(params.tools ? { tools: params.tools } : {}),
+      ...(params.tools?.length ? { tools: params.tools } : {}),
       ...(params.instructions ? { instructions: params.instructions } : {}),
     };
     this.send(event);

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -91,7 +91,7 @@ const { MockManager } = vi.hoisted(() => {
         type: "response.create",
         generate: false,
         model: params.model,
-        ...(params.tools ? { tools: params.tools } : {}),
+        ...(params.tools?.length ? { tools: params.tools } : {}),
         ...(params.instructions ? { instructions: params.instructions } : {}),
       });
     }
@@ -1707,6 +1707,7 @@ describe("createOpenAIWebSocketStreamFn", () => {
     expect(sent).toHaveLength(2);
     expect(sent[0]?.type).toBe("response.create");
     expect(sent[0]?.generate).toBe(false);
+    expect(sent[0]?.tools).toBeUndefined();
     expect(sent[1]?.type).toBe("response.create");
   });
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -242,6 +242,7 @@ export async function runEmbeddedPiAgent(
           defaultProvider: provider,
           defaultModel: modelId,
         });
+      const shouldHonorPersistedLiveSelection = params.ignorePersistedLiveModelSelection !== true;
       const {
         advanceAuthProfile,
         initializeAuthProfile,
@@ -449,7 +450,9 @@ export async function runEmbeddedPiAgent(
             };
           }
           runLoopIterations += 1;
-          const nextSelection = resolvePersistedLiveSelection();
+          const nextSelection = shouldHonorPersistedLiveSelection
+            ? resolvePersistedLiveSelection()
+            : null;
           if (hasDifferentLiveSessionModelSelection(resolveCurrentLiveSelection(), nextSelection)) {
             log.info(
               `live session model switch detected before attempt for ${params.sessionId}: ${provider}/${modelId} -> ${nextSelection.provider}/${nextSelection.model}`,
@@ -604,9 +607,10 @@ export async function runEmbeddedPiAgent(
           }
           const failedOrAbortedAttempt =
             aborted || Boolean(promptError) || Boolean(assistantErrorText) || timedOut;
-          const persistedSelection = failedOrAbortedAttempt
-            ? resolvePersistedLiveSelection()
-            : null;
+          const persistedSelection =
+            failedOrAbortedAttempt && shouldHonorPersistedLiveSelection
+              ? resolvePersistedLiveSelection()
+              : null;
           if (
             failedOrAbortedAttempt &&
             canRestartForLiveSwitch &&

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -129,4 +129,13 @@ export type RunEmbeddedPiAgentParams = {
    * where transient service pressure is often model-scoped.
    */
   allowTransientCooldownProbe?: boolean;
+  /**
+   * Preserve the current provider/model candidate even when the session store
+   * is still pinned to a different live selection.
+   *
+   * This is used for explicit fallback candidates so a session's persisted
+   * primary-model preference does not cancel a rate-limit or overload failover
+   * before the fallback attempt executes.
+   */
+  ignorePersistedLiveModelSelection?: boolean;
 };

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -381,6 +381,7 @@ export async function runAgentTurnWithFallback(params: {
               provider,
               runId,
               allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+              ignorePersistedLiveModelSelection: runOptions?.ignorePersistedLiveModelSelection,
               model,
             },
           );

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -116,6 +116,7 @@ export function buildEmbeddedRunBaseParams(params: {
   runId: string;
   authProfile: ReturnType<typeof resolveProviderScopedAuthProfile>;
   allowTransientCooldownProbe?: boolean;
+  ignorePersistedLiveModelSelection?: boolean;
 }) {
   return {
     sessionFile: params.run.sessionFile,
@@ -138,6 +139,7 @@ export function buildEmbeddedRunBaseParams(params: {
     timeoutMs: params.run.timeoutMs,
     runId: params.runId,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
+    ignorePersistedLiveModelSelection: params.ignorePersistedLiveModelSelection,
   };
 }
 
@@ -203,6 +205,7 @@ export function buildEmbeddedRunExecutionParams(params: {
   model: string;
   runId: string;
   allowTransientCooldownProbe?: boolean;
+  ignorePersistedLiveModelSelection?: boolean;
 }) {
   const { authProfile, embeddedContext, senderContext } = buildEmbeddedRunContexts(params);
   const runBaseParams = buildEmbeddedRunBaseParams({
@@ -212,6 +215,7 @@ export function buildEmbeddedRunExecutionParams(params: {
     runId: params.runId,
     authProfile,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
+    ignorePersistedLiveModelSelection: params.ignorePersistedLiveModelSelection,
   });
   return {
     embeddedContext,


### PR DESCRIPTION
## Summary
- preserve explicit fallback candidates when a session store is still pinned to the primary model
- thread the new embedded-run fallback option through the agent runner path
- add a regression covering an overloaded primary with a pinned session override

## Testing
- pnpm test -- src/agents/model-fallback.run-embedded.e2e.test.ts

Fixes #56958