### PR TITLE
fix(ollama): accept baseURL alias so remote Ollama hosts are not ignored

### DIFF
--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -6,32 +6,17 @@ import {
   type ProviderAuthResult,
   type ProviderDiscoveryContext,
 } from "openclaw/plugin-sdk/plugin-entry";
-import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { OLLAMA_DEFAULT_BASE_URL } from "./src/defaults.js";
 import {
   DEFAULT_OLLAMA_EMBEDDING_MODEL,
   createOllamaEmbeddingProvider,
 } from "./src/embedding-provider.js";
+import { readProviderBaseUrl } from "./src/provider-base-url.js";
 import { resolveOllamaApiBase } from "./src/provider-models.js";
 import {
   createConfiguredOllamaCompatStreamWrapper,
   createConfiguredOllamaStreamFn,
 } from "./src/stream.js";
-
-// Users familiar with the OpenAI SDK often write `baseURL` (uppercase) while
-// the openclaw config schema uses `baseUrl`. Accept both spellings so remote
-// Ollama hosts are not silently ignored and requests do not fall back to
-// localhost:11434.
-function readProviderBaseUrl(
-  provider: ModelProviderConfig | (ModelProviderConfig & { baseURL?: string }) | undefined,
-): string | undefined {
-  if (!provider) return undefined;
-  const url =
-    (typeof provider.baseUrl === "string" && provider.baseUrl.trim()) ||
-    (typeof (provider as { baseURL?: string }).baseURL === "string" &&
-      (provider as { baseURL?: string }).baseURL!.trim());
-  return url || undefined;
-}
 
 const PROVIDER_ID = "ollama";
 const DEFAULT_API_KEY = "ollama-local";
@@ -181,7 +166,7 @@ export default definePluginEntry({
       resolveSyntheticAuth: ({ providerConfig }) => {
         const hasApiConfig =
           Boolean(providerConfig?.api?.trim()) ||
-          Boolean(providerConfig?.baseUrl?.trim()) ||
+          Boolean(readProviderBaseUrl(providerConfig)) ||
           (Array.isArray(providerConfig?.models) && providerConfig.models.length > 0);
         if (!hasApiConfig) {
           return undefined;

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -6,6 +6,7 @@ import {
   type ProviderAuthResult,
   type ProviderDiscoveryContext,
 } from "openclaw/plugin-sdk/plugin-entry";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { OLLAMA_DEFAULT_BASE_URL } from "./src/defaults.js";
 import {
   DEFAULT_OLLAMA_EMBEDDING_MODEL,
@@ -16,6 +17,21 @@ import {
   createConfiguredOllamaCompatStreamWrapper,
   createConfiguredOllamaStreamFn,
 } from "./src/stream.js";
+
+// Users familiar with the OpenAI SDK often write `baseURL` (uppercase) while
+// the openclaw config schema uses `baseUrl`. Accept both spellings so remote
+// Ollama hosts are not silently ignored and requests do not fall back to
+// localhost:11434.
+function readProviderBaseUrl(
+  provider: ModelProviderConfig | (ModelProviderConfig & { baseURL?: string }) | undefined,
+): string | undefined {
+  if (!provider) return undefined;
+  const url =
+    (typeof provider.baseUrl === "string" && provider.baseUrl.trim()) ||
+    (typeof (provider as { baseURL?: string }).baseURL === "string" &&
+      (provider as { baseURL?: string }).baseURL!.trim());
+  return url || undefined;
+}
 
 const PROVIDER_ID = "ollama";
 const DEFAULT_API_KEY = "ollama-local";
@@ -90,10 +106,7 @@ export default definePluginEntry({
             return {
               provider: {
                 ...explicit,
-                baseUrl:
-                  typeof explicit.baseUrl === "string" && explicit.baseUrl.trim()
-                    ? resolveOllamaApiBase(explicit.baseUrl)
-                    : OLLAMA_DEFAULT_BASE_URL,
+                baseUrl: resolveOllamaApiBase(readProviderBaseUrl(explicit)),
                 api: explicit.api ?? "ollama",
                 apiKey: ollamaKey ?? explicit.apiKey ?? DEFAULT_API_KEY,
               },
@@ -104,7 +117,7 @@ export default definePluginEntry({
           }
 
           const providerSetup = await loadProviderSetup();
-          const provider = await providerSetup.buildOllamaProvider(explicit?.baseUrl, {
+          const provider = await providerSetup.buildOllamaProvider(readProviderBaseUrl(explicit), {
             quiet: !ollamaKey && !explicit,
           });
           if (provider.models.length === 0 && !ollamaKey && !explicit?.apiKey) {
@@ -148,7 +161,7 @@ export default definePluginEntry({
       createStreamFn: ({ config, model }) => {
         return createConfiguredOllamaStreamFn({
           model,
-          providerBaseUrl: config?.models?.providers?.ollama?.baseUrl,
+          providerBaseUrl: readProviderBaseUrl(config?.models?.providers?.ollama),
         });
       },
       wrapStreamFn: (ctx) => {

--- a/extensions/ollama/src/provider-base-url.ts
+++ b/extensions/ollama/src/provider-base-url.ts
@@ -1,0 +1,16 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+// Users familiar with the OpenAI SDK often write `baseURL` (uppercase) while
+// the openclaw config schema uses `baseUrl`. Accept both spellings so remote
+// Ollama hosts are not silently ignored and requests do not fall back to
+// localhost:11434.
+export function readProviderBaseUrl(
+  provider: ModelProviderConfig | (ModelProviderConfig & { baseURL?: string }) | undefined,
+): string | undefined {
+  if (!provider) return undefined;
+  const url =
+    (typeof provider.baseUrl === "string" && provider.baseUrl.trim()) ||
+    (typeof (provider as { baseURL?: string }).baseURL === "string" &&
+      (provider as { baseURL?: string }).baseURL!.trim());
+  return url || undefined;
+}

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -4,6 +4,7 @@ import { applyAgentDefaultModelPrimary } from "openclaw/plugin-sdk/provider-onbo
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { WizardCancelledError, type WizardPrompter } from "openclaw/plugin-sdk/setup";
 import { OLLAMA_DEFAULT_BASE_URL, OLLAMA_DEFAULT_MODEL } from "./defaults.js";
+import { readProviderBaseUrl } from "./provider-base-url.js";
 import {
   buildOllamaModelDefinition,
   enrichOllamaModelsWithContext,
@@ -486,11 +487,8 @@ export async function ensureOllamaModelPulled(params: {
   if (!params.model.startsWith("ollama/")) {
     return;
   }
-  const ollamaProvider = params.config.models?.providers?.ollama;
   const baseUrl =
-    ollamaProvider?.baseUrl ||
-    (ollamaProvider as { baseURL?: string } | undefined)?.baseURL ||
-    OLLAMA_DEFAULT_BASE_URL;
+    readProviderBaseUrl(params.config.models?.providers?.ollama) ?? OLLAMA_DEFAULT_BASE_URL;
   const modelName = params.model.slice("ollama/".length);
   if (isOllamaCloudModel(modelName)) {
     return;

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -486,7 +486,11 @@ export async function ensureOllamaModelPulled(params: {
   if (!params.model.startsWith("ollama/")) {
     return;
   }
-  const baseUrl = params.config.models?.providers?.ollama?.baseUrl ?? OLLAMA_DEFAULT_BASE_URL;
+  const ollamaProvider = params.config.models?.providers?.ollama;
+  const baseUrl =
+    ollamaProvider?.baseUrl ||
+    (ollamaProvider as { baseURL?: string } | undefined)?.baseURL ||
+    OLLAMA_DEFAULT_BASE_URL;
   const modelName = params.model.slice("ollama/".length);
   if (isOllamaCloudModel(modelName)) {
     return;


### PR DESCRIPTION
## Summary

- Adds `baseURL` (uppercase, OpenAI SDK convention) as an accepted alias for `baseUrl` in the Ollama provider config
- Fixes remote Ollama instances always being silently ignored and falling back to `localhost:11434`
- No behaviour change when `baseUrl` (canonical spelling) is used correctly

## Issue

Closes #54754

**Root cause:** `ModelProviderConfig` defines the field as `baseUrl` (camelCase), but users familiar with the OpenAI SDK commonly write `baseURL` in their `openclaw.json`. Because TypeScript types are erased at runtime, the JSON key `baseURL` survives parsing — but every read site used `provider.baseUrl` which evaluated to `undefined`, triggering the `OLLAMA_DEFAULT_BASE_URL` (`http://127.0.0.1:11434`) fallback. The connection failure was instant (not a timeout) because the request never left the machine.

**Fix:** Introduce a `readProviderBaseUrl` helper in `extensions/ollama/index.ts` that checks `baseUrl` first and falls back to `baseURL`. Apply it at all four read sites:
1. Discovery explicit path (`hasExplicitModels` branch)
2. Ambient discovery fallback (`buildOllamaProvider` call)
3. `createStreamFn` (every streaming request)
4. `ensureOllamaModelPulled` in `setup.ts` (model pull on selection)

## Test plan

- [ ] Configure a remote Ollama host with `"baseURL": "http://<remote-ip>:11434"` — requests should reach the remote host, not localhost
- [ ] Configure with `"baseUrl": "http://<remote-ip>:11434"` (canonical) — behaviour unchanged
- [ ] No `baseUrl`/`baseURL` set — falls back to `http://127.0.0.1:11434` as before
- [ ] Existing Ollama tests pass

## Security impact

None — this change only affects URL resolution for user-configured Ollama endpoints. No credentials or auth paths are modified.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)