### PR TITLE
fix(gateway): restore headerless bearer compatibility on OpenAI-compatible HTTP routes

### DIFF
--- a/src/gateway/http-auth-helpers.test.ts
+++ b/src/gateway/http-auth-helpers.test.ts
@@ -101,6 +101,7 @@ describe("resolveGatewayCompatibilityHttpOperatorScopes", () => {
       resolveGatewayCompatibilityHttpOperatorScopes({
         req,
         authResult: { ok: true, method: "token" },
+        fallbackScopes: CLI_DEFAULT_OPERATOR_SCOPES,
       }),
     ).toEqual(CLI_DEFAULT_OPERATOR_SCOPES);
   });
@@ -112,6 +113,7 @@ describe("resolveGatewayCompatibilityHttpOperatorScopes", () => {
       resolveGatewayCompatibilityHttpOperatorScopes({
         req,
         authResult: { ok: true, method: "password" },
+        fallbackScopes: CLI_DEFAULT_OPERATOR_SCOPES,
       }),
     ).toEqual(CLI_DEFAULT_OPERATOR_SCOPES);
   });

--- a/src/gateway/http-auth-helpers.test.ts
+++ b/src/gateway/http-auth-helpers.test.ts
@@ -1,7 +1,12 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { authorizeGatewayBearerRequestOrReply } from "./http-auth-helpers.js";
+import {
+  authorizeGatewayBearerRequest,
+  authorizeGatewayBearerRequestOrReply,
+  resolveGatewayCompatibilityHttpOperatorScopes,
+} from "./http-auth-helpers.js";
+import { CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
 
 vi.mock("./auth.js", () => ({
   authorizeHttpGatewayConnect: vi.fn(),
@@ -13,11 +18,12 @@ vi.mock("./http-common.js", () => ({
 
 vi.mock("./http-utils.js", () => ({
   getBearerToken: vi.fn(),
+  getHeader: vi.fn(),
 }));
 
 const { authorizeHttpGatewayConnect } = await import("./auth.js");
 const { sendGatewayAuthFailure } = await import("./http-common.js");
-const { getBearerToken } = await import("./http-utils.js");
+const { getBearerToken, getHeader } = await import("./http-utils.js");
 
 describe("authorizeGatewayBearerRequestOrReply", () => {
   const bearerAuth = {
@@ -35,6 +41,16 @@ describe("authorizeGatewayBearerRequestOrReply", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("returns the auth result for successful bearer auth", async () => {
+    vi.mocked(getBearerToken).mockReturnValue("abc");
+    vi.mocked(authorizeHttpGatewayConnect).mockResolvedValue({ ok: true, method: "token" });
+
+    const result = await authorizeGatewayBearerRequest(makeAuthorizeParams());
+
+    expect(result).toEqual({ ok: true, method: "token" });
+    expect(vi.mocked(sendGatewayAuthFailure)).not.toHaveBeenCalled();
   });
 
   it("disables tailscale header auth for HTTP bearer checks", async () => {
@@ -68,5 +84,79 @@ describe("authorizeGatewayBearerRequestOrReply", () => {
       }),
     );
     expect(vi.mocked(sendGatewayAuthFailure)).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveGatewayCompatibilityHttpOperatorScopes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const req = {} as IncomingMessage;
+
+  it("falls back to full operator scopes for headerless token auth", () => {
+    vi.mocked(getHeader).mockReturnValue(undefined);
+
+    expect(
+      resolveGatewayCompatibilityHttpOperatorScopes({
+        req,
+        authResult: { ok: true, method: "token" },
+      }),
+    ).toEqual(CLI_DEFAULT_OPERATOR_SCOPES);
+  });
+
+  it("falls back to full operator scopes for headerless password auth", () => {
+    vi.mocked(getHeader).mockReturnValue(undefined);
+
+    expect(
+      resolveGatewayCompatibilityHttpOperatorScopes({
+        req,
+        authResult: { ok: true, method: "password" },
+      }),
+    ).toEqual(CLI_DEFAULT_OPERATOR_SCOPES);
+  });
+
+  it("honors explicit caller scopes when the header is present", () => {
+    vi.mocked(getHeader).mockReturnValue("operator.approvals, operator.read");
+
+    expect(
+      resolveGatewayCompatibilityHttpOperatorScopes({
+        req,
+        authResult: { ok: true, method: "token" },
+      }),
+    ).toEqual(["operator.approvals", "operator.read"]);
+  });
+
+  it("keeps explicitly empty scope headers empty", () => {
+    vi.mocked(getHeader).mockReturnValue("   ");
+
+    expect(
+      resolveGatewayCompatibilityHttpOperatorScopes({
+        req,
+        authResult: { ok: true, method: "token" },
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not grant implicit scopes for auth mode none", () => {
+    vi.mocked(getHeader).mockReturnValue(undefined);
+
+    expect(
+      resolveGatewayCompatibilityHttpOperatorScopes({
+        req,
+        authResult: { ok: true, method: "none" },
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not grant implicit scopes for trusted-proxy auth", () => {
+    vi.mocked(getHeader).mockReturnValue(undefined);
+
+    expect(
+      resolveGatewayCompatibilityHttpOperatorScopes({
+        req,
+        authResult: { ok: true, method: "trusted-proxy", user: "proxy-user" },
+      }),
+    ).toEqual([]);
   });
 });

--- a/src/gateway/http-auth-helpers.ts
+++ b/src/gateway/http-auth-helpers.ts
@@ -7,7 +7,7 @@ import {
 } from "./auth.js";
 import { sendGatewayAuthFailure } from "./http-common.js";
 import { getBearerToken, getHeader } from "./http-utils.js";
-import { CLI_DEFAULT_OPERATOR_SCOPES, type OperatorScope } from "./method-scopes.js";
+import type { OperatorScope } from "./method-scopes.js";
 
 const OPERATOR_SCOPES_HEADER = "x-openclaw-scopes";
 
@@ -87,7 +87,7 @@ export function resolveGatewayCompatibilityHttpOperatorScopes(params: {
     return requested.scopes;
   }
   if (canImplicitlyTrustCompatibilityScopes(params.authResult)) {
-    return [...(params.fallbackScopes ?? CLI_DEFAULT_OPERATOR_SCOPES)];
+    return [...(params.fallbackScopes ?? [])];
   }
   return [];
 }

--- a/src/gateway/http-auth-helpers.ts
+++ b/src/gateway/http-auth-helpers.ts
@@ -1,19 +1,51 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
-import { authorizeHttpGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
+import {
+  authorizeHttpGatewayConnect,
+  type GatewayAuthResult,
+  type ResolvedGatewayAuth,
+} from "./auth.js";
 import { sendGatewayAuthFailure } from "./http-common.js";
 import { getBearerToken, getHeader } from "./http-utils.js";
+import { CLI_DEFAULT_OPERATOR_SCOPES, type OperatorScope } from "./method-scopes.js";
 
 const OPERATOR_SCOPES_HEADER = "x-openclaw-scopes";
 
-export async function authorizeGatewayBearerRequestOrReply(params: {
+type RequestedOperatorScopes = {
+  present: boolean;
+  scopes: string[];
+};
+
+function parseRequestedOperatorScopes(req: IncomingMessage): RequestedOperatorScopes {
+  const raw = getHeader(req, OPERATOR_SCOPES_HEADER);
+  if (raw === undefined) {
+    return { present: false, scopes: [] };
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { present: true, scopes: [] };
+  }
+  return {
+    present: true,
+    scopes: trimmed
+      .split(",")
+      .map((scope) => scope.trim())
+      .filter((scope) => scope.length > 0),
+  };
+}
+
+function canImplicitlyTrustCompatibilityScopes(authResult: GatewayAuthResult): boolean {
+  return authResult.ok && (authResult.method === "token" || authResult.method === "password");
+}
+
+export async function authorizeGatewayBearerRequest(params: {
   req: IncomingMessage;
   res: ServerResponse;
   auth: ResolvedGatewayAuth;
   trustedProxies?: string[];
   allowRealIpFallback?: boolean;
   rateLimiter?: AuthRateLimiter;
-}): Promise<boolean> {
+}): Promise<GatewayAuthResult | null> {
   const token = getBearerToken(params.req);
   const authResult = await authorizeHttpGatewayConnect({
     auth: params.auth,
@@ -25,18 +57,37 @@ export async function authorizeGatewayBearerRequestOrReply(params: {
   });
   if (!authResult.ok) {
     sendGatewayAuthFailure(params.res, authResult);
-    return false;
+    return null;
   }
-  return true;
+  return authResult;
+}
+
+export async function authorizeGatewayBearerRequestOrReply(params: {
+  req: IncomingMessage;
+  res: ServerResponse;
+  auth: ResolvedGatewayAuth;
+  trustedProxies?: string[];
+  allowRealIpFallback?: boolean;
+  rateLimiter?: AuthRateLimiter;
+}): Promise<boolean> {
+  return (await authorizeGatewayBearerRequest(params)) !== null;
 }
 
 export function resolveGatewayRequestedOperatorScopes(req: IncomingMessage): string[] {
-  const raw = getHeader(req, OPERATOR_SCOPES_HEADER)?.trim();
-  if (!raw) {
-    return [];
+  return parseRequestedOperatorScopes(req).scopes;
+}
+
+export function resolveGatewayCompatibilityHttpOperatorScopes(params: {
+  req: IncomingMessage;
+  authResult: GatewayAuthResult;
+  fallbackScopes?: readonly OperatorScope[];
+}): string[] {
+  const requested = parseRequestedOperatorScopes(params.req);
+  if (requested.present) {
+    return requested.scopes;
   }
-  return raw
-    .split(",")
-    .map((scope) => scope.trim())
-    .filter((scope) => scope.length > 0);
+  if (canImplicitlyTrustCompatibilityScopes(params.authResult)) {
+    return [...(params.fallbackScopes ?? CLI_DEFAULT_OPERATOR_SCOPES)];
+  }
+  return [];
 }

--- a/src/gateway/http-endpoint-helpers.test.ts
+++ b/src/gateway/http-endpoint-helpers.test.ts
@@ -5,8 +5,8 @@ import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 
 vi.mock("./http-auth-helpers.js", () => {
   return {
-    authorizeGatewayBearerRequestOrReply: vi.fn(),
-    resolveGatewayRequestedOperatorScopes: vi.fn(),
+    authorizeGatewayBearerRequest: vi.fn(),
+    resolveGatewayCompatibilityHttpOperatorScopes: vi.fn(),
   };
 });
 
@@ -24,8 +24,8 @@ vi.mock("./method-scopes.js", () => {
   };
 });
 
-const { authorizeGatewayBearerRequestOrReply } = await import("./http-auth-helpers.js");
-const { resolveGatewayRequestedOperatorScopes } = await import("./http-auth-helpers.js");
+const { authorizeGatewayBearerRequest } = await import("./http-auth-helpers.js");
+const { resolveGatewayCompatibilityHttpOperatorScopes } = await import("./http-auth-helpers.js");
 const { readJsonBodyOrError, sendJson, sendMethodNotAllowed } = await import("./http-common.js");
 const { authorizeOperatorScopesForMethod } = await import("./method-scopes.js");
 
@@ -60,7 +60,7 @@ describe("handleGatewayPostJsonEndpoint", () => {
   });
 
   it("returns undefined when auth fails", async () => {
-    vi.mocked(authorizeGatewayBearerRequestOrReply).mockResolvedValue(false);
+    vi.mocked(authorizeGatewayBearerRequest).mockResolvedValue(null);
     const result = await handleGatewayPostJsonEndpoint(
       {
         url: "/v1/ok",
@@ -74,7 +74,7 @@ describe("handleGatewayPostJsonEndpoint", () => {
   });
 
   it("returns body when auth succeeds and JSON parsing succeeds", async () => {
-    vi.mocked(authorizeGatewayBearerRequestOrReply).mockResolvedValue(true);
+    vi.mocked(authorizeGatewayBearerRequest).mockResolvedValue({ ok: true, method: "token" });
     vi.mocked(readJsonBodyOrError).mockResolvedValue({ hello: "world" });
     const result = await handleGatewayPostJsonEndpoint(
       {
@@ -89,8 +89,10 @@ describe("handleGatewayPostJsonEndpoint", () => {
   });
 
   it("returns undefined and replies when required operator scope is missing", async () => {
-    vi.mocked(authorizeGatewayBearerRequestOrReply).mockResolvedValue(true);
-    vi.mocked(resolveGatewayRequestedOperatorScopes).mockReturnValue(["operator.approvals"]);
+    vi.mocked(authorizeGatewayBearerRequest).mockResolvedValue({ ok: true, method: "token" });
+    vi.mocked(resolveGatewayCompatibilityHttpOperatorScopes).mockReturnValue([
+      "operator.approvals",
+    ]);
     vi.mocked(authorizeOperatorScopesForMethod).mockReturnValue({
       allowed: false,
       missingScope: "operator.write",

--- a/src/gateway/http-endpoint-helpers.ts
+++ b/src/gateway/http-endpoint-helpers.ts
@@ -45,17 +45,11 @@ export async function handleGatewayPostJsonEndpoint(
   }
 
   if (opts.requiredOperatorMethod) {
-    const requestedScopes = opts.implicitCompatibilityOperatorScopes
-      ? resolveGatewayCompatibilityHttpOperatorScopes({
-          req,
-          authResult,
-          fallbackScopes: opts.implicitCompatibilityOperatorScopes,
-        })
-      : resolveGatewayCompatibilityHttpOperatorScopes({
-          req,
-          authResult,
-          fallbackScopes: [],
-        });
+    const requestedScopes = resolveGatewayCompatibilityHttpOperatorScopes({
+      req,
+      authResult,
+      fallbackScopes: opts.implicitCompatibilityOperatorScopes ?? [],
+    });
     const scopeAuth = authorizeOperatorScopesForMethod(
       opts.requiredOperatorMethod,
       requestedScopes,

--- a/src/gateway/http-endpoint-helpers.ts
+++ b/src/gateway/http-endpoint-helpers.ts
@@ -2,11 +2,11 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import {
-  authorizeGatewayBearerRequestOrReply,
-  resolveGatewayRequestedOperatorScopes,
+  authorizeGatewayBearerRequest,
+  resolveGatewayCompatibilityHttpOperatorScopes,
 } from "./http-auth-helpers.js";
 import { readJsonBodyOrError, sendJson, sendMethodNotAllowed } from "./http-common.js";
-import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
+import { authorizeOperatorScopesForMethod, type OperatorScope } from "./method-scopes.js";
 
 export async function handleGatewayPostJsonEndpoint(
   req: IncomingMessage,
@@ -19,6 +19,7 @@ export async function handleGatewayPostJsonEndpoint(
     allowRealIpFallback?: boolean;
     rateLimiter?: AuthRateLimiter;
     requiredOperatorMethod?: "chat.send" | (string & Record<never, never>);
+    implicitCompatibilityOperatorScopes?: readonly OperatorScope[];
   },
 ): Promise<false | { body: unknown } | undefined> {
   const url = new URL(req.url ?? "/", `http://${req.headers.host || "localhost"}`);
@@ -31,7 +32,7 @@ export async function handleGatewayPostJsonEndpoint(
     return undefined;
   }
 
-  const authorized = await authorizeGatewayBearerRequestOrReply({
+  const authResult = await authorizeGatewayBearerRequest({
     req,
     res,
     auth: opts.auth,
@@ -39,12 +40,22 @@ export async function handleGatewayPostJsonEndpoint(
     allowRealIpFallback: opts.allowRealIpFallback,
     rateLimiter: opts.rateLimiter,
   });
-  if (!authorized) {
+  if (!authResult) {
     return undefined;
   }
 
   if (opts.requiredOperatorMethod) {
-    const requestedScopes = resolveGatewayRequestedOperatorScopes(req);
+    const requestedScopes = opts.implicitCompatibilityOperatorScopes
+      ? resolveGatewayCompatibilityHttpOperatorScopes({
+          req,
+          authResult,
+          fallbackScopes: opts.implicitCompatibilityOperatorScopes,
+        })
+      : resolveGatewayCompatibilityHttpOperatorScopes({
+          req,
+          authResult,
+          fallbackScopes: [],
+        });
     const scopeAuth = authorizeOperatorScopesForMethod(
       opts.requiredOperatorMethod,
       requestedScopes,

--- a/src/gateway/models-http.test.ts
+++ b/src/gateway/models-http.test.ts
@@ -28,11 +28,17 @@ async function startServer(port: number, opts?: { openAiChatCompletionsEnabled?:
   });
 }
 
-async function getModels(pathname: string, headers?: Record<string, string>) {
-  return await fetch(`http://127.0.0.1:${enabledPort}${pathname}`, {
+async function getModels(
+  pathname: string,
+  headers?: Record<string, string>,
+  opts?: { includeDefaultScopeHeader?: boolean; port?: number; token?: string },
+) {
+  const includeDefaultScopeHeader = opts?.includeDefaultScopeHeader ?? true;
+  const port = opts?.port ?? enabledPort;
+  return await fetch(`http://127.0.0.1:${port}${pathname}`, {
     headers: {
-      authorization: "Bearer secret",
-      ...READ_SCOPE_HEADER,
+      authorization: `Bearer ${opts?.token ?? "secret"}`,
+      ...(includeDefaultScopeHeader ? READ_SCOPE_HEADER : {}),
       ...headers,
     },
   });
@@ -60,6 +66,29 @@ describe("OpenAI-compatible models HTTP API (e2e)", () => {
     const firstId = list.data?.[0]?.id;
     expect(typeof firstId).toBe("string");
     const res = await getModels(`/v1/models/${encodeURIComponent(firstId!)}`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { id?: string; object?: string };
+    expect(json.object).toBe("model");
+    expect(json.id).toBe(firstId);
+  });
+
+  it("serves /v1/models with headerless bearer auth", async () => {
+    const res = await getModels("/v1/models", undefined, { includeDefaultScopeHeader: false });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { object?: string; data?: Array<{ id?: string }> };
+    expect(json.object).toBe("list");
+    expect((json.data?.length ?? 0) > 0).toBe(true);
+  });
+
+  it("serves /v1/models/{id} with headerless bearer auth", async () => {
+    const list = (await (await getModels("/v1/models")).json()) as {
+      data?: Array<{ id?: string }>;
+    };
+    const firstId = list.data?.[0]?.id;
+    expect(typeof firstId).toBe("string");
+    const res = await getModels(`/v1/models/${encodeURIComponent(firstId!)}`, undefined, {
+      includeDefaultScopeHeader: false,
+    });
     expect(res.status).toBe(200);
     const json = (await res.json()) as { id?: string; object?: string };
     expect(json.object).toBe("model");
@@ -119,6 +148,27 @@ describe("OpenAI-compatible models HTTP API (e2e)", () => {
       expect(res.status).toBe(404);
     } finally {
       await server.close({ reason: "models disabled test done" });
+    }
+  });
+
+  it("serves /v1/models with headerless password auth", async () => {
+    const port = await getFreePort();
+    const server = await startGatewayServer(port, {
+      host: "127.0.0.1",
+      auth: { mode: "password", password: "pw-secret" },
+      controlUiEnabled: false,
+      openAiChatCompletionsEnabled: true,
+    });
+    try {
+      const res = await getModels("/v1/models", undefined, {
+        includeDefaultScopeHeader: false,
+        port,
+        token: "pw-secret",
+      });
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({ object: "list" });
+    } finally {
+      await server.close({ reason: "models password auth test done" });
     }
   });
 });

--- a/src/gateway/models-http.ts
+++ b/src/gateway/models-http.ts
@@ -2,10 +2,10 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
-import type { ResolvedGatewayAuth } from "./auth.js";
+import type { GatewayAuthResult, ResolvedGatewayAuth } from "./auth.js";
 import {
-  authorizeGatewayBearerRequestOrReply,
-  resolveGatewayRequestedOperatorScopes,
+  authorizeGatewayBearerRequest,
+  resolveGatewayCompatibilityHttpOperatorScopes,
 } from "./http-auth-helpers.js";
 import { sendInvalidRequest, sendJson, sendMethodNotAllowed } from "./http-common.js";
 import {
@@ -13,7 +13,7 @@ import {
   OPENCLAW_MODEL_ID,
   resolveAgentIdFromModel,
 } from "./http-utils.js";
-import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
+import { authorizeOperatorScopesForMethod, CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
 
 type OpenAiModelsHttpOptions = {
   auth: ResolvedGatewayAuth;
@@ -44,8 +44,8 @@ async function authorizeRequest(
   req: IncomingMessage,
   res: ServerResponse,
   opts: OpenAiModelsHttpOptions,
-): Promise<boolean> {
-  return await authorizeGatewayBearerRequestOrReply({
+): Promise<GatewayAuthResult | null> {
+  return await authorizeGatewayBearerRequest({
     req,
     res,
     auth: opts.auth,
@@ -85,11 +85,16 @@ export async function handleOpenAiModelsHttpRequest(
     return true;
   }
 
-  if (!(await authorizeRequest(req, res, opts))) {
+  const authResult = await authorizeRequest(req, res, opts);
+  if (!authResult) {
     return true;
   }
 
-  const requestedScopes = resolveGatewayRequestedOperatorScopes(req);
+  const requestedScopes = resolveGatewayCompatibilityHttpOperatorScopes({
+    req,
+    authResult,
+    fallbackScopes: CLI_DEFAULT_OPERATOR_SCOPES,
+  });
   const scopeAuth = authorizeOperatorScopesForMethod("models.list", requestedScopes);
   if (!scopeAuth.allowed) {
     sendJson(res, 403, {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -70,6 +70,23 @@ async function postChatCompletions(port: number, body: unknown, headers?: Record
   return res;
 }
 
+async function postChatCompletionsAuthOnly(
+  port: number,
+  body: unknown,
+  headers?: Record<string, string>,
+) {
+  const res = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: "Bearer secret",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+  return res;
+}
+
 async function expectChatCompletionsDisabled(
   start: (port: number) => Promise<{ close: (opts?: { reason?: string }) => Promise<void> }>,
 ) {
@@ -103,6 +120,23 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         openAiChatCompletionsEnabled: false,
       }),
     );
+  });
+
+  it("allows headerless bearer auth on /v1/chat/completions", async () => {
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
+
+    const res = await postChatCompletionsAuthOnly(enabledPort, {
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      object: "chat.completion",
+      choices: [{ message: { content: "hello" } }],
+    });
+    expect(agentCommand).toHaveBeenCalledTimes(1);
   });
 
   it("handles request validation and routing", async () => {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -29,6 +29,7 @@ import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import { resolveGatewayRequestContext, resolveOpenAiCompatModelOverride } from "./http-utils.js";
 import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
+import { CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
 
 type OpenAiHttpOptions = {
   auth: ResolvedGatewayAuth;
@@ -417,6 +418,7 @@ export async function handleOpenAiHttpRequest(
   const handled = await handleGatewayPostJsonEndpoint(req, res, {
     pathname: "/v1/chat/completions",
     requiredOperatorMethod: "chat.send",
+    implicitCompatibilityOperatorScopes: CLI_DEFAULT_OPERATOR_SCOPES,
     auth: opts.auth,
     trustedProxies: opts.trustedProxies,
     allowRealIpFallback: opts.allowRealIpFallback,


### PR DESCRIPTION
## Summary

- Problem: `#56763` reports that `/v1/models` and `/v1/chat/completions` now reject valid gateway bearer auth with `missing scope: operator.read/write` unless clients also send `x-openclaw-scopes`.
- Why it matters: This regressed OpenAI-compatible HTTP clients that were previously documented to work with shared gateway bearer auth alone, including Open WebUI-style integrations.
- What changed: Restore the documented compatibility path on the OpenAI-compatible HTTP routes by granting the default operator scope bundle only when the scope header is absent and shared gateway auth succeeded via `token` or `password`.
- What did NOT change (scope boundary): Explicit `x-openclaw-scopes` remains authoritative, explicit empty/downscoped headers still fail, and `trusted-proxy` does not get the implicit fallback.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #56763
- Related #57113
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the HTTP OpenAI-compatible route checks started enforcing method scopes from `x-openclaw-scopes`, but the shared gateway bearer auth path does not derive scopes onto the request.
- Missing detection / guardrail: there was no route-level regression test covering headerless bearer auth on `/v1/models` and `/v1/chat/completions`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the issue was reported after the recent HTTP scope-hardening work, especially `#56618` for chat completions; `/v1/models` had a similar hardening path already in place.
- Why this regressed now: the scope checks assumed all HTTP clients would send `x-openclaw-scopes`, but the documented compatibility contract for shared bearer auth did not require that.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/models-http.test.ts`, `src/gateway/openai-http.test.ts`, plus helper coverage in `src/gateway/http-auth-helpers.test.ts`
- Scenario the test should lock in: headerless token/password bearer auth succeeds on OpenAI-compatible HTTP routes, while explicit empty or downscoped headers still fail.
- Why this is the smallest reliable guardrail: the regression lives at the HTTP auth-to-method-scope seam, not in the lower-level auth primitive alone.
- Existing test that already covers this (if any): none for the headerless compatibility path
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

OpenAI-compatible HTTP clients using valid gateway bearer auth no longer need to send `x-openclaw-scopes` just to call `/v1/models` or `/v1/chat/completions`. Explicitly supplied scopes still behave as before.

## Diagram (if applicable)

```text
Before:
[HTTP bearer auth succeeds] -> [missing x-openclaw-scopes] -> [required method scope checks []] -> [403 missing scope]

After:
[HTTP bearer auth succeeds] -> [missing x-openclaw-scopes] -> [compatibility fallback for token/password auth] -> [method scope check passes]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / Bun 1.3.x local dev runtime
- Model/provider: not relevant to the auth regression
- Integration/channel (if any): OpenAI-compatible HTTP gateway routes
- Relevant config (redacted): shared gateway auth via token/password

### Steps

1. Start the gateway with shared auth enabled.
2. Call `/v1/models` or `/v1/chat/completions` with valid `Authorization: Bearer ...` and no `x-openclaw-scopes` header.
3. Compare with explicit empty or downscoped `x-openclaw-scopes` headers.

### Expected

- Valid headerless bearer auth succeeds on the OpenAI-compatible HTTP routes.
- Explicit empty or insufficient scopes still fail.

### Actual

- Before this fix, headerless bearer auth fails with `missing scope: operator.read` or `missing scope: operator.write`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - helper-level scope resolution: token/password headerless auth gets the default operator scope bundle; empty/downscoped headers stay denied; trusted-proxy gets no implicit fallback
  - endpoint-level `/v1/models` probes: token headerless `200`, token empty-scope `403`, token downscoped `403`, password headerless `200`
  - changed files pass `oxlint` and `oxfmt --check`
- Edge cases checked:
  - explicit empty scope header remains empty rather than being treated as missing
  - `trusted-proxy` remains excluded from the compatibility fallback
- What you did **not** verify:
  - I did not get a completed focused Vitest run in this environment; the targeted Vitest command stayed in startup/compile with no test-body output, so I am relying on the direct runtime probes plus CI for the full suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: route-local compatibility fallback could be misread as broad auth widening
  - Mitigation: keep it scoped to the OpenAI-compatible HTTP routes, only when the scope header is absent, and only for `token` / `password` auth; explicit scopes and `trusted-proxy` behavior are unchanged
