### PR TITLE
Agents: honor persisted cron runtime model fields

### DIFF
--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -90,6 +90,32 @@ describe("live model switch", () => {
     });
   });
 
+  it("falls back to persisted runtime model fields when override fields are absent", async () => {
+    state.loadSessionStoreMock.mockReturnValue({
+      "agent:main:cron:test": {
+        modelProvider: "anthropic",
+        model: "claude-sonnet-4-6",
+      },
+    });
+
+    const { resolveLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      resolveLiveSessionModelSelection({
+        cfg: { session: { store: "/tmp/custom-store.json" } },
+        sessionKey: "agent:main:cron:test",
+        agentId: "main",
+        defaultProvider: "anthropic",
+        defaultModel: "claude-opus-4-6",
+      }),
+    ).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      authProfileId: undefined,
+      authProfileIdSource: undefined,
+    });
+  });
+
   it("queues a live switch only when an active run was aborted", async () => {
     state.abortEmbeddedPiRunMock.mockReturnValue(true);
 

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -48,8 +48,9 @@ export function resolveLiveSessionModelSelection(params: {
     agentId,
   });
   const entry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
-  const provider = entry?.providerOverride?.trim() || defaultModelRef.provider;
-  const model = entry?.modelOverride?.trim() || defaultModelRef.model;
+  const provider =
+    entry?.providerOverride?.trim() || entry?.modelProvider?.trim() || defaultModelRef.provider;
+  const model = entry?.modelOverride?.trim() || entry?.model?.trim() || defaultModelRef.model;
   const authProfileId = entry?.authProfileOverride?.trim() || undefined;
   return {
     provider,


### PR DESCRIPTION
## Summary
- let live-session model selection fall back to persisted runtime `modelProvider`/`model` fields when override fields are absent
- keep older cron-isolated session entries compatible with the live model switch guard
- add a regression test covering cron-style persisted model fields

Fixes #57191
Related: #57206