### PR TITLE
Agents: resolve image tool relative paths from workspace

### DIFF
--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -975,6 +975,24 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("resolves relative image paths against workspaceDir", async () => {
+    await withTempWorkspacePng(async ({ workspaceDir, imagePath }) => {
+      const fetch = stubMinimaxOkFetch();
+      await withTempAgentDir(async (agentDir) => {
+        const cfg = createMinimaxImageConfig();
+        const tool = createRequiredImageTool({
+          config: cfg,
+          agentDir,
+          workspaceDir,
+          fsPolicy: { workspaceOnly: true },
+        });
+
+        await expectImageToolExecOk(tool, path.relative(workspaceDir, imagePath));
+        expect(fetch).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
   it("sandboxes image paths like the read tool", async () => {
     await withTempSandboxState(async ({ agentDir, sandboxRoot }) => {
       await fs.writeFile(path.join(sandboxRoot, "img.png"), "fake", "utf8");

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getMediaUnderstandingProvider } from "../../media-understanding/provider-registry.js";
@@ -403,6 +404,15 @@ export function createImageTool(options?: {
           }
           if (imageRaw.startsWith("~")) {
             return resolveUserPath(imageRaw);
+          }
+          if (
+            options?.workspaceDir &&
+            !isFileUrl &&
+            !isHttpUrl &&
+            !isDataUrl &&
+            !path.isAbsolute(imageRaw)
+          ) {
+            return path.resolve(options.workspaceDir, imageRaw);
           }
           return imageRaw;
         })();


### PR DESCRIPTION
## Summary
- resolve relative image paths against `workspaceDir` before local-root checks
- keep absolute paths, URLs, sandbox paths, and `~` expansion unchanged
- add a regression test for workspace-relative image inputs

Fixes #57215