### PR TITLE
feat(whatsapp): context-aware emoji reactions via shared resolveReactionMessageId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - LINE/outbound media: add LINE image, video, and audio outbound sends on the LINE-specific delivery path, including explicit preview/tracking handling for videos while keeping generic media sends on the existing image-only route. (#45826) Thanks @masatohoshino.
+- WhatsApp/reactions: agents can now react with emoji on incoming WhatsApp messages, enabling more natural conversational interactions like acknowledging a photo with ❤️ instead of typing a reply. Thanks @mcaxtr.
 
 ### Fixes
 

--- a/extensions/whatsapp/src/channel.test.ts
+++ b/extensions/whatsapp/src/channel.test.ts
@@ -23,6 +23,7 @@ import type { OpenClawConfig } from "./runtime-api.js";
 
 const hoisted = vi.hoisted(() => ({
   sendPollWhatsApp: vi.fn(async () => ({ messageId: "wa-poll-1", toJid: "1555@s.whatsapp.net" })),
+  handleWhatsAppAction: vi.fn(async () => ({ content: [{ type: "text", text: '{"ok":true}' }] })),
   loginWeb: vi.fn(async () => {}),
   pathExists: vi.fn(async () => false),
   listWhatsAppAccountIds: vi.fn(() => [] as string[]),
@@ -40,6 +41,7 @@ vi.mock("./runtime.js", () => ({
     channel: {
       whatsapp: {
         sendPollWhatsApp: hoisted.sendPollWhatsApp,
+        handleWhatsAppAction: hoisted.handleWhatsAppAction,
       },
     },
   }),
@@ -426,5 +428,150 @@ describe("whatsapp group policy", () => {
     expect(resolveWhatsAppGroupToolPolicy({ cfg, groupId: "other@g.us" })).toEqual({
       allow: ["message.send"],
     });
+  });
+});
+
+describe("whatsappPlugin actions.handleAction react messageId resolution", () => {
+  const baseCfg = {
+    channels: { whatsapp: { actions: { reactions: true }, allowFrom: ["*"] } },
+  } as OpenClawConfig;
+
+  beforeEach(() => {
+    hoisted.handleWhatsAppAction.mockClear();
+  });
+
+  it("uses explicit messageId when provided", async () => {
+    await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      params: { messageId: "explicit-id", emoji: "👍", to: "+1555" },
+      cfg: baseCfg,
+      accountId: DEFAULT_ACCOUNT_ID,
+    });
+    expect(hoisted.handleWhatsAppAction).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "explicit-id" }),
+      baseCfg,
+    );
+  });
+
+  it("falls back to toolContext.currentMessageId when messageId omitted", async () => {
+    await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      params: { emoji: "❤️", to: "+1555" },
+      cfg: baseCfg,
+      accountId: DEFAULT_ACCOUNT_ID,
+      toolContext: {
+        currentChannelId: "whatsapp:+1555",
+        currentChannelProvider: "whatsapp",
+        currentMessageId: "ctx-msg-42",
+      },
+    });
+    expect(hoisted.handleWhatsAppAction).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "ctx-msg-42" }),
+      baseCfg,
+    );
+  });
+
+  it("converts numeric toolContext messageId to string", async () => {
+    await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      params: { emoji: "🎉", to: "+1555" },
+      cfg: baseCfg,
+      accountId: DEFAULT_ACCOUNT_ID,
+      toolContext: {
+        currentChannelId: "whatsapp:+1555",
+        currentChannelProvider: "whatsapp",
+        currentMessageId: 12345,
+      },
+    });
+    expect(hoisted.handleWhatsAppAction).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "12345" }),
+      baseCfg,
+    );
+  });
+
+  it("throws ToolInputError when messageId missing and no toolContext", async () => {
+    const err = await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      params: { emoji: "👍", to: "+1555" },
+      cfg: baseCfg,
+      accountId: DEFAULT_ACCOUNT_ID,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).name).toBe("ToolInputError");
+  });
+
+  it("skips context fallback when targeting a different chat", async () => {
+    const err = await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      params: { emoji: "👍", to: "+9999" },
+      cfg: baseCfg,
+      accountId: DEFAULT_ACCOUNT_ID,
+      toolContext: {
+        currentChannelId: "whatsapp:+1555",
+        currentChannelProvider: "whatsapp",
+        currentMessageId: "ctx-msg-42",
+      },
+    }).catch((e: unknown) => e);
+    // Different target chat → context fallback suppressed → ToolInputError
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).name).toBe("ToolInputError");
+  });
+
+  it("uses context fallback when target matches current chat (prefixed)", async () => {
+    await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      params: { emoji: "👍", to: "+1555" },
+      cfg: baseCfg,
+      accountId: DEFAULT_ACCOUNT_ID,
+      toolContext: {
+        currentChannelId: "whatsapp:+1555",
+        currentChannelProvider: "whatsapp",
+        currentMessageId: "ctx-msg-42",
+      },
+    });
+    expect(hoisted.handleWhatsAppAction).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "ctx-msg-42" }),
+      baseCfg,
+    );
+  });
+
+  it("skips context fallback when source is another provider", async () => {
+    const err = await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      params: { emoji: "👍", to: "+1555" },
+      cfg: baseCfg,
+      accountId: DEFAULT_ACCOUNT_ID,
+      toolContext: {
+        currentChannelId: "telegram:-1003841603622",
+        currentChannelProvider: "telegram",
+        currentMessageId: "tg-msg-99",
+      },
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).name).toBe("ToolInputError");
+  });
+
+  it("skips context fallback when currentChannelId is missing with explicit target", async () => {
+    const err = await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      params: { emoji: "👍", to: "+1555" },
+      cfg: baseCfg,
+      accountId: DEFAULT_ACCOUNT_ID,
+      toolContext: {
+        currentChannelProvider: "whatsapp",
+        currentMessageId: "ctx-msg-42",
+      },
+    }).catch((e: unknown) => e);
+    // WhatsApp source but no currentChannelId to compare → fallback suppressed
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).name).toBe("ToolInputError");
   });
 });

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -1,4 +1,5 @@
 import { buildDmGroupAccountAllowlistAdapter } from "openclaw/plugin-sdk/allowlist-config-edit";
+import { resolveReactionMessageId } from "openclaw/plugin-sdk/channel-actions";
 import { createChatChannelPlugin } from "openclaw/plugin-sdk/core";
 import { chunkText } from "openclaw/plugin-sdk/reply-runtime";
 import {
@@ -153,13 +154,39 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
           return { actions: Array.from(actions) };
         },
         supportsAction: ({ action }) => action === "react",
-        handleAction: async ({ action, params, cfg, accountId }) => {
+        handleAction: async ({ action, params, cfg, accountId, toolContext }) => {
           if (action !== "react") {
             throw new Error(`Action ${action} is not supported for provider ${WHATSAPP_CHANNEL}.`);
           }
-          const messageId = readStringParam(params, "messageId", {
-            required: true,
+          // Only fall back to the inbound message id when the current turn
+          // originates from WhatsApp and targets the same chat. Skip the
+          // fallback when the source is another provider (the message id
+          // would be meaningless) or when the caller routes to a different
+          // WhatsApp chat (the id would belong to the wrong conversation).
+          const isWhatsAppSource = toolContext?.currentChannelProvider === WHATSAPP_CHANNEL;
+          const explicitTarget =
+            readStringParam(params, "chatJid") ?? readStringParam(params, "to");
+          const normalizedTarget = explicitTarget ? normalizeWhatsAppTarget(explicitTarget) : null;
+          const normalizedCurrent =
+            isWhatsAppSource && toolContext?.currentChannelId
+              ? normalizeWhatsAppTarget(toolContext.currentChannelId)
+              : null;
+          // When an explicit target is provided, require a known current chat
+          // to compare against. If currentChannelId is missing/unparseable,
+          // treat it as ineligible for fallback to avoid cross-chat leaks.
+          const isCrossChat =
+            normalizedTarget != null &&
+            (normalizedCurrent == null || normalizedTarget !== normalizedCurrent);
+          const scopedContext = !isWhatsAppSource || isCrossChat ? undefined : toolContext;
+          const messageIdRaw = resolveReactionMessageId({
+            args: params,
+            toolContext: scopedContext,
           });
+          if (messageIdRaw == null) {
+            // Delegate to readStringParam so the gateway maps the error to 400.
+            readStringParam(params, "messageId", { required: true });
+          }
+          const messageId = String(messageIdRaw);
           const emoji = readStringParam(params, "emoji", { allowEmpty: true });
           const remove = typeof params.remove === "boolean" ? params.remove : undefined;
           return await getWhatsAppRuntime().channel.whatsapp.handleWhatsAppAction(


### PR DESCRIPTION
## Summary

- Problem: WhatsApp reactions require the model to explicitly provide `messageId`, unlike Telegram, Signal, and Discord which auto-resolve it from inbound context via the shared `resolveReactionMessageId` helper.
- Why it matters: The model can't simply call `message({ action: "react", emoji: "👍" })` to react to the current inbound message — it must echo back the message ID from context, which it often fails to do.
- What changed: Wired `resolveReactionMessageId` from `openclaw/plugin-sdk/channel-actions` into the WhatsApp `handleAction` adapter with safety guards for cross-chat and cross-provider scenarios.
- What did NOT change (scope boundary): No transport changes (`sendReactionWhatsApp`, `send-api.ts`), no schema changes (`message-tool.ts`), no config changes. The `react` action was already declared by `describeMessageTool`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Telegram equivalent landed in c1b75ab8 (PR #20236), shared helper extracted in 7066d5e1
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A — This is a new feature, not a fix. WhatsApp reactions were added (551a8d56, Jan 6 2026) with `messageId: required` and never updated when Telegram got the context fallback (c1b75ab8, Feb 23 2026) or when the shared helper was extracted (7066d5e1, Mar 2 2026).

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/channel.test.ts`
- Scenario the test should lock in:
  - Explicit `messageId` wins over context fallback
  - Omitted `messageId` falls back to `toolContext.currentMessageId` (WhatsApp source only)
  - Numeric `messageId` converted to string
  - Missing `messageId` with no context throws `ToolInputError` (400, not 500)
  - Cross-chat targeting suppresses fallback (normalized comparison handles `whatsapp:+1555` vs `+1555`)
  - Cross-provider source (e.g. Telegram) suppresses fallback
- Why this is the smallest reliable guardrail: Tests exercise the adapter layer in `channel.ts` where the fallback logic lives, mocking the runtime to verify parameter resolution.

## User-visible / Behavior Changes

- The model can now react to the current WhatsApp inbound message by calling `message({ action: "react", emoji: "👍" })` without providing `messageId` — it auto-resolves from context.
- Explicit `messageId` still works as before (no breaking change).
- Requires `message` tool to be available (e.g. `messaging` profile or `tools.alsoAllow: ["message"]`).

## Diagram (if applicable)

```text
Before:
model calls message({ action: "react", emoji: "👍" })
  → ToolInputError: messageId required

After:
model calls message({ action: "react", emoji: "👍" })
  → resolveReactionMessageId falls back to toolContext.currentMessageId
  → sendReactionWhatsApp(chatJid, inboundMsgId, "👍")
  → reaction appears on user's message
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No — `react` action was already declared and gated by `channels.whatsapp.actions.reactions`
- Data access scope changed? No
- Guards: fallback only fires when source is WhatsApp AND target is the same chat (normalized). Cross-chat and cross-provider contexts require explicit `messageId`.

## Repro + Verification

### Environment

- OS: Linux (Ubuntu)
- Runtime/container: Node 22, pnpm
- Model/provider: Anthropic claude-sonnet-4-5
- Integration/channel: WhatsApp (Baileys)
- Relevant config: `tools.profile: "messaging"`, `channels.whatsapp.actions.reactions: true` (default)

### Steps

1. Send a WhatsApp message to the bot
2. In the same conversation, tell the bot: "React to my previous message with 👍"
3. Bot calls `message({ action: "react", emoji: "👍" })` — no `messageId` needed

### Expected

- Emoji reaction appears on the user's WhatsApp message

### Actual

- Emoji reaction appears on the user's WhatsApp message ✓

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Live-tested on OpenClaw 2026.3.28 (cherry-picked) with WhatsApp DM. Gateway logs confirm `tool=message` called and reaction delivered. 7 new unit tests in `channel.test.ts` cover fallback, cross-chat guard, cross-provider guard, and error type preservation.

## Human Verification (required)

- Verified scenarios: DM reaction with omitted messageId (auto-resolved from context), explicit messageId still works
- Edge cases checked: cross-chat targeting (different `to` vs `currentChannelId` with prefix normalization), cross-provider source (Telegram context), missing messageId without context (ToolInputError 400)
- What you did **not** verify: Group reactions (require `participant` field — pre-existing limitation, not introduced by this change)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — explicit `messageId` still works identically
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Group reactions may fail when `messageId` is auto-resolved but `participant` is missing (needed for group message keys).
  - Mitigation: Pre-existing limitation — same behavior as before for groups. `participant` enrichment from context is a follow-up enhancement.