### PR TITLE
fix(gateway): apply bundled allowlist compat for channel plugins at startup

### DIFF
--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -2,9 +2,11 @@ import { randomUUID } from "node:crypto";
 import { normalizeModelRef, parseModelRef } from "../agents/model-selection.js";
 import type { loadConfig } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
+import { withBundledPluginAllowlistCompat } from "../plugins/bundled-compat.js";
 import { resolveGatewayStartupPluginIds } from "../plugins/channel-plugin-ids.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
+import { resolveBundledChannelCompatPluginIds } from "../plugins/providers.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
@@ -391,10 +393,24 @@ export function loadGatewayPlugins(params: {
   baseMethods: string[];
   preferSetupRuntimeForChannelPlugins?: boolean;
 }) {
-  const resolvedConfig = applyPluginAutoEnable({
+  const autoEnabledConfig = applyPluginAutoEnable({
     config: params.cfg,
     env: process.env,
   }).config;
+  // Apply allowlist compat so bundled channel plugins (telegram, whatsapp, etc.)
+  // are not silently filtered out when plugins.allow is configured but does not
+  // explicitly list them — matching the provider compat already applied in
+  // providers.runtime.ts.
+  const channelCompatIds = resolveBundledChannelCompatPluginIds({
+    config: autoEnabledConfig,
+    workspaceDir: params.workspaceDir,
+    env: process.env,
+  });
+  const resolvedConfig =
+    withBundledPluginAllowlistCompat({
+      config: autoEnabledConfig,
+      pluginIds: channelCompatIds,
+    }) ?? autoEnabledConfig;
   const pluginRegistry = loadOpenClawPlugins({
     config: resolvedConfig,
     workspaceDir: params.workspaceDir,

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -64,9 +64,26 @@ export function resolveEnabledProviderPluginIds(params: {
     .toSorted((left, right) => left.localeCompare(right));
 }
 
+export function resolveBundledChannelCompatPluginIds(params: {
+  config?: PluginLoadOptions["config"];
+  workspaceDir?: string;
+  env?: PluginLoadOptions["env"];
+}): string[] {
+  const registry = loadPluginManifestRegistry({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  return registry.plugins
+    .filter((plugin) => plugin.origin === "bundled" && plugin.channels.length > 0)
+    .map((plugin) => plugin.id)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
 export const __testing = {
   resolveEnabledProviderPluginIds,
   resolveBundledProviderCompatPluginIds,
+  resolveBundledChannelCompatPluginIds,
   withBundledProviderVitestCompat,
 } as const;
 


### PR DESCRIPTION
## Summary

- Bundled channel plugins (telegram, whatsapp, discord, etc.) are now exempt from `plugins.allow` allowlist filtering at gateway startup, matching the existing compat already in place for provider plugins
- Adds `resolveBundledChannelCompatPluginIds` to `src/plugins/providers.ts` (parallel to `resolveBundledProviderCompatPluginIds`, filtering on `channels.length > 0`)
- Applies `withBundledPluginAllowlistCompat` in `loadGatewayPlugins` before `loadOpenClawPlugins` is called

## Issue

Closes #55744

**Root cause:** When `plugins.allow` is configured with any non-empty allowlist, `resolveEnableState` in `config-state.ts` short-circuits at the allowlist check and returns `disabled / not in allowlist` before reaching the bundled-by-default fallback. This means bundled channel plugins are silently excluded from the plugin registry at gateway startup unless they are explicitly named in the allowlist.

Provider plugins were already protected by `withBundledPluginAllowlistCompat` in `providers.runtime.ts` and the fix for #55267 in `plugins/status.ts`. The gateway's `loadGatewayPlugins` function (`src/gateway/server-plugins.ts`) applied auto-enable but never applied the channel compat, so the Telegram/WhatsApp/Discord channel plugins were never loaded — resulting in an empty Channels table and no inbound message handling.

## Test plan

- [ ] Configure `plugins.allow` with one or more non-channel entries (e.g. a custom provider plugin)
- [ ] Configure `channels.telegram.enabled: true` with a valid bot token
- [ ] Restart gateway — Telegram should appear in `openclaw status` Channels table
- [ ] Inbound Telegram messages should reach OpenClaw
- [ ] Without `plugins.allow` set — no change in behaviour
- [ ] Channel explicitly disabled via `plugins.entries` still stays disabled

## Security impact

None — this change only prevents bundled channels from being accidentally excluded by allowlist configuration. Channels can still be disabled via `plugins.entries` or by not configuring `channels.<id>.enabled`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)