### PR TITLE
fix(browser): normalize WS3 existing-session attach fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Docs: https://docs.openclaw.ai
 - Agents/replay: repair displaced or missing tool results before strict provider replay, use Codex-compatible `aborted` outputs for OpenAI Responses history, and drop partial aborted/error transport turns before retries.
 - Browser/startup: deduplicate concurrent lazy-start calls per profile so simultaneous browser tool requests no longer race into duplicate Chrome launches and `PortInUseError`. (#61772) Thanks @sukhdeepjohar.
 - Browser/profiles: recover from stale Chromium `Singleton*` profile locks after crashes or host moves by clearing dead/foreign locks and retrying launch once. Thanks @seanc-dev.
+- Browser/existing-session: keep Chrome MCP status probes transport-only and ephemeral, and retry stale cached Playwright attaches once so idle profile checks no longer poison the next real attach. (#57245) Thanks @josephbergvinson.
 - Reply media: allow sandboxed replies to deliver OpenClaw-managed `media/outbound` and `media/tool-*` attachments without treating them as sandbox escapes, while keeping alias-escape checks on the managed media root. Fixes #71138. Thanks @mayor686, @truffle-dev, and @neeravmakwana.
 - CLI/agent: keep `openclaw agent --json` stdout reserved for the JSON response by routing gateway, plugin, and embedded-fallback diagnostics to stderr before execution starts. Fixes #71319.
 - Agents/Gemini: retry reasoning-only, empty, and planning-only Gemini turns instead of letting sessions silently stall. Fixes #71074. (#71362) Thanks @neeravmakwana.

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clickChromeMcpElement,
   buildChromeMcpArgs,
+  ensureChromeMcpAvailable,
   evaluateChromeMcpScript,
   listChromeMcpTabs,
   navigateChromeMcpPage,
@@ -184,6 +185,72 @@ describe("chrome MCP page parsing", () => {
     });
 
     expect(result).toBe(123);
+  });
+
+  it("does not cache an ephemeral availability probe before the next real attach", async () => {
+    let factoryCalls = 0;
+    const closeMocks: Array<ReturnType<typeof vi.fn>> = [];
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      const closeMock = vi.fn().mockResolvedValue(undefined);
+      session.client.close = closeMock as typeof session.client.close;
+      closeMocks.push(closeMock);
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    await ensureChromeMcpAvailable("chrome-live", undefined, { ephemeral: true });
+
+    expect(factoryCalls).toBe(1);
+    expect(closeMocks[0]).toHaveBeenCalledTimes(1);
+
+    const tabs = await listChromeMcpTabs("chrome-live");
+
+    expect(factoryCalls).toBe(2);
+    expect(closeMocks[1]).not.toHaveBeenCalled();
+    expect(tabs).toHaveLength(2);
+  });
+
+  it("does not poison the next real attach after an ephemeral no-page probe", async () => {
+    let factoryCalls = 0;
+    const closeMocks: Array<ReturnType<typeof vi.fn>> = [];
+    const factory: ChromeMcpSessionFactory = async () => {
+      factoryCalls += 1;
+      const session = createFakeSession();
+      const closeMock = vi.fn().mockResolvedValue(undefined);
+      session.client.close = closeMock as typeof session.client.close;
+      closeMocks.push(closeMock);
+      if (factoryCalls === 1) {
+        const callTool = vi.fn(async ({ name }: ToolCall) => {
+          if (name === "list_pages") {
+            return {
+              content: [{ type: "text", text: "No page selected" }],
+              isError: true,
+            };
+          }
+          throw new Error(`unexpected tool ${name}`);
+        });
+        session.client.callTool = callTool as typeof session.client.callTool;
+      }
+      return session;
+    };
+    setChromeMcpSessionFactoryForTest(factory);
+
+    await expect(
+      listChromeMcpTabs("chrome-live", undefined, {
+        ephemeral: true,
+      }),
+    ).rejects.toThrow(/No page selected/);
+
+    expect(factoryCalls).toBe(1);
+    expect(closeMocks[0]).toHaveBeenCalledTimes(1);
+
+    const tabs = await listChromeMcpTabs("chrome-live");
+
+    expect(factoryCalls).toBe(2);
+    expect(closeMocks[1]).not.toHaveBeenCalled();
+    expect(tabs).toHaveLength(2);
   });
 
   it("surfaces MCP tool errors instead of JSON parse noise", async () => {

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -98,6 +98,7 @@ function createFakeSession(): ChromeMcpSession {
 describe("chrome MCP page parsing", () => {
   beforeEach(async () => {
     await resetChromeMcpSessionsForTest();
+    vi.useRealTimers();
   });
 
   afterEach(() => {
@@ -474,7 +475,6 @@ describe("chrome MCP page parsing", () => {
     expect(factoryCalls).toBe(2);
     expect(tabs).toHaveLength(2);
   });
-
   it("reconnects and retries list_pages once when Chrome MCP reports a stale selected page", async () => {
     let factoryCalls = 0;
     const factory: ChromeMcpSessionFactory = async () => {
@@ -612,5 +612,35 @@ describe("chrome MCP page parsing", () => {
     const tabs = await listChromeMcpTabs("chrome-live");
     expect(factoryCalls).toBe(2);
     expect(tabs).toHaveLength(2);
+  });
+
+  it("honors timeoutMs for ephemeral availability probes", async () => {
+    vi.useFakeTimers();
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    const factory: ChromeMcpSessionFactory = async () =>
+      ({
+        client: {
+          callTool: vi.fn(),
+          listTools: vi.fn(),
+          close: closeMock,
+          connect: vi.fn(),
+        },
+        transport: {
+          pid: 123,
+        },
+        ready: new Promise<void>(() => {}),
+      }) as unknown as ChromeMcpSession;
+    setChromeMcpSessionFactoryForTest(factory);
+
+    const promise = ensureChromeMcpAvailable("chrome-live", undefined, {
+      ephemeral: true,
+      timeoutMs: 50,
+    });
+    const expectation = expect(promise).rejects.toThrow(/timed out after 50ms/i);
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expectation;
+    expect(closeMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -463,37 +463,6 @@ async function getExistingSession(
   }
 }
 
-async function waitForChromeMcpReady(
-  session: ChromeMcpSession,
-  profileName: string,
-  timeoutMs?: number,
-): Promise<void> {
-  if (!timeoutMs || timeoutMs <= 0) {
-    await session.ready;
-    return;
-  }
-
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    await Promise.race([
-      session.ready,
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(() => {
-          reject(
-            new BrowserProfileUnavailableError(
-              `Chrome MCP existing-session attach for profile "${profileName}" timed out after ${timeoutMs}ms.`,
-            ),
-          );
-        }, timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
-}
-
 async function createEphemeralSession(
   profileName: string,
   userDataDir?: string,

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -31,6 +31,18 @@ type ChromeMcpSession = {
   ready: Promise<void>;
 };
 
+type ChromeMcpCallOptions = {
+  ephemeral?: boolean;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+};
+
+type ChromeMcpSessionLease = {
+  session: ChromeMcpSession;
+  cacheKey: string;
+  temporary: boolean;
+};
+
 type ChromeMcpSessionFactory = (
   profileName: string,
   userDataDir?: string,
@@ -332,7 +344,42 @@ async function createRealSession(
   };
 }
 
-async function getSession(profileName: string, userDataDir?: string): Promise<ChromeMcpSession> {
+async function waitForChromeMcpReady(
+  session: ChromeMcpSession,
+  profileName: string,
+  timeoutMs?: number,
+): Promise<void> {
+  if (!timeoutMs || timeoutMs <= 0) {
+    await session.ready;
+    return;
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      session.ready,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new BrowserProfileUnavailableError(
+              `Chrome MCP existing-session attach for profile "${profileName}" timed out after ${timeoutMs}ms.`,
+            ),
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+async function getSession(
+  profileName: string,
+  userDataDir?: string,
+  timeoutMs?: number,
+): Promise<ChromeMcpSession> {
   const cacheKey = buildChromeMcpSessionCacheKey(profileName, userDataDir);
   await closeChromeMcpSessionsForProfile(profileName, cacheKey);
 
@@ -364,7 +411,7 @@ async function getSession(profileName: string, userDataDir?: string): Promise<Ch
     }
   }
   try {
-    await session.ready;
+    await waitForChromeMcpReady(session, profileName, timeoutMs);
     return session;
   } catch (err) {
     const current = sessions.get(cacheKey);
@@ -375,23 +422,110 @@ async function getSession(profileName: string, userDataDir?: string): Promise<Ch
   }
 }
 
+async function getExistingSession(
+  cacheKey: string,
+  profileName: string,
+  timeoutMs?: number,
+): Promise<ChromeMcpSession | null> {
+  let session = sessions.get(cacheKey);
+  if (session && session.transport.pid === null) {
+    sessions.delete(cacheKey);
+    session = undefined;
+  }
+  if (session) {
+    try {
+      await waitForChromeMcpReady(session, profileName, timeoutMs);
+      return session;
+    } catch (err) {
+      const current = sessions.get(cacheKey);
+      if (current?.transport === session.transport) {
+        sessions.delete(cacheKey);
+      }
+      throw err;
+    }
+  }
+
+  const pending = pendingSessions.get(cacheKey);
+  if (!pending) {
+    return null;
+  }
+
+  session = await pending;
+  try {
+    await waitForChromeMcpReady(session, profileName, timeoutMs);
+    return session;
+  } catch (err) {
+    const current = sessions.get(cacheKey);
+    if (current?.transport === session.transport) {
+      sessions.delete(cacheKey);
+    }
+    throw err;
+  }
+}
+
+async function createEphemeralSession(
+  profileName: string,
+  userDataDir?: string,
+  timeoutMs?: number,
+): Promise<ChromeMcpSession> {
+  const session = await (sessionFactory ?? createRealSession)(profileName, userDataDir);
+  try {
+    await waitForChromeMcpReady(session, profileName, timeoutMs);
+    return session;
+  } catch (err) {
+    await session.client.close().catch(() => {});
+    throw err;
+  }
+}
+
+async function leaseSession(
+  profileName: string,
+  userDataDir?: string,
+  options: ChromeMcpCallOptions = {},
+): Promise<ChromeMcpSessionLease> {
+  const cacheKey = buildChromeMcpSessionCacheKey(profileName, userDataDir);
+  if (!options.ephemeral) {
+    return {
+      session: await getSession(profileName, userDataDir, options.timeoutMs),
+      cacheKey,
+      temporary: false,
+    };
+  }
+
+  // Status probes should avoid seeding the shared attach session cache, but they can safely
+  // reuse a real cached session if one already exists.
+  const existingSession = await getExistingSession(cacheKey, profileName, options.timeoutMs);
+  if (existingSession) {
+    return {
+      session: existingSession,
+      cacheKey,
+      temporary: false,
+    };
+  }
+
+  return {
+    session: await createEphemeralSession(profileName, userDataDir, options.timeoutMs),
+    cacheKey,
+    temporary: true,
+  };
+}
+
 async function callTool(
   profileName: string,
   userDataDir: string | undefined,
   name: string,
   args: Record<string, unknown> = {},
-  opts?: { timeoutMs?: number; signal?: AbortSignal },
+  options: ChromeMcpCallOptions = {},
 ): Promise<ChromeMcpToolResult> {
-  const cacheKey = buildChromeMcpSessionCacheKey(profileName, userDataDir);
-  const timeoutMs = opts?.timeoutMs;
-  const signal = opts?.signal;
+  const timeoutMs = options.timeoutMs;
+  const signal = options.signal;
   if (signal?.aborted) {
     throw signal.reason ?? new Error("aborted");
   }
 
   for (let attempt = 0; attempt < 2; attempt += 1) {
-    const session = await getSession(profileName, userDataDir);
-    const rawCall = session.client.callTool({
+    const lease = await leaseSession(profileName, userDataDir, options);
+    const rawCall = lease.session.client.callTool({
       name,
       arguments: args,
     }) as Promise<ChromeMcpToolResult>;
@@ -430,10 +564,12 @@ async function callTool(
       void rawCall.catch(() => {});
       // Transport/connection error, timeout, or abort: tear down session so it reconnects.
       // Transport-identity check prevents clobbering a replacement session created concurrently.
-      const cur = sessions.get(cacheKey);
-      if (cur?.transport === session.transport) {
-        sessions.delete(cacheKey);
-        await session.client.close().catch(() => {});
+      if (!lease.temporary) {
+        const cur = sessions.get(lease.cacheKey);
+        if (cur?.transport === lease.session.transport) {
+          sessions.delete(lease.cacheKey);
+          await lease.session.client.close().catch(() => {});
+        }
       }
       throw err;
     } finally {
@@ -443,6 +579,9 @@ async function callTool(
       if (signal && abortListener) {
         signal.removeEventListener("abort", abortListener);
       }
+      if (lease.temporary) {
+        await lease.session.client.close().catch(() => {});
+      }
     }
     // Tool-level errors (element not found, script error, etc.) don't indicate a
     // broken connection. A stale selected-page error does poison the Chrome MCP
@@ -450,10 +589,12 @@ async function callTool(
     if (result.isError) {
       const message = extractToolErrorMessage(result, name);
       if (shouldReconnectForToolError(name, message)) {
-        const cur = sessions.get(cacheKey);
-        if (cur?.transport === session.transport) {
-          sessions.delete(cacheKey);
-          await session.client.close().catch(() => {});
+        if (!lease.temporary) {
+          const cur = sessions.get(lease.cacheKey);
+          if (cur?.transport === lease.session.transport) {
+            sessions.delete(lease.cacheKey);
+            await lease.session.client.close().catch(() => {});
+          }
         }
         if (attempt === 0) {
           continue;
@@ -492,8 +633,12 @@ async function findPageById(
 export async function ensureChromeMcpAvailable(
   profileName: string,
   userDataDir?: string,
+  options: ChromeMcpCallOptions = {},
 ): Promise<void> {
-  await getSession(profileName, userDataDir);
+  const lease = await leaseSession(profileName, userDataDir, options);
+  if (lease.temporary) {
+    await lease.session.client.close().catch(() => {});
+  }
 }
 
 export function getChromeMcpPid(profileName: string): number | null {
@@ -519,16 +664,18 @@ export async function stopAllChromeMcpSessions(): Promise<void> {
 export async function listChromeMcpPages(
   profileName: string,
   userDataDir?: string,
+  options: ChromeMcpCallOptions = {},
 ): Promise<ChromeMcpStructuredPage[]> {
-  const result = await callTool(profileName, userDataDir, "list_pages");
+  const result = await callTool(profileName, userDataDir, "list_pages", {}, options);
   return extractStructuredPages(result);
 }
 
 export async function listChromeMcpTabs(
   profileName: string,
   userDataDir?: string,
+  options: ChromeMcpCallOptions = {},
 ): Promise<BrowserTab[]> {
-  return toBrowserTabs(await listChromeMcpPages(profileName, userDataDir));
+  return toBrowserTabs(await listChromeMcpPages(profileName, userDataDir, options));
 }
 
 export async function openChromeMcpTab(

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -463,6 +463,37 @@ async function getExistingSession(
   }
 }
 
+async function waitForChromeMcpReady(
+  session: ChromeMcpSession,
+  profileName: string,
+  timeoutMs?: number,
+): Promise<void> {
+  if (!timeoutMs || timeoutMs <= 0) {
+    await session.ready;
+    return;
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      session.ready,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new BrowserProfileUnavailableError(
+              `Chrome MCP existing-session attach for profile "${profileName}" timed out after ${timeoutMs}ms.`,
+            ),
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 async function createEphemeralSession(
   profileName: string,
   userDataDir?: string,

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -1,7 +1,11 @@
 import { chromium } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as chromeModule from "./chrome.js";
-import { closePlaywrightBrowserConnection, listPagesViaPlaywright } from "./pw-session.js";
+import {
+  closePlaywrightBrowserConnection,
+  getPageForTargetId,
+  listPagesViaPlaywright,
+} from "./pw-session.js";
 
 const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
 const getChromeWebSocketUrlSpy = vi.spyOn(chromeModule, "getChromeWebSocketUrl");
@@ -30,6 +34,24 @@ function makeBrowser(targetId: string, url: string): BrowserMockBundle {
       ),
       detach: vi.fn(async () => {}),
     })),
+  } as unknown as import("playwright-core").BrowserContext;
+
+  const browser = {
+    contexts: () => [context],
+    on: vi.fn(),
+    off: vi.fn(),
+    close: browserClose,
+  } as unknown as import("playwright-core").Browser;
+
+  return { browser, browserClose };
+}
+
+function makeEmptyBrowser(): BrowserMockBundle {
+  const browserClose = vi.fn(async () => {});
+  const context = {
+    pages: () => [],
+    on: vi.fn(),
+    newCDPSession: vi.fn(),
   } as unknown as import("playwright-core").BrowserContext;
 
   const browser = {
@@ -115,5 +137,38 @@ describe("pw-session connection scoping", () => {
 
     expect(browserA.browserClose).toHaveBeenCalledTimes(1);
     expect(browserB.browserClose).not.toHaveBeenCalled();
+  });
+
+  it("evicts only the stale cdpUrl when getPageForTargetId retries a cached connection", async () => {
+    const staleA = makeEmptyBrowser();
+    const refreshedA = makeBrowser("A", "https://a.example/recovered");
+    const browserB = makeBrowser("B", "https://b.example");
+    let callsForA = 0;
+
+    connectOverCdpSpy.mockImplementation((async (...args: unknown[]) => {
+      const endpointText = String(args[0]);
+      if (endpointText === "http://127.0.0.1:9222") {
+        callsForA += 1;
+        return callsForA === 1 ? staleA.browser : refreshedA.browser;
+      }
+      if (endpointText === "http://127.0.0.1:9333") {
+        return browserB.browser;
+      }
+      throw new Error(`unexpected endpoint: ${endpointText}`);
+    }) as never);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
+    await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9333" });
+
+    const recoveredA = await getPageForTargetId({ cdpUrl: "http://127.0.0.1:9222" });
+    const stillCachedB = await getPageForTargetId({ cdpUrl: "http://127.0.0.1:9333" });
+
+    expect(recoveredA.url()).toBe("https://a.example/recovered");
+    expect(stillCachedB.url()).toBe("https://b.example");
+    expect(staleA.browserClose).toHaveBeenCalledTimes(1);
+    expect(refreshedA.browserClose).not.toHaveBeenCalled();
+    expect(browserB.browserClose).not.toHaveBeenCalled();
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/extensions/browser/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
+++ b/extensions/browser/src/browser/pw-session.get-page-for-targetid.extension-fallback.test.ts
@@ -1,14 +1,69 @@
 import { chromium } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as chromeModule from "./chrome.js";
-import { closePlaywrightBrowserConnection, getPageForTargetId } from "./pw-session.js";
+import {
+  closePlaywrightBrowserConnection,
+  getPageForTargetId,
+  listPagesViaPlaywright,
+} from "./pw-session.js";
 
 const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
 const getChromeWebSocketUrlSpy = vi.spyOn(chromeModule, "getChromeWebSocketUrl");
 
+type MockPageSpec = {
+  targetId?: string;
+  url?: string;
+  title?: string;
+};
+
+type BrowserMockBundle = {
+  browser: import("playwright-core").Browser;
+  browserClose: ReturnType<typeof vi.fn>;
+  pages: import("playwright-core").Page[];
+};
+
+function makeBrowser(pages: MockPageSpec[]): BrowserMockBundle {
+  let context: import("playwright-core").BrowserContext;
+  const browserClose = vi.fn(async () => {});
+  const targetIdByPage = new Map<import("playwright-core").Page, string | undefined>();
+
+  const pageObjects = pages.map((spec, index) => {
+    const page = {
+      on: vi.fn(),
+      context: () => context,
+      title: vi.fn(async () => spec.title ?? spec.targetId ?? `page-${index + 1}`),
+      url: vi.fn(() => spec.url ?? `https://page-${index + 1}.example`),
+    } as unknown as import("playwright-core").Page;
+    targetIdByPage.set(page, spec.targetId);
+    return page;
+  });
+
+  context = {
+    pages: () => pageObjects,
+    on: vi.fn(),
+    newCDPSession: vi.fn(async (page: import("playwright-core").Page) => ({
+      send: vi.fn(async (method: string) =>
+        method === "Target.getTargetInfo"
+          ? { targetInfo: { targetId: targetIdByPage.get(page) } }
+          : {},
+      ),
+      detach: vi.fn(async () => {}),
+    })),
+  } as unknown as import("playwright-core").BrowserContext;
+
+  const browser = {
+    contexts: () => [context],
+    on: vi.fn(),
+    off: vi.fn(),
+    close: browserClose,
+  } as unknown as import("playwright-core").Browser;
+
+  return { browser, browserClose, pages: pageObjects };
+}
+
 afterEach(async () => {
-  connectOverCdpSpy.mockClear();
-  getChromeWebSocketUrlSpy.mockClear();
+  connectOverCdpSpy.mockReset();
+  getChromeWebSocketUrlSpy.mockReset();
   await closePlaywrightBrowserConnection().catch(() => {});
 });
 
@@ -118,5 +173,74 @@ describe("pw-session getPageForTargetId", () => {
     } finally {
       fetchSpy.mockRestore();
     }
+  });
+
+  it("evicts a stale cached page-less browser once and succeeds on a fresh reconnect", async () => {
+    const stale = makeBrowser([]);
+    const fresh = makeBrowser([{ targetId: "TARGET_OK", url: "https://fresh.example" }]);
+
+    connectOverCdpSpy.mockResolvedValueOnce(stale.browser).mockResolvedValueOnce(fresh.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
+
+    const resolved = await getPageForTargetId({ cdpUrl: "http://127.0.0.1:9222" });
+
+    expect(resolved).toBe(fresh.pages[0]);
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
+    expect(stale.browserClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts a stale cached tab-selection miss once and succeeds on a fresh reconnect", async () => {
+    const stale = makeBrowser([
+      { targetId: "TARGET_A", url: "https://alpha.example" },
+      { targetId: "TARGET_C", url: "https://charlie.example" },
+    ]);
+    const fresh = makeBrowser([
+      { targetId: "TARGET_A", url: "https://alpha.example" },
+      { targetId: "TARGET_B", url: "https://beta.example" },
+    ]);
+
+    connectOverCdpSpy.mockResolvedValueOnce(stale.browser).mockResolvedValueOnce(fresh.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await getPageForTargetId({ cdpUrl: "http://127.0.0.1:9333" });
+
+    const resolved = await getPageForTargetId({
+      cdpUrl: "http://127.0.0.1:9333",
+      targetId: "TARGET_B",
+    });
+
+    expect(resolved).toBe(fresh.pages[1]);
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
+    expect(stale.browserClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails after a single reconnect when the refreshed browser is still page-less", async () => {
+    const stale = makeBrowser([]);
+    const stillBroken = makeBrowser([]);
+
+    connectOverCdpSpy
+      .mockResolvedValueOnce(stale.browser)
+      .mockResolvedValueOnce(stillBroken.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9444" });
+
+    await expect(getPageForTargetId({ cdpUrl: "http://127.0.0.1:9444" })).rejects.toThrow(
+      "No pages available in the connected browser.",
+    );
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
+    expect(stale.browserClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not add an extra top-level retry for non-recoverable connect failures", async () => {
+    connectOverCdpSpy.mockRejectedValue(new Error("connectOverCDP exploded"));
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await expect(getPageForTargetId({ cdpUrl: "http://127.0.0.1:9555" })).rejects.toThrow(
+      "connectOverCDP exploded",
+    );
+    expect(connectOverCdpSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -123,6 +123,27 @@ function normalizeCdpUrl(raw: string) {
   return raw.replace(/\/$/, "");
 }
 
+function hasCachedPlaywrightBrowserConnection(cdpUrl: string): boolean {
+  return cachedByCdpUrl.has(normalizeCdpUrl(cdpUrl));
+}
+
+function isRecoverableStalePageSelectionError(err: unknown, reusedCachedBrowser: boolean): boolean {
+  if (!reusedCachedBrowser) {
+    return false;
+  }
+  if (
+    err instanceof Error &&
+    err.message.includes("No pages available in the connected browser.")
+  ) {
+    return true;
+  }
+  if (err instanceof BrowserTabNotFoundError) {
+    return true;
+  }
+  const message = err instanceof Error ? err.message : formatErrorMessage(err);
+  return message.toLowerCase().includes("tab not found");
+}
+
 function findNetworkRequestById(state: PageState, id: string): BrowserNetworkRequest | undefined {
   for (let i = state.requests.length - 1; i >= 0; i -= 1) {
     const candidate = state.requests[i];
@@ -625,7 +646,7 @@ async function resolvePageByTargetIdOrThrow(opts: {
   return page;
 }
 
-export async function getPageForTargetId(opts: {
+async function getPageForTargetIdOnce(opts: {
   cdpUrl: string;
   targetId?: string;
   ssrfPolicy?: SsrFPolicy;
@@ -669,6 +690,23 @@ export async function getPageForTargetId(opts: {
     return first;
   }
   throw new BrowserTabNotFoundError();
+}
+
+export async function getPageForTargetId(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  ssrfPolicy?: SsrFPolicy;
+}): Promise<Page> {
+  const reusedCachedBrowser = hasCachedPlaywrightBrowserConnection(opts.cdpUrl);
+  try {
+    return await getPageForTargetIdOnce(opts);
+  } catch (err) {
+    if (!isRecoverableStalePageSelectionError(err, reusedCachedBrowser)) {
+      throw err;
+    }
+    await closePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl });
+    return await getPageForTargetIdOnce(opts);
+  }
 }
 
 function isTopLevelNavigationRequest(page: Page, request: Request): boolean {
@@ -845,6 +883,22 @@ export async function gotoPageWithNavigationGuard(
         targetId: opts.targetId,
       });
     }
+  }
+}
+
+export async function getPageForTargetId(opts: {
+  cdpUrl: string;
+  targetId?: string;
+}): Promise<Page> {
+  const reusedCachedBrowser = hasCachedPlaywrightBrowserConnection(opts.cdpUrl);
+  try {
+    return await getPageForTargetIdOnce(opts);
+  } catch (err) {
+    if (!isRecoverableStalePageSelectionError(err, reusedCachedBrowser)) {
+      throw err;
+    }
+    await closePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl });
+    return await getPageForTargetIdOnce(opts);
   }
 }
 

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -886,22 +886,6 @@ export async function gotoPageWithNavigationGuard(
   }
 }
 
-export async function getPageForTargetId(opts: {
-  cdpUrl: string;
-  targetId?: string;
-}): Promise<Page> {
-  const reusedCachedBrowser = hasCachedPlaywrightBrowserConnection(opts.cdpUrl);
-  try {
-    return await getPageForTargetIdOnce(opts);
-  } catch (err) {
-    if (!isRecoverableStalePageSelectionError(err, reusedCachedBrowser)) {
-      throw err;
-    }
-    await closePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl });
-    return await getPageForTargetIdOnce(opts);
-  }
-}
-
 export function refLocator(page: Page, ref: string) {
   const normalized = ref.startsWith("@")
     ? ref.slice(1)

--- a/extensions/browser/src/browser/routes/basic.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/basic.existing-session.test.ts
@@ -8,7 +8,11 @@ vi.mock("../chrome-mcp.js", () => ({
 const { BrowserProfileUnavailableError } = await import("../errors.js");
 const { registerBrowserBasicRoutes } = await import("./basic.js");
 
-function createExistingSessionProfileState(params?: { isHttpReachable?: () => Promise<boolean> }) {
+function createExistingSessionProfileState(params?: {
+  isHttpReachable?: () => Promise<boolean>;
+  isTransportAvailable?: () => Promise<boolean>;
+  isReachable?: () => Promise<boolean>;
+}) {
   return {
     resolved: {
       enabled: true,
@@ -31,7 +35,8 @@ function createExistingSessionProfileState(params?: { isHttpReachable?: () => Pr
           attachOnly: true,
         },
         isHttpReachable: params?.isHttpReachable ?? (async () => true),
-        isReachable: async () => true,
+        isTransportAvailable: params?.isTransportAvailable ?? (async () => true),
+        isReachable: params?.isReachable ?? (async () => true),
       }) as never,
   };
 }
@@ -84,6 +89,24 @@ describe("basic browser routes", () => {
       userDataDir: "/tmp/brave-profile",
       executablePath: "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
       pid: 4321,
+    });
+  });
+
+  it("treats attach-only profiles as running when transport is available even if page reachability is false", async () => {
+    const response = await callBasicRouteWithState({
+      state: createExistingSessionProfileState({
+        isTransportAvailable: async () => true,
+        isReachable: async () => false,
+      }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toMatchObject({
+      profile: "chrome-live",
+      driver: "existing-session",
+      transport: "chrome-mcp",
+      running: true,
+      cdpReady: true,
     });
   });
 });

--- a/extensions/browser/src/browser/routes/basic.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/basic.existing-session.test.ts
@@ -63,7 +63,7 @@ describe("basic browser routes", () => {
   it("maps existing-session status failures to JSON browser errors", async () => {
     const response = await callBasicRouteWithState({
       state: createExistingSessionProfileState({
-        isHttpReachable: async () => {
+        isTransportAvailable: async () => {
           throw new BrowserProfileUnavailableError("attach failed");
         },
       }),
@@ -107,6 +107,27 @@ describe("basic browser routes", () => {
       transport: "chrome-mcp",
       running: true,
       cdpReady: true,
+    });
+  });
+
+  it("probes Chrome MCP transport only once for status", async () => {
+    const isHttpReachable = vi.fn(async () => true);
+    const isTransportAvailable = vi.fn(async () => true);
+
+    const response = await callBasicRouteWithState({
+      state: createExistingSessionProfileState({
+        isHttpReachable,
+        isTransportAvailable,
+      }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(isTransportAvailable).toHaveBeenCalledTimes(1);
+    expect(isHttpReachable).not.toHaveBeenCalled();
+    expect(response.body).toMatchObject({
+      cdpHttp: true,
+      cdpReady: true,
+      running: true,
     });
   });
 });

--- a/extensions/browser/src/browser/routes/basic.ts
+++ b/extensions/browser/src/browser/routes/basic.ts
@@ -61,13 +61,15 @@ async function buildBrowserStatus(req: BrowserRequest, ctx: BrowserRouteContext)
     throw new BrowserError(profileCtx.error, profileCtx.status);
   }
 
-  const [cdpHttp, cdpReady] = await Promise.all([
-    profileCtx.isHttpReachable(300),
-    profileCtx.isReachable(600),
-  ]);
+  const capabilities = getBrowserProfileCapabilities(profileCtx.profile);
+  const [cdpHttp, cdpReady] = capabilities.usesChromeMcp
+    ? await (async () => {
+        const ready = await profileCtx.isTransportAvailable(600);
+        return [ready, ready] as const;
+      })()
+    : await Promise.all([profileCtx.isHttpReachable(300), profileCtx.isTransportAvailable(600)]);
 
   const profileState = current.profiles.get(profileCtx.profile.name);
-  const capabilities = getBrowserProfileCapabilities(profileCtx.profile);
   let detectedBrowser: string | null = null;
   let detectedExecutablePath: string | null = null;
   let detectError: string | null = null;

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -90,7 +90,10 @@ export function createProfileAvailability({
 
   const isTransportAvailable = async (timeoutMs?: number) => {
     if (capabilities.usesChromeMcp) {
-      await ensureChromeMcpAvailable(profile.name, profile.userDataDir);
+      await ensureChromeMcpAvailable(profile.name, profile.userDataDir, {
+        ephemeral: true,
+        timeoutMs,
+      });
       return true;
     }
     return await isReachable(timeoutMs);

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -90,6 +90,7 @@ export function createProfileAvailability({
 
   const isTransportAvailable = async (timeoutMs?: number) => {
     if (capabilities.usesChromeMcp) {
+      const { ensureChromeMcpAvailable } = await getChromeMcpModule();
       await ensureChromeMcpAvailable(profile.name, profile.userDataDir, {
         ephemeral: true,
         timeoutMs,

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -46,6 +46,7 @@ type AvailabilityDeps = {
 
 type AvailabilityOps = {
   isHttpReachable: (timeoutMs?: number) => Promise<boolean>;
+  isTransportAvailable: (timeoutMs?: number) => Promise<boolean>;
   isReachable: (timeoutMs?: number) => Promise<boolean>;
   ensureBrowserAvailable: () => Promise<void>;
   stopRunningBrowser: () => Promise<{ stopped: boolean }>;
@@ -87,9 +88,17 @@ export function createProfileAvailability({
     );
   };
 
+  const isTransportAvailable = async (timeoutMs?: number) => {
+    if (capabilities.usesChromeMcp) {
+      await ensureChromeMcpAvailable(profile.name, profile.userDataDir);
+      return true;
+    }
+    return await isReachable(timeoutMs);
+  };
+
   const isHttpReachable = async (timeoutMs?: number) => {
     if (capabilities.usesChromeMcp) {
-      return await isReachable(timeoutMs);
+      return await isTransportAvailable(timeoutMs);
     }
     const { httpTimeoutMs } = resolveTimeouts(timeoutMs);
     return await isChromeReachable(profile.cdpUrl, httpTimeoutMs, getCdpReachabilityPolicy());
@@ -341,6 +350,7 @@ export function createProfileAvailability({
 
   return {
     isHttpReachable,
+    isTransportAvailable,
     isReachable,
     ensureBrowserAvailable,
     stopRunningBrowser,

--- a/extensions/browser/src/browser/server-context.existing-session.test.ts
+++ b/extensions/browser/src/browser/server-context.existing-session.test.ts
@@ -13,7 +13,7 @@ vi.mock("./chrome-mcp.js", () => ({
   openChromeMcpTab: vi.fn(async () => ({
     targetId: "8",
     title: "",
-    url: "https://openclaw.ai",
+    url: "about:blank",
     type: "page",
   })),
   closeChromeMcpTab: vi.fn(async () => {}),
@@ -101,6 +101,53 @@ describe("browser server-context existing-session profile", () => {
         tabCount: 0,
       }),
     ]);
+
+    expect(chromeMcp.ensureChromeMcpAvailable).toHaveBeenCalledWith(
+      "chrome-live",
+      "/tmp/brave-profile",
+      { ephemeral: true },
+    );
+    expect(chromeMcp.listChromeMcpTabs).toHaveBeenCalledWith("chrome-live", "/tmp/brave-profile", {
+      ephemeral: true,
+    });
+  });
+
+  it("keeps the next real attach on the normal sticky session path after an idle status probe", async () => {
+    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
+    const state = makeState();
+    const ctx = createBrowserRouteContext({ getState: () => state });
+    const live = ctx.forProfile("chrome-live");
+
+    vi.mocked(chromeMcp.listChromeMcpTabs).mockRejectedValueOnce(new Error("No page selected"));
+
+    await expect(ctx.listProfiles()).resolves.toEqual([
+      expect.objectContaining({
+        name: "chrome-live",
+        running: true,
+        tabCount: 0,
+      }),
+    ]);
+
+    vi.mocked(chromeMcp.listChromeMcpTabs).mockClear();
+
+    await live.ensureBrowserAvailable();
+    const tabs = await live.listTabs();
+
+    expect(tabs.map((tab) => tab.targetId)).toEqual(["7"]);
+    expect(chromeMcp.ensureChromeMcpAvailable).toHaveBeenLastCalledWith(
+      "chrome-live",
+      "/tmp/brave-profile",
+    );
+    expect(chromeMcp.listChromeMcpTabs).toHaveBeenNthCalledWith(
+      1,
+      "chrome-live",
+      "/tmp/brave-profile",
+    );
+    expect(chromeMcp.listChromeMcpTabs).toHaveBeenNthCalledWith(
+      2,
+      "chrome-live",
+      "/tmp/brave-profile",
+    );
   });
 
   it("routes tab operations through the Chrome MCP backend", async () => {
@@ -118,22 +165,22 @@ describe("browser server-context existing-session profile", () => {
       ])
       .mockResolvedValueOnce([
         { targetId: "7", title: "", url: "https://example.com", type: "page" },
-        { targetId: "8", title: "", url: "https://openclaw.ai", type: "page" },
+        { targetId: "8", title: "", url: "about:blank", type: "page" },
       ])
       .mockResolvedValueOnce([
         { targetId: "7", title: "", url: "https://example.com", type: "page" },
-        { targetId: "8", title: "", url: "https://openclaw.ai", type: "page" },
+        { targetId: "8", title: "", url: "about:blank", type: "page" },
       ])
       .mockResolvedValueOnce([
         { targetId: "7", title: "", url: "https://example.com", type: "page" },
-        { targetId: "8", title: "", url: "https://openclaw.ai", type: "page" },
+        { targetId: "8", title: "", url: "about:blank", type: "page" },
       ]);
 
     await live.ensureBrowserAvailable();
     const tabs = await live.listTabs();
     expect(tabs.map((tab) => tab.targetId)).toEqual(["7"]);
 
-    const opened = await live.openTab("https://openclaw.ai");
+    const opened = await live.openTab("about:blank");
     expect(opened.targetId).toBe("8");
 
     const selected = await live.ensureTabAvailable();
@@ -149,7 +196,7 @@ describe("browser server-context existing-session profile", () => {
     expect(chromeMcp.listChromeMcpTabs).toHaveBeenCalledWith("chrome-live", "/tmp/brave-profile");
     expect(chromeMcp.openChromeMcpTab).toHaveBeenCalledWith(
       "chrome-live",
-      "https://openclaw.ai",
+      "about:blank",
       "/tmp/brave-profile",
     );
     expect(chromeMcp.focusChromeMcpTab).toHaveBeenCalledWith(

--- a/extensions/browser/src/browser/server-context.existing-session.test.ts
+++ b/extensions/browser/src/browser/server-context.existing-session.test.ts
@@ -105,7 +105,7 @@ describe("browser server-context existing-session profile", () => {
     expect(chromeMcp.ensureChromeMcpAvailable).toHaveBeenCalledWith(
       "chrome-live",
       "/tmp/brave-profile",
-      { ephemeral: true },
+      { ephemeral: true, timeoutMs: 300 },
     );
     expect(chromeMcp.listChromeMcpTabs).toHaveBeenCalledWith("chrome-live", "/tmp/brave-profile", {
       ephemeral: true,

--- a/extensions/browser/src/browser/server-context.existing-session.test.ts
+++ b/extensions/browser/src/browser/server-context.existing-session.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "../../test-support/browser-security-runtime.mock.js";
 import type { BrowserServerState } from "./server-context.js";
 
-vi.mock("./chrome-mcp.js", () => ({
+const chromeMcpMock = vi.hoisted(() => ({
   closeChromeMcpSession: vi.fn(async () => true),
   ensureChromeMcpAvailable: vi.fn(async () => {}),
   focusChromeMcpTab: vi.fn(async () => {}),
@@ -20,8 +20,14 @@ vi.mock("./chrome-mcp.js", () => ({
   getChromeMcpPid: vi.fn(() => 4321),
 }));
 
+vi.mock("./chrome-mcp.js", () => chromeMcpMock);
+
+vi.mock("./chrome-mcp.runtime.js", () => ({
+  getChromeMcpModule: vi.fn(async () => chromeMcpMock),
+}));
+
 const { createBrowserRouteContext } = await import("./server-context.js");
-const chromeMcp = await import("./chrome-mcp.js");
+const chromeMcp = chromeMcpMock;
 
 function makeState(): BrowserServerState {
   return {
@@ -93,7 +99,8 @@ describe("browser server-context existing-session profile", () => {
     vi.mocked(chromeMcp.ensureChromeMcpAvailable).mockResolvedValueOnce();
     vi.mocked(chromeMcp.listChromeMcpTabs).mockRejectedValueOnce(new Error("No page selected"));
 
-    await expect(ctx.listProfiles()).resolves.toEqual([
+    const profiles = await ctx.listProfiles();
+    expect(profiles).toEqual([
       expect.objectContaining({
         name: "chrome-live",
         transport: "chrome-mcp",

--- a/extensions/browser/src/browser/server-context.existing-session.test.ts
+++ b/extensions/browser/src/browser/server-context.existing-session.test.ts
@@ -85,6 +85,24 @@ afterEach(() => {
 });
 
 describe("browser server-context existing-session profile", () => {
+  it("reports attach-only profiles as running when the MCP session is available but no page is selected", async () => {
+    fs.mkdirSync("/tmp/brave-profile", { recursive: true });
+    const state = makeState();
+    const ctx = createBrowserRouteContext({ getState: () => state });
+
+    vi.mocked(chromeMcp.ensureChromeMcpAvailable).mockResolvedValueOnce();
+    vi.mocked(chromeMcp.listChromeMcpTabs).mockRejectedValueOnce(new Error("No page selected"));
+
+    await expect(ctx.listProfiles()).resolves.toEqual([
+      expect.objectContaining({
+        name: "chrome-live",
+        transport: "chrome-mcp",
+        running: true,
+        tabCount: 0,
+      }),
+    ]);
+  });
+
   it("routes tab operations through the Chrome MCP backend", async () => {
     fs.mkdirSync("/tmp/brave-profile", { recursive: true });
     const state = makeState();

--- a/extensions/browser/src/browser/server-context.ts
+++ b/extensions/browser/src/browser/server-context.ts
@@ -3,6 +3,7 @@ import {
   resolveCdpReachabilityPolicy,
 } from "./cdp-reachability-policy.js";
 import { usesFastLoopbackCdpProbeClass } from "./cdp-timeouts.js";
+import { listChromeMcpTabs } from "./chrome-mcp.js";
 import { isChromeReachable, resolveOpenClawUserDataDir } from "./chrome.js";
 import type { ResolvedBrowserProfile } from "./config.js";
 import { resolveProfile } from "./config.js";
@@ -181,7 +182,9 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
         try {
           running = await profileCtx.isTransportAvailable(300);
           if (running) {
-            const tabs = await profileCtx.listTabs().catch(() => [] as BrowserTab[]);
+            const tabs = await listChromeMcpTabs(profile.name, profile.userDataDir, {
+              ephemeral: true,
+            }).catch(() => [] as BrowserTab[]);
             tabCount = tabs.filter((t) => t.type === "page").length;
           }
         } catch {

--- a/extensions/browser/src/browser/server-context.ts
+++ b/extensions/browser/src/browser/server-context.ts
@@ -79,14 +79,19 @@ function createProfileContext(
     getProfileState,
   });
 
-  const { ensureBrowserAvailable, isHttpReachable, isReachable, stopRunningBrowser } =
-    createProfileAvailability({
-      opts,
-      profile,
-      state,
-      getProfileState,
-      setProfileRunning,
-    });
+  const {
+    ensureBrowserAvailable,
+    isHttpReachable,
+    isTransportAvailable,
+    isReachable,
+    stopRunningBrowser,
+  } = createProfileAvailability({
+    opts,
+    profile,
+    state,
+    getProfileState,
+    setProfileRunning,
+  });
 
   const { ensureTabAvailable, focusTab, closeTab } = createProfileSelectionOps({
     profile,
@@ -110,6 +115,7 @@ function createProfileContext(
     ensureBrowserAvailable,
     ensureTabAvailable,
     isHttpReachable,
+    isTransportAvailable,
     isReachable,
     listTabs,
     openTab,
@@ -173,9 +179,9 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
 
       if (capabilities.usesChromeMcp) {
         try {
-          running = await profileCtx.isReachable(300);
+          running = await profileCtx.isTransportAvailable(300);
           if (running) {
-            const tabs = await profileCtx.listTabs();
+            const tabs = await profileCtx.listTabs().catch(() => [] as BrowserTab[]);
             tabCount = tabs.filter((t) => t.type === "page").length;
           }
         } catch {
@@ -251,6 +257,7 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
     ensureBrowserAvailable: () => getDefaultContext().ensureBrowserAvailable(),
     ensureTabAvailable: (targetId) => getDefaultContext().ensureTabAvailable(targetId),
     isHttpReachable: (timeoutMs) => getDefaultContext().isHttpReachable(timeoutMs),
+    isTransportAvailable: (timeoutMs) => getDefaultContext().isTransportAvailable(timeoutMs),
     isReachable: (timeoutMs) => getDefaultContext().isReachable(timeoutMs),
     listTabs: () => getDefaultContext().listTabs(),
     openTab: (url, opts) => getDefaultContext().openTab(url, opts),

--- a/extensions/browser/src/browser/server-context.types.ts
+++ b/extensions/browser/src/browser/server-context.types.ts
@@ -36,6 +36,7 @@ type BrowserProfileActions = {
   ensureBrowserAvailable: () => Promise<void>;
   ensureTabAvailable: (targetId?: string) => Promise<BrowserTab>;
   isHttpReachable: (timeoutMs?: number) => Promise<boolean>;
+  isTransportAvailable: (timeoutMs?: number) => Promise<boolean>;
   isReachable: (timeoutMs?: number) => Promise<boolean>;
   listTabs: () => Promise<BrowserTab[]>;
   openTab: (url: string, opts?: { label?: string }) => Promise<BrowserTab>;

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -25,6 +25,7 @@ const state = vi.hoisted(() => ({
   bootstrapError: "",
   bootstrapCode: 1,
   kickstartError: "",
+  kickstartCode: 1,
   kickstartFailuresRemaining: 0,
   disableError: "",
   disableCode: 1,
@@ -178,7 +179,7 @@ vi.mock("./exec-file.js", () => ({
     if (call[0] === "kickstart") {
       if (state.kickstartError && state.kickstartFailuresRemaining > 0) {
         state.kickstartFailuresRemaining -= 1;
-        return { stdout: "", stderr: state.kickstartError, code: 1 };
+        return { stdout: "", stderr: state.kickstartError, code: state.kickstartCode };
       }
       state.serviceLoaded = true;
       state.serviceRunning = true;
@@ -262,6 +263,7 @@ beforeEach(() => {
   state.bootstrapError = "";
   state.bootstrapCode = 1;
   state.kickstartError = "";
+  state.kickstartCode = 1;
   state.kickstartFailuresRemaining = 0;
   state.disableError = "";
   state.disableCode = 1;

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -241,6 +241,14 @@ vi.mock("node:fs/promises", async () => {
     unlink: vi.fn(async (p: string) => {
       state.files.delete(p);
     }),
+    readFile: vi.fn(async (p: string) => {
+      const key = p;
+      const value = state.files.get(key);
+      if (value !== undefined) {
+        return value;
+      }
+      throw new Error(`ENOENT: no such file or directory, open '${key}'`);
+    }),
     writeFile: vi.fn(async (p: string, data: string, opts?: { mode?: number }) => {
       const key = p;
       state.files.set(key, data);


### PR DESCRIPTION
## Summary
- normalize the WS3 existing-session attach-gap retry onto upstream `main`
- normalize truthful attach-only idle profile reporting
- fix sticky Chrome MCP status probes so idle status checks do not poison the next real attach

## Commits included
- `8d41ac65a0` fix(browser): retry stale cached playwright attach once
- `9fdcce5abd` fix(browser): report attach-only profile transport truthfully
- `bcee8fcf6e` Fix sticky Chrome MCP status probes

## Verification
- targeted browser tests passed on the `origin/main`-based normalization branch:
  - `pw-session.get-page-for-targetid.extension-fallback`
  - `pw-session.connections`
  - `chrome-mcp`
  - `server-context.existing-session`
  - `routes/basic.existing-session`
- full `pnpm build` passed on the `origin/main`-based normalization branch
- live isolated-runtime verification also passed:
  - idle `profiles` reports `user: running (0 tabs)` and `openclaw: stopped`
  - after that same idle probe, seeded-page `tabs` and `snapshot` still succeed
  - `18800` stays dark

## Notes
- direct push to upstream `openclaw/main` is not permitted from this host/account, so this PR is the upstream mirroring path for the already-validated fix stack
- there is a separate cold-start timeout caveat on the browser tool surface; that is distinct from the sticky-probe regression fixed here
