### PR TITLE
Feature custom session names/labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- CLI: add `openclaw sessions label` and alias `openclaw sessions rename` to set or clear a session label via the gateway (same field as the control UI Sessions table).
+- Control UI: show resolved session titles in the Sessions table, with the raw session key as secondary detail when a friendlier name is available.
 - MiniMax: add image generation provider for `image-01` model, supporting generate and image-to-image editing with aspect ratio control. (#54487) Thanks @liyuan97.
 - Podman: simplify the container setup around the current rootless user, install the launch helper under `~/.local/bin`, and document the host-CLI `openclaw --container <name> ...` workflow instead of a dedicated `openclaw` service user.
 - Slack/tool actions: add an explicit `upload-file` Slack action that routes file uploads through the existing Slack upload transport, with optional filename/title/comment overrides for channels and DMs.

--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -53,6 +53,7 @@ openclaw sessions rename --session "agent:main:main" "My Custom Name"
 - `--session`: required session key.
 - Positional `label`: new label text (omit when using `--clear`).
 - `--clear`: remove the custom label.
+- `--force`: allow patching an unknown key (creates a new entry in the gateway session store). Use with care; typos will create "phantom" sessions.
 - `--json`: print the `sessions.patch` result as JSON.
 - `--url`, `--token`, `--password`, `--timeout`: optional gateway overrides.
 

--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -1,5 +1,5 @@
 ---
-summary: "CLI reference for `openclaw sessions` (list stored sessions + usage)"
+summary: "CLI reference for `openclaw sessions` (list, label, rename, cleanup)"
 read_when:
   - You want to list stored sessions and see recent activity
 title: "sessions"
@@ -29,6 +29,32 @@ session discovery are broader: they also include disk-only stores found under
 the default `agents/` root or a templated `session.store` root. Those
 discovered stores must resolve to regular `sessions.json` files inside the
 agent root; symlinks and out-of-root paths are skipped.
+
+Text output includes a **Label** column when a session has a user-defined label
+or display name (same values shown in the control UI Sessions table).
+
+## Session label (gateway)
+
+Set or clear a friendly **label** on a session via the running gateway (same
+field as the Sessions table in the control UI). Requires a reachable gateway
+and operator credentials (device pairing or token, same as other gateway CLI
+calls).
+
+`openclaw sessions rename` is an **alias** for `openclaw sessions label` (same
+flags and behavior).
+
+```bash
+openclaw sessions label --session "agent:main:main" "Morning digest"
+openclaw sessions label --session "agent:main:cron:abc123" --clear
+openclaw sessions label --session "agent:main:main" "Hi" --json
+openclaw sessions rename --session "agent:main:main" "My Custom Name"
+```
+
+- `--session`: required session key.
+- Positional `label`: new label text (omit when using `--clear`).
+- `--clear`: remove the custom label.
+- `--json`: print the `sessions.patch` result as JSON.
+- `--url`, `--token`, `--password`, `--timeout`: optional gateway overrides.
 
 JSON examples:
 

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -52,6 +52,7 @@ function registerSessionsLabelSubcommand(
     .description(description)
     .requiredOption("--session <key>", "Session key (for example agent:main:main)")
     .option("--clear", "Remove the custom label", false)
+    .option("--force", "Allow creating a new entry if the session key is unknown", false)
     .option("--json", "Output JSON", false)
     .option("--url <url>", "Gateway WebSocket URL override")
     .option("--token <token>", "Gateway auth token")
@@ -76,6 +77,7 @@ function registerSessionsLabelSubcommand(
             session: opts.session as string,
             label: typeof label === "string" ? label : undefined,
             clear: Boolean(opts.clear),
+            force: Boolean(opts.force),
             json: Boolean(opts.json),
             url: opts.url as string | undefined,
             token: opts.token as string | undefined,

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { healthCommand } from "../../commands/health.js";
 import { sessionsCleanupCommand } from "../../commands/sessions-cleanup.js";
+import { sessionsLabelCommand } from "../../commands/sessions-label.js";
 import { sessionsCommand } from "../../commands/sessions.js";
 import { statusCommand } from "../../commands/status.js";
 import { setVerbose } from "../../globals.js";
@@ -38,6 +39,53 @@ async function runWithVerboseAndTimeout(
   await runCommandWithRuntime(defaultRuntime, async () => {
     await action({ verbose, timeoutMs });
   });
+}
+
+function registerSessionsLabelSubcommand(
+  sessionsCmd: Command,
+  name: "label" | "rename",
+  description: string,
+  exampleRows: Array<[string, string]>,
+): void {
+  sessionsCmd
+    .command(name)
+    .description(description)
+    .requiredOption("--session <key>", "Session key (for example agent:main:main)")
+    .option("--clear", "Remove the custom label", false)
+    .option("--json", "Output JSON", false)
+    .option("--url <url>", "Gateway WebSocket URL override")
+    .option("--token <token>", "Gateway auth token")
+    .option("--password <password>", "Gateway password")
+    .option("--timeout <ms>", "Request timeout in milliseconds", "15000")
+    .argument("[label]", "Friendly label text")
+    .addHelpText(
+      "after",
+      () => `\n${theme.heading("Examples:")}\n${formatHelpExamples(exampleRows)}`,
+    )
+    .action(async (label: string | undefined, opts) => {
+      const timeoutRaw = opts.timeout as string | undefined;
+      const parsedTimeout = parsePositiveIntOrUndefined(timeoutRaw);
+      if (timeoutRaw !== undefined && parsedTimeout === undefined) {
+        defaultRuntime.error("--timeout must be a positive integer (milliseconds)");
+        defaultRuntime.exit(1);
+        return;
+      }
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await sessionsLabelCommand(
+          {
+            session: opts.session as string,
+            label: typeof label === "string" ? label : undefined,
+            clear: Boolean(opts.clear),
+            json: Boolean(opts.json),
+            url: opts.url as string | undefined,
+            token: opts.token as string | undefined,
+            password: opts.password as string | undefined,
+            timeout: parsedTimeout ?? 15_000,
+          },
+          defaultRuntime,
+        );
+      });
+    });
 }
 
 export function registerStatusHealthSessionsCommands(program: Command) {
@@ -154,6 +202,38 @@ export function registerStatusHealthSessionsCommands(program: Command) {
       );
     });
   sessionsCmd.enablePositionalOptions();
+
+  registerSessionsLabelSubcommand(
+    sessionsCmd,
+    "label",
+    "Set or clear a session label (friendly name) via the gateway",
+    [
+      [
+        'openclaw sessions label --session "agent:main:main" "Morning digest"',
+        "Set a friendly name for a session.",
+      ],
+      [
+        'openclaw sessions label --session "agent:main:cron:abc" --clear',
+        "Remove the custom label.",
+      ],
+      ['openclaw sessions label "Hi" --session agent:main:main --json', "Machine-readable result."],
+    ],
+  );
+  registerSessionsLabelSubcommand(
+    sessionsCmd,
+    "rename",
+    "Alias for sessions label: set or clear a session friendly name via the gateway",
+    [
+      [
+        'openclaw sessions rename --session "agent:main:main" "My Custom Name"',
+        "Same behavior as sessions label.",
+      ],
+      [
+        'openclaw sessions rename --session "agent:main:cron:abc" --clear',
+        "Remove the custom label.",
+      ],
+    ],
+  );
 
   sessionsCmd
     .command("cleanup")

--- a/src/commands/sessions-label.test.ts
+++ b/src/commands/sessions-label.test.ts
@@ -65,7 +65,14 @@ describe("sessionsLabelCommand", () => {
   });
 
   it("calls sessions.patch with label", async () => {
-    mocks.callGateway.mockResolvedValue({
+    mocks.callGateway.mockResolvedValueOnce({
+      ts: Date.now(),
+      path: "/p",
+      count: 1,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: Date.now() }],
+    });
+    mocks.callGateway.mockResolvedValueOnce({
       ok: true,
       key: "agent:main:main",
       path: "/p",
@@ -76,7 +83,8 @@ describe("sessionsLabelCommand", () => {
       { session: "agent:main:main", label: "Morning digest", timeout: 5000 },
       runtime,
     );
-    expect(mocks.callGateway).toHaveBeenCalledWith(
+    expect(mocks.callGateway).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         method: "sessions.patch",
         params: { key: "agent:main:main", label: "Morning digest" },
@@ -87,7 +95,14 @@ describe("sessionsLabelCommand", () => {
   });
 
   it("calls sessions.patch with null label when clearing", async () => {
-    mocks.callGateway.mockResolvedValue({
+    mocks.callGateway.mockResolvedValueOnce({
+      ts: Date.now(),
+      path: "/p",
+      count: 1,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: Date.now() }],
+    });
+    mocks.callGateway.mockResolvedValueOnce({
       ok: true,
       key: "agent:main:main",
       path: "/p",
@@ -95,12 +110,32 @@ describe("sessionsLabelCommand", () => {
     });
     const { runtime, logs } = makeRuntime();
     await sessionsLabelCommand({ session: "agent:main:main", clear: true }, runtime);
-    expect(mocks.callGateway).toHaveBeenCalledWith(
+    expect(mocks.callGateway).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         params: { key: "agent:main:main", label: null },
       }),
     );
     expect(logs.some((l) => l.includes("Cleared label"))).toBe(true);
+  });
+
+  it("logs set label even if gateway response omits entry.label", async () => {
+    mocks.callGateway.mockResolvedValueOnce({
+      ts: Date.now(),
+      path: "/p",
+      count: 1,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: Date.now() }],
+    });
+    mocks.callGateway.mockResolvedValueOnce({
+      ok: true,
+      key: "agent:main:main",
+      path: "/p",
+      entry: { sessionId: "s", updatedAt: 1 },
+    });
+    const { runtime, logs } = makeRuntime();
+    await sessionsLabelCommand({ session: "agent:main:main", label: "Morning digest" }, runtime);
+    expect(logs.some((l) => l.includes("Set label") && l.includes("Morning digest"))).toBe(true);
   });
 
   it("writes JSON when --json", async () => {
@@ -110,7 +145,15 @@ describe("sessionsLabelCommand", () => {
       path: "/p",
       entry: { label: "x", sessionId: "s", updatedAt: 1 },
     };
-    mocks.callGateway.mockResolvedValue(payload);
+    mocks.callGateway
+      .mockResolvedValueOnce({
+        ts: Date.now(),
+        path: "/p",
+        count: 1,
+        defaults: { modelProvider: null, model: null, contextTokens: null },
+        sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: Date.now() }],
+      })
+      .mockResolvedValueOnce(payload);
     const logs: string[] = [];
     const runtime: RuntimeEnv = {
       log: (msg: unknown) => logs.push(String(msg)),
@@ -121,5 +164,35 @@ describe("sessionsLabelCommand", () => {
     expect(mocks.callGateway).toHaveBeenCalled();
     expect(logs).toHaveLength(1);
     expect(JSON.parse(logs[0] ?? "{}")).toEqual(payload);
+  });
+
+  it("rejects unknown session keys unless forced", async () => {
+    mocks.callGateway.mockResolvedValueOnce({
+      ts: Date.now(),
+      path: "/p",
+      count: 1,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: Date.now() }],
+    });
+    const { runtime, errors, exits } = makeRuntime();
+    await sessionsLabelCommand({ session: "agent:main:maan", label: "x", timeout: 5000 }, runtime);
+    expect(errors.some((e) => e.toLowerCase().includes("unknown session key"))).toBe(true);
+    expect(exits).toContain(1);
+    expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows unknown session keys when forced", async () => {
+    mocks.callGateway.mockResolvedValueOnce({
+      ok: true,
+      key: "agent:main:maan",
+      path: "/p",
+      entry: { label: "x", sessionId: "s", updatedAt: 1 },
+    });
+    const { runtime, logs } = makeRuntime();
+    await sessionsLabelCommand({ session: "agent:main:maan", label: "x", force: true }, runtime);
+    expect(mocks.callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "sessions.patch" }),
+    );
+    expect(logs.some((l) => l.includes("Set label"))).toBe(true);
   });
 });

--- a/src/commands/sessions-label.test.ts
+++ b/src/commands/sessions-label.test.ts
@@ -65,13 +65,7 @@ describe("sessionsLabelCommand", () => {
   });
 
   it("calls sessions.patch with label", async () => {
-    mocks.callGateway.mockResolvedValueOnce({
-      ts: Date.now(),
-      path: "/p",
-      count: 1,
-      defaults: { modelProvider: null, model: null, contextTokens: null },
-      sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: Date.now() }],
-    });
+    mocks.callGateway.mockResolvedValueOnce({ ok: true, key: "agent:main:main" });
     mocks.callGateway.mockResolvedValueOnce({
       ok: true,
       key: "agent:main:main",
@@ -95,13 +89,7 @@ describe("sessionsLabelCommand", () => {
   });
 
   it("calls sessions.patch with null label when clearing", async () => {
-    mocks.callGateway.mockResolvedValueOnce({
-      ts: Date.now(),
-      path: "/p",
-      count: 1,
-      defaults: { modelProvider: null, model: null, contextTokens: null },
-      sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: Date.now() }],
-    });
+    mocks.callGateway.mockResolvedValueOnce({ ok: true, key: "agent:main:main" });
     mocks.callGateway.mockResolvedValueOnce({
       ok: true,
       key: "agent:main:main",
@@ -120,13 +108,7 @@ describe("sessionsLabelCommand", () => {
   });
 
   it("logs set label even if gateway response omits entry.label", async () => {
-    mocks.callGateway.mockResolvedValueOnce({
-      ts: Date.now(),
-      path: "/p",
-      count: 1,
-      defaults: { modelProvider: null, model: null, contextTokens: null },
-      sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: Date.now() }],
-    });
+    mocks.callGateway.mockResolvedValueOnce({ ok: true, key: "agent:main:main" });
     mocks.callGateway.mockResolvedValueOnce({
       ok: true,
       key: "agent:main:main",
@@ -146,13 +128,7 @@ describe("sessionsLabelCommand", () => {
       entry: { label: "x", sessionId: "s", updatedAt: 1 },
     };
     mocks.callGateway
-      .mockResolvedValueOnce({
-        ts: Date.now(),
-        path: "/p",
-        count: 1,
-        defaults: { modelProvider: null, model: null, contextTokens: null },
-        sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: Date.now() }],
-      })
+      .mockResolvedValueOnce({ ok: true, key: "agent:main:main" })
       .mockResolvedValueOnce(payload);
     const logs: string[] = [];
     const runtime: RuntimeEnv = {
@@ -167,18 +143,47 @@ describe("sessionsLabelCommand", () => {
   });
 
   it("rejects unknown session keys unless forced", async () => {
-    mocks.callGateway.mockResolvedValueOnce({
-      ts: Date.now(),
-      path: "/p",
-      count: 1,
-      defaults: { modelProvider: null, model: null, contextTokens: null },
-      sessions: [{ key: "agent:main:main", kind: "direct", updatedAt: Date.now() }],
-    });
+    mocks.callGateway.mockRejectedValueOnce(new Error("No session found: agent:main:maan"));
     const { runtime, errors, exits } = makeRuntime();
     await sessionsLabelCommand({ session: "agent:main:maan", label: "x", timeout: 5000 }, runtime);
     expect(errors.some((e) => e.toLowerCase().includes("unknown session key"))).toBe(true);
     expect(exits).toContain(1);
     expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+    expect(mocks.callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "sessions.resolve" }),
+    );
+  });
+
+  it("preflights with sessions.resolve so aliases match patch canonicalization", async () => {
+    mocks.callGateway
+      .mockResolvedValueOnce({ ok: true, key: "agent:main:main" })
+      .mockResolvedValueOnce({
+        ok: true,
+        key: "agent:main:main",
+        path: "/p",
+        entry: { label: "Hi", sessionId: "s", updatedAt: 1 },
+      });
+    const { runtime, logs } = makeRuntime();
+    await sessionsLabelCommand({ session: "main", label: "Hi" }, runtime);
+    expect(mocks.callGateway).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "sessions.resolve",
+        params: {
+          key: "main",
+          includeGlobal: true,
+          includeUnknown: true,
+        },
+      }),
+    );
+    expect(mocks.callGateway).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: "sessions.patch",
+        params: { key: "main", label: "Hi" },
+      }),
+    );
+    expect(logs.some((l) => l.includes("Set label") && l.includes("Hi"))).toBe(true);
   });
 
   it("allows unknown session keys when forced", async () => {

--- a/src/commands/sessions-label.test.ts
+++ b/src/commands/sessions-label.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  callGateway: vi.fn(),
+  withProgress: vi.fn(),
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: mocks.callGateway,
+}));
+
+vi.mock("../cli/progress.js", () => ({
+  withProgress: async (
+    _opts: { label: string; indeterminate: boolean; enabled: boolean },
+    fn: () => Promise<unknown>,
+  ) => fn(),
+}));
+
+import { sessionsLabelCommand } from "./sessions-label.js";
+
+function makeRuntime(): { runtime: RuntimeEnv; logs: string[]; errors: string[]; exits: number[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const exits: number[] = [];
+  return {
+    runtime: {
+      log: (msg: unknown) => logs.push(String(msg)),
+      error: (msg: unknown) => errors.push(String(msg)),
+      exit: (code?: number) => exits.push(code ?? 0),
+    },
+    logs,
+    errors,
+    exits,
+  };
+}
+
+describe("sessionsLabelCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects missing session", async () => {
+    const { runtime, errors, exits } = makeRuntime();
+    await sessionsLabelCommand({ session: "", label: "x" }, runtime);
+    expect(errors.some((e) => e.includes("--session"))).toBe(true);
+    expect(exits).toContain(1);
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("rejects clear plus label", async () => {
+    const { runtime, errors, exits } = makeRuntime();
+    await sessionsLabelCommand({ session: "agent:main:main", label: "x", clear: true }, runtime);
+    expect(errors.some((e) => e.includes("clear"))).toBe(true);
+    expect(exits).toContain(1);
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing label when not clearing", async () => {
+    const { runtime, errors, exits } = makeRuntime();
+    await sessionsLabelCommand({ session: "agent:main:main" }, runtime);
+    expect(errors.some((e) => e.includes("label"))).toBe(true);
+    expect(exits).toContain(1);
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("calls sessions.patch with label", async () => {
+    mocks.callGateway.mockResolvedValue({
+      ok: true,
+      key: "agent:main:main",
+      path: "/p",
+      entry: { label: "Morning digest", sessionId: "s", updatedAt: 1 },
+    });
+    const { runtime, logs } = makeRuntime();
+    await sessionsLabelCommand(
+      { session: "agent:main:main", label: "Morning digest", timeout: 5000 },
+      runtime,
+    );
+    expect(mocks.callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "sessions.patch",
+        params: { key: "agent:main:main", label: "Morning digest" },
+        timeoutMs: 5000,
+      }),
+    );
+    expect(logs.some((l) => l.includes("Set label") && l.includes("Morning digest"))).toBe(true);
+  });
+
+  it("calls sessions.patch with null label when clearing", async () => {
+    mocks.callGateway.mockResolvedValue({
+      ok: true,
+      key: "agent:main:main",
+      path: "/p",
+      entry: { sessionId: "s", updatedAt: 1 },
+    });
+    const { runtime, logs } = makeRuntime();
+    await sessionsLabelCommand({ session: "agent:main:main", clear: true }, runtime);
+    expect(mocks.callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { key: "agent:main:main", label: null },
+      }),
+    );
+    expect(logs.some((l) => l.includes("Cleared label"))).toBe(true);
+  });
+
+  it("writes JSON when --json", async () => {
+    const payload = {
+      ok: true as const,
+      key: "agent:main:main",
+      path: "/p",
+      entry: { label: "x", sessionId: "s", updatedAt: 1 },
+    };
+    mocks.callGateway.mockResolvedValue(payload);
+    const logs: string[] = [];
+    const runtime: RuntimeEnv = {
+      log: (msg: unknown) => logs.push(String(msg)),
+      error: () => {},
+      exit: () => {},
+    };
+    await sessionsLabelCommand({ session: "agent:main:main", label: "x", json: true }, runtime);
+    expect(mocks.callGateway).toHaveBeenCalled();
+    expect(logs).toHaveLength(1);
+    expect(JSON.parse(logs[0] ?? "{}")).toEqual(payload);
+  });
+});

--- a/src/commands/sessions-label.test.ts
+++ b/src/commands/sessions-label.test.ts
@@ -154,6 +154,18 @@ describe("sessionsLabelCommand", () => {
     );
   });
 
+  it("surfaces preflight gateway errors instead of rewriting them as unknown session key", async () => {
+    mocks.callGateway.mockRejectedValueOnce(
+      new Error("gateway timeout after 5000ms\nconnection details"),
+    );
+    const { runtime, errors, exits } = makeRuntime();
+    await sessionsLabelCommand({ session: "agent:main:main", label: "x" }, runtime);
+    expect(errors.some((e) => e.includes("gateway timeout"))).toBe(true);
+    expect(errors.some((e) => e.toLowerCase().includes("unknown session key"))).toBe(false);
+    expect(exits).toContain(1);
+    expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+  });
+
   it("preflights with sessions.resolve so aliases match patch canonicalization", async () => {
     mocks.callGateway
       .mockResolvedValueOnce({ ok: true, key: "agent:main:main" })

--- a/src/commands/sessions-label.ts
+++ b/src/commands/sessions-label.ts
@@ -1,7 +1,6 @@
 import { withProgress } from "../cli/progress.js";
 import { callGateway } from "../gateway/call.js";
-import type { SessionsPatchResult, SessionsListParams } from "../gateway/protocol/index.js";
-import type { SessionsListResult } from "../gateway/session-utils.types.js";
+import type { SessionsPatchResult } from "../gateway/protocol/index.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -50,22 +49,22 @@ export async function sessionsLabelCommand(opts: SessionsLabelCommandOpts, runti
         : DEFAULT_TIMEOUT_MS;
 
   if (opts.force !== true) {
-    const listParams: SessionsListParams = {
-      includeGlobal: true,
-      includeUnknown: true,
-    };
-    const list = await callGateway<SessionsListResult>({
-      method: "sessions.list",
-      params: listParams,
-      clientName: GATEWAY_CLIENT_NAMES.CLI,
-      mode: GATEWAY_CLIENT_MODES.CLI,
-      url: opts.url?.trim() || undefined,
-      token: opts.token?.trim() || undefined,
-      password: opts.password?.trim() || undefined,
-      timeoutMs,
-    });
-    const exists = (list.sessions ?? []).some((row) => row.key === sessionKey);
-    if (!exists) {
+    try {
+      await callGateway<{ ok: true; key: string }>({
+        method: "sessions.resolve",
+        params: {
+          key: sessionKey,
+          includeGlobal: true,
+          includeUnknown: true,
+        },
+        clientName: GATEWAY_CLIENT_NAMES.CLI,
+        mode: GATEWAY_CLIENT_MODES.CLI,
+        url: opts.url?.trim() || undefined,
+        token: opts.token?.trim() || undefined,
+        password: opts.password?.trim() || undefined,
+        timeoutMs,
+      });
+    } catch {
       runtime.error(
         `Unknown session key: ${sessionKey}. Run "openclaw sessions" to find the correct key, or pass --force to create a new entry.`,
       );

--- a/src/commands/sessions-label.ts
+++ b/src/commands/sessions-label.ts
@@ -7,6 +7,11 @@ import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-cha
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 
+function isSessionsResolveNotFoundError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  return message.trimStart().startsWith("No session found:");
+}
+
 export type SessionsLabelCommandOpts = {
   session: string;
   label?: string;
@@ -64,10 +69,16 @@ export async function sessionsLabelCommand(opts: SessionsLabelCommandOpts, runti
         password: opts.password?.trim() || undefined,
         timeoutMs,
       });
-    } catch {
-      runtime.error(
-        `Unknown session key: ${sessionKey}. Run "openclaw sessions" to find the correct key, or pass --force to create a new entry.`,
-      );
+    } catch (err) {
+      if (isSessionsResolveNotFoundError(err)) {
+        runtime.error(
+          `Unknown session key: ${sessionKey}. Run "openclaw sessions" to find the correct key, or pass --force to create a new entry.`,
+        );
+        runtime.exit(1);
+        return;
+      }
+      const message = formatErrorMessage(err);
+      runtime.error(message);
       runtime.exit(1);
       return;
     }

--- a/src/commands/sessions-label.ts
+++ b/src/commands/sessions-label.ts
@@ -1,6 +1,7 @@
 import { withProgress } from "../cli/progress.js";
 import { callGateway } from "../gateway/call.js";
-import type { SessionsPatchResult } from "../gateway/protocol/index.js";
+import type { SessionsPatchResult, SessionsListParams } from "../gateway/protocol/index.js";
+import type { SessionsListResult } from "../gateway/session-utils.types.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -11,6 +12,7 @@ export type SessionsLabelCommandOpts = {
   session: string;
   label?: string;
   clear?: boolean;
+  force?: boolean;
   json?: boolean;
   url?: string;
   token?: string;
@@ -47,6 +49,31 @@ export async function sessionsLabelCommand(opts: SessionsLabelCommandOpts, runti
         ? Number.parseInt(timeoutRaw.trim(), 10)
         : DEFAULT_TIMEOUT_MS;
 
+  if (opts.force !== true) {
+    const listParams: SessionsListParams = {
+      includeGlobal: true,
+      includeUnknown: true,
+    };
+    const list = await callGateway<SessionsListResult>({
+      method: "sessions.list",
+      params: listParams,
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+      mode: GATEWAY_CLIENT_MODES.CLI,
+      url: opts.url?.trim() || undefined,
+      token: opts.token?.trim() || undefined,
+      password: opts.password?.trim() || undefined,
+      timeoutMs,
+    });
+    const exists = (list.sessions ?? []).some((row) => row.key === sessionKey);
+    if (!exists) {
+      runtime.error(
+        `Unknown session key: ${sessionKey}. Run "openclaw sessions" to find the correct key, or pass --force to create a new entry.`,
+      );
+      runtime.exit(1);
+      return;
+    }
+  }
+
   const run = async () =>
     await callGateway<SessionsPatchResult>({
       method: "sessions.patch",
@@ -81,10 +108,10 @@ export async function sessionsLabelCommand(opts: SessionsLabelCommandOpts, runti
 
     const key = result.key ?? sessionKey;
     const entryLabel = result.entry?.label;
-    if (clear || !entryLabel) {
+    if (clear) {
       runtime.log(`Cleared label for ${key}`);
     } else {
-      runtime.log(`Set label for ${key}: ${entryLabel}`);
+      runtime.log(`Set label for ${key}: ${entryLabel ?? rawLabel}`);
     }
   } catch (err) {
     const message = formatErrorMessage(err);

--- a/src/commands/sessions-label.ts
+++ b/src/commands/sessions-label.ts
@@ -1,0 +1,94 @@
+import { withProgress } from "../cli/progress.js";
+import { callGateway } from "../gateway/call.js";
+import type { SessionsPatchResult } from "../gateway/protocol/index.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export type SessionsLabelCommandOpts = {
+  session: string;
+  label?: string;
+  clear?: boolean;
+  json?: boolean;
+  url?: string;
+  token?: string;
+  password?: string;
+  timeout?: unknown;
+};
+
+export async function sessionsLabelCommand(opts: SessionsLabelCommandOpts, runtime: RuntimeEnv) {
+  const sessionKey = opts.session?.trim();
+  if (!sessionKey) {
+    runtime.error("--session is required");
+    runtime.exit(1);
+    return;
+  }
+
+  const clear = opts.clear === true;
+  const rawLabel = typeof opts.label === "string" ? opts.label.trim() : "";
+  if (clear && rawLabel) {
+    runtime.error("Pass either --clear or a label, not both");
+    runtime.exit(1);
+    return;
+  }
+  if (!clear && !rawLabel) {
+    runtime.error("Pass a label string or use --clear to remove the label");
+    runtime.exit(1);
+    return;
+  }
+
+  const timeoutRaw = opts.timeout;
+  const timeoutMs =
+    typeof timeoutRaw === "number" && Number.isFinite(timeoutRaw) && timeoutRaw > 0
+      ? Math.floor(timeoutRaw)
+      : typeof timeoutRaw === "string" && /^\d+$/.test(timeoutRaw.trim())
+        ? Number.parseInt(timeoutRaw.trim(), 10)
+        : DEFAULT_TIMEOUT_MS;
+
+  const run = async () =>
+    await callGateway<SessionsPatchResult>({
+      method: "sessions.patch",
+      params: {
+        key: sessionKey,
+        label: clear ? null : rawLabel,
+      },
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+      mode: GATEWAY_CLIENT_MODES.CLI,
+      url: opts.url?.trim() || undefined,
+      token: opts.token?.trim() || undefined,
+      password: opts.password?.trim() || undefined,
+      timeoutMs,
+    });
+
+  try {
+    const result = opts.json
+      ? await run()
+      : await withProgress(
+          {
+            label: "Updating session label…",
+            indeterminate: true,
+            enabled: true,
+          },
+          run,
+        );
+
+    if (opts.json) {
+      writeRuntimeJson(runtime, result);
+      return;
+    }
+
+    const key = result.key ?? sessionKey;
+    const entryLabel = result.entry?.label;
+    if (clear || !entryLabel) {
+      runtime.log(`Cleared label for ${key}`);
+    } else {
+      runtime.log(`Set label for ${key}: ${entryLabel}`);
+    }
+  } catch (err) {
+    const message = formatErrorMessage(err);
+    runtime.error(message);
+    runtime.exit(1);
+  }
+}

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -9,6 +9,8 @@ import { theme } from "../terminal/theme.js";
 
 export type SessionDisplayRow = {
   key: string;
+  label?: string;
+  displayName?: string;
   updatedAt: number | null;
   ageMs: number | null;
   sessionId?: string;
@@ -36,6 +38,7 @@ export type SessionDisplayDefaults = {
 };
 
 export const SESSION_KEY_PAD = 26;
+export const SESSION_LABEL_PAD = 22;
 export const SESSION_AGE_PAD = 9;
 export const SESSION_MODEL_PAD = 14;
 
@@ -45,6 +48,8 @@ export function toSessionDisplayRows(store: Record<string, SessionEntry>): Sessi
       const updatedAt = entry?.updatedAt ?? null;
       return {
         key,
+        label: entry?.label,
+        displayName: entry?.displayName,
         updatedAt,
         ageMs: updatedAt ? Date.now() - updatedAt : null,
         sessionId: entry?.sessionId,
@@ -104,6 +109,19 @@ function truncateSessionKey(key: string): string {
 export function formatSessionKeyCell(key: string, rich: boolean): string {
   const label = truncateSessionKey(key).padEnd(SESSION_KEY_PAD);
   return rich ? theme.accent(label) : label;
+}
+
+export function formatSessionLabelCell(
+  label: string | undefined,
+  displayName: string | undefined,
+  rich: boolean,
+): string {
+  const text = (label?.trim() || displayName?.trim() || "").slice(0, SESSION_LABEL_PAD);
+  const padded = text.padEnd(SESSION_LABEL_PAD);
+  if (!text) {
+    return rich ? theme.muted(padded) : padded;
+  }
+  return rich ? theme.success(padded) : padded;
 }
 
 export function formatSessionAgeCell(updatedAt: number | null | undefined, rich: boolean): string {

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -116,9 +116,14 @@ export function formatSessionLabelCell(
   displayName: string | undefined,
   rich: boolean,
 ): string {
-  const text = (label?.trim() || displayName?.trim() || "").slice(0, SESSION_LABEL_PAD);
-  const padded = text.padEnd(SESSION_LABEL_PAD);
-  if (!text) {
+  const raw = label?.trim() || displayName?.trim() || "";
+  const truncated =
+    raw.length > SESSION_LABEL_PAD && SESSION_LABEL_PAD > 1
+      ? `${raw.slice(0, SESSION_LABEL_PAD - 1)}…`
+      : raw.slice(0, SESSION_LABEL_PAD);
+  const padded = truncated.padEnd(SESSION_LABEL_PAD);
+  const hasValue = raw.length > 0;
+  if (!hasValue) {
     return rich ? theme.muted(padded) : padded;
   }
   return rich ? theme.success(padded) : padded;

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -12,11 +12,13 @@ import {
   formatSessionAgeCell,
   formatSessionFlagsCell,
   formatSessionKeyCell,
+  formatSessionLabelCell,
   formatSessionModelCell,
   resolveSessionDisplayDefaults,
   resolveSessionDisplayModel,
   SESSION_AGE_PAD,
   SESSION_KEY_PAD,
+  SESSION_LABEL_PAD,
   SESSION_MODEL_PAD,
   type SessionDisplayRow,
   toSessionDisplayRows,
@@ -157,6 +159,8 @@ export async function sessionsCommand(
         const model = resolveSessionDisplayModel(cfg, r, displayDefaults);
         return {
           ...r,
+          label: r.label ?? null,
+          displayName: r.displayName ?? null,
           totalTokens: resolveFreshSessionTotalTokens(r) ?? null,
           totalTokensFresh:
             typeof r.totalTokens === "number" ? r.totalTokensFresh !== false : false,
@@ -191,6 +195,7 @@ export async function sessionsCommand(
     ...(showAgentColumn ? ["Agent".padEnd(AGENT_PAD)] : []),
     "Kind".padEnd(KIND_PAD),
     "Key".padEnd(SESSION_KEY_PAD),
+    "Label".padEnd(SESSION_LABEL_PAD),
     "Age".padEnd(SESSION_AGE_PAD),
     "Model".padEnd(SESSION_MODEL_PAD),
     "Tokens (ctx %)".padEnd(TOKENS_PAD),
@@ -210,6 +215,7 @@ export async function sessionsCommand(
         : []),
       formatKindCell(row.kind, rich),
       formatSessionKeyCell(row.key, rich),
+      formatSessionLabelCell(row.label, row.displayName, rich),
       formatSessionAgeCell(row.updatedAt, rich),
       formatSessionModelCell(model, rich),
       formatTokensCell(total, contextTokens ?? null, rich),

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -171,6 +171,39 @@ describe("sessions view", () => {
     expect(link?.textContent?.trim()).toBe("Main Session");
   });
 
+  it("sorts Key column by resolved display title", async () => {
+    const container = document.createElement("div");
+    render(
+      renderSessions({
+        ...buildProps(
+          buildMultiResult([
+            {
+              key: "session:apple",
+              kind: "direct",
+              updatedAt: 100,
+              label: "Zebra",
+            },
+            {
+              key: "session:zebra",
+              kind: "direct",
+              updatedAt: 200,
+              label: "Aardvark",
+            },
+          ]),
+        ),
+        sortColumn: "key",
+        sortDir: "asc",
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    const links = container.querySelectorAll(".session-link");
+    expect(links).toHaveLength(2);
+    expect(links[0]?.textContent?.trim()).toBe("Aardvark");
+    expect(links[1]?.textContent?.trim()).toBe("Zebra");
+  });
+
   it("deselects only the current page from the header checkbox", async () => {
     const onSelectPage = vi.fn();
     const onDeselectPage = vi.fn();

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -127,6 +127,29 @@ describe("sessions view", () => {
     expect(fast?.value).toBe("on");
   });
 
+  it("shows resolved session title in the key column when a label is set", async () => {
+    const container = document.createElement("div");
+    render(
+      renderSessions(
+        buildProps(
+          buildResult({
+            key: "agent:main:cron:abc-123",
+            kind: "unknown",
+            updatedAt: Date.now(),
+            label: "Morning digest",
+          }),
+        ),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const link = container.querySelector(".session-link") as HTMLAnchorElement | null;
+    expect(link?.textContent?.trim()).toBe("Cron: Morning digest");
+    const secondary = container.querySelector(".session-key-display-name");
+    expect(secondary?.textContent?.trim()).toBe("agent:main:cron:abc-123");
+  });
+
   it("deselects only the current page from the header checkbox", async () => {
     const onSelectPage = vi.fn();
     const onDeselectPage = vi.fn();

--- a/ui/src/ui/views/sessions.test.ts
+++ b/ui/src/ui/views/sessions.test.ts
@@ -150,6 +150,27 @@ describe("sessions view", () => {
     expect(secondary?.textContent?.trim()).toBe("agent:main:cron:abc-123");
   });
 
+  it("matches filter query against resolved session display title", async () => {
+    const container = document.createElement("div");
+    render(
+      renderSessions({
+        ...buildProps(
+          buildResult({
+            key: "agent:main:main",
+            kind: "direct",
+            updatedAt: Date.now(),
+          }),
+        ),
+        searchQuery: "main session",
+      }),
+      container,
+    );
+    await Promise.resolve();
+
+    const link = container.querySelector(".session-link") as HTMLAnchorElement | null;
+    expect(link?.textContent?.trim()).toBe("Main Session");
+  });
+
   it("deselects only the current page from the header checkbox", async () => {
     const onSelectPage = vi.fn();
     const onDeselectPage = vi.fn();

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { resolveSessionDisplayName } from "../app-render.helpers.ts";
 import { formatRelativeTimestamp } from "../format.ts";
 import { icons } from "../icons.ts";
 import { pathForTab } from "../navigation.ts";
@@ -433,15 +434,8 @@ function renderRow(
   const verboseLevels = withCurrentLabeledOption(VERBOSE_LEVELS, verbose);
   const reasoning = row.reasoningLevel ?? "";
   const reasoningLevels = withCurrentOption(REASONING_LEVELS, reasoning);
-  const displayName =
-    typeof row.displayName === "string" && row.displayName.trim().length > 0
-      ? row.displayName.trim()
-      : null;
-  const showDisplayName = Boolean(
-    displayName &&
-    displayName !== row.key &&
-    displayName !== (typeof row.label === "string" ? row.label.trim() : ""),
-  );
+  const primaryTitle = resolveSessionDisplayName(row.key, row);
+  const showKeySecondary = primaryTitle !== row.key;
   const canLink = row.kind !== "global";
   const chatUrl = canLink
     ? `${pathForTab("chat", basePath)}?session=${encodeURIComponent(row.key)}`
@@ -466,11 +460,13 @@ function renderRow(
         />
       </td>
       <td class="data-table-key-col">
-        <div class="mono session-key-cell">
+        <div class="mono session-key-cell" title=${row.key}>
           ${canLink
             ? html`<a
                 href=${chatUrl}
                 class="session-link"
+                title=${row.key}
+                aria-label=${showKeySecondary ? `${primaryTitle} (${row.key})` : primaryTitle}
                 @click=${(e: MouseEvent) => {
                   if (
                     e.defaultPrevented ||
@@ -487,11 +483,11 @@ function renderRow(
                     onNavigateToChat(row.key);
                   }
                 }}
-                >${row.key}</a
+                >${primaryTitle}</a
               >`
-            : row.key}
-          ${showDisplayName
-            ? html`<span class="muted session-key-display-name">${displayName}</span>`
+            : primaryTitle}
+          ${showKeySecondary
+            ? html`<span class="muted session-key-display-name">${row.key}</span>`
             : nothing}
         </div>
       </td>

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -161,9 +161,15 @@ function sortRows(
   return [...rows].toSorted((a, b) => {
     let diff = 0;
     switch (column) {
-      case "key":
-        diff = (a.key ?? "").localeCompare(b.key ?? "");
+      case "key": {
+        const titleA = resolveSessionDisplayName(a.key, a);
+        const titleB = resolveSessionDisplayName(b.key, b);
+        diff = titleA.localeCompare(titleB, undefined, { sensitivity: "base" });
+        if (diff === 0) {
+          diff = (a.key ?? "").localeCompare(b.key ?? "");
+        }
         break;
+      }
       case "kind":
         diff = (a.kind ?? "").localeCompare(b.kind ?? "");
         break;

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -141,7 +141,14 @@ function filterRows(rows: GatewaySessionRow[], query: string): GatewaySessionRow
     const label = (row.label ?? "").toLowerCase();
     const kind = (row.kind ?? "").toLowerCase();
     const displayName = (row.displayName ?? "").toLowerCase();
-    return key.includes(q) || label.includes(q) || kind.includes(q) || displayName.includes(q);
+    const resolvedTitle = resolveSessionDisplayName(row.key, row).toLowerCase();
+    return (
+      key.includes(q) ||
+      label.includes(q) ||
+      kind.includes(q) ||
+      displayName.includes(q) ||
+      resolvedTitle.includes(q)
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** Sessions can already have a friendly label, but the UI and `openclaw sessions` still center the long session key, and there was no simple CLI to set or clear a label, so you keep copying ugly keys even when a name is saved.
- **Why it matters:** Operators use the control UI and `openclaw sessions` to triage many sessions; friendly labels reduce mistakes and speed up navigation.
- **What changed:**
  - Added `openclaw sessions label` (alias `rename`) to set or clear a label with `--session`, using existing `sessions.patch` (`--clear` clears the label).
  - Added `--force` to allow patching an unknown session key (explicit escape hatch; avoids accidental phantom sessions by default).
  - Updated `docs/cli/sessions.md` for the new command and flags.
  - `openclaw sessions` text table and JSON now include label / display-name fields.
  - Control UI sessions table uses the display name for the main link; shows the raw key when it differs; `aria-label` avoids redundant `key (key)` when the label matches the key.
  - Sessions filter matches the same resolved display title as the key column (search matches what users see; unit test added).
  - Key column sorting matches the same resolved display title as the key column (sort matches what users see; unit test added).
  - Tests for the CLI command and sessions UI.
  - `CHANGELOG` entry for the release.
- **What did NOT change (scope boundary):** Did not add a new gateway feature or change how channels work; wired the existing “patch session” path into the CLI and improved how labels show up in the UI and terminal.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55555
- Related # (N/A)
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A (not a bug/regression fix).

## Regression Test Plan (if applicable)

N/A (new feature / UX surface, not a regression fix).

## User-visible / Behavior Changes

- **CLI:** `openclaw sessions label` and `openclaw sessions rename` (alias) to set or clear (`--clear`) a session label via `--session <key>`; now validates session key existence via `sessions.list` by default and requires `--force` to patch an unknown key; documented in `docs/cli/sessions.md`.
- **`openclaw sessions`:** Text table includes label-oriented columns where applicable; JSON includes label/display fields for tooling.
- **Control UI:** Sessions table shows a friendly display name when a label exists, with accessible naming on the chat link when label differs from key. Session list filter and Key sort both match the resolved display title (same string as the key column), not only raw key / label / kind / stored `displayName`.
- **CHANGELOG:** User-facing entry added.

 ## AI assistance

- [x] **AI-assisted:** Yes - Cursor
**Testing:** Fully tested locally: `pnpm build`, `pnpm ui:build`, `pnpm check`, `pnpm test`, and `pnpm test -- src/commands/sessions-label.test.ts ui/src/ui/views/sessions.test.ts`.
- **Understanding:** I reviewed the diff, ran the commands above, and can explain the behavior. I also edited and corrected several parts of the AI-suggested code after review.
- **Prompts / session logs:** Used AI to understand the codebase and which files this PR touches; helped put together a local `plan.md` for myself, then reviewed all changes .
- **Review tooling:** Local `codex review --base origin/main` noted the filter vs display-title gap; fixed in a follow-up commit.


## UI Change Screenshots 

**Before the changes**
<img width="1407" height="669" alt="before" src="https://github.com/user-attachments/assets/eb24f0db-43de-445d-bab4-2eba56158c46" />

**After Changes**
<img width="1407" height="669" alt="after" src="https://github.com/user-attachments/assets/4778ff73-e412-4a0d-abc8-db474e06c5d3" />



