### PR TITLE
fix(responses): prevent caller tool names from colliding with built-in tools

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -74,7 +74,10 @@ import {
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
 import { applyPiAutoCompactionGuard } from "../../pi-settings.js";
-import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
+import {
+  toClientToolDefinitions,
+  CLIENT_TOOL_COLLISION_PREFIX,
+} from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
 import { registerProviderStreamForModel } from "../../provider-stream.js";
 import { resolveSandboxContext } from "../../sandbox.js";
@@ -798,13 +801,29 @@ export async function runEmbeddedAttempt(
         sandboxEnabled: !!sandbox?.enabled,
       });
 
-      // Add client tools (OpenResponses hosted tools) to customTools
+      // Add client tools (OpenResponses hosted tools) to customTools.
+      // Detect name collisions with built-in tools and prefix to prevent
+      // caller-provided tools from shadowing server-side execution.
       let clientToolCallDetected: { name: string; params: Record<string, unknown> } | null = null;
       const clientToolLoopDetection = resolveToolLoopDetectionConfig({
         cfg: params.config,
         agentId: sessionAgentId,
       });
-      const clientToolDefs = clientTools
+
+      // Collect built-in tool names for collision detection
+      const builtInToolNames = new Set<string>();
+      for (const tool of effectiveTools) {
+        if (tool.name) {
+          builtInToolNames.add(tool.name);
+        }
+      }
+      for (const tool of customTools) {
+        if (tool.name) {
+          builtInToolNames.add(tool.name);
+        }
+      }
+
+      const clientToolConversion = clientTools
         ? toClientToolDefinitions(
             clientTools,
             (toolName, toolParams) => {
@@ -817,10 +836,41 @@ export async function runEmbeddedAttempt(
               runId: params.runId,
               loopDetection: clientToolLoopDetection,
             },
+            builtInToolNames,
           )
-        : [];
+        : { tools: [], renamedTools: new Map<string, string>() };
+      const clientToolDefs = clientToolConversion.tools;
+      const renamedClientTools = clientToolConversion.renamedTools;
 
       const allCustomTools = [...customTools, ...clientToolDefs];
+
+      // Update allowedToolNames with prefixed names so the model can call them
+      for (const prefixed of renamedClientTools.keys()) {
+        allowedToolNames.add(prefixed);
+      }
+
+      // If any client tools were renamed to avoid collisions, add a system prompt
+      // note so the model uses the prefixed names and understands the mapping.
+      if (renamedClientTools.size > 0) {
+        const lines = [
+          "## Caller-Provided Tool Namespace",
+          "Some caller-provided tools were renamed to avoid conflicts with built-in tools.",
+          `The prefix \`${CLIENT_TOOL_COLLISION_PREFIX}\` was added. Use the prefixed names when calling these tools:`,
+        ];
+        for (const [prefixed, original] of renamedClientTools) {
+          lines.push(
+            `- \`${prefixed}\` — caller-provided (originally \`${original}\`); this is NOT the built-in \`${original}\` tool`,
+          );
+        }
+        lines.push(
+          "",
+          `Built-in tools (${[...builtInToolNames].filter((n) => renamedClientTools.has(`${CLIENT_TOOL_COLLISION_PREFIX}${n}`)).join(", ")}) remain available and execute server-side as normal.`,
+        );
+        const collisionNote = lines.join("\n");
+        systemPromptText = systemPromptText
+          ? `${systemPromptText}\n\n${collisionNote}`
+          : collisionNote;
+      }
 
       ({ session } = await createAgentSession({
         cwd: resolvedWorkspace,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -810,14 +810,10 @@ export async function runEmbeddedAttempt(
         agentId: sessionAgentId,
       });
 
-      // Collect built-in tool names for collision detection
+      // Collect built-in tool names for collision detection.
+      // customTools is a subset of effectiveTools (produced by splitSdkTools), so one loop suffices.
       const builtInToolNames = new Set<string>();
       for (const tool of effectiveTools) {
-        if (tool.name) {
-          builtInToolNames.add(tool.name);
-        }
-      }
-      for (const tool of customTools) {
         if (tool.name) {
           builtInToolNames.add(tool.name);
         }

--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -223,6 +223,19 @@ describe("toClientToolDefinitions — collision detection", () => {
     expect(result.renamedTools.size).toBe(0);
   });
 
+  it("skips rename when prefixed name would collide with another caller tool", () => {
+    // P1: caller provides both "read" (collides with built-in) and "user_read" (already that name)
+    // Renaming "read" → "user_read" would create a duplicate, so rename is skipped
+    const tools = [makeClientTool("read"), makeClientTool(`${CLIENT_TOOL_COLLISION_PREFIX}read`)];
+    const builtInNames = new Set(["read"]);
+    const result = toClientToolDefinitions(tools, undefined, undefined, builtInNames);
+
+    // Neither tool is renamed — "read" can't safely be prefixed, "user_read" has no collision
+    expect(result.tools[0]?.name).toBe("read");
+    expect(result.tools[1]?.name).toBe(`${CLIENT_TOOL_COLLISION_PREFIX}read`);
+    expect(result.renamedTools.size).toBe(0);
+  });
+
   it("preserves description and parameters through rename", () => {
     const tools: ClientToolDefinition[] = [
       {

--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -1,7 +1,12 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
 import { describe, expect, it } from "vitest";
-import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
+import type { ClientToolDefinition } from "./pi-embedded-runner/run/params.js";
+import {
+  toToolDefinitions,
+  toClientToolDefinitions,
+  CLIENT_TOOL_COLLISION_PREFIX,
+} from "./pi-tool-definition-adapter.js";
 
 type ToolExecute = ReturnType<typeof toToolDefinitions>[number]["execute"];
 const extensionContext = {} as Parameters<ToolExecute>[4];
@@ -96,5 +101,189 @@ describe("pi tool definition adapter", () => {
     });
     expect(result.content[0]).toMatchObject({ type: "text" });
     expect((result.content[0] as { text?: string }).text).toContain('"count"');
+  });
+});
+
+describe("toClientToolDefinitions — collision detection", () => {
+  function makeClientTool(name: string): ClientToolDefinition {
+    return {
+      type: "function",
+      function: {
+        name,
+        description: `caller-provided ${name}`,
+        parameters: { type: "object", properties: {} },
+      },
+    };
+  }
+
+  it("does not rename tools when no built-in names are provided", () => {
+    const tools = [makeClientTool("crpc_respond")];
+    const result = toClientToolDefinitions(tools);
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0]?.name).toBe("crpc_respond");
+    expect(result.renamedTools.size).toBe(0);
+  });
+
+  it("does not rename tools when names do not collide", () => {
+    const tools = [makeClientTool("crpc_respond")];
+    const builtInNames = new Set(["read", "write", "exec"]);
+    const result = toClientToolDefinitions(tools, undefined, undefined, builtInNames);
+    expect(result.tools[0]?.name).toBe("crpc_respond");
+    expect(result.renamedTools.size).toBe(0);
+  });
+
+  it("prefixes client tools that collide with built-in names", () => {
+    const tools = [makeClientTool("read"), makeClientTool("exec")];
+    const builtInNames = new Set(["read", "write", "exec", "edit"]);
+    const result = toClientToolDefinitions(tools, undefined, undefined, builtInNames);
+
+    expect(result.tools).toHaveLength(2);
+    expect(result.tools[0]?.name).toBe(`${CLIENT_TOOL_COLLISION_PREFIX}read`);
+    expect(result.tools[1]?.name).toBe(`${CLIENT_TOOL_COLLISION_PREFIX}exec`);
+    expect(result.renamedTools.size).toBe(2);
+    expect(result.renamedTools.get(`${CLIENT_TOOL_COLLISION_PREFIX}read`)).toBe("read");
+    expect(result.renamedTools.get(`${CLIENT_TOOL_COLLISION_PREFIX}exec`)).toBe("exec");
+  });
+
+  it("only prefixes colliding tools, leaves others intact", () => {
+    const tools = [makeClientTool("read"), makeClientTool("crpc_respond")];
+    const builtInNames = new Set(["read", "write", "exec"]);
+    const result = toClientToolDefinitions(tools, undefined, undefined, builtInNames);
+
+    expect(result.tools[0]?.name).toBe(`${CLIENT_TOOL_COLLISION_PREFIX}read`);
+    expect(result.tools[1]?.name).toBe("crpc_respond");
+    expect(result.renamedTools.size).toBe(1);
+  });
+
+  it("passes original name to onClientToolCall callback (collision roundtrip)", async () => {
+    const tools = [makeClientTool("read")];
+    const builtInNames = new Set(["read"]);
+    let callbackName: string | undefined;
+    let callbackParams: Record<string, unknown> | undefined;
+    const result = toClientToolDefinitions(
+      tools,
+      (name, params) => {
+        callbackName = name;
+        callbackParams = params;
+      },
+      undefined,
+      builtInNames,
+    );
+
+    // The tool definition uses the prefixed name (what the LLM sees)
+    const tool = result.tools[0];
+    expect(tool?.name).toBe(`${CLIENT_TOOL_COLLISION_PREFIX}read`);
+
+    // Execute the tool — simulates the LLM calling "user_read"
+    if (tool) {
+      await tool.execute(
+        "call1",
+        { path: "/etc/hostname" },
+        undefined,
+        undefined,
+        extensionContext,
+      );
+    }
+
+    // The callback receives the ORIGINAL name — this is what goes into function_call.name
+    expect(callbackName).toBe("read");
+    expect(callbackParams).toEqual({ path: "/etc/hostname" });
+  });
+
+  it("pending result uses original name (not prefixed)", async () => {
+    const tools = [makeClientTool("exec")];
+    const builtInNames = new Set(["exec"]);
+    const result = toClientToolDefinitions(tools, undefined, undefined, builtInNames);
+    const tool = result.tools[0];
+
+    // The tool definition is prefixed
+    expect(tool?.name).toBe(`${CLIENT_TOOL_COLLISION_PREFIX}exec`);
+
+    // The pending result contains the original name
+    const execResult = await tool.execute(
+      "call2",
+      { command: "echo hello" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+    const details = execResult.details as { tool?: string; status?: string };
+    expect(details?.tool).toBe("exec");
+    expect(details?.status).toBe("pending");
+  });
+
+  it("does not prefix tool already using the collision prefix", () => {
+    // Edge case: caller provides a tool named "user_read" (already prefixed)
+    const tools = [makeClientTool(`${CLIENT_TOOL_COLLISION_PREFIX}read`)];
+    const builtInNames = new Set(["read"]);
+    const result = toClientToolDefinitions(tools, undefined, undefined, builtInNames);
+
+    // "user_read" doesn't collide with "read" directly, so no double-prefixing
+    expect(result.tools[0]?.name).toBe(`${CLIENT_TOOL_COLLISION_PREFIX}read`);
+    expect(result.renamedTools.size).toBe(0);
+  });
+
+  it("preserves description and parameters through rename", () => {
+    const tools: ClientToolDefinition[] = [
+      {
+        type: "function",
+        function: {
+          name: "read",
+          description: "Custom caller read",
+          parameters: {
+            type: "object",
+            properties: { path: { type: "string" } },
+            required: ["path"],
+          },
+        },
+      },
+    ];
+    const builtInNames = new Set(["read"]);
+    const result = toClientToolDefinitions(tools, undefined, undefined, builtInNames);
+    const tool = result.tools[0];
+
+    expect(tool?.name).toBe(`${CLIENT_TOOL_COLLISION_PREFIX}read`);
+    expect(tool?.description).toBe("Custom caller read");
+    expect(tool?.parameters).toEqual({
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+    });
+  });
+
+  it("handles multiple collisions with correct mappings", () => {
+    const tools = [
+      makeClientTool("read"),
+      makeClientTool("write"),
+      makeClientTool("exec"),
+      makeClientTool("crpc_respond"),
+    ];
+    const builtInNames = new Set(["read", "write", "edit", "exec", "process"]);
+    const result = toClientToolDefinitions(tools, undefined, undefined, builtInNames);
+
+    // Three collisions, one non-collision
+    expect(result.renamedTools.size).toBe(3);
+    expect(result.tools.map((t) => t.name)).toEqual([
+      `${CLIENT_TOOL_COLLISION_PREFIX}read`,
+      `${CLIENT_TOOL_COLLISION_PREFIX}write`,
+      `${CLIENT_TOOL_COLLISION_PREFIX}exec`,
+      "crpc_respond",
+    ]);
+
+    // Verify reverse mapping
+    expect(result.renamedTools.get(`${CLIENT_TOOL_COLLISION_PREFIX}read`)).toBe("read");
+    expect(result.renamedTools.get(`${CLIENT_TOOL_COLLISION_PREFIX}write`)).toBe("write");
+    expect(result.renamedTools.get(`${CLIENT_TOOL_COLLISION_PREFIX}exec`)).toBe("exec");
+    expect(result.renamedTools.has("crpc_respond")).toBe(false);
+  });
+
+  it("no collision: built-in names set is empty", () => {
+    const tools = [makeClientTool("read"), makeClientTool("exec")];
+    const builtInNames = new Set<string>();
+    const result = toClientToolDefinitions(tools, undefined, undefined, builtInNames);
+
+    expect(result.tools[0]?.name).toBe("read");
+    expect(result.tools[1]?.name).toBe("exec");
+    expect(result.renamedTools.size).toBe(0);
   });
 });

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -198,16 +198,23 @@ export function toClientToolDefinitions(
   builtInToolNames?: ReadonlySet<string>,
 ): ClientToolConversionResult {
   const renamedTools = new Map<string, string>();
+  // Pre-compute caller-provided names to detect post-rename collisions
+  // (e.g. caller sends both "read" and "user_read" — renaming "read" would duplicate "user_read")
+  const callerToolNames = new Set(tools.map((t) => t.function.name));
 
   const defs = tools.map((tool) => {
     const func = tool.function;
     const originalName = func.name;
 
-    // Detect collision with built-in tools and prefix to avoid shadowing
+    // Detect collision with built-in tools and prefix to avoid shadowing.
+    // Skip rename if the candidate prefixed name is already taken by another caller tool.
     let effectiveName = originalName;
     if (builtInToolNames?.has(originalName)) {
-      effectiveName = `${CLIENT_TOOL_COLLISION_PREFIX}${originalName}`;
-      renamedTools.set(effectiveName, originalName);
+      const candidate = `${CLIENT_TOOL_COLLISION_PREFIX}${originalName}`;
+      if (!callerToolNames.has(candidate)) {
+        effectiveName = candidate;
+        renamedTools.set(effectiveName, originalName);
+      }
     }
 
     return {
@@ -218,7 +225,8 @@ export function toClientToolDefinitions(
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params } = splitToolExecuteArgs(args);
         const outcome = await runBeforeToolCallHook({
-          toolName: effectiveName,
+          // Use originalName so before_tool_call policies match operator-configured names
+          toolName: originalName,
           params,
           toolCallId,
           ctx: hookContext,

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -172,24 +172,53 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
   });
 }
 
-// Convert client tools (OpenResponses hosted tools) to ToolDefinition format
-// These tools are intercepted to return a "pending" result instead of executing
+/** Prefix applied to caller-provided tools that collide with built-in tool names. */
+export const CLIENT_TOOL_COLLISION_PREFIX = "user_";
+
+/**
+ * Result of converting client tools with collision detection.
+ * `renamedTools` maps prefixed names back to the caller's original names
+ * (e.g. `{ "user_read": "read" }`). Empty when no collisions occurred.
+ */
+export interface ClientToolConversionResult {
+  tools: ToolDefinition[];
+  renamedTools: Map<string, string>;
+}
+
+// Convert client tools (OpenResponses hosted tools) to ToolDefinition format.
+// These tools are intercepted to return a "pending" result instead of executing.
+// When `builtInToolNames` is provided, any client tool whose name collides with a
+// built-in is automatically prefixed with `user_` to prevent shadowing server-side
+// tools. The original name is preserved in the onClientToolCall callback so the
+// caller receives the name it expects in the function_call response.
 export function toClientToolDefinitions(
   tools: ClientToolDefinition[],
   onClientToolCall?: (toolName: string, params: Record<string, unknown>) => void,
   hookContext?: HookContext,
-): ToolDefinition[] {
-  return tools.map((tool) => {
+  builtInToolNames?: ReadonlySet<string>,
+): ClientToolConversionResult {
+  const renamedTools = new Map<string, string>();
+
+  const defs = tools.map((tool) => {
     const func = tool.function;
+    const originalName = func.name;
+
+    // Detect collision with built-in tools and prefix to avoid shadowing
+    let effectiveName = originalName;
+    if (builtInToolNames?.has(originalName)) {
+      effectiveName = `${CLIENT_TOOL_COLLISION_PREFIX}${originalName}`;
+      renamedTools.set(effectiveName, originalName);
+    }
+
     return {
-      name: func.name,
-      label: func.name,
+      name: effectiveName,
+      label: effectiveName,
       description: func.description ?? "",
       parameters: func.parameters as ToolDefinition["parameters"],
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
         const { toolCallId, params } = splitToolExecuteArgs(args);
         const outcome = await runBeforeToolCallHook({
-          toolName: func.name,
+          toolName: effectiveName,
           params,
           toolCallId,
           ctx: hookContext,
@@ -199,17 +228,20 @@ export function toClientToolDefinitions(
         }
         const adjustedParams = outcome.params;
         const paramsRecord = isPlainObject(adjustedParams) ? adjustedParams : {};
-        // Notify handler that a client tool was called
+        // Notify handler with the ORIGINAL name so the caller's function_call
+        // response contains the name it expects (not the prefixed version).
         if (onClientToolCall) {
-          onClientToolCall(func.name, paramsRecord);
+          onClientToolCall(originalName, paramsRecord);
         }
         // Return a pending result - the client will execute this tool
         return jsonResult({
           status: "pending",
-          tool: func.name,
+          tool: originalName,
           message: "Tool execution delegated to client",
         });
       },
     } satisfies ToolDefinition;
   });
+
+  return { tools: defs, renamedTools };
 }

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -328,7 +328,9 @@ describe("before_tool_call hook integration for client tools", () => {
       runBeforeToolCallImpl: async () => ({ params: { extra: true } }),
     });
     const onClientToolCall = vi.fn();
-    const [tool] = toClientToolDefinitions(
+    const {
+      tools: [tool],
+    } = toClientToolDefinitions(
       [
         {
           type: "function",


### PR DESCRIPTION
## Summary

When callers provide tools via `/v1/responses` that share names with built-in agent tools (e.g. `read`, `exec`), the built-in tools take priority and the caller's tools become unreachable. This silently breaks tool delegation for any caller whose tools overlap with OpenClaw's built-in tool names.

This PR auto-prefixes colliding caller tools with `user_` and injects a system prompt note so the model knows the mapping. The original name is preserved in callbacks and response output for transparent round-tripping.

## Changes

- **`pi-tool-definition-adapter.ts`** — New `ClientToolConversionResult` return type, `CLIENT_TOOL_COLLISION_PREFIX`, collision detection in `toClientToolDefinitions`
- **`attempt.ts`** — Collects built-in tool names, passes to `toClientToolDefinitions`, updates `allowedToolNames` with prefixed names, injects system prompt collision note
- **`pi-tool-definition-adapter.test.ts`** — 9 test cases covering collision detection, prefix mapping, callback round-trip, no double-prefixing, and parameter preservation
- **`pi-tools.before-tool-call.integration.e2e.test.ts`** — Updated destructuring for new return type

## How it works

1. Before creating agent session, collect all built-in + custom tool names
2. For each caller tool, check if its name collides with a built-in
3. If collision: rename to `user_{name}`, record in `renamedTools` map
4. Inject system prompt note listing the renames
5. In `execute()`, pass original name to `onClientToolCall` and pending result
6. Caller sees original name in `function_call` output (matched by `call_id`)

## Test plan

- [x] Unit tests: 9 cases in `pi-tool-definition-adapter.test.ts`
- [x] TypeScript compiles cleanly
- [x] Manual end-to-end test: curl with colliding `read` tool → model sees `user_read`, response returns original `read` name
- [ ] CI test suite

Fixes #57232

🤖 Generated with [Claude Code](https://claude.com/claude-code)