### PR TITLE
fix(failover): defer profile cooldown marking to unblock rate-limit rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -652,6 +652,7 @@ Docs: https://docs.openclaw.ai
 - Agents/PI: skip the idle wait during aborted embedded-run cleanup, so stopped or timed-out runs clear pending tool state and release the session lock promptly. (#74919) Thanks @medns.
 - Agents/current-time: split UTC into a separate `Reference UTC:` prompt line so local `Current time:` stays anchored to the user's timezone. (#42654) Thanks @chencheng-li.
 - Agents/reasoning: keep embedded reasoning deltas raw for correct same-line streaming while preserving formatted Telegram, Feishu, Discord, and heartbeat delivery at the channel edge. (#78397) Thanks @medns.
+- Agents/failover: rotate auth profiles before deferred cooldown marking on rate-limit failures, so file-lock contention cannot stall profile failover. Fixes #57281. (#57283) Thanks @jeremyknows.
 
 ## 2026.5.3-1
 

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -83,6 +83,7 @@ const installRunEmbeddedMocks = () => {
 };
 
 let runEmbeddedPiAgent: typeof import("./pi-embedded-runner/run.js").runEmbeddedPiAgent;
+let authProfileUsageTesting: typeof import("./auth-profiles/usage.js").__testing;
 let createDiagnosticLogRecordCaptureFn: typeof import("../logging/test-helpers/diagnostic-log-capture.js").createDiagnosticLogRecordCapture;
 let cleanupLogCapture: (() => void) | undefined;
 let resetLoggerFn: typeof import("../logging/logger.js").resetLogger;
@@ -93,6 +94,7 @@ beforeAll(async () => {
   vi.resetModules();
   installRunEmbeddedMocks();
   ({ runEmbeddedPiAgent } = await import("./pi-embedded-runner/run.js"));
+  ({ __testing: authProfileUsageTesting } = await import("./auth-profiles/usage.js"));
   ({ createDiagnosticLogRecordCapture: createDiagnosticLogRecordCaptureFn } =
     await import("../logging/test-helpers/diagnostic-log-capture.js"));
   ({ resetLogger: resetLoggerFn, setLoggerOverride: setLoggerOverrideFn } =
@@ -128,6 +130,7 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  authProfileUsageTesting.setDepsForTest(null);
   cleanupLogCapture?.();
   cleanupLogCapture = undefined;
   setLoggerOverrideFn(null);
@@ -905,6 +908,46 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
     expect(sleepWithAbortMock).not.toHaveBeenCalled();
   });
 
+  it("starts the retry attempt before prompt failure cooldown marking finishes", async () => {
+    let releaseMark: (() => void) | undefined;
+    const markCanFinish = new Promise<void>((resolve) => {
+      releaseMark = resolve;
+    });
+    let markStarted = false;
+    authProfileUsageTesting.setDepsForTest({
+      updateAuthProfileStoreWithLock: async () => {
+        markStarted = true;
+        await markCanFinish;
+        return null;
+      },
+    });
+
+    try {
+      await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+        await writeAuthStore(agentDir);
+        mockPromptErrorThenSuccessfulAttempt("rate limit exceeded");
+
+        const runPromise = runAutoPinnedOpenAiTurn({
+          agentDir,
+          workspaceDir,
+          sessionKey: "agent:test:prompt-deferred-mark",
+          runId: "run:prompt-deferred-mark",
+        });
+
+        await vi.waitFor(() => expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(2));
+        expect(markStarted).toBe(true);
+        releaseMark?.();
+        releaseMark = undefined;
+        await runPromise;
+
+        const usageStats = await readUsageStats(agentDir);
+        expect(typeof usageStats["openai:p2"]?.lastUsed).toBe("number");
+      });
+    } finally {
+      releaseMark?.();
+    }
+  });
+
   it("uses configured overload backoff before rotating profiles", async () => {
     const { usageStats } = await runAutoPinnedRotationCase({
       errorMessage: '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
@@ -1507,8 +1550,9 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
   });
 
   it("skips profiles in cooldown when rotating after failure", async () => {
-    await withTimedAgentWorkspace(async ({ agentDir, workspaceDir, now }) => {
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
       const authPath = path.join(agentDir, "auth-profiles.json");
+      const p2CooldownUntil = Date.now() + 60 * 60 * 1000;
       const payload = {
         version: 1,
         profiles: {
@@ -1518,7 +1562,7 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
         },
         usageStats: {
           "openai:p1": { lastUsed: 1 },
-          "openai:p2": { cooldownUntil: now + 60 * 60 * 1000 }, // p2 in cooldown
+          "openai:p2": { cooldownUntil: p2CooldownUntil }, // p2 in cooldown
           "openai:p3": { lastUsed: 3 },
         },
       };
@@ -1536,7 +1580,7 @@ describe("runEmbeddedPiAgent auth profile rotation", () => {
       const usageStats = await readUsageStats(agentDir);
       expect(typeof usageStats["openai:p1"]?.lastUsed).toBe("number");
       expect(typeof usageStats["openai:p3"]?.lastUsed).toBe("number");
-      expect(usageStats["openai:p2"]?.cooldownUntil).toBe(now + 60 * 60 * 1000);
+      expect(usageStats["openai:p2"]?.cooldownUntil).toBe(p2CooldownUntil);
     });
   });
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -2003,11 +2003,6 @@ export async function runEmbeddedPiAgent(
               promptErrorDetails.reason ?? classifyFailoverReason(errorText, { provider });
             const promptProfileFailureReason =
               resolveRunAuthProfileFailureReason(promptFailoverReason);
-            await maybeMarkAuthProfileFailure({
-              profileId: lastProfileId,
-              reason: promptProfileFailureReason,
-              modelId,
-            });
             const promptFailoverFailure =
               promptFailoverReason !== null || isFailoverErrorMessage(errorText, { provider });
             // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
@@ -2046,6 +2041,15 @@ export async function runEmbeddedPiAgent(
               promptFailoverDecision.action === "rotate_profile" &&
               (await advanceAuthProfile())
             ) {
+              if (failedPromptProfileId && promptProfileFailureReason) {
+                maybeMarkAuthProfileFailure({
+                  profileId: failedPromptProfileId,
+                  reason: promptProfileFailureReason,
+                  modelId,
+                }).catch((err) =>
+                  log.warn(`deferred prompt profile failure mark failed: ${String(err)}`),
+                );
+              }
               traceAttempts.push({
                 provider,
                 model: modelId,
@@ -2071,6 +2075,15 @@ export async function runEmbeddedPiAgent(
                 failoverReason: promptFailoverReason,
                 profileRotated: true,
               });
+            }
+            if (failedPromptProfileId && promptProfileFailureReason) {
+              maybeMarkAuthProfileFailure({
+                profileId: failedPromptProfileId,
+                reason: promptProfileFailureReason,
+                modelId,
+              }).catch((err) =>
+                log.warn(`deferred prompt profile failure mark failed: ${String(err)}`),
+              );
             }
             const fallbackThinking = pickFallbackThinkingLevel({
               message: errorText,

--- a/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.test.ts
@@ -57,6 +57,66 @@ function expectThrownFailoverError(outcome: Outcome): FailoverError {
 }
 
 describe("handleAssistantFailover", () => {
+  describe("rotate_profile branch", () => {
+    it("rotates before waiting on auth profile failure marking", async () => {
+      const events: string[] = [];
+      let releaseMark!: () => void;
+      const markFinished = new Promise<void>((resolve) => {
+        releaseMark = resolve;
+      });
+      const markSettled = new Promise<void>((resolve) => {
+        void markFinished.then(() => resolve());
+      });
+      const maybeMarkAuthProfileFailure = vi.fn(async () => {
+        events.push("mark-start");
+        await markFinished;
+        events.push("mark-finish");
+      });
+
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "rate_limit" },
+          failoverReason: "rate_limit",
+          assistantProfileFailureReason: "rate_limit",
+          lastProfileId: "openai:p1",
+          billingFailure: false,
+          rateLimitFailure: true,
+          maybeMarkAuthProfileFailure,
+          advanceAuthProfile: vi.fn(async () => {
+            events.push("advance");
+            return true;
+          }),
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      expect(events).toEqual(["advance", "mark-start"]);
+      releaseMark();
+      await markSettled;
+      await vi.waitFor(() => expect(events).toEqual(["advance", "mark-start", "mark-finish"]));
+      expect(events).toEqual(["advance", "mark-start", "mark-finish"]);
+    });
+
+    it("does not log profile-specific warnings without a failed profile id", async () => {
+      const warn = vi.fn();
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "rotate_profile", reason: "timeout" },
+          failoverReason: "timeout",
+          timedOut: true,
+          cloudCodeAssistFormatError: true,
+          lastProfileId: undefined,
+          billingFailure: false,
+          advanceAuthProfile: vi.fn(async () => true),
+          warn,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("Profile undefined"));
+    });
+  });
+
   describe("surface_error branch (openclaw#70124)", () => {
     it("throws a billing FailoverError so the webchat can render the provider failure", async () => {
       const logDecision = vi.fn();

--- a/src/agents/pi-embedded-runner/run/assistant-failover.ts
+++ b/src/agents/pi-embedded-runner/run/assistant-failover.ts
@@ -97,22 +97,20 @@ export async function handleAssistantFailover(params: {
   };
 
   if (decision.action === "rotate_profile") {
-    if (params.lastProfileId) {
-      const reason = params.timedOut ? "timeout" : params.assistantProfileFailureReason;
-      await params.maybeMarkAuthProfileFailure({
-        profileId: params.lastProfileId,
-        reason,
-        modelId: params.modelId,
-      });
-      if (params.timedOut && !params.isProbeSession) {
-        params.warn(`Profile ${params.lastProfileId} timed out. Trying next account...`);
+    const failedProfileId = params.lastProfileId;
+    const failureReason = params.timedOut ? "timeout" : params.assistantProfileFailureReason;
+    const markFailedProfile = () => {
+      if (!failedProfileId || !failureReason || failureReason === "timeout") {
+        return;
       }
-      if (params.cloudCodeAssistFormatError) {
-        params.warn(
-          `Profile ${params.lastProfileId} hit Cloud Code Assist format error. Tool calls will be sanitized on retry.`,
-        );
-      }
-    }
+      params
+        .maybeMarkAuthProfileFailure({
+          profileId: failedProfileId,
+          reason: failureReason,
+          modelId: params.modelId,
+        })
+        .catch((err) => params.warn(`deferred profile failure mark failed: ${String(err)}`));
+    };
 
     if (params.failoverReason === "overloaded") {
       overloadProfileRotations += 1;
@@ -124,6 +122,7 @@ export async function handleAssistantFailover(params: {
         params.warn(
           `overload profile rotation cap reached for ${sanitizeForLog(params.provider)}/${sanitizeForLog(params.modelId)} after ${overloadProfileRotations} rotations; escalating to model fallback`,
         );
+        markFailedProfile();
         params.logAssistantFailoverDecision("fallback_model", { status });
         return {
           action: "throw",
@@ -152,6 +151,15 @@ export async function handleAssistantFailover(params: {
     }
 
     const rotated = await params.advanceAuthProfile();
+    markFailedProfile();
+    if (params.timedOut && !params.isProbeSession && failedProfileId) {
+      params.warn(`Profile ${failedProfileId} timed out. Trying next account...`);
+    }
+    if (params.cloudCodeAssistFormatError && failedProfileId) {
+      params.warn(
+        `Profile ${failedProfileId} hit Cloud Code Assist format error. Tool calls will be sanitized on retry.`,
+      );
+    }
     if (rotated) {
       params.logAssistantFailoverDecision("rotate_profile");
       await params.maybeBackoffBeforeOverloadFailover(params.failoverReason);


### PR DESCRIPTION
## Summary
- `markAuthProfileFailure` acquires a file lock (`updateAuthProfileStoreWithLock`) before `advanceAuthProfile` can rotate to the next profile. Under contention (10+ concurrent agents), this blocks for minutes — observed 17-minute gap in production logs
- Rate-limit failover logs `decision=rotate_profile` but never executes it. Timeout failover works because `maybeMarkAuthProfileFailure` returns immediately (early exit on `reason === "timeout"`)
- Fix: rotate FIRST, then mark cooldown non-blocking (fire-and-forget with error logging). Cooldown checks are per-profile, so marking the failed profile doesn't affect the next profile's eligibility


## Real behavior proof
- Behavior or issue addressed: Auth-profile rate-limit failover must rotate to the next profile before marking the failed profile in cooldown, so auth-store lock contention cannot stall the retry.
- Real environment tested: Local OpenClaw embedded failover runtime from this PR head (d2e5556a8888), isolated on-disk auth-profile store, two real auth-profile entries (`proof:p1`, `proof:p2`) for a local OpenAI-compatible provider, and the real auth-profile file-lock sidecar behavior.
- Exact steps or command run after this patch: `node --import tsx .local/real-behavior-proof-57283.mjs`
- Evidence after fix:

```text
[3.263s] AUTH_INITIALIZED profile=proof:p1 runtimeKey=p1 thinkLevel=medium
[3.263s] REQUEST #1 profile=proof:p1 -> 429 rate_limit
[3.264s] LOCK_HELD auth profile store lock before handling p1 rate_limit
[3.265s] COOLDOWN_MARK_STARTED profile=proof:p1 while lockHeld=true
[3.265s] FAILOVER_DECISION rotate_profile
[3.265s] FAILOVER_OUTCOME action=retry currentProfile=proof:p2
[3.265s] REQUEST #2 profile=proof:p2 -> 200 OK while lockHeld=true
[3.266s] LOCK_RELEASED auth profile store lock (after retry reached proof:p2)
[3.321s] COOLDOWN_MARK_FINISHED profile=proof:p1
[3.321s] COOLDOWN_OBSERVED profile=proof:p1 reason=rate_limit failureCount=1
```

- Observed result after fix: The first runtime attempt used `proof:p1` and hit HTTP 429. While the auth-profile store lock was held, OpenClaw advanced runtime auth to `proof:p2` and reached the retry path (`REQUEST #2 ... lockHeld=true`). The failed profile cooldown mark finished afterward.
- What was not tested: No full local test suite or CI gate was run; this was a focused runtime reproduction of the auth-profile rotation behavior only.

### Regression check against pre-fix ordering

The same harness was also run against the parent/pre-fix failover implementation. It reproduced the bad ordering: retry did not reach `proof:p2` until a watchdog released the lock blocking cooldown marking.

```text
[3.158s] AUTH_INITIALIZED profile=proof:p1 runtimeKey=p1 thinkLevel=medium
[3.159s] REQUEST #1 profile=proof:p1 -> 429 rate_limit
[3.159s] LOCK_HELD auth profile store lock before handling p1 rate_limit
[3.160s] COOLDOWN_MARK_STARTED profile=proof:p1 while lockHeld=true
[4.361s] BUG_PROBE retry did not reach proof:p2 while cooldown mark was lock-blocked
[4.366s] LOCK_RELEASED auth profile store lock (watchdog released blocked pre-retry cooldown mark)
[5.530s] COOLDOWN_MARK_FINISHED profile=proof:p1
[5.530s] FAILOVER_DECISION rotate_profile
[5.530s] FAILOVER_OUTCOME action=retry currentProfile=proof:p2
[5.530s] REQUEST #2 profile=proof:p2 -> 200 OK while lockHeld=false
[5.531s] COOLDOWN_OBSERVED profile=proof:p1 reason=rate_limit failureCount=1
```

## Test plan
- [ ] Rate-limit on profile A triggers immediate rotation to profile B (no multi-minute stall)
- [ ] Timeout failover path unchanged (still skips marking)
- [ ] Cooldown is still eventually marked on the failed profile
- [ ] Multi-profile concurrent agents don't deadlock on auth store file lock
- [ ] Prompt-side failover also rotates before marking

Fixes #57281

🤖 Generated with [Claude Code](https://claude.com/claude-code)