### PR TITLE
fix: agent --deliver bypasses LLM turn, delivers message directly

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -370,6 +370,32 @@ async function agentCommandInternal(
       if (sendPolicy === "deny") {
         throw new Error("send blocked by session policy");
       }
+
+      // Direct delivery mode: bypass the LLM turn entirely and deliver the
+      // original message to the target channel, matching `openclaw message send`
+      // semantics.  This prevents the silent-drop bug where the LLM produces
+      // NO_REPLY and exit 0 makes the caller believe delivery succeeded.
+      //
+      // Guard: when internalEvents are present (e.g. subagent announcements),
+      // the LLM is needed to synthesize a human-readable summary from the
+      // internal context.  Fall through to the normal LLM path in that case.
+      if (!opts.internalEvents || opts.internalEvents.length === 0) {
+        const directPayloads = [{ text: opts.message ?? "" }];
+        const directResult = {
+          payloads: directPayloads,
+          meta: { durationMs: 0 },
+        };
+        return await deliverAgentCommandResult({
+          cfg,
+          deps,
+          runtime,
+          opts,
+          outboundSession,
+          sessionEntry,
+          result: directResult as Parameters<typeof deliverAgentCommandResult>[0]["result"],
+          payloads: directPayloads,
+        });
+      }
     }
 
     if (acpResolution?.kind === "stale") {

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -41,7 +41,11 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
       "Run the embedded agent locally (requires model provider API keys in your shell)",
       false,
     )
-    .option("--deliver", "Send the agent's reply back to the selected channel", false)
+    .option(
+      "--deliver",
+      "Deliver the message directly to the selected channel (bypasses LLM)",
+      false,
+    )
     .option("--json", "Output result as JSON", false)
     .option(
       "--timeout <seconds>",

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -139,9 +139,9 @@ describe("agentCliCommand", () => {
     });
   });
 
-  it("skips gateway when --deliver is set (direct delivery bypasses LLM)", async () => {
+  it("routes --deliver through the gateway (channel runtime may be gateway-side)", async () => {
     await withTempStore(async () => {
-      mockLocalAgentReply();
+      mockGatewaySuccessReply();
 
       await agentCliCommand(
         {
@@ -153,8 +153,8 @@ describe("agentCliCommand", () => {
         runtime,
       );
 
-      expect(callGateway).not.toHaveBeenCalled();
-      expect(agentCommand).toHaveBeenCalledTimes(1);
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(agentCommand).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -138,4 +138,23 @@ describe("agentCliCommand", () => {
       expect(runtime.log).toHaveBeenCalledWith("local");
     });
   });
+
+  it("skips gateway when --deliver is set (direct delivery bypasses LLM)", async () => {
+    await withTempStore(async () => {
+      mockLocalAgentReply();
+
+      await agentCliCommand(
+        {
+          message: "notification",
+          to: "+1555",
+          deliver: true,
+          channel: "signal",
+        },
+        runtime,
+      );
+
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -184,9 +184,7 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
     agentId: opts.agent,
     replyAccountId: opts.replyAccount,
   };
-  // Direct delivery bypasses the LLM turn, so route straight to the embedded
-  // agent path which handles it locally without a gateway round-trip.
-  if (opts.local === true || opts.deliver === true) {
+  if (opts.local === true) {
     return await agentCommand(localOpts, runtime, deps);
   }
 

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -184,7 +184,9 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
     agentId: opts.agent,
     replyAccountId: opts.replyAccount,
   };
-  if (opts.local === true) {
+  // Direct delivery bypasses the LLM turn, so route straight to the embedded
+  // agent path which handles it locally without a gateway round-trip.
+  if (opts.local === true || opts.deliver === true) {
     return await agentCommand(localOpts, runtime, deps);
   }
 

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -1190,9 +1190,10 @@ describe("agentCommand", () => {
           deps,
         );
 
+        // Direct delivery: the original message ("hi") is delivered, not the LLM response.
         expect(deps.sendMessageTelegram).toHaveBeenCalledWith(
           "123",
-          "ok",
+          "hi",
           expect.objectContaining({ accountId: undefined, verbose: false }),
         );
       } finally {
@@ -1203,6 +1204,76 @@ describe("agentCommand", () => {
         }
       }
     });
+  });
+
+  it("bypasses LLM turn when --deliver is set", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store, undefined, { botToken: "t-1" });
+      setActivePluginRegistry(
+        createTestRegistry([
+          { pluginId: "telegram", plugin: createTelegramOutboundPlugin(), source: "test" },
+        ]),
+      );
+      const deps = {
+        sendMessageWhatsApp: vi.fn(),
+        sendMessageTelegram: vi.fn().mockResolvedValue({ messageId: "t1", chatId: "123" }),
+        sendMessageSlack: vi.fn(),
+        sendMessageDiscord: vi.fn(),
+        sendMessageSignal: vi.fn(),
+        sendMessageIMessage: vi.fn(),
+      };
+
+      const prevTelegramToken = process.env.TELEGRAM_BOT_TOKEN;
+      process.env.TELEGRAM_BOT_TOKEN = "";
+      const piCallsBefore = vi.mocked(runEmbeddedPiAgent).mock.calls.length;
+      try {
+        await agentCommand(
+          {
+            message: "notification text",
+            to: "123",
+            deliver: true,
+            channel: "telegram",
+          },
+          runtime,
+          deps,
+        );
+
+        // LLM should NOT be invoked for direct delivery.
+        expect(vi.mocked(runEmbeddedPiAgent).mock.calls.length).toBe(piCallsBefore);
+        // The original message should be delivered directly.
+        expect(deps.sendMessageTelegram).toHaveBeenCalledWith(
+          "123",
+          "notification text",
+          expect.objectContaining({}),
+        );
+      } finally {
+        if (prevTelegramToken === undefined) {
+          delete process.env.TELEGRAM_BOT_TOKEN;
+        } else {
+          process.env.TELEGRAM_BOT_TOKEN = prevTelegramToken;
+        }
+      }
+    });
+  });
+
+  it("falls through to LLM when --deliver has internalEvents (subagent announcements)", async () => {
+    const piCallsBefore = vi.mocked(runEmbeddedPiAgent).mock.calls.length;
+
+    // Delivery will fail because no channel plugin is registered, but the
+    // important assertion is that the LLM was invoked (not bypassed).
+    await runEmbeddedWithTempConfig({
+      args: {
+        message: "subagent completed task",
+        to: "+1555",
+        deliver: true,
+        bestEffortDeliver: true,
+        internalEvents: [{ type: "tool_result", tool: "subagent_complete", text: "done" }] as never,
+      },
+    });
+
+    // LLM SHOULD be invoked because internalEvents require LLM summarization.
+    expect(vi.mocked(runEmbeddedPiAgent).mock.calls.length).toBeGreaterThan(piCallsBefore);
   });
 
   it("uses reply channel as the message channel context", async () => {


### PR DESCRIPTION
## Summary

- `agent --deliver` now bypasses the LLM turn entirely and delivers the original `--message` text directly to the target channel, matching `openclaw message send` semantics
- When `internalEvents` are present (e.g. subagent announcements), the LLM path is preserved so internal context is synthesized into a human-readable summary before delivery
- Uses `opts.message` (not `body`) for direct payloads to avoid leaking internal prompt context
- `--deliver` stays on the gateway-first path (channel runtime may be gateway-side); the bypass in `agentCommandInternal` handles both gateway and local execution

## Problem

`openclaw agent --deliver --channel signal --to "+1234567890" --message "notification text"` silently drops messages (exit 0, no delivery). The LLM turn processes the notification text as a user message and responds with NO_REPLY or an internal response — the actual channel delivery never happens.

## Fix

When `--deliver` is set and no `internalEvents` are present, construct a synthetic result with the original message as the payload and pass it directly to `deliverAgentCommandResult`, which handles channel resolution, target validation, and the actual delivery. No LLM turn is spawned.

When `internalEvents` are present (subagent announcement path via `subagent-announce-delivery.ts`), the code falls through to the normal LLM path so the internal context is properly summarized before delivery.

## Test plan

- [x] New test: `bypasses LLM turn when --deliver is set` — verifies `runEmbeddedPiAgent` is not called and the original message is delivered
- [x] New test: `falls through to LLM when --deliver has internalEvents` — verifies LLM is invoked for subagent announcements
- [x] Updated test: `passes through telegram accountId when delivering` — now expects original message text instead of LLM response
- [x] New test: `routes --deliver through the gateway` — verifies gateway path is preserved for `--deliver`
- [x] `pnpm build` passes
- [x] `pnpm check` passes
- [x] `pnpm test` passes (3 pre-existing config schema failures on `origin/main`, unrelated)

Fixes #57284

**AI-assisted:** Fully tested with `pnpm build && pnpm check && pnpm test`.