### PR TITLE
fix(slack): keep block streaming replies in thread (rebased #49715)

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
@@ -130,11 +130,21 @@ describe("slack draft stream initialization", () => {
 });
 
 describe("slack block delivery thread reuse", () => {
-  it("reuses the established thread when first-mode planning is exhausted", () => {
+  it("does not reuse the established thread unless block delivery opts in", () => {
     expect(
       resolveSlackDeliveryThreadTs({
         plannedThreadTs: undefined,
         usedReplyThreadTs: "3000.1",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("reuses the established thread when first-mode block planning is exhausted", () => {
+    expect(
+      resolveSlackDeliveryThreadTs({
+        plannedThreadTs: undefined,
+        usedReplyThreadTs: "3000.1",
+        allowUsedReplyThreadTs: true,
       }),
     ).toBe("3000.1");
   });
@@ -145,6 +155,7 @@ describe("slack block delivery thread reuse", () => {
         forcedThreadTs: "3000.2",
         plannedThreadTs: "3000.3",
         usedReplyThreadTs: "3000.1",
+        allowUsedReplyThreadTs: true,
       }),
     ).toBe("3000.2");
 
@@ -152,6 +163,7 @@ describe("slack block delivery thread reuse", () => {
       resolveSlackDeliveryThreadTs({
         plannedThreadTs: "3000.3",
         usedReplyThreadTs: "3000.1",
+        allowUsedReplyThreadTs: true,
       }),
     ).toBe("3000.3");
   });

--- a/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   isSlackStreamingEnabled,
   resolveSlackDeliveryThreadTs,
+  resolveSlackDraftPreviewThreadTs,
   resolveSlackStreamingThreadHint,
+  resolveTrackedSlackBlockReplyThreadTs,
   shouldEnableSlackPreviewStreaming,
   shouldInitializeSlackDraftStream,
 } from "./dispatch.js";
@@ -166,5 +168,47 @@ describe("slack block delivery thread reuse", () => {
         allowUsedReplyThreadTs: true,
       }),
     ).toBe("3000.3");
+  });
+
+  it("refreshes the cached block thread when a delivered block uses an explicit thread", () => {
+    expect(
+      resolveTrackedSlackBlockReplyThreadTs({
+        deliveredThreadTs: "reply-tag.1",
+        usedBlockReplyThreadTs: "3000.1",
+        trackBlockReplyThreadTs: true,
+      }),
+    ).toBe("reply-tag.1");
+  });
+
+  it("keeps the cached block thread when the delivery should not retarget block reuse", () => {
+    expect(
+      resolveTrackedSlackBlockReplyThreadTs({
+        deliveredThreadTs: "reply-tag.1",
+        usedBlockReplyThreadTs: "3000.1",
+        trackBlockReplyThreadTs: false,
+      }),
+    ).toBe("3000.1");
+  });
+});
+
+describe("slack draft preview thread reuse", () => {
+  it("does not reuse the cached thread in first mode once planning is exhausted", () => {
+    expect(
+      resolveSlackDraftPreviewThreadTs({
+        replyToMode: "first",
+        plannedThreadTs: undefined,
+        usedReplyThreadTs: "3000.1",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("can reuse the cached thread in all mode when planning is exhausted", () => {
+    expect(
+      resolveSlackDraftPreviewThreadTs({
+        replyToMode: "all",
+        plannedThreadTs: undefined,
+        usedReplyThreadTs: "3000.1",
+      }),
+    ).toBe("3000.1");
   });
 });

--- a/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isSlackStreamingEnabled,
+  resolveSlackDeliveryThreadTs,
   resolveSlackStreamingThreadHint,
   shouldEnableSlackPreviewStreaming,
   shouldInitializeSlackDraftStream,
@@ -125,5 +126,33 @@ describe("slack draft stream initialization", () => {
         useStreaming: false,
       }),
     ).toBe(true);
+  });
+});
+
+describe("slack block delivery thread reuse", () => {
+  it("reuses the established thread when first-mode planning is exhausted", () => {
+    expect(
+      resolveSlackDeliveryThreadTs({
+        plannedThreadTs: undefined,
+        usedReplyThreadTs: "3000.1",
+      }),
+    ).toBe("3000.1");
+  });
+
+  it("still prefers an explicit or newly planned thread over the reused thread", () => {
+    expect(
+      resolveSlackDeliveryThreadTs({
+        forcedThreadTs: "3000.2",
+        plannedThreadTs: "3000.3",
+        usedReplyThreadTs: "3000.1",
+      }),
+    ).toBe("3000.2");
+
+    expect(
+      resolveSlackDeliveryThreadTs({
+        plannedThreadTs: "3000.3",
+        usedReplyThreadTs: "3000.1",
+      }),
+    ).toBe("3000.3");
   });
 });

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -35,6 +35,7 @@ import {
   createSlackReplyDeliveryPlan,
   deliverReplies,
   readSlackReplyBlocks,
+  resolveDeliveredSlackReplyThreadTs,
   resolveSlackThreadTs,
 } from "../replies.js";
 import type { PreparedSlackMessage } from "./types.js";
@@ -361,6 +362,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let streamSession: SlackStreamSession | null = null;
   let streamFailed = false;
   let usedReplyThreadTs: string | undefined;
+  let usedBlockReplyThreadTs: string | undefined;
   let observedReplyDelivery = false;
 
   const deliverNormally = async (
@@ -368,13 +370,14 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     options?: {
       forcedThreadTs?: string;
       allowUsedReplyThreadTs?: boolean;
+      trackBlockReplyThreadTs?: boolean;
     },
   ): Promise<void> => {
     const plannedThreadTs = options?.forcedThreadTs ? undefined : replyPlan.nextThreadTs();
     const replyThreadTs = resolveSlackDeliveryThreadTs({
       forcedThreadTs: options?.forcedThreadTs,
       plannedThreadTs,
-      usedReplyThreadTs,
+      usedReplyThreadTs: usedBlockReplyThreadTs,
       allowUsedReplyThreadTs: options?.allowUsedReplyThreadTs,
     });
     await deliverReplies({
@@ -389,9 +392,17 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       ...(slackIdentity ? { identity: slackIdentity } : {}),
     });
     observedReplyDelivery = true;
+    const effectiveReplyThreadTs = resolveDeliveredSlackReplyThreadTs({
+      replyToMode: prepared.replyToMode,
+      payloadReplyToId: payload.replyToId,
+      replyThreadTs,
+    });
     // Record the thread ts only after confirmed delivery success.
-    if (replyThreadTs) {
-      usedReplyThreadTs ??= replyThreadTs;
+    if (effectiveReplyThreadTs) {
+      usedReplyThreadTs ??= effectiveReplyThreadTs;
+      if (options?.trackBlockReplyThreadTs) {
+        usedBlockReplyThreadTs ??= effectiveReplyThreadTs;
+      }
     }
     replyPlan.markSent();
   };
@@ -401,11 +412,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     kind: "tool" | "block" | "final",
   ): Promise<void> => {
     const reply = resolveSendableOutboundReplyParts(payload);
-    const allowUsedReplyThreadTs = kind === "block";
+    const trackBlockReplyThreadTs = kind === "block";
     if (streamFailed || reply.hasMedia || readSlackReplyBlocks(payload)?.length || !reply.hasText) {
       await deliverNormally(payload, {
         forcedThreadTs: streamSession?.threadTs,
-        allowUsedReplyThreadTs,
+        allowUsedReplyThreadTs: trackBlockReplyThreadTs,
+        trackBlockReplyThreadTs,
       });
       return;
     }
@@ -421,7 +433,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             "slack-stream: no reply thread target for stream start, falling back to normal delivery",
           );
           streamFailed = true;
-          await deliverNormally(payload, { allowUsedReplyThreadTs });
+          await deliverNormally(payload, {
+            allowUsedReplyThreadTs: trackBlockReplyThreadTs,
+            trackBlockReplyThreadTs,
+          });
           return;
         }
 
@@ -435,6 +450,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         });
         observedReplyDelivery = true;
         usedReplyThreadTs ??= streamThreadTs;
+        if (trackBlockReplyThreadTs) {
+          usedBlockReplyThreadTs ??= streamThreadTs;
+        }
         replyPlan.markSent();
         return;
       }
@@ -450,7 +468,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       streamFailed = true;
       await deliverNormally(payload, {
         forcedThreadTs: streamSession?.threadTs ?? plannedThreadTs,
-        allowUsedReplyThreadTs,
+        allowUsedReplyThreadTs: trackBlockReplyThreadTs,
+        trackBlockReplyThreadTs,
       });
     }
   };
@@ -522,6 +541,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
       await deliverNormally(payload, {
         allowUsedReplyThreadTs: info.kind === "block",
+        trackBlockReplyThreadTs: info.kind === "block",
       });
     },
     onError: (err, info) => {
@@ -539,11 +559,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         resolveThreadTs: () => {
           const ts = resolveSlackDeliveryThreadTs({
             plannedThreadTs: replyPlan.nextThreadTs(),
-            usedReplyThreadTs,
+            usedReplyThreadTs: usedBlockReplyThreadTs,
             allowUsedReplyThreadTs: true,
           });
           if (ts) {
             usedReplyThreadTs ??= ts;
+            usedBlockReplyThreadTs ??= ts;
           }
           return ts;
         },

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -136,6 +136,29 @@ export function resolveSlackDeliveryThreadTs(params: {
   );
 }
 
+export function resolveTrackedSlackBlockReplyThreadTs(params: {
+  deliveredThreadTs?: string;
+  usedBlockReplyThreadTs?: string;
+  trackBlockReplyThreadTs?: boolean;
+}): string | undefined {
+  if (params.trackBlockReplyThreadTs && params.deliveredThreadTs) {
+    return params.deliveredThreadTs;
+  }
+  return params.usedBlockReplyThreadTs;
+}
+
+export function resolveSlackDraftPreviewThreadTs(params: {
+  replyToMode: "off" | "first" | "all";
+  plannedThreadTs?: string;
+  usedReplyThreadTs?: string;
+}): string | undefined {
+  return resolveSlackDeliveryThreadTs({
+    plannedThreadTs: params.plannedThreadTs,
+    usedReplyThreadTs: params.usedReplyThreadTs,
+    allowUsedReplyThreadTs: params.replyToMode === "all",
+  });
+}
+
 function shouldUseStreaming(params: {
   streamingEnabled: boolean;
   threadTs: string | undefined;
@@ -400,10 +423,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     // Record the thread ts only after confirmed delivery success.
     if (effectiveReplyThreadTs) {
       usedReplyThreadTs ??= effectiveReplyThreadTs;
-      if (options?.trackBlockReplyThreadTs) {
-        usedBlockReplyThreadTs ??= effectiveReplyThreadTs;
-      }
     }
+    usedBlockReplyThreadTs = resolveTrackedSlackBlockReplyThreadTs({
+      deliveredThreadTs: effectiveReplyThreadTs,
+      usedBlockReplyThreadTs,
+      trackBlockReplyThreadTs: options?.trackBlockReplyThreadTs,
+    });
     replyPlan.markSent();
   };
 
@@ -557,10 +582,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         accountId: account.accountId,
         maxChars: Math.min(ctx.textLimit, SLACK_TEXT_LIMIT),
         resolveThreadTs: () => {
-          const ts = resolveSlackDeliveryThreadTs({
+          const ts = resolveSlackDraftPreviewThreadTs({
+            replyToMode: prepared.replyToMode,
             plannedThreadTs: replyPlan.nextThreadTs(),
             usedReplyThreadTs: usedBlockReplyThreadTs,
-            allowUsedReplyThreadTs: true,
           });
           if (ts) {
             usedReplyThreadTs ??= ts;

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -126,8 +126,13 @@ export function resolveSlackDeliveryThreadTs(params: {
   forcedThreadTs?: string;
   plannedThreadTs?: string;
   usedReplyThreadTs?: string;
+  allowUsedReplyThreadTs?: boolean;
 }): string | undefined {
-  return params.forcedThreadTs ?? params.plannedThreadTs ?? params.usedReplyThreadTs;
+  return (
+    params.forcedThreadTs ??
+    params.plannedThreadTs ??
+    (params.allowUsedReplyThreadTs ? params.usedReplyThreadTs : undefined)
+  );
 }
 
 function shouldUseStreaming(params: {
@@ -358,11 +363,19 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let usedReplyThreadTs: string | undefined;
   let observedReplyDelivery = false;
 
-  const deliverNormally = async (payload: ReplyPayload, forcedThreadTs?: string): Promise<void> => {
+  const deliverNormally = async (
+    payload: ReplyPayload,
+    options?: {
+      forcedThreadTs?: string;
+      allowUsedReplyThreadTs?: boolean;
+    },
+  ): Promise<void> => {
+    const plannedThreadTs = options?.forcedThreadTs ? undefined : replyPlan.nextThreadTs();
     const replyThreadTs = resolveSlackDeliveryThreadTs({
-      forcedThreadTs,
-      plannedThreadTs: replyPlan.nextThreadTs(),
+      forcedThreadTs: options?.forcedThreadTs,
+      plannedThreadTs,
       usedReplyThreadTs,
+      allowUsedReplyThreadTs: options?.allowUsedReplyThreadTs,
     });
     await deliverReplies({
       replies: [payload],
@@ -383,10 +396,17 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     replyPlan.markSent();
   };
 
-  const deliverWithStreaming = async (payload: ReplyPayload): Promise<void> => {
+  const deliverWithStreaming = async (
+    payload: ReplyPayload,
+    kind: "tool" | "block" | "final",
+  ): Promise<void> => {
     const reply = resolveSendableOutboundReplyParts(payload);
+    const allowUsedReplyThreadTs = kind === "block";
     if (streamFailed || reply.hasMedia || readSlackReplyBlocks(payload)?.length || !reply.hasText) {
-      await deliverNormally(payload, streamSession?.threadTs);
+      await deliverNormally(payload, {
+        forcedThreadTs: streamSession?.threadTs,
+        allowUsedReplyThreadTs,
+      });
       return;
     }
 
@@ -401,7 +421,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             "slack-stream: no reply thread target for stream start, falling back to normal delivery",
           );
           streamFailed = true;
-          await deliverNormally(payload);
+          await deliverNormally(payload, { allowUsedReplyThreadTs });
           return;
         }
 
@@ -428,16 +448,19 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         danger(`slack-stream: streaming API call failed: ${String(err)}, falling back`),
       );
       streamFailed = true;
-      await deliverNormally(payload, streamSession?.threadTs ?? plannedThreadTs);
+      await deliverNormally(payload, {
+        forcedThreadTs: streamSession?.threadTs ?? plannedThreadTs,
+        allowUsedReplyThreadTs,
+      });
     }
   };
 
   const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
     ...replyPipeline,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
-    deliver: async (payload) => {
+    deliver: async (payload, info) => {
       if (useStreaming) {
-        await deliverWithStreaming(payload);
+        await deliverWithStreaming(payload, info.kind);
         return;
       }
 
@@ -497,7 +520,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         hasStreamedMessage = false;
       }
 
-      await deliverNormally(payload);
+      await deliverNormally(payload, {
+        allowUsedReplyThreadTs: info.kind === "block",
+      });
     },
     onError: (err, info) => {
       runtime.error?.(danger(`slack ${info.kind} reply failed: ${String(err)}`));
@@ -515,6 +540,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           const ts = resolveSlackDeliveryThreadTs({
             plannedThreadTs: replyPlan.nextThreadTs(),
             usedReplyThreadTs,
+            allowUsedReplyThreadTs: true,
           });
           if (ts) {
             usedReplyThreadTs ??= ts;

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -122,6 +122,14 @@ export function resolveSlackStreamingThreadHint(params: {
   });
 }
 
+export function resolveSlackDeliveryThreadTs(params: {
+  forcedThreadTs?: string;
+  plannedThreadTs?: string;
+  usedReplyThreadTs?: string;
+}): string | undefined {
+  return params.forcedThreadTs ?? params.plannedThreadTs ?? params.usedReplyThreadTs;
+}
+
 function shouldUseStreaming(params: {
   streamingEnabled: boolean;
   threadTs: string | undefined;
@@ -351,7 +359,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let observedReplyDelivery = false;
 
   const deliverNormally = async (payload: ReplyPayload, forcedThreadTs?: string): Promise<void> => {
-    const replyThreadTs = forcedThreadTs ?? replyPlan.nextThreadTs();
+    const replyThreadTs = resolveSlackDeliveryThreadTs({
+      forcedThreadTs,
+      plannedThreadTs: replyPlan.nextThreadTs(),
+      usedReplyThreadTs,
+    });
     await deliverReplies({
       replies: [payload],
       target: prepared.replyTarget,
@@ -500,7 +512,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         accountId: account.accountId,
         maxChars: Math.min(ctx.textLimit, SLACK_TEXT_LIMIT),
         resolveThreadTs: () => {
-          const ts = replyPlan.nextThreadTs();
+          const ts = resolveSlackDeliveryThreadTs({
+            plannedThreadTs: replyPlan.nextThreadTs(),
+            usedReplyThreadTs,
+          });
           if (ts) {
             usedReplyThreadTs ??= ts;
           }

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -6,7 +6,7 @@ vi.mock("../send.js", () => ({
 }));
 
 let deliverReplies: typeof import("./replies.js").deliverReplies;
-import { deliverSlackSlashReplies } from "./replies.js";
+import { deliverSlackSlashReplies, resolveDeliveredSlackReplyThreadTs } from "./replies.js";
 
 function baseParams(overrides?: Record<string, unknown>) {
   return {
@@ -119,5 +119,27 @@ describe("deliverSlackSlashReplies chunking", () => {
       text,
       response_type: "ephemeral",
     });
+  });
+});
+
+describe("resolveDeliveredSlackReplyThreadTs", () => {
+  it("prefers explicit reply targets when reply threading is enabled", () => {
+    expect(
+      resolveDeliveredSlackReplyThreadTs({
+        replyToMode: "first",
+        payloadReplyToId: "reply-tag.1",
+        replyThreadTs: "planned.1",
+      }),
+    ).toBe("reply-tag.1");
+  });
+
+  it("ignores explicit reply targets when reply threading is off", () => {
+    expect(
+      resolveDeliveredSlackReplyThreadTs({
+        replyToMode: "off",
+        payloadReplyToId: "reply-tag.1",
+        replyThreadTs: "planned.1",
+      }),
+    ).toBe("planned.1");
   });
 });

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -38,10 +38,11 @@ export async function deliverReplies(params: {
   identity?: SlackSendIdentity;
 }) {
   for (const payload of params.replies) {
-    // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
-    // must not force threading.
-    const inlineReplyToId = params.replyToMode === "off" ? undefined : payload.replyToId;
-    const threadTs = inlineReplyToId ?? params.replyThreadTs;
+    const threadTs = resolveDeliveredSlackReplyThreadTs({
+      replyToMode: params.replyToMode,
+      payloadReplyToId: payload.replyToId,
+      replyThreadTs: params.replyThreadTs,
+    });
     const reply = resolveSendableOutboundReplyParts(payload);
     const slackBlocks = readSlackReplyBlocks(payload);
     if (!reply.hasContent && !slackBlocks?.length) {
@@ -101,6 +102,17 @@ export async function deliverReplies(params: {
       params.runtime.log?.(`delivered reply to ${params.target}`);
     }
   }
+}
+
+export function resolveDeliveredSlackReplyThreadTs(params: {
+  replyToMode: "off" | "first" | "all";
+  payloadReplyToId?: string;
+  replyThreadTs?: string;
+}): string | undefined {
+  // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
+  // must not force threading.
+  const inlineReplyToId = params.replyToMode === "off" ? undefined : params.payloadReplyToId;
+  return inlineReplyToId ?? params.replyThreadTs;
 }
 
 export type SlackRespondFn = (payload: {


### PR DESCRIPTION
Rebased and manually ported from #49715 onto current main.

**Problem:** With Slack `blockStreaming: true` and `replyToModeByChatType.channel: "first"`, the first block replies in-thread but later blocks can fall back to the main channel.

**Fix (4 commits):**
1. `resolveSlackDeliveryThreadTs`: reuse established thread when first-mode planning is exhausted
2. Preserve first-mode follow-up routing with `deliverNormally` options
3. Scope thread reuse to block deliveries only (via `usedBlockReplyThreadTs`)
4. `resolveTrackedSlackBlockReplyThreadTs`: refresh cached block thread on explicit reply targets; `resolveSlackDraftPreviewThreadTs`: keep draft previews off-thread in `replyToMode=first`

Tests added for all new helpers.

Original author: @xiwuqi
Closes #49341