### PR TITLE
Control UI: clear queued connect timeout on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/SQLite transient handling: keep unhandled `SQLITE_CANTOPEN`, `SQLITE_BUSY`, `SQLITE_LOCKED`, and `SQLITE_IOERR` failures non-fatal in the global rejection handler so macOS LaunchAgent restarts do not enter a crash-throttle loop. (#57018)
 - Control UI/gateway: reconnect the browser client when gateway event sequence gaps are detected, so stale non-chat state recovers automatically instead of only telling the user to refresh. (#23912) thanks @Olshansk.
 - ClawDock/docs: move the helper scripts to `scripts/clawdock`, publish ClawDock as a first-class docs page on the docs site, and document reinstalling local helper copies from the new raw GitHub path. (#23912) thanks @Olshansk.
+- Control UI/gateway: clear queued browser connect timeouts on client stop so aborted or replaced gateway clients do not send delayed connect requests after shutdown. (#57338) thanks @gumadeiras.
 
 ## 2026.3.24
 

--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -92,6 +92,16 @@ type ConnectFrame = {
   };
 };
 
+function stubWindowGlobals(storage?: ReturnType<typeof createStorageMock>) {
+  vi.stubGlobal("window", {
+    location: { href: "http://127.0.0.1:18789/" },
+    localStorage: storage,
+    setTimeout: (handler: (...args: unknown[]) => void, timeout?: number, ...args: unknown[]) =>
+      globalThis.setTimeout(() => handler(...args), timeout),
+    clearTimeout: (timeoutId: number | undefined) => globalThis.clearTimeout(timeoutId),
+  });
+}
+
 function getLatestWebSocket(): MockWebSocket {
   const ws = wsInstances.at(-1);
   if (!ws) {
@@ -182,15 +192,7 @@ describe("GatewayBrowserClient", () => {
     });
 
     vi.stubGlobal("localStorage", storage);
-    const windowLike = Object.assign(globalThis, {
-      location: { href: "http://127.0.0.1:18789/" },
-      localStorage: storage,
-    });
-    vi.stubGlobal("window", windowLike);
-    Object.defineProperty(window, "localStorage", {
-      configurable: true,
-      value: storage,
-    });
+    stubWindowGlobals(storage);
     localStorage.clear();
     vi.stubGlobal("WebSocket", MockWebSocket);
 
@@ -433,6 +435,14 @@ describe("GatewayBrowserClient", () => {
 });
 
 describe("shouldRetryWithDeviceToken", () => {
+  beforeEach(() => {
+    stubWindowGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("allows a bounded retry for trusted loopback endpoints", () => {
     expect(
       shouldRetryWithDeviceToken({

--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -182,6 +182,11 @@ describe("GatewayBrowserClient", () => {
     });
 
     vi.stubGlobal("localStorage", storage);
+    const windowLike = Object.assign(globalThis, {
+      location: { href: "http://127.0.0.1:18789/" },
+      localStorage: storage,
+    });
+    vi.stubGlobal("window", windowLike);
     Object.defineProperty(window, "localStorage", {
       configurable: true,
       value: storage,
@@ -374,6 +379,26 @@ describe("GatewayBrowserClient", () => {
     expect(wsInstances).toHaveLength(2);
 
     client.stop();
+    vi.useRealTimers();
+  });
+
+  it("cancels a queued connect send when stopped before the timeout fires", async () => {
+    vi.useFakeTimers();
+
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+
+    client.start();
+    const ws = getLatestWebSocket();
+    ws.emitOpen();
+
+    client.stop();
+    await vi.advanceTimersByTimeAsync(750);
+
+    expect(ws.sent).toHaveLength(0);
+
     vi.useRealTimers();
   });
 

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -294,6 +294,10 @@ export class GatewayBrowserClient {
 
   stop() {
     this.closed = true;
+    if (this.connectTimer !== null) {
+      window.clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
     this.ws?.close();
     this.ws = null;
     this.pendingConnectError = undefined;


### PR DESCRIPTION
## Summary
- clear the browser client's queued `connect` timeout when the client is stopped
- add focused regression coverage for the delayed-connect cancellation path
- add a changelog entry for the Control UI gateway cleanup fix

## Validation
- `pnpm --dir ui exec vitest run --config vitest.node.config.ts src/ui/gateway.node.test.ts -t "cancels a queued connect send when stopped before the timeout fires"`

## Notes
- This is intentionally split out from PR #23912 so the ClawDock/docs work stays isolated.
- Running the full `src/ui/gateway.node.test.ts` file on current `main` still hits one pre-existing failure in the `shouldRetryWithDeviceToken` loopback test, unrelated to this change.
