### PR TITLE
fix(exec): harden async approval followup delivery in webchat-only sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/native commands: prefix native command menu callback payloads and preserve `CommandSource: "native"` when Telegram replays them through callback queries, so `/fast` and other native command menus keep working even when text-command routing is disabled. Thanks @vincentkoc.
 - Docs/anchors: fix broken English docs links and make Mint anchor audits run against the English-source docs tree. (#57039) thanks @velvet-shark.
 - Cron/announce: preserve all deliverable text payloads for announce mode instead of collapsing to the last chunk, so multi-line cron reports deliver in full to Telegram forum topics.
+- Harden async approval followup delivery in webchat-only sessions (#57359) Thanks @joshavant.
 
 ## 2026.3.28
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -195,6 +195,12 @@ The Gateway treats these as **claims** and enforces server-side allowlists.
 - Operator clients resolve by calling `exec.approval.resolve` (requires `operator.approvals` scope).
 - For `host=node`, `exec.approval.request` must include `systemRunPlan` (canonical `argv`/`cwd`/`rawCommand`/session metadata). Requests missing `systemRunPlan` are rejected.
 
+## Agent delivery fallback
+
+- `agent` requests can include `deliver=true` to request outbound delivery.
+- `bestEffortDeliver=false` keeps strict behavior: unresolved or internal-only delivery targets return `INVALID_REQUEST`.
+- `bestEffortDeliver=true` allows fallback to session-only execution when no external deliverable route can be resolved (for example internal/webchat sessions or ambiguous multi-channel configs).
+
 ## Versioning
 
 - `PROTOCOL_VERSION` lives in `src/gateway/protocol/schema.ts`.

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -315,6 +315,15 @@ When approvals are required, the exec tool returns immediately with an approval 
 correlate later system events (`Exec finished` / `Exec denied`). If no decision arrives before the
 timeout, the request is treated as an approval timeout and surfaced as a denial reason.
 
+### Followup delivery behavior
+
+After an approved async exec finishes, OpenClaw sends a followup `agent` turn to the same session.
+
+- If a valid external delivery target exists (deliverable channel plus target `to`), followup delivery uses that channel.
+- In webchat-only or internal-session flows with no external target, followup delivery stays session-only (`deliver: false`).
+- If a caller explicitly requests strict external delivery with no resolvable external channel, the request fails with `INVALID_REQUEST`.
+- If `bestEffortDeliver` is enabled and no external channel can be resolved, delivery is downgraded to session-only instead of failing.
+
 The confirmation dialog includes:
 
 - command + args

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -44,8 +44,8 @@ describe("sendExecApprovalFollowup", () => {
     const payload = vi.mocked(callGatewayTool).mock.calls[0]?.[2] as Record<string, unknown>;
     expect(payload.deliver).toBe(false);
     expect(payload).not.toHaveProperty("bestEffortDeliver");
-    expect(payload.channel).toBeUndefined();
-    expect(payload.to).toBeUndefined();
+    expect(payload.channel).toBe("webchat");
+    expect(payload.to).toBe("chat:123");
   });
 
   it("enables delivery for valid external turn source targets", async () => {

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -1,14 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("./tools/gateway.js", () => ({
-  callGatewayTool: vi.fn(),
-}));
-
-import { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
-import { callGatewayTool } from "./tools/gateway.js";
+let sendExecApprovalFollowup: typeof import("./bash-tools.exec-approval-followup.js").sendExecApprovalFollowup;
+let callGatewayTool: typeof import("./tools/gateway.js").callGatewayTool;
 
 describe("sendExecApprovalFollowup", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.doMock("./tools/gateway.js", () => ({
+      callGatewayTool: vi.fn(),
+    }));
+    ({ sendExecApprovalFollowup } = await import("./bash-tools.exec-approval-followup.js"));
+    ({ callGatewayTool } = await import("./tools/gateway.js"));
     vi.mocked(callGatewayTool).mockReset();
     vi.mocked(callGatewayTool).mockResolvedValue({});
   });

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./tools/gateway.js", () => ({
+  callGatewayTool: vi.fn(),
+}));
+
+import { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
+import { callGatewayTool } from "./tools/gateway.js";
+
+describe("sendExecApprovalFollowup", () => {
+  beforeEach(() => {
+    vi.mocked(callGatewayTool).mockReset();
+    vi.mocked(callGatewayTool).mockResolvedValue({});
+  });
+
+  it("keeps followup session-only when no external delivery target exists", async () => {
+    const ok = await sendExecApprovalFollowup({
+      approvalId: "approval-1",
+      sessionKey: "agent:main:main",
+      resultText: "Exec finished (gateway id=approval-1, code 0)",
+    });
+
+    expect(ok).toBe(true);
+    expect(callGatewayTool).toHaveBeenCalledTimes(1);
+    const payload = vi.mocked(callGatewayTool).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(payload.deliver).toBe(false);
+    expect(payload).not.toHaveProperty("bestEffortDeliver");
+    expect(payload.channel).toBeUndefined();
+    expect(payload.to).toBeUndefined();
+  });
+
+  it("keeps followup session-only when turn source is internal webchat", async () => {
+    const ok = await sendExecApprovalFollowup({
+      approvalId: "approval-2",
+      sessionKey: "agent:main:main",
+      turnSourceChannel: "webchat",
+      turnSourceTo: "chat:123",
+      resultText: "Exec finished (gateway id=approval-2, code 0)",
+    });
+
+    expect(ok).toBe(true);
+    const payload = vi.mocked(callGatewayTool).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(payload.deliver).toBe(false);
+    expect(payload).not.toHaveProperty("bestEffortDeliver");
+    expect(payload.channel).toBeUndefined();
+    expect(payload.to).toBeUndefined();
+  });
+
+  it("enables delivery for valid external turn source targets", async () => {
+    const ok = await sendExecApprovalFollowup({
+      approvalId: "approval-3",
+      sessionKey: "agent:main:main",
+      turnSourceChannel: " discord ",
+      turnSourceTo: "channel:123",
+      turnSourceAccountId: "default",
+      resultText: "Exec finished (gateway id=approval-3, code 0)",
+    });
+
+    expect(ok).toBe(true);
+    const payload = vi.mocked(callGatewayTool).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(payload.deliver).toBe(true);
+    expect(payload.bestEffortDeliver).toBe(true);
+    expect(payload.channel).toBe("discord");
+    expect(payload.to).toBe("channel:123");
+    expect(payload.accountId).toBe("default");
+  });
+});

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -1,4 +1,5 @@
 import { resolveExternalBestEffortDeliveryTarget } from "../infra/outbound/best-effort-delivery.js";
+import { isGatewayMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 type ExecApprovalFollowupParams = {
@@ -60,6 +61,11 @@ export async function sendExecApprovalFollowup(
     accountId: params.turnSourceAccountId,
     threadId: params.turnSourceThreadId,
   });
+  const normalizedTurnSourceChannel = normalizeMessageChannel(params.turnSourceChannel);
+  const sessionOnlyOriginChannel =
+    normalizedTurnSourceChannel && isGatewayMessageChannel(normalizedTurnSourceChannel)
+      ? normalizedTurnSourceChannel
+      : undefined;
 
   await callGatewayTool(
     "agent",
@@ -69,10 +75,22 @@ export async function sendExecApprovalFollowup(
       message: buildExecApprovalFollowupPrompt(resultText),
       deliver: deliveryTarget.deliver,
       ...(deliveryTarget.deliver ? { bestEffortDeliver: true as const } : {}),
-      channel: deliveryTarget.channel,
-      to: deliveryTarget.to,
-      accountId: deliveryTarget.accountId,
-      threadId: deliveryTarget.threadId,
+      channel: deliveryTarget.deliver ? deliveryTarget.channel : sessionOnlyOriginChannel,
+      to: deliveryTarget.deliver
+        ? deliveryTarget.to
+        : sessionOnlyOriginChannel
+          ? params.turnSourceTo
+          : undefined,
+      accountId: deliveryTarget.deliver
+        ? deliveryTarget.accountId
+        : sessionOnlyOriginChannel
+          ? params.turnSourceAccountId
+          : undefined,
+      threadId: deliveryTarget.deliver
+        ? deliveryTarget.threadId
+        : sessionOnlyOriginChannel
+          ? params.turnSourceThreadId
+          : undefined,
       idempotencyKey: `exec-approval-followup:${params.approvalId}`,
     },
     { expectFinal: true },

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -1,4 +1,4 @@
-import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
+import { resolveExternalBestEffortDeliveryTarget } from "../infra/outbound/best-effort-delivery.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 type ExecApprovalFollowupParams = {
@@ -54,17 +54,12 @@ export async function sendExecApprovalFollowup(
     return false;
   }
 
-  const normalizedChannel = normalizeMessageChannel(params.turnSourceChannel);
-  const channel =
-    normalizedChannel && isDeliverableMessageChannel(normalizedChannel)
-      ? normalizedChannel
-      : undefined;
-  const to = params.turnSourceTo?.trim();
-  const hasDeliveryTarget = Boolean(channel && to);
-  const threadId =
-    params.turnSourceThreadId != null && params.turnSourceThreadId !== ""
-      ? String(params.turnSourceThreadId)
-      : undefined;
+  const deliveryTarget = resolveExternalBestEffortDeliveryTarget({
+    channel: params.turnSourceChannel,
+    to: params.turnSourceTo,
+    accountId: params.turnSourceAccountId,
+    threadId: params.turnSourceThreadId,
+  });
 
   await callGatewayTool(
     "agent",
@@ -72,12 +67,12 @@ export async function sendExecApprovalFollowup(
     {
       sessionKey,
       message: buildExecApprovalFollowupPrompt(resultText),
-      deliver: hasDeliveryTarget,
-      ...(hasDeliveryTarget ? { bestEffortDeliver: true as const } : {}),
-      channel: hasDeliveryTarget ? channel : undefined,
-      to: hasDeliveryTarget ? to : undefined,
-      accountId: hasDeliveryTarget ? params.turnSourceAccountId?.trim() || undefined : undefined,
-      threadId: hasDeliveryTarget ? threadId : undefined,
+      deliver: deliveryTarget.deliver,
+      ...(deliveryTarget.deliver ? { bestEffortDeliver: true as const } : {}),
+      channel: deliveryTarget.channel,
+      to: deliveryTarget.to,
+      accountId: deliveryTarget.accountId,
+      threadId: deliveryTarget.threadId,
       idempotencyKey: `exec-approval-followup:${params.approvalId}`,
     },
     { expectFinal: true },

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -1,3 +1,4 @@
+import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import { callGatewayTool } from "./tools/gateway.js";
 
 type ExecApprovalFollowupParams = {
@@ -53,8 +54,13 @@ export async function sendExecApprovalFollowup(
     return false;
   }
 
-  const channel = params.turnSourceChannel?.trim();
+  const normalizedChannel = normalizeMessageChannel(params.turnSourceChannel);
+  const channel =
+    normalizedChannel && isDeliverableMessageChannel(normalizedChannel)
+      ? normalizedChannel
+      : undefined;
   const to = params.turnSourceTo?.trim();
+  const hasDeliveryTarget = Boolean(channel && to);
   const threadId =
     params.turnSourceThreadId != null && params.turnSourceThreadId !== ""
       ? String(params.turnSourceThreadId)
@@ -66,12 +72,12 @@ export async function sendExecApprovalFollowup(
     {
       sessionKey,
       message: buildExecApprovalFollowupPrompt(resultText),
-      deliver: true,
-      bestEffortDeliver: true,
-      channel: channel && to ? channel : undefined,
-      to: channel && to ? to : undefined,
-      accountId: channel && to ? params.turnSourceAccountId?.trim() || undefined : undefined,
-      threadId: channel && to ? threadId : undefined,
+      deliver: hasDeliveryTarget,
+      ...(hasDeliveryTarget ? { bestEffortDeliver: true as const } : {}),
+      channel: hasDeliveryTarget ? channel : undefined,
+      to: hasDeliveryTarget ? to : undefined,
+      accountId: hasDeliveryTarget ? params.turnSourceAccountId?.trim() || undefined : undefined,
+      threadId: hasDeliveryTarget ? threadId : undefined,
       idempotencyKey: `exec-approval-followup:${params.approvalId}`,
     },
     { expectFinal: true },

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./bash-tools.exec-approval-followup.js", () => ({
+  sendExecApprovalFollowup: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  logWarn: vi.fn(),
+}));
+
+import { logWarn } from "../logger.js";
+import { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
+import { sendExecApprovalFollowupResult } from "./bash-tools.exec-host-shared.js";
+
+describe("sendExecApprovalFollowupResult", () => {
+  beforeEach(() => {
+    vi.mocked(sendExecApprovalFollowup).mockReset();
+    vi.mocked(logWarn).mockReset();
+  });
+
+  it("logs repeated followup dispatch failures once per approval id and error message", async () => {
+    vi.mocked(sendExecApprovalFollowup).mockRejectedValue(new Error("Channel is required"));
+
+    const target = {
+      approvalId: "approval-log-once",
+      sessionKey: "agent:main:main",
+    };
+    await sendExecApprovalFollowupResult(target, "Exec finished");
+    await sendExecApprovalFollowupResult(target, "Exec finished");
+
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    expect(logWarn).toHaveBeenCalledWith(
+      "exec approval followup dispatch failed (id=approval-log-once): Channel is required",
+    );
+  });
+});

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -1,19 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("./bash-tools.exec-approval-followup.js", () => ({
-  sendExecApprovalFollowup: vi.fn(),
-}));
-
-vi.mock("../logger.js", () => ({
-  logWarn: vi.fn(),
-}));
-
-import { logWarn } from "../logger.js";
-import { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
-import { sendExecApprovalFollowupResult } from "./bash-tools.exec-host-shared.js";
+let sendExecApprovalFollowupResult: typeof import("./bash-tools.exec-host-shared.js").sendExecApprovalFollowupResult;
+let sendExecApprovalFollowup: typeof import("./bash-tools.exec-approval-followup.js").sendExecApprovalFollowup;
+let logWarn: typeof import("../logger.js").logWarn;
 
 describe("sendExecApprovalFollowupResult", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.doMock("./bash-tools.exec-approval-followup.js", () => ({
+      sendExecApprovalFollowup: vi.fn(),
+    }));
+    vi.doMock("../logger.js", () => ({
+      logWarn: vi.fn(),
+    }));
+    ({ sendExecApprovalFollowupResult } = await import("./bash-tools.exec-host-shared.js"));
+    ({ sendExecApprovalFollowup } = await import("./bash-tools.exec-approval-followup.js"));
+    ({ logWarn } = await import("../logger.js"));
     vi.mocked(sendExecApprovalFollowup).mockReset();
     vi.mocked(logWarn).mockReset();
   });

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let sendExecApprovalFollowupResult: typeof import("./bash-tools.exec-host-shared.js").sendExecApprovalFollowupResult;
+let maxExecApprovalFollowupFailureLogKeys: typeof import("./bash-tools.exec-host-shared.js").MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS;
 let sendExecApprovalFollowup: typeof import("./bash-tools.exec-approval-followup.js").sendExecApprovalFollowup;
 let logWarn: typeof import("../logger.js").logWarn;
 
@@ -13,7 +14,10 @@ describe("sendExecApprovalFollowupResult", () => {
     vi.doMock("../logger.js", () => ({
       logWarn: vi.fn(),
     }));
-    ({ sendExecApprovalFollowupResult } = await import("./bash-tools.exec-host-shared.js"));
+    ({
+      sendExecApprovalFollowupResult,
+      MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS: maxExecApprovalFollowupFailureLogKeys,
+    } = await import("./bash-tools.exec-host-shared.js"));
     ({ sendExecApprovalFollowup } = await import("./bash-tools.exec-approval-followup.js"));
     ({ logWarn } = await import("../logger.js"));
     vi.mocked(sendExecApprovalFollowup).mockReset();
@@ -33,6 +37,32 @@ describe("sendExecApprovalFollowupResult", () => {
     expect(logWarn).toHaveBeenCalledTimes(1);
     expect(logWarn).toHaveBeenCalledWith(
       "exec approval followup dispatch failed (id=approval-log-once): Channel is required",
+    );
+  });
+
+  it("evicts oldest followup failure dedupe keys after reaching the cap", async () => {
+    vi.mocked(sendExecApprovalFollowup).mockRejectedValue(new Error("Channel is required"));
+
+    for (let i = 0; i <= maxExecApprovalFollowupFailureLogKeys; i += 1) {
+      await sendExecApprovalFollowupResult(
+        {
+          approvalId: `approval-${i}`,
+          sessionKey: "agent:main:main",
+        },
+        "Exec finished",
+      );
+    }
+    await sendExecApprovalFollowupResult(
+      {
+        approvalId: "approval-0",
+        sessionKey: "agent:main:main",
+      },
+      "Exec finished",
+    );
+
+    expect(logWarn).toHaveBeenCalledTimes(maxExecApprovalFollowupFailureLogKeys + 2);
+    expect(logWarn).toHaveBeenLastCalledWith(
+      "exec approval followup dispatch failed (id=approval-0): Channel is required",
     );
   });
 });

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -25,7 +25,23 @@ import { DEFAULT_APPROVAL_TIMEOUT_MS } from "./bash-tools.exec-runtime.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 
 type ResolvedExecApprovals = ReturnType<typeof resolveExecApprovals>;
+export const MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS = 256;
 const loggedExecApprovalFollowupFailures = new Set<string>();
+
+function rememberExecApprovalFollowupFailureKey(key: string): boolean {
+  if (loggedExecApprovalFollowupFailures.has(key)) {
+    return false;
+  }
+  loggedExecApprovalFollowupFailures.add(key);
+  // Bound memory growth for long-lived processes that see many unique approval failures.
+  if (loggedExecApprovalFollowupFailures.size > MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS) {
+    const oldestKey = loggedExecApprovalFollowupFailures.values().next().value;
+    if (typeof oldestKey === "string") {
+      loggedExecApprovalFollowupFailures.delete(oldestKey);
+    }
+  }
+  return true;
+}
 
 export type ExecHostApprovalContext = {
   approvals: ResolvedExecApprovals;
@@ -339,10 +355,9 @@ export async function sendExecApprovalFollowupResult(
   }).catch((error) => {
     const message = error instanceof Error ? error.message : String(error);
     const key = `${target.approvalId}:${message}`;
-    if (loggedExecApprovalFollowupFailures.has(key)) {
+    if (!rememberExecApprovalFollowupFailureKey(key)) {
       return;
     }
-    loggedExecApprovalFollowupFailures.add(key);
     logWarn(`exec approval followup dispatch failed (id=${target.approvalId}): ${message}`);
   });
 }

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -14,6 +14,7 @@ import {
   type ExecAsk,
   type ExecSecurity,
 } from "../infra/exec-approvals.js";
+import { logWarn } from "../logger.js";
 import { sendExecApprovalFollowup } from "./bash-tools.exec-approval-followup.js";
 import {
   type ExecApprovalRegistration,
@@ -24,6 +25,7 @@ import { DEFAULT_APPROVAL_TIMEOUT_MS } from "./bash-tools.exec-runtime.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 
 type ResolvedExecApprovals = ReturnType<typeof resolveExecApprovals>;
+const loggedExecApprovalFollowupFailures = new Set<string>();
 
 export type ExecHostApprovalContext = {
   approvals: ResolvedExecApprovals;
@@ -334,7 +336,15 @@ export async function sendExecApprovalFollowupResult(
     turnSourceAccountId: target.turnSourceAccountId,
     turnSourceThreadId: target.turnSourceThreadId,
     resultText,
-  }).catch(() => {});
+  }).catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    const key = `${target.approvalId}:${message}`;
+    if (loggedExecApprovalFollowupFailures.has(key)) {
+      return;
+    }
+    loggedExecApprovalFollowupFailures.add(key);
+    logWarn(`exec approval followup dispatch failed (id=${target.approvalId}): ${message}`);
+  });
 }
 
 export function buildExecApprovalPendingToolResult(params: {

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -472,6 +472,56 @@ describe("exec approvals", () => {
     );
   });
 
+  it("executes approved commands and emits a session-only followup in webchat-only mode", async () => {
+    const agentCalls: Array<Record<string, unknown>> = [];
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-exec-followup-sidefx-"));
+    const markerPath = path.join(tempDir, "marker.txt");
+
+    mockAcceptedApprovalFlow({
+      onAgent: (params) => {
+        agentCalls.push(params);
+      },
+    });
+
+    const tool = createExecTool({
+      host: "gateway",
+      ask: "always",
+      approvalRunningNoticeMs: 0,
+      sessionKey: "agent:main:main",
+      elevated: { enabled: true, allowed: true, defaultLevel: "ask" },
+    });
+
+    const result = await tool.execute("call-gw-followup-webchat", {
+      command: "node -e \"require('node:fs').writeFileSync('marker.txt','ok')\"",
+      workdir: tempDir,
+      gatewayUrl: undefined,
+      gatewayToken: undefined,
+    });
+
+    expect(result.details.status).toBe("approval-pending");
+
+    await expect.poll(() => agentCalls.length, { timeout: 3_000, interval: 20 }).toBe(1);
+    expect(agentCalls[0]).toEqual(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        deliver: false,
+      }),
+    );
+
+    await expect
+      .poll(
+        async () => {
+          try {
+            return await fs.readFile(markerPath, "utf8");
+          } catch {
+            return "";
+          }
+        },
+        { timeout: 5_000, interval: 50 },
+      )
+      .toBe("ok");
+  });
+
   it("uses a deny-specific followup prompt so prior output is not reused", async () => {
     const agentCalls: Array<Record<string, unknown>> = [];
 

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -462,7 +462,7 @@ describe("exec approvals", () => {
     expect(agentCalls[0]).toEqual(
       expect.objectContaining({
         sessionKey: "agent:main:main",
-        deliver: true,
+        deliver: false,
         idempotencyKey: expect.stringContaining("exec-approval-followup:"),
       }),
     );

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -492,7 +492,9 @@ async function sendSubagentAnnounceDirectly(params: {
           threadId: effectiveDirectOrigin?.threadId,
         })
       : { deliver: false };
-    const normalizedSessionOnlyOriginChannel = normalizeMessageChannel(sessionOnlyOrigin?.channel);
+    const normalizedSessionOnlyOriginChannel = !params.requesterIsSubagent
+      ? normalizeMessageChannel(sessionOnlyOrigin?.channel)
+      : undefined;
     const sessionOnlyOriginChannel =
       normalizedSessionOnlyOriginChannel &&
       isGatewayMessageChannel(normalizedSessionOnlyOriginChannel)

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -7,6 +7,7 @@ import {
   resolveStorePath,
 } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
+import { resolveExternalBestEffortDeliveryTarget } from "../infra/outbound/best-effort-delivery.js";
 import { createBoundDeliveryRouter } from "../infra/outbound/bound-delivery-router.js";
 import { resolveConversationIdFromTargets } from "../infra/outbound/conversation-id.js";
 import type { ConversationRef } from "../infra/outbound/session-binding-service.js";
@@ -473,22 +474,14 @@ async function sendSubagentAnnounceDirectly(params: {
       params.expectsCompletionMessage && completionDirectOrigin
         ? completionDirectOrigin
         : directOrigin;
-    const directChannel =
-      typeof effectiveDirectOrigin?.channel === "string"
-        ? effectiveDirectOrigin.channel.trim()
-        : "";
-    const directTo =
-      typeof effectiveDirectOrigin?.to === "string" ? effectiveDirectOrigin.to.trim() : "";
-    const shouldDeliverExternally =
-      !params.requesterIsSubagent &&
-      Boolean(directChannel) &&
-      Boolean(directTo) &&
-      !isInternalMessageChannel(directChannel);
-
-    const threadId =
-      effectiveDirectOrigin?.threadId != null && effectiveDirectOrigin.threadId !== ""
-        ? String(effectiveDirectOrigin.threadId)
-        : undefined;
+    const deliveryTarget = !params.requesterIsSubagent
+      ? resolveExternalBestEffortDeliveryTarget({
+          channel: effectiveDirectOrigin?.channel,
+          to: effectiveDirectOrigin?.to,
+          accountId: effectiveDirectOrigin?.accountId,
+          threadId: effectiveDirectOrigin?.threadId,
+        })
+      : { deliver: false };
     if (params.signal?.aborted) {
       return {
         delivered: false,
@@ -506,13 +499,13 @@ async function sendSubagentAnnounceDirectly(params: {
           params: {
             sessionKey: canonicalRequesterSessionKey,
             message: params.triggerMessage,
-            deliver: shouldDeliverExternally,
+            deliver: deliveryTarget.deliver,
             bestEffortDeliver: params.bestEffortDeliver,
             internalEvents: params.internalEvents,
-            channel: !params.requesterIsSubagent ? directChannel || undefined : undefined,
-            accountId: !params.requesterIsSubagent ? effectiveDirectOrigin?.accountId : undefined,
-            to: !params.requesterIsSubagent ? directTo || undefined : undefined,
-            threadId: !params.requesterIsSubagent ? threadId : undefined,
+            channel: deliveryTarget.channel,
+            accountId: deliveryTarget.accountId,
+            to: deliveryTarget.to,
+            threadId: deliveryTarget.threadId,
             inputProvenance: {
               kind: "inter_session",
               sourceSessionKey: params.sourceSessionKey,

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -22,7 +22,12 @@ import {
   normalizeDeliveryContext,
   resolveConversationDeliveryTarget,
 } from "../utils/delivery-context.js";
-import { INTERNAL_MESSAGE_CHANNEL, isInternalMessageChannel } from "../utils/message-channel.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  isGatewayMessageChannel,
+  isInternalMessageChannel,
+  normalizeMessageChannel,
+} from "../utils/message-channel.js";
 import { buildAnnounceIdempotencyKey, resolveQueueAnnounceId } from "./announce-idempotency.js";
 import type { AgentInternalEvent } from "./internal-events.js";
 import { isEmbeddedPiRunActive, queueEmbeddedPiMessage } from "./pi-embedded.js";
@@ -449,6 +454,7 @@ async function sendSubagentAnnounceDirectly(params: {
   directIdempotencyKey: string;
   completionDirectOrigin?: DeliveryContext;
   directOrigin?: DeliveryContext;
+  requesterSessionOrigin?: DeliveryContext;
   sourceSessionKey?: string;
   sourceChannel?: string;
   sourceTool?: string;
@@ -470,10 +476,14 @@ async function sendSubagentAnnounceDirectly(params: {
   try {
     const completionDirectOrigin = normalizeDeliveryContext(params.completionDirectOrigin);
     const directOrigin = normalizeDeliveryContext(params.directOrigin);
+    const requesterSessionOrigin = normalizeDeliveryContext(params.requesterSessionOrigin);
     const effectiveDirectOrigin =
       params.expectsCompletionMessage && completionDirectOrigin
         ? completionDirectOrigin
         : directOrigin;
+    const sessionOnlyOrigin = effectiveDirectOrigin?.channel
+      ? effectiveDirectOrigin
+      : requesterSessionOrigin;
     const deliveryTarget = !params.requesterIsSubagent
       ? resolveExternalBestEffortDeliveryTarget({
           channel: effectiveDirectOrigin?.channel,
@@ -482,6 +492,12 @@ async function sendSubagentAnnounceDirectly(params: {
           threadId: effectiveDirectOrigin?.threadId,
         })
       : { deliver: false };
+    const normalizedSessionOnlyOriginChannel = normalizeMessageChannel(sessionOnlyOrigin?.channel);
+    const sessionOnlyOriginChannel =
+      normalizedSessionOnlyOriginChannel &&
+      isGatewayMessageChannel(normalizedSessionOnlyOriginChannel)
+        ? normalizedSessionOnlyOriginChannel
+        : undefined;
     if (params.signal?.aborted) {
       return {
         delivered: false,
@@ -502,10 +518,22 @@ async function sendSubagentAnnounceDirectly(params: {
             deliver: deliveryTarget.deliver,
             bestEffortDeliver: params.bestEffortDeliver,
             internalEvents: params.internalEvents,
-            channel: deliveryTarget.channel,
-            accountId: deliveryTarget.accountId,
-            to: deliveryTarget.to,
-            threadId: deliveryTarget.threadId,
+            channel: deliveryTarget.deliver ? deliveryTarget.channel : sessionOnlyOriginChannel,
+            accountId: deliveryTarget.deliver
+              ? deliveryTarget.accountId
+              : sessionOnlyOriginChannel
+                ? sessionOnlyOrigin?.accountId
+                : undefined,
+            to: deliveryTarget.deliver
+              ? deliveryTarget.to
+              : sessionOnlyOriginChannel
+                ? sessionOnlyOrigin?.to
+                : undefined,
+            threadId: deliveryTarget.deliver
+              ? deliveryTarget.threadId
+              : sessionOnlyOriginChannel
+                ? sessionOnlyOrigin?.threadId
+                : undefined,
             inputProvenance: {
               kind: "inter_session",
               sourceSessionKey: params.sourceSessionKey,
@@ -539,6 +567,7 @@ export async function deliverSubagentAnnouncement(params: {
   steerMessage: string;
   internalEvents?: AgentInternalEvent[];
   summaryLine?: string;
+  requesterSessionOrigin?: DeliveryContext;
   requesterOrigin?: DeliveryContext;
   completionDirectOrigin?: DeliveryContext;
   directOrigin?: DeliveryContext;
@@ -577,6 +606,7 @@ export async function deliverSubagentAnnouncement(params: {
         directIdempotencyKey: params.directIdempotencyKey,
         completionDirectOrigin: params.completionDirectOrigin,
         directOrigin: params.directOrigin,
+        requesterSessionOrigin: params.requesterSessionOrigin,
         sourceSessionKey: params.sourceSessionKey,
         sourceChannel: params.sourceChannel,
         sourceTool: params.sourceTool,

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -298,4 +298,40 @@ describe("subagent announce seam flow", () => {
       }),
     );
   });
+
+  it("keeps nested subagent completion announces channel-less in session-only mode", async () => {
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:worker",
+      childRunId: "run-nested-subagent-direct-announce",
+      requesterSessionKey: "agent:main:subagent:orchestrator",
+      requesterDisplayKey: "orchestrator",
+      requesterOrigin: {
+        channel: "telegram",
+        to: "-100123",
+        accountId: "default",
+      },
+      task: "deliver nested completion",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "done",
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const call = agentSpy.mock.calls[0]?.[0];
+    const params = call?.params ?? {};
+    expect(params.sessionKey).toBe("agent:main:subagent:orchestrator");
+    expect(params.deliver).toBe(false);
+    expect(params.bestEffortDeliver).toBe(true);
+    expect(params.channel).toBeUndefined();
+    expect(params.to).toBeUndefined();
+    expect(params.accountId).toBeUndefined();
+    expect(params.threadId).toBeUndefined();
+  });
 });

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -258,4 +258,45 @@ describe("subagent announce seam flow", () => {
     );
     expect(agentSpy).not.toHaveBeenCalled();
   });
+
+  it("keeps completion direct announce session-only when requester origin is webchat", async () => {
+    ({ runSubagentAnnounceFlow } = await import("./subagent-announce.js"));
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:webchat",
+      childRunId: "run-webchat-direct-announce",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: {
+        channel: "webchat",
+        to: "chat:123",
+        accountId: "default",
+      },
+      task: "deliver completion",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "done",
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({
+          sessionKey: "agent:main:main",
+          deliver: false,
+          bestEffortDeliver: true,
+          channel: undefined,
+          to: undefined,
+          accountId: undefined,
+        }),
+      }),
+    );
+  });
 });

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -260,7 +260,6 @@ describe("subagent announce seam flow", () => {
   });
 
   it("keeps completion direct announce session-only when requester origin is webchat", async () => {
-    ({ runSubagentAnnounceFlow } = await import("./subagent-announce.js"));
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:webchat",
       childRunId: "run-webchat-direct-announce",
@@ -292,9 +291,9 @@ describe("subagent announce seam flow", () => {
           sessionKey: "agent:main:main",
           deliver: false,
           bestEffortDeliver: true,
-          channel: undefined,
-          to: undefined,
-          accountId: undefined,
+          channel: "webchat",
+          to: "chat:123",
+          accountId: "default",
         }),
       }),
     );

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -596,6 +596,7 @@ export async function runSubagentAnnounceFlow(params: {
       steerMessage: triggerMessage,
       internalEvents,
       summaryLine: taskLabel,
+      requesterSessionOrigin: targetRequesterOrigin,
       requesterOrigin:
         expectsCompletionMessage && !requesterIsSubagent
           ? completionDirectOrigin

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -726,6 +726,33 @@ describe("gateway agent handler", () => {
     expect(callArgs.bestEffortDeliver).toBe(false);
   });
 
+  it("downgrades to session-only when bestEffortDeliver=true and no external channel is configured", async () => {
+    mocks.agentCommand.mockClear();
+    primeMainAgentRun();
+    const respond = vi.fn();
+
+    await invokeAgent(
+      {
+        message: "best effort delivery fallback",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        bestEffortDeliver: true,
+        idempotencyKey: "test-best-effort-delivery-fallback",
+      },
+      { reqId: "best-effort-delivery-fallback", respond },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const accepted = respond.mock.calls.find(
+      (call: unknown[]) =>
+        call[0] === true && (call[1] as Record<string, unknown>)?.status === "accepted",
+    );
+    expect(accepted).toBeDefined();
+    const rejected = respond.mock.calls.find((call: unknown[]) => call[0] === false);
+    expect(rejected).toBeUndefined();
+  });
+
   it("rejects public spawned-run metadata fields", async () => {
     primeMainAgentRun();
     mocks.agentCommand.mockClear();

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -730,6 +730,7 @@ describe("gateway agent handler", () => {
     mocks.agentCommand.mockClear();
     primeMainAgentRun();
     const respond = vi.fn();
+    const logInfo = vi.fn();
 
     await invokeAgent(
       {
@@ -740,7 +741,17 @@ describe("gateway agent handler", () => {
         bestEffortDeliver: true,
         idempotencyKey: "test-best-effort-delivery-fallback",
       },
-      { reqId: "best-effort-delivery-fallback", respond },
+      {
+        reqId: "best-effort-delivery-fallback",
+        respond,
+        context: {
+          dedupe: new Map(),
+          addChatRun: vi.fn(),
+          logGateway: { info: logInfo, error: vi.fn() },
+          broadcastToConnIds: vi.fn(),
+          getSessionEventSubscriberConnIds: () => new Set(),
+        } as unknown as GatewayRequestContext,
+      },
     );
 
     await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
@@ -751,6 +762,10 @@ describe("gateway agent handler", () => {
     expect(accepted).toBeDefined();
     const rejected = respond.mock.calls.find((call: unknown[]) => call[0] === false);
     expect(rejected).toBeUndefined();
+    expect(logInfo).toHaveBeenCalledTimes(1);
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.stringContaining("agent delivery downgraded to session-only (bestEffortDeliver)"),
+    );
   });
 
   it("rejects public spawned-run metadata fields", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -658,8 +658,13 @@ export const agentHandlers: GatewayRequestHandlers = {
           resolvedAccountId,
         };
       } catch (err) {
-        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
-        return;
+        if (!bestEffortDeliver) {
+          respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
+          return;
+        }
+        context.logGateway.info(
+          `agent delivery downgraded to session-only (bestEffortDeliver): ${String(err)}`,
+        );
       }
     }
 
@@ -677,15 +682,20 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
 
     if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          "delivery channel is required: pass --channel/--reply-channel or use a main session with a previous channel",
-        ),
+      if (!bestEffortDeliver) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "delivery channel is required: pass --channel/--reply-channel or use a main session with a previous channel",
+          ),
+        );
+        return;
+      }
+      context.logGateway.info(
+        "agent delivery downgraded to session-only (bestEffortDeliver): no deliverable channel",
       );
-      return;
     }
 
     const normalizedTurnSource = normalizeMessageChannel(turnSourceChannel);

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -645,6 +645,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     let resolvedAccountId = deliveryPlan.resolvedAccountId;
     let resolvedTo = deliveryPlan.resolvedTo;
     let effectivePlan = deliveryPlan;
+    let deliveryDowngradeReason: string | null = null;
 
     if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
       const cfgResolved = cfgForAgent ?? cfg;
@@ -668,9 +669,7 @@ export const agentHandlers: GatewayRequestHandlers = {
           respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
           return;
         }
-        context.logGateway.info(
-          `agent delivery downgraded to session-only (bestEffortDeliver): ${String(err)}`,
-        );
+        deliveryDowngradeReason = String(err);
       }
     }
 
@@ -705,7 +704,9 @@ export const agentHandlers: GatewayRequestHandlers = {
         return;
       }
       context.logGateway.info(
-        "agent delivery downgraded to session-only (bestEffortDeliver): no deliverable channel",
+        deliveryDowngradeReason
+          ? `agent delivery downgraded to session-only (bestEffortDeliver): ${deliveryDowngradeReason}`
+          : "agent delivery downgraded to session-only (bestEffortDeliver): no deliverable channel",
       );
     }
 

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -21,6 +21,7 @@ import {
   resolveAgentDeliveryPlan,
   resolveAgentOutboundTarget,
 } from "../../infra/outbound/agent-delivery.js";
+import { shouldDowngradeDeliveryToSessionOnly } from "../../infra/outbound/best-effort-delivery.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import { classifySessionKeyShape, normalizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -658,7 +659,12 @@ export const agentHandlers: GatewayRequestHandlers = {
           resolvedAccountId,
         };
       } catch (err) {
-        if (!bestEffortDeliver) {
+        const shouldDowngrade = shouldDowngradeDeliveryToSessionOnly({
+          wantsDelivery,
+          bestEffortDeliver,
+          resolvedChannel,
+        });
+        if (!shouldDowngrade) {
           respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
           return;
         }
@@ -682,7 +688,12 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
 
     if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
-      if (!bestEffortDeliver) {
+      const shouldDowngrade = shouldDowngradeDeliveryToSessionOnly({
+        wantsDelivery,
+        bestEffortDeliver,
+        resolvedChannel,
+      });
+      if (!shouldDowngrade) {
         respond(
           false,
           undefined,

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -444,6 +444,7 @@ describe("gateway server agent", () => {
         message: "hi",
         sessionKey: "main",
         deliver: true,
+        bestEffortDeliver: false,
         idempotencyKey: "idem-agent-missing-provider",
       });
       expect(res.ok).toBe(false);

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -77,6 +77,26 @@ const createStubChannelPlugin = (params: {
   },
 });
 
+const createConfiguredChannelPlugin = (params: {
+  id: ChannelPlugin["id"];
+  label: string;
+}): ChannelPlugin => ({
+  ...createChannelTestPluginBase({
+    id: params.id,
+    label: params.label,
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({}),
+      isConfigured: async () => true,
+    },
+  }),
+  outbound: {
+    deliveryMode: "direct",
+    sendText: async () => ({ channel: params.id, messageId: "msg-test" }),
+    sendMedia: async () => ({ channel: params.id, messageId: "msg-test" }),
+  },
+});
+
 const emptyRegistry = createRegistry([]);
 const defaultRegistry = createRegistry([
   {
@@ -302,6 +322,34 @@ describe("gateway server agent", () => {
       deliver: true,
       bestEffortDeliver: true,
       idempotencyKey: "idem-agent-webchat-best-effort",
+    });
+    expect(res.ok).toBe(true);
+    expectAgentRoutingCall({ channel: "webchat", deliver: false });
+  });
+
+  test("agent downgrades to session-only when multiple channels are configured but no external target resolves", async () => {
+    const registry = createRegistry([
+      {
+        pluginId: "discord",
+        source: "test",
+        plugin: createConfiguredChannelPlugin({ id: "discord", label: "Discord" }),
+      },
+      {
+        pluginId: "telegram",
+        source: "test",
+        plugin: createConfiguredChannelPlugin({ id: "telegram", label: "Telegram" }),
+      },
+    ]);
+    setRegistry(registry);
+    await writeMainSessionEntry({
+      sessionId: "sess-main-multi-configured-best-effort",
+    });
+    const res = await rpcReq(ws, "agent", {
+      message: "hi",
+      sessionKey: "main",
+      deliver: true,
+      bestEffortDeliver: true,
+      idempotencyKey: "idem-agent-multi-configured-best-effort",
     });
     expect(res.ok).toBe(true);
     expectAgentRoutingCall({ channel: "webchat", deliver: false });

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -279,12 +279,32 @@ describe("gateway server agent", () => {
       sessionKey: "main",
       channel: "last",
       deliver: true,
+      bestEffortDeliver: false,
       idempotencyKey: "idem-agent-webchat",
     });
     expect(res.ok).toBe(false);
     expect(res.error?.code).toBe("INVALID_REQUEST");
     expect(res.error?.message).toMatch(/Channel is required|runtime not initialized/);
     expect(vi.mocked(agentCommand)).not.toHaveBeenCalled();
+  });
+
+  test("agent downgrades to session-only delivery when best-effort is enabled and last channel is webchat", async () => {
+    testState.allowFrom = ["+1555"];
+    await writeMainSessionEntry({
+      sessionId: "sess-main-webchat-best-effort",
+      lastChannel: "webchat",
+      lastTo: "+1555",
+    });
+    const res = await rpcReq(ws, "agent", {
+      message: "hi",
+      sessionKey: "main",
+      channel: "last",
+      deliver: true,
+      bestEffortDeliver: true,
+      idempotencyKey: "idem-agent-webchat-best-effort",
+    });
+    expect(res.ok).toBe(true);
+    expectAgentRoutingCall({ channel: "webchat", deliver: false });
   });
 
   test("agent uses webchat for internal runs when last provider is webchat", async () => {

--- a/src/infra/outbound/best-effort-delivery.test.ts
+++ b/src/infra/outbound/best-effort-delivery.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveExternalBestEffortDeliveryTarget,
+  shouldDowngradeDeliveryToSessionOnly,
+} from "./best-effort-delivery.js";
+
+describe("best-effort delivery helpers", () => {
+  it("resolves external delivery targets only for deliverable channels with to", () => {
+    expect(
+      resolveExternalBestEffortDeliveryTarget({
+        channel: "discord",
+        to: "channel:123",
+        accountId: "default",
+        threadId: "thread-1",
+      }),
+    ).toEqual({
+      deliver: true,
+      channel: "discord",
+      to: "channel:123",
+      accountId: "default",
+      threadId: "thread-1",
+    });
+  });
+
+  it("keeps webchat/internal targets session-only", () => {
+    expect(
+      resolveExternalBestEffortDeliveryTarget({
+        channel: "webchat",
+        to: "chat:123",
+      }),
+    ).toEqual({
+      deliver: false,
+      channel: undefined,
+      to: undefined,
+      accountId: undefined,
+      threadId: undefined,
+    });
+  });
+
+  it("returns session-only when to is missing", () => {
+    expect(
+      resolveExternalBestEffortDeliveryTarget({
+        channel: "telegram",
+      }),
+    ).toEqual({
+      deliver: false,
+      channel: undefined,
+      to: undefined,
+      accountId: undefined,
+      threadId: undefined,
+    });
+  });
+
+  it("downgrades to session-only only for best-effort internal delivery requests", () => {
+    expect(
+      shouldDowngradeDeliveryToSessionOnly({
+        wantsDelivery: true,
+        bestEffortDeliver: true,
+        resolvedChannel: "webchat",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldDowngradeDeliveryToSessionOnly({
+        wantsDelivery: true,
+        bestEffortDeliver: false,
+        resolvedChannel: "webchat",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldDowngradeDeliveryToSessionOnly({
+        wantsDelivery: true,
+        bestEffortDeliver: true,
+        resolvedChannel: "discord",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/infra/outbound/best-effort-delivery.ts
+++ b/src/infra/outbound/best-effort-delivery.ts
@@ -1,0 +1,53 @@
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  isDeliverableMessageChannel,
+  normalizeMessageChannel,
+} from "../../utils/message-channel.js";
+
+export type ExternalBestEffortDeliveryTarget = {
+  deliver: boolean;
+  channel?: string;
+  to?: string;
+  accountId?: string;
+  threadId?: string;
+};
+
+export function resolveExternalBestEffortDeliveryTarget(params: {
+  channel?: string | null;
+  to?: string | null;
+  accountId?: string | null;
+  threadId?: string | number | null;
+}): ExternalBestEffortDeliveryTarget {
+  const normalizedChannel = normalizeMessageChannel(params.channel);
+  const channel =
+    normalizedChannel && isDeliverableMessageChannel(normalizedChannel)
+      ? normalizedChannel
+      : undefined;
+  const to = typeof params.to === "string" && params.to.trim() ? params.to.trim() : undefined;
+  const deliver = Boolean(channel && to);
+  return {
+    deliver,
+    channel: deliver ? channel : undefined,
+    to: deliver ? to : undefined,
+    accountId:
+      deliver && typeof params.accountId === "string" && params.accountId.trim()
+        ? params.accountId.trim()
+        : undefined,
+    threadId:
+      deliver && params.threadId != null && params.threadId !== ""
+        ? String(params.threadId)
+        : undefined,
+  };
+}
+
+export function shouldDowngradeDeliveryToSessionOnly(params: {
+  wantsDelivery: boolean;
+  bestEffortDeliver: boolean;
+  resolvedChannel: string;
+}): boolean {
+  return (
+    params.wantsDelivery &&
+    params.bestEffortDeliver &&
+    params.resolvedChannel === INTERNAL_MESSAGE_CHANNEL
+  );
+}


### PR DESCRIPTION
## Summary

Fixes async exec-approval followup delivery in webchat-only/internal-session setups by downgrading to session-only delivery when no external target exists, while preserving strict-delivery errors when explicitly requested.

Related issues:
- Closes #55088
- Closes #51936

## What Changed

- Hardened exec approval followup routing:
  - followup uses external delivery only when a deliverable channel + `to` exists
  - internal/webchat-only followups stay session-only (`deliver: false`)
- Added gateway best-effort downgrade behavior:
  - `bestEffortDeliver=true` + no external route => session-only fallback (no `INVALID_REQUEST`)
  - strict delivery behavior preserved when `bestEffortDeliver=false`
- Added deduped warning logging for swallowed followup dispatch failures
- Refactored delivery logic into shared helper:
  - `src/infra/outbound/best-effort-delivery.ts`
- Applied shared helper to:
  - exec followups
  - subagent completion direct announce
  - gateway `agent` delivery downgrade checks
- Added regression coverage, including:
  - webchat-only exec approval completion path (exec side effect + session-only followup)
  - subagent completion announce in webchat-only origin

## Behavior After This PR

- External target present:
  - followup uses external delivery normally
- Webchat-only / no external target:
  - followup remains in session context
- Strict external delivery requested without resolvable channel:
  - still returns `INVALID_REQUEST`
- Best-effort delivery without resolvable channel:
  - downgrades to session-only delivery

## Validation

Targeted tests run for touched surfaces:
- `pnpm test -- src/agents/bash-tools.exec-approval-followup.test.ts`
- `pnpm test -- src/agents/bash-tools.exec-host-shared.test.ts`
- `pnpm test -- src/agents/bash-tools.exec.approval-id.test.ts -t "starts a direct agent follow-up after approved gateway exec completes"`
- `pnpm test -- src/agents/bash-tools.exec.approval-id.test.ts -t "webchat-only mode"`
- `pnpm test -- src/infra/outbound/best-effort-delivery.test.ts`
- `pnpm test -- src/agents/subagent-announce.test.ts -t "webchat"`
- `pnpm test -- src/gateway/server-methods/agent.test.ts`
- `pnpm test -- src/gateway/server.agent.gateway-server-agent-b.test.ts -t "agent downgrades to session-only delivery when best-effort is enabled and last channel is webchat"`
- `pnpm test -- src/gateway/server.agent.gateway-server-agent-a.test.ts -t "agent errors when delivery requested and no last channel exists"`

## Risk / Compatibility

- No config migration required
- No expected break for valid external channel configurations
- Behavior change is limited to safer fallback handling when no external route is available
