### PR TITLE
fix(plugins): discover channel config schemas for external plugins

### DIFF
--- a/src/plugins/bundled-plugin-metadata.ts
+++ b/src/plugins/bundled-plugin-metadata.ts
@@ -265,7 +265,7 @@ function getJiti(modulePath: string) {
   return loader;
 }
 
-function resolveChannelConfigSchemaModulePath(pluginDir: string): string | undefined {
+export function resolveChannelConfigSchemaModulePath(pluginDir: string): string | undefined {
   for (const relativePath of SOURCE_CONFIG_SCHEMA_CANDIDATES) {
     const candidate = path.join(pluginDir, relativePath);
     if (fs.existsSync(candidate)) {
@@ -283,7 +283,9 @@ function resolveChannelConfigSchemaModulePath(pluginDir: string): string | undef
   return undefined;
 }
 
-function loadChannelConfigSurfaceModuleSync(modulePath: string): ChannelConfigSurface | null {
+export function loadChannelConfigSurfaceModuleSync(
+  modulePath: string,
+): ChannelConfigSurface | null {
   try {
     const imported = getJiti(modulePath)(modulePath) as Record<string, unknown>;
     return resolveConfigSchemaExport(imported);

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -4,6 +4,10 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
 import { loadBundleManifest } from "./bundle-manifest.js";
+import {
+  resolveChannelConfigSchemaModulePath,
+  loadChannelConfigSurfaceModuleSync,
+} from "./bundled-plugin-metadata.js";
 import { normalizePluginsConfig, type NormalizedPluginsConfig } from "./config-state.js";
 import { discoverOpenClawPlugins, type PluginCandidate } from "./discovery.js";
 import {
@@ -207,6 +211,59 @@ function isCompatiblePluginIdHint(idHint: string | undefined, manifestId: string
   );
 }
 
+/**
+ * For external (non-bundled) plugins that declare `channels` but no
+ * `channelConfigs` in their manifest, attempt to discover channel config
+ * schemas from well-known source module paths (e.g. `src/config-schema.ts`,
+ * `channel-config-api.ts`).  This mirrors the synthetic schema discovery
+ * that `collectBundledChannelConfigs` performs for bundled plugins, ensuring
+ * the Control UI can render config forms for third-party channel plugins.
+ */
+function discoverChannelConfigsFromSource(params: {
+  pluginDir: string;
+  manifest: PluginManifest;
+  channelConfigs: Record<string, PluginManifestChannelConfig> | undefined;
+}): Record<string, PluginManifestChannelConfig> | undefined {
+  const channelIds = params.manifest.channels ?? [];
+  if (channelIds.length === 0) {
+    return params.channelConfigs;
+  }
+
+  // If every declared channel already has a schema, nothing to discover.
+  const needsDiscovery = channelIds.some((id) => !params.channelConfigs?.[id]?.schema);
+  if (!needsDiscovery) {
+    return params.channelConfigs;
+  }
+
+  const surfaceModulePath = resolveChannelConfigSchemaModulePath(params.pluginDir);
+  if (!surfaceModulePath) {
+    return params.channelConfigs;
+  }
+
+  const surface = loadChannelConfigSurfaceModuleSync(surfaceModulePath);
+  if (!surface?.schema) {
+    return params.channelConfigs;
+  }
+
+  const result: Record<string, PluginManifestChannelConfig> = {
+    ...params.channelConfigs,
+  };
+  for (const channelId of channelIds) {
+    if (result[channelId]?.schema) {
+      continue;
+    }
+    result[channelId] = {
+      ...result[channelId],
+      schema: surface.schema,
+      ...(surface.uiHints && Object.keys(surface.uiHints).length > 0
+        ? { uiHints: surface.uiHints }
+        : {}),
+    };
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
 function buildRecord(params: {
   manifest: PluginManifest;
   candidate: PluginCandidate;
@@ -214,9 +271,13 @@ function buildRecord(params: {
   schemaCacheKey?: string;
   configSchema?: Record<string, unknown>;
 }): PluginManifestRecord {
-  const channelConfigs = mergePackageChannelMetaIntoChannelConfigs({
-    channelConfigs: params.manifest.channelConfigs,
-    packageChannel: params.candidate.packageManifest?.channel,
+  const channelConfigs = discoverChannelConfigsFromSource({
+    pluginDir: params.candidate.rootDir,
+    manifest: params.manifest,
+    channelConfigs: mergePackageChannelMetaIntoChannelConfigs({
+      channelConfigs: params.manifest.channelConfigs,
+      packageChannel: params.candidate.packageManifest?.channel,
+    }),
   });
   return {
     id: params.manifest.id,

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -224,7 +224,7 @@ function discoverChannelConfigsFromSource(params: {
   manifest: PluginManifest;
   channelConfigs: Record<string, PluginManifestChannelConfig> | undefined;
 }): Record<string, PluginManifestChannelConfig> | undefined {
-  const channelIds = params.manifest.channels ?? [];
+  const channelIds = params.manifest.channels?.map((id) => id.trim()).filter(Boolean) ?? [];
   if (channelIds.length === 0) {
     return params.channelConfigs;
   }

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -256,8 +256,17 @@ function discoverChannelConfigsFromSource(params: {
       ...result[channelId],
       schema: surface.schema,
       ...(surface.uiHints && Object.keys(surface.uiHints).length > 0
-        ? { uiHints: surface.uiHints }
-        : {}),
+        ? {
+            uiHints: {
+              ...surface.uiHints,
+              ...(result[channelId]?.uiHints && Object.keys(result[channelId].uiHints).length > 0
+                ? result[channelId].uiHints
+                : {}),
+            },
+          }
+        : result[channelId]?.uiHints
+          ? { uiHints: result[channelId].uiHints }
+          : {}),
     };
   }
 


### PR DESCRIPTION
## Problem

External channel plugins loaded via `plugins.load.paths` that provide a `src/config-schema.ts` (or equivalent surface module) but do not declare `channelConfigs` in their `openclaw.plugin.json` manifest are invisible to the Control UI schema resolution pipeline. The UI shows **"Channel config schema unavailable"** even though the channel is fully operational (polling, sending, receiving).

Affected: any third-party channel plugin (e.g. [openclaw-zulip](https://github.com/rafaelreis-r/openclaw-zulip)) that follows the standard pattern of exporting a Zod config schema from `src/config-schema.ts` and consuming it via `buildChannelConfigSchema()` at runtime.

## Root Cause

`buildRecord()` in `manifest-registry.ts` only reads `channelConfigs` from the static `openclaw.plugin.json` manifest file. The **synthetic schema discovery** that `collectBundledChannelConfigs` performs — loading `src/config-schema.ts` via jiti and resolving exports through `resolveConfigSchemaExport` — only runs for bundled plugins inside `bundled-plugin-metadata.ts`.

This means:
- Bundled channels (Telegram, Discord, etc.) → schema discovered from source → UI renders config form ✅
- External channels (Zulip, etc.) → schema only in manifest (usually empty) → UI shows "unavailable" ❌

## Fix

**2 files, 68 insertions, 5 deletions.**

### `src/plugins/bundled-plugin-metadata.ts`
- Export `resolveChannelConfigSchemaModulePath()` and `loadChannelConfigSurfaceModuleSync()` (previously private)

### `src/plugins/manifest-registry.ts`
- Add `discoverChannelConfigsFromSource()` — for plugins that declare `channels` but have no `channelConfigs` schema in their manifest, discovers the schema by loading the config surface module via the same jiti pipeline used for bundled plugins
- Modify `buildRecord()` to call this function, wrapping the existing `mergePackageChannelMetaIntoChannelConfigs` result

The function:
1. Skips if no channels declared or all channels already have schemas (zero overhead for bundled plugins)
2. Uses the same well-known paths (`src/config-schema.ts`, `channel-config-api.ts`, `runtime-api.ts`, `api.ts`)
3. Uses the same `resolveConfigSchemaExport` logic (matches `*ChannelConfigSchema`, `*ConfigSchema` exports, calls `buildChannelConfigSchema` on raw Zod schemas)
4. Merges discovered schemas without overwriting any existing manifest-declared schemas

## Testing

- All `bundled-plugin-metadata` tests pass (8/8) ✅
- All `loader` tests pass (73/73) ✅
- All `runtime-schema` + `validation.channel-metadata` tests pass (4/4) ✅
- All `captured-registration` + `shape.contract` tests pass (2/2) ✅
- **End-to-end verified** against the [openclaw-zulip](https://github.com/rafaelreis-r/openclaw-zulip) plugin: Zulip config schema (13 properties) correctly discovered and surfaced through `collectChannelSchemaMetadata` → `buildConfigSchema`

Note: `tsgo` has a pre-existing failure on `main` (`src/commands/tasks.ts:87 — Cannot find name summarizeTaskRecords`), unrelated to this change.