### PR TITLE
Web UI: make chat sessions feel ChatGPT-like

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -5,11 +5,10 @@
 /* Chat Group Layout - default (assistant/other on left) */
 .chat-group {
   display: flex;
-  gap: 10px;
+  gap: 14px;
   align-items: flex-start;
-  margin-bottom: 14px;
-  margin-left: 4px;
-  margin-right: 16px;
+  margin: 0 auto 22px;
+  width: min(100%, 840px);
 }
 
 /* User messages on right */
@@ -21,9 +20,9 @@
 .chat-group-messages {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 6px;
   flex: 1 1 auto;
-  max-width: min(900px, 68%);
+  max-width: min(100%, 720px);
   align-items: flex-start;
 }
 
@@ -34,7 +33,7 @@
 
 @media (max-width: 600px) {
   .chat-group-messages {
-    max-width: 82%;
+    max-width: 88%;
   }
 }
 
@@ -47,7 +46,9 @@
   display: flex;
   gap: 8px;
   align-items: baseline;
-  margin-top: 6px;
+  margin-top: 2px;
+  padding: 0 4px;
+  flex-wrap: wrap;
 }
 
 .chat-sender-name {
@@ -142,17 +143,17 @@
 
 /* Avatar Styles */
 .chat-avatar {
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-md);
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
   background: var(--panel-strong);
   display: grid;
   place-items: center;
   font-weight: 600;
-  font-size: 13px;
+  font-size: 12px;
   flex-shrink: 0;
-  align-self: flex-end;
-  margin-bottom: 4px;
+  align-self: flex-start;
+  margin-top: 2px;
   border: 1px solid var(--border);
 }
 
@@ -188,14 +189,17 @@ img.chat-avatar {
 .chat-bubble {
   position: relative;
   display: block;
-  border: 1px solid var(--border);
-  background: var(--card);
-  border-radius: var(--radius-lg);
-  padding: 10px 14px;
-  box-shadow: none;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  background: color-mix(in srgb, var(--card) 96%, transparent);
+  border-radius: 20px;
+  padding: 12px 16px;
+  box-shadow:
+    0 10px 24px color-mix(in srgb, black 6%, transparent),
+    inset 0 1px 0 color-mix(in srgb, white 6%, transparent);
   transition:
     background var(--duration-fast) ease-out,
-    border-color var(--duration-fast) ease-out;
+    border-color var(--duration-fast) ease-out,
+    box-shadow var(--duration-fast) ease-out;
   width: auto;
   max-width: 100%;
   box-sizing: border-box;
@@ -304,13 +308,16 @@ img.chat-avatar {
 }
 
 .chat-bubble:hover {
-  background: var(--bg-hover);
+  background: color-mix(in srgb, var(--bg-hover) 92%, transparent);
+  box-shadow:
+    0 14px 28px color-mix(in srgb, black 8%, transparent),
+    inset 0 1px 0 color-mix(in srgb, white 6%, transparent);
 }
 
 /* User bubbles have different styling */
 .chat-group.user .chat-bubble {
-  background: var(--accent-subtle);
-  border-color: transparent;
+  background: color-mix(in srgb, var(--accent) 16%, var(--card) 84%);
+  border-color: color-mix(in srgb, var(--accent) 22%, transparent);
 }
 
 :root[data-theme-mode="light"] .chat-group.user .chat-bubble {
@@ -319,7 +326,7 @@ img.chat-avatar {
 }
 
 .chat-group.user .chat-bubble:hover {
-  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
 }
 
 /* Streaming animation */
@@ -360,10 +367,10 @@ img.chat-avatar {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 11px;
+  font-size: 10px;
   line-height: 1;
   color: var(--muted);
-  margin-top: 4px;
+  margin-top: 2px;
   flex-wrap: wrap;
 }
 

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -52,15 +52,20 @@
 /* Chat thread - scrollable middle section, transparent */
 .chat-thread {
   flex: 1 1 0;
-  /* Grow, shrink, and use 0 base for proper scrolling */
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 0 6px 6px;
-  margin: 0 0 0 0;
+  padding: 8px 0 12px;
+  margin: 0;
   min-height: 0;
-  /* Allow shrinking for flex scroll behavior */
-  border-radius: var(--radius-md);
   background: transparent;
+}
+
+.chat-thread-inner {
+  width: min(100%, 920px);
+  margin: 0 auto;
+  padding: 8px 18px 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .chat-thread-inner > :first-child {
@@ -367,20 +372,27 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  margin: 0 18px 14px;
+  width: min(100%, 920px);
+  margin: 8px auto 18px;
   padding: 0;
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--card) 94%, var(--bg) 6%);
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border-radius: 24px;
   flex-shrink: 0;
   transition:
     border-color var(--duration-fast) ease,
-    box-shadow var(--duration-fast) ease;
+    box-shadow var(--duration-fast) ease,
+    background var(--duration-fast) ease;
+  box-shadow:
+    0 18px 48px color-mix(in srgb, black 12%, transparent),
+    inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
 }
 
 .agent-chat__input:focus-within {
-  border-color: var(--border-strong);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--border-strong) 24%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 20%, var(--border) 80%);
+  box-shadow:
+    0 24px 54px color-mix(in srgb, black 16%, transparent),
+    0 0 0 3px color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 @supports (backdrop-filter: blur(1px)) {
@@ -392,16 +404,16 @@
 
 .agent-chat__input > textarea {
   width: 100%;
-  min-height: 40px;
-  max-height: 150px;
+  min-height: 52px;
+  max-height: 220px;
   resize: none;
-  padding: 12px 14px 8px;
+  padding: 16px 18px 10px;
   border: none;
   background: transparent;
   color: var(--text);
-  font-size: 0.92rem;
+  font-size: 15px;
   font-family: inherit;
-  line-height: 1.4;
+  line-height: 1.55;
   outline: none;
   box-sizing: border-box;
 }
@@ -418,15 +430,15 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 6px 10px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+  padding: 8px 12px 12px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 68%, transparent);
 }
 
 .agent-chat__toolbar-left,
 .agent-chat__toolbar-right {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
 }
 
 .agent-chat__input-btn,
@@ -434,9 +446,9 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
-  border-radius: var(--radius-sm);
+  min-width: 34px;
+  height: 34px;
+  border-radius: 999px;
   border: none;
   background: transparent;
   color: var(--muted);
@@ -482,29 +494,33 @@
 }
 
 .agent-chat__token-count {
-  font-size: 0.7rem;
+  font-size: 11px;
   color: var(--muted);
   white-space: nowrap;
   flex-shrink: 0;
   align-self: center;
+  padding: 0 6px;
 }
 
 .chat-send-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
-  border-radius: var(--radius-md);
+  min-width: 38px;
+  height: 38px;
+  border-radius: 999px;
   border: none;
-  background: transparent;
-  color: var(--muted);
+  background: color-mix(in srgb, var(--accent) 88%, white 12%);
+  color: var(--accent-foreground, white);
   cursor: pointer;
   flex-shrink: 0;
   transition:
     background var(--duration-fast) ease,
-    color var(--duration-fast) ease;
+    color var(--duration-fast) ease,
+    transform var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
   padding: 0;
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--accent) 26%, transparent);
 }
 
 .chat-send-btn svg {
@@ -518,22 +534,26 @@
 }
 
 .chat-send-btn:hover:not(:disabled) {
-  color: var(--text);
-  background: var(--bg-hover);
+  transform: translateY(-1px);
+  background: color-mix(in srgb, var(--accent) 94%, white 6%);
+  box-shadow: 0 14px 28px color-mix(in srgb, var(--accent) 34%, transparent);
 }
 
 .chat-send-btn:disabled {
-  opacity: 0.3;
+  opacity: 0.45;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .chat-send-btn--stop {
   background: var(--danger);
   color: var(--destructive-foreground);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--danger) 24%, transparent);
 }
 
 .chat-send-btn--stop:hover:not(:disabled) {
   background: color-mix(in srgb, var(--danger) 85%, #fff);
+  box-shadow: 0 14px 28px color-mix(in srgb, var(--danger) 30%, transparent);
 }
 
 .slash-menu {
@@ -742,6 +762,10 @@
   flex-wrap: wrap;
 }
 
+.chat-page-controls .chat-controls {
+  gap: 8px;
+}
+
 .chat-controls__session {
   min-width: 140px;
   max-width: 300px;
@@ -757,6 +781,11 @@
 .chat-controls__model {
   min-width: 170px;
   max-width: 320px;
+}
+
+.chat-page-controls__model .chat-controls__model {
+  min-width: 200px;
+  max-width: 360px;
 }
 
 .chat-controls__thinking {
@@ -867,7 +896,9 @@
 
 /* Chat loading skeleton */
 .chat-loading-skeleton {
-  padding: 4px 0;
+  width: min(100%, 840px);
+  margin: 0 auto;
+  padding: 8px 0;
   animation: fade-in 0.3s var(--ease-out);
 }
 
@@ -878,8 +909,10 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  gap: 12px;
-  padding: 48px 24px;
+  width: min(100%, 760px);
+  margin: 0 auto;
+  gap: 14px;
+  padding: 56px 24px 72px;
   flex: 1;
   min-height: 0;
 }
@@ -889,10 +922,12 @@
 }
 
 .agent-chat__welcome h2 {
-  font-size: 20px;
-  font-weight: 600;
+  font-size: clamp(28px, 3.8vw, 42px);
+  line-height: 1.04;
+  letter-spacing: -0.05em;
+  font-weight: 700;
   margin: 0;
-  color: var(--foreground);
+  color: var(--text-strong);
 }
 
 .agent-chat__avatar--logo {
@@ -939,7 +974,7 @@
 }
 
 .agent-chat__hint {
-  font-size: 13px;
+  font-size: 14px;
   color: var(--muted);
   margin: 0;
 }
@@ -959,26 +994,28 @@
   flex-wrap: wrap;
   gap: 8px;
   justify-content: center;
-  max-width: 480px;
-  margin-top: 8px;
+  max-width: 640px;
+  margin-top: 12px;
 }
 
 .agent-chat__suggestion {
   font-size: 13px;
-  padding: 8px 16px;
+  padding: 10px 16px;
   border-radius: var(--radius-full);
   border: 1px solid var(--border);
-  background: var(--panel);
-  color: var(--foreground);
+  background: color-mix(in srgb, var(--card) 90%, transparent);
+  color: var(--text);
   cursor: pointer;
   transition:
     background 0.15s,
-    border-color 0.15s;
+    border-color 0.15s,
+    transform 0.15s;
 }
 
 .agent-chat__suggestion:hover {
-  background: var(--panel-strong);
+  background: color-mix(in srgb, var(--bg-hover) 92%, transparent);
   border-color: var(--accent);
+  transform: translateY(-1px);
 }
 
 /* Mobile dropdown toggle — hidden on desktop */

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -758,12 +758,38 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 12px;
+  gap: 8px;
   flex-wrap: wrap;
+  padding: 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bg-elevated) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
 }
 
 .chat-page-controls .chat-controls {
   gap: 8px;
+}
+
+.chat-controls .btn--icon {
+  width: 34px;
+  height: 34px;
+  min-width: 34px;
+  border-radius: 999px;
+}
+
+.chat-controls__count {
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  background: color-mix(in srgb, var(--accent) 88%, white 12%);
+  color: var(--accent-foreground, white);
 }
 
 .chat-controls__session {
@@ -958,13 +984,13 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 500;
   color: var(--muted);
-  background: var(--panel);
-  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-elevated) 90%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
   border-radius: var(--radius-full);
-  padding: 4px 12px;
+  padding: 5px 12px;
 }
 
 .agent-chat__badge img {
@@ -977,6 +1003,7 @@
   font-size: 14px;
   color: var(--muted);
   margin: 0;
+  max-width: 42rem;
 }
 
 .agent-chat__hint kbd {

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -12,18 +12,18 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  /* Smooth transition when sidebar opens/closes */
   transition: flex 250ms ease-out;
 }
 
 .chat-sidebar {
   flex: 1;
   min-width: 300px;
-  border-left: 1px solid var(--border);
+  border-left: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
   display: flex;
   flex-direction: column;
   overflow: hidden;
   animation: slide-in 200ms ease-out;
+  background: color-mix(in srgb, var(--bg-elevated) 86%, transparent);
 }
 
 @keyframes slide-in {
@@ -42,7 +42,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: var(--panel);
+  background: transparent;
 }
 
 .sidebar-header {
@@ -55,7 +55,7 @@
   position: sticky;
   top: 0;
   z-index: 10;
-  background: var(--panel);
+  background: color-mix(in srgb, var(--bg-elevated) 92%, transparent);
 }
 
 /* Smaller close button for sidebar */
@@ -74,7 +74,7 @@
 .sidebar-content {
   flex: 1;
   overflow: auto;
-  padding: 16px;
+  padding: 18px 18px 24px;
 }
 
 .sidebar-markdown {

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -19,8 +19,8 @@
 }
 
 .chat-text {
-  font-size: 14px;
-  line-height: 1.5;
+  font-size: 15px;
+  line-height: 1.65;
   word-wrap: break-word;
   overflow-wrap: break-word;
 }
@@ -58,8 +58,8 @@
 
 .chat-text :where(.markdown-inline-image) {
   display: block;
-  max-width: min(100%, 420px);
-  max-height: 320px;
+  max-width: min(100%, 520px);
+  max-height: 360px;
   width: auto;
   height: auto;
   margin-top: 0.75em;
@@ -78,9 +78,9 @@
 }
 
 .chat-text :where(pre) {
-  background: rgba(0, 0, 0, 0.15);
-  border-radius: var(--radius-sm);
-  padding: 10px 12px;
+  background: rgba(0, 0, 0, 0.16);
+  border-radius: 14px;
+  padding: 12px 14px;
   overflow-x: auto;
 }
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2426,11 +2426,12 @@ td.data-table-key-col {
 
 /* Chat queue */
 .chat-queue {
-  margin-top: 12px;
+  width: min(100%, 920px);
+  margin: 12px auto 0;
   padding: 12px;
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
-  background: var(--card);
+  background: color-mix(in srgb, var(--card) 94%, transparent);
   display: grid;
   gap: 8px;
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -428,6 +428,10 @@
   scrollbar-width: none;
 }
 
+.sidebar-nav > nav {
+  display: block;
+}
+
 .sidebar-nav::-webkit-scrollbar {
   display: none;
 }
@@ -482,6 +486,106 @@
   display: grid;
   gap: 6px;
   margin-bottom: 16px;
+}
+
+.sidebar-chat-section {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.sidebar-chat-new {
+  justify-content: flex-start;
+  min-height: 44px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent) 14%, var(--bg-elevated) 86%) 0%,
+    color-mix(in srgb, var(--accent) 8%, var(--bg) 92%) 100%
+  );
+  border-color: color-mix(in srgb, var(--accent) 22%, var(--border) 78%);
+  color: var(--text-strong);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 10%, transparent),
+    0 12px 24px color-mix(in srgb, black 12%, transparent);
+}
+
+.sidebar-chat-new .nav-item__icon {
+  color: var(--accent);
+  opacity: 1;
+}
+
+.sidebar-chat-list {
+  display: grid;
+  gap: 8px;
+}
+
+.sidebar-chat-list__label {
+  padding: 0 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 74%, var(--text) 26%);
+}
+
+.sidebar-chat-list__empty {
+  padding: 0 10px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.sidebar-chat-item {
+  width: 100%;
+  display: grid;
+  gap: 4px;
+  padding: 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--bg-elevated) 68%, transparent);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) ease,
+    background var(--duration-fast) ease,
+    transform var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.sidebar-chat-item:hover {
+  border-color: color-mix(in srgb, var(--accent) 18%, var(--border) 82%);
+  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
+  transform: translateY(-1px);
+}
+
+.sidebar-chat-item--active {
+  border-color: color-mix(in srgb, var(--accent) 26%, transparent);
+  background: color-mix(in srgb, var(--accent-subtle) 88%, var(--bg-elevated) 12%);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 10%, transparent);
+}
+
+.sidebar-chat-item__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-strong);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar-chat-item__preview {
+  font-size: 12px;
+  color: var(--muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.sidebar-chat-item__meta {
+  font-size: 11px;
+  color: color-mix(in srgb, var(--muted) 80%, var(--text) 20%);
 }
 
 .nav-section:last-child {
@@ -645,6 +749,17 @@
 .sidebar--collapsed .nav-section {
   gap: 6px;
   margin-bottom: 16px;
+}
+
+.sidebar--collapsed .sidebar-chat-section {
+  justify-items: center;
+}
+
+.sidebar--collapsed .sidebar-chat-new {
+  justify-content: center;
+  width: 44px;
+  min-height: 44px;
+  padding: 0;
 }
 
 .sidebar--collapsed .nav-item {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1181,7 +1181,7 @@
 }
 
 .content-header--chat-shell {
-  padding: 8px 8px 12px;
+  padding: 4px 8px 10px;
   align-items: flex-start;
   gap: 20px;
 }
@@ -1189,7 +1189,7 @@
 .chat-page-heading {
   min-width: 0;
   display: grid;
-  gap: 6px;
+  gap: 8px;
 }
 
 .chat-page-heading__eyebrow {
@@ -1198,7 +1198,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: color-mix(in srgb, var(--muted) 84%, var(--text) 16%);
 }
 
 .chat-page-heading__title-row {
@@ -1211,7 +1211,7 @@
 
 .chat-page-heading__title {
   min-width: 0;
-  font-size: 28px;
+  font-size: 32px;
   line-height: 1.05;
   font-weight: 700;
   letter-spacing: -0.04em;
@@ -1236,11 +1236,9 @@
 
 .chat-page-heading__sub {
   max-width: min(72ch, 100%);
-  font-size: 13px;
+  font-size: 14px;
   color: var(--muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  white-space: normal;
 }
 
 .page-meta--chat-shell {
@@ -1253,7 +1251,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: flex-end;
-  gap: 12px;
+  gap: 10px;
   flex-wrap: wrap;
 }
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -122,6 +122,11 @@
   flex: 1;
 }
 
+.topnav-shell--chat .topnav-shell__content {
+  display: flex;
+  align-items: center;
+}
+
 .topbar .nav-collapse-toggle {
   width: 36px;
   height: 36px;
@@ -163,6 +168,53 @@
 .topnav-shell .dashboard-header__breadcrumb-current {
   color: var(--text-strong);
   font-weight: 650;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-topbar-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.chat-topbar-brand__badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--bg-elevated) 90%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.chat-topbar-brand__copy {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.chat-topbar-brand__title {
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.15;
+  color: var(--text-strong);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-topbar-brand__sub {
+  font-size: 12px;
+  color: var(--muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -534,34 +586,102 @@
   color: var(--muted);
 }
 
+.sidebar-chat-hub {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  gap: 14px;
+}
+
+.sidebar-chat-hub__top,
+.sidebar-chat-hub__bottom {
+  display: grid;
+  gap: 10px;
+}
+
+.sidebar-chat-hub__list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  padding-right: 2px;
+}
+
+.sidebar-chat-group {
+  display: grid;
+  gap: 8px;
+}
+
+.sidebar-chat-group__label,
+.sidebar-chat-hub__bottom-label {
+  padding: 0 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 74%, var(--text) 26%);
+}
+
+.sidebar-chat-hub__bottom {
+  padding-top: 12px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+}
+
+.sidebar-chat-utility {
+  display: grid;
+  gap: 6px;
+}
+
+.sidebar-chat-utility .nav-item {
+  min-height: 38px;
+}
+
+.sidebar-nav--chat {
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-shell__body--chat {
+  min-height: 0;
+}
+
 .sidebar-chat-item {
   width: 100%;
-  display: grid;
-  gap: 4px;
-  padding: 10px;
-  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--bg-elevated) 68%, transparent);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 14px;
+  background: transparent;
   color: inherit;
   text-align: left;
   cursor: pointer;
   transition:
     border-color var(--duration-fast) ease,
     background var(--duration-fast) ease,
-    transform var(--duration-fast) ease,
     color var(--duration-fast) ease;
 }
 
 .sidebar-chat-item:hover {
-  border-color: color-mix(in srgb, var(--accent) 18%, var(--border) 82%);
+  border-color: color-mix(in srgb, var(--border) 82%, transparent);
   background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
-  transform: translateY(-1px);
 }
 
 .sidebar-chat-item--active {
-  border-color: color-mix(in srgb, var(--accent) 26%, transparent);
-  background: color-mix(in srgb, var(--accent-subtle) 88%, var(--bg-elevated) 12%);
-  box-shadow: inset 0 1px 0 color-mix(in srgb, white 10%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 20%, transparent);
+  background: color-mix(in srgb, var(--accent-subtle) 90%, var(--bg-elevated) 10%);
+}
+
+.sidebar-chat-item__body {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: grid;
+  gap: 4px;
 }
 
 .sidebar-chat-item__title {
@@ -586,6 +706,9 @@
 .sidebar-chat-item__meta {
   font-size: 11px;
   color: color-mix(in srgb, var(--muted) 80%, var(--text) 20%);
+  flex: 0 0 auto;
+  white-space: nowrap;
+  padding-top: 2px;
 }
 
 .nav-section:last-child {
@@ -753,6 +876,13 @@
 
 .sidebar--collapsed .sidebar-chat-section {
   justify-items: center;
+}
+
+.sidebar--collapsed .sidebar-chat-hub__bottom,
+.sidebar--collapsed .sidebar-chat-hub__list,
+.sidebar--collapsed .sidebar-chat-group__label,
+.sidebar--collapsed .sidebar-chat-hub__bottom-label {
+  display: none;
 }
 
 .sidebar--collapsed .sidebar-chat-new {
@@ -1048,6 +1178,87 @@
   justify-content: space-between;
   gap: 16px;
   padding-bottom: 0;
+}
+
+.content-header--chat-shell {
+  padding: 8px 8px 12px;
+  align-items: flex-start;
+  gap: 20px;
+}
+
+.chat-page-heading {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.chat-page-heading__eyebrow {
+  font-size: 11px;
+  line-height: 1.1;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.chat-page-heading__title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.chat-page-heading__title {
+  min-width: 0;
+  font-size: 28px;
+  line-height: 1.05;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  color: var(--text-strong);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-page-heading__meta {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--bg-elevated) 86%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.chat-page-heading__sub {
+  max-width: min(72ch, 100%);
+  font-size: 13px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.page-meta--chat-shell {
+  display: flex;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+}
+
+.chat-page-controls {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.chat-page-controls__model {
+  flex: 0 1 auto;
 }
 
 .content--chat .content-header > div:first-child {

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -130,6 +130,26 @@
     scrollbar-width: none;
   }
 
+  .sidebar-chat-section {
+    margin-bottom: 18px;
+  }
+
+  .sidebar-chat-new,
+  .sidebar--collapsed .sidebar-chat-new {
+    width: 100%;
+    min-height: 44px;
+    padding: 0 12px;
+    justify-content: flex-start;
+  }
+
+  .sidebar-chat-list {
+    gap: 6px;
+  }
+
+  .sidebar-chat-item {
+    padding: 10px 12px;
+  }
+
   .sidebar-nav::-webkit-scrollbar,
   .sidebar--collapsed .sidebar-nav::-webkit-scrollbar {
     display: none;
@@ -165,6 +185,12 @@
     padding: 0;
     margin: 0 auto;
     border-radius: var(--radius-lg);
+  }
+
+  .shell--nav-collapsed:not(.shell--nav-drawer-open) .sidebar--collapsed .sidebar-chat-new {
+    width: 44px;
+    padding: 0;
+    justify-content: center;
   }
 
   .sidebar--collapsed .nav-item--active::before,

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -83,6 +83,18 @@
     box-shadow: inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
   }
 
+  .chat-topbar-brand__badge {
+    display: none;
+  }
+
+  .chat-topbar-brand__title {
+    font-size: 13px;
+  }
+
+  .chat-topbar-brand__sub {
+    max-width: 28vw;
+  }
+
   .sidebar,
   .sidebar--collapsed {
     width: 100%;
@@ -143,6 +155,18 @@
   }
 
   .sidebar-chat-list {
+    gap: 6px;
+  }
+
+  .sidebar-chat-hub {
+    gap: 12px;
+  }
+
+  .sidebar-chat-hub__list {
+    gap: 12px;
+  }
+
+  .sidebar-chat-group {
     gap: 6px;
   }
 
@@ -365,6 +389,10 @@
     gap: 2px;
   }
 
+  .content-header--chat-shell {
+    display: none;
+  }
+
   /* Show the mobile gear toggle (lives in topbar now) */
   .chat-mobile-controls-wrapper {
     display: flex;
@@ -401,6 +429,18 @@
     flex-direction: column;
     gap: 4px;
     width: 100%;
+  }
+
+  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__model {
+    min-width: unset;
+    max-width: unset;
+    width: 100%;
+  }
+
+  .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__model select {
+    width: 100%;
+    font-size: 14px;
+    padding: 10px 12px;
   }
 
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session {
@@ -523,6 +563,20 @@
     max-width: 90%;
   }
 
+  .chat-thread-inner {
+    padding: 6px 10px 0;
+  }
+
+  .chat-group {
+    width: 100%;
+    gap: 10px;
+    margin-bottom: 18px;
+  }
+
+  .chat-group-messages {
+    max-width: 100%;
+  }
+
   .chat-bubble {
     padding: 8px 12px;
     border-radius: var(--radius-md);
@@ -541,10 +595,17 @@
 
   .agent-chat__input {
     margin: 0 8px 10px;
+    width: auto;
   }
 
   .agent-chat__toolbar {
     padding: 4px 8px;
+  }
+
+  .agent-chat__input > textarea {
+    min-height: 48px;
+    padding: 14px 16px 10px;
+    font-size: 15px;
   }
 
   .agent-chat__input-btn,

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -572,11 +572,12 @@ export function resolveChatSidebarSessions(state: AppViewState, limit = 8) {
       title: row.derivedTitle?.trim() || row.label?.trim() || row.displayName?.trim() || row.key,
       preview: row.lastMessagePreview?.replace(/\s+/g, " ").trim() || "",
       updatedLabel: row.updatedAt ? formatRelativeTimestamp(row.updatedAt) : "",
+      updatedAtMs: row.updatedAt,
       active: row.key === state.sessionKey,
     }));
 }
 
-function renderChatModelSelect(state: AppViewState) {
+export function renderChatModelSelect(state: AppViewState) {
   const { currentOverride, defaultLabel, options } = resolveChatModelSelectState(state);
   const busy =
     state.chatLoading || state.chatSending || Boolean(state.chatRunId) || state.chatStream !== null;

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -257,7 +257,6 @@ export function renderChatControls(state: AppViewState) {
       >
         ${refreshIcon}
       </button>
-      <span class="chat-controls__separator">|</span>
       <button
         class="btn btn--sm btn--icon ${showThinking ? "active" : ""}"
         ?disabled=${disableThinkingToggle}
@@ -322,6 +321,9 @@ export function renderChatControls(state: AppViewState) {
           : t("chat.hideCronSessions")}
       >
         ${renderCronFilterIcon(hiddenCronCount)}
+        ${hiddenCronCount > 0
+          ? html`<span class="chat-controls__count">${hiddenCronCount}</span>`
+          : nothing}
       </button>
     </div>
   `;

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,6 +1,9 @@
 import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
-import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
+import {
+  parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
+} from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { refreshChat } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
@@ -13,7 +16,8 @@ import {
 } from "./chat-model-select-state.ts";
 import { refreshVisibleToolsEffectiveForCurrentSession } from "./controllers/agents.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
-import { loadSessions } from "./controllers/sessions.ts";
+import { createSession, loadSessions } from "./controllers/sessions.ts";
+import { formatRelativeTimestamp } from "./format.ts";
 import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
@@ -517,13 +521,59 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   void refreshSessionOptions(state);
 }
 
+export async function createDashboardChatSession(state: AppViewState): Promise<string | null> {
+  if (!state.client || !state.connected) {
+    return null;
+  }
+  const nextSessionKey = await createSession(state, {
+    agentId: resolveAgentIdFromSessionKey(state.sessionKey),
+    parentSessionKey: state.sessionKey,
+  });
+  if (!nextSessionKey) {
+    return null;
+  }
+  switchChatSession(state, nextSessionKey);
+  return nextSessionKey;
+}
+
 async function refreshSessionOptions(state: AppViewState) {
   await loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
     activeMinutes: 0,
     limit: 0,
     includeGlobal: true,
     includeUnknown: true,
+    includeDerivedTitles: true,
+    includeLastMessage: true,
   });
+}
+
+export function resolveChatSidebarSessions(state: AppViewState, limit = 8) {
+  const rows = state.sessionsResult?.sessions ?? [];
+  const currentAgentId = resolveAgentIdFromSessionKey(state.sessionKey);
+  const hideCron = state.sessionsHideCron ?? true;
+  return rows
+    .filter((row) => {
+      const parsed = parseAgentSessionKey(row.key);
+      if (parsed && parsed.agentId !== currentAgentId) {
+        return false;
+      }
+      if (row.kind === "global" || row.kind === "unknown") {
+        return false;
+      }
+      if (hideCron && isCronSessionKey(row.key)) {
+        return false;
+      }
+      return true;
+    })
+    .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
+    .slice(0, limit)
+    .map((row) => ({
+      key: row.key,
+      title: row.derivedTitle?.trim() || row.label?.trim() || row.displayName?.trim() || row.key,
+      preview: row.lastMessagePreview?.replace(/\s+/g, " ").trim() || "",
+      updatedLabel: row.updatedAt ? formatRelativeTimestamp(row.updatedAt) : "",
+      active: row.key === state.sessionKey,
+    }));
 }
 
 function renderChatModelSelect(state: AppViewState) {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -9,9 +9,11 @@ import { getSafeLocalStorage } from "../local-storage.ts";
 import { refreshChatAvatar } from "./app-chat.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
 import {
+  createDashboardChatSession,
   renderChatControls,
   renderChatMobileToggle,
   renderChatSessionSelect,
+  resolveChatSidebarSessions,
   renderTab,
   renderSidebarConnectionStatus,
   renderTopbarThemeModeToggle,
@@ -294,6 +296,66 @@ function resolveAssistantAvatarUrl(state: AppViewState): string | undefined {
   return identity?.avatarUrl;
 }
 
+function renderSidebarChatSection(state: AppViewState, navCollapsed: boolean) {
+  const sessions = resolveChatSidebarSessions(state, 8);
+  const creating = state.chatSending || Boolean(state.chatRunId);
+  return html`
+    <section class="sidebar-chat-section ${navCollapsed ? "sidebar-chat-section--collapsed" : ""}">
+      <button
+        type="button"
+        class="nav-item sidebar-chat-new"
+        ?disabled=${!state.connected || creating}
+        @click=${async () => {
+          const created = await createDashboardChatSession(state);
+          if (created) {
+            state.setTab("chat");
+          }
+        }}
+        title=${t("overview.quickActions.newSession")}
+        aria-label=${t("overview.quickActions.newSession")}
+      >
+        <span class="nav-item__icon" aria-hidden="true">${icons.plus}</span>
+        ${!navCollapsed
+          ? html`<span class="nav-item__text">${t("overview.quickActions.newSession")}</span>`
+          : nothing}
+      </button>
+      ${navCollapsed
+        ? nothing
+        : html`
+            <div class="sidebar-chat-list" aria-label=${t("overview.cards.recentSessions")}>
+              <div class="sidebar-chat-list__label">${t("overview.cards.recentSessions")}</div>
+              ${sessions.length === 0
+                ? html`<div class="sidebar-chat-list__empty">${t("usage.sessions.noRecent")}</div>`
+                : sessions.map(
+                    (session) => html`
+                      <button
+                        type="button"
+                        class="sidebar-chat-item ${session.active
+                          ? "sidebar-chat-item--active"
+                          : ""}"
+                        @click=${() => {
+                          switchChatSession(state, session.key);
+                          state.setTab("chat");
+                        }}
+                        title=${session.title}
+                        aria-current=${session.active ? "page" : "false"}
+                      >
+                        <div class="sidebar-chat-item__title">${session.title}</div>
+                        ${session.preview
+                          ? html`<div class="sidebar-chat-item__preview">${session.preview}</div>`
+                          : nothing}
+                        ${session.updatedLabel
+                          ? html`<div class="sidebar-chat-item__meta">${session.updatedLabel}</div>`
+                          : nothing}
+                      </button>
+                    `,
+                  )}
+            </div>
+          `}
+    </section>
+  `;
+}
+
 export function renderApp(state: AppViewState) {
   const updatableState = state as AppViewState & { requestUpdate?: () => void };
   const requestHostUpdate =
@@ -500,44 +562,48 @@ export function renderApp(state: AppViewState) {
               </button>
             </div>
             <div class="sidebar-shell__body">
-              <nav class="sidebar-nav">
-                ${TAB_GROUPS.map((group) => {
-                  const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
-                  const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
-                  const showItems = navCollapsed || hasActiveTab || !isGroupCollapsed;
+              <div class="sidebar-nav">
+                ${renderSidebarChatSection(state, navCollapsed)}
+                <nav>
+                  ${TAB_GROUPS.map((group) => {
+                    const isGroupCollapsed =
+                      state.settings.navGroupsCollapsed[group.label] ?? false;
+                    const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
+                    const showItems = navCollapsed || hasActiveTab || !isGroupCollapsed;
 
-                  return html`
-                    <section class="nav-section ${!showItems ? "nav-section--collapsed" : ""}">
-                      ${!navCollapsed
-                        ? html`
-                            <button
-                              class="nav-section__label"
-                              @click=${() => {
-                                const next = { ...state.settings.navGroupsCollapsed };
-                                next[group.label] = !isGroupCollapsed;
-                                state.applySettings({
-                                  ...state.settings,
-                                  navGroupsCollapsed: next,
-                                });
-                              }}
-                              aria-expanded=${showItems}
-                            >
-                              <span class="nav-section__label-text"
-                                >${t(`nav.${group.label}`)}</span
+                    return html`
+                      <section class="nav-section ${!showItems ? "nav-section--collapsed" : ""}">
+                        ${!navCollapsed
+                          ? html`
+                              <button
+                                class="nav-section__label"
+                                @click=${() => {
+                                  const next = { ...state.settings.navGroupsCollapsed };
+                                  next[group.label] = !isGroupCollapsed;
+                                  state.applySettings({
+                                    ...state.settings,
+                                    navGroupsCollapsed: next,
+                                  });
+                                }}
+                                aria-expanded=${showItems}
                               >
-                              <span class="nav-section__chevron"> ${icons.chevronDown} </span>
-                            </button>
-                          `
-                        : nothing}
-                      <div class="nav-section__items">
-                        ${group.tabs.map((tab) =>
-                          renderTab(state, tab, { collapsed: navCollapsed }),
-                        )}
-                      </div>
-                    </section>
-                  `;
-                })}
-              </nav>
+                                <span class="nav-section__label-text"
+                                  >${t(`nav.${group.label}`)}</span
+                                >
+                                <span class="nav-section__chevron"> ${icons.chevronDown} </span>
+                              </button>
+                            `
+                          : nothing}
+                        <div class="nav-section__items">
+                          ${group.tabs.map((tab) =>
+                            renderTab(state, tab, { collapsed: navCollapsed }),
+                          )}
+                        </div>
+                      </section>
+                    `;
+                  })}
+                </nav>
+              </div>
             </div>
             <div class="sidebar-shell__footer">
               <div class="sidebar-utility-group">

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -528,11 +528,14 @@ function renderChatSidebar(state: AppViewState, navCollapsed: boolean) {
 
 function renderChatHeader(state: AppViewState) {
   const active = resolveChatActiveSession(state);
-  const subline = active?.preview || active?.updatedLabel || t("subtitles.chat");
+  const hasMessages = state.chatMessages.length > 0;
+  const subline = hasMessages
+    ? active?.preview || active?.updatedLabel || t("subtitles.chat")
+    : "Pick a recent chat or start a fresh session to keep work separated.";
   return html`
     <section class="content-header content-header--chat-shell">
       <div class="chat-page-heading">
-        <div class="chat-page-heading__eyebrow">OpenClaw chat</div>
+        <div class="chat-page-heading__eyebrow">Session workspace</div>
         <div class="chat-page-heading__title-row">
           <div class="chat-page-heading__title">${active?.title ?? t("tabs.chat")}</div>
           ${active?.updatedLabel

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -11,8 +11,8 @@ import { renderUsageTab } from "./app-render-usage-tab.ts";
 import {
   createDashboardChatSession,
   renderChatControls,
+  renderChatModelSelect,
   renderChatMobileToggle,
-  renderChatSessionSelect,
   resolveChatSidebarSessions,
   renderTab,
   renderSidebarConnectionStatus,
@@ -280,6 +280,8 @@ type AutomationSectionKey = (typeof AUTOMATION_SECTION_KEYS)[number];
 type InfrastructureSectionKey = (typeof INFRASTRUCTURE_SECTION_KEYS)[number];
 type AiAgentsSectionKey = (typeof AI_AGENTS_SECTION_KEYS)[number];
 
+type ChatSidebarSessionEntry = ReturnType<typeof resolveChatSidebarSessions>[number];
+
 function resolveAssistantAvatarUrl(state: AppViewState): string | undefined {
   const list = state.agentsList?.agents ?? [];
   const parsed = parseAgentSessionKey(state.sessionKey);
@@ -353,6 +355,215 @@ function renderSidebarChatSection(state: AppViewState, navCollapsed: boolean) {
             </div>
           `}
     </section>
+  `;
+}
+
+function formatChatSessionBucketLabel(timestampMs: number | null | undefined): string {
+  if (!timestampMs || !Number.isFinite(timestampMs)) {
+    return "Older";
+  }
+  const now = new Date();
+  const target = new Date(timestampMs);
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const startOfTarget = new Date(
+    target.getFullYear(),
+    target.getMonth(),
+    target.getDate(),
+  ).getTime();
+  const dayDiff = Math.round((startOfToday - startOfTarget) / 86_400_000);
+  if (dayDiff <= 0) {
+    return "Today";
+  }
+  if (dayDiff === 1) {
+    return "Yesterday";
+  }
+  if (dayDiff < 7) {
+    return "Last 7 Days";
+  }
+  if (dayDiff < 30) {
+    return "Last 30 Days";
+  }
+  return "Older";
+}
+
+function groupChatSidebarSessions(sessions: ChatSidebarSessionEntry[]) {
+  const groups = new Map<string, ChatSidebarSessionEntry[]>();
+  for (const session of sessions) {
+    const label = formatChatSessionBucketLabel(session.updatedAtMs);
+    const existing = groups.get(label);
+    if (existing) {
+      existing.push(session);
+    } else {
+      groups.set(label, [session]);
+    }
+  }
+  return Array.from(groups.entries()).map(([label, entries]) => ({ label, entries }));
+}
+
+function resolveChatActiveSession(state: AppViewState) {
+  const sessions = resolveChatSidebarSessions(state, 40);
+  return sessions.find((entry) => entry.active) ?? sessions[0] ?? null;
+}
+
+function resolveChatTopbarIdentity(state: AppViewState) {
+  const currentAgentId = resolveAgentIdFromSessionKey(state.sessionKey);
+  const agent = state.agentsList?.agents?.find((entry) => entry.id === currentAgentId) ?? null;
+  return {
+    agentName:
+      agent?.identity?.name?.trim() || agent?.name?.trim() || currentAgentId || "Assistant",
+    session: resolveChatActiveSession(state),
+  };
+}
+
+function renderChatSidebarSectionNav(state: AppViewState, navCollapsed: boolean) {
+  return html`
+    <div class="sidebar-chat-utility" aria-label="OpenClaw sections">
+      ${renderTab(state, "overview", { collapsed: navCollapsed })}
+      ${renderTab(state, "sessions", { collapsed: navCollapsed })}
+      ${renderTab(state, "usage", { collapsed: navCollapsed })}
+      ${renderTab(state, "channels", { collapsed: navCollapsed })}
+      ${renderTab(state, "agents", { collapsed: navCollapsed })}
+    </div>
+  `;
+}
+
+function renderChatSidebar(state: AppViewState, navCollapsed: boolean) {
+  const sessions = resolveChatSidebarSessions(state, 40);
+  const creating = state.chatSending || Boolean(state.chatRunId);
+  const groups = groupChatSidebarSessions(sessions);
+
+  if (navCollapsed) {
+    return html`
+      <section class="sidebar-chat-section sidebar-chat-hub sidebar-chat-hub--collapsed">
+        <button
+          type="button"
+          class="nav-item sidebar-chat-new"
+          ?disabled=${!state.connected || creating}
+          @click=${async () => {
+            const created = await createDashboardChatSession(state);
+            if (created) {
+              state.setTab("chat");
+            }
+          }}
+          title=${t("overview.quickActions.newSession")}
+          aria-label=${t("overview.quickActions.newSession")}
+        >
+          <span class="nav-item__icon" aria-hidden="true">${icons.plus}</span>
+        </button>
+        ${renderChatSidebarSectionNav(state, navCollapsed)}
+      </section>
+    `;
+  }
+
+  return html`
+    <section class="sidebar-chat-section sidebar-chat-hub" aria-label="Chat sessions">
+      <div class="sidebar-chat-hub__top">
+        <button
+          type="button"
+          class="nav-item sidebar-chat-new"
+          ?disabled=${!state.connected || creating}
+          @click=${async () => {
+            const created = await createDashboardChatSession(state);
+            if (created) {
+              state.setTab("chat");
+            }
+          }}
+          title=${t("overview.quickActions.newSession")}
+          aria-label=${t("overview.quickActions.newSession")}
+        >
+          <span class="nav-item__icon" aria-hidden="true">${icons.plus}</span>
+          <span class="nav-item__text">${t("overview.quickActions.newSession")}</span>
+        </button>
+      </div>
+      <div class="sidebar-chat-hub__list" aria-label=${t("overview.cards.recentSessions")}>
+        ${groups.length === 0
+          ? html`<div class="sidebar-chat-list__empty">${t("usage.sessions.noRecent")}</div>`
+          : groups.map(
+              (group) => html`
+                <section class="sidebar-chat-group">
+                  <div class="sidebar-chat-group__label">${group.label}</div>
+                  <div class="sidebar-chat-list">
+                    ${group.entries.map(
+                      (session) => html`
+                        <button
+                          type="button"
+                          class="sidebar-chat-item ${session.active
+                            ? "sidebar-chat-item--active"
+                            : ""}"
+                          @click=${() => {
+                            switchChatSession(state, session.key);
+                            state.setTab("chat");
+                          }}
+                          title=${session.title}
+                          aria-current=${session.active ? "page" : "false"}
+                        >
+                          <div class="sidebar-chat-item__body">
+                            <div class="sidebar-chat-item__title">${session.title}</div>
+                            ${session.preview
+                              ? html`<div class="sidebar-chat-item__preview">
+                                  ${session.preview}
+                                </div>`
+                              : nothing}
+                          </div>
+                          ${session.updatedLabel
+                            ? html`<div class="sidebar-chat-item__meta">
+                                ${session.updatedLabel}
+                              </div>`
+                            : nothing}
+                        </button>
+                      `,
+                    )}
+                  </div>
+                </section>
+              `,
+            )}
+      </div>
+      <div class="sidebar-chat-hub__bottom">
+        <div class="sidebar-chat-hub__bottom-label">Workspace</div>
+        ${renderChatSidebarSectionNav(state, navCollapsed)}
+      </div>
+    </section>
+  `;
+}
+
+function renderChatHeader(state: AppViewState) {
+  const active = resolveChatActiveSession(state);
+  const subline = active?.preview || active?.updatedLabel || t("subtitles.chat");
+  return html`
+    <section class="content-header content-header--chat-shell">
+      <div class="chat-page-heading">
+        <div class="chat-page-heading__eyebrow">OpenClaw chat</div>
+        <div class="chat-page-heading__title-row">
+          <div class="chat-page-heading__title">${active?.title ?? t("tabs.chat")}</div>
+          ${active?.updatedLabel
+            ? html`<div class="chat-page-heading__meta">${active.updatedLabel}</div>`
+            : nothing}
+        </div>
+        <div class="chat-page-heading__sub">${subline}</div>
+      </div>
+      <div class="page-meta page-meta--chat-shell">
+        <div class="chat-page-controls">
+          <div class="chat-page-controls__model">${renderChatModelSelect(state)}</div>
+          ${renderChatControls(state)}
+        </div>
+      </div>
+    </section>
+  `;
+}
+
+function renderTopbarCenterContent(state: AppViewState) {
+  if (state.tab !== "chat") {
+    return html`<dashboard-header .tab=${state.tab}></dashboard-header>`;
+  }
+  const { agentName, session } = resolveChatTopbarIdentity(state);
+  return html`
+    <div class="chat-topbar-brand" aria-label="Chat workspace">
+      <div class="chat-topbar-brand__badge">OpenClaw</div>
+      <div class="chat-topbar-brand__copy">
+        <div class="chat-topbar-brand__title">${agentName}</div>
+        <div class="chat-topbar-brand__sub">${session?.title ?? t("tabs.chat")}</div>
+      </div>
+    </div>
   `;
 }
 
@@ -491,7 +702,7 @@ export function renderApp(state: AppViewState) {
         }}
       ></button>
       <header class="topbar">
-        <div class="topnav-shell">
+        <div class="topnav-shell ${isChat ? "topnav-shell--chat" : ""}">
           <button
             type="button"
             class="topbar-nav-toggle"
@@ -504,9 +715,7 @@ export function renderApp(state: AppViewState) {
           >
             <span class="nav-collapse-toggle__icon" aria-hidden="true">${icons.menu}</span>
           </button>
-          <div class="topnav-shell__content">
-            <dashboard-header .tab=${state.tab}></dashboard-header>
-          </div>
+          <div class="topnav-shell__content">${renderTopbarCenterContent(state)}</div>
           <div class="topnav-shell__actions">
             <button
               class="topbar-search"
@@ -540,7 +749,9 @@ export function renderApp(state: AppViewState) {
                         alt="OpenClaw"
                       />
                       <span class="sidebar-brand__copy">
-                        <span class="sidebar-brand__eyebrow">${t("nav.control")}</span>
+                        <span class="sidebar-brand__eyebrow"
+                          >${t(isChat ? "nav.chat" : "nav.control")}</span
+                        >
                         <span class="sidebar-brand__title">OpenClaw</span>
                       </span>
                     `}
@@ -561,48 +772,56 @@ export function renderApp(state: AppViewState) {
                 >
               </button>
             </div>
-            <div class="sidebar-shell__body">
-              <div class="sidebar-nav">
-                ${renderSidebarChatSection(state, navCollapsed)}
-                <nav>
-                  ${TAB_GROUPS.map((group) => {
-                    const isGroupCollapsed =
-                      state.settings.navGroupsCollapsed[group.label] ?? false;
-                    const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
-                    const showItems = navCollapsed || hasActiveTab || !isGroupCollapsed;
+            <div class="sidebar-shell__body ${isChat ? "sidebar-shell__body--chat" : ""}">
+              <div class="sidebar-nav ${isChat ? "sidebar-nav--chat" : ""}">
+                ${isChat
+                  ? renderChatSidebar(state, navCollapsed)
+                  : html`
+                      ${renderSidebarChatSection(state, navCollapsed)}
+                      <nav>
+                        ${TAB_GROUPS.map((group) => {
+                          const isGroupCollapsed =
+                            state.settings.navGroupsCollapsed[group.label] ?? false;
+                          const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
+                          const showItems = navCollapsed || hasActiveTab || !isGroupCollapsed;
 
-                    return html`
-                      <section class="nav-section ${!showItems ? "nav-section--collapsed" : ""}">
-                        ${!navCollapsed
-                          ? html`
-                              <button
-                                class="nav-section__label"
-                                @click=${() => {
-                                  const next = { ...state.settings.navGroupsCollapsed };
-                                  next[group.label] = !isGroupCollapsed;
-                                  state.applySettings({
-                                    ...state.settings,
-                                    navGroupsCollapsed: next,
-                                  });
-                                }}
-                                aria-expanded=${showItems}
-                              >
-                                <span class="nav-section__label-text"
-                                  >${t(`nav.${group.label}`)}</span
-                                >
-                                <span class="nav-section__chevron"> ${icons.chevronDown} </span>
-                              </button>
-                            `
-                          : nothing}
-                        <div class="nav-section__items">
-                          ${group.tabs.map((tab) =>
-                            renderTab(state, tab, { collapsed: navCollapsed }),
-                          )}
-                        </div>
-                      </section>
-                    `;
-                  })}
-                </nav>
+                          return html`
+                            <section
+                              class="nav-section ${!showItems ? "nav-section--collapsed" : ""}"
+                            >
+                              ${!navCollapsed
+                                ? html`
+                                    <button
+                                      class="nav-section__label"
+                                      @click=${() => {
+                                        const next = { ...state.settings.navGroupsCollapsed };
+                                        next[group.label] = !isGroupCollapsed;
+                                        state.applySettings({
+                                          ...state.settings,
+                                          navGroupsCollapsed: next,
+                                        });
+                                      }}
+                                      aria-expanded=${showItems}
+                                    >
+                                      <span class="nav-section__label-text"
+                                        >${t(`nav.${group.label}`)}</span
+                                      >
+                                      <span class="nav-section__chevron">
+                                        ${icons.chevronDown}
+                                      </span>
+                                    </button>
+                                  `
+                                : nothing}
+                              <div class="nav-section__items">
+                                ${group.tabs.map((tab) =>
+                                  renderTab(state, tab, { collapsed: navCollapsed }),
+                                )}
+                              </div>
+                            </section>
+                          `;
+                        })}
+                      </nav>
+                    `}
               </div>
             </div>
             <div class="sidebar-shell__footer">
@@ -674,20 +893,19 @@ export function renderApp(state: AppViewState) {
           : nothing}
         ${state.tab === "config"
           ? nothing
-          : html`<section class="content-header">
-              <div>
-                ${isChat
-                  ? renderChatSessionSelect(state)
-                  : html`<div class="page-title">${titleForTab(state.tab)}</div>`}
-                ${isChat ? nothing : html`<div class="page-sub">${subtitleForTab(state.tab)}</div>`}
-              </div>
-              <div class="page-meta">
-                ${state.lastError
-                  ? html`<div class="pill danger">${state.lastError}</div>`
-                  : nothing}
-                ${isChat ? renderChatControls(state) : nothing}
-              </div>
-            </section>`}
+          : isChat
+            ? renderChatHeader(state)
+            : html`<section class="content-header">
+                <div>
+                  <div class="page-title">${titleForTab(state.tab)}</div>
+                  <div class="page-sub">${subtitleForTab(state.tab)}</div>
+                </div>
+                <div class="page-meta">
+                  ${state.lastError
+                    ? html`<div class="pill danger">${state.lastError}</div>`
+                    : nothing}
+                </div>
+              </section>`}
         ${state.tab === "overview"
           ? renderOverview({
               connected: state.connected,

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -273,6 +273,8 @@ export async function refreshActiveTab(host: SettingsHost) {
       host as unknown as Parameters<typeof scheduleChatScroll>[0],
       !host.chatHasAutoScrolled,
     );
+    // Load sessions so the sidebar shows recent session cards on initial page load
+    await loadSessions(host as unknown as OpenClawApp);
   }
   if (
     host.tab === "config" ||

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -29,6 +29,7 @@ import {
   handleFirstUpdated,
   handleUpdated,
 } from "./app-lifecycle.ts";
+import { createDashboardChatSession } from "./app-render.helpers.ts";
 import { renderApp } from "./app-render.ts";
 import {
   exportLogs as exportLogsInternal,
@@ -469,6 +470,11 @@ export class OpenClawApp extends LitElement {
         this.paletteQuery = "";
         this.paletteActiveIndex = 0;
       }
+      return;
+    }
+    if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === "n") {
+      e.preventDefault();
+      void this.handleCreateDashboardChatSession();
     }
   };
 
@@ -636,6 +642,16 @@ export class OpenClawApp extends LitElement {
       messageOverride,
       opts,
     );
+  }
+
+  async handleCreateDashboardChatSession() {
+    const created = await createDashboardChatSession(this as unknown as AppViewState);
+    if (!created) {
+      return;
+    }
+    if (this.tab !== "chat") {
+      this.setTab("chat");
+    }
   }
 
   async handleWhatsAppStart(force: boolean) {

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { deleteSessionsAndRefresh, subscribeSessions, type SessionsState } from "./sessions.ts";
+import {
+  createSession,
+  deleteSessionsAndRefresh,
+  loadSessions,
+  subscribeSessions,
+  type SessionsState,
+} from "./sessions.ts";
 
 type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
 
@@ -11,9 +17,9 @@ if (!("window" in globalThis)) {
   });
 }
 
-function createState(request: RequestFn, overrides: Partial<SessionsState> = {}): SessionsState {
+function createState(request?: RequestFn, overrides: Partial<SessionsState> = {}): SessionsState {
   return {
-    client: { request } as unknown as SessionsState["client"],
+    client: request ? ({ request } as unknown as SessionsState["client"]) : null,
     connected: true,
     sessionsLoading: false,
     sessionsResult: null,
@@ -71,6 +77,8 @@ describe("deleteSessionsAndRefresh", () => {
     expect(request).toHaveBeenNthCalledWith(3, "sessions.list", {
       includeGlobal: true,
       includeUnknown: true,
+      includeDerivedTitles: true,
+      includeLastMessage: true,
     });
     expect(state.sessionsLoading).toBe(false);
   });
@@ -118,5 +126,86 @@ describe("deleteSessionsAndRefresh", () => {
 
     expect(deleted).toEqual([]);
     expect(request).not.toHaveBeenCalled();
+  });
+});
+
+describe("createSession", () => {
+  it("creates a dashboard chat session and refreshes sessions", async () => {
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "sessions.create") {
+        expect(params).toEqual({
+          agentId: "main",
+          parentSessionKey: "main",
+        });
+        return { key: "agent:main:dashboard:session-1" };
+      }
+      if (method === "sessions.list") {
+        return {
+          ts: 0,
+          path: "",
+          count: 1,
+          defaults: { modelProvider: null, model: null, contextTokens: null },
+          sessions: [{ key: "agent:main:dashboard:session-1", kind: "direct", updatedAt: null }],
+        };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const state = createState(request);
+
+    const key = await createSession(state, {
+      agentId: "main",
+      parentSessionKey: "main",
+    });
+
+    expect(key).toBe("agent:main:dashboard:session-1");
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.create", {
+      agentId: "main",
+      parentSessionKey: "main",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
+      includeGlobal: true,
+      includeUnknown: true,
+      includeDerivedTitles: true,
+      includeLastMessage: true,
+    });
+  });
+
+  it("stores the error and returns null when create fails", async () => {
+    const state = createState();
+    state.client = {
+      request: vi.fn(async (method: string) => {
+        if (method === "sessions.create") {
+          throw new Error("nope");
+        }
+        return {};
+      }),
+    } as unknown as NonNullable<SessionsState["client"]>;
+
+    const key = await createSession(state);
+
+    expect(key).toBeNull();
+    expect(state.sessionsError).toContain("nope");
+  });
+});
+
+describe("loadSessions", () => {
+  it("requests derived titles and last-message previews by default", async () => {
+    const request = vi.fn(async () => ({
+      ts: 0,
+      path: "",
+      count: 0,
+      defaults: { modelProvider: null, model: null, contextTokens: null },
+      sessions: [],
+    }));
+    const state = createState(request);
+
+    await loadSessions(state);
+
+    expect(request).toHaveBeenCalledWith("sessions.list", {
+      includeGlobal: true,
+      includeUnknown: true,
+      includeDerivedTitles: true,
+      includeLastMessage: true,
+    });
   });
 });

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -36,6 +36,8 @@ export async function loadSessions(
     limit?: number;
     includeGlobal?: boolean;
     includeUnknown?: boolean;
+    includeDerivedTitles?: boolean;
+    includeLastMessage?: boolean;
   },
 ) {
   if (!state.client || !state.connected) {
@@ -54,6 +56,8 @@ export async function loadSessions(
     const params: Record<string, unknown> = {
       includeGlobal,
       includeUnknown,
+      includeDerivedTitles: overrides?.includeDerivedTitles ?? true,
+      includeLastMessage: overrides?.includeLastMessage ?? true,
     };
     if (activeMinutes > 0) {
       params.activeMinutes = activeMinutes;
@@ -74,6 +78,31 @@ export async function loadSessions(
     }
   } finally {
     state.sessionsLoading = false;
+  }
+}
+
+export async function createSession(
+  state: SessionsState,
+  params?: {
+    agentId?: string;
+    label?: string;
+    parentSessionKey?: string;
+  },
+): Promise<string | null> {
+  if (!state.client || !state.connected) {
+    return null;
+  }
+  try {
+    const res = await state.client.request<{ key?: string }>("sessions.create", {
+      ...(params?.agentId ? { agentId: params.agentId } : {}),
+      ...(params?.label ? { label: params.label } : {}),
+      ...(params?.parentSessionKey ? { parentSessionKey: params.parentSessionKey } : {}),
+    });
+    await loadSessions(state);
+    return typeof res?.key === "string" && res.key.trim() ? res.key.trim() : null;
+  } catch (err) {
+    state.sessionsError = String(err);
+    return null;
   }
 }
 

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -105,6 +105,61 @@ describe("control UI routing", () => {
     expect(app.querySelector(".sidebar-brand")).not.toBeNull();
     expect(app.querySelector(".sidebar-brand__logo")).not.toBeNull();
     expect(app.querySelector(".sidebar-brand__copy")).not.toBeNull();
+    expect(app.querySelector(".sidebar-chat-section")).not.toBeNull();
+    expect(app.querySelector(".sidebar-chat-new")).not.toBeNull();
+  });
+
+  it("starts a new dashboard chat from Cmd/Ctrl+N", async () => {
+    const app = mountApp("/channels");
+    app.client = {
+      stop: () => {},
+      request: async (method: string, params?: Record<string, unknown>) => {
+        if (method === "sessions.create") {
+          expect(params).toMatchObject({ parentSessionKey: "main" });
+          return { key: "agent:main:dashboard:new-chat" };
+        }
+        if (method === "sessions.list") {
+          return {
+            ts: 0,
+            path: "",
+            count: 1,
+            defaults: { modelProvider: null, model: null, contextTokens: null },
+            sessions: [
+              {
+                key: "agent:main:dashboard:new-chat",
+                kind: "direct",
+                updatedAt: Date.now(),
+                derivedTitle: "Fresh task",
+              },
+            ],
+          };
+        }
+        if (method === "chat.history") {
+          return { messages: [], thinkingLevel: null };
+        }
+        if (method === "models.list") {
+          return { models: [] };
+        }
+        return {};
+      },
+    } as typeof app.client;
+    await app.updateComplete;
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "n",
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await app.updateComplete;
+    await nextFrame();
+
+    expect(app.tab).toBe("chat");
+    expect(app.sessionKey).toBe("agent:main:dashboard:new-chat");
+    expect(window.location.pathname).toBe("/chat");
+    expect(window.location.search).toBe("?session=agent%3Amain%3Adashboard%3Anew-chat");
   });
 
   it("does not render a desktop sidebar resizer or inject a custom nav width", async () => {

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -106,7 +106,19 @@ describe("control UI routing", () => {
     expect(app.querySelector(".sidebar-brand__logo")).not.toBeNull();
     expect(app.querySelector(".sidebar-brand__copy")).not.toBeNull();
     expect(app.querySelector(".sidebar-chat-section")).not.toBeNull();
+    expect(app.querySelector(".sidebar-chat-hub")).not.toBeNull();
+    expect(app.querySelector(".sidebar-chat-hub__list")).not.toBeNull();
+    expect(app.querySelector(".sidebar-chat-hub__bottom")).not.toBeNull();
     expect(app.querySelector(".sidebar-chat-new")).not.toBeNull();
+  });
+
+  it("renders the chat-first content header", async () => {
+    const app = mountApp("/chat");
+    await app.updateComplete;
+
+    expect(app.querySelector(".content-header--chat-shell")).not.toBeNull();
+    expect(app.querySelector(".chat-page-heading__title")).not.toBeNull();
+    expect(app.querySelector(".chat-page-controls__model")).not.toBeNull();
   });
 
   it("starts a new dashboard chat from Cmd/Ctrl+N", async () => {

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -375,6 +375,8 @@ export type GatewaySessionRow = {
   kind: "direct" | "group" | "global" | "unknown";
   label?: string;
   displayName?: string;
+  derivedTitle?: string;
+  lastMessagePreview?: string;
   surface?: string;
   subject?: string;
   room?: string;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -4,7 +4,7 @@ import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { i18n } from "../../i18n/index.ts";
 import { getSafeLocalStorage } from "../../local-storage.ts";
-import { renderChatSessionSelect } from "../app-render.helpers.ts";
+import { renderChatSessionSelect, resolveChatSidebarSessions } from "../app-render.helpers.ts";
 import type { AppViewState } from "../app-view-state.ts";
 import {
   createModelCatalog,
@@ -1191,5 +1191,63 @@ describe("chat view", () => {
     expect(labels.filter((label) => label === "Deep Chat (alpha) / main")).toHaveLength(1);
     expect(labels).toContain("Deep Chat (alpha) / main · named-main");
     expect(labels).toContain("Coding (beta) / main");
+  });
+
+  it("builds a recent chat list from dashboard sessions for the active agent", () => {
+    const { state } = createChatHeaderState({ omitSessionFromList: true });
+    state.sessionKey = "agent:main:dashboard:active";
+    state.settings.sessionKey = state.sessionKey;
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 4,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        {
+          key: "agent:main:dashboard:older",
+          kind: "direct",
+          updatedAt: 100,
+          derivedTitle: "Older task",
+          lastMessagePreview: "Review the changelog",
+        },
+        {
+          key: "agent:main:dashboard:active",
+          kind: "direct",
+          updatedAt: 200,
+          label: "Current task",
+          lastMessagePreview: "Finish the implementation",
+        },
+        {
+          key: "agent:beta:dashboard:other-agent",
+          kind: "direct",
+          updatedAt: 300,
+          derivedTitle: "Other agent",
+        },
+        {
+          key: "agent:main:cron:job-1",
+          kind: "direct",
+          updatedAt: 400,
+          derivedTitle: "Cron run",
+        },
+      ],
+    };
+
+    const sessions = resolveChatSidebarSessions(state);
+
+    expect(sessions).toHaveLength(2);
+    expect(sessions.map((entry) => entry.key)).toEqual([
+      "agent:main:dashboard:active",
+      "agent:main:dashboard:older",
+    ]);
+    expect(sessions[0]).toMatchObject({
+      title: "Current task",
+      preview: "Finish the implementation",
+      active: true,
+    });
+    expect(sessions[1]).toMatchObject({
+      title: "Older task",
+      preview: "Review the changelog",
+      active: false,
+    });
   });
 });

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1242,11 +1242,13 @@ describe("chat view", () => {
     expect(sessions[0]).toMatchObject({
       title: "Current task",
       preview: "Finish the implementation",
+      updatedAtMs: 200,
       active: true,
     });
     expect(sessions[1]).toMatchObject({
       title: "Older task",
       preview: "Review the changelog",
+      updatedAtMs: 100,
       active: false,
     });
   });

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -651,11 +651,13 @@ function renderWelcomeState(props: ChatProps): TemplateResult {
         : html`<div class="agent-chat__avatar agent-chat__avatar--logo">
             <img src=${logoUrl} alt="OpenClaw" />
           </div>`}
-      <h2>${name}</h2>
+      <h2>Start a new conversation with ${name}</h2>
       <div class="agent-chat__badges">
-        <span class="agent-chat__badge"><img src=${logoUrl} alt="" /> Ready to chat</span>
+        <span class="agent-chat__badge"><img src=${logoUrl} alt="" /> Session-first chat</span>
       </div>
-      <p class="agent-chat__hint">Type a message below &middot; <kbd>/</kbd> for commands</p>
+      <p class="agent-chat__hint">
+        Each session keeps its own context. Pick a prompt below or type your own message.
+      </p>
       <div class="agent-chat__suggestions">
         ${WELCOME_SUGGESTIONS.map(
           (text) => html`


### PR DESCRIPTION
## Summary
- turn the chat tab into a conversation-first shell with a dedicated sessions sidebar, grouped recent chats, and a compact workspace nav
- replace the dashboard-style chat chrome with a current-conversation header, calmer top bar, and a more focused centered message canvas
- refine the composer, bubbles, and responsive layout while keeping the config/settings surfaces covered by targeted UI tests

## Verification
- pnpm test -- ui/src/ui/views/chat.test.ts
- pnpm --dir ui test --project browser -- src/ui/navigation.browser.test.ts src/ui/views/config.browser.test.ts src/ui/config-form.browser.test.ts
- pnpm --dir ui test --project unit -- src/ui/controllers/config.test.ts src/ui/app-settings.test.ts
- pnpm build