### PR TITLE
fix(gateway): use configured probe auth during restart health checks

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -52,6 +52,7 @@ const probeGateway = vi.fn<
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.hoisted(() => vi.fn(() => ({})));
 const recoverInstalledLaunchAgent = vi.hoisted(() => vi.fn());
+const resolveLocalGatewayProbeAuthSafeWithEnvFallback = vi.hoisted(() => vi.fn());
 
 vi.mock("../../config/config.js", () => ({
   loadConfig: () => loadConfig(),
@@ -73,6 +74,11 @@ vi.mock("../../gateway/probe.js", () => ({
     auth?: { token?: string; password?: string };
     timeoutMs: number;
   }) => probeGateway(opts),
+}));
+
+vi.mock("../../gateway/probe-auth.js", () => ({
+  resolveLocalGatewayProbeAuthSafeWithEnvFallback: (params: unknown) =>
+    resolveLocalGatewayProbeAuthSafeWithEnvFallback(params),
 }));
 
 vi.mock("../../config/commands.js", () => ({
@@ -159,6 +165,7 @@ describe("runDaemonRestart health checks", () => {
     isRestartEnabled.mockReset();
     loadConfig.mockReset();
     recoverInstalledLaunchAgent.mockReset();
+    resolveLocalGatewayProbeAuthSafeWithEnvFallback.mockReset();
 
     service.readCommand.mockResolvedValue({
       programArguments: ["openclaw", "gateway", "--port", "18789"],
@@ -198,6 +205,7 @@ describe("runDaemonRestart health checks", () => {
       configSnapshot: { commands: { restart: true } },
     });
     isRestartEnabled.mockReturnValue(true);
+    resolveLocalGatewayProbeAuthSafeWithEnvFallback.mockResolvedValue({});
     signalVerifiedGatewayPidSync.mockImplementation(() => {});
     formatGatewayPidList.mockImplementation((pids) => pids.join(", "));
   });
@@ -344,6 +352,7 @@ describe("runDaemonRestart health checks", () => {
   it("prefers unmanaged restart over launchd repair when a gateway listener is present", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
     findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+
     mockUnmanagedRestart({ runPostRestartCheck: true });
 
     await runDaemonRestart({ json: true });
@@ -352,6 +361,24 @@ describe("runDaemonRestart health checks", () => {
     expect(recoverInstalledLaunchAgent).not.toHaveBeenCalled();
     expect(waitForGatewayHealthyListener).toHaveBeenCalledTimes(1);
     expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();
+  });
+
+  it("passes configured probe auth into unmanaged restart health checks", async () => {
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+    resolveLocalGatewayProbeAuthSafeWithEnvFallback.mockResolvedValue({
+      token: "cfg-token",
+      password: "cfg-password",
+    });
+    mockUnmanagedRestart({ runPostRestartCheck: true });
+
+    await runDaemonRestart({ json: true });
+
+    expect(waitForGatewayHealthyListener).toHaveBeenCalledWith({
+      port: 18789,
+      attempts: 120,
+      delayMs: 500,
+      probeAuth: { token: "cfg-token", password: "cfg-password" },
+    });
   });
 
   it("re-bootstraps an installed LaunchAgent on restart when no unmanaged listener exists", async () => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -1,6 +1,7 @@
 import { isRestartEnabled } from "../../config/commands.js";
 import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
 import { resolveGatewayService } from "../../daemon/service.js";
+import { resolveLocalGatewayProbeAuthSafeWithEnvFallback } from "../../gateway/probe-auth.js";
 import { probeGateway } from "../../gateway/probe.js";
 import {
   findVerifiedGatewayListenerPidsOnPortSync,
@@ -62,6 +63,14 @@ async function resolveGatewayLifecyclePort(service = resolveGatewayService()) {
 
   const portFromArgs = parsePortFromArgs(command?.programArguments);
   return portFromArgs ?? resolveGatewayPort(await readBestEffortConfig(), mergedEnv);
+}
+
+async function resolveGatewayRestartProbeAuth() {
+  const cfg = await readBestEffortConfig().catch(() => undefined);
+  return await resolveLocalGatewayProbeAuthSafeWithEnvFallback({
+    cfg,
+    env: process.env,
+  });
 }
 
 function resolveGatewayPortFallback(): Promise<number> {
@@ -197,11 +206,13 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       return await recoverInstalledLaunchAgent({ result: "restarted" });
     },
     postRestartCheck: async ({ warnings, fail, stdout }) => {
+      const probeAuth = await resolveGatewayRestartProbeAuth();
       if (restartedWithoutServiceManager) {
         const health = await waitForGatewayHealthyListener({
           port: restartPort,
           attempts: POST_RESTART_HEALTH_ATTEMPTS,
           delayMs: POST_RESTART_HEALTH_DELAY_MS,
+          probeAuth,
         });
         if (health.healthy) {
           return;
@@ -230,6 +241,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         port: restartPort,
         attempts: POST_RESTART_HEALTH_ATTEMPTS,
         delayMs: POST_RESTART_HEALTH_DELAY_MS,
+        probeAuth,
         includeUnknownListenersAsStale: process.platform === "win32",
       });
 
@@ -251,6 +263,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
           port: restartPort,
           attempts: POST_RESTART_HEALTH_ATTEMPTS,
           delayMs: POST_RESTART_HEALTH_DELAY_MS,
+          probeAuth,
           includeUnknownListenersAsStale: process.platform === "win32",
         });
       }

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -40,6 +40,7 @@ function makeGatewayService(
 async function inspectGatewayRestartWithSnapshot(params: {
   runtime: { status: "running"; pid: number } | { status: "stopped" };
   portUsage: PortUsage;
+  probeAuth?: { token?: string; password?: string };
   includeUnknownListenersAsStale?: boolean;
 }) {
   const service = makeGatewayService(params.runtime);
@@ -48,6 +49,7 @@ async function inspectGatewayRestartWithSnapshot(params: {
   return inspectGatewayRestart({
     service,
     port: 18789,
+    ...(params.probeAuth === undefined ? {} : { probeAuth: params.probeAuth }),
     ...(params.includeUnknownListenersAsStale === undefined
       ? {}
       : { includeUnknownListenersAsStale: params.includeUnknownListenersAsStale }),
@@ -195,6 +197,26 @@ describe("inspectGatewayRestart", () => {
     expect(snapshot.healthy).toBe(true);
     expect(probeGateway).toHaveBeenCalledWith(
       expect.objectContaining({ url: "ws://127.0.0.1:18789" }),
+    );
+  });
+
+  it("passes configured probe auth into reachability checks", async () => {
+    const snapshot = await inspectGatewayRestartWithSnapshot({
+      runtime: { status: "running", pid: 8000 },
+      probeAuth: { token: "cfg-token" },
+      portUsage: {
+        port: 18789,
+        status: "busy",
+        listeners: [{ pid: 9000, ppid: 8999, commandLine: "openclaw-gateway" }],
+        hints: [],
+      },
+    });
+
+    expect(snapshot.healthy).toBe(false);
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: { token: "cfg-token", password: undefined },
+      }),
     );
   });
 

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -34,6 +34,11 @@ export type GatewayPortHealthSnapshot = {
   healthy: boolean;
 };
 
+export type GatewayProbeAuth = {
+  token?: string;
+  password?: string;
+};
+
 function hasListenerAttributionGap(portUsage: PortUsage): boolean {
   if (portUsage.status !== "busy" || portUsage.listeners.length > 0) {
     return false;
@@ -65,9 +70,13 @@ function looksLikeAuthClose(code: number | undefined, reason: string | undefined
   );
 }
 
-async function confirmGatewayReachable(port: number): Promise<boolean> {
-  const token = process.env.OPENCLAW_GATEWAY_TOKEN?.trim() || undefined;
-  const password = process.env.OPENCLAW_GATEWAY_PASSWORD?.trim() || undefined;
+async function confirmGatewayReachable(
+  port: number,
+  probeAuth?: GatewayProbeAuth,
+): Promise<boolean> {
+  const token = probeAuth?.token?.trim() || process.env.OPENCLAW_GATEWAY_TOKEN?.trim() || undefined;
+  const password =
+    probeAuth?.password?.trim() || process.env.OPENCLAW_GATEWAY_PASSWORD?.trim() || undefined;
   const probe = await probeGateway({
     url: `ws://127.0.0.1:${port}`,
     auth: token || password ? { token, password } : undefined,
@@ -77,7 +86,10 @@ async function confirmGatewayReachable(port: number): Promise<boolean> {
   return probe.ok || looksLikeAuthClose(probe.close?.code, probe.close?.reason);
 }
 
-async function inspectGatewayPortHealth(port: number): Promise<GatewayPortHealthSnapshot> {
+async function inspectGatewayPortHealth(
+  port: number,
+  probeAuth?: GatewayProbeAuth,
+): Promise<GatewayPortHealthSnapshot> {
   let portUsage: PortUsage;
   try {
     portUsage = await inspectPortUsage(port);
@@ -94,7 +106,7 @@ async function inspectGatewayPortHealth(port: number): Promise<GatewayPortHealth
   let healthy = false;
   if (portUsage.status === "busy") {
     try {
-      healthy = await confirmGatewayReachable(port);
+      healthy = await confirmGatewayReachable(port, probeAuth);
     } catch {
       // best-effort probe
     }
@@ -107,6 +119,7 @@ export async function inspectGatewayRestart(params: {
   service: GatewayService;
   port: number;
   env?: NodeJS.ProcessEnv;
+  probeAuth?: GatewayProbeAuth;
   includeUnknownListenersAsStale?: boolean;
 }): Promise<GatewayRestartSnapshot> {
   const env = params.env ?? process.env;
@@ -132,7 +145,7 @@ export async function inspectGatewayRestart(params: {
 
   if (portUsage.status === "busy" && runtime.status !== "running") {
     try {
-      const reachable = await confirmGatewayReachable(params.port);
+      const reachable = await confirmGatewayReachable(params.port, params.probeAuth);
       if (reachable) {
         return {
           runtime,
@@ -174,7 +187,7 @@ export async function inspectGatewayRestart(params: {
   let healthy = running && ownsPort;
   if (!healthy && running && portUsage.status === "busy") {
     try {
-      healthy = await confirmGatewayReachable(params.port);
+      healthy = await confirmGatewayReachable(params.port, params.probeAuth);
     } catch {
       // best-effort probe
     }
@@ -239,6 +252,7 @@ export async function waitForGatewayHealthyRestart(params: {
   attempts?: number;
   delayMs?: number;
   env?: NodeJS.ProcessEnv;
+  probeAuth?: GatewayProbeAuth;
   includeUnknownListenersAsStale?: boolean;
 }): Promise<GatewayRestartSnapshot> {
   const attempts = params.attempts ?? DEFAULT_RESTART_HEALTH_ATTEMPTS;
@@ -248,6 +262,7 @@ export async function waitForGatewayHealthyRestart(params: {
     service: params.service,
     port: params.port,
     env: params.env,
+    probeAuth: params.probeAuth,
     includeUnknownListenersAsStale: params.includeUnknownListenersAsStale,
   });
 
@@ -278,6 +293,7 @@ export async function waitForGatewayHealthyRestart(params: {
       service: params.service,
       port: params.port,
       env: params.env,
+      probeAuth: params.probeAuth,
       includeUnknownListenersAsStale: params.includeUnknownListenersAsStale,
     });
   }
@@ -289,18 +305,19 @@ export async function waitForGatewayHealthyListener(params: {
   port: number;
   attempts?: number;
   delayMs?: number;
+  probeAuth?: GatewayProbeAuth;
 }): Promise<GatewayPortHealthSnapshot> {
   const attempts = params.attempts ?? DEFAULT_RESTART_HEALTH_ATTEMPTS;
   const delayMs = params.delayMs ?? DEFAULT_RESTART_HEALTH_DELAY_MS;
 
-  let snapshot = await inspectGatewayPortHealth(params.port);
+  let snapshot = await inspectGatewayPortHealth(params.port, params.probeAuth);
 
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     if (snapshot.healthy) {
       return snapshot;
     }
     await sleep(delayMs);
-    snapshot = await inspectGatewayPortHealth(params.port);
+    snapshot = await inspectGatewayPortHealth(params.port, params.probeAuth);
   }
 
   return snapshot;

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -405,9 +405,17 @@ export async function gatherDaemonStatus(
       )
     : undefined;
   let daemonProbeAuth: { token?: string; password?: string } | undefined;
+  let localRestartProbeAuth: { token?: string; password?: string } | undefined;
   let rpcAuthWarning: string | undefined;
   if (opts.probe) {
     const probeMode = daemonCfg.gateway?.mode === "remote" ? "remote" : "local";
+    localRestartProbeAuth = await loadGatewayProbeAuthModule().then(
+      ({ resolveLocalGatewayProbeAuthSafeWithEnvFallback }) =>
+        resolveLocalGatewayProbeAuthSafeWithEnvFallback({
+          cfg: daemonCfg,
+          env: mergedDaemonEnv as NodeJS.ProcessEnv,
+        }),
+    );
     try {
       daemonProbeAuth = resolveGatewayProbeCredentialsFromConfig({
         cfg: daemonCfg,
@@ -475,6 +483,7 @@ export async function gatherDaemonStatus(
               service,
               port: daemonPort,
               env: serviceEnv,
+              probeAuth: localRestartProbeAuth,
             }),
           )
           .catch(() => undefined)

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -6,6 +6,7 @@ import {
 } from "../../commands/doctor-completion.js";
 import { doctorCommand } from "../../commands/doctor.js";
 import {
+  readBestEffortConfig,
   readConfigFileSnapshot,
   replaceConfigFile,
   resolveGatewayPort,
@@ -13,6 +14,7 @@ import {
 import { formatConfigIssueLines } from "../../config/issue-format.js";
 import { asResolvedSourceConfig, asRuntimeConfig } from "../../config/materialize.js";
 import { resolveGatewayService } from "../../daemon/service.js";
+import { resolveLocalGatewayProbeAuthSafeWithEnvFallback } from "../../gateway/probe-auth.js";
 import { nodeVersionSatisfiesEngine } from "../../infra/runtime-guard.js";
 import {
   channelToNpmTag,
@@ -106,6 +108,14 @@ const UPDATE_QUIPS = [
 
 function pickUpdateQuip(): string {
   return UPDATE_QUIPS[Math.floor(Math.random() * UPDATE_QUIPS.length)] ?? "Update complete.";
+}
+
+async function resolveUpdateRestartProbeAuth() {
+  const cfg = await readBestEffortConfig().catch(() => undefined);
+  return await resolveLocalGatewayProbeAuthSafeWithEnvFallback({
+    cfg,
+    env: process.env,
+  });
 }
 
 function resolveGatewayInstallEntrypointCandidates(root?: string): string[] {
@@ -693,9 +703,11 @@ async function maybeRestartService(params: {
 
       if (!params.opts.json && restartInitiated) {
         const service = resolveGatewayService();
+        const probeAuth = await resolveUpdateRestartProbeAuth();
         let health = await waitForGatewayHealthyRestart({
           service,
           port: params.gatewayPort,
+          probeAuth,
         });
         if (!health.healthy && health.staleGatewayPids.length > 0) {
           if (!params.opts.json) {
@@ -710,6 +722,7 @@ async function maybeRestartService(params: {
           health = await waitForGatewayHealthyRestart({
             service,
             port: params.gatewayPort,
+            probeAuth,
           });
         }
 

--- a/src/gateway/probe-auth.test.ts
+++ b/src/gateway/probe-auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  resolveLocalGatewayProbeAuthSafeWithEnvFallback,
   resolveGatewayProbeAuthSafe,
   resolveGatewayProbeAuthSafeWithSecretInputs,
   resolveGatewayProbeAuthWithSecretInputs,
@@ -187,6 +188,44 @@ describe("resolveGatewayProbeAuthWithSecretInputs", () => {
     expect(auth).toEqual({
       token: "resolved-daemon-token",
       password: undefined,
+    });
+  });
+});
+
+describe("resolveLocalGatewayProbeAuthSafeWithEnvFallback", () => {
+  it("forces local probe auth even when gateway routing mode is remote", async () => {
+    const auth = await resolveLocalGatewayProbeAuthSafeWithEnvFallback({
+      cfg: {
+        gateway: {
+          mode: "remote",
+          auth: {
+            token: "local-token",
+          },
+          remote: {
+            token: "remote-token",
+          },
+        },
+      } as OpenClawConfig,
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(auth).toEqual({
+      token: "local-token",
+      password: undefined,
+    });
+  });
+
+  it("falls back to env credentials when config is unavailable", async () => {
+    const auth = await resolveLocalGatewayProbeAuthSafeWithEnvFallback({
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: "env-token",
+        OPENCLAW_GATEWAY_PASSWORD: "env-password",
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(auth).toEqual({
+      token: "env-token",
+      password: "env-password",
     });
   });
 });

--- a/src/gateway/probe-auth.ts
+++ b/src/gateway/probe-auth.ts
@@ -82,6 +82,28 @@ export async function resolveGatewayProbeAuthSafeWithSecretInputs(params: {
   }
 }
 
+export async function resolveLocalGatewayProbeAuthSafeWithEnvFallback(params: {
+  cfg?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): Promise<{ token?: string; password?: string }> {
+  const fallbackAuth = {
+    token: params.env?.OPENCLAW_GATEWAY_TOKEN?.trim() || undefined,
+    password: params.env?.OPENCLAW_GATEWAY_PASSWORD?.trim() || undefined,
+  };
+  if (!params.cfg) {
+    return fallbackAuth;
+  }
+  const { auth } = await resolveGatewayProbeAuthSafeWithSecretInputs({
+    cfg: params.cfg,
+    mode: "local",
+    env: params.env,
+  });
+  return {
+    token: auth.token ?? fallbackAuth.token,
+    password: auth.password ?? fallbackAuth.password,
+  };
+}
+
 export function resolveGatewayProbeAuthSafe(params: {
   cfg: OpenClawConfig;
   mode: "local" | "remote";


### PR DESCRIPTION
## Summary
- pass resolved probe auth into gateway restart health checks instead of relying only on process env vars
- reuse the same configured auth resolution path for daemon restart and update-triggered restart verification
- cover the restart-health probe path with a regression test and align status health inspection with the same auth

## Problem
When local gateway auth is configured in openclaw.json but OPENCLAW_GATEWAY_TOKEN is not exported in the current shell, openclaw gateway restart can report a timeout even though the launchd or service-managed gateway eventually comes up and starts listening.

Gateway status already resolves probe auth from config, but restart health checks were probing reachability with env-only auth. That mismatch caused false negatives during warm-up and token-authenticated restarts.

## Fix
- add optional probe auth plumbing to restart health inspection helpers
- resolve probe auth from config before restart health polling in daemon lifecycle and update restart flows
- pass resolved probe auth into status restart inspection as well

## Verification
- pnpm vitest run src/cli/daemon-cli/restart-health.test.ts src/cli/daemon-cli/status.gather.test.ts
- pnpm lint
- pnpm build