### PR TITLE
fix(status): cap cache hit rate at 100% in status display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Docs: https://docs.openclaw.ai
 - Docs/anchors: fix broken English docs links and make Mint anchor audits run against the English-source docs tree. (#57039) thanks @velvet-shark.
 - Cron/announce: preserve all deliverable text payloads for announce mode instead of collapsing to the last chunk, so multi-line cron reports deliver in full to Telegram forum topics.
 - Harden async approval followup delivery in webchat-only sessions (#57359) Thanks @joshavant.
+- Status: fix cache hit rate exceeding 100% by deriving denominator from prompt-side token fields instead of potentially undersized totalTokens. Fixes #26643.
 
 ## 2026.3.28
 

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -16,13 +16,19 @@ export const formatDuration = (ms: number | null | undefined) => {
 export const formatTokensCompact = (
   sess: Pick<
     SessionStatus,
-    "totalTokens" | "contextTokens" | "percentUsed" | "cacheRead" | "cacheWrite"
+    | "inputTokens"
+    | "totalTokens"
+    | "contextTokens"
+    | "percentUsed"
+    | "cacheRead"
+    | "cacheWrite"
   >,
 ) => {
   const used = sess.totalTokens;
   const ctx = sess.contextTokens;
   const cacheRead = sess.cacheRead;
   const cacheWrite = sess.cacheWrite;
+  const inputTokens = sess.inputTokens;
 
   let result = "";
   if (used == null) {
@@ -36,10 +42,23 @@ export const formatTokensCompact = (
 
   // Add cache hit rate if there are cached reads
   if (typeof cacheRead === "number" && cacheRead > 0) {
+    const cacheWriteTokens =
+      typeof cacheWrite === "number" && Number.isFinite(cacheWrite) && cacheWrite >= 0
+        ? cacheWrite
+        : 0;
+    const promptTokensFromParts =
+      typeof inputTokens === "number" && Number.isFinite(inputTokens) && inputTokens >= 0
+        ? inputTokens + cacheRead + cacheWriteTokens
+        : undefined;
+    // Legacy entries can carry an undersized totalTokens value. Keep the cache
+    // denominator aligned with the prompt-side token fields when available, and
+    // never let the fallback denominator drop below the known cached prompt
+    // tokens.
     const total =
-      typeof used === "number"
-        ? used
-        : cacheRead + (typeof cacheWrite === "number" ? cacheWrite : 0);
+      promptTokensFromParts ??
+      (typeof used === "number" && Number.isFinite(used) && used > 0
+        ? Math.max(used, cacheRead + cacheWriteTokens)
+        : cacheRead + cacheWriteTokens);
     const hitRate = Math.round((cacheRead / total) * 100);
     result += ` · 🗄️ ${hitRate}% cached`;
   }

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -632,6 +632,50 @@ describe("statusCommand", () => {
     ).toBe(true);
   });
 
+  it("caps cached percentage at the prompt-token denominator for legacy session totals", async () => {
+    const originalLoadSessionStore = mocks.loadSessionStore.getMockImplementation();
+    mocks.loadSessionStore.mockReturnValue({
+      "+1000": {
+        ...createDefaultSessionStoreEntry(),
+        inputTokens: undefined,
+        cacheRead: 1_200,
+        cacheWrite: 0,
+        totalTokens: 1_000,
+      },
+    });
+    try {
+      const logs = await runStatusAndGetLogs();
+      expect(logs.some((line) => line.includes("100% cached"))).toBe(true);
+      expect(logs.some((line) => line.includes("120% cached"))).toBe(false);
+    } finally {
+      if (originalLoadSessionStore) {
+        mocks.loadSessionStore.mockImplementation(originalLoadSessionStore);
+      }
+    }
+  });
+
+  it("uses prompt-side tokens for cached percentage when they differ from totalTokens", async () => {
+    const originalLoadSessionStore = mocks.loadSessionStore.getMockImplementation();
+    mocks.loadSessionStore.mockReturnValue({
+      "+1000": {
+        ...createDefaultSessionStoreEntry(),
+        inputTokens: 500,
+        cacheRead: 2_000,
+        cacheWrite: 500,
+        totalTokens: 5_000,
+      },
+    });
+    try {
+      const logs = await runStatusAndGetLogs();
+      expect(logs.some((line) => line.includes("67% cached"))).toBe(true);
+      expect(logs.some((line) => line.includes("40% cached"))).toBe(false);
+    } finally {
+      if (originalLoadSessionStore) {
+        mocks.loadSessionStore.mockImplementation(originalLoadSessionStore);
+      }
+    }
+  });
+
   it("shows node-only gateway info when no local gateway service is installed", async () => {
     mocks.resolveGatewayService.mockReturnValueOnce({
       label: "LaunchAgent",


### PR DESCRIPTION
## Summary

`formatTokensCompact()` computed cache hit rate using `totalTokens` as the denominator. Legacy session rows with undersized `totalTokens` produced impossible values like "120% cached".

## Fix

Use `inputTokens + cacheRead + cacheWrite` when prompt-side fields are available. Fall back to `max(totalTokens, cacheRead + cacheWrite)` for legacy data so the denominator never drops below the known cached tokens.

## Testing

- 14 test suites, 64 tests pass in `src/commands/status`
- Typecheck (`pnpm tsgo`) clean
- New regression tests:
  - Legacy undersized totalTokens → clamped to 100% (not 120%)
  - inputTokens-present path → uses correct prompt-side denominator (67% vs old 40%)

Fixes #26643