### PR TITLE
Agents: deliver media attachments from tool results

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -232,14 +232,14 @@ export async function handleToolExecutionEnd(
     const outputText = extractToolResultText(sanitizedResult);
     const mediaUrls = extractToolResultMediaUrls(sanitizedResult);
     if (mediaUrls?.length) {
-      try {
-        void ctx.params.onToolResult({
+      void ctx.params
+        .onToolResult({
           text: outputText,
           mediaUrls,
+        })
+        .catch(() => {
+          // ignore tool result delivery failures
         });
-      } catch {
-        // ignore tool result delivery failures
-      }
     } else if (ctx.shouldEmitToolOutput() && outputText) {
       ctx.emitToolOutput(toolName, meta, outputText);
     }

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -7,6 +7,7 @@ import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
 import { isMessagingTool, isMessagingToolSendAction } from "./pi-embedded-messaging.js";
 import {
   extractToolErrorMessage,
+  extractToolResultMediaUrls,
   extractToolResultText,
   extractMessagingToolSend,
   isToolResultError,
@@ -227,9 +228,19 @@ export async function handleToolExecutionEnd(
     `embedded run tool end: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
 
-  if (ctx.params.onToolResult && ctx.shouldEmitToolOutput()) {
+  if (ctx.params.onToolResult) {
     const outputText = extractToolResultText(sanitizedResult);
-    if (outputText) {
+    const mediaUrls = extractToolResultMediaUrls(sanitizedResult);
+    if (mediaUrls?.length) {
+      try {
+        void ctx.params.onToolResult({
+          text: outputText,
+          mediaUrls,
+        });
+      } catch {
+        // ignore tool result delivery failures
+      }
+    } else if (ctx.shouldEmitToolOutput() && outputText) {
       ctx.emitToolOutput(toolName, meta, outputText);
     }
   }

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.e2e.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.e2e.test.ts
@@ -236,4 +236,58 @@ describe("subscribeEmbeddedPiSession", () => {
     const readOutput = onToolResult.mock.calls[2][0];
     expect(readOutput.text).toContain("file data");
   });
+
+  it("emits media attachments from tool result details without requiring full verbose output", async () => {
+    let handler: ((evt: unknown) => void) | undefined;
+    const session: StubSession = {
+      subscribe: (fn) => {
+        handler = fn;
+        return () => {};
+      },
+    };
+
+    const onToolResult = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session: session as unknown as Parameters<typeof subscribeEmbeddedPiSession>[0]["session"],
+      runId: "run-image-generate",
+      verboseLevel: "on",
+      onToolResult,
+    });
+
+    handler?.({
+      type: "tool_execution_start",
+      toolName: "image_generate",
+      toolCallId: "tool-image-1",
+      args: { prompt: "cat" },
+    });
+
+    await Promise.resolve();
+
+    expect(onToolResult).toHaveBeenCalledTimes(1);
+
+    handler?.({
+      type: "tool_execution_end",
+      toolName: "image_generate",
+      toolCallId: "tool-image-1",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Generated 1 image with minimax/image-01." }],
+        details: {
+          media: {
+            mediaUrls: ["/home/openclaw/.openclaw/media/tool-image-generation/cat.png"],
+          },
+          paths: ["/home/openclaw/.openclaw/media/tool-image-generation/cat.png"],
+        },
+      },
+    });
+
+    await Promise.resolve();
+
+    expect(onToolResult).toHaveBeenCalledTimes(2);
+    expect(onToolResult.mock.calls[1]?.[0]).toEqual({
+      text: "Generated 1 image with minimax/image-01.",
+      mediaUrls: ["/home/openclaw/.openclaw/media/tool-image-generation/cat.png"],
+    });
+  });
 });

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -118,6 +118,64 @@ export function extractToolResultText(result: unknown): string | undefined {
   return texts.join("\n");
 }
 
+export function extractToolResultMediaUrls(result: unknown): string[] | undefined {
+  if (!result || typeof result !== "object") {
+    return undefined;
+  }
+
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  const push = (value: unknown) => {
+    if (typeof value !== "string") {
+      return;
+    }
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      return;
+    }
+    seen.add(trimmed);
+    urls.push(trimmed);
+  };
+  const pushMany = (value: unknown) => {
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        push(entry);
+      }
+      return;
+    }
+    push(value);
+  };
+
+  const record = result as Record<string, unknown>;
+  pushMany(record.mediaUrls);
+  push(record.mediaUrl);
+  pushMany(record.paths);
+  push(record.path);
+  push(record.filePath);
+
+  const details = record.details;
+  if (details && typeof details === "object") {
+    const detailRecord = details as Record<string, unknown>;
+    pushMany(detailRecord.mediaUrls);
+    push(detailRecord.mediaUrl);
+    pushMany(detailRecord.paths);
+    push(detailRecord.path);
+    push(detailRecord.filePath);
+
+    const media = detailRecord.media;
+    if (media && typeof media === "object") {
+      const mediaRecord = media as Record<string, unknown>;
+      pushMany(mediaRecord.mediaUrls);
+      push(mediaRecord.mediaUrl);
+      pushMany(mediaRecord.paths);
+      push(mediaRecord.path);
+      push(mediaRecord.filePath);
+    }
+  }
+
+  return urls.length > 0 ? urls : undefined;
+}
+
 export function isToolResultError(result: unknown): boolean {
   if (!result || typeof result !== "object") {
     return false;


### PR DESCRIPTION
#### Summary
Tool results that include attachments in structured `details` were only exposing `content[].text` to the reply pipeline, so channels never received the generated file path for automatic delivery. This updates tool-result handling to forward extracted media references alongside the existing text summary.

#### Repro Steps
1. In Feishu, trigger `image_generate`.
2. Observe the tool result contains a local file path under `~/.openclaw/media/tool-image-generation/...`.
3. Observe no image is automatically sent even though a manual `message action=send filePath=...` succeeds.

#### Root Cause
`handleToolExecutionEnd()` only used `extractToolResultText()`, and that helper only reads `content[].text`. The subscription layer dropped `details.media.mediaUrls` and path-style fallbacks, so outbound reply delivery never received any `mediaUrls` to send.

#### Behavior Changes
- Auto tool-result replies now forward media references from structured tool result details.
- Extraction dedupes `details.media.mediaUrls`, `details.paths`, and related path-style fallbacks.
- Added regression coverage for media-bearing tool results in non-`full` verbose mode.

#### Codebase and GitHub Search
- Reviewed issue [#57396](https://github.com/openclaw/openclaw/issues/57396).
- Searched the codebase for `tool_execution_end`, `details.media`, `mediaUrls`, and tool-result reply routing.
- Verified the relevant path through `src/agents/pi-embedded-subscribe.handlers.tools.ts`, `src/agents/pi-embedded-subscribe.tools.ts`, and `src/infra/outbound/deliver.ts`.

#### Tests
- `pnpm check`
- `pnpm build`
- `pnpm exec vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.waits-multiple-compaction-retries-before-resolving.e2e.test.ts -t "emits media attachments from tool result details without requiring full verbose output"`
- `pnpm test` started locally before PR creation; it is a long-running suite and was still in progress at PR creation time.

**Sign-Off**

- Models used: Cursor assistant
- Submitter effort: high
- Agent notes: lobster-biscuit
