### PR TITLE
Fix project-local .env regression (#57408)

### DIFF
--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -97,7 +97,7 @@ describe("loadDotEnv", () => {
     });
   });
 
-  it("blocks dangerous and workspace-control vars from CWD .env (except project-level path overrides)", async () => {
+  it("allows OPENCLAW_CONFIG_PATH from workspace .env but blocks OPENCLAW_STATE_DIR", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
         await writeEnvFile(
@@ -125,8 +125,9 @@ describe("loadDotEnv", () => {
         expect(process.env.SAFE_KEY).toBe("from-cwd");
         expect(process.env.BAR).toBe("from-global");
         expect(process.env.NODE_OPTIONS).toBeUndefined();
-        // Project-level path overrides ARE allowed from workspace .env
-        expect(process.env.OPENCLAW_STATE_DIR).toBe("./project-state");
+        // OPENCLAW_STATE_DIR is blocked to prevent .env redirect attacks
+        expect(process.env.OPENCLAW_STATE_DIR).toBe(stateDir);
+        // OPENCLAW_CONFIG_PATH is allowed as a project-level override
         expect(process.env.OPENCLAW_CONFIG_PATH).toBe("./project-config.json");
         expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
         expect(process.env.HTTP_PROXY).toBeUndefined();
@@ -134,7 +135,7 @@ describe("loadDotEnv", () => {
     });
   });
 
-  it("allows OPENCLAW_STATE_DIR and OPENCLAW_CONFIG_PATH from workspace .env (project-level overrides)", async () => {
+  it("allows OPENCLAW_CONFIG_PATH from workspace .env but blocks OPENCLAW_STATE_DIR", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ cwdDir }) => {
         await writeEnvFile(
@@ -147,7 +148,7 @@ describe("loadDotEnv", () => {
 
         loadWorkspaceDotEnvFile(path.join(cwdDir, ".env"), { quiet: true });
 
-        expect(process.env.OPENCLAW_STATE_DIR).toBe("./project-state");
+        expect(process.env.OPENCLAW_STATE_DIR).toBeUndefined();
         expect(process.env.OPENCLAW_CONFIG_PATH).toBe("./project-config.json");
       });
     });
@@ -218,30 +219,31 @@ describe("loadDotEnv", () => {
 });
 
 describe("loadCliDotEnv", () => {
-  it("allows OPENCLAW_STATE_DIR from workspace .env as a project-level override", async () => {
+  it("blocks OPENCLAW_STATE_DIR from workspace .env even when unset in process env", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ cwdDir }) => {
-        await writeEnvFile(path.join(cwdDir, ".env"), "OPENCLAW_STATE_DIR=./project-state\n");
+        await writeEnvFile(path.join(cwdDir, ".env"), "OPENCLAW_STATE_DIR=./evil-state\n");
 
-        // Delete the fixture-provided value to test that workspace .env loads it
+        // Delete the fixture-provided value so the blocking must come from
+        // the workspace blocklist, not the "already set" skip.
         delete process.env.OPENCLAW_STATE_DIR;
         vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
 
         loadCliDotEnv({ quiet: true });
 
-        expect(process.env.OPENCLAW_STATE_DIR).toBe("./project-state");
+        expect(process.env.OPENCLAW_STATE_DIR).toBeUndefined();
       });
     });
   });
 
-  it("allows project-level OPENCLAW_STATE_DIR and OPENCLAW_CONFIG_PATH from workspace .env", async () => {
+  it("blocks workspace .env takeover vars before loading the global fallback", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
         await writeEnvFile(
           path.join(cwdDir, ".env"),
           [
             "SAFE_KEY=from-cwd",
-            "OPENCLAW_STATE_DIR=./project-state",
+            "OPENCLAW_STATE_DIR=./evil-state",
             "OPENCLAW_CONFIG_PATH=./project-config.json",
             "NODE_OPTIONS=--require ./evil.js",
             "ANTHROPIC_BASE_URL=https://evil.example.com/v1",
@@ -260,8 +262,7 @@ describe("loadCliDotEnv", () => {
 
         expect(process.env.SAFE_KEY).toBe("from-cwd");
         expect(process.env.BAR).toBe("from-global");
-        // Project-level overrides should be loaded from workspace .env
-        expect(process.env.OPENCLAW_STATE_DIR).toBe("./project-state");
+        expect(process.env.OPENCLAW_STATE_DIR).toBe(stateDir);
         expect(process.env.OPENCLAW_CONFIG_PATH).toBe("./project-config.json");
         expect(process.env.NODE_OPTIONS).toBeUndefined();
         expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -97,7 +97,7 @@ describe("loadDotEnv", () => {
     });
   });
 
-  it("blocks dangerous and workspace-control vars from CWD .env", async () => {
+  it("blocks dangerous and workspace-control vars from CWD .env (except project-level path overrides)", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
         await writeEnvFile(
@@ -105,8 +105,8 @@ describe("loadDotEnv", () => {
           [
             "SAFE_KEY=from-cwd",
             "NODE_OPTIONS=--require ./evil.js",
-            "OPENCLAW_STATE_DIR=./evil-state",
-            "OPENCLAW_CONFIG_PATH=./evil-config.json",
+            "OPENCLAW_STATE_DIR=./project-state",
+            "OPENCLAW_CONFIG_PATH=./project-config.json",
             "ANTHROPIC_BASE_URL=https://evil.example.com/v1",
             "HTTP_PROXY=http://evil-proxy:8080",
           ].join("\n"),
@@ -125,20 +125,21 @@ describe("loadDotEnv", () => {
         expect(process.env.SAFE_KEY).toBe("from-cwd");
         expect(process.env.BAR).toBe("from-global");
         expect(process.env.NODE_OPTIONS).toBeUndefined();
-        expect(process.env.OPENCLAW_STATE_DIR).toBe(stateDir);
-        expect(process.env.OPENCLAW_CONFIG_PATH).toBeUndefined();
+        // Project-level path overrides ARE allowed from workspace .env
+        expect(process.env.OPENCLAW_STATE_DIR).toBe("./project-state");
+        expect(process.env.OPENCLAW_CONFIG_PATH).toBe("./project-config.json");
         expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
         expect(process.env.HTTP_PROXY).toBeUndefined();
       });
     });
   });
 
-  it("blocks OPENCLAW_STATE_DIR from workspace .env even when unset in process env", async () => {
+  it("allows OPENCLAW_STATE_DIR and OPENCLAW_CONFIG_PATH from workspace .env (project-level overrides)", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ cwdDir }) => {
         await writeEnvFile(
           path.join(cwdDir, ".env"),
-          "OPENCLAW_STATE_DIR=./evil-state\nOPENCLAW_CONFIG_PATH=./evil-config.json\n",
+          "OPENCLAW_STATE_DIR=./project-state\nOPENCLAW_CONFIG_PATH=./project-config.json\n",
         );
 
         delete process.env.OPENCLAW_STATE_DIR;
@@ -146,8 +147,8 @@ describe("loadDotEnv", () => {
 
         loadWorkspaceDotEnvFile(path.join(cwdDir, ".env"), { quiet: true });
 
-        expect(process.env.OPENCLAW_STATE_DIR).toBeUndefined();
-        expect(process.env.OPENCLAW_CONFIG_PATH).toBeUndefined();
+        expect(process.env.OPENCLAW_STATE_DIR).toBe("./project-state");
+        expect(process.env.OPENCLAW_CONFIG_PATH).toBe("./project-config.json");
       });
     });
   });
@@ -217,32 +218,31 @@ describe("loadDotEnv", () => {
 });
 
 describe("loadCliDotEnv", () => {
-  it("blocks OPENCLAW_STATE_DIR from workspace .env even when unset in process env", async () => {
+  it("allows OPENCLAW_STATE_DIR from workspace .env as a project-level override", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ cwdDir }) => {
-        await writeEnvFile(path.join(cwdDir, ".env"), "OPENCLAW_STATE_DIR=./evil-state\n");
+        await writeEnvFile(path.join(cwdDir, ".env"), "OPENCLAW_STATE_DIR=./project-state\n");
 
-        // Delete the fixture-provided value so the blocking must come from
-        // the workspace blocklist, not the "already set" skip.
+        // Delete the fixture-provided value to test that workspace .env loads it
         delete process.env.OPENCLAW_STATE_DIR;
         vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
 
         loadCliDotEnv({ quiet: true });
 
-        expect(process.env.OPENCLAW_STATE_DIR).toBeUndefined();
+        expect(process.env.OPENCLAW_STATE_DIR).toBe("./project-state");
       });
     });
   });
 
-  it("blocks workspace .env takeover vars before loading the global fallback", async () => {
+  it("allows project-level OPENCLAW_STATE_DIR and OPENCLAW_CONFIG_PATH from workspace .env", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
         await writeEnvFile(
           path.join(cwdDir, ".env"),
           [
             "SAFE_KEY=from-cwd",
-            "OPENCLAW_STATE_DIR=./evil-state",
-            "OPENCLAW_CONFIG_PATH=./evil-config.json",
+            "OPENCLAW_STATE_DIR=./project-state",
+            "OPENCLAW_CONFIG_PATH=./project-config.json",
             "NODE_OPTIONS=--require ./evil.js",
             "ANTHROPIC_BASE_URL=https://evil.example.com/v1",
           ].join("\n"),
@@ -260,8 +260,9 @@ describe("loadCliDotEnv", () => {
 
         expect(process.env.SAFE_KEY).toBe("from-cwd");
         expect(process.env.BAR).toBe("from-global");
-        expect(process.env.OPENCLAW_STATE_DIR).toBe(stateDir);
-        expect(process.env.OPENCLAW_CONFIG_PATH).toBeUndefined();
+        // Project-level overrides should be loaded from workspace .env
+        expect(process.env.OPENCLAW_STATE_DIR).toBe("./project-state");
+        expect(process.env.OPENCLAW_CONFIG_PATH).toBe("./project-config.json");
         expect(process.env.NODE_OPTIONS).toBeUndefined();
         expect(process.env.ANTHROPIC_BASE_URL).toBeUndefined();
       });

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -99,10 +99,16 @@ export function loadWorkspaceDotEnvFile(filePath: string, opts?: { quiet?: boole
 export function loadDotEnv(opts?: { quiet?: boolean }) {
   const quiet = opts?.quiet ?? true;
   const cwdEnvPath = path.join(process.cwd(), ".env");
+
+  // Resolve the global env path BEFORE loading workspace .env so that
+  // workspace .env cannot redirect which global config is loaded.
+  // This preserves the security invariant that untrusted workspace .env
+  // cannot hijack the user's global ~/.openclaw/.env config.
+  const globalEnvPath = path.join(resolveConfigDir(process.env), ".env");
+
   loadWorkspaceDotEnvFile(cwdEnvPath, { quiet });
 
   // Then load global fallback: ~/.openclaw/.env (or OPENCLAW_STATE_DIR/.env),
   // without overriding any env vars already present.
-  const globalEnvPath = path.join(resolveConfigDir(process.env), ".env");
   loadRuntimeDotEnvFile(globalEnvPath, { quiet });
 }

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -8,10 +8,6 @@ import {
   normalizeEnvVarKey,
 } from "./host-env-security.js";
 
-// NOTE: OPENCLAW_CONFIG_PATH and OPENCLAW_STATE_DIR are intentionally NOT blocked
-// from workspace .env files. These are legitimate project-level configuration overrides
-// that enable per-project setups without requiring shell environment variables.
-// If someone can write to .env, they already control the project anyway.
 const BLOCKED_WORKSPACE_DOTENV_KEYS = new Set([
   "ALL_PROXY",
   "HTTP_PROXY",
@@ -22,7 +18,13 @@ const BLOCKED_WORKSPACE_DOTENV_KEYS = new Set([
   "OPENCLAW_HOME",
   "OPENCLAW_OAUTH_DIR",
   "OPENCLAW_PROFILE",
+  "OPENCLAW_STATE_DIR",
   "PI_CODING_AGENT_DIR",
+  // NOTE: OPENCLAW_CONFIG_PATH is intentionally NOT blocked from workspace .env.
+  // It's a legitimate project-level configuration override that enables users to
+  // specify their project's config file without requiring shell environment variables.
+  // OPENCLAW_STATE_DIR remains blocked to prevent a malicious .env from redirecting
+  // which global config is loaded or creating a shadow .env with blocked vars.
 ]);
 
 const BLOCKED_WORKSPACE_DOTENV_SUFFIXES = ["_BASE_URL"];

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -8,6 +8,10 @@ import {
   normalizeEnvVarKey,
 } from "./host-env-security.js";
 
+// NOTE: OPENCLAW_CONFIG_PATH and OPENCLAW_STATE_DIR are intentionally NOT blocked
+// from workspace .env files. These are legitimate project-level configuration overrides
+// that enable per-project setups without requiring shell environment variables.
+// If someone can write to .env, they already control the project anyway.
 const BLOCKED_WORKSPACE_DOTENV_KEYS = new Set([
   "ALL_PROXY",
   "HTTP_PROXY",
@@ -19,10 +23,6 @@ const BLOCKED_WORKSPACE_DOTENV_KEYS = new Set([
   "OPENCLAW_OAUTH_DIR",
   "OPENCLAW_PROFILE",
   "PI_CODING_AGENT_DIR",
-  // NOTE: OPENCLAW_CONFIG_PATH and OPENCLAW_STATE_DIR are intentionally NOT blocked
-  // from workspace .env files. These are legitimate project-level configuration overrides
-  // that enable per-project setups without requiring shell environment variables.
-  // If someone can write to .env, they already control the project anyway.
 ]);
 
 const BLOCKED_WORKSPACE_DOTENV_SUFFIXES = ["_BASE_URL"];

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -15,12 +15,14 @@ const BLOCKED_WORKSPACE_DOTENV_KEYS = new Set([
   "NODE_TLS_REJECT_UNAUTHORIZED",
   "NO_PROXY",
   "OPENCLAW_AGENT_DIR",
-  "OPENCLAW_CONFIG_PATH",
   "OPENCLAW_HOME",
   "OPENCLAW_OAUTH_DIR",
   "OPENCLAW_PROFILE",
-  "OPENCLAW_STATE_DIR",
   "PI_CODING_AGENT_DIR",
+  // NOTE: OPENCLAW_CONFIG_PATH and OPENCLAW_STATE_DIR are intentionally NOT blocked
+  // from workspace .env files. These are legitimate project-level configuration overrides
+  // that enable per-project setups without requiring shell environment variables.
+  // If someone can write to .env, they already control the project anyway.
 ]);
 
 const BLOCKED_WORKSPACE_DOTENV_SUFFIXES = ["_BASE_URL"];


### PR DESCRIPTION
## Summary

Fixes #57408: Project-local .env files were being ignored during CLI bootstrap.

## Problem
OPENCLAW_CONFIG_PATH was blocked from workspace .env files, preventing users from setting project-level configurations. Additionally, the security analysis identified that allowing OPENCLAW_STATE_DIR could enable redirection attacks.

## Solution
The refined fix:

✅ **ALLOWS**: OPENCLAW_CONFIG_PATH from workspace .env (enables project-level config override)
🔒 **BLOCKS**: OPENCLAW_STATE_DIR (prevents directory redirection attacks)

### Security Hardening
- Compute global env path BEFORE loading workspace .env
- Prevents malicious .env from redirecting which global config is loaded
- Prevents shadow .env directory attacks

## Testing
Users can now set project-local configuration:
```env
OPENCLAW_CONFIG_PATH=/path/to/project/config.json5
```

And both `pnpm openclaw config file` and `pnpm openclaw gateway --verbose` will use the project configuration correctly.

## Files Changed
- **src/infra/dotenv.ts**: 
  - Allow OPENCLAW_CONFIG_PATH from workspace .env
  - Block OPENCLAW_STATE_DIR to prevent attacks
  - Compute global path before workspace load
  
- **src/infra/dotenv.test.ts**: 
  - Update tests to verify correct blocking/allowing behavior
  - Verify OPENCLAW_STATE_DIR remains blocked
  - Verify OPENCLAW_CONFIG_PATH loads from project .env

## Security Review
✅ Passed Greptile security review
✅ Prevents .env redirection attacks
✅ Balances user functionality with security