### PR TITLE
feat(tasks): harden maintenance repair paths

### DIFF
--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -544,6 +544,7 @@ export async function statusCommand(
     }).trimEnd(),
   );
   if (summary.taskAudit.errors > 0) {
+    runtime.log("");
     runtime.log(
       theme.muted(`Task maintenance: ${formatCliCommand("openclaw tasks maintenance --apply")}`),
     );

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -543,6 +543,11 @@ export async function statusCommand(
       rows: overviewRows,
     }).trimEnd(),
   );
+  if (summary.taskAudit.errors > 0) {
+    runtime.log(
+      theme.muted(`Task maintenance: ${formatCliCommand("openclaw tasks maintenance --apply")}`),
+    );
+  }
 
   if (pluginCompatibility.length > 0) {
     runtime.log("");

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -213,6 +213,40 @@ const mocks = vi.hoisted(() => ({
   }),
   runSecurityAudit: vi.fn().mockResolvedValue(createDefaultSecurityAuditResult()),
   buildPluginCompatibilityNotices: vi.fn((): PluginCompatibilityNotice[] => []),
+  getInspectableTaskRegistrySummary: vi.fn().mockReturnValue({
+    total: 0,
+    active: 0,
+    terminal: 0,
+    failures: 0,
+    byStatus: {
+      queued: 0,
+      running: 0,
+      succeeded: 0,
+      failed: 0,
+      timed_out: 0,
+      cancelled: 0,
+      lost: 0,
+    },
+    byRuntime: {
+      subagent: 0,
+      acp: 0,
+      cli: 0,
+      cron: 0,
+    },
+  }),
+  getInspectableTaskAuditSummary: vi.fn().mockReturnValue({
+    total: 0,
+    warnings: 0,
+    errors: 0,
+    byCode: {
+      stale_queued: 0,
+      stale_running: 0,
+      lost: 0,
+      delivery_failed: 0,
+      missing_cleanup: 0,
+      inconsistent_timestamps: 0,
+    },
+  }),
   resolveGatewayService: vi.fn().mockReturnValue({
     label: "LaunchAgent",
     loadedText: "loaded",
@@ -433,6 +467,10 @@ vi.mock("../daemon/node-service.js", () => ({
 vi.mock("../node-host/config.js", () => ({
   loadNodeHostConfig: mocks.loadNodeHostConfig,
 }));
+vi.mock("../tasks/task-registry.maintenance.js", () => ({
+  getInspectableTaskRegistrySummary: mocks.getInspectableTaskRegistrySummary,
+  getInspectableTaskAuditSummary: mocks.getInspectableTaskAuditSummary,
+}));
 vi.mock("../security/audit.js", () => ({
   runSecurityAudit: mocks.runSecurityAudit,
 }));
@@ -485,6 +523,42 @@ describe("statusCommand", () => {
     });
     mocks.buildPluginCompatibilityNotices.mockReset();
     mocks.buildPluginCompatibilityNotices.mockReturnValue([]);
+    mocks.getInspectableTaskRegistrySummary.mockReset();
+    mocks.getInspectableTaskRegistrySummary.mockReturnValue({
+      total: 0,
+      active: 0,
+      terminal: 0,
+      failures: 0,
+      byStatus: {
+        queued: 0,
+        running: 0,
+        succeeded: 0,
+        failed: 0,
+        timed_out: 0,
+        cancelled: 0,
+        lost: 0,
+      },
+      byRuntime: {
+        subagent: 0,
+        acp: 0,
+        cli: 0,
+        cron: 0,
+      },
+    });
+    mocks.getInspectableTaskAuditSummary.mockReset();
+    mocks.getInspectableTaskAuditSummary.mockReturnValue({
+      total: 0,
+      warnings: 0,
+      errors: 0,
+      byCode: {
+        stale_queued: 0,
+        stale_running: 0,
+        lost: 0,
+        delivery_failed: 0,
+        missing_cleanup: 0,
+        inconsistent_timestamps: 0,
+      },
+    });
     mocks.hasPotentialConfiguredChannels.mockReset();
     mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
     mocks.runSecurityAudit.mockReset();
@@ -630,6 +704,47 @@ describe("statusCommand", () => {
           line.includes("openclaw --profile isolated status --all"),
       ),
     ).toBe(true);
+  });
+
+  it("shows a maintenance hint when task audit errors are present", async () => {
+    mocks.getInspectableTaskRegistrySummary.mockReturnValue({
+      total: 1,
+      active: 1,
+      terminal: 0,
+      failures: 1,
+      byStatus: {
+        queued: 0,
+        running: 1,
+        succeeded: 0,
+        failed: 0,
+        timed_out: 0,
+        cancelled: 0,
+        lost: 0,
+      },
+      byRuntime: {
+        subagent: 0,
+        acp: 1,
+        cli: 0,
+        cron: 0,
+      },
+    });
+    mocks.getInspectableTaskAuditSummary.mockReturnValue({
+      total: 1,
+      warnings: 0,
+      errors: 1,
+      byCode: {
+        stale_queued: 0,
+        stale_running: 1,
+        lost: 0,
+        delivery_failed: 0,
+        missing_cleanup: 0,
+        inconsistent_timestamps: 0,
+      },
+    });
+
+    const joined = await runStatusAndGetJoinedLogs();
+
+    expect(joined).toContain("tasks maintenance --apply");
   });
 
   it("caps cached percentage at the prompt-token denominator for legacy session totals", async () => {

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -108,24 +108,32 @@ function resolveCleanupAfter(task: TaskRecord): number {
 }
 
 function markTaskLost(task: TaskRecord, now: number): TaskRecord {
+  const cleanupAfter = task.cleanupAfter ?? resolveCleanupAfter(projectTaskLost(task, now));
   const updated =
     updateTaskRecordById(task.taskId, {
       status: "lost",
       endedAt: task.endedAt ?? now,
       lastEventAt: now,
       error: task.error ?? "backing session missing",
+      cleanupAfter,
     }) ?? task;
   void maybeDeliverTaskTerminalUpdate(updated.taskId);
   return updated;
 }
 
 function projectTaskLost(task: TaskRecord, now: number): TaskRecord {
-  return {
+  const projected: TaskRecord = {
     ...task,
     status: "lost",
     endedAt: task.endedAt ?? now,
     lastEventAt: now,
     error: task.error ?? "backing session missing",
+  };
+  return {
+    ...projected,
+    ...(typeof projected.cleanupAfter === "number"
+      ? {}
+      : { cleanupAfter: resolveCleanupAfter(projected) }),
   };
 }
 

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -108,7 +108,7 @@ function resolveCleanupAfter(task: TaskRecord): number {
 }
 
 function markTaskLost(task: TaskRecord, now: number): TaskRecord {
-  const cleanupAfter = task.cleanupAfter ?? resolveCleanupAfter(projectTaskLost(task, now));
+  const cleanupAfter = task.cleanupAfter ?? projectTaskLost(task, now).cleanupAfter;
   const updated =
     updateTaskRecordById(task.taskId, {
       status: "lost",

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -817,6 +817,38 @@ describe("task-registry", () => {
     });
   });
 
+  it("marks orphaned tasks lost with cleanupAfter in a single maintenance pass", async () => {
+    await withTempDir({ prefix: "openclaw-task-registry-" }, async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const now = Date.now();
+
+      const task = createTaskRecord({
+        runtime: "acp",
+        requesterSessionKey: "agent:main:main",
+        childSessionKey: "agent:main:acp:missing",
+        runId: "run-lost-maintenance",
+        task: "Missing child",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+      updateTaskRecordById(task.taskId, {
+        lastEventAt: now - 10 * 60_000,
+      });
+
+      expect(runTaskRegistryMaintenance()).toEqual({
+        reconciled: 1,
+        cleanupStamped: 0,
+        pruned: 0,
+      });
+      expect(getTaskById(task.taskId)).toMatchObject({
+        status: "lost",
+        error: "backing session missing",
+      });
+      expect(getTaskById(task.taskId)?.cleanupAfter).toBeGreaterThan(now);
+    });
+  });
+
   it("prunes old terminal tasks during maintenance sweeps", async () => {
     await withTempDir({ prefix: "openclaw-task-registry-" }, async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;


### PR DESCRIPTION
## Summary

- Problem: task maintenance still left one repair gap: tasks marked `lost` did not get `cleanupAfter` until a later pass, and `status` surfaced audit errors without telling operators the repair command.
- Why it matters: repair drift keeps old broken rows around longer than intended and makes task health actionable only if the operator already knows the maintenance CLI.
- What changed: maintenance now stamps `cleanupAfter` in the same pass that marks a task `lost`, inspection-time lost projections mirror that retention, and `openclaw status` prints a direct maintenance hint when task audit errors are present.
- What did NOT change (scope boundary): no executor changes, no task schema expansion, no Redis/Temporal work, no producer-specific lifecycle refactors.

## Change Type (select all)

- [x] Feature
- [x] Refactor required for the fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage
- [x] UI / DX

## Linked Issue/PR

- Closes #
- Related #57423
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: task maintenance reconciled `lost` state and retention in two separate passes.
- Missing detection / guardrail: there was no test asserting that a newly-lost task gets `cleanupAfter` immediately.
- Prior context (`git blame`, prior PR, issue, or refactor if known): follow-up to the task maintenance/status work in #57423.
- Why this regressed now: the initial maintenance pass optimized for state reconciliation first and cleanup stamping second.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file: `src/tasks/task-registry.test.ts`, `src/commands/status.test.ts`
- Scenario the test should lock in: a task reconciled to `lost` is immediately cleanup-eligible, and status shows the maintenance command when task audit errors exist.
- Why this is the smallest reliable guardrail: both behaviors sit at the task-registry and status-command seams.
- Existing test that already covers this (if any): task maintenance tests already covered prune and missing-cleanup stamping.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw status` now prints a direct `openclaw tasks maintenance --apply` hint when task audit errors are present.
- newly-lost tasks now get `cleanupAfter` immediately in the same maintenance pass.

## Diagram (if applicable)

```text
Before:
[maintenance pass] -> [mark lost] -> [later pass] -> [stamp cleanupAfter]
[operator] -> [status shows audit errors] -> [must remember repair command]

After:
[maintenance pass] -> [mark lost + stamp cleanupAfter]
[operator] -> [status shows audit errors + repair command]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local state dir

### Steps

1. Create a task whose backing session is gone and whose last event is past the lost grace window.
2. Run maintenance.
3. Inspect the task row and run formatted status with task audit errors present.

### Expected

- maintenance marks the task `lost` and stamps `cleanupAfter` immediately.
- status prints the repair command when task audit errors exist.

### Actual

- Matches expected in scoped tests.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: lost-task maintenance repair, formatted status maintenance hint.
- Edge cases checked: inspection-only lost projection still leaves the registry untouched; maintenance still reports `cleanupStamped: 0` for the lost reconciliation path because retention is applied as part of the reconciliation itself.
- What you did **not** verify: full `pnpm test` suite; `pnpm check` on current `main`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: task maintenance semantics could drift from task audit semantics again.
  - Mitigation: the new test asserts single-pass lost reconciliation with immediate cleanup retention.
- Risk: `pnpm check` is still red on latest `main` due to the unrelated `src/agents/skills.test-helpers.ts:34` error.
  - Mitigation: scoped task/status tests are green for this change.

## AI Assistance

- AI-assisted: yes
- Testing: `pnpm test -- src/tasks/task-registry.test.ts src/commands/status.test.ts`
- `codex review --base origin/main`: not re-run in this tiny follow-up because the local transport issue to `127.0.0.1` remained unresolved in the earlier PR cycle.
