### PR TITLE
fix(models): resolve openrouter:free and openrouter:auto compatibility aliases

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -83,7 +83,10 @@ function createAgentFallbackConfig(params: {
   } as OpenClawConfig;
 }
 
-function createProviderWithModelsConfig(provider: string, models: Array<Record<string, unknown>>) {
+function createProviderWithModelsConfig(
+  provider: string,
+  models: Array<Record<string, unknown>>,
+) {
   return {
     models: {
       providers: {
@@ -130,7 +133,9 @@ describe("model-selection", () => {
 
   describe("modelKey", () => {
     it("keeps canonical OpenRouter native ids without duplicating the provider", () => {
-      expect(modelKey("openrouter", "openrouter/hunter-alpha")).toBe("openrouter/hunter-alpha");
+      expect(modelKey("openrouter", "openrouter/hunter-alpha")).toBe(
+        "openrouter/hunter-alpha",
+      );
     });
   });
 
@@ -178,13 +183,19 @@ describe("model-selection", () => {
       },
       {
         name: "keeps dated anthropic model ids unchanged",
-        variants: ["anthropic/claude-sonnet-4-20250514", "claude-sonnet-4-20250514"],
+        variants: [
+          "anthropic/claude-sonnet-4-20250514",
+          "claude-sonnet-4-20250514",
+        ],
         defaultProvider: "anthropic",
         expected: { provider: "anthropic", model: "claude-sonnet-4-20250514" },
       },
       {
         name: "normalizes deprecated google flash preview ids",
-        variants: ["google/gemini-3.1-flash-preview", "gemini-3.1-flash-preview"],
+        variants: [
+          "google/gemini-3.1-flash-preview",
+          "gemini-3.1-flash-preview",
+        ],
         defaultProvider: "google",
         expected: { provider: "google", model: "gemini-3-flash-preview" },
       },
@@ -192,7 +203,10 @@ describe("model-selection", () => {
         name: "normalizes gemini 3.1 flash-lite ids",
         variants: ["google/gemini-3.1-flash-lite", "gemini-3.1-flash-lite"],
         defaultProvider: "google",
-        expected: { provider: "google", model: "gemini-3.1-flash-lite-preview" },
+        expected: {
+          provider: "google",
+          model: "gemini-3.1-flash-lite-preview",
+        },
       },
       {
         name: "keeps OpenAI codex refs on the openai provider",
@@ -210,25 +224,52 @@ describe("model-selection", () => {
         name: "passes through openrouter upstream provider ids",
         variants: ["openrouter/anthropic/claude-sonnet-4-5"],
         defaultProvider: "openai",
-        expected: { provider: "openrouter", model: "anthropic/claude-sonnet-4-5" },
+        expected: {
+          provider: "openrouter",
+          model: "anthropic/claude-sonnet-4-5",
+        },
+      },
+      {
+        name: "resolves openrouter:free compatibility alias to openrouter provider",
+        variants: ["openrouter:free", " openrouter:free ", "OPENROUTER:FREE"],
+        defaultProvider: "anthropic",
+        expected: {
+          provider: "openrouter",
+          model: "meta-llama/llama-3.3-70b-instruct:free",
+        },
+      },
+      {
+        name: "resolves openrouter:auto compatibility alias to openrouter provider",
+        variants: ["openrouter:auto", " openrouter:auto "],
+        defaultProvider: "anthropic",
+        expected: { provider: "openrouter", model: "auto" },
       },
       {
         name: "normalizes Vercel Claude shorthand to anthropic-prefixed model ids",
         variants: ["vercel-ai-gateway/claude-opus-4.6"],
         defaultProvider: "openai",
-        expected: { provider: "vercel-ai-gateway", model: "anthropic/claude-opus-4.6" },
+        expected: {
+          provider: "vercel-ai-gateway",
+          model: "anthropic/claude-opus-4.6",
+        },
       },
       {
         name: "normalizes Vercel Anthropic aliases without double-prefixing",
         variants: ["vercel-ai-gateway/opus-4.6"],
         defaultProvider: "openai",
-        expected: { provider: "vercel-ai-gateway", model: "anthropic/claude-opus-4-6" },
+        expected: {
+          provider: "vercel-ai-gateway",
+          model: "anthropic/claude-opus-4-6",
+        },
       },
       {
         name: "keeps already-prefixed Vercel Anthropic models unchanged",
         variants: ["vercel-ai-gateway/anthropic/claude-opus-4.6"],
         defaultProvider: "openai",
-        expected: { provider: "vercel-ai-gateway", model: "anthropic/claude-opus-4.6" },
+        expected: {
+          provider: "vercel-ai-gateway",
+          model: "anthropic/claude-opus-4.6",
+        },
       },
       {
         name: "passes through non-Claude Vercel model ids unchanged",
@@ -244,9 +285,15 @@ describe("model-selection", () => {
       },
       {
         name: "normalizes gemini 3.1 flash-lite ids for google-vertex",
-        variants: ["google-vertex/gemini-3.1-flash-lite", "gemini-3.1-flash-lite"],
+        variants: [
+          "google-vertex/gemini-3.1-flash-lite",
+          "gemini-3.1-flash-lite",
+        ],
         defaultProvider: "google-vertex",
-        expected: { provider: "google-vertex", model: "gemini-3.1-flash-lite-preview" },
+        expected: {
+          provider: "google-vertex",
+          model: "gemini-3.1-flash-lite-preview",
+        },
       },
     ])("$name", ({ variants, defaultProvider, expected }) => {
       expectParsedModelVariants(variants, defaultProvider, expected);
@@ -254,14 +301,20 @@ describe("model-selection", () => {
 
     it("round-trips normalized refs through modelKey", () => {
       const parsed = parseModelRef(" opus-4.6 ", "anthropic");
-      expect(parsed).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+      expect(parsed).toEqual({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      });
       expect(modelKey(parsed?.provider ?? "", parsed?.model ?? "")).toBe(
         "anthropic/claude-opus-4-6",
       );
     });
-    it.each(["", "  ", "/", "anthropic/", "/model"])("returns null for invalid ref %j", (raw) => {
-      expect(parseModelRef(raw, "anthropic")).toBeNull();
-    });
+    it.each(["", "  ", "/", "anthropic/", "/model"])(
+      "returns null for invalid ref %j",
+      (raw) => {
+        expect(parseModelRef(raw, "anthropic")).toBeNull();
+      },
+    );
   });
 
   describe("inferUniqueProviderFromConfiguredModels", () => {
@@ -365,8 +418,13 @@ describe("model-selection", () => {
         provider: "anthropic",
         model: "claude-3-5-sonnet",
       });
-      expect(index.byAlias.get("smart")?.ref).toEqual({ provider: "openai", model: "gpt-4o" });
-      expect(index.byKey.get(modelKey("anthropic", "claude-3-5-sonnet"))).toEqual(["fast"]);
+      expect(index.byAlias.get("smart")?.ref).toEqual({
+        provider: "openai",
+        model: "gpt-4o",
+      });
+      expect(
+        index.byKey.get(modelKey("anthropic", "claude-3-5-sonnet")),
+      ).toEqual(["fast"]);
     });
   });
 
@@ -381,7 +439,11 @@ describe("model-selection", () => {
       expect(result.allowAny).toBe(false);
       expect(result.allowedKeys.has("anthropic/claude-sonnet-4-6")).toBe(true);
       expect(result.allowedCatalog).toEqual([
-        { provider: "anthropic", id: "claude-sonnet-4-6", name: "claude-sonnet-4-6" },
+        {
+          provider: "anthropic",
+          id: "claude-sonnet-4-6",
+          name: "claude-sonnet-4-6",
+        },
       ]);
     });
 
@@ -483,7 +545,10 @@ describe("model-selection", () => {
     it("should resolve from string with alias", () => {
       const index = {
         byAlias: new Map([
-          ["fast", { alias: "fast", ref: { provider: "anthropic", model: "sonnet" } }],
+          [
+            "fast",
+            { alias: "fast", ref: { provider: "anthropic", model: "sonnet" } },
+          ],
         ]),
         byKey: new Map(),
       };
@@ -561,7 +626,13 @@ describe("model-selection", () => {
     it("strips profile suffix before alias resolution", () => {
       const index = {
         byAlias: new Map([
-          ["kimi", { alias: "kimi", ref: { provider: "nvidia", model: "moonshotai/kimi-k2.5" } }],
+          [
+            "kimi",
+            {
+              alias: "kimi",
+              ref: { provider: "nvidia", model: "moonshotai/kimi-k2.5" },
+            },
+          ],
         ]),
         byKey: new Map(),
       };
@@ -598,9 +669,14 @@ describe("model-selection", () => {
           defaultModel: "gemini-pro",
         });
 
-        expect(result).toEqual({ provider: "anthropic", model: "claude-3-5-sonnet" });
+        expect(result).toEqual({
+          provider: "anthropic",
+          model: "claude-3-5-sonnet",
+        });
         expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('Falling back to "anthropic/claude-3-5-sonnet"'),
+          expect.stringContaining(
+            'Falling back to "anthropic/claude-3-5-sonnet"',
+          ),
         );
       } finally {
         setLoggerOverride(null);
@@ -631,7 +707,9 @@ describe("model-selection", () => {
           model: "\u001B[31mclaude-3-5-sonnet\nspoof",
         });
         const warning = warnSpy.mock.calls[0]?.[0] as string;
-        expect(warning).toContain('Falling back to "anthropic/claude-3-5-sonnet"');
+        expect(warning).toContain(
+          'Falling back to "anthropic/claude-3-5-sonnet"',
+        );
         expect(warning).not.toContain("\u001B");
         expect(warning).not.toContain("\n");
       } finally {
@@ -680,13 +758,54 @@ describe("model-selection", () => {
         },
       ]);
       const result = resolveConfiguredRefForTest(cfg);
-      expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+      expect(result).toEqual({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      });
     });
 
     it("should fall back to hardcoded default when no custom providers have models", () => {
       const cfg = createProviderWithModelsConfig("empty-provider", []);
       const result = resolveConfiguredRefForTest(cfg);
-      expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+      expect(result).toEqual({
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+      });
+    });
+
+    it("resolves openrouter:free alias without misattributing to anthropic", () => {
+      const cfg: Partial<OpenClawConfig> = {
+        agents: {
+          defaults: {
+            model: { primary: "openrouter:free" },
+          },
+        },
+      };
+      const result = resolveConfiguredModelRef({
+        cfg: cfg as OpenClawConfig,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-opus-4-6",
+      });
+      expect(result).toEqual({
+        provider: "openrouter",
+        model: "meta-llama/llama-3.3-70b-instruct:free",
+      });
+    });
+
+    it("resolves openrouter:auto alias without misattributing to anthropic", () => {
+      const cfg: Partial<OpenClawConfig> = {
+        agents: {
+          defaults: {
+            model: { primary: "openrouter:auto" },
+          },
+        },
+      };
+      const result = resolveConfiguredModelRef({
+        cfg: cfg as OpenClawConfig,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-opus-4-6",
+      });
+      expect(result).toEqual({ provider: "openrouter", model: "auto" });
     });
 
     it("should warn when specified model cannot be resolved and falls back to default", () => {
@@ -707,9 +826,14 @@ describe("model-selection", () => {
           defaultModel: "claude-opus-4-6",
         });
 
-        expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+        expect(result).toEqual({
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        });
         expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('Falling back to default "anthropic/claude-opus-4-6"'),
+          expect.stringContaining(
+            'Falling back to default "anthropic/claude-opus-4-6"',
+          ),
         );
       } finally {
         warnSpy.mockRestore();
@@ -801,7 +925,9 @@ describe("model-selection", () => {
 
 describe("normalizeModelSelection", () => {
   it("returns trimmed string for string input", () => {
-    expect(normalizeModelSelection("ollama/llama3.2:3b")).toBe("ollama/llama3.2:3b");
+    expect(normalizeModelSelection("ollama/llama3.2:3b")).toBe(
+      "ollama/llama3.2:3b",
+    );
   });
 
   it("returns undefined for empty/whitespace string", () => {
@@ -810,9 +936,9 @@ describe("normalizeModelSelection", () => {
   });
 
   it("extracts primary from object", () => {
-    expect(normalizeModelSelection({ primary: "google/gemini-2.5-flash" })).toBe(
-      "google/gemini-2.5-flash",
-    );
+    expect(
+      normalizeModelSelection({ primary: "google/gemini-2.5-flash" }),
+    ).toBe("google/gemini-2.5-flash");
   });
 
   it("returns undefined for object without primary", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -328,17 +328,20 @@ export function resolveConfiguredModelRef(params: {
       defaultProvider: params.defaultProvider,
     });
     if (!trimmed.includes("/")) {
-      // Check OpenRouter compatibility aliases (e.g. "openrouter:free") before
-      // any user-defined alias or provider-fallback logic. (#57066)
-      const compatAlias = OPENROUTER_COMPAT_ALIASES[trimmed.toLowerCase()];
-      if (compatAlias) {
-        return { ...compatAlias };
-      }
-
+      // User-defined aliases take priority over built-in compat aliases,
+      // consistent with resolveModelRefFromString where user aliases are
+      // checked before parseModelRef (which holds the compat table).
       const aliasKey = normalizeAliasKey(trimmed);
       const aliasMatch = aliasIndex.byAlias.get(aliasKey);
       if (aliasMatch) {
         return aliasMatch.ref;
+      }
+
+      // OpenRouter compatibility aliases (e.g. "openrouter:free") — checked
+      // after user aliases so users can override them. (#57066)
+      const compatAlias = OPENROUTER_COMPAT_ALIASES[trimmed.toLowerCase()];
+      if (compatAlias) {
+        return { ...compatAlias };
       }
 
       // Default to anthropic if no provider is specified, but warn as this is deprecated.

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -30,11 +30,34 @@ export type ModelRef = {
   model: string;
 };
 
-export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
+export type ThinkLevel =
+  | "off"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "adaptive";
 
 export type ModelAliasIndex = {
   byAlias: Map<string, { alias: string; ref: ModelRef }>;
   byKey: Map<string, string[]>;
+};
+
+/**
+ * OpenRouter compatibility aliases for bare `openrouter:<suffix>` shorthand
+ * strings (no slash). These are resolved before provider/model splitting so
+ * they are never misattributed to the default provider (e.g. anthropic).
+ *
+ * - `openrouter:free`  → a well-known free-tier model on OpenRouter
+ * - `openrouter:auto`  → OpenRouter's internal auto-routing model
+ */
+const OPENROUTER_COMPAT_ALIASES: Record<string, ModelRef> = {
+  "openrouter:free": {
+    provider: "openrouter",
+    model: "meta-llama/llama-3.3-70b-instruct:free",
+  },
+  "openrouter:auto": { provider: "openrouter", model: "auto" },
 };
 
 function normalizeAliasKey(value: string): string {
@@ -82,7 +105,9 @@ export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {
     return true;
   }
   const backends = cfg?.agents?.defaults?.cliBackends ?? {};
-  return Object.keys(backends).some((key) => normalizeProviderId(key) === normalized);
+  return Object.keys(backends).some(
+    (key) => normalizeProviderId(key) === normalized,
+  );
 }
 
 function normalizeAnthropicModelId(model: string): string {
@@ -133,14 +158,27 @@ function normalizeProviderModelId(provider: string, model: string): string {
 
 export function normalizeModelRef(provider: string, model: string): ModelRef {
   const normalizedProvider = normalizeProviderId(provider);
-  const normalizedModel = normalizeProviderModelId(normalizedProvider, model.trim());
+  const normalizedModel = normalizeProviderModelId(
+    normalizedProvider,
+    model.trim(),
+  );
   return { provider: normalizedProvider, model: normalizedModel };
 }
 
-export function parseModelRef(raw: string, defaultProvider: string): ModelRef | null {
+export function parseModelRef(
+  raw: string,
+  defaultProvider: string,
+): ModelRef | null {
   const trimmed = raw.trim();
   if (!trimmed) {
     return null;
+  }
+  // Resolve OpenRouter compatibility aliases (e.g. "openrouter:free") before
+  // any slash-split logic, so they are never misattributed to the default
+  // provider. (#57066)
+  const compatAlias = OPENROUTER_COMPAT_ALIASES[trimmed.toLowerCase()];
+  if (compatAlias) {
+    return compatAlias;
   }
   const slash = trimmed.indexOf("/");
   if (slash === -1) {
@@ -190,7 +228,10 @@ export function inferUniqueProviderFromConfiguredModels(params: {
   return providers.values().next().value;
 }
 
-export function resolveAllowlistModelKey(raw: string, defaultProvider: string): string | null {
+export function resolveAllowlistModelKey(
+  raw: string,
+  defaultProvider: string,
+): string | null {
   const parsed = parseModelRef(raw, defaultProvider);
   if (!parsed) {
     return null;
@@ -209,7 +250,10 @@ export function buildConfiguredAllowlistKeys(params: {
 
   const keys = new Set<string>();
   for (const raw of rawAllowlist) {
-    const key = resolveAllowlistModelKey(String(raw ?? ""), params.defaultProvider);
+    const key = resolveAllowlistModelKey(
+      String(raw ?? ""),
+      params.defaultProvider,
+    );
     if (key) {
       keys.add(key);
     }
@@ -230,7 +274,9 @@ export function buildModelAliasIndex(params: {
     if (!parsed) {
       continue;
     }
-    const alias = String((entryRaw as { alias?: string } | undefined)?.alias ?? "").trim();
+    const alias = String(
+      (entryRaw as { alias?: string } | undefined)?.alias ?? "",
+    ).trim();
     if (!alias) {
       continue;
     }
@@ -273,7 +319,8 @@ export function resolveConfiguredModelRef(params: {
   defaultProvider: string;
   defaultModel: string;
 }): ModelRef {
-  const rawModel = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model) ?? "";
+  const rawModel =
+    resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model) ?? "";
   if (rawModel) {
     const trimmed = rawModel.trim();
     const aliasIndex = buildModelAliasIndex({
@@ -281,6 +328,13 @@ export function resolveConfiguredModelRef(params: {
       defaultProvider: params.defaultProvider,
     });
     if (!trimmed.includes("/")) {
+      // Check OpenRouter compatibility aliases (e.g. "openrouter:free") before
+      // any user-defined alias or provider-fallback logic. (#57066)
+      const compatAlias = OPENROUTER_COMPAT_ALIASES[trimmed.toLowerCase()];
+      if (compatAlias) {
+        return compatAlias;
+      }
+
       const aliasKey = normalizeAliasKey(trimmed);
       const aliasMatch = aliasIndex.byAlias.get(aliasKey);
       if (aliasMatch) {
@@ -306,8 +360,12 @@ export function resolveConfiguredModelRef(params: {
 
     // User specified a model but it could not be resolved — warn before falling back.
     const safe = sanitizeForLog(trimmed);
-    const safeFallback = sanitizeForLog(`${params.defaultProvider}/${params.defaultModel}`);
-    log.warn(`Model "${safe}" could not be resolved. Falling back to default "${safeFallback}".`);
+    const safeFallback = sanitizeForLog(
+      `${params.defaultProvider}/${params.defaultModel}`,
+    );
+    log.warn(
+      `Model "${safe}" could not be resolved. Falling back to default "${safeFallback}".`,
+    );
   }
   // Before falling back to the hardcoded default, check if the default provider
   // is actually available. If it isn't but other providers are configured, prefer
@@ -315,7 +373,9 @@ export function resolveConfiguredModelRef(params: {
   // from a removed provider. (See #38880)
   const configuredProviders = params.cfg.models?.providers;
   if (configuredProviders && typeof configuredProviders === "object") {
-    const hasDefaultProvider = Boolean(configuredProviders[params.defaultProvider]);
+    const hasDefaultProvider = Boolean(
+      configuredProviders[params.defaultProvider],
+    );
     if (!hasDefaultProvider) {
       const availableProvider = Object.entries(configuredProviders).find(
         ([, providerCfg]) =>
@@ -364,9 +424,15 @@ export function resolveDefaultModelForAgent(params: {
   });
 }
 
-function resolveAllowedFallbacks(params: { cfg: OpenClawConfig; agentId?: string }): string[] {
+function resolveAllowedFallbacks(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+}): string[] {
   if (params.agentId) {
-    const override = resolveAgentModelFallbacksOverride(params.cfg, params.agentId);
+    const override = resolveAgentModelFallbacksOverride(
+      params.cfg,
+      params.agentId,
+    );
     if (override !== undefined) {
       return override;
     }
@@ -401,7 +467,9 @@ export function resolveSubagentSpawnModelSelection(params: {
       cfg: params.cfg,
       agentId: params.agentId,
     }) ??
-    normalizeModelSelection(resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model)) ??
+    normalizeModelSelection(
+      resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model),
+    ) ??
     `${runtimeDefault.provider}/${runtimeDefault.model}`
   );
 }
@@ -427,8 +495,12 @@ export function buildAllowedModelSet(params: {
     defaultModel && params.defaultProvider
       ? parseModelRef(defaultModel, params.defaultProvider)
       : null;
-  const defaultKey = defaultRef ? modelKey(defaultRef.provider, defaultRef.model) : undefined;
-  const catalogKeys = new Set(params.catalog.map((entry) => modelKey(entry.provider, entry.id)));
+  const defaultKey = defaultRef
+    ? modelKey(defaultRef.provider, defaultRef.model)
+    : undefined;
+  const catalogKeys = new Set(
+    params.catalog.map((entry) => modelKey(entry.provider, entry.id)),
+  );
 
   if (allowAny) {
     if (defaultKey) {
@@ -486,7 +558,9 @@ export function buildAllowedModelSet(params: {
   }
 
   const allowedCatalog = [
-    ...params.catalog.filter((entry) => allowedKeys.has(modelKey(entry.provider, entry.id))),
+    ...params.catalog.filter((entry) =>
+      allowedKeys.has(modelKey(entry.provider, entry.id)),
+    ),
     ...syntheticCatalogEntries.values(),
   ];
 
@@ -527,7 +601,9 @@ export function getModelRefStatus(params: {
   const key = modelKey(params.ref.provider, params.ref.model);
   return {
     key,
-    inCatalog: params.catalog.some((entry) => modelKey(entry.provider, entry.id) === key),
+    inCatalog: params.catalog.some(
+      (entry) => modelKey(entry.provider, entry.id) === key,
+    ),
     allowAny: allowed.allowAny,
     allowed: allowed.allowAny || allowed.allowedKeys.has(key),
   };

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -178,7 +178,7 @@ export function parseModelRef(
   // provider. (#57066)
   const compatAlias = OPENROUTER_COMPAT_ALIASES[trimmed.toLowerCase()];
   if (compatAlias) {
-    return compatAlias;
+    return { ...compatAlias };
   }
   const slash = trimmed.indexOf("/");
   if (slash === -1) {
@@ -332,7 +332,7 @@ export function resolveConfiguredModelRef(params: {
       // any user-defined alias or provider-fallback logic. (#57066)
       const compatAlias = OPENROUTER_COMPAT_ALIASES[trimmed.toLowerCase()];
       if (compatAlias) {
-        return compatAlias;
+        return { ...compatAlias };
       }
 
       const aliasKey = normalizeAliasKey(trimmed);


### PR DESCRIPTION
## Summary
- Fix #57066: `openrouter:free` was mis-resolved to `anthropic/openrouter:free` because `parseModelRef` only splits on `/`
- Add `OPENROUTER_COMPAT_ALIASES` map with explicit mappings for `openrouter:free` → `meta-llama/llama-3.3-70b-instruct:free` and `openrouter:auto` → `auto`
- Check alias table in both `parseModelRef` and `resolveConfiguredModelRef` before the slash-split logic
- Return shallow copies from alias table to prevent shared reference mutation

## Test plan
- [x] Added tests for both aliases in `parseModelRef` and `resolveConfiguredModelRef`
- [x] 64/65 model-selection tests pass (1 pre-existing failure unrelated)
- [ ] Manual: set agent model to `openrouter:free`, verify it resolves correctly

🦞 Generated with [Claude Code](https://claude.com/claude-code)