### PR TITLE
fix(google): strip OpenAI-specific store field from openai-completions payloads

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -18,7 +18,8 @@ const resolveProviderCapabilitiesWithPluginMock = vi.fn(
 );
 
 vi.mock("../plugins/provider-runtime.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../plugins/provider-runtime.js")>();
+  const actual =
+    await importOriginal<typeof import("../plugins/provider-runtime.js")>();
   const {
     createOpenRouterSystemCacheWrapper,
     createOpenRouterWrapper,
@@ -35,7 +36,11 @@ vi.mock("../plugins/provider-runtime.js", async (importOriginal) => {
         return undefined;
       }
       const transport = params.context.extraParams?.transport;
-      if (transport === "auto" || transport === "sse" || transport === "websocket") {
+      if (
+        transport === "auto" ||
+        transport === "sse" ||
+        transport === "websocket"
+      ) {
         return params.context.extraParams;
       }
       return {
@@ -76,16 +81,26 @@ vi.mock("../plugins/provider-runtime.js", async (importOriginal) => {
       }
 
       const skipReasoningInjection =
-        params.context.modelId === "auto" || isProxyReasoningUnsupported(params.context.modelId);
-      const thinkingLevel = skipReasoningInjection ? undefined : params.context.thinkingLevel;
-      return createOpenRouterSystemCacheWrapper(createOpenRouterWrapper(streamFn, thinkingLevel));
+        params.context.modelId === "auto" ||
+        isProxyReasoningUnsupported(params.context.modelId);
+      const thinkingLevel = skipReasoningInjection
+        ? undefined
+        : params.context.thinkingLevel;
+      return createOpenRouterSystemCacheWrapper(
+        createOpenRouterWrapper(streamFn, thinkingLevel),
+      );
     },
-    resolveProviderCapabilitiesWithPlugin: (params: { provider: string; workspaceDir?: string }) =>
-      resolveProviderCapabilitiesWithPluginMock(params),
+    resolveProviderCapabilitiesWithPlugin: (params: {
+      provider: string;
+      workspaceDir?: string;
+    }) => resolveProviderCapabilitiesWithPluginMock(params),
   };
 });
 
-import { applyExtraParamsToAgent, resolveExtraParams } from "./pi-embedded-runner.js";
+import {
+  applyExtraParamsToAgent,
+  resolveExtraParams,
+} from "./pi-embedded-runner.js";
 import { log } from "./pi-embedded-runner/logger.js";
 
 describe("resolveExtraParams", () => {
@@ -256,9 +271,15 @@ describe("resolveExtraParams", () => {
 
 describe("applyExtraParamsToAgent", () => {
   function createOptionsCaptureAgent() {
-    const calls: Array<(SimpleStreamOptions & { openaiWsWarmup?: boolean }) | undefined> = [];
+    const calls: Array<
+      (SimpleStreamOptions & { openaiWsWarmup?: boolean }) | undefined
+    > = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
-      calls.push(options as (SimpleStreamOptions & { openaiWsWarmup?: boolean }) | undefined);
+      calls.push(
+        options as
+          | (SimpleStreamOptions & { openaiWsWarmup?: boolean })
+          | undefined,
+      );
       return {} as ReturnType<StreamFn>;
     };
     return {
@@ -267,7 +288,10 @@ describe("applyExtraParamsToAgent", () => {
     };
   }
 
-  function buildAnthropicModelConfig(modelKey: string, params: Record<string, unknown>) {
+  function buildAnthropicModelConfig(
+    modelKey: string,
+    params: Record<string, unknown>,
+  ) {
     return {
       agents: {
         defaults: {
@@ -313,7 +337,10 @@ describe("applyExtraParamsToAgent", () => {
   function runParallelToolCallsPayloadMutationCase(params: {
     applyProvider: string;
     applyModelId: string;
-    model: Model<"openai-completions"> | Model<"openai-responses"> | Model<"anthropic-messages">;
+    model:
+      | Model<"openai-completions">
+      | Model<"openai-responses">
+      | Model<"anthropic-messages">;
     cfg?: Record<string, unknown>;
     extraParamsOverride?: Record<string, unknown>;
     payload?: Record<string, unknown>;
@@ -362,7 +389,9 @@ describe("applyExtraParamsToAgent", () => {
     // reasoning (e.g. deepseek/deepseek-r1).
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
-      const payload: Record<string, unknown> = { model: "deepseek/deepseek-r1" };
+      const payload: Record<string, unknown> = {
+        model: "deepseek/deepseek-r1",
+      };
       options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
@@ -401,7 +430,14 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "openrouter", "openrouter/auto", undefined, "low");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "openrouter",
+      "openrouter/auto",
+      undefined,
+      "low",
+    );
 
     const model = {
       api: "openai-completions",
@@ -425,7 +461,14 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "openrouter", "openrouter/auto", undefined, "off");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "openrouter",
+      "openrouter/auto",
+      undefined,
+      "off",
+    );
 
     const model = {
       api: "openai-completions",
@@ -443,14 +486,23 @@ describe("applyExtraParamsToAgent", () => {
   it("does not inject effort when payload already has reasoning.max_tokens", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
-      const payload: Record<string, unknown> = { reasoning: { max_tokens: 256 } };
+      const payload: Record<string, unknown> = {
+        reasoning: { max_tokens: 256 },
+      };
       options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "openrouter", "openrouter/auto", undefined, "low");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "openrouter",
+      "openrouter/auto",
+      undefined,
+      "low",
+    );
 
     const model = {
       api: "openai-completions",
@@ -665,7 +717,9 @@ describe("applyExtraParamsToAgent", () => {
       });
 
       expect(payload).not.toHaveProperty("parallel_tool_calls");
-      expect(warnSpy).toHaveBeenCalledWith("ignoring invalid parallel_tool_calls param: false");
+      expect(warnSpy).toHaveBeenCalledWith(
+        "ignoring invalid parallel_tool_calls param: false",
+      );
     } finally {
       warnSpy.mockRestore();
     }
@@ -743,7 +797,14 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "moonshot", "kimi-k2.5", undefined, "off");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "moonshot",
+      "kimi-k2.5",
+      undefined,
+      "off",
+    );
 
     const model = {
       api: "openai-completions",
@@ -767,7 +828,14 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "moonshot", "kimi-k2.5", undefined, "low");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "moonshot",
+      "kimi-k2.5",
+      undefined,
+      "low",
+    );
 
     const model = {
       api: "openai-completions",
@@ -794,7 +862,14 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "moonshot", "kimi-k2.5", undefined, "low");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "moonshot",
+      "kimi-k2.5",
+      undefined,
+      "low",
+    );
 
     const model = {
       api: "openai-completions",
@@ -832,7 +907,14 @@ describe("applyExtraParamsToAgent", () => {
       },
     };
 
-    applyExtraParamsToAgent(agent, cfg, "moonshot", "kimi-k2.5", undefined, "high");
+    applyExtraParamsToAgent(
+      agent,
+      cfg,
+      "moonshot",
+      "kimi-k2.5",
+      undefined,
+      "high",
+    );
 
     const model = {
       api: "openai-completions",
@@ -856,7 +938,14 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "ollama", "kimi-k2.5:cloud", undefined, "low");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "ollama",
+      "kimi-k2.5:cloud",
+      undefined,
+      "low",
+    );
 
     const model = {
       api: "openai-completions",
@@ -881,7 +970,14 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "ollama", "kimi-k2.5:cloud", undefined, "off");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "ollama",
+      "kimi-k2.5:cloud",
+      undefined,
+      "off",
+    );
 
     const model = {
       api: "openai-completions",
@@ -907,7 +1003,14 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "ollama", "kimi-k2.5:cloud", undefined, "low");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "ollama",
+      "kimi-k2.5:cloud",
+      undefined,
+      "low",
+    );
 
     const model = {
       api: "openai-completions",
@@ -948,7 +1051,14 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "kimi", "kimi-code", undefined, "low");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "kimi",
+      "kimi-code",
+      undefined,
+      "low",
+    );
 
     const model = {
       api: "anthropic-messages",
@@ -992,7 +1102,14 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "anthropic", "claude-sonnet-4-6", undefined, "low");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "anthropic",
+      "claude-sonnet-4-6",
+      undefined,
+      "low",
+    );
 
     const model = {
       api: "anthropic-messages",
@@ -1153,7 +1270,14 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "atproxy", "gemini-3.1-pro-high", undefined, "high");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "atproxy",
+      "gemini-3.1-pro-high",
+      undefined,
+      "high",
+    );
 
     const model = {
       api: "google-generative-ai",
@@ -1165,7 +1289,9 @@ describe("applyExtraParamsToAgent", () => {
 
     expect(payloads).toHaveLength(1);
     const thinkingConfig = (
-      payloads[0]?.config as { thinkingConfig?: Record<string, unknown> } | undefined
+      payloads[0]?.config as
+        | { thinkingConfig?: Record<string, unknown> }
+        | undefined
     )?.thinkingConfig;
     expect(thinkingConfig).toEqual({
       includeThoughts: true,
@@ -1174,7 +1300,11 @@ describe("applyExtraParamsToAgent", () => {
     expect(
       (
         payloads[0]?.contents as
-          | Array<{ parts?: Array<{ inlineData?: { mimeType?: string; data?: string } }> }>
+          | Array<{
+              parts?: Array<{
+                inlineData?: { mimeType?: string; data?: string };
+              }>;
+            }>
           | undefined
       )?.[0]?.parts?.[1]?.inlineData,
     ).toEqual({
@@ -1200,7 +1330,14 @@ describe("applyExtraParamsToAgent", () => {
     };
     const agent = { streamFn: baseStreamFn };
 
-    applyExtraParamsToAgent(agent, undefined, "atproxy", "gemini-3.1-pro-high", undefined, "high");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "atproxy",
+      "gemini-3.1-pro-high",
+      undefined,
+      "high",
+    );
 
     const model = {
       api: "google-generative-ai",
@@ -1508,7 +1645,12 @@ describe("applyExtraParamsToAgent", () => {
   it("disables prompt caching for non-Anthropic Bedrock models", () => {
     const { calls, agent } = createOptionsCaptureAgent();
 
-    applyExtraParamsToAgent(agent, undefined, "amazon-bedrock", "amazon.nova-micro-v1");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "amazon-bedrock",
+      "amazon.nova-micro-v1",
+    );
 
     const model = {
       api: "openai-completions",
@@ -1526,7 +1668,12 @@ describe("applyExtraParamsToAgent", () => {
   it("keeps Anthropic Bedrock models eligible for provider-side caching", () => {
     const { calls, agent } = createOptionsCaptureAgent();
 
-    applyExtraParamsToAgent(agent, undefined, "amazon-bedrock", "us.anthropic.claude-sonnet-4-5");
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "amazon-bedrock",
+      "us.anthropic.claude-sonnet-4-5",
+    );
 
     const model = {
       api: "openai-completions",
@@ -1557,7 +1704,12 @@ describe("applyExtraParamsToAgent", () => {
       },
     };
 
-    applyExtraParamsToAgent(agent, cfg, "amazon-bedrock", "us.anthropic.claude-opus-4-6-v1");
+    applyExtraParamsToAgent(
+      agent,
+      cfg,
+      "amazon-bedrock",
+      "us.anthropic.claude-opus-4-6-v1",
+    );
 
     const model = {
       api: "openai-completions",
@@ -1574,7 +1726,9 @@ describe("applyExtraParamsToAgent", () => {
 
   it("adds Anthropic 1M beta header when context1m is enabled for Opus/Sonnet", () => {
     const { calls, agent } = createOptionsCaptureAgent();
-    const cfg = buildAnthropicModelConfig("anthropic/claude-opus-4-6", { context1m: true });
+    const cfg = buildAnthropicModelConfig("anthropic/claude-opus-4-6", {
+      context1m: true,
+    });
 
     applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-opus-4-6");
 
@@ -1678,7 +1832,9 @@ describe("applyExtraParamsToAgent", () => {
   });
 
   it("ignores context1m for non-Opus/Sonnet Anthropic models", () => {
-    const cfg = buildAnthropicModelConfig("anthropic/claude-haiku-3-5", { context1m: true });
+    const cfg = buildAnthropicModelConfig("anthropic/claude-haiku-3-5", {
+      context1m: true,
+    });
     const headers = runAnthropicHeaderCase({
       cfg,
       modelId: "claude-haiku-3-5",
@@ -2041,7 +2197,9 @@ describe("applyExtraParamsToAgent", () => {
       });
 
       expect(payload).not.toHaveProperty("service_tier");
-      expect(warnSpy).toHaveBeenCalledWith("ignoring invalid OpenAI service tier param: invalid");
+      expect(warnSpy).toHaveBeenCalledWith(
+        "ignoring invalid OpenAI service tier param: invalid",
+      );
     } finally {
       warnSpy.mockRestore();
     }
@@ -2140,7 +2298,63 @@ describe("applyExtraParamsToAgent", () => {
       },
     });
     expect(payload).not.toHaveProperty("store");
-    expect(payload.context_management).toEqual([{ type: "compaction", compact_threshold: 12_345 }]);
+    expect(payload.context_management).toEqual([
+      { type: "compaction", compact_threshold: 12_345 },
+    ]);
+  });
+
+  it("strips store from openai-completions payload for Google provider with supportsStore=false", () => {
+    // Regression test for https://github.com/openclaw/openclaw/issues/57033
+    // Google Gemini OpenAI-compatible endpoint rejects unknown `store` field.
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "google",
+      applyModelId: "gemini-2.5-pro",
+      model: {
+        api: "openai-completions",
+        provider: "google",
+        id: "gemini-2.5-pro",
+        name: "gemini-2.5-pro",
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+        compat: { supportsStore: false },
+      } as unknown as Model<"openai-completions">,
+      payload: { store: false, model: "gemini-2.5-pro" },
+    });
+    expect(payload).not.toHaveProperty("store");
+  });
+
+  it("does not strip store from openai-completions payload when supportsStore is not false", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-4o",
+      model: {
+        api: "openai-completions",
+        provider: "openai",
+        id: "gpt-4o",
+        name: "gpt-4o",
+        baseUrl: "https://api.openai.com/v1",
+        compat: { supportsStore: true },
+      } as unknown as Model<"openai-completions">,
+      payload: { store: false, model: "gpt-4o" },
+    });
+    // store should be left untouched when supportsStore is not false
+    expect(payload.store).toBe(false);
+  });
+
+  it("strips store from openai-completions payload for any non-OpenAI provider with supportsStore=false", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "custom-provider",
+      applyModelId: "some-model",
+      model: {
+        api: "openai-completions",
+        provider: "custom-provider",
+        id: "some-model",
+        name: "some-model",
+        baseUrl: "https://custom-provider.example.com/v1",
+        compat: { supportsStore: false },
+      } as unknown as Model<"openai-completions">,
+      payload: { store: false, model: "some-model" },
+    });
+    expect(payload).not.toHaveProperty("store");
   });
 
   it("auto-injects OpenAI Responses context_management compaction for direct OpenAI models", () => {
@@ -2225,7 +2439,9 @@ describe("applyExtraParamsToAgent", () => {
         context_management: [{ type: "compaction", compact_threshold: 12_345 }],
       },
     });
-    expect(payload.context_management).toEqual([{ type: "compaction", compact_threshold: 12_345 }]);
+    expect(payload.context_management).toEqual([
+      { type: "compaction", compact_threshold: 12_345 },
+    ]);
   });
 
   it("allows disabling OpenAI Responses context_management compaction via model params", () => {

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -9,7 +9,11 @@ type OpenAIServiceTier = "auto" | "default" | "flex" | "priority";
 type OpenAIReasoningEffort = "low" | "medium" | "high";
 
 const OPENAI_RESPONSES_APIS = new Set(["openai-responses"]);
-const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai", "azure-openai-responses"]);
+const OPENAI_RESPONSES_PROVIDERS = new Set([
+  "openai",
+  "azure-openai",
+  "azure-openai-responses",
+]);
 
 function isDirectOpenAIBaseUrl(baseUrl: unknown): boolean {
   if (typeof baseUrl !== "string" || !baseUrl.trim()) {
@@ -19,7 +23,9 @@ function isDirectOpenAIBaseUrl(baseUrl: unknown): boolean {
   try {
     const host = new URL(baseUrl).hostname.toLowerCase();
     return (
-      host === "api.openai.com" || host === "chatgpt.com" || host.endsWith(".openai.azure.com")
+      host === "api.openai.com" ||
+      host === "chatgpt.com" ||
+      host.endsWith(".openai.azure.com")
     );
   } catch {
     const normalized = baseUrl.toLowerCase();
@@ -69,7 +75,8 @@ function shouldApplyOpenAIAttributionHeaders(model: {
   }
   if (
     model.provider === "openai-codex" &&
-    (model.api === "openai-codex-responses" || model.api === "openai-responses") &&
+    (model.api === "openai-codex-responses" ||
+      model.api === "openai-responses") &&
     isOpenAICodexBaseUrl(model.baseUrl)
   ) {
     return "openai-codex";
@@ -111,7 +118,9 @@ function parsePositiveInteger(value: unknown): number | undefined {
   return undefined;
 }
 
-function resolveOpenAIResponsesCompactThreshold(model: { contextWindow?: unknown }): number {
+function resolveOpenAIResponsesCompactThreshold(model: {
+  contextWindow?: unknown;
+}): number {
   const contextWindow = parsePositiveInteger(model.contextWindow);
   if (contextWindow) {
     return Math.max(1_000, Math.floor(contextWindow * 0.7));
@@ -151,7 +160,17 @@ function shouldStripResponsesStore(
   if (typeof model.api !== "string") {
     return false;
   }
-  return OPENAI_RESPONSES_APIS.has(model.api) && model.compat?.supportsStore === false;
+  if (OPENAI_RESPONSES_APIS.has(model.api)) {
+    return model.compat?.supportsStore === false;
+  }
+  // Strip `store` from openai-completions payloads when the provider doesn't
+  // support it. The upstream pi-ai library sets `store: false` for all
+  // completions providers not in its isNonStandard list (e.g. Google Gemini
+  // OpenAI-compatible endpoints), causing 400 errors from unknown field.
+  if (model.api === "openai-completions") {
+    return model.compat?.supportsStore === false;
+  }
+  return false;
 }
 
 function applyOpenAIResponsesPayloadOverrides(params: {
@@ -167,7 +186,10 @@ function applyOpenAIResponsesPayloadOverrides(params: {
   if (params.stripStore) {
     delete params.payloadObj.store;
   }
-  if (params.useServerCompaction && params.payloadObj.context_management === undefined) {
+  if (
+    params.useServerCompaction &&
+    params.payloadObj.context_management === undefined
+  ) {
     params.payloadObj.context_management = [
       {
         type: "compaction",
@@ -177,7 +199,9 @@ function applyOpenAIResponsesPayloadOverrides(params: {
   }
 }
 
-function normalizeOpenAIServiceTier(value: unknown): OpenAIServiceTier | undefined {
+function normalizeOpenAIServiceTier(
+  value: unknown,
+): OpenAIServiceTier | undefined {
   if (typeof value !== "string") {
     return undefined;
   }
@@ -246,7 +270,9 @@ export function resolveOpenAIFastMode(
   return normalized;
 }
 
-function resolveFastModeReasoningEffort(modelId: unknown): OpenAIReasoningEffort {
+function resolveFastModeReasoningEffort(
+  modelId: unknown,
+): OpenAIReasoningEffort {
   if (typeof modelId !== "string") {
     return "low";
   }
@@ -272,7 +298,11 @@ function applyOpenAIFastModePayloadOverrides(params: {
   const existingText = params.payloadObj.text;
   if (existingText === undefined) {
     params.payloadObj.text = { verbosity: "low" };
-  } else if (existingText && typeof existingText === "object" && !Array.isArray(existingText)) {
+  } else if (
+    existingText &&
+    typeof existingText === "object" &&
+    !Array.isArray(existingText)
+  ) {
     const textObj = existingText as Record<string, unknown>;
     if (textObj.verbosity === undefined) {
       textObj.verbosity = "low";
@@ -295,7 +325,10 @@ export function createOpenAIResponsesContextManagementWrapper(
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     const forceStore = shouldForceResponsesStore(model);
-    const useServerCompaction = shouldEnableOpenAIResponsesServerCompaction(model, extraParams);
+    const useServerCompaction = shouldEnableOpenAIResponsesServerCompaction(
+      model,
+      extraParams,
+    );
     const stripStore = shouldStripResponsesStore(model, forceStore);
     if (!forceStore && !useServerCompaction && !stripStore) {
       return underlying(model, context, options);
@@ -323,11 +356,14 @@ export function createOpenAIResponsesContextManagementWrapper(
   };
 }
 
-export function createOpenAIFastModeWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+export function createOpenAIFastModeWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     if (
-      (model.api !== "openai-responses" && model.api !== "openai-codex-responses") ||
+      (model.api !== "openai-responses" &&
+        model.api !== "openai-codex-responses") ||
       (model.provider !== "openai" && model.provider !== "openai-codex")
     ) {
       return underlying(model, context, options);
@@ -361,15 +397,23 @@ export function createOpenAIServiceTierWrapper(
     ) {
       return underlying(model, context, options);
     }
-    return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
-      if (payloadObj.service_tier === undefined) {
-        payloadObj.service_tier = serviceTier;
-      }
-    });
+    return streamWithPayloadPatch(
+      underlying,
+      model,
+      context,
+      options,
+      (payloadObj) => {
+        if (payloadObj.service_tier === undefined) {
+          payloadObj.service_tier = serviceTier;
+        }
+      },
+    );
   };
 }
 
-export function createCodexDefaultTransportWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+export function createCodexDefaultTransportWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) =>
     underlying(model, context, {
@@ -378,7 +422,9 @@ export function createCodexDefaultTransportWrapper(baseStreamFn: StreamFn | unde
     });
 }
 
-export function createOpenAIDefaultTransportWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+export function createOpenAIDefaultTransportWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     const typedOptions = options as


### PR DESCRIPTION
## Summary
- Fix #57033: Google Gemini's OpenAI-compatible endpoint rejects the `store` field with HTTP 400
- Extend `shouldStripResponsesStore` to also strip `store` from `openai-completions` payloads when `model.compat?.supportsStore === false`
- Reuses existing `createOpenAIResponsesContextManagementWrapper` infrastructure, no new wrappers needed

## Test plan
- [x] Added 3 new tests: strip for Google provider, preserve for OpenAI, strip for generic non-OpenAI
- [x] 80/83 extra-params tests pass (3 pre-existing failures unrelated)
- [ ] Manual: configure Google provider with `openai-completions` API, send prompt, verify no 400 error

🦞 Generated with [Claude Code](https://claude.com/claude-code)