### PR TITLE
fix: skip loading unused bundled channels when plugins.allow is set

### DIFF
--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -3,8 +3,62 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 afterEach(() => {
   vi.doUnmock("../../plugins/discovery.js");
   vi.doUnmock("../../plugins/manifest-registry.js");
+  vi.doUnmock("../../config/io.js");
   vi.resetModules();
 });
+
+function mockDiscoveryWithChannels(channelIds: string[]) {
+  const candidates = channelIds.map((id) => ({
+    rootDir: `/fake/extensions/${id}`,
+    source: `/fake/extensions/${id}/index.ts`,
+    origin: "bundled",
+  }));
+  const plugins = channelIds.map((id) => ({
+    id,
+    rootDir: `/fake/extensions/${id}`,
+    origin: "bundled",
+    channels: [{ id }],
+    setupSource: null,
+  }));
+
+  vi.doMock("../../plugins/discovery.js", () => ({
+    discoverOpenClawPlugins: () => ({
+      candidates,
+      diagnostics: [],
+    }),
+  }));
+  vi.doMock("../../plugins/manifest-registry.js", () => ({
+    loadPluginManifestRegistry: () => ({
+      plugins,
+      diagnostics: [],
+    }),
+  }));
+  // Mock the boundary file check and jiti loader so loadBundledModule
+  // returns a fake channel plugin entry without hitting the filesystem.
+  vi.doMock("../../infra/boundary-file-read.js", () => ({
+    openBoundaryFileSync: ({ absolutePath }: { absolutePath: string }) => ({
+      ok: true,
+      path: absolutePath,
+      fd: 999,
+    }),
+  }));
+  vi.doMock("jiti", () => ({
+    createJiti: () => (modulePath: string) => {
+      const id = modulePath.split("/").at(-2) ?? "unknown";
+      return { default: { channelPlugin: { id } } };
+    },
+  }));
+  vi.doMock("../../plugins/sdk-alias.js", () => ({
+    buildPluginLoaderAliasMap: () => ({}),
+    buildPluginLoaderJitiOptions: () => ({}),
+    shouldPreferNativeJiti: () => false,
+  }));
+  // Stub fs.closeSync since we return a fake fd.
+  vi.doMock("node:fs", async () => {
+    const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+    return { ...actual, default: { ...actual, closeSync: () => {} } };
+  });
+}
 
 describe("bundled channel entry shape guards", () => {
   it("treats missing bundled discovery results as empty", async () => {
@@ -26,5 +80,60 @@ describe("bundled channel entry shape guards", () => {
 
     expect(bundled.listBundledChannelPlugins()).toEqual([]);
     expect(bundled.listBundledChannelSetupPlugins()).toEqual([]);
+  });
+});
+
+describe("bundled channel plugins.allow filtering", () => {
+  it("skips channels not in plugins.allow", async () => {
+    vi.resetModules();
+    mockDiscoveryWithChannels(["discord", "slack", "imessage", "telegram"]);
+    vi.doMock("../../config/io.js", () => ({
+      loadConfig: () => ({
+        plugins: { allow: ["discord", "slack"] },
+      }),
+    }));
+
+    const bundled = await import("./bundled.js");
+    const plugins = bundled.listBundledChannelPlugins();
+    const ids = plugins.map((p) => p.id);
+
+    expect(ids).toContain("discord");
+    expect(ids).toContain("slack");
+    expect(ids).not.toContain("imessage");
+    expect(ids).not.toContain("telegram");
+  });
+
+  it("loads all channels when plugins.allow is not set", async () => {
+    vi.resetModules();
+    mockDiscoveryWithChannels(["discord", "slack", "imessage"]);
+    vi.doMock("../../config/io.js", () => ({
+      loadConfig: () => ({}),
+    }));
+
+    const bundled = await import("./bundled.js");
+    const plugins = bundled.listBundledChannelPlugins();
+    const ids = plugins.map((p) => p.id);
+
+    expect(ids).toContain("discord");
+    expect(ids).toContain("slack");
+    expect(ids).toContain("imessage");
+  });
+
+  it("loads all channels when loadConfig throws", async () => {
+    vi.resetModules();
+    mockDiscoveryWithChannels(["discord", "slack", "imessage"]);
+    vi.doMock("../../config/io.js", () => ({
+      loadConfig: () => {
+        throw new Error("config not ready");
+      },
+    }));
+
+    const bundled = await import("./bundled.js");
+    const plugins = bundled.listBundledChannelPlugins();
+    const ids = plugins.map((p) => p.id);
+
+    expect(ids).toContain("discord");
+    expect(ids).toContain("slack");
+    expect(ids).toContain("imessage");
   });
 });

--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -4,6 +4,7 @@ afterEach(() => {
   vi.doUnmock("../../plugins/discovery.js");
   vi.doUnmock("../../plugins/manifest-registry.js");
   vi.doUnmock("../../config/io.js");
+  vi.doUnmock("../../plugins/config-state.js");
   vi.resetModules();
 });
 
@@ -58,6 +59,17 @@ function mockDiscoveryWithChannels(channelIds: string[]) {
     const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
     return { ...actual, default: { ...actual, closeSync: () => {} } };
   });
+  // Provide a minimal normalizePluginsConfig that trims and returns allow list.
+  vi.doMock("../../plugins/config-state.js", () => ({
+    normalizePluginsConfig: (plugins?: { allow?: string[] }) => ({
+      enabled: true,
+      allow: (plugins?.allow ?? []).map((s: string) => s.trim()).filter(Boolean),
+      deny: [],
+      loadPaths: [],
+      slots: { memory: "memory-core" },
+      entries: {},
+    }),
+  }));
 }
 
 describe("bundled channel entry shape guards", () => {

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -217,7 +217,8 @@ function resolveEnabledChannelIds(): ReadonlySet<string> | undefined {
       return new Set(allow);
     }
   } catch {
-    // Config not available yet (e.g. during early bootstrap); load all channels.
+    // Config load failed for any reason (file missing, parse error, early bootstrap, etc.).
+    // Fall back to loading all channels — this is always safe.
   }
   return undefined;
 }

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { createJiti } from "jiti";
+import { loadConfig } from "../../config/io.js";
 import { openBoundaryFileSync } from "../../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { discoverOpenClawPlugins } from "../../plugins/discovery.js";
@@ -116,7 +117,9 @@ function loadBundledModule(modulePath: string, rootDir: string): unknown {
   return loadModule(safePath)(safePath);
 }
 
-function loadGeneratedBundledChannelEntries(): readonly GeneratedBundledChannelEntry[] {
+function loadGeneratedBundledChannelEntries(
+  enabledChannelIds?: ReadonlySet<string>,
+): readonly GeneratedBundledChannelEntry[] {
   const discovery = discoverOpenClawPlugins({ cache: false });
   const manifestRegistry = loadPluginManifestRegistry({
     cache: false,
@@ -139,6 +142,15 @@ function loadGeneratedBundledChannelEntries(): readonly GeneratedBundledChannelE
       continue;
     }
     seenIds.add(manifest.id);
+
+    // Skip loading channels that are not in the enabled set.
+    // This avoids jiti-loading every bundled extension at startup,
+    // which is critical on low-power ARM64 hosts (e.g. Raspberry Pi)
+    // where parsing dozens of unused module trees causes multi-minute
+    // startup delays and can trigger circular-dependency stack overflows.
+    if (enabledChannelIds && !enabledChannelIds.has(manifest.id)) {
+      continue;
+    }
 
     try {
       const entry = resolveChannelPluginModuleEntry(
@@ -192,12 +204,31 @@ type BundledChannelState = {
 
 let cachedBundledChannelState: BundledChannelState | null = null;
 
+/**
+ * Build the set of channel IDs that should be loaded based on config.
+ * When `plugins.allow` is set, only load channels whose plugin id is in the
+ * allowlist. Returns `undefined` when no filtering should be applied (load all).
+ */
+function resolveEnabledChannelIds(): ReadonlySet<string> | undefined {
+  try {
+    const config = loadConfig();
+    const allow = config.plugins?.allow;
+    if (Array.isArray(allow) && allow.length > 0) {
+      return new Set(allow);
+    }
+  } catch {
+    // Config not available yet (e.g. during early bootstrap); load all channels.
+  }
+  return undefined;
+}
+
 function getBundledChannelState(): BundledChannelState {
   if (cachedBundledChannelState) {
     return cachedBundledChannelState;
   }
 
-  const entries = loadGeneratedBundledChannelEntries();
+  const enabledChannelIds = resolveEnabledChannelIds();
+  const entries = loadGeneratedBundledChannelEntries(enabledChannelIds);
   const plugins = entries.map(({ entry }) => entry.channelPlugin);
   const setupPlugins = entries.flatMap(({ setupEntry }) => {
     const plugin = setupEntry?.plugin;

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -3,6 +3,7 @@ import { createJiti } from "jiti";
 import { loadConfig } from "../../config/io.js";
 import { openBoundaryFileSync } from "../../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { normalizePluginsConfig } from "../../plugins/config-state.js";
 import { discoverOpenClawPlugins } from "../../plugins/discovery.js";
 import { loadPluginManifestRegistry } from "../../plugins/manifest-registry.js";
 import type { PluginRuntime } from "../../plugins/runtime/types.js";
@@ -212,9 +213,9 @@ let cachedBundledChannelState: BundledChannelState | null = null;
 function resolveEnabledChannelIds(): ReadonlySet<string> | undefined {
   try {
     const config = loadConfig();
-    const allow = config.plugins?.allow;
-    if (Array.isArray(allow) && allow.length > 0) {
-      return new Set(allow);
+    const normalized = normalizePluginsConfig(config.plugins);
+    if (normalized.allow.length > 0) {
+      return new Set(normalized.allow);
     }
   } catch {
     // Config load failed for any reason (file missing, parse error, early bootstrap, etc.).


### PR DESCRIPTION
## Summary

- When `plugins.allow` is configured, skip jiti-loading bundled channel extensions that are not in the allowlist
- This avoids loading every bundled extension's module tree at startup, which on low-power ARM64 hosts (Raspberry Pi 4) causes 10+ minute startup hangs and circular-dependency stack overflows

## Problem

After `8e0ab35b0e` (refactor: decouple bundled plugin runtime loading), `loadGeneratedBundledChannelEntries()` iterates over **all** discovered plugin candidates and jiti-loads each one unconditionally — even when `plugins.allow` restricts the gateway to only a few channels.

On a Raspberry Pi 4 (ARM64), this causes:
1. 10+ minutes of 100% CPU with zero log output before the process reaches the listen stage
2. `RangeError: Maximum call stack size exceeded` on the imessage plugin load path (circular dependency)

The gateway never binds to its port and effectively fails to start.

## Fix

Add an `enabledChannelIds` filter to `loadGeneratedBundledChannelEntries()`. When `plugins.allow` is set in config, only channels whose plugin id is in the allowlist are jiti-loaded. All others are skipped before any module loading occurs.

This is a minimal, backwards-compatible change:
- When `plugins.allow` is **not set** (default), all channels load as before
- When `plugins.allow` **is set**, only allowed channels are loaded
- Config loading failures are caught and fall back to loading all channels

## Test plan

- [ ] Verify gateway starts on ARM64 (Raspberry Pi 4) with `plugins.allow: ["discord", "slack"]` and 2026.3.29+ code
- [x] Verify gateway starts normally on x86_64/Apple Silicon without `plugins.allow` (all channels load) — build passes on macOS
- [x] Verify `listBundledChannelPlugins()` returns only allowed channels when `plugins.allow` is set — unit tests in `bundled.shape-guard.test.ts`

Fixes #57398

cc @steipete @jospalmbier