### PR TITLE
fix(cron): honour payload.model override even when not in allowlist

### DIFF
--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -1,11 +1,13 @@
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import {
+  buildModelAliasIndex,
   getModelRefStatus,
   normalizeModelSelection,
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
+  resolveModelRefFromString,
 } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { CronJob } from "../types.js";
@@ -112,17 +114,34 @@ export async function resolveCronModelSelection(
     });
     if ("error" in resolvedOverride) {
       if (resolvedOverride.error.startsWith("model not allowed:")) {
-        return {
-          ok: true,
-          provider,
-          model,
-          warning: `cron: payload.model '${modelOverride}' not allowed, falling back to agent defaults`,
-        };
+        // payload.model is an explicit user override — honour it even when
+        // the model is not in agents.defaults.models.  The user chose this
+        // model for this specific cron job and per documented priority
+        // (payload > hooks > agent defaults) it should take precedence.
+        // (#57367)
+        const aliasIndex = buildModelAliasIndex({
+          cfg: params.cfgWithAgentDefaults,
+          defaultProvider: resolvedDefault.provider,
+        });
+        const parsed = resolveModelRefFromString({
+          raw: modelOverride,
+          defaultProvider: resolvedDefault.provider,
+          aliasIndex,
+        });
+        if (parsed) {
+          provider = parsed.ref.provider;
+          model = parsed.ref.model;
+        }
+        // If parsing unexpectedly fails (should not happen since
+        // resolveAllowedModelRef already parsed it successfully),
+        // provider/model stay at current defaults.
+      } else {
+        return { ok: false, error: resolvedOverride.error };
       }
-      return { ok: false, error: resolvedOverride.error };
+    } else {
+      provider = resolvedOverride.ref.provider;
+      model = resolvedOverride.ref.model;
     }
-    provider = resolvedOverride.ref.provider;
-    model = resolvedOverride.ref.model;
   }
 
   if (!modelOverride && !hooksGmailModelApplied) {

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -207,30 +207,32 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       expect(runParams.model).toBe("claude-sonnet-4-6");
     });
 
-    it("falls back to agent defaults when payload.model is not allowed", async () => {
+    it("applies payload.model even when not in allowlist (#57367)", async () => {
       resolveAllowedModelRefMock.mockReturnValueOnce({
         error: "model not allowed: anthropic/claude-sonnet-4-6",
       });
 
-      await runSkillFilterCase({
-        cfg: {
-          agents: {
-            defaults: {
-              model: { primary: "openai-codex/gpt-5.4", fallbacks: defaultFallbacks },
+      const result = await runCronIsolatedAgentTurn(
+        makeIsolatedAgentTurnParams({
+          cfg: {
+            agents: {
+              defaults: {
+                model: { primary: "openai-codex/gpt-5.4", fallbacks: defaultFallbacks },
+              },
             },
           },
-        },
-        job: makeSkillJob({
-          payload: { kind: "agentTurn", message: "test", model: "anthropic/claude-sonnet-4-6" },
+          job: makeSkillJob({
+            payload: { kind: "agentTurn", message: "test", model: "anthropic/claude-sonnet-4-6" },
+          }),
         }),
-      });
-      expect(logWarnMock).toHaveBeenCalledWith(
-        "cron: payload.model 'anthropic/claude-sonnet-4-6' not allowed, falling back to agent defaults",
       );
-      expectDefaultModelCall({
-        primary: "openai-codex/gpt-5.4",
-        fallbacks: defaultFallbacks,
-      });
+
+      expect(result.status).toBe("ok");
+      expect(logWarnMock).not.toHaveBeenCalled();
+      expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
+      const runParams = runWithModelFallbackMock.mock.calls[0][0];
+      expect(runParams.provider).toBe("anthropic");
+      expect(runParams.model).toBe("claude-sonnet-4-6");
     });
 
     it("returns an error when payload.model is invalid", async () => {


### PR DESCRIPTION
## Summary

Fixes #57367

- When a cron job's `payload.model` was set to a model not present in `agents.defaults.models`, the model was silently dropped and the agent default was used instead
- This contradicts the documented priority: payload override (highest) > hook-specific defaults > agent config default
- Now, when `resolveAllowedModelRef` rejects the model as "not allowed", we re-parse it via `resolveModelRefFromString` and apply it anyway, since `payload.model` is an explicit user configuration

## Root cause

`buildAllowedModelSet` only includes models from `agents.defaults.models` keys + the default model + fallbacks. Models configured in providers but not in the allowlist were silently rejected, causing the cron executor to fall back to the agent default with only a warning log.

## Changes

- `src/cron/isolated-agent/model-selection.ts`: When payload.model is "not allowed", re-resolve it via `resolveModelRefFromString` instead of silently falling back
- `src/cron/isolated-agent/run.skill-filter.test.ts`: Updated test to verify the new behaviour — payload.model is now applied even when not in the allowlist

## Test plan

- [x] All 41 related unit tests pass (`run.skill-filter`, `run.cron-model-override`, `model-formatting`)
- [ ] Manual test: configure a provider model not in `agents.defaults.models`, set it as `payload.model` on a cron job, verify it executes with the specified model

🤖 Generated with [Claude Code](https://claude.com/claude-code)