### PR TITLE
refactor(tasks): add executor facade

### DIFF
--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -6,7 +6,7 @@ import { onAgentEvent } from "../infra/agent-events.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
-import { recordTaskProgressByRunId } from "../tasks/task-registry.js";
+import { recordTaskRunProgressByRunId } from "../tasks/task-executor.js";
 
 const DEFAULT_STREAM_FLUSH_MS = 2_500;
 const DEFAULT_NO_OUTPUT_NOTICE_MS = 60_000;
@@ -204,7 +204,7 @@ export function startAcpSpawnParentStreamRelay(params: {
     wake();
   };
   const emitStartNotice = () => {
-    recordTaskProgressByRunId({
+    recordTaskRunProgressByRunId({
       runId,
       lastEventAt: Date.now(),
       eventSummary: "Started.",
@@ -271,7 +271,7 @@ export function startAcpSpawnParentStreamRelay(params: {
       return;
     }
     stallNotified = true;
-    recordTaskProgressByRunId({
+    recordTaskRunProgressByRunId({
       runId,
       lastEventAt: Date.now(),
       eventSummary: `No output for ${Math.round(noOutputNoticeMs / 1000)}s. It may be waiting for input.`,
@@ -317,7 +317,7 @@ export function startAcpSpawnParentStreamRelay(params: {
 
       if (stallNotified) {
         stallNotified = false;
-        recordTaskProgressByRunId({
+        recordTaskRunProgressByRunId({
           runId,
           lastEventAt: Date.now(),
           eventSummary: "Resumed output.",

--- a/src/tasks/task-executor.test.ts
+++ b/src/tasks/task-executor.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { withTempDir } from "../test-helpers/temp-dir.js";
+import {
+  completeTaskRunByRunId,
+  createQueuedTaskRun,
+  createRunningTaskRun,
+  failTaskRunByRunId,
+  recordTaskRunProgressByRunId,
+  setDetachedTaskDeliveryStatusByRunId,
+  startTaskRunByRunId,
+} from "./task-executor.js";
+import { findTaskByRunId, resetTaskRegistryForTests } from "./task-registry.js";
+
+const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+
+describe("task-executor", () => {
+  afterEach(() => {
+    if (ORIGINAL_STATE_DIR === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+    }
+    resetTaskRegistryForTests();
+  });
+
+  it("advances a queued run through start and completion", async () => {
+    await withTempDir({ prefix: "openclaw-task-executor-" }, async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const created = createQueuedTaskRun({
+        runtime: "acp",
+        requesterSessionKey: "agent:main:main",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-executor-queued",
+        task: "Investigate issue",
+      });
+
+      expect(created.status).toBe("queued");
+
+      startTaskRunByRunId({
+        runId: "run-executor-queued",
+        startedAt: 100,
+        lastEventAt: 100,
+        eventSummary: "Started.",
+      });
+
+      completeTaskRunByRunId({
+        runId: "run-executor-queued",
+        endedAt: 250,
+        lastEventAt: 250,
+        terminalSummary: "Done.",
+      });
+
+      expect(findTaskByRunId("run-executor-queued")).toMatchObject({
+        taskId: created.taskId,
+        status: "succeeded",
+        startedAt: 100,
+        endedAt: 250,
+        terminalSummary: "Done.",
+      });
+    });
+  });
+
+  it("records progress, failure, and delivery status through the executor", async () => {
+    await withTempDir({ prefix: "openclaw-task-executor-" }, async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const created = createRunningTaskRun({
+        runtime: "subagent",
+        requesterSessionKey: "agent:main:main",
+        childSessionKey: "agent:codex:subagent:child",
+        runId: "run-executor-fail",
+        task: "Write summary",
+        startedAt: 10,
+      });
+
+      recordTaskRunProgressByRunId({
+        runId: "run-executor-fail",
+        lastEventAt: 20,
+        progressSummary: "Collecting results",
+        eventSummary: "Collecting results",
+      });
+
+      failTaskRunByRunId({
+        runId: "run-executor-fail",
+        endedAt: 40,
+        lastEventAt: 40,
+        error: "tool failed",
+      });
+
+      setDetachedTaskDeliveryStatusByRunId({
+        runId: "run-executor-fail",
+        deliveryStatus: "failed",
+      });
+
+      expect(findTaskByRunId("run-executor-fail")).toMatchObject({
+        taskId: created.taskId,
+        status: "failed",
+        progressSummary: "Collecting results",
+        error: "tool failed",
+        deliveryStatus: "failed",
+      });
+    });
+  });
+});

--- a/src/tasks/task-executor.ts
+++ b/src/tasks/task-executor.ts
@@ -1,0 +1,143 @@
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  cancelTaskById,
+  createTaskRecord,
+  markTaskLostById,
+  markTaskRunningByRunId,
+  markTaskTerminalByRunId,
+  recordTaskProgressByRunId,
+  setTaskRunDeliveryStatusByRunId,
+} from "./task-registry.js";
+import type {
+  TaskDeliveryState,
+  TaskDeliveryStatus,
+  TaskNotifyPolicy,
+  TaskRecord,
+  TaskRuntime,
+  TaskStatus,
+  TaskTerminalOutcome,
+} from "./task-registry.types.js";
+
+export function createQueuedTaskRun(params: {
+  runtime: TaskRuntime;
+  sourceId?: string;
+  requesterSessionKey: string;
+  requesterOrigin?: TaskDeliveryState["requesterOrigin"];
+  childSessionKey?: string;
+  parentTaskId?: string;
+  agentId?: string;
+  runId?: string;
+  label?: string;
+  task: string;
+  preferMetadata?: boolean;
+  notifyPolicy?: TaskNotifyPolicy;
+  deliveryStatus?: TaskDeliveryStatus;
+}): TaskRecord {
+  return createTaskRecord({
+    ...params,
+    status: "queued",
+  });
+}
+
+export function createRunningTaskRun(params: {
+  runtime: TaskRuntime;
+  sourceId?: string;
+  requesterSessionKey: string;
+  requesterOrigin?: TaskDeliveryState["requesterOrigin"];
+  childSessionKey?: string;
+  parentTaskId?: string;
+  agentId?: string;
+  runId?: string;
+  label?: string;
+  task: string;
+  notifyPolicy?: TaskNotifyPolicy;
+  deliveryStatus?: TaskDeliveryStatus;
+  preferMetadata?: boolean;
+  startedAt?: number;
+  lastEventAt?: number;
+  progressSummary?: string | null;
+}): TaskRecord {
+  return createTaskRecord({
+    ...params,
+    status: "running",
+  });
+}
+
+export function startTaskRunByRunId(params: {
+  runId: string;
+  startedAt?: number;
+  lastEventAt?: number;
+  progressSummary?: string | null;
+  eventSummary?: string | null;
+}) {
+  return markTaskRunningByRunId(params);
+}
+
+export function recordTaskRunProgressByRunId(params: {
+  runId: string;
+  lastEventAt?: number;
+  progressSummary?: string | null;
+  eventSummary?: string | null;
+}) {
+  return recordTaskProgressByRunId(params);
+}
+
+export function completeTaskRunByRunId(params: {
+  runId: string;
+  endedAt: number;
+  lastEventAt?: number;
+  progressSummary?: string | null;
+  terminalSummary?: string | null;
+  terminalOutcome?: TaskTerminalOutcome | null;
+}) {
+  return markTaskTerminalByRunId({
+    runId: params.runId,
+    status: "succeeded",
+    endedAt: params.endedAt,
+    lastEventAt: params.lastEventAt,
+    progressSummary: params.progressSummary,
+    terminalSummary: params.terminalSummary,
+    terminalOutcome: params.terminalOutcome,
+  });
+}
+
+export function failTaskRunByRunId(params: {
+  runId: string;
+  status?: Extract<TaskStatus, "failed" | "timed_out" | "cancelled">;
+  endedAt: number;
+  lastEventAt?: number;
+  error?: string;
+  progressSummary?: string | null;
+  terminalSummary?: string | null;
+}) {
+  return markTaskTerminalByRunId({
+    runId: params.runId,
+    status: params.status ?? "failed",
+    endedAt: params.endedAt,
+    lastEventAt: params.lastEventAt,
+    error: params.error,
+    progressSummary: params.progressSummary,
+    terminalSummary: params.terminalSummary,
+  });
+}
+
+export function markTaskRunLostById(params: {
+  taskId: string;
+  endedAt: number;
+  lastEventAt?: number;
+  error?: string;
+  cleanupAfter?: number;
+}) {
+  return markTaskLostById(params);
+}
+
+export function setDetachedTaskDeliveryStatusByRunId(params: {
+  runId: string;
+  deliveryStatus: TaskDeliveryStatus;
+}) {
+  return setTaskRunDeliveryStatusByRunId(params);
+}
+
+export async function cancelDetachedTaskRunById(params: { cfg: OpenClawConfig; taskId: string }) {
+  return cancelTaskById(params);
+}


### PR DESCRIPTION
## Summary

- Problem: task lifecycle writes still come straight from the registry surface, so there is no explicit executor seam for detached/background runs.
- Why it matters: the remaining task work needs a stable contract before ACP, subagents, and cron can migrate producer-by-producer without more registry churn.
- What changed: added a thin `src/tasks/task-executor.ts` facade over the existing task lifecycle helpers, switched ACP parent-stream progress reporting to use it, and added focused executor tests.
- What did NOT change (scope boundary): no backend change, no cron target split, no heartbeat semantics change, and no broad producer migration yet.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Prior context (`git blame`, prior PR, issue, or refactor if known): N/A
- Why this regressed now: N/A
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/tasks/task-executor.test.ts`
- Scenario the test should lock in: queued/start/complete and running/progress/fail/delivery executor flows keep mapping to the existing task ledger correctly.
- Why this is the smallest reliable guardrail: it validates the new executor seam directly without pulling broader producer behavior into this checkpoint PR.
- Existing test that already covers this (if any): `src/tasks/task-registry.test.ts` still covers the downstream task behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
producer -> task-registry lifecycle helper -> task row

After:
producer -> task-executor -> task-registry lifecycle helper -> task row
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): ACP parent-stream progress path
- Relevant config (redacted): default local task sqlite state

### Steps

1. Create a detached/background run through the executor seam.
2. Advance it through progress / terminal transitions.
3. Verify the resulting task row still matches existing registry semantics.

### Expected

- The executor is only a thin seam over current task lifecycle behavior.

### Actual

- The executor now owns a first explicit lifecycle contract, with one ACP progress consumer switched to it.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test -- src/tasks/task-executor.test.ts src/tasks/task-registry.test.ts`
  - `pnpm build`
- Edge cases checked:
  - queued -> running -> succeeded path
  - running -> progress -> failed path
  - ACP parent-stream progress path still compiles through the new seam
- What you did **not** verify:
  - full ACP/subagent/cron producer migration; those are follow-up PRs in the sequence
  - `codex review --base origin/main` could not complete locally because the tool hit the known local `127.0.0.1` transport failure

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: thin facade adds an extra layer without yet removing direct registry imports elsewhere.
  - Mitigation: this PR keeps the layer intentionally small and migrates one contained consumer only; later PRs move producers in sequence.

AI-assisted: yes. Fully tested on the touched surface.
