### PR TITLE
fix(plugins): bundled channel plugins bypass plugins.allow allowlist

### DIFF
--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -171,6 +171,13 @@ describe("resolveEffectiveEnableState", () => {
       },
       { enabled: false, reason: "disabled in config" },
     ],
+    [
+      {
+        enabled: true,
+        allow: ["lossless-claw"],
+      },
+      { enabled: true },
+    ],
   ] as const)("resolves bundled telegram state for %o", (config, expected) => {
     expect(resolveBundledTelegramState(config)).toEqual(expected);
   });

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -303,7 +303,7 @@ export function resolveEffectiveEnableState(params: {
   const base = resolveEnableState(params.id, params.origin, params.config, params.enabledByDefault);
   if (
     !base.enabled &&
-    base.reason === "bundled (disabled by default)" &&
+    (base.reason === "bundled (disabled by default)" || base.reason === "not in allowlist") &&
     isBundledChannelEnabledByChannelConfig(params.rootConfig, params.id)
   ) {
     return { enabled: true };


### PR DESCRIPTION
## Summary

Fixes #57219

- When `plugins.allow` was configured with a custom plugin list, bundled channel plugins (Telegram, WhatsApp, Discord, etc.) were silently disabled
- `resolveEffectiveEnableState()` only recovered bundled plugins blocked with reason `"bundled (disabled by default)"`, missing the `"not in allowlist"` case
- One-line fix: expand the condition to also restore channel plugins blocked by the allowlist when `channels.<id>.enabled: true` is set

## Root cause

In `config-state.ts`, `resolveEnableState()` returns `{ enabled: false, reason: "not in allowlist" }` for any plugin not in `plugins.allow`. The wrapper `resolveEffectiveEnableState()` was designed to override this for bundled channels with active channel config, but only checked for the `"bundled (disabled by default)"` reason string.

## Changes

- `src/plugins/config-state.ts`: Add `"not in allowlist"` to the recovery condition in `resolveEffectiveEnableState()`
- `src/plugins/config-state.test.ts`: Add test case for allowlist + bundled channel scenario

## Test plan

- [x] 32 related unit tests pass (`config-state`, `enable`)
- [ ] Manual: configure `plugins.allow: ["some-plugin"]` with Telegram enabled, verify Telegram still responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)