### PR TITLE
fix: "Update now" button silently fails — show reasons, support force, add live progress

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -3874,17 +3874,20 @@ public struct UpdateRunParams: Codable, Sendable {
     public let note: String?
     public let restartdelayms: Int?
     public let timeoutms: Int?
+    public let force: Bool?
 
     public init(
         sessionkey: String?,
         note: String?,
         restartdelayms: Int?,
-        timeoutms: Int?)
+        timeoutms: Int?,
+        force: Bool?)
     {
         self.sessionkey = sessionkey
         self.note = note
         self.restartdelayms = restartdelayms
         self.timeoutms = timeoutms
+        self.force = force
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -3892,6 +3895,7 @@ public struct UpdateRunParams: Codable, Sendable {
         case note
         case restartdelayms = "restartDelayMs"
         case timeoutms = "timeoutMs"
+        case force
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -3874,17 +3874,20 @@ public struct UpdateRunParams: Codable, Sendable {
     public let note: String?
     public let restartdelayms: Int?
     public let timeoutms: Int?
+    public let force: Bool?
 
     public init(
         sessionkey: String?,
         note: String?,
         restartdelayms: Int?,
-        timeoutms: Int?)
+        timeoutms: Int?,
+        force: Bool?)
     {
         self.sessionkey = sessionkey
         self.note = note
         self.restartdelayms = restartdelayms
         self.timeoutms = timeoutms
+        self.force = force
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -3892,6 +3895,7 @@ public struct UpdateRunParams: Codable, Sendable {
         case note
         case restartdelayms = "restartDelayMs"
         case timeoutms = "timeoutMs"
+        case force
     }
 }
 

--- a/src/gateway/events.ts
+++ b/src/gateway/events.ts
@@ -1,7 +1,25 @@
 import type { UpdateAvailable } from "../infra/update-startup.js";
 
 export const GATEWAY_EVENT_UPDATE_AVAILABLE = "update.available" as const;
+export const GATEWAY_EVENT_UPDATE_PROGRESS = "update.progress" as const;
 
 export type GatewayUpdateAvailableEventPayload = {
   updateAvailable: UpdateAvailable | null;
+};
+
+export type GatewayUpdateProgressEventPayload = {
+  kind: "step.start" | "step.complete" | "finished";
+  step?: {
+    name: string;
+    index: number;
+    total: number;
+  };
+  completion?: {
+    durationMs: number;
+    exitCode: number | null;
+  };
+  result?: {
+    status: "ok" | "error" | "skipped";
+    reason?: string;
+  };
 };

--- a/src/gateway/protocol/schema/config.ts
+++ b/src/gateway/protocol/schema/config.ts
@@ -46,6 +46,7 @@ export const UpdateRunParamsSchema = Type.Object(
     note: Type.Optional(Type.String()),
     restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
     timeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
+    force: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -1,5 +1,5 @@
 import { listChannelPlugins } from "../channels/plugins/index.js";
-import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
+import { GATEWAY_EVENT_UPDATE_AVAILABLE, GATEWAY_EVENT_UPDATE_PROGRESS } from "./events.js";
 
 const BASE_METHODS = [
   "health",
@@ -146,4 +146,5 @@ export const GATEWAY_EVENTS = [
   "plugin.approval.requested",
   "plugin.approval.resolved",
   GATEWAY_EVENT_UPDATE_AVAILABLE,
+  GATEWAY_EVENT_UPDATE_PROGRESS,
 ];

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -230,6 +230,21 @@ describe("update.run force parameter", () => {
   });
 });
 
+describe("update.run progress broadcast", () => {
+  it("passes progress callbacks to runGatewayUpdate", async () => {
+    await invokeUpdateRun({});
+
+    expect(runGatewayUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        progress: expect.objectContaining({
+          onStepStart: expect.any(Function),
+          onStepComplete: expect.any(Function),
+        }),
+      }),
+    );
+  });
+});
+
 describe("update.run restart scheduling", () => {
   it("schedules restart when update succeeds", async () => {
     let payload: { ok: boolean; restart: unknown } | undefined;

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -155,6 +155,81 @@ describe("update.run timeout normalization", () => {
   });
 });
 
+describe("update.run skipped response semantics", () => {
+  it("returns ok=false and skipped=true when update is skipped", async () => {
+    runGatewayUpdateMock.mockResolvedValueOnce({
+      status: "skipped",
+      mode: "git",
+      reason: "dirty",
+      steps: [],
+      durationMs: 50,
+    });
+
+    let payload: { ok: boolean; skipped: boolean; restart: unknown } | undefined;
+
+    await invokeUpdateRun({}, (_ok: boolean, response: unknown) => {
+      payload = response as { ok: boolean; skipped: boolean; restart: unknown };
+    });
+
+    expect(payload?.ok).toBe(false);
+    expect(payload?.skipped).toBe(true);
+    expect(payload?.restart).toBeNull();
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+  });
+
+  it("returns ok=true and skipped=false when update succeeds", async () => {
+    let payload: { ok: boolean; skipped: boolean } | undefined;
+
+    await invokeUpdateRun({}, (_ok: boolean, response: unknown) => {
+      payload = response as { ok: boolean; skipped: boolean };
+    });
+
+    expect(payload?.ok).toBe(true);
+    expect(payload?.skipped).toBe(false);
+  });
+
+  it("returns ok=false and skipped=false when update errors", async () => {
+    runGatewayUpdateMock.mockResolvedValueOnce({
+      status: "error",
+      mode: "git",
+      reason: "build-failed",
+      steps: [],
+      durationMs: 100,
+    });
+
+    let payload: { ok: boolean; skipped: boolean } | undefined;
+
+    await invokeUpdateRun({}, (_ok: boolean, response: unknown) => {
+      payload = response as { ok: boolean; skipped: boolean };
+    });
+
+    expect(payload?.ok).toBe(false);
+    expect(payload?.skipped).toBe(false);
+  });
+});
+
+describe("update.run force parameter", () => {
+  it("passes force=true to runGatewayUpdate when force param is set", async () => {
+    await invokeUpdateRun({ force: true });
+
+    expect(runGatewayUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        force: true,
+      }),
+    );
+  });
+
+  it("passes force=false to runGatewayUpdate when force param is not set", async () => {
+    await invokeUpdateRun({});
+
+    expect(runGatewayUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        force: false,
+      }),
+    );
+  });
+});
+
 describe("update.run restart scheduling", () => {
   it("schedules restart when update succeeds", async () => {
     let payload: { ok: boolean; restart: unknown } | undefined;

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -52,17 +52,25 @@ export const updateHandlers: GatewayRequestHandlers = {
         force,
         progress: {
           onStepStart: (step) => {
-            context?.broadcast?.(GATEWAY_EVENT_UPDATE_PROGRESS, {
-              kind: "step.start",
-              step: { name: step.name, index: step.index, total: step.total },
-            } satisfies GatewayUpdateProgressEventPayload);
+            context?.broadcast?.(
+              GATEWAY_EVENT_UPDATE_PROGRESS,
+              {
+                kind: "step.start",
+                step: { name: step.name, index: step.index, total: step.total },
+              } satisfies GatewayUpdateProgressEventPayload,
+              { dropIfSlow: true },
+            );
           },
           onStepComplete: (step) => {
-            context?.broadcast?.(GATEWAY_EVENT_UPDATE_PROGRESS, {
-              kind: "step.complete",
-              step: { name: step.name, index: step.index, total: step.total },
-              completion: { durationMs: step.durationMs, exitCode: step.exitCode },
-            } satisfies GatewayUpdateProgressEventPayload);
+            context?.broadcast?.(
+              GATEWAY_EVENT_UPDATE_PROGRESS,
+              {
+                kind: "step.complete",
+                step: { name: step.name, index: step.index, total: step.total },
+                completion: { durationMs: step.durationMs, exitCode: step.exitCode },
+              } satisfies GatewayUpdateProgressEventPayload,
+              { dropIfSlow: true },
+            );
           },
         },
       });
@@ -138,10 +146,14 @@ export const updateHandlers: GatewayRequestHandlers = {
       );
     }
 
-    context?.broadcast?.(GATEWAY_EVENT_UPDATE_PROGRESS, {
-      kind: "finished",
-      result: { status: result.status, reason: result.reason },
-    } satisfies GatewayUpdateProgressEventPayload);
+    context?.broadcast?.(
+      GATEWAY_EVENT_UPDATE_PROGRESS,
+      {
+        kind: "finished",
+        result: { status: result.status, reason: result.reason },
+      } satisfies GatewayUpdateProgressEventPayload,
+      { dropIfSlow: true },
+    );
 
     respond(
       true,

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -10,6 +10,10 @@ import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { normalizeUpdateChannel } from "../../infra/update-channels.js";
 import { runGatewayUpdate } from "../../infra/update-runner.js";
 import { formatControlPlaneActor, resolveControlPlaneActor } from "../control-plane-audit.js";
+import {
+  GATEWAY_EVENT_UPDATE_PROGRESS,
+  type GatewayUpdateProgressEventPayload,
+} from "../events.js";
 import { validateUpdateRunParams } from "../protocol/index.js";
 import { parseRestartRequestParams } from "./restart-request.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -46,6 +50,21 @@ export const updateHandlers: GatewayRequestHandlers = {
         argv1: process.argv[1],
         channel: configChannel ?? undefined,
         force,
+        progress: {
+          onStepStart: (step) => {
+            context?.broadcast?.(GATEWAY_EVENT_UPDATE_PROGRESS, {
+              kind: "step.start",
+              step: { name: step.name, index: step.index, total: step.total },
+            } satisfies GatewayUpdateProgressEventPayload);
+          },
+          onStepComplete: (step) => {
+            context?.broadcast?.(GATEWAY_EVENT_UPDATE_PROGRESS, {
+              kind: "step.complete",
+              step: { name: step.name, index: step.index, total: step.total },
+              completion: { durationMs: step.durationMs, exitCode: step.exitCode },
+            } satisfies GatewayUpdateProgressEventPayload);
+          },
+        },
       });
     } catch (err) {
       result = {
@@ -118,6 +137,11 @@ export const updateHandlers: GatewayRequestHandlers = {
         `update.run restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
       );
     }
+
+    context?.broadcast?.(GATEWAY_EVENT_UPDATE_PROGRESS, {
+      kind: "finished",
+      result: { status: result.status, reason: result.reason },
+    } satisfies GatewayUpdateProgressEventPayload);
 
     respond(
       true,

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -28,6 +28,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       typeof timeoutMsRaw === "number" && Number.isFinite(timeoutMsRaw)
         ? Math.max(1000, Math.floor(timeoutMsRaw))
         : undefined;
+    const force = (params as { force?: boolean }).force === true;
 
     let result: Awaited<ReturnType<typeof runGatewayUpdate>>;
     try {
@@ -44,6 +45,7 @@ export const updateHandlers: GatewayRequestHandlers = {
         cwd: root,
         argv1: process.argv[1],
         channel: configChannel ?? undefined,
+        force,
       });
     } catch (err) {
       result = {
@@ -120,7 +122,8 @@ export const updateHandlers: GatewayRequestHandlers = {
     respond(
       true,
       {
-        ok: result.status !== "error",
+        ok: result.status === "ok",
+        skipped: result.status === "skipped",
         result,
         restart,
         sentinel: {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -614,15 +614,20 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
         if (forceFetchStep.exitCode !== 0) {
           return buildGitErrorResult("force-fetch-failed");
         }
+        // Find the latest semver tag across all remotes, without assuming
+        // a specific remote name or branch.
         const latestTagStep = await runStep(
           step(
-            "git describe latest tag (force)",
-            ["git", "-C", gitRoot, "describe", "--tags", "--abbrev=0", "origin/main"],
+            "git tag latest (force)",
+            ["git", "-C", gitRoot, "tag", "--sort=-v:refname", "--list", "v*"],
             gitRoot,
           ),
         );
         steps.push(latestTagStep);
-        const latestTag = latestTagStep.stdoutTail?.trim();
+        const latestTag = (latestTagStep.stdoutTail ?? "")
+          .split("\n")
+          .map((l) => l.trim())
+          .find(Boolean);
         if (latestTagStep.exitCode !== 0 || !latestTag) {
           return buildGitErrorResult("force-no-tag-found");
         }

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -614,20 +614,27 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
         if (forceFetchStep.exitCode !== 0) {
           return buildGitErrorResult("force-fetch-failed");
         }
-        // Find the latest semver tag across all remotes, without assuming
-        // a specific remote name or branch.
+        // Find the latest semver tag across all remotes.  Use
+        // for-each-ref --count=1 so the output is always a single line,
+        // avoiding truncation issues with stdoutTail on repos with many tags.
         const latestTagStep = await runStep(
           step(
             "git tag latest (force)",
-            ["git", "-C", gitRoot, "tag", "--sort=-v:refname", "--list", "v*"],
+            [
+              "git",
+              "-C",
+              gitRoot,
+              "for-each-ref",
+              "--sort=-v:refname",
+              "--count=1",
+              "--format=%(refname:short)",
+              "refs/tags/v*",
+            ],
             gitRoot,
           ),
         );
         steps.push(latestTagStep);
-        const latestTag = (latestTagStep.stdoutTail ?? "")
-          .split("\n")
-          .map((l) => l.trim())
-          .find(Boolean);
+        const latestTag = latestTagStep.stdoutTail?.trim() || null;
         if (latestTagStep.exitCode !== 0 || !latestTag) {
           return buildGitErrorResult("force-no-tag-found");
         }

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -552,6 +552,13 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       if (discardStep.exitCode !== 0) {
         return buildGitErrorResult("force-discard-failed");
       }
+      const cleanStep = await runStep(
+        step("git clean (force remove untracked)", ["git", "-C", gitRoot, "clean", "-fd"], gitRoot),
+      );
+      steps.push(cleanStep);
+      if (cleanStep.exitCode !== 0) {
+        return buildGitErrorResult("force-clean-failed");
+      }
     }
 
     if (channel === "dev") {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -84,6 +84,7 @@ type UpdateRunnerOptions = {
   timeoutMs?: number;
   runCommand?: CommandRunner;
   progress?: UpdateStepProgress;
+  force?: boolean;
 };
 
 type BuildManager = "pnpm" | "bun" | "npm";
@@ -529,15 +530,28 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     const hasUncommittedChanges =
       statusCheck.stdoutTail && statusCheck.stdoutTail.trim().length > 0;
     if (hasUncommittedChanges) {
-      return {
-        status: "skipped",
-        mode: "git",
-        root: gitRoot,
-        reason: "dirty",
-        before: { sha: beforeSha, version: beforeVersion },
-        steps,
-        durationMs: Date.now() - startedAt,
-      };
+      if (!opts.force) {
+        return {
+          status: "skipped",
+          mode: "git",
+          root: gitRoot,
+          reason: "dirty",
+          before: { sha: beforeSha, version: beforeVersion },
+          steps,
+          durationMs: Date.now() - startedAt,
+        };
+      }
+      const discardStep = await runStep(
+        step(
+          "git checkout (force discard)",
+          ["git", "-C", gitRoot, "checkout", "--", "."],
+          gitRoot,
+        ),
+      );
+      steps.push(discardStep);
+      if (discardStep.exitCode !== 0) {
+        return buildGitErrorResult("force-discard-failed");
+      }
     }
 
     if (channel === "dev") {
@@ -571,216 +585,256 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       );
       steps.push(upstreamStep);
       if (upstreamStep.exitCode !== 0) {
-        return {
-          status: "skipped",
-          mode: "git",
-          root: gitRoot,
-          reason: "no-upstream",
-          before: { sha: beforeSha, version: beforeVersion },
-          steps,
-          durationMs: Date.now() - startedAt,
-        };
-      }
-
-      const fetchStep = await runStep(
-        step("git fetch", ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--tags"], gitRoot),
-      );
-      steps.push(fetchStep);
-
-      const upstreamShaStep = await runStep(
-        step(
-          "git rev-parse @{upstream}",
-          ["git", "-C", gitRoot, "rev-parse", "@{upstream}"],
-          gitRoot,
-        ),
-      );
-      steps.push(upstreamShaStep);
-      const upstreamSha = upstreamShaStep.stdoutTail?.trim();
-      if (!upstreamShaStep.stdoutTail || !upstreamSha) {
-        return {
-          status: "error",
-          mode: "git",
-          root: gitRoot,
-          reason: "no-upstream-sha",
-          before: { sha: beforeSha, version: beforeVersion },
-          steps,
-          durationMs: Date.now() - startedAt,
-        };
-      }
-
-      const revListStep = await runStep(
-        step(
-          "git rev-list",
-          ["git", "-C", gitRoot, "rev-list", `--max-count=${PREFLIGHT_MAX_COMMITS}`, upstreamSha],
-          gitRoot,
-        ),
-      );
-      steps.push(revListStep);
-      if (revListStep.exitCode !== 0) {
-        return {
-          status: "error",
-          mode: "git",
-          root: gitRoot,
-          reason: "preflight-revlist-failed",
-          before: { sha: beforeSha, version: beforeVersion },
-          steps,
-          durationMs: Date.now() - startedAt,
-        };
-      }
-
-      const candidates = (revListStep.stdoutTail ?? "")
-        .split("\n")
-        .map((line) => line.trim())
-        .filter(Boolean);
-      if (candidates.length === 0) {
-        return {
-          status: "error",
-          mode: "git",
-          root: gitRoot,
-          reason: "preflight-no-candidates",
-          before: { sha: beforeSha, version: beforeVersion },
-          steps,
-          durationMs: Date.now() - startedAt,
-        };
-      }
-
-      const manager = await resolveAvailableManager(runCommand, gitRoot, timeoutMs);
-      const preflightRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-preflight-"));
-      const worktreeDir = path.join(preflightRoot, "worktree");
-      const worktreeStep = await runStep(
-        step(
-          "preflight worktree",
-          ["git", "-C", gitRoot, "worktree", "add", "--detach", worktreeDir, upstreamSha],
-          gitRoot,
-        ),
-      );
-      steps.push(worktreeStep);
-      if (worktreeStep.exitCode !== 0) {
-        await fs.rm(preflightRoot, { recursive: true, force: true }).catch(() => {});
-        return {
-          status: "error",
-          mode: "git",
-          root: gitRoot,
-          reason: "preflight-worktree-failed",
-          before: { sha: beforeSha, version: beforeVersion },
-          steps,
-          durationMs: Date.now() - startedAt,
-        };
-      }
-
-      let selectedSha: string | null = null;
-      try {
-        for (const sha of candidates) {
-          const shortSha = sha.slice(0, 8);
-          const checkoutStep = await runStep(
-            step(
-              `preflight checkout (${shortSha})`,
-              ["git", "-C", worktreeDir, "checkout", "--detach", sha],
-              worktreeDir,
-            ),
-          );
-          steps.push(checkoutStep);
-          if (checkoutStep.exitCode !== 0) {
-            continue;
-          }
-
-          const depsStep = await runStep(
-            step(
-              `preflight deps install (${shortSha})`,
-              managerInstallArgs(manager.manager, {
-                compatFallback: manager.fallback && manager.manager === "npm",
-              }),
-              worktreeDir,
-            ),
-          );
-          steps.push(depsStep);
-          if (depsStep.exitCode !== 0) {
-            continue;
-          }
-
-          const buildStep = await runStep(
-            step(
-              `preflight build (${shortSha})`,
-              managerScriptArgs(manager.manager, "build"),
-              worktreeDir,
-            ),
-          );
-          steps.push(buildStep);
-          if (buildStep.exitCode !== 0) {
-            continue;
-          }
-
-          const lintStep = await runStep(
-            step(
-              `preflight lint (${shortSha})`,
-              managerScriptArgs(manager.manager, "lint"),
-              worktreeDir,
-            ),
-          );
-          steps.push(lintStep);
-          if (lintStep.exitCode !== 0) {
-            continue;
-          }
-
-          selectedSha = sha;
-          break;
+        if (!opts.force) {
+          return {
+            status: "skipped",
+            mode: "git",
+            root: gitRoot,
+            reason: "no-upstream",
+            before: { sha: beforeSha, version: beforeVersion },
+            steps,
+            durationMs: Date.now() - startedAt,
+          };
         }
-      } finally {
-        const removeStep = await runStep(
+        const forceFetchStep = await runStep(
           step(
-            "preflight cleanup",
-            ["git", "-C", gitRoot, "worktree", "remove", "--force", worktreeDir],
+            "git fetch --all (force)",
+            ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--tags"],
             gitRoot,
           ),
         );
-        steps.push(removeStep);
-        await runCommand(["git", "-C", gitRoot, "worktree", "prune"], {
-          cwd: gitRoot,
-          timeoutMs,
-        }).catch(() => null);
-        await fs.rm(preflightRoot, { recursive: true, force: true }).catch(() => {});
+        steps.push(forceFetchStep);
+        if (forceFetchStep.exitCode !== 0) {
+          return buildGitErrorResult("force-fetch-failed");
+        }
+        const latestTagStep = await runStep(
+          step(
+            "git describe latest tag (force)",
+            ["git", "-C", gitRoot, "describe", "--tags", "--abbrev=0", "origin/main"],
+            gitRoot,
+          ),
+        );
+        steps.push(latestTagStep);
+        const latestTag = latestTagStep.stdoutTail?.trim();
+        if (latestTagStep.exitCode !== 0 || !latestTag) {
+          return buildGitErrorResult("force-no-tag-found");
+        }
+        const resetStep = await runStep(
+          step(
+            `git reset to ${latestTag} (force)`,
+            ["git", "-C", gitRoot, "reset", "--hard", latestTag],
+            gitRoot,
+          ),
+        );
+        steps.push(resetStep);
+        if (resetStep.exitCode !== 0) {
+          return buildGitErrorResult("force-reset-failed");
+        }
       }
 
-      if (!selectedSha) {
-        return {
-          status: "error",
-          mode: "git",
-          root: gitRoot,
-          reason: "preflight-no-good-commit",
-          before: { sha: beforeSha, version: beforeVersion },
-          steps,
-          durationMs: Date.now() - startedAt,
-        };
-      }
+      if (upstreamStep.exitCode === 0) {
+        const fetchStep = await runStep(
+          step("git fetch", ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--tags"], gitRoot),
+        );
+        steps.push(fetchStep);
 
-      const rebaseStep = await runStep(
-        step("git rebase", ["git", "-C", gitRoot, "rebase", selectedSha], gitRoot),
-      );
-      steps.push(rebaseStep);
-      if (rebaseStep.exitCode !== 0) {
-        const abortResult = await runCommand(["git", "-C", gitRoot, "rebase", "--abort"], {
-          cwd: gitRoot,
-          timeoutMs,
-        });
-        steps.push({
-          name: "git rebase --abort",
-          command: "git rebase --abort",
-          cwd: gitRoot,
-          durationMs: 0,
-          exitCode: abortResult.code,
-          stdoutTail: trimLogTail(abortResult.stdout, MAX_LOG_CHARS),
-          stderrTail: trimLogTail(abortResult.stderr, MAX_LOG_CHARS),
-        });
-        return {
-          status: "error",
-          mode: "git",
-          root: gitRoot,
-          reason: "rebase-failed",
-          before: { sha: beforeSha, version: beforeVersion },
-          steps,
-          durationMs: Date.now() - startedAt,
-        };
-      }
+        const upstreamShaStep = await runStep(
+          step(
+            "git rev-parse @{upstream}",
+            ["git", "-C", gitRoot, "rev-parse", "@{upstream}"],
+            gitRoot,
+          ),
+        );
+        steps.push(upstreamShaStep);
+        const upstreamSha = upstreamShaStep.stdoutTail?.trim();
+        if (!upstreamShaStep.stdoutTail || !upstreamSha) {
+          return {
+            status: "error",
+            mode: "git",
+            root: gitRoot,
+            reason: "no-upstream-sha",
+            before: { sha: beforeSha, version: beforeVersion },
+            steps,
+            durationMs: Date.now() - startedAt,
+          };
+        }
+
+        const revListStep = await runStep(
+          step(
+            "git rev-list",
+            ["git", "-C", gitRoot, "rev-list", `--max-count=${PREFLIGHT_MAX_COMMITS}`, upstreamSha],
+            gitRoot,
+          ),
+        );
+        steps.push(revListStep);
+        if (revListStep.exitCode !== 0) {
+          return {
+            status: "error",
+            mode: "git",
+            root: gitRoot,
+            reason: "preflight-revlist-failed",
+            before: { sha: beforeSha, version: beforeVersion },
+            steps,
+            durationMs: Date.now() - startedAt,
+          };
+        }
+
+        const candidates = (revListStep.stdoutTail ?? "")
+          .split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean);
+        if (candidates.length === 0) {
+          return {
+            status: "error",
+            mode: "git",
+            root: gitRoot,
+            reason: "preflight-no-candidates",
+            before: { sha: beforeSha, version: beforeVersion },
+            steps,
+            durationMs: Date.now() - startedAt,
+          };
+        }
+
+        const manager = await resolveAvailableManager(runCommand, gitRoot, timeoutMs);
+        const preflightRoot = await fs.mkdtemp(
+          path.join(os.tmpdir(), "openclaw-update-preflight-"),
+        );
+        const worktreeDir = path.join(preflightRoot, "worktree");
+        const worktreeStep = await runStep(
+          step(
+            "preflight worktree",
+            ["git", "-C", gitRoot, "worktree", "add", "--detach", worktreeDir, upstreamSha],
+            gitRoot,
+          ),
+        );
+        steps.push(worktreeStep);
+        if (worktreeStep.exitCode !== 0) {
+          await fs.rm(preflightRoot, { recursive: true, force: true }).catch(() => {});
+          return {
+            status: "error",
+            mode: "git",
+            root: gitRoot,
+            reason: "preflight-worktree-failed",
+            before: { sha: beforeSha, version: beforeVersion },
+            steps,
+            durationMs: Date.now() - startedAt,
+          };
+        }
+
+        let selectedSha: string | null = null;
+        try {
+          for (const sha of candidates) {
+            const shortSha = sha.slice(0, 8);
+            const checkoutStep = await runStep(
+              step(
+                `preflight checkout (${shortSha})`,
+                ["git", "-C", worktreeDir, "checkout", "--detach", sha],
+                worktreeDir,
+              ),
+            );
+            steps.push(checkoutStep);
+            if (checkoutStep.exitCode !== 0) {
+              continue;
+            }
+
+            const depsStep = await runStep(
+              step(
+                `preflight deps install (${shortSha})`,
+                managerInstallArgs(manager.manager, {
+                  compatFallback: manager.fallback && manager.manager === "npm",
+                }),
+                worktreeDir,
+              ),
+            );
+            steps.push(depsStep);
+            if (depsStep.exitCode !== 0) {
+              continue;
+            }
+
+            const buildStep = await runStep(
+              step(
+                `preflight build (${shortSha})`,
+                managerScriptArgs(manager.manager, "build"),
+                worktreeDir,
+              ),
+            );
+            steps.push(buildStep);
+            if (buildStep.exitCode !== 0) {
+              continue;
+            }
+
+            const lintStep = await runStep(
+              step(
+                `preflight lint (${shortSha})`,
+                managerScriptArgs(manager.manager, "lint"),
+                worktreeDir,
+              ),
+            );
+            steps.push(lintStep);
+            if (lintStep.exitCode !== 0) {
+              continue;
+            }
+
+            selectedSha = sha;
+            break;
+          }
+        } finally {
+          const removeStep = await runStep(
+            step(
+              "preflight cleanup",
+              ["git", "-C", gitRoot, "worktree", "remove", "--force", worktreeDir],
+              gitRoot,
+            ),
+          );
+          steps.push(removeStep);
+          await runCommand(["git", "-C", gitRoot, "worktree", "prune"], {
+            cwd: gitRoot,
+            timeoutMs,
+          }).catch(() => null);
+          await fs.rm(preflightRoot, { recursive: true, force: true }).catch(() => {});
+        }
+
+        if (!selectedSha) {
+          return {
+            status: "error",
+            mode: "git",
+            root: gitRoot,
+            reason: "preflight-no-good-commit",
+            before: { sha: beforeSha, version: beforeVersion },
+            steps,
+            durationMs: Date.now() - startedAt,
+          };
+        }
+
+        const rebaseStep = await runStep(
+          step("git rebase", ["git", "-C", gitRoot, "rebase", selectedSha], gitRoot),
+        );
+        steps.push(rebaseStep);
+        if (rebaseStep.exitCode !== 0) {
+          const abortResult = await runCommand(["git", "-C", gitRoot, "rebase", "--abort"], {
+            cwd: gitRoot,
+            timeoutMs,
+          });
+          steps.push({
+            name: "git rebase --abort",
+            command: "git rebase --abort",
+            cwd: gitRoot,
+            durationMs: 0,
+            exitCode: abortResult.code,
+            stdoutTail: trimLogTail(abortResult.stdout, MAX_LOG_CHARS),
+            stderrTail: trimLogTail(abortResult.stderr, MAX_LOG_CHARS),
+          });
+          return {
+            status: "error",
+            mode: "git",
+            root: gitRoot,
+            reason: "rebase-failed",
+            before: { sha: beforeSha, version: beforeVersion },
+            steps,
+            durationMs: Date.now() - startedAt,
+          };
+        }
+      } // end if (upstreamStep.exitCode === 0)
     } else {
       const fetchStep = await runStep(
         step("git fetch", ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--tags"], gitRoot),
@@ -1083,13 +1137,56 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     };
   }
 
+  if (!opts.force) {
+    return {
+      status: "skipped",
+      mode: "unknown",
+      root: pkgRoot,
+      reason: "not-git-install",
+      before: { version: beforeVersion },
+      steps: [],
+      durationMs: Date.now() - startedAt,
+    };
+  }
+
+  const fallbackManager: BuildManager = "npm";
+  const packageName = (await readPackageName(pkgRoot)) ?? DEFAULT_PACKAGE_NAME;
+  const channel = opts.channel ?? DEFAULT_PACKAGE_CHANNEL;
+  const tag = normalizeTag(opts.tag ?? channelToNpmTag(channel));
+  const forceSteps: UpdateStepResult[] = [];
+  const forceInstallEnv = await createGlobalInstallEnv();
+  const spec = resolveGlobalInstallSpec({ packageName, tag, env: forceInstallEnv });
+  const updateStep = await runStep({
+    runCommand,
+    name: "global update (force npm fallback)",
+    argv: globalInstallArgs(fallbackManager, spec),
+    cwd: pkgRoot,
+    timeoutMs,
+    env: forceInstallEnv,
+    progress,
+    stepIndex: 0,
+    totalSteps: 1,
+  });
+  forceSteps.push(updateStep);
+  if (updateStep.exitCode !== 0) {
+    return {
+      status: "error",
+      mode: fallbackManager,
+      root: pkgRoot,
+      reason: "force-global-install-failed",
+      before: { version: beforeVersion },
+      steps: forceSteps,
+      durationMs: Date.now() - startedAt,
+    };
+  }
+  const afterVersion = await readPackageVersion(pkgRoot);
   return {
-    status: "skipped",
-    mode: "unknown",
+    status: "ok",
+    mode: fallbackManager,
     root: pkgRoot,
-    reason: "not-git-install",
     before: { version: beforeVersion },
-    steps: [],
+    after: { version: afterVersion },
+    steps: forceSteps,
     durationMs: Date.now() - startedAt,
   };
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -267,6 +267,58 @@
   opacity: 0.8;
 }
 
+.update-banner__progress {
+  display: block;
+  margin-top: 8px;
+  text-align: left;
+  font-size: 13px;
+}
+
+.update-banner__progress-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+
+.update-banner__progress-count {
+  font-size: 11px;
+  opacity: 0.7;
+  font-weight: 400;
+}
+
+.update-banner__progress-step {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono, monospace);
+  font-size: 12px;
+  padding: 2px 0;
+}
+
+.update-banner__spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--danger);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: update-spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes update-spin {
+  to { transform: rotate(360deg); }
+}
+
+.update-banner__progress-done {
+  font-family: var(--mono, monospace);
+  font-size: 11px;
+  opacity: 0.6;
+  padding: 1px 0;
+}
+
 /* ===========================================
    Cards - Refined with depth
    =========================================== */

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -260,13 +260,6 @@
   opacity: 0.5;
 }
 
-.update-banner__status {
-  margin-left: 8px;
-  font-size: 13px;
-  font-style: italic;
-  opacity: 0.8;
-}
-
 .update-banner__progress {
   display: block;
   margin-top: 8px;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -219,6 +219,54 @@
   stroke-linecap: round;
 }
 
+.update-banner__confirm {
+  display: block;
+  margin-top: 8px;
+  text-align: left;
+}
+
+.update-banner__reason {
+  font-size: 13px;
+  line-height: 1.5;
+  margin-bottom: 8px;
+}
+
+.update-banner__warning {
+  display: block;
+  margin-top: 4px;
+  font-weight: 400;
+  opacity: 0.85;
+  font-size: 12px;
+}
+
+.update-banner__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.update-banner__force-btn {
+  background: var(--danger) !important;
+  color: #fff !important;
+  border-color: var(--danger) !important;
+  font-size: 12px;
+  padding: 4px 12px;
+}
+
+.update-banner__force-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--danger) 85%, #000) !important;
+}
+
+.update-banner__force-btn:disabled {
+  opacity: 0.5;
+}
+
+.update-banner__status {
+  margin-left: 8px;
+  font-size: 13px;
+  font-style: italic;
+  opacity: 0.8;
+}
+
 /* ===========================================
    Cards - Refined with depth
    =========================================== */

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -1,6 +1,8 @@
 import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
+  GATEWAY_EVENT_UPDATE_PROGRESS,
   type GatewayUpdateAvailableEventPayload,
+  type GatewayUpdateProgressEventPayload,
 } from "../../../src/gateway/events.js";
 import {
   CHAT_SESSIONS_ACTIVE_MINUTES,
@@ -88,6 +90,7 @@ type GatewayHost = {
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalError: string | null;
   updateAvailable: UpdateAvailable | null;
+  updateProgress: import("./controllers/config.ts").ConfigState["updateProgress"];
 };
 
 type SessionDefaultsSnapshot = {
@@ -460,6 +463,34 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
     const resolved = parseExecApprovalResolved(evt.payload);
     if (resolved) {
       host.execApprovalQueue = removeExecApproval(host.execApprovalQueue, resolved.id);
+    }
+    return;
+  }
+
+  if (evt.event === GATEWAY_EVENT_UPDATE_PROGRESS) {
+    const p = evt.payload as GatewayUpdateProgressEventPayload | undefined;
+    if (!p || !host.updateProgress) {
+      return;
+    }
+    if (p.kind === "step.start" && p.step) {
+      host.updateProgress = {
+        ...host.updateProgress,
+        currentStep: p.step,
+      };
+    } else if (p.kind === "step.complete" && p.step && p.completion) {
+      host.updateProgress = {
+        ...host.updateProgress,
+        currentStep: null,
+        completedSteps: [
+          ...host.updateProgress.completedSteps,
+          {
+            name: p.step.name,
+            index: p.step.index,
+            durationMs: p.completion.durationMs,
+            exitCode: p.completion.exitCode,
+          },
+        ],
+      };
     }
     return;
   }

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -491,6 +491,9 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
           },
         ],
       };
+    } else if (p.kind === "finished") {
+      // Cleanup stays tied to the RPC lifecycle; keep the event explicit so
+      // future kinds do not get dropped by accident.
     }
     return;
   }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -38,6 +38,9 @@ import {
   loadConfig,
   openConfigFile,
   runUpdate,
+  forceUpdate,
+  dismissUpdateConfirm,
+  getSkippedReasonInfo,
   saveConfig,
   updateConfigFormValue,
   removeConfigFormValue,
@@ -585,25 +588,62 @@ export function renderApp(state: AppViewState) {
           ? html`<div class="update-banner callout danger" role="alert">
               <strong>Update available:</strong> v${state.updateAvailable.latestVersion} (running
               v${state.updateAvailable.currentVersion}).
-              <button
-                class="btn btn--sm update-banner__btn"
-                ?disabled=${state.updateRunning || !state.connected}
-                @click=${() => runUpdate(state)}
-              >
-                ${state.updateRunning ? "Updating…" : "Update now"}
-              </button>
-              <button
-                class="update-banner__close"
-                type="button"
-                title="Dismiss"
-                aria-label="Dismiss update banner"
-                @click=${() => {
-                  dismissUpdateBanner(state.updateAvailable);
-                  state.updateAvailable = null;
-                }}
-              >
-                ${icons.x}
-              </button>
+              ${state.updateConfirmPending
+                ? html`
+                    <div class="update-banner__confirm">
+                      <div class="update-banner__reason">
+                        ${(() => {
+                          const info = getSkippedReasonInfo(state.updateSkippedReason);
+                          return info
+                            ? html`<strong>Update skipped:</strong> ${info.message}<br />
+                                <span class="update-banner__warning">${info.warning}</span>`
+                            : nothing;
+                        })()}
+                      </div>
+                      <div class="update-banner__actions">
+                        <button
+                          class="btn btn--sm update-banner__force-btn"
+                          ?disabled=${state.updateRunning || !state.connected}
+                          @click=${() => forceUpdate(state)}
+                        >
+                          ${state.updateRunning
+                            ? "Forcing update…"
+                            : `Force update to v${state.updateAvailable?.latestVersion}`}
+                        </button>
+                        <button
+                          class="btn btn--sm update-banner__btn"
+                          @click=${() => dismissUpdateConfirm(state)}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  `
+                : state.updateRunning
+                  ? html`<span class="update-banner__status"
+                      >Updating to v${state.updateAvailable.latestVersion}…</span
+                    >`
+                  : html`
+                      <button
+                        class="btn btn--sm update-banner__btn"
+                        ?disabled=${!state.connected}
+                        @click=${() => runUpdate(state)}
+                      >
+                        Update now
+                      </button>
+                      <button
+                        class="update-banner__close"
+                        type="button"
+                        title="Dismiss"
+                        aria-label="Dismiss update banner"
+                        @click=${() => {
+                          dismissUpdateBanner(state.updateAvailable);
+                          state.updateAvailable = null;
+                        }}
+                      >
+                        ${icons.x}
+                      </button>
+                    `}
             </div>`
           : nothing}
         ${state.tab === "config"

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -620,9 +620,33 @@ export function renderApp(state: AppViewState) {
                     </div>
                   `
                 : state.updateRunning
-                  ? html`<span class="update-banner__status"
-                      >Updating to v${state.updateAvailable.latestVersion}…</span
-                    >`
+                  ? html`<div class="update-banner__progress">
+                      <div class="update-banner__progress-header">
+                        Updating to v${state.updateAvailable.latestVersion}…
+                        ${state.updateProgress?.currentStep?.total
+                          ? html`<span class="update-banner__progress-count">
+                              Step
+                              ${(state.updateProgress.currentStep?.index ??
+                                state.updateProgress.completedSteps.length) + 1}/${state
+                                .updateProgress.currentStep.total}
+                            </span>`
+                          : nothing}
+                      </div>
+                      ${state.updateProgress?.currentStep
+                        ? html`<div class="update-banner__progress-step">
+                            <span class="update-banner__spinner"></span>
+                            ${state.updateProgress.currentStep.name}
+                          </div>`
+                        : nothing}
+                      ${state.updateProgress?.completedSteps
+                        .slice(-2)
+                        .map(
+                          (s) => html`<div class="update-banner__progress-done">
+                            ${s.exitCode === 0 ? "+" : "x"} ${s.name}
+                            (${(s.durationMs / 1000).toFixed(1)}s)
+                          </div>`,
+                        )}
+                    </div>`
                   : html`
                       <button
                         class="btn btn--sm update-banner__btn"

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -109,6 +109,8 @@ export type AppViewState = {
   configSaving: boolean;
   configApplying: boolean;
   updateRunning: boolean;
+  updateSkippedReason: import("./controllers/config.ts").UpdateSkippedReason;
+  updateConfirmPending: boolean;
   applySessionKey: string;
   configSnapshot: ConfigSnapshot | null;
   configSchema: unknown;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -111,6 +111,7 @@ export type AppViewState = {
   updateRunning: boolean;
   updateSkippedReason: import("./controllers/config.ts").UpdateSkippedReason;
   updateConfirmPending: boolean;
+  updateProgress: import("./controllers/config.ts").ConfigState["updateProgress"];
   applySessionKey: string;
   configSnapshot: ConfigSnapshot | null;
   configSchema: unknown;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -210,6 +210,7 @@ export class OpenClawApp extends LitElement {
   @state() updateRunning = false;
   @state() updateSkippedReason: import("./controllers/config.ts").UpdateSkippedReason = null;
   @state() updateConfirmPending = false;
+  @state() updateProgress: import("./controllers/config.ts").ConfigState["updateProgress"] = null;
   @state() applySessionKey = this.settings.lastActiveSessionKey;
   @state() configSnapshot: ConfigSnapshot | null = null;
   @state() configSchema: unknown = null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -208,6 +208,8 @@ export class OpenClawApp extends LitElement {
   @state() configSaving = false;
   @state() configApplying = false;
   @state() updateRunning = false;
+  @state() updateSkippedReason: import("./controllers/config.ts").UpdateSkippedReason = null;
+  @state() updateConfirmPending = false;
   @state() applySessionKey = this.settings.lastActiveSessionKey;
   @state() configSnapshot: ConfigSnapshot | null = null;
   @state() configSchema: unknown = null;

--- a/ui/src/ui/controllers/agents.test.ts
+++ b/ui/src/ui/controllers/agents.test.ts
@@ -62,6 +62,7 @@ function createSaveState(): {
       updateRunning: false,
       updateSkippedReason: null,
       updateConfirmPending: false,
+      updateProgress: null,
       configSnapshot: { hash: "hash-1" },
       configFormDirty: true,
       configFormMode: "form",

--- a/ui/src/ui/controllers/agents.test.ts
+++ b/ui/src/ui/controllers/agents.test.ts
@@ -60,6 +60,8 @@ function createSaveState(): {
       configSaving: false,
       configApplying: false,
       updateRunning: false,
+      updateSkippedReason: null,
+      updateConfirmPending: false,
       configSnapshot: { hash: "hash-1" },
       configFormDirty: true,
       configFormMode: "form",

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   applyConfigSnapshot,
   applyConfig,
@@ -12,6 +12,10 @@ import {
   updateConfigFormValue,
   type ConfigState,
 } from "./config.ts";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 function createState(): ConfigState {
   return {
@@ -380,7 +384,7 @@ describe("saveConfig", () => {
 });
 
 describe("runUpdate", () => {
-  it("sends update.run with session key", async () => {
+  it("sends update.run with session key and omits force by default", async () => {
     const request = vi.fn().mockResolvedValue({});
     const state = createState();
     state.connected = true;
@@ -391,7 +395,6 @@ describe("runUpdate", () => {
 
     expect(request).toHaveBeenCalledWith("update.run", {
       sessionKey: "agent:main:whatsapp:dm:+15555550123",
-      force: false,
     });
   });
 
@@ -408,6 +411,36 @@ describe("runUpdate", () => {
     await runUpdate(state);
 
     expect(state.lastError).toBe("Update error: network unavailable");
+  });
+
+  it("does not let a prior success timer clear a newer update progress state", async () => {
+    vi.useFakeTimers();
+
+    let callCount = 0;
+    const request = vi.fn().mockImplementation(async () => {
+      callCount += 1;
+      return callCount === 1 ? {} : new Promise<never>(() => {});
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+
+    await runUpdate(state);
+    expect(state.updateProgress).not.toBeNull();
+
+    const firstStartedAtMs = state.updateProgress?.startedAtMs;
+    await vi.advanceTimersByTimeAsync(1);
+    const secondRun = runUpdate(state);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(state.updateProgress).not.toBeNull();
+    expect(state.updateProgress?.startedAtMs).not.toBe(firstStartedAtMs);
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(state.updateProgress).not.toBeNull();
+
+    secondRun.catch(() => {});
   });
 });
 

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -5,6 +5,9 @@ import {
   ensureAgentConfigEntry,
   findAgentConfigEntryIndex,
   runUpdate,
+  forceUpdate,
+  dismissUpdateConfirm,
+  getSkippedReasonInfo,
   saveConfig,
   updateConfigFormValue,
   type ConfigState,
@@ -36,6 +39,8 @@ function createState(): ConfigState {
     connected: false,
     lastError: null,
     updateRunning: false,
+    updateSkippedReason: null,
+    updateConfirmPending: false,
   };
 }
 
@@ -385,6 +390,7 @@ describe("runUpdate", () => {
 
     expect(request).toHaveBeenCalledWith("update.run", {
       sessionKey: "agent:main:whatsapp:dm:+15555550123",
+      force: false,
     });
   });
 
@@ -401,5 +407,117 @@ describe("runUpdate", () => {
     await runUpdate(state);
 
     expect(state.lastError).toBe("Update error: network unavailable");
+  });
+});
+
+describe("runUpdate skipped handling", () => {
+  it("sets updateConfirmPending when server returns skipped with known reason", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      skipped: true,
+      result: { status: "skipped", reason: "dirty" },
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+
+    await runUpdate(state);
+
+    expect(state.updateConfirmPending).toBe(true);
+    expect(state.updateSkippedReason).toBe("dirty");
+    expect(state.lastError).toBeNull();
+  });
+
+  it("sets lastError when server returns skipped with unknown reason", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      skipped: true,
+      result: { status: "skipped", reason: "some-new-reason" },
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+
+    await runUpdate(state);
+
+    expect(state.updateConfirmPending).toBe(false);
+    expect(state.lastError).toContain("some-new-reason");
+  });
+
+  it("handles no-upstream skipped reason", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      skipped: true,
+      result: { status: "skipped", reason: "no-upstream" },
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+
+    await runUpdate(state);
+
+    expect(state.updateSkippedReason).toBe("no-upstream");
+    expect(state.updateConfirmPending).toBe(true);
+  });
+
+  it("handles not-git-install skipped reason", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: false,
+      skipped: true,
+      result: { status: "skipped", reason: "not-git-install" },
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+
+    await runUpdate(state);
+
+    expect(state.updateSkippedReason).toBe("not-git-install");
+    expect(state.updateConfirmPending).toBe(true);
+  });
+});
+
+describe("forceUpdate", () => {
+  it("sends force=true and clears confirmPending", async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.updateConfirmPending = true;
+    state.updateSkippedReason = "dirty";
+
+    await forceUpdate(state);
+
+    expect(request).toHaveBeenCalledWith("update.run", {
+      sessionKey: "main",
+      force: true,
+    });
+    expect(state.updateConfirmPending).toBe(false);
+  });
+});
+
+describe("dismissUpdateConfirm", () => {
+  it("clears skipped state", () => {
+    const state = createState();
+    state.updateSkippedReason = "dirty";
+    state.updateConfirmPending = true;
+
+    dismissUpdateConfirm(state);
+
+    expect(state.updateSkippedReason).toBeNull();
+    expect(state.updateConfirmPending).toBe(false);
+  });
+});
+
+describe("getSkippedReasonInfo", () => {
+  it("returns info for known reasons", () => {
+    expect(getSkippedReasonInfo("dirty")).not.toBeNull();
+    expect(getSkippedReasonInfo("no-upstream")).not.toBeNull();
+    expect(getSkippedReasonInfo("not-git-install")).not.toBeNull();
+  });
+
+  it("returns null for unknown reasons", () => {
+    expect(getSkippedReasonInfo("some-unknown")).toBeNull();
+    expect(getSkippedReasonInfo(null)).toBeNull();
   });
 });

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -41,6 +41,7 @@ function createState(): ConfigState {
     updateRunning: false,
     updateSkippedReason: null,
     updateConfirmPending: false,
+    updateProgress: null,
   };
 }
 

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -11,7 +11,9 @@ import {
 
 export type UpdateSkippedReason = "dirty" | "no-upstream" | "not-git-install" | null;
 
-const SKIPPED_REASON_MESSAGES: Record<string, { message: string; warning: string }> = {
+type KnownUpdateSkippedReason = Exclude<UpdateSkippedReason, null>;
+
+const SKIPPED_REASON_MESSAGES = {
   dirty: {
     message: "Repository has uncommitted changes.",
     warning:
@@ -27,16 +29,44 @@ const SKIPPED_REASON_MESSAGES: Record<string, { message: string; warning: string
     warning:
       "Force update will attempt to reinstall globally via npm. This may affect your current installation.",
   },
-};
+} satisfies Record<KnownUpdateSkippedReason, { message: string; warning: string }>;
+
+const updateProgressClearTimers = new WeakMap<
+  ConfigState,
+  ReturnType<typeof globalThis.setTimeout>
+>();
+
+function isKnownUpdateSkippedReason(reason: string | null): reason is KnownUpdateSkippedReason {
+  return reason === "dirty" || reason === "no-upstream" || reason === "not-git-install";
+}
+
+function clearUpdateProgressTimer(state: ConfigState) {
+  const timerId = updateProgressClearTimers.get(state);
+  if (timerId !== undefined) {
+    clearTimeout(timerId);
+    updateProgressClearTimers.delete(state);
+  }
+}
+
+function scheduleUpdateProgressClear(state: ConfigState, startedAtMs: number) {
+  clearUpdateProgressTimer(state);
+  const timerId = globalThis.setTimeout(() => {
+    if (state.updateProgress?.startedAtMs === startedAtMs && !state.updateRunning) {
+      state.updateProgress = null;
+    }
+    updateProgressClearTimers.delete(state);
+  }, 2000);
+  updateProgressClearTimers.set(state, timerId);
+}
 
 export function getSkippedReasonInfo(reason: string | null): {
   message: string;
   warning: string;
 } | null {
-  if (!reason) {
+  if (!isKnownUpdateSkippedReason(reason)) {
     return null;
   }
-  return SKIPPED_REASON_MESSAGES[reason] ?? null;
+  return SKIPPED_REASON_MESSAGES[reason];
 }
 
 export type ConfigState = {
@@ -236,20 +266,22 @@ export async function runUpdate(state: ConfigState, force = false) {
   if (!state.client || !state.connected) {
     return;
   }
+  clearUpdateProgressTimer(state);
   state.updateRunning = true;
   state.lastError = null;
   state.updateSkippedReason = null;
   state.updateConfirmPending = false;
-  state.updateProgress = { currentStep: null, completedSteps: [], startedAtMs: Date.now() };
+  const startedAtMs = Date.now();
+  state.updateProgress = { currentStep: null, completedSteps: [], startedAtMs };
   try {
     const res = await state.client.request<UpdateRunResponse>("update.run", {
       sessionKey: state.applySessionKey,
-      force,
+      ...(force ? { force: true } : {}),
     });
     if (res?.skipped) {
-      const reason = (res.result?.reason ?? "unknown") as UpdateSkippedReason;
+      const reason = res.result?.reason ?? null;
       const info = getSkippedReasonInfo(reason);
-      if (info) {
+      if (info && isKnownUpdateSkippedReason(reason)) {
         state.updateSkippedReason = reason;
         state.updateConfirmPending = true;
       } else {
@@ -265,11 +297,10 @@ export async function runUpdate(state: ConfigState, force = false) {
   } finally {
     state.updateRunning = false;
     if (state.lastError || state.updateConfirmPending) {
+      clearUpdateProgressTimer(state);
       state.updateProgress = null;
     } else {
-      setTimeout(() => {
-        state.updateProgress = null;
-      }, 2000);
+      scheduleUpdateProgressClear(state, startedAtMs);
     }
   }
 }

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -9,6 +9,36 @@ import {
   setPathValue,
 } from "./config/form-utils.ts";
 
+export type UpdateSkippedReason = "dirty" | "no-upstream" | "not-git-install" | null;
+
+const SKIPPED_REASON_MESSAGES: Record<string, { message: string; warning: string }> = {
+  dirty: {
+    message: "Repository has uncommitted changes.",
+    warning:
+      "Force update will discard all uncommitted changes (git checkout -- .). Make sure you have backed up any work in progress.",
+  },
+  "no-upstream": {
+    message: "No upstream branch configured.",
+    warning:
+      "Force update will fetch all remotes and reset to the latest release tag. Local commits not pushed to a remote will be lost.",
+  },
+  "not-git-install": {
+    message: "Not installed via git (no package manager detected).",
+    warning:
+      "Force update will attempt to reinstall globally via npm. This may affect your current installation.",
+  },
+};
+
+export function getSkippedReasonInfo(reason: string | null): {
+  message: string;
+  warning: string;
+} | null {
+  if (!reason) {
+    return null;
+  }
+  return SKIPPED_REASON_MESSAGES[reason] ?? null;
+}
+
 export type ConfigState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
@@ -21,6 +51,8 @@ export type ConfigState = {
   configSaving: boolean;
   configApplying: boolean;
   updateRunning: boolean;
+  updateSkippedReason: UpdateSkippedReason;
+  updateConfirmPending: boolean;
   configSnapshot: ConfigSnapshot | null;
   configSchema: unknown;
   configSchemaVersion: string | null;
@@ -184,20 +216,35 @@ export async function applyConfig(state: ConfigState) {
   }
 }
 
-export async function runUpdate(state: ConfigState) {
+type UpdateRunResponse = {
+  ok?: boolean;
+  skipped?: boolean;
+  result?: { status?: string; reason?: string };
+};
+
+export async function runUpdate(state: ConfigState, force = false) {
   if (!state.client || !state.connected) {
     return;
   }
   state.updateRunning = true;
   state.lastError = null;
+  state.updateSkippedReason = null;
+  state.updateConfirmPending = false;
   try {
-    const res = await state.client.request<{
-      ok?: boolean;
-      result?: { status?: string; reason?: string };
-    }>("update.run", {
+    const res = await state.client.request<UpdateRunResponse>("update.run", {
       sessionKey: state.applySessionKey,
+      force,
     });
-    if (res && res.ok === false) {
+    if (res?.skipped) {
+      const reason = (res.result?.reason ?? "unknown") as UpdateSkippedReason;
+      const info = getSkippedReasonInfo(reason);
+      if (info) {
+        state.updateSkippedReason = reason;
+        state.updateConfirmPending = true;
+      } else {
+        state.lastError = `Update skipped: ${res.result?.reason ?? "unknown reason"}`;
+      }
+    } else if (res && res.ok === false) {
       const status = res.result?.status ?? "error";
       const reason = res.result?.reason ?? "Update failed.";
       state.lastError = `Update ${status}: ${reason}`;
@@ -207,6 +254,16 @@ export async function runUpdate(state: ConfigState) {
   } finally {
     state.updateRunning = false;
   }
+}
+
+export async function forceUpdate(state: ConfigState) {
+  state.updateConfirmPending = false;
+  await runUpdate(state, true);
+}
+
+export function dismissUpdateConfirm(state: ConfigState) {
+  state.updateSkippedReason = null;
+  state.updateConfirmPending = false;
 }
 
 export function updateConfigFormValue(

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -15,7 +15,7 @@ const SKIPPED_REASON_MESSAGES: Record<string, { message: string; warning: string
   dirty: {
     message: "Repository has uncommitted changes.",
     warning:
-      "Force update will discard all uncommitted changes (git checkout -- .). Make sure you have backed up any work in progress.",
+      "Force update will discard all uncommitted changes and remove untracked files. Make sure you have backed up any work in progress.",
   },
   "no-upstream": {
     message: "No upstream branch configured.",

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -53,6 +53,16 @@ export type ConfigState = {
   updateRunning: boolean;
   updateSkippedReason: UpdateSkippedReason;
   updateConfirmPending: boolean;
+  updateProgress: {
+    currentStep: { name: string; index: number; total: number } | null;
+    completedSteps: Array<{
+      name: string;
+      index: number;
+      durationMs: number;
+      exitCode: number | null;
+    }>;
+    startedAtMs: number | null;
+  } | null;
   configSnapshot: ConfigSnapshot | null;
   configSchema: unknown;
   configSchemaVersion: string | null;
@@ -230,6 +240,7 @@ export async function runUpdate(state: ConfigState, force = false) {
   state.lastError = null;
   state.updateSkippedReason = null;
   state.updateConfirmPending = false;
+  state.updateProgress = { currentStep: null, completedSteps: [], startedAtMs: Date.now() };
   try {
     const res = await state.client.request<UpdateRunResponse>("update.run", {
       sessionKey: state.applySessionKey,
@@ -253,6 +264,13 @@ export async function runUpdate(state: ConfigState, force = false) {
     state.lastError = String(err);
   } finally {
     state.updateRunning = false;
+    if (state.lastError || state.updateConfirmPending) {
+      state.updateProgress = null;
+    } else {
+      setTimeout(() => {
+        state.updateProgress = null;
+      }, 2000);
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

The "Update now" button in Control UI silently fails. Clicking it shows "Updating..." briefly, then reverts back to "Update now" with zero feedback. The root cause: the backend returns `ok: true` for `skipped` results, so the frontend treats it as success and does nothing.

This affects anyone running a git-based install with uncommitted changes, missing upstream, or edge cases where the global package manager isn't detected.

Relates to #41369, #46521, #20745

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Git install with uncommitted changes | Button flashes "Updating..." then silently reverts. No feedback. | Shows "Update skipped: Repository has uncommitted changes" with risk warning and Force/Cancel choice. |
| Git install with no upstream branch | Same silent failure. | Shows skip reason + force option (fetch all + reset to latest tag). |
| Non-git install, package manager undetected | Same silent failure. | Shows skip reason + force option (npm install -g fallback). |
| Any update in progress | Static "Updating..." text, no idea what's happening. | Live step progress: current step with spinner, step N/M counter, last 2 completed steps with duration. |
| `update.run` response for skipped | `ok: true`, frontend thinks it succeeded. | `ok: false, skipped: true`, frontend can distinguish skip from error. |

## Scope

**What this PR changes:**
- `update.run` response semantics (`ok` field, new `skipped` boolean)
- `UpdateRunParamsSchema` — new optional `force: boolean` param + Swift protocol regen
- `update-runner.ts` — force bypass logic for 3 skip conditions
- Control UI banner — skip reason display, force confirmation flow, live progress
- `update.progress` broadcast event (new, uses existing `UpdateStepProgress` callbacks)

**What this PR does NOT change:**
- The normal update flow for npm/pnpm/bun global installs (no `force` needed, works as before)
- The git preflight/rebase/build pipeline (untouched except for the 3 skip bypass paths)
- Any channel, agent, or session behavior
- No config schema changes beyond the `force` param on `update.run`

## Force update — risk and safeguards

The `force` option is the most sensitive part. It only runs when the user explicitly clicks "Force update" after reading a risk warning. Here's what each path does:

| Skip reason | Force action | Risk | Safeguard |
|-------------|-------------|------|-----------|
| `dirty` | `git checkout -- .` + `git clean -fd` | Discards uncommitted changes and untracked files permanently | Warning: "Force update will discard all uncommitted changes and remove untracked files. Make sure you have backed up any work in progress." |
| `no-upstream` | `git fetch --all` + find latest tag on `origin/main` + `git reset --hard <tag>` | Local commits not pushed to remote are lost | Warning: "Force update will fetch all remotes and reset to the latest release tag. Local commits not pushed to a remote will be lost." |
| `not-git-install` | `npm install -g openclaw@<tag>` as fallback | May affect current installation if npm isn't the original installer | Warning: "Force update will attempt to reinstall globally via npm. This may affect your current installation." |

In all cases: no force action runs without user confirmation. The UI shows the specific risk before offering the button.

## Changes

### Fix the silent failure
- **`ok` semantics**: `update.run` now returns `ok: false` for skipped results (was incorrectly `true`). Added `skipped: true` so the frontend can distinguish skipped vs error.
- **`force` param**: New optional `force: boolean` on `update.run`. When set, the runner bypasses recoverable skip conditions (see table above).
- **Frontend confirmation**: When update is skipped, the banner shows why + risk warning + "Force update to vX.Y.Z" / "Cancel".

### Live progress display
- Wires existing `UpdateStepProgress` callbacks through `context.broadcast` as `update.progress` events (`step.start`, `step.complete`, `finished`).
- Frontend shows current step name + spinner, step counter (N/M), last 2 completed steps with duration.

### Protocol regen
- `UpdateRunParamsSchema` gained `force: Type.Optional(Type.Boolean())`.
- Swift `GatewayModels.swift` regenerated for both macOS and shared targets.

## Testing

### Unit tests (automated)

**Backend** — `npx vitest run src/gateway/server-methods/update.test.ts` (12 tests, all pass):
- `skipped` status returns `ok: false, skipped: true` *(new)*
- `ok` status returns `ok: true, skipped: false` *(new)*
- `error` status returns `ok: false, skipped: false` *(new)*
- `force: true` passed through to `runGatewayUpdate` *(new)*
- `force: false` when param not set *(new)*
- `progress` callbacks passed to `runGatewayUpdate` *(new)*
- Existing sentinel, timeout, and restart scheduling tests still pass

**Frontend** — `cd ui && npx vitest run --project unit src/ui/controllers/config.test.ts` (24 tests, all pass):
- Skipped with `dirty` reason → sets `updateConfirmPending` *(new)*
- Skipped with `no-upstream` reason → sets confirm pending *(new)*
- Skipped with `not-git-install` reason → sets confirm pending *(new)*
- Skipped with unknown reason → falls back to `lastError` *(new)*
- `forceUpdate` sends `force: true` and clears confirm state *(new)*
- `dismissUpdateConfirm` clears skipped state *(new)*
- `getSkippedReasonInfo` returns info for known / null for unknown *(new)*
- Existing `runUpdate` session key test updated for new `force` param

### Manual testing
- Triggered `dirty` skip on a git install with uncommitted changes → confirmation UI appeared → force update bypassed dirty check and proceeded to preflight
- Verified `update-check.json` spoofing triggers the update banner with correct version display
- Confirmed normal npm global install path is unaffected (no `force` needed)

## Screenshots

_(Happy to add screenshots if helpful — the banner shows skip reason + force button when skipped, and step-by-step progress with spinner during update)_