### PR TITLE
AuthVault: Secure Isolated Sandbox for Secrets

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -260,6 +260,42 @@ Optional per-id errors:
 }
 ```
 
+### AuthVault (external resolver)
+
+AuthVault Daemon can act as an `exec` provider to keep API keys, gateway tokens, and other SecretRef-backed values out of plaintext config.
+
+This example wires `gateway.auth.token` through an `exec` SecretRef:
+
+```json5
+{
+  secrets: {
+    providers: {
+      authvault: {
+        source: "exec",
+        command: "/path/to/authvault",
+        args: ["resolve"],
+        passEnv: ["AUTHVAULT_DATA_DIR"],
+        jsonOnly: true,
+        allowInsecurePath: true, // Windows-only: use only for trusted paths
+      },
+    },
+  },
+  gateway: {
+    auth: {
+      mode: "token",
+      token: { source: "exec", provider: "authvault", id: "gateway.auth.token" },
+    },
+  },
+}
+```
+
+Store the token inside AuthVault, then run `openclaw secrets reload` (or restart the gateway) to activate:
+
+```bash
+authvault set-secret gateway.auth.token "<token>"
+openclaw secrets reload
+```
+
 ### `sops`
 
 ```json5


### PR DESCRIPTION

## Summary

**Introduce AuthVault** — a secure, isolated sandbox for sensitive credentials (passwords, API keys, tokens) inside OpenClaw.

OpenClaw can now securely access secrets through authorized interfaces **without ever seeing the raw sensitive values**.

## Motivation

Sensitive credentials like gateway tokens and API keys should **never** live in plaintext configuration files.

This PR adds a clean, production-ready example showing how to use **AuthVault** (a secure external resolver) together with OpenClaw’s `exec` SecretRef provider.

### With AuthVault you get:
- Secrets stored in an isolated sandbox that **OpenClaw cannot directly access**
- OpenClaw only receives **authorized, mediated, and temporary** access
- Significantly reduced risk of credential leakage via config files, logs, or misconfigurations

## Key Changes

- **`docs/gateway/secrets.md`**  
  - Added new section: **“AuthVault (Secure External Resolver)”**
  - Included clear configuration example for wiring `gateway.auth.token` via AuthVault + `exec` SecretRef
  - Added minimal usage commands and recommended best practices

## Testing

- `pnpm check`
- `pnpm test`

## Notes

- This is a **documentation-only** change
- No runtime behavior changes to the core OpenClaw
- `allowInsecurePath` is explicitly documented as **Windows-only** (intended for trusted paths only)

---

**Security Improvement**: Protect your secrets with AuthVault — keep sensitive data invisible to OpenClaw while maintaining full functionality.