### PR TITLE
feat: add bootstrap-alternate-files bundled hook

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -166,7 +166,7 @@ type WorkspaceSetupState = {
 };
 
 /** Set of recognized bootstrap filenames for runtime validation */
-const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
+export const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
   DEFAULT_AGENTS_FILENAME,
   DEFAULT_SOUL_FILENAME,
   DEFAULT_TOOLS_FILENAME,

--- a/src/hooks/bundled/bootstrap-alternate-files/HOOK.md
+++ b/src/hooks/bundled/bootstrap-alternate-files/HOOK.md
@@ -1,0 +1,79 @@
+---
+name: bootstrap-alternate-files
+description: "Override workspace bootstrap files with content from external sources"
+homepage: https://docs.openclaw.ai/automation/hooks#bootstrap-alternate-files
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🔄",
+        "events": ["agent:bootstrap"],
+        "requires": { "config": ["workspace.dir"] },
+        "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
+      },
+  }
+---
+
+# Bootstrap Alternate Files Hook
+
+Replaces workspace bootstrap file slots with content read from external sources (for example
+Dropbox-backed shared files). Useful when core persona/identity files live outside the workspace
+root and cannot be symlinked due to boundary restrictions.
+
+## Why
+
+OpenClaw's workspace loader enforces a strict boundary: files must resolve canonically inside
+the workspace root. Symlinks to external locations (cloud storage, shared directories) are
+rejected and show as `[MISSING]` in Project Context.
+
+This hook runs after the workspace loader and replaces missing (or present) slots in-place
+with content from explicitly configured external paths. Because the paths are provided by the
+operator in configuration, this is an intentional, auditable escape hatch rather than a
+general boundary weakening.
+
+## Configuration
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "enabled": true,
+      "entries": {
+        "bootstrap-alternate-files": {
+          "enabled": true,
+          "files": {
+            "SOUL.md": "~/Library/CloudStorage/Dropbox/openclaw-shared/SOUL.md",
+            "IDENTITY.md": "~/Library/CloudStorage/Dropbox/openclaw-shared/IDENTITY.md"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Options
+
+- `files` (object): map of bootstrap slot name → absolute source path.
+  - Keys must be recognized bootstrap basenames (`AGENTS.md`, `SOUL.md`, `TOOLS.md`,
+    `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, `MEMORY.md`, `memory.md`).
+  - Values are paths resolved via `~` expansion. Relative paths are not supported.
+  - Source files are read directly; no workspace boundary check is applied.
+  - If a source file is unreadable (missing, permission error, cloud storage unavailable),
+    the existing workspace entry is left unchanged and a warning is logged.
+
+## Behaviour
+
+- Replaces slots **in-place**: position in the injected context is preserved.
+- Replaces both present and missing workspace entries.
+- Does not append duplicates.
+- On any per-file error, falls back gracefully rather than failing the whole hook.
+- Hardlink protection: source paths that are hardlinks to other files are accepted
+  (unlike the workspace loader which rejects hardlinks). The source path is
+  operator-configured and therefore trusted.
+
+## Notes
+
+- `files` keys that do not match a recognized bootstrap basename are skipped with a warning.
+- Source path `~` is expanded to the process home directory.
+- This hook does not write anything to disk; context is modified in-memory only.

--- a/src/hooks/bundled/bootstrap-alternate-files/HOOK.md
+++ b/src/hooks/bundled/bootstrap-alternate-files/HOOK.md
@@ -62,7 +62,7 @@ general boundary weakening.
   - If a source file is unreadable (missing, permission error, cloud storage unavailable),
     the existing workspace entry is left unchanged and a warning is logged.
 
-## Behaviour
+## Behavior
 
 - Replaces slots **in-place**: position in the injected context is preserved.
 - Replaces both present and missing workspace entries.

--- a/src/hooks/bundled/bootstrap-alternate-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-alternate-files/handler.test.ts
@@ -186,6 +186,28 @@ describe("bootstrap-alternate-files hook", () => {
     expect(context.bootstrapFiles[0]?.missing).toBe(true);
   });
 
+  it("warns when configured alternate has no matching slot in bootstrapFiles", async () => {
+    // MEMORY.md is only conditionally added to bootstrapFiles when a local file exists.
+    // If a user configures an alternate for MEMORY.md but there is no local memory file,
+    // the slot is absent from bootstrapFiles and the alternate should warn.
+    const sourceFile = path.join(tmpDir, "MEMORY-unmatched.md");
+    await fs.writeFile(sourceFile, "# Shared Memory", "utf-8");
+
+    // bootstrapFiles does NOT contain MEMORY.md (simulates no local memory file)
+    const context = makeContext(
+      [makeBootstrapFile("AGENTS.md"), makeBootstrapFile("SOUL.md")],
+      createAlternateConfig({ "MEMORY.md": sourceFile }),
+    );
+
+    // Should not throw; the two present slots are unchanged
+    await expect(
+      handler(createHookEvent("agent", "bootstrap", "agent:main:main", context)),
+    ).resolves.toBeUndefined();
+
+    expect(context.bootstrapFiles).toHaveLength(2);
+    expect(context.bootstrapFiles.map((f) => f.name)).toEqual(["AGENTS.md", "SOUL.md"]);
+  });
+
   it("expands tilde in source paths", async () => {
     // Write a file in tmpDir and create a tilde path that points to it.
     // We can't easily test with a real home dir, so verify the file IS found

--- a/src/hooks/bundled/bootstrap-alternate-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-alternate-files/handler.test.ts
@@ -1,0 +1,236 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../config/config.js";
+import type { AgentBootstrapHookContext } from "../../hooks.js";
+import { createHookEvent } from "../../hooks.js";
+import handler from "./handler.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createAlternateConfig(
+  files: Record<string, string>,
+  enabled = true,
+): OpenClawConfig {
+  return {
+    hooks: {
+      internal: {
+        entries: {
+          "bootstrap-alternate-files": {
+            enabled,
+            files,
+          },
+        },
+      },
+    },
+  };
+}
+
+function makeBootstrapFile(
+  name: string,
+  opts: { content?: string; missing?: boolean; sourcePath?: string } = {},
+): AgentBootstrapHookContext["bootstrapFiles"][number] {
+  return {
+    name: name as AgentBootstrapHookContext["bootstrapFiles"][number]["name"],
+    path: opts.sourcePath ?? `/workspace/${name}`,
+    ...(opts.missing ? { missing: true } : { content: opts.content ?? `# ${name}`, missing: false }),
+  };
+}
+
+function makeContext(
+  files: AgentBootstrapHookContext["bootstrapFiles"],
+  cfg: OpenClawConfig,
+): AgentBootstrapHookContext {
+  return { workspaceDir: "/workspace", bootstrapFiles: files, cfg, sessionKey: "agent:main:main" };
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures — temp dir for real source files
+// ---------------------------------------------------------------------------
+
+let tmpDir = "";
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-alternate-hook-"));
+});
+
+afterAll(async () => {
+  if (tmpDir) {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("bootstrap-alternate-files hook", () => {
+  it("replaces a missing workspace entry with external source content", async () => {
+    const sourceFile = path.join(tmpDir, "SOUL.md");
+    await fs.writeFile(sourceFile, "# External Soul\nBe cool.", "utf-8");
+
+    const context = makeContext(
+      [makeBootstrapFile("SOUL.md", { missing: true })],
+      createAlternateConfig({ "SOUL.md": sourceFile }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    const soul = context.bootstrapFiles.find((f) => f.name === "SOUL.md");
+    expect(soul?.missing).toBe(false);
+    expect(soul?.content).toBe("# External Soul\nBe cool.");
+    expect(soul?.path).toBe(sourceFile);
+  });
+
+  it("replaces a present workspace entry with external source content", async () => {
+    const sourceFile = path.join(tmpDir, "IDENTITY.md");
+    await fs.writeFile(sourceFile, "# External Identity\n- **Name:** flicker", "utf-8");
+
+    const context = makeContext(
+      [makeBootstrapFile("IDENTITY.md", { content: "# Old Identity", missing: false })],
+      createAlternateConfig({ "IDENTITY.md": sourceFile }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    const identity = context.bootstrapFiles.find((f) => f.name === "IDENTITY.md");
+    expect(identity?.content).toBe("# External Identity\n- **Name:** flicker");
+  });
+
+  it("preserves list position when replacing", async () => {
+    const sourceFile = path.join(tmpDir, "SOUL-position.md");
+    await fs.writeFile(sourceFile, "# Soul", "utf-8");
+
+    const context = makeContext(
+      [
+        makeBootstrapFile("AGENTS.md"),
+        makeBootstrapFile("SOUL.md", { missing: true }),
+        makeBootstrapFile("TOOLS.md"),
+      ],
+      createAlternateConfig({ "SOUL.md": sourceFile }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    expect(context.bootstrapFiles.map((f) => f.name)).toEqual(["AGENTS.md", "SOUL.md", "TOOLS.md"]);
+    expect(context.bootstrapFiles[1]?.missing).toBe(false);
+  });
+
+  it("leaves entry unchanged when source file is missing", async () => {
+    const context = makeContext(
+      [makeBootstrapFile("SOUL.md", { missing: true })],
+      createAlternateConfig({ "SOUL.md": path.join(tmpDir, "does-not-exist.md") }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    expect(context.bootstrapFiles[0]?.missing).toBe(true);
+  });
+
+  it("leaves entry unchanged when source is temporarily unavailable (EAGAIN)", async () => {
+    // We can't easily simulate EAGAIN, so we just verify ENOENT fallback path leaves
+    // the entry unchanged and does not throw.
+    const context = makeContext(
+      [makeBootstrapFile("SOUL.md", { missing: true })],
+      createAlternateConfig({ "SOUL.md": "/nonexistent/path/SOUL.md" }),
+    );
+
+    await expect(
+      handler(createHookEvent("agent", "bootstrap", "agent:main:main", context)),
+    ).resolves.toBeUndefined();
+
+    expect(context.bootstrapFiles[0]?.missing).toBe(true);
+  });
+
+  it("skips config entries with unrecognized bootstrap names", async () => {
+    const sourceFile = path.join(tmpDir, "CUSTOM.md");
+    await fs.writeFile(sourceFile, "custom content", "utf-8");
+
+    const context = makeContext(
+      [makeBootstrapFile("AGENTS.md")],
+      createAlternateConfig({ "CUSTOM.md": sourceFile }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    // AGENTS.md untouched, no error thrown
+    expect(context.bootstrapFiles).toHaveLength(1);
+    expect(context.bootstrapFiles[0]?.name).toBe("AGENTS.md");
+  });
+
+  it("does nothing when hook is disabled", async () => {
+    const sourceFile = path.join(tmpDir, "SOUL-disabled.md");
+    await fs.writeFile(sourceFile, "should not appear", "utf-8");
+
+    const context = makeContext(
+      [makeBootstrapFile("SOUL.md", { missing: true })],
+      createAlternateConfig({ "SOUL.md": sourceFile }, false),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    expect(context.bootstrapFiles[0]?.missing).toBe(true);
+  });
+
+  it("does nothing when files map is empty", async () => {
+    const context = makeContext(
+      [makeBootstrapFile("SOUL.md", { missing: true })],
+      createAlternateConfig({}),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    expect(context.bootstrapFiles[0]?.missing).toBe(true);
+  });
+
+  it("expands tilde in source paths", async () => {
+    // Write a file in tmpDir and create a tilde path that points to it.
+    // We can't easily test with a real home dir, so verify the file IS found
+    // by providing an absolute path that happens to use home dir prefix.
+    const homeDir = os.homedir();
+    const relToHome = path.relative(homeDir, tmpDir);
+    // Only run this sub-test if tmpDir is inside home
+    if (relToHome.startsWith("..")) {
+      return;
+    }
+    const tildePath = path.join("~", relToHome, "SOUL-tilde.md");
+    const absFile = path.join(tmpDir, "SOUL-tilde.md");
+    await fs.writeFile(absFile, "# Tilde Soul", "utf-8");
+
+    const context = makeContext(
+      [makeBootstrapFile("SOUL.md", { missing: true })],
+      createAlternateConfig({ "SOUL.md": tildePath }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    expect(context.bootstrapFiles[0]?.content).toBe("# Tilde Soul");
+  });
+
+  it("handles multiple replacements in a single pass", async () => {
+    const soulFile = path.join(tmpDir, "SOUL-multi.md");
+    const identFile = path.join(tmpDir, "IDENTITY-multi.md");
+    await fs.writeFile(soulFile, "# Multi Soul", "utf-8");
+    await fs.writeFile(identFile, "# Multi Identity", "utf-8");
+
+    const context = makeContext(
+      [
+        makeBootstrapFile("SOUL.md", { missing: true }),
+        makeBootstrapFile("AGENTS.md"),
+        makeBootstrapFile("IDENTITY.md", { missing: true }),
+      ],
+      createAlternateConfig({ "SOUL.md": soulFile, "IDENTITY.md": identFile }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    const soul = context.bootstrapFiles.find((f) => f.name === "SOUL.md");
+    const identity = context.bootstrapFiles.find((f) => f.name === "IDENTITY.md");
+    expect(soul?.content).toBe("# Multi Soul");
+    expect(identity?.content).toBe("# Multi Identity");
+    expect(context.bootstrapFiles.find((f) => f.name === "AGENTS.md")?.content).toBe("# AGENTS.md");
+  });
+});

--- a/src/hooks/bundled/bootstrap-alternate-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-alternate-files/handler.test.ts
@@ -208,6 +208,20 @@ describe("bootstrap-alternate-files hook", () => {
     expect(context.bootstrapFiles.map((f) => f.name)).toEqual(["AGENTS.md", "SOUL.md"]);
   });
 
+  it("rejects relative source paths with a warning", async () => {
+    const context = makeContext(
+      [makeBootstrapFile("SOUL.md", { missing: true })],
+      createAlternateConfig({ "SOUL.md": "relative/path/SOUL.md" }),
+    );
+
+    // Should not throw; the relative path is skipped so SOUL.md stays missing
+    await expect(
+      handler(createHookEvent("agent", "bootstrap", "agent:main:main", context)),
+    ).resolves.toBeUndefined();
+
+    expect(context.bootstrapFiles[0]?.missing).toBe(true);
+  });
+
   it("expands tilde in source paths", async () => {
     // Write a file in tmpDir and create a tilde path that points to it.
     // We can't easily test with a real home dir, so verify the file IS found

--- a/src/hooks/bundled/bootstrap-alternate-files/handler.ts
+++ b/src/hooks/bundled/bootstrap-alternate-files/handler.ts
@@ -115,6 +115,17 @@ const bootstrapAlternateFilesHook: HookHandler = async (event) => {
   }
 
   context.bootstrapFiles = updated;
+
+  // Warn for any configured alternate that found no matching slot.
+  // This most commonly happens with MEMORY.md, which is only conditionally
+  // added to bootstrapFiles when a local memory file actually exists.
+  for (const slotName of alternates.keys()) {
+    if (!updated.some((f) => f.name === slotName)) {
+      log.warn(
+        `configured alternate for "${slotName}" has no matching slot in bootstrap files — the slot was not loaded (no local file exists for this bootstrap name)`,
+      );
+    }
+  }
 };
 
 export default bootstrapAlternateFilesHook;

--- a/src/hooks/bundled/bootstrap-alternate-files/handler.ts
+++ b/src/hooks/bundled/bootstrap-alternate-files/handler.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { VALID_BOOTSTRAP_NAMES, type WorkspaceBootstrapFile } from "../../../agents/workspace.js";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import { resolveHookConfig } from "../../config.js";
+import { isAgentBootstrapEvent, type HookHandler } from "../../hooks.js";
+
+const HOOK_KEY = "bootstrap-alternate-files";
+const log = createSubsystemLogger("bootstrap-alternate-files");
+
+/**
+ * Expand a leading `~` to the user home directory.
+ * Returns the original string unchanged if it does not start with `~`.
+ */
+function expandHomeTilde(filePath: string): string {
+  if (filePath.startsWith("~/") || filePath === "~") {
+    return path.join(os.homedir(), filePath.slice(1));
+  }
+  return filePath;
+}
+
+/**
+ * Parse and validate the `files` config value.
+ * Returns a map of bootstrap slot name → resolved absolute source path.
+ * Entries with invalid slot names or non-string paths are logged and skipped.
+ */
+function resolveAlternateFileMap(
+  hookConfig: Record<string, unknown>,
+): Map<string, string> {
+  const result = new Map<string, string>();
+  const raw = hookConfig.files;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return result;
+  }
+  for (const [slotName, sourcePath] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof sourcePath !== "string" || !sourcePath.trim()) {
+      log.warn(`skipping "${slotName}": source path must be a non-empty string`);
+      continue;
+    }
+    if (!VALID_BOOTSTRAP_NAMES.has(slotName)) {
+      log.warn(
+        `skipping "${slotName}": not a recognized bootstrap basename (${[...VALID_BOOTSTRAP_NAMES].join(", ")})`,
+      );
+      continue;
+    }
+    const resolved = path.resolve(expandHomeTilde(sourcePath.trim()));
+    result.set(slotName, resolved);
+  }
+  return result;
+}
+
+/**
+ * Attempt to read a source file. Returns the content string on success, or null on any
+ * read failure (missing file, permission error, cloud storage unavailability, etc.).
+ */
+async function tryReadSourceFile(sourcePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(sourcePath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      log.warn(`source file not found: ${sourcePath}`);
+    } else if (code === "EACCES" || code === "EPERM") {
+      log.warn(`source file permission denied: ${sourcePath}`);
+    } else if (code === "EAGAIN" || code === "EDEADLK") {
+      // Cloud storage (Dropbox FileProvider) can return these transiently.
+      log.warn(`source file temporarily unavailable (${code}): ${sourcePath}`);
+    } else {
+      log.warn(`failed to read source file ${sourcePath}: ${String(err)}`);
+    }
+    return null;
+  }
+}
+
+const bootstrapAlternateFilesHook: HookHandler = async (event) => {
+  if (!isAgentBootstrapEvent(event)) {
+    return;
+  }
+
+  const context = event.context;
+  const hookConfig = resolveHookConfig(context.cfg, HOOK_KEY);
+  if (!hookConfig || hookConfig.enabled === false) {
+    return;
+  }
+
+  const alternates = resolveAlternateFileMap(hookConfig as Record<string, unknown>);
+  if (alternates.size === 0) {
+    return;
+  }
+
+  const updated: WorkspaceBootstrapFile[] = [];
+  for (const file of context.bootstrapFiles) {
+    const sourcePath = alternates.get(file.name);
+    if (!sourcePath) {
+      // No alternate configured for this slot — keep as-is.
+      updated.push(file);
+      continue;
+    }
+
+    const content = await tryReadSourceFile(sourcePath);
+    if (content === null) {
+      // Read failed — leave the existing entry unchanged (may be missing: true).
+      log.debug(`keeping existing entry for ${file.name} (source read failed)`);
+      updated.push(file);
+    } else {
+      log.debug(`replaced ${file.name} from ${sourcePath}`);
+      updated.push({
+        name: file.name,
+        path: sourcePath,
+        content,
+        missing: false,
+      });
+    }
+  }
+
+  context.bootstrapFiles = updated;
+};
+
+export default bootstrapAlternateFilesHook;

--- a/src/hooks/bundled/bootstrap-alternate-files/handler.ts
+++ b/src/hooks/bundled/bootstrap-alternate-files/handler.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { VALID_BOOTSTRAP_NAMES, type WorkspaceBootstrapFile } from "../../../agents/workspace.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import { resolveUserPath } from "../../../utils.js";
 import { resolveHookConfig } from "../../config.js";
 import { isAgentBootstrapEvent, type HookHandler } from "../../hooks.js";
 
@@ -10,20 +10,9 @@ const HOOK_KEY = "bootstrap-alternate-files";
 const log = createSubsystemLogger("bootstrap-alternate-files");
 
 /**
- * Expand a leading `~` to the user home directory.
- * Returns the original string unchanged if it does not start with `~`.
- */
-function expandHomeTilde(filePath: string): string {
-  if (filePath.startsWith("~/") || filePath === "~") {
-    return path.join(os.homedir(), filePath.slice(1));
-  }
-  return filePath;
-}
-
-/**
  * Parse and validate the `files` config value.
  * Returns a map of bootstrap slot name → resolved absolute source path.
- * Entries with invalid slot names or non-string paths are logged and skipped.
+ * Entries with invalid slot names, non-string paths, or relative paths are logged and skipped.
  */
 function resolveAlternateFileMap(
   hookConfig: Record<string, unknown>,
@@ -44,8 +33,15 @@ function resolveAlternateFileMap(
       );
       continue;
     }
-    const resolved = path.resolve(expandHomeTilde(sourcePath.trim()));
-    result.set(slotName, resolved);
+    // Use the shared home-path resolver for consistent ~ and OPENCLAW_HOME handling.
+    const expanded = resolveUserPath(sourcePath.trim());
+    if (!path.isAbsolute(expanded)) {
+      log.warn(
+        `skipping "${slotName}": source path must be absolute after expansion (got "${expanded}") — relative paths are not supported`,
+      );
+      continue;
+    }
+    result.set(slotName, expanded);
   }
   return result;
 }
@@ -122,7 +118,8 @@ const bootstrapAlternateFilesHook: HookHandler = async (event) => {
   for (const slotName of alternates.keys()) {
     if (!updated.some((f) => f.name === slotName)) {
       log.warn(
-        `configured alternate for "${slotName}" has no matching slot in bootstrap files — the slot was not loaded (no local file exists for this bootstrap name)`,
+        `configured alternate for "${slotName}" has no matching slot in bootstrap files — ` +
+          `the slot was not loaded (no local file exists for this bootstrap name)`,
       );
     }
   }


### PR DESCRIPTION
## Summary

Adds a new bundled hook `bootstrap-alternate-files` that replaces workspace bootstrap file slots (e.g. `SOUL.md`, `IDENTITY.md`) with content read from explicitly configured external source paths.

## Motivation

The workspace loader enforces a strict realpath boundary: files must canonically resolve inside the workspace root. Symlinks to external locations (Dropbox, iCloud, network shares) are rejected and silently show as `[MISSING]` in Project Context. This breaks a common and documented setup where `SOUL.md`/`IDENTITY.md` are symlinked to a Dropbox-backed shared directory so the same persona files are used across multiple machines.

## Design

The hook fires on `agent:bootstrap` after the workspace loader has run. It reads a user-configured map of slot name → external source path and replaces matching entries in-place. Because the source paths are explicitly operator-configured (not inferred from symlinks), this is a controlled, auditable escape hatch that does not weaken the general boundary model.

- `replace` semantics: existing slot entry replaced in-place, preserving list position
- Graceful fallback: if a source file is unreadable (ENOENT, EAGAIN, EDEADLK from cloud storage), the existing workspace entry is left unchanged
- Skips unrecognized bootstrap basenames with a warning
- Tilde expansion for home dir paths

## Configuration

```json
{
  "hooks": {
    "internal": {
      "entries": {
        "bootstrap-alternate-files": {
          "enabled": true,
          "files": {
            "SOUL.md": "~/Dropbox/openclaw-shared/SOUL.md",
            "IDENTITY.md": "~/Dropbox/openclaw-shared/IDENTITY.md"
          }
        }
      }
    }
  }
}
```

## Changes

- `src/hooks/bundled/bootstrap-alternate-files/handler.ts` — hook implementation
- `src/hooks/bundled/bootstrap-alternate-files/HOOK.md` — docs/metadata
- `src/hooks/bundled/bootstrap-alternate-files/handler.test.ts` — 10 tests, all passing
- `src/agents/workspace.ts` — export `VALID_BOOTSTRAP_NAMES` (was unexported private const)