### PR TITLE
Google: reuse provider config for Gemini web search

### DIFF
--- a/docs/tools/gemini-search.md
+++ b/docs/tools/gemini-search.md
@@ -22,7 +22,9 @@ citations.
     API key.
   </Step>
   <Step title="Store the key">
-    Set `GEMINI_API_KEY` in the Gateway environment, or configure via:
+    Set `GEMINI_API_KEY` in the Gateway environment, configure Gemini web
+    search directly, or reuse `models.providers.google.apiKey` from your model
+    provider config:
 
     ```bash
     openclaw configure --section web
@@ -40,10 +42,20 @@ citations.
       google: {
         config: {
           webSearch: {
-            apiKey: "AIza...", // optional if GEMINI_API_KEY is set
+            apiKey: "AIza...", // optional if GEMINI_API_KEY or models.providers.google.apiKey is set
+            baseUrl: "https://proxy.example.com/google", // optional; falls back to models.providers.google.baseUrl
             model: "gemini-2.5-flash", // default
           },
         },
+      },
+    },
+  },
+  models: {
+    providers: {
+      google: {
+        apiKey: "AIza...", // optional fallback for web_search and other Google features
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        models: [],
       },
     },
   },
@@ -59,6 +71,12 @@ citations.
 
 **Environment alternative:** set `GEMINI_API_KEY` in the Gateway environment.
 For a gateway install, put it in `~/.openclaw/.env`.
+
+Gemini web search resolves configuration in this order:
+
+1. `tools.web.search.gemini.*` or `plugins.entries.google.config.webSearch.*`
+2. `GEMINI_API_KEY` for the API key only
+3. `models.providers.google.apiKey` / `models.providers.google.baseUrl`
 
 ## How it works
 
@@ -85,6 +103,9 @@ Provider-specific filters like `country`, `language`, `freshness`, and
 The default model is `gemini-2.5-flash` (fast and cost-effective). Any Gemini
 model that supports grounding can be used via
 `plugins.entries.google.config.webSearch.model`.
+
+`models.providers.google` is used only for API key and base URL fallback. It
+does not override the web search model.
 
 ## Related
 

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -88,17 +88,17 @@ local while `web_search` and `x_search` can use xAI Responses under the hood.
 
 ### Provider comparison
 
-| Provider                               | Result style               | Filters                                          | API key                                     |
-| -------------------------------------- | -------------------------- | ------------------------------------------------ | ------------------------------------------- |
-| [Brave](/tools/brave-search)           | Structured snippets        | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                             |
-| [DuckDuckGo](/tools/duckduckgo-search) | Structured snippets        | --                                               | None (key-free)                             |
-| [Exa](/tools/exa-search)               | Structured + extracted     | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                               |
-| [Firecrawl](/tools/firecrawl)          | Structured snippets        | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                         |
-| [Gemini](/tools/gemini-search)         | AI-synthesized + citations | --                                               | `GEMINI_API_KEY`                            |
-| [Grok](/tools/grok-search)             | AI-synthesized + citations | --                                               | `XAI_API_KEY`                               |
-| [Kimi](/tools/kimi-search)             | AI-synthesized + citations | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`         |
-| [Perplexity](/tools/perplexity-search) | Structured snippets        | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` |
-| [Tavily](/tools/tavily)                | Structured snippets        | Via `tavily_search` tool                         | `TAVILY_API_KEY`                            |
+| Provider                               | Result style               | Filters                                          | API key                                             |
+| -------------------------------------- | -------------------------- | ------------------------------------------------ | --------------------------------------------------- |
+| [Brave](/tools/brave-search)           | Structured snippets        | Country, language, time, `llm-context` mode      | `BRAVE_API_KEY`                                     |
+| [DuckDuckGo](/tools/duckduckgo-search) | Structured snippets        | --                                               | None (key-free)                                     |
+| [Exa](/tools/exa-search)               | Structured + extracted     | Neural/keyword mode, date, content extraction    | `EXA_API_KEY`                                       |
+| [Firecrawl](/tools/firecrawl)          | Structured snippets        | Via `firecrawl_search` tool                      | `FIRECRAWL_API_KEY`                                 |
+| [Gemini](/tools/gemini-search)         | AI-synthesized + citations | --                                               | `GEMINI_API_KEY` / `models.providers.google.apiKey` |
+| [Grok](/tools/grok-search)             | AI-synthesized + citations | --                                               | `XAI_API_KEY`                                       |
+| [Kimi](/tools/kimi-search)             | AI-synthesized + citations | --                                               | `KIMI_API_KEY` / `MOONSHOT_API_KEY`                 |
+| [Perplexity](/tools/perplexity-search) | Structured snippets        | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY`         |
+| [Tavily](/tools/tavily)                | Structured snippets        | Via `tavily_search` tool                         | `TAVILY_API_KEY`                                    |
 
 ## Auto-detection
 
@@ -109,7 +109,7 @@ If no `provider` is set, OpenClaw checks for API keys in this order and uses
 the first one found:
 
 1. **Brave** -- `BRAVE_API_KEY` or `plugins.entries.brave.config.webSearch.apiKey`
-2. **Gemini** -- `GEMINI_API_KEY` or `plugins.entries.google.config.webSearch.apiKey`
+2. **Gemini** -- `GEMINI_API_KEY`, `plugins.entries.google.config.webSearch.apiKey`, or `models.providers.google.apiKey`
 3. **Grok** -- `XAI_API_KEY` or `plugins.entries.xai.config.webSearch.apiKey`
 4. **Kimi** -- `KIMI_API_KEY` / `MOONSHOT_API_KEY` or `plugins.entries.moonshot.config.webSearch.apiKey`
 5. **Perplexity** -- `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey`

--- a/extensions/google/image-generation-provider.test.ts
+++ b/extensions/google/image-generation-provider.test.ts
@@ -1,7 +1,6 @@
 import * as providerAuthRuntime from "openclaw/plugin-sdk/provider-auth-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildGoogleImageGenerationProvider } from "./image-generation-provider.js";
-import { __testing as geminiWebSearchTesting } from "./src/gemini-web-search-provider.js";
 
 function mockGoogleApiKeyAuth() {
   vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
@@ -281,22 +280,6 @@ describe("Google image-generation provider", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-image-preview:generateContent",
       expect.any(Object),
-    );
-  });
-
-  it("prefers scoped configured Gemini API keys over environment fallbacks", () => {
-    expect(
-      geminiWebSearchTesting.resolveGeminiApiKey({
-        apiKey: "gemini-secret",
-      }),
-    ).toBe("gemini-secret");
-  });
-
-  it("falls back to the default Gemini model when unset or blank", () => {
-    expect(geminiWebSearchTesting.resolveGeminiModel()).toBe("gemini-2.5-flash");
-    expect(geminiWebSearchTesting.resolveGeminiModel({ model: "  " })).toBe("gemini-2.5-flash");
-    expect(geminiWebSearchTesting.resolveGeminiModel({ model: "gemini-2.5-pro" })).toBe(
-      "gemini-2.5-pro",
     );
   });
 });

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -35,9 +35,13 @@
   "uiHints": {
     "webSearch.apiKey": {
       "label": "Gemini Search API Key",
-      "help": "Gemini API key for Google Search grounding (fallback: GEMINI_API_KEY env var).",
+      "help": "Gemini API key for Google Search grounding (fallback: GEMINI_API_KEY env var or models.providers.google.apiKey).",
       "sensitive": true,
       "placeholder": "AIza..."
+    },
+    "webSearch.baseUrl": {
+      "label": "Gemini Search Base URL",
+      "help": "Optional Gemini API base URL override for web search grounding. Falls back to models.providers.google.baseUrl."
     },
     "webSearch.model": {
       "label": "Gemini Search Model",
@@ -59,6 +63,9 @@
         "properties": {
           "apiKey": {
             "type": ["string", "object"]
+          },
+          "baseUrl": {
+            "type": "string"
           },
           "model": {
             "type": "string"

--- a/extensions/google/src/gemini-web-search-provider.test.ts
+++ b/extensions/google/src/gemini-web-search-provider.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withEnv } from "../../../test/helpers/extensions/env.js";
+import { __testing, createGeminiWebSearchProvider } from "./gemini-web-search-provider.js";
+
+const geminiApiKeyEnv = ["GEMINI_API", "KEY"].join("_");
+
+describe("gemini web search provider", () => {
+  const priorFetch = global.fetch;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    global.fetch = priorFetch;
+  });
+
+  it("prefers scoped configured Gemini API keys over environment and provider fallbacks", () => {
+    withEnv({ [geminiApiKeyEnv]: "gemini-env-secret" }, () => {
+      expect(
+        __testing.resolveGeminiApiKey(
+          {
+            apiKey: "gemini-secret",
+          },
+          {
+            baseUrl: "https://example.com",
+            apiKey: "provider-secret",
+            models: [],
+          },
+        ),
+      ).toBe("gemini-secret");
+    });
+  });
+
+  it("falls back to GEMINI_API_KEY before models.providers.google.apiKey", () => {
+    withEnv({ [geminiApiKeyEnv]: "gemini-env-secret" }, () => {
+      expect(
+        __testing.resolveGeminiApiKey(
+          {},
+          {
+            baseUrl: "https://example.com",
+            apiKey: "provider-secret",
+            models: [],
+          },
+        ),
+      ).toBe("gemini-env-secret");
+    });
+  });
+
+  it("falls back to models.providers.google.apiKey when dedicated config is unset", () => {
+    expect(
+      __testing.resolveGeminiApiKey(
+        {},
+        {
+          baseUrl: "https://example.com",
+          apiKey: "provider-secret",
+          models: [],
+        },
+      ),
+    ).toBe("provider-secret");
+  });
+
+  it("prefers scoped Gemini baseUrl over models.providers.google.baseUrl", () => {
+    expect(
+      __testing.resolveGeminiBaseUrl(
+        {
+          baseUrl: "https://search-proxy.example.com/gemini",
+        },
+        {
+          baseUrl: "https://generativelanguage.googleapis.com",
+          models: [],
+        },
+      ),
+    ).toBe("https://search-proxy.example.com/gemini");
+  });
+
+  it("falls back to models.providers.google.baseUrl and normalizes bare Google hosts", () => {
+    expect(
+      __testing.resolveGeminiBaseUrl(undefined, {
+        baseUrl: "https://generativelanguage.googleapis.com",
+        models: [],
+      }),
+    ).toBe("https://generativelanguage.googleapis.com/v1beta");
+  });
+
+  it("falls back to the default Gemini model when unset or blank", () => {
+    expect(__testing.resolveGeminiModel()).toBe("gemini-2.5-flash");
+    expect(__testing.resolveGeminiModel({ model: "  " })).toBe("gemini-2.5-flash");
+    expect(__testing.resolveGeminiModel({ model: "gemini-2.5-pro" })).toBe("gemini-2.5-pro");
+  });
+
+  it("returns a missing-key error when no dedicated, env, or provider fallback exists", async () => {
+    const provider = createGeminiWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: {},
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const result = await tool.execute({
+      query: "openclaw",
+    });
+
+    expect(result).toMatchObject({
+      error: "missing_gemini_api_key",
+    });
+    expect(result).toMatchObject({
+      message: expect.stringContaining("models.providers.google.apiKey"),
+    });
+  });
+
+  it("uses models.providers.google apiKey and baseUrl fallback at execution time", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: {
+              parts: [{ text: "grounded answer" }],
+            },
+          },
+        ],
+      }),
+    });
+    global.fetch = fetchMock as typeof global.fetch;
+
+    const provider = createGeminiWebSearchProvider();
+    const tool = provider.createTool({
+      config: {
+        models: {
+          providers: {
+            google: {
+              apiKey: "provider-secret",
+              baseUrl: "https://generativelanguage.googleapis.com",
+              models: [],
+            },
+          },
+        },
+      },
+      searchConfig: {},
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const result = await tool.execute({
+      query: "openclaw",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-goog-api-key": "provider-secret",
+        }),
+      }),
+    );
+    expect(result).toMatchObject({
+      provider: "gemini",
+      model: "gemini-2.5-flash",
+    });
+  });
+});

--- a/extensions/google/src/gemini-web-search-provider.test.ts
+++ b/extensions/google/src/gemini-web-search-provider.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { withEnv } from "../../../test/helpers/extensions/env.js";
+import { withEnv } from "../../../test/helpers/plugins/env.js";
 import { __testing, createGeminiWebSearchProvider } from "./gemini-web-search-provider.js";
 
 const geminiApiKeyEnv = ["GEMINI_API", "KEY"].join("_");

--- a/extensions/google/src/gemini-web-search-provider.test.ts
+++ b/extensions/google/src/gemini-web-search-provider.test.ts
@@ -87,6 +87,53 @@ describe("gemini web search provider", () => {
     expect(__testing.resolveGeminiModel({ model: "gemini-2.5-pro" })).toBe("gemini-2.5-pro");
   });
 
+  it("exposes models.providers.google.apiKey to configured credential lookup for auto-detect", () => {
+    const provider = createGeminiWebSearchProvider();
+
+    expect(
+      provider.getConfiguredCredentialValue?.({
+        models: {
+          providers: {
+            google: {
+              apiKey: "provider-secret",
+              baseUrl: "https://example.com",
+              models: [],
+            },
+          },
+        },
+      } as never),
+    ).toBe("provider-secret");
+  });
+
+  it("prefers dedicated Gemini web search config over models.providers.google.apiKey for auto-detect", () => {
+    const provider = createGeminiWebSearchProvider();
+
+    expect(
+      provider.getConfiguredCredentialValue?.({
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: "scoped-secret",
+                },
+              },
+            },
+          },
+        },
+        models: {
+          providers: {
+            google: {
+              apiKey: "provider-secret",
+              baseUrl: "https://example.com",
+              models: [],
+            },
+          },
+        },
+      } as never),
+    ).toBe("scoped-secret");
+  });
+
   it("returns a missing-key error when no dedicated, env, or provider fallback exists", async () => {
     const provider = createGeminiWebSearchProvider();
     const tool = provider.createTool({

--- a/extensions/google/src/gemini-web-search-provider.test.ts
+++ b/extensions/google/src/gemini-web-search-provider.test.ts
@@ -134,6 +134,35 @@ describe("gemini web search provider", () => {
     ).toBe("scoped-secret");
   });
 
+  it("treats blank scoped Gemini web search keys as unset for auto-detect fallback", () => {
+    const provider = createGeminiWebSearchProvider();
+
+    expect(
+      provider.getConfiguredCredentialValue?.({
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: "   ",
+                },
+              },
+            },
+          },
+        },
+        models: {
+          providers: {
+            google: {
+              apiKey: "provider-secret",
+              baseUrl: "https://example.com",
+              models: [],
+            },
+          },
+        },
+      } as never),
+    ).toBe("provider-secret");
+  });
+
   it("returns a missing-key error when no dedicated, env, or provider fallback exists", async () => {
     const provider = createGeminiWebSearchProvider();
     const tool = provider.createTool({

--- a/extensions/google/src/gemini-web-search-provider.test.ts
+++ b/extensions/google/src/gemini-web-search-provider.test.ts
@@ -134,6 +134,34 @@ describe("gemini web search provider", () => {
     ).toBe("scoped-secret");
   });
 
+  it("preserves scoped SecretRef values for auto-detect resolution", () => {
+    const provider = createGeminiWebSearchProvider();
+
+    expect(
+      provider.getConfiguredCredentialValue?.({
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: {
+                    source: "env",
+                    provider: "default",
+                    id: "GEMINI_REF",
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as never),
+    ).toEqual({
+      source: "env",
+      provider: "default",
+      id: "GEMINI_REF",
+    });
+  });
+
   it("treats blank scoped Gemini web search keys as unset for auto-detect fallback", () => {
     const provider = createGeminiWebSearchProvider();
 
@@ -161,6 +189,43 @@ describe("gemini web search provider", () => {
         },
       } as never),
     ).toBe("provider-secret");
+  });
+
+  it("preserves provider SecretRef fallback values for auto-detect resolution", () => {
+    const provider = createGeminiWebSearchProvider();
+
+    expect(
+      provider.getConfiguredCredentialValue?.({
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: {
+                  apiKey: "   ",
+                },
+              },
+            },
+          },
+        },
+        models: {
+          providers: {
+            google: {
+              apiKey: {
+                source: "env",
+                provider: "default",
+                id: "GOOGLE_PROVIDER_REF",
+              },
+              baseUrl: "https://example.com",
+              models: [],
+            },
+          },
+        },
+      } as never),
+    ).toEqual({
+      source: "env",
+      provider: "default",
+      id: "GOOGLE_PROVIDER_REF",
+    });
   });
 
   it("returns a missing-key error when no dedicated, env, or provider fallback exists", async () => {

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -98,18 +98,21 @@ function resolveGeminiConfiguredCredentialValue(
         };
       }
     | undefined,
-): string | undefined {
-  const scopedApiKey = readConfiguredSecretString(
-    resolveProviderWebSearchPluginConfig(config, "google")?.apiKey,
-    "plugins.entries.google.config.webSearch.apiKey",
-  );
-  if (scopedApiKey) {
+): unknown {
+  const scopedApiKey = resolveProviderWebSearchPluginConfig(config, "google")?.apiKey;
+  if (typeof scopedApiKey === "string") {
+    if (scopedApiKey.trim().length > 0) {
+      return scopedApiKey;
+    }
+  } else if (scopedApiKey !== undefined) {
     return scopedApiKey;
   }
-  return readConfiguredSecretString(
-    config?.models?.providers?.google?.apiKey,
-    "models.providers.google.apiKey",
-  );
+
+  const providerApiKey = config?.models?.providers?.google?.apiKey;
+  if (typeof providerApiKey === "string") {
+    return providerApiKey.trim().length > 0 ? providerApiKey : undefined;
+  }
+  return providerApiKey;
 }
 
 function resolveGeminiBaseUrl(gemini?: GeminiConfig, providerConfig?: ModelProviderConfig): string {

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -284,7 +284,8 @@ export function createGeminiWebSearchProvider(): WebSearchProviderPlugin {
     setCredentialValue: (searchConfigTarget, value) =>
       setScopedCredentialValue(searchConfigTarget, "gemini", value),
     getConfiguredCredentialValue: (config) =>
-      resolveProviderWebSearchPluginConfig(config, "google")?.apiKey,
+      resolveProviderWebSearchPluginConfig(config, "google")?.apiKey ??
+      config?.models?.providers?.google?.apiKey,
     setConfiguredCredentialValue: (configTarget, value) => {
       setProviderWebSearchPluginConfigValue(configTarget, "google", "apiKey", value);
     },

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -1,4 +1,5 @@
 import { Type } from "@sinclair/typebox";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   buildSearchCacheKey,
   buildUnsupportedSearchFilterResponse,
@@ -25,13 +26,13 @@ import {
   wrapWebContent,
   writeCachedSearchPayload,
 } from "openclaw/plugin-sdk/provider-web-search";
-import { DEFAULT_GOOGLE_API_BASE_URL } from "../api.js";
+import { DEFAULT_GOOGLE_API_BASE_URL, normalizeGoogleApiBaseUrl } from "../api.js";
 
 const DEFAULT_GEMINI_MODEL = "gemini-2.5-flash";
-const GEMINI_API_BASE = DEFAULT_GOOGLE_API_BASE_URL;
 
 type GeminiConfig = {
   apiKey?: string;
+  baseUrl?: string;
   model?: string;
 };
 
@@ -65,10 +66,28 @@ function resolveGeminiConfig(searchConfig?: SearchConfigRecord): GeminiConfig {
     : {};
 }
 
-function resolveGeminiApiKey(gemini?: GeminiConfig): string | undefined {
+function resolveGeminiApiKey(
+  gemini?: GeminiConfig,
+  providerConfig?: ModelProviderConfig,
+): string | undefined {
   return (
     readConfiguredSecretString(gemini?.apiKey, "tools.web.search.gemini.apiKey") ??
-    readProviderEnvValue(["GEMINI_API_KEY"])
+    readProviderEnvValue(["GEMINI_API_KEY"]) ??
+    readConfiguredSecretString(providerConfig?.apiKey, "models.providers.google.apiKey")
+  );
+}
+
+function resolveGeminiBaseUrl(gemini?: GeminiConfig, providerConfig?: ModelProviderConfig): string {
+  const configuredBaseUrl =
+    typeof gemini?.baseUrl === "string" && gemini.baseUrl.trim().length > 0
+      ? gemini.baseUrl.trim()
+      : undefined;
+  const providerBaseUrl =
+    typeof providerConfig?.baseUrl === "string" && providerConfig.baseUrl.trim().length > 0
+      ? providerConfig.baseUrl.trim()
+      : undefined;
+  return normalizeGoogleApiBaseUrl(
+    configuredBaseUrl ?? providerBaseUrl ?? DEFAULT_GOOGLE_API_BASE_URL,
   );
 }
 
@@ -80,10 +99,11 @@ function resolveGeminiModel(gemini?: GeminiConfig): string {
 async function runGeminiSearch(params: {
   query: string;
   apiKey: string;
+  baseUrl: string;
   model: string;
   timeoutSeconds: number;
 }): Promise<{ content: string; citations: Array<{ url: string; title?: string }> }> {
-  const endpoint = `${GEMINI_API_BASE}/models/${params.model}:generateContent`;
+  const endpoint = `${params.baseUrl}/models/${params.model}:generateContent`;
 
   return withTrustedWebSearchEndpoint(
     {
@@ -175,6 +195,7 @@ function createGeminiSchema() {
 
 function createGeminiToolDefinition(
   searchConfig?: SearchConfigRecord,
+  providerConfig?: ModelProviderConfig,
 ): WebSearchProviderToolDefinition {
   return {
     description:
@@ -188,12 +209,12 @@ function createGeminiToolDefinition(
       }
 
       const geminiConfig = resolveGeminiConfig(searchConfig);
-      const apiKey = resolveGeminiApiKey(geminiConfig);
+      const apiKey = resolveGeminiApiKey(geminiConfig, providerConfig);
       if (!apiKey) {
         return {
           error: "missing_gemini_api_key",
           message:
-            "web_search (gemini) needs an API key. Set GEMINI_API_KEY in the Gateway environment, or configure tools.web.search.gemini.apiKey.",
+            "web_search (gemini) needs an API key. Set GEMINI_API_KEY in the Gateway environment, configure tools.web.search.gemini.apiKey, or set models.providers.google.apiKey.",
           docs: "https://docs.openclaw.ai/tools/web",
         };
       }
@@ -203,11 +224,13 @@ function createGeminiToolDefinition(
         readNumberParam(params, "count", { integer: true }) ??
         searchConfig?.maxResults ??
         undefined;
+      const baseUrl = resolveGeminiBaseUrl(geminiConfig, providerConfig);
       const model = resolveGeminiModel(geminiConfig);
       const cacheKey = buildSearchCacheKey([
         "gemini",
         query,
         resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
+        baseUrl,
         model,
       ]);
       const cached = readCachedSearchPayload(cacheKey);
@@ -219,6 +242,7 @@ function createGeminiToolDefinition(
       const result = await runGeminiSearch({
         query,
         apiKey,
+        baseUrl,
         model,
         timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
       });
@@ -271,11 +295,13 @@ export function createGeminiWebSearchProvider(): WebSearchProviderPlugin {
           "gemini",
           resolveProviderWebSearchPluginConfig(ctx.config, "google"),
         ) as SearchConfigRecord | undefined,
+        ctx.config?.models?.providers?.google,
       ),
   };
 }
 
 export const __testing = {
   resolveGeminiApiKey,
+  resolveGeminiBaseUrl,
   resolveGeminiModel,
 } as const;

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -77,6 +77,41 @@ function resolveGeminiApiKey(
   );
 }
 
+function resolveGeminiConfiguredCredentialValue(
+  config:
+    | {
+        plugins?: {
+          entries?: {
+            google?: {
+              config?: {
+                webSearch?: {
+                  apiKey?: unknown;
+                };
+              };
+            };
+          };
+        };
+        models?: {
+          providers?: {
+            google?: ModelProviderConfig;
+          };
+        };
+      }
+    | undefined,
+): string | undefined {
+  const scopedApiKey = readConfiguredSecretString(
+    resolveProviderWebSearchPluginConfig(config, "google")?.apiKey,
+    "plugins.entries.google.config.webSearch.apiKey",
+  );
+  if (scopedApiKey) {
+    return scopedApiKey;
+  }
+  return readConfiguredSecretString(
+    config?.models?.providers?.google?.apiKey,
+    "models.providers.google.apiKey",
+  );
+}
+
 function resolveGeminiBaseUrl(gemini?: GeminiConfig, providerConfig?: ModelProviderConfig): string {
   const configuredBaseUrl =
     typeof gemini?.baseUrl === "string" && gemini.baseUrl.trim().length > 0
@@ -283,9 +318,7 @@ export function createGeminiWebSearchProvider(): WebSearchProviderPlugin {
     getCredentialValue: (searchConfig) => getScopedCredentialValue(searchConfig, "gemini"),
     setCredentialValue: (searchConfigTarget, value) =>
       setScopedCredentialValue(searchConfigTarget, "gemini", value),
-    getConfiguredCredentialValue: (config) =>
-      resolveProviderWebSearchPluginConfig(config, "google")?.apiKey ??
-      config?.models?.providers?.google?.apiKey,
+    getConfiguredCredentialValue: (config) => resolveGeminiConfiguredCredentialValue(config),
     setConfiguredCredentialValue: (configTarget, value) => {
       setProviderWebSearchPluginConfigValue(configTarget, "google", "apiKey", value);
     },
@@ -304,5 +337,6 @@ export function createGeminiWebSearchProvider(): WebSearchProviderPlugin {
 export const __testing = {
   resolveGeminiApiKey,
   resolveGeminiBaseUrl,
+  resolveGeminiConfiguredCredentialValue,
   resolveGeminiModel,
 } as const;


### PR DESCRIPTION
## Summary

- Problem: Gemini web_search required its own dedicated key flow and did not reuse `models.providers.google.apiKey` or `models.providers.google.baseUrl`.
- Why it matters: users configuring Google once under `models.providers.google` still had to duplicate web_search auth and could not route Gemini web search through a custom base URL.
- What changed: Gemini web_search now falls back to `models.providers.google` for API key and base URL, supports `webSearch.baseUrl`, and has dedicated web_search tests plus updated docs/metadata.
- What did NOT change (scope boundary): no other web_search providers were generalized in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: [extensions/google/src/gemini-web-search-provider.ts](extensions/google/src/gemini-web-search-provider.ts) only resolved Gemini web_search auth from dedicated web_search config or `GEMINI_API_KEY`, and always used a hardcoded Google base URL.
- Missing detection / guardrail: there was no provider-level execution test for Gemini web_search to assert fallback from `models.providers.google`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: the provider-level `models.providers.google` path existed for other Google surfaces, but Gemini web_search never adopted it.
- If unknown, what was ruled out: ruled out generated metadata or docs as the root cause; the missing behavior was in runtime config resolution.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/google/src/gemini-web-search-provider.test.ts`
- Scenario the test should lock in: dedicated config stays highest priority, then `GEMINI_API_KEY`, then `models.providers.google.apiKey` and `models.providers.google.baseUrl`; execution uses provider fallback and returns a missing-key error when none exist.
- Why this is the smallest reliable guardrail: it exercises the actual Gemini web_search provider wiring without needing a full gateway run.
- Existing test that already covers this (if any): `src/plugins/bundled-plugin-metadata.test.ts` and `src/plugins/web-search-providers.test.ts` cover generated metadata and provider registration.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Gemini web_search can now reuse `models.providers.google.apiKey`.
- Gemini web_search can now reuse `models.providers.google.baseUrl`.
- Gemini plugin config now exposes `webSearch.baseUrl` metadata and docs.

## Diagram (if applicable)

```text
Before:
[web_search gemini] -> [tools.web.search.gemini / GEMINI_API_KEY only] -> [hardcoded Google base URL]

After:
[web_search gemini] -> [dedicated web_search config]
                    -> [GEMINI_API_KEY]
                    -> [models.providers.google]
                    -> [request with resolved base URL]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (Yes)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: the only change is credential/base URL fallback within Gemini web_search. Dedicated config remains highest priority, tests cover fallback order, and existing trusted web tools network guards still wrap the request path.

## Repro + Verification

### Environment

- OS: Ubuntu 24.04.3 LTS dev container
- Runtime/container: Node.js 24.11.1 in Codespaces dev container
- Model/provider: Google Gemini web_search provider
- Integration/channel (if any): N/A
- Relevant config (redacted): `models.providers.google.apiKey`, `models.providers.google.baseUrl`, `plugins.entries.google.config.webSearch.*`

### Steps

1. Configure Gemini web_search without `tools.web.search.gemini.apiKey`.
2. Set `models.providers.google.apiKey` and optionally `models.providers.google.baseUrl`.
3. Invoke Gemini web_search.

### Expected

- Gemini web_search uses provider fallback credentials and base URL.

### Actual

- Verified by provider execution tests and metadata/docs updates in this PR.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: provider fallback for API key and base URL; dedicated config precedence; missing-key error path; generated metadata and provider registry tests.
- Edge cases checked: bare `https://generativelanguage.googleapis.com` normalizes to `/v1beta`; dedicated web_search config still overrides provider fallback.
- What you did **not** verify: full repo `pnpm check` did not complete locally because `pnpm tsgo` was terminated by `SIGTERM` in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Gemini web_search could pick the wrong credential source.
  - Mitigation: dedicated config remains highest priority and dedicated tests cover the full fallback chain.
- Risk: custom Google base URLs might be malformed.
  - Mitigation: reuse existing Google base URL normalization and test bare-host normalization.
