### PR TITLE
fix: strip reasoning replay for Azure OpenAI Responses API

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -126,7 +126,7 @@ import {
   buildEmbeddedSystemPrompt,
   createSystemPromptOverride,
 } from "../system-prompt.js";
-import { dropThinkingBlocks } from "../thinking.js";
+import { dropThinkingBlocks, stripThinkingSignatures } from "../thinking.js";
 import { collectAllowedToolNames } from "../tool-name-allowlist.js";
 import { installToolResultContextGuard } from "../tool-result-context-guard.js";
 import { splitSdkTools } from "../tool-split.js";
@@ -994,6 +994,33 @@ export async function runEmbeddedAttempt(
         params.model.api === "openai-responses" ||
         params.model.api === "openai-codex-responses"
       ) {
+        // Azure OpenAI (and other non-direct-OpenAI Responses API providers)
+        // reject replayed reasoning items in input. Strip thinkingSignature so
+        // pi-ai's convertResponsesMessages won't convert them to reasoning
+        // input items. Direct OpenAI and Codex handle replay fine.
+        if (
+          params.model.provider !== "openai" &&
+          params.model.provider !== "openai-codex"
+        ) {
+          const inner = activeSession.agent.streamFn;
+          activeSession.agent.streamFn = (model, context, options) => {
+            const ctx = context as unknown as { messages?: unknown };
+            const messages = ctx?.messages;
+            if (!Array.isArray(messages)) {
+              return inner(model, context, options);
+            }
+            const sanitized = stripThinkingSignatures(messages as AgentMessage[]);
+            if (sanitized === messages) {
+              return inner(model, context, options);
+            }
+            const nextContext = {
+              ...(context as unknown as Record<string, unknown>),
+              messages: sanitized,
+            } as unknown;
+            return inner(model, nextContext as typeof context, options);
+          };
+        }
+
         const inner = activeSession.agent.streamFn;
         activeSession.agent.streamFn = (model, context, options) => {
           const ctx = context as unknown as { messages?: unknown };

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -997,7 +997,30 @@ export async function runEmbeddedAttempt(
         // Azure OpenAI (and other non-direct-OpenAI Responses API providers)
         // reject replayed reasoning items in input. Strip thinkingSignature so
         // pi-ai's convertResponsesMessages won't convert them to reasoning
-        // input items. Direct OpenAI and Codex handle replay fine.
+        const inner = activeSession.agent.streamFn;
+        activeSession.agent.streamFn = (model, context, options) => {
+          const ctx = context as unknown as { messages?: unknown };
+          const messages = ctx?.messages;
+          if (!Array.isArray(messages)) {
+            return inner(model, context, options);
+          }
+          const sanitized = downgradeOpenAIFunctionCallReasoningPairs(messages as AgentMessage[]);
+          if (sanitized === messages) {
+            return inner(model, context, options);
+          }
+          const nextContext = {
+            ...(context as unknown as Record<string, unknown>),
+            messages: sanitized,
+          } as unknown;
+          return inner(model, nextContext as typeof context, options);
+        };
+
+        // Azure OpenAI (and other non-direct-OpenAI Responses API providers)
+        // reject replayed reasoning items in input. Strip signatures so
+        // pi-ai's convertResponsesMessages won't replay reasoning items or
+        // original message-item IDs. Installed AFTER downgrade so it runs
+        // BEFORE it — downgrade then sees signature-free messages and won't
+        // preserve call_id|fc_* pairings that reference removed reasoning.
         if (
           params.model.provider !== "openai" &&
           params.model.provider !== "openai-codex"
@@ -1020,24 +1043,6 @@ export async function runEmbeddedAttempt(
             return inner(model, nextContext as typeof context, options);
           };
         }
-
-        const inner = activeSession.agent.streamFn;
-        activeSession.agent.streamFn = (model, context, options) => {
-          const ctx = context as unknown as { messages?: unknown };
-          const messages = ctx?.messages;
-          if (!Array.isArray(messages)) {
-            return inner(model, context, options);
-          }
-          const sanitized = downgradeOpenAIFunctionCallReasoningPairs(messages as AgentMessage[]);
-          if (sanitized === messages) {
-            return inner(model, context, options);
-          }
-          const nextContext = {
-            ...(context as unknown as Record<string, unknown>),
-            messages: sanitized,
-          } as unknown;
-          return inner(model, nextContext as typeof context, options);
-        };
       }
 
       const innerStreamFn = activeSession.agent.streamFn;

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -53,13 +53,15 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
 }
 
 /**
- * Strip `thinkingSignature` from `type: "thinking"` content blocks without
- * removing the blocks themselves.
+ * Strip pi-ai replay signatures (`thinkingSignature` on thinking blocks,
+ * `textSignature` on text blocks) from assistant messages.
  *
- * This prevents pi-ai's `convertResponsesMessages` from replaying reasoning
- * items (which some providers like Azure OpenAI reject) while preserving the
- * thinking text for display.
+ * `thinkingSignature` causes pi-ai's `convertResponsesMessages` to replay
+ * reasoning items.  `textSignature` embeds the original message-item ID so
+ * the provider can enforce reasoning/message pairing.  Providers like Azure
+ * OpenAI reject either of these replay artifacts, so both must be removed.
  *
+ * The block content itself is preserved for display.
  * Returns the original array reference when nothing was changed.
  */
 export function stripThinkingSignatures(messages: AgentMessage[]): AgentMessage[] {
@@ -73,11 +75,11 @@ export function stripThinkingSignatures(messages: AgentMessage[]): AgentMessage[
     const nextContent: AssistantContentBlock[] = [];
     let changed = false;
     for (const block of msg.content) {
-      const b = block as { type?: unknown; thinkingSignature?: unknown };
-      if (b && typeof b === "object" && b.type === "thinking" && b.thinkingSignature) {
+      const b = block as { type?: unknown; thinkingSignature?: unknown; textSignature?: unknown };
+      if (b && typeof b === "object" && (b.thinkingSignature || b.textSignature)) {
         touched = true;
         changed = true;
-        const { thinkingSignature: _, ...rest } = b as Record<string, unknown>;
+        const { thinkingSignature: _t, textSignature: _s, ...rest } = b as Record<string, unknown>;
         nextContent.push(rest as unknown as AssistantContentBlock);
         continue;
       }

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -78,7 +78,7 @@ export function stripThinkingSignatures(messages: AgentMessage[]): AgentMessage[
         touched = true;
         changed = true;
         const { thinkingSignature: _, ...rest } = b as Record<string, unknown>;
-        nextContent.push(rest as AssistantContentBlock);
+        nextContent.push(rest as unknown as AssistantContentBlock);
         continue;
       }
       nextContent.push(block);

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -51,3 +51,43 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
   }
   return touched ? out : messages;
 }
+
+/**
+ * Strip `thinkingSignature` from `type: "thinking"` content blocks without
+ * removing the blocks themselves.
+ *
+ * This prevents pi-ai's `convertResponsesMessages` from replaying reasoning
+ * items (which some providers like Azure OpenAI reject) while preserving the
+ * thinking text for display.
+ *
+ * Returns the original array reference when nothing was changed.
+ */
+export function stripThinkingSignatures(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+  for (const msg of messages) {
+    if (!isAssistantMessageWithContent(msg)) {
+      out.push(msg);
+      continue;
+    }
+    const nextContent: AssistantContentBlock[] = [];
+    let changed = false;
+    for (const block of msg.content) {
+      const b = block as { type?: unknown; thinkingSignature?: unknown };
+      if (b && typeof b === "object" && b.type === "thinking" && b.thinkingSignature) {
+        touched = true;
+        changed = true;
+        const { thinkingSignature: _, ...rest } = b as Record<string, unknown>;
+        nextContent.push(rest as AssistantContentBlock);
+        continue;
+      }
+      nextContent.push(block);
+    }
+    if (!changed) {
+      out.push(msg);
+      continue;
+    }
+    out.push({ ...msg, content: nextContent });
+  }
+  return touched ? out : messages;
+}


### PR DESCRIPTION
## Summary

Azure OpenAI rejects replayed reasoning items in Responses API input with:
```
400 Item 'rs_...' of type 'reasoning' was provided without its required following item.
```

This happens on every multi-turn conversation because pi-ai's `convertResponsesMessages` parses `thinkingSignature` on thinking blocks and pushes them as reasoning input items. Direct OpenAI accepts these, but Azure OpenAI does not.

- Add `stripThinkingSignatures()` in `thinking.ts` that removes `thinkingSignature` from thinking blocks while preserving the thinking display content
- Wire it into the `streamFn` wrapper chain in `attempt.ts` for non-direct-OpenAI Responses API providers (`azure-openai`, `azure-openai-responses`, etc.)
- Direct OpenAI and Codex providers are unaffected (they handle reasoning replay correctly)

## Test plan

- [x] Verified fix on Azure OpenAI GPT-5.4 with `openai-responses` API — multi-turn conversations work without 400 errors
- [ ] Existing tests should pass (no behavioral change for direct OpenAI/Codex providers)