### PR TITLE
Browser: restore relay attach selection UX

### DIFF
--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "OpenClaw browser tool plugin",
   "type": "module",
+  "dependencies": {
+    "local-browser-bridge": "file:/Users/minseo/Library/Mobile Documents/com~apple~CloudDocs/openclaw-workspace/projects/local-browser-bridge"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -5,7 +5,7 @@
   "description": "OpenClaw browser tool plugin",
   "type": "module",
   "dependencies": {
-    "local-browser-bridge": "file:/Users/minseo/Library/Mobile Documents/com~apple~CloudDocs/openclaw-workspace/projects/local-browser-bridge"
+    "local-browser-bridge": "git+https://github.com/mindsurf0176-ui/local-browser-bridge.git#2d172d131f15b166d8403c68807a35fe9d8d8471"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -49,7 +49,33 @@ export type ResolvedBrowserProfile = {
   color: string;
   driver: "openclaw" | "existing-session";
   attachOnly: boolean;
+  relayAttachUx?: {
+    provider: "local-browser-bridge";
+    mode: "relay";
+    sharedTabScope: "current-shared-tab";
+  };
 };
+
+function resolveRelayAttachUx(raw: unknown): ResolvedBrowserProfile["relayAttachUx"] {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+
+  const value = raw as Record<string, unknown>;
+  if (
+    value.provider !== "local-browser-bridge" ||
+    value.mode !== "relay" ||
+    value.sharedTabScope !== "current-shared-tab"
+  ) {
+    return undefined;
+  }
+
+  return {
+    provider: "local-browser-bridge",
+    mode: "relay",
+    sharedTabScope: "current-shared-tab",
+  };
+}
 
 function normalizeHexColor(raw: string | undefined) {
   const value = (raw ?? "").trim();
@@ -321,6 +347,9 @@ export function resolveProfile(
   let cdpPort = profile.cdpPort ?? 0;
   let cdpUrl = "";
   const driver = profile.driver === "existing-session" ? "existing-session" : "openclaw";
+  const relayAttachUx = resolveRelayAttachUx(
+    (profile as typeof profile & { relayAttachUx?: unknown }).relayAttachUx,
+  );
 
   if (driver === "existing-session") {
     // existing-session uses Chrome MCP auto-connect; no CDP port/URL needed
@@ -334,6 +363,7 @@ export function resolveProfile(
       color: profile.color,
       driver,
       attachOnly: true,
+      relayAttachUx,
     };
   }
 
@@ -357,6 +387,7 @@ export function resolveProfile(
     color: profile.color,
     driver,
     attachOnly: profile.attachOnly ?? resolved.attachOnly,
+    relayAttachUx,
   };
 }
 

--- a/extensions/browser/src/browser/local-browser-bridge-relay-attach-ux.ts
+++ b/extensions/browser/src/browser/local-browser-bridge-relay-attach-ux.ts
@@ -1,0 +1,50 @@
+import { interpretBrowserAttachUxFromError } from "local-browser-bridge";
+import type { ResolvedBrowserProfile } from "./config.js";
+
+type RelayBranch = "click-toolbar-button" | "use-current-shared-tab";
+
+export function isLocalBrowserBridgeRelayProfile(profile: ResolvedBrowserProfile): boolean {
+  return (
+    profile.relayAttachUx?.provider === "local-browser-bridge" &&
+    profile.relayAttachUx.mode === "relay" &&
+    profile.relayAttachUx.sharedTabScope === "current-shared-tab"
+  );
+}
+
+function appendRelayUx(base: string, branch: RelayBranch): string {
+  const ux = interpretBrowserAttachUxFromError({
+    details: {
+      context: {
+        browser: "chrome",
+        attachMode: "relay",
+        operation: "attach",
+      },
+      relay: {
+        branch,
+        retryable: true,
+        userActionRequired: true,
+        phase: "target-selection",
+        sharedTabScope: "current-shared-tab",
+        currentSharedTabMatches: branch === "use-current-shared-tab",
+      },
+    },
+  });
+  const details = [ux?.prompt, ux?.scopeNote].filter(
+    (value): value is string => typeof value === "string" && value.length > 0,
+  );
+  return details.length > 0 ? `${base} ${details.join(" ")}` : base;
+}
+
+export function formatLocalBrowserBridgeRelayAttachRequiredError(profileName: string): string {
+  return appendRelayUx(
+    `tab not found (no attached Chrome tabs for profile "${profileName}").`,
+    "click-toolbar-button",
+  );
+}
+
+export function formatLocalBrowserBridgeRelayStaleTargetError(): string {
+  return appendRelayUx(
+    "tab not found (the requested Chrome relay target is no longer the currently shared tab).",
+    "use-current-shared-tab",
+  );
+}

--- a/extensions/browser/src/browser/local-browser-bridge.d.ts
+++ b/extensions/browser/src/browser/local-browser-bridge.d.ts
@@ -1,0 +1,46 @@
+declare module "local-browser-bridge" {
+  export type SupportedBrowser = "safari" | "chrome";
+  export type BrowserAttachMode = "direct" | "relay";
+  export type ChromeRelayFailureOperation = "attach" | "resumeSession";
+  export type ChromeRelayFailureBranch =
+    | "click-toolbar-button"
+    | "share-tab"
+    | "share-original-tab-again"
+    | "use-current-shared-tab"
+    | "install-extension"
+    | "reconnect-extension"
+    | "configure-relay-probe"
+    | "repair-relay-probe"
+    | "unsupported";
+  export interface ChromeRelayErrorDetails {
+    context: {
+      browser: "chrome";
+      attachMode: "relay";
+      operation: ChromeRelayFailureOperation;
+    };
+    relay: {
+      branch: ChromeRelayFailureBranch;
+      retryable: boolean;
+      userActionRequired: boolean;
+      phase: "diagnostics" | "target-selection" | "session-precondition" | "shared-tab-match";
+      sharedTabScope: "current-shared-tab";
+      currentSharedTabMatches?: boolean;
+      resumable?: boolean;
+      resumeRequiresUserGesture?: boolean;
+      expiresAt?: string;
+      sessionId?: string;
+    };
+  }
+  export interface BrowserAttachUxInterpretation {
+    prompt: string | undefined;
+    scopeNote: string | undefined;
+    readOnly: boolean;
+    sharedTabScoped: boolean;
+  }
+  export function interpretBrowserAttachUxFromError(args: {
+    details: ChromeRelayErrorDetails | Pick<ChromeRelayErrorDetails, "relay"> | null | undefined;
+    browser?: SupportedBrowser;
+    attachMode?: BrowserAttachMode;
+    operation?: ChromeRelayFailureOperation;
+  }): BrowserAttachUxInterpretation | undefined;
+}

--- a/extensions/browser/src/browser/server-context.selection.local-browser-bridge.test.ts
+++ b/extensions/browser/src/browser/server-context.selection.local-browser-bridge.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ResolvedBrowserProfile } from "./config.js";
+import { BrowserTabNotFoundError } from "./errors.js";
+import { createProfileSelectionOps } from "./server-context.selection.js";
+
+function makeRelayProfile(): ResolvedBrowserProfile {
+  return {
+    name: "relay",
+    cdpPort: 18792,
+    cdpUrl: "http://127.0.0.1:18792",
+    cdpHost: "127.0.0.1",
+    cdpIsLoopback: true,
+    color: "#00AA00",
+    driver: "openclaw",
+    attachOnly: true,
+    relayAttachUx: {
+      provider: "local-browser-bridge",
+      mode: "relay",
+      sharedTabScope: "current-shared-tab",
+    },
+  };
+}
+
+describe("browser server-context selection local-browser-bridge relay UX", () => {
+  it("returns attach-required guidance when no shared tab is attached", async () => {
+    const state = {
+      profile: makeRelayProfile(),
+      running: null,
+      lastTargetId: null,
+      reconcile: null,
+    };
+    const ops = createProfileSelectionOps({
+      profile: state.profile,
+      getProfileState: () => state,
+      ensureBrowserAvailable: vi.fn(async () => {}),
+      listTabs: vi.fn(async () => []),
+      openTab: vi.fn(async () => {
+        throw new Error("relay selection should not open a local tab");
+      }),
+    });
+
+    await expect(ops.ensureTabAvailable()).rejects.toBeInstanceOf(BrowserTabNotFoundError);
+    await expect(ops.ensureTabAvailable()).rejects.toThrow(
+      /click the relay extension button on the tab you want to share/i,
+    );
+    await expect(ops.ensureTabAvailable()).rejects.toThrow(/remains read-only/i);
+  });
+
+  it("falls back to the current shared tab when a stale relay target is the only choice", async () => {
+    const state = {
+      profile: makeRelayProfile(),
+      running: null,
+      lastTargetId: null,
+      reconcile: null,
+    };
+    const ops = createProfileSelectionOps({
+      profile: state.profile,
+      getProfileState: () => state,
+      ensureBrowserAvailable: vi.fn(async () => {}),
+      listTabs: vi.fn(async () => [
+        {
+          targetId: "TAB_A",
+          title: "Shared Tab",
+          url: "https://example.com",
+          type: "page",
+        },
+      ]),
+      openTab: vi.fn(async () => {
+        throw new Error("unexpected openTab");
+      }),
+    });
+
+    const chosen = await ops.ensureTabAvailable("STALE_TARGET");
+    expect(chosen.targetId).toBe("TAB_A");
+    expect(state.lastTargetId).toBe("TAB_A");
+  });
+
+  it("returns shared-tab scope guidance when a relay target is stale and out of scope", async () => {
+    const state = {
+      profile: makeRelayProfile(),
+      running: null,
+      lastTargetId: null,
+      reconcile: null,
+    };
+    const ops = createProfileSelectionOps({
+      profile: state.profile,
+      getProfileState: () => state,
+      ensureBrowserAvailable: vi.fn(async () => {}),
+      listTabs: vi.fn(async () => [
+        {
+          targetId: "TAB_A",
+          title: "Tab A",
+          url: "https://a.example",
+          type: "page",
+        },
+        {
+          targetId: "TAB_B",
+          title: "Tab B",
+          url: "https://b.example",
+          type: "page",
+        },
+      ]),
+      openTab: vi.fn(async () => {
+        throw new Error("unexpected openTab");
+      }),
+    });
+
+    await expect(ops.ensureTabAvailable("STALE_TARGET")).rejects.toThrow(/currently shared tab/i);
+    await expect(ops.ensureTabAvailable("STALE_TARGET")).rejects.toThrow(/remains read-only/i);
+  });
+
+  it("keeps the default local-managed blank-tab fallback when relay UX is not enabled", async () => {
+    const state = {
+      profile: {
+        ...makeRelayProfile(),
+        relayAttachUx: undefined,
+      },
+      running: null,
+      lastTargetId: null,
+      reconcile: null,
+    };
+    const openTab = vi.fn(async () => ({
+      targetId: "OPENED",
+      title: "Opened",
+      url: "about:blank",
+      wsUrl: "ws://127.0.0.1/devtools/page/OPENED",
+      type: "page" as const,
+    }));
+    const listTabs = vi
+      .fn<
+        () => Promise<
+          Array<{ targetId: string; title: string; url: string; wsUrl?: string; type?: string }>
+        >
+      >()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          targetId: "OPENED",
+          title: "Opened",
+          url: "about:blank",
+          wsUrl: "ws://127.0.0.1/devtools/page/OPENED",
+          type: "page",
+        },
+      ]);
+    const ops = createProfileSelectionOps({
+      profile: state.profile,
+      getProfileState: () => state,
+      ensureBrowserAvailable: vi.fn(async () => {}),
+      listTabs,
+      openTab,
+    });
+
+    const chosen = await ops.ensureTabAvailable();
+    expect(openTab).toHaveBeenCalledWith("about:blank");
+    expect(chosen.targetId).toBe("OPENED");
+  });
+});

--- a/extensions/browser/src/browser/server-context.selection.ts
+++ b/extensions/browser/src/browser/server-context.selection.ts
@@ -3,6 +3,11 @@ import { appendCdpPath } from "./cdp.js";
 import { closeChromeMcpTab, focusChromeMcpTab } from "./chrome-mcp.js";
 import type { ResolvedBrowserProfile } from "./config.js";
 import { BrowserTabNotFoundError, BrowserTargetAmbiguousError } from "./errors.js";
+import {
+  formatLocalBrowserBridgeRelayAttachRequiredError,
+  formatLocalBrowserBridgeRelayStaleTargetError,
+  isLocalBrowserBridgeRelayProfile,
+} from "./local-browser-bridge-relay-attach-ux.js";
 import { getBrowserProfileCapabilities } from "./profile-capabilities.js";
 import type { PwAiModule } from "./pw-ai-module.js";
 import { getPwAiModule } from "./pw-ai-module.js";
@@ -32,17 +37,26 @@ export function createProfileSelectionOps({
 }: SelectionDeps): SelectionOps {
   const cdpHttpBase = normalizeCdpHttpBaseForJsonEndpoints(profile.cdpUrl);
   const capabilities = getBrowserProfileCapabilities(profile);
+  const usesLocalBrowserBridgeRelay = isLocalBrowserBridgeRelayProfile(profile);
 
   const ensureTabAvailable = async (targetId?: string): Promise<BrowserTab> => {
     await ensureBrowserAvailable();
     const profileState = getProfileState();
     const tabs1 = await listTabs();
     if (tabs1.length === 0) {
+      if (usesLocalBrowserBridgeRelay) {
+        throw new BrowserTabNotFoundError(
+          formatLocalBrowserBridgeRelayAttachRequiredError(profile.name),
+        );
+      }
       await openTab("about:blank");
     }
 
     const tabs = await listTabs();
-    const candidates = capabilities.supportsPerTabWs ? tabs.filter((t) => Boolean(t.wsUrl)) : tabs;
+    const candidates =
+      usesLocalBrowserBridgeRelay || !capabilities.supportsPerTabWs
+        ? tabs
+        : tabs.filter((t) => Boolean(t.wsUrl));
 
     const resolveById = (raw: string) => {
       const resolved = resolveTargetIdFromTabs(raw, candidates);
@@ -66,12 +80,18 @@ export function createProfileSelectionOps({
       return page ?? candidates.at(0) ?? null;
     };
 
-    const chosen = targetId ? resolveById(targetId) : pickDefault();
+    let chosen = targetId ? resolveById(targetId) : pickDefault();
+    if (!chosen && usesLocalBrowserBridgeRelay && candidates.length === 1) {
+      chosen = candidates[0] ?? null;
+    }
 
     if (chosen === "AMBIGUOUS") {
       throw new BrowserTargetAmbiguousError();
     }
     if (!chosen) {
+      if (usesLocalBrowserBridgeRelay && targetId?.trim()) {
+        throw new BrowserTabNotFoundError(formatLocalBrowserBridgeRelayStaleTargetError());
+      }
       throw new BrowserTabNotFoundError();
     }
     profileState.lastTargetId = chosen.targetId;

--- a/package.json
+++ b/package.json
@@ -1258,6 +1258,7 @@
       "@whiskeysockets/baileys",
       "authenticate-pam",
       "esbuild",
+      "local-browser-bridge",
       "node-llama-cpp",
       "protobufjs",
       "sharp"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,7 +270,11 @@ importers:
 
   extensions/brave: {}
 
-  extensions/browser: {}
+  extensions/browser:
+    dependencies:
+      local-browser-bridge:
+        specifier: file:/Users/minseo/Library/Mobile Documents/com~apple~CloudDocs/openclaw-workspace/projects/local-browser-bridge
+        version: file:../../../Users/minseo/Library/Mobile Documents/com~apple~CloudDocs/openclaw-workspace/projects/local-browser-bridge
 
   extensions/byteplus: {}
 
@@ -5006,6 +5010,10 @@ packages:
 
   lit@3.3.2:
     resolution: {integrity: sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==}
+
+  local-browser-bridge@file:../../../Users/minseo/Library/Mobile Documents/com~apple~CloudDocs/openclaw-workspace/projects/local-browser-bridge:
+    resolution: {directory: ../../../Users/minseo/Library/Mobile Documents/com~apple~CloudDocs/openclaw-workspace/projects/local-browser-bridge, type: directory}
+    hasBin: true
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -11660,6 +11668,8 @@ snapshots:
       '@lit/reactive-element': 2.1.2
       lit-element: 4.2.2
       lit-html: 3.3.2
+
+  local-browser-bridge@file:../../../Users/minseo/Library/Mobile Documents/com~apple~CloudDocs/openclaw-workspace/projects/local-browser-bridge: {}
 
   lodash.camelcase@4.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,8 +273,8 @@ importers:
   extensions/browser:
     dependencies:
       local-browser-bridge:
-        specifier: file:/Users/minseo/Library/Mobile Documents/com~apple~CloudDocs/openclaw-workspace/projects/local-browser-bridge
-        version: file:../../../Users/minseo/Library/Mobile Documents/com~apple~CloudDocs/openclaw-workspace/projects/local-browser-bridge
+        specifier: git+https://github.com/mindsurf0176-ui/local-browser-bridge.git#2d172d131f15b166d8403c68807a35fe9d8d8471
+        version: https://codeload.github.com/mindsurf0176-ui/local-browser-bridge/tar.gz/2d172d131f15b166d8403c68807a35fe9d8d8471
 
   extensions/byteplus: {}
 
@@ -5011,8 +5011,9 @@ packages:
   lit@3.3.2:
     resolution: {integrity: sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==}
 
-  local-browser-bridge@file:../../../Users/minseo/Library/Mobile Documents/com~apple~CloudDocs/openclaw-workspace/projects/local-browser-bridge:
-    resolution: {directory: ../../../Users/minseo/Library/Mobile Documents/com~apple~CloudDocs/openclaw-workspace/projects/local-browser-bridge, type: directory}
+  local-browser-bridge@https://codeload.github.com/mindsurf0176-ui/local-browser-bridge/tar.gz/2d172d131f15b166d8403c68807a35fe9d8d8471:
+    resolution: {tarball: https://codeload.github.com/mindsurf0176-ui/local-browser-bridge/tar.gz/2d172d131f15b166d8403c68807a35fe9d8d8471}
+    version: 0.1.0
     hasBin: true
 
   lodash.camelcase@4.3.0:
@@ -11669,7 +11670,7 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.2
 
-  local-browser-bridge@file:../../../Users/minseo/Library/Mobile Documents/com~apple~CloudDocs/openclaw-workspace/projects/local-browser-bridge: {}
+  local-browser-bridge@https://codeload.github.com/mindsurf0176-ui/local-browser-bridge/tar.gz/2d172d131f15b166d8403c68807a35fe9d8d8471: {}
 
   lodash.camelcase@4.3.0: {}
 


### PR DESCRIPTION
## Summary
- restore relay attach selection guidance via a thin local-browser-bridge adapter in the current browser extension seam
- add an optional relayAttachUx marker on resolved browser profiles so the behavior stays additive and opt-in
- add focused selection tests for attach-required, stale shared-tab targets, and single shared-tab fallback

## Verification
- pnpm test -- extensions/browser/src/browser/server-context.selection.local-browser-bridge.test.ts
- scripts/committer hook ran pnpm check before commit