### PR TITLE
fix(agents): dispose bundled MCP runtime after local runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: keep late compaction-retry rejections handled after the aggregate timeout path wins without swallowing real pre-timeout wait failures, so timed-out retries no longer surface an unhandled rejection on later unsubscribe. (#57451) Thanks @mpz4life and @vincentkoc.
 - Matrix/delivery recovery: treat Synapse `User not in room` replay failures as permanent during startup recovery so poisoned queued messages move to `failed/` instead of crash-looping Matrix after restart. (#57426) thanks @dlardo.
 - Plugins/facades: guard bundled plugin facade loads with a cache-first sentinel so circular re-entry stops crashing `xai`, `sglang`, and `vllm` during gateway plugin startup. (#57508) Thanks @openperf.
+- Agents/MCP: dispose bundled MCP runtimes after one-shot `openclaw agent --local` runs finish, while preserving bundled MCP state across in-run retries so local JSON runs exit cleanly without restarting stateful MCP tools mid-run.
 
 ## 2026.3.28
 

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -471,7 +471,7 @@ export function runAgentAttempt(params: {
     streamParams: params.opts.streamParams,
     agentDir: params.agentDir,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
-    cleanupBundleMcpOnAttemptEnd: params.opts.cleanupBundleMcpOnAttemptEnd,
+    cleanupBundleMcpOnRunEnd: params.opts.cleanupBundleMcpOnRunEnd,
     onAgentEvent: params.onAgentEvent,
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -471,6 +471,7 @@ export function runAgentAttempt(params: {
     streamParams: params.opts.streamParams,
     agentDir: params.agentDir,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
+    cleanupBundleMcpOnAttemptEnd: params.opts.cleanupBundleMcpOnAttemptEnd,
     onAgentEvent: params.onAgentEvent,
     bootstrapPromptWarningSignaturesSeen,
     bootstrapPromptWarningSignature,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -88,6 +88,8 @@ export type AgentCommandOpts = {
   streamParams?: AgentStreamParams;
   /** Explicit workspace directory override (for subagents to inherit parent workspace). */
   workspaceDir?: SpawnedRunMetadata["workspaceDir"];
+  /** Force bundled MCP teardown at the end of each attempt for one-shot local runs. */
+  cleanupBundleMcpOnAttemptEnd?: boolean;
 };
 
 export type AgentCommandIngressOpts = Omit<

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -88,8 +88,8 @@ export type AgentCommandOpts = {
   streamParams?: AgentStreamParams;
   /** Explicit workspace directory override (for subagents to inherit parent workspace). */
   workspaceDir?: SpawnedRunMetadata["workspaceDir"];
-  /** Force bundled MCP teardown at the end of each attempt for one-shot local runs. */
-  cleanupBundleMcpOnAttemptEnd?: boolean;
+  /** Force bundled MCP teardown when a one-shot local run completes. */
+  cleanupBundleMcpOnRunEnd?: boolean;
 };
 
 export type AgentCommandIngressOpts = Omit<

--- a/src/agents/pi-bundle-mcp-materialize.ts
+++ b/src/agents/pi-bundle-mcp-materialize.ts
@@ -62,6 +62,7 @@ function toAgentToolResult(params: {
 export async function materializeBundleMcpToolsForRun(params: {
   runtime: SessionMcpRuntime;
   reservedToolNames?: Iterable<string>;
+  disposeRuntime?: () => Promise<void>;
 }): Promise<BundleMcpToolRuntime> {
   params.runtime.markUsed();
   const catalog = await params.runtime.getCatalog();
@@ -102,7 +103,9 @@ export async function materializeBundleMcpToolsForRun(params: {
 
   return {
     tools,
-    dispose: async () => {},
+    dispose: async () => {
+      await params.disposeRuntime?.();
+    },
   };
 }
 
@@ -119,11 +122,9 @@ export async function createBundleMcpToolRuntime(params: {
   const materialized = await materializeBundleMcpToolsForRun({
     runtime,
     reservedToolNames: params.reservedToolNames,
-  });
-  return {
-    tools: materialized.tools,
-    dispose: async () => {
+    disposeRuntime: async () => {
       await runtime.dispose();
     },
-  };
+  });
+  return materialized;
 }

--- a/src/agents/pi-bundle-mcp-runtime.test.ts
+++ b/src/agents/pi-bundle-mcp-runtime.test.ts
@@ -213,4 +213,63 @@ describe("session MCP runtime", () => {
     expect(await fs.readFile(startupCounterPath, "utf8")).toBe("1");
     expect(__testing.getCachedSessionIds()).not.toContain("session-d");
   });
+
+  it("materialized disposal can retire a manager-owned runtime", async () => {
+    const workspaceDir = await makeTempDir("openclaw-bundle-mcp-tools-");
+    const startupCounterPath = path.join(workspaceDir, "bundle-starts.txt");
+    const pidPath = path.join(workspaceDir, "bundle.pid");
+    const exitMarkerPath = path.join(workspaceDir, "bundle.exit");
+    const pluginRoot = path.join(workspaceDir, ".openclaw", "extensions", "bundle-probe");
+    const serverScriptPath = path.join(pluginRoot, "servers", "bundle-probe.mjs");
+    await writeBundleProbeMcpServer(serverScriptPath, {
+      startupCounterPath,
+      pidPath,
+      exitMarkerPath,
+    });
+    await writeClaudeBundle({ pluginRoot, serverScriptPath });
+
+    const runtimeA = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-e",
+      sessionKey: "agent:test:session-e",
+      workspaceDir,
+      cfg: {
+        plugins: {
+          entries: {
+            "bundle-probe": { enabled: true },
+          },
+        },
+      },
+    });
+    const materialized = await materializeBundleMcpToolsForRun({
+      runtime: runtimeA,
+      disposeRuntime: async () => {
+        await disposeSessionMcpRuntime("session-e");
+      },
+    });
+
+    expect(materialized.tools.map((tool) => tool.name)).toEqual(["bundleProbe__bundle_probe"]);
+    expect(await waitForFileText(pidPath)).toMatch(/^\d+$/);
+
+    await materialized.dispose();
+
+    expect(await waitForFileText(exitMarkerPath)).toBe("exited");
+    expect(__testing.getCachedSessionIds()).not.toContain("session-e");
+
+    const runtimeB = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-e",
+      sessionKey: "agent:test:session-e",
+      workspaceDir,
+      cfg: {
+        plugins: {
+          entries: {
+            "bundle-probe": { enabled: true },
+          },
+        },
+      },
+    });
+
+    expect(runtimeB).not.toBe(runtimeA);
+    await materializeBundleMcpToolsForRun({ runtime: runtimeB });
+    expect(await fs.readFile(startupCounterPath, "utf8")).toBe("2");
+  });
 });

--- a/src/agents/pi-embedded-runner.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.e2e.test.ts
@@ -15,6 +15,10 @@ import {
 } from "./test-helpers/pi-embedded-runner-e2e-fixtures.js";
 
 const runEmbeddedAttemptMock = vi.fn();
+const disposeSessionMcpRuntimeMock = vi.fn<(sessionId: string) => Promise<void>>(async () => {
+  return undefined;
+});
+let refreshRuntimeAuthOnFirstPromptError = false;
 
 vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@mariozechner/pi-ai")>();
@@ -94,6 +98,9 @@ const installRunEmbeddedMocks = () => {
   vi.doMock("./pi-embedded-runner/run/attempt.js", () => ({
     runEmbeddedAttempt: (params: unknown) => runEmbeddedAttemptMock(params),
   }));
+  vi.doMock("./pi-bundle-mcp-tools.js", () => ({
+    disposeSessionMcpRuntime: (sessionId: string) => disposeSessionMcpRuntimeMock(sessionId),
+  }));
   vi.doMock("./pi-embedded-runner/model.js", async (importOriginal) => {
     const actual = await importOriginal<typeof import("./pi-embedded-runner/model.js")>();
     return {
@@ -102,6 +109,16 @@ const installRunEmbeddedMocks = () => {
         createResolvedEmbeddedRunnerModel(provider, modelId),
     };
   });
+  vi.doMock("./pi-embedded-runner/run/auth-controller.js", () => ({
+    createEmbeddedRunAuthController: () => ({
+      advanceAuthProfile: vi.fn(async () => false),
+      initializeAuthProfile: vi.fn(async () => undefined),
+      maybeRefreshRuntimeAuthForAuthError: vi.fn(async (_errorText: string, runtimeAuthRetry) => {
+        return refreshRuntimeAuthOnFirstPromptError && runtimeAuthRetry !== true;
+      }),
+      stopRuntimeAuthRefreshTimer: vi.fn(),
+    }),
+  }));
   vi.doMock("../plugins/provider-runtime.js", async (importOriginal) => {
     const actual = await importOriginal<typeof import("../plugins/provider-runtime.js")>();
     return {
@@ -144,6 +161,8 @@ afterAll(async () => {
 beforeEach(() => {
   vi.useRealTimers();
   runEmbeddedAttemptMock.mockReset();
+  disposeSessionMcpRuntimeMock.mockReset();
+  refreshRuntimeAuthOnFirstPromptError = false;
   runEmbeddedAttemptMock.mockImplementation(async () => {
     throw new Error("unexpected extra runEmbeddedAttempt call");
   });
@@ -245,7 +264,7 @@ const runDefaultEmbeddedTurn = async (sessionFile: string, prompt: string, sessi
 };
 
 describe("runEmbeddedPiAgent", () => {
-  it("forwards one-shot bundle MCP cleanup to each embedded attempt", async () => {
+  it("disposes bundle MCP once when a one-shot local run completes", async () => {
     const sessionFile = nextSessionFile();
     const cfg = createEmbeddedPiRunnerOpenAiConfig(["mock-1"]);
     const sessionKey = nextSessionKey();
@@ -269,15 +288,58 @@ describe("runEmbeddedPiAgent", () => {
       model: "mock-1",
       timeoutMs: 5_000,
       agentDir,
-      runId: nextRunId("bundle-mcp-cleanup"),
+      runId: nextRunId("bundle-mcp-run-cleanup"),
       enqueue: immediateEnqueue,
-      cleanupBundleMcpOnAttemptEnd: true,
+      cleanupBundleMcpOnRunEnd: true,
     });
 
     expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(1);
-    expect(runEmbeddedAttemptMock.mock.calls[0]?.[0]).toMatchObject({
-      cleanupBundleMcpOnAttemptEnd: true,
+    expect(disposeSessionMcpRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(disposeSessionMcpRuntimeMock).toHaveBeenCalledWith("session:test");
+  });
+
+  it("preserves bundle MCP state across retries within one local run", async () => {
+    refreshRuntimeAuthOnFirstPromptError = true;
+    const sessionFile = nextSessionFile();
+    const cfg = createEmbeddedPiRunnerOpenAiConfig(["mock-1"]);
+    const sessionKey = nextSessionKey();
+    runEmbeddedAttemptMock
+      .mockImplementationOnce(async () => {
+        expect(disposeSessionMcpRuntimeMock).not.toHaveBeenCalled();
+        return makeEmbeddedRunnerAttempt({
+          promptError: new Error("401 unauthorized"),
+        });
+      })
+      .mockImplementationOnce(async () => {
+        expect(disposeSessionMcpRuntimeMock).not.toHaveBeenCalled();
+        return makeEmbeddedRunnerAttempt({
+          assistantTexts: ["ok"],
+          lastAssistant: buildEmbeddedRunnerAssistant({
+            content: [{ type: "text", text: "ok" }],
+          }),
+        });
+      });
+
+    const result = await runEmbeddedPiAgent({
+      sessionId: "session:test",
+      sessionKey,
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "hello",
+      provider: "openai",
+      model: "mock-1",
+      timeoutMs: 5_000,
+      agentDir,
+      runId: nextRunId("bundle-mcp-retry"),
+      enqueue: immediateEnqueue,
+      cleanupBundleMcpOnRunEnd: true,
     });
+
+    expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]).toMatchObject({ text: "ok" });
+    expect(disposeSessionMcpRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(disposeSessionMcpRuntimeMock).toHaveBeenCalledWith("session:test");
   });
 
   it("handles prompt error paths without dropping user state", async () => {

--- a/src/agents/pi-embedded-runner.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.e2e.test.ts
@@ -245,6 +245,41 @@ const runDefaultEmbeddedTurn = async (sessionFile: string, prompt: string, sessi
 };
 
 describe("runEmbeddedPiAgent", () => {
+  it("forwards one-shot bundle MCP cleanup to each embedded attempt", async () => {
+    const sessionFile = nextSessionFile();
+    const cfg = createEmbeddedPiRunnerOpenAiConfig(["mock-1"]);
+    const sessionKey = nextSessionKey();
+    runEmbeddedAttemptMock.mockResolvedValueOnce(
+      makeEmbeddedRunnerAttempt({
+        assistantTexts: ["ok"],
+        lastAssistant: buildEmbeddedRunnerAssistant({
+          content: [{ type: "text", text: "ok" }],
+        }),
+      }),
+    );
+
+    await runEmbeddedPiAgent({
+      sessionId: "session:test",
+      sessionKey,
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "hello",
+      provider: "openai",
+      model: "mock-1",
+      timeoutMs: 5_000,
+      agentDir,
+      runId: nextRunId("bundle-mcp-cleanup"),
+      enqueue: immediateEnqueue,
+      cleanupBundleMcpOnAttemptEnd: true,
+    });
+
+    expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedAttemptMock.mock.calls[0]?.[0]).toMatchObject({
+      cleanupBundleMcpOnAttemptEnd: true,
+    });
+  });
+
   it("handles prompt error paths without dropping user state", async () => {
     const sessionFile = nextSessionFile();
     const cfg = createEmbeddedPiRunnerOpenAiConfig(["mock-error"]);

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -39,6 +39,7 @@ import {
 } from "../model-auth.js";
 import { normalizeProviderId } from "../model-selection.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
+import { disposeSessionMcpRuntime } from "../pi-bundle-mcp-tools.js";
 import {
   classifyFailoverReason,
   extractObservedOverflowTokenCount,
@@ -538,7 +539,6 @@ export async function runEmbeddedPiAgent(
             onReasoningEnd: params.onReasoningEnd,
             onToolResult: params.onToolResult,
             onAgentEvent: params.onAgentEvent,
-            cleanupBundleMcpOnAttemptEnd: params.cleanupBundleMcpOnAttemptEnd,
             extraSystemPrompt: params.extraSystemPrompt,
             inputProvenance: params.inputProvenance,
             streamParams: params.streamParams,
@@ -1432,6 +1432,13 @@ export async function runEmbeddedPiAgent(
       } finally {
         await contextEngine.dispose?.();
         stopRuntimeAuthRefreshTimer();
+        if (params.cleanupBundleMcpOnRunEnd === true) {
+          await disposeSessionMcpRuntime(params.sessionId).catch((error) => {
+            log.warn(
+              `bundle-mcp cleanup failed after run for ${params.sessionId}: ${describeUnknownError(error)}`,
+            );
+          });
+        }
       }
     }),
   );

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -538,6 +538,7 @@ export async function runEmbeddedPiAgent(
             onReasoningEnd: params.onReasoningEnd,
             onToolResult: params.onToolResult,
             onAgentEvent: params.onAgentEvent,
+            cleanupBundleMcpOnAttemptEnd: params.cleanupBundleMcpOnAttemptEnd,
             extraSystemPrompt: params.extraSystemPrompt,
             inputProvenance: params.inputProvenance,
             streamParams: params.streamParams,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -497,9 +497,11 @@ export async function runEmbeddedAttempt(
             ...tools.map((tool) => tool.name),
             ...(clientTools?.map((tool) => tool.function.name) ?? []),
           ],
-          disposeRuntime: async () => {
-            await disposeSessionMcpRuntime(params.sessionId);
-          },
+          disposeRuntime: params.cleanupBundleMcpOnAttemptEnd
+            ? async () => {
+                await disposeSessionMcpRuntime(params.sessionId);
+              }
+            : undefined,
         })
       : undefined;
     const bundleLspRuntime = toolsEnabled

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -59,6 +59,7 @@ import { createOpenAIWebSocketStreamFn, releaseWsSession } from "../../openai-ws
 import { resolveOwnerDisplaySetting } from "../../owner-display.js";
 import { createBundleLspToolRuntime } from "../../pi-bundle-lsp-runtime.js";
 import {
+  disposeSessionMcpRuntime,
   getOrCreateSessionMcpRuntime,
   materializeBundleMcpToolsForRun,
 } from "../../pi-bundle-mcp-tools.js";
@@ -496,6 +497,9 @@ export async function runEmbeddedAttempt(
             ...tools.map((tool) => tool.name),
             ...(clientTools?.map((tool) => tool.function.name) ?? []),
           ],
+          disposeRuntime: async () => {
+            await disposeSessionMcpRuntime(params.sessionId);
+          },
         })
       : undefined;
     const bundleLspRuntime = toolsEnabled
@@ -1878,6 +1882,7 @@ export async function runEmbeddedAttempt(
       });
       session?.dispose();
       releaseWsSession(params.sessionId);
+      await bundleMcpRuntime?.dispose();
       await bundleLspRuntime?.dispose();
       await sessionLock.release();
     }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -59,7 +59,6 @@ import { createOpenAIWebSocketStreamFn, releaseWsSession } from "../../openai-ws
 import { resolveOwnerDisplaySetting } from "../../owner-display.js";
 import { createBundleLspToolRuntime } from "../../pi-bundle-lsp-runtime.js";
 import {
-  disposeSessionMcpRuntime,
   getOrCreateSessionMcpRuntime,
   materializeBundleMcpToolsForRun,
 } from "../../pi-bundle-mcp-tools.js";
@@ -497,11 +496,6 @@ export async function runEmbeddedAttempt(
             ...tools.map((tool) => tool.name),
             ...(clientTools?.map((tool) => tool.function.name) ?? []),
           ],
-          disposeRuntime: params.cleanupBundleMcpOnAttemptEnd
-            ? async () => {
-                await disposeSessionMcpRuntime(params.sessionId);
-              }
-            : undefined,
         })
       : undefined;
     const bundleLspRuntime = toolsEnabled
@@ -1884,7 +1878,6 @@ export async function runEmbeddedAttempt(
       });
       session?.dispose();
       releaseWsSession(params.sessionId);
-      await bundleMcpRuntime?.dispose();
       await bundleLspRuntime?.dispose();
       await sessionLock.release();
     }

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -133,9 +133,9 @@ export type RunEmbeddedPiAgentParams = {
    */
   allowTransientCooldownProbe?: boolean;
   /**
-   * Dispose bundled MCP runtimes when an attempt ends instead of preserving
+   * Dispose bundled MCP runtimes when the overall run ends instead of preserving
    * the session-scoped cache. Intended for one-shot local CLI runs that must
    * exit promptly after emitting the final JSON result.
    */
-  cleanupBundleMcpOnAttemptEnd?: boolean;
+  cleanupBundleMcpOnRunEnd?: boolean;
 };

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -132,4 +132,10 @@ export type RunEmbeddedPiAgentParams = {
    * where transient service pressure is often model-scoped.
    */
   allowTransientCooldownProbe?: boolean;
+  /**
+   * Dispose bundled MCP runtimes when an attempt ends instead of preserving
+   * the session-scoped cache. Intended for one-shot local CLI runs that must
+   * exit promptly after emitting the final JSON result.
+   */
+  cleanupBundleMcpOnAttemptEnd?: boolean;
 };

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -135,7 +135,24 @@ describe("agentCliCommand", () => {
 
       expect(callGateway).not.toHaveBeenCalled();
       expect(agentCommand).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(agentCommand).mock.calls[0]?.[0]).toMatchObject({
+        cleanupBundleMcpOnAttemptEnd: true,
+      });
       expect(runtime.log).toHaveBeenCalledWith("local");
+    });
+  });
+
+  it("does not force bundle MCP cleanup on gateway fallback", async () => {
+    await withTempStore(async () => {
+      vi.mocked(callGateway).mockRejectedValue(new Error("gateway not connected"));
+      mockLocalAgentReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(agentCommand).mock.calls[0]?.[0]).not.toMatchObject({
+        cleanupBundleMcpOnAttemptEnd: true,
+      });
     });
   });
 });

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -136,7 +136,7 @@ describe("agentCliCommand", () => {
       expect(callGateway).not.toHaveBeenCalled();
       expect(agentCommand).toHaveBeenCalledTimes(1);
       expect(vi.mocked(agentCommand).mock.calls[0]?.[0]).toMatchObject({
-        cleanupBundleMcpOnAttemptEnd: true,
+        cleanupBundleMcpOnRunEnd: true,
       });
       expect(runtime.log).toHaveBeenCalledWith("local");
     });
@@ -151,7 +151,7 @@ describe("agentCliCommand", () => {
 
       expect(agentCommand).toHaveBeenCalledTimes(1);
       expect(vi.mocked(agentCommand).mock.calls[0]?.[0]).not.toMatchObject({
-        cleanupBundleMcpOnAttemptEnd: true,
+        cleanupBundleMcpOnRunEnd: true,
       });
     });
   });

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -183,6 +183,7 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
     ...opts,
     agentId: opts.agent,
     replyAccountId: opts.replyAccount,
+    cleanupBundleMcpOnAttemptEnd: opts.local === true,
   };
   if (opts.local === true) {
     return await agentCommand(localOpts, runtime, deps);

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -183,7 +183,7 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
     ...opts,
     agentId: opts.agent,
     replyAccountId: opts.replyAccount,
-    cleanupBundleMcpOnAttemptEnd: opts.local === true,
+    cleanupBundleMcpOnRunEnd: opts.local === true,
   };
   if (opts.local === true) {
     return await agentCommand(localOpts, runtime, deps);


### PR DESCRIPTION
## Summary

- Problem: `openclaw agent --local --json` could print the final JSON result and still hang instead of exiting.
- Why it matters: one-shot local runs leave bundled MCP subprocesses alive, which blocks automation and makes successful runs look timed out.
- What changed: the embedded attempt cleanup path now disposes the per-run bundled MCP runtime, and the materialized MCP tool runtime can forward disposal to the owning session runtime manager.
- What did NOT change (scope boundary): this does not change the already-fixed `sglang` recursive load issue from `2026.3.28`; this PR only fixes the current-main post-response hang caused by lingering bundled MCP children.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #57023
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `src/agents/pi-embedded-runner/run/attempt.ts` materialized bundle MCP tools from a session-scoped runtime, but the attempt cleanup path did not dispose that `bundleMcpRuntime`, so bundled stdio MCP children like `mcp-metricool` stayed alive after the turn completed.
- Missing detection / guardrail: coverage existed for explicit session-runtime disposal, but not for the per-run materialized runtime retiring a manager-owned session runtime during one-shot local runs.
- Prior context (`git blame`, prior PR, issue, or refactor if known): session-scoped bundle MCP caching landed in `#55073` / `#55090`; this is a cleanup follow-up on that lifecycle.
- Why this regressed now: once the old `sglang` recursive load bug was gone on current `main`, local one-shot runs exposed the remaining bundled MCP cleanup gap.
- If unknown, what was ruled out: ruled out the older `sglang` import-cycle regression on current `main`; direct `extensions/sglang/api.ts` / `openclaw/plugin-sdk/provider-setup` imports no longer reproduce the old recursive-load hang.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-bundle-mcp-runtime.test.ts`
- Scenario the test should lock in: disposing a materialized bundled MCP runtime can retire a manager-owned session runtime, terminate the child process, and force the next materialization to start a fresh runtime.
- Why this is the smallest reliable guardrail: the failure is in the session-runtime/materialization seam, and the targeted test verifies real stdio child-process teardown without needing a full live model run.
- Existing test that already covers this (if any): the existing `disposes startup-in-flight runtimes without leaking MCP processes` case in `src/agents/pi-bundle-mcp-runtime.test.ts` already covered explicit manager disposal during startup; this PR adds the missing materialized-runtime cleanup path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw agent --local --json` now exits after the run completes instead of hanging behind bundled MCP subprocesses.
- Bundled MCP tool materialization can optionally forward disposal to the owning runtime manager instead of being a no-op.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3.1
- Runtime/container: local `pnpm` workspace
- Model/provider: local embedded run (`openclaw agent --local`)
- Integration/channel (if any): bundled MCP (`mcp-metricool`)
- Relevant config (redacted): agent `wooyuu-live-data`

### Steps

1. Run `pnpm openclaw agent --local --agent wooyuu-live-data --message 'read-only test' --thinking off --json` on current `main`.
2. Observe that the final JSON result is printed.
3. Observe that the process does not exit and `ps` still shows `openclaw-agent` plus `mcp-metricool`.

### Expected

- The command should print the final JSON result and exit 0.
- No bundled MCP child processes should remain after the one-shot run completes.

### Actual

- Before the fix, the command printed the final JSON result but hung until killed, and `ps` showed lingering `mcp-metricool` children.
- After the fix, the same command exits 0 in ~25s and no lingering `mcp-metricool` processes remain.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm exec vitest run src/agents/pi-bundle-mcp-runtime.test.ts`
  - `pnpm build`
  - `pnpm check`
  - `pnpm openclaw agent --local --agent wooyuu-live-data --message 'read-only test' --thinking off --json`
- Edge cases checked:
  - manager-owned bundle MCP runtimes can now be retired via materialized runtime disposal
  - the next materialization recreates a fresh runtime and respawns the MCP child
  - no residual `openclaw-agent` / `mcp-metricool` processes remain after the local one-shot run exits
- What you did **not** verify:
  - I did not rerun gateway-backed `openclaw agent --agent ...` in this PR flow because the current bug here was isolated to the local one-shot embedded runner cleanup path.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: disposing a materialized runtime could accidentally close a session runtime that another active turn is still using.
  - Mitigation: the embedded attempt only wires the disposal callback for the one-shot run-scoped materialization path that owns this cleanup point; the regression test locks in the intended retirement behavior for a single session runtime.
- Risk: bundle MCP cleanup could regress stdio tool availability on later turns.
  - Mitigation: the new regression test verifies that the next materialization recreates the runtime and respawns the server cleanly.
