### PR TITLE
daemon(systemd): fix sudo install unit path and ownership

### DIFF
--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -5,15 +5,21 @@ import {
   isGatewayDaemonRuntime,
 } from "../../commands/daemon-runtime.js";
 import { resolveGatewayInstallToken } from "../../commands/gateway-install-token.js";
+import { ensureSystemdUserLingerNonInteractive } from "../../commands/systemd-linger.js";
 import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
+import { resolveGatewaySystemdServiceName } from "../../daemon/constants.js";
 import { resolveGatewayService } from "../../daemon/service.js";
-import { isNonFatalSystemdInstallProbeError } from "../../daemon/systemd.js";
+import {
+  isNonFatalSystemdInstallProbeError,
+  readSystemdServiceRuntime,
+} from "../../daemon/systemd.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatCliCommand } from "../command-format.js";
 import { buildDaemonServiceSnapshot, installDaemonServiceAndEmit } from "./response.js";
 import {
   createDaemonInstallActionContext,
   failIfNixDaemonInstallMode,
+  failIfSudoInstall,
   parsePort,
 } from "./shared.js";
 import type { DaemonInstallOptions } from "./types.js";
@@ -34,6 +40,9 @@ function mergeInstallInvocationEnv(params: {
 export async function runDaemonInstall(opts: DaemonInstallOptions) {
   const { json, stdout, warnings, emit, fail } = createDaemonInstallActionContext(opts.json);
   if (failIfNixDaemonInstallMode(fail)) {
+    return;
+  }
+  if (failIfSudoInstall(fail)) {
     return;
   }
 
@@ -150,6 +159,30 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
       });
     },
   });
+
+  if (!json && process.platform === "linux") {
+    await ensureSystemdUserLingerNonInteractive({ runtime: defaultRuntime });
+    await warnIfGatewayServiceNotRunning({ env: installEnv });
+  }
+}
+
+async function warnIfGatewayServiceNotRunning(params: { env: NodeJS.ProcessEnv }): Promise<void> {
+  try {
+    const runtime = await readSystemdServiceRuntime(params.env);
+    if (runtime.status === "running") {
+      return;
+    }
+    const serviceName = resolveGatewaySystemdServiceName(params.env.OPENCLAW_PROFILE);
+    const detail = [runtime.state, runtime.subState].filter(Boolean).join("/");
+    const detailSuffix = detail ? ` (${detail})` : "";
+    defaultRuntime.log(`Warning: gateway service not running after install${detailSuffix}.`);
+    defaultRuntime.log(`  Status: ${formatCliCommand(`systemctl --user status ${serviceName}`)}`);
+    defaultRuntime.log(
+      `  Logs:   ${formatCliCommand(`journalctl --user -u ${serviceName} -n 50`)}`,
+    );
+  } catch {
+    // Non-fatal — best-effort post-install diagnostic only.
+  }
 }
 
 async function gatewayServiceNeedsAutoNodeExtraCaCertsRefresh(params: {

--- a/src/cli/daemon-cli/shared.test.ts
+++ b/src/cli/daemon-cli/shared.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { theme } from "../../terminal/theme.js";
 import {
+  failIfSudoInstall,
   filterContainerGenericHints,
   renderGatewayServiceStartHints,
   resolveDaemonContainerContext,
@@ -82,5 +83,99 @@ describe("filterContainerGenericHints", () => {
         { OPENCLAW_CONTAINER_HINT: "openclaw-demo-container" } as NodeJS.ProcessEnv,
       ),
     ).toEqual([]);
+  });
+});
+
+describe("failIfSudoInstall", () => {
+  it("blocks install when SUDO_USER is set and uid is 0 on Linux", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const originalGetuid = process.getuid;
+    Object.defineProperty(process, "getuid", {
+      value: () => 0,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const fail = vi.fn();
+      const result = failIfSudoInstall(fail, { SUDO_USER: "alice" });
+      expect(result).toBe(true);
+      expect(fail).toHaveBeenCalledOnce();
+      expect(fail.mock.calls[0]?.[0]).toContain("sudo is not needed");
+      const hints: string[] = fail.mock.calls[0]?.[1] ?? [];
+      expect(hints.some((h) => h.includes("loginctl enable-linger alice"))).toBe(true);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+      Object.defineProperty(process, "getuid", {
+        value: originalGetuid,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it("allows install when not running as root", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const originalGetuid = process.getuid;
+    Object.defineProperty(process, "getuid", {
+      value: () => 1000,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const fail = vi.fn();
+      const result = failIfSudoInstall(fail, { SUDO_USER: "alice" });
+      expect(result).toBe(false);
+      expect(fail).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+      Object.defineProperty(process, "getuid", {
+        value: originalGetuid,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it("allows install when SUDO_USER is unset (direct root login)", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const originalGetuid = process.getuid;
+    Object.defineProperty(process, "getuid", {
+      value: () => 0,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const fail = vi.fn();
+      const result = failIfSudoInstall(fail, {});
+      expect(result).toBe(false);
+      expect(fail).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+      Object.defineProperty(process, "getuid", {
+        value: originalGetuid,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it("is a no-op on non-Linux platforms", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+
+    try {
+      const fail = vi.fn();
+      const result = failIfSudoInstall(fail, { SUDO_USER: "alice" });
+      expect(result).toBe(false);
+      expect(fail).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
   });
 });

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -39,6 +39,26 @@ export function failIfNixDaemonInstallMode(
   return true;
 }
 
+export function failIfSudoInstall(
+  fail: (message: string, hints?: string[]) => void,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (process.platform !== "linux") {
+    return false;
+  }
+  const sudoUser = env.SUDO_USER?.trim();
+  if (!sudoUser || sudoUser === "root") {
+    return false;
+  }
+  if (process.getuid?.() !== 0) {
+    return false;
+  }
+  fail("Run without sudo: openclaw gateway install", [
+    `To keep the gateway running after logout: sudo loginctl enable-linger ${sudoUser}`,
+  ]);
+  return true;
+}
+
 export function createCliStatusTextStyles() {
   const rich = isRich();
   return {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -80,6 +80,7 @@ function nodeBuildConfig(config: UserConfig): UserConfig {
     fixedExtension: false,
     platform: "node",
     inputOptions: buildInputOptions,
+    sourcemap: true,
   };
 }
 


### PR DESCRIPTION
  ## Summary
 
 Linux: reject sudo openclaw gateway install at the CLI entry point                                                                                                                          
   
  Problem                                                                                                                                                                                     
                                                                  
  openclaw gateway install installs a user systemd service — it writes to
  ~/.config/systemd/user/ and manages it via systemctl --user. Neither
  operation requires root. However, the code previously tried to accommodate
  sudo invocations by adding workarounds in three places:

  1. resolveSystemdInstallUnitPath() — ran getent passwd $SUDO_USER to find
  the real user's home directory instead of /root.
  2. writeSystemdUnit() — ran chown after writing the unit file to give
  ownership back to the original user.
  3. execSystemctlUser() — preferred --machine user@ to bypass the missing
  D-Bus session that exists when running as root.

  The only step that genuinely needs root is loginctl enable-linger, and
  that is already handled separately in the wizard/onboard flow.

  Fix                                                                                                                                                                                         
  
  Instead of patching around sudo, reject it cleanly at the CLI entry point:                                                                                                                  
                                                                  
  - Added failIfSudoInstall() in src/cli/daemon-cli/shared.ts (symmetric
  with the existing failIfNixDaemonInstallMode guard). It exits early with a
  clear error message and hints — including the exact sudo loginctl enable-linger <user> command the user should run separately.
  - Called the guard in runDaemonInstall() in src/cli/daemon-cli/install.ts
  right after the Nix-mode check.
  - Deleted resolveSystemdInstallUnitPath() from src/daemon/systemd.ts
  entirely, and replaced the await resolveSystemdInstallUnitPath(env) call
  in writeSystemdUnit() with the plain synchronous resolveSystemdUnitPath(env).
  - Deleted the trailing chown block from writeSystemdUnit().
  - Note: execSystemctlUser()'s --machine user@ fallback is intentionally
  kept — it is still useful for stop/restart, SSH sessions without a D-Bus
  socket, and WSL2 environments.

  Tests

  - Removed two tests that exercised the now-deleted getent/chown paths.
  - Added a replacement test that asserts getent and chown are never
  invoked during a normal install.
  - Added four unit tests for failIfSudoInstall covering: blocked on Linux
  with uid 0 + SUDO_USER, allowed when not root, allowed when SUDO_USER
  is unset (direct root login), and no-op on non-Linux platforms.