### PR TITLE
fix: make registerChannel/registerHttpRoute idempotent for same-plugin re-registration

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2004,7 +2004,7 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
         },
       },
       {
-        label: "rejects duplicate channel ids during plugin registration",
+        label: "silently updates channel on same-plugin re-registration",
         pluginId: "channel-dup",
         body: `module.exports = { id: "channel-dup", register(api) {
   api.registerChannel({

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2045,12 +2045,12 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
   });
 } };`,
         assert: (registry: ReturnType<typeof loadOpenClawPlugins>) => {
+          // Same plugin re-registering the same channel is now idempotent (silent update).
           expect(registry.channels.filter((entry) => entry.plugin.id === "demo")).toHaveLength(1);
-          expectRegistryErrorDiagnostic({
-            registry,
-            pluginId: "channel-dup",
-            message: "channel already registered: demo (channel-dup)",
-          });
+          // The second registration should update the channel in place with the latest metadata.
+          expect(
+            registry.channels.find((entry) => entry.plugin.id === "demo")?.plugin.meta?.label,
+          ).toBe("Demo Duplicate");
         },
       },
       {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -532,12 +532,16 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       if (existingRuntime.pluginId === record.id) {
         // Same plugin re-registering the same channel (e.g. hot-reload) — update in place.
         existingRuntime.plugin = plugin;
+        existingRuntime.pluginName = record.name;
         existingRuntime.source = record.source;
+        existingRuntime.rootDir = record.rootDir;
         const existingSetup = registry.channelSetups.find((entry) => entry.plugin.id === id);
         if (existingSetup) {
           existingSetup.plugin = plugin;
+          existingSetup.pluginName = record.name;
           existingSetup.source = record.source;
           existingSetup.enabled = record.enabled;
+          existingSetup.rootDir = record.rootDir;
         }
         return;
       }
@@ -554,8 +558,10 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       if (existingSetup.pluginId === record.id) {
         // Same plugin re-registering — update in place.
         existingSetup.plugin = plugin;
+        existingSetup.pluginName = record.name;
         existingSetup.source = record.source;
         existingSetup.enabled = record.enabled;
+        existingSetup.rootDir = record.rootDir;
         return;
       }
       pushDiagnostic({

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -468,7 +468,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       if (!existing) {
         return;
       }
-      if (!params.replaceExisting) {
+      if (!params.replaceExisting && existing.pluginId !== record.id) {
         pushDiagnostic({
           level: "error",
           pluginId: record.id,
@@ -529,6 +529,18 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
     const existingRuntime = registry.channels.find((entry) => entry.plugin.id === id);
     if (mode !== "setup-only" && existingRuntime) {
+      if (existingRuntime.pluginId === record.id) {
+        // Same plugin re-registering the same channel (e.g. hot-reload) — update in place.
+        existingRuntime.plugin = plugin;
+        existingRuntime.source = record.source;
+        const existingSetup = registry.channelSetups.find((entry) => entry.plugin.id === id);
+        if (existingSetup) {
+          existingSetup.plugin = plugin;
+          existingSetup.source = record.source;
+          existingSetup.enabled = record.enabled;
+        }
+        return;
+      }
       pushDiagnostic({
         level: "error",
         pluginId: record.id,
@@ -539,6 +551,13 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
     const existingSetup = registry.channelSetups.find((entry) => entry.plugin.id === id);
     if (existingSetup) {
+      if (existingSetup.pluginId === record.id) {
+        // Same plugin re-registering — update in place.
+        existingSetup.plugin = plugin;
+        existingSetup.source = record.source;
+        existingSetup.enabled = record.enabled;
+        return;
+      }
       pushDiagnostic({
         level: "error",
         pluginId: record.id,


### PR DESCRIPTION
## Summary

- `registerChannel()` now silently updates in place when the same plugin re-registers the same channel ID (e.g. during hot-reload), instead of rejecting with an error diagnostic
- `registerHttpRoute()` now auto-replaces the existing route when the same plugin re-registers the same path, without requiring explicit `replaceExisting: true`
- Cross-plugin duplicate registration still correctly errors in both cases

## Problem

When the plugin hot-reload system calls `register()` on an already-active plugin, `registerChannel()` and `registerHttpRoute()` rejected the duplicate with error diagnostics but the plugin's `register()` function still ran to completion — creating new closures, objects, and internal state on each cycle. On a 2GB VPS, the webchat plugin's `register()` was called ~789 times in one day via hot-reload (batches of 4 every ~40 seconds), causing the gateway heap to hit ~950MB and crash-loop 328 times.

## Fix

- `registerChannel()`: When same plugin ID + same channel ID, update the existing channel/setup entries in place and return (no diagnostic, no accumulation)
- `registerHttpRoute()`: When same plugin ID + same path, treat as implicit `replaceExisting: true` — replace the handler in place (this path already existed for explicit `replaceExisting`)

## Test plan

- [x] Existing duplicate-channel test updated: same-plugin re-registration now silently updates metadata instead of producing error diagnostic
- [x] All 73 plugin loader tests pass
- [x] All 7 HTTP registry tests pass (including existing `replaceExisting` coverage)
- [x] All 9 channel-pin tests pass
- [x] All 24 gateway server-plugins tests pass
- [x] 113 total tests pass, 0 failures
- [x] Pre-commit hooks pass (lint, typecheck, conflict markers)

## AI disclosure

- **AI-assisted**: Generated with Claude Code
- **Testing level**: Fully tested — 113 tests pass, 0 failures; pre-commit hooks (lint, typecheck) pass
- **Understanding**: I understand and can explain all changes in this PR
- **Bot reviews**: All Codex and Greptile review comments addressed (greptile P2 fixed in second commit; Codex P1 cache concern acknowledged with follow-up planned)

## Known CI notes

The following CI failures are **not introduced by this PR**:
- `checks-windows-node-test-1` — also fails on `main`
- `checks-node-test-1` — CI infrastructure crash (all 310 tests in the shard passed; process exited code 1)
- `checks-node-channels-3` — `TypeError: listFn is not a function` in `test/helpers/channels/plugins-core-extension-contract.ts`, a shared test helper unrelated to the files changed in this PR

Fixes #57514

🤖 Generated with [Claude Code](https://claude.com/claude-code)