### PR TITLE
fix(dashboard): SecretRef fields corrupt on config save; model picker shows Not set

### DIFF
--- a/docs/design/macos-talk-voice-and-voicewake-keepalive.md
+++ b/docs/design/macos-talk-voice-and-voicewake-keepalive.md
@@ -1,0 +1,573 @@
+# macOS Talk Voice Selection + Voice Wake Follow-Up Design
+
+Status: revised proposal
+Owner: local dev branch / Ben + flicker
+Scope: macOS app (`apps/macos`) and shared speech support (`apps/shared/OpenClawKit`)
+
+## Summary
+
+This design revises the original macOS voice-improvements plan to match the current mainline architecture.
+
+It still targets the same two product goals:
+
+1. **Configurable system voice for Talk Mode**
+   - When Talk Mode uses local macOS system TTS, users can choose an exact installed macOS voice.
+   - Selection is persisted by `AVSpeechSynthesisVoice.identifier`.
+
+2. **Conversational follow-up after Voice Wake**
+   - After a Voice Wake request is spoken and the assistant responds audibly, the app should support a short follow-up window.
+   - If the user asks a quick follow-up within that window, the app should capture and send it without requiring a second wake word.
+   - If no follow-up arrives before timeout, the app returns to normal wake-word-only behavior.
+
+The key change from the original plan is architectural:
+
+> **Voice Wake follow-up should no longer be modeled as “temporary Talk Mode”.**
+>
+> On current mainline, Voice Wake and Talk Mode are separate runtimes with different state machines, UX, and send paths. The best structure is to keep Talk Mode persistent and independent, while adding a Voice Wake-specific follow-up session model on top of the existing Voice Wake runtime/coordinator path.
+
+This keeps the product intent while fitting the actual codebase cleanly.
+
+---
+
+## Why this design was revised
+
+The original plan was written around an assumed relationship where Voice Wake effectively handed off into Talk Mode. That is no longer a good fit for current mainline.
+
+### What changed since the original plan
+
+Current mainline separates the relevant responsibilities like this:
+
+- **Talk Mode**
+  - `TalkModeRuntime`
+  - `TalkModeController`
+  - `TalkSystemSpeechSynthesizer`
+  - persistent toggle via `AppState.talkEnabled`
+  - continuous listening / speaking loop
+
+- **Voice Wake**
+  - `VoiceWakeRuntime`
+  - `VoiceSessionCoordinator`
+  - `VoiceWakeForwarder`
+  - wake-word-triggered capture window
+  - overlay-driven request/forward flow
+
+### Current Voice Wake behavior
+
+Today, Voice Wake:
+
+1. detects wake phrase in `VoiceWakeRuntime`
+2. captures a short transcript window
+3. finalizes and forwards the transcript through `VoiceWakeForwarder`
+4. restarts the recognizer for the next wake word
+
+This is not currently a Talk Mode session. It is a separate one-shot capture/forward path.
+
+### Current Talk Mode behavior
+
+Today, Talk Mode:
+
+1. is enabled explicitly through `talkEnabled`
+2. runs its own recognition loop in `TalkModeRuntime`
+3. chooses either ElevenLabs or local system speech for output
+4. remains persistent until disabled
+
+### Consequence
+
+Trying to force Voice Wake follow-up behavior into a “temporary Talk Mode” abstraction would introduce avoidable coupling:
+
+- Talk Mode UI and persistence semantics would become muddier
+- Voice Wake would need to manipulate Talk Mode enabled state or fake a Talk session origin
+- runtime responsibilities would blur between two already-distinct subsystems
+
+So the revised design preserves the original product goal, but re-anchors Feature 2 inside the **Voice Wake architecture**, not the Talk Mode architecture.
+
+---
+
+## Goals
+
+### Goal 1: Configurable system voice
+
+Allow Talk Mode system TTS to use a specific installed macOS voice chosen in-app.
+
+### Goal 1A: Tahoe-aware voice UX enhancements
+
+Improve the voice picker and metadata using newer Apple APIs available on current Tahoe:
+
+- voice quality
+- voice traits
+- Personal Voice authorization awareness
+- live refresh when installed voices change
+
+### Goal 2: Voice Wake follow-up window
+
+After a Voice Wake request receives an audible assistant reply, keep a short Voice Wake-specific follow-up session alive so the user can ask a follow-up question without repeating the wake word.
+
+---
+
+## Non-goals
+
+- No custom speech synthesis provider or audio unit work
+- No SSML / expressive speech authoring
+- No requirement to mirror macOS Accessibility “System Voice” automatically
+- No mandatory Personal Voice-specific permission flow in v1
+- No change to Talk Mode’s persistent/manual semantics
+- No attempt to unify Voice Wake and Talk Mode into a single runtime in v1
+- No generalized full-duplex spoken conversation framework in this milestone
+
+---
+
+## Architecture overview
+
+## Feature 1 remains mostly unchanged
+
+Feature 1 still belongs to the Talk Mode / system TTS path:
+
+- `TalkModeRuntime.playSystemVoice(...)`
+- `TalkSystemSpeechSynthesizer`
+- macOS settings / local persisted preferences
+
+That part of the original design remains sound.
+
+## Feature 2 is restructured
+
+Feature 2 should now be layered on the Voice Wake request lifecycle:
+
+- request capture starts in `VoiceWakeRuntime`
+- request text is forwarded via `VoiceWakeForwarder`
+- assistant reply is delivered through normal app/gateway channels
+- once the spoken reply for that Voice Wake-triggered request finishes, a **Voice Wake follow-up session** opens
+- during the follow-up session, the app listens for speech without requiring a wake word
+- timeout or completion returns the app to normal wake-word-only mode
+
+This is a **Voice Wake follow-up state machine**, not a Talk Mode session.
+
+---
+
+## Feature 1: Configurable system voice
+
+### Current behavior
+
+`TalkSystemSpeechSynthesizer` currently uses language-based selection:
+
+```swift
+if let language, let voice = AVSpeechSynthesisVoice(language: language) {
+    utterance.voice = voice
+}
+```
+
+This chooses a voice by locale/language, not by a user-selected installed voice.
+
+### Revised design
+
+Add one new field to the local macOS Talk settings model:
+
+```json
+{
+  "talk": {
+    "macosVoiceIdentifier": "com.apple.speech.synthesis.voice.custom.siri.aaron.premium"
+  }
+}
+```
+
+The runtime selection order should be:
+
+1. explicit configured `macosVoiceIdentifier`
+2. language-based voice fallback
+3. default utterance voice
+
+### Important implementation note
+
+This identifier is **local macOS app preference/state**, even if represented in the same general Talk config surface. It should not require a remote gateway feature to function.
+
+### Logging
+
+Add structured logs for:
+
+- configured identifier
+- resolved voice identifier
+- resolved name
+- quality / traits when available
+- fallback reason
+
+### Why Feature 1 still stands cleanly
+
+Unlike Feature 2, the relevant code path is still straightforward and has not drifted architecturally. Current mainline adds watchdog hardening but does not conflict with explicit voice selection.
+
+---
+
+## Feature 2: Voice Wake follow-up window
+
+## Product intent
+
+The original user goal remains:
+
+> After saying the wake word and receiving a spoken response, the user should be able to ask a brief follow-up naturally, without needing to say the wake word again immediately.
+
+## Revised conceptual model
+
+Instead of “temporary Talk Mode”, define a new concept:
+
+### Voice Wake Follow-Up Session
+
+A Voice Wake Follow-Up Session is a short-lived post-reply state in which:
+
+- wake-word detection is temporarily bypassed
+- direct speech capture is allowed
+- the next utterance is treated as a follow-up to the prior Voice Wake request
+- after timeout or completion, the system returns to ordinary Voice Wake mode
+
+This session is:
+
+- **created by Voice Wake**,
+- **consumed by Voice Wake**,
+- **independent from Talk Mode enablement**.
+
+---
+
+## Why not temporary Talk Mode?
+
+### Problems with the original framing
+
+If we modeled follow-up as temporary Talk Mode, we would need to answer awkward questions:
+
+- Is `talkEnabled` true during the temporary session?
+- Should the Talk overlay appear as if the user manually enabled Talk Mode?
+- Should Talk Mode settings like pause/interrupt behave exactly the same?
+- Who owns the session lifecycle: `TalkModeRuntime` or `VoiceWakeRuntime`?
+- How do we avoid races with real manual Talk Mode already being enabled?
+
+Those questions are symptoms of the abstraction mismatch.
+
+### Better fit
+
+A Voice Wake follow-up session avoids this by keeping ownership local:
+
+- `VoiceWakeRuntime` owns speech capture state
+- `VoiceSessionCoordinator` owns request/follow-up session UX state
+- Talk Mode remains a separate persistent mode
+
+---
+
+## Proposed runtime model for Feature 2
+
+Introduce an explicit Voice Wake post-reply lifecycle.
+
+### New high-level states
+
+At a conceptual level, Voice Wake should distinguish:
+
+1. **Wake listening**
+   - normal wake-word recognition active
+2. **Triggered capture**
+   - wake word heard, command/following speech being captured
+3. **Request in flight**
+   - transcript finalized and forwarded, waiting for assistant completion
+4. **Reply playback**
+   - assistant response is being spoken
+5. **Follow-up listening**
+   - short no-wake-word follow-up window active
+6. **Cooldown / restore**
+   - cleanup, then return to wake listening
+
+Not all of these must be represented as a single enum initially, but the architecture should preserve this lifecycle.
+
+---
+
+## Trigger for opening follow-up listening
+
+The follow-up session should begin only when all of the following are true:
+
+1. the request originated from Voice Wake
+2. the assistant reply was actually delivered with audible local speech playback
+3. reply playback finished successfully (or reached a “speech complete” signal)
+4. the feature is enabled and timeout > 0
+
+This is important: opening the follow-up window merely because a Voice Wake request was forwarded is too early and will feel wrong.
+
+The user expectation is “you answered me, now I can quickly ask one more thing.”
+
+---
+
+## Required architectural hook
+
+The major missing piece in current mainline is a reliable way for the macOS app to know:
+
+- this reply belongs to a Voice Wake-originated request
+- local speech playback for that reply started/finished
+
+So Feature 2 needs a lightweight correlation model.
+
+### Proposed approach: Voice Wake request correlation token
+
+When `VoiceWakeRuntime` forwards a request, attach a local request/session token to the request lifecycle on the macOS side.
+
+The exact transport mechanism can vary, but architecturally we need:
+
+- a **local session token** created at Voice Wake capture finalization
+- a coordinator-owned record that marks that token as awaiting spoken reply
+- a way for the reply playback path to signal start/finish against that token
+
+### Design principle
+
+Do **not** make Feature 2 depend on brittle transcript matching or “last reply wins” heuristics.
+
+Correlation should be explicit if possible. If some gateway/channel surfaces make perfect correlation hard, the macOS-side implementation may use a narrower first version limited to the local chat/reply path where correlation is already knowable.
+
+---
+
+## Proposed ownership
+
+### `VoiceWakeRuntime`
+
+Responsible for:
+
+- wake listening
+- triggered capture
+- follow-up listening capture
+- transition back to wake mode
+
+### `VoiceSessionCoordinator`
+
+Responsible for:
+
+- session token creation
+- overlay/session lifecycle metadata
+- whether a voice request is awaiting reply, in playback, or in follow-up window
+- timer state for follow-up expiry
+
+### speech playback path
+
+Responsible for:
+
+- reporting when a Voice Wake-correlated reply starts playback
+- reporting when it finishes or fails
+
+### `TalkModeRuntime`
+
+Not responsible for follow-up session ownership.
+
+Talk Mode may still provide implementation patterns for audio capture or playback behavior, but it should not become the state owner for Voice Wake follow-up.
+
+---
+
+## UI / UX semantics for Feature 2
+
+### Settings language
+
+The settings should avoid implying that manual Talk Mode is involved.
+
+Recommended wording:
+
+**Keep listening briefly for follow-up questions after a Voice Wake reply**
+
+Help text:
+
+> After OpenClaw answers a Voice Wake request out loud, keep listening for a short follow-up question without requiring the wake word again. If you stay silent until the timeout, OpenClaw returns to normal Voice Wake mode.
+
+### Why this wording matters
+
+It explains the behavior in user terms without leaking the internal runtime distinction.
+
+---
+
+## Detailed Feature 2 behavior
+
+### Normal path
+
+1. User says wake word + request
+2. `VoiceWakeRuntime` captures and forwards transcript
+3. app waits for response
+4. response is spoken locally
+5. after playback finishes, follow-up window opens
+6. if user speaks within timeout:
+   - capture follow-up utterance directly
+   - send as follow-up request
+   - await spoken reply again
+   - optionally reopen follow-up window after that reply
+7. if timeout expires:
+   - exit follow-up window
+   - restore wake-word listening only
+
+### Timeout semantics
+
+- config stored as milliseconds
+- UI shown in seconds
+- `0` or disabled means no follow-up window
+- timeout starts after spoken reply playback completes, not when request is sent
+
+### Retry / error semantics
+
+If the reply is not spoken locally, do **not** enter follow-up mode.
+
+If playback fails midway, default to returning to normal wake listening unless a later UX pass shows a better fallback.
+
+### Manual Talk Mode interaction
+
+If manual Talk Mode is already enabled, Feature 2 should not try to layer a Voice Wake follow-up window on top.
+
+Recommended v1 rule:
+
+- when manual Talk Mode is active, Voice Wake follow-up behavior is suppressed or considered irrelevant because continuous conversation is already available.
+
+This avoids state conflicts and user confusion.
+
+---
+
+## Config
+
+## Feature 1
+
+```json
+{
+  "talk": {
+    "macosVoiceIdentifier": "com.apple.speech.synthesis.voice.custom.siri.aaron.premium"
+  }
+}
+```
+
+## Feature 2
+
+```json
+{
+  "talk": {
+    "voiceWakeFollowupMs": 10000
+  }
+}
+```
+
+### Naming note
+
+The old plan used `voiceWakeKeepAliveMs`.
+
+The revised name `voiceWakeFollowupMs` is recommended because:
+
+- it better describes the user-facing purpose
+- it avoids implying that Talk Mode itself is being kept alive
+- it fits the new architecture more honestly
+
+If backward compatibility with prior local experimentation matters, the parser can accept both names temporarily and normalize to the new one.
+
+---
+
+## API and state implications
+
+### Feature 1
+
+- Extend `TalkSystemSpeechSynthesizer.speak(...)` to accept optional `voiceIdentifier`
+- Persist local selected identifier in app state/settings
+- thread the value into `TalkModeRuntime.playSystemVoice(...)`
+
+### Feature 2
+
+Needs new local coordination/state, likely along these lines:
+
+- Voice Wake request/session token
+- follow-up mode enabled flag + timeout
+- callback/event when relevant reply playback starts/finishes
+- timer-driven expiry back to wake listening
+
+This should be implemented as incremental local architecture, not a giant refactor.
+
+---
+
+## Testing strategy
+
+## Feature 1
+
+### Unit tests
+
+- identifier selection wins over language
+- invalid identifier falls back to language
+- missing identifier + missing language falls back to utterance default
+
+### Manual checks
+
+- choose a specific installed voice
+- hear correct voice in Talk Mode
+- invalid stored identifier falls back safely
+
+## Feature 2
+
+### Unit / state tests
+
+- Voice Wake request opens “awaiting reply” state
+- spoken reply completion opens follow-up listening state
+- follow-up timeout returns to wake listening
+- no spoken reply => no follow-up window
+- manual Talk Mode active => follow-up window suppressed
+
+### Integration tests
+
+- local playback callback path can signal coordinator correctly
+- Voice Wake follow-up capture sends a second utterance without requiring wake word
+
+### Manual checks
+
+- trigger Voice Wake, get spoken response, ask follow-up without wake word
+- remain silent past timeout and confirm return to wake-word-only mode
+- confirm manual Talk Mode behavior is unchanged
+
+---
+
+## Risks and mitigation
+
+### Risk 1: reply correlation is messy
+
+Mitigation:
+
+- design around explicit local session tokens wherever possible
+- scope v1 to the local audible-reply path only if necessary
+
+### Risk 2: state conflicts with manual Talk Mode
+
+Mitigation:
+
+- explicitly keep Talk Mode separate
+- suppress or bypass follow-up mode when manual Talk Mode is active
+
+### Risk 3: users cannot tell which mode they are in
+
+Mitigation:
+
+- use overlay/coordinator states that clearly distinguish:
+  - wake listening
+  - processing reply
+  - listening for follow-up
+
+### Risk 4: accidental room speech gets captured during follow-up
+
+Mitigation:
+
+- short default timeout
+- open window only after spoken reply finishes
+- reset to wake mode aggressively on silence/timeout
+
+---
+
+## Recommended delivery sequence
+
+1. **Milestone 1 — explicit macOS system voice selection**
+   - low risk, direct user value, architecturally stable
+2. **Milestone 2 — voice picker polish / Tahoe metadata**
+   - quality-of-life layering on Feature 1
+3. **Milestone 3 — Voice Wake follow-up architecture + runtime**
+   - build on revised state model, not old temporary Talk Mode assumptions
+
+---
+
+## Final design decision
+
+### Preserve the original product goals
+
+Yes.
+
+### Preserve the original implementation framing for Feature 2
+
+No.
+
+The correct current-mainline design is:
+
+- **Feature 1** remains a Talk Mode / system TTS enhancement.
+- **Feature 2** becomes a Voice Wake follow-up session feature, owned by Voice Wake runtime/coordinator state rather than temporary Talk Mode.
+
+That is the cleanest way to deliver the original user experience without fighting the current architecture.

--- a/docs/engineering/macos-talk-voice-and-voicewake-keepalive-checklist.md
+++ b/docs/engineering/macos-talk-voice-and-voicewake-keepalive-checklist.md
@@ -1,0 +1,363 @@
+# Engineering Checklist: macOS Talk Voice Selection + Voice Wake Follow-Up
+
+Status: active implementation plan
+Scope: local development in `~/src/openclaw`
+Commit strategy: complete each milestone fully, test it, and create a local commit before moving to the next milestone.
+
+Related design doc:
+
+- `docs/design/macos-talk-voice-and-voicewake-keepalive.md`
+
+---
+
+## Delivery strategy
+
+We will deliver three milestones:
+
+1. **Milestone 1 — Feature 1:** Configurable system voice baseline
+2. **Milestone 2 — Feature 1A:** Tahoe-aware metadata, sorting, preview UX, live voice refresh
+3. **Milestone 3 — Feature 2:** Voice Wake follow-up session architecture and runtime
+
+Each milestone must satisfy all of the following before commit:
+
+- implementation complete
+- tests added/updated
+- local build passes
+- targeted manual verification complete
+- local commit created
+
+---
+
+# Milestone 1 — Feature 1: Configurable system voice baseline
+
+## Goal
+
+Allow Talk Mode system TTS to use an exact installed macOS voice identified by a persisted voice identifier.
+
+## Product outcome
+
+- Users can choose a specific macOS voice.
+- Talk Mode uses that exact voice when local system TTS is active.
+- If the configured identifier is unavailable, runtime falls back safely.
+
+## Config / model work
+
+- [ ] Decide canonical local persistence location for `macosVoiceIdentifier`
+- [ ] Ensure value round-trips cleanly
+- [ ] Keep behavior backward-compatible when field is absent
+
+## Runtime work
+
+- [ ] Extend `TalkSystemSpeechSynthesizer` to accept optional explicit voice identifier
+- [ ] Resolve configured voice using `AVSpeechSynthesisVoice(identifier:)`
+- [ ] Fall back to `AVSpeechSynthesisVoice(language:)` when identifier is absent or unavailable
+- [ ] Fall back again to utterance default behavior when no language is available
+- [ ] Add logging for selected voice and fallback reasons
+- [ ] Thread selected identifier from macOS app state/settings into `TalkModeRuntime.playSystemVoice(...)`
+- [ ] Preserve existing watchdog / timeout behavior
+
+## UI / state work
+
+- [ ] Add minimal settings support for choosing between default system voice and specific voice
+- [ ] Add basic installed-voice picker using identifier persistence
+- [ ] Map identifier -> display name in the picker without storing the name separately
+- [ ] Show warning state if saved identifier is not currently installed
+
+## Unit tests
+
+- [ ] Voice resolution test: exact identifier wins
+- [ ] Voice resolution test: invalid identifier falls back to language
+- [ ] Voice resolution test: no identifier + no language falls back to default behavior
+- [ ] Logging/fallback path test where practical
+
+## Integration / runtime tests
+
+- [ ] Extend Talk runtime/system voice tests to verify explicit voice identifier path is used
+- [ ] Verify no regression to ElevenLabs fallback logic
+- [ ] Verify recent system-voice timeout watchdog behavior remains intact
+
+## Manual verification
+
+- [ ] Build app successfully
+- [ ] Launch local app build
+- [ ] Select a specific installed voice
+- [ ] Confirm Talk Mode uses selected voice audibly
+- [ ] Test with a deliberately invalid identifier and confirm graceful fallback
+
+## Build / verification gates
+
+- [ ] `pnpm build`
+- [ ] `swift build --package-path apps/macos`
+- [ ] `ALLOW_ADHOC_SIGNING=1 ./scripts/package-mac-app.sh`
+- [ ] Relevant test target(s) pass
+
+## Commit gate
+
+- [ ] Review `git diff`
+- [ ] Commit locally with milestone-specific message
+
+### Suggested commit message
+
+`feat(macos-talk): support explicit system voice selection by identifier`
+
+---
+
+# Milestone 2 — Feature 1A: Tahoe-aware metadata, sorting, preview UX, live voice refresh
+
+## Goal
+
+Polish the voice picker and preview behavior using the currently available Tahoe AVSpeech metadata and notifications.
+
+## Product outcome
+
+- Voice picker is quality-aware and easy to browse.
+- Better voices appear first.
+- Selecting a new voice plays a short preview.
+- Picker can react if installed voices change while settings is open.
+
+## Tahoe-aware feature work
+
+- [ ] Add quality mapping: Premium / Enhanced / Standard
+- [ ] Add system-language detection for grouping/sorting
+- [ ] Availability-gate `voiceTraits` support on `macOS 14+`
+- [ ] If available, surface `Personal Voice` / `Novelty` trait badges in the picker
+- [ ] Availability-gate Personal Voice authorization awareness on `macOS 14+`
+- [ ] Observe `AVSpeechSynthesizer.availableVoicesDidChangeNotification` and refresh voice catalog/UI
+
+## Picker UX work
+
+- [ ] Group voices into sections:
+  - [ ] Premium — System Language
+  - [ ] Enhanced — System Language
+  - [ ] Standard — System Language
+  - [ ] Premium — Other Languages
+  - [ ] Enhanced — Other Languages
+  - [ ] Standard — Other Languages
+- [ ] Sort alphabetically within each section
+- [ ] Show name + locale + quality badge per row
+- [ ] Show trait badges when available
+
+## Preview UX work
+
+- [ ] Add preview service / helper that can speak a short sentence for the selected voice
+- [ ] Stop/cancel current preview before playing a new one
+- [ ] Trigger preview only when selection actually changes
+- [ ] Do not auto-preview on initial settings load
+- [ ] Reuse same underlying voice resolution path where practical
+
+## Recommended architecture work
+
+- [ ] Introduce voice catalog abstraction for easier testing
+- [ ] Introduce preview synthesis abstraction for easier testing
+- [ ] Add view model or helper layer for grouped/sorted picker data
+
+## Unit tests
+
+- [ ] Voice grouping test: system-language voices sorted before others
+- [ ] Voice grouping test: Premium > Enhanced > Standard ordering
+- [ ] Stable alphabetical ordering test within sections
+- [ ] Trait mapping test on availability-gated code paths
+- [ ] Preview logic test: selection change triggers one preview
+- [ ] Preview logic test: same selection does not replay unnecessarily
+- [ ] Preview logic test: second selection cancels previous preview
+- [ ] Voice catalog refresh test for notification-driven updates
+
+## Integration / runtime tests
+
+- [ ] Voice picker model integration test with representative fake voice catalog
+- [ ] Preview integration-style test through preview abstraction
+
+## Manual verification
+
+- [ ] Open settings and confirm grouped picker ordering is correct
+- [ ] Confirm best voices in system language appear first
+- [ ] Select multiple voices and confirm short preview plays on change
+- [ ] Confirm preview does not fire on first render
+- [ ] If possible, add/remove or download a voice and confirm picker refreshes
+
+## Build / verification gates
+
+- [ ] `pnpm build`
+- [ ] `swift build --package-path apps/macos`
+- [ ] `ALLOW_ADHOC_SIGNING=1 ./scripts/package-mac-app.sh`
+- [ ] Relevant test target(s) pass
+
+## Commit gate
+
+- [ ] Review `git diff`
+- [ ] Commit locally with milestone-specific message
+
+### Suggested commit message
+
+`feat(macos-talk): add quality-sorted voice picker with preview and Tahoe metadata`
+
+---
+
+# Milestone 3 — Feature 2: Voice Wake follow-up session
+
+## Goal
+
+After a Voice Wake request receives an audible spoken reply, keep a short follow-up listening window open so the user can ask a follow-up question without repeating the wake word.
+
+## Product outcome
+
+- Voice Wake feels conversational without becoming permanently open-ended.
+- The user can ask a quick follow-up after an audible reply.
+- Ambient room speech after a pause no longer keeps triggering replies indefinitely.
+- Manual Talk Mode remains separate and unchanged.
+
+## Architectural principles
+
+- [ ] Do **not** model this as temporary Talk Mode
+- [ ] Keep Talk Mode ownership in `TalkModeRuntime`
+- [ ] Keep Voice Wake ownership in `VoiceWakeRuntime` + `VoiceSessionCoordinator`
+- [ ] Treat follow-up as a Voice Wake-specific post-reply session
+- [ ] Suppress or bypass follow-up mode when manual Talk Mode is already active
+
+## Milestone 3A — correlation and state model
+
+### Goal
+
+Establish the local state model needed to know when a Voice Wake-originated request has received a spoken reply and is eligible for follow-up capture.
+
+### State / model work
+
+- [ ] Define Voice Wake request/session token model
+- [ ] Add coordinator state for:
+  - [ ] request pending / awaiting reply
+  - [ ] reply playback active
+  - [ ] follow-up listening active
+  - [ ] follow-up expiry timer
+- [ ] Decide where token/session state lives (`VoiceSessionCoordinator` recommended)
+- [ ] Decide how Voice Wake-originated requests are correlated with reply playback lifecycle
+- [ ] Ensure state cleanup on cancellation, stop, failure, and overlay dismissal
+
+### Integration points
+
+- [ ] Identify the local speech playback path(s) that can emit playback start/finish callbacks for Voice Wake-originated replies
+- [ ] Add callback/event hooks needed for coordinator transitions
+- [ ] Verify that silent/non-audible replies do not open follow-up mode
+
+### Tests
+
+- [ ] State test: Voice Wake request enters awaiting-reply state
+- [ ] State test: spoken reply completion opens follow-up-ready state
+- [ ] State test: playback failure / no audible reply does not open follow-up mode
+- [ ] State test: cleanup clears token/session correctly
+
+### Suggested commit message
+
+`refactor(macos-voicewake): add follow-up session correlation model`
+
+---
+
+## Milestone 3B — runtime follow-up capture flow
+
+### Goal
+
+Teach `VoiceWakeRuntime` to enter a short no-wake-word follow-up capture window after a correlated spoken reply completes.
+
+### Runtime work
+
+- [ ] Add follow-up listening entry point in `VoiceWakeRuntime`
+- [ ] Reuse as much existing capture/finalize logic as possible
+- [ ] Distinguish wake-triggered capture from follow-up capture path where needed
+- [ ] Start follow-up timer only after reply playback finishes
+- [ ] Reset/close follow-up state after follow-up utterance is sent
+- [ ] Return to ordinary wake listening after timeout or cleanup
+- [ ] Ensure no double-trigger races with recognizer restart logic
+- [ ] Ensure normal Voice Wake cooldown/restart behavior still works after follow-up completion
+
+### Tests
+
+- [ ] Runtime test: follow-up window opens after spoken reply completion
+- [ ] Runtime test: speech inside follow-up window is captured without wake word
+- [ ] Runtime test: silence timeout returns to wake listening
+- [ ] Runtime test: follow-up flow does not regress ordinary wake-word flow
+
+### Manual verification
+
+- [ ] Trigger Voice Wake
+- [ ] Receive spoken reply
+- [ ] Ask short follow-up without wake word
+- [ ] Confirm follow-up is sent successfully
+- [ ] Stay silent past timeout and confirm return to wake listening
+
+### Suggested commit message
+
+`feat(macos-voicewake): add post-reply follow-up listening window`
+
+---
+
+## Milestone 3C — settings and UX polish
+
+### Goal
+
+Add user controls and clear UX language for the Voice Wake follow-up feature.
+
+### Config / settings work
+
+- [ ] Add persisted follow-up timeout setting using canonical name `voiceWakeFollowupMs`
+- [ ] Optionally accept legacy experimental name `voiceWakeKeepAliveMs` if useful during development
+- [ ] Keep UI in seconds but persist in milliseconds
+- [ ] Support disabled / zero timeout cleanly
+
+### UI work
+
+- [ ] Add Voice Wake settings toggle:
+  - [ ] `Keep listening briefly for follow-up questions after a Voice Wake reply`
+- [ ] Add seconds slider with 1-second steps from 1 to 60
+- [ ] Add synchronized whole-number numeric field (1–60)
+- [ ] Add explanatory help text
+- [ ] Add or update overlay/coordinator visual state if needed to distinguish follow-up listening from ordinary wake listening
+
+### Tests
+
+- [ ] Config parsing/state test for `voiceWakeFollowupMs`
+- [ ] UI model test: slider and numeric field stay synchronized
+- [ ] UI validation test: numeric field clamps/rejects out-of-range values
+- [ ] UX/state test: manual Talk Mode active suppresses follow-up window behavior
+
+### Manual verification
+
+- [ ] Confirm settings copy is clear and does not imply Talk Mode is being enabled
+- [ ] Confirm enabling/disabling feature updates behavior immediately or on next session as intended
+- [ ] Confirm disabled setting fully suppresses follow-up mode
+
+### Suggested commit message
+
+`feat(macos-voicewake): add configurable follow-up timeout controls`
+
+---
+
+## Cross-milestone regression checks
+
+- [ ] Manual Talk Mode behavior unchanged
+- [ ] Voice Wake ordinary one-shot request path unchanged when follow-up feature disabled
+- [ ] Existing system-voice fallback still works without ElevenLabs configuration
+- [ ] Existing system-voice timeout watchdog still behaves correctly
+- [ ] Overlay dismissal / recognizer restart remains stable
+- [ ] No regressions in push-to-talk flow
+
+---
+
+## Final integration checklist
+
+- [ ] Re-read the design doc before final polish
+- [ ] Run full relevant tests
+- [ ] Run local app build and packaged app test
+- [ ] Review logs for voice selection and follow-up lifecycle clarity
+- [ ] Review `git diff`
+- [ ] Create final local commit(s)
+
+---
+
+## Recommended implementation order recap
+
+1. Milestone 1 — explicit system voice selection baseline
+2. Milestone 2 — voice picker polish / preview / Tahoe metadata
+3. Milestone 3A — follow-up correlation model
+4. Milestone 3B — follow-up capture runtime
+5. Milestone 3C — follow-up settings + UX polish
+
+This order keeps the low-risk Talk Mode voice improvements independent from the more architectural Voice Wake follow-up work while preserving the original product goals.

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -239,10 +239,23 @@ export async function discoverBedrockModels(params: {
 export async function resolveImplicitBedrockProvider(params: {
   config?: { models?: { bedrockDiscovery?: BedrockDiscoveryConfig } };
   env?: NodeJS.ProcessEnv;
+  bearerToken?: string;
 }): Promise<ModelProviderConfig | null> {
-  const env = params.env ?? process.env;
+  const baseEnv = params.env ?? process.env;
   const discoveryConfig = params.config?.models?.bedrockDiscovery;
   const enabled = discoveryConfig?.enabled;
+
+  // If a bearer token is provided via plugin config and not already present, inject it.
+  // Set on process.env so the AWS SDK client picks it up, and also build an augmented
+  // env for credential detection below in case params.env is a separate object.
+  let env = baseEnv;
+  if (params.bearerToken && !baseEnv["AWS_BEARER_TOKEN_BEDROCK"]?.trim()) {
+    process.env["AWS_BEARER_TOKEN_BEDROCK"] = params.bearerToken;
+    if (baseEnv !== process.env) {
+      env = { ...baseEnv, AWS_BEARER_TOKEN_BEDROCK: params.bearerToken };
+    }
+  }
+
   const hasAwsCreds = resolveAwsSdkEnvVarName(env) !== undefined;
   if (enabled === false) {
     return null;

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -240,16 +240,19 @@ export async function resolveImplicitBedrockProvider(params: {
   config?: { models?: { bedrockDiscovery?: BedrockDiscoveryConfig } };
   env?: NodeJS.ProcessEnv;
   bearerToken?: string;
+  region?: string;
 }): Promise<ModelProviderConfig | null> {
   const baseEnv = params.env ?? process.env;
   const discoveryConfig = params.config?.models?.bedrockDiscovery;
   const enabled = discoveryConfig?.enabled;
 
-  // If a bearer token is provided via plugin config and not already present, inject it.
-  // Set on process.env so the AWS SDK client picks it up, and also build an augmented
-  // env for credential detection below in case params.env is a separate object.
+  // If a bearer token is provided via plugin config, inject it into process.env so the
+  // AWS SDK client picks it up. We overwrite if the incoming token differs from the
+  // current env value so that a rotated/changed token takes effect without requiring a
+  // process restart. We only skip injection when they are identical (avoids redundant
+  // writes on repeated catalog refreshes).
   let env = baseEnv;
-  if (params.bearerToken && !baseEnv["AWS_BEARER_TOKEN_BEDROCK"]?.trim()) {
+  if (params.bearerToken && params.bearerToken !== baseEnv["AWS_BEARER_TOKEN_BEDROCK"]?.trim()) {
     process.env["AWS_BEARER_TOKEN_BEDROCK"] = params.bearerToken;
     if (baseEnv !== process.env) {
       env = { ...baseEnv, AWS_BEARER_TOKEN_BEDROCK: params.bearerToken };
@@ -264,7 +267,9 @@ export async function resolveImplicitBedrockProvider(params: {
     return null;
   }
 
-  const region = discoveryConfig?.region ?? env.AWS_REGION ?? env.AWS_DEFAULT_REGION ?? "us-east-1";
+  const region =
+    params.region?.trim() ||
+    (discoveryConfig?.region ?? env.AWS_REGION ?? env.AWS_DEFAULT_REGION ?? "us-east-1");
   const models = await discoverBedrockModels({
     region,
     config: discoveryConfig,

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -246,17 +246,27 @@ export async function resolveImplicitBedrockProvider(params: {
   const discoveryConfig = params.config?.models?.bedrockDiscovery;
   const enabled = discoveryConfig?.enabled;
 
-  // If a bearer token is provided via plugin config, inject it into process.env so the
-  // AWS SDK client picks it up. We overwrite if the incoming token differs from the
-  // current env value so that a rotated/changed token takes effect without requiring a
-  // process restart. We only skip injection when they are identical (avoids redundant
-  // writes on repeated catalog refreshes).
+  // Sync process.env["AWS_BEARER_TOKEN_BEDROCK"] with the plugin-configured bearer token
+  // so the AWS SDK client (which reads process.env directly) picks up the correct value.
+  // - Set/overwrite when a token is provided and differs from the current env value,
+  //   so that rotated tokens take effect without a process restart.
+  // - Clear when no token is configured, so that removing the plugin config actually
+  //   stops bearer-token auth rather than leaving a stale value in process.env.
   let env = baseEnv;
-  if (params.bearerToken && params.bearerToken !== baseEnv["AWS_BEARER_TOKEN_BEDROCK"]?.trim()) {
-    process.env["AWS_BEARER_TOKEN_BEDROCK"] = params.bearerToken;
-    if (baseEnv !== process.env) {
-      env = { ...baseEnv, AWS_BEARER_TOKEN_BEDROCK: params.bearerToken };
+  const currentEnvToken = baseEnv["AWS_BEARER_TOKEN_BEDROCK"]?.trim();
+  if (params.bearerToken) {
+    if (params.bearerToken !== currentEnvToken) {
+      process.env["AWS_BEARER_TOKEN_BEDROCK"] = params.bearerToken;
+      if (baseEnv !== process.env) {
+        env = { ...baseEnv, AWS_BEARER_TOKEN_BEDROCK: params.bearerToken };
+      }
     }
+  } else if (currentEnvToken && baseEnv === process.env) {
+    // Token was removed from plugin config — clear the stale env var so the
+    // AWS SDK does not continue authenticating with it.
+    delete process.env["AWS_BEARER_TOKEN_BEDROCK"];
+    env = { ...baseEnv };
+    delete (env as Record<string, string | undefined>)["AWS_BEARER_TOKEN_BEDROCK"];
   }
 
   const hasAwsCreds = resolveAwsSdkEnvVarName(env) !== undefined;

--- a/extensions/amazon-bedrock/index.ts
+++ b/extensions/amazon-bedrock/index.ts
@@ -30,10 +30,15 @@ export default definePluginEntry({
             | Record<string, unknown>
             | undefined;
           const bearerToken = normalizeSecretInputString(pluginConfig?.bearerToken) ?? undefined;
+          const region =
+            typeof pluginConfig?.region === "string"
+              ? pluginConfig.region.trim() || undefined
+              : undefined;
           const implicit = await resolveImplicitBedrockProvider({
             config: ctx.config,
             env: ctx.env,
             bearerToken,
+            region,
           });
           if (!implicit) {
             return null;

--- a/extensions/amazon-bedrock/index.ts
+++ b/extensions/amazon-bedrock/index.ts
@@ -29,7 +29,21 @@ export default definePluginEntry({
           const pluginConfig = ctx.config.plugins?.entries?.["amazon-bedrock"]?.config as
             | Record<string, unknown>
             | undefined;
-          const bearerToken = normalizeSecretInputString(pluginConfig?.bearerToken) ?? undefined;
+          // Resolve bearer token from plugin config. Supports plain strings and
+          // env-backed SecretRefs ({ source: "env", id: "MY_VAR" }). File/exec refs
+          // are not supported in catalog runs (non-interactive); they silently
+          // fall through to undefined so env/credential discovery still works.
+          const bearerTokenRaw = pluginConfig?.bearerToken;
+          const bearerToken =
+            normalizeSecretInputString(bearerTokenRaw) ??
+            (bearerTokenRaw &&
+            typeof bearerTokenRaw === "object" &&
+            (bearerTokenRaw as Record<string, unknown>).source === "env" &&
+            typeof (bearerTokenRaw as Record<string, unknown>).id === "string"
+              ? normalizeSecretInputString(
+                  ctx.env[(bearerTokenRaw as Record<string, unknown>).id as string],
+                )
+              : undefined);
           const region =
             typeof pluginConfig?.region === "string"
               ? pluginConfig.region.trim() || undefined

--- a/extensions/amazon-bedrock/index.ts
+++ b/extensions/amazon-bedrock/index.ts
@@ -3,6 +3,7 @@ import {
   createBedrockNoCacheWrapper,
   isAnthropicBedrockModel,
 } from "openclaw/plugin-sdk/provider-stream";
+import { normalizeSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import {
   mergeImplicitBedrockProvider,
   resolveBedrockConfigApiKey,
@@ -25,9 +26,14 @@ export default definePluginEntry({
       catalog: {
         order: "simple",
         run: async (ctx) => {
+          const pluginConfig = ctx.config.plugins?.entries?.["amazon-bedrock"]?.config as
+            | Record<string, unknown>
+            | undefined;
+          const bearerToken = normalizeSecretInputString(pluginConfig?.bearerToken) ?? undefined;
           const implicit = await resolveImplicitBedrockProvider({
             config: ctx.config,
             env: ctx.env,
+            bearerToken,
           });
           if (!implicit) {
             return null;

--- a/extensions/amazon-bedrock/openclaw.plugin.json
+++ b/extensions/amazon-bedrock/openclaw.plugin.json
@@ -5,6 +5,15 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "bearerToken": {
+        "type": ["string", "object"],
+        "description": "AWS bearer token for Bedrock API access. Supports secret refs like { source: \"env\", provider: \"default\", id: \"AWS_BEARER_TOKEN_BEDROCK\" }"
+      },
+      "region": {
+        "type": "string",
+        "description": "AWS region for Bedrock API calls. Defaults to us-east-1."
+      }
+    }
   }
 }

--- a/extensions/discord/src/config-ui-hints.ts
+++ b/extensions/discord/src/config-ui-hints.ts
@@ -192,5 +192,6 @@ export const discordChannelConfigUiHints = {
   token: {
     label: "Discord Bot Token",
     help: "Discord bot token used for gateway and REST API authentication for this provider account. Keep this secret out of committed config and rotate immediately after any leak.",
+    sensitive: true,
   },
 } satisfies Record<string, ChannelConfigUiHint>;

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -166,7 +166,7 @@ type WorkspaceSetupState = {
 };
 
 /** Set of recognized bootstrap filenames for runtime validation */
-const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
+export const VALID_BOOTSTRAP_NAMES: ReadonlySet<string> = new Set([
   DEFAULT_AGENTS_FILENAME,
   DEFAULT_SOUL_FILENAME,
   DEFAULT_TOOLS_FILENAME,

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -658,6 +658,17 @@ function restoreRedactedValuesWithLookup(
           (hints[candidate]?.sensitive === true || isUserInfoUrlPath(path))
         ) {
           result[key] = restoreOriginalValueOrThrow({ key, path: candidate, original: orig });
+        } else if (
+          typeof value === "object" &&
+          value !== null &&
+          hints[candidate]?.sensitive === true &&
+          isSecretRefShape(value as Record<string, unknown>) &&
+          (value as Record<string, unknown>).id === REDACTED_SENTINEL
+        ) {
+          // SecretRef objects at a sensitive-hinted path have only their `id`
+          // field redacted (not the whole object). Restore the original value
+          // wholesale so the sentinel id never reaches Zod validation.
+          result[key] = restoreOriginalValueOrThrow({ key, path: candidate, original: orig });
         } else if (typeof value === "object" && value !== null) {
           result[key] = restoreRedactedValuesWithLookup(value, orig[key], lookup, candidate, hints);
         }

--- a/src/hooks/bundled/bootstrap-alternate-files/HOOK.md
+++ b/src/hooks/bundled/bootstrap-alternate-files/HOOK.md
@@ -1,0 +1,79 @@
+---
+name: bootstrap-alternate-files
+description: "Override workspace bootstrap files with content from external sources"
+homepage: https://docs.openclaw.ai/automation/hooks#bootstrap-alternate-files
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🔄",
+        "events": ["agent:bootstrap"],
+        "requires": { "config": ["workspace.dir"] },
+        "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
+      },
+  }
+---
+
+# Bootstrap Alternate Files Hook
+
+Replaces workspace bootstrap file slots with content read from external sources (for example
+Dropbox-backed shared files). Useful when core persona/identity files live outside the workspace
+root and cannot be symlinked due to boundary restrictions.
+
+## Why
+
+OpenClaw's workspace loader enforces a strict boundary: files must resolve canonically inside
+the workspace root. Symlinks to external locations (cloud storage, shared directories) are
+rejected and show as `[MISSING]` in Project Context.
+
+This hook runs after the workspace loader and replaces missing (or present) slots in-place
+with content from explicitly configured external paths. Because the paths are provided by the
+operator in configuration, this is an intentional, auditable escape hatch rather than a
+general boundary weakening.
+
+## Configuration
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "enabled": true,
+      "entries": {
+        "bootstrap-alternate-files": {
+          "enabled": true,
+          "files": {
+            "SOUL.md": "~/Library/CloudStorage/Dropbox/openclaw-shared/SOUL.md",
+            "IDENTITY.md": "~/Library/CloudStorage/Dropbox/openclaw-shared/IDENTITY.md"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Options
+
+- `files` (object): map of bootstrap slot name → absolute source path.
+  - Keys must be recognized bootstrap basenames (`AGENTS.md`, `SOUL.md`, `TOOLS.md`,
+    `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, `MEMORY.md`, `memory.md`).
+  - Values are paths resolved via `~` expansion. Relative paths are not supported.
+  - Source files are read directly; no workspace boundary check is applied.
+  - If a source file is unreadable (missing, permission error, cloud storage unavailable),
+    the existing workspace entry is left unchanged and a warning is logged.
+
+## Behaviour
+
+- Replaces slots **in-place**: position in the injected context is preserved.
+- Replaces both present and missing workspace entries.
+- Does not append duplicates.
+- On any per-file error, falls back gracefully rather than failing the whole hook.
+- Hardlink protection: source paths that are hardlinks to other files are accepted
+  (unlike the workspace loader which rejects hardlinks). The source path is
+  operator-configured and therefore trusted.
+
+## Notes
+
+- `files` keys that do not match a recognized bootstrap basename are skipped with a warning.
+- Source path `~` is expanded to the process home directory.
+- This hook does not write anything to disk; context is modified in-memory only.

--- a/src/hooks/bundled/bootstrap-alternate-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-alternate-files/handler.test.ts
@@ -1,0 +1,236 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../../config/config.js";
+import type { AgentBootstrapHookContext } from "../../hooks.js";
+import { createHookEvent } from "../../hooks.js";
+import handler from "./handler.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createAlternateConfig(
+  files: Record<string, string>,
+  enabled = true,
+): OpenClawConfig {
+  return {
+    hooks: {
+      internal: {
+        entries: {
+          "bootstrap-alternate-files": {
+            enabled,
+            files,
+          },
+        },
+      },
+    },
+  };
+}
+
+function makeBootstrapFile(
+  name: string,
+  opts: { content?: string; missing?: boolean; sourcePath?: string } = {},
+): AgentBootstrapHookContext["bootstrapFiles"][number] {
+  return {
+    name: name as AgentBootstrapHookContext["bootstrapFiles"][number]["name"],
+    path: opts.sourcePath ?? `/workspace/${name}`,
+    ...(opts.missing ? { missing: true } : { content: opts.content ?? `# ${name}`, missing: false }),
+  };
+}
+
+function makeContext(
+  files: AgentBootstrapHookContext["bootstrapFiles"],
+  cfg: OpenClawConfig,
+): AgentBootstrapHookContext {
+  return { workspaceDir: "/workspace", bootstrapFiles: files, cfg, sessionKey: "agent:main:main" };
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures — temp dir for real source files
+// ---------------------------------------------------------------------------
+
+let tmpDir = "";
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-alternate-hook-"));
+});
+
+afterAll(async () => {
+  if (tmpDir) {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("bootstrap-alternate-files hook", () => {
+  it("replaces a missing workspace entry with external source content", async () => {
+    const sourceFile = path.join(tmpDir, "SOUL.md");
+    await fs.writeFile(sourceFile, "# External Soul\nBe cool.", "utf-8");
+
+    const context = makeContext(
+      [makeBootstrapFile("SOUL.md", { missing: true })],
+      createAlternateConfig({ "SOUL.md": sourceFile }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    const soul = context.bootstrapFiles.find((f) => f.name === "SOUL.md");
+    expect(soul?.missing).toBe(false);
+    expect(soul?.content).toBe("# External Soul\nBe cool.");
+    expect(soul?.path).toBe(sourceFile);
+  });
+
+  it("replaces a present workspace entry with external source content", async () => {
+    const sourceFile = path.join(tmpDir, "IDENTITY.md");
+    await fs.writeFile(sourceFile, "# External Identity\n- **Name:** flicker", "utf-8");
+
+    const context = makeContext(
+      [makeBootstrapFile("IDENTITY.md", { content: "# Old Identity", missing: false })],
+      createAlternateConfig({ "IDENTITY.md": sourceFile }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    const identity = context.bootstrapFiles.find((f) => f.name === "IDENTITY.md");
+    expect(identity?.content).toBe("# External Identity\n- **Name:** flicker");
+  });
+
+  it("preserves list position when replacing", async () => {
+    const sourceFile = path.join(tmpDir, "SOUL-position.md");
+    await fs.writeFile(sourceFile, "# Soul", "utf-8");
+
+    const context = makeContext(
+      [
+        makeBootstrapFile("AGENTS.md"),
+        makeBootstrapFile("SOUL.md", { missing: true }),
+        makeBootstrapFile("TOOLS.md"),
+      ],
+      createAlternateConfig({ "SOUL.md": sourceFile }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    expect(context.bootstrapFiles.map((f) => f.name)).toEqual(["AGENTS.md", "SOUL.md", "TOOLS.md"]);
+    expect(context.bootstrapFiles[1]?.missing).toBe(false);
+  });
+
+  it("leaves entry unchanged when source file is missing", async () => {
+    const context = makeContext(
+      [makeBootstrapFile("SOUL.md", { missing: true })],
+      createAlternateConfig({ "SOUL.md": path.join(tmpDir, "does-not-exist.md") }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    expect(context.bootstrapFiles[0]?.missing).toBe(true);
+  });
+
+  it("leaves entry unchanged when source is temporarily unavailable (EAGAIN)", async () => {
+    // We can't easily simulate EAGAIN, so we just verify ENOENT fallback path leaves
+    // the entry unchanged and does not throw.
+    const context = makeContext(
+      [makeBootstrapFile("SOUL.md", { missing: true })],
+      createAlternateConfig({ "SOUL.md": "/nonexistent/path/SOUL.md" }),
+    );
+
+    await expect(
+      handler(createHookEvent("agent", "bootstrap", "agent:main:main", context)),
+    ).resolves.toBeUndefined();
+
+    expect(context.bootstrapFiles[0]?.missing).toBe(true);
+  });
+
+  it("skips config entries with unrecognized bootstrap names", async () => {
+    const sourceFile = path.join(tmpDir, "CUSTOM.md");
+    await fs.writeFile(sourceFile, "custom content", "utf-8");
+
+    const context = makeContext(
+      [makeBootstrapFile("AGENTS.md")],
+      createAlternateConfig({ "CUSTOM.md": sourceFile }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    // AGENTS.md untouched, no error thrown
+    expect(context.bootstrapFiles).toHaveLength(1);
+    expect(context.bootstrapFiles[0]?.name).toBe("AGENTS.md");
+  });
+
+  it("does nothing when hook is disabled", async () => {
+    const sourceFile = path.join(tmpDir, "SOUL-disabled.md");
+    await fs.writeFile(sourceFile, "should not appear", "utf-8");
+
+    const context = makeContext(
+      [makeBootstrapFile("SOUL.md", { missing: true })],
+      createAlternateConfig({ "SOUL.md": sourceFile }, false),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    expect(context.bootstrapFiles[0]?.missing).toBe(true);
+  });
+
+  it("does nothing when files map is empty", async () => {
+    const context = makeContext(
+      [makeBootstrapFile("SOUL.md", { missing: true })],
+      createAlternateConfig({}),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    expect(context.bootstrapFiles[0]?.missing).toBe(true);
+  });
+
+  it("expands tilde in source paths", async () => {
+    // Write a file in tmpDir and create a tilde path that points to it.
+    // We can't easily test with a real home dir, so verify the file IS found
+    // by providing an absolute path that happens to use home dir prefix.
+    const homeDir = os.homedir();
+    const relToHome = path.relative(homeDir, tmpDir);
+    // Only run this sub-test if tmpDir is inside home
+    if (relToHome.startsWith("..")) {
+      return;
+    }
+    const tildePath = path.join("~", relToHome, "SOUL-tilde.md");
+    const absFile = path.join(tmpDir, "SOUL-tilde.md");
+    await fs.writeFile(absFile, "# Tilde Soul", "utf-8");
+
+    const context = makeContext(
+      [makeBootstrapFile("SOUL.md", { missing: true })],
+      createAlternateConfig({ "SOUL.md": tildePath }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    expect(context.bootstrapFiles[0]?.content).toBe("# Tilde Soul");
+  });
+
+  it("handles multiple replacements in a single pass", async () => {
+    const soulFile = path.join(tmpDir, "SOUL-multi.md");
+    const identFile = path.join(tmpDir, "IDENTITY-multi.md");
+    await fs.writeFile(soulFile, "# Multi Soul", "utf-8");
+    await fs.writeFile(identFile, "# Multi Identity", "utf-8");
+
+    const context = makeContext(
+      [
+        makeBootstrapFile("SOUL.md", { missing: true }),
+        makeBootstrapFile("AGENTS.md"),
+        makeBootstrapFile("IDENTITY.md", { missing: true }),
+      ],
+      createAlternateConfig({ "SOUL.md": soulFile, "IDENTITY.md": identFile }),
+    );
+
+    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+
+    const soul = context.bootstrapFiles.find((f) => f.name === "SOUL.md");
+    const identity = context.bootstrapFiles.find((f) => f.name === "IDENTITY.md");
+    expect(soul?.content).toBe("# Multi Soul");
+    expect(identity?.content).toBe("# Multi Identity");
+    expect(context.bootstrapFiles.find((f) => f.name === "AGENTS.md")?.content).toBe("# AGENTS.md");
+  });
+});

--- a/src/hooks/bundled/bootstrap-alternate-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-alternate-files/handler.test.ts
@@ -11,10 +11,7 @@ import handler from "./handler.js";
 // Helpers
 // ---------------------------------------------------------------------------
 
-function createAlternateConfig(
-  files: Record<string, string>,
-  enabled = true,
-): OpenClawConfig {
+function createAlternateConfig(files: Record<string, string>, enabled = true): OpenClawConfig {
   return {
     hooks: {
       internal: {
@@ -36,7 +33,9 @@ function makeBootstrapFile(
   return {
     name: name as AgentBootstrapHookContext["bootstrapFiles"][number]["name"],
     path: opts.sourcePath ?? `/workspace/${name}`,
-    ...(opts.missing ? { missing: true } : { content: opts.content ?? `# ${name}`, missing: false }),
+    ...(opts.missing
+      ? { missing: true }
+      : { content: opts.content ?? `# ${name}`, missing: false }),
   };
 }
 
@@ -186,29 +185,26 @@ describe("bootstrap-alternate-files hook", () => {
     expect(context.bootstrapFiles[0]?.missing).toBe(true);
   });
 
-  it("expands tilde in source paths", async () => {
-    // Write a file in tmpDir and create a tilde path that points to it.
-    // We can't easily test with a real home dir, so verify the file IS found
-    // by providing an absolute path that happens to use home dir prefix.
-    const homeDir = os.homedir();
-    const relToHome = path.relative(homeDir, tmpDir);
-    // Only run this sub-test if tmpDir is inside home
-    if (relToHome.startsWith("..")) {
-      return;
-    }
-    const tildePath = path.join("~", relToHome, "SOUL-tilde.md");
-    const absFile = path.join(tmpDir, "SOUL-tilde.md");
-    await fs.writeFile(absFile, "# Tilde Soul", "utf-8");
+  it.skipIf(path.relative(os.homedir(), tmpDir).startsWith(".."))(
+    "expands tilde in source paths",
+    async () => {
+      // Write a file in tmpDir and create a tilde path that points to it.
+      const homeDir = os.homedir();
+      const relToHome = path.relative(homeDir, tmpDir);
+      const tildePath = path.join("~", relToHome, "SOUL-tilde.md");
+      const absFile = path.join(tmpDir, "SOUL-tilde.md");
+      await fs.writeFile(absFile, "# Tilde Soul", "utf-8");
 
-    const context = makeContext(
-      [makeBootstrapFile("SOUL.md", { missing: true })],
-      createAlternateConfig({ "SOUL.md": tildePath }),
-    );
+      const context = makeContext(
+        [makeBootstrapFile("SOUL.md", { missing: true })],
+        createAlternateConfig({ "SOUL.md": tildePath }),
+      );
 
-    await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
+      await handler(createHookEvent("agent", "bootstrap", "agent:main:main", context));
 
-    expect(context.bootstrapFiles[0]?.content).toBe("# Tilde Soul");
-  });
+      expect(context.bootstrapFiles[0]?.content).toBe("# Tilde Soul");
+    },
+  );
 
   it("handles multiple replacements in a single pass", async () => {
     const soulFile = path.join(tmpDir, "SOUL-multi.md");

--- a/src/hooks/bundled/bootstrap-alternate-files/handler.ts
+++ b/src/hooks/bundled/bootstrap-alternate-files/handler.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { VALID_BOOTSTRAP_NAMES, type WorkspaceBootstrapFile } from "../../../agents/workspace.js";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import { resolveHookConfig } from "../../config.js";
+import { isAgentBootstrapEvent, type HookHandler } from "../../hooks.js";
+
+const HOOK_KEY = "bootstrap-alternate-files";
+const log = createSubsystemLogger("bootstrap-alternate-files");
+
+/**
+ * Expand a leading `~` to the user home directory.
+ * Returns the original string unchanged if it does not start with `~`.
+ */
+function expandHomeTilde(filePath: string): string {
+  if (filePath.startsWith("~/") || filePath === "~") {
+    return path.join(os.homedir(), filePath.slice(1));
+  }
+  return filePath;
+}
+
+/**
+ * Parse and validate the `files` config value.
+ * Returns a map of bootstrap slot name → resolved absolute source path.
+ * Entries with invalid slot names or non-string paths are logged and skipped.
+ */
+function resolveAlternateFileMap(
+  hookConfig: Record<string, unknown>,
+): Map<string, string> {
+  const result = new Map<string, string>();
+  const raw = hookConfig.files;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return result;
+  }
+  for (const [slotName, sourcePath] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof sourcePath !== "string" || !sourcePath.trim()) {
+      log.warn(`skipping "${slotName}": source path must be a non-empty string`);
+      continue;
+    }
+    if (!VALID_BOOTSTRAP_NAMES.has(slotName)) {
+      log.warn(
+        `skipping "${slotName}": not a recognized bootstrap basename (${[...VALID_BOOTSTRAP_NAMES].join(", ")})`,
+      );
+      continue;
+    }
+    const resolved = path.resolve(expandHomeTilde(sourcePath.trim()));
+    result.set(slotName, resolved);
+  }
+  return result;
+}
+
+/**
+ * Attempt to read a source file. Returns the content string on success, or null on any
+ * read failure (missing file, permission error, cloud storage unavailability, etc.).
+ */
+async function tryReadSourceFile(sourcePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(sourcePath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      log.warn(`source file not found: ${sourcePath}`);
+    } else if (code === "EACCES" || code === "EPERM") {
+      log.warn(`source file permission denied: ${sourcePath}`);
+    } else if (code === "EAGAIN" || code === "EDEADLK") {
+      // Cloud storage (Dropbox FileProvider) can return these transiently.
+      log.warn(`source file temporarily unavailable (${code}): ${sourcePath}`);
+    } else {
+      log.warn(`failed to read source file ${sourcePath}: ${String(err)}`);
+    }
+    return null;
+  }
+}
+
+const bootstrapAlternateFilesHook: HookHandler = async (event) => {
+  if (!isAgentBootstrapEvent(event)) {
+    return;
+  }
+
+  const context = event.context;
+  const hookConfig = resolveHookConfig(context.cfg, HOOK_KEY);
+  if (!hookConfig || hookConfig.enabled === false) {
+    return;
+  }
+
+  const alternates = resolveAlternateFileMap(hookConfig as Record<string, unknown>);
+  if (alternates.size === 0) {
+    return;
+  }
+
+  const updated: WorkspaceBootstrapFile[] = [];
+  for (const file of context.bootstrapFiles) {
+    const sourcePath = alternates.get(file.name);
+    if (!sourcePath) {
+      // No alternate configured for this slot — keep as-is.
+      updated.push(file);
+      continue;
+    }
+
+    const content = await tryReadSourceFile(sourcePath);
+    if (content === null) {
+      // Read failed — leave the existing entry unchanged (may be missing: true).
+      log.debug(`keeping existing entry for ${file.name} (source read failed)`);
+      updated.push(file);
+    } else {
+      log.debug(`replaced ${file.name} from ${sourcePath}`);
+      updated.push({
+        name: file.name,
+        path: sourcePath,
+        content,
+        missing: false,
+      });
+    }
+  }
+
+  context.bootstrapFiles = updated;
+};
+
+export default bootstrapAlternateFilesHook;

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -150,7 +150,17 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
       configSchema: {
         type: "object",
         additionalProperties: false,
-        properties: {},
+        properties: {
+          bearerToken: {
+            type: ["string", "object"],
+            description:
+              'AWS bearer token for Bedrock API access. Supports secret refs like { source: "env", provider: "default", id: "AWS_BEARER_TOKEN_BEDROCK" }',
+          },
+          region: {
+            type: "string",
+            description: "AWS region for Bedrock API calls. Defaults to us-east-1.",
+          },
+        },
       },
       enabledByDefault: true,
       providers: ["amazon-bedrock"],

--- a/ui/src/ui/views/agents-panels-overview.ts
+++ b/ui/src/ui/views/agents-panels-overview.ts
@@ -135,9 +135,9 @@ export function renderAgentOverview(params: {
                 onModelChange(agent.id, (e.target as HTMLSelectElement).value || null)}
             >
               ${isDefault
-                ? html` <option value="">Not set</option> `
+                ? html` <option value="" ?selected=${!effectivePrimary}>Not set</option> `
                 : html`
-                    <option value="">
+                    <option value="" ?selected=${!entryPrimary}>
                       ${defaultPrimary ? `Inherit default (${defaultPrimary})` : "Inherit default"}
                     </option>
                   `}

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -608,7 +608,12 @@ export function buildModelOptions(
   if (options.length === 0) {
     return nothing;
   }
-  return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
+  return options.map(
+    (option) =>
+      html`<option value=${option.value} ?selected=${option.value === current}>
+        ${option.label}
+      </option>`,
+  );
 }
 
 type CompiledPattern =

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -637,14 +637,26 @@ function renderTextInput(params: {
     revealSensitive: params.revealSensitive ?? false,
     isSensitivePathRevealed: params.isSensitivePathRevealed,
   });
-  const placeholder = sensitiveState.isRedacted
-    ? REDACTED_PLACEHOLDER
+  // If the stored value is a structured object (e.g. a SecretRef like
+  // { source: "env", provider: "default", id: "MY_TOKEN" }), rendering it
+  // as a plain text input would produce String(value) = "[object Object]"
+  // when the field is revealed. That corrupt string would then be written
+  // back into form state and sent to config.set, failing Zod validation.
+  // Treat structured values as permanently read-only in the text input and
+  // direct the user to Raw mode where they can edit the JSON directly.
+  const isStructuredValue =
+    value !== null && value !== undefined && typeof value === "object" && !Array.isArray(value);
+  const effectiveRedacted = sensitiveState.isRedacted || isStructuredValue;
+  const structuredPlaceholder = isStructuredValue
+    ? "Structured value (SecretRef) — use Raw mode to edit"
+    : null;
+  const placeholder = effectiveRedacted
+    ? (structuredPlaceholder ?? REDACTED_PLACEHOLDER)
     : (hint?.placeholder ??
       // oxlint-disable typescript/no-base-to-string
       (schema.default !== undefined ? `Default: ${String(schema.default)}` : ""));
-  const displayValue = sensitiveState.isRedacted ? "" : (value ?? "");
-  const effectiveInputType =
-    sensitiveState.isSensitive && !sensitiveState.isRedacted ? "text" : inputType;
+  const displayValue = effectiveRedacted ? "" : (value ?? "");
+  const effectiveInputType = sensitiveState.isSensitive && !effectiveRedacted ? "text" : inputType;
 
   return html`
     <div class="cfg-field">
@@ -653,18 +665,18 @@ function renderTextInput(params: {
       <div class="cfg-input-wrap">
         <input
           type=${effectiveInputType}
-          class="cfg-input${sensitiveState.isRedacted ? " cfg-input--redacted" : ""}"
+          class="cfg-input${effectiveRedacted ? " cfg-input--redacted" : ""}"
           placeholder=${placeholder}
           .value=${displayValue == null ? "" : String(displayValue)}
           ?disabled=${disabled}
-          ?readonly=${sensitiveState.isRedacted}
+          ?readonly=${effectiveRedacted}
           @click=${() => {
-            if (sensitiveState.isRedacted && params.onToggleSensitivePath) {
+            if (sensitiveState.isRedacted && !isStructuredValue && params.onToggleSensitivePath) {
               params.onToggleSensitivePath(path);
             }
           }}
           @input=${(e: Event) => {
-            if (sensitiveState.isRedacted) {
+            if (effectiveRedacted) {
               return;
             }
             const raw = (e.target as HTMLInputElement).value;
@@ -680,26 +692,28 @@ function renderTextInput(params: {
             onPatch(path, raw);
           }}
           @change=${(e: Event) => {
-            if (inputType === "number" || sensitiveState.isRedacted) {
+            if (inputType === "number" || effectiveRedacted) {
               return;
             }
             const raw = (e.target as HTMLInputElement).value;
             onPatch(path, raw.trim());
           }}
         />
-        ${renderSensitiveToggleButton({
-          path,
-          state: sensitiveState,
-          disabled,
-          onToggleSensitivePath: params.onToggleSensitivePath,
-        })}
+        ${!isStructuredValue
+          ? renderSensitiveToggleButton({
+              path,
+              state: sensitiveState,
+              disabled,
+              onToggleSensitivePath: params.onToggleSensitivePath,
+            })
+          : nothing}
         ${schema.default !== undefined
           ? html`
               <button
                 type="button"
                 class="cfg-input__reset"
                 title="Reset to default"
-                ?disabled=${disabled || sensitiveState.isRedacted}
+                ?disabled=${disabled || effectiveRedacted}
                 @click=${() => onPatch(path, schema.default)}
               >
                 ↺


### PR DESCRIPTION
## Problem

Any `config.set` from the dashboard was rejected with:
```
GatewayRequestError: invalid config: channels.discord.token.id: Env secret reference id must match /^[A-Z][A-Z0-9_]{0,127}$/
```

Also: the Primary model picker on `/agents` always showed "Not set" after page load or refresh.

## Root Cause

The Discord `token` ui-hint was missing `sensitive: true`. This caused `restoreRedactedValues` to use the pattern-guessing path, which checked `isSensitivePath('channels.discord.token.id')` — **false**, since the path ends in `id` not `token`. The `__OPENCLAW_REDACTED__` sentinel inside the SecretRef's `id` field was never restored before Zod validation, so validation failed.

## Fixes

**Fix 1** (`extensions/discord/src/config-ui-hints.ts`):
Add `sensitive: true` to the Discord token hint so the lookup-based restore path is used.

**Fix 2** (`src/config/redact-snapshot.ts`):
In `restoreRedactedValuesWithLookup`, detect when a sensitive-hinted path holds a SecretRef object whose `id` field contains the redacted sentinel, and restore the whole original value rather than recursing into sub-fields that have no individual hint entries. Mirrors the asymmetric behavior in `redactSecretRefId`.

**Fix 3** (`ui/src/ui/views/config-form.node.ts`):
`renderTextInput` was calling `String(value)` on the DOM input's `.value` property. When `value` is a SecretRef object and the field is revealed, this produces `[object Object]` which gets written into `configForm` state and sent to `config.set`. Guard: treat structured (non-primitive) values as permanently read-only with a "use Raw mode to edit" placeholder, and suppress the reveal toggle.

**Fix 4** (`ui/src/ui/views/agents-panels-overview.ts`, `agents-utils.ts`):
The Primary model picker on `/agents` always showed "Not set" after load/refresh. Cause: `<select>.value` binding fires before async catalog options are in the DOM. Fix: add `?selected=${value === current}` to each `<option>` so selection is set declaratively rather than relying on the parent `<select>`'s `.value` property.