### PR TITLE
msteams: add group management actions (add/remove participant, rename)

### DIFF
--- a/extensions/msteams/src/channel.actions.test.ts
+++ b/extensions/msteams/src/channel.actions.test.ts
@@ -6,7 +6,10 @@ import { msteamsPlugin } from "./channel.js";
 const {
   editMessageMSTeamsMock,
   deleteMessageMSTeamsMock,
+  getChannelInfoMSTeamsMock,
+  getMemberInfoMSTeamsMock,
   getMessageMSTeamsMock,
+  listChannelsMSTeamsMock,
   listReactionsMSTeamsMock,
   pinMessageMSTeamsMock,
   reactMessageMSTeamsMock,
@@ -17,7 +20,10 @@ const {
 } = vi.hoisted(() => ({
   editMessageMSTeamsMock: vi.fn(),
   deleteMessageMSTeamsMock: vi.fn(),
+  getChannelInfoMSTeamsMock: vi.fn(),
+  getMemberInfoMSTeamsMock: vi.fn(),
   getMessageMSTeamsMock: vi.fn(),
+  listChannelsMSTeamsMock: vi.fn(),
   listReactionsMSTeamsMock: vi.fn(),
   pinMessageMSTeamsMock: vi.fn(),
   reactMessageMSTeamsMock: vi.fn(),
@@ -31,7 +37,10 @@ vi.mock("./channel.runtime.js", () => ({
   msTeamsChannelRuntime: {
     editMessageMSTeams: editMessageMSTeamsMock,
     deleteMessageMSTeams: deleteMessageMSTeamsMock,
+    getChannelInfoMSTeams: getChannelInfoMSTeamsMock,
+    getMemberInfoMSTeams: getMemberInfoMSTeamsMock,
     getMessageMSTeams: getMessageMSTeamsMock,
+    listChannelsMSTeams: listChannelsMSTeamsMock,
     listReactionsMSTeams: listReactionsMSTeamsMock,
     pinMessageMSTeams: pinMessageMSTeamsMock,
     reactMessageMSTeams: reactMessageMSTeamsMock,
@@ -45,7 +54,10 @@ vi.mock("./channel.runtime.js", () => ({
 const actionMocks = [
   editMessageMSTeamsMock,
   deleteMessageMSTeamsMock,
+  getChannelInfoMSTeamsMock,
+  getMemberInfoMSTeamsMock,
   getMessageMSTeamsMock,
+  listChannelsMSTeamsMock,
   listReactionsMSTeamsMock,
   pinMessageMSTeamsMock,
   reactMessageMSTeamsMock,
@@ -101,6 +113,7 @@ async function runAction(params: {
   params?: Record<string, unknown>;
   toolContext?: Record<string, unknown>;
   mediaLocalRoots?: readonly string[];
+  mediaReadFile?: (filePath: string) => Promise<Buffer>;
 }) {
   const handleAction = requireMSTeamsHandleAction();
   return await handleAction({
@@ -109,6 +122,7 @@ async function runAction(params: {
     cfg: params.cfg ?? {},
     params: params.params ?? {},
     mediaLocalRoots: params.mediaLocalRoots,
+    mediaReadFile: params.mediaReadFile,
     toolContext: params.toolContext,
   } as Parameters<ReturnType<typeof requireMSTeamsHandleAction>>[0]);
 }
@@ -167,6 +181,7 @@ async function expectSuccessfulAction(params: {
   actionParams?: Parameters<typeof runAction>[0]["params"];
   toolContext?: Parameters<typeof runAction>[0]["toolContext"];
   mediaLocalRoots?: Parameters<typeof runAction>[0]["mediaLocalRoots"];
+  mediaReadFile?: Parameters<typeof runAction>[0]["mediaReadFile"];
   runtimeParams: Record<string, unknown>;
   details: Record<string, unknown>;
   contentDetails?: Record<string, unknown>;
@@ -176,6 +191,7 @@ async function expectSuccessfulAction(params: {
     action: params.action,
     params: params.actionParams,
     mediaLocalRoots: params.mediaLocalRoots,
+    mediaReadFile: params.mediaReadFile,
     toolContext: params.toolContext,
   });
   expectActionRuntimeCall(params.mockFn, params.runtimeParams);
@@ -233,6 +249,7 @@ describe("msteamsPlugin message actions", () => {
   });
 
   it("routes upload-file through sendMessageMSTeams with filename override", async () => {
+    const mediaReadFile = vi.fn(async () => Buffer.from("pdf"));
     await expectSuccessfulAction({
       mockFn: sendMessageMSTeamsMock,
       mockResult: {
@@ -247,12 +264,14 @@ describe("msteamsPlugin message actions", () => {
         filename: "Q1-report.pdf",
       },
       mediaLocalRoots: ["/tmp"],
+      mediaReadFile,
       runtimeParams: {
         to: targetChannelId,
         text: "Quarterly report",
         mediaUrl: " /tmp/report.pdf ",
         filename: "Q1-report.pdf",
         mediaLocalRoots: ["/tmp"],
+        mediaReadFile,
       },
       details: {
         ok: true,
@@ -265,6 +284,69 @@ describe("msteamsPlugin message actions", () => {
         action: "upload-file",
         messageId: "msg-upload-1",
         conversationId: "conv-upload-1",
+      },
+    });
+  });
+
+  it("routes member-info through the Teams runtime", async () => {
+    await expectSuccessfulAction({
+      mockFn: getMemberInfoMSTeamsMock,
+      mockResult: { member: { id: "user-1" } },
+      action: "member-info",
+      actionParams: { userId: " user-1 " },
+      runtimeParams: { userId: "user-1" },
+      details: okMSTeamsActionDetails("member-info", {
+        member: { id: "user-1" },
+      }),
+      contentDetails: {
+        ok: true,
+        channel: "msteams",
+        action: "member-info",
+        member: { id: "user-1" },
+      },
+    });
+  });
+
+  it("routes channel-list through the Teams runtime", async () => {
+    await expectSuccessfulAction({
+      mockFn: listChannelsMSTeamsMock,
+      mockResult: { channels: [{ id: "channel-1" }] },
+      action: "channel-list",
+      actionParams: { teamId: " team-1 " },
+      runtimeParams: { teamId: "team-1" },
+      details: okMSTeamsActionDetails("channel-list", {
+        channels: [{ id: "channel-1" }],
+      }),
+      contentDetails: {
+        ok: true,
+        channel: "msteams",
+        action: "channel-list",
+        channels: [{ id: "channel-1" }],
+      },
+    });
+  });
+
+  it("routes channel-info through the Teams runtime", async () => {
+    await expectSuccessfulAction({
+      mockFn: getChannelInfoMSTeamsMock,
+      mockResult: { channel: { id: "channel-1" } },
+      action: "channel-info",
+      actionParams: {
+        teamId: " team-1 ",
+        channelId: " channel-1 ",
+      },
+      runtimeParams: {
+        teamId: "team-1",
+        channelId: "channel-1",
+      },
+      details: okMSTeamsActionDetails("channel-info", {
+        channelInfo: { id: "channel-1" },
+      }),
+      contentDetails: {
+        ok: true,
+        channel: "msteams",
+        action: "channel-info",
+        channelInfo: { id: "channel-1" },
       },
     });
   });

--- a/extensions/msteams/src/channel.runtime.ts
+++ b/extensions/msteams/src/channel.runtime.ts
@@ -2,6 +2,11 @@ import {
   listMSTeamsDirectoryGroupsLive as listMSTeamsDirectoryGroupsLiveImpl,
   listMSTeamsDirectoryPeersLive as listMSTeamsDirectoryPeersLiveImpl,
 } from "./directory-live.js";
+import {
+  addParticipantMSTeams as addParticipantMSTeamsImpl,
+  removeParticipantMSTeams as removeParticipantMSTeamsImpl,
+  renameGroupMSTeams as renameGroupMSTeamsImpl,
+} from "./graph-group-management.js";
 import { getMemberInfoMSTeams as getMemberInfoMSTeamsImpl } from "./graph-members.js";
 import {
   getMessageMSTeams as getMessageMSTeamsImpl,
@@ -32,6 +37,7 @@ import {
 // is currently wired through its own test surface; do not re-import it here
 // until channel.ts is migrated to that signature, otherwise identifiers collide.
 export const msTeamsChannelRuntime = {
+  addParticipantMSTeams: addParticipantMSTeamsImpl,
   deleteMessageMSTeams: deleteMessageMSTeamsImpl,
   editMessageMSTeams: editMessageMSTeamsImpl,
   getChannelInfoMSTeams: getChannelInfoMSTeamsImpl,
@@ -42,6 +48,8 @@ export const msTeamsChannelRuntime = {
   listReactionsMSTeams: listReactionsMSTeamsImpl,
   pinMessageMSTeams: pinMessageMSTeamsImpl,
   reactMessageMSTeams: reactMessageMSTeamsImpl,
+  removeParticipantMSTeams: removeParticipantMSTeamsImpl,
+  renameGroupMSTeams: renameGroupMSTeamsImpl,
   searchMessagesMSTeams: searchMessagesMSTeamsImpl,
   unpinMessageMSTeams: unpinMessageMSTeamsImpl,
   unreactMessageMSTeams: unreactMessageMSTeamsImpl,

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -1,0 +1,48 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { describe, expect, it } from "vitest";
+import { msteamsPlugin } from "./channel.js";
+import { msTeamsApprovalAuth } from "./approval-auth.js";
+
+function createConfiguredMSTeamsCfg(): OpenClawConfig {
+  return {
+    channels: {
+      msteams: {
+        appId: "app-id",
+        appPassword: "secret",
+        tenantId: "tenant-id",
+      },
+    },
+  };
+}
+
+describe("msteamsPlugin", () => {
+  it("exposes approval auth through approvalCapability", () => {
+    expect(msteamsPlugin.approvalCapability).toBe(msTeamsApprovalAuth);
+  });
+
+  it("advertises legacy and group-management message-tool actions together", () => {
+    const actions = msteamsPlugin.actions?.describeMessageTool?.({
+      cfg: createConfiguredMSTeamsCfg(),
+    })?.actions;
+
+    expect(actions).toEqual(
+      expect.arrayContaining([
+        "upload-file",
+        "member-info",
+        "channel-list",
+        "channel-info",
+        "addParticipant",
+        "removeParticipant",
+        "renameGroup",
+      ]),
+    );
+  });
+
+  it("reuses the shared Teams target-id matcher for explicit targets", () => {
+    const looksLikeId = msteamsPlugin.messaging?.targetResolver?.looksLikeId;
+
+    expect(looksLikeId?.("29:1a2b3c4d5e6f")).toBe(true);
+    expect(looksLikeId?.("a:1bfPersonalChat")).toBe(true);
+    expect(looksLikeId?.("user:Jane Doe")).toBe(false);
+  });
+});

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -6,12 +6,12 @@ import type {
   ChannelMessageActionAdapter,
   ChannelMessageToolDiscovery,
 } from "openclaw/plugin-sdk/channel-contract";
+import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import {
   createAllowlistProviderGroupPolicyWarningCollector,
   projectConfigWarningCollector,
 } from "openclaw/plugin-sdk/channel-policy";
-import { createChatChannelPlugin } from "openclaw/plugin-sdk/core";
 import {
   createChannelDirectoryAdapter,
   createRuntimeDirectoryLiveAdapter,

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -36,6 +36,7 @@ import type { ProbeMSTeamsResult } from "./probe.js";
 import {
   normalizeMSTeamsMessagingTarget,
   normalizeMSTeamsUserInput,
+  looksLikeMSTeamsTargetId,
   parseMSTeamsConversationId,
   parseMSTeamsTeamChannelInput,
   resolveMSTeamsChannelAllowlist,
@@ -329,6 +330,9 @@ function describeMSTeamsMessageTool({
           "react",
           "reactions",
           "search",
+          "member-info",
+          "channel-list",
+          "channel-info",
           "addParticipant",
           "removeParticipant",
           "renameGroup",
@@ -389,21 +393,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
         normalizeTarget: normalizeMSTeamsMessagingTarget,
         resolveOutboundSessionRoute: (params) => resolveMSTeamsOutboundSessionRoute(params),
         targetResolver: {
-          looksLikeId: (raw) => {
-            const trimmed = raw.trim();
-            if (!trimmed) {
-              return false;
-            }
-            if (/^conversation:/i.test(trimmed)) {
-              return true;
-            }
-            if (/^user:/i.test(trimmed)) {
-              // Only treat as ID if the value after user: looks like a UUID
-              const id = trimmed.slice("user:".length).trim();
-              return /^[0-9a-fA-F-]{16,}$/.test(id);
-            }
-            return trimmed.includes("@thread");
-          },
+          looksLikeId: (raw) => looksLikeMSTeamsTargetId(raw),
           hint: "<conversationId|user:ID|conversation:ID>",
         },
       },
@@ -627,6 +617,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
                     readOptionalTrimmedString(ctx.params, "filename") ??
                     readOptionalTrimmedString(ctx.params, "title"),
                   mediaLocalRoots: ctx.mediaLocalRoots,
+                  mediaReadFile: ctx.mediaReadFile,
                 });
                 return jsonActionResultWithDetails(
                   {

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -176,8 +176,16 @@ function resolveActionTarget(
       : (currentChannelId?.trim() ?? "");
 }
 
+function resolveGraphActionTarget(
+  params: Record<string, unknown>,
+  currentChannelId?: string | null,
+  currentGraphChannelId?: string | null,
+): string {
+  return resolveActionTarget(params, currentGraphChannelId ?? currentChannelId);
+}
+
 function resolveActionMessageId(params: Record<string, unknown>): string {
-  return typeof params.messageId === "string" ? params.messageId.trim() : "";
+  return normalizeOptionalString(params.messageId) ?? "";
 }
 
 function resolveActionPinnedMessageId(params: Record<string, unknown>): string {
@@ -189,7 +197,7 @@ function resolveActionPinnedMessageId(params: Record<string, unknown>): string {
 }
 
 function resolveActionQuery(params: Record<string, unknown>): string {
-  return typeof params.query === "string" ? params.query.trim() : "";
+  return normalizeOptionalString(params.query) ?? "";
 }
 
 function resolveActionContent(params: Record<string, unknown>): string {
@@ -225,8 +233,16 @@ function resolveRequiredActionTarget(params: {
   actionLabel: string;
   toolParams: Record<string, unknown>;
   currentChannelId?: string | null;
+  currentGraphChannelId?: string | null;
+  graphOnly?: boolean;
 }): string | ReturnType<typeof actionError> {
-  const to = resolveActionTarget(params.toolParams, params.currentChannelId);
+  const to = params.graphOnly
+    ? resolveGraphActionTarget(
+        params.toolParams,
+        params.currentChannelId,
+        params.currentGraphChannelId,
+      )
+    : resolveActionTarget(params.toolParams, params.currentChannelId);
   if (!to) {
     return actionError(`${params.actionLabel} requires a target (to).`);
   }
@@ -237,8 +253,16 @@ function resolveRequiredActionMessageTarget(params: {
   actionLabel: string;
   toolParams: Record<string, unknown>;
   currentChannelId?: string | null;
+  currentGraphChannelId?: string | null;
+  graphOnly?: boolean;
 }): { to: string; messageId: string } | ReturnType<typeof actionError> {
-  const to = resolveActionTarget(params.toolParams, params.currentChannelId);
+  const to = params.graphOnly
+    ? resolveGraphActionTarget(
+        params.toolParams,
+        params.currentChannelId,
+        params.currentGraphChannelId,
+      )
+    : resolveActionTarget(params.toolParams, params.currentChannelId);
   const messageId = resolveActionMessageId(params.toolParams);
   if (!to || !messageId) {
     return actionError(`${params.actionLabel} requires a target (to) and messageId.`);
@@ -250,8 +274,16 @@ function resolveRequiredActionPinnedMessageTarget(params: {
   actionLabel: string;
   toolParams: Record<string, unknown>;
   currentChannelId?: string | null;
+  currentGraphChannelId?: string | null;
+  graphOnly?: boolean;
 }): { to: string; pinnedMessageId: string } | ReturnType<typeof actionError> {
-  const to = resolveActionTarget(params.toolParams, params.currentChannelId);
+  const to = params.graphOnly
+    ? resolveGraphActionTarget(
+        params.toolParams,
+        params.currentChannelId,
+        params.currentGraphChannelId,
+      )
+    : resolveActionTarget(params.toolParams, params.currentChannelId);
   const pinnedMessageId = resolveActionPinnedMessageId(params.toolParams);
   if (!to || !pinnedMessageId) {
     return actionError(`${params.actionLabel} requires a target (to) and pinnedMessageId.`);
@@ -263,12 +295,16 @@ async function runWithRequiredActionTarget<T>(params: {
   actionLabel: string;
   toolParams: Record<string, unknown>;
   currentChannelId?: string | null;
+  currentGraphChannelId?: string | null;
+  graphOnly?: boolean;
   run: (to: string) => Promise<T>;
 }): Promise<T | ReturnType<typeof actionError>> {
   const to = resolveRequiredActionTarget({
     actionLabel: params.actionLabel,
     toolParams: params.toolParams,
     currentChannelId: params.currentChannelId,
+    currentGraphChannelId: params.currentGraphChannelId,
+    graphOnly: params.graphOnly,
   });
   if (typeof to !== "string") {
     return to;
@@ -280,12 +316,16 @@ async function runWithRequiredActionMessageTarget<T>(params: {
   actionLabel: string;
   toolParams: Record<string, unknown>;
   currentChannelId?: string | null;
+  currentGraphChannelId?: string | null;
+  graphOnly?: boolean;
   run: (target: { to: string; messageId: string }) => Promise<T>;
 }): Promise<T | ReturnType<typeof actionError>> {
   const target = resolveRequiredActionMessageTarget({
     actionLabel: params.actionLabel,
     toolParams: params.toolParams,
     currentChannelId: params.currentChannelId,
+    currentGraphChannelId: params.currentGraphChannelId,
+    graphOnly: params.graphOnly,
   });
   if ("isError" in target) {
     return target;
@@ -297,12 +337,16 @@ async function runWithRequiredActionPinnedMessageTarget<T>(params: {
   actionLabel: string;
   toolParams: Record<string, unknown>;
   currentChannelId?: string | null;
+  currentGraphChannelId?: string | null;
+  graphOnly?: boolean;
   run: (target: { to: string; pinnedMessageId: string }) => Promise<T>;
 }): Promise<T | ReturnType<typeof actionError>> {
   const target = resolveRequiredActionPinnedMessageTarget({
     actionLabel: params.actionLabel,
     toolParams: params.toolParams,
     currentChannelId: params.currentChannelId,
+    currentGraphChannelId: params.currentGraphChannelId,
+    graphOnly: params.graphOnly,
   });
   if ("isError" in target) {
     return target;
@@ -697,6 +741,8 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
               actionLabel: "Read",
               toolParams: ctx.params,
               currentChannelId: ctx.toolContext?.currentChannelId,
+              currentGraphChannelId: ctx.toolContext?.currentGraphChannelId,
+              graphOnly: true,
               run: async (target) => {
                 const { getMessageMSTeams } = await loadMSTeamsChannelRuntime();
                 const message = await getMessageMSTeams({
@@ -714,6 +760,8 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
               actionLabel: "Pin",
               toolParams: ctx.params,
               currentChannelId: ctx.toolContext?.currentChannelId,
+              currentGraphChannelId: ctx.toolContext?.currentGraphChannelId,
+              graphOnly: true,
               run: async (target) => {
                 const { pinMessageMSTeams } = await loadMSTeamsChannelRuntime();
                 const result = await pinMessageMSTeams({
@@ -731,6 +779,8 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
               actionLabel: "Unpin",
               toolParams: ctx.params,
               currentChannelId: ctx.toolContext?.currentChannelId,
+              currentGraphChannelId: ctx.toolContext?.currentGraphChannelId,
+              graphOnly: true,
               run: async (target) => {
                 const { unpinMessageMSTeams } = await loadMSTeamsChannelRuntime();
                 const result = await unpinMessageMSTeams({
@@ -748,6 +798,8 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
               actionLabel: "List-pins",
               toolParams: ctx.params,
               currentChannelId: ctx.toolContext?.currentChannelId,
+              currentGraphChannelId: ctx.toolContext?.currentGraphChannelId,
+              graphOnly: true,
               run: async (to) => {
                 const { listPinsMSTeams } = await loadMSTeamsChannelRuntime();
                 const result = await listPinsMSTeams({ cfg: ctx.cfg, to });
@@ -761,6 +813,8 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
               actionLabel: "React",
               toolParams: ctx.params,
               currentChannelId: ctx.toolContext?.currentChannelId,
+              currentGraphChannelId: ctx.toolContext?.currentGraphChannelId,
+              graphOnly: true,
               run: async (target) => {
                 const emoji = typeof ctx.params.emoji === "string" ? ctx.params.emoji.trim() : "";
                 const remove = typeof ctx.params.remove === "boolean" ? ctx.params.remove : false;
@@ -813,6 +867,8 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
               actionLabel: "Reactions",
               toolParams: ctx.params,
               currentChannelId: ctx.toolContext?.currentChannelId,
+              currentGraphChannelId: ctx.toolContext?.currentGraphChannelId,
+              graphOnly: true,
               run: async (target) => {
                 const { listReactionsMSTeams } = await loadMSTeamsChannelRuntime();
                 const result = await listReactionsMSTeams({
@@ -830,6 +886,8 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
               actionLabel: "Search",
               toolParams: ctx.params,
               currentChannelId: ctx.toolContext?.currentChannelId,
+              currentGraphChannelId: ctx.toolContext?.currentGraphChannelId,
+              graphOnly: true,
               run: async (to) => {
                 const query = resolveActionQuery(ctx.params);
                 if (!query) {
@@ -848,6 +906,43 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
                 });
                 return jsonMSTeamsOkActionResult("search", result);
               },
+            });
+          }
+
+          if (ctx.action === "member-info") {
+            const userId = normalizeOptionalString(ctx.params.userId) ?? "";
+            if (!userId) {
+              return actionError("member-info requires a userId.");
+            }
+            const { getMemberInfoMSTeams } = await loadMSTeamsChannelRuntime();
+            const result = await getMemberInfoMSTeams({ cfg: ctx.cfg, userId });
+            return jsonMSTeamsOkActionResult("member-info", result);
+          }
+
+          if (ctx.action === "channel-list") {
+            const teamId = normalizeOptionalString(ctx.params.teamId) ?? "";
+            if (!teamId) {
+              return actionError("channel-list requires a teamId.");
+            }
+            const { listChannelsMSTeams } = await loadMSTeamsChannelRuntime();
+            const result = await listChannelsMSTeams({ cfg: ctx.cfg, teamId });
+            return jsonMSTeamsOkActionResult("channel-list", result);
+          }
+
+          if (ctx.action === "channel-info") {
+            const teamId = normalizeOptionalString(ctx.params.teamId) ?? "";
+            const channelId = normalizeOptionalString(ctx.params.channelId) ?? "";
+            if (!teamId || !channelId) {
+              return actionError("channel-info requires teamId and channelId.");
+            }
+            const { getChannelInfoMSTeams } = await loadMSTeamsChannelRuntime();
+            const result = await getChannelInfoMSTeams({
+              cfg: ctx.cfg,
+              teamId,
+              channelId,
+            });
+            return jsonMSTeamsOkActionResult("channel-info", {
+              channelInfo: result.channel,
             });
           }
 

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -1,3 +1,4 @@
+import { Type } from "@sinclair/typebox";
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import { createMessageToolCardSchema } from "openclaw/plugin-sdk/channel-actions";
@@ -344,6 +345,12 @@ function describeMSTeamsMessageTool({
       ? {
           properties: {
             card: createMessageToolCardSchema(),
+            pinnedMessageId: Type.Optional(
+              Type.String({
+                description:
+                  "Pinned message resource ID for unpin (from pin or list-pins, not the chat message ID).",
+              }),
+            ),
           },
         }
       : null,

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -31,6 +31,7 @@ import {
 } from "../runtime-api.js";
 import { msTeamsApprovalAuth } from "./approval-auth.js";
 import { MSTeamsChannelConfigSchema } from "./config-schema.js";
+import { collectMSTeamsMutableAllowlistWarnings } from "./doctor.js";
 import { resolveMSTeamsGroupToolPolicy } from "./policy.js";
 import type { ProbeMSTeamsResult } from "./probe.js";
 import {
@@ -388,6 +389,13 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
           }),
       },
       approvalCapability: msTeamsApprovalAuth,
+      doctor: {
+        dmAllowFromMode: "topOnly",
+        groupModel: "hybrid",
+        groupAllowFromFallbackToAllowFrom: false,
+        warnOnEmptyGroupSenderAllowlist: true,
+        collectMutableAllowlistWarnings: collectMSTeamsMutableAllowlistWarnings,
+      },
       setup: msteamsSetupAdapter,
       messaging: {
         normalizeTarget: normalizeMSTeamsMessagingTarget,

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -1,35 +1,39 @@
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
+import { createMessageToolCardSchema } from "openclaw/plugin-sdk/channel-actions";
 import { createTopLevelChannelConfigAdapter } from "openclaw/plugin-sdk/channel-config-helpers";
-import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
+import type {
+  ChannelMessageActionAdapter,
+  ChannelMessageToolDiscovery,
+} from "openclaw/plugin-sdk/channel-contract";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import {
   createAllowlistProviderGroupPolicyWarningCollector,
   projectConfigWarningCollector,
 } from "openclaw/plugin-sdk/channel-policy";
+import { createChatChannelPlugin } from "openclaw/plugin-sdk/core";
+import {
+  createChannelDirectoryAdapter,
+  createRuntimeDirectoryLiveAdapter,
+  listDirectoryEntriesFromSources,
+} from "openclaw/plugin-sdk/directory-runtime";
 import { createLazyRuntimeNamedExport } from "openclaw/plugin-sdk/lazy-runtime";
 import { createRuntimeOutboundDelegates } from "openclaw/plugin-sdk/outbound-runtime";
 import { createComputedAccountStatusAdapter } from "openclaw/plugin-sdk/status-helpers";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
-import { msteamsActionsAdapter } from "./actions.js";
-import { msTeamsApprovalAuth } from "./approval-auth.js";
+import type { ChannelMessageActionName, ChannelPlugin, OpenClawConfig } from "../runtime-api.js";
 import {
   buildProbeChannelStatusSummary,
   chunkTextForOutbound,
   createDefaultChannelRuntimeState,
   DEFAULT_ACCOUNT_ID,
   PAIRING_APPROVED_MESSAGE,
-  type ChannelPlugin,
-  type OpenClawConfig,
-} from "./channel-api.js";
+} from "../runtime-api.js";
+import { msTeamsApprovalAuth } from "./approval-auth.js";
 import { MSTeamsChannelConfigSchema } from "./config-schema.js";
-import { msteamsDirectoryAdapter } from "./directory.js";
-import { collectMSTeamsMutableAllowlistWarnings } from "./doctor.js";
-import { formatUnknownError } from "./errors.js";
 import { resolveMSTeamsGroupToolPolicy } from "./policy.js";
 import type { ProbeMSTeamsResult } from "./probe.js";
 import {
-  looksLikeMSTeamsTargetId,
   normalizeMSTeamsMessagingTarget,
   normalizeMSTeamsUserInput,
   parseMSTeamsConversationId,
@@ -37,7 +41,6 @@ import {
   resolveMSTeamsChannelAllowlist,
   resolveMSTeamsUserAllowlist,
 } from "./resolve-allowlist.js";
-import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { resolveMSTeamsOutboundSessionRoute } from "./session-route.js";
 import { msteamsSetupAdapter } from "./setup-core.js";
 import { msteamsSetupWizard } from "./setup-surface.js";
@@ -112,6 +115,236 @@ const msteamsConfigAdapter = createTopLevelChannelConfigAdapter<
   resolveDefaultTo: (account) => account.defaultTo,
 });
 
+function jsonActionResult(data: Record<string, unknown>) {
+  const text = JSON.stringify(data);
+  return {
+    content: [{ type: "text" as const, text }],
+    details: data,
+  };
+}
+
+function jsonMSTeamsActionResult(action: string, data: Record<string, unknown> = {}) {
+  return jsonActionResult({ channel: "msteams", action, ...data });
+}
+
+function jsonMSTeamsOkActionResult(action: string, data: Record<string, unknown> = {}) {
+  return jsonActionResult({ ok: true, channel: "msteams", action, ...data });
+}
+
+function jsonMSTeamsConversationResult(conversationId: string | undefined) {
+  return jsonActionResultWithDetails(
+    {
+      ok: true,
+      channel: "msteams",
+      conversationId,
+    },
+    { ok: true, channel: "msteams" },
+  );
+}
+
+function jsonActionResultWithDetails(
+  contentData: Record<string, unknown>,
+  details: Record<string, unknown>,
+) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(contentData) }],
+    details,
+  };
+}
+
+const MSTEAMS_REACTION_TYPES = ["like", "heart", "laugh", "surprised", "sad", "angry"] as const;
+
+function actionError(message: string) {
+  return {
+    isError: true as const,
+    content: [{ type: "text" as const, text: message }],
+    details: { error: message },
+  };
+}
+
+function resolveActionTarget(
+  params: Record<string, unknown>,
+  currentChannelId?: string | null,
+): string {
+  return typeof params.to === "string"
+    ? params.to.trim()
+    : typeof params.target === "string"
+      ? params.target.trim()
+      : (currentChannelId?.trim() ?? "");
+}
+
+function resolveActionMessageId(params: Record<string, unknown>): string {
+  return typeof params.messageId === "string" ? params.messageId.trim() : "";
+}
+
+function resolveActionPinnedMessageId(params: Record<string, unknown>): string {
+  return typeof params.pinnedMessageId === "string"
+    ? params.pinnedMessageId.trim()
+    : typeof params.messageId === "string"
+      ? params.messageId.trim()
+      : "";
+}
+
+function resolveActionQuery(params: Record<string, unknown>): string {
+  return typeof params.query === "string" ? params.query.trim() : "";
+}
+
+function resolveActionContent(params: Record<string, unknown>): string {
+  return typeof params.text === "string"
+    ? params.text
+    : typeof params.content === "string"
+      ? params.content
+      : typeof params.message === "string"
+        ? params.message
+        : "";
+}
+
+function readOptionalTrimmedString(
+  params: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  return typeof params[key] === "string" ? params[key].trim() || undefined : undefined;
+}
+
+function resolveActionUploadFilePath(params: Record<string, unknown>): string | undefined {
+  for (const key of ["filePath", "path", "media"] as const) {
+    if (typeof params[key] === "string") {
+      const value = params[key];
+      if (value.trim()) {
+        return value;
+      }
+    }
+  }
+  return undefined;
+}
+
+function resolveRequiredActionTarget(params: {
+  actionLabel: string;
+  toolParams: Record<string, unknown>;
+  currentChannelId?: string | null;
+}): string | ReturnType<typeof actionError> {
+  const to = resolveActionTarget(params.toolParams, params.currentChannelId);
+  if (!to) {
+    return actionError(`${params.actionLabel} requires a target (to).`);
+  }
+  return to;
+}
+
+function resolveRequiredActionMessageTarget(params: {
+  actionLabel: string;
+  toolParams: Record<string, unknown>;
+  currentChannelId?: string | null;
+}): { to: string; messageId: string } | ReturnType<typeof actionError> {
+  const to = resolveActionTarget(params.toolParams, params.currentChannelId);
+  const messageId = resolveActionMessageId(params.toolParams);
+  if (!to || !messageId) {
+    return actionError(`${params.actionLabel} requires a target (to) and messageId.`);
+  }
+  return { to, messageId };
+}
+
+function resolveRequiredActionPinnedMessageTarget(params: {
+  actionLabel: string;
+  toolParams: Record<string, unknown>;
+  currentChannelId?: string | null;
+}): { to: string; pinnedMessageId: string } | ReturnType<typeof actionError> {
+  const to = resolveActionTarget(params.toolParams, params.currentChannelId);
+  const pinnedMessageId = resolveActionPinnedMessageId(params.toolParams);
+  if (!to || !pinnedMessageId) {
+    return actionError(`${params.actionLabel} requires a target (to) and pinnedMessageId.`);
+  }
+  return { to, pinnedMessageId };
+}
+
+async function runWithRequiredActionTarget<T>(params: {
+  actionLabel: string;
+  toolParams: Record<string, unknown>;
+  currentChannelId?: string | null;
+  run: (to: string) => Promise<T>;
+}): Promise<T | ReturnType<typeof actionError>> {
+  const to = resolveRequiredActionTarget({
+    actionLabel: params.actionLabel,
+    toolParams: params.toolParams,
+    currentChannelId: params.currentChannelId,
+  });
+  if (typeof to !== "string") {
+    return to;
+  }
+  return await params.run(to);
+}
+
+async function runWithRequiredActionMessageTarget<T>(params: {
+  actionLabel: string;
+  toolParams: Record<string, unknown>;
+  currentChannelId?: string | null;
+  run: (target: { to: string; messageId: string }) => Promise<T>;
+}): Promise<T | ReturnType<typeof actionError>> {
+  const target = resolveRequiredActionMessageTarget({
+    actionLabel: params.actionLabel,
+    toolParams: params.toolParams,
+    currentChannelId: params.currentChannelId,
+  });
+  if ("isError" in target) {
+    return target;
+  }
+  return await params.run(target);
+}
+
+async function runWithRequiredActionPinnedMessageTarget<T>(params: {
+  actionLabel: string;
+  toolParams: Record<string, unknown>;
+  currentChannelId?: string | null;
+  run: (target: { to: string; pinnedMessageId: string }) => Promise<T>;
+}): Promise<T | ReturnType<typeof actionError>> {
+  const target = resolveRequiredActionPinnedMessageTarget({
+    actionLabel: params.actionLabel,
+    toolParams: params.toolParams,
+    currentChannelId: params.currentChannelId,
+  });
+  if ("isError" in target) {
+    return target;
+  }
+  return await params.run(target);
+}
+
+function describeMSTeamsMessageTool({
+  cfg,
+}: Parameters<
+  NonNullable<ChannelMessageActionAdapter["describeMessageTool"]>
+>[0]): ChannelMessageToolDiscovery {
+  const enabled =
+    cfg.channels?.msteams?.enabled !== false &&
+    Boolean(resolveMSTeamsCredentials(cfg.channels?.msteams));
+  return {
+    actions: enabled
+      ? ([
+          "upload-file",
+          "poll",
+          "edit",
+          "delete",
+          "pin",
+          "unpin",
+          "list-pins",
+          "read",
+          "react",
+          "reactions",
+          "search",
+          "addParticipant",
+          "removeParticipant",
+          "renameGroup",
+        ] satisfies ChannelMessageActionName[])
+      : [],
+    capabilities: enabled ? ["cards"] : [],
+    schema: enabled
+      ? {
+          properties: {
+            card: createMessageToolCardSchema(),
+          },
+        }
+      : null,
+  };
+}
+
 export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsResult> =
   createChatChannelPlugin({
     base: {
@@ -151,27 +384,73 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
           }),
       },
       approvalCapability: msTeamsApprovalAuth,
-      doctor: {
-        dmAllowFromMode: "topOnly",
-        groupModel: "hybrid",
-        groupAllowFromFallbackToAllowFrom: false,
-        warnOnEmptyGroupSenderAllowlist: true,
-        collectMutableAllowlistWarnings: collectMSTeamsMutableAllowlistWarnings,
-      },
       setup: msteamsSetupAdapter,
-      secrets: {
-        secretTargetRegistryEntries,
-        collectRuntimeConfigAssignments,
-      },
       messaging: {
         normalizeTarget: normalizeMSTeamsMessagingTarget,
         resolveOutboundSessionRoute: (params) => resolveMSTeamsOutboundSessionRoute(params),
         targetResolver: {
-          looksLikeId: (raw) => looksLikeMSTeamsTargetId(raw),
+          looksLikeId: (raw) => {
+            const trimmed = raw.trim();
+            if (!trimmed) {
+              return false;
+            }
+            if (/^conversation:/i.test(trimmed)) {
+              return true;
+            }
+            if (/^user:/i.test(trimmed)) {
+              // Only treat as ID if the value after user: looks like a UUID
+              const id = trimmed.slice("user:".length).trim();
+              return /^[0-9a-fA-F-]{16,}$/.test(id);
+            }
+            return trimmed.includes("@thread");
+          },
           hint: "<conversationId|user:ID|conversation:ID>",
         },
       },
-      directory: msteamsDirectoryAdapter,
+      directory: createChannelDirectoryAdapter({
+        self: async ({ cfg }) => {
+          const creds = resolveMSTeamsCredentials(cfg.channels?.msteams);
+          if (!creds) {
+            return null;
+          }
+          return { kind: "user" as const, id: creds.appId, name: creds.appId };
+        },
+        listPeers: async ({ cfg, query, limit }) =>
+          listDirectoryEntriesFromSources({
+            kind: "user",
+            sources: [
+              cfg.channels?.msteams?.allowFrom ?? [],
+              Object.keys(cfg.channels?.msteams?.dms ?? {}),
+            ],
+            query,
+            limit,
+            normalizeId: (raw) => {
+              const normalized = normalizeMSTeamsMessagingTarget(raw) ?? raw;
+              const lowered = normalized.toLowerCase();
+              if (lowered.startsWith("user:") || lowered.startsWith("conversation:")) {
+                return normalized;
+              }
+              return `user:${normalized}`;
+            },
+          }),
+        listGroups: async ({ cfg, query, limit }) =>
+          listDirectoryEntriesFromSources({
+            kind: "group",
+            sources: [
+              Object.values(cfg.channels?.msteams?.teams ?? {}).flatMap((team) =>
+                Object.keys(team.channels ?? {}),
+              ),
+            ],
+            query,
+            limit,
+            normalizeId: (raw) => `conversation:${raw.replace(/^conversation:/i, "").trim()}`,
+          }),
+        ...createRuntimeDirectoryLiveAdapter({
+          getRuntime: loadMSTeamsChannelRuntime,
+          listPeersLive: (runtime) => runtime.listMSTeamsDirectoryPeersLive,
+          listGroupsLive: (runtime) => runtime.listMSTeamsDirectoryGroupsLive,
+        }),
+      }),
       resolver: {
         resolveTargets: async ({ cfg, inputs, kind, runtime }) => {
           const results = inputs.map((input) => ({
@@ -211,7 +490,7 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
                 applyResolvedEntry(target, entry);
               });
             } catch (err) {
-              runtime.error?.(`msteams resolve failed: ${formatUnknownError(err)}`);
+              runtime.error?.(`msteams resolve failed: ${String(err)}`);
               markPendingLookupFailed(pending);
             }
           };
@@ -300,7 +579,341 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
           return results;
         },
       },
-      actions: msteamsActionsAdapter,
+      actions: {
+        describeMessageTool: describeMSTeamsMessageTool,
+        handleAction: async (ctx) => {
+          // Handle send action with card parameter
+          if (ctx.action === "send" && ctx.params.card) {
+            const card = ctx.params.card as Record<string, unknown>;
+            return await runWithRequiredActionTarget({
+              actionLabel: "Card send",
+              toolParams: ctx.params,
+              run: async (to) => {
+                const { sendAdaptiveCardMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await sendAdaptiveCardMSTeams({
+                  cfg: ctx.cfg,
+                  to,
+                  card,
+                });
+                return jsonActionResultWithDetails(
+                  {
+                    ok: true,
+                    channel: "msteams",
+                    messageId: result.messageId,
+                    conversationId: result.conversationId,
+                  },
+                  { ok: true, channel: "msteams", messageId: result.messageId },
+                );
+              },
+            });
+          }
+          if (ctx.action === "upload-file") {
+            const mediaUrl = resolveActionUploadFilePath(ctx.params);
+            if (!mediaUrl) {
+              return actionError("Upload-file requires media, filePath, or path.");
+            }
+            return await runWithRequiredActionTarget({
+              actionLabel: "Upload-file",
+              toolParams: ctx.params,
+              currentChannelId: ctx.toolContext?.currentChannelId,
+              run: async (to) => {
+                const { sendMessageMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await sendMessageMSTeams({
+                  cfg: ctx.cfg,
+                  to,
+                  text: resolveActionContent(ctx.params),
+                  mediaUrl,
+                  filename:
+                    readOptionalTrimmedString(ctx.params, "filename") ??
+                    readOptionalTrimmedString(ctx.params, "title"),
+                  mediaLocalRoots: ctx.mediaLocalRoots,
+                });
+                return jsonActionResultWithDetails(
+                  {
+                    ok: true,
+                    channel: "msteams",
+                    action: "upload-file",
+                    messageId: result.messageId,
+                    conversationId: result.conversationId,
+                    ...(result.pendingUploadId ? { pendingUploadId: result.pendingUploadId } : {}),
+                  },
+                  {
+                    ok: true,
+                    channel: "msteams",
+                    messageId: result.messageId,
+                    ...(result.pendingUploadId ? { pendingUploadId: result.pendingUploadId } : {}),
+                  },
+                );
+              },
+            });
+          }
+          if (ctx.action === "edit") {
+            const content = resolveActionContent(ctx.params);
+            if (!content) {
+              return actionError("Edit requires content.");
+            }
+            return await runWithRequiredActionMessageTarget({
+              actionLabel: "Edit",
+              toolParams: ctx.params,
+              currentChannelId: ctx.toolContext?.currentChannelId,
+              run: async (target) => {
+                const { editMessageMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await editMessageMSTeams({
+                  cfg: ctx.cfg,
+                  to: target.to,
+                  activityId: target.messageId,
+                  text: content,
+                });
+                return jsonMSTeamsConversationResult(result.conversationId);
+              },
+            });
+          }
+
+          if (ctx.action === "delete") {
+            return await runWithRequiredActionMessageTarget({
+              actionLabel: "Delete",
+              toolParams: ctx.params,
+              currentChannelId: ctx.toolContext?.currentChannelId,
+              run: async (target) => {
+                const { deleteMessageMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await deleteMessageMSTeams({
+                  cfg: ctx.cfg,
+                  to: target.to,
+                  activityId: target.messageId,
+                });
+                return jsonMSTeamsConversationResult(result.conversationId);
+              },
+            });
+          }
+
+          if (ctx.action === "read") {
+            return await runWithRequiredActionMessageTarget({
+              actionLabel: "Read",
+              toolParams: ctx.params,
+              currentChannelId: ctx.toolContext?.currentChannelId,
+              run: async (target) => {
+                const { getMessageMSTeams } = await loadMSTeamsChannelRuntime();
+                const message = await getMessageMSTeams({
+                  cfg: ctx.cfg,
+                  to: target.to,
+                  messageId: target.messageId,
+                });
+                return jsonMSTeamsOkActionResult("read", { message });
+              },
+            });
+          }
+
+          if (ctx.action === "pin") {
+            return await runWithRequiredActionMessageTarget({
+              actionLabel: "Pin",
+              toolParams: ctx.params,
+              currentChannelId: ctx.toolContext?.currentChannelId,
+              run: async (target) => {
+                const { pinMessageMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await pinMessageMSTeams({
+                  cfg: ctx.cfg,
+                  to: target.to,
+                  messageId: target.messageId,
+                });
+                return jsonMSTeamsActionResult("pin", result);
+              },
+            });
+          }
+
+          if (ctx.action === "unpin") {
+            return await runWithRequiredActionPinnedMessageTarget({
+              actionLabel: "Unpin",
+              toolParams: ctx.params,
+              currentChannelId: ctx.toolContext?.currentChannelId,
+              run: async (target) => {
+                const { unpinMessageMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await unpinMessageMSTeams({
+                  cfg: ctx.cfg,
+                  to: target.to,
+                  pinnedMessageId: target.pinnedMessageId,
+                });
+                return jsonMSTeamsActionResult("unpin", result);
+              },
+            });
+          }
+
+          if (ctx.action === "list-pins") {
+            return await runWithRequiredActionTarget({
+              actionLabel: "List-pins",
+              toolParams: ctx.params,
+              currentChannelId: ctx.toolContext?.currentChannelId,
+              run: async (to) => {
+                const { listPinsMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await listPinsMSTeams({ cfg: ctx.cfg, to });
+                return jsonMSTeamsOkActionResult("list-pins", result);
+              },
+            });
+          }
+
+          if (ctx.action === "react") {
+            return await runWithRequiredActionMessageTarget({
+              actionLabel: "React",
+              toolParams: ctx.params,
+              currentChannelId: ctx.toolContext?.currentChannelId,
+              run: async (target) => {
+                const emoji = typeof ctx.params.emoji === "string" ? ctx.params.emoji.trim() : "";
+                const remove = typeof ctx.params.remove === "boolean" ? ctx.params.remove : false;
+                if (!emoji) {
+                  return {
+                    isError: true,
+                    content: [
+                      {
+                        type: "text" as const,
+                        text: `React requires an emoji (reaction type). Valid types: ${MSTEAMS_REACTION_TYPES.join(", ")}.`,
+                      },
+                    ],
+                    details: {
+                      error: "React requires an emoji (reaction type).",
+                      validTypes: [...MSTEAMS_REACTION_TYPES],
+                    },
+                  };
+                }
+                if (remove) {
+                  const { unreactMessageMSTeams } = await loadMSTeamsChannelRuntime();
+                  const result = await unreactMessageMSTeams({
+                    cfg: ctx.cfg,
+                    to: target.to,
+                    messageId: target.messageId,
+                    reactionType: emoji,
+                  });
+                  return jsonMSTeamsActionResult("react", {
+                    removed: true,
+                    reactionType: emoji,
+                    ...result,
+                  });
+                }
+                const { reactMessageMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await reactMessageMSTeams({
+                  cfg: ctx.cfg,
+                  to: target.to,
+                  messageId: target.messageId,
+                  reactionType: emoji,
+                });
+                return jsonMSTeamsActionResult("react", {
+                  reactionType: emoji,
+                  ...result,
+                });
+              },
+            });
+          }
+
+          if (ctx.action === "reactions") {
+            return await runWithRequiredActionMessageTarget({
+              actionLabel: "Reactions",
+              toolParams: ctx.params,
+              currentChannelId: ctx.toolContext?.currentChannelId,
+              run: async (target) => {
+                const { listReactionsMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await listReactionsMSTeams({
+                  cfg: ctx.cfg,
+                  to: target.to,
+                  messageId: target.messageId,
+                });
+                return jsonMSTeamsOkActionResult("reactions", result);
+              },
+            });
+          }
+
+          if (ctx.action === "search") {
+            return await runWithRequiredActionTarget({
+              actionLabel: "Search",
+              toolParams: ctx.params,
+              currentChannelId: ctx.toolContext?.currentChannelId,
+              run: async (to) => {
+                const query = resolveActionQuery(ctx.params);
+                if (!query) {
+                  return actionError("Search requires a target (to) and query.");
+                }
+                const limit = typeof ctx.params.limit === "number" ? ctx.params.limit : undefined;
+                const from =
+                  typeof ctx.params.from === "string" ? ctx.params.from.trim() : undefined;
+                const { searchMessagesMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await searchMessagesMSTeams({
+                  cfg: ctx.cfg,
+                  to,
+                  query,
+                  from: from || undefined,
+                  limit,
+                });
+                return jsonMSTeamsOkActionResult("search", result);
+              },
+            });
+          }
+
+          if (ctx.action === "addParticipant") {
+            const userId = typeof ctx.params.userId === "string" ? ctx.params.userId.trim() : "";
+            if (!userId) {
+              return actionError("addParticipant requires a userId.");
+            }
+            return await runWithRequiredActionTarget({
+              actionLabel: "addParticipant",
+              toolParams: ctx.params,
+              currentChannelId: ctx.toolContext?.currentChannelId,
+              run: async (to) => {
+                const role = readOptionalTrimmedString(ctx.params, "role");
+                const { addParticipantMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await addParticipantMSTeams({
+                  cfg: ctx.cfg,
+                  to,
+                  userId,
+                  role,
+                });
+                return jsonMSTeamsOkActionResult("addParticipant", result);
+              },
+            });
+          }
+
+          if (ctx.action === "removeParticipant") {
+            const userId = typeof ctx.params.userId === "string" ? ctx.params.userId.trim() : "";
+            if (!userId) {
+              return actionError("removeParticipant requires a userId.");
+            }
+            return await runWithRequiredActionTarget({
+              actionLabel: "removeParticipant",
+              toolParams: ctx.params,
+              currentChannelId: ctx.toolContext?.currentChannelId,
+              run: async (to) => {
+                const { removeParticipantMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await removeParticipantMSTeams({
+                  cfg: ctx.cfg,
+                  to,
+                  userId,
+                });
+                return jsonMSTeamsOkActionResult("removeParticipant", result);
+              },
+            });
+          }
+
+          if (ctx.action === "renameGroup") {
+            const name = typeof ctx.params.name === "string" ? ctx.params.name.trim() : "";
+            if (!name) {
+              return actionError("renameGroup requires a name.");
+            }
+            return await runWithRequiredActionTarget({
+              actionLabel: "renameGroup",
+              toolParams: ctx.params,
+              currentChannelId: ctx.toolContext?.currentChannelId,
+              run: async (to) => {
+                const { renameGroupMSTeams } = await loadMSTeamsChannelRuntime();
+                const result = await renameGroupMSTeams({
+                  cfg: ctx.cfg,
+                  to,
+                  name,
+                });
+                return jsonMSTeamsOkActionResult("renameGroup", result);
+              },
+            });
+          }
+
+          // Return null to fall through to default handler
+          return null as never;
+        },
+      },
       status: createComputedAccountStatusAdapter<ResolvedMSTeamsAccount, ProbeMSTeamsResult>({
         defaultRuntime: createDefaultChannelRuntimeState(DEFAULT_ACCOUNT_ID, { port: null }),
         buildChannelSummary: ({ snapshot }) =>
@@ -310,9 +923,9 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
         probeAccount: async ({ cfg }) =>
           await (await loadMSTeamsChannelRuntime()).probeMSTeams(cfg.channels?.msteams),
         formatCapabilitiesProbe: ({ probe }) => {
-          const teamsProbe = probe as ProbeMSTeamsResult | undefined;
+          const teamsProbe = probe;
           const lines: Array<{ text: string; tone?: "error" }> = [];
-          const appId = normalizeOptionalString(teamsProbe?.appId) ?? "";
+          const appId = typeof teamsProbe?.appId === "string" ? teamsProbe.appId.trim() : "";
           if (appId) {
             lines.push({ text: `App: ${appId}` });
           }

--- a/extensions/msteams/src/graph-group-management.test.ts
+++ b/extensions/msteams/src/graph-group-management.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
+import {
+  addParticipantMSTeams,
+  removeParticipantMSTeams,
+  renameGroupMSTeams,
+} from "./graph-group-management.js";
+
+const mockState = vi.hoisted(() => ({
+  resolveGraphToken: vi.fn(),
+  fetchGraphJson: vi.fn(),
+  postGraphJson: vi.fn(),
+  deleteGraphRequest: vi.fn(),
+  patchGraphJson: vi.fn(),
+  findPreferredDmByUserId: vi.fn(),
+}));
+
+vi.mock("./graph.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./graph.js")>();
+  return {
+    ...actual,
+    resolveGraphToken: mockState.resolveGraphToken,
+    fetchGraphJson: mockState.fetchGraphJson,
+    postGraphJson: mockState.postGraphJson,
+    deleteGraphRequest: mockState.deleteGraphRequest,
+    patchGraphJson: mockState.patchGraphJson,
+  };
+});
+
+vi.mock("./conversation-store-fs.js", () => ({
+  createMSTeamsConversationStoreFs: () => ({
+    findPreferredDmByUserId: mockState.findPreferredDmByUserId,
+  }),
+}));
+
+const TOKEN = "test-graph-token";
+const CHAT_ID = "19:abc@thread.tacv2";
+const CHANNEL_TO = "team-id-1/channel-id-1";
+
+describe("addParticipantMSTeams", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.resolveGraphToken.mockResolvedValue(TOKEN);
+  });
+
+  it("adds member to a chat with default role", async () => {
+    mockState.postGraphJson.mockResolvedValue({});
+
+    const result = await addParticipantMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: CHAT_ID,
+      userId: "user-aad-id-1",
+    });
+
+    expect(result).toEqual({ added: { userId: "user-aad-id-1", chatId: CHAT_ID } });
+    expect(mockState.postGraphJson).toHaveBeenCalledWith({
+      token: TOKEN,
+      path: `/chats/${encodeURIComponent(CHAT_ID)}/members`,
+      body: {
+        "@odata.type": "#microsoft.graph.aadUserConversationMember",
+        roles: ["member"],
+        "user@odata.bind": "https://graph.microsoft.com/v1.0/users('user-aad-id-1')",
+      },
+    });
+  });
+
+  it("adds member to a chat with owner role", async () => {
+    mockState.postGraphJson.mockResolvedValue({});
+
+    const result = await addParticipantMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: CHAT_ID,
+      userId: "user-aad-id-2",
+      role: "owner",
+    });
+
+    expect(result).toEqual({ added: { userId: "user-aad-id-2", chatId: CHAT_ID } });
+    expect(mockState.postGraphJson).toHaveBeenCalledWith({
+      token: TOKEN,
+      path: `/chats/${encodeURIComponent(CHAT_ID)}/members`,
+      body: {
+        "@odata.type": "#microsoft.graph.aadUserConversationMember",
+        roles: ["owner"],
+        "user@odata.bind": "https://graph.microsoft.com/v1.0/users('user-aad-id-2')",
+      },
+    });
+  });
+
+  it("constructs correct user@odata.bind URL", async () => {
+    mockState.postGraphJson.mockResolvedValue({});
+
+    await addParticipantMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: CHAT_ID,
+      userId: "abc-def-123",
+    });
+
+    const calledBody = mockState.postGraphJson.mock.calls[0][0].body;
+    expect(calledBody["user@odata.bind"]).toBe(
+      "https://graph.microsoft.com/v1.0/users('abc-def-123')",
+    );
+  });
+
+  it("adds member to a channel", async () => {
+    mockState.postGraphJson.mockResolvedValue({});
+
+    const result = await addParticipantMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: CHANNEL_TO,
+      userId: "user-aad-id-3",
+    });
+
+    expect(result).toEqual({ added: { userId: "user-aad-id-3", chatId: CHANNEL_TO } });
+    expect(mockState.postGraphJson).toHaveBeenCalledWith({
+      token: TOKEN,
+      path: "/teams/team-id-1/channels/channel-id-1/members",
+      body: {
+        "@odata.type": "#microsoft.graph.aadUserConversationMember",
+        roles: ["member"],
+        "user@odata.bind": "https://graph.microsoft.com/v1.0/users('user-aad-id-3')",
+      },
+    });
+  });
+});
+
+describe("removeParticipantMSTeams", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.resolveGraphToken.mockResolvedValue(TOKEN);
+  });
+
+  it("lists members, finds match, deletes by membershipId", async () => {
+    mockState.fetchGraphJson.mockResolvedValue({
+      value: [
+        { id: "membership-1", userId: "user-aad-id-1" },
+        { id: "membership-2", userId: "user-aad-id-2" },
+      ],
+    });
+    mockState.deleteGraphRequest.mockResolvedValue(undefined);
+
+    const result = await removeParticipantMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: CHAT_ID,
+      userId: "user-aad-id-2",
+    });
+
+    expect(result).toEqual({ removed: { userId: "user-aad-id-2", chatId: CHAT_ID } });
+    expect(mockState.fetchGraphJson).toHaveBeenCalledWith({
+      token: TOKEN,
+      path: `/chats/${encodeURIComponent(CHAT_ID)}/members`,
+    });
+    expect(mockState.deleteGraphRequest).toHaveBeenCalledWith({
+      token: TOKEN,
+      path: `/chats/${encodeURIComponent(CHAT_ID)}/members/membership-2`,
+    });
+  });
+
+  it("throws when user not found in member list", async () => {
+    mockState.fetchGraphJson.mockResolvedValue({
+      value: [
+        { id: "membership-1", userId: "user-aad-id-1" },
+        { id: "membership-3", userId: "user-aad-id-3" },
+      ],
+    });
+
+    await expect(
+      removeParticipantMSTeams({
+        cfg: {} as OpenClawConfig,
+        to: CHAT_ID,
+        userId: "user-not-in-list",
+      }),
+    ).rejects.toThrow("User user-not-in-list is not a member of this conversation");
+  });
+
+  it("removes member from a channel", async () => {
+    mockState.fetchGraphJson.mockResolvedValue({
+      value: [{ id: "membership-5", userId: "user-aad-id-5" }],
+    });
+    mockState.deleteGraphRequest.mockResolvedValue(undefined);
+
+    const result = await removeParticipantMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: CHANNEL_TO,
+      userId: "user-aad-id-5",
+    });
+
+    expect(result).toEqual({ removed: { userId: "user-aad-id-5", chatId: CHANNEL_TO } });
+    expect(mockState.fetchGraphJson).toHaveBeenCalledWith({
+      token: TOKEN,
+      path: "/teams/team-id-1/channels/channel-id-1/members",
+    });
+    expect(mockState.deleteGraphRequest).toHaveBeenCalledWith({
+      token: TOKEN,
+      path: "/teams/team-id-1/channels/channel-id-1/members/membership-5",
+    });
+  });
+});
+
+describe("renameGroupMSTeams", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.resolveGraphToken.mockResolvedValue(TOKEN);
+  });
+
+  it("renames a chat with topic", async () => {
+    mockState.patchGraphJson.mockResolvedValue(undefined);
+
+    const result = await renameGroupMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: CHAT_ID,
+      name: "New Chat Name",
+    });
+
+    expect(result).toEqual({ renamed: { chatId: CHAT_ID, newName: "New Chat Name" } });
+    expect(mockState.patchGraphJson).toHaveBeenCalledWith({
+      token: TOKEN,
+      path: `/chats/${encodeURIComponent(CHAT_ID)}`,
+      body: { topic: "New Chat Name" },
+    });
+  });
+
+  it("renames a channel with displayName", async () => {
+    mockState.patchGraphJson.mockResolvedValue(undefined);
+
+    const result = await renameGroupMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: CHANNEL_TO,
+      name: "New Channel Name",
+    });
+
+    expect(result).toEqual({ renamed: { chatId: CHANNEL_TO, newName: "New Channel Name" } });
+    expect(mockState.patchGraphJson).toHaveBeenCalledWith({
+      token: TOKEN,
+      path: "/teams/team-id-1/channels/channel-id-1",
+      body: { displayName: "New Channel Name" },
+    });
+  });
+});

--- a/extensions/msteams/src/graph-group-management.test.ts
+++ b/extensions/msteams/src/graph-group-management.test.ts
@@ -194,6 +194,39 @@ describe("removeParticipantMSTeams", () => {
       path: "/teams/team-id-1/channels/channel-id-1/members/membership-5",
     });
   });
+
+  it("follows member pagination before concluding the user is missing", async () => {
+    mockState.fetchGraphJson
+      .mockResolvedValueOnce({
+        value: [{ id: "membership-1", userId: "user-aad-id-1" }],
+        "@odata.nextLink":
+          "https://graph.microsoft.com/v1.0/chats/19%3Aabc%40thread.tacv2/members?$skip=2",
+      })
+      .mockResolvedValueOnce({
+        value: [{ id: "membership-9", userId: "user-aad-id-9" }],
+      });
+    mockState.deleteGraphRequest.mockResolvedValue(undefined);
+
+    const result = await removeParticipantMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: CHAT_ID,
+      userId: "user-aad-id-9",
+    });
+
+    expect(result).toEqual({ removed: { userId: "user-aad-id-9", chatId: CHAT_ID } });
+    expect(mockState.fetchGraphJson).toHaveBeenNthCalledWith(1, {
+      token: TOKEN,
+      path: `/chats/${encodeURIComponent(CHAT_ID)}/members`,
+    });
+    expect(mockState.fetchGraphJson).toHaveBeenNthCalledWith(2, {
+      token: TOKEN,
+      path: `/chats/${encodeURIComponent(CHAT_ID)}/members?$skip=2`,
+    });
+    expect(mockState.deleteGraphRequest).toHaveBeenCalledWith({
+      token: TOKEN,
+      path: `/chats/${encodeURIComponent(CHAT_ID)}/members/membership-9`,
+    });
+  });
 });
 
 describe("renameGroupMSTeams", () => {

--- a/extensions/msteams/src/graph-group-management.ts
+++ b/extensions/msteams/src/graph-group-management.ts
@@ -1,0 +1,133 @@
+import type { OpenClawConfig } from "../runtime-api.js";
+import { resolveConversationPath, resolveGraphConversationId } from "./graph-messages.js";
+import {
+  deleteGraphRequest,
+  fetchGraphJson,
+  patchGraphJson,
+  postGraphJson,
+  resolveGraphToken,
+} from "./graph.js";
+
+// ---------------------------------------------------------------------------
+// Add Participant
+// ---------------------------------------------------------------------------
+
+export type AddParticipantMSTeamsParams = {
+  cfg: OpenClawConfig;
+  to: string;
+  userId: string;
+  role?: string;
+};
+
+export type AddParticipantMSTeamsResult = {
+  added: { userId: string; chatId: string };
+};
+
+/**
+ * Add a user to a chat or channel via Graph API.
+ */
+export async function addParticipantMSTeams(
+  params: AddParticipantMSTeamsParams,
+): Promise<AddParticipantMSTeamsResult> {
+  const token = await resolveGraphToken(params.cfg);
+  const conversationId = await resolveGraphConversationId(params.to);
+  const conv = resolveConversationPath(conversationId);
+
+  const body = {
+    "@odata.type": "#microsoft.graph.aadUserConversationMember",
+    roles: [params.role || "member"],
+    "user@odata.bind": `https://graph.microsoft.com/v1.0/users('${params.userId}')`,
+  };
+
+  await postGraphJson<unknown>({
+    token,
+    path: `${conv.basePath}/members`,
+    body,
+  });
+
+  return { added: { userId: params.userId, chatId: conversationId } };
+}
+
+// ---------------------------------------------------------------------------
+// Remove Participant
+// ---------------------------------------------------------------------------
+
+export type RemoveParticipantMSTeamsParams = {
+  cfg: OpenClawConfig;
+  to: string;
+  userId: string;
+};
+
+export type RemoveParticipantMSTeamsResult = {
+  removed: { userId: string; chatId: string };
+};
+
+type GraphConversationMember = {
+  id?: string;
+  userId?: string;
+};
+
+/**
+ * Remove a user from a chat or channel via Graph API.
+ * Lists members first to resolve the membership ID, then deletes.
+ */
+export async function removeParticipantMSTeams(
+  params: RemoveParticipantMSTeamsParams,
+): Promise<RemoveParticipantMSTeamsResult> {
+  const token = await resolveGraphToken(params.cfg);
+  const conversationId = await resolveGraphConversationId(params.to);
+  const conv = resolveConversationPath(conversationId);
+
+  // List members to find the membership ID for the target user
+  const membersRes = await fetchGraphJson<{ value?: GraphConversationMember[] }>({
+    token,
+    path: `${conv.basePath}/members`,
+  });
+
+  const member = (membersRes.value ?? []).find((m) => m.userId === params.userId);
+  if (!member?.id) {
+    throw new Error(`User ${params.userId} is not a member of this conversation`);
+  }
+
+  await deleteGraphRequest({
+    token,
+    path: `${conv.basePath}/members/${encodeURIComponent(member.id)}`,
+  });
+
+  return { removed: { userId: params.userId, chatId: conversationId } };
+}
+
+// ---------------------------------------------------------------------------
+// Rename Group
+// ---------------------------------------------------------------------------
+
+export type RenameGroupMSTeamsParams = {
+  cfg: OpenClawConfig;
+  to: string;
+  name: string;
+};
+
+export type RenameGroupMSTeamsResult = {
+  renamed: { chatId: string; newName: string };
+};
+
+/**
+ * Rename a chat (topic) or channel (displayName) via Graph API.
+ */
+export async function renameGroupMSTeams(
+  params: RenameGroupMSTeamsParams,
+): Promise<RenameGroupMSTeamsResult> {
+  const token = await resolveGraphToken(params.cfg);
+  const conversationId = await resolveGraphConversationId(params.to);
+  const conv = resolveConversationPath(conversationId);
+
+  const body = conv.kind === "chat" ? { topic: params.name } : { displayName: params.name };
+
+  await patchGraphJson<unknown>({
+    token,
+    path: conv.basePath,
+    body,
+  });
+
+  return { renamed: { chatId: conversationId, newName: params.name } };
+}

--- a/extensions/msteams/src/graph-group-management.ts
+++ b/extensions/msteams/src/graph-group-management.ts
@@ -67,6 +67,11 @@ type GraphConversationMember = {
   userId?: string;
 };
 
+type GraphConversationMemberResponse = {
+  value?: GraphConversationMember[];
+  "@odata.nextLink"?: string;
+};
+
 /**
  * Remove a user from a chat or channel via Graph API.
  * Lists members first to resolve the membership ID, then deletes.
@@ -78,13 +83,29 @@ export async function removeParticipantMSTeams(
   const conversationId = await resolveGraphConversationId(params.to);
   const conv = resolveConversationPath(conversationId);
 
-  // List members to find the membership ID for the target user
-  const membersRes = await fetchGraphJson<{ value?: GraphConversationMember[] }>({
-    token,
-    path: `${conv.basePath}/members`,
-  });
-
-  const member = (membersRes.value ?? []).find((m) => m.userId === params.userId);
+  // List members to find the membership ID for the target user. Graph can
+  // paginate large chats/channels, so walk `@odata.nextLink` before concluding
+  // the user is missing.
+  const MAX_PAGES = 10;
+  let nextPath: string | undefined = `${conv.basePath}/members`;
+  let page = 0;
+  let member: GraphConversationMember | undefined;
+  while (nextPath && page < MAX_PAGES && !member) {
+    const membersRes: GraphConversationMemberResponse =
+      await fetchGraphJson<GraphConversationMemberResponse>({
+        token,
+        path: nextPath,
+      });
+    member = (membersRes.value ?? []).find(
+      (candidate: GraphConversationMember) => candidate.userId === params.userId,
+    );
+    if (member) {
+      break;
+    }
+    const nextLink: string | undefined = membersRes["@odata.nextLink"];
+    nextPath = nextLink ? nextLink.replace("https://graph.microsoft.com/v1.0", "") : undefined;
+    page++;
+  }
   if (!member?.id) {
     throw new Error(`User ${params.userId} is not a member of this conversation`);
   }

--- a/extensions/msteams/src/graph-messages.ts
+++ b/extensions/msteams/src/graph-messages.ts
@@ -64,7 +64,7 @@ function stripTargetPrefix(raw: string): string {
  * actual `19:xxx@thread.*` chat ID that Graph API requires.
  * Conversation IDs and `teamId/channelId` pairs pass through unchanged.
  */
-async function resolveGraphConversationId(to: string): Promise<string> {
+export async function resolveGraphConversationId(to: string): Promise<string> {
   const trimmed = to.trim();
   const isUserTarget = /^user:/i.test(trimmed);
   const cleaned = stripTargetPrefix(trimmed);
@@ -99,7 +99,7 @@ async function resolveGraphConversationId(to: string): Promise<string> {
   );
 }
 
-function resolveConversationPath(to: string): {
+export function resolveConversationPath(to: string): {
   kind: "chat" | "channel";
   basePath: string;
   chatId?: string;

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -270,6 +270,32 @@ export async function deleteGraphRequest(params: { token: string; path: string }
   });
 }
 
+export async function patchGraphJson<T>(params: {
+  token: string;
+  path: string;
+  body?: unknown;
+}): Promise<T> {
+  const res = await fetch(`${GRAPH_ROOT}${params.path}`, {
+    method: "PATCH",
+    headers: {
+      "User-Agent": buildUserAgent(),
+      Authorization: `Bearer ${params.token}`,
+      "Content-Type": "application/json",
+    },
+    body: params.body !== undefined ? JSON.stringify(params.body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `Graph PATCH ${params.path} failed (${res.status}): ${text || "unknown error"}`,
+    );
+  }
+  if (res.status === 204 || res.headers.get("content-length") === "0") {
+    return undefined as T;
+  }
+  return (await res.json()) as T;
+}
+
 export async function listChannelsForTeam(token: string, teamId: string): Promise<GraphChannel[]> {
   const path = `/teams/${encodeURIComponent(teamId)}/channels?$select=id,displayName`;
   const { items } = await fetchAllGraphPages<GraphChannel>({ token, path, maxPages: 10 });

--- a/extensions/msteams/src/graph.ts
+++ b/extensions/msteams/src/graph.ts
@@ -37,7 +37,7 @@ export function escapeOData(value: string): string {
 async function requestGraph(params: {
   token: string;
   path: string;
-  method?: "GET" | "POST" | "DELETE";
+  method?: "GET" | "POST" | "PATCH" | "DELETE";
   root?: string;
   headers?: Record<string, string>;
   body?: unknown;
@@ -275,21 +275,13 @@ export async function patchGraphJson<T>(params: {
   path: string;
   body?: unknown;
 }): Promise<T> {
-  const res = await fetch(`${GRAPH_ROOT}${params.path}`, {
+  const res = await requestGraph({
+    token: params.token,
+    path: params.path,
     method: "PATCH",
-    headers: {
-      "User-Agent": buildUserAgent(),
-      Authorization: `Bearer ${params.token}`,
-      "Content-Type": "application/json",
-    },
-    body: params.body !== undefined ? JSON.stringify(params.body) : undefined,
+    body: params.body,
+    errorPrefix: "Graph PATCH",
   });
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(
-      `Graph PATCH ${params.path} failed (${res.status}): ${text || "unknown error"}`,
-    );
-  }
   if (res.status === 204 || res.headers.get("content-length") === "0") {
     return undefined as T;
   }


### PR DESCRIPTION
## Summary
- Adds `addParticipant`, `removeParticipant`, and `renameGroup` message actions to the MS Teams extension
- `addParticipant`: adds a user to a chat/channel via Graph API with configurable role
- `removeParticipant`: resolves membership ID then removes user from chat/channel
- `renameGroup`: renames a chat (topic) or channel (displayName) via PATCH
- Adds `patchGraphJson` helper to graph.ts
- Exports `resolveConversationPath` and `resolveGraphConversationId` from graph-messages.ts for reuse

## Test plan
- [x] Unit tests for all three group management functions
- [x] Tests cover chat and channel target routing
- [x] Tests cover error cases (user not found, missing params)
- [x] `pnpm test -- extensions/msteams` passes
- [x] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)