### PR TITLE
fix(memory): keep qmd session paths roundtrip-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 - Memory/QMD: rebind collections when QMD reports a changed pattern but omits path metadata, so config pattern changes stop being silently ignored on restart. (#49897) Thanks @Madruru.
 - Memory/QMD: warn explicitly when `memory.backend=qmd` is configured but the `qmd` binary is missing, so doctor and runtime fallback no longer fail as a silent builtin downgrade. (#50439) Thanks @Jimmy-xuzimo and @vincentkoc.
 - Memory/QMD: pass a direct-session key on `openclaw memory search` so CLI QMD searches no longer get denied as `session=<none>` under direct-only scope defaults. (#43517) Thanks @waynecc-at and @vincentkoc.
+- Memory/QMD: keep `memory_search` session-hit paths roundtrip-safe when exported session markdown lives under the workspace `qmd/` directory, so `memory_get` can read the exact returned path instead of failing on the generic `qmd/sessions/...` alias. (#43519) Thanks @holgergruenhagen and @vincentkoc.
 - Agents/memory flush: keep daily memory flush files append-only during embedded attempts so compaction writes do not overwrite earlier notes. (#53725) Thanks @HPluseven.
 - Web UI/markdown: stop bare auto-links from swallowing adjacent CJK text while preserving valid mixed-script path and query characters in rendered links. (#48410) Thanks @jnuyao.
 - BlueBubbles/iMessage: coalesce URL-only inbound messages with their link-preview balloon again so sharing a bare link no longer drops the URL from agent context. Thanks @vincentkoc.

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -182,6 +182,15 @@ describe("QmdMemoryManager", () => {
     // install explicit shim fixtures inline.
     cfg = {
       agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "mock-embed",
+            store: { path: path.join(workspaceDir, "index.sqlite"), vector: { enabled: false } },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+          },
+        },
         list: [{ id: agentId, default: true, workspace: workspaceDir }],
       },
       memory: {
@@ -3365,6 +3374,99 @@ describe("QmdMemoryManager", () => {
         source: "memory",
       },
     ]);
+    await manager.close();
+  });
+
+  it("returns collection-scoped qmd paths when session exports live under the workspace qmd directory", async () => {
+    workspaceDir = path.join(stateDir, "agents", agentId);
+    await fs.mkdir(workspaceDir, { recursive: true });
+    cfg = {
+      agents: {
+        list: [{ id: agentId, default: true, workspace: workspaceDir }],
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          sessions: { enabled: true },
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify([
+            {
+              file: "qmd://sessions-main/session-1.md",
+              score: 0.84,
+              snippet: "@@ -2,1\nsession canary",
+            },
+          ]),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "full" });
+    const inner = manager as unknown as {
+      collectionRoots: Map<string, { path: string }>;
+      resolveReadPath: (relPath: string) => string;
+    };
+    const sessionRoot = inner.collectionRoots.get("sessions-main");
+    expect(sessionRoot?.path).toBeTruthy();
+    const exportedSessionPath = path.join(sessionRoot!.path, "session-1.md");
+
+    const results = await manager.search("session canary", {
+      sessionKey: "agent:main:slack:dm:u123",
+    });
+    expect(results).toEqual([
+      {
+        path: "qmd/sessions-main/session-1.md",
+        startLine: 2,
+        endLine: 2,
+        score: 0.84,
+        snippet: "@@ -2,1\nsession canary",
+        source: "sessions",
+      },
+    ]);
+
+    expect(inner.resolveReadPath(results[0]!.path)).toBe(exportedSessionPath);
+    const realLstat = fs.lstat;
+    const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (target, options) => {
+      if (typeof target === "string" && path.resolve(target) === exportedSessionPath) {
+        return {
+          isFile: () => true,
+          isSymbolicLink: () => false,
+        } as Awaited<ReturnType<typeof realLstat>>;
+      }
+      return await realLstat(target, options);
+    });
+    const realReadFile = fs.readFile;
+    const readSpy = vi.spyOn(fs, "readFile").mockImplementation(async (target, options) => {
+      if (typeof target === "string" && path.resolve(target) === exportedSessionPath) {
+        return "# Session session-1\n\nsession canary\n";
+      }
+      return await realReadFile(target, options as never);
+    });
+
+    try {
+      const readResult = await manager.readFile({ relPath: results[0]!.path });
+      expect(readResult).toEqual({
+        path: "qmd/sessions-main/session-1.md",
+        text: "# Session session-1\n\nsession canary\n",
+      });
+    } finally {
+      lstatSpy.mockRestore();
+      readSpy.mockRestore();
+    }
+
     await manager.close();
   });
 

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -2192,15 +2192,22 @@ export class QmdMemoryManager implements MemorySearchManager {
     relativeToWorkspace: string,
     absPath: string,
   ): string {
+    const sanitized = collectionRelativePath.replace(/^\/+/, "");
     const insideWorkspace = this.isInsideWorkspace(relativeToWorkspace);
     if (insideWorkspace) {
       const normalized = relativeToWorkspace.replace(/\\/g, "/");
       if (!normalized) {
         return path.basename(absPath);
       }
+      // `qmd/<collection>/...` is a reserved virtual path namespace consumed by
+      // readFile(). If a real workspace file happens to live under `qmd/...`,
+      // return the explicit collection-scoped virtual path so search->read
+      // remains roundtrip-safe.
+      if (normalized === "qmd" || normalized.startsWith("qmd/")) {
+        return `qmd/${collection}/${sanitized}`;
+      }
       return normalized;
     }
-    const sanitized = collectionRelativePath.replace(/^\/+/, "");
     return `qmd/${collection}/${sanitized}`;
   }
 


### PR DESCRIPTION
## Summary

- Problem: when a QMD-backed file lives under the workspace `qmd/` directory, `memory_search` returned that workspace-relative path, but `memory_get` treats `qmd/<collection>/...` as a reserved virtual namespace and therefore rejected the generic `qmd/sessions/...` alias.
- Why it matters: QMD session hits could not roundtrip from `memory_search` into `memory_get`, which broke normal session-backed recall flows.
- What changed: search result serialization now preserves workspace-relative paths except when they collide with the reserved `qmd/` virtual namespace; in that collision case it returns the collection-scoped virtual path instead.
- What did NOT change (scope boundary): this does not change normal workspace path handling or QMD read semantics outside the reserved `qmd/` prefix collision case.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43519
- Related #43523
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `extensions/memory-core/src/memory/qmd-manager.ts` preferred workspace-relative paths for hits inside the workspace, but `readFile()` reserves the `qmd/<collection>/...` prefix for virtual QMD collection reads. Session exports under `${workspace}/qmd/...` therefore serialized to an ambiguous path that `memory_get` interpreted as the wrong collection.
- Missing detection / guardrail: there was no regression test for the case where session exports live under the workspace `qmd/` directory and the returned path must still be roundtrip-safe.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #43523 identified the same failure mode on older code.
- Why this regressed now: current path formatting still allowed real workspace files to collide with the reserved virtual QMD namespace.
- If unknown, what was ruled out: raw `qmd://collection/...` file resolution already worked; the breakage is specifically in OpenClaw's search-hit path formatting layer.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- `extensions/memory-core/src/memory/qmd-manager.test.ts`
- Scenario the test should lock in: when session exports live under the workspace `qmd/` directory, `memory_search` returns `qmd/<real-collection>/...` and `readFile()` succeeds with that exact path.
- Why this is the smallest reliable guardrail: the bug is a pure path-translation mismatch inside `QmdMemoryManager`, and the existing manager test harness already covers both search-hit formatting and read-path resolution.
- Existing test that already covers this (if any): adjacent tests already cover `qmd://` file URIs and QMD path read safety, but not the reserved-prefix collision case.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `memory_get` can now read the exact QMD session-hit path returned by `memory_search` even when exported session markdown lives under the workspace `qmd/` directory.

## Diagram (if applicable)

```text
Before:
search hit inside workspace qmd/sessions/... -> returns qmd/sessions/... -> memory_get interprets "sessions" as collection name -> fails

After:
search hit inside workspace qmd/sessions/... -> returns qmd/sessions-main/... -> memory_get resolves the real collection -> succeeds
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): memory_search / memory_get
- Relevant config (redacted): `memory.backend=qmd` with session indexing enabled and a workspace under the agent state dir

### Steps

1. Place session-export markdown under a workspace `qmd/` directory.
2. Return that hit from QMD search as `qmd://sessions-main/...`.
3. Feed the returned path back into `memory_get`.

### Expected

- The returned path is collection-scoped and directly readable.

### Actual

- The old path formatting returned the generic `qmd/sessions/...` alias, which `memory_get` rejected as an unknown collection.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: focused QMD manager regression for the workspace-`qmd/` collision case plus adjacent `qmd://` URI and read-path safety tests.
- Edge cases checked: normal `qmd://collection/...` URI resolution still works and non-markdown / symlink reads remain blocked.
- What you did **not** verify: live manual run against a real QMD install outside the test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: workspace files under a real `qmd/` directory now serialize differently than other workspace-relative files.
  - Mitigation: the change is intentionally limited to the reserved `qmd/` namespace that `readFile()` already treats specially, so it restores roundtrip safety without changing unrelated workspace paths.
