### PR TITLE
fix(agents): add OpenRouter attribution to direct completions

### DIFF
--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -273,10 +273,10 @@ export async function loadCompactHooksHarness(): Promise<{
   });
 
   vi.doMock("@mariozechner/pi-coding-agent", () => ({
-    AuthStorage: class AuthStorage {},
-    ModelRegistry: class ModelRegistry {},
+    AuthStorage: function AuthStorage() {},
+    ModelRegistry: function ModelRegistry() {},
     createAgentSession: createAgentSessionMock,
-    DefaultResourceLoader: class DefaultResourceLoader {},
+    DefaultResourceLoader: function DefaultResourceLoader() {},
     SessionManager: {
       open: vi.fn(() => ({})),
     },

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -2,7 +2,15 @@ import { vi, type Mock } from "vitest";
 import { clearAgentHarnesses } from "../harness/registry.js";
 
 type MockResolvedModel = {
-  model: { provider: string; api: string; id: string; input: unknown[] };
+  model: {
+    provider: string;
+    api: string;
+    id: string;
+    input: unknown[];
+    headers?: Record<string, string>;
+    baseUrl?: string;
+    contextWindow?: number;
+  };
   error: null;
   authStorage: { setRuntimeApiKey: Mock<(provider?: string, apiKey?: string) => void> };
   modelRegistry: Record<string, never>;
@@ -92,6 +100,37 @@ export const registerProviderStreamForModelMock: Mock<(params?: unknown) => unkn
 export const applyExtraParamsToAgentMock = vi.fn(() => ({ effectiveExtraParams: {} }));
 export const resolveAgentTransportOverrideMock: Mock<(params?: unknown) => string | undefined> =
   vi.fn(() => undefined);
+export const createAgentSessionMock = vi.fn();
+
+function createMockAgentSession() {
+  const session = {
+    sessionId: "session-1",
+    messages: sessionMessages.map((message) =>
+      typeof structuredClone === "function"
+        ? structuredClone(message)
+        : JSON.parse(JSON.stringify(message)),
+    ),
+    agent: {
+      streamFn: vi.fn(),
+      transport: "sse",
+      state: {
+        get messages() {
+          return session.messages;
+        },
+        set messages(messages: unknown[]) {
+          session.messages = [...(messages as typeof session.messages)];
+        },
+      },
+    },
+    compact: vi.fn(async () => {
+      session.messages.splice(1);
+      return await sessionCompactImpl();
+    }),
+    abortCompaction: sessionAbortCompactionMock,
+    dispose: vi.fn(),
+  };
+  return { session };
+}
 
 export function resetCompactSessionStateMocks(): void {
   sanitizeSessionHistoryMock.mockReset();
@@ -182,6 +221,8 @@ export function resetCompactHooksHarnessMocks(): void {
     tokensBefore: 120,
     details: { ok: true },
   });
+  createAgentSessionMock.mockReset();
+  createAgentSessionMock.mockImplementation(async () => createMockAgentSession());
 
   triggerInternalHook.mockReset();
   resetCompactSessionStateMocks();
@@ -232,38 +273,10 @@ export async function loadCompactHooksHarness(): Promise<{
   });
 
   vi.doMock("@mariozechner/pi-coding-agent", () => ({
-    AuthStorage: function AuthStorage() {},
-    ModelRegistry: function ModelRegistry() {},
-    createAgentSession: vi.fn(async () => {
-      const session = {
-        sessionId: "session-1",
-        messages: sessionMessages.map((message) =>
-          typeof structuredClone === "function"
-            ? structuredClone(message)
-            : JSON.parse(JSON.stringify(message)),
-        ),
-        agent: {
-          streamFn: vi.fn(),
-          transport: "sse",
-          state: {
-            get messages() {
-              return session.messages;
-            },
-            set messages(messages: unknown[]) {
-              session.messages = [...(messages as typeof session.messages)];
-            },
-          },
-        },
-        compact: vi.fn(async () => {
-          session.messages.splice(1);
-          return await sessionCompactImpl();
-        }),
-        abortCompaction: sessionAbortCompactionMock,
-        dispose: vi.fn(),
-      };
-      return { session };
-    }),
-    DefaultResourceLoader: function DefaultResourceLoader() {},
+    AuthStorage: class AuthStorage {},
+    ModelRegistry: class ModelRegistry {},
+    createAgentSession: createAgentSessionMock,
+    DefaultResourceLoader: class DefaultResourceLoader {},
     SessionManager: {
       open: vi.fn(() => ({})),
     },

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -4,6 +4,7 @@ import {
   applyExtraParamsToAgentMock,
   contextEngineCompactMock,
   createOpenClawCodingToolsMock,
+  createAgentSessionMock,
   ensureRuntimePluginsLoaded,
   estimateTokensMock,
   getMemorySearchManagerMock,
@@ -646,6 +647,44 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
         }),
         agentDir: "/tmp",
         workspaceDir: "/tmp",
+      }),
+    );
+  });
+
+  it("applies OpenRouter attribution headers before creating the compaction session", async () => {
+    resolveModelMock.mockReturnValue({
+      model: {
+        provider: "openrouter",
+        api: "openai-completions",
+        id: "anthropic/claude-sonnet-4-5",
+        input: ["text"],
+        headers: { "X-Custom": "1" },
+      },
+      error: null,
+      authStorage: { setRuntimeApiKey: vi.fn() },
+      modelRegistry: {},
+    } as never);
+
+    const result = await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      customInstructions: "focus on decisions",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(createAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: expect.objectContaining({
+          provider: "openrouter",
+          headers: {
+            "HTTP-Referer": "https://openclaw.ai",
+            "X-OpenRouter-Title": "OpenClaw",
+            "X-OpenRouter-Categories": "cli-agent",
+            "X-Custom": "1",
+          },
+        }),
       }),
     );
   });

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -77,6 +77,7 @@ import {
 import { createPreparedEmbeddedPiSettingsManager } from "../pi-project-settings.js";
 import { createOpenClawCodingTools } from "../pi-tools.js";
 import { wrapStreamFnTextTransforms } from "../plugin-text-transforms.js";
+import { applyProviderAttributionHeadersToModel } from "../provider-attribution.js";
 import { registerProviderStreamForModel } from "../provider-stream.js";
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
 import { resolveSandboxContext } from "../sandbox.js";
@@ -488,18 +489,20 @@ export async function compactEmbeddedPiSessionDirect(
       modelContextWindow: runtimeModelWithContext.contextWindow,
       defaultTokens: DEFAULT_CONTEXT_TOKENS,
     });
-    const effectiveModel = applyAuthHeaderOverride(
-      applyLocalNoAuthHeaderOverride(
-        ctxInfo.tokens < (runtimeModelWithContext.contextWindow ?? Infinity)
-          ? { ...runtimeModelWithContext, contextWindow: ctxInfo.tokens }
-          : runtimeModelWithContext,
-        apiKeyInfo,
+    const effectiveModel = applyProviderAttributionHeadersToModel(
+      applyAuthHeaderOverride(
+        applyLocalNoAuthHeaderOverride(
+          ctxInfo.tokens < (runtimeModelWithContext.contextWindow ?? Infinity)
+            ? { ...runtimeModelWithContext, contextWindow: ctxInfo.tokens }
+            : runtimeModelWithContext,
+          apiKeyInfo,
+        ),
+        // Skip header injection when runtime auth exchange produced a
+        // different credential — the SDK reads the exchanged token from
+        // authStorage automatically.
+        hasRuntimeAuthExchange ? null : apiKeyInfo,
+        params.config,
       ),
-      // Skip header injection when runtime auth exchange produced a
-      // different credential — the SDK reads the exchanged token from
-      // authStorage automatically.
-      hasRuntimeAuthExchange ? null : apiKeyInfo,
-      params.config,
     );
 
     const runAbortController = new AbortController();

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyProviderAttributionHeadersToModel,
   listProviderAttributionPolicies,
   resolveProviderAttributionHeaders,
   resolveProviderAttributionIdentity,
@@ -843,5 +844,27 @@ describe("provider attribution", () => {
         testCase.expected,
       );
     }
+  });
+
+  it("applies provider attribution headers to direct-completion models without clobbering existing headers", () => {
+    expect(
+      applyProviderAttributionHeadersToModel(
+        {
+          provider: "openrouter",
+          headers: {
+            "X-Custom": "1",
+          },
+        },
+        { OPENCLAW_VERSION: "2026.3.22" },
+      ),
+    ).toEqual({
+      provider: "openrouter",
+      headers: {
+        "HTTP-Referer": "https://openclaw.ai",
+        "X-OpenRouter-Title": "OpenClaw",
+        "X-OpenRouter-Categories": "cli-agent",
+        "X-Custom": "1",
+      },
+    });
   });
 });

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -867,4 +867,25 @@ describe("provider attribution", () => {
       },
     });
   });
+
+  it("skips direct-completion OpenRouter attribution for custom proxy baseUrls", () => {
+    expect(
+      applyProviderAttributionHeadersToModel(
+        {
+          provider: "openrouter",
+          baseUrl: "https://proxy.example.com/v1",
+          headers: {
+            "X-Custom": "1",
+          },
+        },
+        { OPENCLAW_VERSION: "2026.3.22" },
+      ),
+    ).toEqual({
+      provider: "openrouter",
+      baseUrl: "https://proxy.example.com/v1",
+      headers: {
+        "X-Custom": "1",
+      },
+    });
+  });
 });

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -868,6 +868,30 @@ describe("provider attribution", () => {
     });
   });
 
+  it("does not let model headers override protected OpenRouter attribution keys", () => {
+    expect(
+      applyProviderAttributionHeadersToModel(
+        {
+          provider: "openrouter",
+          headers: {
+            "http-referer": "https://example.com",
+            "X-OpenRouter-Title": "Custom Title",
+            "X-Custom": "1",
+          },
+        },
+        { OPENCLAW_VERSION: "2026.3.22" },
+      ),
+    ).toEqual({
+      provider: "openrouter",
+      headers: {
+        "X-Custom": "1",
+        "HTTP-Referer": "https://openclaw.ai",
+        "X-OpenRouter-Title": "OpenClaw",
+        "X-OpenRouter-Categories": "cli-agent",
+      },
+    });
+  });
+
   it("skips direct-completion OpenRouter attribution for custom proxy baseUrls", () => {
     expect(
       applyProviderAttributionHeadersToModel(

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -461,12 +461,20 @@ export function resolveProviderAttributionHeaders(
 }
 
 export function applyProviderAttributionHeadersToModel<
-  T extends { provider?: string | null; headers?: Record<string, string> | undefined },
+  T extends {
+    provider?: string | null;
+    baseUrl?: string | null;
+    headers?: Record<string, string> | undefined;
+  },
 >(model: T, env: RuntimeVersionEnv = process.env as RuntimeVersionEnv): T {
   const normalizedProvider = normalizeProviderId(model.provider ?? "");
   // Only OpenRouter attribution is applied via direct-completion model headers.
   // OpenAI / OpenAI-Codex attribution stays on the stream-wrapper path for now.
   if (normalizedProvider !== "openrouter") {
+    return model;
+  }
+  const endpointClass = resolveProviderEndpoint(model.baseUrl).endpointClass;
+  if (endpointClass !== "default" && endpointClass !== "openrouter") {
     return model;
   }
   const attributionHeaders = resolveProviderAttributionHeaders(normalizedProvider, env);

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -460,6 +460,28 @@ export function resolveProviderAttributionHeaders(
   return policy.headers;
 }
 
+export function applyProviderAttributionHeadersToModel<
+  T extends { provider?: string | null; headers?: Record<string, string> | undefined },
+>(model: T, env: RuntimeVersionEnv = process.env as RuntimeVersionEnv): T {
+  const normalizedProvider = normalizeProviderId(model.provider ?? "");
+  // Only OpenRouter attribution is applied via direct-completion model headers.
+  // OpenAI / OpenAI-Codex attribution stays on the stream-wrapper path for now.
+  if (normalizedProvider !== "openrouter") {
+    return model;
+  }
+  const attributionHeaders = resolveProviderAttributionHeaders(normalizedProvider, env);
+  if (!attributionHeaders || Object.keys(attributionHeaders).length === 0) {
+    return model;
+  }
+  return {
+    ...model,
+    headers: {
+      ...attributionHeaders,
+      ...model.headers,
+    },
+  };
+}
+
 export function resolveProviderRequestPolicy(
   input: ProviderRequestPolicyInput,
   env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -1,4 +1,5 @@
 import {
+  normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
@@ -481,11 +482,21 @@ export function applyProviderAttributionHeadersToModel<
   if (!attributionHeaders || Object.keys(attributionHeaders).length === 0) {
     return model;
   }
+  const protectedAttributionKeys = new Set(
+    Object.keys(attributionHeaders).map((key) => normalizeLowercaseStringOrEmpty(key)),
+  );
+  const unprotectedModelHeaders = model.headers
+    ? Object.fromEntries(
+        Object.entries(model.headers).filter(
+          ([key]) => !protectedAttributionKeys.has(normalizeLowercaseStringOrEmpty(key)),
+        ),
+      )
+    : undefined;
   return {
     ...model,
     headers: {
+      ...unprotectedModelHeaders,
       ...attributionHeaders,
-      ...model.headers,
     },
   };
 }

--- a/src/agents/simple-completion-transport.test.ts
+++ b/src/agents/simple-completion-transport.test.ts
@@ -158,4 +158,78 @@ describe("prepareModelForSimpleCompletion", () => {
       api: "openclaw-openai-responses-transport",
     });
   });
+
+  it("applies OpenRouter attribution headers to direct simple completion models", () => {
+    const model: Model<"openai-completions"> = {
+      id: "anthropic/claude-sonnet-4-5",
+      name: "Claude Sonnet",
+      api: "openai-completions",
+      provider: "openrouter",
+      baseUrl: "https://openrouter.ai/api/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+      headers: {
+        "X-Custom": "1",
+      },
+    };
+
+    const result = prepareModelForSimpleCompletion({ model });
+
+    expect(result).toEqual({
+      ...model,
+      headers: {
+        "HTTP-Referer": "https://openclaw.ai",
+        "X-OpenRouter-Title": "OpenClaw",
+        "X-OpenRouter-Categories": "cli-agent",
+        "X-Custom": "1",
+      },
+    });
+  });
+
+  it("keeps OpenRouter attribution headers when the simple transport alias is used", () => {
+    const model: Model<"openai-completions"> = {
+      id: "anthropic/claude-sonnet-4-5",
+      name: "Claude Sonnet",
+      api: "openai-completions",
+      provider: "openrouter",
+      baseUrl: "https://openrouter.ai/api/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+      headers: {
+        "X-Custom": "1",
+      },
+    };
+
+    resolveProviderStreamFn.mockReturnValueOnce(undefined);
+    buildTransportAwareSimpleStreamFn.mockReturnValueOnce("transport-stream");
+    prepareTransportAwareSimpleModel.mockReturnValueOnce({
+      ...model,
+      api: "openclaw-openai-completions-transport",
+    });
+
+    const result = prepareModelForSimpleCompletion({ model });
+
+    expect(prepareTransportAwareSimpleModel).toHaveBeenCalledWith(model);
+    expect(buildTransportAwareSimpleStreamFn).toHaveBeenCalledWith(model);
+    expect(ensureCustomApiRegistered).toHaveBeenCalledWith(
+      "openclaw-openai-completions-transport",
+      "transport-stream",
+    );
+    expect(result).toEqual({
+      ...model,
+      api: "openclaw-openai-completions-transport",
+      headers: {
+        "HTTP-Referer": "https://openclaw.ai",
+        "X-OpenRouter-Title": "OpenClaw",
+        "X-OpenRouter-Categories": "cli-agent",
+        "X-Custom": "1",
+      },
+    });
+  });
 });

--- a/src/agents/simple-completion-transport.ts
+++ b/src/agents/simple-completion-transport.ts
@@ -2,6 +2,7 @@ import { getApiProvider, type Api, type Model } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../config/config.js";
 import { createAnthropicVertexStreamFnForModel } from "./anthropic-vertex-stream.js";
 import { ensureCustomApiRegistered } from "./custom-api-registry.js";
+import { applyProviderAttributionHeadersToModel } from "./provider-attribution.js";
 import { registerProviderStreamForModel } from "./provider-stream.js";
 import {
   buildTransportAwareSimpleStreamFn,
@@ -20,7 +21,7 @@ export function prepareModelForSimpleCompletion<TApi extends Api>(params: {
   const { model, cfg } = params;
   // Only provider-owned custom APIs need runtime stream registration here.
   if (!getApiProvider(model.api) && registerProviderStreamForModel({ model, cfg })) {
-    return model;
+    return applyProviderAttributionHeadersToModel(model);
   }
 
   const transportAwareModel = prepareTransportAwareSimpleModel(model);
@@ -28,15 +29,15 @@ export function prepareModelForSimpleCompletion<TApi extends Api>(params: {
     const streamFn = buildTransportAwareSimpleStreamFn(model);
     if (streamFn) {
       ensureCustomApiRegistered(transportAwareModel.api, streamFn);
-      return transportAwareModel;
+      return applyProviderAttributionHeadersToModel(transportAwareModel);
     }
   }
 
   if (model.provider === "anthropic-vertex") {
     const api = resolveAnthropicVertexSimpleApi(model.baseUrl);
     ensureCustomApiRegistered(api, createAnthropicVertexStreamFnForModel(model));
-    return { ...model, api };
+    return applyProviderAttributionHeadersToModel({ ...model, api });
   }
 
-  return model;
+  return applyProviderAttributionHeadersToModel(model);
 }

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -99,6 +99,7 @@ async function stubPdfToolInfra(
     provider?: string;
     input?: string[];
     modelFound?: boolean;
+    headers?: Record<string, string>;
   },
 ) {
   const loadSpy = vi.spyOn(webMedia, "loadWebMediaRaw").mockResolvedValue(FAKE_PDF_MEDIA as never);
@@ -114,6 +115,7 @@ async function stubPdfToolInfra(
             provider: params?.provider ?? "anthropic",
             maxTokens: 8192,
             input: params?.input ?? ["text", "document"],
+            headers: params?.headers,
           }) as never;
   vi.spyOn(modelDiscovery, "discoverModels").mockReturnValue({ find } as never);
 
@@ -278,6 +280,53 @@ describe("createPdfTool", () => {
       expect(result).toMatchObject({
         content: [{ type: "text", text: "fallback summary" }],
         details: { native: false, model: OPENAI_PDF_MODEL },
+      });
+    });
+  });
+
+  it("applies OpenRouter attribution headers for extraction fallback requests", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, {
+        provider: "openrouter",
+        input: ["text"],
+        headers: {
+          "X-Custom": "1",
+        },
+      });
+
+      const extractModule = await import("../../media/pdf-extract.js");
+      vi.spyOn(extractModule, "extractPdfContent").mockResolvedValue({
+        text: "Extracted content",
+        images: [],
+      });
+
+      completeMock.mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "openrouter summary" }],
+      } as never);
+
+      const cfg = withPdfModel("openrouter/anthropic/claude-sonnet-4-5");
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      const result = await tool.execute("t1", {
+        prompt: "summarize",
+        pdf: "/tmp/doc.pdf",
+      });
+
+      expect(result).toMatchObject({
+        content: [{ type: "text", text: "openrouter summary" }],
+        details: { native: false, model: "openrouter/anthropic/claude-sonnet-4-5" },
+      });
+      const [effectiveModel] = completeMock.mock.calls[0] ?? [];
+      expect(effectiveModel).toMatchObject({
+        provider: "openrouter",
+        headers: {
+          "HTTP-Referer": "https://openclaw.ai",
+          "X-OpenRouter-Title": "OpenClaw",
+          "X-OpenRouter-Categories": "cli-agent",
+          "X-Custom": "1",
+        },
       });
     });
   });

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -3,6 +3,7 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { extractPdfContent, type PdfExtractedContent } from "../../media/pdf-extract.js";
 import { loadWebMediaRaw } from "../../media/web-media.js";
+import { applyProviderAttributionHeadersToModel } from "../provider-attribution.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -144,6 +145,7 @@ async function runPdfPrompt(params: {
     modelOverride: params.modelOverride,
     run: async (provider, modelId) => {
       const model = resolveModelFromRegistry({ modelRegistry, provider, modelId });
+      const completionModel = applyProviderAttributionHeadersToModel(model);
       const apiKey = await resolveModelRuntimeApiKey({
         model,
         cfg: effectiveCfg,
@@ -201,7 +203,7 @@ async function runPdfPrompt(params: {
           images: [],
         }));
         const context = buildPdfExtractionContext(params.prompt, textOnlyExtractions);
-        const message = await complete(model, context, {
+        const message = await complete(completionModel, context, {
           apiKey,
           maxTokens: resolvePdfToolMaxTokens(model.maxTokens),
         });
@@ -210,7 +212,7 @@ async function runPdfPrompt(params: {
       }
 
       const context = buildPdfExtractionContext(params.prompt, extractions);
-      const message = await complete(model, context, {
+      const message = await complete(completionModel, context, {
         apiKey,
         maxTokens: resolvePdfToolMaxTokens(model.maxTokens),
       });

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -229,6 +229,55 @@ describe("describeImageWithModel", () => {
     expect(context?.messages?.[0]?.content).toHaveLength(1);
   });
 
+  it("applies OpenRouter attribution headers to direct image completion models", async () => {
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        provider: "openrouter",
+        id: "anthropic/claude-sonnet-4-5",
+        input: ["text", "image"],
+        headers: {
+          "X-Custom": "1",
+        },
+      })),
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-completions",
+      provider: "openrouter",
+      model: "anthropic/claude-sonnet-4-5",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "openrouter ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "openrouter",
+      model: "anthropic/claude-sonnet-4-5",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "openrouter ok",
+      model: "anthropic/claude-sonnet-4-5",
+    });
+    const [effectiveModel] = completeMock.mock.calls[0] ?? [];
+    expect(effectiveModel).toMatchObject({
+      provider: "openrouter",
+      headers: {
+        "HTTP-Referer": "https://openclaw.ai",
+        "X-OpenRouter-Title": "OpenClaw",
+        "X-OpenRouter-Categories": "cli-agent",
+        "X-Custom": "1",
+      },
+    });
+  });
+
   it("normalizes deprecated google flash ids before lookup and keeps profile auth selection", async () => {
     const findMock = vi.fn((provider: string, modelId: string) => {
       expect(provider).toBe("google");

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -8,6 +8,7 @@ import {
 } from "../agents/model-auth.js";
 import { normalizeModelRef } from "../agents/model-selection.js";
 import { ensureOpenClawModelsJson } from "../agents/models-config.js";
+import { applyProviderAttributionHeadersToModel } from "../agents/provider-attribution.js";
 import { coerceImageAssistantText } from "../agents/tools/image-tool.helpers.js";
 import type {
   ImageDescriptionRequest,
@@ -186,6 +187,7 @@ export async function describeImagesWithModel(
   }
 
   const context = buildImageContext(prompt, params.images);
+  const effectiveModel = applyProviderAttributionHeadersToModel(model);
   const controller = new AbortController();
   const timeout =
     typeof params.timeoutMs === "number" &&
@@ -193,7 +195,7 @@ export async function describeImagesWithModel(
     params.timeoutMs > 0
       ? setTimeout(() => controller.abort(), params.timeoutMs)
       : undefined;
-  const message = await complete(model, context, {
+  const message = await complete(effectiveModel, context, {
     apiKey,
     maxTokens: resolveImageToolMaxTokens(model.maxTokens, params.maxTokens ?? 512),
     signal: controller.signal,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: direct OpenRouter completion paths bypassed the normal stream-wrapper attribution flow, so image analysis, PDF extraction fallback, simple completion transport, and compaction could miss OpenRouter app attribution headers.
- Why it matters: requests that skip attribution are harder to attribute correctly on the provider side and do not match the behavior of the main chat path.
- What changed: added a narrow helper that applies OpenRouter attribution headers to direct-completion models, then used it in image, PDF fallback, simple completion transport, and compaction paths; added regression coverage for each path.
- What did NOT change (scope boundary): no OpenAI hidden-attribution changes, no `X-OpenRouter-Title` to `X-Title` migration, and no provider behavior changes outside OpenRouter direct-completion paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57498
- Related #50267
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: direct `complete(...)` call sites and compaction built/used models outside the normal OpenRouter stream-wrapper path, so provider attribution headers were never applied there.
- Missing detection / guardrail: there was no shared helper for applying attribution to direct-completion models, and there was no regression test asserting headers on those paths.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #57498 called out image and compaction specifically; #50267 moved in the right direction for image but did not cover the broader direct-completion surface.
- Why this regressed now: OpenRouter attribution existed in the wrapped chat path, which made the gap easy to miss in direct-call code paths.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/provider-attribution.test.ts`
  - `src/media-understanding/image.test.ts`
  - `src/agents/tools/pdf-tool.test.ts`
  - `src/agents/simple-completion-transport.test.ts`
  - `src/agents/pi-embedded-runner/compact.hooks.test.ts`
- Scenario the test should lock in: OpenRouter direct-completion models keep existing headers and also include OpenRouter attribution headers before the request/session is created.
- Why this is the smallest reliable guardrail: the bug is about request-model preparation, so focused unit coverage catches it without depending on external OpenRouter analytics.
- Existing test that already covers this (if any): none for the missing attribution behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

OpenRouter direct-completion requests now carry the same OpenClaw attribution headers as the wrapped chat path for:
- image understanding
- PDF extraction fallback
- simple completion transport
- compaction
