### PR TITLE
fix: release gateway lock on shutdown timeout (#57052)

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -483,6 +483,52 @@ describe("runGatewayLoop", () => {
       );
     });
   });
+
+  it("releases lock synchronously before forced exit on shutdown timeout", async () => {
+    vi.clearAllMocks();
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      vi.useFakeTimers();
+      const releaseSync = vi.fn();
+      acquireGatewayLock.mockResolvedValueOnce({
+        lockPath: "/tmp/test-gateway.lock",
+        release: vi.fn(async () => {}),
+        releaseSync,
+      });
+
+      const close = vi.fn(() => new Promise<void>(() => {}));
+      const { start, started } = createSignaledStart(close);
+      const exitCallOrder: string[] = [];
+      const { runtime } = createRuntimeWithExitSignal(exitCallOrder);
+      let resolveExit: (code: number) => void = () => {};
+      const exitPromise = new Promise<number>((resolve) => {
+        resolveExit = resolve;
+      });
+      runtime.exit = vi.fn((_code: number) => {
+        exitCallOrder.push("exit");
+        resolveExit(1);
+      });
+
+      const { runGatewayLoop } = await import("./run-loop.js");
+      void runGatewayLoop({
+        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+      });
+      await waitForStart(started);
+      const sigterm = captureSignal("SIGTERM");
+
+      sigterm();
+      await vi.advanceTimersByTimeAsync(25_000);
+
+      await expect(exitPromise).resolves.toBe(1);
+      expect(releaseSync).toHaveBeenCalledTimes(1);
+      expect(exitCallOrder).toEqual(["exit"]);
+      expect(gatewayLog.error).toHaveBeenCalledWith(
+        "shutdown timed out; exiting without full cleanup",
+      );
+      vi.useRealTimers();
+    });
+  });
 });
 
 describe("gateway discover routing helpers", () => {

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -3,7 +3,9 @@ import type { GatewayBonjourBeacon } from "../../infra/bonjour-discovery.js";
 import { pickBeaconHost, pickGatewayPort } from "./discover.js";
 
 const acquireGatewayLock = vi.fn(async (_opts?: { port?: number }) => ({
+  lockPath: "/tmp/test-gateway.lock",
   release: vi.fn(async () => {}),
+  releaseSync: vi.fn(),
 }));
 const consumeGatewaySigusr1RestartAuthorization = vi.fn(() => true);
 const isGatewaySigusr1RestartExternallyAllowed = vi.fn(() => false);
@@ -360,7 +362,9 @@ describe("runGatewayLoop", () => {
     await withIsolatedSignals(async ({ captureSignal }) => {
       const lockRelease = vi.fn(async () => {});
       acquireGatewayLock.mockResolvedValueOnce({
+        lockPath: "/tmp/test-gateway.lock",
         release: lockRelease,
+        releaseSync: vi.fn(),
       });
 
       // Override process-respawn to return "spawned" mode
@@ -457,7 +461,9 @@ describe("runGatewayLoop", () => {
       const lockRelease = vi.fn(async () => {});
       acquireGatewayLock
         .mockResolvedValueOnce({
+          lockPath: "/tmp/test-gateway.lock",
           release: lockRelease,
+          releaseSync: vi.fn(),
         })
         .mockRejectedValueOnce(new Error("lock timeout"));
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -48,10 +48,24 @@ export async function runGatewayLoop(params: {
     process.removeListener("SIGTERM", onSigterm);
     process.removeListener("SIGINT", onSigint);
     process.removeListener("SIGUSR1", onSigusr1);
+    process.removeListener("exit", onProcessExit);
+  };
+  /** Synchronous best-effort lock release for forced-exit paths. */
+  const releaseLockSync = () => {
+    if (!lock) {
+      return;
+    }
+    lock.releaseSync();
+    lock = null;
   };
   const exitProcess = (code: number) => {
+    process.removeListener("exit", onProcessExit);
     cleanupSignals();
     params.runtime.exit(code);
+  };
+  /** Safety-net: release lock if the process exits without going through exitProcess. */
+  const onProcessExit = () => {
+    releaseLockSync();
   };
   const releaseLockIfHeld = async (): Promise<boolean> => {
     if (!lock) {
@@ -144,6 +158,9 @@ export async function runGatewayLoop(params: {
       : SHUTDOWN_TIMEOUT_MS;
     const forceExitTimer = setTimeout(() => {
       gatewayLog.error("shutdown timed out; exiting without full cleanup");
+      // Best-effort synchronous lock release before forced exit to prevent
+      // stale lock files from blocking subsequent gateway starts. (#57052)
+      releaseLockSync();
       // Keep the in-process watchdog below the supervisor stop budget so this
       // path wins before launchd/systemd escalates to a hard kill. Exit
       // non-zero on any timeout so supervised installs restart cleanly.
@@ -242,6 +259,7 @@ export async function runGatewayLoop(params: {
   process.on("SIGTERM", onSigterm);
   process.on("SIGINT", onSigint);
   process.on("SIGUSR1", onSigusr1);
+  process.on("exit", onProcessExit);
 
   try {
     const onIteration = createRestartIterationHook(() => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -59,7 +59,6 @@ export async function runGatewayLoop(params: {
     lock = null;
   };
   const exitProcess = (code: number) => {
-    process.removeListener("exit", onProcessExit);
     cleanupSignals();
     params.runtime.exit(code);
   };

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -419,4 +419,73 @@ describe("gateway lock", () => {
 
     connectSpy.mockRestore();
   });
+
+  it("cleans up stale lock left by a dead pid on non-linux platforms", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    const { lockPath } = resolveLockPath(env);
+
+    const deadPid = 2_147_483_647;
+    const lockDir = path.dirname(lockPath);
+    await fs.mkdir(lockDir, { recursive: true });
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({
+        pid: deadPid,
+        createdAt: new Date().toISOString(),
+        configPath: resolveLockPath(env).configPath,
+      }),
+      "utf8",
+    );
+
+    const lock = await acquireForTest(env, {
+      timeoutMs: 200,
+      pollIntervalMs: 5,
+      platform: "darwin",
+    });
+    expect(lock).not.toBeNull();
+
+    const payload = JSON.parse(await fs.readFile(lockPath, "utf8"));
+    expect(payload.pid).toBe(process.pid);
+
+    await lock?.release();
+  });
+
+  it("releaseSync removes lock file synchronously", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    const lock = await acquireForTest(env);
+    expect(lock).not.toBeNull();
+
+    const exists = fsSync.existsSync(lock!.lockPath);
+    expect(exists).toBe(true);
+
+    lock!.releaseSync();
+    const existsAfter = fsSync.existsSync(lock!.lockPath);
+    expect(existsAfter).toBe(false);
+  });
+
+  it("releaseSync is idempotent and does not throw", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+    const lock = await acquireForTest(env);
+    expect(lock).not.toBeNull();
+
+    lock!.releaseSync();
+    expect(() => lock!.releaseSync()).not.toThrow();
+  });
+
+  it("acquires lock after stale lock left by shutdown timeout (no port)", async () => {
+    vi.useRealTimers();
+    const env = await makeEnv();
+
+    const firstLock = await acquireForTest(env);
+    expect(firstLock).not.toBeNull();
+
+    firstLock!.releaseSync();
+
+    const secondLock = await acquireForTest(env);
+    expect(secondLock).not.toBeNull();
+    await secondLock?.release();
+  });
 });

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -288,14 +288,28 @@ export async function acquireGatewayLock(
         payload.startTime = startTime;
       }
       await handle.writeFile(JSON.stringify(payload), "utf8");
+      let released = false;
+      const markReleased = () => {
+        if (released) {
+          return false;
+        }
+        released = true;
+        return true;
+      };
       return {
         lockPath,
         configPath,
         release: async () => {
+          if (!markReleased()) {
+            return;
+          }
           await handle.close().catch(() => undefined);
           await fs.rm(lockPath, { force: true });
         },
         releaseSync: () => {
+          if (!markReleased()) {
+            return;
+          }
           try {
             // Use synchronous close via the underlying file descriptor to
             // guarantee the handle is released before rmSync runs. The async

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -33,6 +33,12 @@ export type GatewayLockHandle = {
   lockPath: string;
   configPath: string;
   release: () => Promise<void>;
+  /**
+   * Synchronous best-effort lock release for use in forced-exit paths
+   * (signal handlers, process.on('exit'), shutdown timeouts) where async
+   * operations cannot be awaited.
+   */
+  releaseSync: () => void;
 };
 
 export type GatewayLockOptions = {
@@ -288,6 +294,18 @@ export async function acquireGatewayLock(
         release: async () => {
           await handle.close().catch(() => undefined);
           await fs.rm(lockPath, { force: true });
+        },
+        releaseSync: () => {
+          try {
+            handle.close().catch(() => undefined);
+          } catch {
+            // best-effort
+          }
+          try {
+            fsSync.rmSync(lockPath, { force: true });
+          } catch {
+            // best-effort
+          }
         },
       };
     } catch (err) {

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -297,9 +297,15 @@ export async function acquireGatewayLock(
         },
         releaseSync: () => {
           try {
-            handle.close().catch(() => undefined);
+            // Use synchronous close via the underlying file descriptor to
+            // guarantee the handle is released before rmSync runs. The async
+            // handle.close() cannot complete in forced-exit paths such as
+            // process.on('exit') or the shutdown timeout timer, and on
+            // Windows the still-open handle would cause rmSync to fail with
+            // EBUSY.
+            fsSync.closeSync(handle.fd);
           } catch {
-            // best-effort
+            // best-effort — fd may already be closed
           }
           try {
             fsSync.rmSync(lockPath, { force: true });


### PR DESCRIPTION
## Summary

- Problem: Gateway shutdown timeout handler calls `exitProcess(1)` without releasing the lock file (`~/.openclaw/gateway.lock`). Subsequent `openclaw gateway start` fails with "lock timeout after 5000ms".
- Why it matters: Beta release blocker — users must manually delete the lock file or `kill -9` the stale process to restart the gateway.
- What changed: Added synchronous `releaseSync()` method to `GatewayLockHandle`, called in the forced-exit timer and a `process.on('exit')` safety-net handler.
- What did NOT change: Normal graceful shutdown path (async `release()`) is untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57052
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `forceExitTimer` callback in `run-loop.ts` called `exitProcess(1)` → `params.runtime.exit(code)` without releasing the lock. The async `releaseLockIfHeld()` was only awaited in the normal shutdown path, not the timeout fallback.
- Missing detection / guardrail: No `process.on('exit')` safety-net to clean up lock on unexpected exits.
- Prior context: The shutdown timeout path was designed for hard-exit scenarios but didn't account for lock file cleanup.
- Why this regressed now: As gateway complexity grew, shutdown operations increasingly exceed the 5s timeout, making this path trigger more frequently.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/gateway-lock.test.ts`
- Scenario the test should lock in: `releaseSync()` removes lock file synchronously; idempotent when called multiple times; dead-PID stale lock detection.
- Why this is the smallest reliable guardrail: Unit tests directly verify the new `releaseSync()` method behavior.
- If no new test is added, why not: 4 new tests added.

## User-visible / Behavior Changes

- Gateway lock file is now reliably cleaned up on shutdown timeout, preventing "lock timeout" errors on subsequent starts.
- `process.on('exit')` safety-net ensures lock cleanup even on unexpected process termination.

## Diagram (if applicable)

```text
Before:
[SIGTERM] -> [shutdown timeout 5s] -> exitProcess(1) -> lock file remains -> next start FAILS

After:
[SIGTERM] -> [shutdown timeout 5s] -> releaseSync() -> exitProcess(1) -> lock file removed -> next start OK
                                                     └─ process.on('exit') safety-net
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 14.x
- Runtime/container: Node.js v25.4.0
- Model/provider: N/A (infrastructure)

### Steps

1. `openclaw gateway start`
2. `openclaw gateway stop` (or send SIGTERM)
3. Wait for shutdown timeout (5s)
4. `openclaw gateway start` again

### Expected

- Gateway restarts successfully after timeout shutdown.

### Actual (before fix)

- "lock timeout after 5000ms" error, start fails.

## Evidence

- [x] Failing test/log before + passing after
- 22/22 tests pass (13 gateway-lock + 9 run-loop)

## Human Verification (required)

- Verified scenarios: `releaseSync()` removes lock; idempotent calls; `process.on('exit')` handler registered; mock shape updated for run-loop tests.
- Edge cases checked: Double `releaseSync()` call; `releaseSync()` when no lock held; error swallowing in best-effort cleanup.
- What you did **not** verify: Multi-process race condition with real file descriptors (tested with mocks).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `releaseSync()` swallows errors silently in forced-exit paths.
  - Mitigation: This is intentional best-effort behavior — in forced-exit contexts, logging may not work and throwing would prevent process exit.
