### PR TITLE
fix: use agent identity name for heartbeat session label (#57521)

### DIFF
--- a/src/agents/identity.ts
+++ b/src/agents/identity.ts
@@ -46,11 +46,19 @@ export function resolveAckReaction(
   return emoji || DEFAULT_ACK_REACTION;
 }
 
-export function resolveIdentityNamePrefix(
+export function resolveIdentityName(
   cfg: OpenClawConfig,
   agentId: string,
 ): string | undefined {
   const name = resolveAgentIdentity(cfg, agentId)?.name?.trim();
+  return name || undefined;
+}
+
+export function resolveIdentityNamePrefix(
+  cfg: OpenClawConfig,
+  agentId: string,
+): string | undefined {
+  const name = resolveIdentityName(cfg, agentId);
   if (!name) {
     return undefined;
   }

--- a/src/infra/heartbeat-runner.session-label.test.ts
+++ b/src/infra/heartbeat-runner.session-label.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
+import { seedMainSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+
+installHeartbeatRunnerTestRuntime();
+
+describe("runHeartbeatOnce – session label uses agent identity name", () => {
+  it("sets ConversationLabel to identity.name when configured", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            {
+              id: "main",
+              identity: { name: "Jarvis" },
+              heartbeat: { every: "5m", target: "telegram", to: "123" },
+            },
+          ],
+          defaults: {
+            workspace: tmpDir,
+          },
+        },
+        session: { store: storePath },
+      };
+
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "123",
+      });
+
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: {
+          telegram: vi.fn().mockResolvedValue({ messageId: "m1" }),
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalled();
+      const calledCtx = replySpy.mock.calls[0]?.[0] as { ConversationLabel?: string };
+      expect(calledCtx.ConversationLabel).toBe("Jarvis");
+    });
+  });
+
+  it("falls back to agentId when identity.name is not configured", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "telegram", to: "123" },
+          },
+        },
+        session: { store: storePath },
+      };
+
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "123",
+      });
+
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: {
+          telegram: vi.fn().mockResolvedValue({ messageId: "m1" }),
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalled();
+      const calledCtx = replySpy.mock.calls[0]?.[0] as { ConversationLabel?: string };
+      // When no identity.name, should fall back to the agentId (default: "main")
+      expect(calledCtx.ConversationLabel).toBe("main");
+    });
+  });
+
+  it("does not use 'heartbeat' as ConversationLabel", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "telegram", to: "456" },
+          },
+        },
+        session: { store: storePath },
+      };
+
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "456",
+      });
+
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: {
+          telegram: vi.fn().mockResolvedValue({ messageId: "m1" }),
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalled();
+      const calledCtx = replySpy.mock.calls[0]?.[0] as { ConversationLabel?: string };
+      expect(calledCtx.ConversationLabel).not.toBe("heartbeat");
+    });
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -11,7 +11,7 @@ import {
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
 import { appendCronStyleCurrentTimeLine } from "../agents/current-time.js";
-import { resolveEffectiveMessagesConfig } from "../agents/identity.js";
+import { resolveEffectiveMessagesConfig, resolveIdentityName } from "../agents/identity.js";
 import { resolveEmbeddedSessionLane } from "../agents/pi-embedded-runner.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import { resolveHeartbeatReplyPayload } from "../auto-reply/heartbeat-reply-payload.js";
@@ -912,9 +912,7 @@ export async function runHeartbeatOnce(opts: {
 
     const store = loadSessionStore(storePath);
     const current = store[sessionKey];
-    // Initialize stub entry on first run when current doesn't exist
     const base = current ?? {
-      // Generate valid sessionId - derive from sessionKey without colons
       sessionId: sessionKey.replace(/:/g, "_"),
       updatedAt: startedAt,
       createdAt: startedAt,
@@ -941,10 +939,12 @@ export async function runHeartbeatOnce(opts: {
     consumeSystemEventEntries(sessionKey, preflight.pendingEventEntries);
   };
 
+  const identityName = resolveIdentityName(cfg, agentId);
   const ctx = {
     Body: appendCronStyleCurrentTimeLine(prompt, cfg, startedAt),
     From: sender,
     To: sender,
+    ConversationLabel: identityName ?? agentId,
     OriginatingChannel:
       !suppressOriginatingContext && delivery.channel !== "none" ? delivery.channel : undefined,
     OriginatingTo: !suppressOriginatingContext ? delivery.to : undefined,


### PR DESCRIPTION
## Summary

- Problem: After heartbeat triggers, the session label displays "heartbeat" instead of the agent's configured identity name (e.g. "main" or "Jarvis").
- Why it matters: Confusing UX — users see all heartbeat-triggered sessions labeled "heartbeat" instead of the agent's identity, making it hard to distinguish sessions.
- What changed: Added explicit `ConversationLabel` field to the heartbeat message context, set to `resolveIdentityName(cfg, agentId)` with fallback to `agentId`.
- What did NOT change: The `From` field still uses the heartbeat sender ID for routing purposes; only the display label is affected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57521
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `runHeartbeatOnce` sets `From: sender` where `sender` comes from `resolveHeartbeatSenderId()` which has a hardcoded `"heartbeat"` fallback. This `From` value flows through `resolveConversationLabel()` → `deriveSessionOrigin()`, causing `origin.label` to be set to `"heartbeat"`.
- Missing detection / guardrail: No test asserting that heartbeat session labels use agent identity names.
- Prior context: `resolveConversationLabel()` checks for an explicit `ConversationLabel` first, but heartbeat context never set one.
- Why this regressed now: Unknown — may have always been this way, or a refactor of the sender resolution path dropped the identity name propagation.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/heartbeat-runner.session-label.test.ts`
- Scenario the test should lock in: ConversationLabel uses identity.name when configured, falls back to agentId, never uses literal "heartbeat".
- Why this is the smallest reliable guardrail: Directly tests the ctx object construction with identity name resolution.
- If no new test is added, why not: 3 new tests added.

## User-visible / Behavior Changes

- Heartbeat-triggered sessions now display the agent's identity name (e.g. "Jarvis", "main") instead of "heartbeat".

## Diagram (if applicable)

```text
Before:
[heartbeat trigger] -> ctx.From = "heartbeat" -> origin.label = "heartbeat"

After:
[heartbeat trigger] -> ctx.ConversationLabel = identity.name ?? agentId -> origin.label = "Jarvis"
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Ubuntu 24.04
- Runtime/container: Node.js v25.4.0
- Model/provider: Any

### Steps

1. Configure agent with `identity.name: "Jarvis"`
2. Wait for heartbeat trigger
3. Check session label

### Expected

- Session label shows "Jarvis"

### Actual (before fix)

- Session label shows "heartbeat"

## Evidence

- [x] Failing test/log before + passing after
- 72/72 heartbeat tests pass (3 new + 69 existing across 8 test files)

## Human Verification (required)

- Verified scenarios: Identity name resolution with configured name; fallback to agentId; regression guard against "heartbeat" literal.
- Edge cases checked: No identity configured (falls back to agentId); empty identity name.
- What you did **not** verify: End-to-end UI display of session label.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None
