### PR TITLE
feat(plugins): add transform_context hook for per-LLM-call message re…

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -853,6 +853,21 @@ export async function runEmbeddedAttempt(
             params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
           ),
         ),
+        pluginTransform: hookRunner?.hasHooks("transform_context")
+          ? async (messages: AgentMessage[]) => {
+              const result = await hookRunner.runTransformContext(
+                { messages },
+                {
+                  runId: params.runId,
+                  agentId: sessionAgentId,
+                  sessionKey: params.sessionKey,
+                  sessionId: params.sessionId,
+                  workspaceDir: params.workspaceDir,
+                },
+              );
+              return (result?.messages as AgentMessage[]) ?? messages;
+            }
+          : undefined,
       });
       const cacheTrace = createCacheTrace({
         cfg: params.config,

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -190,6 +190,9 @@ function enforceToolResultContextBudgetInPlace(params: {
 export function installToolResultContextGuard(params: {
   agent: GuardableAgent;
   contextWindowTokens: number;
+  /** Optional async callback invoked after the original transformContext but before
+   *  budget enforcement. Plugins use this to compress/rewrite messages (e.g. SCCS). */
+  pluginTransform?: (messages: AgentMessage[]) => Promise<AgentMessage[] | undefined>;
 }): () => void {
   const contextWindowTokens = Math.max(1, Math.floor(params.contextWindowTokens));
   const contextBudgetChars = Math.max(
@@ -213,9 +216,19 @@ export function installToolResultContextGuard(params: {
   const originalTransformContext = mutableAgent.transformContext;
 
   mutableAgent.transformContext = (async (messages: AgentMessage[], signal: AbortSignal) => {
-    const transformed = originalTransformContext
+    let transformed = originalTransformContext
       ? await originalTransformContext.call(mutableAgent, messages, signal)
       : messages;
+
+    // Run plugin transform (e.g., SCCS compression) before budget enforcement.
+    if (params.pluginTransform) {
+      const pluginMessages = await params.pluginTransform(
+        Array.isArray(transformed) ? transformed : messages,
+      );
+      if (pluginMessages) {
+        transformed = pluginMessages;
+      }
+    }
 
     const contextMessages = Array.isArray(transformed) ? transformed : messages;
     enforceToolResultContextBudgetInPlace({

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -59,6 +59,8 @@ import type {
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
+  PluginHookTransformContextEvent,
+  PluginHookTransformContextResult,
 } from "./types.js";
 
 // Re-export types for consumers
@@ -96,6 +98,8 @@ export type {
   PluginHookToolResultPersistResult,
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
+  PluginHookTransformContextEvent,
+  PluginHookTransformContextResult,
   PluginHookSessionContext,
   PluginHookSessionStartEvent,
   PluginHookSessionEndEvent,
@@ -540,6 +544,27 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
    */
   async function runLlmOutput(event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext) {
     return runVoidHook("llm_output", event, ctx);
+  }
+
+  /**
+   * Run transform_context hook.
+   * Allows plugins to modify the full messages array before each LLM call.
+   * Runs sequentially; the last handler that returns { messages } wins.
+   */
+  async function runTransformContext(
+    event: PluginHookTransformContextEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookTransformContextResult | undefined> {
+    return runModifyingHook<"transform_context", PluginHookTransformContextResult>(
+      "transform_context",
+      event,
+      ctx,
+      {
+        mergeResults: (acc, next) => ({
+          messages: lastDefined(acc?.messages, next.messages),
+        }),
+      },
+    );
   }
 
   /**
@@ -1043,6 +1068,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runBeforeAgentStart,
     runLlmInput,
     runLlmOutput,
+    runTransformContext,
     runAgentEnd,
     runBeforeCompaction,
     runAfterCompaction,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1799,6 +1799,7 @@ export type PluginHookName =
   | "before_agent_start"
   | "llm_input"
   | "llm_output"
+  | "transform_context"
   | "agent_end"
   | "before_compaction"
   | "after_compaction"
@@ -1828,6 +1829,7 @@ export const PLUGIN_HOOK_NAMES = [
   "before_agent_start",
   "llm_input",
   "llm_output",
+  "transform_context",
   "agent_end",
   "before_compaction",
   "after_compaction",
@@ -1980,6 +1982,23 @@ export type PluginHookLlmInputEvent = {
   prompt: string;
   historyMessages: unknown[];
   imagesCount: number;
+};
+
+// transform_context hook
+// Fires before every LLM call in the agentic loop (via Agent.transformContext).
+// Plugins can inspect and modify the full messages array before it is sent to the LLM.
+// This is the primary hook for context compression, summarization, or message rewriting.
+export type PluginHookTransformContextEvent = {
+  /** The complete messages array about to be sent to the LLM. */
+  messages: unknown[];
+};
+
+export type PluginHookTransformContextResult = {
+  /**
+   * If provided, replaces the messages array sent to the LLM.
+   * Return only the modified messages — the caller will use this in place of the original.
+   */
+  messages?: unknown[];
 };
 
 // llm_output hook
@@ -2488,6 +2507,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookLlmOutputEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<void> | void;
+  transform_context: (
+    event: PluginHookTransformContextEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookTransformContextResult | void> | PluginHookTransformContextResult | void;
   agent_end: (event: PluginHookAgentEndEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
   before_compaction: (
     event: PluginHookBeforeCompactionEvent,


### PR DESCRIPTION
## Summary

- **Problem:** Plugins have no way to modify the full messages array before each LLM call in the agentic loop. Existing hooks (`before_prompt_build`, `llm_input`, `tool_result_persist`) are either one-shot, observation-only, or per-message — none provide context-level access on every LLM turn. And `assemble` is called per attempt but not per-llm, which is outside the `activeSession.prompt()` loop.
- **Why it matters:** Context compression strategies need to see the entire message history to make intelligent decisions. Without this hook, such compression is impossible to implement as a plugin.
- **What changed:** Added a new `transform_context` plugin hook that wraps `Agent.transformContext`, firing before every LLM call with the complete messages array. Plugins can return a modified messages array that replaces the original. Execution order: original transformContext → plugin hook → budget enforcement (truncation/compaction).
- **What did NOT change:** No changes to pi-agent-core internals, budget enforcement logic, existing hooks, or the agentic loop control flow. The hook is purely additive — if no plugin registers `transform_context`, behavior is identical to before.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None. This is a new plugin API surface — no behavior changes unless a plugin explicitly registers a `transform_context` handler.

## Diagram (if applicable)

```text
Before (no hook):
agentic loop → agent.transformContext(msgs) → budget enforcement → LLM

After (with plugin):
agentic loop → agent.transformContext(msgs)
                → original transformContext
                → plugin transform_context hook  ← NEW: plugins can rewrite msgs
                → budget enforcement
                → LLM
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js / Bun
- Model/provider: N/A (hook level, model-agnostic)

### Steps

1. Register a plugin with a `transform_context` handler
2. Run an agentic session that triggers multiple LLM calls (e.g. a coding task requiring tool use)
3. Verify the handler receives the full messages array on each LLM call
4. Verify returning `{ messages: modified }` from the handler replaces the messages sent to the LLM
5. Verify the last tool result in the array is preserved (not compressed) when the handler implements SCCS logic

### Expected

- Handler fires before every LLM call
- Returned messages array is used by the LLM
- Budget enforcement still runs after the plugin hook (as a safety net)

### Actual

(To be verified)

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `transform_context` hook type definitions compile without errors
  - `runTransformContext` runner integrates into HookRunner export
  - `installToolResultContextGuard` accepts and invokes the optional `pluginTransform` callback
  - `attempt.ts` correctly wires `hookRunner.runTransformContext` into the guard
  - Plugin-side handler in `openclaw-plugin` registers via `api.on("transform_context", ...)`
- Edge cases checked:
  - No `transform_context` handlers registered → `pluginTransform` is `undefined`, no-op
  - Handler returns `undefined` → original messages pass through unchanged
  - Handler returns `{ messages }` → modified messages replace original
- What you did **not** verify:
  - End-to-end runtime test with a live LLM session (requires CI/test environment)

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- **Risk:** A misbehaving plugin could return a malformed messages array, causing the LLM call to fail.
  - **Mitigation:** Budget enforcement runs after the plugin hook as a safety net. Existing error handling in the agentic loop will catch malformed input and retry/abort as appropriate. This is the same trust model as `before_prompt_build` (which can also inject arbitrary content).