### PR TITLE
fix(agents): deduplicate bootstrap files by path

### DIFF
--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -49,7 +49,10 @@ describe("getOrLoadBootstrapFiles", () => {
   });
 
   it("returns cached result on second call", async () => {
-    const firstResult = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
+    const firstResult = await getOrLoadBootstrapFiles({
+      workspaceDir: "/ws",
+      sessionKey: "session-1",
+    });
     const result = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
 
     expect(result).toBe(firstResult);
@@ -84,6 +87,58 @@ describe("getOrLoadBootstrapFiles", () => {
     expect(result).toHaveLength(2);
     expect(result[0].content).toBe("# Agent v1"); // first occurrence kept
     expect(result[1].content).toBe("# Soul");
+  });
+
+  it("deduplicates case-insensitively (Windows paths)", async () => {
+    const filesWithCaseDup: WorkspaceBootstrapFile[] = [
+      {
+        name: "AGENTS.md" as WorkspaceBootstrapFile["name"],
+        path: "C:\\Users\\ws\\AGENTS.md",
+        content: "first",
+        missing: false,
+      },
+      {
+        name: "AGENTS.md" as WorkspaceBootstrapFile["name"],
+        path: "c:\\users\\ws\\agents.md",
+        content: "second",
+        missing: false,
+      },
+    ];
+    mockLoad().mockResolvedValueOnce(filesWithCaseDup);
+
+    const result = await getOrLoadBootstrapFiles({
+      workspaceDir: "C:\\Users\\ws",
+      sessionKey: "session-case",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe("first");
+  });
+
+  it("deduplicates paths with mixed separators", async () => {
+    const filesWithMixedSep: WorkspaceBootstrapFile[] = [
+      {
+        name: "AGENTS.md" as WorkspaceBootstrapFile["name"],
+        path: "/ws/sub/../AGENTS.md",
+        content: "first",
+        missing: false,
+      },
+      {
+        name: "AGENTS.md" as WorkspaceBootstrapFile["name"],
+        path: "/ws/AGENTS.md",
+        content: "second",
+        missing: false,
+      },
+    ];
+    mockLoad().mockResolvedValueOnce(filesWithMixedSep);
+
+    const result = await getOrLoadBootstrapFiles({
+      workspaceDir: "/ws",
+      sessionKey: "session-sep",
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe("first");
   });
 
   it("handles empty files array", async () => {

--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -67,6 +67,35 @@ describe("getOrLoadBootstrapFiles", () => {
     expect(r2).toBe(files2);
     expect(mockLoad()).toHaveBeenCalledTimes(2);
   });
+
+  it("deduplicates by path, keeping first occurrence", async () => {
+    const filesWithDup = [
+      makeFile("AGENTS.md", "# Agent v1"),
+      makeFile("SOUL.md", "# Soul"),
+      makeFile("AGENTS.md", "# Agent v2"), // duplicate path
+    ];
+    mockLoad().mockResolvedValueOnce(filesWithDup);
+
+    const result = await getOrLoadBootstrapFiles({
+      workspaceDir: "/ws",
+      sessionKey: "session-dedup",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toBe("# Agent v1"); // first occurrence kept
+    expect(result[1].content).toBe("# Soul");
+  });
+
+  it("handles empty files array", async () => {
+    mockLoad().mockResolvedValueOnce([]);
+
+    const result = await getOrLoadBootstrapFiles({
+      workspaceDir: "/ws",
+      sessionKey: "session-empty",
+    });
+
+    expect(result).toHaveLength(0);
+  });
 });
 
 describe("clearBootstrapSnapshot", () => {

--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -44,15 +44,15 @@ describe("getOrLoadBootstrapFiles", () => {
       sessionKey: "session-1",
     });
 
-    expect(result).toBe(files);
+    expect(result).toEqual(files);
     expect(mockLoad()).toHaveBeenCalledTimes(1);
   });
 
   it("returns cached result on second call", async () => {
-    await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
+    const firstResult = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
     const result = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
 
-    expect(result).toBe(files);
+    expect(result).toBe(firstResult);
     expect(mockLoad()).toHaveBeenCalledTimes(1);
   });
 
@@ -63,8 +63,8 @@ describe("getOrLoadBootstrapFiles", () => {
     const r1 = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-1" });
     const r2 = await getOrLoadBootstrapFiles({ workspaceDir: "/ws", sessionKey: "session-2" });
 
-    expect(r1).toBe(files);
-    expect(r2).toBe(files2);
+    expect(r1).toEqual(files);
+    expect(r2).toEqual(files2);
     expect(mockLoad()).toHaveBeenCalledTimes(2);
   });
 

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -12,8 +12,19 @@ export async function getOrLoadBootstrapFiles(params: {
   }
 
   const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  cache.set(params.sessionKey, files);
-  return files;
+
+  // Deduplicate by path, keeping first occurrence
+  const seen = new Set<string>();
+  const deduped = files.filter((file) => {
+    if (seen.has(file.path)) {
+      return false;
+    }
+    seen.add(file.path);
+    return true;
+  });
+
+  cache.set(params.sessionKey, deduped);
+  return deduped;
 }
 
 export function clearBootstrapSnapshot(sessionKey: string): void {

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
 import { loadWorkspaceBootstrapFiles, type WorkspaceBootstrapFile } from "./workspace.js";
 
 const cache = new Map<string, WorkspaceBootstrapFile[]>();
+
+/** Normalize a path for dedup comparison: consistent separators + lowercase for Windows. */
+function normalizeForDedup(p: string): string {
+  return path.normalize(p).toLowerCase();
+}
 
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
@@ -13,13 +19,14 @@ export async function getOrLoadBootstrapFiles(params: {
 
   const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
 
-  // Deduplicate by path, keeping first occurrence
+  // Deduplicate by normalized path (case-insensitive), keeping first occurrence
   const seen = new Set<string>();
   const deduped = files.filter((file) => {
-    if (seen.has(file.path)) {
+    const key = normalizeForDedup(file.path);
+    if (seen.has(key)) {
       return false;
     }
-    seen.add(file.path);
+    seen.add(key);
     return true;
   });
 


### PR DESCRIPTION
## Summary

Prevents duplicate bootstrap file entries from accumulating on restart.

- Deduplicates by path, keeping first occurrence
- Adds comprehensive test coverage

## Related

- Supersedes #56725 and #56721
- Fixes bootstrap file duplication on restart