### PR TITLE
feat: expose recent inter-session activity in sessions history

### DIFF
--- a/src/agents/tools/sessions-history-tool.recent-activity.test.ts
+++ b/src/agents/tools/sessions-history-tool.recent-activity.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { extractRecentInterSessionActivity } from "./sessions-history-tool.js";
+
+describe("extractRecentInterSessionActivity", () => {
+  it("returns newest inter-session provenance entries first", () => {
+    const result = extractRecentInterSessionActivity([
+      { role: "user", content: "normal user message" },
+      {
+        role: "user",
+        content: "forwarded from ops",
+        provenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:ops:main",
+          sourceChannel: "internal",
+          sourceTool: "sessions_send",
+        },
+      },
+      {
+        role: "assistant",
+        content: "latest linked activity",
+        provenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:skippy:main",
+          sourceChannel: "internal",
+          sourceTool: "sessions_send",
+        },
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        text: "latest linked activity",
+        provenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:skippy:main",
+          sourceChannel: "internal",
+          sourceTool: "sessions_send",
+        },
+      },
+      {
+        role: "user",
+        text: "forwarded from ops",
+        provenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:ops:main",
+          sourceChannel: "internal",
+          sourceTool: "sessions_send",
+        },
+      },
+    ]);
+  });
+
+  it("caps returned activity items", () => {
+    const result = extractRecentInterSessionActivity(
+      [
+        {
+          role: "user",
+          content: "one",
+          provenance: { kind: "inter_session", sourceTool: "sessions_send" },
+        },
+        {
+          role: "user",
+          content: "two",
+          provenance: { kind: "inter_session", sourceTool: "sessions_send" },
+        },
+      ],
+      1,
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.text).toBe("two");
+  });
+});

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -25,8 +25,77 @@ const SessionsHistoryToolSchema = Type.Object({
 
 const SESSIONS_HISTORY_MAX_BYTES = 80 * 1024;
 const SESSIONS_HISTORY_TEXT_MAX_CHARS = 4000;
+const SESSIONS_HISTORY_ACTIVITY_MAX_ITEMS = 5;
 
 // sandbox policy handling is shared with sessions-list-tool via sessions-helpers.ts
+
+export function extractRecentInterSessionActivity(
+  messages: Array<unknown>,
+  maxItems = SESSIONS_HISTORY_ACTIVITY_MAX_ITEMS,
+): Array<{
+  role: string;
+  text: string;
+  provenance: {
+    kind: string;
+    sourceSessionKey?: string;
+    sourceChannel?: string;
+    sourceTool?: string;
+  };
+}> {
+  const items: Array<{
+    role: string;
+    text: string;
+    provenance: {
+      kind: string;
+      sourceSessionKey?: string;
+      sourceChannel?: string;
+      sourceTool?: string;
+    };
+  }> = [];
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const entry = messages[i];
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const record = entry as {
+      role?: unknown;
+      content?: unknown;
+      text?: unknown;
+      provenance?: unknown;
+    };
+    const provenance =
+      record.provenance && typeof record.provenance === "object"
+        ? (record.provenance as Record<string, unknown>)
+        : undefined;
+    if (provenance?.kind !== "inter_session") {
+      continue;
+    }
+    const role = typeof record.role === "string" ? record.role : "unknown";
+    const rawText =
+      typeof record.content === "string"
+        ? record.content
+        : typeof record.text === "string"
+          ? record.text
+          : "";
+    const sanitized = truncateHistoryText(rawText || "");
+    items.push({
+      role,
+      text: sanitized.text,
+      provenance: {
+        kind: "inter_session",
+        sourceSessionKey:
+          typeof provenance.sourceSessionKey === "string" ? provenance.sourceSessionKey : undefined,
+        sourceChannel:
+          typeof provenance.sourceChannel === "string" ? provenance.sourceChannel : undefined,
+        sourceTool: typeof provenance.sourceTool === "string" ? provenance.sourceTool : undefined,
+      },
+    });
+    if (items.length >= maxItems) {
+      break;
+    }
+  }
+  return items;
+}
 
 function truncateHistoryText(text: string): {
   text: string;
@@ -243,6 +312,7 @@ export function createSessionsHistoryTool(opts?: {
       });
       const rawMessages = Array.isArray(result?.messages) ? result.messages : [];
       const selectedMessages = includeTools ? rawMessages : stripToolMessages(rawMessages);
+      const recentInterSessionActivity = extractRecentInterSessionActivity(selectedMessages);
       const sanitizedMessages = selectedMessages.map((message) => sanitizeHistoryMessage(message));
       const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
       const contentRedacted = sanitizedMessages.some((entry) => entry.redacted);
@@ -259,6 +329,7 @@ export function createSessionsHistoryTool(opts?: {
       return jsonResult({
         sessionKey: displayKey,
         messages: hardened.items,
+        recentInterSessionActivity,
         truncated: droppedMessages || contentTruncated || hardened.hardCapped,
         droppedMessages: droppedMessages || hardened.hardCapped,
         contentTruncated,

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -187,22 +187,27 @@ export class TelegramPollingSession {
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
-    bot.api.config.use((prev, method, payload, signal) => {
+    bot.api.config.use(async (prev, method, payload, signal) => {
       if (method === "getUpdates") {
         lastGetUpdatesAt = Date.now();
-        // Reset backoff after a successful getUpdates cycle so that
+      }
+      const result = await prev(method, payload, signal);
+      if (method === "getUpdates") {
+        // Reset backoff after a *successful* getUpdates response so that
         // transient network blips don't permanently inflate the delay.
         this.#restartAttempts = 0;
       }
-      return prev(method, payload, signal);
+      return result;
     });
 
     const runner = run(bot, this.opts.runnerOptions);
     this.#activeRunner = runner;
     const fetchAbortController = this.#activeFetchAbort;
     let stopPromise: Promise<void> | undefined;
-    let stalledRestart = false;
+    let restartReason: "stall" | "zombie" | undefined;
+    let stopRequested = false;
     const stopRunner = () => {
+      stopRequested = true;
       fetchAbortController?.abort();
       stopPromise ??= Promise.resolve(runner.stop())
         .then(() => undefined)
@@ -238,7 +243,7 @@ export class TelegramPollingSession {
       // --- existing transport-level stall check ---
       const elapsed = Date.now() - lastGetUpdatesAt;
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
-        stalledRestart = true;
+        restartReason = "stall";
         this.opts.log(
           `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart.`,
         );
@@ -256,14 +261,14 @@ export class TelegramPollingSession {
           accountId: this.opts.accountId,
         });
         const lastInbound = activity.inboundAt;
-        // Only check if we have ever received a message AND enough time
-        // has passed since the polling cycle started (avoid false
-        // positives during quiet periods right after startup).
-        if (lastInbound !== null) {
+        // Only check if we received a message *during this cycle* and it
+        // has since gone stale.  The `lastInbound >= pollingStartedAt`
+        // guard prevents false positives from cross-cycle timestamps
+        // (the channel-activity singleton persists across restarts).
+        if (lastInbound !== null && lastInbound >= pollingStartedAt) {
           const inboundAge = Date.now() - lastInbound;
-          const sinceStart = Date.now() - pollingStartedAt;
-          if (inboundAge > zombieTimeoutMs && sinceStart > zombieTimeoutMs) {
-            stalledRestart = true;
+          if (inboundAge > zombieTimeoutMs) {
+            restartReason = "zombie";
             this.opts.log(
               `[telegram] Zombie polling detected (last inbound ${formatDurationPrecise(inboundAge)} ago, threshold ${formatDurationPrecise(zombieTimeoutMs)}); forcing restart.`,
             );
@@ -276,24 +281,41 @@ export class TelegramPollingSession {
 
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
     try {
-      // Race runner.task() against a drain timeout.  If runner.stop() was
-      // called (e.g. by the stall/zombie watchdog) but the grammY runner's
-      // task promise never settles, we force-break out after a timeout so
-      // the outer loop can create a fresh bot + runner.
+      // Wait for the runner task to complete, but guard against hangs.
+      // If runner.stop() was called (e.g. by the stall/zombie watchdog) but
+      // the grammY runner's task promise never settles, we force-break out
+      // after a timeout so the outer loop can create a fresh bot + runner.
       const taskPromise = runner.task() ?? Promise.resolve();
       let drainTimedOut = false;
+      // The drain timer only activates once stopRequested is true.
+      // During healthy polling, runner.task() stays pending (that's normal)
+      // and the drain timer never fires.
       const drainTimer = new Promise<void>((resolve) => {
-        const t = setTimeout(() => {
-          drainTimedOut = true;
-          resolve();
-        }, RUNNER_TASK_DRAIN_TIMEOUT_MS);
-        if (typeof t === "object" && "unref" in t) {
-          t.unref();
+        const checkInterval = setInterval(() => {
+          if (!stopRequested) {
+            return;
+          }
+          clearInterval(checkInterval);
+          const t = setTimeout(() => {
+            drainTimedOut = true;
+            resolve();
+          }, RUNNER_TASK_DRAIN_TIMEOUT_MS);
+          if (typeof t === "object" && "unref" in t) {
+            t.unref();
+          }
+          // Cancel the timer early if runner.task() settles on its own.
+          taskPromise.then(
+            () => clearTimeout(t),
+            () => clearTimeout(t),
+          );
+        }, 1000);
+        if (typeof checkInterval === "object" && "unref" in checkInterval) {
+          checkInterval.unref();
         }
-        // Cancel the timer early if runner.task() settles on its own.
+        // Also cancel the check interval if taskPromise settles normally.
         taskPromise.then(
-          () => clearTimeout(t),
-          () => clearTimeout(t),
+          () => clearInterval(checkInterval),
+          () => clearInterval(checkInterval),
         );
       });
       // Wrap taskPromise so rejections don't escape Promise.race unhandled.
@@ -320,11 +342,14 @@ export class TelegramPollingSession {
       if (this.opts.abortSignal?.aborted) {
         return "exit";
       }
-      const reason = stalledRestart
-        ? "polling stall detected"
-        : this.#forceRestarted
-          ? "unhandled network error"
-          : "runner stopped (maxRetryTime exceeded or graceful stop)";
+      const reason =
+        restartReason === "stall"
+          ? "polling stall detected"
+          : restartReason === "zombie"
+            ? "zombie polling detected"
+            : this.#forceRestarted
+              ? "unhandled network error"
+              : "runner stopped (maxRetryTime exceeded or graceful stop)";
       this.#forceRestarted = false;
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram polling runner stopped (${reason}); restarting in ${delay}.`,

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -1,5 +1,6 @@
 import { type RunOptions, run } from "@grammyjs/runner";
 import { computeBackoff, sleepWithAbort } from "../infra/backoff.js";
+import { getChannelActivity } from "../infra/channel-activity.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { formatDurationPrecise } from "../infra/format-time/format-duration.ts";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -16,6 +17,18 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 
+/**
+ * Maximum time the polling loop can run without any inbound message before
+ * we treat the connection as a zombie and force a restart.  This catches
+ * the case where `getUpdates` calls succeed on schedule (so the existing
+ * 90 s transport stall watchdog never fires) but the TCP connection has
+ * silently stopped delivering data.
+ *
+ * Configurable via `channels.telegram.accounts.<id>.network.zombieTimeoutMs`
+ * in openclaw.json; defaults to 15 minutes.
+ */
+const DEFAULT_ZOMBIE_INBOUND_TIMEOUT_MS = 15 * 60_000;
+
 type TelegramBot = ReturnType<typeof createTelegramBot>;
 
 type TelegramPollingSessionOpts = {
@@ -29,6 +42,8 @@ type TelegramPollingSessionOpts = {
   getLastUpdateId: () => number | null;
   persistUpdateId: (updateId: number) => Promise<void>;
   log: (line: string) => void;
+  /** Override the default zombie-inbound timeout (ms). 0 disables the check. */
+  zombieInboundTimeoutMs?: number;
 };
 
 export class TelegramPollingSession {
@@ -198,10 +213,18 @@ export class TelegramPollingSession {
       }
     };
 
+    const zombieTimeoutMs = this.opts.zombieInboundTimeoutMs ?? DEFAULT_ZOMBIE_INBOUND_TIMEOUT_MS;
+    // Record the time when this polling cycle started so we don't trigger
+    // the zombie check before the bot has had a reasonable window to
+    // receive its first message.
+    const pollingStartedAt = Date.now();
+
     const watchdog = setInterval(() => {
       if (this.opts.abortSignal?.aborted) {
         return;
       }
+
+      // --- existing transport-level stall check ---
       const elapsed = Date.now() - lastGetUpdatesAt;
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
         stalledRestart = true;
@@ -209,6 +232,34 @@ export class TelegramPollingSession {
           `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart.`,
         );
         void stopRunner();
+        return;
+      }
+
+      // --- zombie polling check (issue #28622) ---
+      // getUpdates calls may succeed on schedule, but the TCP connection
+      // silently stops delivering data.  Detect this by checking how long
+      // it has been since the last *actual* inbound message.
+      if (zombieTimeoutMs > 0 && runner.isRunning()) {
+        const activity = getChannelActivity({
+          channel: "telegram",
+          accountId: this.opts.accountId,
+        });
+        const lastInbound = activity.inboundAt;
+        // Only check if we have ever received a message AND enough time
+        // has passed since the polling cycle started (avoid false
+        // positives during quiet periods right after startup).
+        if (lastInbound !== null) {
+          const inboundAge = Date.now() - lastInbound;
+          const sinceStart = Date.now() - pollingStartedAt;
+          if (inboundAge > zombieTimeoutMs && sinceStart > zombieTimeoutMs) {
+            stalledRestart = true;
+            this.opts.log(
+              `[telegram] Zombie polling detected (last inbound ${formatDurationPrecise(inboundAge)} ago, threshold ${formatDurationPrecise(zombieTimeoutMs)}); forcing restart.`,
+            );
+            void stopRunner();
+            return;
+          }
+        }
       }
     }, POLL_WATCHDOG_INTERVAL_MS);
 

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -18,6 +18,14 @@ const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 
 /**
+ * Maximum time to wait for `runner.task()` to settle after `runner.stop()`
+ * has been called.  If the grammY runner hangs (stop doesn't resolve the
+ * task promise), we force-break out of the polling cycle so `runUntilAbort`
+ * can create a fresh bot + runner.
+ */
+const RUNNER_TASK_DRAIN_TIMEOUT_MS = 30_000;
+
+/**
  * Maximum time the polling loop can run without any inbound message before
  * we treat the connection as a zombie and force a restart.  This catches
  * the case where `getUpdates` calls succeed on schedule (so the existing
@@ -268,7 +276,47 @@ export class TelegramPollingSession {
 
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
     try {
-      await runner.task();
+      // Race runner.task() against a drain timeout.  If runner.stop() was
+      // called (e.g. by the stall/zombie watchdog) but the grammY runner's
+      // task promise never settles, we force-break out after a timeout so
+      // the outer loop can create a fresh bot + runner.
+      const taskPromise = runner.task() ?? Promise.resolve();
+      let drainTimedOut = false;
+      const drainTimer = new Promise<void>((resolve) => {
+        const t = setTimeout(() => {
+          drainTimedOut = true;
+          resolve();
+        }, RUNNER_TASK_DRAIN_TIMEOUT_MS);
+        if (typeof t === "object" && "unref" in t) {
+          t.unref();
+        }
+        // Cancel the timer early if runner.task() settles on its own.
+        taskPromise.then(
+          () => clearTimeout(t),
+          () => clearTimeout(t),
+        );
+      });
+      // Wrap taskPromise so rejections don't escape Promise.race unhandled.
+      const safeTask = taskPromise.then(
+        () => {},
+        () => {},
+      );
+      await Promise.race([safeTask, drainTimer]);
+
+      if (drainTimedOut) {
+        // runner.task() hung — force restart.
+        this.opts.log(
+          `[telegram] runner.task() did not settle within ${formatDurationPrecise(RUNNER_TASK_DRAIN_TIMEOUT_MS)} after stop; forcing restart.`,
+        );
+        this.#forceRestarted = false;
+        const shouldRestart = await this.#waitBeforeRestart(
+          (delay) => `Telegram polling runner hung; restarting in ${delay}.`,
+        );
+        return shouldRestart ? "continue" : "exit";
+      }
+      // Task settled — re-await to propagate the original result/error.
+      await taskPromise;
+
       if (this.opts.abortSignal?.aborted) {
         return "exit";
       }

--- a/src/telegram/polling-session.ts
+++ b/src/telegram/polling-session.ts
@@ -182,6 +182,9 @@ export class TelegramPollingSession {
     bot.api.config.use((prev, method, payload, signal) => {
       if (method === "getUpdates") {
         lastGetUpdatesAt = Date.now();
+        // Reset backoff after a successful getUpdates cycle so that
+        // transient network blips don't permanently inflate the delay.
+        this.#restartAttempts = 0;
       }
       return prev(method, payload, signal);
     });


### PR DESCRIPTION
## Summary
- surface recent inter-session provenance entries in sessions_history output
- keep entries bounded and sanitized for prompt use
- add focused vitest coverage for the extraction helper

## Tests
- npx vitest run src/agents/tools/sessions-history-tool.recent-activity.test.ts
- node_modules/.bin/tsc -p tsconfig.json --noEmit

Closes #57593