### PR TITLE
fix(discord): treat reconnect-exhausted as clean stop to prevent gateway crash

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -849,13 +849,10 @@ describe("runDiscordGatewayLifecycle", () => {
     abortController.abort();
 
     await expect(lifecyclePromise).resolves.toBeUndefined();
-    expect(runtimeLog).not.toHaveBeenCalledWith(
-      expect.stringContaining("ignoring expected reconnect-exhausted during shutdown"),
-    );
-    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("Max reconnect attempts"));
+    expect(runtimeLog).toHaveBeenCalledWith(expect.stringContaining("reconnect-exhausted"));
   });
 
-  it("rejects reconnect-exhausted queued before startup when shutdown has not begun", async () => {
+  it("treats reconnect-exhausted queued before startup as clean stop even without shutdown", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
     const pendingGatewayEvents: DiscordGatewayEvent[] = [];
 
@@ -881,9 +878,9 @@ describe("runDiscordGatewayLifecycle", () => {
       ),
     );
 
-    await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow(
-      "Max reconnect attempts",
-    );
+    // reconnect-exhausted should never crash the process — it resolves cleanly
+    // even when lifecycleStopping is not yet set (health-monitor race).
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
   });
 
   it("does not push connected: true when abortSignal is already aborted", async () => {

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -67,9 +67,11 @@ export async function runDiscordGatewayLifecycle(params: {
     // When we deliberately set maxAttempts=0 and disconnected (health-monitor
     // stale-socket restart), Carbon fires "Max reconnect attempts (0)". This
     // is expected — log at info instead of error to avoid false alarms.
-    if (lifecycleStopping && event.type === "reconnect-exhausted") {
+    // Also handle the race where the health monitor triggers a restart before
+    // lifecycleStopping is set (code 1005 scenario).
+    if (event.type === "reconnect-exhausted") {
       params.runtime.log?.(
-        `discord: ignoring expected reconnect-exhausted during shutdown: ${event.message}`,
+        `discord: reconnect-exhausted (lifecycle stopping: ${lifecycleStopping}): ${event.message}`,
       );
       return "stop";
     }
@@ -82,14 +84,11 @@ export async function runDiscordGatewayLifecycle(params: {
       if (decision !== "stop") {
         return "continue";
       }
-      // Don't throw for expected shutdown events. `reconnect-exhausted` can be
-      // queued just before an abort-driven shutdown flips `lifecycleStopping`,
-      // so only suppress it when shutdown is already underway.
-      if (
-        event.type === "disallowed-intents" ||
-        (event.type === "reconnect-exhausted" &&
-          (lifecycleStopping || params.abortSignal?.aborted === true))
-      ) {
+      // Don't throw for expected shutdown events.
+      // `reconnect-exhausted` must never crash the process — it can arrive
+      // from a health-monitor-initiated restart before `lifecycleStopping` is
+      // set, so we treat it as a clean stop signal unconditionally.
+      if (event.type === "disallowed-intents" || event.type === "reconnect-exhausted") {
         return "stop";
       }
       throw event.err;


### PR DESCRIPTION
## Summary

Fixes #57291 — Gateway crashes with uncaught exception when the health monitor detects a stale Discord socket and triggers a restart.

## Problem

When the health monitor restarts a stale Discord WebSocket, it calls `stopChannel` + `startChannel`. During teardown, Carbon fires `"Max reconnect attempts (0) reached after code 1005"`. This error was only suppressed when `lifecycleStopping` was already set, but the health-monitor restart path triggers the error *before* the lifecycle flag is updated — a race condition that causes an uncaught exception and kills the gateway process (~every 90 minutes on affected setups).

## Fix

Treat `reconnect-exhausted` as a clean stop signal unconditionally in both `handleGatewayEvent` and `drainPendingGatewayErrors`. This event semantically means "the connection ended" — it should never crash the process. The health monitor will re-establish the connection via `startChannel`.

## Changes

- `provider.lifecycle.ts`: Remove the `lifecycleStopping` guard from `reconnect-exhausted` handling in both `handleGatewayEvent` (log at info level) and `drainPendingGatewayErrors` (return "stop" instead of throw)
- `provider.lifecycle.test.ts`: Update tests to reflect the new behavior — `reconnect-exhausted` now resolves cleanly even without shutdown

## Testing

- All 22 existing lifecycle tests pass
- All 4 gateway-supervisor tests pass
- The previously-throwing test case now expects clean resolution
