### PR TITLE
feat: auto-register media-understanding for custom providers

### DIFF
--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -50,7 +50,41 @@ async function resolveImageRuntime(params: {
   const modelRegistry = discoverModels(authStorage, params.agentDir);
   const resolvedRef = normalizeModelRef(params.provider, params.model);
   const model = modelRegistry.find(resolvedRef.provider, resolvedRef.model) as Model<Api> | null;
+  // Fallback to inline (user-configured) model when not in built-in registry.
+  // This supports custom/third-party providers that are not part of the pi-ai
+  // model catalog but are configured in openclaw.json.
   if (!model) {
+    const providerConfig = (params.cfg as Record<string, unknown> | undefined)?.models as
+      | Record<string, unknown>
+      | undefined;
+    const providers = providerConfig?.providers as Record<string, Record<string, unknown>> | undefined;
+    const providerEntry = providers?.[resolvedRef.provider];
+    const inlineModels = Array.isArray(providerEntry?.models)
+      ? (providerEntry!.models as Array<Record<string, unknown>>)
+      : [];
+    const inlineModel = inlineModels.find((m) => m.id === resolvedRef.model);
+    if (
+      inlineModel &&
+      Array.isArray(inlineModel.input) &&
+      (inlineModel.input as string[]).includes("image")
+    ) {
+      const builtModel = {
+        ...inlineModel,
+        provider: resolvedRef.provider,
+        baseUrl: providerEntry?.baseUrl,
+        api: inlineModel.api ?? providerEntry?.api,
+      } as Model<Api>;
+      const apiKeyInfo = await getApiKeyForModel({
+        model: builtModel,
+        cfg: params.cfg,
+        agentDir: params.agentDir,
+        profileId: params.profile,
+        preferredProfile: params.preferredProfile,
+      });
+      const apiKey = requireApiKey(apiKeyInfo, builtModel.provider);
+      authStorage.setRuntimeApiKey(builtModel.provider, apiKey);
+      return { apiKey, model: builtModel };
+    }
     throw new Error(`Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`);
   }
   if (!model.input?.includes("image")) {

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -66,7 +66,7 @@ async function resolveImageRuntime(params: {
     if (
       inlineModel &&
       Array.isArray(inlineModel.input) &&
-      (inlineModel.input as string[]).includes("image")
+      (inlineModel.input).includes("image")
     ) {
       const builtModel = {
         ...inlineModel,

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -59,8 +59,9 @@ async function resolveImageRuntime(params: {
       | undefined;
     const providers = providerConfig?.providers as Record<string, Record<string, unknown>> | undefined;
     const providerEntry = providers?.[resolvedRef.provider];
-    const inlineModels = Array.isArray(providerEntry?.models)
-      ? (providerEntry!.models as Array<Record<string, unknown>>)
+    const rawModels = providerEntry?.models;
+    const inlineModels: Array<Record<string, unknown>> = Array.isArray(rawModels)
+      ? rawModels
       : [];
     const inlineModel = inlineModels.find((m) => m.id === resolvedRef.model);
     if (

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -66,7 +66,7 @@ async function resolveImageRuntime(params: {
     if (
       inlineModel &&
       Array.isArray(inlineModel.input) &&
-      (inlineModel.input).includes("image")
+      inlineModel.input.includes("image")
     ) {
       const builtModel = {
         ...inlineModel,

--- a/src/media-understanding/provider-registry.ts
+++ b/src/media-understanding/provider-registry.ts
@@ -55,7 +55,9 @@ export function buildMediaUnderstandingRegistry(
   if (configuredProviders && typeof configuredProviders === "object") {
     for (const [providerId, providerConfig] of Object.entries(configuredProviders)) {
       const normalizedKey = normalizeMediaProviderId(providerId);
-      if (registry.has(normalizedKey)) continue;
+      if (registry.has(normalizedKey)) {
+        continue;
+      }
       const api = (providerConfig as Record<string, unknown> | undefined)?.api;
       if (api === "anthropic-messages" || api === "openai-responses" || api === "openai-completions") {
         const models = Array.isArray(
@@ -72,7 +74,7 @@ export function buildMediaUnderstandingRegistry(
             capabilities: ["image"],
             describeImage: describeImageWithModel,
             describeImages: describeImagesWithModel,
-          } as MediaUnderstandingProvider);
+          });
         }
       }
     }

--- a/src/media-understanding/provider-registry.ts
+++ b/src/media-understanding/provider-registry.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolvePluginCapabilityProviders } from "../plugins/capability-provider-runtime.js";
 import { normalizeMediaProviderId } from "./provider-id.js";
 import type { MediaUnderstandingProvider } from "./types.js";
+import { describeImageWithModel, describeImagesWithModel } from "./image.js";
 
 function mergeProviderIntoRegistry(
   registry: Map<string, MediaUnderstandingProvider>,
@@ -44,6 +45,36 @@ export function buildMediaUnderstandingRegistry(
           }
         : provider;
       registry.set(normalizedKey, merged);
+    }
+  }
+  // Auto-register custom providers that use a known API format (e.g.
+  // "anthropic-messages") and declare image input support.  This allows
+  // third-party or self-hosted providers to be used by the `image` tool
+  // without requiring a dedicated media-understanding plugin.
+  const configuredProviders = cfg?.models?.providers;
+  if (configuredProviders && typeof configuredProviders === "object") {
+    for (const [providerId, providerConfig] of Object.entries(configuredProviders)) {
+      const normalizedKey = normalizeMediaProviderId(providerId);
+      if (registry.has(normalizedKey)) continue;
+      const api = (providerConfig as Record<string, unknown> | undefined)?.api;
+      if (api === "anthropic-messages" || api === "openai-responses" || api === "openai-completions") {
+        const models = Array.isArray(
+          (providerConfig as Record<string, unknown> | undefined)?.models,
+        )
+          ? ((providerConfig as Record<string, unknown>).models as Array<Record<string, unknown>>)
+          : [];
+        const hasImageModel = models.some(
+          (m) => Array.isArray(m?.input) && (m.input as string[]).includes("image"),
+        );
+        if (hasImageModel) {
+          registry.set(normalizedKey, {
+            id: providerId,
+            capabilities: ["image"],
+            describeImage: describeImageWithModel,
+            describeImages: describeImagesWithModel,
+          } as MediaUnderstandingProvider);
+        }
+      }
     }
   }
   return registry;

--- a/src/media-understanding/provider-registry.ts
+++ b/src/media-understanding/provider-registry.ts
@@ -66,7 +66,7 @@ export function buildMediaUnderstandingRegistry(
           ? ((providerConfig as Record<string, unknown>).models as Array<Record<string, unknown>>)
           : [];
         const hasImageModel = models.some(
-          (m) => Array.isArray(m?.input) && (m.input as string[]).includes("image"),
+          (m) => Array.isArray(m?.input) && (m.input).includes("image"),
         );
         if (hasImageModel) {
           registry.set(normalizedKey, {

--- a/src/media-understanding/provider-registry.ts
+++ b/src/media-understanding/provider-registry.ts
@@ -2,7 +2,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolvePluginCapabilityProviders } from "../plugins/capability-provider-runtime.js";
 import { normalizeMediaProviderId } from "./provider-id.js";
 import type { MediaUnderstandingProvider } from "./types.js";
-import { describeImageWithModel, describeImagesWithModel } from "./image.js";
+import { describeImageWithModel, describeImagesWithModel } from "./image-runtime.js";
 
 function mergeProviderIntoRegistry(
   registry: Map<string, MediaUnderstandingProvider>,

--- a/src/media-understanding/provider-registry.ts
+++ b/src/media-understanding/provider-registry.ts
@@ -58,12 +58,12 @@ export function buildMediaUnderstandingRegistry(
       if (registry.has(normalizedKey)) {
         continue;
       }
-      const api = (providerConfig as Record<string, unknown> | undefined)?.api;
+      const record = providerConfig as Record<string, unknown>;
+      const api = record?.api;
       if (api === "anthropic-messages" || api === "openai-responses" || api === "openai-completions") {
-        const models = Array.isArray(
-          (providerConfig as Record<string, unknown> | undefined)?.models,
-        )
-          ? ((providerConfig as Record<string, unknown>).models as Array<Record<string, unknown>>)
+        const rawModels = record?.models;
+        const models: Array<Record<string, unknown>> = Array.isArray(rawModels)
+          ? (rawModels as Array<Record<string, unknown>>)
           : [];
         const hasImageModel = models.some(
           (m) => Array.isArray(m?.input) && m.input.includes("image"),

--- a/src/media-understanding/provider-registry.ts
+++ b/src/media-understanding/provider-registry.ts
@@ -66,7 +66,7 @@ export function buildMediaUnderstandingRegistry(
           ? ((providerConfig as Record<string, unknown>).models as Array<Record<string, unknown>>)
           : [];
         const hasImageModel = models.some(
-          (m) => Array.isArray(m?.input) && (m.input).includes("image"),
+          (m) => Array.isArray(m?.input) && m.input.includes("image"),
         );
         if (hasImageModel) {
           registry.set(normalizedKey, {

--- a/src/media-understanding/provider-registry.ts
+++ b/src/media-understanding/provider-registry.ts
@@ -63,7 +63,7 @@ export function buildMediaUnderstandingRegistry(
       if (api === "anthropic-messages" || api === "openai-responses" || api === "openai-completions") {
         const rawModels = record?.models;
         const models: Array<Record<string, unknown>> = Array.isArray(rawModels)
-          ? (rawModels as Array<Record<string, unknown>>)
+          ? rawModels
           : [];
         const hasImageModel = models.some(
           (m) => Array.isArray(m?.input) && m.input.includes("image"),


### PR DESCRIPTION
## Summary

- **Problem:** The `image` tool fails with `No media-understanding provider registered for <provider>` when using custom/third-party providers (e.g. providers configured with `api: "anthropic-messages"` that proxy to Anthropic-compatible endpoints). Only providers with dedicated plugins (anthropic, openai, google, etc.) work.
- **Why it matters:** Users who self-host or use third-party API proxies cannot use the `image` tool at all, even though their provider fully supports vision/image analysis via a compatible API format.
- **What changed:** (1) `buildMediaUnderstandingRegistry` now auto-registers custom providers that use a known API format (`anthropic-messages`, `openai-responses`, `openai-completions`) and declare `image` in their model `input` array. (2) `resolveImageRuntime` falls back to inline (user-configured) models when the built-in pi-ai model registry has no match.
- **What did NOT change:** No changes to existing provider plugins, built-in model registry, or any other media-understanding behavior. Providers already registered via plugins are skipped (no override).

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- This PR fixes a bug where custom providers cannot use the `image` tool
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** `buildMediaUnderstandingRegistry` only registers providers from built-in list + plugin registrations. Custom providers configured in `openclaw.json` are never registered. `resolveImageRuntime` only looks up models in the built-in pi-ai model registry, which does not include user-configured inline models.
- **Missing detection / guardrail:** No fallback path for custom providers in the media-understanding pipeline.
- **Prior context:** The media-understanding system was designed around known provider plugins. Custom/third-party providers were not considered for the `image` tool.
- **Why this regressed now:** Not a regression — this is a gap in the original design.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/media-understanding/provider-registry.test.ts`
- Scenario the test should lock in: Custom provider with `api: "anthropic-messages"` and `input: ["text", "image"]` should appear in the registry.
- Why this is the smallest reliable guardrail: Unit test on `buildMediaUnderstandingRegistry` with a mock config containing a custom provider.
- If no new test is added, why not: Tests require build infrastructure setup; the fix was verified manually end-to-end.

## User-visible / Behavior Changes

- The `image` tool now works with custom providers that use `anthropic-messages`, `openai-responses`, or `openai-completions` API format, as long as the model config includes `input: ["text", "image"]`.
- No config changes required — existing configurations that already declare image input will automatically work.

## Diagram (if applicable)

```text
Before:
[image tool] -> buildMediaUnderstandingRegistry -> registry (built-in + plugins only)
             -> resolveImageRuntime -> modelRegistry.find() -> NOT FOUND -> ERROR

After:
[image tool] -> buildMediaUnderstandingRegistry -> registry (built-in + plugins + auto-registered custom)
             -> resolveImageRuntime -> modelRegistry.find() -> NOT FOUND -> fallback to inline model -> OK
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — uses the same `describeImageWithModel`/`describeImagesWithModel` path as built-in providers
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15 (Apple Silicon)
- Runtime: Node.js v22.22.0, OpenClaw 2026.3.23-1
- Model/provider: Custom provider using `api: "anthropic-messages"` with vision-capable model
- Relevant config (redacted):
```json
{
  "models": {
    "providers": {
      "my-provider": {
        "api": "anthropic-messages",
        "baseUrl": "https://my-proxy.example.com/v1",
        "models": [{ "id": "my-model", "input": ["text", "image"] }]
      }
    }
  },
  "agents": {
    "defaults": {
      "imageModel": { "primary": "my-provider/my-model" }
    }
  }
}
```

### Steps

1. Configure a custom provider with `api: "anthropic-messages"` and a model with `input: ["text", "image"]`
2. Set `agents.defaults.imageModel.primary` to the custom provider model
3. Use the `image` tool to analyze an image

### Expected

- Image is analyzed and text description is returned

### Actual

- Before fix: `No media-understanding provider registered for my-provider`
- After fix: Image is correctly analyzed and described

## Evidence

- [x] Verified end-to-end: `image` tool successfully calls custom provider and returns accurate image description
- [x] Verified that built-in providers still work correctly (no regression)
- [x] Verified that providers already registered via plugins are not overridden

## Human Verification (required)

- **Verified scenarios:** Image analysis via custom provider (certificate document, PPT slides), correct OCR output confirmed
- **Edge cases checked:** Provider already registered via plugin (skipped correctly), provider without image model (not registered), provider with unknown API format (not registered)
- **What I did NOT verify:** `pnpm build && pnpm test` (no build environment set up on this machine)

## AI-Assisted PR 🤖

- [x] This PR was AI-assisted (OpenClaw + Claude Opus 4)
- [x] Lightly tested (manual end-to-end verification, no unit test run)
- [x] I understand what the code does
- [ ] Codex review was run locally

## Review Conversations

- [x] I will reply to or resolve every bot review conversation I address.
- [x] I will leave unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** Circular import between `provider-registry.ts` and `image.ts`
  - **Mitigation:** `image.ts` already exports `describeImageWithModel` / `describeImagesWithModel` as top-level exports; `provider-registry.ts` imports them directly. No circular dependency issue since `provider-registry.ts` does not import from `image.ts` at module scope in a way that would cause issues (both are leaf modules).
- **Risk:** Custom provider model missing required fields (e.g. `maxTokens`, `contextWindow`)
  - **Mitigation:** The fallback model is spread from the user config which may include these fields. `describeImageWithModel` already handles missing optional fields gracefully.