### PR TITLE
fix(telegram): allow RFC 2544 benchmark IPs in media download SSRF policy (#57452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 - Agents/memory flush: keep daily memory flush files append-only during embedded attempts so compaction writes do not overwrite earlier notes. (#53725) Thanks @HPluseven.
 - Web UI/markdown: stop bare auto-links from swallowing adjacent CJK text while preserving valid mixed-script path and query characters in rendered links. (#48410) Thanks @jnuyao.
 - BlueBubbles/iMessage: coalesce URL-only inbound messages with their link-preview balloon again so sharing a bare link no longer drops the URL from agent context. Thanks @vincentkoc.
+- Telegram/media: allow RFC 2544 benchmark-range Telegram CDN resolutions during media downloads, so voice messages, PDFs, and other attachments no longer fail with `Failed to download media`. (#57624) Thanks @MoerAI.
 - Sandbox/browser: install `fonts-noto-cjk` in the sandbox browser image so screenshots render Chinese, Japanese, and Korean text correctly instead of tofu boxes. Fixes #35597. Thanks @carrotRakko and @vincentkoc.
 - Memory/FTS: add configurable trigram tokenization plus short-CJK substring fallback so memory search can find Chinese, Japanese, and Korean text without breaking mixed long-and-short queries. Thanks @carrotRakko.
 - Hooks/config: accept runtime channel plugin ids in `hooks.mappings[].channel` (for example `feishu`) instead of rejecting non-core channels during config validation. (#56226) Thanks @AiKrai001.

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -155,7 +155,7 @@ async function expectTransientGetFileRetrySuccess() {
     expect.objectContaining({
       url: `https://api.telegram.org/file/bot${BOT_TOKEN}/voice/file_0.oga`,
       ssrfPolicy: {
-        allowRfc2544BenchmarkRange: false,
+        allowRfc2544BenchmarkRange: true,
         hostnameAllowlist: ["api.telegram.org"],
       },
     }),
@@ -533,7 +533,7 @@ describe("resolveMedia original filename preservation", () => {
         ssrfPolicy: {
           hostnameAllowlist: ["api.telegram.org", "192.168.1.50"],
           allowedHostnames: ["192.168.1.50"],
-          allowRfc2544BenchmarkRange: false,
+          allowRfc2544BenchmarkRange: true,
         },
       }),
     );

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -41,7 +41,7 @@ function buildTelegramMediaSsrfPolicy(apiRoot?: string) {
     // enforcing SSRF checks on the resolved and redirected targets.
     hostnameAllowlist: hostnames,
     ...(allowedHostnames ? { allowedHostnames } : {}),
-    allowRfc2544BenchmarkRange: false,
+    allowRfc2544BenchmarkRange: true,
   };
 }
 


### PR DESCRIPTION
## Summary
Telegram CDN file servers sometimes resolve to IPs in the RFC 2544 benchmark range (198.18.0.0/15). The Telegram SSRF policy set `allowRfc2544BenchmarkRange: false`, blocking legitimate media downloads and causing "Failed to download media" errors for voice messages, PDFs, and other files.

## Root Cause
`buildTelegramMediaSsrfPolicy()` in `extensions/telegram/src/bot/delivery.resolve-media.ts` set `allowRfc2544BenchmarkRange: false` while Discord and Slack both set it to `true`. When Telegram's CDN servers resolve to addresses in the 198.18.0.0/15 range, the SSRF check rejects the download.

## Changes
- `extensions/telegram/src/bot/delivery.resolve-media.ts`: change `allowRfc2544BenchmarkRange` from `false` to `true`, matching Discord and Slack behavior
- `extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts`: update test expectations to match

## Test
All 23 tests pass in `delivery.resolve-media-retry.test.ts`.

Closes #57452
Closes #57564