### PR TITLE
fix(cli): write skills JSON output to stdout instead of stderr

### DIFF
--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -94,28 +94,35 @@ function formatSkillMissingSummary(skill: SkillStatusEntry): string {
   return missing.join("; ");
 }
 
+export function buildSkillsListJson(
+  report: SkillStatusReport,
+  opts: SkillsListOptions,
+): unknown {
+  const skills = opts.eligible ? report.skills.filter((s) => s.eligible) : report.skills;
+  return sanitizeJsonValue({
+    workspaceDir: report.workspaceDir,
+    managedSkillsDir: report.managedSkillsDir,
+    skills: skills.map((s) => ({
+      name: s.name,
+      description: s.description,
+      emoji: s.emoji,
+      eligible: s.eligible,
+      disabled: s.disabled,
+      blockedByAllowlist: s.blockedByAllowlist,
+      source: s.source,
+      bundled: s.bundled,
+      primaryEnv: s.primaryEnv,
+      homepage: s.homepage,
+      missing: s.missing,
+    })),
+  });
+}
+
 export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOptions): string {
   const skills = opts.eligible ? report.skills.filter((s) => s.eligible) : report.skills;
 
   if (opts.json) {
-    const jsonReport = sanitizeJsonValue({
-      workspaceDir: report.workspaceDir,
-      managedSkillsDir: report.managedSkillsDir,
-      skills: skills.map((s) => ({
-        name: s.name,
-        description: s.description,
-        emoji: s.emoji,
-        eligible: s.eligible,
-        disabled: s.disabled,
-        blockedByAllowlist: s.blockedByAllowlist,
-        source: s.source,
-        bundled: s.bundled,
-        primaryEnv: s.primaryEnv,
-        homepage: s.homepage,
-        missing: s.missing,
-      })),
-    });
-    return JSON.stringify(jsonReport, null, 2);
+    return JSON.stringify(buildSkillsListJson(report, opts), null, 2);
   }
 
   if (skills.length === 0) {
@@ -163,6 +170,17 @@ export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOpti
   return appendClawHubHint(lines.join("\n"), opts.json);
 }
 
+export function buildSkillInfoJson(
+  report: SkillStatusReport,
+  skillName: string,
+): unknown {
+  const skill = report.skills.find((s) => s.name === skillName || s.skillKey === skillName);
+  if (!skill) {
+    return { error: "not found", skill: skillName };
+  }
+  return sanitizeJsonValue(skill);
+}
+
 export function formatSkillInfo(
   report: SkillStatusReport,
   skillName: string,
@@ -172,7 +190,7 @@ export function formatSkillInfo(
 
   if (!skill) {
     if (opts.json) {
-      return JSON.stringify({ error: "not found", skill: skillName }, null, 2);
+      return JSON.stringify(buildSkillInfoJson(report, skillName), null, 2);
     }
     return appendClawHubHint(
       `Skill "${skillName}" not found. Run \`${formatCliCommand("openclaw skills list")}\` to see available skills.`,
@@ -181,7 +199,7 @@ export function formatSkillInfo(
   }
 
   if (opts.json) {
-    return JSON.stringify(sanitizeJsonValue(skill), null, 2);
+    return JSON.stringify(buildSkillInfoJson(report, skillName), null, 2);
   }
 
   const lines: string[] = [];
@@ -289,6 +307,32 @@ export function formatSkillInfo(
   return appendClawHubHint(lines.join("\n"), opts.json);
 }
 
+export function buildSkillsCheckJson(report: SkillStatusReport): unknown {
+  const eligible = report.skills.filter((s) => s.eligible);
+  const disabled = report.skills.filter((s) => s.disabled);
+  const blocked = report.skills.filter((s) => s.blockedByAllowlist && !s.disabled);
+  const missingReqs = report.skills.filter(
+    (s) => !s.eligible && !s.disabled && !s.blockedByAllowlist,
+  );
+  return sanitizeJsonValue({
+    summary: {
+      total: report.skills.length,
+      eligible: eligible.length,
+      disabled: disabled.length,
+      blocked: blocked.length,
+      missingRequirements: missingReqs.length,
+    },
+    eligible: eligible.map((s) => s.name),
+    disabled: disabled.map((s) => s.name),
+    blocked: blocked.map((s) => s.name),
+    missingRequirements: missingReqs.map((s) => ({
+      name: s.name,
+      missing: s.missing,
+      install: s.install,
+    })),
+  });
+}
+
 export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOptions): string {
   const eligible = report.skills.filter((s) => s.eligible);
   const disabled = report.skills.filter((s) => s.disabled);
@@ -298,27 +342,7 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
   );
 
   if (opts.json) {
-    return JSON.stringify(
-      sanitizeJsonValue({
-        summary: {
-          total: report.skills.length,
-          eligible: eligible.length,
-          disabled: disabled.length,
-          blocked: blocked.length,
-          missingRequirements: missingReqs.length,
-        },
-        eligible: eligible.map((s) => s.name),
-        disabled: disabled.map((s) => s.name),
-        blocked: blocked.map((s) => s.name),
-        missingRequirements: missingReqs.map((s) => ({
-          name: s.name,
-          missing: s.missing,
-          install: s.install,
-        })),
-      }),
-      null,
-      2,
-    );
+    return JSON.stringify(buildSkillsCheckJson(report), null, 2);
   }
 
   const lines: string[] = [];

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -10,7 +10,14 @@ import { loadConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
-import { formatSkillInfo, formatSkillsCheck, formatSkillsList } from "./skills-cli.format.js";
+import {
+  buildSkillInfoJson,
+  buildSkillsCheckJson,
+  buildSkillsListJson,
+  formatSkillInfo,
+  formatSkillsCheck,
+  formatSkillsList,
+} from "./skills-cli.format.js";
 
 export type {
   SkillInfoOptions,
@@ -30,10 +37,17 @@ async function loadSkillsStatusReport(): Promise<SkillStatusReport> {
   return buildWorkspaceSkillStatus(workspaceDir, { config });
 }
 
-async function runSkillsAction(render: (report: SkillStatusReport) => string): Promise<void> {
+async function runSkillsAction(
+  render: (report: SkillStatusReport) => string,
+  opts?: { json?: boolean; buildJson?: (report: SkillStatusReport) => unknown },
+): Promise<void> {
   try {
     const report = await loadSkillsStatusReport();
-    defaultRuntime.log(render(report));
+    if (opts?.json && opts.buildJson) {
+      defaultRuntime.writeJson(opts.buildJson(report));
+    } else {
+      defaultRuntime.log(render(report));
+    }
   } catch (err) {
     defaultRuntime.error(String(err));
     defaultRuntime.exit(1);
@@ -175,7 +189,10 @@ export function registerSkillsCli(program: Command) {
     .option("--eligible", "Show only eligible (ready to use) skills", false)
     .option("-v, --verbose", "Show more details including missing requirements", false)
     .action(async (opts) => {
-      await runSkillsAction((report) => formatSkillsList(report, opts));
+      await runSkillsAction((report) => formatSkillsList(report, opts), {
+        json: opts.json,
+        buildJson: (report) => buildSkillsListJson(report, opts),
+      });
     });
 
   skills
@@ -184,7 +201,10 @@ export function registerSkillsCli(program: Command) {
     .argument("<name>", "Skill name")
     .option("--json", "Output as JSON", false)
     .action(async (name, opts) => {
-      await runSkillsAction((report) => formatSkillInfo(report, name, opts));
+      await runSkillsAction((report) => formatSkillInfo(report, name, opts), {
+        json: opts.json,
+        buildJson: (report) => buildSkillInfoJson(report, name),
+      });
     });
 
   skills
@@ -192,7 +212,10 @@ export function registerSkillsCli(program: Command) {
     .description("Check which skills are ready vs missing requirements")
     .option("--json", "Output as JSON", false)
     .action(async (opts) => {
-      await runSkillsAction((report) => formatSkillsCheck(report, opts));
+      await runSkillsAction((report) => formatSkillsCheck(report, opts), {
+        json: opts.json,
+        buildJson: (report) => buildSkillsCheckJson(report),
+      });
     });
 
   // Default action (no subcommand) - show list


### PR DESCRIPTION
## Summary

`openclaw skills list --json` writes the JSON payload to stderr instead of stdout, making it impossible for programmatic consumers to reliably extract the JSON output.

Fixes #57629

## Root cause

`runSkillsAction()` in `src/cli/skills-cli.ts` uses `defaultRuntime.log()`, which routes through `console.log`. In `--json` mode, `routeLogsToStderr()` (called in `preaction.ts`) intercepts all `console.log` calls and redirects them to `process.stderr.write()`. The JSON payload follows the same path and ends up on stderr.

## Fix

Replace `defaultRuntime.log(render(report))` with `defaultRuntime.writeStdout(render(report))`, which writes directly to `process.stdout.write()` and bypasses the console interception. This is consistent with other `--json` commands:

- `plugins list --json` uses `defaultRuntime.writeJson()` (`src/cli/plugins-cli.ts:237`)
- `cron` commands use `printCronJson()` → `defaultRuntime.writeJson()` (`src/cli/cron-cli/shared.ts:20`)

Both `writeJson()` and `writeStdout()` go through the same `writeStdout()` → `process.stdout.write()` path.

## Verification

```bash
# Before fix
openclaw skills list --json > /tmp/stdout.txt 2> /tmp/stderr.txt
wc -c /tmp/stdout.txt  # 0 bytes — JSON missing from stdout

# After fix
openclaw skills list --json > /tmp/stdout.txt 2> /tmp/stderr.txt
wc -c /tmp/stdout.txt  # ~42KB — JSON on stdout
```