### PR TITLE
fix(cron): recover flat schedule params and coerce non-object job values

### DIFF
--- a/src/agents/tools/cron-tool.flat-params.test.ts
+++ b/src/agents/tools/cron-tool.flat-params.test.ts
@@ -36,4 +36,114 @@ describe("cron tool flat-params", () => {
     expect(method).toBe("cron.add");
     expect(params.sessionKey).toBe("agent:main:telegram:group:-100123:topic:99");
   });
+
+  it("reconstructs schedule from top-level every shorthand (#56996)", async () => {
+    const tool = createCronTool({}, { callGatewayTool: callGatewayToolMock });
+    await tool.execute("call-flat-every", {
+      action: "add",
+      name: "test",
+      every: 300_000,
+      message: "ping",
+    });
+
+    const [method, _opts, params] = callGatewayToolMock.mock.calls[0] as [
+      string,
+      unknown,
+      Record<string, unknown>,
+    ];
+    expect(method).toBe("cron.add");
+    expect(params.schedule).toEqual({ kind: "every", everyMs: 300_000 });
+    expect(params.every).toBeUndefined();
+  });
+
+  it("reconstructs schedule from top-level cron shorthand", async () => {
+    const tool = createCronTool({}, { callGatewayTool: callGatewayToolMock });
+    await tool.execute("call-flat-cron", {
+      action: "add",
+      name: "daily",
+      cron: "0 9 * * *",
+      tz: "America/New_York",
+      message: "morning check",
+    });
+
+    const [_method, _opts, params] = callGatewayToolMock.mock.calls[0] as [
+      string,
+      unknown,
+      Record<string, unknown>,
+    ];
+    expect(params.schedule).toEqual({ kind: "cron", expr: "0 9 * * *", tz: "America/New_York" });
+    expect(params.cron).toBeUndefined();
+    expect(params.tz).toBeUndefined();
+  });
+
+  it("reconstructs schedule from top-level at shorthand", async () => {
+    const tool = createCronTool({}, { callGatewayTool: callGatewayToolMock });
+    await tool.execute("call-flat-at", {
+      action: "add",
+      name: "once",
+      at: "2026-04-01T12:00:00Z",
+      message: "reminder",
+    });
+
+    const [_method, _opts, params] = callGatewayToolMock.mock.calls[0] as [
+      string,
+      unknown,
+      Record<string, unknown>,
+    ];
+    expect(params.schedule).toEqual({ kind: "at", at: "2026-04-01T12:00:00.000Z" });
+    expect(params.at).toBeUndefined();
+  });
+
+  it("coerces null job to undefined and triggers flat-params recovery", async () => {
+    const tool = createCronTool({}, { callGatewayTool: callGatewayToolMock });
+    await tool.execute("call-null-job", {
+      action: "add",
+      job: null,
+      name: "test",
+      every: 60_000,
+      message: "ping",
+    });
+
+    const [method, _opts, params] = callGatewayToolMock.mock.calls[0] as [
+      string,
+      unknown,
+      Record<string, unknown>,
+    ];
+    expect(method).toBe("cron.add");
+    expect(params.schedule).toEqual({ kind: "every", everyMs: 60_000 });
+  });
+
+  it("reconstructs schedule from everyMs shorthand", async () => {
+    const tool = createCronTool({}, { callGatewayTool: callGatewayToolMock });
+    await tool.execute("call-flat-everyMs", {
+      action: "add",
+      name: "test",
+      everyMs: 120_000,
+      message: "ping",
+    });
+
+    const [_method, _opts, params] = callGatewayToolMock.mock.calls[0] as [
+      string,
+      unknown,
+      Record<string, unknown>,
+    ];
+    expect(params.schedule).toEqual({ kind: "every", everyMs: 120_000 });
+  });
+
+  it("adds schedule shorthand keys for update flat-params recovery", async () => {
+    const tool = createCronTool({}, { callGatewayTool: callGatewayToolMock });
+    await tool.execute("call-flat-update", {
+      action: "update",
+      jobId: "job-1",
+      every: 600_000,
+    });
+
+    const [method, _opts, params] = callGatewayToolMock.mock.calls[0] as [
+      string,
+      unknown,
+      { id?: string; patch?: Record<string, unknown> },
+    ];
+    expect(method).toBe("cron.update");
+    expect(params.patch?.schedule).toEqual({ kind: "every", everyMs: 600_000 });
+  });
 });

--- a/src/agents/tools/cron-tool.flat-params.test.ts
+++ b/src/agents/tools/cron-tool.flat-params.test.ts
@@ -94,7 +94,7 @@ describe("cron tool flat-params", () => {
     expect(params.at).toBeUndefined();
   });
 
-  it("coerces null job to undefined and triggers flat-params recovery", async () => {
+  it("handles null job via flat-params recovery", async () => {
     const tool = createCronTool({}, { callGatewayTool: callGatewayToolMock });
     await tool.execute("call-null-job", {
       action: "add",
@@ -128,6 +128,30 @@ describe("cron tool flat-params", () => {
       Record<string, unknown>,
     ];
     expect(params.schedule).toEqual({ kind: "every", everyMs: 120_000 });
+  });
+
+  it("propagates staggerMs into cron shorthand schedule", async () => {
+    const tool = createCronTool({}, { callGatewayTool: callGatewayToolMock });
+    await tool.execute("call-flat-cron-stagger", {
+      action: "add",
+      name: "staggered",
+      cron: "0 0 * * *",
+      staggerMs: 5000,
+      message: "ping",
+    });
+
+    const [_method, _opts, params] = callGatewayToolMock.mock.calls[0] as [
+      string,
+      unknown,
+      Record<string, unknown>,
+    ];
+    expect(params.schedule).toEqual({
+      kind: "cron",
+      expr: "0 0 * * *",
+      staggerMs: 5000,
+    });
+    expect(params.staggerMs).toBeUndefined();
+    expect(params.cron).toBeUndefined();
   });
 
   it("adds schedule shorthand keys for update flat-params recovery", async () => {

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -35,10 +35,12 @@ const CronToolSchema = Type.Object(
     gatewayToken: Type.Optional(Type.String()),
     timeoutMs: Type.Optional(Type.Number()),
     includeDisabled: Type.Optional(Type.Boolean()),
-    job: Type.Optional(Type.Object({}, { additionalProperties: true })),
+    // Use permissive types for job/patch: LLMs may send null, a string wrapper,
+    // or omit nesting entirely (flat-params recovery handles all these at runtime).
+    job: Type.Optional(Type.Unsafe<Record<string, unknown>>({})),
     jobId: Type.Optional(Type.String()),
     id: Type.Optional(Type.String()),
-    patch: Type.Optional(Type.Object({}, { additionalProperties: true })),
+    patch: Type.Optional(Type.Unsafe<Record<string, unknown>>({})),
     text: Type.Optional(Type.String()),
     mode: optionalStringEnum(CRON_WAKE_MODES),
     runMode: optionalStringEnum(CRON_RUN_MODES),
@@ -305,6 +307,12 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
             }),
           );
         case "add": {
+          // Coerce non-object job values (null, string) to undefined so flat-params
+          // recovery triggers instead of failing schema validation (#56996).
+          if (params.job != null && typeof params.job !== "object") {
+            params.job = undefined;
+          }
+
           // Flat-params recovery: non-frontier models (e.g. Grok) sometimes flatten
           // job properties to the top level alongside `action` instead of nesting
           // them inside `job`. When `params.job` is missing or empty, reconstruct
@@ -334,6 +342,16 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               "thinking",
               "timeoutSeconds",
               "allowUnsafeExternalContent",
+              "failureAlert",
+              // Schedule shorthand keys (LLMs often flatten these)
+              "every",
+              "everyMs",
+              "cron",
+              "at",
+              "tz",
+              "stagger",
+              "staggerMs",
+              "exact",
             ]);
             const synthetic: Record<string, unknown> = {};
             let found = false;
@@ -343,6 +361,46 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
                 found = true;
               }
             }
+
+            // Reconstruct schedule from shorthand keys when not already present.
+            if (!synthetic.schedule) {
+              const everyMs =
+                typeof synthetic.everyMs === "number"
+                  ? synthetic.everyMs
+                  : typeof synthetic.every === "number"
+                    ? synthetic.every
+                    : undefined;
+              if (typeof everyMs === "number" && everyMs > 0) {
+                synthetic.schedule = { kind: "every", everyMs };
+              } else if (typeof synthetic.cron === "string" && synthetic.cron.trim()) {
+                synthetic.schedule = {
+                  kind: "cron",
+                  expr: synthetic.cron.trim(),
+                  ...(typeof synthetic.tz === "string" && synthetic.tz.trim()
+                    ? { tz: synthetic.tz.trim() }
+                    : {}),
+                };
+              } else if (synthetic.at !== undefined) {
+                const atValue =
+                  typeof synthetic.at === "string" ? synthetic.at : JSON.stringify(synthetic.at);
+                synthetic.schedule = { kind: "at", at: atValue };
+              }
+            }
+
+            // Clean up shorthand keys that are now folded into schedule.
+            for (const key of [
+              "every",
+              "everyMs",
+              "cron",
+              "at",
+              "tz",
+              "stagger",
+              "staggerMs",
+              "exact",
+            ]) {
+              delete synthetic[key];
+            }
+
             // Only use the synthetic job if at least one meaningful field is present
             // (schedule, payload, message, or text are the minimum signals that the
             // LLM intended to create a job).
@@ -456,6 +514,11 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
             throw new Error("jobId required (id accepted for backward compatibility)");
           }
 
+          // Coerce non-object patch values to undefined (#56996).
+          if (params.patch != null && typeof params.patch !== "object") {
+            params.patch = undefined;
+          }
+
           // Flat-params recovery for patch
           if (
             !params.patch ||
@@ -477,6 +540,15 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               "wakeMode",
               "failureAlert",
               "allowUnsafeExternalContent",
+              // Schedule shorthand keys
+              "every",
+              "everyMs",
+              "cron",
+              "at",
+              "tz",
+              "stagger",
+              "staggerMs",
+              "exact",
             ]);
             const synthetic: Record<string, unknown> = {};
             let found = false;
@@ -486,6 +558,46 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
                 found = true;
               }
             }
+
+            // Reconstruct schedule from shorthand keys when not already present.
+            if (!synthetic.schedule) {
+              const everyMs =
+                typeof synthetic.everyMs === "number"
+                  ? synthetic.everyMs
+                  : typeof synthetic.every === "number"
+                    ? synthetic.every
+                    : undefined;
+              if (typeof everyMs === "number" && everyMs > 0) {
+                synthetic.schedule = { kind: "every", everyMs };
+              } else if (typeof synthetic.cron === "string" && synthetic.cron.trim()) {
+                synthetic.schedule = {
+                  kind: "cron",
+                  expr: synthetic.cron.trim(),
+                  ...(typeof synthetic.tz === "string" && synthetic.tz.trim()
+                    ? { tz: synthetic.tz.trim() }
+                    : {}),
+                };
+              } else if (synthetic.at !== undefined) {
+                const atValue =
+                  typeof synthetic.at === "string" ? synthetic.at : JSON.stringify(synthetic.at);
+                synthetic.schedule = { kind: "at", at: atValue };
+              }
+            }
+
+            // Clean up shorthand keys folded into schedule.
+            for (const key of [
+              "every",
+              "everyMs",
+              "cron",
+              "at",
+              "tz",
+              "stagger",
+              "staggerMs",
+              "exact",
+            ]) {
+              delete synthetic[key];
+            }
+
             if (found) {
               params.patch = synthetic;
             }

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -307,8 +307,9 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
             }),
           );
         case "add": {
-          // Coerce non-object job values (null, string) to undefined so flat-params
-          // recovery triggers instead of failing schema validation (#56996).
+          // Coerce non-null non-object job values (e.g. a bare string) to undefined so
+          // flat-params recovery triggers instead of failing schema validation (#56996).
+          // Note: null is handled implicitly below by `!params.job` being truthy.
           if (params.job != null && typeof params.job !== "object") {
             params.job = undefined;
           }
@@ -378,6 +379,9 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
                   expr: synthetic.cron.trim(),
                   ...(typeof synthetic.tz === "string" && synthetic.tz.trim()
                     ? { tz: synthetic.tz.trim() }
+                    : {}),
+                  ...(typeof synthetic.staggerMs === "number"
+                    ? { staggerMs: synthetic.staggerMs }
                     : {}),
                 };
               } else if (synthetic.at !== undefined) {
@@ -575,6 +579,9 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
                   expr: synthetic.cron.trim(),
                   ...(typeof synthetic.tz === "string" && synthetic.tz.trim()
                     ? { tz: synthetic.tz.trim() }
+                    : {}),
+                  ...(typeof synthetic.staggerMs === "number"
+                    ? { staggerMs: synthetic.staggerMs }
                     : {}),
                 };
               } else if (synthetic.at !== undefined) {


### PR DESCRIPTION
## Summary

Fixes #56996 — `cron add` fails with "job: must be object" when LLMs send flat parameters.

**Root cause:** Two issues in `cron-tool.ts`:
1. The `job` field used `Type.Object` in the tool schema, which rejects `null`/non-object values at provider-level validation before the tool's flat-params recovery can run.
2. The flat-params recovery only captured structured job fields (`name`, `message`, `schedule`, etc.) but missed schedule shorthand keys (`every`, `everyMs`, `cron`, `at`, `tz`), so LLM-generated flat params like `{ every: 300000, message: "ping" }` lost the schedule.

**Changes:**
- Relax `job`/`patch` schema from `Type.Object` to `Type.Unsafe({})` so provider-level validation accepts any value
- Coerce non-object `job`/`patch` values (null, string) to `undefined` before flat-params recovery
- Add schedule shorthand keys to `JOB_KEYS` / `PATCH_KEYS` (`every`, `everyMs`, `cron`, `at`, `tz`, `stagger`, `staggerMs`, `exact`)
- Reconstruct `schedule` object from shorthand keys when not already present
- Clean up shorthand keys after folding into `schedule` to avoid downstream schema rejection
- Apply the same fix to both `add` and `update` code paths

## Test plan

- [x] 6 new test cases in `cron-tool.flat-params.test.ts`:
  - `every` shorthand → reconstructs `{ kind: "every", everyMs }` schedule
  - `cron` + `tz` shorthand → reconstructs `{ kind: "cron", expr, tz }` schedule
  - `at` shorthand → reconstructs `{ kind: "at", at }` schedule
  - `everyMs` shorthand → reconstructs schedule correctly
  - `job: null` → coerced to undefined, triggers flat-params recovery
  - `update` action with `every` shorthand → reconstructs schedule in patch
- [x] Existing 33 cron-tool tests pass
- [x] Existing flat-params test (sessionKey preservation) passes