### PR TITLE
gateway: clear unbound scopes for trusted-proxy auth

### DIFF
--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -3,6 +3,7 @@ import {
   evaluateMissingDeviceIdentity,
   isTrustedProxyControlUiOperatorAuth,
   resolveControlUiAuthPolicy,
+  shouldClearUnboundScopesForMissingDeviceIdentity,
   shouldSkipControlUiPairing,
 } from "./connect-policy.js";
 
@@ -299,5 +300,73 @@ describe("ws connect policy", () => {
         }),
       ).toBe(tc.expected);
     }
+  });
+
+  test("clears unbound scopes for device-less shared auth outside explicit preservation cases", () => {
+    const nonControlUi = resolveControlUiAuthPolicy({
+      isControlUi: false,
+      controlUiConfig: undefined,
+      deviceRaw: null,
+    });
+    const controlUi = resolveControlUiAuthPolicy({
+      isControlUi: true,
+      controlUiConfig: { allowInsecureAuth: true },
+      deviceRaw: null,
+    });
+
+    expect(
+      shouldClearUnboundScopesForMissingDeviceIdentity({
+        decision: { kind: "allow" },
+        controlUiAuthPolicy: nonControlUi,
+        preserveInsecureLocalControlUiScopes: false,
+        authMethod: "token",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldClearUnboundScopesForMissingDeviceIdentity({
+        decision: { kind: "allow" },
+        controlUiAuthPolicy: nonControlUi,
+        preserveInsecureLocalControlUiScopes: false,
+        authMethod: "password",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldClearUnboundScopesForMissingDeviceIdentity({
+        decision: { kind: "allow" },
+        controlUiAuthPolicy: nonControlUi,
+        preserveInsecureLocalControlUiScopes: false,
+        authMethod: "trusted-proxy",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldClearUnboundScopesForMissingDeviceIdentity({
+        decision: { kind: "allow" },
+        controlUiAuthPolicy: nonControlUi,
+        preserveInsecureLocalControlUiScopes: false,
+        authMethod: "token",
+        trustedProxyAuthOk: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldClearUnboundScopesForMissingDeviceIdentity({
+        decision: { kind: "allow" },
+        controlUiAuthPolicy: controlUi,
+        preserveInsecureLocalControlUiScopes: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldClearUnboundScopesForMissingDeviceIdentity({
+        decision: { kind: "reject-device-required" },
+        controlUiAuthPolicy: nonControlUi,
+        preserveInsecureLocalControlUiScopes: false,
+        authMethod: undefined,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -346,7 +346,7 @@ describe("ws connect policy", () => {
         decision: { kind: "allow" },
         controlUiAuthPolicy: nonControlUi,
         preserveInsecureLocalControlUiScopes: false,
-        authMethod: "token",
+        authMethod: undefined,
         trustedProxyAuthOk: true,
       }),
     ).toBe(true);

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -81,6 +81,26 @@ export type MissingDeviceIdentityDecision =
   | { kind: "reject-unauthorized" }
   | { kind: "reject-device-required" };
 
+export function shouldClearUnboundScopesForMissingDeviceIdentity(params: {
+  decision: MissingDeviceIdentityDecision;
+  controlUiAuthPolicy: ControlUiAuthPolicy;
+  preserveInsecureLocalControlUiScopes: boolean;
+  authMethod: string | undefined;
+  trustedProxyAuthOk?: boolean;
+}): boolean {
+  return (
+    params.decision.kind !== "allow" ||
+    (!params.controlUiAuthPolicy.allowBypass &&
+      !params.preserveInsecureLocalControlUiScopes &&
+      // trusted-proxy auth can bypass pairing for some clients, but those
+      // self-declared scopes are still unbound without device identity.
+      (params.authMethod === "token" ||
+        params.authMethod === "password" ||
+        params.authMethod === "trusted-proxy" ||
+        params.trustedProxyAuthOk === true))
+  );
+}
+
 export function evaluateMissingDeviceIdentity(params: {
   hasDeviceIdentity: boolean;
   role: GatewayRole;

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -90,6 +90,7 @@ import {
   evaluateMissingDeviceIdentity,
   isTrustedProxyControlUiOperatorAuth,
   resolveControlUiAuthPolicy,
+  shouldClearUnboundScopesForMissingDeviceIdentity,
   shouldSkipControlUiPairing,
 } from "./connect-policy.js";
 import {
@@ -548,10 +549,13 @@ export function attachGatewayWsMessageHandler(params: {
           // allow path, including trusted token-authenticated backend operators.
           if (
             !device &&
-            (decision.kind !== "allow" ||
-              (!controlUiAuthPolicy.allowBypass &&
-                !preserveInsecureLocalControlUiScopes &&
-                (authMethod === "token" || authMethod === "password" || trustedProxyAuthOk)))
+            shouldClearUnboundScopesForMissingDeviceIdentity({
+              decision,
+              controlUiAuthPolicy,
+              preserveInsecureLocalControlUiScopes,
+              authMethod,
+              trustedProxyAuthOk,
+            })
           ) {
             clearUnboundScopes();
           }


### PR DESCRIPTION
## Summary
- extract the unbound-scope clearing decision into a dedicated ws-connect policy helper
- clear self-declared scopes for device-less `trusted-proxy` connects the same way token/password shared auth already does in this path

## Changes
- update the ws message-handler to use the shared helper when deciding whether to wipe unbound scopes
- add policy-level coverage for token, password, trusted-proxy, preserve, and reject branches

## Validation
- Ran `pnpm test -- src/gateway/server/ws-connection/connect-policy.test.ts`
- Ran `pnpm test -- src/gateway/server.auth.browser-hardening.test.ts -t "clears scopes for trusted-proxy non-control-ui browser sessions"`
- Ran local agentic review with `claude -p "/review"` and addressed the follow-up test coverage/comments it flagged

## Notes
- Residual risk or follow-up: a targeted `src/gateway/server.auth.control-ui.test.ts` trusted-proxy case currently returns `CONTROL_UI_DEVICE_IDENTITY_REQUIRED` before this helper is reached, so this change keeps validation scoped to the affected non-control-ui path
