### PR TITLE
Discord: gate audio preflight on member access

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -765,6 +765,66 @@ describe("preflightDiscordMessage", () => {
     expect(result?.wasMentioned).toBe(true);
   });
 
+  it("does not transcribe guild audio from unauthorized members", async () => {
+    const channelId = "channel-audio-unauthorized-1";
+    const guildId = "guild-audio-unauthorized-1";
+    const client = createGuildTextClient(channelId);
+
+    const message = createDiscordMessage({
+      id: "m-audio-unauthorized-1",
+      channelId,
+      content: "",
+      attachments: [
+        {
+          id: "att-1",
+          url: "https://cdn.discordapp.com/attachments/voice.ogg",
+          content_type: "audio/ogg",
+          filename: "voice.ogg",
+        },
+      ],
+      author: {
+        id: "user-2",
+        bot: false,
+        username: "Mallory",
+      },
+    });
+
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg: {
+          ...DEFAULT_PREFLIGHT_CFG,
+          messages: {
+            groupChat: {
+              mentionPatterns: ["openclaw"],
+            },
+          },
+        } as import("openclaw/plugin-sdk/config-runtime").OpenClawConfig,
+        discordConfig: {} as DiscordConfig,
+        data: createGuildEvent({
+          channelId,
+          guildId,
+          author: message.author,
+          message,
+        }),
+        client,
+      }),
+      guildEntries: {
+        [guildId]: {
+          channels: {
+            [channelId]: {
+              allow: true,
+              requireMention: true,
+              users: ["user-1"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
   it("drops guild message without mention when channel has configuredBinding and requireMention: true", async () => {
     const conversationRuntime = await import("openclaw/plugin-sdk/conversation-runtime");
     const channelId = "ch-binding-1";

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -689,6 +689,7 @@ export async function preflightDiscordMessage(
 
   if (isGuildMessage && hasAccessRestrictions && !memberAllowed) {
     logDebug(`[discord-preflight] drop: member not allowed`);
+    // Keep stable Discord user IDs out of routine deny-path logs.
     logVerbose("Blocked discord guild sender (not in users/roles allowlist)");
     return null;
   }

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -679,9 +679,21 @@ export async function preflightDiscordMessage(
     shouldRequireMention: shouldRequireMentionByConfig,
     bypassMentionRequirement,
   });
+  const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
+    channelConfig,
+    guildInfo,
+    memberRoleIds,
+    sender,
+    allowNameMatching,
+  });
 
-  // Preflight audio transcription for mention detection in guilds.
-  // This allows voice notes to be checked for mentions before being dropped.
+  if (isGuildMessage && hasAccessRestrictions && !memberAllowed) {
+    logDebug(`[discord-preflight] drop: member not allowed`);
+    logVerbose(`Blocked discord guild sender ${sender.id} (not in users/roles allowlist)`);
+    return null;
+  }
+
+  // Only authorized guild senders should reach the expensive transcription path.
   const { hasTypedText, transcript: preflightTranscript } =
     await resolveDiscordPreflightAudioMentionContext({
       message,
@@ -725,13 +737,6 @@ export async function preflightDiscordMessage(
     surface: "discord",
   });
   const hasControlCommandInMessage = hasControlCommand(baseText, params.cfg);
-  const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
-    channelConfig,
-    guildInfo,
-    memberRoleIds,
-    sender,
-    allowNameMatching,
-  });
 
   if (!isDirectMessage) {
     const { ownerAllowList, ownerAllowed: ownerOk } = resolveDiscordOwnerAccess({
@@ -831,12 +836,6 @@ export async function preflightDiscordMessage(
       limit: params.historyLimit,
       entry: historyEntry ?? null,
     });
-    return null;
-  }
-
-  if (isGuildMessage && hasAccessRestrictions && !memberAllowed) {
-    logDebug(`[discord-preflight] drop: member not allowed`);
-    logVerbose(`Blocked discord guild sender ${sender.id} (not in users/roles allowlist)`);
     return null;
   }
 

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -689,7 +689,7 @@ export async function preflightDiscordMessage(
 
   if (isGuildMessage && hasAccessRestrictions && !memberAllowed) {
     logDebug(`[discord-preflight] drop: member not allowed`);
-    logVerbose(`Blocked discord guild sender ${sender.id} (not in users/roles allowlist)`);
+    logVerbose("Blocked discord guild sender (not in users/roles allowlist)");
     return null;
   }
 


### PR DESCRIPTION
## Summary
- skips Discord audio preflight work for guild senders who fail channel member access checks
- keeps mention handling behavior unchanged for authorized senders

## Changes
- moved guild member access evaluation ahead of audio preflight transcription in `extensions/discord/src/monitor/message-handler.preflight.ts`
- added a regression test covering unauthorized audio-only guild messages in `extensions/discord/src/monitor/message-handler.preflight.test.ts`
- removed the stable user identifier from the verbose unauthorized-sender log message

## Validation
- ran `pnpm test -- extensions/discord/src/monitor/message-handler.preflight.test.ts`
- ran `pnpm check` via `scripts/committer`
- ran local agentic review with `claude -p "/review"` and there was no actionable feedback

## Notes
- residual risk or follow-up: none identified beyond the scoped local validation above
