### PR TITLE
feat: support all file types as webchat attachments

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -35,7 +35,11 @@ import {
   isChatStopCommandText,
   resolveChatRunExpiresAtMs,
 } from "../chat-abort.js";
-import { type ChatImageContent, parseMessageWithAttachments } from "../chat-attachments.js";
+import {
+  type ChatAttachment,
+  type ChatImageContent,
+  parseMessageWithAttachments,
+} from "../chat-attachments.js";
 import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "../chat-sanitize.js";
 import { augmentChatHistoryWithCliSessionImports } from "../cli-session-history.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
@@ -341,6 +345,41 @@ async function persistChatSendImages(params: {
     } catch (err) {
       params.logGateway.warn(
         `chat.send: failed to persist inbound image (${img.mimeType}): ${formatForLog(err)}`,
+      );
+    }
+  }
+  return saved;
+}
+
+/**
+ * Persist non-image attachments (audio, documents, etc.) from chat.send to the
+ * media store so they are available on the local filesystem for the media
+ * understanding pipeline.  Images are handled separately by persistChatSendImages.
+ */
+async function persistChatSendNonImageAttachments(params: {
+  attachments: ChatAttachment[];
+  client: GatewayRequestHandlerOptions["client"];
+  logGateway: GatewayRequestContext["logGateway"];
+}): Promise<SavedMedia[]> {
+  if (params.attachments.length === 0 || isAcpBridgeClient(params.client)) {
+    return [];
+  }
+  const saved: SavedMedia[] = [];
+  for (const att of params.attachments) {
+    if (!att.content || typeof att.content !== "string") {
+      continue;
+    }
+    const mime = att.mimeType ?? "application/octet-stream";
+    // Skip images — they are already persisted by persistChatSendImages
+    if (mime.startsWith("image/")) {
+      continue;
+    }
+    try {
+      saved.push(await saveMediaBuffer(Buffer.from(att.content, "base64"), mime, "inbound"));
+    } catch (err) {
+      const label = att.fileName ?? att.type ?? "attachment";
+      params.logGateway.warn(
+        `chat.send: failed to persist inbound attachment ${label} (${mime}): ${formatForLog(err)}`,
       );
     }
   }
@@ -1483,6 +1522,24 @@ export const chatHandlers: GatewayRequestHandlers = {
         logGateway: context.logGateway,
       });
 
+      // Persist non-image attachments (audio, documents, etc.) alongside images
+      // so that the media understanding pipeline can process them, just like
+      // channel-based media (Telegram, Discord, etc.).
+      const persistedNonImageAttachmentsPromise = persistChatSendNonImageAttachments({
+        attachments: normalizedAttachments,
+        client,
+        logGateway: context.logGateway,
+      });
+
+      // Resolve all persisted media before constructing the context so that
+      // hasInboundMedia(ctx) returns true and applyMediaUnderstanding fires for
+      // text-only models.
+      const [persistedImages, persistedNonImages] = await Promise.all([
+        persistedImagesPromise,
+        persistedNonImageAttachmentsPromise,
+      ]);
+      const allPersistedMedia = [...persistedImages, ...persistedNonImages];
+
       const trimmedMessage = parsedMessage.trim();
       const injectThinking = Boolean(
         p.thinking && trimmedMessage && !trimmedMessage.startsWith("/"),
@@ -1534,6 +1591,12 @@ export const chatHandlers: GatewayRequestHandlers = {
         SenderName: clientInfo?.displayName,
         SenderUsername: clientInfo?.displayName,
         GatewayClientScopes: client?.connect?.scopes,
+        // Bridge persisted media into the context so that the media understanding
+        // pipeline (hasInboundMedia → applyMediaUnderstanding) fires for webchat
+        // attachments, matching the behaviour of channel-based media (Telegram,
+        // Discord, etc.).  Without these fields, text-only models silently drop
+        // inbound images/files because the understanding step is skipped.
+        ...resolveChatSendTranscriptMediaFields(allPersistedMedia),
       };
 
       const agentId = resolveSessionAgentId({
@@ -1567,7 +1630,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           if (!transcriptPath) {
             return;
           }
-          const persistedImages = await persistedImagesPromise;
+          const persistedImages = allPersistedMedia;
           emitSessionTranscriptUpdate({
             sessionFile: transcriptPath,
             sessionKey,
@@ -1604,7 +1667,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           transcriptPath,
           sessionKey,
           message: parsedMessage,
-          savedImages: await persistedImagesPromise,
+          savedImages: allPersistedMedia,
         });
       };
       const dispatcher = createReplyDispatcher({

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -369,7 +369,7 @@ async function persistChatSendNonImageAttachments(params: {
     if (!att.content || typeof att.content !== "string") {
       continue;
     }
-    const mime = att.mimeType ?? "application/octet-stream";
+    const mime = att.mimeType || "application/octet-stream";
     // Skip images — they are already persisted by persistChatSendImages
     if (mime.startsWith("image/")) {
       continue;
@@ -1630,13 +1630,13 @@ export const chatHandlers: GatewayRequestHandlers = {
           if (!transcriptPath) {
             return;
           }
-          const persistedImages = allPersistedMedia;
+          const persistedMedia = allPersistedMedia;
           emitSessionTranscriptUpdate({
             sessionFile: transcriptPath,
             sessionKey,
             message: buildChatSendTranscriptMessage({
               message: parsedMessage,
-              savedImages: persistedImages,
+              savedImages: persistedMedia,
               timestamp: now,
             }),
           });

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -274,8 +274,8 @@
   background: rgba(0, 0, 0, 0.6);
 }
 
-/* Message images (sent images displayed in chat) */
-.chat-message-images {
+/* Message media (images and files displayed in chat) */
+.chat-message-media {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
@@ -295,8 +295,36 @@
   transform: scale(1.02);
 }
 
-/* User message images align right */
-.chat-group.user .chat-message-images {
+.chat-message-file {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: var(--radius-md);
+  background: var(--surface-secondary, rgba(128, 128, 128, 0.1));
+  border: 1px solid var(--border);
+  max-width: 280px;
+}
+
+.chat-message-file__icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+.chat-message-file__name,
+.chat-message-file__type {
+  font-size: 13px;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.8;
+}
+
+/* User message media align right */
+.chat-group.user .chat-message-media {
   justify-content: flex-end;
 }
 
@@ -697,6 +725,45 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.chat-attachment-thumb--file {
+  width: auto;
+  min-width: 60px;
+  max-width: 140px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-secondary, #f0f0f0);
+  padding: 4px 8px;
+  box-sizing: border-box;
+}
+
+.chat-attachment-file-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+}
+
+.chat-attachment-file-icon svg {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+.chat-attachment-file-name {
+  font-size: 10px;
+  line-height: 1.2;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
+  opacity: 0.7;
 }
 
 .chat-attachment-remove {

--- a/ui/src/ui/chat/attachment-support.ts
+++ b/ui/src/ui/chat/attachment-support.ts
@@ -1,5 +1,10 @@
-export const CHAT_ATTACHMENT_ACCEPT = "image/*";
+export const CHAT_ATTACHMENT_ACCEPT = "*/*";
+
+const UNSUPPORTED_MIME_PREFIXES = ["video/"];
 
 export function isSupportedChatAttachmentMimeType(mimeType: string | null | undefined): boolean {
-  return typeof mimeType === "string" && mimeType.startsWith("image/");
+  if (typeof mimeType !== "string") {
+    return false;
+  }
+  return !UNSUPPORTED_MIME_PREFIXES.some((prefix) => mimeType.startsWith(prefix));
 }

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -23,10 +23,17 @@ type ImageBlock = {
   alt?: string;
 };
 
-function extractImages(message: unknown): ImageBlock[] {
+type FileBlock = {
+  fileName?: string;
+  mimeType: string;
+};
+
+type MediaBlock = { kind: "image"; block: ImageBlock } | { kind: "file"; block: FileBlock };
+
+function extractMedia(message: unknown): MediaBlock[] {
   const m = message as Record<string, unknown>;
   const content = m.content;
-  const images: ImageBlock[] = [];
+  const media: MediaBlock[] = [];
 
   if (Array.isArray(content)) {
     for (const block of content) {
@@ -43,21 +50,29 @@ function extractImages(message: unknown): ImageBlock[] {
           const mediaType = (source.media_type as string) || "image/png";
           // If data is already a data URL, use it directly
           const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
-          images.push({ url });
+          media.push({ kind: "image", block: { url } });
         } else if (typeof b.url === "string") {
-          images.push({ url: b.url });
+          media.push({ kind: "image", block: { url: b.url } });
         }
       } else if (b.type === "image_url") {
         // OpenAI format
         const imageUrl = b.image_url as Record<string, unknown> | undefined;
         if (typeof imageUrl?.url === "string") {
-          images.push({ url: imageUrl.url });
+          media.push({ kind: "image", block: { url: imageUrl.url } });
         }
+      } else if (b.type === "file") {
+        media.push({
+          kind: "file",
+          block: {
+            fileName: typeof b.fileName === "string" ? b.fileName : undefined,
+            mimeType: typeof b.mimeType === "string" ? b.mimeType : "application/octet-stream",
+          },
+        });
       }
     }
   }
 
-  return images;
+  return media;
 }
 
 export function renderReadingIndicatorGroup(assistant?: AssistantIdentity, basePath?: string) {
@@ -522,8 +537,8 @@ function isAvatarUrl(value: string): boolean {
   );
 }
 
-function renderMessageImages(images: ImageBlock[]) {
-  if (images.length === 0) {
+function renderMessageMedia(media: MediaBlock[]) {
+  if (media.length === 0) {
     return nothing;
   }
 
@@ -532,16 +547,39 @@ function renderMessageImages(images: ImageBlock[]) {
   };
 
   return html`
-    <div class="chat-message-images">
-      ${images.map(
-        (img) => html`
-          <img
-            src=${img.url}
-            alt=${img.alt ?? "Attached image"}
-            class="chat-message-image"
-            @click=${() => openImage(img.url)}
-          />
-        `,
+    <div class="chat-message-media">
+      ${media.map((item) =>
+        item.kind === "image"
+          ? html`
+              <img
+                src=${item.block.url}
+                alt="Attached image"
+                class="chat-message-image"
+                @click=${() => openImage(item.block.url)}
+              />
+            `
+          : html`
+              <div class="chat-message-file">
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="chat-message-file__icon"
+                >
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                  <line x1="16" y1="13" x2="8" y2="13" />
+                  <line x1="16" y1="17" x2="8" y2="17" />
+                  <polyline points="10 9 9 9 8 9" />
+                </svg>
+                ${item.block.fileName
+                  ? html`<span class="chat-message-file__name">${item.block.fileName}</span>`
+                  : html`<span class="chat-message-file__type">${item.block.mimeType}</span>`}
+              </div>
+            `,
       )}
     </div>
   `;
@@ -653,8 +691,8 @@ function renderGroupedMessage(
 
   const toolCards = (opts.showToolCalls ?? true) ? extractToolCards(message) : [];
   const hasToolCards = toolCards.length > 0;
-  const images = extractImages(message);
-  const hasImages = images.length > 0;
+  const media = extractMedia(message);
+  const hasMedia = media.length > 0;
 
   const extractedText = extractTextCached(message);
   const extractedThinking =
@@ -678,7 +716,7 @@ function renderGroupedMessage(
 
   // Suppress empty bubbles when tool cards are the only content and toggle is off
   const visibleToolCards = hasToolCards && (opts.showToolCalls ?? true);
-  if (!markdown && !visibleToolCards && !hasImages) {
+  if (!markdown && !visibleToolCards && !hasMedia) {
     return nothing;
   }
 
@@ -714,7 +752,7 @@ function renderGroupedMessage(
                     : nothing}
               </summary>
               <div class="chat-tool-msg-body">
-                ${renderMessageImages(images)}
+                ${renderMessageMedia(media)}
                 ${reasoningMarkdown
                   ? html`<div class="chat-thinking">
                       ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}
@@ -738,7 +776,7 @@ function renderGroupedMessage(
             </details>
           `
         : html`
-            ${renderMessageImages(images)}
+            ${renderMessageMedia(media)}
             ${reasoningMarkdown
               ? html`<div class="chat-thinking">
                   ${unsafeHTML(toSanitizedMarkdownHtml(reasoningMarkdown))}

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -184,9 +184,12 @@ export async function sendChatMessage(
   // Add image previews to the message for display
   if (hasAttachments) {
     for (const att of attachments) {
+      const isImage = att.mimeType.startsWith("image/");
       contentBlocks.push({
-        type: "image",
-        source: { type: "base64", media_type: att.mimeType, data: att.dataUrl },
+        type: isImage ? "image" : "file",
+        ...(isImage
+          ? { source: { type: "base64", media_type: att.mimeType, data: att.dataUrl } }
+          : { fileName: att.fileName, mimeType: att.mimeType }),
       });
     }
   }
@@ -216,9 +219,10 @@ export async function sendChatMessage(
             return null;
           }
           return {
-            type: "image",
+            type: att.mimeType.startsWith("image/") ? "image" : "file",
             mimeType: parsed.mimeType,
             content: parsed.content,
+            ...(att.fileName ? { fileName: att.fileName } : {}),
           };
         })
         .filter((a): a is NonNullable<typeof a> => a !== null)

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -2,6 +2,7 @@ export type ChatAttachment = {
   id: string;
   dataUrl: string;
   mimeType: string;
+  fileName?: string;
 };
 
 export type ChatQueueItem = {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -388,6 +388,7 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
         id: generateAttachmentId(),
         dataUrl,
         mimeType: file.type,
+        fileName: file.name,
       };
       const current = props.attachments ?? [];
       props.onAttachmentsChange?.([...current, newAttachment]);
@@ -415,6 +416,7 @@ function handleFileSelect(e: Event, props: ChatProps) {
         id: generateAttachmentId(),
         dataUrl: reader.result as string,
         mimeType: file.type,
+        fileName: file.name,
       });
       pending--;
       if (pending === 0) {
@@ -446,6 +448,7 @@ function handleDrop(e: DragEvent, props: ChatProps) {
         id: generateAttachmentId(),
         dataUrl: reader.result as string,
         mimeType: file.type,
+        fileName: file.name,
       });
       pending--;
       if (pending === 0) {
@@ -454,6 +457,10 @@ function handleDrop(e: DragEvent, props: ChatProps) {
     });
     reader.readAsDataURL(file);
   }
+}
+
+function isImageMimeType(mime: string): boolean {
+  return mime.startsWith("image/");
 }
 
 function renderAttachmentPreview(props: ChatProps): TemplateResult | typeof nothing {
@@ -465,8 +472,32 @@ function renderAttachmentPreview(props: ChatProps): TemplateResult | typeof noth
     <div class="chat-attachments-preview">
       ${attachments.map(
         (att) => html`
-          <div class="chat-attachment-thumb">
-            <img src=${att.dataUrl} alt="Attachment preview" />
+          <div
+            class="chat-attachment-thumb ${isImageMimeType(att.mimeType)
+              ? ""
+              : "chat-attachment-thumb--file"}"
+          >
+            ${isImageMimeType(att.mimeType)
+              ? html`<img src=${att.dataUrl} alt="Attachment preview" />`
+              : html`<div class="chat-attachment-file-icon">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                    <line x1="16" y1="13" x2="8" y2="13" />
+                    <line x1="16" y1="17" x2="8" y2="17" />
+                    <polyline points="10 9 9 9 8 9" />
+                  </svg>
+                  ${att.fileName
+                    ? html`<span class="chat-attachment-file-name">${att.fileName}</span>`
+                    : nothing}
+                </div>`}
             <button
               class="chat-attachment-remove"
               type="button"


### PR DESCRIPTION
## Summary

- **Server-side**: Persist non-image attachments (audio, PDF, documents, etc.) to the media store and set `MediaPath`/`MediaPaths`/`MediaType`/`MediaTypes` on `MsgContext`, enabling the media understanding pipeline (`hasInboundMedia` -> `applyMediaUnderstanding`) for text-only models
- **UI**: Accept all file types (not just `image/*`) in the file picker and drag-and-drop, display a generic file icon with filename for non-image attachments in both the input preview and message bubbles

Previously webchat only accepted `image/*` attachments, and even those were silently dropped for text-only models because `MediaPath` was not set on the context. This change matches the behavior of channel-based clients (Telegram, Discord, etc.).

## Changes

### Server (`src/gateway/server-methods/chat.ts`)
- Add `persistChatSendNonImageAttachments()` to persist audio, PDF, and other non-image attachments to the media store
- Await both image and non-image persistence before constructing `MsgContext`
- Spread `resolveChatSendTranscriptMediaFields(allPersistedMedia)` into `ctx` so `hasInboundMedia()` returns `true`
- Update transcript references to use merged `allPersistedMedia`

### UI (`ui/src/ui/`)
- `attachment-support.ts`: Accept all MIME types, only exclude `video/*`
- `ui-types.ts`: Add optional `fileName` to `ChatAttachment`
- `views/chat.ts`: Save `fileName` on attachment creation, render file icon for non-image previews
- `controllers/chat.ts`: Distinguish image vs file content blocks in local messages and API payloads
- `grouped-render.ts`: Replace `extractImages`/`renderMessageImages` with `extractMedia`/`renderMessageMedia` supporting both image and file blocks
- `layout.css`: Add `.chat-message-file` and `.chat-attachment-thumb--file` styles

## Test plan

- [x] `pnpm check` passes (type check, lint, format)
- [x] Upload image via webchat -> displays thumbnail in preview, renders image in message bubble
- [x] Upload non-image file (PDF, audio, etc.) -> displays file icon + name in preview, renders file badge in message bubble
- [x] Server receives attachment, persists to media store, triggers media understanding pipeline
- [x] Existing image-only behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)