### PR TITLE
gateway: enforce embeddings HTTP write scope

### DIFF
--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -5,6 +5,8 @@ import { getFreePort, installGatewayTestHooks } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
+const WRITE_SCOPE_HEADER = { "x-openclaw-scopes": "operator.write" };
+
 let startGatewayServer: typeof import("./server.js").startGatewayServer;
 let createEmbeddingProviderMock: ReturnType<
   typeof vi.fn<
@@ -81,6 +83,7 @@ async function postEmbeddings(body: unknown, headers?: Record<string, string>) {
     headers: {
       authorization: "Bearer secret",
       "content-type": "application/json",
+      ...WRITE_SCOPE_HEADER,
       ...headers,
     },
     body: JSON.stringify(body),
@@ -162,6 +165,64 @@ describe("OpenAI-compatible embeddings HTTP API (e2e)", () => {
     expect(res.status).toBe(400);
     const json = (await res.json()) as { error?: { type?: string } };
     expect(json.error?.type).toBe("invalid_request_error");
+  });
+
+  it("rejects operator scopes that lack write access", async () => {
+    const res = await postEmbeddings(
+      {
+        model: "openclaw/default",
+        input: "hello",
+      },
+      { "x-openclaw-scopes": "operator.read" },
+    );
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: "missing scope: operator.write",
+      },
+    });
+  });
+
+  it("rejects requests with no declared operator scopes", async () => {
+    const res = await postEmbeddings(
+      {
+        model: "openclaw/default",
+        input: "hello",
+      },
+      { "x-openclaw-scopes": "" },
+    );
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: "missing scope: operator.write",
+      },
+    });
+  });
+
+  it("rejects requests when the operator scopes header is missing", async () => {
+    const res = await fetch(`http://127.0.0.1:${enabledPort}/v1/embeddings`, {
+      method: "POST",
+      headers: {
+        authorization: "Bearer secret",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "openclaw/default",
+        input: "hello",
+      }),
+    });
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: "missing scope: operator.write",
+      },
+    });
   });
 
   it("rejects invalid agent targets", async () => {

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -209,6 +209,7 @@ export async function handleOpenAiEmbeddingsHttpRequest(
 ): Promise<boolean> {
   const handled = await handleGatewayPostJsonEndpoint(req, res, {
     pathname: "/v1/embeddings",
+    requiredOperatorMethod: "chat.send",
     auth: opts.auth,
     trustedProxies: opts.trustedProxies,
     allowRealIpFallback: opts.allowRealIpFallback,


### PR DESCRIPTION
## Summary
- enforce the existing operator.write gate on `/v1/embeddings`
- align embeddings authorization with the other OpenAI-compatible write endpoints

## Changes
- pass `requiredOperatorMethod: "chat.send"` when `/v1/embeddings` uses the shared HTTP endpoint helper
- update the embeddings HTTP regression suite so successful requests declare `operator.write`
- add coverage for `operator.read`, empty `x-openclaw-scopes`, and a missing `x-openclaw-scopes` header

## Validation
- ran `pnpm test -- src/gateway/embeddings-http.test.ts`
- ran local agentic review with `claude -p "/review"` and added the missing no-header regression case it flagged

## Notes
- residual risk or follow-up: I could not query the broader security-advisory REST listing because the current GitHub token hit a rate limit, but public PR search did not show an existing overlapping fix
