### PR TITLE
gateway: trim control UI bootstrap payload

### DIFF
--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -4,6 +4,4 @@ export type ControlUiBootstrapConfig = {
   basePath: string;
   assistantName: string;
   assistantAvatar: string;
-  assistantAgentId: string;
-  serverVersion?: string;
 };

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -27,7 +27,6 @@ describe("handleControlUiHttpRequest", () => {
       basePath: string;
       assistantName: string;
       assistantAvatar: string;
-      assistantAgentId: string;
     };
   }
 
@@ -196,7 +195,8 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.basePath).toBe("");
         expect(parsed.assistantName).toBe("</script><script>alert(1)//");
         expect(parsed.assistantAvatar).toBe("/avatar/main");
-        expect(parsed.assistantAgentId).toBe("main");
+        expect(parsed).not.toHaveProperty("assistantAgentId");
+        expect(parsed).not.toHaveProperty("serverVersion");
       },
     });
   });
@@ -222,7 +222,8 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.basePath).toBe("/openclaw");
         expect(parsed.assistantName).toBe("Ops");
         expect(parsed.assistantAvatar).toBe("/openclaw/avatar/main");
-        expect(parsed.assistantAgentId).toBe("main");
+        expect(parsed).not.toHaveProperty("assistantAgentId");
+        expect(parsed).not.toHaveProperty("serverVersion");
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -10,7 +10,6 @@ import {
 import { isWithinDir } from "../infra/path-safety.js";
 import { openVerifiedFileSync } from "../infra/safe-open-sync.js";
 import { AVATAR_MAX_BYTES } from "../shared/avatar-policy.js";
-import { resolveRuntimeServiceVersion } from "../version.js";
 import { DEFAULT_ASSISTANT_IDENTITY, resolveAssistantIdentity } from "./assistant-identity.js";
 import {
   CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
@@ -365,8 +364,6 @@ export function handleControlUiHttpRequest(
       basePath,
       assistantName: identity.name,
       assistantAvatar: avatarValue ?? identity.avatar,
-      assistantAgentId: identity.agentId,
-      serverVersion: resolveRuntimeServiceVersion(process.env),
     } satisfies ControlUiBootstrapConfig);
     return true;
   }

--- a/ui/src/ui/controllers/control-ui-bootstrap.test.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.test.ts
@@ -12,8 +12,6 @@ describe("loadControlUiBootstrapConfig", () => {
         basePath: "/openclaw",
         assistantName: "Ops",
         assistantAvatar: "O",
-        assistantAgentId: "main",
-        serverVersion: "2026.3.7",
       }),
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
@@ -34,8 +32,8 @@ describe("loadControlUiBootstrapConfig", () => {
     );
     expect(state.assistantName).toBe("Ops");
     expect(state.assistantAvatar).toBe("O");
-    expect(state.assistantAgentId).toBe("main");
-    expect(state.serverVersion).toBe("2026.3.7");
+    expect(state.assistantAgentId).toBeNull();
+    expect(state.serverVersion).toBeNull();
 
     vi.unstubAllGlobals();
   });
@@ -59,6 +57,8 @@ describe("loadControlUiBootstrapConfig", () => {
       expect.objectContaining({ method: "GET" }),
     );
     expect(state.assistantName).toBe("Assistant");
+    expect(state.assistantAgentId).toBeNull();
+    expect(state.serverVersion).toBeNull();
 
     vi.unstubAllGlobals();
   });
@@ -81,6 +81,8 @@ describe("loadControlUiBootstrapConfig", () => {
       `/openclaw${CONTROL_UI_BOOTSTRAP_CONFIG_PATH}`,
       expect.objectContaining({ method: "GET" }),
     );
+    expect(state.assistantAgentId).toBeNull();
+    expect(state.serverVersion).toBeNull();
 
     vi.unstubAllGlobals();
   });

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -37,14 +37,11 @@ export async function loadControlUiBootstrapConfig(state: ControlUiBootstrapStat
     }
     const parsed = (await res.json()) as ControlUiBootstrapConfig;
     const normalized = normalizeAssistantIdentity({
-      agentId: parsed.assistantAgentId ?? null,
       name: parsed.assistantName,
       avatar: parsed.assistantAvatar ?? null,
     });
     state.assistantName = normalized.name;
     state.assistantAvatar = normalized.avatar;
-    state.assistantAgentId = normalized.agentId ?? null;
-    state.serverVersion = parsed.serverVersion ?? null;
   } catch {
     // Ignore bootstrap failures; UI will update identity after connecting.
   }

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -50,7 +50,6 @@ export default defineConfig(() => {
                 basePath: "/",
                 assistantName: "",
                 assistantAvatar: "",
-                assistantAgentId: "",
               }),
             );
           });


### PR DESCRIPTION
## Summary
- Stops the Control UI bootstrap endpoint from returning extra runtime identifiers the page does not need
- Keeps the bootstrap payload limited to the assistant display fields and configured base path

## Changes
- Removed `assistantAgentId` and `serverVersion` from the Control UI bootstrap response and shared contract
- Updated gateway and UI bootstrap tests to assert the leaner payload
- Updated the local Vite stub to match the shipped bootstrap shape

## Validation
- Ran `pnpm test -- src/gateway/control-ui.http.test.ts`
- Ran `pnpm --dir ui exec vitest run src/ui/controllers/control-ui-bootstrap.test.ts --environment jsdom`
- Ran `pnpm build`
- Attempted local agentic review with `claude -p "/review"`, but the CLI timed out twice without producing output

## Notes
- The Control UI still refreshes assistant identity after connecting
- Version information continues to arrive from the normal gateway handshake rather than the bootstrap JSON
