### PR TITLE
Plugins: block install when source scan fails

### DIFF
--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -93,7 +93,6 @@ async function scanDirectoryTarget(params: {
   includeFiles?: string[];
   logger: InstallScanLogger;
   path: string;
-  scanFailureMessage: string;
   suspiciousMessage: string;
   targetName: string;
   warningMessage: string;
@@ -116,7 +115,6 @@ async function scanDirectoryTarget(params: {
     }
     return builtinScan;
   } catch (err) {
-    params.logger.warn?.(params.scanFailureMessage.replace("{error}", String(err)));
     return buildBuiltinScanFromError(err);
   }
 }
@@ -153,7 +151,6 @@ function buildBlockedScanResult(params: {
 async function scanFileTarget(params: {
   logger: InstallScanLogger;
   path: string;
-  scanFailureMessage: string;
   suspiciousMessage: string;
   targetName: string;
   warningMessage: string;
@@ -163,7 +160,6 @@ async function scanFileTarget(params: {
     includeFiles: [params.path],
     logger: params.logger,
     path: directory,
-    scanFailureMessage: params.scanFailureMessage,
     suspiciousMessage: params.suspiciousMessage,
     targetName: params.targetName,
     warningMessage: params.warningMessage,
@@ -264,7 +260,6 @@ export async function scanBundleInstallSourceRuntime(params: {
   const builtinScan = await scanDirectoryTarget({
     logger: params.logger,
     path: params.sourceDir,
-    scanFailureMessage: `Bundle "${params.pluginId}" code safety scan failed ({error}). Installation blocked; run "openclaw security audit --deep" for details.`,
     suspiciousMessage: `Bundle "{target}" has {count} suspicious code pattern(s). Run "openclaw security audit --deep" for details.`,
     targetName: params.pluginId,
     warningMessage: `WARNING: Bundle "${params.pluginId}" contains dangerous code patterns`,
@@ -329,7 +324,6 @@ export async function scanPackageInstallSourceRuntime(params: {
     includeFiles: forcedScanEntries,
     logger: params.logger,
     path: params.packageDir,
-    scanFailureMessage: `Plugin "${params.pluginId}" code safety scan failed ({error}). Installation blocked; run "openclaw security audit --deep" for details.`,
     suspiciousMessage: `Plugin "{target}" has {count} suspicious code pattern(s). Run "openclaw security audit --deep" for details.`,
     targetName: params.pluginId,
     warningMessage: `WARNING: Plugin "${params.pluginId}" contains dangerous code patterns`,
@@ -373,7 +367,6 @@ export async function scanFileInstallSourceRuntime(params: {
   const builtinScan = await scanFileTarget({
     logger: params.logger,
     path: params.filePath,
-    scanFailureMessage: `Plugin file "${params.pluginId}" code safety scan failed ({error}). Installation blocked; run "openclaw security audit --deep" for details.`,
     suspiciousMessage: `Plugin file "{target}" has {count} suspicious code pattern(s). Run "openclaw security audit --deep" for details.`,
     targetName: params.pluginId,
     warningMessage: `WARNING: Plugin file "${params.pluginId}" contains dangerous code patterns`,

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -35,6 +35,7 @@ type PluginInstallRequestKind =
 
 export type InstallSecurityScanResult = {
   blocked?: {
+    code?: "security_scan_blocked" | "security_scan_failed";
     reason: string;
   };
 };
@@ -46,6 +47,17 @@ function buildCriticalDetails(params: {
     .filter((finding) => finding.severity === "critical")
     .map((finding) => `${finding.message} (${finding.file}:${finding.line})`)
     .join("; ");
+}
+
+function buildCriticalBlockReason(params: {
+  findings: Array<{ file: string; line: number; message: string; severity: string }>;
+  targetLabel: string;
+}) {
+  return `${params.targetLabel} blocked: dangerous code patterns detected: ${buildCriticalDetails({ findings: params.findings })}`;
+}
+
+function buildScanFailureBlockReason(params: { error: string; targetLabel: string }) {
+  return `${params.targetLabel} blocked: code safety scan failed (${params.error}). Run "openclaw security audit --deep" for details.`;
 }
 
 function buildBuiltinScanFromError(error: unknown): BuiltinInstallScan {
@@ -107,6 +119,35 @@ async function scanDirectoryTarget(params: {
     params.logger.warn?.(params.scanFailureMessage.replace("{error}", String(err)));
     return buildBuiltinScanFromError(err);
   }
+}
+
+function buildBlockedScanResult(params: {
+  builtinScan: BuiltinInstallScan;
+  targetLabel: string;
+}): InstallSecurityScanResult | undefined {
+  if (params.builtinScan.status === "error") {
+    return {
+      blocked: {
+        code: "security_scan_failed",
+        reason: buildScanFailureBlockReason({
+          error: params.builtinScan.error ?? "unknown error",
+          targetLabel: params.targetLabel,
+        }),
+      },
+    };
+  }
+  if (params.builtinScan.critical > 0) {
+    return {
+      blocked: {
+        code: "security_scan_blocked",
+        reason: buildCriticalBlockReason({
+          findings: params.builtinScan.findings,
+          targetLabel: params.targetLabel,
+        }),
+      },
+    };
+  }
+  return undefined;
 }
 
 async function scanFileTarget(params: {
@@ -223,13 +264,17 @@ export async function scanBundleInstallSourceRuntime(params: {
   const builtinScan = await scanDirectoryTarget({
     logger: params.logger,
     path: params.sourceDir,
-    scanFailureMessage: `Bundle "${params.pluginId}" code safety scan failed ({error}). Installation continues; run "openclaw security audit --deep" after install.`,
+    scanFailureMessage: `Bundle "${params.pluginId}" code safety scan failed ({error}). Installation blocked; run "openclaw security audit --deep" for details.`,
     suspiciousMessage: `Bundle "{target}" has {count} suspicious code pattern(s). Run "openclaw security audit --deep" for details.`,
     targetName: params.pluginId,
     warningMessage: `WARNING: Bundle "${params.pluginId}" contains dangerous code patterns`,
   });
+  const builtinBlocked = buildBlockedScanResult({
+    builtinScan,
+    targetLabel: `Bundle "${params.pluginId}" installation`,
+  });
 
-  return await runBeforeInstallHook({
+  const hookResult = await runBeforeInstallHook({
     logger: params.logger,
     installLabel: `Bundle "${params.pluginId}" installation`,
     origin: "plugin-bundle",
@@ -248,6 +293,7 @@ export async function scanBundleInstallSourceRuntime(params: {
       ...(params.version ? { version: params.version } : {}),
     },
   });
+  return hookResult?.blocked ? hookResult : builtinBlocked;
 }
 
 export async function scanPackageInstallSourceRuntime(params: {
@@ -283,13 +329,17 @@ export async function scanPackageInstallSourceRuntime(params: {
     includeFiles: forcedScanEntries,
     logger: params.logger,
     path: params.packageDir,
-    scanFailureMessage: `Plugin "${params.pluginId}" code safety scan failed ({error}). Installation continues; run "openclaw security audit --deep" after install.`,
+    scanFailureMessage: `Plugin "${params.pluginId}" code safety scan failed ({error}). Installation blocked; run "openclaw security audit --deep" for details.`,
     suspiciousMessage: `Plugin "{target}" has {count} suspicious code pattern(s). Run "openclaw security audit --deep" for details.`,
     targetName: params.pluginId,
     warningMessage: `WARNING: Plugin "${params.pluginId}" contains dangerous code patterns`,
   });
+  const builtinBlocked = buildBlockedScanResult({
+    builtinScan,
+    targetLabel: `Plugin "${params.pluginId}" installation`,
+  });
 
-  return await runBeforeInstallHook({
+  const hookResult = await runBeforeInstallHook({
     logger: params.logger,
     installLabel: `Plugin "${params.pluginId}" installation`,
     origin: "plugin-package",
@@ -310,6 +360,7 @@ export async function scanPackageInstallSourceRuntime(params: {
       extensions: params.extensions.slice(),
     },
   });
+  return hookResult?.blocked ? hookResult : builtinBlocked;
 }
 
 export async function scanFileInstallSourceRuntime(params: {
@@ -322,13 +373,17 @@ export async function scanFileInstallSourceRuntime(params: {
   const builtinScan = await scanFileTarget({
     logger: params.logger,
     path: params.filePath,
-    scanFailureMessage: `Plugin file "${params.pluginId}" code safety scan failed ({error}). Installation continues; run "openclaw security audit --deep" after install.`,
+    scanFailureMessage: `Plugin file "${params.pluginId}" code safety scan failed ({error}). Installation blocked; run "openclaw security audit --deep" for details.`,
     suspiciousMessage: `Plugin file "{target}" has {count} suspicious code pattern(s). Run "openclaw security audit --deep" for details.`,
     targetName: params.pluginId,
     warningMessage: `WARNING: Plugin file "${params.pluginId}" contains dangerous code patterns`,
   });
+  const builtinBlocked = buildBlockedScanResult({
+    builtinScan,
+    targetLabel: `Plugin file "${params.pluginId}" installation`,
+  });
 
-  return await runBeforeInstallHook({
+  const hookResult = await runBeforeInstallHook({
     logger: params.logger,
     installLabel: `Plugin file "${params.pluginId}" installation`,
     origin: "plugin-file",
@@ -346,4 +401,5 @@ export async function scanFileInstallSourceRuntime(params: {
       extensions: [path.basename(params.filePath)],
     },
   });
+  return hookResult?.blocked ? hookResult : builtinBlocked;
 }

--- a/src/plugins/install-security-scan.ts
+++ b/src/plugins/install-security-scan.ts
@@ -4,6 +4,7 @@ type InstallScanLogger = {
 
 export type InstallSecurityScanResult = {
   blocked?: {
+    code?: "security_scan_blocked" | "security_scan_failed";
     reason: string;
   };
 };

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -870,6 +870,7 @@ describe("installPluginFromArchive", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toBe("Blocked by enterprise policy");
+      expect(result.code).toBeUndefined();
     }
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler.mock.calls[0]?.[0]).toMatchObject({

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -251,6 +251,19 @@ async function installFromDirWithWarnings(params: { pluginDir: string; extension
   return { result, warnings };
 }
 
+async function installFromFileWithWarnings(params: { extensionsDir: string; filePath: string }) {
+  const warnings: string[] = [];
+  const result = await installPluginFromFile({
+    filePath: params.filePath,
+    extensionsDir: params.extensionsDir,
+    logger: {
+      info: () => {},
+      warn: (msg: string) => warnings.push(msg),
+    },
+  });
+  return { result, warnings };
+}
+
 function setupManifestInstallFixture(params: { manifestId: string }) {
   const caseDir = makeTempDir();
   const stateDir = path.join(caseDir, "state");
@@ -723,7 +736,7 @@ describe("installPluginFromArchive", () => {
     expect.unreachable("expected install to fail without openclaw.extensions");
   });
 
-  it("warns when plugin contains dangerous code patterns", async () => {
+  it("blocks package installs when plugin contains dangerous code patterns", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
     fs.writeFileSync(
@@ -741,7 +754,29 @@ describe("installPluginFromArchive", () => {
 
     const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
 
-    expect(result.ok).toBe(true);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('Plugin "dangerous-plugin" installation blocked');
+      expect(result.error).toContain("dangerous code patterns detected");
+    }
+    expect(warnings.some((w) => w.includes("dangerous code pattern"))).toBe(true);
+  });
+
+  it("blocks bundle installs when bundle contains dangerous code patterns", async () => {
+    const { pluginDir, extensionsDir } = setupBundleInstallFixture({
+      bundleFormat: "codex",
+      name: "Dangerous Bundle",
+    });
+    fs.writeFileSync(path.join(pluginDir, "payload.js"), "eval('danger');\n", "utf-8");
+
+    const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('Bundle "dangerous-bundle" installation blocked');
+    }
     expect(warnings.some((w) => w.includes("dangerous code pattern"))).toBe(true);
   });
 
@@ -886,12 +921,12 @@ describe("installPluginFromArchive", () => {
 
     const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
 
-    expect(result.ok).toBe(true);
+    expect(result.ok).toBe(false);
     expect(warnings.some((w) => w.includes("hidden/node_modules path"))).toBe(true);
     expect(warnings.some((w) => w.includes("dangerous code pattern"))).toBe(true);
   });
 
-  it("continues install when scanner throws", async () => {
+  it("blocks install when scanner throws", async () => {
     const scanSpy = vi
       .spyOn(installSecurityScan, "scanPackageInstallSource")
       .mockRejectedValueOnce(new Error("scanner exploded"));
@@ -910,8 +945,12 @@ describe("installPluginFromArchive", () => {
 
     const { result, warnings } = await installFromDirWithWarnings({ pluginDir, extensionsDir });
 
-    expect(result.ok).toBe(true);
-    expect(warnings.some((w) => w.includes("code safety scan failed"))).toBe(true);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED);
+      expect(result.error).toContain("code safety scan failed (Error: scanner exploded)");
+    }
+    expect(warnings).toEqual([]);
     scanSpy.mockRestore();
   });
 });
@@ -1224,6 +1263,27 @@ describe("installPluginFromPath", () => {
       targetType: "plugin",
       requestKind: "plugin-file",
     });
+  });
+
+  it("blocks plain file installs when the scanner finds dangerous code patterns", async () => {
+    const baseDir = makeTempDir();
+    const extensionsDir = path.join(baseDir, "extensions");
+    fs.mkdirSync(extensionsDir, { recursive: true });
+
+    const sourcePath = path.join(baseDir, "payload.js");
+    fs.writeFileSync(sourcePath, "eval('danger');\n", "utf-8");
+
+    const { result, warnings } = await installFromFileWithWarnings({
+      filePath: sourcePath,
+      extensionsDir,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
+      expect(result.error).toContain('Plugin file "payload" installation blocked');
+    }
+    expect(warnings.some((w) => w.includes("dangerous code pattern"))).toBe(true);
   });
 
   it("blocks hardlink alias overwrites when installing a plain file plugin", async () => {

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -48,6 +48,8 @@ export const PLUGIN_INSTALL_ERROR_CODE = {
   EMPTY_OPENCLAW_EXTENSIONS: "empty_openclaw_extensions",
   NPM_PACKAGE_NOT_FOUND: "npm_package_not_found",
   PLUGIN_ID_MISMATCH: "plugin_id_mismatch",
+  SECURITY_SCAN_BLOCKED: "security_scan_blocked",
+  SECURITY_SCAN_FAILED: "security_scan_failed",
 } as const;
 
 export type PluginInstallErrorCode =
@@ -394,12 +396,21 @@ async function installBundleFromSourceDir(
       version: manifestRes.manifest.version,
     });
     if (scanResult?.blocked) {
-      return { ok: false, error: scanResult.blocked.reason };
+      return {
+        ok: false,
+        error: scanResult.blocked.reason,
+        code:
+          scanResult.blocked.code === "security_scan_failed"
+            ? PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED
+            : PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED,
+      };
     }
   } catch (err) {
-    logger.warn?.(
-      `Bundle "${pluginId}" code safety scan failed (${String(err)}). Installation continues; run "openclaw security audit --deep" after install.`,
-    );
+    return {
+      ok: false,
+      error: `Bundle "${pluginId}" installation blocked: code safety scan failed (${String(err)}). Run "openclaw security audit --deep" for details.`,
+      code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED,
+    };
   }
 
   return await installPluginDirectoryIntoExtensions({
@@ -573,12 +584,21 @@ async function installPluginFromPackageDir(
       version: typeof manifest.version === "string" ? manifest.version : undefined,
     });
     if (scanResult?.blocked) {
-      return { ok: false, error: scanResult.blocked.reason };
+      return {
+        ok: false,
+        error: scanResult.blocked.reason,
+        code:
+          scanResult.blocked.code === "security_scan_failed"
+            ? PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED
+            : PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED,
+      };
     }
   } catch (err) {
-    logger.warn?.(
-      `Plugin "${pluginId}" code safety scan failed (${String(err)}). Installation continues; run "openclaw security audit --deep" after install.`,
-    );
+    return {
+      ok: false,
+      error: `Plugin "${pluginId}" installation blocked: code safety scan failed (${String(err)}). Run "openclaw security audit --deep" for details.`,
+      code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED,
+    };
   }
 
   const deps = manifest.dependencies ?? {};
@@ -736,12 +756,21 @@ export async function installPluginFromFile(params: {
       requestedSpecifier: installPolicyRequest.requestedSpecifier,
     });
     if (scanResult?.blocked) {
-      return { ok: false, error: scanResult.blocked.reason };
+      return {
+        ok: false,
+        error: scanResult.blocked.reason,
+        code:
+          scanResult.blocked.code === "security_scan_failed"
+            ? PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED
+            : PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED,
+      };
     }
   } catch (err) {
-    logger.warn?.(
-      `Plugin file "${pluginId}" code safety scan failed (${String(err)}). Installation continues; run "openclaw security audit --deep" after install.`,
-    );
+    return {
+      ok: false,
+      error: `Plugin file "${pluginId}" installation blocked: code safety scan failed (${String(err)}). Run "openclaw security audit --deep" for details.`,
+      code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED,
+    };
   }
 
   logger.info?.(`Installing to ${targetFile}…`);

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -8,6 +8,7 @@ import {
 } from "../infra/install-safe-path.js";
 import { type NpmIntegrityDrift, type NpmSpecResolution } from "../infra/install-source-utils.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
+import type { InstallSecurityScanResult } from "./install-security-scan.js";
 import {
   resolvePackageExtensionEntries,
   type PackageManifest as PluginPackageManifest,
@@ -214,6 +215,20 @@ function buildDirectoryInstallResult(params: {
   };
 }
 
+function buildBlockedInstallResult(params: {
+  blocked: NonNullable<NonNullable<InstallSecurityScanResult>["blocked"]>;
+}): Extract<InstallPluginResult, { ok: false }> {
+  return {
+    ok: false,
+    error: params.blocked.reason,
+    ...(params.blocked.code === "security_scan_failed"
+      ? { code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED }
+      : params.blocked.code === "security_scan_blocked"
+        ? { code: PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED }
+        : {}),
+  };
+}
+
 type PackageInstallCommonParams = {
   extensionsDir?: string;
   timeoutMs?: number;
@@ -396,14 +411,7 @@ async function installBundleFromSourceDir(
       version: manifestRes.manifest.version,
     });
     if (scanResult?.blocked) {
-      return {
-        ok: false,
-        error: scanResult.blocked.reason,
-        code:
-          scanResult.blocked.code === "security_scan_failed"
-            ? PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED
-            : PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED,
-      };
+      return buildBlockedInstallResult({ blocked: scanResult.blocked });
     }
   } catch (err) {
     return {
@@ -584,14 +592,7 @@ async function installPluginFromPackageDir(
       version: typeof manifest.version === "string" ? manifest.version : undefined,
     });
     if (scanResult?.blocked) {
-      return {
-        ok: false,
-        error: scanResult.blocked.reason,
-        code:
-          scanResult.blocked.code === "security_scan_failed"
-            ? PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED
-            : PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED,
-      };
+      return buildBlockedInstallResult({ blocked: scanResult.blocked });
     }
   } catch (err) {
     return {
@@ -756,14 +757,7 @@ export async function installPluginFromFile(params: {
       requestedSpecifier: installPolicyRequest.requestedSpecifier,
     });
     if (scanResult?.blocked) {
-      return {
-        ok: false,
-        error: scanResult.blocked.reason,
-        code:
-          scanResult.blocked.code === "security_scan_failed"
-            ? PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED
-            : PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED,
-      };
+      return buildBlockedInstallResult({ blocked: scanResult.blocked });
     }
   } catch (err) {
     return {


### PR DESCRIPTION
## Summary
- Block plugin installs when install-time source scanning finds critical patterns
- Block plugin installs when the install-time source scan cannot complete

## Changes
- Convert builtin install scan results into explicit blocking outcomes for bundle, package, and file install paths
- Return install error codes that distinguish blocked findings from scan failures
- Keep `before_install` hook handling, but only let an explicit hook block override the builtin scan result
- Add regression coverage for package, bundle, hidden-entry, file, and scanner-failure install flows

## Validation
- Ran `pnpm test -- src/plugins/install.test.ts`
- Ran `pnpm check`
- Ran `pnpm build`
- Ran local agentic review with `claude -p "/review"` and addressed the hook precedence feedback

## Notes
- Related PR `#54885` explored opt-in scan blocking; this change applies blocking consistently for builtin critical findings and scan failures
