### PR TITLE
Add non-batch memory embedding concurrency control

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -540,7 +540,17 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   }
 
   protected getIndexConcurrency(): number {
-    return this.batch.enabled ? this.batch.concurrency : EMBEDDING_INDEX_CONCURRENCY;
+    if (this.batch.enabled) {
+      return this.batch.concurrency;
+    }
+    const configured = this.settings.remote?.nonBatchConcurrency;
+    if (typeof configured === "number" && Number.isFinite(configured)) {
+      return Math.max(1, Math.floor(configured));
+    }
+    if (this.provider?.id === "ollama") {
+      return 1;
+    }
+    return EMBEDDING_INDEX_CONCURRENCY;
   }
 
   private clearIndexedFileData(pathname: string, source: MemorySource): void {

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -115,11 +115,15 @@ describe("memory search config", () => {
   function expectMergedRemoteConfig(
     resolved: ReturnType<typeof resolveMemorySearchConfig>,
     apiKey: unknown,
+    extras?: { nonBatchConcurrency?: number },
   ) {
     expect(resolved?.remote).toEqual({
       baseUrl: "https://agent.example/v1",
       apiKey,
       headers: { "X-Default": "on" },
+      ...(typeof extras?.nonBatchConcurrency === "number"
+        ? { nonBatchConcurrency: extras.nonBatchConcurrency }
+        : {}),
       batch: {
         enabled: false,
         wait: true,
@@ -404,6 +408,18 @@ describe("memory search config", () => {
       provider: "default",
       id: "OPENAI_API_KEY",
     });
+  });
+
+  it("merges remote non-batch concurrency from defaults with agent overrides", () => {
+    const cfg = configWithRemoteDefaults({
+      apiKey: "default-key", // pragma: allowlist secret
+      headers: { "X-Default": "on" },
+      nonBatchConcurrency: 1,
+    });
+
+    const resolved = resolveMemorySearchConfig(cfg, "main");
+
+    expectMergedRemoteConfig(resolved, "default-key", { nonBatchConcurrency: 1 });
   });
 
   it("gates session sources behind experimental flag", () => {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -22,6 +22,7 @@ export type ResolvedMemorySearchConfig = {
     baseUrl?: string;
     apiKey?: SecretInput;
     headers?: Record<string, string>;
+    nonBatchConcurrency?: number;
     batch?: {
       enabled: boolean;
       wait: boolean;
@@ -184,6 +185,8 @@ function mergeConfig(
         baseUrl: overrideRemote?.baseUrl ?? defaultRemote?.baseUrl,
         apiKey: overrideRemote?.apiKey ?? defaultRemote?.apiKey,
         headers: overrideRemote?.headers ?? defaultRemote?.headers,
+        nonBatchConcurrency:
+          overrideRemote?.nonBatchConcurrency ?? defaultRemote?.nonBatchConcurrency,
         batch,
       }
     : undefined;

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -13418,6 +13418,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
       help: "Adds custom HTTP headers to remote embedding requests, merged with provider defaults. Use this for proxy auth and tenant routing headers, and keep values minimal to avoid leaking sensitive metadata.",
       tags: ["advanced"],
     },
+    "agents.defaults.memorySearch.remote.nonBatchConcurrency": {
+      label: "Remote Non-Batch Embedding Concurrency",
+      help: "Limits how many non-batch embedding tasks run at the same time during indexing. This is especially useful for slower local providers such as Ollama on small machines, where setting it to 1 can avoid timeout-heavy reindex failures.",
+      tags: ["performance"],
+    },
     "agents.defaults.memorySearch.remote.batch.enabled": {
       label: "Remote Batch Embedding Enabled",
       help: "Enables provider batch APIs for embedding jobs when supported (OpenAI/Gemini), improving throughput on larger index runs. Keep this enabled unless debugging provider batch failures or running very small workloads.",

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -81,6 +81,7 @@ const TARGET_KEYS = [
   "agents.defaults.memorySearch.remote.baseUrl",
   "agents.defaults.memorySearch.remote.apiKey",
   "agents.defaults.memorySearch.remote.headers",
+  "agents.defaults.memorySearch.remote.nonBatchConcurrency",
   "agents.defaults.memorySearch.remote.batch.enabled",
   "agents.defaults.memorySearch.remote.batch.wait",
   "agents.defaults.memorySearch.remote.batch.concurrency",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -828,6 +828,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Supplies a dedicated API key for remote embedding calls used by memory indexing and query-time embeddings. Use this when memory embeddings should use different credentials than global defaults or environment variables.",
   "agents.defaults.memorySearch.remote.headers":
     "Adds custom HTTP headers to remote embedding requests, merged with provider defaults. Use this for proxy auth and tenant routing headers, and keep values minimal to avoid leaking sensitive metadata.",
+  "agents.defaults.memorySearch.remote.nonBatchConcurrency":
+    "Limits how many non-batch embedding tasks run at the same time during indexing. This is especially useful for slower local providers such as Ollama on small machines, where setting it to 1 can avoid timeout-heavy reindex failures.",
   "agents.defaults.memorySearch.remote.batch.enabled":
     "Enables provider batch APIs for embedding jobs when supported (OpenAI/Gemini), improving throughput on larger index runs. Keep this enabled unless debugging provider batch failures or running very small workloads.",
   "agents.defaults.memorySearch.remote.batch.wait":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -346,6 +346,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.remote.baseUrl": "Remote Embedding Base URL",
   "agents.defaults.memorySearch.remote.apiKey": "Remote Embedding API Key",
   "agents.defaults.memorySearch.remote.headers": "Remote Embedding Headers",
+  "agents.defaults.memorySearch.remote.nonBatchConcurrency":
+    "Remote Non-Batch Embedding Concurrency",
   "agents.defaults.memorySearch.remote.batch.enabled": "Remote Batch Embedding Enabled",
   "agents.defaults.memorySearch.remote.batch.wait": "Remote Batch Wait for Completion",
   "agents.defaults.memorySearch.remote.batch.concurrency": "Remote Batch Concurrency",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -346,6 +346,8 @@ export type MemorySearchConfig = {
     baseUrl?: string;
     apiKey?: SecretInput;
     headers?: Record<string, string>;
+    /** Max concurrent non-batch embedding tasks during indexing. Useful for slower local providers such as Ollama. */
+    nonBatchConcurrency?: number;
     batch?: {
       /** Enable batch API for embedding indexing (OpenAI/Gemini; default: true). */
       enabled?: boolean;


### PR DESCRIPTION
## Summary

This PR adds `agents.defaults.memorySearch.remote.nonBatchConcurrency` to control indexing concurrency when memory embeddings run through the non-batch path.

This is especially useful for slower or local providers such as Ollama, where aggressive parallel indexing can cause timeout-heavy reindex failures on small machines like Raspberry Pi or low-resource VPS hosts.

## What changed

- added `memorySearch.remote.nonBatchConcurrency` config support
- propagated the setting through resolved memory config
- used it in non-batch indexing concurrency selection
- added a conservative fallback for `ollama` to use concurrency `1`
- documented the new config key
- added config merge coverage in tests

## Why

Batch controls currently help only providers that expose batch embedding APIs.

Providers that fall back to non-batch indexing, especially Ollama, can still hit timeout failures because indexing concurrency remains too high for constrained hardware.

This change makes non-batch indexing tunable and improves local-first reliability.

## Real-world motivation

In a Raspberry Pi-class environment running local Ollama:

- memory reindex repeatedly timed out
- reducing chunk size helped but was not sufficient
- forcing effective non-batch concurrency to `1` made indexing complete successfully
- semantic search worked correctly after reindex

## Example config

```json
{
  "agents": {
    "defaults": {
      "memorySearch": {
        "provider": "ollama",
        "remote": {
          "baseUrl": "http://127.0.0.1:11434",
          "apiKey": "ollama",
          "nonBatchConcurrency": 1
        }
      }
    }
  }
}

