### PR TITLE
fix: inline exec heartbeat event output

### DIFF
--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -47,18 +47,32 @@ describe("heartbeat event prompts", () => {
   it.each([
     {
       name: "builds user-relay exec prompt by default",
+      events: ["Exec finished (node=n1, code 0)\nreport ready"],
       opts: undefined,
-      expected: ["Please relay the command output to the user", "If it failed"],
+      expected: [
+        "Exec finished (node=n1, code 0)",
+        "report ready",
+        "Please relay the command output to the user",
+        "If it failed",
+      ],
       unexpected: ["Handle the result internally"],
     },
     {
       name: "builds internal-only exec prompt when delivery is disabled",
+      events: ["Exec finished (node=n1, code 1)\nboom"],
       opts: { deliverToUser: false },
-      expected: ["Handle the result internally"],
+      expected: ["Exec finished (node=n1, code 1)", "boom", "Handle the result internally"],
       unexpected: ["Please relay the command output to the user"],
     },
-  ])("$name", ({ opts, expected, unexpected }) => {
-    const prompt = buildExecEventPrompt(opts);
+    {
+      name: "falls back clearly when exec output is empty",
+      events: ["", "   "],
+      opts: undefined,
+      expected: ["no command output was found"],
+      unexpected: ["The command output is:"],
+    },
+  ])("$name", ({ events, opts, expected, unexpected }) => {
+    const prompt = buildExecEventPrompt(events, opts);
     for (const part of expected) {
       expect(prompt).toContain(part);
     }

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -37,16 +37,35 @@ export function buildCronEventPrompt(
   );
 }
 
-export function buildExecEventPrompt(opts?: { deliverToUser?: boolean }): string {
+export function buildExecEventPrompt(
+  pendingEvents: string[],
+  opts?: { deliverToUser?: boolean },
+): string {
   const deliverToUser = opts?.deliverToUser ?? true;
+  const eventText = pendingEvents.join("\n").trim();
+  if (!eventText) {
+    if (!deliverToUser) {
+      return (
+        "An async command you ran earlier has completed, but no command output was found. " +
+        "Handle the result internally. Do not relay it to the user unless explicitly requested."
+      );
+    }
+    return (
+      "An async command you ran earlier has completed, but no command output was found. " +
+      "Explain that the completion notice arrived without usable output and ask for the command or logs only if needed."
+    );
+  }
   if (!deliverToUser) {
     return (
-      "An async command you ran earlier has completed. The result is shown in the system messages above. " +
-      "Handle the result internally. Do not relay it to the user unless explicitly requested."
+      "An async command you ran earlier has completed. The command output is:\n\n" +
+      eventText +
+      "\n\nHandle the result internally. Do not relay it to the user unless explicitly requested."
     );
   }
   return (
-    "An async command you ran earlier has completed. The result is shown in the system messages above. " +
+    "An async command you ran earlier has completed. The command output is:\n\n" +
+    eventText +
+    "\n\n" +
     "Please relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
     "If it failed, explain what went wrong."
   );

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -229,6 +229,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
 
     expect(result.status).toBe("ran");
     expect(calledCtx?.Provider).toBe("exec-event");
+    expect(calledCtx?.Body).toContain("exec finished: deploy succeeded");
     expect(calledCtx?.Body).toContain("Handle the result internally");
     expect(sendTelegram).not.toHaveBeenCalled();
   });

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1380,6 +1380,7 @@ describe("runHeartbeatOnce", () => {
       expect(sendWhatsApp).toHaveBeenCalledTimes(0);
       const calledCtx = replySpy.mock.calls[0]?.[0] as { Provider?: string; Body?: string };
       expect(calledCtx.Provider).toBe("exec-event");
+      expect(calledCtx.Body).toContain("exec finished: backup completed");
       expect(calledCtx.Body).toContain("Handle the result internally");
       expect(calledCtx.Body).not.toContain("Please relay the command output to the user");
     } finally {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -501,6 +501,7 @@ function resolveHeartbeatRunPrompt(params: {
   const pendingEvents = params.preflight.shouldInspectPendingEvents
     ? pendingEventEntries.map((event) => event.text)
     : [];
+  const execEvents = pendingEvents.filter(isExecCompletionEvent);
   const cronEvents = pendingEventEntries
     .filter(
       (event) =>
@@ -508,10 +509,10 @@ function resolveHeartbeatRunPrompt(params: {
         isCronSystemEvent(event.text),
     )
     .map((event) => event.text);
-  const hasExecCompletion = pendingEvents.some(isExecCompletionEvent);
+  const hasExecCompletion = execEvents.length > 0;
   const hasCronEvents = cronEvents.length > 0;
   const basePrompt = hasExecCompletion
-    ? buildExecEventPrompt({ deliverToUser: params.canRelayToUser })
+    ? buildExecEventPrompt(execEvents, { deliverToUser: params.canRelayToUser })
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents, { deliverToUser: params.canRelayToUser })
       : resolveHeartbeatPrompt(params.cfg, params.heartbeat);


### PR DESCRIPTION
## Summary
- inline exec completion event text into heartbeat prompts instead of relying on "system messages above"
- preserve internal-only vs user-relay behavior while handling empty exec payloads explicitly
- add regression coverage so exec-event heartbeat prompts include the underlying event body

## Problem
Heartbeat preflight could detect an `exec finished` event and choose the exec-completion prompt, but by the time the model ran, the ephemeral system-event queue was not guaranteed to still contain the event body. That produced follow-up heartbeats that only saw the generic template and responded with messages like "I don't see the async command result".

## Testing
- `node node_modules/vitest/vitest.mjs run src/infra/heartbeat-events-filter.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`
