### PR TITLE
Exec approvals: prevent interpreter allow-always persistence

### DIFF
--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -658,7 +658,7 @@ $0 \\"$1\\"" touch {marker}`,
 
     const second = evaluateShellAllowlist({
       command: `awk 'BEGIN{system("id > ${path.join(dir, "marker")}")}'`,
-      allowlist: [],
+      allowlist: persisted.map((pattern) => ({ pattern })),
       safeBins,
       cwd: dir,
       env,

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -174,6 +174,26 @@ describe("resolveAllowAlwaysPatterns", () => {
     expect(patterns).toEqual([exe]);
   });
 
+  it("does not persist interpreter-like executables for allow-always", () => {
+    const awk = path.join("/tmp", "awk");
+    const patterns = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: `${awk} '{print $1}' data.csv`,
+          argv: [awk, "{print $1}", "data.csv"],
+          resolution: makeMockCommandResolution({
+            execution: makeMockExecutableResolution({
+              rawExecutable: awk,
+              resolvedPath: awk,
+              executableName: "awk",
+            }),
+          }),
+        },
+      ],
+    });
+    expect(patterns).toEqual([]);
+  });
+
   it("unwraps shell wrappers and persists the inner executable instead", () => {
     if (process.platform === "win32") {
       return;
@@ -617,6 +637,42 @@ $0 \\"$1\\"" touch {marker}`,
       env,
       persistedPattern: echo,
     });
+  });
+
+  it("prevents allow-always bypass for awk interpreters", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    makeExecutable(dir, "awk");
+    const env = makePathEnv(dir);
+    const safeBins = resolveSafeBins(undefined);
+
+    const { persisted } = resolvePersistedPatterns({
+      command: "awk '{print $1}' data.csv",
+      dir,
+      env,
+      safeBins,
+    });
+    expect(persisted).toEqual([]);
+
+    const second = evaluateShellAllowlist({
+      command: `awk 'BEGIN{system("id > ${path.join(dir, "marker")}")}'`,
+      allowlist: [],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(false);
+    expect(
+      requiresExecApproval({
+        ask: "on-miss",
+        security: "allowlist",
+        analysisOk: second.analysisOk,
+        allowlistSatisfied: second.allowlistSatisfied,
+      }),
+    ).toBe(true);
   });
 
   it("prevents allow-always bypass for script wrapper chains", () => {

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -675,6 +675,34 @@ $0 \\"$1\\"" touch {marker}`,
     ).toBe(true);
   });
 
+  it("prevents allow-always bypass for shell-carried awk interpreters", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    makeExecutable(dir, "awk");
+    const env = makePathEnv(dir);
+    const safeBins = resolveSafeBins(undefined);
+
+    const { persisted } = resolvePersistedPatterns({
+      command: `sh -lc '$0 "$@"' awk '{print $1}' data.csv`,
+      dir,
+      env,
+      safeBins,
+    });
+    expect(persisted).toEqual([]);
+
+    const second = evaluateShellAllowlist({
+      command: `sh -lc '$0 "$@"' awk 'BEGIN{system("id > /tmp/pwned")}'`,
+      allowlist: persisted.map((pattern) => ({ pattern })),
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(false);
+  });
+
   it("prevents allow-always bypass for script wrapper chains", () => {
     if (process.platform !== "darwin" && process.platform !== "freebsd") {
       return;

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -535,6 +535,9 @@ function collectAllowAlwaysPatterns(params: {
     env: params.env,
   });
   if (positionalArgvPath) {
+    if (isInterpreterLikeAllowlistPattern(positionalArgvPath)) {
+      return;
+    }
     params.out.add(positionalArgvPath);
     return;
   }

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -15,6 +15,7 @@ import {
   type ExecutableResolution,
 } from "./exec-approvals-analysis.js";
 import type { ExecAllowlistEntry } from "./exec-approvals.js";
+import { isInterpreterLikeAllowlistPattern } from "./exec-inline-eval.js";
 import {
   DEFAULT_SAFE_BINS,
   SAFE_BIN_PROFILES,
@@ -519,6 +520,9 @@ function collectAllowAlwaysPatterns(params: {
 
   const candidatePath = resolveExecutionTargetCandidatePath(segment.resolution, params.cwd);
   if (!candidatePath) {
+    return;
+  }
+  if (isInterpreterLikeAllowlistPattern(candidatePath)) {
     return;
   }
   if (!trustPlan.shellWrapperExecutable) {

--- a/src/infra/exec-inline-eval.test.ts
+++ b/src/infra/exec-inline-eval.test.ts
@@ -25,6 +25,8 @@ describe("exec inline eval detection", () => {
   it("matches interpreter-like allowlist patterns", () => {
     expect(isInterpreterLikeAllowlistPattern("/usr/bin/python3")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("**/node")).toBe(true);
+    expect(isInterpreterLikeAllowlistPattern("/usr/bin/awk")).toBe(true);
+    expect(isInterpreterLikeAllowlistPattern("**/gawk")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("/usr/bin/rg")).toBe(false);
   });
 });

--- a/src/infra/exec-inline-eval.test.ts
+++ b/src/infra/exec-inline-eval.test.ts
@@ -11,6 +11,8 @@ describe("exec inline eval detection", () => {
     { argv: ["/usr/bin/node", "--eval", "console.log('hi')"], expected: "node --eval" },
     { argv: ["perl", "-E", "say 1"], expected: "perl -e" },
     { argv: ["osascript", "-e", "beep"], expected: "osascript -e" },
+    { argv: ["awk", "BEGIN { print 1 }"], expected: "awk inline program" },
+    { argv: ["gawk", "-F", ",", "{print $1}", "data.csv"], expected: "gawk inline program" },
   ] as const)("detects interpreter eval flags for %j", ({ argv, expected }) => {
     const hit = detectInterpreterInlineEvalArgv([...argv]);
     expect(hit).not.toBeNull();
@@ -20,6 +22,7 @@ describe("exec inline eval detection", () => {
   it("ignores normal script execution", () => {
     expect(detectInterpreterInlineEvalArgv(["python3", "script.py"])).toBeNull();
     expect(detectInterpreterInlineEvalArgv(["node", "script.js"])).toBeNull();
+    expect(detectInterpreterInlineEvalArgv(["awk", "-f", "script.awk", "data.csv"])).toBeNull();
   });
 
   it("matches interpreter-like allowlist patterns", () => {

--- a/src/infra/exec-inline-eval.test.ts
+++ b/src/infra/exec-inline-eval.test.ts
@@ -27,6 +27,8 @@ describe("exec inline eval detection", () => {
     expect(isInterpreterLikeAllowlistPattern("**/node")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("/usr/bin/awk")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("**/gawk")).toBe(true);
+    expect(isInterpreterLikeAllowlistPattern("/usr/bin/mawk")).toBe(true);
+    expect(isInterpreterLikeAllowlistPattern("nawk")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("/usr/bin/rg")).toBe(false);
   });
 });

--- a/src/infra/exec-inline-eval.ts
+++ b/src/infra/exec-inline-eval.ts
@@ -13,6 +13,14 @@ type InterpreterFlagSpec = {
   prefixFlags?: readonly string[];
 };
 
+type PositionalInterpreterSpec = {
+  names: readonly string[];
+  fileFlags: ReadonlySet<string>;
+  fileFlagPrefixes?: readonly string[];
+  exactValueFlags: ReadonlySet<string>;
+  prefixValueFlags?: readonly string[];
+};
+
 const INTERPRETER_INLINE_EVAL_SPECS: readonly InterpreterFlagSpec[] = [
   { names: ["python", "python2", "python3", "pypy", "pypy3"], exactFlags: new Set(["-c"]) },
   {
@@ -26,18 +34,47 @@ const INTERPRETER_INLINE_EVAL_SPECS: readonly InterpreterFlagSpec[] = [
   { names: ["osascript"], exactFlags: new Set(["-e"]) },
 ];
 
+const POSITIONAL_INTERPRETER_INLINE_EVAL_SPECS: readonly PositionalInterpreterSpec[] = [
+  {
+    names: ["awk", "gawk", "mawk", "nawk"],
+    fileFlags: new Set(["-f", "--file"]),
+    fileFlagPrefixes: ["-f", "--file="],
+    exactValueFlags: new Set([
+      "-f",
+      "--file",
+      "-F",
+      "--field-separator",
+      "-v",
+      "--assign",
+      "-i",
+      "--include",
+      "-l",
+      "--load",
+      "-W",
+    ]),
+    prefixValueFlags: ["-F", "--field-separator=", "-v", "--assign=", "--include=", "--load="],
+  },
+];
+
 const INTERPRETER_ALLOWLIST_NAMES = new Set(
-  INTERPRETER_INLINE_EVAL_SPECS.flatMap((entry) => entry.names).concat([
-    "awk",
-    "gawk",
-    "mawk",
-    "nawk",
-  ]),
+  INTERPRETER_INLINE_EVAL_SPECS.flatMap((entry) => entry.names).concat(
+    POSITIONAL_INTERPRETER_INLINE_EVAL_SPECS.flatMap((entry) => entry.names),
+  ),
 );
 
 function findInterpreterSpec(executable: string): InterpreterFlagSpec | null {
   const normalized = normalizeExecutableToken(executable);
   for (const spec of INTERPRETER_INLINE_EVAL_SPECS) {
+    if (spec.names.includes(normalized)) {
+      return spec;
+    }
+  }
+  return null;
+}
+
+function findPositionalInterpreterSpec(executable: string): PositionalInterpreterSpec | null {
+  const normalized = normalizeExecutableToken(executable);
+  for (const spec of POSITIONAL_INTERPRETER_INLINE_EVAL_SPECS) {
     if (spec.names.includes(normalized)) {
       return spec;
     }
@@ -56,7 +93,37 @@ export function detectInterpreterInlineEvalArgv(
     return null;
   }
   const spec = findInterpreterSpec(executable);
-  if (!spec) {
+  if (spec) {
+    for (let idx = 1; idx < argv.length; idx += 1) {
+      const token = argv[idx]?.trim();
+      if (!token) {
+        continue;
+      }
+      if (token === "--") {
+        break;
+      }
+      const lower = token.toLowerCase();
+      if (spec.exactFlags.has(lower)) {
+        return {
+          executable,
+          normalizedExecutable: normalizeExecutableToken(executable),
+          flag: lower,
+          argv,
+        };
+      }
+      if (spec.prefixFlags?.some((prefix) => lower.startsWith(prefix))) {
+        return {
+          executable,
+          normalizedExecutable: normalizeExecutableToken(executable),
+          flag: lower,
+          argv,
+        };
+      }
+    }
+  }
+
+  const positionalSpec = findPositionalInterpreterSpec(executable);
+  if (!positionalSpec) {
     return null;
   }
   for (let idx = 1; idx < argv.length; idx += 1) {
@@ -65,30 +132,55 @@ export function detectInterpreterInlineEvalArgv(
       continue;
     }
     if (token === "--") {
-      break;
-    }
-    const lower = token.toLowerCase();
-    if (spec.exactFlags.has(lower)) {
+      const nextToken = argv[idx + 1]?.trim();
+      if (!nextToken) {
+        return null;
+      }
       return {
         executable,
         normalizedExecutable: normalizeExecutableToken(executable),
-        flag: lower,
+        flag: "<program>",
         argv,
       };
     }
-    if (spec.prefixFlags?.some((prefix) => lower.startsWith(prefix))) {
-      return {
-        executable,
-        normalizedExecutable: normalizeExecutableToken(executable),
-        flag: lower,
-        argv,
-      };
+    if (positionalSpec.fileFlags.has(token)) {
+      return null;
     }
+    if (
+      positionalSpec.fileFlagPrefixes?.some(
+        (prefix) => token.startsWith(prefix) && token.length > prefix.length,
+      )
+    ) {
+      return null;
+    }
+    if (positionalSpec.exactValueFlags.has(token)) {
+      idx += 1;
+      continue;
+    }
+    if (
+      positionalSpec.prefixValueFlags?.some(
+        (prefix) => token.startsWith(prefix) && token.length > prefix.length,
+      )
+    ) {
+      continue;
+    }
+    if (token.startsWith("-")) {
+      continue;
+    }
+    return {
+      executable,
+      normalizedExecutable: normalizeExecutableToken(executable),
+      flag: "<program>",
+      argv,
+    };
   }
   return null;
 }
 
 export function describeInterpreterInlineEval(hit: InterpreterInlineEvalHit): string {
+  if (hit.flag === "<program>") {
+    return `${hit.normalizedExecutable} inline program`;
+  }
   return `${hit.normalizedExecutable} ${hit.flag}`;
 }
 

--- a/src/infra/exec-inline-eval.ts
+++ b/src/infra/exec-inline-eval.ts
@@ -26,8 +26,13 @@ const INTERPRETER_INLINE_EVAL_SPECS: readonly InterpreterFlagSpec[] = [
   { names: ["osascript"], exactFlags: new Set(["-e"]) },
 ];
 
-const INTERPRETER_INLINE_EVAL_NAMES = new Set(
-  INTERPRETER_INLINE_EVAL_SPECS.flatMap((entry) => entry.names),
+const INTERPRETER_ALLOWLIST_NAMES = new Set(
+  INTERPRETER_INLINE_EVAL_SPECS.flatMap((entry) => entry.names).concat([
+    "awk",
+    "gawk",
+    "mawk",
+    "nawk",
+  ]),
 );
 
 function findInterpreterSpec(executable: string): InterpreterFlagSpec | null {
@@ -93,11 +98,11 @@ export function isInterpreterLikeAllowlistPattern(pattern: string | undefined | 
     return false;
   }
   const normalized = normalizeExecutableToken(trimmed);
-  if (INTERPRETER_INLINE_EVAL_NAMES.has(normalized)) {
+  if (INTERPRETER_ALLOWLIST_NAMES.has(normalized)) {
     return true;
   }
   const basename = trimmed.replace(/\\/g, "/").split("/").pop() ?? trimmed;
   const withoutExe = basename.endsWith(".exe") ? basename.slice(0, -4) : basename;
   const strippedWildcards = withoutExe.replace(/[*?[\]{}()]/g, "");
-  return INTERPRETER_INLINE_EVAL_NAMES.has(strippedWildcards);
+  return INTERPRETER_ALLOWLIST_NAMES.has(strippedWildcards);
 }

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -909,7 +909,7 @@ description: test skill
           allowlist: [{ pattern: "/usr/bin/python3" }],
         },
         ops: {
-          allowlist: [{ pattern: "/usr/local/bin/node" }],
+          allowlist: [{ pattern: "/usr/local/bin/awk" }],
         },
       },
     });


### PR DESCRIPTION
## Summary
- treats awk-family executables as interpreter-like allowlist entries
- skips persisting interpreter paths from allow-always decisions
- adds regression coverage for allow-always persistence and audit warnings

## Changes
- expanded interpreter-like pattern detection to include `awk`, `gawk`, `mawk`, and `nawk`
- blocked `resolveAllowAlwaysPatterns()` from storing interpreter executable paths
- added tests covering the awk allow-always path and audit warning behavior

## Validation
- Ran `pnpm test -- src/infra/exec-inline-eval.test.ts src/infra/exec-approvals-allow-always.test.ts src/security/audit.test.ts`
- Ran `pnpm check`
- Ran local agentic review with `claude -p "/review"` and addressed the only lint cleanup it surfaced during validation

## Notes
- Residual risk or follow-up: existing interpreter-style allowlist entries can still exist in config and are audited separately; this change prevents new allow-always persistence for the awk family.