### PR TITLE
fix(gateway): require node pairing before enabling node commands

### DIFF
--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -242,6 +242,7 @@ describe("gateway update.run", () => {
 
 describe("gateway node command allowlist", () => {
   test("enforces command allowlists across node clients", async () => {
+    const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
     const waitForConnectedCount = async (count: number) => {
       await expect
         .poll(async () => {
@@ -270,11 +271,22 @@ describe("gateway node command allowlist", () => {
     let allowedClient: GatewayClient | undefined;
 
     try {
+      const systemDeviceIdentity = loadOrCreateDeviceIdentity(
+        path.join(os.tmpdir(), `openclaw-node-system-run-${Date.now()}-${Math.random()}.json`),
+      );
+      const emptyDeviceIdentity = loadOrCreateDeviceIdentity(
+        path.join(os.tmpdir(), `openclaw-node-empty-${Date.now()}-${Math.random()}.json`),
+      );
+      const allowedDeviceIdentity = loadOrCreateDeviceIdentity(
+        path.join(os.tmpdir(), `openclaw-node-allowed-${Date.now()}-${Math.random()}.json`),
+      );
+
       systemClient = await connectNodeClientWithPairing({
         port,
         commands: ["system.run"],
         instanceId: "node-system-run",
         displayName: "node-system-run",
+        deviceIdentity: systemDeviceIdentity,
       });
       const systemNodeId = await getConnectedNodeId();
       const disallowedRes = await rpcReq(ws, "node.invoke", {
@@ -285,7 +297,7 @@ describe("gateway node command allowlist", () => {
       });
       expect(disallowedRes.ok).toBe(false);
       expect(disallowedRes.error?.message).toContain("node command not allowed");
-      systemClient.stop();
+      await systemClient.stopAndWait();
       await waitForConnectedCount(0);
 
       emptyClient = await connectNodeClientWithPairing({
@@ -293,6 +305,7 @@ describe("gateway node command allowlist", () => {
         commands: [],
         instanceId: "node-empty",
         displayName: "node-empty",
+        deviceIdentity: emptyDeviceIdentity,
       });
       const emptyNodeId = await getConnectedNodeId();
       const missingRes = await rpcReq(ws, "node.invoke", {
@@ -303,7 +316,7 @@ describe("gateway node command allowlist", () => {
       });
       expect(missingRes.ok).toBe(false);
       expect(missingRes.error?.message).toContain("node command not allowed");
-      emptyClient.stop();
+      await emptyClient.stopAndWait();
       await waitForConnectedCount(0);
 
       let resolveInvoke: ((payload: { id?: string; nodeId?: string }) => void) | null = null;
@@ -316,6 +329,7 @@ describe("gateway node command allowlist", () => {
         commands: ["canvas.snapshot"],
         instanceId: "node-allowed",
         displayName: "node-allowed",
+        deviceIdentity: allowedDeviceIdentity,
         onEvent: (evt) => {
           if (evt.event === "node.invoke.request") {
             const payload = evt.payload as { id?: string; nodeId?: string };
@@ -361,9 +375,9 @@ describe("gateway node command allowlist", () => {
       const invokeNullRes = await invokeNullResP;
       expect(invokeNullRes.ok).toBe(true);
     } finally {
-      systemClient?.stop();
-      emptyClient?.stop();
-      allowedClient?.stop();
+      await systemClient?.stopAndWait();
+      await emptyClient?.stopAndWait();
+      await allowedClient?.stopAndWait();
     }
   });
 
@@ -405,6 +419,19 @@ describe("gateway node command allowlist", () => {
       const nodeId = node?.nodeId ?? "";
       expect(nodeId).toBeTruthy();
 
+      const pairingList = await rpcReq<{
+        pending?: Array<{ nodeId?: string; commands?: string[] }>;
+      }>(ws, "node.pair.list", {});
+      expect(pairingList.ok).toBe(true);
+      expect(pairingList.payload?.pending ?? []).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            nodeId,
+            commands: ["canvas.snapshot", "system.run"],
+          }),
+        ]),
+      );
+
       const canvasRes = await rpcReq(ws, "node.invoke", {
         nodeId,
         command: "canvas.snapshot",
@@ -423,7 +450,7 @@ describe("gateway node command allowlist", () => {
       expect(systemRunRes.ok).toBe(false);
       expect(systemRunRes.error?.message ?? "").toContain("node command not allowed");
     } finally {
-      nodeClient?.stop();
+      await nodeClient?.stopAndWait();
     }
   });
 

--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -98,6 +98,42 @@ const connectNodeClientWithPairing = async (params: Parameters<typeof connectNod
   }
 };
 
+const connectNodeClientWithNodePairing = async (
+  params: Parameters<typeof connectNodeClient>[0],
+) => {
+  const provisionalClient = await connectNodeClientWithPairing(params);
+  const listRes = await rpcReq<{
+    nodes?: Array<{ nodeId: string; displayName?: string; connected?: boolean }>;
+  }>(ws, "node.list", {});
+  const provisionalNode = (listRes.payload?.nodes ?? []).find((node) => {
+    if (!node.connected) {
+      return false;
+    }
+    if (params.displayName) {
+      return node.displayName === params.displayName;
+    }
+    return true;
+  });
+  const nodeId = provisionalNode?.nodeId ?? "";
+  expect(nodeId).toBeTruthy();
+
+  await provisionalClient.stopAndWait();
+
+  const { approveNodePairing, requestNodePairing } = await import("../infra/node-pairing.js");
+  const request = await requestNodePairing({
+    nodeId,
+    displayName: params.displayName,
+    platform: params.platform ?? "ios",
+    deviceFamily: params.deviceFamily,
+    commands: params.commands,
+  });
+  await approveNodePairing(request.request.requestId, {
+    callerScopes: ["operator.admin", "operator.write"],
+  });
+
+  return await connectNodeClient(params);
+};
+
 describe("gateway role enforcement", () => {
   test("enforces operator and node permissions", async () => {
     let nodeClient: GatewayClient | undefined;
@@ -275,7 +311,7 @@ describe("gateway node command allowlist", () => {
         new Promise<{ id?: string; nodeId?: string }>((resolve) => {
           resolveInvoke = resolve;
         });
-      allowedClient = await connectNodeClientWithPairing({
+      allowedClient = await connectNodeClientWithNodePairing({
         port,
         commands: ["canvas.snapshot"],
         instanceId: "node-allowed",
@@ -331,6 +367,66 @@ describe("gateway node command allowlist", () => {
     }
   });
 
+  test("blocks all declared commands until node pairing exists", async () => {
+    const findConnectedNode = async (displayName: string) => {
+      const listRes = await rpcReq<{
+        nodes?: Array<{
+          nodeId: string;
+          displayName?: string;
+          connected?: boolean;
+          commands?: string[];
+        }>;
+      }>(ws, "node.list", {});
+      return (listRes.payload?.nodes ?? []).find(
+        (node) => node.connected && node.displayName === displayName,
+      );
+    };
+
+    const displayName = "node-device-paired-only";
+    let nodeClient: GatewayClient | undefined;
+
+    try {
+      nodeClient = await connectNodeClientWithPairing({
+        port,
+        commands: ["canvas.snapshot", "system.run"],
+        platform: "darwin",
+        instanceId: displayName,
+        displayName,
+      });
+
+      await expect
+        .poll(async () => {
+          const node = await findConnectedNode(displayName);
+          return node?.commands?.toSorted() ?? [];
+        }, FAST_WAIT_OPTS)
+        .toEqual([]);
+
+      const node = await findConnectedNode(displayName);
+      const nodeId = node?.nodeId ?? "";
+      expect(nodeId).toBeTruthy();
+
+      const canvasRes = await rpcReq(ws, "node.invoke", {
+        nodeId,
+        command: "canvas.snapshot",
+        params: { format: "png" },
+        idempotencyKey: "allowlist-device-paired-only-canvas",
+      });
+      expect(canvasRes.ok).toBe(false);
+      expect(canvasRes.error?.message ?? "").toContain("node command not allowed");
+
+      const systemRunRes = await rpcReq(ws, "node.invoke", {
+        nodeId,
+        command: "system.run",
+        params: { command: "echo blocked" },
+        idempotencyKey: "allowlist-device-paired-only-system-run",
+      });
+      expect(systemRunRes.ok).toBe(false);
+      expect(systemRunRes.error?.message ?? "").toContain("node command not allowed");
+    } finally {
+      nodeClient?.stop();
+    }
+  });
+
   test("rejects reconnect metadata spoof for paired node devices", async () => {
     const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
     const deviceIdentityPath = path.join(
@@ -350,7 +446,7 @@ describe("gateway node command allowlist", () => {
         displayName: "node-platform-pin",
         deviceIdentity,
       });
-      iosClient.stop();
+      await iosClient.stopAndWait();
       await expect
         .poll(async () => {
           const listRes = await rpcReq<{ nodes?: Array<{ connected?: boolean }> }>(
@@ -417,7 +513,7 @@ describe("gateway node command allowlist", () => {
 
       let client: GatewayClient | undefined;
       try {
-        client = await connectNodeClientWithPairing({
+        client = await connectNodeClientWithNodePairing({
           port,
           commands: ["system.run", "canvas.snapshot"],
           platform: testCase.platform,

--- a/src/gateway/server.roles-allowlist-update.test.ts
+++ b/src/gateway/server.roles-allowlist-update.test.ts
@@ -454,6 +454,57 @@ describe("gateway node command allowlist", () => {
     }
   });
 
+  test("records only allowlisted commands in pending node pairing requests", async () => {
+    const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
+    const deviceIdentityPath = path.join(
+      os.tmpdir(),
+      `openclaw-allowlisted-pending-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+    );
+    const deviceIdentity = loadOrCreateDeviceIdentity(deviceIdentityPath);
+    const displayName = "node-pending-allowlisted-only";
+    let nodeClient: GatewayClient | undefined;
+
+    try {
+      nodeClient = await connectNodeClientWithPairing({
+        port,
+        commands: ["system.run", "canvas.snapshot"],
+        platform: "İOS",
+        deviceFamily: "iPhone",
+        instanceId: displayName,
+        displayName,
+        deviceIdentity,
+      });
+
+      const listRes = await rpcReq<{
+        nodes?: Array<{
+          nodeId: string;
+          displayName?: string;
+          connected?: boolean;
+        }>;
+      }>(ws, "node.list", {});
+      const nodeId =
+        (listRes.payload?.nodes ?? []).find(
+          (node) => node.connected && node.displayName === displayName,
+        )?.nodeId ?? "";
+      expect(nodeId).toBeTruthy();
+
+      const pairingList = await rpcReq<{
+        pending?: Array<{ nodeId?: string; commands?: string[] }>;
+      }>(ws, "node.pair.list", {});
+      expect(pairingList.ok).toBe(true);
+      expect(pairingList.payload?.pending ?? []).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            nodeId,
+            commands: ["canvas.snapshot"],
+          }),
+        ]),
+      );
+    } finally {
+      await nodeClient?.stopAndWait();
+    }
+  });
+
   test("rejects reconnect metadata spoof for paired node devices", async () => {
     const { loadOrCreateDeviceIdentity } = await import("../infra/device-identity.js");
     const deviceIdentityPath = path.join(
@@ -497,7 +548,7 @@ describe("gateway node command allowlist", () => {
         }),
       ).rejects.toThrow(/pairing required/i);
     } finally {
-      iosClient?.stop();
+      await iosClient?.stopAndWait();
     }
   });
 
@@ -573,7 +624,7 @@ describe("gateway node command allowlist", () => {
         expect(systemRunRes.ok).toBe(false);
         expect(systemRunRes.error?.message ?? "").toContain("node command not allowed");
       } finally {
-        client?.stop();
+        await client?.stopAndWait();
       }
     }
   });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -18,7 +18,11 @@ import {
   updatePairedDeviceMetadata,
   verifyDeviceToken,
 } from "../../../infra/device-pairing.js";
-import { getPairedNode, updatePairedNodeMetadata } from "../../../infra/node-pairing.js";
+import {
+  getPairedNode,
+  requestNodePairing,
+  updatePairedNodeMetadata,
+} from "../../../infra/node-pairing.js";
 import { recordRemoteNodeInfo, refreshRemoteNodeBins } from "../../../infra/skills-remote.js";
 import { upsertPresence } from "../../../infra/system-presence.js";
 import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
@@ -960,12 +964,32 @@ export function attachGatewayWsMessageHandler(params: {
         if (role === "node") {
           const cfg = loadConfig();
           const nodeId = connectParams.device?.id ?? connectParams.client.id;
-          const pairedNode = await getPairedNode(nodeId);
+          const declared = Array.isArray(connectParams.commands) ? connectParams.commands : [];
+          let pairedNode = await getPairedNode(nodeId);
+          if (!pairedNode) {
+            const pending = await requestNodePairing({
+              nodeId,
+              displayName: connectParams.client.displayName,
+              platform: connectParams.client.platform,
+              version: connectParams.client.version,
+              deviceFamily: connectParams.client.deviceFamily,
+              modelIdentifier: connectParams.client.modelIdentifier,
+              caps: connectParams.caps,
+              commands: declared,
+              remoteIp: reportedClientIp,
+            });
+            if (pending.status === "pending" && pending.created) {
+              const requestContext = buildRequestContext();
+              requestContext.broadcast("node.pair.requested", pending.request, {
+                dropIfSlow: true,
+              });
+            }
+            pairedNode = await getPairedNode(nodeId);
+          }
           const allowlist = resolveNodeCommandAllowlist(cfg, {
             platform: connectParams.client.platform,
             deviceFamily: connectParams.client.deviceFamily,
           });
-          const declared = Array.isArray(connectParams.commands) ? connectParams.commands : [];
           const pairedCommands = new Set(pairedNode?.commands ?? []);
           const filtered = declared
             .map((cmd) => cmd.trim())

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -966,15 +966,10 @@ export function attachGatewayWsMessageHandler(params: {
             deviceFamily: connectParams.client.deviceFamily,
           });
           const declared = Array.isArray(connectParams.commands) ? connectParams.commands : [];
-          const pairedCommands = pairedNode ? new Set(pairedNode.commands ?? []) : null;
+          const pairedCommands = new Set(pairedNode?.commands ?? []);
           const filtered = declared
             .map((cmd) => cmd.trim())
-            .filter(
-              (cmd) =>
-                cmd.length > 0 &&
-                allowlist.has(cmd) &&
-                (pairedCommands === null || pairedCommands.has(cmd)),
-            );
+            .filter((cmd) => cmd.length > 0 && allowlist.has(cmd) && pairedCommands.has(cmd));
           connectParams.commands = filtered;
         }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -965,6 +965,13 @@ export function attachGatewayWsMessageHandler(params: {
           const cfg = loadConfig();
           const nodeId = connectParams.device?.id ?? connectParams.client.id;
           const declared = Array.isArray(connectParams.commands) ? connectParams.commands : [];
+          const allowlist = resolveNodeCommandAllowlist(cfg, {
+            platform: connectParams.client.platform,
+            deviceFamily: connectParams.client.deviceFamily,
+          });
+          const allowlistedDeclared = declared
+            .map((cmd) => cmd.trim())
+            .filter((cmd) => cmd.length > 0 && allowlist.has(cmd));
           let pairedNode = await getPairedNode(nodeId);
           if (!pairedNode) {
             const pending = await requestNodePairing({
@@ -975,7 +982,7 @@ export function attachGatewayWsMessageHandler(params: {
               deviceFamily: connectParams.client.deviceFamily,
               modelIdentifier: connectParams.client.modelIdentifier,
               caps: connectParams.caps,
-              commands: declared,
+              commands: allowlistedDeclared,
               remoteIp: reportedClientIp,
             });
             if (pending.status === "pending" && pending.created) {
@@ -986,14 +993,8 @@ export function attachGatewayWsMessageHandler(params: {
             }
             pairedNode = await getPairedNode(nodeId);
           }
-          const allowlist = resolveNodeCommandAllowlist(cfg, {
-            platform: connectParams.client.platform,
-            deviceFamily: connectParams.client.deviceFamily,
-          });
           const pairedCommands = new Set(pairedNode?.commands ?? []);
-          const filtered = declared
-            .map((cmd) => cmd.trim())
-            .filter((cmd) => cmd.length > 0 && allowlist.has(cmd) && pairedCommands.has(cmd));
+          const filtered = allowlistedDeclared.filter((cmd) => pairedCommands.has(cmd));
           connectParams.commands = filtered;
         }
 


### PR DESCRIPTION
## Summary
- require an approved node pairing record before exposing any declared node commands at connect time
- update gateway allowlist coverage to distinguish device-only pairing from full node pairing

## Changes
- changed the websocket connect path to intersect declared commands with the node pairing record even when no node pairing exists
- added a regression for device-paired-only nodes and updated existing allowlist tests to perform explicit node pairing where command access is expected

## Validation
- Ran `pnpm test -- src/gateway/server.roles-allowlist-update.test.ts -t "blocks all declared commands until node pairing exists"`
- Ran `pnpm test -- src/gateway/server.roles-allowlist-update.test.ts`
- Ran `pnpm check`
- Ran local agentic review with `claude -p "/review"` and addressed the follow-up test setup changes it implied

## Notes
- Residual risk or follow-up: older tests that assumed device pairing alone was sufficient for command access were updated to model explicit node pairing instead
