### PR TITLE
fix(sandbox): fail fast on incompatible default image

### DIFF
--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -332,13 +332,15 @@ Build it once:
 scripts/sandbox-setup.sh
 ```
 
-Note: the default image does **not** include Node. If a skill needs Node (or
+The default image already includes the baseline tooling required for sandboxed
+file mutation (`bash`, `git`, `jq`, `python3`, `ripgrep`), but it does **not**
+include Node. If a skill needs Node (or
 other runtimes), either bake a custom image or install via
 `sandbox.docker.setupCommand` (requires network egress + writable root +
 root user).
 
 If you want a more functional sandbox image with common tooling (for example
-`curl`, `jq`, `nodejs`, `python3`, `git`), build:
+`curl`, `jq`, `nodejs`, `go`, `rustc`), build:
 
 ```bash
 scripts/sandbox-common-setup.sh

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -355,6 +355,15 @@ scripts/sandbox-setup.sh
     Containers are auto-created per session on demand.
   </Accordion>
 
+  <Accordion title="Edit or write fails with python3: not found">
+    Your sandbox container was created from an incompatible image. Rebuild the
+    image with
+    [`scripts/sandbox-setup.sh`](https://github.com/openclaw/openclaw/blob/main/scripts/sandbox-setup.sh)
+    or rebuild your custom image so it includes `python3`, then run
+    `docker compose run --rm openclaw-cli sandbox recreate --all` to replace old
+    runtimes.
+  </Accordion>
+
   <Accordion title="Permission errors in sandbox">
     Set `docker.user` to a UID:GID that matches your mounted workspace ownership,
     or chown the workspace folder.

--- a/src/agents/sandbox/docker.ensure-docker-image.test.ts
+++ b/src/agents/sandbox/docker.ensure-docker-image.test.ts
@@ -1,0 +1,137 @@
+import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type SpawnCall = {
+  command: string;
+  args: string[];
+};
+
+type MockDockerChild = EventEmitter & {
+  stdout: Readable;
+  stderr: Readable;
+  stdin: { end: (input?: string | Buffer) => void };
+  kill: (signal?: NodeJS.Signals) => void;
+};
+
+const spawnState = vi.hoisted(() => ({
+  calls: [] as SpawnCall[],
+  inspectResults: new Map<string, { code: number; stdout?: string; stderr?: string }>(),
+}));
+
+function createMockDockerChild(): MockDockerChild {
+  const child = new EventEmitter() as MockDockerChild;
+  child.stdout = new Readable({ read() {} });
+  child.stderr = new Readable({ read() {} });
+  child.stdin = { end: () => undefined };
+  child.kill = () => undefined;
+  return child;
+}
+
+function spawnDockerProcess(command: string, args: string[]) {
+  spawnState.calls.push({ command, args });
+  const child = createMockDockerChild();
+
+  let code = 0;
+  let stdout = "";
+  let stderr = "";
+  if (command !== "docker") {
+    code = 1;
+    stderr = `unexpected command: ${command}`;
+  } else if (args[0] === "image" && args[1] === "inspect") {
+    const image = args[2] ?? "";
+    const result = spawnState.inspectResults.get(image);
+    code = result?.code ?? 1;
+    stdout = result?.stdout ?? "";
+    stderr = result?.stderr ?? `Error: No such image: ${image}`;
+  } else {
+    code = 0;
+  }
+
+  queueMicrotask(() => {
+    if (stdout) {
+      child.stdout.emit("data", Buffer.from(stdout));
+    }
+    if (stderr) {
+      child.stderr.emit("data", Buffer.from(stderr));
+    }
+    child.emit("close", code);
+  });
+
+  return child;
+}
+
+async function createChildProcessMock(
+  importOriginal: () => Promise<typeof import("node:child_process")>,
+) {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    spawn: spawnDockerProcess,
+  };
+}
+
+vi.mock("node:child_process", async (importOriginal) =>
+  createChildProcessMock(() => importOriginal<typeof import("node:child_process")>()),
+);
+
+let ensureDockerImage: typeof import("./docker.js").ensureDockerImage;
+
+async function loadFreshDockerModuleForTest() {
+  vi.resetModules();
+  vi.doMock("node:child_process", async (importOriginal) =>
+    createChildProcessMock(() => importOriginal<typeof import("node:child_process")>()),
+  );
+  ({ ensureDockerImage } = await import("./docker.js"));
+}
+
+describe("ensureDockerImage", () => {
+  beforeEach(async () => {
+    spawnState.calls.length = 0;
+    spawnState.inspectResults.clear();
+    await loadFreshDockerModuleForTest();
+  });
+
+  it("fails fast with an actionable message when the default sandbox image is missing", async () => {
+    spawnState.inspectResults.set("openclaw-sandbox:bookworm-slim", {
+      code: 1,
+      stderr: "Error: No such image: openclaw-sandbox:bookworm-slim",
+    });
+
+    let err: unknown;
+    try {
+      await ensureDockerImage("openclaw-sandbox:bookworm-slim");
+    } catch (caught) {
+      err = caught;
+    }
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/scripts\/sandbox-setup\.sh/);
+    expect((err as Error).message).toMatch(/python3/);
+
+    const dockerCalls = spawnState.calls.filter((call) => call.command === "docker");
+    expect(dockerCalls).toHaveLength(1);
+    expect(
+      dockerCalls.every((call) => call.args[0] === "image" && call.args[1] === "inspect"),
+    ).toBe(true);
+    expect(dockerCalls.some((call) => call.args[0] === "pull")).toBe(false);
+    expect(dockerCalls.some((call) => call.args[0] === "tag")).toBe(false);
+  });
+
+  it("keeps the generic message for non-default images", async () => {
+    spawnState.inspectResults.set("ghcr.io/example/custom-sandbox:latest", {
+      code: 1,
+      stderr: "Error: No such image: ghcr.io/example/custom-sandbox:latest",
+    });
+
+    await expect(ensureDockerImage("ghcr.io/example/custom-sandbox:latest")).rejects.toThrow(
+      /Build or pull it first/,
+    );
+    expect(spawnState.calls).toHaveLength(1);
+    expect(spawnState.calls[0]?.args).toEqual([
+      "image",
+      "inspect",
+      "ghcr.io/example/custom-sandbox:latest",
+    ]);
+  });
+});

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -255,17 +255,23 @@ async function dockerImageExists(image: string) {
   throw new Error(`Failed to inspect sandbox image: ${stderr}`);
 }
 
+function formatMissingSandboxImageMessage(image: string) {
+  if (image === DEFAULT_SANDBOX_IMAGE) {
+    return [
+      `Default sandbox image not found: ${image}.`,
+      `Build it with ${formatCliCommand("scripts/sandbox-setup.sh")} from a source checkout, or set agents.defaults.sandbox.docker.image to an existing compatible image.`,
+      "OpenClaw no longer aliases debian:bookworm-slim because the default sandbox requires tools such as python3.",
+    ].join(" ");
+  }
+  return `Sandbox image not found: ${image}. Build or pull it first.`;
+}
+
 export async function ensureDockerImage(image: string) {
   const exists = await dockerImageExists(image);
   if (exists) {
     return;
   }
-  if (image === DEFAULT_SANDBOX_IMAGE) {
-    await execDocker(["pull", "debian:bookworm-slim"]);
-    await execDocker(["tag", "debian:bookworm-slim", DEFAULT_SANDBOX_IMAGE]);
-    return;
-  }
-  throw new Error(`Sandbox image not found: ${image}. Build or pull it first.`);
+  throw new Error(formatMissingSandboxImageMessage(image));
 }
 
 export async function dockerContainerState(name: string) {

--- a/src/agents/sandbox/fs-bridge-mutation-helper.ts
+++ b/src/agents/sandbox/fs-bridge-mutation-helper.ts
@@ -6,6 +6,8 @@ import type {
 } from "./fs-bridge-path-safety.js";
 import type { SandboxFsCommandPlan } from "./fs-bridge-shell-command-plans.js";
 
+export const SANDBOX_PINNED_MUTATION_OPERATION_MARKER = "operation = sys.argv[1]";
+
 export const SANDBOX_PINNED_MUTATION_PYTHON_CANDIDATES = [
   "/usr/bin/python3",
   "/usr/local/bin/python3",
@@ -20,7 +22,7 @@ export const SANDBOX_PINNED_MUTATION_PYTHON = [
   "import stat",
   "import sys",
   "",
-  "operation = sys.argv[1]",
+  SANDBOX_PINNED_MUTATION_OPERATION_MARKER,
   "",
   "DIR_FLAGS = os.O_RDONLY",
   "if hasattr(os, 'O_DIRECTORY'):",

--- a/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
+++ b/src/agents/sandbox/fs-bridge.anchored-ops.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { SANDBOX_PINNED_MUTATION_OPERATION_MARKER } from "./fs-bridge-mutation-helper.js";
 import {
   createSandbox,
   createSandboxFsBridge,
@@ -111,11 +112,12 @@ describe("sandbox fs bridge anchored ops", () => {
       const opCall = mockedExecDockerRaw.mock.calls.find(
         ([args]) =>
           typeof args[5] === "string" &&
-          args[5].includes("python3 /dev/fd/3 \"$@\" 3<<'PY'") &&
+          args[5].includes(SANDBOX_PINNED_MUTATION_OPERATION_MARKER) &&
           getDockerArg(args, 1) === testCase.expectedArgs[0],
       );
       expect(opCall).toBeDefined();
       const args = opCall?.[0] ?? [];
+      expect(String(args[5] ?? "")).toContain('exec "$python_cmd" -c "$python_script" "$@"');
       testCase.expectedArgs.forEach((value, index) => {
         expect(getDockerArg(args, index + 1)).toBe(value);
       });

--- a/src/agents/sandbox/fs-bridge.shell.test.ts
+++ b/src/agents/sandbox/fs-bridge.shell.test.ts
@@ -158,9 +158,13 @@ describe("sandbox fs bridge shell compatibility", () => {
 
     const scripts = getScriptsFromCalls();
     expect(scripts.some((script) => script.includes("python3 - \"$@\" <<'PY'"))).toBe(false);
-    expect(scripts.some((script) => script.includes("python3 /dev/fd/3 \"$@\" 3<<'PY'"))).toBe(
-      true,
-    );
+    expect(
+      scripts.some(
+        (script) =>
+          script.includes(SANDBOX_PINNED_MUTATION_OPERATION_MARKER) &&
+          script.includes('exec "$python_cmd" -c "$python_script" "$@"'),
+      ),
+    ).toBe(true);
     expect(scripts.some((script) => script.includes('cat >"$1"'))).toBe(false);
     expect(scripts.some((script) => script.includes('cat >"$tmp"'))).toBe(false);
     expect(scripts.some((script) => script.includes("os.replace("))).toBe(true);

--- a/src/agents/sandbox/fs-bridge.shell.test.ts
+++ b/src/agents/sandbox/fs-bridge.shell.test.ts
@@ -1,10 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { SANDBOX_PINNED_MUTATION_OPERATION_MARKER } from "./fs-bridge-mutation-helper.js";
 import {
   createSandbox,
   createSandboxFsBridge,
   createSeededSandboxFsBridge,
+  dockerExecResult,
   getScriptsFromCalls,
   installFsBridgeTestHarness,
   mockedExecDockerRaw,
@@ -14,6 +16,30 @@ import {
 
 describe("sandbox fs bridge shell compatibility", () => {
   installFsBridgeTestHarness();
+
+  function installMissingPythonMutationFailure(
+    message = "sandbox pinned mutation helper requires python3 or python",
+  ) {
+    mockedExecDockerRaw.mockImplementation(async (args) => {
+      const script = String(args[5] ?? "");
+      if (script.includes('readlink -f -- "$cursor"')) {
+        return dockerExecResult("/workspace/b.txt\n");
+      }
+      if (script.includes(SANDBOX_PINNED_MUTATION_OPERATION_MARKER)) {
+        const error = Object.assign(new Error(message), {
+          code: 127,
+          stdout: Buffer.alloc(0),
+          stderr: Buffer.from(message),
+        });
+        throw error;
+      }
+      return {
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      };
+    });
+  }
 
   it("uses POSIX-safe shell prologue in all bridge commands", async () => {
     await withTempDir("openclaw-fs-bridge-shell-", async (stateDir) => {
@@ -151,7 +177,10 @@ describe("sandbox fs bridge shell compatibility", () => {
       await bridge.rename({ from: "a.txt", to: "nested/b.txt" });
 
       const scripts = getScriptsFromCalls();
-      expect(scripts.filter((script) => script.includes("operation = sys.argv[1]")).length).toBe(3);
+      expect(
+        scripts.filter((script) => script.includes(SANDBOX_PINNED_MUTATION_OPERATION_MARKER))
+          .length,
+      ).toBe(3);
       expect(scripts.some((script) => script.includes('mkdir -p -- "$2"'))).toBe(false);
       expect(scripts.some((script) => script.includes('rm -f -- "$2"'))).toBe(false);
       expect(scripts.some((script) => script.includes('mv -- "$3" "$2/$4"'))).toBe(false);
@@ -174,5 +203,128 @@ describe("sandbox fs bridge shell compatibility", () => {
 
     const scripts = getScriptsFromCalls();
     expect(scripts.some((script) => script.includes("os.replace("))).toBe(false);
+  });
+
+  it.each([
+    {
+      label: "writeFile",
+      run: (bridge: ReturnType<typeof createSandboxFsBridge>) =>
+        bridge.writeFile({ filePath: "b.txt", data: "hello" }),
+    },
+    {
+      label: "mkdirp",
+      run: (bridge: ReturnType<typeof createSandboxFsBridge>) =>
+        bridge.mkdirp({ filePath: "nested" }),
+    },
+    {
+      label: "remove",
+      run: (bridge: ReturnType<typeof createSandboxFsBridge>) =>
+        bridge.remove({ filePath: "b.txt" }),
+    },
+    {
+      label: "rename",
+      run: (bridge: ReturnType<typeof createSandboxFsBridge>) =>
+        bridge.rename({ from: "a.txt", to: "b.txt" }),
+    },
+  ])(
+    "surfaces a repair message for $label when the mutation helper cannot find a Python runtime",
+    async ({ run }) => {
+      installMissingPythonMutationFailure();
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          containerName: "openclaw-sbx-bad",
+        }),
+      });
+
+      let err: unknown;
+      try {
+        await run(bridge);
+      } catch (caught) {
+        err = caught;
+      }
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/sandbox image is incompatible/i);
+      expect((err as Error).message).toMatch(/openclaw sandbox recreate --all/i);
+    },
+  );
+
+  it("keeps rewriting the legacy python3 not found shell error for Docker sandboxes", async () => {
+    installMissingPythonMutationFailure("sh: 1: python3: not found");
+
+    const bridge = createSandboxFsBridge({
+      sandbox: createSandbox({
+        containerName: "openclaw-sbx-legacy",
+      }),
+    });
+
+    let err: unknown;
+    try {
+      await bridge.writeFile({ filePath: "b.txt", data: "hello" });
+    } catch (caught) {
+      err = caught;
+    }
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/sandbox image is incompatible/i);
+    expect((err as Error).message).toMatch(/openclaw sandbox recreate --all/i);
+  });
+
+  it("does not rewrite python3 failures for non-docker backends", async () => {
+    const sshError = Object.assign(new Error("python3: not found"), {
+      code: 127,
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.from("python3: not found"),
+    });
+    const bridge = createSandboxFsBridge({
+      sandbox: createSandbox({
+        backendId: "ssh",
+        backend: {
+          id: "ssh",
+          runtimeId: "ssh-runtime",
+          runtimeLabel: "ssh-runtime",
+          workdir: "/workspace",
+          buildExecSpec: async () => ({
+            argv: [],
+            env: process.env,
+            stdinMode: "pipe-closed",
+          }),
+          runShellCommand: async ({ script }) => {
+            if (script.includes('readlink -f -- "$cursor"')) {
+              return {
+                stdout: Buffer.from("/workspace/b.txt\n"),
+                stderr: Buffer.alloc(0),
+                code: 0,
+              };
+            }
+            throw sshError;
+          },
+        },
+      }),
+    });
+
+    await expect(bridge.writeFile({ filePath: "b.txt", data: "hello" })).rejects.toBe(sshError);
+  });
+
+  it("keeps custom-image repair guidance focused on rebuilding that image", async () => {
+    installMissingPythonMutationFailure();
+
+    const sandbox = createSandbox({
+      containerName: "openclaw-sbx-custom",
+    });
+    sandbox.docker.image = "ghcr.io/example/custom-sandbox:latest";
+    const bridge = createSandboxFsBridge({ sandbox });
+
+    let err: unknown;
+    try {
+      await bridge.writeFile({ filePath: "b.txt", data: "hello" });
+    } catch (caught) {
+      err = caught;
+    }
+
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/ghcr\.io\/example\/custom-sandbox:latest/);
+    expect((err as Error).message).not.toMatch(/scripts\/sandbox-setup\.sh/i);
   });
 });

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -1,11 +1,14 @@
 import fs from "node:fs";
+import { formatCliCommand } from "../../cli/command-format.js";
 import type { SandboxBackendCommandResult } from "./backend.js";
+import { DEFAULT_SANDBOX_IMAGE } from "./constants.js";
 import { runDockerSandboxShellCommand } from "./docker-backend.js";
 import {
   buildPinnedMkdirpPlan,
   buildPinnedRemovePlan,
   buildPinnedRenamePlan,
   buildPinnedWritePlan,
+  SANDBOX_PINNED_MUTATION_OPERATION_MARKER,
 } from "./fs-bridge-mutation-helper.js";
 import { SandboxFsPathGuard } from "./fs-bridge-path-safety.js";
 import { buildStatPlan, type SandboxFsCommandPlan } from "./fs-bridge-shell-command-plans.js";
@@ -21,6 +24,12 @@ type RunCommandOptions = {
   stdin?: Buffer | string;
   allowFailure?: boolean;
   signal?: AbortSignal;
+};
+
+type SandboxCommandFailure = Error & {
+  code?: number;
+  stdout?: Buffer;
+  stderr?: Buffer;
 };
 
 export type SandboxResolvedPath = {
@@ -64,6 +73,41 @@ export type SandboxFsBridge = {
 
 export function createSandboxFsBridge(params: { sandbox: SandboxContext }): SandboxFsBridge {
   return new SandboxFsBridgeImpl(params.sandbox);
+}
+
+function isDockerSandbox(sandbox: SandboxContext): boolean {
+  return !sandbox.backend || sandbox.backend.id === "docker";
+}
+
+function formatIncompatibleSandboxImageMessage(params: {
+  containerName: string;
+  image: string;
+}): string {
+  const message = [
+    `Sandbox image is incompatible with OpenClaw file tools: no Python runtime was found inside container ${params.containerName}.`,
+    `Rebuild the configured sandbox image (${params.image}) so it includes python3 or python, then run ${formatCliCommand("openclaw sandbox recreate --all")}.`,
+  ];
+  if (params.image === DEFAULT_SANDBOX_IMAGE) {
+    message.push(
+      `For the default image, rebuild it with ${formatCliCommand("scripts/sandbox-setup.sh")} from a source checkout.`,
+    );
+  }
+  return message.join(" ");
+}
+
+function isMissingSandboxPythonError(error: unknown): error is SandboxCommandFailure {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const stderr =
+    typeof (error as SandboxCommandFailure).stderr?.toString === "function"
+      ? ((error as SandboxCommandFailure).stderr?.toString("utf8") ?? "")
+      : "";
+  const message = `${error.message}\n${stderr}`.toLowerCase();
+  return (
+    /\b(?:python3|python)\b.*\b(?:command )?not found\b/.test(message) ||
+    message.includes("sandbox pinned mutation helper requires python3 or python")
+  );
 }
 
 class SandboxFsBridgeImpl implements SandboxFsBridge {
@@ -250,24 +294,47 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
     script: string,
     options: RunCommandOptions = {},
   ): Promise<SandboxBackendCommandResult> {
-    const backend = this.sandbox.backend;
-    if (backend) {
-      return await backend.runShellCommand({
+    try {
+      const backend = this.sandbox.backend;
+      if (backend) {
+        return await backend.runShellCommand({
+          script,
+          args: options.args,
+          stdin: options.stdin,
+          allowFailure: options.allowFailure,
+          signal: options.signal,
+        });
+      }
+      return await runDockerSandboxShellCommand({
+        containerName: this.sandbox.containerName,
         script,
         args: options.args,
         stdin: options.stdin,
         allowFailure: options.allowFailure,
         signal: options.signal,
       });
+    } catch (error) {
+      if (
+        !options.allowFailure &&
+        isDockerSandbox(this.sandbox) &&
+        script.includes(SANDBOX_PINNED_MUTATION_OPERATION_MARKER) &&
+        isMissingSandboxPythonError(error)
+      ) {
+        throw Object.assign(
+          new Error(
+            formatIncompatibleSandboxImageMessage({
+              containerName: this.sandbox.containerName,
+              image: this.sandbox.docker.image,
+            }),
+          ),
+          {
+            code: "INVALID_CONFIG",
+            cause: error,
+          },
+        );
+      }
+      throw error;
     }
-    return await runDockerSandboxShellCommand({
-      containerName: this.sandbox.containerName,
-      script,
-      args: options.args,
-      stdin: options.stdin,
-      allowFailure: options.allowFailure,
-      signal: options.signal,
-    });
   }
 
   private async readPinnedFile(target: SandboxResolvedFsPath): Promise<Buffer> {


### PR DESCRIPTION
## Summary

- Problem: `ensureDockerImage()` could silently alias plain `debian:bookworm-slim` as `openclaw-sandbox:bookworm-slim`, producing a default-tagged sandbox image that lacked the Python runtime required by sandbox mutation helpers.
- Why it matters: `read` could still work, but `write` / `edit` / `mkdirp` / `remove` / `rename` could fail inside Docker sandboxes with missing-Python errors, matching `#57713`.
- What changed: the default Docker sandbox image now fails fast when missing instead of silently aliasing plain Debian, and Docker mutation failures caused by a missing Python runtime are translated into a precise repair path for already-created incompatible runtimes.
- What did NOT change: no remote-shell behavior changes, no sandbox bootstrap redesign, no runtime auto-pull/build fallback, and no changes to successful sandbox mutation flows.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57713
- Related #51166
- Related #56785

## User-visible / Behavior Changes

- Missing default Docker sandbox image now fails early with clear recovery guidance instead of silently creating an incompatible default tag.
- Existing Docker sandboxes created from an incompatible image now surface direct rebuild + recreate instructions when mutation helpers fail due to a missing Python runtime.
- Docker sandbox docs now reflect the default-image contract and the correct recreate path for Docker Compose installs.

## Security Impact (required)

- New permissions/capabilities: No
- Secrets/tokens handling changed: No
- New/changed network calls: No
- Command/tool execution surface changed: No
- Data access scope changed: No

## Repro + Verification

### Environment

- OS: macOS 15.x
- Runtime/container: Node 24 / pnpm workspace
- Integration/channel: Docker sandbox mutation path
- Relevant config: default Docker sandbox image

### Steps

1. Simulate a missing `openclaw-sandbox:bookworm-slim` image and verify `ensureDockerImage()`.
2. Simulate Docker mutation-helper failures caused by a missing Python runtime.
3. Verify `writeFile`, `mkdirp`, `remove`, and `rename` surface the repair message.
4. Verify custom-image and non-Docker paths keep their focused behavior.

### Expected

- Default image provisioning fails fast with a clear repair message.
- Already-bad Docker sandboxes tell the operator how to rebuild the image and recreate runtimes.
- Unrelated sandbox backends and successful mutation paths stay unchanged.

### Actual

- Focused regression tests and build checks pass with the behavior above.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run locally:

- `pnpm exec vitest run src/agents/sandbox/docker.ensure-docker-image.test.ts src/agents/sandbox/fs-bridge.shell.test.ts src/agents/sandbox/fs-bridge.boundary.test.ts src/agents/sandbox/fs-bridge.anchored-ops.test.ts src/agents/sandbox/docker.config-hash-recreate.test.ts`
- `pnpm exec vitest run extensions/memory-core/src/memory/qmd-manager.slugified-paths.test.ts`
- `pnpm exec vitest run src/media-understanding/media-understanding-misc.test.ts`
- `pnpm build`

## Human Verification (required)

- Verified scenarios: missing default image fails fast; custom images keep focused guidance; Docker mutation repair messaging covers `writeFile`, `mkdirp`, `remove`, and `rename`; non-Docker backends keep the original error.
- Edge cases checked: legacy `python3: not found` errors still rewrite correctly; current pinned-helper failures that report `python3 or python` also rewrite correctly; helper-launch tests now track the exported mutation marker instead of stale shell snippets.
- What I did not verify: full GitHub CI matrix outcomes before submission.

## Compatibility / Migration

- Backward compatible: Yes
- Config/env changes: No
- Migration needed: No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or point `agents.defaults.sandbox.docker.image` at a known-compatible custom image.
- Files/config to restore: `src/agents/sandbox/docker.ts`, `src/agents/sandbox/fs-bridge.ts`, `src/agents/sandbox/fs-bridge-mutation-helper.ts`, `docs/gateway/sandboxing.md`, `docs/install/docker.md`
- Known bad symptoms reviewers should watch for: default sandbox startup failing without the new repair message, or Docker mutation failures being rewritten for non-Docker backends.

## Risks and Mitigations

- Risk: the Docker mutation repair path could accidentally rewrite unrelated backend failures.
  - Mitigation: the rewrite is limited to Docker sandboxes, the pinned mutation-helper path, and missing-Python failures.
- Risk: sandbox tests could drift from the helper launch contract as the helper evolves.
  - Mitigation: the shell tests now key off the exported mutation marker and the current wrapper contract instead of the old hardcoded heredoc launch string.
