### PR TITLE
fix: detect Mistral strict9 tool call ID mode through proxy providers

### DIFF
--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -205,6 +205,27 @@ describe("resolveProviderCapabilities", () => {
     expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
   });
 
+  it("detects strict9 tool call ID mode for Mistral models accessed via proxy providers", () => {
+    // When Mistral models are accessed through OpenRouter or other proxy
+    // providers, the provider capabilities won't include Mistral-specific
+    // hints. The cross-provider fallback should still detect the model.
+    expect(resolveTranscriptToolCallIdMode("openrouter", "mistral/mistral-small-2603")).toBe(
+      "strict9",
+    );
+    expect(resolveTranscriptToolCallIdMode("openrouter", "mistral-large-latest")).toBe("strict9");
+    expect(resolveTranscriptToolCallIdMode("openrouter", "codestral-latest")).toBe("strict9");
+    expect(resolveTranscriptToolCallIdMode("openrouter", "mistralai/pixtral-large-latest")).toBe(
+      "strict9",
+    );
+    // Non-Mistral models via proxy should not trigger strict9
+    expect(resolveTranscriptToolCallIdMode("openrouter", "anthropic/claude-sonnet-4-5")).toBe(
+      undefined,
+    );
+    expect(resolveTranscriptToolCallIdMode("openrouter", "google/gemini-2.5-pro")).toBe(undefined);
+    // Direct Mistral provider should still work
+    expect(resolveTranscriptToolCallIdMode("mistral", "mistral-small-2603")).toBe("strict9");
+  });
+
   it("treats kimi aliases as native anthropic tool payload providers", () => {
     expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi")).toBe(false);
     expect(requiresOpenAiCompatibleAnthropicToolPayload("kimi-code")).toBe(false);

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -22,6 +22,31 @@ export type ProviderCapabilityLookupOptions = {
   env?: NodeJS.ProcessEnv;
 };
 
+/**
+ * Mistral models enforce a strict 9-character alphanumeric tool call ID format.
+ * This constant is shared between the Mistral provider fallback and the
+ * cross-provider model-hint check so that the restriction is detected even
+ * when a Mistral model is accessed through a proxy/aggregator provider like
+ * OpenRouter that has no provider-specific capability overrides.
+ */
+const MISTRAL_MODEL_HINTS = [
+  "mistral",
+  "mixtral",
+  "codestral",
+  "pixtral",
+  "devstral",
+  "ministral",
+  "mistralai",
+];
+
+/**
+ * Model hints that require strict9 tool call IDs regardless of provider.
+ * When a model is accessed through a proxy (e.g. OpenRouter), the provider's
+ * own capabilities won't include these hints — this cross-provider list
+ * ensures the restriction is still applied based on the model ID alone.
+ */
+const CROSS_PROVIDER_STRICT9_MODEL_HINTS: string[] = [...MISTRAL_MODEL_HINTS];
+
 const DEFAULT_PROVIDER_CAPABILITIES: ProviderCapabilities = {
   anthropicToolSchemaMode: "native",
   anthropicToolChoiceMode: "native",
@@ -43,15 +68,7 @@ const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities
   },
   mistral: {
     transcriptToolCallIdMode: "strict9",
-    transcriptToolCallIdModelHints: [
-      "mistral",
-      "mixtral",
-      "codestral",
-      "pixtral",
-      "devstral",
-      "ministral",
-      "mistralai",
-    ],
+    transcriptToolCallIdModelHints: MISTRAL_MODEL_HINTS,
   },
   moonshot: {
     openAiPayloadNormalizationMode: "moonshot-thinking",
@@ -229,6 +246,12 @@ export function resolveTranscriptToolCallIdMode(
     return mode;
   }
   if (modelIncludesAnyHint(modelId, capabilities.transcriptToolCallIdModelHints)) {
+    return "strict9";
+  }
+  // Cross-provider fallback: detect models that require strict9 IDs even when
+  // accessed through a proxy/aggregator provider (e.g. Mistral via OpenRouter)
+  // whose own capabilities don't include the model hints.
+  if (modelIncludesAnyHint(modelId, CROSS_PROVIDER_STRICT9_MODEL_HINTS)) {
     return "strict9";
   }
   return undefined;

--- a/src/agents/transcript-policy.policy.test.ts
+++ b/src/agents/transcript-policy.policy.test.ts
@@ -21,4 +21,14 @@ describe("resolveTranscriptPolicy e2e smoke", () => {
     expect(policy.sanitizeToolCallIds).toBe(true);
     expect(policy.toolCallIdMode).toBe("strict9");
   });
+
+  it("uses strict9 tool-call sanitization for Mistral models accessed via OpenRouter", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openrouter",
+      modelId: "mistral/mistral-small-2603",
+      modelApi: "openai-completions",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict9");
+  });
 });


### PR DESCRIPTION
## Problem

When a Mistral model is accessed through OpenRouter (or another proxy/aggregator provider), tool calls fail with a 400 error:

```
400 Provider returned error
{"message":"Tool call id was exec1774786568428215 but must be a-z, A-Z, 0-9, with a length of 9."}
```

This causes the gateway to enter an unrecoverable retry loop, making all channels unresponsive.

## Root Cause

`resolveTranscriptToolCallIdMode` in `provider-capabilities.ts` resolves the provider's capabilities and checks for strict9 model hints — but only against the provider's own hint list. When the provider is `openrouter` (which has no Mistral-specific overrides), the default empty hint list is used and strict9 mode is never triggered.

The sanitization machinery (`tool-call-id.ts`, `transcript-policy.ts`) is already fully wired up for strict9 mode. The only gap is detection.

## Fix

- Extract Mistral model hints into a shared `MISTRAL_MODEL_HINTS` constant (removes duplication with the Mistral provider fallback)
- Add a `CROSS_PROVIDER_STRICT9_MODEL_HINTS` list that is checked as a fallback in `resolveTranscriptToolCallIdMode` when the provider's own capabilities don't trigger strict9
- This ensures Mistral's 9-char alphanumeric tool call ID requirement is enforced regardless of which provider routes the request

## Tests

- **provider-capabilities.test.ts**: 7 new assertions testing Mistral model detection through OpenRouter (including negative cases for non-Mistral models)
- **transcript-policy.policy.test.ts**: End-to-end test confirming strict9 + sanitizeToolCallIds for Mistral via OpenRouter with openai-completions API

All existing tests pass unchanged (the fix is purely additive — a new fallback path that only activates when the provider-specific check returns nothing).

## Files Changed

- `src/agents/provider-capabilities.ts` — cross-provider strict9 fallback + shared constant
- `src/agents/provider-capabilities.test.ts` — regression tests
- `src/agents/transcript-policy.policy.test.ts` — e2e regression test

Fixes #57672