### PR TITLE
Signal quote reply

### DIFF
--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -475,7 +475,6 @@ describe("signal createSignalEventHandler inbound context", () => {
   it("surfaces quoted Signal reply context in MsgContext", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({
-        // oxlint-disable-next-line typescript/no-explicit-any
         cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
         historyLimit: 0,
       }),
@@ -508,7 +507,6 @@ describe("signal createSignalEventHandler inbound context", () => {
   it("marks media-only Signal quotes as quoted replies", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({
-        // oxlint-disable-next-line typescript/no-explicit-any
         cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
         historyLimit: 0,
       }),

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -1,11 +1,6 @@
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { expectChannelInboundContextContract as expectInboundContextContract } from "openclaw/plugin-sdk/testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-vi.useRealTimers();
-const [
-  { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
-  { createSignalEventHandler },
-] = await Promise.all([import("./event-handler.test-harness.js"), import("./event-handler.js")]);
 
 const { sendTypingMock, sendReadReceiptMock, dispatchInboundMessageMock, capture } = vi.hoisted(
   () => {
@@ -28,28 +23,397 @@ const { sendTypingMock, sendReadReceiptMock, dispatchInboundMessageMock, capture
   },
 );
 
+vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
+  resolveHumanDelayConfig: vi.fn(() => undefined),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-feedback", () => ({
+  logTypingFailure: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-pairing", () => ({
+  createChannelPairingChallengeIssuer: vi.fn(() => async () => {}),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", () => ({
+  buildMentionRegexes: vi.fn(() => []),
+  createChannelInboundDebouncer: vi.fn(
+    <T>(params: { onFlush: (entries: T[]) => Promise<void> | void }) => ({
+      debouncer: {
+        enqueue: async (entry: T) => {
+          await params.onFlush([entry]);
+        },
+      },
+    }),
+  ),
+  formatInboundEnvelope: vi.fn(
+    (params: {
+      body?: string;
+      chatType?: string;
+      senderLabel?: string;
+      sender?: { name?: string; id?: string };
+    }) => {
+      const body = params.body ?? "";
+      if (params.chatType && params.chatType !== "direct") {
+        const senderLabel =
+          params.senderLabel?.trim() ||
+          params.sender?.name?.trim() ||
+          params.sender?.id?.trim() ||
+          "";
+        return senderLabel ? `${senderLabel}: ${body}` : body;
+      }
+      return body;
+    },
+  ),
+  formatInboundFromLabel: vi.fn(
+    (params: {
+      isGroup?: boolean;
+      groupLabel?: string;
+      groupId?: string;
+      directLabel?: string;
+      directId?: string;
+    }) => {
+      if (params.isGroup) {
+        const label = params.groupLabel?.trim() || "Group";
+        const id = params.groupId?.trim();
+        return id ? `${label} id:${id}` : label;
+      }
+      const directLabel = params.directLabel?.trim();
+      const directId = params.directId?.trim();
+      if (!directId || directId === directLabel) {
+        return directLabel ?? "";
+      }
+      return directLabel ? `${directLabel} id:${directId}` : directId;
+    },
+  ),
+  matchesMentionPatterns: vi.fn(() => false),
+  resolveEnvelopeFormatOptions: vi.fn(() => ({})),
+  shouldDebounceTextInbound: vi.fn(() => false),
+  logInboundDrop: vi.fn(),
+  resolveMentionGatingWithBypass: vi.fn((params: { wasMentioned?: boolean }) => ({
+    effectiveWasMentioned: params.wasMentioned === true,
+    shouldSkip: false,
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-reply-pipeline", () => ({
+  createChannelReplyPipeline: vi.fn(
+    (params: {
+      typing?: { start?: () => Promise<void> | void; stop?: () => Promise<void> | void };
+    }) => ({
+      onModelSelected: undefined,
+      typingCallbacks: params.typing
+        ? {
+            start: params.typing.start,
+            stop: params.typing.stop,
+          }
+        : {},
+    }),
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/hook-runtime", () => ({
+  createInternalHookEvent: vi.fn((...args: unknown[]) => ({ args })),
+  fireAndForgetHook: vi.fn(),
+  toInternalMessageReceivedContext: vi.fn((ctx: Record<string, unknown>) => ctx),
+  triggerInternalHook: vi.fn(async () => undefined),
+}));
+
+vi.mock("openclaw/plugin-sdk/infra-runtime", () => ({
+  enqueueSystemEvent: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/command-auth", () => ({
+  hasControlCommand: vi.fn((text: string) => text.trim().startsWith("/")),
+  resolveControlCommandGate: vi.fn(
+    (params: {
+      authorizers: Array<{ configured: boolean; allowed: boolean }>;
+      hasControlCommand: boolean;
+    }) => {
+      const anyConfigured = params.authorizers.some((entry) => entry.configured);
+      const anyAllowed = params.authorizers.some((entry) => entry.allowed);
+      return {
+        commandAuthorized: params.hasControlCommand ? (anyConfigured ? anyAllowed : false) : true,
+        shouldBlock: params.hasControlCommand && anyConfigured && !anyAllowed,
+      };
+    },
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/config-runtime", () => ({
+  resolveChannelContextVisibilityMode: vi.fn(
+    (params: { cfg?: { channels?: { signal?: { contextVisibility?: string } } } }) =>
+      params.cfg?.channels?.signal?.contextVisibility ?? "all",
+  ),
+  resolveChannelGroupPolicy: vi.fn(() => ({
+    defaultConfig: { ingest: false },
+    groupConfig: undefined,
+  })),
+  resolveChannelGroupRequireMention: vi.fn(() => false),
+  readSessionUpdatedAt: vi.fn(() => undefined),
+  resolveStorePath: vi.fn(() => "/tmp/openclaw-signal-test-sessions.json"),
+}));
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", () => ({
+  recordInboundSession: vi.fn(async () => {}),
+  upsertChannelPairingRequest: vi.fn(async () => {}),
+}));
+
+vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
+  kindFromMime: vi.fn((contentType?: string) => {
+    const normalized = contentType?.split(";")[0]?.trim().toLowerCase();
+    if (!normalized) {
+      return undefined;
+    }
+    if (normalized.startsWith("image/")) {
+      return "image";
+    }
+    if (normalized.startsWith("audio/")) {
+      return "audio";
+    }
+    if (normalized.startsWith("video/")) {
+      return "video";
+    }
+    return "attachment";
+  }),
+}));
+
+vi.mock("openclaw/plugin-sdk/reply-history", () => ({
+  buildPendingHistoryContextFromMap: vi.fn(
+    (params: {
+      currentMessage: string;
+      historyMap: Map<
+        string,
+        Array<{ sender: string; body: string; timestamp?: number; messageId?: string }>
+      >;
+      historyKey: string;
+      formatEntry: (entry: {
+        sender: string;
+        body: string;
+        timestamp?: number;
+        messageId?: string;
+      }) => string;
+    }) => {
+      const previous = params.historyMap.get(params.historyKey) ?? [];
+      const formatted = previous.map((entry) => params.formatEntry(entry));
+      return [...formatted, params.currentMessage].join("\n");
+    },
+  ),
+  clearHistoryEntriesIfEnabled: vi.fn(
+    (params: { historyMap: Map<string, unknown[]>; historyKey: string }) => {
+      params.historyMap.delete(params.historyKey);
+    },
+  ),
+  recordPendingHistoryEntryIfEnabled: vi.fn(
+    (params: { historyMap: Map<string, unknown[]>; historyKey: string; entry: unknown }) => {
+      const current = params.historyMap.get(params.historyKey) ?? [];
+      current.push(params.entry);
+      params.historyMap.set(params.historyKey, current);
+    },
+  ),
+}));
+
 vi.mock("../send.js", () => ({
   sendMessageSignal: vi.fn(),
   sendTypingSignal: sendTypingMock,
   sendReadReceiptSignal: sendReadReceiptMock,
 }));
 
-vi.mock("../../../../src/auto-reply/dispatch.js", async () => {
-  const actual = await vi.importActual<typeof import("../../../../src/auto-reply/dispatch.js")>(
-    "../../../../src/auto-reply/dispatch.js",
+vi.mock("openclaw/plugin-sdk/reply-runtime", () => {
+  const finalizeInboundContext = vi.fn(
+    (ctx: Record<string, unknown>) => ctx as unknown as MsgContext,
+  );
+  const createReplyDispatcherWithTyping = vi.fn(
+    (params: { typingCallbacks?: { start?: () => Promise<void> | void } }) => ({
+      dispatcher: {},
+      replyOptions: {
+        onReplyStart: async () => {
+          await Promise.resolve(params.typingCallbacks?.start?.());
+        },
+      },
+      markDispatchIdle: () => {},
+    }),
   );
   return {
-    ...actual,
+    finalizeInboundContext,
+    createReplyDispatcherWithTyping,
     dispatchInboundMessage: dispatchInboundMessageMock,
     dispatchInboundMessageWithDispatcher: dispatchInboundMessageMock,
     dispatchInboundMessageWithBufferedDispatcher: dispatchInboundMessageMock,
   };
 });
 
+vi.mock("openclaw/plugin-sdk/routing", () => ({
+  resolveAgentRoute: vi.fn((params: { accountId: string; peer: { kind: string; id: string } }) => ({
+    agentId: "main",
+    accountId: params.accountId,
+    sessionKey: `agent:main:signal:${params.peer.kind}:${params.peer.id}`,
+    mainSessionKey: "agent:main:main",
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+  danger: vi.fn((text: string) => text),
+  logVerbose: vi.fn(),
+  shouldLogVerbose: vi.fn(() => false),
+}));
+
+vi.mock("openclaw/plugin-sdk/security-runtime", () => ({
+  DM_GROUP_ACCESS_REASON: {
+    GROUP_POLICY_ALLOWED: "group_policy_allowed",
+    GROUP_POLICY_DISABLED: "group_policy_disabled",
+    GROUP_POLICY_EMPTY_ALLOWLIST: "group_policy_empty_allowlist",
+    GROUP_POLICY_NOT_ALLOWLISTED: "group_policy_not_allowlisted",
+    DM_POLICY_OPEN: "dm_policy_open",
+    DM_POLICY_DISABLED: "dm_policy_disabled",
+    DM_POLICY_ALLOWLISTED: "dm_policy_allowlisted",
+    DM_POLICY_PAIRING_REQUIRED: "dm_policy_pairing_required",
+    DM_POLICY_NOT_ALLOWLISTED: "dm_policy_not_allowlisted",
+  },
+  evaluateSupplementalContextVisibility: vi.fn(
+    (params: { mode?: string | null; kind?: string | null; senderAllowed?: boolean }) => {
+      const mode = params.mode ?? "all";
+      if (mode === "none") {
+        return { include: false };
+      }
+      if (mode === "allowlist") {
+        return { include: params.senderAllowed === true };
+      }
+      if (mode === "allowlist_quote") {
+        return { include: params.kind === "quote" ? true : params.senderAllowed === true };
+      }
+      return { include: true };
+    },
+  ),
+  resolvePinnedMainDmOwnerFromAllowlist: vi.fn(() => undefined),
+  readStoreAllowFromForDmPolicy: vi.fn(async () => []),
+  resolveDmGroupAccessWithLists: vi.fn(
+    (params: {
+      isGroup: boolean;
+      dmPolicy?: string | null;
+      groupPolicy?: string | null;
+      allowFrom?: Array<string | number> | null;
+      groupAllowFrom?: Array<string | number> | null;
+      storeAllowFrom?: Array<string | number> | null;
+      isSenderAllowed: (allowFrom: string[]) => boolean;
+    }) => {
+      const normalizeList = (entries?: Array<string | number> | null) =>
+        (entries ?? []).map((entry) => String(entry));
+      const effectiveAllowFrom =
+        params.dmPolicy === "allowlist"
+          ? normalizeList(params.allowFrom)
+          : Array.from(
+              new Set([
+                ...normalizeList(params.allowFrom),
+                ...normalizeList(params.storeAllowFrom),
+              ]),
+            );
+      const effectiveGroupAllowFrom = normalizeList(params.groupAllowFrom ?? params.allowFrom);
+
+      if (params.isGroup) {
+        if (params.groupPolicy === "disabled") {
+          return {
+            decision: "block",
+            reasonCode: "group_policy_disabled",
+            reason: "groupPolicy=disabled",
+            effectiveAllowFrom,
+            effectiveGroupAllowFrom,
+          };
+        }
+        if (
+          (params.groupPolicy ?? "allowlist") === "allowlist" &&
+          effectiveGroupAllowFrom.length === 0
+        ) {
+          return {
+            decision: "block",
+            reasonCode: "group_policy_empty_allowlist",
+            reason: "groupPolicy=allowlist (empty allowlist)",
+            effectiveAllowFrom,
+            effectiveGroupAllowFrom,
+          };
+        }
+        if (
+          (params.groupPolicy ?? "allowlist") === "allowlist" &&
+          !params.isSenderAllowed(effectiveGroupAllowFrom)
+        ) {
+          return {
+            decision: "block",
+            reasonCode: "group_policy_not_allowlisted",
+            reason: "groupPolicy=allowlist (not allowlisted)",
+            effectiveAllowFrom,
+            effectiveGroupAllowFrom,
+          };
+        }
+        return {
+          decision: "allow",
+          reasonCode: "group_policy_allowed",
+          reason: `groupPolicy=${params.groupPolicy ?? "allowlist"}`,
+          effectiveAllowFrom,
+          effectiveGroupAllowFrom,
+        };
+      }
+
+      if (params.dmPolicy === "disabled") {
+        return {
+          decision: "block",
+          reasonCode: "dm_policy_disabled",
+          reason: "dmPolicy=disabled",
+          effectiveAllowFrom,
+          effectiveGroupAllowFrom,
+        };
+      }
+      if (params.dmPolicy === "open") {
+        return {
+          decision: "allow",
+          reasonCode: "dm_policy_open",
+          reason: "dmPolicy=open",
+          effectiveAllowFrom,
+          effectiveGroupAllowFrom,
+        };
+      }
+      if (params.isSenderAllowed(effectiveAllowFrom)) {
+        return {
+          decision: "allow",
+          reasonCode: "dm_policy_allowlisted",
+          reason: `dmPolicy=${params.dmPolicy ?? "pairing"} (allowlisted)`,
+          effectiveAllowFrom,
+          effectiveGroupAllowFrom,
+        };
+      }
+      if ((params.dmPolicy ?? "pairing") === "pairing") {
+        return {
+          decision: "pairing",
+          reasonCode: "dm_policy_pairing_required",
+          reason: "dmPolicy=pairing (not allowlisted)",
+          effectiveAllowFrom,
+          effectiveGroupAllowFrom,
+        };
+      }
+      return {
+        decision: "block",
+        reasonCode: "dm_policy_not_allowlisted",
+        reason: `dmPolicy=${params.dmPolicy ?? "pairing"} (not allowlisted)`,
+        effectiveAllowFrom,
+        effectiveGroupAllowFrom,
+      };
+    },
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/text-runtime", () => ({
+  normalizeE164: vi.fn((value: string | undefined | null) => value ?? undefined),
+}));
+
 vi.mock("../../../../src/pairing/pairing-store.js", () => ({
   readChannelAllowFromStore: vi.fn().mockResolvedValue([]),
   upsertChannelPairingRequest: vi.fn(),
 }));
+
+vi.useRealTimers();
+
+const { createBaseSignalEventHandlerDeps, createSignalReceiveEvent } =
+  await import("./event-handler.test-harness.js");
+const { createSignalEventHandler } = await import("./event-handler.js");
 
 describe("signal createSignalEventHandler inbound context", () => {
   beforeEach(() => {

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -486,6 +486,38 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(capture.ctx?.ReplyToIsQuote).toBe(true);
   });
 
+  it("marks media-only Signal quotes as quoted replies", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "replying to photo",
+          attachments: [],
+          quote: {
+            id: 1700000001000,
+            author: {
+              uuid: "8f8f8f8f-1111-2222-3333-444444444444",
+              name: "Photo Sender",
+            },
+          },
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.ReplyToId).toBe("1700000001000");
+    expect(capture.ctx?.ReplyToBody).toBeUndefined();
+    expect(capture.ctx?.ReplyToSender).toBe("Photo Sender");
+    expect(capture.ctx?.ReplyToIsQuote).toBe(true);
+  });
+
   it("normalizes direct chat To/OriginatingTo targets to canonical Signal ids", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -94,6 +94,19 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", () => ({
     effectiveWasMentioned: params.wasMentioned === true,
     shouldSkip: false,
   })),
+  resolveInboundMentionDecision: vi.fn(
+    (params: {
+      facts: { canDetectMention?: boolean; wasMentioned?: boolean };
+      policy: { isGroup?: boolean; requireMention?: boolean };
+    }) => ({
+      effectiveWasMentioned: params.facts.wasMentioned === true,
+      shouldSkip:
+        params.policy.isGroup === true &&
+        params.policy.requireMention === true &&
+        params.facts.canDetectMention === true &&
+        params.facts.wasMentioned !== true,
+    }),
+  ),
 }));
 
 vi.mock("openclaw/plugin-sdk/channel-reply-pipeline", () => ({
@@ -402,6 +415,12 @@ vi.mock("openclaw/plugin-sdk/security-runtime", () => ({
 
 vi.mock("openclaw/plugin-sdk/text-runtime", () => ({
   normalizeE164: vi.fn((value: string | undefined | null) => value ?? undefined),
+  normalizeLowercaseStringOrEmpty: vi.fn((value: unknown) =>
+    typeof value === "string" ? value.trim().toLowerCase() : "",
+  ),
+  normalizeOptionalString: vi.fn((value: unknown) =>
+    typeof value === "string" ? value.trim() || undefined : undefined,
+  ),
 }));
 
 vi.mock("../../../../src/pairing/pairing-store.js", () => ({

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -89,6 +89,39 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(String(contextWithBody.Body ?? "")).not.toContain("[from:");
   });
 
+  it("surfaces quoted Signal reply context in MsgContext", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        // oxlint-disable-next-line typescript/no-explicit-any
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "my reply",
+          attachments: [],
+          quote: {
+            id: 1700000000999,
+            text: "not really, no",
+            author: {
+              number: "+15550009999",
+              name: "Sagan",
+            },
+          },
+        },
+      }),
+    );
+
+    expect(capture.ctx).toBeTruthy();
+    expect(capture.ctx?.ReplyToId).toBe("1700000000999");
+    expect(capture.ctx?.ReplyToBody).toBe("not really, no");
+    expect(capture.ctx?.ReplyToSender).toBe("Sagan");
+    expect(capture.ctx?.ReplyToIsQuote).toBe(true);
+  });
+
   it("normalizes direct chat To/OriginatingTo targets to canonical Signal ids", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -832,9 +832,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       quote?.id !== undefined && quote?.id !== null && String(quote.id).trim().length > 0
         ? String(quote.id).trim()
         : undefined;
-    const hasVisibleQuoteContext = quoteVisibilityDecision.include
-      ? Boolean(quotedId || visibleQuoteText || visibleQuoteSender)
-      : false;
+    const hasVisibleQuoteContext = quoteVisibilityDecision.include && Boolean(quote);
     const visibleQuoteId = hasVisibleQuoteContext ? quotedId : undefined;
     const bodyText = messageText || placeholder || visibleQuoteText || "";
     if (!bodyText) {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -122,6 +122,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     mediaTypes?: string[];
     commandAuthorized: boolean;
     wasMentioned?: boolean;
+    replyToId?: string;
     replyToBody?: string;
     replyToSender?: string;
     replyToIsQuote?: boolean;
@@ -216,6 +217,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       Provider: "signal" as const,
       Surface: "signal" as const,
       MessageSid: entry.messageId,
+      ReplyToId: entry.replyToId,
       ReplyToBody: entry.replyToBody,
       ReplyToSender: entry.replyToSender,
       ReplyToIsQuote: entry.replyToIsQuote,
@@ -549,14 +551,19 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         sender,
       });
     const quoteText = normalizeOptionalString(dataMessage?.quote?.text) ?? "";
-    const { contextVisibilityMode, quoteSenderAllowed, visibleQuoteText, visibleQuoteSender } =
-      resolveSignalQuoteContext({
-        cfg: deps.cfg,
-        accountId: deps.accountId,
-        isGroup,
-        dataMessage,
-        effectiveGroupAllow,
-      });
+    const {
+      contextVisibilityMode,
+      decision: quoteVisibilityDecision,
+      quoteSenderAllowed,
+      visibleQuoteText,
+      visibleQuoteSender,
+    } = resolveSignalQuoteContext({
+      cfg: deps.cfg,
+      accountId: deps.accountId,
+      isGroup,
+      dataMessage,
+      effectiveGroupAllow,
+    });
     if (quoteText && !visibleQuoteText && isGroup) {
       logVerbose(
         `signal: drop quote context (mode=${contextVisibilityMode}, sender_allowed=${quoteSenderAllowed ? "yes" : "no"})`,
@@ -820,6 +827,15 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       }
     }
 
+    const quote = dataMessage.quote ?? undefined;
+    const quotedId =
+      quote?.id !== undefined && quote?.id !== null && String(quote.id).trim().length > 0
+        ? String(quote.id).trim()
+        : undefined;
+    const hasVisibleQuoteContext = quoteVisibilityDecision.include
+      ? Boolean(quotedId || visibleQuoteText || visibleQuoteSender)
+      : false;
+    const visibleQuoteId = hasVisibleQuoteContext ? quotedId : undefined;
     const bodyText = messageText || placeholder || visibleQuoteText || "";
     if (!bodyText) {
       return;
@@ -872,9 +888,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
+      replyToId: visibleQuoteId,
       replyToBody: visibleQuoteText || undefined,
       replyToSender: visibleQuoteSender,
-      replyToIsQuote: visibleQuoteText ? true : undefined,
+      replyToIsQuote: hasVisibleQuoteContext ? true : undefined,
     });
   };
 }

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -39,7 +39,15 @@ export type SignalDataMessage = {
   } | null;
   quote?: {
     text?: string | null;
-    author?: string | null;
+    id?: number | string | null;
+    author?:
+      | string
+      | {
+          number?: string | null;
+          uuid?: string | null;
+          name?: string | null;
+        }
+      | null;
     authorUuid?: string | null;
   } | null;
   reaction?: SignalReactionMessage | null;

--- a/extensions/signal/src/monitor/inbound-context.ts
+++ b/extensions/signal/src/monitor/inbound-context.ts
@@ -32,9 +32,13 @@ export function resolveSignalQuoteContext(params: {
     accountId: params.accountId,
   });
   const quoteText = normalizeOptionalString(params.dataMessage?.quote?.text) ?? "";
+  const quoteAuthor = params.dataMessage?.quote?.author;
   const quoteSender = resolveSignalSender({
-    sourceNumber: params.dataMessage?.quote?.author ?? null,
-    sourceUuid: params.dataMessage?.quote?.authorUuid ?? null,
+    sourceNumber: typeof quoteAuthor === "string" ? quoteAuthor : (quoteAuthor?.number ?? null),
+    sourceUuid:
+      (typeof quoteAuthor === "object" && quoteAuthor ? quoteAuthor.uuid : null) ??
+      params.dataMessage?.quote?.authorUuid ??
+      null,
   });
   const quoteSenderAllowed =
     !params.isGroup || params.effectiveGroupAllow.length === 0
@@ -54,6 +58,12 @@ export function resolveSignalQuoteContext(params: {
     quoteSenderAllowed,
     visibleQuoteText: decision.include ? quoteText : "",
     visibleQuoteSender:
-      decision.include && quoteSender ? formatSignalSenderDisplay(quoteSender) : undefined,
+      !decision.include
+        ? undefined
+        : typeof quoteAuthor === "object" && quoteAuthor?.name?.trim()
+          ? quoteAuthor.name.trim()
+          : quoteSender
+            ? formatSignalSenderDisplay(quoteSender)
+            : undefined,
   };
 }

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2341,6 +2341,10 @@ describe("dispatchReplyFromConfig", () => {
       AccountId: "acc-1",
       GroupSpace: "guild-123",
       GroupChannel: "alerts",
+      ReplyToId: "reply-42",
+      ReplyToBody: "quoted text",
+      ReplyToSender: "Bob",
+      ReplyToIsQuote: true,
     });
 
     const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
@@ -2361,6 +2365,10 @@ describe("dispatchReplyFromConfig", () => {
           senderE164: "+15555550123",
           guildId: "guild-123",
           channelName: "alerts",
+          replyToId: "reply-42",
+          replyToBody: "quoted text",
+          replyToSender: "Bob",
+          replyToIsQuote: true,
         }),
       }),
       expect.objectContaining({
@@ -2565,6 +2573,10 @@ describe("dispatchReplyFromConfig", () => {
       Body: "who are you",
       MessageSid: "msg-claim-plugin-1",
       SessionKey: "agent:main:discord:channel:1481858418548412579",
+      ReplyToId: "reply-msg-1",
+      ReplyToBody: "previous question",
+      ReplyToSender: "Grace",
+      ReplyToIsQuote: true,
     });
     const replyResolver = vi.fn(async () => ({ text: "should not run" }) satisfies ReplyPayload);
 
@@ -2579,6 +2591,12 @@ describe("dispatchReplyFromConfig", () => {
         accountId: "default",
         conversationId: "channel:1481858418548412579",
         content: "who are you",
+        metadata: expect.objectContaining({
+          replyToId: "reply-msg-1",
+          replyToBody: "previous question",
+          replyToSender: "Grace",
+          replyToIsQuote: true,
+        }),
       }),
       expect.objectContaining({
         channelId: "discord",

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -277,6 +277,10 @@ export function toPluginInboundClaimEvent(
       channelName: canonical.channelName,
       groupId: canonical.groupId,
       topicName: canonical.topicName,
+      replyToId: canonical.replyToId,
+      replyToBody: canonical.replyToBody,
+      replyToSender: canonical.replyToSender,
+      replyToIsQuote: canonical.replyToIsQuote,
     },
   };
 }
@@ -304,6 +308,10 @@ export function toPluginMessageReceivedEvent(
       guildId: canonical.guildId,
       channelName: canonical.channelName,
       topicName: canonical.topicName,
+      replyToId: canonical.replyToId,
+      replyToBody: canonical.replyToBody,
+      replyToSender: canonical.replyToSender,
+      replyToIsQuote: canonical.replyToIsQuote,
     },
   };
 }

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -46,6 +46,10 @@ export type CanonicalInboundMessageHookContext = {
   originatingTo?: string;
   guildId?: string;
   channelName?: string;
+  replyToId?: string;
+  replyToBody?: string;
+  replyToSender?: string;
+  replyToIsQuote?: boolean;
   isGroup: boolean;
   groupId?: string;
   topicName?: string;
@@ -130,6 +134,10 @@ export function deriveInboundMessageHookContext(
     originatingTo: ctx.OriginatingTo,
     guildId: ctx.GroupSpace,
     channelName: ctx.GroupChannel,
+    replyToId: ctx.ReplyToId,
+    replyToBody: ctx.ReplyToBody,
+    replyToSender: ctx.ReplyToSender,
+    replyToIsQuote: ctx.ReplyToIsQuote,
     isGroup,
     groupId: isGroup ? conversationId : undefined,
     topicName: ctx.TopicName,
@@ -334,6 +342,10 @@ export function toInternalMessageReceivedContext(
       guildId: canonical.guildId,
       channelName: canonical.channelName,
       topicName: canonical.topicName,
+      replyToId: canonical.replyToId,
+      replyToBody: canonical.replyToBody,
+      replyToSender: canonical.replyToSender,
+      replyToIsQuote: canonical.replyToIsQuote,
     },
   };
 }


### PR DESCRIPTION
## Summary

  Describe the problem and fix in 2–5 bullets:

  - Problem: Signal quoted replies were only used as a fallback body, so quote id/author context was dropped before hooks saw the message, as a result OpenClaw could not see quote replies. This PR adds that feature.
  - What changed: Signal inbound handling now maps quote metadata into `MsgContext`, hook mappers forward that reply metadata into plugin/internal hook events, and the Signal inbound-context test was rewritten to mock heavy seams before import so the coverage actually runs.
  - This PR depends on running signal-cli 0.13.14 or greater. I explicitly didn't couple verifying that is present with this PR, but can do so in a follow-up PR. I have a draft of doing it in Doctor but ran into test timeout hell with doctor-install.ts tests. 
  - The tests I (via Codex) wrote are also heavily mocked due to timeout issues. Happy to discuss trade-offs / adjust.
 
  ## Change Type (select all)

  - [x] Bug fix
  - [x] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Integrations
  - [x] API / contracts
  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related #
  - [x] This PR fixes a bug or regression

  ## Root Cause / Regression History (if applicable)

  - Root cause: `extensions/signal/src/monitor/event-handler.ts` only treated `dataMessage.quote.text` as a body fallback and never mapped quote id/author into finalized inbound context; `src/hooks/message-hook-mappers.ts` also did not forward reply metadata into plugin/internal hook events.
  - Missing detection / guardrail: no Signal hook-path test asserted `ReplyTo*` propagation end-to-end, and the old inbound-context test was heavy enough to stall on import.
  - Prior context (`git blame`, prior PR, issue, or refactor if known): long-standing omission in Signal inbound context plus generic hook canonicalization; not tied to a known recent refactor.
  - Why this regressed now: not a recent regression, more an exposed gap once reply-aware hook consumers needed quote context.
  - If unknown, what was ruled out: N/A

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [ ] Unit test
    - [x] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file: `extensions/signal/src/monitor/event-handler.inbound-context.test.ts` and `src/auto-reply/reply/dispatch-from-config.test.ts`
  - Scenario the test should lock in: a quoted Signal inbound message populates `ReplyToId`, `ReplyToBody`, `ReplyToSender`, and `ReplyToIsQuote` in `MsgContext`, and hook metadata preserves those fields.
  - Why this is the smallest reliable guardrail: it covers Signal parsing, finalized inbound context, and hook mapping without needing a live Signal daemon.
  - Existing test that already covers this (if any): `src/auto-reply/reply/dispatch-from-config.test.ts` now covers reply metadata on hook emission once the inbound context includes it.
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  - Signal inbound hook consumers now receive quoted-reply metadata in hook payloads: `replyToId`, `replyToBody`, `replyToSender`, and `replyToIsQuote`.
  - No config, env, or default behavior changes.
  - Test-only change: the focused Signal inbound-context test no longer stalls on import.

  ## Diagram (if applicable)

  ```text
  Before:
  Signal quoted reply -> quote text maybe used as fallback body -> hook metadata loses reply context

  After:
  Signal quoted reply -> MsgContext ReplyTo* fields -> canonical hook context -> plugin/internal hooks receive reply metadata
```

  ## Security Impact (required)

  - New permissions/capabilities? (No)
  - Secrets/tokens handling changed? (No)
  - New/changed network calls? (No)
  - Command/tool execution surface changed? (No)
  - Data access scope changed? (No)
  - If any Yes, explain risk + mitigation: N/A

  ## Repro + Verification

  ### Environment

  - OS: tested Linux & macOS
  - Runtime/container: Node 24 + pnpm + Vitest
  - Model/provider: gpt 5.4
  - Integration/channel (if any): Signal
  - Relevant config (redacted): synthetic Signal receive envelope via test harness; default Signal test deps with quoted reply payload

  ### Steps

  1. From main or latest release, quote reply in Signal, and ask the OpenClaw to play it back. 

  ### Expected

  - OpenClaw can see the quoted message.

  ### Actual

  - OpenClaw cannot see the quoted message.

  ## Evidence

  Attach at least one:

  - [ ] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [x] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios: quoted Signal replies can be played back by OpenClaw assertions still pass; hook metadata propagation is covered in src/auto-reply/reply/dispatch-from-config.test.ts.
  - Edge cases checked: quote id normalization to string, quote author fallback ordering, and no import-time hang in the focused Signal test.
  - What you did not verify: live Signal daemon roundtrip or third-party plugin end-to-end hook consumption.

<img width="1047" height="262" alt="Screenshot 2026-03-30 at 10 44 15 AM" src="https://github.com/user-attachments/assets/91a88abc-6cbe-4d2f-bfbd-ef46b49d822a" />

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? (Yes)
  - Config/env changes? (No)
  - Migration needed? (No)
  - If yes, exact upgrade steps: N/A

  ## Risks and Mitigations

  - Risk: reply metadata is now present in hook payloads where some plugin consumers may have assumed it was absent.
      - Mitigation: the fields are additive and optional, so existing consumers can ignore them safely.
  - Risk: the new test uses aggressive pre-import mocks and could drift from runtime behavior.
      - Mitigation: the assertions stay focused on externally observable handler behavior, and pnpm check plus the targeted Signal test remain green.