### PR TITLE
docs: add positional interpreter category to exec-approvals

### DIFF
--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -196,10 +196,18 @@ Examples:
 - `lua -e`
 - `osascript -e`
 
+Positional interpreters — commands that accept code as a positional argument rather than behind a flag — are also treated as interpreter-like:
+
+- `awk`, `gawk`, `mawk`, `nawk`
+
+These are blocked from `allow-always` persistence regardless of `strictInlineEval`, because their
+first positional argument is executable code (e.g. `awk '{print $1}'`), making stable file binding
+infeasible.
+
 This is defense-in-depth for interpreter loaders that do not map cleanly to one stable file operand. In strict mode:
 
-- these commands still need explicit approval;
-- `allow-always` does not persist new allowlist entries for them automatically.
+- flag-based inline eval commands still need explicit approval;
+- `allow-always` does not persist new allowlist entries for any interpreter-like command (flag-based or positional) automatically.
 
 ## Allowlist (per agent)
 

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -206,8 +206,9 @@ infeasible.
 
 This is defense-in-depth for interpreter loaders that do not map cleanly to one stable file operand. In strict mode:
 
-- flag-based inline eval commands still need explicit approval;
-- `allow-always` does not persist new allowlist entries for any interpreter-like command (flag-based or positional) automatically.
+- flag-based inline eval commands still need explicit approval (approval-only even when the interpreter binary is allowlisted);
+- `allow-always` does not persist new allowlist entries for any interpreter-like command (flag-based or positional) automatically;
+- positional interpreters (awk family) are not additionally restricted by strict mode beyond `allow-always` blocking — their code-as-argument nature already prevents stable file binding regardless of the setting.
 
 ## Allowlist (per agent)
 


### PR DESCRIPTION
## Summary

PR #57772 added `awk`/`gawk`/`mawk`/`nawk` as **positional interpreter** types that are now:
- blocked from `allow-always` persistence via `isInterpreterLikeAllowlistPattern()`
- detected as interpreter-like in allowlist pattern evaluation

The exec-approvals doc currently only lists flag-based inline eval interpreters (`python -c`, `node -e`, etc.) and does not mention this new positional interpreter category.

## Changes

`docs/tools/exec-approvals.md`:

- Added a "Positional interpreters" paragraph under the inline eval hardening section, listing `awk`, `gawk`, `mawk`, `nawk`
- Clarified that positional interpreters are blocked from `allow-always` regardless of `strictInlineEval` (since code is a positional arg, not behind a flag)
- Updated the summary bullets to distinguish flag-based and positional interpreter behavior

## Context

Companion to #57772 — keeps the docs 1:1 with the runtime behavior for the new positional interpreter detection.