### PR TITLE
test(extensions): add unit tests for speech-core, image-generation-core, and media-understanding-core

### DIFF
--- a/extensions/image-generation-core/src/runtime.test.ts
+++ b/extensions/image-generation-core/src/runtime.test.ts
@@ -17,9 +17,9 @@ const {
 } = vi.hoisted(() => ({
   mockGetImageGenerationProvider: vi.fn(),
   mockParseImageGenerationModelRef: vi.fn(),
-  mockListImageGenerationProviders: vi.fn(() => []),
+  mockListImageGenerationProviders: vi.fn(),
   mockResolveAgentModelPrimaryValue: vi.fn((v: unknown) => v),
-  mockResolveAgentModelFallbackValues: vi.fn(() => []),
+  mockResolveAgentModelFallbackValues: vi.fn(),
   mockIsFailoverError: vi.fn(() => false),
   mockDescribeFailoverError: vi.fn(),
   mockLog: { debug: vi.fn() },

--- a/extensions/image-generation-core/src/runtime.test.ts
+++ b/extensions/image-generation-core/src/runtime.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — must use vi.hoisted so they are available before
+// the actual module import is evaluated.
+// ---------------------------------------------------------------------------
+
+const {
+  mockGetImageGenerationProvider,
+  mockParseImageGenerationModelRef,
+  mockListImageGenerationProviders,
+  mockResolveAgentModelPrimaryValue,
+  mockResolveAgentModelFallbackValues,
+  mockIsFailoverError,
+  mockDescribeFailoverError,
+  mockLog,
+} = vi.hoisted(() => ({
+  mockGetImageGenerationProvider: vi.fn(),
+  mockParseImageGenerationModelRef: vi.fn(),
+  mockListImageGenerationProviders: vi.fn(() => []),
+  mockResolveAgentModelPrimaryValue: vi.fn((v: unknown) => v),
+  mockResolveAgentModelFallbackValues: vi.fn(() => []),
+  mockIsFailoverError: vi.fn(() => false),
+  mockDescribeFailoverError: vi.fn(),
+  mockLog: { debug: vi.fn() },
+}));
+
+vi.mock("../api.js", () => ({
+  createSubsystemLogger: vi.fn(() => mockLog),
+  getImageGenerationProvider: mockGetImageGenerationProvider,
+  getProviderEnvVars: vi.fn(() => []),
+  isFailoverError: mockIsFailoverError,
+  describeFailoverError: mockDescribeFailoverError,
+  listImageGenerationProviders: mockListImageGenerationProviders,
+  parseImageGenerationModelRef: mockParseImageGenerationModelRef,
+  resolveAgentModelFallbackValues: mockResolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue: mockResolveAgentModelPrimaryValue,
+}));
+
+import { generateImage, listRuntimeImageGenerationProviders } from "./runtime.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSuccessProvider(overrides?: Partial<{ model: string }>) {
+  return {
+    generateImage: vi.fn(async () => ({
+      images: [
+        {
+          buffer: Buffer.from("png-data"),
+          mimeType: "image/png",
+          fileName: "image-1.png",
+        },
+      ],
+      model: overrides?.model ?? "dall-e-3",
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// generateImage
+// ---------------------------------------------------------------------------
+
+describe("generateImage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsFailoverError.mockReturnValue(false);
+    mockListImageGenerationProviders.mockReturnValue([]);
+    mockResolveAgentModelFallbackValues.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("throws when no model is configured (no candidates)", async () => {
+    // No modelOverride, no config → parseImageGenerationModelRef always returns null
+    mockParseImageGenerationModelRef.mockReturnValue(null);
+    mockResolveAgentModelPrimaryValue.mockReturnValue(undefined);
+
+    await expect(generateImage({ cfg: {}, prompt: "draw a cat" })).rejects.toThrow(
+      /No image-generation model configured/,
+    );
+  });
+
+  it("error message includes provider/model suggestion when providers are registered", async () => {
+    mockParseImageGenerationModelRef.mockReturnValue(null);
+    mockResolveAgentModelPrimaryValue.mockReturnValue(undefined);
+    mockListImageGenerationProviders.mockReturnValue([{ id: "openai", defaultModel: "dall-e-3" }]);
+
+    await expect(generateImage({ cfg: {}, prompt: "draw a cat" })).rejects.toThrow(
+      /openai\/dall-e-3/,
+    );
+  });
+
+  it("throws when the provider is not registered in the registry", async () => {
+    mockParseImageGenerationModelRef.mockReturnValue({ provider: "unknown", model: "v1" });
+    mockGetImageGenerationProvider.mockReturnValue(undefined);
+
+    await expect(
+      generateImage({ cfg: {}, prompt: "draw a cat", modelOverride: "unknown/v1" }),
+    ).rejects.toThrow(/No image-generation provider registered for unknown/);
+  });
+
+  it("throws when the provider returns an empty images array", async () => {
+    mockParseImageGenerationModelRef.mockReturnValue({ provider: "openai", model: "dall-e-3" });
+    mockGetImageGenerationProvider.mockReturnValue({
+      generateImage: vi.fn(async () => ({ images: [], model: "dall-e-3" })),
+    });
+
+    await expect(
+      generateImage({ cfg: {}, prompt: "draw a cat", modelOverride: "openai/dall-e-3" }),
+    ).rejects.toThrow("Image generation provider returned no images.");
+  });
+
+  it("returns the generated images on success", async () => {
+    mockParseImageGenerationModelRef.mockReturnValue({ provider: "openai", model: "dall-e-3" });
+    const provider = makeSuccessProvider();
+    mockGetImageGenerationProvider.mockReturnValue(provider);
+
+    const result = await generateImage({
+      cfg: {},
+      prompt: "draw a cat",
+      modelOverride: "openai/dall-e-3",
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0]).toMatchObject({
+      buffer: Buffer.from("png-data"),
+      mimeType: "image/png",
+    });
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("dall-e-3");
+    expect(result.attempts).toHaveLength(0);
+  });
+
+  it("passes prompt, count, size, and aspectRatio to the provider", async () => {
+    mockParseImageGenerationModelRef.mockReturnValue({ provider: "openai", model: "dall-e-3" });
+    const provider = makeSuccessProvider();
+    mockGetImageGenerationProvider.mockReturnValue(provider);
+
+    await generateImage({
+      cfg: {},
+      prompt: "wide shot",
+      modelOverride: "openai/dall-e-3",
+      count: 2,
+      size: "1792x1024",
+      aspectRatio: "16:9",
+    });
+
+    expect(provider.generateImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: "wide shot",
+        count: 2,
+        size: "1792x1024",
+        aspectRatio: "16:9",
+        model: "dall-e-3",
+        provider: "openai",
+      }),
+    );
+  });
+
+  it("falls back to the second candidate when the first throws", async () => {
+    mockParseImageGenerationModelRef
+      .mockReturnValueOnce({ provider: "failing", model: "v1" })
+      .mockReturnValueOnce({ provider: "openai", model: "dall-e-3" });
+    mockResolveAgentModelFallbackValues.mockReturnValue(["openai/dall-e-3"]);
+
+    const failingProvider = {
+      generateImage: vi.fn(async () => {
+        throw new Error("provider unavailable");
+      }),
+    };
+    const successProvider = makeSuccessProvider();
+    mockGetImageGenerationProvider
+      .mockReturnValueOnce(failingProvider)
+      .mockReturnValueOnce(successProvider);
+
+    const result = await generateImage({
+      cfg: {},
+      prompt: "draw a cat",
+      modelOverride: "failing/v1",
+    });
+
+    expect(result.provider).toBe("openai");
+    expect(result.attempts).toHaveLength(1);
+    expect(result.attempts[0]).toMatchObject({
+      provider: "failing",
+      model: "v1",
+      error: "provider unavailable",
+    });
+  });
+
+  it("throws with a summary of all attempts when all candidates fail", async () => {
+    mockParseImageGenerationModelRef
+      .mockReturnValueOnce({ provider: "a", model: "m1" })
+      .mockReturnValueOnce({ provider: "b", model: "m2" });
+    mockResolveAgentModelFallbackValues.mockReturnValue(["b/m2"]);
+
+    const failA = {
+      generateImage: vi.fn(async () => {
+        throw new Error("error A");
+      }),
+    };
+    const failB = {
+      generateImage: vi.fn(async () => {
+        throw new Error("error B");
+      }),
+    };
+    mockGetImageGenerationProvider.mockReturnValueOnce(failA).mockReturnValueOnce(failB);
+
+    await expect(
+      generateImage({ cfg: {}, prompt: "draw a cat", modelOverride: "a/m1" }),
+    ).rejects.toThrow(/All image generation models failed.*2/);
+  });
+
+  it("skips duplicate provider/model combinations", async () => {
+    // modelOverride and the config's primary value both parse to the same
+    // provider/model pair — the seen-set in resolveImageGenerationCandidates
+    // must drop the duplicate so generateImage is called exactly once.
+    mockParseImageGenerationModelRef
+      .mockReturnValueOnce({ provider: "openai", model: "dall-e-3" }) // from modelOverride
+      .mockReturnValueOnce({ provider: "openai", model: "dall-e-3" }); // from cfg primary
+    mockResolveAgentModelPrimaryValue.mockReturnValue("openai/dall-e-3");
+    const provider = makeSuccessProvider();
+    mockGetImageGenerationProvider.mockReturnValue(provider);
+
+    await generateImage({
+      cfg: {},
+      prompt: "draw a cat",
+      modelOverride: "openai/dall-e-3",
+    });
+
+    // Deduplication collapsed two identical candidates into one attempt.
+    expect(provider.generateImage).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listRuntimeImageGenerationProviders
+// ---------------------------------------------------------------------------
+
+describe("listRuntimeImageGenerationProviders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("delegates to listImageGenerationProviders", () => {
+    const providers = [{ id: "openai" }, { id: "fal" }];
+    mockListImageGenerationProviders.mockReturnValue(providers);
+
+    const result = listRuntimeImageGenerationProviders();
+    expect(result).toBe(providers);
+    expect(mockListImageGenerationProviders).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards the config argument to listImageGenerationProviders", () => {
+    mockListImageGenerationProviders.mockReturnValue([]);
+    const cfg = { models: { providers: {} } };
+
+    listRuntimeImageGenerationProviders({ config: cfg });
+    expect(mockListImageGenerationProviders).toHaveBeenCalledWith(cfg);
+  });
+
+  it("calls listImageGenerationProviders with undefined when no config is given", () => {
+    mockListImageGenerationProviders.mockReturnValue([]);
+
+    listRuntimeImageGenerationProviders();
+    expect(mockListImageGenerationProviders).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/extensions/media-understanding-core/src/runtime.test.ts
+++ b/extensions/media-understanding-core/src/runtime.test.ts
@@ -1,0 +1,404 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — hoisted so they are available before module evaluation.
+// ---------------------------------------------------------------------------
+
+const {
+  mockBuildProviderRegistry,
+  mockCreateMediaAttachmentCache,
+  mockNormalizeMediaAttachments,
+  mockNormalizeMediaProviderId,
+  mockRunCapability,
+  mockReadFile,
+} = vi.hoisted(() => ({
+  mockBuildProviderRegistry: vi.fn(),
+  mockCreateMediaAttachmentCache: vi.fn(),
+  mockNormalizeMediaAttachments: vi.fn(),
+  mockNormalizeMediaProviderId: vi.fn((id: string) => id),
+  mockRunCapability: vi.fn(),
+  mockReadFile: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
+  buildProviderRegistry: mockBuildProviderRegistry,
+  createMediaAttachmentCache: mockCreateMediaAttachmentCache,
+  normalizeMediaAttachments: mockNormalizeMediaAttachments,
+  normalizeMediaProviderId: mockNormalizeMediaProviderId,
+  runCapability: mockRunCapability,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  // Top-level named export covers any future refactor to named imports.
+  readFile: mockReadFile,
+  // Default export covers the current `import fs from "node:fs/promises"` usage.
+  default: { readFile: mockReadFile },
+}));
+
+import {
+  describeImageFile,
+  describeImageFileWithModel,
+  describeVideoFile,
+  runMediaUnderstandingFile,
+  transcribeAudioFile,
+} from "./runtime.js";
+
+// Reset mock implementations after every test so persistent mockImplementation
+// calls do not bleed across tests when running with --isolate=false.
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCache() {
+  return { cleanup: vi.fn(async () => {}) };
+}
+
+function makeCapabilityResult(overrides?: {
+  kind?: string;
+  text?: string;
+  provider?: string;
+  model?: string;
+}) {
+  return {
+    outputs: [
+      {
+        kind: overrides?.kind ?? "image.description",
+        text: overrides?.text ?? "A fluffy cat",
+        provider: overrides?.provider ?? "openai",
+        model: overrides?.model ?? "gpt-5.4",
+      },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// runMediaUnderstandingFile
+// ---------------------------------------------------------------------------
+
+describe("runMediaUnderstandingFile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNormalizeMediaProviderId.mockImplementation((id: string) => id);
+  });
+
+  it("returns undefined text when normalizeMediaAttachments returns empty array", async () => {
+    mockNormalizeMediaAttachments.mockReturnValue([]);
+
+    const result = await runMediaUnderstandingFile({
+      capability: "image",
+      filePath: "/tmp/cat.png",
+      cfg: {},
+    });
+
+    expect(result).toEqual({ text: undefined });
+    expect(mockRunCapability).not.toHaveBeenCalled();
+  });
+
+  it("returns early without calling providers when capability is disabled in config", async () => {
+    mockNormalizeMediaAttachments.mockReturnValue([{ id: "attach-1" }]);
+
+    const result = await runMediaUnderstandingFile({
+      capability: "image",
+      filePath: "/tmp/cat.png",
+      cfg: { tools: { media: { image: { enabled: false } } } },
+    });
+
+    expect(result).toEqual({
+      text: undefined,
+      provider: undefined,
+      model: undefined,
+      output: undefined,
+    });
+    expect(mockRunCapability).not.toHaveBeenCalled();
+  });
+
+  it("returns text, provider, and model on success", async () => {
+    mockNormalizeMediaAttachments.mockReturnValue([{ id: "attach-1" }]);
+    const cache = makeCache();
+    mockCreateMediaAttachmentCache.mockReturnValue(cache);
+    mockBuildProviderRegistry.mockReturnValue(new Map());
+    mockRunCapability.mockResolvedValue(makeCapabilityResult());
+
+    const result = await runMediaUnderstandingFile({
+      capability: "image",
+      filePath: "/tmp/cat.png",
+      cfg: {},
+    });
+
+    expect(result.text).toBe("A fluffy cat");
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("gpt-5.4");
+    expect(result.output).toBeDefined();
+  });
+
+  it("trims whitespace from output text", async () => {
+    mockNormalizeMediaAttachments.mockReturnValue([{ id: "attach-1" }]);
+    mockCreateMediaAttachmentCache.mockReturnValue(makeCache());
+    mockBuildProviderRegistry.mockReturnValue(new Map());
+    mockRunCapability.mockResolvedValue(makeCapabilityResult({ text: "  padded text  " }));
+
+    const result = await runMediaUnderstandingFile({
+      capability: "image",
+      filePath: "/tmp/cat.png",
+      cfg: {},
+    });
+
+    expect(result.text).toBe("padded text");
+  });
+
+  it("returns undefined text when output text is whitespace-only", async () => {
+    mockNormalizeMediaAttachments.mockReturnValue([{ id: "attach-1" }]);
+    mockCreateMediaAttachmentCache.mockReturnValue(makeCache());
+    mockBuildProviderRegistry.mockReturnValue(new Map());
+    mockRunCapability.mockResolvedValue(makeCapabilityResult({ text: "   " }));
+
+    const result = await runMediaUnderstandingFile({
+      capability: "image",
+      filePath: "/tmp/cat.png",
+      cfg: {},
+    });
+
+    expect(result.text).toBeUndefined();
+  });
+
+  it("calls cache.cleanup even when runCapability throws", async () => {
+    mockNormalizeMediaAttachments.mockReturnValue([{ id: "attach-1" }]);
+    const cache = makeCache();
+    mockCreateMediaAttachmentCache.mockReturnValue(cache);
+    mockBuildProviderRegistry.mockReturnValue(new Map());
+    mockRunCapability.mockRejectedValue(new Error("provider failure"));
+
+    await expect(
+      runMediaUnderstandingFile({
+        capability: "image",
+        filePath: "/tmp/cat.png",
+        cfg: {},
+      }),
+    ).rejects.toThrow("provider failure");
+
+    expect(cache.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls cache.cleanup on success", async () => {
+    mockNormalizeMediaAttachments.mockReturnValue([{ id: "attach-1" }]);
+    const cache = makeCache();
+    mockCreateMediaAttachmentCache.mockReturnValue(cache);
+    mockBuildProviderRegistry.mockReturnValue(new Map());
+    mockRunCapability.mockResolvedValue(makeCapabilityResult());
+
+    await runMediaUnderstandingFile({
+      capability: "image",
+      filePath: "/tmp/cat.png",
+      cfg: {},
+    });
+
+    expect(cache.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses audio.transcription output kind for audio capability", async () => {
+    mockNormalizeMediaAttachments.mockReturnValue([{ id: "attach-1" }]);
+    mockCreateMediaAttachmentCache.mockReturnValue(makeCache());
+    mockBuildProviderRegistry.mockReturnValue(new Map());
+    mockRunCapability.mockResolvedValue(
+      makeCapabilityResult({ kind: "audio.transcription", text: "Hello world" }),
+    );
+
+    const result = await runMediaUnderstandingFile({
+      capability: "audio",
+      filePath: "/tmp/clip.mp3",
+      cfg: {},
+    });
+
+    expect(result.text).toBe("Hello world");
+    expect(mockRunCapability).toHaveBeenCalledWith(
+      expect.objectContaining({ capability: "audio" }),
+    );
+  });
+
+  it("uses video.description output kind for video capability", async () => {
+    mockNormalizeMediaAttachments.mockReturnValue([{ id: "attach-1" }]);
+    mockCreateMediaAttachmentCache.mockReturnValue(makeCache());
+    mockBuildProviderRegistry.mockReturnValue(new Map());
+    mockRunCapability.mockResolvedValue(
+      makeCapabilityResult({ kind: "video.description", text: "A cat jumping" }),
+    );
+
+    const result = await runMediaUnderstandingFile({
+      capability: "video",
+      filePath: "/tmp/video.mp4",
+      cfg: {},
+    });
+
+    expect(result.text).toBe("A cat jumping");
+    expect(mockRunCapability).toHaveBeenCalledWith(
+      expect.objectContaining({ capability: "video" }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describeImageFile / describeVideoFile / transcribeAudioFile
+// ---------------------------------------------------------------------------
+
+describe("describeImageFile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("delegates to runMediaUnderstandingFile with capability=image", async () => {
+    mockNormalizeMediaAttachments.mockReturnValue([]);
+
+    const result = await describeImageFile({ filePath: "/tmp/img.jpg", cfg: {} });
+
+    expect(result).toEqual({ text: undefined });
+    expect(mockNormalizeMediaAttachments).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("describeVideoFile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("delegates to runMediaUnderstandingFile with capability=video", async () => {
+    mockNormalizeMediaAttachments.mockReturnValue([]);
+
+    const result = await describeVideoFile({ filePath: "/tmp/vid.mp4", cfg: {} });
+
+    expect(result).toEqual({ text: undefined });
+    expect(mockNormalizeMediaAttachments).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("transcribeAudioFile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns only text from the underlying result", async () => {
+    mockNormalizeMediaAttachments.mockReturnValue([{ id: "a" }]);
+    mockCreateMediaAttachmentCache.mockReturnValue(makeCache());
+    mockBuildProviderRegistry.mockReturnValue(new Map());
+    mockRunCapability.mockResolvedValue(
+      makeCapabilityResult({ kind: "audio.transcription", text: "Transcribed" }),
+    );
+
+    const result = await transcribeAudioFile({ filePath: "/tmp/clip.ogg", cfg: {} });
+
+    expect(result).toEqual({ text: "Transcribed" });
+    expect(Object.keys(result)).toEqual(["text"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describeImageFileWithModel
+// ---------------------------------------------------------------------------
+
+describe("describeImageFileWithModel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNormalizeMediaProviderId.mockImplementation((id: string) => id);
+  });
+
+  it("throws when the provider is not registered or lacks describeImage", async () => {
+    const registry = new Map();
+    mockBuildProviderRegistry.mockReturnValue(registry);
+
+    await expect(
+      describeImageFileWithModel({
+        filePath: "/tmp/cat.png",
+        cfg: {},
+        provider: "unknown-provider",
+        model: "v1",
+        prompt: "describe this",
+      }),
+    ).rejects.toThrow(/Provider does not support image analysis: unknown-provider/);
+  });
+
+  it("throws when provider exists but has no describeImage method", async () => {
+    const registry = new Map([["openai", { someOtherMethod: vi.fn() }]]);
+    mockBuildProviderRegistry.mockReturnValue(registry);
+
+    await expect(
+      describeImageFileWithModel({
+        filePath: "/tmp/cat.png",
+        cfg: {},
+        provider: "openai",
+        model: "gpt-5.4",
+        prompt: "describe this",
+      }),
+    ).rejects.toThrow(/Provider does not support image analysis: openai/);
+  });
+
+  it("calls provider.describeImage with correct params", async () => {
+    const mockDescribeImage = vi.fn(async () => ({ text: "A cat" }));
+    const registry = new Map([["openai", { describeImage: mockDescribeImage }]]);
+    mockBuildProviderRegistry.mockReturnValue(registry);
+    mockReadFile.mockResolvedValue(Buffer.from("image-bytes"));
+
+    await describeImageFileWithModel({
+      filePath: "/tmp/cat.png",
+      cfg: {},
+      provider: "openai",
+      model: "gpt-5.4",
+      prompt: "describe this",
+      maxTokens: 256,
+      timeoutMs: 10_000,
+    });
+
+    expect(mockDescribeImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: Buffer.from("image-bytes"),
+        fileName: "cat.png",
+        provider: "openai",
+        model: "gpt-5.4",
+        prompt: "describe this",
+        maxTokens: 256,
+        timeoutMs: 10_000,
+        cfg: {},
+        agentDir: "",
+      }),
+    );
+  });
+
+  it("defaults timeoutMs to 30000 when not provided", async () => {
+    const mockDescribeImage = vi.fn(async () => ({ text: "A cat" }));
+    const registry = new Map([["openai", { describeImage: mockDescribeImage }]]);
+    mockBuildProviderRegistry.mockReturnValue(registry);
+    mockReadFile.mockResolvedValue(Buffer.from("image-bytes"));
+
+    await describeImageFileWithModel({
+      filePath: "/tmp/cat.png",
+      cfg: {},
+      provider: "openai",
+      model: "gpt-5.4",
+      prompt: "describe this",
+    });
+
+    expect(mockDescribeImage).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 30_000 }));
+  });
+
+  it("passes agentDir to provider.describeImage", async () => {
+    const mockDescribeImage = vi.fn(async () => ({ text: "ok" }));
+    const registry = new Map([["openai", { describeImage: mockDescribeImage }]]);
+    mockBuildProviderRegistry.mockReturnValue(registry);
+    mockReadFile.mockResolvedValue(Buffer.from("img"));
+
+    await describeImageFileWithModel({
+      filePath: "/tmp/cat.png",
+      cfg: {},
+      provider: "openai",
+      model: "gpt-5.4",
+      prompt: "what is this",
+      agentDir: "/agents/my-agent",
+    });
+
+    expect(mockDescribeImage).toHaveBeenCalledWith(
+      expect.objectContaining({ agentDir: "/agents/my-agent" }),
+    );
+  });
+});

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -1,0 +1,372 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getTtsMaxLength,
+  isSummarizationEnabled,
+  isTtsEnabled,
+  resolveTtsAutoMode,
+  resolveTtsConfig,
+  resolveTtsPrefsPath,
+  setTtsAutoMode,
+  setTtsEnabled,
+  setTtsMaxLength,
+  setSummarizationEnabled,
+  _test,
+} from "./tts.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTempPrefs(): { prefsPath: string; cleanup: () => void } {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "openclaw-tts-test-"));
+  const prefsPath = path.join(dir, "tts.json");
+  return {
+    prefsPath,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveTtsConfig — pure config transformation
+// ---------------------------------------------------------------------------
+
+describe("resolveTtsConfig", () => {
+  it("returns defaults when config is empty", () => {
+    const result = resolveTtsConfig({});
+    expect(result.auto).toBe("off");
+    expect(result.mode).toBe("final");
+    expect(result.providerSource).toBe("default");
+    expect(result.provider).toBe("");
+    expect(result.maxTextLength).toBe(4096);
+    expect(result.timeoutMs).toBe(30_000);
+    expect(result.modelOverrides.enabled).toBe(true);
+    expect(result.providerConfigs).toEqual({});
+  });
+
+  it("sets auto=always when enabled:true", () => {
+    const result = resolveTtsConfig({ messages: { tts: { enabled: true } } });
+    expect(result.auto).toBe("always");
+  });
+
+  it("sets auto=off when enabled:false", () => {
+    const result = resolveTtsConfig({ messages: { tts: { enabled: false } } });
+    expect(result.auto).toBe("off");
+  });
+
+  it("prefers explicit auto field over the enabled flag", () => {
+    const result = resolveTtsConfig({
+      messages: { tts: { enabled: true, auto: "tagged" } },
+    });
+    expect(result.auto).toBe("tagged");
+  });
+
+  it("supports all documented auto modes", () => {
+    for (const mode of ["always", "tagged", "inbound", "off"] as const) {
+      const result = resolveTtsConfig({ messages: { tts: { auto: mode } } });
+      expect(result.auto).toBe(mode);
+    }
+  });
+
+  it("marks providerSource as config when provider is explicitly set", () => {
+    const result = resolveTtsConfig({
+      messages: { tts: { provider: "elevenlabs" } },
+    });
+    expect(result.providerSource).toBe("config");
+    expect(result.provider).toBe("elevenlabs");
+  });
+
+  it("marks providerSource as default when no provider is set", () => {
+    const result = resolveTtsConfig({ messages: { tts: {} } });
+    expect(result.providerSource).toBe("default");
+    expect(result.provider).toBe("");
+  });
+
+  it("respects custom maxTextLength", () => {
+    const result = resolveTtsConfig({
+      messages: { tts: { maxTextLength: 2000 } },
+    });
+    expect(result.maxTextLength).toBe(2000);
+  });
+
+  it("respects custom timeoutMs", () => {
+    const result = resolveTtsConfig({
+      messages: { tts: { timeoutMs: 10_000 } },
+    });
+    expect(result.timeoutMs).toBe(10_000);
+  });
+
+  it("respects custom mode", () => {
+    const result = resolveTtsConfig({ messages: { tts: { mode: "stream" } } });
+    expect(result.mode).toBe("stream");
+  });
+
+  it("collects provider-specific configs from providers map", () => {
+    const result = resolveTtsConfig({
+      messages: {
+        tts: {
+          providers: {
+            elevenlabs: { apiKey: "el-key" },
+            deepgram: { apiKey: "dg-key" },
+          },
+        },
+      },
+    });
+    expect(result.providerConfigs["elevenlabs"]).toEqual({ apiKey: "el-key" });
+    expect(result.providerConfigs["deepgram"]).toEqual({ apiKey: "dg-key" });
+  });
+
+  it("attaches summaryModel when set", () => {
+    const result = resolveTtsConfig({
+      messages: { tts: { summaryModel: "gpt-5.4" } },
+    });
+    expect(result.summaryModel).toBe("gpt-5.4");
+  });
+
+  it("returns undefined summaryModel when not set", () => {
+    const result = resolveTtsConfig({});
+    expect(result.summaryModel).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _test.resolveModelOverridePolicy — pure policy transformation
+// ---------------------------------------------------------------------------
+
+describe("resolveModelOverridePolicy", () => {
+  const { resolveModelOverridePolicy } = _test;
+
+  it("returns all-false policy when enabled:false", () => {
+    const policy = resolveModelOverridePolicy({ enabled: false });
+    expect(policy.enabled).toBe(false);
+    expect(policy.allowText).toBe(false);
+    expect(policy.allowProvider).toBe(false);
+    expect(policy.allowVoice).toBe(false);
+    expect(policy.allowModelId).toBe(false);
+    expect(policy.allowVoiceSettings).toBe(false);
+    expect(policy.allowNormalization).toBe(false);
+    expect(policy.allowSeed).toBe(false);
+  });
+
+  it("returns permissive defaults when overrides is undefined", () => {
+    const policy = resolveModelOverridePolicy(undefined);
+    expect(policy.enabled).toBe(true);
+    expect(policy.allowText).toBe(true);
+    // allowProvider defaults to false per implementation
+    expect(policy.allowProvider).toBe(false);
+    expect(policy.allowVoice).toBe(true);
+    expect(policy.allowModelId).toBe(true);
+    expect(policy.allowVoiceSettings).toBe(true);
+    expect(policy.allowNormalization).toBe(true);
+    expect(policy.allowSeed).toBe(true);
+  });
+
+  it("returns permissive defaults when enabled is not set", () => {
+    const policy = resolveModelOverridePolicy({});
+    expect(policy.enabled).toBe(true);
+    expect(policy.allowText).toBe(true);
+  });
+
+  it("respects partial overrides", () => {
+    const policy = resolveModelOverridePolicy({
+      enabled: true,
+      allowText: false,
+      allowProvider: true,
+      allowVoice: false,
+    });
+    expect(policy.allowText).toBe(false);
+    expect(policy.allowProvider).toBe(true);
+    expect(policy.allowVoice).toBe(false);
+    // unset fields keep their defaults
+    expect(policy.allowModelId).toBe(true);
+  });
+
+  it("enabled:true with explicit all-false overrides sets all to false", () => {
+    const policy = resolveModelOverridePolicy({
+      enabled: true,
+      allowText: false,
+      allowProvider: false,
+      allowVoice: false,
+      allowModelId: false,
+      allowVoiceSettings: false,
+      allowNormalization: false,
+      allowSeed: false,
+    });
+    expect(policy.enabled).toBe(true);
+    expect(policy.allowText).toBe(false);
+    expect(policy.allowVoice).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prefs — auto mode  (file I/O with isolated temp dir)
+// ---------------------------------------------------------------------------
+
+describe("TTS prefs — auto mode", () => {
+  let prefsPath: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ({ prefsPath, cleanup } = makeTempPrefs());
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("isTtsEnabled returns false by default (auto=off)", () => {
+    const config = resolveTtsConfig({});
+    expect(isTtsEnabled(config, prefsPath)).toBe(false);
+  });
+
+  it("isTtsEnabled returns true when config has enabled:true", () => {
+    const config = resolveTtsConfig({ messages: { tts: { enabled: true } } });
+    expect(isTtsEnabled(config, prefsPath)).toBe(true);
+  });
+
+  it("setTtsAutoMode persists and resolveTtsAutoMode reads it back", () => {
+    const config = resolveTtsConfig({});
+    setTtsAutoMode(prefsPath, "tagged");
+    const mode = resolveTtsAutoMode({ config, prefsPath });
+    expect(mode).toBe("tagged");
+  });
+
+  it("prefs-level auto overrides config-level auto", () => {
+    // config says "always", prefs says "tagged"
+    const config = resolveTtsConfig({ messages: { tts: { auto: "always" } } });
+    setTtsAutoMode(prefsPath, "tagged");
+    expect(resolveTtsAutoMode({ config, prefsPath })).toBe("tagged");
+  });
+
+  it("sessionAuto takes priority over both config and prefs", () => {
+    const config = resolveTtsConfig({});
+    setTtsAutoMode(prefsPath, "always");
+    const mode = resolveTtsAutoMode({ config, prefsPath, sessionAuto: "off" });
+    expect(mode).toBe("off");
+  });
+
+  it("setTtsEnabled(true) stores auto=always", () => {
+    const config = resolveTtsConfig({});
+    setTtsEnabled(prefsPath, true);
+    expect(isTtsEnabled(config, prefsPath)).toBe(true);
+    expect(resolveTtsAutoMode({ config, prefsPath })).toBe("always");
+  });
+
+  it("setTtsEnabled(false) stores auto=off", () => {
+    const config = resolveTtsConfig({ messages: { tts: { enabled: true } } });
+    setTtsEnabled(prefsPath, false);
+    expect(isTtsEnabled(config, prefsPath)).toBe(false);
+    expect(resolveTtsAutoMode({ config, prefsPath })).toBe("off");
+  });
+
+  it("setTtsAutoMode creates the prefs directory if missing", () => {
+    // Use a sub-directory that does not yet exist under the temp dir.
+    const nestedDir = path.join(prefsPath, "..", "sub");
+    const nested = path.join(nestedDir, "tts.json");
+    try {
+      setTtsAutoMode(nested, "tagged");
+      const config = resolveTtsConfig({});
+      expect(resolveTtsAutoMode({ config, prefsPath: nested })).toBe("tagged");
+    } finally {
+      rmSync(nestedDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prefs — max length
+// ---------------------------------------------------------------------------
+
+describe("TTS prefs — max length", () => {
+  let prefsPath: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ({ prefsPath, cleanup } = makeTempPrefs());
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("getTtsMaxLength returns 1500 by default", () => {
+    expect(getTtsMaxLength(prefsPath)).toBe(1500);
+  });
+
+  it("setTtsMaxLength persists and getTtsMaxLength reads it back", () => {
+    setTtsMaxLength(prefsPath, 800);
+    expect(getTtsMaxLength(prefsPath)).toBe(800);
+  });
+
+  it("setTtsMaxLength overwrites a previous value", () => {
+    setTtsMaxLength(prefsPath, 800);
+    setTtsMaxLength(prefsPath, 1200);
+    expect(getTtsMaxLength(prefsPath)).toBe(1200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prefs — summarization
+// ---------------------------------------------------------------------------
+
+describe("TTS prefs — summarization", () => {
+  let prefsPath: string;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ({ prefsPath, cleanup } = makeTempPrefs());
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("isSummarizationEnabled returns true by default", () => {
+    expect(isSummarizationEnabled(prefsPath)).toBe(true);
+  });
+
+  it("setSummarizationEnabled(false) persists", () => {
+    setSummarizationEnabled(prefsPath, false);
+    expect(isSummarizationEnabled(prefsPath)).toBe(false);
+  });
+
+  it("setSummarizationEnabled(true) re-enables after disable", () => {
+    setSummarizationEnabled(prefsPath, false);
+    setSummarizationEnabled(prefsPath, true);
+    expect(isSummarizationEnabled(prefsPath)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTtsPrefsPath — path resolution
+// ---------------------------------------------------------------------------
+
+describe("resolveTtsPrefsPath", () => {
+  const ENV_KEY = "OPENCLAW_TTS_PREFS";
+
+  beforeEach(() => {
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    delete process.env[ENV_KEY];
+  });
+
+  it("returns a non-empty string for a config with no prefsPath set", () => {
+    const config = resolveTtsConfig({});
+    const resolved = resolveTtsPrefsPath(config);
+    expect(typeof resolved).toBe("string");
+    expect(resolved.length).toBeGreaterThan(0);
+  });
+
+  it("uses prefsPath from config when explicitly set", () => {
+    const config = resolveTtsConfig({
+      messages: { tts: { prefsPath: "/custom/dir/tts.json" } },
+    });
+    const resolved = resolveTtsPrefsPath(config);
+    // resolveUserPath may expand ~ but the tail must match
+    expect(resolved).toContain("custom/dir/tts.json");
+  });
+});

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -99,8 +99,8 @@ describe("resolveTtsConfig", () => {
   });
 
   it("respects custom mode", () => {
-    const result = resolveTtsConfig({ messages: { tts: { mode: "stream" } } });
-    expect(result.mode).toBe("stream");
+    const result = resolveTtsConfig({ messages: { tts: { mode: "all" } } });
+    expect(result.mode).toBe("all");
   });
 
   it("collects provider-specific configs from providers map", () => {


### PR DESCRIPTION
## Summary

- **Problem:** Three bundled extension packages (`speech-core`, `image-generation-core`, `media-understanding-core`) had zero test coverage, leaving core runtime and config logic unverified.
- **Why it matters:** These extensions are on the critical path for TTS playback, AI image generation, and media understanding (image/audio/video). Regressions in their runtime and config logic are currently invisible to CI.
- **What changed:** Added one `*.test.ts` file per extension, covering the primary exported functions with unit tests using `vi.hoisted` + `vi.mock` for ESM-safe isolation.
- **What did NOT change:** No production code was modified. All changes are purely additive test files.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: N/A
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A — this is a test coverage addition, not a bug fix.

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 22.04)
- Runtime/container: Node 22.22.2, pnpm 10.32.1
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `pnpm test -- extensions/speech-core/src/tts.test.ts`
2. `pnpm test -- extensions/image-generation-core/src/runtime.test.ts`
3. `pnpm test -- extensions/media-understanding-core/src/runtime.test.ts`

### Expected

- All tests pass.

### Actual

- All 63 tests pass across 3 files.

## Evidence

- [x] Failing test/log before + passing after

Before (no test files existed):
```
Test Files  0 passed (0)
     Tests  0 passed (0)
```

After:
```
Test Files  3 passed (3)
     Tests  63 passed (63)
```

## Human Verification (required)

- Verified scenarios: all 63 tests pass locally under Node 22.22.2 / pnpm 10.32.1
- Edge cases checked: empty attachment list, disabled capability, whitespace-only output, `cache.cleanup()` called in `finally` block, provider failover and deduplication, `afterEach` mock resets for `--isolate=false` safety
- What you did **not** verify: live provider calls (require real API keys)

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None — test-only additions carry no production risk.