### PR TITLE
fix(voice-call): canonicalize Telnyx replay request keys

### DIFF
--- a/extensions/voice-call/src/webhook-security.test.ts
+++ b/extensions/voice-call/src/webhook-security.test.ts
@@ -393,6 +393,45 @@ describe("verifyTelnyxWebhook", () => {
     expectReplayResultPair(first, second);
   });
 
+  it("treats Base64 and Base64URL signatures as the same replayed request", () => {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+    const pemPublicKey = publicKey.export({ format: "pem", type: "spki" }).toString();
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const rawBody = JSON.stringify({
+      data: { event_type: "call.initiated", payload: { call_control_id: "call-1" } },
+      nonce: crypto.randomUUID(),
+    });
+    const signedPayload = `${timestamp}|${rawBody}`;
+    const signature = crypto.sign(null, Buffer.from(signedPayload), privateKey).toString("base64");
+    const urlSafeSignature = signature.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+    const first = verifyTelnyxWebhook(
+      {
+        headers: {
+          "telnyx-signature-ed25519": signature,
+          "telnyx-timestamp": timestamp,
+        },
+        rawBody,
+        url: "https://example.com/voice/webhook",
+        method: "POST" as const,
+      },
+      pemPublicKey,
+    );
+    const second = verifyTelnyxWebhook(
+      {
+        headers: {
+          "telnyx-signature-ed25519": urlSafeSignature,
+          "telnyx-timestamp": timestamp,
+        },
+        rawBody,
+        url: "https://example.com/voice/webhook",
+        method: "POST" as const,
+      },
+      pemPublicKey,
+    );
+
+    expectReplayResultPair(first, second);
+  });
+
   it("returns a stable request key when verification is skipped", () => {
     const ctx = {
       headers: {},

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -534,6 +534,8 @@ export function verifyTelnyxWebhook(
   try {
     const signedPayload = `${timestamp}|${ctx.rawBody}`;
     const signatureBuffer = decodeBase64OrBase64Url(signature);
+    // Canonicalize equivalent Base64/Base64URL encodings before replay hashing.
+    const canonicalSignature = signatureBuffer.toString("base64");
     const key = importEd25519PublicKey(publicKey);
 
     const isValid = crypto.verify(null, Buffer.from(signedPayload), key, signatureBuffer);
@@ -548,7 +550,7 @@ export function verifyTelnyxWebhook(
       return { ok: false, reason: "Timestamp too old" };
     }
 
-    const replayKey = `telnyx:${sha256Hex(`${timestamp}\n${signature}\n${ctx.rawBody}`)}`;
+    const replayKey = `telnyx:${sha256Hex(`${timestamp}\n${canonicalSignature}\n${ctx.rawBody}`)}`;
     const isReplay = markReplay(telnyxReplayCache, replayKey);
     return { ok: true, isReplay, verifiedRequestKey: replayKey };
   } catch (err) {


### PR DESCRIPTION
## Summary
- canonicalize verified Telnyx signatures before deriving the replay request key
- keep replay detection stable across equivalent Base64 and Base64URL encodings

## Changes
- update `verifyTelnyxWebhook` to hash a canonical Base64 form of the decoded signature bytes
- add a regression test covering the same signed payload delivered with Base64 and Base64URL signature encodings

## Validation
- ran `pnpm test -- extensions/voice-call/src/webhook-security.test.ts`
- ran `pnpm check`
- ran `pnpm build`
- ran local agentic review with `claude -p "/review"` and addressed the feedback by documenting the canonicalization step inline

## Notes
- residual risk or follow-up: full `pnpm test` was not run locally; the change is covered by targeted webhook regression coverage plus repo check/build gates
