### PR TITLE
Guard marketplace and Ollama network requests

### DIFF
--- a/extensions/ollama/src/provider-models.ssrf.test.ts
+++ b/extensions/ollama/src/provider-models.ssrf.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { buildOllamaBaseUrlSsrFPolicy } from "./provider-models.js";
+
+describe("buildOllamaBaseUrlSsrFPolicy", () => {
+  it("allows only the configured Ollama hostname for HTTP(S) URLs", () => {
+    expect(buildOllamaBaseUrlSsrFPolicy("http://127.0.0.1:11434")).toEqual({
+      allowedHostnames: ["127.0.0.1"],
+    });
+    expect(buildOllamaBaseUrlSsrFPolicy("https://ollama.example.com/v1")).toEqual({
+      allowedHostnames: ["ollama.example.com"],
+    });
+  });
+
+  it("returns no allowlist for empty or invalid base URLs", () => {
+    expect(buildOllamaBaseUrlSsrFPolicy("")).toBeUndefined();
+    expect(buildOllamaBaseUrlSsrFPolicy("ftp://ollama.example.com")).toBeUndefined();
+    expect(buildOllamaBaseUrlSsrFPolicy("not-a-url")).toBeUndefined();
+  });
+});

--- a/extensions/ollama/src/provider-models.ssrf.test.ts
+++ b/extensions/ollama/src/provider-models.ssrf.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest";
 import { buildOllamaBaseUrlSsrFPolicy } from "./provider-models.js";
 
 describe("buildOllamaBaseUrlSsrFPolicy", () => {
-  it("allows only the configured Ollama hostname for HTTP(S) URLs", () => {
+  it("pins requests to the configured Ollama hostname for HTTP(S) URLs", () => {
     expect(buildOllamaBaseUrlSsrFPolicy("http://127.0.0.1:11434")).toEqual({
       allowedHostnames: ["127.0.0.1"],
+      hostnameAllowlist: ["127.0.0.1"],
     });
     expect(buildOllamaBaseUrlSsrFPolicy("https://ollama.example.com/v1")).toEqual({
       allowedHostnames: ["ollama.example.com"],
+      hostnameAllowlist: ["ollama.example.com"],
     });
   });
 

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -1,4 +1,5 @@
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-onboard";
+import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   OLLAMA_DEFAULT_BASE_URL,
   OLLAMA_DEFAULT_CONTEXT_WINDOW,
@@ -28,6 +29,22 @@ export type OllamaModelWithContext = OllamaTagModel & {
 
 const OLLAMA_SHOW_CONCURRENCY = 8;
 
+export function buildOllamaBaseUrlSsrFPolicy(baseUrl: string): SsrFPolicy | undefined {
+  const trimmed = baseUrl.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return undefined;
+    }
+    return { allowedHostnames: [parsed.hostname] };
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveOllamaApiBase(configuredBaseUrl?: string): string {
   if (!configuredBaseUrl) {
     return OLLAMA_DEFAULT_BASE_URL;
@@ -41,28 +58,41 @@ export async function queryOllamaContextWindow(
   modelName: string,
 ): Promise<number | undefined> {
   try {
-    const response = await fetch(`${apiBase}/api/show`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: modelName }),
-      signal: AbortSignal.timeout(3000),
+    const { response, release } = await fetchWithSsrFGuard({
+      url: `${apiBase}/api/show`,
+      init: {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: modelName }),
+        signal: AbortSignal.timeout(3000),
+      },
+      policy: buildOllamaBaseUrlSsrFPolicy(apiBase),
+      auditContext: "ollama-provider-models.show",
     });
-    if (!response.ok) {
-      return undefined;
-    }
-    const data = (await response.json()) as { model_info?: Record<string, unknown> };
-    if (!data.model_info) {
-      return undefined;
-    }
-    for (const [key, value] of Object.entries(data.model_info)) {
-      if (key.endsWith(".context_length") && typeof value === "number" && Number.isFinite(value)) {
-        const contextWindow = Math.floor(value);
-        if (contextWindow > 0) {
-          return contextWindow;
+    try {
+      if (!response.ok) {
+        return undefined;
+      }
+      const data = (await response.json()) as { model_info?: Record<string, unknown> };
+      if (!data.model_info) {
+        return undefined;
+      }
+      for (const [key, value] of Object.entries(data.model_info)) {
+        if (
+          key.endsWith(".context_length") &&
+          typeof value === "number" &&
+          Number.isFinite(value)
+        ) {
+          const contextWindow = Math.floor(value);
+          if (contextWindow > 0) {
+            return contextWindow;
+          }
         }
       }
+      return undefined;
+    } finally {
+      await release();
     }
-    return undefined;
   } catch {
     return undefined;
   }
@@ -112,15 +142,24 @@ export async function fetchOllamaModels(
 ): Promise<{ reachable: boolean; models: OllamaTagModel[] }> {
   try {
     const apiBase = resolveOllamaApiBase(baseUrl);
-    const response = await fetch(`${apiBase}/api/tags`, {
-      signal: AbortSignal.timeout(5000),
+    const { response, release } = await fetchWithSsrFGuard({
+      url: `${apiBase}/api/tags`,
+      init: {
+        signal: AbortSignal.timeout(5000),
+      },
+      policy: buildOllamaBaseUrlSsrFPolicy(apiBase),
+      auditContext: "ollama-provider-models.tags",
     });
-    if (!response.ok) {
-      return { reachable: true, models: [] };
+    try {
+      if (!response.ok) {
+        return { reachable: true, models: [] };
+      }
+      const data = (await response.json()) as OllamaTagsResponse;
+      const models = (data.models ?? []).filter((m) => m.name);
+      return { reachable: true, models };
+    } finally {
+      await release();
     }
-    const data = (await response.json()) as OllamaTagsResponse;
-    const models = (data.models ?? []).filter((m) => m.name);
-    return { reachable: true, models };
   } catch {
     return { reachable: false, models: [] };
   }

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -39,7 +39,10 @@ export function buildOllamaBaseUrlSsrFPolicy(baseUrl: string): SsrFPolicy | unde
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return undefined;
     }
-    return { allowedHostnames: [parsed.hostname] };
+    return {
+      allowedHostnames: [parsed.hostname],
+      hostnameAllowlist: [parsed.hostname],
+    };
   } catch {
     return undefined;
   }

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -3,8 +3,10 @@ import { upsertAuthProfileWithLock } from "openclaw/plugin-sdk/provider-auth";
 import { applyAgentDefaultModelPrimary } from "openclaw/plugin-sdk/provider-onboard";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { WizardCancelledError, type WizardPrompter } from "openclaw/plugin-sdk/setup";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { OLLAMA_DEFAULT_BASE_URL, OLLAMA_DEFAULT_MODEL } from "./defaults.js";
 import {
+  buildOllamaBaseUrlSsrFPolicy,
   buildOllamaModelDefinition,
   enrichOllamaModelsWithContext,
   fetchOllamaModels,
@@ -64,18 +66,27 @@ function formatOllamaPullStatus(status: string): { text: string; hidePercent: bo
 async function checkOllamaCloudAuth(baseUrl: string): Promise<OllamaCloudAuthResult> {
   try {
     const apiBase = resolveOllamaApiBase(baseUrl);
-    const response = await fetch(`${apiBase}/api/me`, {
-      method: "POST",
-      signal: AbortSignal.timeout(5000),
+    const { response, release } = await fetchWithSsrFGuard({
+      url: `${apiBase}/api/me`,
+      init: {
+        method: "POST",
+        signal: AbortSignal.timeout(5000),
+      },
+      policy: buildOllamaBaseUrlSsrFPolicy(apiBase),
+      auditContext: "ollama-setup.me",
     });
-    if (response.status === 401) {
-      const data = (await response.json()) as { signin_url?: string };
-      return { signedIn: false, signinUrl: data.signin_url };
+    try {
+      if (response.status === 401) {
+        const data = (await response.json()) as { signin_url?: string };
+        return { signedIn: false, signinUrl: data.signin_url };
+      }
+      if (!response.ok) {
+        return { signedIn: false };
+      }
+      return { signedIn: true };
+    } finally {
+      await release();
     }
-    if (!response.ok) {
-      return { signedIn: false };
-    }
-    return { signedIn: true };
   } catch {
     return { signedIn: false };
   }
@@ -98,82 +109,91 @@ async function pullOllamaModelCore(params: {
   const baseUrl = resolveOllamaApiBase(params.baseUrl);
   const modelName = normalizeOllamaModelName(params.modelName) ?? params.modelName.trim();
   try {
-    const response = await fetch(`${baseUrl}/api/pull`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: modelName }),
+    const { response, release } = await fetchWithSsrFGuard({
+      url: `${baseUrl}/api/pull`,
+      init: {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: modelName }),
+      },
+      policy: buildOllamaBaseUrlSsrFPolicy(baseUrl),
+      auditContext: "ollama-setup.pull",
     });
-    if (!response.ok) {
-      return { ok: false, message: `Failed to download ${modelName} (HTTP ${response.status})` };
-    }
-    if (!response.body) {
-      return { ok: false, message: `Failed to download ${modelName} (no response body)` };
-    }
-
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    const layers = new Map<string, { total: number; completed: number }>();
-
-    const parseLine = (line: string): OllamaPullResult => {
-      const trimmed = line.trim();
-      if (!trimmed) {
-        return { ok: true };
+    try {
+      if (!response.ok) {
+        return { ok: false, message: `Failed to download ${modelName} (HTTP ${response.status})` };
       }
-      try {
-        const chunk = JSON.parse(trimmed) as OllamaPullChunk;
-        if (chunk.error) {
-          return { ok: false, message: `Download failed: ${chunk.error}` };
-        }
-        if (!chunk.status) {
+      if (!response.body) {
+        return { ok: false, message: `Failed to download ${modelName} (no response body)` };
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      const layers = new Map<string, { total: number; completed: number }>();
+
+      const parseLine = (line: string): OllamaPullResult => {
+        const trimmed = line.trim();
+        if (!trimmed) {
           return { ok: true };
         }
-        if (chunk.total && chunk.completed !== undefined) {
-          layers.set(chunk.status, { total: chunk.total, completed: chunk.completed });
-          let totalSum = 0;
-          let completedSum = 0;
-          for (const layer of layers.values()) {
-            totalSum += layer.total;
-            completedSum += layer.completed;
+        try {
+          const chunk = JSON.parse(trimmed) as OllamaPullChunk;
+          if (chunk.error) {
+            return { ok: false, message: `Download failed: ${chunk.error}` };
           }
-          params.onStatus?.(
-            chunk.status,
-            totalSum > 0 ? Math.round((completedSum / totalSum) * 100) : null,
-          );
-        } else {
-          params.onStatus?.(chunk.status, null);
+          if (!chunk.status) {
+            return { ok: true };
+          }
+          if (chunk.total && chunk.completed !== undefined) {
+            layers.set(chunk.status, { total: chunk.total, completed: chunk.completed });
+            let totalSum = 0;
+            let completedSum = 0;
+            for (const layer of layers.values()) {
+              totalSum += layer.total;
+              completedSum += layer.completed;
+            }
+            params.onStatus?.(
+              chunk.status,
+              totalSum > 0 ? Math.round((completedSum / totalSum) * 100) : null,
+            );
+          } else {
+            params.onStatus?.(chunk.status, null);
+          }
+        } catch {
+          // Ignore malformed streaming lines from Ollama.
         }
-      } catch {
-        // Ignore malformed streaming lines from Ollama.
-      }
-      return { ok: true };
-    };
+        return { ok: true };
+      };
 
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          const parsed = parseLine(line);
+          if (!parsed.ok) {
+            return parsed;
+          }
+        }
       }
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-      for (const line of lines) {
-        const parsed = parseLine(line);
+
+      const trailing = buffer.trim();
+      if (trailing) {
+        const parsed = parseLine(trailing);
         if (!parsed.ok) {
           return parsed;
         }
       }
-    }
 
-    const trailing = buffer.trim();
-    if (trailing) {
-      const parsed = parseLine(trailing);
-      if (!parsed.ok) {
-        return parsed;
-      }
+      return { ok: true };
+    } finally {
+      await release();
     }
-
-    return { ok: true };
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     return { ok: false, message: `Failed to download ${modelName}: ${reason}` };

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -5,11 +5,34 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../test-utils/env.js";
 
 const installPluginFromPathMock = vi.fn();
+const fetchWithSsrFGuardMock = vi.hoisted(() =>
+  vi.fn(async (params: { url: string; init?: RequestInit }) => {
+    // Keep unit tests focused on guarded call sites, not AbortSignal timer behavior.
+    const { signal: _signal, ...init } = params.init ?? {};
+    const response = await fetch(params.url, init);
+    return {
+      response,
+      finalUrl: params.url,
+      release: async () => {
+        await response.body?.cancel().catch(() => undefined);
+      },
+    };
+  }),
+);
 const runCommandWithTimeoutMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./install.js", () => ({
   installPluginFromPath: (...args: unknown[]) => installPluginFromPathMock(...args),
 }));
+
+vi.mock("../infra/net/fetch-guard.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/net/fetch-guard.js")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: (params: { url: string; init?: RequestInit }) =>
+      fetchWithSsrFGuardMock(params),
+  };
+});
 
 vi.mock("../process/exec.js", () => ({
   runCommandWithTimeout: (...args: unknown[]) => runCommandWithTimeoutMock(...args),
@@ -144,6 +167,7 @@ function expectLocalMarketplaceInstallResult(params: {
 
 describe("marketplace plugins", () => {
   afterEach(() => {
+    fetchWithSsrFGuardMock.mockClear();
     installPluginFromPathMock.mockReset();
     runCommandWithTimeoutMock.mockReset();
     vi.unstubAllGlobals();
@@ -292,6 +316,10 @@ describe("marketplace plugins", () => {
       expect(result).toEqual({
         ok: false,
         error: "failed to download https://example.com/frontend-design.tgz: empty response body",
+      });
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith({
+        url: "https://example.com/frontend-design.tgz",
+        auditContext: "marketplace-plugin-download",
       });
       expect(installPluginFromPathMock).not.toHaveBeenCalled();
     });

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { Writable } from "node:stream";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { resolveOsHomeRelativePath } from "../infra/home-dir.js";
+import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { resolveUserPath } from "../utils.js";
 import { installPluginFromPath, type InstallPluginResult } from "./install.js";
@@ -589,27 +590,34 @@ async function downloadUrlToTempFile(url: string): Promise<
       error: string;
     }
 > {
-  const response = await fetch(url);
-  if (!response.ok) {
-    return { ok: false, error: `failed to download ${url}: HTTP ${response.status}` };
-  }
-  if (!response.body) {
-    return { ok: false, error: `failed to download ${url}: empty response body` };
-  }
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    auditContext: "marketplace-plugin-download",
+  });
+  try {
+    if (!response.ok) {
+      return { ok: false, error: `failed to download ${url}: HTTP ${response.status}` };
+    }
+    if (!response.body) {
+      return { ok: false, error: `failed to download ${url}: empty response body` };
+    }
 
-  const pathname = new URL(url).pathname;
-  const fileName = path.basename(pathname) || "plugin.tgz";
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-marketplace-download-"));
-  const targetPath = path.join(tmpDir, fileName);
-  const fileStream = createWriteStream(targetPath);
-  await response.body.pipeTo(Writable.toWeb(fileStream));
-  return {
-    ok: true,
-    path: targetPath,
-    cleanup: async () => {
-      await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
-    },
-  };
+    const pathname = new URL(url).pathname;
+    const fileName = path.basename(pathname) || "plugin.tgz";
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-marketplace-download-"));
+    const targetPath = path.join(tmpDir, fileName);
+    const fileStream = createWriteStream(targetPath);
+    await response.body.pipeTo(Writable.toWeb(fileStream));
+    return {
+      ok: true,
+      path: targetPath,
+      cleanup: async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
+      },
+    };
+  } finally {
+    await release();
+  }
 }
 
 function ensureInsideMarketplaceRoot(


### PR DESCRIPTION
## Summary
- guard marketplace archive downloads with the shared fetch guard
- route Ollama discovery, auth, and pull requests through guarded fetches scoped to the configured host

## Changes
- replaced the raw marketplace download fetch with `fetchWithSsrFGuard` and ensured dispatcher cleanup after streaming completes
- added an Ollama hostname policy helper and applied guarded fetches to `/api/show`, `/api/tags`, `/api/me`, and `/api/pull`
- added focused regression coverage for marketplace download guard usage and the Ollama base URL policy helper

## Validation
- Ran `pnpm test -- src/plugins/marketplace.test.ts extensions/ollama/index.test.ts extensions/ollama/src/provider-models.ssrf.test.ts`
- Ran `pnpm build`
- Ran local agentic review via `claude -p "/review"` and added helper coverage afterward

## Notes
- The existing deeper Ollama fetch-path tests were not extended in this patch; the new helper test covers the added hostname policy branch directly.
