### PR TITLE
fix: handle message_start before message_stop from provider (closes #57654)

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -21,7 +21,8 @@ function createContext(
       onBlockReply,
     },
     state: {
-      lastAssistant: lastAssistant as EmbeddedPiSubscribeContext["state"]["lastAssistant"],
+      lastAssistantMessage:
+        lastAssistant as EmbeddedPiSubscribeContext["state"]["lastAssistantMessage"],
       pendingCompactionRetry: 0,
       pendingToolMediaUrls: [],
       pendingToolAudioAsVoice: false,

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -35,7 +35,7 @@ export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
 }
 
 export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
-  const lastAssistant = ctx.state.lastAssistant;
+  const lastAssistant = ctx.state.lastAssistantMessage;
   const isError = isAssistantMessage(lastAssistant) && lastAssistant.stopReason === "error";
 
   if (isError && lastAssistant) {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -143,6 +143,7 @@ export function handleMessageStart(
   evt: AgentEvent & { message: AgentMessage },
 ) {
   const msg = evt.message;
+
   if (msg?.role !== "assistant" || isTranscriptOnlyOpenClawAssistantMessage(msg)) {
     return;
   }
@@ -154,12 +155,13 @@ export function handleMessageStart(
   // re-trigger block replies.
   // FIX: tolerate providers emitting message_start without message_stop
   if (ctx.state.deltaBuffer || ctx.state.lastStreamedAssistant !== undefined) {
-    const lastMsg = ctx.state.lastAssistantMessage ?? msg;
-
-    handleMessageEnd(ctx, {
-      ...evt,
-      message: lastMsg,
-    });
+    const lastMsg = ctx.state.lastAssistantMessage;
+    if (lastMsg) {
+      handleMessageEnd(ctx, {
+        ...evt,
+        message: lastMsg,
+      });
+    }
   }
 
   ctx.resetAssistantMessageState(ctx.state.assistantTexts.length); // Use assistant message_start as the earliest "writing" signal for typing.
@@ -353,9 +355,6 @@ export function handleMessageEnd(
   ctx: EmbeddedPiSubscribeContext,
   evt: AgentEvent & { message: AgentMessage },
 ) {
-  if (!ctx.state.deltaBuffer && ctx.state.lastStreamedAssistant === undefined) {
-    return;
-  }
   const msg = evt.message;
   if (msg?.role !== "assistant" || isTranscriptOnlyOpenClawAssistantMessage(msg)) {
     return;
@@ -364,6 +363,10 @@ export function handleMessageEnd(
   const assistantMessage = msg;
   ctx.noteLastAssistant(assistantMessage);
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);
+
+  if (!ctx.state.deltaBuffer && ctx.state.lastStreamedAssistant === undefined) {
+    return;
+  }
   if (ctx.state.deterministicApprovalPromptSent) {
     return;
   }

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -1,7 +1,7 @@
 import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import {
@@ -152,8 +152,17 @@ export function handleMessageStart(
   // Start-of-message is a safer reset point than message_end: some providers
   // may deliver late text_end updates after message_end, which would otherwise
   // re-trigger block replies.
-  ctx.resetAssistantMessageState(ctx.state.assistantTexts.length);
-  // Use assistant message_start as the earliest "writing" signal for typing.
+  // FIX: tolerate providers emitting message_start without message_stop
+  if (ctx.state.deltaBuffer || ctx.state.lastStreamedAssistant !== undefined) {
+    const lastMsg = ctx.state.lastAssistantMessage ?? msg;
+
+    handleMessageEnd(ctx, {
+      ...evt,
+      message: lastMsg,
+    });
+  }
+
+  ctx.resetAssistantMessageState(ctx.state.assistantTexts.length); // Use assistant message_start as the earliest "writing" signal for typing.
   void ctx.params.onAssistantMessageStart?.();
 }
 
@@ -344,6 +353,9 @@ export function handleMessageEnd(
   ctx: EmbeddedPiSubscribeContext,
   evt: AgentEvent & { message: AgentMessage },
 ) {
+  if (!ctx.state.deltaBuffer && ctx.state.lastStreamedAssistant === undefined) {
+    return;
+  }
   const msg = evt.message;
   if (msg?.role !== "assistant" || isTranscriptOnlyOpenClawAssistantMessage(msg)) {
     return;
@@ -392,7 +404,11 @@ export function handleMessageEnd(
     }
   }
 
-  if (!ctx.params.silentExpected && !ctx.state.emittedAssistantUpdate && (cleanedText || hasMedia)) {
+  if (
+    !ctx.params.silentExpected &&
+    !ctx.state.emittedAssistantUpdate &&
+    (cleanedText || hasMedia)
+  ) {
     const data = buildAssistantStreamData({
       text: cleanedText,
       delta: cleanedText,

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -55,6 +55,7 @@ export type EmbeddedPiSubscribeState = {
   lastBlockReplyText?: string;
   reasoningStreamOpen: boolean;
   assistantMessageIndex: number;
+  lastAssistantMessage?: AgentMessage;
   lastAssistantTextMessageIndex: number;
   lastAssistantTextNormalized?: string;
   lastAssistantTextTrimmed?: string;
@@ -80,7 +81,6 @@ export type EmbeddedPiSubscribeState = {
   pendingToolMediaUrls: string[];
   pendingToolAudioAsVoice: boolean;
   deterministicApprovalPromptSent: boolean;
-  lastAssistant?: AgentMessage;
 };
 
 export type EmbeddedPiSubscribeContext = {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -1,8 +1,8 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { createStreamingDirectiveAccumulator } from "../auto-reply/reply/streaming-directives.js";
-import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
@@ -626,7 +626,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
 
   const noteLastAssistant = (msg: AgentMessage) => {
     if (msg?.role === "assistant") {
-      state.lastAssistant = msg;
+      state.lastAssistantMessage = msg;
     }
   };
 


### PR DESCRIPTION
## Summary

- Problem: Some providers emit `message_start` before a previous `message_stop`, causing inconsistent state and duplicate/invalid streaming behavior.
- Why it matters: This breaks long-running sessions (e.g. Kimi via Moonshot/Lark) and results in errors or stalled responses.
- What changed: When a new `message_start` arrives while a previous assistant message is still open, we proactively finalize the previous message using the last known assistant message before resetting state.
- What did NOT change (scope boundary): No changes to provider integrations, transport layers, or message schemas.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57654
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The system assumed strict event ordering (`message_start` always followed by `message_stop`), but some providers violate this.
- Missing detection / guardrail: No guard existed to close an in-flight assistant message when a new `message_start` arrives.
- Prior context: Streaming logic relied on provider correctness for lifecycle boundaries.
- Why this regressed now: New provider behavior (Kimi/Moonshot) emits out-of-order events under long-running conditions.
- If unknown, what was ruled out: Not related to transport, buffering, or directive parsing.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test or file:
  - pi-embedded-subscribe.handlers.messages.ts
- Scenario the test should lock in:
  - Receiving `message_start` before prior `message_stop` does not break streaming and correctly finalizes prior message.
- Why this is the smallest reliable guardrail:
  - Requires lifecycle sequencing rather than isolated unit logic.
- Existing test that already covers this (if any):
  - None
- If no new test is added, why not:
  - Existing lifecycle tests cover adjacent behavior; this change aligns with those expectations.

## User-visible / Behavior Changes

- Fixes broken or stalled responses when providers emit out-of-order lifecycle events.
- Prevents duplicate or partial assistant outputs in streaming scenarios.

## Diagram (if applicable)

```text
Before:
message_start (A)
text_delta (A)
message_start (B)
state reset without closing A

After:
message_start (A)
text_delta (A)
message_start (B)
finalize A
reset state
start B cleanly