### PR TITLE
feat(acpx): add computer use support for Claude Code sessions

### DIFF
--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -64,6 +64,9 @@
           },
           "required": ["command"]
         }
+      },
+      "computerUse": {
+        "type": "boolean"
       }
     }
   },
@@ -111,6 +114,11 @@
     "mcpServers": {
       "label": "MCP Servers",
       "help": "Named MCP server definitions to inject into ACPX-backed session bootstrap. Each entry needs a command and can include args and env.",
+      "advanced": true
+    },
+    "computerUse": {
+      "label": "Computer Use",
+      "help": "Enable the built-in computer-use MCP server in Claude Code sessions. macOS only (research preview). Requires Claude Code v2.1.85+, Accessibility and Screen Recording permissions.",
       "advanced": true
     }
   }

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -269,6 +269,37 @@ describe("acpx plugin config parsing", () => {
     ).toThrow("strictWindowsCmdWrapper must be a boolean");
   });
 
+  it("defaults computerUse to false when not specified", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(resolved.computerUse).toBe(false);
+  });
+
+  it("accepts computerUse boolean override", () => {
+    const resolved = resolveAcpxPluginConfig({
+      rawConfig: {
+        computerUse: true,
+      },
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(resolved.computerUse).toBe(true);
+  });
+
+  it("rejects non-boolean computerUse", () => {
+    expect(() =>
+      resolveAcpxPluginConfig({
+        rawConfig: {
+          computerUse: "yes",
+        },
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toThrow("computerUse must be a boolean");
+  });
+
   it("keeps the runtime json schema in sync with the manifest config schema", () => {
     const manifest = JSON.parse(
       fs.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -96,6 +96,22 @@ export type AcpxPluginConfig = {
   timeoutSeconds?: number;
   queueOwnerTtlSeconds?: number;
   mcpServers?: Record<string, McpServerConfig>;
+  /**
+   * Enable the built-in `computer-use` MCP server in Claude Code sessions.
+   *
+   * **Requirements:**
+   * - Claude Code v2.1.85+
+   * - macOS only (research preview)
+   * - macOS Accessibility and Screen Recording permissions must be granted
+   * - The underlying `claude-agent-acp` adapter may need updating to support
+   *   the `--settings` flag for enabling built-in MCP servers.
+   *
+   * When enabled, the runtime passes
+   * `--settings '{"enableBuiltinMcpServers":["computer-use"]}'` to acpx prompt
+   * commands so Claude Code can open apps, click through UIs, take screenshots,
+   * and interact with the desktop.
+   */
+  computerUse?: boolean;
 };
 
 export type ResolvedAcpxPluginConfig = {
@@ -112,6 +128,11 @@ export type ResolvedAcpxPluginConfig = {
   timeoutSeconds?: number;
   queueOwnerTtlSeconds: number;
   mcpServers: Record<string, McpServerConfig>;
+  /**
+   * Enable the built-in `computer-use` MCP server in Claude Code sessions.
+   * Defaults to `false`. macOS only — requires Accessibility and Screen Recording permissions.
+   */
+  computerUse: boolean;
 };
 
 const DEFAULT_PERMISSION_MODE: AcpxPermissionMode = "approve-reads";
@@ -171,6 +192,7 @@ const AcpxPluginConfigSchema = z.strictObject({
     .min(0, { error: "queueOwnerTtlSeconds must be a number >= 0" })
     .optional(),
   mcpServers: z.record(z.string(), McpServerConfigSchema).optional(),
+  computerUse: z.boolean({ error: "computerUse must be a boolean" }).optional(),
 });
 
 function formatAcpxConfigIssue(issue: z.ZodIssue | undefined): string {
@@ -326,5 +348,6 @@ export function resolveAcpxPluginConfig(params: {
     timeoutSeconds: normalized.timeoutSeconds,
     queueOwnerTtlSeconds: normalized.queueOwnerTtlSeconds ?? DEFAULT_QUEUE_OWNER_TTL_SECONDS,
     mcpServers,
+    computerUse: normalized.computerUse === true,
   };
 }

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1073,6 +1073,100 @@ describe("AcpxRuntime", () => {
     expect(promptArgs).not.toContain("--settings");
   });
 
+  it("passes --settings to sessions-ensure when computerUse is enabled", async () => {
+    const { config, logPath } = await createMockRuntimeFixture();
+    const runtime = new AcpxRuntime(
+      {
+        ...config,
+        computerUse: true,
+      },
+      { logger: NOOP_LOGGER },
+    );
+
+    await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:cu-ensure",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    const logs = await readMockRuntimeLogEntries(logPath);
+    const ensure = logs.find(
+      (entry) =>
+        entry.kind === "ensure" && String(entry.sessionName ?? "") === "agent:codex:acp:cu-ensure",
+    );
+    expect(ensure).toBeDefined();
+    const ensureArgs = (ensure?.args as string[]) ?? [];
+    const settingsIndex = ensureArgs.indexOf("--settings");
+    expect(settingsIndex).toBeGreaterThanOrEqual(0);
+    const settingsValue = JSON.parse(ensureArgs[settingsIndex + 1]);
+    expect(settingsValue).toEqual({
+      enableBuiltinMcpServers: ["computer-use"],
+    });
+  });
+
+  it("passes --settings to sessions-new when computerUse is enabled", async () => {
+    process.env.MOCK_ACPX_ENSURE_EMPTY = "1";
+    try {
+      const { config, logPath } = await createMockRuntimeFixture();
+      const runtime = new AcpxRuntime(
+        {
+          ...config,
+          computerUse: true,
+        },
+        { logger: NOOP_LOGGER },
+      );
+
+      await runtime.ensureSession({
+        sessionKey: "agent:codex:acp:cu-new",
+        agent: "codex",
+        mode: "persistent",
+      });
+
+      const logs = await readMockRuntimeLogEntries(logPath);
+      const newEntry = logs.find(
+        (entry) =>
+          entry.kind === "new" && String(entry.sessionName ?? "") === "agent:codex:acp:cu-new",
+      );
+      expect(newEntry).toBeDefined();
+      const newArgs = (newEntry?.args as string[]) ?? [];
+      const settingsIndex = newArgs.indexOf("--settings");
+      expect(settingsIndex).toBeGreaterThanOrEqual(0);
+      const settingsValue = JSON.parse(newArgs[settingsIndex + 1]);
+      expect(settingsValue).toEqual({
+        enableBuiltinMcpServers: ["computer-use"],
+      });
+    } finally {
+      delete process.env.MOCK_ACPX_ENSURE_EMPTY;
+    }
+  });
+
+  it("does not pass --settings to session creation when computerUse is disabled", async () => {
+    const { config, logPath } = await createMockRuntimeFixture();
+    const runtime = new AcpxRuntime(
+      {
+        ...config,
+        computerUse: false,
+      },
+      { logger: NOOP_LOGGER },
+    );
+
+    await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:no-cu-ensure",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    const logs = await readMockRuntimeLogEntries(logPath);
+    const ensure = logs.find(
+      (entry) =>
+        entry.kind === "ensure" &&
+        String(entry.sessionName ?? "") === "agent:codex:acp:no-cu-ensure",
+    );
+    expect(ensure).toBeDefined();
+    const ensureArgs = (ensure?.args as string[]) ?? [];
+    expect(ensureArgs).not.toContain("--settings");
+  });
+
   it("includes platform warning in doctor report when computerUse is enabled on non-macOS", async () => {
     const { config } = await createMockRuntimeFixture();
     const runtime = new AcpxRuntime(

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -31,6 +31,7 @@ beforeAll(async () => {
       strictWindowsCmdWrapper: true,
       queueOwnerTtlSeconds: 0.1,
       mcpServers: {},
+      computerUse: false,
     },
     { logger: NOOP_LOGGER },
   );
@@ -993,6 +994,108 @@ describe("AcpxRuntime", () => {
     expect(report.ok).toBe(false);
     expect(report.code).toBe("ACP_BACKEND_UNAVAILABLE");
     expect(report.installCommand).toContain("acpx");
+  });
+
+  it("passes --settings with computer-use MCP server when computerUse is enabled", async () => {
+    const { config, logPath } = await createMockRuntimeFixture();
+    const runtime = new AcpxRuntime(
+      {
+        ...config,
+        computerUse: true,
+      },
+      { logger: NOOP_LOGGER },
+    );
+
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:computer-use",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    for await (const _event of runtime.runTurn({
+      handle,
+      text: "test-computer-use",
+      mode: "prompt",
+      requestId: "req-computer-use",
+    })) {
+      // Drain events.
+    }
+
+    const logs = await readMockRuntimeLogEntries(logPath);
+    const prompt = logs.find(
+      (entry) =>
+        entry.kind === "prompt" &&
+        String(entry.sessionName ?? "") === "agent:codex:acp:computer-use",
+    );
+    expect(prompt).toBeDefined();
+    const promptArgs = (prompt?.args as string[]) ?? [];
+    const settingsIndex = promptArgs.indexOf("--settings");
+    expect(settingsIndex).toBeGreaterThanOrEqual(0);
+    const settingsValue = JSON.parse(promptArgs[settingsIndex + 1]);
+    expect(settingsValue).toEqual({
+      enableBuiltinMcpServers: ["computer-use"],
+    });
+  });
+
+  it("does not pass --settings when computerUse is disabled", async () => {
+    const { config, logPath } = await createMockRuntimeFixture();
+    const runtime = new AcpxRuntime(
+      {
+        ...config,
+        computerUse: false,
+      },
+      { logger: NOOP_LOGGER },
+    );
+
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:no-computer-use",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    for await (const _event of runtime.runTurn({
+      handle,
+      text: "test-no-computer-use",
+      mode: "prompt",
+      requestId: "req-no-computer-use",
+    })) {
+      // Drain events.
+    }
+
+    const logs = await readMockRuntimeLogEntries(logPath);
+    const prompt = logs.find(
+      (entry) =>
+        entry.kind === "prompt" &&
+        String(entry.sessionName ?? "") === "agent:codex:acp:no-computer-use",
+    );
+    expect(prompt).toBeDefined();
+    const promptArgs = (prompt?.args as string[]) ?? [];
+    expect(promptArgs).not.toContain("--settings");
+  });
+
+  it("includes platform warning in doctor report when computerUse is enabled on non-macOS", async () => {
+    const { config } = await createMockRuntimeFixture();
+    const runtime = new AcpxRuntime(
+      {
+        ...config,
+        computerUse: true,
+      },
+      { logger: NOOP_LOGGER },
+    );
+
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+    try {
+      const report = await runtime.doctor();
+      expect(report.ok).toBe(true);
+      expect(report.message).toContain("computerUse is enabled but requires macOS");
+      expect(report.message).toContain("linux");
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, "platform", originalPlatform);
+      }
+    }
   });
 
   it("falls back to 'sessions new' when 'sessions ensure' returns no session IDs", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -1024,17 +1024,29 @@ export class AcpxRuntime implements AcpRuntime {
     };
   }
 
+  /**
+   * Build the common CLI prefix shared by all acpx sub-commands.
+   * Includes `--format json --json-strict --cwd <cwd>` and, when
+   * computer-use is enabled, the `--settings` flag that registers the
+   * built-in computer-use MCP server.  Centralising this ensures the
+   * flag is forwarded to session-creation paths (sessions new / ensure)
+   * as well as per-turn prompt commands.
+   */
+  private buildBasePrefix(cwd: string): string[] {
+    const prefix = ["--format", "json", "--json-strict", "--cwd", cwd];
+    if (this.config.computerUse) {
+      prefix.push("--settings", JSON.stringify({ enableBuiltinMcpServers: ["computer-use"] }));
+    }
+    return prefix;
+  }
+
   private async buildPromptArgs(params: {
     agent: string;
     sessionName: string;
     cwd: string;
   }): Promise<string[]> {
     const prefix = [
-      "--format",
-      "json",
-      "--json-strict",
-      "--cwd",
-      params.cwd,
+      ...this.buildBasePrefix(params.cwd),
       ...buildPermissionArgs(this.config.permissionMode),
       "--non-interactive-permissions",
       this.config.nonInteractivePermissions,
@@ -1043,9 +1055,6 @@ export class AcpxRuntime implements AcpRuntime {
       prefix.push("--timeout", String(this.config.timeoutSeconds));
     }
     prefix.push("--ttl", String(this.queueOwnerTtlSeconds));
-    if (this.config.computerUse) {
-      prefix.push("--settings", JSON.stringify({ enableBuiltinMcpServers: ["computer-use"] }));
-    }
     return await this.buildVerbArgs({
       agent: params.agent,
       cwd: params.cwd,
@@ -1060,7 +1069,7 @@ export class AcpxRuntime implements AcpRuntime {
     command: string[];
     prefix?: string[];
   }): Promise<string[]> {
-    const prefix = params.prefix ?? ["--format", "json", "--json-strict", "--cwd", params.cwd];
+    const prefix = params.prefix ?? this.buildBasePrefix(params.cwd);
     const agentCommand = await this.resolveRawAgentCommand({
       agent: params.agent,
       cwd: params.cwd,

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -960,9 +960,15 @@ export class AcpxRuntime implements AcpRuntime {
     }
 
     this.healthy = true;
+    const computerUseNote =
+      this.config.computerUse && process.platform !== "darwin"
+        ? " [warning: computerUse is enabled but requires macOS — current platform: " +
+          process.platform +
+          "]"
+        : "";
     return {
       ok: true,
-      message: `acpx command available (${this.config.command}, version ${result.versionCheck.version}${this.config.expectedVersion ? `, expected ${this.config.expectedVersion}` : ""})`,
+      message: `acpx command available (${this.config.command}, version ${result.versionCheck.version}${this.config.expectedVersion ? `, expected ${this.config.expectedVersion}` : ""})${computerUseNote}`,
     };
   }
 
@@ -1037,6 +1043,9 @@ export class AcpxRuntime implements AcpRuntime {
       prefix.push("--timeout", String(this.config.timeoutSeconds));
     }
     prefix.push("--ttl", String(this.queueOwnerTtlSeconds));
+    if (this.config.computerUse) {
+      prefix.push("--settings", JSON.stringify({ enableBuiltinMcpServers: ["computer-use"] }));
+    }
     return await this.buildVerbArgs({
       agent: params.agent,
       cwd: params.cwd,

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -390,6 +390,7 @@ export async function createMockRuntimeFixture(params?: {
     strictWindowsCmdWrapper: true,
     queueOwnerTtlSeconds: params?.queueOwnerTtlSeconds ?? 0.1,
     mcpServers: params?.mcpServers ?? {},
+    computerUse: false,
   };
 
   return {


### PR DESCRIPTION
## Summary

Adds `computerUse` config option to the acpx plugin, enabling Claude Code's new built-in `computer-use` MCP server for GUI interaction from ACP-managed sessions.

**Context:** Claude Code [announced computer use in the CLI](https://x.com/claudeai/status/2038663014098899416) (March 30, 2026) — a research preview that lets Claude open apps, click through UIs, take screenshots, and test what it builds, all from the terminal.

## Changes

### Config (`extensions/acpx/src/config.ts`)
- Added `computerUse?: boolean` to `AcpxPluginConfig` with JSDoc documenting requirements
- Added `computerUse: boolean` to `ResolvedAcpxPluginConfig` (defaults to `false`)
- Added Zod validation for the new field

### Runtime (`extensions/acpx/src/runtime.ts`)
- When `computerUse` is enabled, passes `--settings '{"enableBuiltinMcpServers":["computer-use"]}'` to acpx prompt commands
- `doctor()` warns when `computerUse` is enabled on non-macOS platforms

### Plugin Manifest (`extensions/acpx/openclaw.plugin.json`)
- Added `computerUse` to config schema and UI hints (marked as advanced)

### Tests
- 3 new config tests (defaults, accepts true, rejects non-boolean)
- 3 new runtime tests (settings flag propagation, omission when disabled, platform warning)
- Updated test fixtures

## Requirements for Users
- Claude Code v2.1.85+
- macOS only (research preview)
- macOS Accessibility and Screen Recording permissions must be granted
- Pro or Max plan required

## Usage
```json
{
  "plugins": {
    "entries": {
      "acpx": {
        "config": {
          "computerUse": true
        }
      }
    }
  }
}
```

## Notes
- The `enableBuiltinMcpServers` settings key is based on the current Claude Code settings pattern. If the upstream API uses a different key, this will need updating.
- The `claude-agent-acp` adapter (currently v0.21.0) may need an upstream update to fully support the `--settings` passthrough for built-in MCP servers.
- Computer use requires an interactive session in standalone Claude Code; behavior through the ACP protocol path may vary until upstream support is confirmed.