### PR TITLE
fix(security): prevent command injection in config.openFile

### DIFF
--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,4 +1,4 @@
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import {
   createConfigIO,
   parseConfigJson5,
@@ -502,13 +502,18 @@ export const configHandlers: GatewayRequestHandlers = {
     }
     const configPath = createConfigIO().configPath;
     const platform = process.platform;
-    const cmd = platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open";
-    exec(`${cmd} ${JSON.stringify(configPath)}`, (err) => {
+    const cb = (err: Error | null) => {
       if (err) {
         respond(true, { ok: false, path: configPath, error: err.message }, undefined);
         return;
       }
       respond(true, { ok: true, path: configPath }, undefined);
-    });
+    };
+    if (platform === "win32") {
+      // "start" is a cmd.exe built-in; use cmd /c start "" <path> to avoid shell injection.
+      execFile("cmd", ["/c", "start", "", configPath], cb);
+    } else {
+      execFile(platform === "darwin" ? "open" : "xdg-open", [configPath], cb);
+    }
   },
 };


### PR DESCRIPTION
## Summary
- Replace `child_process.exec()` with `execFile()` in the `config.openFile` gateway method
- `exec()` passes input through the system shell, allowing command injection via `OPENCLAW_CONFIG_PATH` environment variable (e.g., `$(id > /tmp/proof)`)
- `execFile()` does not use a shell, preventing injection of shell metacharacters
- On Windows, uses `execFile("cmd", ["/c", "start", "", configPath])` since `start` is a cmd.exe built-in

Fixes #57827

## Security impact
- **Severity**: High (unauthenticated RCE)
- **Vector**: Attacker-controlled `OPENCLAW_CONFIG_PATH` env var processed by `exec()` with `{shell: true}`
- **Fix**: `execFile()` bypasses shell interpretation entirely

## Test plan
- [ ] Verify `config.openFile` still opens the config file on macOS (`open`), Linux (`xdg-open`), and Windows (`cmd /c start`)
- [ ] Verify that shell metacharacters in the config path (e.g., `$(command)`, backticks, pipes) are treated as literal path characters
- [ ] Verify the gateway method still returns proper error/success responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)