### PR TITLE
fix(ui): show identity.name from IDENTITY.md in agent switcher dropdown

### DIFF
--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -159,7 +159,8 @@ export function renderAgents(props: AgentsProps) {
                 : agents.map(
                     (agent) => html`
                       <option value=${agent.id} ?selected=${agent.id === selectedId}>
-                        ${normalizeAgentLabel(agent)}${agentBadgeText(agent.id, defaultId)
+                        ${props.agentIdentityById[agent.id]?.name?.trim() ||
+                        normalizeAgentLabel(agent)}${agentBadgeText(agent.id, defaultId)
                           ? ` (${agentBadgeText(agent.id, defaultId)})`
                           : ""}
                       </option>


### PR DESCRIPTION
## Summary
- The agent dropdown shows `agent.id` (e.g., "main", "dev") instead of human-readable `identity.name` (e.g., "小金", "开发助手")
- Root cause: the dropdown only reads identity data from `openclaw.json` config, but most users configure identity names in workspace `IDENTITY.md` files
- The `agent.identity.get` endpoint already reads `IDENTITY.md` and the data is already loaded into `agentIdentityById` — the dropdown just wasn't using it
- Fix: prefer the resolved identity name from `agentIdentityById` (sourced from `IDENTITY.md`) with fallback to the existing `normalizeAgentLabel()` logic (config → agent.id)

Fixes #57822

## Test plan
- [ ] Configure agents with `identity.name` in IDENTITY.md workspace files (not in openclaw.json)
- [ ] Open the Gateway Web UI agents page
- [ ] Verify the agent switcher dropdown shows the identity names from IDENTITY.md
- [ ] Verify agents without IDENTITY.md still show a sensible fallback (config name or agent.id)
- [ ] Verify the CLI `openclaw agents list` output matches the Web UI dropdown labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)