### PR TITLE
fix(google): remove zero thinkingBudget for Gemini models

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1321,6 +1321,43 @@ describe("applyExtraParamsToAgent", () => {
     });
   });
 
+  it("removes zero Google thinkingBudget (Gemini rejects 0)", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        config: {
+          thinkingConfig: {
+            includeThoughts: true,
+            thinkingBudget: 0,
+          },
+        },
+      };
+      options?.onPayload?.(payload, _model);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "atproxy", "gemini-3.1-pro-high", undefined, "high");
+
+    const model = {
+      api: "google-generative-ai",
+      provider: "atproxy",
+      id: "gemini-3.1-pro-high",
+    } as Model<"google-generative-ai">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    const thinkingConfig = (
+      payloads[0]?.config as { thinkingConfig?: Record<string, unknown> } | undefined
+    )?.thinkingConfig;
+    expect(thinkingConfig).toEqual({
+      includeThoughts: true,
+      thinkingLevel: "HIGH",
+    });
+  });
+
   it("keeps valid Google thinkingBudget unchanged", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {

--- a/src/agents/pi-embedded-runner/google-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/google-stream-wrappers.ts
@@ -47,12 +47,13 @@ export function sanitizeGoogleThinkingPayload(params: {
   }
   const thinkingConfigObj = thinkingConfig as Record<string, unknown>;
   const thinkingBudget = thinkingConfigObj.thinkingBudget;
-  if (typeof thinkingBudget !== "number" || thinkingBudget >= 0) {
+  if (typeof thinkingBudget !== "number" || thinkingBudget > 0) {
     return;
   }
 
-  // pi-ai can emit thinkingBudget=-1 for some Gemini 3.1 IDs; a negative budget
-  // is invalid for Google-compatible backends and can lead to malformed handling.
+  // pi-ai can emit thinkingBudget=-1 or 0 for some Gemini model IDs; a negative
+  // or zero budget is invalid for Google-compatible backends (Gemini rejects 0
+  // with 400: "The model does not support setting thinking_budget to 0").
   delete thinkingConfigObj.thinkingBudget;
 
   if (


### PR DESCRIPTION
## Summary
- Gemini API rejects `thinkingBudget: 0` with 400: "The model does not support setting thinking_budget to 0"
- The existing guard only removed negative budgets (`< 0`) but allowed zero through
- One-character fix: change `>= 0` to `> 0` so both zero and negative budgets are stripped
- Adds a test case for the zero budget scenario

Fixes #57683

## Test plan
- [ ] Run `pnpm test src/agents/pi-embedded-runner-extraparams.test.ts` — new test "removes zero Google thinkingBudget" should pass
- [ ] Configure a Gemini 2.5 Pro model with thinking enabled
- [ ] Verify requests no longer fail with 400 "thinking_budget to 0" errors
- [ ] Verify positive thinkingBudget values (e.g., 2048) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)