### PR TITLE
fix(providers): apply Mistral strict9 tool call ID sanitization via OpenRouter

### DIFF
--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -31,7 +31,19 @@ const DEFAULT_PROVIDER_CAPABILITIES: ProviderCapabilities = {
   openAiCompatTurnValidation: true,
   geminiThoughtSignatureSanitization: false,
   transcriptToolCallIdMode: "default",
-  transcriptToolCallIdModelHints: [],
+  // Mistral models require strict 9-char alphanumeric tool call IDs regardless
+  // of the routing provider (e.g. OpenRouter, custom proxies).  Include these
+  // hints in the defaults so the strict9 sanitization triggers even when the
+  // provider entry itself does not specify them.
+  transcriptToolCallIdModelHints: [
+    "mistral",
+    "mixtral",
+    "codestral",
+    "pixtral",
+    "devstral",
+    "ministral",
+    "mistralai",
+  ],
   geminiThoughtSignatureModelHints: [],
   dropThinkingBlockModelHints: [],
 };


### PR DESCRIPTION
## Summary
- Mistral models require tool call IDs to be exactly 9 alphanumeric characters
- OpenClaw already has `strict9` sanitization mode, but it only triggers when the provider is "mistral" directly
- When Mistral models are accessed through OpenRouter (or any proxy), the provider is "openrouter" which has no Mistral model hints — sanitization never fires
- Result: 400 errors like `Tool call id was exec1774786568428215 but must be a-z, A-Z, 0-9, with a length of 9`
- Fix: move Mistral model name hints into the default provider capabilities so `strict9` mode triggers based on model ID regardless of the routing provider

Fixes #57672

## Test plan
- [ ] Configure a Mistral model via OpenRouter (e.g., `mistral/mistral-small-2603`)
- [ ] Send a message that triggers tool calls
- [ ] Verify tool calls succeed without 400 errors about tool call ID format
- [ ] Verify direct Mistral provider still works (hints are now in both defaults and mistral-specific config)
- [ ] Verify non-Mistral models via OpenRouter are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)