### PR TITLE
docs: fix incorrect Kimi Coding provider ID and model refs

### DIFF
--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -184,7 +184,7 @@ Config lives under `plugins.entries.moonshot.config.webSearch`:
 
 ## Notes
 
- - Moonshot model refs use `moonshot/<modelId>`. Kimi Coding model refs use `kimi/<modelId>`.
+- Moonshot model refs use `moonshot/<modelId>`. Kimi Coding model refs use `kimi/<modelId>`.
 - Current Kimi Coding default model ref is `kimi/kimi-code`. Legacy `kimi/k2p5` remains accepted as a compatibility model id.
 - Kimi web search uses `KIMI_API_KEY` or `MOONSHOT_API_KEY`, and defaults to `https://api.moonshot.ai/v1` with model `kimi-k2.5`.
 - Override pricing and context metadata in `models.providers` if needed.

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -184,7 +184,7 @@ Config lives under `plugins.entries.moonshot.config.webSearch`:
 
 ## Notes
 
-- Moonshot model refs use `moonshot/<modelId>`. Kimi Coding model refs use `kimi/<modelId>` (the provider ID is `kimi`, not `kimi-coding`).
+ - Moonshot model refs use `moonshot/<modelId>`. Kimi Coding model refs use `kimi/<modelId>`.
 - Current Kimi Coding default model ref is `kimi/kimi-code`. Legacy `kimi/k2p5` remains accepted as a compatibility model id.
 - Kimi web search uses `KIMI_API_KEY` or `MOONSHOT_API_KEY`, and defaults to `https://api.moonshot.ai/v1` with model `kimi-k2.5`.
 - Override pricing and context metadata in `models.providers` if needed.

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -136,7 +136,7 @@ Choose **Kimi** in the web-search section to store
     defaults: {
       model: { primary: "kimi/kimi-code" },
       models: {
-        "kimi/kimi-code": { alias: "Kimi Code" },
+        "kimi/kimi-code": { alias: "Kimi" },
       },
     },
   },
@@ -184,7 +184,7 @@ Config lives under `plugins.entries.moonshot.config.webSearch`:
 
 ## Notes
 
-- Moonshot model refs use `moonshot/<modelId>`. Kimi Coding model refs use `kimi/<modelId>`.
+- Moonshot model refs use `moonshot/<modelId>`. Kimi Coding model refs use `kimi/<modelId>` (the provider ID is `kimi`, not `kimi-coding`).
 - Current Kimi Coding default model ref is `kimi/kimi-code`. Legacy `kimi/k2p5` remains accepted as a compatibility model id.
 - Kimi web search uses `KIMI_API_KEY` or `MOONSHOT_API_KEY`, and defaults to `https://api.moonshot.ai/v1` with model `kimi-k2.5`.
 - Override pricing and context metadata in `models.providers` if needed.

--- a/docs/zh-CN/concepts/model-providers.md
+++ b/docs/zh-CN/concepts/model-providers.md
@@ -334,15 +334,15 @@ Kimi K2 模型 ID：
 
 Kimi Coding 使用 Moonshot AI 的 Anthropic 兼容端点：
 
-- 提供商：`kimi-coding`
+- 提供商：`kimi`
 - 身份验证：`KIMI_API_KEY`
-- 示例模型：`kimi-coding/k2p5`
+- 示例模型：`kimi/kimi-code`
 
 ```json5
 {
   env: { KIMI_API_KEY: "sk-..." },
   agents: {
-    defaults: { model: { primary: "kimi-coding/k2p5" } },
+    defaults: { model: { primary: "kimi/kimi-code" } },
   },
 }
 ```

--- a/docs/zh-CN/providers/moonshot.md
+++ b/docs/zh-CN/providers/moonshot.md
@@ -143,7 +143,7 @@ openclaw onboard --auth-choice kimi-code-api-key
 
 ## 说明
 
-- Moonshot 模型引用使用 `moonshot/<modelId>`。Kimi Coding 模型引用使用 `kimi/<modelId>`（提供商 ID 是 `kimi`，而非 `kimi-coding`）。
+- Moonshot 模型引用使用 `moonshot/<modelId>`。Kimi Coding 模型引用使用 `kimi/<modelId>`。
 - 如有需要，可在 `models.providers` 中覆盖定价和上下文元数据。
 - 如果 Moonshot 为某个模型发布了不同的上下文限制，请相应调整
   `contextWindow`。

--- a/docs/zh-CN/providers/moonshot.md
+++ b/docs/zh-CN/providers/moonshot.md
@@ -18,7 +18,7 @@ x-i18n:
 
 Moonshot 提供带有 OpenAI 兼容端点的 Kimi API。配置该
 提供商，并将默认模型设置为 `moonshot/kimi-k2.5`，或者使用
-`kimi-coding/k2p5` 作为 Kimi Coding。
+`kimi/kimi-code` 作为 Kimi Coding。
 
 当前 Kimi K2 模型 ID：
 
@@ -132,9 +132,9 @@ openclaw onboard --auth-choice kimi-code-api-key
   env: { KIMI_API_KEY: "sk-..." },
   agents: {
     defaults: {
-      model: { primary: "kimi-coding/k2p5" },
+      model: { primary: "kimi/kimi-code" },
       models: {
-        "kimi-coding/k2p5": { alias: "Kimi K2.5" },
+        "kimi/kimi-code": { alias: "Kimi" },
       },
     },
   },
@@ -143,7 +143,7 @@ openclaw onboard --auth-choice kimi-code-api-key
 
 ## 说明
 
-- Moonshot 模型引用使用 `moonshot/<modelId>`。Kimi Coding 模型引用使用 `kimi-coding/<modelId>`。
+- Moonshot 模型引用使用 `moonshot/<modelId>`。Kimi Coding 模型引用使用 `kimi/<modelId>`（提供商 ID 是 `kimi`，而非 `kimi-coding`）。
 - 如有需要，可在 `models.providers` 中覆盖定价和上下文元数据。
 - 如果 Moonshot 为某个模型发布了不同的上下文限制，请相应调整
   `contextWindow`。


### PR DESCRIPTION
## Problem

The Kimi Coding docs reference `kimi-coding/k2p5` as the model ref, but the plugin actually registers with:
- **Provider ID:** `kimi` (not `kimi-coding`)
- **Default model ID:** `kimi-code` (not `k2p5`)

So the correct model ref is `kimi/kimi-code`.

`kimi-coding` is listed as an alias in the plugin registration (`extensions/kimi-coding/index.ts` line 21), but the actual provider ID is `kimi` (line 7). The legacy model ID `k2p5` exists in the catalog but `kimi-code` is the current default.

This caused confusion during setup — `openclaw models auth login --provider kimi-coding` works (via alias), but the resulting config uses `kimi/kimi-code`, not `kimi-coding/k2p5` as the docs suggest.

## Changes

Updated all Kimi Coding model refs from `kimi-coding/k2p5` to `kimi/kimi-code` in:
- `docs/concepts/model-providers.md`
- `docs/providers/moonshot.md`
- `docs/zh-CN/concepts/model-providers.md`
- `docs/zh-CN/providers/moonshot.md`