### PR TITLE
fix(discord): pass accountId to reaction helpers for multi-account setups

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -181,11 +181,13 @@ export async function processDiscordMessage(
     setReaction: async (emoji) => {
       await reactMessageDiscord(messageChannelId, message.id, emoji, {
         rest: discordRest,
+        accountId,
       });
     },
     removeReaction: async (emoji) => {
       await removeReactionDiscord(messageChannelId, message.id, emoji, {
         rest: discordRest,
+        accountId,
       });
     },
   };


### PR DESCRIPTION
## Summary
- In multi-account Discord setups, ack reactions fail with `Discord bot token missing for account "default"`
- Root cause: `reactMessageDiscord` and `removeReactionDiscord` are called with `{ rest: discordRest }` but without `accountId`, causing `createDiscordClient` to fall back to the "default" account
- The non-default account's `rest` client is already provided and works for replies, but the token resolution still runs and fails for the wrong account
- Fix: pass the in-scope `accountId` to both `setReaction` and `removeReaction` calls (2-line change)

Fixes #57749

## Test plan
- [ ] Configure Discord with multiple accounts, binding a non-default account to an agent
- [ ] Enable ack reactions (`messages.ackReaction`)
- [ ] Send a guild message mentioning the non-default bot account
- [ ] Verify the bot adds the ack reaction (e.g., ⚡) to the inbound message
- [ ] Verify the default account's reactions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)