### PR TITLE
feat(gateway): add memory proxy for Graphiti/Cognee (SPEC-006)

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1820,7 +1820,20 @@ export class QmdMemoryManager implements MemorySearchManager {
     preferredCollection?: string;
     preferredFile?: string;
   }): { rel: string; abs: string; source: MemorySource } | null {
+    log.debug(
+      `qmd resolveDocLocationFromHints input: ${JSON.stringify({
+        uri: hints.preferredFile,
+        pathHints: hints,
+        collection: hints.preferredCollection,
+      })}`,
+    );
     if (!hints.preferredCollection || !hints.preferredFile) {
+      log.debug(
+        `qmd resolveDocLocationFromHints output: ${JSON.stringify({
+          resolvedDocs: [],
+          reason: "missing-hints",
+        })}`,
+      );
       return null;
     }
     const indexedLocation = this.resolveIndexedDocLocationFromHint(
@@ -1828,6 +1841,12 @@ export class QmdMemoryManager implements MemorySearchManager {
       hints.preferredFile,
     );
     if (indexedLocation) {
+      log.debug(
+        `qmd resolveDocLocationFromHints output: ${JSON.stringify({
+          resolvedDocs: [indexedLocation.rel],
+          strategy: "indexed",
+        })}`,
+      );
       return indexedLocation;
     }
     const collectionRelativePath = this.toCollectionRelativePath(
@@ -1835,9 +1854,24 @@ export class QmdMemoryManager implements MemorySearchManager {
       hints.preferredFile,
     );
     if (!collectionRelativePath) {
+      log.debug(
+        `qmd resolveDocLocationFromHints output: ${JSON.stringify({
+          resolvedDocs: [],
+          strategy: "slugified-fallback",
+          reason: "no-collection-relative-path",
+        })}`,
+      );
       return null;
     }
-    return this.toDocLocation(hints.preferredCollection, collectionRelativePath);
+    const location = this.toDocLocation(hints.preferredCollection, collectionRelativePath);
+    log.debug(
+      `qmd resolveDocLocationFromHints output: ${JSON.stringify({
+        resolvedDocs: location ? [location.rel] : [],
+        strategy: "slugified-fallback",
+        collectionRelativePath,
+      })}`,
+    );
+    return location;
   }
 
   private resolveIndexedDocLocationFromHint(
@@ -1846,7 +1880,25 @@ export class QmdMemoryManager implements MemorySearchManager {
   ): { rel: string; abs: string; source: MemorySource } | null {
     const trimmedCollection = collection.trim();
     const trimmedFile = preferredFile.trim();
+    log.debug(
+      `qmd resolveIndexedDocLocationFromHint input: ${JSON.stringify({
+        uri: preferredFile,
+        pathHints: {
+          preferredCollection: collection,
+          preferredFile,
+        },
+        collection,
+        trimmedCollection,
+        trimmedFile,
+      })}`,
+    );
     if (!trimmedCollection || !trimmedFile) {
+      log.debug(
+        `qmd resolveIndexedDocLocationFromHint output: ${JSON.stringify({
+          resolvedDocs: [],
+          reason: "missing-trimmed-hints",
+        })}`,
+      );
       return null;
     }
     const exactPath = path.normalize(trimmedFile).replace(/\\/g, "/");
@@ -1857,7 +1909,16 @@ export class QmdMemoryManager implements MemorySearchManager {
         .prepare("SELECT path FROM documents WHERE collection = ? AND path = ? AND active = 1")
         .all(trimmedCollection, exactPath) as Array<{ path: string }>;
       if (exactRows.length > 0) {
-        return this.toDocLocation(trimmedCollection, exactRows[0].path);
+        const location = this.toDocLocation(trimmedCollection, exactRows[0].path);
+        log.debug(
+          `qmd resolveIndexedDocLocationFromHint output: ${JSON.stringify({
+            resolvedDocs: exactRows.map((row) => row.path),
+            strategy: "exact-index-match",
+            exactPath,
+            returnedDoc: location?.rel ?? null,
+          })}`,
+        );
+        return location;
       }
       rows = db
         .prepare("SELECT path FROM documents WHERE collection = ? AND active = 1")
@@ -1873,6 +1934,14 @@ export class QmdMemoryManager implements MemorySearchManager {
       return null;
     }
     const matches = rows.filter((row) => this.matchesPreferredFileHint(row.path, trimmedFile));
+    log.debug(
+      `qmd resolveIndexedDocLocationFromHint output: ${JSON.stringify({
+        resolvedDocs: matches.map((row) => row.path),
+        candidateDocs: rows.map((row) => row.path),
+        exactPath,
+        matchCount: matches.length,
+      })}`,
+    );
     if (matches.length !== 1) {
       return null;
     }

--- a/src/gateway/memory-proxy.test.ts
+++ b/src/gateway/memory-proxy.test.ts
@@ -1,0 +1,510 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, request as httpRequest } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedGatewayAuth } from "./auth.js";
+import {
+  MEMORY_PROXY_CONFIGURED_AGENTS,
+  classifyMemoryOperation,
+  evaluateMemoryAcl,
+  handleMemoryProxyHttpRequest,
+  initializeMemoryProxyAuditState,
+  listConfiguredMemoryAgents,
+  resolveMemoryDataset,
+  resolveMemoryProxyTarget,
+  resolveTrustedMemoryAgentId,
+  resetMemoryProxyStateForTests,
+} from "./memory-proxy.js";
+
+const AUTH_NONE = { mode: "none", modeSource: "config" } as unknown as ResolvedGatewayAuth;
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>).toSorted(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  return `{${entries
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+    .join(",")}}`;
+}
+
+async function startMemoryProxyServer() {
+  const server = createServer((req, res) => {
+    void handleMemoryProxyHttpRequest(req, res, { auth: AUTH_NONE });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to get test server address");
+  }
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      );
+    },
+  };
+}
+
+async function sendJsonRequest(params: {
+  baseUrl: string;
+  method: string;
+  path: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) {
+  const url = new URL(params.path, params.baseUrl);
+  const payload = params.body === undefined ? undefined : JSON.stringify(params.body);
+  return await new Promise<{
+    status: number;
+    headers: Record<string, string | string[]>;
+    body: string;
+  }>((resolve, reject) => {
+    const req = httpRequest(
+      url,
+      {
+        method: params.method,
+        headers: {
+          ...(payload
+            ? {
+                "content-type": "application/json",
+                "content-length": String(Buffer.byteLength(payload)),
+              }
+            : {}),
+          ...params.headers,
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers as Record<string, string | string[]>,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+      },
+    );
+    req.on("error", reject);
+    if (payload) {
+      req.write(payload);
+    }
+    req.end();
+  });
+}
+
+async function readAuditEntries(homeDir: string): Promise<Record<string, unknown>[]> {
+  const path = join(homeDir, ".openclaw", "audit", "memory-access.jsonl");
+  const content = await readFile(path, "utf8");
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("memory-proxy", () => {
+  let tempHome: string;
+  let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+
+  beforeEach(async () => {
+    tempHome = await mkdtemp(join(tmpdir(), "memory-proxy-"));
+    vi.stubEnv("HOME", tempHome);
+    resetMemoryProxyStateForTests();
+    fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    resetMemoryProxyStateForTests();
+    await rm(tempHome, { recursive: true, force: true });
+  });
+
+  it("routes graphiti and cognee prefixes to local upstreams", () => {
+    expect(resolveMemoryProxyTarget("/graphiti/search")).toEqual({
+      service: "graphiti",
+      targetBaseUrl: "http://127.0.0.1:8100",
+      upstreamPath: "/search",
+    });
+    expect(resolveMemoryProxyTarget("/cognee/add")).toEqual({
+      service: "cognee",
+      targetBaseUrl: "http://127.0.0.1:8200",
+      upstreamPath: "/add",
+    });
+    expect(resolveMemoryProxyTarget("/v1/chat/completions")).toBeNull();
+  });
+
+  it("derives trusted agent id from session key and ignores caller-supplied agent headers", () => {
+    const req = {
+      url: "/graphiti/search",
+      headers: {
+        host: "localhost",
+        "x-openclaw-session-key": "agent:david:main",
+        "x-openclaw-agent-id": "sentinel",
+      },
+    };
+    expect(resolveTrustedMemoryAgentId({ req: req as never })).toBe("david");
+  });
+
+  it("falls back to openclaw model when no session key is present", () => {
+    const req = { url: "/graphiti/search", headers: { host: "localhost" } };
+    expect(
+      resolveTrustedMemoryAgentId({
+        req: req as never,
+        body: { model: "openclaw/clara" },
+      }),
+    ).toBe("clara");
+  });
+
+  it("extracts cognee datasets from query or body", () => {
+    expect(
+      resolveMemoryDataset({
+        service: "cognee",
+        pathname: "/search",
+        searchParams: new URLSearchParams("dataset=case-eea"),
+      }),
+    ).toBe("case-eea");
+    expect(
+      resolveMemoryDataset({
+        service: "cognee",
+        pathname: "/add",
+        searchParams: new URLSearchParams(),
+        body: { dataset: "platform-architecture" },
+      }),
+    ).toBe("platform-architecture");
+  });
+
+  it("classifies graphiti and cognee operations", () => {
+    expect(classifyMemoryOperation({ service: "graphiti", pathname: "/episodes" })).toBe("write");
+    expect(classifyMemoryOperation({ service: "graphiti", pathname: "/search" })).toBe("read");
+    expect(classifyMemoryOperation({ service: "cognee", pathname: "/memify" })).toBe("memify");
+    expect(classifyMemoryOperation({ service: "cognee", pathname: "/delete" })).toBe("delete");
+    expect(classifyMemoryOperation({ service: "cognee", pathname: "/add" })).toBe("write");
+  });
+
+  it("enforces case read ACLs for case-eea and case-hrsp across configured agents", () => {
+    // Rachel is intentionally absent from MEMORY_PROXY_CONFIGURED_AGENTS because she reaches
+    // memory via MCP, not this gateway proxy. The gateway ACL still includes her as
+    // defense-in-depth if that ever changes, so these proxy-path tests cover only agents that
+    // can actually hit this handler.
+    const allowedReaders = new Set(["sentinel", "bosshog", "bella"]);
+    for (const dataset of ["case-eea", "case-hrsp"] as const) {
+      for (const agentId of MEMORY_PROXY_CONFIGURED_AGENTS) {
+        const acl = evaluateMemoryAcl({
+          agentId,
+          service: "cognee",
+          operation: "read",
+          dataset,
+        });
+        expect(acl.allowed).toBe(allowedReaders.has(agentId));
+      }
+    }
+  });
+
+  it("enforces dataset write ACLs for all configured agents", () => {
+    // Rachel routes via MCP rather than the gateway proxy, so the proxy test matrix excludes her.
+    // The ACL map still names Rachel explicitly as defense-in-depth for future routing changes.
+    const cases = [
+      ["case-eea", new Set(["sentinel"])],
+      ["case-hrsp", new Set(["sentinel"])],
+      ["podcast-research", new Set(["malcolm", "rook"])],
+      ["platform-compliance", new Set(["sentinel", "clara"])],
+      ["platform-architecture", new Set(["david", "clara"])],
+    ] as const;
+
+    for (const [dataset, allowed] of cases) {
+      for (const agentId of MEMORY_PROXY_CONFIGURED_AGENTS) {
+        const acl = evaluateMemoryAcl({
+          agentId,
+          service: "cognee",
+          operation: "write",
+          dataset,
+        });
+        expect(acl.allowed).toBe(allowed.has(agentId));
+      }
+    }
+  });
+
+  it("restricts delete/retract and disables memify on case datasets", () => {
+    expect(
+      evaluateMemoryAcl({
+        agentId: "sentinel",
+        service: "cognee",
+        operation: "delete",
+        dataset: "podcast-research",
+      }).allowed,
+    ).toBe(true);
+    expect(
+      evaluateMemoryAcl({
+        agentId: "david",
+        service: "graphiti",
+        operation: "retract",
+        dataset: null,
+      }).allowed,
+    ).toBe(false);
+    expect(
+      evaluateMemoryAcl({
+        agentId: "clara",
+        service: "cognee",
+        operation: "memify",
+        dataset: "case-hrsp",
+      }).allowed,
+    ).toBe(false);
+    expect(
+      evaluateMemoryAcl({
+        agentId: "clara",
+        service: "cognee",
+        operation: "memify",
+        dataset: "platform-compliance",
+      }).allowed,
+    ).toBe(true);
+  });
+
+  it("tracks the expected 13 configured agents for ACL verification", () => {
+    expect(MEMORY_PROXY_CONFIGURED_AGENTS).toHaveLength(13);
+    expect(new Set(MEMORY_PROXY_CONFIGURED_AGENTS).size).toBe(13);
+    expect(listConfiguredMemoryAgents()).not.toContain("rachel");
+  });
+
+  it("restores the audit hash chain from the last persisted entry on restart", async () => {
+    const auditDir = join(tempHome, ".openclaw", "audit");
+    await mkdir(auditDir, { recursive: true });
+    await writeFile(
+      join(auditDir, "memory-access.jsonl"),
+      `${JSON.stringify({ current_hash: "persisted-hash" })}\n`,
+      "utf8",
+    );
+
+    await initializeMemoryProxyAuditState();
+
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ results: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const listener = await startMemoryProxyServer();
+    try {
+      const response = await sendJsonRequest({
+        baseUrl: listener.baseUrl,
+        method: "POST",
+        path: "/graphiti/search",
+        headers: { "x-openclaw-session-key": "agent:david:main" },
+        body: { query: "hello" },
+      });
+      expect(response.status).toBe(200);
+    } finally {
+      await listener.close();
+    }
+
+    const entries = await readAuditEntries(tempHome);
+    expect(entries.at(-1)?.previous_hash).toBe("persisted-hash");
+  });
+
+  it("handles the full allow path auth to ACL to proxy to audit", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ results: [{ id: 1 }, { id: 2 }] }), {
+        status: 200,
+        headers: { "content-type": "application/json", "x-upstream": "ok" },
+      }),
+    );
+
+    const listener = await startMemoryProxyServer();
+    try {
+      const response = await sendJsonRequest({
+        baseUrl: listener.baseUrl,
+        method: "POST",
+        path: "/cognee/search?dataset=platform-compliance&agent_id=spoofed",
+        headers: {
+          "x-openclaw-session-key": "agent:clara:main",
+          "x-openclaw-agent-id": "sentinel",
+        },
+        body: {
+          dataset: "platform-compliance",
+          query: "show me the architecture notes",
+          agent_id: "spoofed",
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toContain('"id":1');
+      expect(response.headers["x-upstream"]).toBe("ok");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      const [upstreamUrl, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(upstreamUrl).toContain("http://127.0.0.1:8200/search?");
+      expect(upstreamUrl).toContain("dataset=platform-compliance");
+      expect(upstreamUrl).toContain("agent_id=clara");
+      expect(init.method).toBe("POST");
+      expect(new Headers(init.headers).get("x-openclaw-agent-id")).toBe("clara");
+      expect(typeof init.body).toBe("string");
+      const forwarded = JSON.parse(init.body as string);
+      expect(forwarded.agent_id).toBe("clara");
+
+      const entries = await readAuditEntries(tempHome);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        record_type: "access",
+        agent_id: "clara",
+        dataset: "platform-compliance",
+        status: "allow",
+        result_count: 2,
+      });
+    } finally {
+      await listener.close();
+    }
+  });
+
+  it("denies unauthorized case access and emits an anomaly alert", async () => {
+    const listener = await startMemoryProxyServer();
+    try {
+      const response = await sendJsonRequest({
+        baseUrl: listener.baseUrl,
+        method: "POST",
+        path: "/cognee/search?dataset=case-hrsp",
+        headers: { "x-openclaw-session-key": "agent:david:main" },
+        body: { dataset: "case-hrsp", query: "classified" },
+      });
+
+      expect(response.status).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+      const parsed = JSON.parse(response.body) as { error: { type: string } };
+      expect(parsed.error.type).toBe("forbidden");
+
+      const entries = await readAuditEntries(tempHome);
+      expect(entries).toHaveLength(2);
+      expect(entries[0]).toMatchObject({
+        record_type: "access",
+        status: "deny",
+        dataset: "case-hrsp",
+        agent_id: "david",
+      });
+      expect(entries[1]).toMatchObject({
+        record_type: "alert",
+        category: "unauthorized_case_access",
+        dataset: "case-hrsp",
+        agent_id: "david",
+      });
+    } finally {
+      await listener.close();
+    }
+  });
+
+  it("records the correct chained audit hashes", async () => {
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ results: [{ id: 1 }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const listener = await startMemoryProxyServer();
+    try {
+      for (let i = 0; i < 2; i += 1) {
+        const response = await sendJsonRequest({
+          baseUrl: listener.baseUrl,
+          method: "POST",
+          path: "/graphiti/search",
+          headers: { "x-openclaw-session-key": "agent:david:main" },
+          body: { query: `q-${i}` },
+        });
+        expect(response.status).toBe(200);
+      }
+    } finally {
+      await listener.close();
+    }
+
+    const entries = await readAuditEntries(tempHome);
+    let previousHash = "GENESIS";
+    for (const entry of entries) {
+      expect(entry.previous_hash).toBe(previousHash);
+      const { current_hash: _currentHash, ...entryWithoutCurrentHash } = entry;
+      const payload = stableStringify({ ...entryWithoutCurrentHash, previous_hash: previousHash });
+      const expectedHash = createHash("sha256")
+        .update(`${previousHash}\n${payload}`, "utf8")
+        .digest("hex");
+      expect(entry.current_hash).toBe(expectedHash);
+      previousHash = String(entry.current_hash);
+    }
+  });
+
+  it("triggers a bulk export anomaly alert", async () => {
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ results: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const listener = await startMemoryProxyServer();
+    try {
+      const response = await sendJsonRequest({
+        baseUrl: listener.baseUrl,
+        method: "GET",
+        path: "/cognee/export?dataset=podcast-research&limit=101",
+        headers: { "x-openclaw-session-key": "agent:malcolm:main" },
+      });
+      expect(response.status).toBe(200);
+    } finally {
+      await listener.close();
+    }
+
+    const entries = await readAuditEntries(tempHome);
+    expect(entries[0]).toMatchObject({
+      record_type: "alert",
+      category: "bulk_export_attempt",
+      dataset: "podcast-research",
+      agent_id: "malcolm",
+    });
+    expect(entries[1]).toMatchObject({
+      record_type: "access",
+      status: "allow",
+    });
+  });
+
+  it("triggers a query spike anomaly alert", async () => {
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ results: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    const listener = await startMemoryProxyServer();
+    try {
+      for (let i = 0; i < 21; i += 1) {
+        const response = await sendJsonRequest({
+          baseUrl: listener.baseUrl,
+          method: "GET",
+          path: "/graphiti/search",
+          headers: { "x-openclaw-session-key": "agent:david:main" },
+        });
+        expect(response.status).toBe(200);
+      }
+    } finally {
+      await listener.close();
+    }
+
+    const entries = await readAuditEntries(tempHome);
+    expect(
+      entries.some((entry) => entry.record_type === "alert" && entry.category === "query_spike"),
+    ).toBe(true);
+  });
+});

--- a/src/gateway/memory-proxy.ts
+++ b/src/gateway/memory-proxy.ts
@@ -1,0 +1,661 @@
+import { createHash } from "node:crypto";
+import { mkdir, appendFile, readFile } from "node:fs/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { loadConfig } from "../config/config.js";
+import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
+import { authorizeGatewayBearerRequestOrReply } from "./http-auth-helpers.js";
+import {
+  readJsonBodyOrError,
+  sendInvalidRequest,
+  sendJson,
+  sendMethodNotAllowed,
+} from "./http-common.js";
+import { resolveAgentIdFromModel, getHeader } from "./http-utils.js";
+
+const GRAPHITI_PREFIX = "/graphiti";
+const COGNEE_PREFIX = "/cognee";
+const GRAPHITI_TARGET = "http://127.0.0.1:8100";
+const COGNEE_TARGET = "http://127.0.0.1:8200";
+const MAX_BODY_BYTES = 1_000_000;
+const BULK_EXPORT_LIMIT = 100;
+const QUERY_SPIKE_WINDOW_MS = 60_000;
+const QUERY_SPIKE_THRESHOLD = 20;
+const AGENT_HEADER_NAMES = [
+  "x-openclaw-agent-id",
+  "x-openclaw-agent",
+  "agent_id",
+  "agent-id",
+] as const;
+
+export const MEMORY_PROXY_CONFIGURED_AGENTS = [
+  "atlas",
+  "bella",
+  "bosshog",
+  "clara",
+  "david",
+  "dex",
+  "gunner",
+  "lucy",
+  "malcolm",
+  "peter",
+  "quincy",
+  "rook",
+  "sentinel",
+] as const;
+
+export type MemoryService = "graphiti" | "cognee";
+export type MemoryOperation = "read" | "write" | "delete" | "retract" | "memify";
+
+const CASE_READERS = new Set(["rachel", "sentinel", "bosshog", "bella"]);
+const DELETE_AGENTS = new Set(["rachel", "sentinel"]);
+const DATASET_WRITE_ACL = new Map<string, Set<string>>([
+  ["case-eea", new Set(["rachel", "sentinel"])],
+  ["case-hrsp", new Set(["rachel", "sentinel"])],
+  ["podcast-research", new Set(["rachel", "malcolm", "rook"])],
+  ["platform-compliance", new Set(["rachel", "sentinel", "clara"])],
+  ["platform-architecture", new Set(["david", "clara", "rachel"])],
+]);
+const MEMIFY_DISABLED_DATASETS = new Set(["case-eea", "case-hrsp"]);
+const ALERT_CATEGORIES = {
+  bulkExport: "bulk_export_attempt",
+  querySpike: "query_spike",
+  unauthorizedCaseAccess: "unauthorized_case_access",
+} as const;
+
+type QueryWindow = { hits: number[] };
+const queryWindows = new Map<string, QueryWindow>();
+const GENESIS_AUDIT_HASH = "GENESIS";
+
+let auditWriteChain: Promise<void> = Promise.resolve();
+let auditInitPromise: Promise<void> | null = null;
+let previousAuditHash = GENESIS_AUDIT_HASH;
+
+export function resolveMemoryProxyTarget(
+  pathname: string,
+): { service: MemoryService; targetBaseUrl: string; upstreamPath: string } | null {
+  if (pathname === GRAPHITI_PREFIX || pathname.startsWith(`${GRAPHITI_PREFIX}/`)) {
+    return {
+      service: "graphiti",
+      targetBaseUrl: GRAPHITI_TARGET,
+      upstreamPath: pathname.slice(GRAPHITI_PREFIX.length) || "/",
+    };
+  }
+  if (pathname === COGNEE_PREFIX || pathname.startsWith(`${COGNEE_PREFIX}/`)) {
+    return {
+      service: "cognee",
+      targetBaseUrl: COGNEE_TARGET,
+      upstreamPath: pathname.slice(COGNEE_PREFIX.length) || "/",
+    };
+  }
+  return null;
+}
+
+function trimString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readBodyModel(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") {
+    return undefined;
+  }
+  const record = body as Record<string, unknown>;
+  return trimString(record.model);
+}
+
+export function resolveTrustedMemoryAgentId(params: {
+  req: IncomingMessage;
+  body?: unknown;
+}): string | undefined {
+  const explicitSessionKey =
+    trimString(getHeader(params.req, "x-openclaw-session-key")) ||
+    trimString(
+      new URL(params.req.url ?? "/", "http://localhost").searchParams.get("session_key"),
+    ) ||
+    (params.body && typeof params.body === "object"
+      ? trimString((params.body as Record<string, unknown>).session_key) ||
+        trimString((params.body as Record<string, unknown>).sessionKey)
+      : undefined);
+
+  if (explicitSessionKey && parseAgentSessionKey(explicitSessionKey)) {
+    return resolveAgentIdFromSessionKey(explicitSessionKey);
+  }
+
+  return resolveAgentIdFromModel(readBodyModel(params.body));
+}
+
+export function resolveMemoryDataset(params: {
+  service: MemoryService;
+  pathname: string;
+  searchParams: URLSearchParams;
+  body?: unknown;
+}): string | null {
+  if (params.service !== "cognee") {
+    return null;
+  }
+  const queryDataset = trimString(params.searchParams.get("dataset"));
+  if (queryDataset) {
+    return queryDataset;
+  }
+  if (!params.body || typeof params.body !== "object") {
+    return null;
+  }
+  const record = params.body as Record<string, unknown>;
+  return trimString(record.dataset) ?? null;
+}
+
+export function classifyMemoryOperation(params: {
+  service: MemoryService;
+  pathname: string;
+  body?: unknown;
+}): MemoryOperation {
+  const lowered = params.pathname.toLowerCase();
+  if (/\/(delete|remove)(\/|$)/.test(lowered)) {
+    return "delete";
+  }
+  if (/\/(retract|expire)(\/|$)/.test(lowered)) {
+    return "retract";
+  }
+  if (/\/(memify)(\/|$)/.test(lowered)) {
+    return "memify";
+  }
+  if (params.service === "graphiti") {
+    if (/\/(episodes?|add)(\/|$)/.test(lowered)) {
+      return "write";
+    }
+    return "read";
+  }
+  if (/\/(add|cognify|ingest|upload|document)(\/|$)/.test(lowered)) {
+    return "write";
+  }
+  if (params.body && typeof params.body === "object") {
+    const record = params.body as Record<string, unknown>;
+    if (record.content !== undefined || record.source_type !== undefined) {
+      return "write";
+    }
+  }
+  return "read";
+}
+
+export function evaluateMemoryAcl(params: {
+  agentId: string;
+  service: MemoryService;
+  operation: MemoryOperation;
+  dataset: string | null;
+}): { allowed: boolean; reason?: string } {
+  const agentId = params.agentId.toLowerCase();
+  const dataset = params.dataset?.toLowerCase() ?? null;
+
+  if (params.operation === "delete" || params.operation === "retract") {
+    return DELETE_AGENTS.has(agentId)
+      ? { allowed: true }
+      : { allowed: false, reason: "delete/retract restricted to rachel and sentinel" };
+  }
+
+  if (params.service === "graphiti") {
+    return { allowed: true };
+  }
+
+  if (params.operation === "memify") {
+    if (dataset && MEMIFY_DISABLED_DATASETS.has(dataset)) {
+      return { allowed: false, reason: `memify disabled for dataset ${dataset}` };
+    }
+    return { allowed: true };
+  }
+
+  if (params.operation === "read") {
+    if (
+      dataset &&
+      (dataset === "case-eea" || dataset === "case-hrsp") &&
+      !CASE_READERS.has(agentId)
+    ) {
+      return { allowed: false, reason: `read restricted for dataset ${dataset}` };
+    }
+    return { allowed: true };
+  }
+
+  if (params.operation === "write") {
+    if (!dataset) {
+      return { allowed: false, reason: "dataset required for cognee write operations" };
+    }
+    const writers = DATASET_WRITE_ACL.get(dataset);
+    if (!writers) {
+      return { allowed: true };
+    }
+    return writers.has(agentId)
+      ? { allowed: true }
+      : { allowed: false, reason: `write restricted for dataset ${dataset}` };
+  }
+
+  return { allowed: true };
+}
+
+function summarizeQueryText(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") {
+    return undefined;
+  }
+  const record = body as Record<string, unknown>;
+  const first =
+    trimString(record.query) ||
+    trimString(record.content) ||
+    trimString(record.text) ||
+    trimString(record.prompt);
+  return first ? first.slice(0, 500) : undefined;
+}
+
+function resolveAuditLogPath(): string {
+  return `${process.env.HOME ?? "~"}/.openclaw/audit/memory-access.jsonl`;
+}
+
+async function restorePreviousAuditHashFromLog(): Promise<string> {
+  try {
+    const content = await readFile(resolveAuditLogPath(), "utf8");
+    const lastLine = content
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .at(-1);
+    if (!lastLine) {
+      return GENESIS_AUDIT_HASH;
+    }
+    const parsed = JSON.parse(lastLine) as Record<string, unknown>;
+    return typeof parsed.current_hash === "string" && parsed.current_hash.trim().length > 0
+      ? parsed.current_hash
+      : GENESIS_AUDIT_HASH;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return GENESIS_AUDIT_HASH;
+    }
+    return GENESIS_AUDIT_HASH;
+  }
+}
+
+export async function initializeMemoryProxyAuditState(): Promise<void> {
+  if (!auditInitPromise) {
+    auditInitPromise = (async () => {
+      previousAuditHash = await restorePreviousAuditHashFromLog();
+    })();
+  }
+  await auditInitPromise;
+}
+
+export function resetMemoryProxyStateForTests(): void {
+  queryWindows.clear();
+  auditWriteChain = Promise.resolve();
+  auditInitPromise = null;
+  previousAuditHash = GENESIS_AUDIT_HASH;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>).toSorted(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  return `{${entries
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+    .join(",")}}`;
+}
+
+async function appendAuditEntry(entry: Record<string, unknown>) {
+  auditWriteChain = auditWriteChain.then(async () => {
+    const auditLogPath = resolveAuditLogPath();
+    await mkdir(auditLogPath.replace(/\/[^/]+$/, ""), { recursive: true });
+    const previousHash =
+      typeof entry.previous_hash === "string" ? entry.previous_hash : previousAuditHash;
+    const payload = stableStringify({ ...entry, previous_hash: previousHash });
+    const currentHash = createHash("sha256")
+      .update(`${previousHash}\n${payload}`, "utf8")
+      .digest("hex");
+    previousAuditHash = currentHash;
+    const line = `${stableStringify({ ...entry, previous_hash: previousHash, current_hash: currentHash })}\n`;
+    await appendFile(auditLogPath, line, "utf8");
+  });
+  await auditWriteChain;
+}
+
+async function logMemoryAccess(params: {
+  agentId: string;
+  service: MemoryService;
+  operation: MemoryOperation;
+  dataset: string | null;
+  status: "allow" | "deny";
+  reason?: string;
+  queryText?: string;
+  resultCount?: number;
+  path: string;
+}) {
+  const prev = previousAuditHash;
+  await appendAuditEntry({
+    record_type: "access",
+    timestamp: new Date().toISOString(),
+    agent_id: params.agentId,
+    service: params.service,
+    operation: params.operation,
+    dataset: params.dataset,
+    query_text: params.queryText ?? null,
+    result_count: params.resultCount ?? null,
+    status: params.status,
+    reason: params.reason ?? null,
+    path: params.path,
+    previous_hash: prev,
+  });
+}
+
+async function logMemoryAlert(params: {
+  agentId: string;
+  service: MemoryService;
+  category: string;
+  dataset: string | null;
+  path: string;
+  detail: string;
+}) {
+  const prev = previousAuditHash;
+  await appendAuditEntry({
+    record_type: "alert",
+    timestamp: new Date().toISOString(),
+    agent_id: params.agentId,
+    service: params.service,
+    category: params.category,
+    dataset: params.dataset,
+    path: params.path,
+    detail: params.detail,
+    previous_hash: prev,
+  });
+}
+
+function maybeDetectBulkExport(params: {
+  pathname: string;
+  searchParams: URLSearchParams;
+  body?: unknown;
+}): string | undefined {
+  const loweredPath = params.pathname.toLowerCase();
+  if (/(export|dump|backup|download)/.test(loweredPath)) {
+    return `path matched bulk-export pattern: ${loweredPath}`;
+  }
+  const limitRaw = params.searchParams.get("limit") ?? params.searchParams.get("top_k");
+  const limit = limitRaw ? Number(limitRaw) : Number.NaN;
+  if (Number.isFinite(limit) && limit > BULK_EXPORT_LIMIT) {
+    return `requested limit ${limit} exceeds ${BULK_EXPORT_LIMIT}`;
+  }
+  if (params.body && typeof params.body === "object") {
+    const record = params.body as Record<string, unknown>;
+    const bodyLimit = Number(record.limit ?? record.top_k ?? record.max_results);
+    if (Number.isFinite(bodyLimit) && bodyLimit > BULK_EXPORT_LIMIT) {
+      return `requested body limit ${bodyLimit} exceeds ${BULK_EXPORT_LIMIT}`;
+    }
+  }
+  return undefined;
+}
+
+function maybeDetectQuerySpike(
+  agentId: string,
+  service: MemoryService,
+  operation: MemoryOperation,
+): string | undefined {
+  if (operation !== "read") {
+    return undefined;
+  }
+  const now = Date.now();
+  const key = `${agentId}:${service}`;
+  const window = queryWindows.get(key) ?? { hits: [] };
+  window.hits = window.hits.filter((ts) => now - ts <= QUERY_SPIKE_WINDOW_MS);
+  window.hits.push(now);
+  queryWindows.set(key, window);
+  if (window.hits.length > QUERY_SPIKE_THRESHOLD) {
+    return `${window.hits.length} read queries within ${QUERY_SPIKE_WINDOW_MS}ms`;
+  }
+  return undefined;
+}
+
+function stripCallerAgentHeaders(headers: IncomingMessage["headers"]): Headers {
+  const forwardHeaders = new Headers();
+  for (const [name, value] of Object.entries(headers)) {
+    if (value == null) {
+      continue;
+    }
+    const lowered = name.toLowerCase();
+    if (
+      lowered === "host" ||
+      lowered === "content-length" ||
+      AGENT_HEADER_NAMES.includes(lowered as never)
+    ) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        forwardHeaders.append(name, entry);
+      }
+    } else {
+      forwardHeaders.set(name, value);
+    }
+  }
+  return forwardHeaders;
+}
+
+function buildForwardBody(params: {
+  req: IncomingMessage;
+  service: MemoryService;
+  trustedAgentId: string;
+  body?: unknown;
+}): BodyInit | undefined {
+  if (params.req.method === "GET" || params.req.method === "HEAD") {
+    return undefined;
+  }
+  if (params.body === undefined) {
+    return undefined;
+  }
+  if (params.body && typeof params.body === "object" && !Array.isArray(params.body)) {
+    const record = { ...(params.body as Record<string, unknown>) };
+    delete record.agent_id;
+    delete record.agentId;
+    return JSON.stringify({ ...record, agent_id: params.trustedAgentId });
+  }
+  return JSON.stringify(params.body);
+}
+
+function injectTrustedAgentQuery(searchParams: URLSearchParams, trustedAgentId: string): string {
+  searchParams.delete("agent_id");
+  searchParams.delete("agentId");
+  searchParams.set("agent_id", trustedAgentId);
+  const rendered = searchParams.toString();
+  return rendered ? `?${rendered}` : "";
+}
+
+export async function handleMemoryProxyHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: {
+    auth: ResolvedGatewayAuth;
+    trustedProxies?: string[];
+    allowRealIpFallback?: boolean;
+    rateLimiter?: AuthRateLimiter;
+  },
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const route = resolveMemoryProxyTarget(url.pathname);
+  if (!route) {
+    return false;
+  }
+
+  if (!["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"].includes(req.method ?? "")) {
+    sendMethodNotAllowed(res, "GET, POST, PUT, PATCH, DELETE, HEAD");
+    return true;
+  }
+
+  const authorized = await authorizeGatewayBearerRequestOrReply({
+    req,
+    res,
+    auth: opts.auth,
+    trustedProxies: opts.trustedProxies,
+    allowRealIpFallback: opts.allowRealIpFallback,
+    rateLimiter: opts.rateLimiter,
+  });
+  if (!authorized) {
+    return true;
+  }
+
+  let body: unknown;
+  if (!["GET", "HEAD"].includes(req.method ?? "")) {
+    body = await readJsonBodyOrError(req, res, MAX_BODY_BYTES);
+    if (body === undefined) {
+      return true;
+    }
+  }
+
+  const trustedAgentId = resolveTrustedMemoryAgentId({ req, body });
+  if (!trustedAgentId) {
+    sendInvalidRequest(res, "Missing trusted agent session context for memory request.");
+    return true;
+  }
+
+  const dataset = resolveMemoryDataset({
+    service: route.service,
+    pathname: route.upstreamPath,
+    searchParams: url.searchParams,
+    body,
+  });
+  const operation = classifyMemoryOperation({
+    service: route.service,
+    pathname: route.upstreamPath,
+    body,
+  });
+  const acl = evaluateMemoryAcl({
+    agentId: trustedAgentId,
+    service: route.service,
+    operation,
+    dataset,
+  });
+  const queryText = summarizeQueryText(body);
+
+  const bulkExportDetail = maybeDetectBulkExport({
+    pathname: route.upstreamPath,
+    searchParams: url.searchParams,
+    body,
+  });
+  if (bulkExportDetail) {
+    await logMemoryAlert({
+      agentId: trustedAgentId,
+      service: route.service,
+      category: ALERT_CATEGORIES.bulkExport,
+      dataset,
+      path: route.upstreamPath,
+      detail: bulkExportDetail,
+    });
+  }
+  const querySpikeDetail = maybeDetectQuerySpike(trustedAgentId, route.service, operation);
+  if (querySpikeDetail) {
+    await logMemoryAlert({
+      agentId: trustedAgentId,
+      service: route.service,
+      category: ALERT_CATEGORIES.querySpike,
+      dataset,
+      path: route.upstreamPath,
+      detail: querySpikeDetail,
+    });
+  }
+
+  if (!acl.allowed) {
+    await logMemoryAccess({
+      agentId: trustedAgentId,
+      service: route.service,
+      operation,
+      dataset,
+      status: "deny",
+      reason: acl.reason,
+      queryText,
+      path: route.upstreamPath,
+    });
+    if (dataset && (dataset === "case-eea" || dataset === "case-hrsp")) {
+      await logMemoryAlert({
+        agentId: trustedAgentId,
+        service: route.service,
+        category: ALERT_CATEGORIES.unauthorizedCaseAccess,
+        dataset,
+        path: route.upstreamPath,
+        detail: acl.reason ?? "unauthorized case dataset access",
+      });
+    }
+    sendJson(res, 403, {
+      ok: false,
+      error: { type: "forbidden", message: acl.reason ?? "forbidden" },
+    });
+    return true;
+  }
+
+  const headers = stripCallerAgentHeaders(req.headers);
+  headers.set("x-openclaw-agent-id", trustedAgentId);
+  headers.set("x-openclaw-agent", trustedAgentId);
+  if (body !== undefined) {
+    headers.set("content-type", "application/json; charset=utf-8");
+  }
+  const upstreamUrl = `${route.targetBaseUrl}${route.upstreamPath}${injectTrustedAgentQuery(url.searchParams, trustedAgentId)}`;
+  const upstreamResponse = await fetch(upstreamUrl, {
+    method: req.method,
+    headers,
+    body: buildForwardBody({ req, service: route.service, trustedAgentId, body }),
+    redirect: "manual",
+  });
+
+  res.statusCode = upstreamResponse.status;
+  upstreamResponse.headers.forEach((value, key) => {
+    if (key.toLowerCase() === "transfer-encoding") {
+      return;
+    }
+    res.setHeader(key, value);
+  });
+  const responseText = req.method === "HEAD" ? "" : await upstreamResponse.text();
+  const contentType = upstreamResponse.headers.get("content-type") ?? "";
+  let resultCount: number | undefined;
+  if (contentType.includes("application/json") && responseText) {
+    try {
+      const parsed = JSON.parse(responseText) as Record<string, unknown>;
+      if (Array.isArray(parsed.results)) {
+        resultCount = parsed.results.length;
+      } else if (Array.isArray(parsed.data)) {
+        resultCount = parsed.data.length;
+      } else if (typeof parsed.count === "number") {
+        resultCount = parsed.count;
+      }
+    } catch {
+      // Ignore count extraction for non-JSON payloads.
+    }
+  }
+
+  await logMemoryAccess({
+    agentId: trustedAgentId,
+    service: route.service,
+    operation,
+    dataset,
+    status: "allow",
+    queryText,
+    resultCount,
+    path: route.upstreamPath,
+  });
+
+  res.end(responseText);
+  return true;
+}
+
+export function listConfiguredMemoryAgents(): string[] {
+  const cfg = loadConfig();
+  const configured = Array.isArray(cfg.agents?.list)
+    ? cfg.agents.list
+        .map((entry) =>
+          String(entry?.id ?? "")
+            .trim()
+            .toLowerCase(),
+        )
+        .filter(Boolean)
+    : [];
+  return Array.from(new Set(configured)).toSorted();
+}

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -56,6 +56,7 @@ import {
 } from "./hooks.js";
 import { sendGatewayAuthFailure, setDefaultSecurityHeaders } from "./http-common.js";
 import { getBearerToken } from "./http-utils.js";
+import { handleMemoryProxyHttpRequest } from "./memory-proxy.js";
 import { handleOpenAiModelsHttpRequest } from "./models-http.js";
 import { resolveRequestClientIp } from "./net.js";
 import { handleOpenAiHttpRequest } from "./openai-http.js";
@@ -864,6 +865,16 @@ export function createGatewayHttpServer(opts: {
           name: "sessions-history",
           run: () =>
             handleSessionHistoryHttpRequest(req, res, {
+              auth: resolvedAuth,
+              trustedProxies,
+              allowRealIpFallback,
+              rateLimiter,
+            }),
+        },
+        {
+          name: "memory-proxy",
+          run: () =>
+            handleMemoryProxyHttpRequest(req, res, {
               auth: resolvedAuth,
               trustedProxies,
               allowRealIpFallback,

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -18,6 +18,7 @@ import type { ResolvedGatewayAuth } from "./auth.js";
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import type { ControlUiRootState } from "./control-ui.js";
 import type { HooksConfigResolved } from "./hooks.js";
+import { initializeMemoryProxyAuditState } from "./memory-proxy.js";
 import { isLoopbackHost, resolveGatewayListenHosts } from "./net.js";
 import {
   createGatewayBroadcaster,
@@ -170,6 +171,8 @@ export async function createGatewayRuntimeState(params: {
           "Host-header origin fallback weakens origin checks and should only be used as break-glass.",
       );
     }
+    await initializeMemoryProxyAuditState();
+
     const httpServers: HttpServer[] = [];
     const httpBindHosts: string[] = [];
     for (const host of bindHosts) {


### PR DESCRIPTION
## Summary

- Add dedicated memory proxy module (`src/gateway/memory-proxy.ts`) for Graphiti and Cognee integration
- Proxy routes: `/graphiti/*` → `127.0.0.1:8100`, `/cognee/*` → `127.0.0.1:8200`
- Trusted agent identity injection from session context (fail-closed, strips caller-supplied headers)
- Static dataset ACLs with tiered read access on case datasets (`case-eea`, `case-hrsp`)
- Tamper-evident audit logging with hash chaining to `~/.openclaw/audit/memory-access.jsonl`
- Anomaly detection for bulk exports, query spikes, and unauthorized case access
- Delete/retract operations restricted to rachel + sentinel with mandatory audit entries
- Memify disabled on case datasets (forensic data is append-only)

## Test plan

- [x] 15 unit/integration tests passing
- [x] All 13 agents ACL-tested (allow + deny paths)
- [x] case-hrsp and case-eea read ACL enforcement verified
- [x] Hash chain correctness test
- [x] Anomaly detection trigger tests
- [x] Typecheck clean
- [x] Build clean
- [ ] Quincy B3 live validation (blocked on OpenAI API key scope — separate fix)

Ref: SPEC-006 v1.1