### PR TITLE
fix(ui): clear pending run state on cross-run final to fix stuck typing indicator

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -99,7 +99,7 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Hello");
   });
 
-  it("appends final payload from another run without clearing active stream", () => {
+  it("appends final payload from another run and clears pending run state", () => {
     const state = createState({
       sessionKey: "main",
       chatRunId: "run-user",
@@ -115,10 +115,12 @@ describe("handleChatEvent", () => {
         content: [{ type: "text", text: "Sub-agent findings" }],
       },
     };
-    expect(handleChatEvent(state, payload)).toBe(null);
-    expect(state.chatRunId).toBe("run-user");
-    expect(state.chatStream).toBe("Working...");
-    expect(state.chatStreamStartedAt).toBe(123);
+    expect(handleChatEvent(state, payload)).toBe("final");
+    // Pending run state must be cleared so the UI exits typing indicator.
+    // See https://github.com/openclaw/openclaw/issues/57795
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
     expect(state.chatMessages).toHaveLength(1);
     expect(state.chatMessages[0]).toEqual(payload.message);
   });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -285,7 +285,13 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       const finalMessage = normalizeFinalAssistantMessage(payload.message);
       if (finalMessage && !isAssistantSilentReply(finalMessage)) {
         state.chatMessages = [...state.chatMessages, finalMessage];
-        return null;
+        // Clear pending run state so the UI exits the typing/processing
+        // indicator. Without this, the parent agent appears stuck in typing
+        // state after subagent completion even though the final response is
+        // already visible. See #57795.
+        state.chatRunId = null;
+        state.chatStream = null;
+        state.chatStreamStartedAt = null;
       }
       return "final";
     }


### PR DESCRIPTION
## Summary

- When a cross-run `final` event carries a real assistant message, clear `chatRunId`, `chatStream`, and `chatStreamStartedAt` so the UI exits the typing/processing indicator.
- NO_REPLY / empty cross-run finals still preserve parent run state (the parent agent may still be processing).

## Root cause

In `handleChatEvent`, the cross-run final branch (line 283–293) appended the subagent's message but returned without clearing the pending run state. This left the parent agent visually stuck in typing state even after the final response was visible. Refreshing the page cleared it immediately — confirming a frontend state bug, not a backend hang.

## Validation

- `pnpm test -- ui/src/ui/controllers/chat.test.ts` — updated test to expect state cleared on cross-run final with message content
- Existing tests for NO_REPLY / empty / delta cross-run events remain unchanged

## Notes

- The fix is scoped to the case where `finalMessage` is present and non-silent. If a cross-run final is NO_REPLY or has no message, the parent run state is preserved since the parent agent may still be actively streaming.
- This does not affect same-run final handling (line 303–319), which already clears state correctly.

Closes #57795