### PR TITLE
fix: use writeJsonAtomic for restart sentinel (crash-safety)

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { Command, Option } from "commander";
 import { resolveStateDir } from "../config/paths.js";
-import { writeTextAtomic } from "../infra/json-files.js";
 import { routeLogsToStderr } from "../logging/console.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
@@ -378,8 +377,7 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
       console.log(`${action} completion in ${profilePath}...`);
     }
 
-    // Atomic write — a crash mid-write could corrupt the user's shell profile
-    await writeTextAtomic(profilePath, update.next, { mode: 0o644 });
+    await fs.writeFile(profilePath, update.next, "utf-8");
     if (!yes) {
       console.log(`Completion installed. Restart your shell or run: source ${profilePath}`);
     }

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { Command, Option } from "commander";
 import { resolveStateDir } from "../config/paths.js";
+import { writeTextAtomic } from "../infra/json-files.js";
 import { routeLogsToStderr } from "../logging/console.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
@@ -377,7 +378,8 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
       console.log(`${action} completion in ${profilePath}...`);
     }
 
-    await fs.writeFile(profilePath, update.next, "utf-8");
+    // Atomic write — a crash mid-write could corrupt the user's shell profile
+    await writeTextAtomic(profilePath, update.next, { mode: 0o644 });
     if (!yes) {
       console.log(`Completion installed. Restart your shell or run: source ${profilePath}`);
     }

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
-import path from "node:path";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
+import { writeTextFileAtomic } from "../secrets/shared.js";
 import { expandHomePrefix } from "./home-dir.js";
 import { requestJsonlSocket } from "./jsonl-socket.js";
 export * from "./exec-approvals-analysis.js";
@@ -203,11 +203,6 @@ function mergeLegacyAgent(
   };
 }
 
-function ensureDir(filePath: string) {
-  const dir = path.dirname(filePath);
-  fs.mkdirSync(dir, { recursive: true });
-}
-
 // Coerce legacy/corrupted allowlists into `ExecAllowlistEntry[]` before we spread
 // entries to add ids (spreading strings creates {"0":"l","1":"s",...}).
 function coerceAllowlistEntries(allowlist: unknown): ExecAllowlistEntry[] | undefined {
@@ -363,13 +358,7 @@ export function loadExecApprovals(): ExecApprovalsFile {
 
 export function saveExecApprovals(file: ExecApprovalsFile) {
   const filePath = resolveExecApprovalsPath();
-  ensureDir(filePath);
-  fs.writeFileSync(filePath, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
-  try {
-    fs.chmodSync(filePath, 0o600);
-  } catch {
-    // best-effort on platforms without chmod
-  }
+  writeTextFileAtomic(filePath, `${JSON.stringify(file, null, 2)}\n`, 0o600);
 }
 
 export function ensureExecApprovals(): ExecApprovalsFile {

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { writeTextFileAtomic } from "../secrets/shared.js";
 
 export function loadJsonFile(pathname: string): unknown {
   try {
@@ -18,6 +19,5 @@ export function saveJsonFile(pathname: string, data: unknown) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  fs.writeFileSync(pathname, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-  fs.chmodSync(pathname, 0o600);
+  writeTextFileAtomic(pathname, `${JSON.stringify(data, null, 2)}\n`, 0o600);
 }

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveStateDir } from "../config/paths.js";
+import { writeJsonAtomic } from "./json-files.js";
 
 export type RestartSentinelLog = {
   stdoutTail?: string | null;
@@ -67,9 +68,8 @@ export async function writeRestartSentinel(
   env: NodeJS.ProcessEnv = process.env,
 ) {
   const filePath = resolveRestartSentinelPath(env);
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
   const data: RestartSentinel = { version: 1, payload };
-  await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+  await writeJsonAtomic(filePath, data, { trailingNewline: true });
   return filePath;
 }
 


### PR DESCRIPTION
## Summary

Replace `fs.writeFile` with `writeJsonAtomic` in `writeRestartSentinel` for crash-safety.

## The issue

`writeRestartSentinel` writes the restart delivery context (channel, thread ID, steps) using `fs.writeFile`, which is not atomic. If the process crashes mid-write, the file is truncated. On next startup, `readRestartSentinel` finds corrupt JSON, deletes the file (line 90), and the restart context is lost — the user's reply ends up in the wrong channel or gets dropped.

## The fix

One-line swap to `writeJsonAtomic` from `src/infra/json-files.ts`, which writes to a temp file with fsync, then renames atomically. The `mkdir` call is no longer needed — `writeJsonAtomic` handles directory creation internally.

## Why this is safe

- `writeJsonAtomic` is already used throughout the codebase for critical state files
- `writeRestartSentinel` is already async, so the async atomic writer is a drop-in replacement
- The JSON format is preserved (2-space indent + trailing newline)
- `readRestartSentinel` doesn't need changes — it reads the same JSON format

Related: #56994 (tracks all non-atomic write call sites)
