### PR TITLE
fix(cron): guard against undefined values in cron table formatter

### DIFF
--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -133,7 +133,8 @@ const CRON_TARGET_PAD = 9;
 const CRON_AGENT_PAD = 10;
 const CRON_MODEL_PAD = 20;
 
-const pad = (value: string, width: number) => value.padEnd(width);
+/** Pad a value for table display; missing values render as "-" (not available). */
+const pad = (value: string | undefined | null, width: number) => (value ?? "-").padEnd(width);
 
 const truncate = (value: string, width: number) => {
   if (value.length <= width) {


### PR DESCRIPTION
## Summary

- Widen the `pad` helper in `src/cli/cron-cli/shared.ts` to accept `string | undefined | null`, falling back to `"-"` for missing values.
- Prevents `TypeError: Cannot read properties of undefined (reading 'padEnd')` when cron jobs have undefined fields.

## Validation

- Verified the `pad` function signature change is type-safe: `(value ?? "-").padEnd(width)` always receives a string.
- The `"-"` fallback is consistent with how other columns already handle absent data (e.g., `job.sessionTarget ?? "-"` on line 241, `job.agentId ?? "-"` on line 242).

## Notes

- This is a defense-in-depth fix. Ideally the gateway should not produce jobs with missing `id`/`name`, but the formatter should not crash when it happens.
- The error repeats every ~60 seconds in logs, cluttering debugging output.

Closes #57872