### PR TITLE
Fix/push undefined error (closes #57821)

### DIFF
--- a/src/agents/openai-ws-message-conversion.ts
+++ b/src/agents/openai-ws-message-conversion.ts
@@ -469,13 +469,15 @@ export function buildAssistantMessageFromResponse(
   const content: AssistantMessage["content"] = [];
   let assistantPhase: OpenAIResponsesAssistantPhase | undefined;
 
-  for (const item of response.output ?? []) {
+  const output = Array.isArray(response.output) ? response.output : [];
+  for (const item of output) {
     if (item.type === "message") {
       const itemPhase = normalizeAssistantPhase(item.phase);
       if (itemPhase) {
         assistantPhase = itemPhase;
       }
-      for (const part of item.content ?? []) {
+      const parts = Array.isArray(item.content) ? item.content : [];
+      for (const part of parts) {
         if (part.type === "output_text" && part.text) {
           content.push({
             type: "text",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenClaw crashes with "Cannot read properties of undefined (reading 'push')" when third-party Anthropic-compatible providers return non-standard response shapes (e.g. missing/invalid `output` or `content` arrays).
- Why it matters: This causes 100% failure rate for affected providers, making the agent unusable.
- What changed: Added defensive guards to treat `response.output` and `item.content` as arrays only when valid, falling back to empty arrays otherwise.
- What did NOT change (scope boundary): No changes to provider integrations, schemas, or message transformation logic beyond safe parsing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57821
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The code assumed `response.output` and nested `content` fields always conform to the official schema and are valid arrays.
- Missing detection / guardrail: No runtime validation or fallback existed for malformed or non-standard provider responses.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Parsing logic was written against strict OpenAI/Anthropic-compatible schemas.
- Why this regressed now: Third-party relay providers introduced slight schema deviations (extra fields, missing arrays).
- If unknown, what was ruled out: Not related to transport, networking, or streaming lifecycle.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  openai-ws-message-conversion
- Scenario the test should lock in:
  Handling responses where `output` or `content` are undefined or malformed without crashing.
- Why this is the smallest reliable guardrail:
  Requires real response shape variation rather than isolated unit logic.
- Existing test that already covers this (if any):
  None
- If no new test is added, why not:
  Fix is defensive and aligns with existing parsing expectations.

## User-visible / Behavior Changes

Prevents crashes when using third-party Anthropic-compatible providers with non-standard payloads. Agent responses now proceed normally instead of failing.

## Diagram (if applicable)

```text
Before:
provider response (non-standard)
parser assumes arrays
runtime crash

After:
provider response (non-standard)
safe fallback to []
parser continues
response succeeds