### PR TITLE
fix: stage inbound media to workspace when sandbox mode is off

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -53,6 +53,20 @@ async function writeInboundMedia(
   return mediaPath;
 }
 
+function setupWorkspaceFallback(home: string): {
+  cfg: ReturnType<typeof createSandboxMediaStageConfig>;
+  workspaceDir: string;
+} {
+  const cfg = createSandboxMediaStageConfig(home);
+  // Override: sandbox off, workspaceOnly enabled
+  cfg.agents!.defaults!.sandbox = undefined;
+  cfg.tools = { fs: { workspaceOnly: true } };
+  const workspaceDir = join(home, "openclaw");
+  // Return null from ensureSandboxWorkspaceForSession (sandbox off)
+  vi.mocked(ensureSandboxWorkspaceForSession).mockResolvedValue(null);
+  return { cfg, workspaceDir };
+}
+
 describe("stageSandboxMedia", () => {
   it("stages allowed media and blocks unsafe paths", async () => {
     await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
@@ -147,6 +161,58 @@ describe("stageSandboxMedia", () => {
       });
 
       await expect(fs.readFile(victimPath, "utf8")).resolves.toBe("ORIGINAL");
+      expect(ctx.MediaPath).toBe(mediaPath);
+      expect(sessionCtx.MediaPath).toBe(mediaPath);
+    });
+  });
+
+  it("stages media into workspace when sandbox is off and workspaceOnly is true", async () => {
+    await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
+      const { cfg, workspaceDir } = setupWorkspaceFallback(home);
+
+      const mediaPath = await writeInboundMedia(home, "photo.jpg", "image-data");
+      const { ctx, sessionCtx } = createSandboxMediaContexts(mediaPath);
+
+      await stageSandboxMedia({
+        ctx,
+        sessionCtx,
+        cfg,
+        sessionKey: "agent:main:wa:+1234",
+        workspaceDir,
+      });
+
+      const expectedRelative = "media/inbound/photo.jpg";
+      expect(ctx.MediaPath).toBe(expectedRelative);
+      expect(sessionCtx.MediaPath).toBe(expectedRelative);
+      await expect(
+        fs.stat(join(workspaceDir, "media", "inbound", "photo.jpg")),
+      ).resolves.toBeTruthy();
+      const content = await fs.readFile(
+        join(workspaceDir, "media", "inbound", "photo.jpg"),
+        "utf8",
+      );
+      expect(content).toBe("image-data");
+    });
+  });
+
+  it("does not stage media into workspace when sandbox is off and workspaceOnly is false", async () => {
+    await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
+      const { cfg, workspaceDir } = setupWorkspaceFallback(home);
+      // Override: workspaceOnly disabled
+      cfg.tools = { fs: { workspaceOnly: false } };
+
+      const mediaPath = await writeInboundMedia(home, "photo.jpg", "image-data");
+      const { ctx, sessionCtx } = createSandboxMediaContexts(mediaPath);
+
+      await stageSandboxMedia({
+        ctx,
+        sessionCtx,
+        cfg,
+        sessionKey: "agent:main:wa:+1234",
+        workspaceDir,
+      });
+
+      // Path should remain absolute (no staging needed)
       expect(ctx.MediaPath).toBe(mediaPath);
       expect(sessionCtx.MediaPath).toBe(mediaPath);
     });

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -43,10 +43,13 @@ export async function stageSandboxMedia(params: {
   const remoteMediaCacheDir = ctx.MediaRemoteHost
     ? path.join(CONFIG_DIR, "media", "remote-cache", sessionKey)
     : null;
-  // When sandbox is off but a workspace dir is provided, stage media there so that
-  // workspaceOnly restrictions don't block native image injection and tool access.
+  // When sandbox is off but a workspace dir is provided and workspaceOnly is enabled,
+  // stage media there so that workspaceOnly restrictions don't block native image
+  // injection and tool access. Skip for workspaceOnly: false — absolute paths work fine.
   const workspaceFallbackDir =
-    !sandbox && !remoteMediaCacheDir && workspaceDir ? workspaceDir : null;
+    !sandbox && !remoteMediaCacheDir && workspaceDir && cfg.tools?.fs?.workspaceOnly
+      ? workspaceDir
+      : null;
   const effectiveWorkspaceDir = sandbox?.workspaceDir ?? remoteMediaCacheDir ?? workspaceFallbackDir;
   if (!effectiveWorkspaceDir) {
     return;

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -43,7 +43,11 @@ export async function stageSandboxMedia(params: {
   const remoteMediaCacheDir = ctx.MediaRemoteHost
     ? path.join(CONFIG_DIR, "media", "remote-cache", sessionKey)
     : null;
-  const effectiveWorkspaceDir = sandbox?.workspaceDir ?? remoteMediaCacheDir;
+  // When sandbox is off but a workspace dir is provided, stage media there so that
+  // workspaceOnly restrictions don't block native image injection and tool access.
+  const workspaceFallbackDir =
+    !sandbox && !remoteMediaCacheDir && workspaceDir ? workspaceDir : null;
+  const effectiveWorkspaceDir = sandbox?.workspaceDir ?? remoteMediaCacheDir ?? workspaceFallbackDir;
   if (!effectiveWorkspaceDir) {
     return;
   }
@@ -74,7 +78,8 @@ export async function stageSandboxMedia(params: {
     if (!fileName) {
       continue;
     }
-    const relativeDest = sandbox ? path.join("media", "inbound", fileName) : fileName;
+    const useSubdir = Boolean(sandbox) || Boolean(workspaceFallbackDir);
+    const relativeDest = useSubdir ? path.join("media", "inbound", fileName) : fileName;
     const dest = path.join(effectiveWorkspaceDir, relativeDest);
 
     try {
@@ -105,8 +110,11 @@ export async function stageSandboxMedia(params: {
       continue;
     }
 
-    // For sandbox use relative path, for remote cache use absolute path
-    const stagedPath = sandbox ? path.posix.join("media", "inbound", fileName) : dest;
+    // For sandbox or workspace fallback use relative path, for remote cache use absolute path
+    const stagedPath =
+      sandbox || workspaceFallbackDir
+        ? path.posix.join("media", "inbound", fileName)
+        : dest;
     staged.set(source, stagedPath);
   }
 


### PR DESCRIPTION
## Summary

When `tools.fs.workspaceOnly: true` but Docker sandbox mode is `"off"` (the default), inbound media files (images, videos, etc.) from WhatsApp and other channels are never staged into the workspace. This causes **native vision image injection to silently fail** — the model sees `[media attached: /path/to/image.jpg]` text but never receives the actual image pixels.

**Root cause:** `stageSandboxMedia()` only staged media when Docker sandbox was enabled or a remote host was present. With sandbox off and no remote host, it returned early, leaving `ctx.MediaPath` as an absolute path under `~/.openclaw/media/inbound/`. Both `loadImageFromRef` (native vision) and the agent's `read` tool reject this path because it's outside the workspace root.

**Fix:** When neither Docker sandbox nor remote host is active, fall back to staging media directly into the workspace directory (`{workspace}/media/inbound/{file}`) and rewrite `ctx.MediaPath` to a workspace-relative path.

## Reproduction

1. Configure `tools.fs.workspaceOnly: true` (no `agents.defaults.sandbox`)
2. Use a vision-capable model (gpt-5.4, claude-sonnet-4, etc.)
3. Send an image via WhatsApp
4. The model responds that it can see an image was attached but cannot see its content

## Test plan

- [x] Send image via WhatsApp with `workspaceOnly: true` + sandbox off → model should describe image content
- [ ] Send image via WhatsApp with Docker sandbox enabled → existing behavior unchanged
- [ ] Send image via WhatsApp with `workspaceOnly: false` + sandbox off → should still work (no staging needed, direct path access allowed)
- [ ] Multiple images in one message → all staged correctly with unique filenames
- [ ] Verify staged files appear under `{workspace}/media/inbound/`
- [ ] Verify `ctx.MediaPath` is rewritten to relative path (e.g. `media/inbound/xxx.jpg`)

🦞 Generated with [Claude Code](https://claude.com/claude-code)