### PR TITLE
fix: use FALLBACK_TEMPLATE_DIR when no candidate path exists (fixes isolated agentTurn cron jobs)

### DIFF
--- a/src/agents/workspace-templates.ts
+++ b/src/agents/workspace-templates.ts
@@ -42,7 +42,7 @@ export async function resolveWorkspaceTemplateDir(opts?: {
       }
     }
 
-    cachedTemplateDir = candidates[0] ?? FALLBACK_TEMPLATE_DIR;
+    cachedTemplateDir = FALLBACK_TEMPLATE_DIR;
     return cachedTemplateDir;
   })();
 


### PR DESCRIPTION
## Fix: Use FALLBACK_TEMPLATE_DIR when no candidate path exists

Closes #57945

### Problem

`resolveWorkspaceTemplateDir()` iterates through candidate paths and falls through to:

```ts
cachedTemplateDir = candidates[0] ?? FALLBACK_TEMPLATE_DIR;
```

When no candidate path exists (the common case after `npm install -g openclaw`), this returns `candidates[0]` — the packageRoot-relative path — instead of `FALLBACK_TEMPLATE_DIR`.

`candidates[0]` is `{packageRoot}/docs/reference/templates`, which does not exist in the published npm package because the bundling process only outputs to `dist/`. This caused all isolated `agentTurn` cron jobs to fail at launch with:

```
Error: Missing workspace template: AGENTS.md (...\openclaw\dist\docs\reference\templates\AGENTS.md). Ensure docs/reference/templates are packaged.
```

### Fix

Change the fallback from `candidates[0]` to `FALLBACK_TEMPLATE_DIR`:

```ts
// Before
cachedTemplateDir = candidates[0] ?? FALLBACK_TEMPLATE_DIR;

// After
cachedTemplateDir = FALLBACK_TEMPLATE_DIR;
```

`FALLBACK_TEMPLATE_DIR` is resolved relative to the source file using `import.meta.url`:

```ts
const FALLBACK_TEMPLATE_DIR = path.resolve(
  path.dirname(fileURLToPath(import.meta.url)),
  "../../docs/reference/templates",
);
```

When bundled, `import.meta.url` points to the compiled file in `dist/`, so this resolves to `{packageRoot}/docs/reference/templates` — which is the correct location and is included in the npm package via the `"docs/"` entry in `package.json` files.

### Impact

- Fixes critical regression where 20+ cron jobs fail simultaneously on fresh installs
- No behavior change when the template dir is found via a candidate path
- Single line change, minimal risk
