### PR TITLE
fix(macOS): write gateway LaunchAgent plist with 0600

### DIFF
--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -32,7 +32,7 @@ import type {
 } from "./service-types.js";
 
 const LAUNCH_AGENT_DIR_MODE = 0o755;
-const LAUNCH_AGENT_PLIST_MODE = 0o644;
+const LAUNCH_AGENT_PLIST_MODE = 0o600;
 
 function resolveLaunchAgentLabel(args?: { env?: Record<string, string | undefined> }): string {
   const envLabel = args?.env?.OPENCLAW_LAUNCHD_LABEL?.trim();


### PR DESCRIPTION
## Summary

Write the macOS gateway LaunchAgent plist with `0600` instead of `0644`.

This matches the expected owner-only permissions for the plist created under:

- `~/Library/LaunchAgents/ai.openclaw.gateway.plist`

Closes #57967.

## Changes

- change `LAUNCH_AGENT_PLIST_MODE` from `0o644` to `0o600`

## Why

The current mode leaves the plist group/world-readable. For a user-specific LaunchAgent written by OpenClaw, `0600` is the safer default and aligns better with other local file hardening in the project.

## Testing

Manual:
1. `openclaw gateway start`
2. `stat -f "%Lp %N" ~/Library/LaunchAgents/ai.openclaw.gateway.plist`
3. verify mode is `600`
