### PR TITLE
fix(config): deduplicate config warning logs to prevent spam

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -81,6 +81,7 @@ const OPEN_DM_POLICY_ALLOW_FROM_RE =
 const CONFIG_AUDIT_LOG_FILENAME = "config-audit.jsonl";
 const CONFIG_HEALTH_STATE_FILENAME = "config-health.json";
 const loggedInvalidConfigs = new Set<string>();
+const loggedConfigWarnings = new Set<string>();
 
 type ConfigWriteAuditResult = "rename" | "copy-fallback" | "failed";
 
@@ -1789,7 +1790,11 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
               `- ${sanitizeTerminalText(iss.path || "<root>")}: ${sanitizeTerminalText(iss.message)}`,
           )
           .join("\n");
-        deps.logger.warn(`Config warnings:\\n${details}`);
+        const warnKey = `${configPath}:\n${details}`;
+        if (!loggedConfigWarnings.has(warnKey)) {
+          loggedConfigWarnings.add(warnKey);
+          deps.logger.warn(`Config warnings:\\n${details}`);
+        }
       }
       warnIfConfigFromFuture(validated.config, deps.logger);
       const cfg = materializeRuntimeConfig(validated.config, "load");
@@ -2118,7 +2123,11 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       const details = validated.warnings
         .map((warning) => `- ${warning.path}: ${warning.message}`)
         .join("\n");
-      deps.logger.warn(`Config warnings:\n${details}`);
+      const warnKey = `${configPath}:\n${details}`;
+      if (!loggedConfigWarnings.has(warnKey)) {
+        loggedConfigWarnings.add(warnKey);
+        deps.logger.warn(`Config warnings:\n${details}`);
+      }
     }
 
     // Restore ${VAR} env var references that were resolved during config loading.


### PR DESCRIPTION
## Problem

Config warnings in `createConfigIO` had no deduplication guard, while invalid-config *errors* already had one (`loggedInvalidConfigs` Set).

This caused a single warning (e.g. a plugin `idHint` mismatch) to be logged on **every config read** — which happens on every CLI invocation. In practice this produces hundreds of identical lines to stderr:

```
Config warnings:\n- plugins.entries.signet-memory-openclaw: plugin id mismatch (manifest uses "signet-memory-openclaw", entry hints "index")
Config warnings:\n- plugins.entries.signet-memory-openclaw: plugin id mismatch ...
... (955 more times on `clawdbot --help`)
```

## Fix

Add a parallel `loggedConfigWarnings` Set using the same pattern already used for errors. Key is `configPath + details` so each unique warning logs once per process lifecycle.

Fixed both callsites in `createConfigIO`:
- `loadConfigFile` — config warnings with escaped newline (`\\n`)
- `writeConfigFile` — config warnings with real newline (`\n`)

## Testing

- Reproduce: add any plugin config that triggers a warning (e.g. `load.paths` pointing to `dist/index.js` when plugin manifest id differs from filename stem)
- Before: running `clawdbot --help` emits the same warning 900+ times
- After: warning emitted once, subsequent reads are silenced for the process lifecycle