### PR TITLE
fix(exec): dedupe Discord approval delivery

### DIFF
--- a/extensions/discord/src/approval-native.test.ts
+++ b/extensions/discord/src/approval-native.test.ts
@@ -1,5 +1,16 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { clearSessionStoreCacheForTest } from "../../../src/config/sessions.js";
 import { createDiscordNativeApprovalAdapter } from "./approval-native.js";
+
+const STORE_PATH = path.join(os.tmpdir(), "openclaw-discord-approval-native-test.json");
+
+function writeStore(store: Record<string, unknown>) {
+  fs.writeFileSync(STORE_PATH, `${JSON.stringify(store, null, 2)}\n`, "utf8");
+  clearSessionStoreCacheForTest();
+}
 
 describe("createDiscordNativeApprovalAdapter", () => {
   it("normalizes prefixed turn-source channel ids", async () => {
@@ -31,6 +42,41 @@ describe("createDiscordNativeApprovalAdapter", () => {
 
     const target = await adapter.native?.resolveOriginTarget?.({
       cfg: {} as never,
+      accountId: "main",
+      approvalKind: "plugin",
+      request: {
+        id: "abc",
+        request: {
+          title: "Plugin approval",
+          description: "Let plugin proceed",
+          sessionKey: "agent:main:discord:dm:123456789",
+          turnSourceChannel: "discord",
+          turnSourceTo: "123456789",
+          turnSourceAccountId: "main",
+        },
+        createdAtMs: 1,
+        expiresAtMs: 2,
+      },
+    });
+
+    expect(target).toBeNull();
+  });
+
+  it("ignores session-store turn targets for Discord DM sessions", async () => {
+    writeStore({
+      "agent:main:discord:dm:123456789": {
+        sessionId: "sess",
+        updatedAt: Date.now(),
+        origin: { provider: "discord", to: "123456789", accountId: "main" },
+        lastChannel: "discord",
+        lastTo: "123456789",
+        lastAccountId: "main",
+      },
+    });
+
+    const adapter = createDiscordNativeApprovalAdapter();
+    const target = await adapter.native?.resolveOriginTarget?.({
+      cfg: { session: { store: STORE_PATH } } as never,
       accountId: "main",
       approvalKind: "plugin",
       request: {

--- a/extensions/discord/src/approval-native.ts
+++ b/extensions/discord/src/approval-native.ts
@@ -1,5 +1,4 @@
-import { createApproverRestrictedNativeApprovalAdapter } from "openclaw/plugin-sdk/approval-runtime";
-import { resolveExecApprovalSessionTarget } from "openclaw/plugin-sdk/approval-runtime";
+import { createApproverRestrictedNativeApprovalAdapter, resolveExecApprovalSessionTarget } from "openclaw/plugin-sdk/approval-runtime";
 import type { DiscordExecApprovalConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type {
   ExecApprovalRequest,

--- a/extensions/discord/src/approval-native.ts
+++ b/extensions/discord/src/approval-native.ts
@@ -1,11 +1,11 @@
 import { createApproverRestrictedNativeApprovalAdapter } from "openclaw/plugin-sdk/approval-runtime";
+import { resolveExecApprovalSessionTarget } from "openclaw/plugin-sdk/approval-runtime";
 import type { DiscordExecApprovalConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type {
   ExecApprovalRequest,
   ExecApprovalSessionTarget,
   PluginApprovalRequest,
 } from "openclaw/plugin-sdk/infra-runtime";
-import { resolveExecApprovalSessionTarget } from "openclaw/plugin-sdk/approval-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { listDiscordAccountIds, resolveDiscordAccount } from "./accounts.js";
 import {
@@ -137,11 +137,16 @@ function resolveDiscordOriginTarget(params: {
   if (turnSourceTarget) {
     return { to: turnSourceTarget.to };
   }
+  if (sessionKind === "dm") {
+    return null;
+  }
   if (sessionTarget?.channel === "discord") {
     const targetTo = normalizeDiscordOriginChannelId(sessionTarget.to);
     return targetTo ? { to: targetTo } : null;
   }
-  const legacyChannelId = extractDiscordChannelId(params.request.request.sessionKey?.trim() || null);
+  const legacyChannelId = extractDiscordChannelId(
+    params.request.request.sessionKey?.trim() || null,
+  );
   if (legacyChannelId) {
     return { to: legacyChannelId };
   }

--- a/extensions/discord/src/monitor/exec-approvals.test.ts
+++ b/extensions/discord/src/monitor/exec-approvals.test.ts
@@ -46,7 +46,9 @@ const mockRestPatch = vi.hoisted(() => vi.fn());
 const mockRestDelete = vi.hoisted(() => vi.fn());
 const gatewayClientStarts = vi.hoisted(() => vi.fn());
 const gatewayClientStops = vi.hoisted(() => vi.fn());
-const gatewayClientRequests = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => ({ ok: true })));
+const gatewayClientRequests = vi.hoisted(() =>
+  vi.fn(async (..._args: unknown[]) => ({ ok: true })),
+);
 const gatewayClientParams = vi.hoisted(() => [] as Array<Record<string, unknown>>);
 const mockGatewayClientCtor = vi.hoisted(() => vi.fn());
 const mockResolveGatewayConnectionAuth = vi.hoisted(() => vi.fn());
@@ -955,9 +957,7 @@ describe("DiscordExecApprovalHandler delivery routing", () => {
       Routes.channelMessages("999888777"),
       expect.objectContaining({
         body: expect.objectContaining({
-          content: expect.stringContaining(
-            "I sent approval DMs to the approvers for this account",
-          ),
+          content: expect.stringContaining("I sent approval DMs to the approvers for this account"),
         }),
       }),
     );
@@ -986,6 +986,45 @@ describe("DiscordExecApprovalHandler delivery routing", () => {
       Routes.channelMessages("999888777"),
       expect.anything(),
     );
+  });
+
+  it("dedupes delivery when the origin route and approver DM resolve to the same Discord channel", async () => {
+    const handler = createHandler({
+      enabled: true,
+      approvers: ["999"],
+      target: "both",
+    });
+
+    mockRestPost.mockImplementation(async (route: string) => {
+      if (route === Routes.channelMessages("123")) {
+        return { id: "msg-1", channel_id: "123" };
+      }
+      if (route === Routes.userChannels()) {
+        return { id: "123" };
+      }
+      throw new Error(`unexpected route: ${route}`);
+    });
+
+    await handler.handleApprovalRequested(
+      createRequest({
+        sessionKey: "agent:main:discord:channel:123",
+        turnSourceChannel: "discord",
+        turnSourceTo: "123",
+        turnSourceAccountId: "default",
+      }),
+    );
+
+    expect(mockRestPost).toHaveBeenCalledTimes(2);
+    expect(mockRestPost).toHaveBeenNthCalledWith(
+      1,
+      Routes.channelMessages("123"),
+      expect.objectContaining({
+        body: expect.any(Object),
+      }),
+    );
+    expect(mockRestPost).toHaveBeenNthCalledWith(2, Routes.userChannels(), {
+      body: { recipient_id: "999" },
+    });
   });
 
   it("delivers plugin approvals through the shared runtime flow", async () => {

--- a/extensions/discord/src/monitor/exec-approvals.ts
+++ b/extensions/discord/src/monitor/exec-approvals.ts
@@ -623,6 +623,9 @@ export class DiscordExecApprovalHandler {
       adapter: nativeApprovalAdapter.native,
     });
     const pendingEntries: PendingApproval[] = [];
+    // "target=both" can collapse onto one Discord DM surface when the origin route
+    // and approver DM resolve to the same concrete channel id.
+    const deliveredChannelIds = new Set<string>();
     const originTarget = deliveryPlan.originTarget;
     if (deliveryPlan.notifyOriginWhenDmOnly && originTarget) {
       try {
@@ -640,6 +643,12 @@ export class DiscordExecApprovalHandler {
 
     for (const deliveryTarget of deliveryPlan.targets) {
       if (deliveryTarget.surface === "origin") {
+        if (deliveredChannelIds.has(deliveryTarget.target.to)) {
+          logDebug(
+            `discord exec approvals: skipping duplicate approval ${request.id} for channel ${deliveryTarget.target.to}`,
+          );
+          continue;
+        }
         try {
           const message = (await discordRequest(
             () =>
@@ -654,6 +663,7 @@ export class DiscordExecApprovalHandler {
               discordMessageId: message.id,
               discordChannelId: deliveryTarget.target.to,
             });
+            deliveredChannelIds.add(deliveryTarget.target.to);
 
             logDebug(
               `discord exec approvals: sent approval ${request.id} to channel ${deliveryTarget.target.to}`,
@@ -679,6 +689,12 @@ export class DiscordExecApprovalHandler {
           logError(`discord exec approvals: failed to create DM for user ${userId}`);
           continue;
         }
+        if (deliveredChannelIds.has(dmChannel.id)) {
+          logDebug(
+            `discord exec approvals: skipping duplicate approval ${request.id} for DM channel ${dmChannel.id}`,
+          );
+          continue;
+        }
 
         const message = (await discordRequest(
           () =>
@@ -697,6 +713,7 @@ export class DiscordExecApprovalHandler {
           discordMessageId: message.id,
           discordChannelId: dmChannel.id,
         });
+        deliveredChannelIds.add(dmChannel.id);
 
         logDebug(`discord exec approvals: sent approval ${request.id} to user ${userId}`);
       } catch (err) {


### PR DESCRIPTION
## Summary

- Problem: Discord DM-origin approvals could post two approval cards when `channels.discord.execApprovals.target="both"` was enabled.
- Why it matters: approvers saw duplicate approval cards in the same DM even though only one approval request existed.
- What changed: dedupe Discord approval sends by the resolved Discord channel id, and ignore session-store fallback origin targets for true `discord:dm:*` sessions.
- What did NOT change (scope boundary): no Telegram changes, no approval auth changes, and no exec approval policy/runtime changes outside Discord delivery.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #57838
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the shared approval planner deduped logical targets before Discord resolved approver DMs into concrete channel ids. When the origin route and approver DM later collapsed onto the same Discord DM channel, `DiscordExecApprovalHandler` still posted twice.
- Missing detection / guardrail: there was no send-time dedupe keyed by the resolved `discordChannelId`, and the `discord:dm:*` session-store fallback could still reintroduce an origin target.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this regressed in the shared channel approval unification from #57838, which moved Discord native approval delivery onto the shared planner/runtime.
- Why this regressed now: `target="both"` intentionally schedules origin + approver delivery, but Discord DM surfaces can converge after DM creation rather than at plan time.
- If unknown, what was ruled out: ruled out multiple approval requests and multiple gateway instances; the live repro was one request delivered twice to the same DM surface.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/exec-approvals.test.ts`
- Scenario the test should lock in: origin delivery and approver DM delivery resolve to the same concrete Discord channel id under `target="both"`, and only one card is posted.
- Why this is the smallest reliable guardrail: the bug appears after Discord resolves `Routes.userChannels()` into a DM channel id, so it needs the delivery seam rather than a pure planner unit test.
- Existing test that already covers this (if any): `extensions/discord/src/approval-native.test.ts` now also covers the narrower `discord:dm:*` session-store fallback path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Discord DM-origin approvals no longer send duplicate approval cards when origin delivery and approver DM delivery collapse onto the same DM surface.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local gateway + Discord plugin runtime on latest `main`
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): `channels.discord.execApprovals.enabled=true`, `channels.discord.execApprovals.target="both"`, single approver configured

### Steps

1. Start latest `main` with Discord exec approvals enabled and `target="both"`.
2. Trigger an exec approval from a Discord DM with an approver who also receives DM approvals.
3. Observe delivery in the approver DM.

### Expected

- One approval card in the DM.

### Actual

- Two approval cards in the same DM.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the duplicate-card behavior on latest `main`, patched the clean smoke runtime, and confirmed the same Discord DM-origin approval flow produced only one card after the fix.
- Edge cases checked: focused Discord regression tests for the concrete channel-id collision and the `discord:dm:*` session-store fallback; `pnpm build` passed.
- What you did **not** verify: Telegram flows and non-Discord approval surfaces.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR, or temporarily switch Discord exec approval target from `both` to `dm` or `channel`.
- Files/config to restore: `extensions/discord/src/monitor/exec-approvals.ts`, `extensions/discord/src/approval-native.ts`
- Known bad symptoms reviewers should watch for: duplicate Discord approval cards in a DM, or missing approval delivery for true `discord:dm:*` sessions.

## Risks and Mitigations

- Risk: deduping by resolved Discord channel id could accidentally suppress a legitimate second post if two logical targets are intentionally meant to land in the same Discord channel.
  - Mitigation: the dedupe key is scoped per approval request, and the only legitimate collision here is the duplicate DM/origin convergence we want to suppress.
