### PR TITLE
Agents: fix subagent model precedence

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -12,6 +12,7 @@ import {
   modelKey,
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
+  resolveSubagentConfiguredModelSelection,
   resolveThinkingDefault,
   resolveModelRefFromString,
 } from "./model-selection.js";
@@ -855,5 +856,50 @@ describe("normalizeModelSelection", () => {
     expect(normalizeModelSelection(undefined)).toBeUndefined();
     expect(normalizeModelSelection(null)).toBeUndefined();
     expect(normalizeModelSelection(42)).toBeUndefined();
+  });
+});
+
+describe("resolveSubagentConfiguredModelSelection", () => {
+  it("prefers the agent primary model over agents.defaults.subagents.model", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          subagents: { model: "openai/gpt-5.4" },
+        },
+        list: [
+          {
+            id: "research",
+            model: { primary: "anthropic/claude-opus-4-6" },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    expect(resolveSubagentConfiguredModelSelection({ cfg, agentId: "research" })).toBe(
+      "anthropic/claude-opus-4-6",
+    );
+  });
+
+  it("still prefers agent subagents.model over the agent primary model", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          subagents: { model: "openai/gpt-5.4" },
+        },
+        list: [
+          {
+            id: "research",
+            model: { primary: "anthropic/claude-opus-4-6" },
+            subagents: { model: "google/gemini-2.5-pro" },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    expect(resolveSubagentConfiguredModelSelection({ cfg, agentId: "research" })).toBe(
+      "google/gemini-2.5-pro",
+    );
   });
 });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -440,8 +440,8 @@ export function resolveSubagentConfiguredModelSelection(params: {
   const agentConfig = resolveAgentConfig(params.cfg, params.agentId);
   return (
     normalizeModelSelection(agentConfig?.subagents?.model) ??
-    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model) ??
-    normalizeModelSelection(agentConfig?.model)
+    normalizeModelSelection(agentConfig?.model) ??
+    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model)
   );
 }
 

--- a/src/cron/isolated-agent.subagent-model.test.ts
+++ b/src/cron/isolated-agent.subagent-model.test.ts
@@ -95,12 +95,16 @@ async function runSubagentModelCase(params: {
   home: string;
   cfgOverrides?: Partial<OpenClawConfig>;
   jobModelOverride?: string;
+  agentId?: string;
 }) {
   const storePath = await writeSessionStore(params.home);
   mockEmbeddedAgent();
   const job = makeJob();
   if (params.jobModelOverride) {
     job.payload = { kind: "agentTurn", message: "do work", model: params.jobModelOverride };
+  }
+  if (params.agentId) {
+    job.agentId = params.agentId;
   }
 
   await runCronIsolatedAgentTurn({
@@ -190,6 +194,27 @@ describe("runCronIsolatedAgentTurn: subagent model resolution (#11461)", () => {
       });
       expect(call?.provider).toBe("openai");
       expect(call?.model).toBe("gpt-4o");
+    });
+  });
+
+  it("prefers the agent model over agents.defaults.subagents.model", async () => {
+    await withTempHome(async (home) => {
+      const call = await runSubagentModelCase({
+        home,
+        agentId: "research",
+        cfgOverrides: {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-sonnet-4-5",
+              workspace: path.join(home, "openclaw"),
+              subagents: { model: "ollama/llama3.2:3b" },
+            },
+            list: [{ id: "research", model: { primary: "anthropic/claude-opus-4-6" } }],
+          },
+        },
+      });
+      expect(call?.provider).toBe("anthropic");
+      expect(call?.model).toBe("claude-opus-4-6");
     });
   });
 });

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -19,6 +19,7 @@ export type ResolveCronModelSelectionParams = {
   cfg: OpenClawConfig;
   cfgWithAgentDefaults: OpenClawConfig;
   agentConfigOverride?: {
+    model?: unknown;
     subagents?: {
       model?: unknown;
     };
@@ -61,6 +62,7 @@ export async function resolveCronModelSelection(
 
   const subagentModelRaw =
     normalizeModelSelection(params.agentConfigOverride?.subagents?.model) ??
+    normalizeModelSelection(params.agentConfigOverride?.model) ??
     normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model);
   if (subagentModelRaw) {
     const resolvedSubagent = resolveAllowedModelRef({

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -65,7 +65,7 @@ async function applySubagentModelPatch(cfg: OpenClawConfig) {
 }
 
 function makeKimiSubagentCfg(params: {
-  agentPrimaryModel: string;
+  agentPrimaryModel?: string;
   agentSubagentModel?: string;
   defaultsSubagentModel?: string;
 }): OpenClawConfig {
@@ -83,7 +83,7 @@ function makeKimiSubagentCfg(params: {
       list: [
         {
           id: "kimi",
-          model: { primary: params.agentPrimaryModel },
+          model: params.agentPrimaryModel ? { primary: params.agentPrimaryModel } : undefined,
           subagents: params.agentSubagentModel ? { model: params.agentSubagentModel } : undefined,
         },
       ],
@@ -400,7 +400,6 @@ describe("gateway sessions patch", () => {
 
   test("allows global defaults.subagents.model for subagent session even when missing from global allowlist", async () => {
     const cfg = makeKimiSubagentCfg({
-      agentPrimaryModel: "anthropic/claude-sonnet-4-6",
       defaultsSubagentModel: SUBAGENT_MODEL,
     });
 


### PR DESCRIPTION
## Summary

- Problem: `sessions_spawn` and related subagent model resolution preferred `agents.defaults.subagents.model` over a named agent's own `model.primary`, so per-agent model defaults were ignored.
- Why it matters: named agents could not reliably keep their configured primary model for spawned subagents unless every spawn call repeated an explicit `model` override.
- What changed: reordered subagent model precedence to prefer `agents.list[].subagents.model`, then `agents.list[].model.primary`, then `agents.defaults.subagents.model`, and mirrored that precedence in isolated cron model resolution.
- What did NOT change (scope boundary): explicit spawn/job `model` overrides still win, and no broader agent/default model resolution behavior was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57993
- Related #57993
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `resolveSubagentConfiguredModelSelection` in `src/agents/model-selection.ts` placed `agents.defaults.subagents.model` ahead of the target agent's own `model`, so the global subagent default masked the per-agent primary model.
- Missing detection / guardrail: there was no regression test asserting that a named agent's `model.primary` beats the global subagent default when `subagents.model` is unset.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #57993 reported the precedence mismatch with a direct repro.
- Why this regressed now: the precedence chain encoded the wrong specificity order.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/model-selection.test.ts`, `src/cron/isolated-agent.subagent-model.test.ts`, and `src/gateway/sessions-patch.test.ts`
- Scenario the test should lock in: named agent `model.primary` is used for subagents unless a more specific `agents.list[].subagents.model` or explicit runtime override is present.
- Why this is the smallest reliable guardrail: it locks the precedence helper directly and covers the two mirrored runtime consumers that depended on the old order.
- Existing test that already covers this (if any): `src/gateway/sessions-patch.test.ts` already covered adjacent allowlist behavior and was updated to stay aligned with the corrected precedence.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Named agents now keep their own `model.primary` for spawned subagents when `agents.list[].subagents.model` is unset, even if `agents.defaults.subagents.model` is configured.
- Isolated cron runs now apply the same precedence when targeting a named agent.

## Diagram (if applicable)

```text
Before:
subagent spawn -> global defaults.subagents.model -> agent model.primary ignored

After:
subagent spawn -> agent subagents.model (if set) -> else agent model.primary -> else global defaults.subagents.model
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15 / Darwin 25.x
- Runtime/container: local Node 22+ / pnpm workspace
- Model/provider: config-driven subagent model selection
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.subagents.model`, `agents.list[].model.primary`, optional `agents.list[].subagents.model`

### Steps

1. Configure `agents.defaults.subagents.model` and a named agent with a different `model.primary`.
2. Spawn a subagent for that named agent without an explicit `model` override.
3. Inspect the resolved subagent model.

### Expected

- The named agent's `model.primary` is used unless `agents.list[].subagents.model` is configured.

### Actual

- Before this fix, `agents.defaults.subagents.model` won and masked the named agent's `model.primary`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced the precedence issue in code inspection, updated the precedence helper, ran targeted regression tests for model selection, cron isolated-agent subagent resolution, and gateway sessions patch behavior; also ran `pnpm check` and `pnpm build`.
- Edge cases checked: agent `subagents.model` still outranks agent `model.primary`; explicit runtime/job model overrides still outrank config defaults; global `defaults.subagents.model` still applies when the agent has no explicit model.
- What you did **not** verify: I did not change or validate unrelated CLI help output; repo-wide `pnpm test` still reports the existing unrelated failure in `src/cli/config-cli.test.ts` about `--container` examples in help text.

## AI Assistance

- AI-assisted: yes

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: another runtime path could still encode a different subagent model precedence order.
  - Mitigation: the helper and isolated cron path now match, and regression tests cover both direct helper precedence and mirrored runtime usage.

Made with [Cursor](https://cursor.com)