### PR TITLE
WhatsApp: hydrate participating groups on connect

### DIFF
--- a/extensions/whatsapp/src/inbound.media.test.ts
+++ b/extensions/whatsapp/src/inbound.media.test.ts
@@ -100,6 +100,7 @@ vi.mock("./session.js", async () => {
     sendPresenceUpdate: vi.fn().mockResolvedValue(undefined),
     sendMessage: vi.fn().mockResolvedValue(undefined),
     readMessages: vi.fn().mockResolvedValue(undefined),
+    groupFetchAllParticipating: vi.fn().mockResolvedValue({}),
     updateMediaMessage: vi.fn(),
     logger: {},
     user: { id: "me@s.whatsapp.net" },

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -53,6 +53,14 @@ export async function monitorWebInbox(options: {
     authDir: options.authDir,
   });
   await waitForWaConnection(sock);
+  try {
+    const groups = await sock.groupFetchAllParticipating();
+    if (shouldLogVerbose()) {
+      logVerbose(`Hydrated ${Object.keys(groups ?? {}).length} participating groups on connect`);
+    }
+  } catch (err) {
+    logVerbose(`Failed to hydrate participating groups on connect: ${String(err)}`);
+  }
   const connectedAtMs = Date.now();
 
   let onCloseResolve: ((reason: WebListenerCloseReason) => void) | null = null;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -53,14 +53,6 @@ export async function monitorWebInbox(options: {
     authDir: options.authDir,
   });
   await waitForWaConnection(sock);
-  try {
-    const groups = await sock.groupFetchAllParticipating();
-    if (shouldLogVerbose()) {
-      logVerbose(`Hydrated ${Object.keys(groups ?? {}).length} participating groups on connect`);
-    }
-  } catch (err) {
-    logVerbose(`Failed to hydrate participating groups on connect: ${String(err)}`);
-  }
   const connectedAtMs = Date.now();
 
   let onCloseResolve: ((reason: WebListenerCloseReason) => void) | null = null;
@@ -538,6 +530,20 @@ export async function monitorWebInbox(options: {
     "connection.update",
     handleConnectionUpdate as unknown as (...args: unknown[]) => void,
   );
+
+  void (async () => {
+    try {
+      const groups = await sock.groupFetchAllParticipating();
+      if (shouldLogVerbose()) {
+        logVerbose(`Hydrated ${Object.keys(groups ?? {}).length} participating groups on connect`);
+      }
+    } catch (err) {
+      const error = String(err);
+      inboundLogger.warn({ error }, "failed hydrating participating groups on connect");
+      inboundConsoleLog.warn(`Failed hydrating participating groups on connect: ${error}`);
+      logVerbose(`Failed to hydrate participating groups on connect: ${error}`);
+    }
+  })();
 
   const sendApi = createWebSendApi({
     sock: {

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
@@ -147,6 +147,34 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
+  it("does not block inbound listeners while group hydration is pending", async () => {
+    let resolveHydration!: () => void;
+    const sock = getSock();
+    const pendingHydration = new Promise<Record<string, never>>((resolve) => {
+      resolveHydration = () => resolve({});
+    });
+    sock.groupFetchAllParticipating.mockImplementationOnce(() => pendingHydration);
+    const onMessage = vi.fn(async () => {
+      return;
+    });
+
+    const { listener } = await startInboxMonitor(onMessage as InboxOnMessage);
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("pending-hydration"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "ping",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+
+    resolveHydration();
+    await listener.close();
+  });
+
   it("deduplicates redelivered messages by id", async () => {
     const onMessage = vi.fn(async () => {
       return;

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
@@ -6,6 +6,7 @@ import {
   InboxOnMessage,
   buildNotifyMessageUpsert,
   getAuthDir,
+  getSock,
   installWebMonitorInboxUnitTestHooks,
   startInboxMonitor,
   waitForMessageCalls,
@@ -122,6 +123,26 @@ describe("web monitor inbox", () => {
     expect(sock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
       text: "pong",
     });
+
+    await listener.close();
+  });
+
+  it("hydrates participating groups once after connect", async () => {
+    const { listener, sock } = await startInboxMonitor(vi.fn(async () => {}) as InboxOnMessage);
+
+    expect(sock.groupFetchAllParticipating).toHaveBeenCalledTimes(1);
+
+    await listener.close();
+  });
+
+  it("continues when group hydration fails on connect", async () => {
+    const sock = getSock();
+    sock.groupFetchAllParticipating.mockRejectedValueOnce(new Error("no groups"));
+
+    const { listener } = await startInboxMonitor(vi.fn(async () => {}) as InboxOnMessage);
+
+    expect(sock.groupFetchAllParticipating).toHaveBeenCalledTimes(1);
+    expect(sock.sendPresenceUpdate).toHaveBeenCalledWith("available");
 
     await listener.close();
   });

--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -39,6 +39,7 @@ export type MockSock = {
   sendPresenceUpdate: AnyMockFn;
   sendMessage: AnyMockFn;
   readMessages: AnyMockFn;
+  groupFetchAllParticipating: AnyMockFn;
   updateMediaMessage: AnyMockFn;
   logger: Record<string, unknown>;
   signalRepository: {
@@ -65,6 +66,7 @@ function createMockSock(): MockSock {
     sendPresenceUpdate: createResolvedMock(),
     sendMessage: createResolvedMock(),
     readMessages: createResolvedMock(),
+    groupFetchAllParticipating: vi.fn().mockResolvedValue({}),
     updateMediaMessage: vi.fn(),
     logger: {},
     signalRepository: {

--- a/test/mocks/baileys.ts
+++ b/test/mocks/baileys.ts
@@ -21,6 +21,7 @@ export type MockBaileysSocket = {
   sendPresenceUpdate: ReturnType<typeof vi.fn>;
   sendMessage: ReturnType<typeof vi.fn>;
   readMessages: ReturnType<typeof vi.fn>;
+  groupFetchAllParticipating: ReturnType<typeof vi.fn>;
   user?: { id?: string };
 };
 
@@ -138,6 +139,7 @@ export function createMockBaileys(): {
       sendPresenceUpdate: vi.fn().mockResolvedValue(undefined),
       sendMessage: vi.fn().mockResolvedValue({ key: { id: "msg123" } }),
       readMessages: vi.fn().mockResolvedValue(undefined),
+      groupFetchAllParticipating: vi.fn().mockResolvedValue({}),
       user: { id: "123@s.whatsapp.net" },
     };
     setImmediate(() => ev.emit("connection.update", { connection: "open" }));


### PR DESCRIPTION
#### Summary
This fixes a linked-device WhatsApp regression where DMs could arrive but group messages never started flowing on a freshly linked session.

#### Repro Steps
1. Link a fresh WhatsApp companion device.
2. Send a DM and confirm it arrives.
3. Send a message in an existing group and observe that no inbound group event is delivered.

#### Root Cause
OpenClaw waited for the socket to connect and then started listening for inbound events, but it never explicitly hydrated participating groups. In current Baileys, `groupFetchAllParticipating()` only runs automatically after a `dirty/groups` sync event, so newly linked sessions could miss the group bootstrap needed to start receiving live group traffic.

#### Behavior Changes
- Call `groupFetchAllParticipating()` once after the WhatsApp socket connects.
- Keep startup resilient by swallowing hydration failures and continuing to send presence / process inbox traffic.
- Add focused regression coverage for the successful and failing hydration paths.

#### Codebase and GitHub Search
- Verified the current inbox bootstrap path in `extensions/whatsapp/src/inbound/monitor.ts`.
- Verified current Baileys group bootstrap behavior and confirmed `groupFetchAllParticipating()` was not called by OpenClaw on connect.
- Checked the reported regression in [openclaw/openclaw#57989](https://github.com/openclaw/openclaw/issues/57989). lobster-biscuit

#### Tests
- `pnpm check` ✅
- `pnpm build` ✅
- `pnpm test -- extensions/whatsapp/src/session.test.ts extensions/whatsapp/src/inbound.media.test.ts extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test.ts extensions/whatsapp/src/monitor-inbox.blocks-messages-from-unauthorized-senders-not-allowfrom.test.ts extensions/whatsapp/src/monitor-inbox.allows-messages-from-senders-allowfrom-list.test.ts` ✅
- `pnpm test` ⚠️ fails on unrelated existing test `src/tts/status-config.test.ts` (`provider` expected `auto`, received `microsoft`)

#### Manual Testing
N/A

**Sign-Off**

- Models used: Cursor agent
- Submitter effort: investigated issue #57989 in current code, implemented the smallest targeted fix, and reran validation on the upstream-based branch
- Agent notes: AI assistance was used for implementation and validation; the change is limited to WhatsApp inbox bootstrap behavior and regression tests

Made with [Cursor](https://cursor.com)