### PR TITLE
fix(openrouter): enable strict9 tool call ID sanitization

### DIFF
--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -26,6 +26,16 @@ const resolveProviderCapabilitiesWithPluginMock = vi.fn((params: { provider: str
         openAiCompatTurnValidation: false,
         geminiThoughtSignatureSanitization: true,
         geminiThoughtSignatureModelHints: ["gemini"],
+        transcriptToolCallIdMode: "strict9",
+        transcriptToolCallIdModelHints: [
+          "mistral",
+          "mixtral",
+          "codestral",
+          "pixtral",
+          "devstral",
+          "ministral",
+          "mistralai",
+        ],
       };
     case "openai-codex":
       return {

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -26,7 +26,6 @@ const resolveProviderCapabilitiesWithPluginMock = vi.fn((params: { provider: str
         openAiCompatTurnValidation: false,
         geminiThoughtSignatureSanitization: true,
         geminiThoughtSignatureModelHints: ["gemini"],
-        transcriptToolCallIdMode: "strict9",
         transcriptToolCallIdModelHints: [
           "mistral",
           "mixtral",

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -72,9 +72,8 @@ const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities
   openrouter: {
     // OpenRouter routes to various backends (Mistral, Claude, etc.)
     // which may have different tool call ID requirements.
-    // Enable strict9 sanitization to ensure compatibility with
-    // restrictive backends like Mistral (requires 9-char alphanumeric IDs).
-    transcriptToolCallIdMode: "strict9",
+    // Enable strict9 sanitization only for Mistral-named models to ensure
+    // compatibility with restrictive backends (requires 9-char alphanumeric IDs).
     transcriptToolCallIdModelHints: [
       "mistral",
       "mixtral",

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -69,6 +69,22 @@ const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities
     geminiThoughtSignatureSanitization: true,
     geminiThoughtSignatureModelHints: ["gemini"],
   },
+  openrouter: {
+    // OpenRouter routes to various backends (Mistral, Claude, etc.)
+    // which may have different tool call ID requirements.
+    // Enable strict9 sanitization to ensure compatibility with
+    // restrictive backends like Mistral (requires 9-char alphanumeric IDs).
+    transcriptToolCallIdMode: "strict9",
+    transcriptToolCallIdModelHints: [
+      "mistral",
+      "mixtral",
+      "codestral",
+      "pixtral",
+      "devstral",
+      "ministral",
+      "mistralai",
+    ],
+  },
   openai: {
     providerFamily: "openai",
   },


### PR DESCRIPTION
## Summary
- Enables `strict9` tool call ID sanitization for OpenRouter provider
- Activates only for Mistral-named models via model hints (mistral, mixtral, codestral, pixtral, devstral, ministerial, mistralai)

## Why
When routing through OpenRouter to Mistral, tool call IDs were not being sanitized to meet Mistral's strict requirement (9-char alphanumeric). This caused 400 errors:
```
Tool call id was exec1774786568428215 but must be a-z, A-Z, 0-9, with a length of 9.
```

The fix adds `transcriptToolCallIdModelHints` to the openrouter provider, enabling proper tool call ID sanitization only for Mistral-named models when routed through OpenRouter.

## Testing
- [x] Code compiles without errors
- [x] Related tests updated (provider-capabilities.test.ts)

Fixes #57672