### PR TITLE
fix(xai): normalize image tool results for responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Docs: https://docs.openclaw.ai
 - Diffs: fall back to plain text when `lang` hints are invalid during diff render and viewer hydration, so bad or stale language values no longer break the diff viewer. (#57902) Thanks @gumadeiras.
 - Doctor/plugins: skip false Matrix legacy-helper warnings when no migration plans exist, and keep bundled `enabledByDefault` plugins in the gateway startup set. (#57931) Thanks @dinakars777.
 - Matrix/CLI send: start one-off Matrix send clients before outbound delivery so `openclaw message send --channel matrix` restores E2EE in encrypted rooms instead of sending plain events. (#57936) Thanks @gumadeiras.
+- xAI/Responses: normalize image-bearing tool results for xAI responses payloads, including OpenResponses-style `input_image.source` parts, so image tool replays no longer 422 on the follow-up turn. (#58017) Thanks @neeravmakwana.
 - Cron/isolated sessions: carry the full live-session provider, model, and auth-profile selection across retry restarts so cron jobs with model overrides no longer fail or loop on mid-run model-switch requests. (#57972) Thanks @issaba1.
 - Matrix/direct rooms: stop trusting remote `is_direct`, honor explicit local `is_direct: false` for discovered DM candidates, and avoid extra member-state lookups for shared rooms so DM routing and repair stay aligned. (#57124) Thanks @w-sss.
 - Agents/sandbox: make remote FS bridge reads pin the parent path and open the file atomically in the helper so read access cannot race path resolution. Thanks @AntAISecurityLab and @vincentkoc.

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -172,4 +172,123 @@ describe("xai stream wrappers", () => {
       },
     ]);
   });
+
+  it("keeps multiple tool outputs contiguous before replaying collected images", () => {
+    const payload: Record<string, unknown> = {
+      input: [
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: [
+            { type: "input_text", text: "first" },
+            {
+              type: "input_image",
+              detail: "auto",
+              image_url: "data:image/png;base64,QUFBQQ==",
+            },
+          ],
+        },
+        {
+          type: "function_call_output",
+          call_id: "call_2",
+          output: [
+            { type: "input_text", text: "second" },
+            {
+              type: "input_image",
+              detail: "auto",
+              image_url: "data:image/png;base64,QkJCQg==",
+            },
+          ],
+        },
+      ],
+    };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload, {} as Model<"openai-responses">);
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrapped = createXaiToolPayloadCompatibilityWrapper(baseStreamFn);
+
+    void wrapped(
+      {
+        api: "openai-responses",
+        provider: "xai",
+        id: "grok-4-fast",
+        input: ["text", "image"],
+      } as Model<"openai-responses">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(payload.input).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "call_1",
+        output: "first",
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_2",
+        output: "second",
+      },
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_text", text: "Attached image(s) from tool result:" },
+          {
+            type: "input_image",
+            detail: "auto",
+            image_url: "data:image/png;base64,QUFBQQ==",
+          },
+          {
+            type: "input_image",
+            detail: "auto",
+            image_url: "data:image/png;base64,QkJCQg==",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("drops image blocks and uses fallback text for models without image input", () => {
+    const payload: Record<string, unknown> = {
+      input: [
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: [
+            {
+              type: "input_image",
+              detail: "auto",
+              image_url: "data:image/png;base64,QUJDRA==",
+            },
+          ],
+        },
+      ],
+    };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload, {} as Model<"openai-responses">);
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrapped = createXaiToolPayloadCompatibilityWrapper(baseStreamFn);
+
+    void wrapped(
+      {
+        api: "openai-responses",
+        provider: "xai",
+        id: "grok-4-fast",
+        input: ["text"],
+      } as Model<"openai-responses">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(payload.input).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "call_1",
+        output: "(see attached image)",
+      },
+    ]);
+  });
 });

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -117,4 +117,59 @@ describe("xai stream wrappers", () => {
     expect(payload).not.toHaveProperty("reasoningEffort");
     expect(payload).not.toHaveProperty("reasoning_effort");
   });
+
+  it("moves image-bearing tool results out of function_call_output payloads", () => {
+    const payload: Record<string, unknown> = {
+      input: [
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: [
+            { type: "input_text", text: "Read image" },
+            {
+              type: "input_image",
+              detail: "auto",
+              image_url: "data:image/png;base64,QUJDRA==",
+            },
+          ],
+        },
+      ],
+    };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload, {} as Model<"openai-responses">);
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrapped = createXaiToolPayloadCompatibilityWrapper(baseStreamFn);
+
+    void wrapped(
+      {
+        api: "openai-responses",
+        provider: "xai",
+        id: "grok-4-fast",
+        input: ["text", "image"],
+      } as Model<"openai-responses">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(payload.input).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "call_1",
+        output: "Read image",
+      },
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_text", text: "Attached image(s) from tool result:" },
+          {
+            type: "input_image",
+            detail: "auto",
+            image_url: "data:image/png;base64,QUJDRA==",
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -173,6 +173,67 @@ describe("xai stream wrappers", () => {
     ]);
   });
 
+  it("replays source-based input_image parts from tool results", () => {
+    const payload: Record<string, unknown> = {
+      input: [
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: [
+            { type: "input_text", text: "Read image" },
+            {
+              type: "input_image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "QUJDRA==",
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload, {} as Model<"openai-responses">);
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrapped = createXaiToolPayloadCompatibilityWrapper(baseStreamFn);
+
+    void wrapped(
+      {
+        api: "openai-responses",
+        provider: "xai",
+        id: "grok-4-fast",
+        input: ["text", "image"],
+      } as Model<"openai-responses">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(payload.input).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "call_1",
+        output: "Read image",
+      },
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_text", text: "Attached image(s) from tool result:" },
+          {
+            type: "input_image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "QUJDRA==",
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it("keeps multiple tool outputs contiguous before replaying collected images", () => {
     const payload: Record<string, unknown> = {
       input: [

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -37,10 +37,47 @@ function supportsExplicitImageInput(model: { input?: unknown }): boolean {
   return Array.isArray(model.input) && model.input.includes("image");
 }
 
+const TOOL_RESULT_IMAGE_REPLAY_TEXT = "Attached image(s) from tool result:";
+
+type ReplayableInputImagePart =
+  | {
+      type: "input_image";
+      source: { type: "url"; url: string } | { type: "base64"; media_type: string; data: string };
+    }
+  | { type: "input_image"; image_url: string; detail?: string };
+
 type NormalizedFunctionCallOutput = {
   normalizedItem: unknown;
   imageParts: Array<Record<string, unknown>>;
 };
+
+function isReplayableInputImagePart(
+  part: Record<string, unknown>,
+): part is ReplayableInputImagePart {
+  if (part.type !== "input_image") {
+    return false;
+  }
+  if (typeof part.image_url === "string") {
+    return true;
+  }
+  if (!part.source || typeof part.source !== "object") {
+    return false;
+  }
+  const source = part.source as {
+    type?: unknown;
+    url?: unknown;
+    media_type?: unknown;
+    data?: unknown;
+  };
+  if (source.type === "url") {
+    return typeof source.url === "string";
+  }
+  return (
+    source.type === "base64" &&
+    typeof source.media_type === "string" &&
+    typeof source.data === "string"
+  );
+}
 
 function normalizeXaiResponsesFunctionCallOutput(
   item: unknown,
@@ -65,9 +102,8 @@ function normalizeXaiResponsesFunctionCallOutput(
     .join("");
 
   const imageParts = includeImages
-    ? outputParts.filter(
-        (part): part is { type: "input_image"; image_url: string; detail?: string } =>
-          part.type === "input_image" && typeof part.image_url === "string",
+    ? outputParts.filter((part): part is ReplayableInputImagePart =>
+        isReplayableInputImagePart(part),
       )
     : [];
   const hadNonTextParts = outputParts.some((part) => part.type !== "input_text");
@@ -104,7 +140,7 @@ function normalizeXaiResponsesToolResultPayload(
       type: "message",
       role: "user",
       content: [
-        { type: "input_text", text: "Attached image(s) from tool result:" },
+        { type: "input_text", text: TOOL_RESULT_IMAGE_REPLAY_TEXT },
         ...collectedImageParts,
       ],
     });

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -33,6 +33,72 @@ function stripUnsupportedStrictFlag(tool: unknown): unknown {
   return { ...toolObj, function: nextFunction };
 }
 
+function supportsExplicitImageInput(model: { input?: unknown }): boolean {
+  return Array.isArray(model.input) && model.input.includes("image");
+}
+
+function normalizeXaiResponsesFunctionCallOutput(
+  item: unknown,
+  includeImages: boolean,
+): Array<Record<string, unknown>> {
+  if (!item || typeof item !== "object") {
+    return [];
+  }
+
+  const itemObj = item as Record<string, unknown>;
+  if (itemObj.type !== "function_call_output" || !Array.isArray(itemObj.output)) {
+    return [itemObj];
+  }
+
+  const outputParts = itemObj.output as Array<Record<string, unknown>>;
+  const textOutput = outputParts
+    .filter(
+      (part): part is { type: "input_text"; text: string } =>
+        part.type === "input_text" && typeof part.text === "string",
+    )
+    .map((part) => part.text)
+    .join("");
+
+  const imageParts = includeImages
+    ? outputParts.filter(
+        (part): part is { type: "input_image"; image_url: string; detail?: string } =>
+          part.type === "input_image" && typeof part.image_url === "string",
+      )
+    : [];
+  const hadNonTextParts = outputParts.some((part) => part.type !== "input_text");
+
+  const normalizedItems: Array<Record<string, unknown>> = [
+    {
+      ...itemObj,
+      output: textOutput || (hadNonTextParts ? "(see attached image)" : ""),
+    },
+  ];
+
+  if (imageParts.length > 0) {
+    normalizedItems.push({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "Attached image(s) from tool result:" }, ...imageParts],
+    });
+  }
+
+  return normalizedItems;
+}
+
+function normalizeXaiResponsesToolResultPayload(
+  payloadObj: Record<string, unknown>,
+  model: { api?: unknown; input?: unknown },
+): void {
+  if (model.api !== "openai-responses" || !Array.isArray(payloadObj.input)) {
+    return;
+  }
+
+  const includeImages = supportsExplicitImageInput(model);
+  payloadObj.input = payloadObj.input.flatMap((item) =>
+    normalizeXaiResponsesFunctionCallOutput(item, includeImages),
+  );
+}
+
 export function createXaiToolPayloadCompatibilityWrapper(
   baseStreamFn: StreamFn | undefined,
 ): StreamFn {
@@ -47,6 +113,7 @@ export function createXaiToolPayloadCompatibilityWrapper(
           if (Array.isArray(payloadObj.tools)) {
             payloadObj.tools = payloadObj.tools.map((tool) => stripUnsupportedStrictFlag(tool));
           }
+          normalizeXaiResponsesToolResultPayload(payloadObj, model);
           delete payloadObj.reasoning;
           delete payloadObj.reasoningEffort;
           delete payloadObj.reasoning_effort;

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -37,17 +37,22 @@ function supportsExplicitImageInput(model: { input?: unknown }): boolean {
   return Array.isArray(model.input) && model.input.includes("image");
 }
 
+type NormalizedFunctionCallOutput = {
+  normalizedItem: unknown;
+  imageParts: Array<Record<string, unknown>>;
+};
+
 function normalizeXaiResponsesFunctionCallOutput(
   item: unknown,
   includeImages: boolean,
-): Array<Record<string, unknown>> {
+): NormalizedFunctionCallOutput {
   if (!item || typeof item !== "object") {
-    return [];
+    return { normalizedItem: item, imageParts: [] };
   }
 
   const itemObj = item as Record<string, unknown>;
   if (itemObj.type !== "function_call_output" || !Array.isArray(itemObj.output)) {
-    return [itemObj];
+    return { normalizedItem: itemObj, imageParts: [] };
   }
 
   const outputParts = itemObj.output as Array<Record<string, unknown>>;
@@ -67,22 +72,13 @@ function normalizeXaiResponsesFunctionCallOutput(
     : [];
   const hadNonTextParts = outputParts.some((part) => part.type !== "input_text");
 
-  const normalizedItems: Array<Record<string, unknown>> = [
-    {
+  return {
+    normalizedItem: {
       ...itemObj,
       output: textOutput || (hadNonTextParts ? "(see attached image)" : ""),
     },
-  ];
-
-  if (imageParts.length > 0) {
-    normalizedItems.push({
-      type: "message",
-      role: "user",
-      content: [{ type: "input_text", text: "Attached image(s) from tool result:" }, ...imageParts],
-    });
-  }
-
-  return normalizedItems;
+    imageParts,
+  };
 }
 
 function normalizeXaiResponsesToolResultPayload(
@@ -94,9 +90,27 @@ function normalizeXaiResponsesToolResultPayload(
   }
 
   const includeImages = supportsExplicitImageInput(model);
-  payloadObj.input = payloadObj.input.flatMap((item) =>
-    normalizeXaiResponsesFunctionCallOutput(item, includeImages),
-  );
+  const normalizedInput: unknown[] = [];
+  const collectedImageParts: Array<Record<string, unknown>> = [];
+
+  for (const item of payloadObj.input) {
+    const normalized = normalizeXaiResponsesFunctionCallOutput(item, includeImages);
+    normalizedInput.push(normalized.normalizedItem);
+    collectedImageParts.push(...normalized.imageParts);
+  }
+
+  if (collectedImageParts.length > 0) {
+    normalizedInput.push({
+      type: "message",
+      role: "user",
+      content: [
+        { type: "input_text", text: "Attached image(s) from tool result:" },
+        ...collectedImageParts,
+      ],
+    });
+  }
+
+  payloadObj.input = normalizedInput;
 }
 
 export function createXaiToolPayloadCompatibilityWrapper(


### PR DESCRIPTION
## Summary

- Problem: xAI `openai-responses` requests could replay image-bearing tool results as array-valued `function_call_output.output`, which xAI rejects with a 422 deserialization error.
- Why it matters: `read(image)` and similar tool flows could succeed on the tool call itself, then crash on the next model turn instead of continuing the session.
- What changed: the xAI stream payload compatibility wrapper now rewrites array-valued `function_call_output` items into string outputs and, when the model explicitly supports image input, emits the image blocks as a following user message instead.
- What did NOT change (scope boundary): core transcript structures, non-xAI providers, and upstream `pi-ai` response conversion logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57981
- Related #57981
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the xAI provider uses the OpenAI Responses transport, and the current payload builder can emit image-bearing tool results as `function_call_output.output = [input_text, input_image]`; xAI rejects that shape.
- Missing detection / guardrail: the xAI compatibility wrapper stripped unsupported reasoning/schema fields but did not normalize image-bearing tool-result payloads.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #57981 captured the failing payload shape and 422 symptom for `read(image)` flows.
- Why this regressed now: the provider path preserved structured image tool results into the Responses payload, but xAI's endpoint is stricter than direct OpenAI here.
- If unknown, what was ruled out: verified current code still reproduces the array-valued `function_call_output.output` payload; this is not already normalized in the current xAI wrapper layer.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/xai/stream.test.ts`
- Scenario the test should lock in: image-bearing tool results sent through the xAI `openai-responses` wrapper must become string `function_call_output.output` plus a following user image message.
- Why this is the smallest reliable guardrail: the bug lives inside the xAI payload compatibility wrapper, so a focused wrapper test exercises the exact failing shape without depending on live provider calls.
- Existing test that already covers this (if any): none for this payload shape.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- xAI-backed sessions can continue after tool results that include image blocks instead of failing on the follow-up turn with a 422.

## Diagram (if applicable)

```text
Before:
[tool returns text + image blocks] -> [function_call_output.output contains input_image] -> [xAI 422]

After:
[tool returns text + image blocks] -> [function_call_output.output becomes text] -> [image blocks replayed as user message] -> [session continues]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (local verification) and issue repro from Ubuntu in #57981
- Runtime/container: local repo checkout
- Model/provider: xAI / `openai-responses`
- Integration/channel (if any): agent session / tool replay
- Relevant config (redacted): xAI provider using `https://api.x.ai/v1`

### Steps

1. Configure an xAI model on the `openai-responses` path.
2. Produce a tool result with text plus image blocks, such as `read` on a PNG.
3. Replay that result into the next model turn.

### Expected

- The follow-up request stays xAI-compatible and the session continues.

### Actual

- Before this change, the request can include array-valued `function_call_output.output` with `input_image`, which causes xAI to fail with a 422.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced the current payload shape locally, added a regression test for the xAI wrapper, ran `pnpm test -- extensions/xai/stream.test.ts`, ran `pnpm test:extension xai`, and ran `pnpm build`.
- Edge cases checked: tool results with text plus image blocks; models that do not explicitly advertise image input keep a string-only tool output.
- What you did **not** verify: live xAI API execution in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: xAI models without explicit image input support could still receive invalid image blocks.
  - Mitigation: the wrapper only forwards image blocks when the resolved model explicitly declares `image` input support; otherwise it keeps a string-only tool output.

## Notes

- AI-assisted: yes.
- `pnpm check` currently stops on unrelated existing `tsgo` errors in `extensions/diffs/src/language-hints.test.ts` on top of `origin/main`; the touched xAI lane and build both passed.

Made with [Cursor](https://cursor.com)