### PR TITLE
Add retry limit for code 1000 connection recovery

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -43,6 +43,7 @@ import {
 import { GatewayBrowserClient } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
 import type { UiSettings } from "./storage.ts";
+import { getSafeSessionStorage } from "../local-storage.ts";
 import type {
   AgentsListResult,
   PresenceEntry,
@@ -263,19 +264,42 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
         resolveGatewayErrorDetailCode(error) ??
         (typeof error?.code === "string" ? error.code : null);
 
-      //Recover from stale permission state on code 1000 . Limit reloads to prevent infinite loops (max 3 reloads in 5 minutes)
+      // Recover from stale permission state on code 1000. Limit reloads to prevent infinite loops (max 3 reloads in 5 minutes)
       if (code === 1000) {
         const MAX_RELOADS = 3;
         const WINDOW_MS = 5 * 60 * 1000; // 5 minutes
         const now = Date.now();
-        const reloadData = JSON.parse(sessionStorage.getItem("gatewayReloadCount") || "{\"count\":0,\"firstTime\":0}");
-        if (now - reloadData.firstTime > WINDOW_MS) {
-          reloadData.count = 0;
-          reloadData.firstTime = now;
+        const RELOAD_COUNT_KEY = "openclaw.control.gatewayReloadCount.v1";
+
+        let shouldReload = false;
+        try {
+          const storage = getSafeSessionStorage();
+          if (storage) {
+            let count = 0;
+            let firstTime = 0;
+            try {
+              const raw = storage.getItem(RELOAD_COUNT_KEY);
+              if (raw) {
+                const parsed = JSON.parse(raw);
+                if (typeof parsed.count === "number") count = parsed.count;
+                if (typeof parsed.firstTime === "number") firstTime = parsed.firstTime;
+              }
+            } catch {
+            }
+            if (now - firstTime > WINDOW_MS) {
+              count = 0;
+              firstTime = now;
+            }
+            if (count < MAX_RELOADS) {
+              count++;
+              storage.setItem(RELOAD_COUNT_KEY, JSON.stringify({ count, firstTime }));
+              shouldReload = true;
+            }
+          }
+        } catch {
         }
-        if (reloadData.count < MAX_RELOADS) {
-          reloadData.count++;
-          sessionStorage.setItem("gatewayReloadCount", JSON.stringify(reloadData));
+
+        if (shouldReload) {
           window.location.reload();
         } else {
           host.lastError = `Connection lost (code 1000). Reload limit reached. Please refresh manually if browser control is unavailable.`;

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -262,6 +262,27 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       host.lastErrorCode =
         resolveGatewayErrorDetailCode(error) ??
         (typeof error?.code === "string" ? error.code : null);
+
+      //Recover from stale permission state on code 1000 . Limit reloads to prevent infinite loops (max 3 reloads in 5 minutes)
+      if (code === 1000) {
+        const MAX_RELOADS = 3;
+        const WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+        const now = Date.now();
+        const reloadData = JSON.parse(sessionStorage.getItem("gatewayReloadCount") || "{\"count\":0,\"firstTime\":0}");
+        if (now - reloadData.firstTime > WINDOW_MS) {
+          reloadData.count = 0;
+          reloadData.firstTime = now;
+        }
+        if (reloadData.count < MAX_RELOADS) {
+          reloadData.count++;
+          sessionStorage.setItem("gatewayReloadCount", JSON.stringify(reloadData));
+          window.location.reload();
+        } else {
+          host.lastError = `Connection lost (code 1000). Reload limit reached. Please refresh manually if browser control is unavailable.`;
+        }
+        return;
+      }
+
       if (code !== 1012) {
         if (error?.message) {
           host.lastError =

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -281,8 +281,12 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
               const raw = storage.getItem(RELOAD_COUNT_KEY);
               if (raw) {
                 const parsed = JSON.parse(raw);
-                if (typeof parsed.count === "number") count = parsed.count;
-                if (typeof parsed.firstTime === "number") firstTime = parsed.firstTime;
+                if (typeof parsed.count === "number") {
+                  count = parsed.count;
+                }
+                if (typeof parsed.firstTime === "number") {
+                  firstTime = parsed.firstTime;
+                }
               }
             } catch {
             }


### PR DESCRIPTION
  - Auto-reload page on WebSocket close code 1000 to recover from stale permission state
  - Limit to max 3 reloads within 5 minutes to prevent infinite loops
  - Use sessionStorage to persist reload counter across page refreshes
  fix #52511
maybe a little brute force but solve the problem