### PR TITLE
fix(matrix): repair fresh invited DMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Docs: https://docs.openclaw.ai
 - Agents/sandbox: make remote FS bridge reads pin the parent path and open the file atomically in the helper so read access cannot race path resolution. Thanks @AntAISecurityLab and @vincentkoc.
 - Exec/env: block Python package index override variables from request-scoped host exec environment sanitization so package fetches cannot be redirected through a caller-supplied index. Thanks @nexrin and @vincentkoc.
 - Telegram/audio: transcode Telegram voice-note `.ogg` attachments before the local `whisper-cli` auto fallback runs, and keep mention-preflight transcription enabled in auto mode when `tools.media.audio` is unset.
+- Matrix/direct rooms: recover fresh auto-joined 1:1 DMs without eagerly persisting invite-only `m.direct` mappings, while keeping named, aliased, and explicitly configured rooms on the room path. (#58024) Thanks @gumadeiras.
 
 ## 2026.3.28
 

--- a/extensions/matrix/src/matrix/actions/summary.ts
+++ b/extensions/matrix/src/matrix/actions/summary.ts
@@ -1,3 +1,4 @@
+import { isMatrixNotFoundError } from "../errors.js";
 import { resolveMatrixMessageAttachment, resolveMatrixMessageBody } from "../media-text.js";
 import { fetchMatrixPollMessageSummary } from "../poll-summary.js";
 import type { MatrixClient } from "../sdk.js";
@@ -58,10 +59,7 @@ export async function readPinnedEvents(client: MatrixClient, roomId: string): Pr
     const pinned = content.pinned;
     return pinned.filter((id) => id.trim().length > 0);
   } catch (err: unknown) {
-    const errObj = err as { statusCode?: number; body?: { errcode?: string } };
-    const httpStatus = errObj.statusCode;
-    const errcode = errObj.body?.errcode;
-    if (httpStatus === 404 || errcode === "M_NOT_FOUND") {
+    if (isMatrixNotFoundError(err)) {
       return [];
     }
     throw err;

--- a/extensions/matrix/src/matrix/direct-management.test.ts
+++ b/extensions/matrix/src/matrix/direct-management.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { inspectMatrixDirectRooms, repairMatrixDirectRooms } from "./direct-management.js";
+import {
+  inspectMatrixDirectRooms,
+  promoteMatrixDirectRoomCandidate,
+  repairMatrixDirectRooms,
+} from "./direct-management.js";
 import type { MatrixClient } from "./sdk.js";
 import { EventType } from "./send/types.js";
 
@@ -196,5 +200,105 @@ describe("repairMatrixDirectRooms", () => {
         remoteUserId: "alice",
       }),
     ).rejects.toThrow('Matrix user IDs must be fully qualified (got "alice")');
+  });
+});
+
+describe("promoteMatrixDirectRoomCandidate", () => {
+  it("classifies a strict room as direct and repairs m.direct", async () => {
+    const setAccountData = vi.fn(async () => undefined);
+    const client = createClient({
+      getJoinedRoomMembers: vi.fn(async () => ["@bot:example.org", "@alice:example.org"]),
+      setAccountData,
+    });
+
+    const result = await promoteMatrixDirectRoomCandidate({
+      client,
+      remoteUserId: "@alice:example.org",
+      roomId: "!fresh:example.org",
+    });
+
+    expect(result).toEqual({
+      classifyAsDirect: true,
+      repaired: true,
+      roomId: "!fresh:example.org",
+      reason: "promoted",
+    });
+    expect(setAccountData).toHaveBeenCalledWith(
+      EventType.Direct,
+      expect.objectContaining({
+        "@alice:example.org": ["!fresh:example.org"],
+      }),
+    );
+  });
+
+  it("does not classify rooms with local is_direct false as direct", async () => {
+    const setAccountData = vi.fn(async () => undefined);
+    const client = createClient({
+      getJoinedRoomMembers: vi.fn(async () => ["@bot:example.org", "@alice:example.org"]),
+      getRoomStateEvent: vi.fn(async (_roomId: string, _eventType: string, stateKey: string) =>
+        stateKey === "@bot:example.org" ? { is_direct: false } : {},
+      ),
+      setAccountData,
+    });
+
+    const result = await promoteMatrixDirectRoomCandidate({
+      client,
+      remoteUserId: "@alice:example.org",
+      roomId: "!blocked:example.org",
+    });
+
+    expect(result).toEqual({
+      classifyAsDirect: false,
+      repaired: false,
+      reason: "local-explicit-false",
+    });
+    expect(setAccountData).not.toHaveBeenCalled();
+  });
+
+  it("returns already-mapped without rewriting account data", async () => {
+    const setAccountData = vi.fn(async () => undefined);
+    const client = createClient({
+      getAccountData: vi.fn(async () => ({
+        "@alice:example.org": ["!mapped:example.org", "!older:example.org"],
+      })),
+      getJoinedRoomMembers: vi.fn(async () => ["@bot:example.org", "@alice:example.org"]),
+      setAccountData,
+    });
+
+    const result = await promoteMatrixDirectRoomCandidate({
+      client,
+      remoteUserId: "@alice:example.org",
+      roomId: "!mapped:example.org",
+    });
+
+    expect(result).toEqual({
+      classifyAsDirect: true,
+      repaired: false,
+      roomId: "!mapped:example.org",
+      reason: "already-mapped",
+    });
+    expect(setAccountData).not.toHaveBeenCalled();
+  });
+
+  it("still classifies the room as direct when repair fails", async () => {
+    const client = createClient({
+      getJoinedRoomMembers: vi.fn(async () => ["@bot:example.org", "@alice:example.org"]),
+      setAccountData: vi.fn(async () => {
+        throw new Error("account data unavailable");
+      }),
+    });
+
+    const result = await promoteMatrixDirectRoomCandidate({
+      client,
+      remoteUserId: "@alice:example.org",
+      roomId: "!fresh:example.org",
+    });
+
+    expect(result).toEqual({
+      classifyAsDirect: true,
+      repaired: false,
+      roomId: "!fresh:example.org",
+      reason: "repair-failed",
+    });
   });
 });

--- a/extensions/matrix/src/matrix/direct-management.test.ts
+++ b/extensions/matrix/src/matrix/direct-management.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   inspectMatrixDirectRooms,
+  persistMatrixDirectRoomMapping,
   promoteMatrixDirectRoomCandidate,
   repairMatrixDirectRooms,
 } from "./direct-management.js";
@@ -299,6 +300,49 @@ describe("promoteMatrixDirectRoomCandidate", () => {
       repaired: false,
       roomId: "!fresh:example.org",
       reason: "repair-failed",
+    });
+  });
+
+  it("serializes concurrent m.direct writes so distinct mappings are not lost", async () => {
+    let directContent: Record<string, string[]> = {};
+    let releaseFirstWrite: (() => void) | null = null;
+    const firstWriteStarted = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    let writeCount = 0;
+    const setAccountData = vi.fn(async (_eventType: string, content: Record<string, string[]>) => {
+      writeCount += 1;
+      if (writeCount === 1) {
+        await firstWriteStarted;
+      }
+      directContent = { ...content };
+    });
+    const client = createClient({
+      getAccountData: vi.fn(async () => ({ ...directContent })),
+      setAccountData,
+    });
+
+    const firstWrite = persistMatrixDirectRoomMapping({
+      client,
+      remoteUserId: "@alice:example.org",
+      roomId: "!alice:example.org",
+    });
+    await vi.waitFor(() => {
+      expect(setAccountData).toHaveBeenCalledTimes(1);
+    });
+
+    const secondWrite = persistMatrixDirectRoomMapping({
+      client,
+      remoteUserId: "@bob:example.org",
+      roomId: "!bob:example.org",
+    });
+
+    releaseFirstWrite?.();
+    await expect(Promise.all([firstWrite, secondWrite])).resolves.toEqual([true, true]);
+
+    expect(directContent).toEqual({
+      "@alice:example.org": ["!alice:example.org"],
+      "@bob:example.org": ["!bob:example.org"],
     });
   });
 });

--- a/extensions/matrix/src/matrix/direct-management.ts
+++ b/extensions/matrix/src/matrix/direct-management.ts
@@ -1,3 +1,4 @@
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/core";
 import { inspectMatrixDirectRoomEvidence } from "./direct-room.js";
 import type { MatrixClient } from "./sdk.js";
 import { EventType, type MatrixDirectAccountData } from "./send/types.js";
@@ -39,6 +40,15 @@ export type MatrixDirectRoomPromotionResult =
       repaired: false;
       reason: "not-strict" | "local-explicit-false";
     };
+
+type MatrixDirectRoomMappingWriteResult = {
+  changed: boolean;
+  directContentBefore: MatrixDirectAccountData;
+  directContentAfter: MatrixDirectAccountData;
+};
+
+const DIRECT_ACCOUNT_DATA_QUEUE_KEY = EventType.Direct;
+const directAccountDataWriteQueues = new WeakMap<MatrixClient, KeyedAsyncQueue>();
 
 async function readMatrixDirectAccountData(client: MatrixClient): Promise<MatrixDirectAccountData> {
   try {
@@ -89,6 +99,55 @@ function normalizeRoomIdList(values: readonly string[]): string[] {
   return normalized;
 }
 
+function hasPrimaryMatrixDirectRoomMapping(params: {
+  directContent: MatrixDirectAccountData;
+  remoteUserId: string;
+  roomId: string;
+}): boolean {
+  return normalizeMappedRoomIds(params.directContent, params.remoteUserId)[0] === params.roomId;
+}
+
+function resolveDirectAccountDataWriteQueue(client: MatrixClient): KeyedAsyncQueue {
+  const existing = directAccountDataWriteQueues.get(client);
+  if (existing) {
+    return existing;
+  }
+  const created = new KeyedAsyncQueue();
+  directAccountDataWriteQueues.set(client, created);
+  return created;
+}
+
+async function writeMatrixDirectRoomMapping(params: {
+  client: MatrixClient;
+  remoteUserId: string;
+  roomId: string;
+}): Promise<MatrixDirectRoomMappingWriteResult> {
+  return await resolveDirectAccountDataWriteQueue(params.client).enqueue(
+    DIRECT_ACCOUNT_DATA_QUEUE_KEY,
+    async () => {
+      const directContentBefore = await readMatrixDirectAccountData(params.client);
+      const directContentAfter = buildNextDirectContent({
+        directContent: directContentBefore,
+        remoteUserId: params.remoteUserId,
+        roomId: params.roomId,
+      });
+      const changed = !hasPrimaryMatrixDirectRoomMapping({
+        directContent: directContentBefore,
+        remoteUserId: params.remoteUserId,
+        roomId: params.roomId,
+      });
+      if (changed) {
+        await params.client.setAccountData(EventType.Direct, directContentAfter);
+      }
+      return {
+        changed,
+        directContentBefore,
+        directContentAfter,
+      };
+    },
+  );
+}
+
 async function classifyDirectRoomCandidate(params: {
   client: MatrixClient;
   roomId: string;
@@ -134,20 +193,13 @@ export async function persistMatrixDirectRoomMapping(params: {
   roomId: string;
 }): Promise<boolean> {
   const remoteUserId = normalizeRemoteUserId(params.remoteUserId);
-  const directContent = await readMatrixDirectAccountData(params.client);
-  const current = normalizeMappedRoomIds(directContent, remoteUserId);
-  if (current[0] === params.roomId) {
-    return false;
-  }
-  await params.client.setAccountData(
-    EventType.Direct,
-    buildNextDirectContent({
-      directContent,
+  return (
+    await writeMatrixDirectRoomMapping({
+      client: params.client,
       remoteUserId,
       roomId: params.roomId,
-    }),
-  );
-  return true;
+    })
+  ).changed;
 }
 
 export async function promoteMatrixDirectRoomCandidate(params: {
@@ -178,17 +230,6 @@ export async function promoteMatrixDirectRoomCandidate(params: {
     };
   }
 
-  const directContent = await readMatrixDirectAccountData(params.client);
-  const mappedRoomIds = normalizeMappedRoomIds(directContent, remoteUserId);
-  if (mappedRoomIds[0] === params.roomId) {
-    return {
-      classifyAsDirect: true,
-      repaired: false,
-      roomId: params.roomId,
-      reason: "already-mapped",
-    };
-  }
-
   try {
     const repaired = await persistMatrixDirectRoomMapping({
       client: params.client,
@@ -199,7 +240,7 @@ export async function promoteMatrixDirectRoomCandidate(params: {
       classifyAsDirect: true,
       repaired,
       roomId: params.roomId,
-      reason: "promoted",
+      reason: repaired ? "promoted" : "already-mapped",
     };
   } catch {
     return {
@@ -278,7 +319,6 @@ export async function repairMatrixDirectRooms(params: {
   encrypted?: boolean;
 }): Promise<MatrixDirectRoomRepairResult> {
   const remoteUserId = normalizeRemoteUserId(params.remoteUserId);
-  const directContentBefore = await readMatrixDirectAccountData(params.client);
   const inspected = await inspectMatrixDirectRooms({
     client: params.client,
     remoteUserId,
@@ -289,27 +329,17 @@ export async function repairMatrixDirectRooms(params: {
       encrypted: params.encrypted === true,
     }));
   const createdRoomId = inspected.activeRoomId ? null : activeRoomId;
-  const directContentAfter = buildNextDirectContent({
-    directContent: directContentBefore,
+  const mappingWrite = await writeMatrixDirectRoomMapping({
+    client: params.client,
     remoteUserId,
     roomId: activeRoomId,
   });
-  const changed =
-    JSON.stringify(directContentAfter[remoteUserId] ?? []) !==
-    JSON.stringify(directContentBefore[remoteUserId] ?? []);
-  if (changed) {
-    await persistMatrixDirectRoomMapping({
-      client: params.client,
-      remoteUserId,
-      roomId: activeRoomId,
-    });
-  }
   return {
     ...inspected,
     activeRoomId,
     createdRoomId,
-    changed,
-    directContentBefore,
-    directContentAfter,
+    changed: mappingWrite.changed,
+    directContentBefore: mappingWrite.directContentBefore,
+    directContentAfter: mappingWrite.directContentAfter,
   };
 }

--- a/extensions/matrix/src/matrix/direct-management.ts
+++ b/extensions/matrix/src/matrix/direct-management.ts
@@ -27,6 +27,19 @@ export type MatrixDirectRoomRepairResult = MatrixDirectRoomInspection & {
   directContentAfter: MatrixDirectAccountData;
 };
 
+export type MatrixDirectRoomPromotionResult =
+  | {
+      classifyAsDirect: true;
+      repaired: boolean;
+      roomId: string;
+      reason: "promoted" | "already-mapped" | "repair-failed";
+    }
+  | {
+      classifyAsDirect: false;
+      repaired: false;
+      reason: "not-strict" | "local-explicit-false";
+    };
+
 async function readMatrixDirectAccountData(client: MatrixClient): Promise<MatrixDirectAccountData> {
   try {
     const direct = (await client.getAccountData(EventType.Direct)) as MatrixDirectAccountData;
@@ -135,6 +148,67 @@ export async function persistMatrixDirectRoomMapping(params: {
     }),
   );
   return true;
+}
+
+export async function promoteMatrixDirectRoomCandidate(params: {
+  client: MatrixClient;
+  remoteUserId: string;
+  roomId: string;
+  selfUserId?: string | null;
+}): Promise<MatrixDirectRoomPromotionResult> {
+  const remoteUserId = normalizeRemoteUserId(params.remoteUserId);
+  const evidence = await inspectMatrixDirectRoomEvidence({
+    client: params.client,
+    roomId: params.roomId,
+    remoteUserId,
+    selfUserId: params.selfUserId,
+  });
+  if (!evidence.strict) {
+    return {
+      classifyAsDirect: false,
+      repaired: false,
+      reason: "not-strict",
+    };
+  }
+  if (evidence.memberStateFlag === false) {
+    return {
+      classifyAsDirect: false,
+      repaired: false,
+      reason: "local-explicit-false",
+    };
+  }
+
+  const directContent = await readMatrixDirectAccountData(params.client);
+  const mappedRoomIds = normalizeMappedRoomIds(directContent, remoteUserId);
+  if (mappedRoomIds[0] === params.roomId) {
+    return {
+      classifyAsDirect: true,
+      repaired: false,
+      roomId: params.roomId,
+      reason: "already-mapped",
+    };
+  }
+
+  try {
+    const repaired = await persistMatrixDirectRoomMapping({
+      client: params.client,
+      remoteUserId,
+      roomId: params.roomId,
+    });
+    return {
+      classifyAsDirect: true,
+      repaired,
+      roomId: params.roomId,
+      reason: "promoted",
+    };
+  } catch {
+    return {
+      classifyAsDirect: true,
+      repaired: false,
+      roomId: params.roomId,
+      reason: "repair-failed",
+    };
+  }
 }
 
 export async function inspectMatrixDirectRooms(params: {

--- a/extensions/matrix/src/matrix/errors.ts
+++ b/extensions/matrix/src/matrix/errors.ts
@@ -1,0 +1,10 @@
+export function isMatrixNotFoundError(err: unknown): boolean {
+  const errObj = err as { statusCode?: number; body?: { errcode?: string } };
+  if (errObj?.statusCode === 404 || errObj?.body?.errcode === "M_NOT_FOUND") {
+    return true;
+  }
+  const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return (
+    message.includes("m_not_found") || message.includes("[404]") || message.includes("not found")
+  );
+}

--- a/extensions/matrix/src/matrix/monitor/auto-join.test.ts
+++ b/extensions/matrix/src/matrix/monitor/auto-join.test.ts
@@ -4,19 +4,6 @@ import { setMatrixRuntime } from "../../runtime.js";
 import type { MatrixConfig } from "../../types.js";
 import { registerMatrixAutoJoin } from "./auto-join.js";
 
-const hoisted = vi.hoisted(() => ({
-  promoteMatrixDirectRoomCandidate: vi.fn(async () => ({
-    classifyAsDirect: true as const,
-    repaired: true,
-    roomId: "!room:example.org",
-    reason: "promoted" as const,
-  })),
-}));
-
-vi.mock("../direct-management.js", () => ({
-  promoteMatrixDirectRoomCandidate: hoisted.promoteMatrixDirectRoomCandidate,
-}));
-
 type InviteHandler = (roomId: string, inviteEvent: unknown) => Promise<void>;
 
 function createClientStub() {
@@ -78,7 +65,6 @@ async function triggerInvite(
 
 describe("registerMatrixAutoJoin", () => {
   beforeEach(() => {
-    hoisted.promoteMatrixDirectRoomCandidate.mockClear();
     setMatrixRuntime({
       logging: {
         shouldLogVerbose: () => false,
@@ -95,7 +81,6 @@ describe("registerMatrixAutoJoin", () => {
 
     await triggerInvite(getInviteHandler);
     expect(joinRoom).toHaveBeenCalledWith("!room:example.org");
-    expect(hoisted.promoteMatrixDirectRoomCandidate).not.toHaveBeenCalled();
   });
 
   it("does not auto-join invites by default", async () => {
@@ -194,7 +179,7 @@ describe("registerMatrixAutoJoin", () => {
     expect(joinRoom).toHaveBeenCalledWith("!room:example.org");
   });
 
-  it("attempts eager direct repair after joining a sender-scoped invite", async () => {
+  it("joins sender-scoped invites without eager direct repair", async () => {
     const { getInviteHandler, joinRoom } = registerAutoJoinHarness({
       accountConfig: {
         autoJoin: "always",
@@ -204,22 +189,15 @@ describe("registerMatrixAutoJoin", () => {
     await triggerInvite(getInviteHandler, { sender: "@alice:example.org" });
 
     expect(joinRoom).toHaveBeenCalledWith("!room:example.org");
-    expect(hoisted.promoteMatrixDirectRoomCandidate).toHaveBeenCalledWith({
-      client: expect.any(Object),
-      remoteUserId: "@alice:example.org",
-      roomId: "!room:example.org",
-    });
   });
 
-  it("skips eager direct repair when the invite sender is unavailable", async () => {
+  it("still joins invites when the sender is unavailable", async () => {
     const { getInviteHandler } = registerAutoJoinHarness({
       accountConfig: {
         autoJoin: "always",
       },
     });
 
-    await triggerInvite(getInviteHandler, {});
-
-    expect(hoisted.promoteMatrixDirectRoomCandidate).not.toHaveBeenCalled();
+    await expect(triggerInvite(getInviteHandler, {})).resolves.toBeUndefined();
   });
 });

--- a/extensions/matrix/src/matrix/monitor/auto-join.test.ts
+++ b/extensions/matrix/src/matrix/monitor/auto-join.test.ts
@@ -4,6 +4,19 @@ import { setMatrixRuntime } from "../../runtime.js";
 import type { MatrixConfig } from "../../types.js";
 import { registerMatrixAutoJoin } from "./auto-join.js";
 
+const hoisted = vi.hoisted(() => ({
+  promoteMatrixDirectRoomCandidate: vi.fn(async () => ({
+    classifyAsDirect: true as const,
+    repaired: true,
+    roomId: "!room:example.org",
+    reason: "promoted" as const,
+  })),
+}));
+
+vi.mock("../direct-management.js", () => ({
+  promoteMatrixDirectRoomCandidate: hoisted.promoteMatrixDirectRoomCandidate,
+}));
+
 type InviteHandler = (roomId: string, inviteEvent: unknown) => Promise<void>;
 
 function createClientStub() {
@@ -54,14 +67,18 @@ function registerAutoJoinHarness(params: {
   return harness;
 }
 
-async function triggerInvite(getInviteHandler: () => InviteHandler | null) {
+async function triggerInvite(
+  getInviteHandler: () => InviteHandler | null,
+  inviteEvent: unknown = {},
+) {
   const inviteHandler = getInviteHandler();
   expect(inviteHandler).toBeTruthy();
-  await inviteHandler!("!room:example.org", {});
+  await inviteHandler!("!room:example.org", inviteEvent);
 }
 
 describe("registerMatrixAutoJoin", () => {
   beforeEach(() => {
+    hoisted.promoteMatrixDirectRoomCandidate.mockClear();
     setMatrixRuntime({
       logging: {
         shouldLogVerbose: () => false,
@@ -78,6 +95,7 @@ describe("registerMatrixAutoJoin", () => {
 
     await triggerInvite(getInviteHandler);
     expect(joinRoom).toHaveBeenCalledWith("!room:example.org");
+    expect(hoisted.promoteMatrixDirectRoomCandidate).not.toHaveBeenCalled();
   });
 
   it("does not auto-join invites by default", async () => {
@@ -174,5 +192,34 @@ describe("registerMatrixAutoJoin", () => {
 
     await triggerInvite(getInviteHandler);
     expect(joinRoom).toHaveBeenCalledWith("!room:example.org");
+  });
+
+  it("attempts eager direct repair after joining a sender-scoped invite", async () => {
+    const { getInviteHandler, joinRoom } = registerAutoJoinHarness({
+      accountConfig: {
+        autoJoin: "always",
+      },
+    });
+
+    await triggerInvite(getInviteHandler, { sender: "@alice:example.org" });
+
+    expect(joinRoom).toHaveBeenCalledWith("!room:example.org");
+    expect(hoisted.promoteMatrixDirectRoomCandidate).toHaveBeenCalledWith({
+      client: expect.any(Object),
+      remoteUserId: "@alice:example.org",
+      roomId: "!room:example.org",
+    });
+  });
+
+  it("skips eager direct repair when the invite sender is unavailable", async () => {
+    const { getInviteHandler } = registerAutoJoinHarness({
+      accountConfig: {
+        autoJoin: "always",
+      },
+    });
+
+    await triggerInvite(getInviteHandler, {});
+
+    expect(hoisted.promoteMatrixDirectRoomCandidate).not.toHaveBeenCalled();
   });
 });

--- a/extensions/matrix/src/matrix/monitor/auto-join.ts
+++ b/extensions/matrix/src/matrix/monitor/auto-join.ts
@@ -1,6 +1,7 @@
 import type { RuntimeEnv } from "../../runtime-api.js";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { MatrixConfig } from "../../types.js";
+import { promoteMatrixDirectRoomCandidate } from "../direct-management.js";
 import type { MatrixClient } from "../sdk.js";
 
 export function registerMatrixAutoJoin(params: {
@@ -61,7 +62,7 @@ export function registerMatrixAutoJoin(params: {
   };
 
   // Handle invites directly so both "always" and "allowlist" modes share the same path.
-  client.on("room.invite", async (roomId: string, _inviteEvent: unknown) => {
+  client.on("room.invite", async (roomId: string, inviteEvent: unknown) => {
     if (autoJoin === "allowlist") {
       const allowedAliasRoomIds = await resolveAllowedAliasRoomIds();
       const allowed =
@@ -78,6 +79,28 @@ export function registerMatrixAutoJoin(params: {
     try {
       await client.joinRoom(roomId);
       logVerbose(`matrix: joined room ${roomId}`);
+      const inviteSender =
+        typeof inviteEvent === "object" &&
+        inviteEvent &&
+        typeof (inviteEvent as { sender?: unknown }).sender === "string"
+          ? (inviteEvent as { sender: string }).sender.trim()
+          : "";
+      if (inviteSender) {
+        try {
+          const promotion = await promoteMatrixDirectRoomCandidate({
+            client,
+            remoteUserId: inviteSender,
+            roomId,
+          });
+          if (promotion.classifyAsDirect) {
+            logVerbose(
+              `matrix: eager direct repair room=${roomId} reason=${promotion.reason} repaired=${String(promotion.repaired)}`,
+            );
+          }
+        } catch (err) {
+          logVerbose(`matrix: eager direct repair skipped room=${roomId} (${String(err)})`);
+        }
+      }
     } catch (err) {
       runtime.error?.(`matrix: failed to join room ${roomId}: ${String(err)}`);
     }

--- a/extensions/matrix/src/matrix/monitor/auto-join.ts
+++ b/extensions/matrix/src/matrix/monitor/auto-join.ts
@@ -1,7 +1,6 @@
 import type { RuntimeEnv } from "../../runtime-api.js";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { MatrixConfig } from "../../types.js";
-import { promoteMatrixDirectRoomCandidate } from "../direct-management.js";
 import type { MatrixClient } from "../sdk.js";
 
 export function registerMatrixAutoJoin(params: {
@@ -62,7 +61,7 @@ export function registerMatrixAutoJoin(params: {
   };
 
   // Handle invites directly so both "always" and "allowlist" modes share the same path.
-  client.on("room.invite", async (roomId: string, inviteEvent: unknown) => {
+  client.on("room.invite", async (roomId: string, _inviteEvent: unknown) => {
     if (autoJoin === "allowlist") {
       const allowedAliasRoomIds = await resolveAllowedAliasRoomIds();
       const allowed =
@@ -79,28 +78,6 @@ export function registerMatrixAutoJoin(params: {
     try {
       await client.joinRoom(roomId);
       logVerbose(`matrix: joined room ${roomId}`);
-      const inviteSender =
-        typeof inviteEvent === "object" &&
-        inviteEvent &&
-        typeof (inviteEvent as { sender?: unknown }).sender === "string"
-          ? (inviteEvent as { sender: string }).sender.trim()
-          : "";
-      if (inviteSender) {
-        try {
-          const promotion = await promoteMatrixDirectRoomCandidate({
-            client,
-            remoteUserId: inviteSender,
-            roomId,
-          });
-          if (promotion.classifyAsDirect) {
-            logVerbose(
-              `matrix: eager direct repair room=${roomId} reason=${promotion.reason} repaired=${String(promotion.repaired)}`,
-            );
-          }
-        } catch (err) {
-          logVerbose(`matrix: eager direct repair skipped room=${roomId} (${String(err)})`);
-        }
-      }
     } catch (err) {
       runtime.error?.(`matrix: failed to join room ${roomId}: ${String(err)}`);
     }

--- a/extensions/matrix/src/matrix/monitor/direct.test.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MatrixClient } from "../sdk.js";
+import { EventType } from "../send/types.js";
 import { createDirectRoomTracker } from "./direct.js";
 
 type MockStateEvents = Record<string, Record<string, unknown>>;
@@ -9,15 +10,27 @@ function createMockClient(params: {
   members?: string[];
   stateEvents?: MockStateEvents;
   dmCacheAvailable?: boolean;
+  directAccountData?: Record<string, string[]>;
+  setAccountDataError?: Error;
 }) {
   let members = params.members ?? ["@alice:example.org", "@bot:example.org"];
   const stateEvents = params.stateEvents ?? {};
+  let directAccountData = params.directAccountData ?? {};
+  const dmRoomIds = new Set<string>();
+  if (params.isDm === true) {
+    dmRoomIds.add("!room:example.org");
+  }
   return {
     dms: {
       update: vi.fn().mockResolvedValue(params.dmCacheAvailable !== false),
-      isDm: vi.fn().mockReturnValue(params.isDm === true),
+      isDm: vi.fn().mockImplementation((roomId: string) => dmRoomIds.has(roomId)),
     },
     getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+    getAccountData: vi
+      .fn()
+      .mockImplementation(async (eventType: string) =>
+        eventType === EventType.Direct ? directAccountData : undefined,
+      ),
     getJoinedRoomMembers: vi.fn().mockImplementation(async () => members),
     getRoomStateEvent: vi
       .fn()
@@ -29,6 +42,26 @@ function createMockClient(params: {
         }
         return state;
       }),
+    setAccountData: vi.fn().mockImplementation(async (eventType: string, content: unknown) => {
+      if (params.setAccountDataError) {
+        throw params.setAccountDataError;
+      }
+      if (eventType !== EventType.Direct) {
+        return;
+      }
+      directAccountData = (content as Record<string, string[]>) ?? {};
+      dmRoomIds.clear();
+      for (const value of Object.values(directAccountData)) {
+        if (!Array.isArray(value)) {
+          continue;
+        }
+        for (const roomId of value) {
+          if (typeof roomId === "string" && roomId.trim()) {
+            dmRoomIds.add(roomId);
+          }
+        }
+      }
+    }),
     __setMembers(next: string[]) {
       members = next;
     },
@@ -37,8 +70,10 @@ function createMockClient(params: {
       update: ReturnType<typeof vi.fn>;
       isDm: ReturnType<typeof vi.fn>;
     };
+    getAccountData: ReturnType<typeof vi.fn>;
     getJoinedRoomMembers: ReturnType<typeof vi.fn>;
     getRoomStateEvent: ReturnType<typeof vi.fn>;
+    setAccountData: ReturnType<typeof vi.fn>;
     __setMembers: (members: string[]) => void;
   };
 }
@@ -196,6 +231,76 @@ describe("createDirectRoomTracker", () => {
         senderId: "@alice:example.org",
       }),
     ).resolves.toBe(false);
+  });
+
+  it("treats strict rooms from recent invites as DMs after the dm cache has seeded", async () => {
+    const client = createMockClient({ isDm: false, dmCacheAvailable: true });
+    const tracker = createDirectRoomTracker(client);
+    tracker.rememberInvite("!room:example.org", "@alice:example.org");
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(true);
+
+    expect(client.setAccountData).toHaveBeenCalledWith(
+      EventType.Direct,
+      expect.objectContaining({
+        "@alice:example.org": ["!room:example.org"],
+      }),
+    );
+  });
+
+  it("keeps recent invite candidates across room invalidation", async () => {
+    const client = createMockClient({ isDm: false, dmCacheAvailable: true });
+    const tracker = createDirectRoomTracker(client);
+    tracker.rememberInvite("!room:example.org", "@alice:example.org");
+    tracker.invalidateRoom("!room:example.org");
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("still rejects recent invite candidates when self member state is_direct is false", async () => {
+    const client = createMockClient({
+      isDm: false,
+      dmCacheAvailable: true,
+      stateEvents: {
+        "!room:example.org|m.room.member|@bot:example.org": { is_direct: false },
+      },
+    });
+    const tracker = createDirectRoomTracker(client);
+    tracker.rememberInvite("!room:example.org", "@alice:example.org");
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("still treats recent invite candidates as DMs when m.direct repair fails", async () => {
+    const client = createMockClient({
+      isDm: false,
+      dmCacheAvailable: true,
+      setAccountDataError: new Error("account data unavailable"),
+    });
+    const tracker = createDirectRoomTracker(client);
+    tracker.rememberInvite("!room:example.org", "@alice:example.org");
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(true);
   });
 
   it("does not classify 2-member rooms whose sender is not a joined member when falling back", async () => {

--- a/extensions/matrix/src/matrix/monitor/direct.test.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.test.ts
@@ -286,6 +286,26 @@ describe("createDirectRoomTracker", () => {
     ).resolves.toBe(false);
   });
 
+  it("does not promote recent invite candidates when local vetoes mark the room as non-DM", async () => {
+    const client = createMockClient({
+      isDm: false,
+      dmCacheAvailable: true,
+    });
+    const tracker = createDirectRoomTracker(client, {
+      canPromoteRecentInvite: () => false,
+    });
+    tracker.rememberInvite("!room:example.org", "@alice:example.org");
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(false);
+
+    expect(client.setAccountData).not.toHaveBeenCalled();
+  });
+
   it("still treats recent invite candidates as DMs when m.direct repair fails", async () => {
     const client = createMockClient({
       isDm: false,

--- a/extensions/matrix/src/matrix/monitor/direct.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.ts
@@ -14,6 +14,7 @@ type DirectMessageCheck = {
 
 type DirectRoomTrackerOptions = {
   log?: (message: string) => void;
+  canPromoteRecentInvite?: (roomId: string) => boolean | Promise<boolean>;
 };
 
 const DM_CACHE_TTL_MS = 30_000;
@@ -116,6 +117,15 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
     return cached.remoteUserId === normalizedRemoteUserId;
   };
 
+  const canPromoteRecentInvite = async (roomId: string): Promise<boolean> => {
+    try {
+      return (await opts.canPromoteRecentInvite?.(roomId)) ?? true;
+    } catch (err) {
+      log(`matrix: recent invite promotion veto failed room=${roomId} (${String(err)})`);
+      return false;
+    }
+  };
+
   return {
     invalidateRoom: (roomId: string): void => {
       joinedMembersCache.delete(roomId);
@@ -180,7 +190,7 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
           return true;
         }
 
-        if (hasRecentInviteCandidate(roomId, senderId)) {
+        if (hasRecentInviteCandidate(roomId, senderId) && (await canPromoteRecentInvite(roomId))) {
           const promotion = await promoteMatrixDirectRoomCandidate({
             client,
             remoteUserId: senderId ?? "",

--- a/extensions/matrix/src/matrix/monitor/direct.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.ts
@@ -18,6 +18,7 @@ type DirectRoomTrackerOptions = {
 };
 
 const DM_CACHE_TTL_MS = 30_000;
+const RECENT_INVITE_TTL_MS = 30_000;
 const MAX_TRACKED_DM_ROOMS = 1024;
 const MAX_TRACKED_DM_MEMBER_FLAGS = 2048;
 
@@ -110,7 +111,7 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
     if (!cached) {
       return false;
     }
-    if (Date.now() - cached.ts >= DM_CACHE_TTL_MS) {
+    if (Date.now() - cached.ts >= RECENT_INVITE_TTL_MS) {
       recentInviteCandidates.delete(roomId);
       return false;
     }

--- a/extensions/matrix/src/matrix/monitor/direct.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.ts
@@ -1,3 +1,4 @@
+import { promoteMatrixDirectRoomCandidate } from "../direct-management.js";
 import {
   hasDirectMatrixMemberFlag,
   isStrictDirectMembership,
@@ -38,6 +39,7 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
   let cachedSelfUserId: string | null = null;
   const joinedMembersCache = new Map<string, { members: string[]; ts: number }>();
   const directMemberFlagCache = new Map<string, { isDirect: boolean | null; ts: number }>();
+  const recentInviteCandidates = new Map<string, { remoteUserId: string; ts: number }>();
 
   const ensureSelfUserId = async (): Promise<string | null> => {
     if (cachedSelfUserId) {
@@ -98,6 +100,22 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
     return isDirect;
   };
 
+  const hasRecentInviteCandidate = (roomId: string, remoteUserId?: string | null): boolean => {
+    const normalizedRemoteUserId = remoteUserId?.trim();
+    if (!normalizedRemoteUserId) {
+      return false;
+    }
+    const cached = recentInviteCandidates.get(roomId);
+    if (!cached) {
+      return false;
+    }
+    if (Date.now() - cached.ts >= DM_CACHE_TTL_MS) {
+      recentInviteCandidates.delete(roomId);
+      return false;
+    }
+    return cached.remoteUserId === normalizedRemoteUserId;
+  };
+
   return {
     invalidateRoom: (roomId: string): void => {
       joinedMembersCache.delete(roomId);
@@ -108,6 +126,17 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
       }
       lastDmUpdateMs = 0;
       log(`matrix: invalidated dm cache room=${roomId}`);
+    },
+    rememberInvite: (roomId: string, remoteUserId: string): void => {
+      const normalizedRemoteUserId = remoteUserId.trim();
+      if (!normalizedRemoteUserId) {
+        return;
+      }
+      rememberBounded(recentInviteCandidates, roomId, {
+        remoteUserId: normalizedRemoteUserId,
+        ts: Date.now(),
+      });
+      log(`matrix: remembered invite candidate room=${roomId} sender=${normalizedRemoteUserId}`);
     },
     isDirectMessage: async (params: DirectMessageCheck): Promise<boolean> => {
       const { roomId, senderId } = params;
@@ -149,6 +178,21 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
             `matrix: dm detected via exact 2-member fallback before dm cache seed room=${roomId}`,
           );
           return true;
+        }
+
+        if (hasRecentInviteCandidate(roomId, senderId)) {
+          const promotion = await promoteMatrixDirectRoomCandidate({
+            client,
+            remoteUserId: senderId ?? "",
+            roomId,
+            selfUserId,
+          });
+          if (promotion.classifyAsDirect) {
+            log(
+              `matrix: dm detected via recent invite room=${roomId} reason=${promotion.reason} repaired=${String(promotion.repaired)}`,
+            );
+            return true;
+          }
         }
       }
 

--- a/extensions/matrix/src/matrix/monitor/events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/events.test.ts
@@ -285,6 +285,27 @@ describe("registerMatrixMonitorEvents verification routing", () => {
     expect(rememberInvite).toHaveBeenCalledWith("!room:example.org", "@alice:example.org");
   });
 
+  it("ignores lifecycle-only invite events emitted with self sender ids", async () => {
+    const { invalidateRoom, rememberInvite, roomInviteListener } = createHarness();
+    if (!roomInviteListener) {
+      throw new Error("room.invite listener was not registered");
+    }
+
+    roomInviteListener("!room:example.org", {
+      event_id: "$invite-self",
+      sender: "@bot:example.org",
+      type: EventType.RoomMember,
+      origin_server_ts: Date.now(),
+      content: {
+        membership: "invite",
+      },
+      state_key: "@bot:example.org",
+    });
+
+    expect(invalidateRoom).toHaveBeenCalledWith("!room:example.org");
+    expect(rememberInvite).not.toHaveBeenCalled();
+  });
+
   it("does not synthesize invite provenance from room joins", async () => {
     const { invalidateRoom, rememberInvite, roomJoinListener } = createHarness();
     if (!roomJoinListener) {

--- a/extensions/matrix/src/matrix/monitor/events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/events.test.ts
@@ -71,6 +71,7 @@ function createHarness(params?: {
   );
   const sendMessage = vi.fn(async (_roomId: string, _payload: { body?: string }) => "$notice");
   const invalidateRoom = vi.fn();
+  const rememberInvite = vi.fn();
   const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
   const formatNativeDependencyHint = vi.fn(() => "install hint");
   const logVerboseMessage = vi.fn();
@@ -130,6 +131,7 @@ function createHarness(params?: {
     readStoreAllowFrom,
     directTracker: {
       invalidateRoom,
+      rememberInvite,
     },
     logVerboseMessage,
     warnedEncryptedRooms: new Set<string>(),
@@ -148,6 +150,7 @@ function createHarness(params?: {
     onRoomMessage,
     sendMessage,
     invalidateRoom,
+    rememberInvite,
     roomEventListener,
     listVerifications,
     readStoreAllowFrom,
@@ -161,6 +164,8 @@ function createHarness(params?: {
     verificationSummaryListener: listeners.get("verification.summary") as
       | VerificationSummaryListener
       | undefined,
+    roomInviteListener: listeners.get("room.invite") as RoomEventListener | undefined,
+    roomJoinListener: listeners.get("room.join") as RoomEventListener | undefined,
   };
 }
 
@@ -256,6 +261,49 @@ describe("registerMatrixMonitorEvents verification routing", () => {
     });
 
     expect(invalidateRoom).toHaveBeenCalledWith("!room:example.org");
+  });
+
+  it("remembers invite provenance on room invites", async () => {
+    const { invalidateRoom, rememberInvite, roomInviteListener } = createHarness();
+    if (!roomInviteListener) {
+      throw new Error("room.invite listener was not registered");
+    }
+
+    roomInviteListener("!room:example.org", {
+      event_id: "$invite1",
+      sender: "@alice:example.org",
+      type: EventType.RoomMember,
+      origin_server_ts: Date.now(),
+      content: {
+        membership: "invite",
+        is_direct: true,
+      },
+      state_key: "@bot:example.org",
+    });
+
+    expect(invalidateRoom).toHaveBeenCalledWith("!room:example.org");
+    expect(rememberInvite).toHaveBeenCalledWith("!room:example.org", "@alice:example.org");
+  });
+
+  it("does not synthesize invite provenance from room joins", async () => {
+    const { invalidateRoom, rememberInvite, roomJoinListener } = createHarness();
+    if (!roomJoinListener) {
+      throw new Error("room.join listener was not registered");
+    }
+
+    roomJoinListener("!room:example.org", {
+      event_id: "$join1",
+      sender: "@bot:example.org",
+      type: EventType.RoomMember,
+      origin_server_ts: Date.now(),
+      content: {
+        membership: "join",
+      },
+      state_key: "@bot:example.org",
+    });
+
+    expect(invalidateRoom).toHaveBeenCalledWith("!room:example.org");
+    expect(rememberInvite).not.toHaveBeenCalled();
   });
 
   it("posts verification request notices directly into the room", async () => {

--- a/extensions/matrix/src/matrix/monitor/events.ts
+++ b/extensions/matrix/src/matrix/monitor/events.ts
@@ -127,7 +127,10 @@ export function registerMatrixMonitorEvents(params: {
     directTracker?.invalidateRoom(roomId);
     const eventId = event?.event_id ?? "unknown";
     const sender = event?.sender ?? "unknown";
-    if (typeof event?.sender === "string" && event.sender.trim()) {
+    const invitee = typeof event?.state_key === "string" ? event.state_key.trim() : "";
+    const senderIsInvitee =
+      typeof event?.sender === "string" && invitee && event.sender.trim() === invitee;
+    if (typeof event?.sender === "string" && event.sender.trim() && !senderIsInvitee) {
       directTracker?.rememberInvite?.(roomId, event.sender);
     }
     const isDirect = (event?.content as { is_direct?: boolean } | undefined)?.is_direct === true;

--- a/extensions/matrix/src/matrix/monitor/events.ts
+++ b/extensions/matrix/src/matrix/monitor/events.ts
@@ -40,6 +40,7 @@ export function registerMatrixMonitorEvents(params: {
   readStoreAllowFrom: () => Promise<string[]>;
   directTracker?: {
     invalidateRoom: (roomId: string) => void;
+    rememberInvite?: (roomId: string, remoteUserId: string) => void;
   };
   logVerboseMessage: (message: string) => void;
   warnedEncryptedRooms: Set<string>;
@@ -126,6 +127,9 @@ export function registerMatrixMonitorEvents(params: {
     directTracker?.invalidateRoom(roomId);
     const eventId = event?.event_id ?? "unknown";
     const sender = event?.sender ?? "unknown";
+    if (typeof event?.sender === "string" && event.sender.trim()) {
+      directTracker?.rememberInvite?.(roomId, event.sender);
+    }
     const isDirect = (event?.content as { is_direct?: boolean } | undefined)?.is_direct === true;
     logVerboseMessage(
       `matrix: invite room=${roomId} sender=${sender} direct=${String(isDirect)} id=${eventId}`,

--- a/extensions/matrix/src/matrix/monitor/index.test.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test.ts
@@ -8,6 +8,9 @@ const hoisted = vi.hoisted(() => {
   const state = {
     startClientError: null as Error | null,
   };
+  const accountConfig = {
+    dm: {},
+  };
   const inboundDeduper = {
     claimEvent: vi.fn(() => true),
     commitEvent: vi.fn(async () => undefined),
@@ -22,6 +25,15 @@ const hoisted = vi.hoisted(() => {
     drainPendingDecryptions: vi.fn(async () => undefined),
   };
   const createMatrixRoomMessageHandler = vi.fn(() => vi.fn());
+  const createDirectRoomTracker = vi.fn(() => ({
+    isDirectMessage: vi.fn(async () => false),
+  }));
+  const getRoomInfo = vi.fn(async () => ({
+    altAliases: [],
+    nameResolved: true,
+    aliasesResolved: true,
+  }));
+  const getMemberDisplayName = vi.fn(async () => "Bot");
   const resolveTextChunkLimit = vi.fn<
     (cfg: unknown, channel: unknown, accountId?: unknown) => number
   >(() => 4000);
@@ -37,8 +49,12 @@ const hoisted = vi.hoisted(() => {
   const setMatrixRuntime = vi.fn();
   return {
     callOrder,
+    accountConfig,
     client,
+    createDirectRoomTracker,
     createMatrixRoomMessageHandler,
+    getMemberDisplayName,
+    getRoomInfo,
     inboundDeduper,
     logger,
     registeredOnRoomMessage: null as null | ((roomId: string, event: unknown) => Promise<void>),
@@ -61,6 +77,7 @@ vi.mock("../../runtime-api.js", () => {
     MarkdownConfigSchema: z.any().optional(),
     PAIRING_APPROVED_MESSAGE: "paired",
     ToolPolicySchema: z.any().optional(),
+    addAllowlistUserEntriesFromConfigEntry: vi.fn(),
     buildChannelConfigSchema: (schema: unknown) => schema,
     buildChannelKeyCandidates: () => [],
     buildProbeChannelStatusSummary: (
@@ -93,7 +110,40 @@ vi.mock("../../runtime-api.js", () => {
       groupPolicy: "allowlist",
       providerMissingFallbackApplied: false,
     }),
-    resolveChannelEntryMatch: () => null,
+    resolveChannelEntryMatch: ({
+      entries,
+      keys,
+      wildcardKey,
+    }: {
+      entries: Record<string, unknown>;
+      keys: string[];
+      wildcardKey: string;
+    }) => {
+      for (const key of keys) {
+        if (Object.prototype.hasOwnProperty.call(entries, key)) {
+          return {
+            entry: entries[key],
+            key,
+            wildcardEntry: Object.prototype.hasOwnProperty.call(entries, wildcardKey)
+              ? entries[wildcardKey]
+              : undefined,
+            wildcardKey: Object.prototype.hasOwnProperty.call(entries, wildcardKey)
+              ? wildcardKey
+              : undefined,
+          };
+        }
+      }
+      return {
+        entry: undefined,
+        key: undefined,
+        wildcardEntry: Object.prototype.hasOwnProperty.call(entries, wildcardKey)
+          ? entries[wildcardKey]
+          : undefined,
+        wildcardKey: Object.prototype.hasOwnProperty.call(entries, wildcardKey)
+          ? wildcardKey
+          : undefined,
+      };
+    },
     resolveDefaultGroupPolicy: () => "allowlist",
     resolveOutboundSendDep: () => null,
     resolveThreadBindingFarewellText: () => null,
@@ -152,9 +202,7 @@ vi.mock("../accounts.js", async (importOriginal) => {
     resolveConfiguredMatrixBotUserIds: vi.fn(() => new Set<string>()),
     resolveMatrixAccount: () => ({
       accountId: "default",
-      config: {
-        dm: {},
-      },
+      config: hoisted.accountConfig,
     }),
   };
 });
@@ -234,9 +282,7 @@ vi.mock("./auto-join.js", () => ({
 }));
 
 vi.mock("./direct.js", () => ({
-  createDirectRoomTracker: vi.fn(() => ({
-    isDirectMessage: vi.fn(async () => false),
-  })),
+  createDirectRoomTracker: hoisted.createDirectRoomTracker,
 }));
 
 vi.mock("./events.js", () => ({
@@ -262,10 +308,8 @@ vi.mock("./legacy-crypto-restore.js", () => ({
 
 vi.mock("./room-info.js", () => ({
   createMatrixRoomInfoResolver: vi.fn(() => ({
-    getRoomInfo: vi.fn(async () => ({
-      altAliases: [],
-    })),
-    getMemberDisplayName: vi.fn(async () => "Bot"),
+    getRoomInfo: hoisted.getRoomInfo,
+    getMemberDisplayName: hoisted.getMemberDisplayName,
   })),
 }));
 
@@ -292,8 +336,18 @@ describe("monitorMatrixProvider", () => {
   beforeEach(() => {
     hoisted.callOrder.length = 0;
     hoisted.state.startClientError = null;
+    hoisted.accountConfig.dm = {};
     hoisted.resolveTextChunkLimit.mockReset().mockReturnValue(4000);
     hoisted.releaseSharedClientInstance.mockReset().mockResolvedValue(true);
+    hoisted.createDirectRoomTracker.mockReset().mockReturnValue({
+      isDirectMessage: vi.fn(async () => false),
+    });
+    hoisted.getRoomInfo.mockReset().mockResolvedValue({
+      altAliases: [],
+      nameResolved: true,
+      aliasesResolved: true,
+    });
+    hoisted.getMemberDisplayName.mockReset().mockResolvedValue("Bot");
     hoisted.registeredOnRoomMessage = null;
     hoisted.setActiveMatrixClient.mockReset();
     hoisted.stopThreadBindingManager.mockReset();
@@ -436,6 +490,45 @@ describe("monitorMatrixProvider", () => {
     expect(hoisted.callOrder.indexOf("stop-deduper")).toBeLessThan(
       hoisted.callOrder.indexOf("release-client"),
     );
+  });
+
+  it("wires recent-invite promotion to fail closed when room metadata is unresolved", async () => {
+    await startMonitorAndAbortAfterStartup();
+
+    const trackerOpts = hoisted.createDirectRoomTracker.mock.calls[0]?.[1] as
+      | { canPromoteRecentInvite?: (roomId: string) => Promise<boolean> }
+      | undefined;
+    if (!trackerOpts?.canPromoteRecentInvite) {
+      throw new Error("recent invite promotion callback was not wired");
+    }
+
+    hoisted.getRoomInfo.mockResolvedValueOnce({
+      altAliases: [],
+      nameResolved: false,
+      aliasesResolved: false,
+    });
+
+    await expect(trackerOpts.canPromoteRecentInvite("!room:example.org")).resolves.toBe(false);
+  });
+
+  it("wires recent-invite promotion to reject named rooms", async () => {
+    await startMonitorAndAbortAfterStartup();
+
+    const trackerOpts = hoisted.createDirectRoomTracker.mock.calls[0]?.[1] as
+      | { canPromoteRecentInvite?: (roomId: string) => Promise<boolean> }
+      | undefined;
+    if (!trackerOpts?.canPromoteRecentInvite) {
+      throw new Error("recent invite promotion callback was not wired");
+    }
+
+    hoisted.getRoomInfo.mockResolvedValueOnce({
+      name: "Ops Room",
+      altAliases: [],
+      nameResolved: true,
+      aliasesResolved: true,
+    });
+
+    await expect(trackerOpts.canPromoteRecentInvite("!room:example.org")).resolves.toBe(false);
   });
 });
 

--- a/extensions/matrix/src/matrix/monitor/index.test.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test.ts
@@ -337,6 +337,7 @@ describe("monitorMatrixProvider", () => {
     hoisted.callOrder.length = 0;
     hoisted.state.startClientError = null;
     hoisted.accountConfig.dm = {};
+    delete (hoisted.accountConfig as { rooms?: Record<string, unknown> }).rooms;
     hoisted.resolveTextChunkLimit.mockReset().mockReturnValue(4000);
     hoisted.releaseSharedClientInstance.mockReset().mockResolvedValue(true);
     hoisted.createDirectRoomTracker.mockReset().mockReturnValue({
@@ -523,6 +524,29 @@ describe("monitorMatrixProvider", () => {
 
     hoisted.getRoomInfo.mockResolvedValueOnce({
       name: "Ops Room",
+      altAliases: [],
+      nameResolved: true,
+      aliasesResolved: true,
+    });
+
+    await expect(trackerOpts.canPromoteRecentInvite("!room:example.org")).resolves.toBe(false);
+  });
+
+  it("wires recent-invite promotion to reject wildcard-configured rooms", async () => {
+    (hoisted.accountConfig as { rooms?: Record<string, unknown> }).rooms = {
+      "*": { enabled: false },
+    };
+
+    await startMonitorAndAbortAfterStartup();
+
+    const trackerOpts = hoisted.createDirectRoomTracker.mock.calls[0]?.[1] as
+      | { canPromoteRecentInvite?: (roomId: string) => Promise<boolean> }
+      | undefined;
+    if (!trackerOpts?.canPromoteRecentInvite) {
+      throw new Error("recent invite promotion callback was not wired");
+    }
+
+    hoisted.getRoomInfo.mockResolvedValueOnce({
       altAliases: [],
       nameResolved: true,
       aliasesResolved: true,

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -26,8 +26,8 @@ import { createDirectRoomTracker } from "./direct.js";
 import { registerMatrixMonitorEvents } from "./events.js";
 import { createMatrixRoomMessageHandler } from "./handler.js";
 import { createMatrixInboundEventDeduper } from "./inbound-dedupe.js";
+import { shouldPromoteRecentInviteRoom } from "./recent-invite.js";
 import { createMatrixRoomInfoResolver } from "./room-info.js";
-import { resolveMatrixRoomConfig } from "./rooms.js";
 import { runMatrixStartupMaintenance } from "./startup.js";
 
 export type MonitorMatrixOpts = {
@@ -217,19 +217,12 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   const { getRoomInfo, getMemberDisplayName } = createMatrixRoomInfoResolver(client);
   const directTracker = createDirectRoomTracker(client, {
     log: logVerboseMessage,
-    canPromoteRecentInvite: async (roomId) => {
-      const roomInfo = await getRoomInfo(roomId, { includeAliases: true });
-      const roomAliases = [roomInfo.canonicalAlias ?? "", ...roomInfo.altAliases].filter(Boolean);
-      if ((roomInfo.name?.trim() ?? "") || roomAliases.length > 0) {
-        return false;
-      }
-      const roomConfig = resolveMatrixRoomConfig({
-        rooms: roomsConfig,
+    canPromoteRecentInvite: async (roomId) =>
+      shouldPromoteRecentInviteRoom({
         roomId,
-        aliases: roomAliases,
-      });
-      return roomConfig.matchSource !== "direct";
-    },
+        roomInfo: await getRoomInfo(roomId, { includeAliases: true }),
+        rooms: roomsConfig,
+      }),
   });
   registerMatrixAutoJoin({ client, accountConfig, runtime });
   const warnedEncryptedRooms = new Set<string>();

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -27,6 +27,7 @@ import { registerMatrixMonitorEvents } from "./events.js";
 import { createMatrixRoomMessageHandler } from "./handler.js";
 import { createMatrixInboundEventDeduper } from "./inbound-dedupe.js";
 import { createMatrixRoomInfoResolver } from "./room-info.js";
+import { resolveMatrixRoomConfig } from "./rooms.js";
 import { runMatrixStartupMaintenance } from "./startup.js";
 
 export type MonitorMatrixOpts = {
@@ -213,12 +214,27 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   // Cold starts should ignore old room history, but once we have a persisted
   // /sync cursor we want restart backlogs to replay just like other channels.
   const dropPreStartupMessages = !client.hasPersistedSyncState();
-  const directTracker = createDirectRoomTracker(client, { log: logVerboseMessage });
+  const { getRoomInfo, getMemberDisplayName } = createMatrixRoomInfoResolver(client);
+  const directTracker = createDirectRoomTracker(client, {
+    log: logVerboseMessage,
+    canPromoteRecentInvite: async (roomId) => {
+      const roomInfo = await getRoomInfo(roomId, { includeAliases: true });
+      const roomAliases = [roomInfo.canonicalAlias ?? "", ...roomInfo.altAliases].filter(Boolean);
+      if ((roomInfo.name?.trim() ?? "") || roomAliases.length > 0) {
+        return false;
+      }
+      const roomConfig = resolveMatrixRoomConfig({
+        rooms: roomsConfig,
+        roomId,
+        aliases: roomAliases,
+      });
+      return roomConfig.matchSource !== "direct";
+    },
+  });
   registerMatrixAutoJoin({ client, accountConfig, runtime });
   const warnedEncryptedRooms = new Set<string>();
   const warnedCryptoMissingRooms = new Set<string>();
 
-  const { getRoomInfo, getMemberDisplayName } = createMatrixRoomInfoResolver(client);
   const handleRoomMessage = createMatrixRoomMessageHandler({
     client,
     core,

--- a/extensions/matrix/src/matrix/monitor/recent-invite.test.ts
+++ b/extensions/matrix/src/matrix/monitor/recent-invite.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { shouldPromoteRecentInviteRoom } from "./recent-invite.js";
+
+describe("shouldPromoteRecentInviteRoom", () => {
+  it("fails closed when room metadata could not be resolved", () => {
+    expect(
+      shouldPromoteRecentInviteRoom({
+        roomId: "!room:example.org",
+        roomInfo: {
+          altAliases: [],
+          nameResolved: false,
+          aliasesResolved: true,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects named or aliased rooms", () => {
+    expect(
+      shouldPromoteRecentInviteRoom({
+        roomId: "!named:example.org",
+        roomInfo: {
+          name: "Ops Room",
+          altAliases: [],
+          nameResolved: true,
+          aliasesResolved: true,
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldPromoteRecentInviteRoom({
+        roomId: "!aliased:example.org",
+        roomInfo: {
+          canonicalAlias: "#ops:example.org",
+          altAliases: [],
+          nameResolved: true,
+          aliasesResolved: true,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects rooms explicitly configured by direct match", () => {
+    expect(
+      shouldPromoteRecentInviteRoom({
+        roomId: "!room:example.org",
+        roomInfo: {
+          altAliases: [],
+          nameResolved: true,
+          aliasesResolved: true,
+        },
+        rooms: {
+          "!room:example.org": {
+            enabled: true,
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("allows strict unnamed invite rooms without direct room config", () => {
+    expect(
+      shouldPromoteRecentInviteRoom({
+        roomId: "!room:example.org",
+        roomInfo: {
+          altAliases: [],
+          nameResolved: true,
+          aliasesResolved: true,
+        },
+      }),
+    ).toBe(true);
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/recent-invite.test.ts
+++ b/extensions/matrix/src/matrix/monitor/recent-invite.test.ts
@@ -59,6 +59,24 @@ describe("shouldPromoteRecentInviteRoom", () => {
     ).toBe(false);
   });
 
+  it("rejects rooms matched only by wildcard config", () => {
+    expect(
+      shouldPromoteRecentInviteRoom({
+        roomId: "!room:example.org",
+        roomInfo: {
+          altAliases: [],
+          nameResolved: true,
+          aliasesResolved: true,
+        },
+        rooms: {
+          "*": {
+            enabled: false,
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
   it("allows strict unnamed invite rooms without direct room config", () => {
     expect(
       shouldPromoteRecentInviteRoom({

--- a/extensions/matrix/src/matrix/monitor/recent-invite.ts
+++ b/extensions/matrix/src/matrix/monitor/recent-invite.ts
@@ -26,5 +26,5 @@ export function shouldPromoteRecentInviteRoom(params: {
     roomId: params.roomId,
     aliases: roomAliases,
   });
-  return roomConfig.matchSource !== "direct";
+  return roomConfig.matchSource === undefined;
 }

--- a/extensions/matrix/src/matrix/monitor/recent-invite.ts
+++ b/extensions/matrix/src/matrix/monitor/recent-invite.ts
@@ -1,0 +1,30 @@
+import type { MatrixRoomConfig } from "../../types.js";
+import type { MatrixRoomInfo } from "./room-info.js";
+import { resolveMatrixRoomConfig } from "./rooms.js";
+
+export function shouldPromoteRecentInviteRoom(params: {
+  roomId: string;
+  roomInfo: Pick<
+    MatrixRoomInfo,
+    "name" | "canonicalAlias" | "altAliases" | "nameResolved" | "aliasesResolved"
+  >;
+  rooms?: Record<string, MatrixRoomConfig>;
+}): boolean {
+  if (!params.roomInfo.nameResolved || !params.roomInfo.aliasesResolved) {
+    return false;
+  }
+
+  const roomAliases = [params.roomInfo.canonicalAlias ?? "", ...params.roomInfo.altAliases].filter(
+    Boolean,
+  );
+  if ((params.roomInfo.name?.trim() ?? "") || roomAliases.length > 0) {
+    return false;
+  }
+
+  const roomConfig = resolveMatrixRoomConfig({
+    rooms: params.rooms,
+    roomId: params.roomId,
+    aliases: roomAliases,
+  });
+  return roomConfig.matchSource !== "direct";
+}

--- a/extensions/matrix/src/matrix/monitor/room-info.test.ts
+++ b/extensions/matrix/src/matrix/monitor/room-info.test.ts
@@ -35,9 +35,22 @@ describe("createMatrixRoomInfoResolver", () => {
     const client = createClientStub();
     const resolver = createMatrixRoomInfoResolver(client);
 
+    await expect(resolver.getRoomInfo("!room:example.org")).resolves.toEqual({
+      name: "Room !room:example.org",
+      altAliases: [],
+      nameResolved: true,
+      aliasesResolved: false,
+    });
     await resolver.getRoomInfo("!room:example.org");
-    await resolver.getRoomInfo("!room:example.org");
-    await resolver.getRoomInfo("!room:example.org", { includeAliases: true });
+    await expect(
+      resolver.getRoomInfo("!room:example.org", { includeAliases: true }),
+    ).resolves.toEqual({
+      name: "Room !room:example.org",
+      canonicalAlias: "#alias-!room:example.org:example.org",
+      altAliases: ["#alt-!room:example.org:example.org"],
+      nameResolved: true,
+      aliasesResolved: true,
+    });
     await resolver.getRoomInfo("!room:example.org", { includeAliases: true });
     await resolver.getMemberDisplayName("!room:example.org", "@alice:example.org");
     await resolver.getMemberDisplayName("!room:example.org", "@alice:example.org");
@@ -68,6 +81,28 @@ describe("createMatrixRoomInfoResolver", () => {
     ).resolves.toBe("@alice:example.org");
 
     expect(client.getRoomStateEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks unresolved room metadata when room info lookups fail", async () => {
+    const client = {
+      getRoomStateEvent: vi.fn(async (_roomId: string, eventType: string) => {
+        if (eventType === "m.room.member") {
+          return {};
+        }
+        throw new Error("room info unavailable");
+      }),
+    } as unknown as MatrixClient & {
+      getRoomStateEvent: ReturnType<typeof vi.fn>;
+    };
+    const resolver = createMatrixRoomInfoResolver(client);
+
+    await expect(
+      resolver.getRoomInfo("!room:example.org", { includeAliases: true }),
+    ).resolves.toEqual({
+      altAliases: [],
+      aliasesResolved: false,
+      nameResolved: false,
+    });
   });
 
   it("caches fallback user IDs when member display-name lookups fail", async () => {

--- a/extensions/matrix/src/matrix/monitor/room-info.test.ts
+++ b/extensions/matrix/src/matrix/monitor/room-info.test.ts
@@ -105,6 +105,55 @@ describe("createMatrixRoomInfoResolver", () => {
     });
   });
 
+  it("retries room metadata after a transient lookup failure", async () => {
+    const client = {
+      getRoomStateEvent: vi.fn(async (_roomId: string, eventType: string) => {
+        if (eventType === "m.room.name") {
+          if (
+            client.getRoomStateEvent.mock.calls.filter(([, type]) => type === eventType).length ===
+            1
+          ) {
+            throw new Error("name lookup unavailable");
+          }
+          return { name: "Recovered Room" };
+        }
+        if (eventType === "m.room.canonical_alias") {
+          if (
+            client.getRoomStateEvent.mock.calls.filter(([, type]) => type === eventType).length ===
+            1
+          ) {
+            throw new Error("alias lookup unavailable");
+          }
+          return {
+            alias: "#recovered:example.org",
+            alt_aliases: ["#alt-recovered:example.org"],
+          };
+        }
+        return {};
+      }),
+    } as unknown as MatrixClient & {
+      getRoomStateEvent: ReturnType<typeof vi.fn>;
+    };
+    const resolver = createMatrixRoomInfoResolver(client);
+
+    await expect(
+      resolver.getRoomInfo("!room:example.org", { includeAliases: true }),
+    ).resolves.toEqual({
+      altAliases: [],
+      aliasesResolved: false,
+      nameResolved: false,
+    });
+    await expect(
+      resolver.getRoomInfo("!room:example.org", { includeAliases: true }),
+    ).resolves.toEqual({
+      name: "Recovered Room",
+      canonicalAlias: "#recovered:example.org",
+      altAliases: ["#alt-recovered:example.org"],
+      nameResolved: true,
+      aliasesResolved: true,
+    });
+  });
+
   it("caches fallback user IDs when member display-name lookups fail", async () => {
     const client = {
       getRoomStateEvent: vi.fn(async (): Promise<Record<string, unknown>> => {

--- a/extensions/matrix/src/matrix/monitor/room-info.test.ts
+++ b/extensions/matrix/src/matrix/monitor/room-info.test.ts
@@ -105,6 +105,33 @@ describe("createMatrixRoomInfoResolver", () => {
     });
   });
 
+  it("treats missing room metadata as resolved-empty state", async () => {
+    const client = {
+      getRoomStateEvent: vi.fn(async (_roomId: string, eventType: string) => {
+        if (eventType === "m.room.name" || eventType === "m.room.canonical_alias") {
+          const err = new Error("M_NOT_FOUND");
+          Object.assign(err, {
+            statusCode: 404,
+            body: { errcode: "M_NOT_FOUND" },
+          });
+          throw err;
+        }
+        return {};
+      }),
+    } as unknown as MatrixClient & {
+      getRoomStateEvent: ReturnType<typeof vi.fn>;
+    };
+    const resolver = createMatrixRoomInfoResolver(client);
+
+    await expect(
+      resolver.getRoomInfo("!room:example.org", { includeAliases: true }),
+    ).resolves.toEqual({
+      altAliases: [],
+      aliasesResolved: true,
+      nameResolved: true,
+    });
+  });
+
   it("retries room metadata after a transient lookup failure", async () => {
     const client = {
       getRoomStateEvent: vi.fn(async (_roomId: string, eventType: string) => {

--- a/extensions/matrix/src/matrix/monitor/room-info.ts
+++ b/extensions/matrix/src/matrix/monitor/room-info.ts
@@ -47,7 +47,9 @@ export function createMatrixRoomInfoResolver(client: MatrixClient) {
       // ignore
     }
     const info = { name, nameResolved };
-    rememberBounded(roomNameCache, roomId, info, MAX_TRACKED_ROOM_INFO);
+    if (nameResolved) {
+      rememberBounded(roomNameCache, roomId, info, MAX_TRACKED_ROOM_INFO);
+    }
     return info;
   };
 
@@ -75,7 +77,9 @@ export function createMatrixRoomInfoResolver(client: MatrixClient) {
       // ignore
     }
     const info = { canonicalAlias, altAliases, aliasesResolved };
-    rememberBounded(roomAliasCache, roomId, info, MAX_TRACKED_ROOM_INFO);
+    if (aliasesResolved) {
+      rememberBounded(roomAliasCache, roomId, info, MAX_TRACKED_ROOM_INFO);
+    }
     return info;
   };
 

--- a/extensions/matrix/src/matrix/monitor/room-info.ts
+++ b/extensions/matrix/src/matrix/monitor/room-info.ts
@@ -1,3 +1,4 @@
+import { isMatrixNotFoundError } from "../errors.js";
 import type { MatrixClient } from "../sdk.js";
 
 export type MatrixRoomInfo = {
@@ -43,8 +44,10 @@ export function createMatrixRoomInfoResolver(client: MatrixClient) {
       if (nameState && typeof nameState.name === "string") {
         name = nameState.name;
       }
-    } catch {
-      // ignore
+    } catch (err) {
+      if (isMatrixNotFoundError(err)) {
+        nameResolved = true;
+      }
     }
     const info = { name, nameResolved };
     if (nameResolved) {
@@ -73,8 +76,10 @@ export function createMatrixRoomInfoResolver(client: MatrixClient) {
       if (Array.isArray(rawAliases)) {
         altAliases = rawAliases.filter((entry): entry is string => typeof entry === "string");
       }
-    } catch {
-      // ignore
+    } catch (err) {
+      if (isMatrixNotFoundError(err)) {
+        aliasesResolved = true;
+      }
     }
     const info = { canonicalAlias, altAliases, aliasesResolved };
     if (aliasesResolved) {

--- a/extensions/matrix/src/matrix/monitor/room-info.ts
+++ b/extensions/matrix/src/matrix/monitor/room-info.ts
@@ -4,6 +4,8 @@ export type MatrixRoomInfo = {
   name?: string;
   canonicalAlias?: string;
   altAliases: string[];
+  nameResolved: boolean;
+  aliasesResolved: boolean;
 };
 
 const MAX_TRACKED_ROOM_INFO = 1024;
@@ -20,40 +22,48 @@ function rememberBounded<T>(map: Map<string, T>, key: string, value: T, maxEntri
 }
 
 export function createMatrixRoomInfoResolver(client: MatrixClient) {
-  const roomNameCache = new Map<string, string | undefined>();
-  const roomAliasCache = new Map<string, Pick<MatrixRoomInfo, "canonicalAlias" | "altAliases">>();
+  const roomNameCache = new Map<string, Pick<MatrixRoomInfo, "name" | "nameResolved">>();
+  const roomAliasCache = new Map<
+    string,
+    Pick<MatrixRoomInfo, "canonicalAlias" | "altAliases" | "aliasesResolved">
+  >();
   const memberDisplayNameCache = new Map<string, string>();
 
-  const getRoomName = async (roomId: string): Promise<string | undefined> => {
+  const getRoomName = async (
+    roomId: string,
+  ): Promise<Pick<MatrixRoomInfo, "name" | "nameResolved">> => {
     if (roomNameCache.has(roomId)) {
-      return roomNameCache.get(roomId);
+      return roomNameCache.get(roomId) ?? { nameResolved: false };
     }
     let name: string | undefined;
+    let nameResolved = false;
     try {
-      const nameState = await client.getRoomStateEvent(roomId, "m.room.name", "").catch(() => null);
+      const nameState = await client.getRoomStateEvent(roomId, "m.room.name", "");
+      nameResolved = true;
       if (nameState && typeof nameState.name === "string") {
         name = nameState.name;
       }
     } catch {
       // ignore
     }
-    rememberBounded(roomNameCache, roomId, name, MAX_TRACKED_ROOM_INFO);
-    return name;
+    const info = { name, nameResolved };
+    rememberBounded(roomNameCache, roomId, info, MAX_TRACKED_ROOM_INFO);
+    return info;
   };
 
   const getRoomAliases = async (
     roomId: string,
-  ): Promise<Pick<MatrixRoomInfo, "canonicalAlias" | "altAliases">> => {
+  ): Promise<Pick<MatrixRoomInfo, "canonicalAlias" | "altAliases" | "aliasesResolved">> => {
     const cached = roomAliasCache.get(roomId);
     if (cached) {
       return cached;
     }
     let canonicalAlias: string | undefined;
     let altAliases: string[] = [];
+    let aliasesResolved = false;
     try {
-      const aliasState = await client
-        .getRoomStateEvent(roomId, "m.room.canonical_alias", "")
-        .catch(() => null);
+      const aliasState = await client.getRoomStateEvent(roomId, "m.room.canonical_alias", "");
+      aliasesResolved = true;
       if (aliasState && typeof aliasState.alias === "string") {
         canonicalAlias = aliasState.alias;
       }
@@ -64,7 +74,7 @@ export function createMatrixRoomInfoResolver(client: MatrixClient) {
     } catch {
       // ignore
     }
-    const info = { canonicalAlias, altAliases };
+    const info = { canonicalAlias, altAliases, aliasesResolved };
     rememberBounded(roomAliasCache, roomId, info, MAX_TRACKED_ROOM_INFO);
     return info;
   };
@@ -73,12 +83,12 @@ export function createMatrixRoomInfoResolver(client: MatrixClient) {
     roomId: string,
     opts: { includeAliases?: boolean } = {},
   ): Promise<MatrixRoomInfo> => {
-    const name = await getRoomName(roomId);
+    const { name, nameResolved } = await getRoomName(roomId);
     if (!opts.includeAliases) {
-      return { name, altAliases: [] };
+      return { name, altAliases: [], nameResolved, aliasesResolved: false };
     }
     const aliases = await getRoomAliases(roomId);
-    return { name, ...aliases };
+    return { name, nameResolved, ...aliases };
   };
 
   const getMemberDisplayName = async (roomId: string, userId: string): Promise<string> => {

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -16,6 +16,7 @@ import type { SsrFPolicy } from "../runtime-api.js";
 import { resolveMatrixRoomKeyBackupReadinessError } from "./backup-health.js";
 import { FileBackedMatrixSyncStore } from "./client/file-sync-store.js";
 import { createMatrixJsSdkClientLogger } from "./client/logging.js";
+import { isMatrixNotFoundError } from "./errors.js";
 import { MatrixCryptoBootstrapper } from "./sdk/crypto-bootstrap.js";
 import type { MatrixCryptoBootstrapResult } from "./sdk/crypto-bootstrap.js";
 import { createMatrixCryptoFacade, type MatrixCryptoFacade } from "./sdk/crypto-facade.js";
@@ -143,17 +144,6 @@ export type MatrixOwnDeviceDeleteResult = {
 function normalizeOptionalString(value: string | null | undefined): string | null {
   const normalized = value?.trim();
   return normalized ? normalized : null;
-}
-
-function isMatrixNotFoundError(err: unknown): boolean {
-  const errObj = err as { statusCode?: number; body?: { errcode?: string } };
-  if (errObj?.statusCode === 404 || errObj?.body?.errcode === "M_NOT_FOUND") {
-    return true;
-  }
-  const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
-  return (
-    message.includes("m_not_found") || message.includes("[404]") || message.includes("not found")
-  );
 }
 
 function isUnsupportedAuthenticatedMediaEndpointError(err: unknown): boolean {


### PR DESCRIPTION
## Summary

- Problem: fresh Matrix DMs that auto-join without bot-side `m.direct` state were still classified as group rooms after the DM cache had seeded.
- Why it matters: the first unmentioned inbound DM could be dropped by room mention gating even though the room was a real 1:1 DM.
- What changed: added a shared Matrix direct-room promotion helper, tracked recent invite provenance in the direct tracker, promoted fresh strict invite rooms with best-effort `m.direct` repair, and reused the same helper for optional eager repair after auto-join.
- What did NOT change (scope boundary): no global return to “all 2-member rooms are DMs”, no mention-gating special cases, and no trust in remote `is_direct` member state.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #57030
- Related #56599
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: once Matrix `m.direct` had seeded, `createDirectRoomTracker().isDirectMessage(...)` treated strict 2-member rooms without bot-side `m.direct` or local `is_direct: true` as group rooms, even when they had just arrived via a fresh self invite.
- Missing detection / guardrail: we had unit coverage for seeded-cache strict 2-member rooms staying group, but no guardrail for the fresh-invite path or for best-effort repair when `m.direct` was missing.
- Prior context (`git blame`, prior PR, issue, or refactor if known): `#56599` intentionally removed the broad “strict 2-member room => DM” fallback after cache seed.
- Why this regressed now: the broad fallback was tightened correctly, but the fresh-invite DM case never got a narrower replacement signal.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/matrix/src/matrix/direct-management.test.ts`, `extensions/matrix/src/matrix/monitor/direct.test.ts`, `extensions/matrix/src/matrix/monitor/events.test.ts`, `extensions/matrix/src/matrix/monitor/auto-join.test.ts`
- Scenario the test should lock in: a fresh invited strict 1:1 room with seeded DM cache and missing `m.direct` is still classified as DM, repairs `m.direct` best-effort, and does not let join-only provenance re-open the old 2-member-room bug.
- Why this is the smallest reliable guardrail: the bug lives at the direct-tracker/event seam, so pure handler tests are too mocked and full end-to-end Matrix coverage is heavier than needed.
- Existing test that already covers this (if any): existing seeded-cache strict-room tests and `#56599` protections stay in place.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Fresh Matrix DMs that auto-join without bot-side `m.direct` state now behave like DMs on the first inbound message instead of being blocked by room mention gating.
- Bot-side `m.direct` repair now happens best-effort from the same shared helper used by the runtime classifier.

## Diagram (if applicable)

```text
Before:
[user starts Matrix DM] -> [bot auto-joins] -> [seeded dm cache, no bot m.direct] -> [classified as group] -> [requireMention blocks first message]

After:
[user starts Matrix DM] -> [bot auto-joins] -> [recent invite + strict 1:1 evidence] -> [classified as DM] -> [best-effort m.direct repair] -> [first message handled]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Matrix plugin
- Relevant config (redacted): Matrix auto-join enabled, seeded DM cache, missing bot-side `m.direct`, room mention gating enabled for groups

### Steps

1. Start from a seeded Matrix DM cache where a new DM room is not yet in bot-side `m.direct`.
2. Receive a fresh self invite, auto-join the room, then receive the first unmentioned inbound message from the inviter.
3. Verify the tracker classifies the room as direct and best-effort repairs `m.direct`.

### Expected

- The first inbound DM is handled as a DM.
- Small non-DM rooms without invite provenance still stay group rooms.

### Actual

- Verified by targeted tests and local gates; no failures remained after the fix.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: shared direct-room promotion helper behavior, seeded-cache fresh-invite direct classification, best-effort repair failure path, invite-event wiring, join-event non-provenance, eager auto-join repair call path, and existing direct-room resolution tests.
- Edge cases checked: local `is_direct: false` veto, stale `m.direct`, join-only rooms without invite provenance, repair-write failure still classifying the current message as direct.
- What you did **not** verify: live Matrix homeserver/manual end-to-end runtime verification.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: fresh invited strict 1:1 rooms could be over-classified if invite provenance were too broad.
  - Mitigation: only invite provenance is trusted for the fresh path; join-only events never unlock DM classification, and local `is_direct: false` still vetoes.
- Risk: a required generated Swift policy file changed after rebasing onto current `main`.
  - Mitigation: included the deterministic generated sync so `pnpm check` stays green on the PR head.
