### PR TITLE
fix(subagents): include exec tool result output in parent completion events

### DIFF
--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -39,6 +39,7 @@ type SubagentOutputSnapshot = {
   latestSilentText?: string;
   latestRawText?: string;
   assistantFragments: string[];
+  toolResultFragments: string[];
   toolCallCount: number;
 };
 
@@ -84,6 +85,15 @@ function extractToolResultText(content: unknown): string {
     }
     if (typeof obj.summary === "string") {
       return sanitizeTextContent(obj.summary);
+    }
+    // Handle nested content arrays (e.g. AgentToolResult wrapping)
+    if (Array.isArray(obj.content)) {
+      const nested = extractTextFromChatContent(obj.content, {
+        sanitizeText: sanitizeTextContent,
+        normalizeText: (text) => text,
+        joinWith: "\n",
+      });
+      return nested?.trim() ?? "";
     }
   }
   if (!Array.isArray(content)) {
@@ -169,6 +179,7 @@ function countAssistantToolCalls(content: unknown): number {
 function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutputSnapshot {
   const snapshot: SubagentOutputSnapshot = {
     assistantFragments: [],
+    toolResultFragments: [],
     toolCallCount: 0,
   };
   for (const message of messages) {
@@ -177,7 +188,13 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
     }
     const role = (message as { role?: unknown }).role;
     if (role === "assistant") {
-      snapshot.toolCallCount += countAssistantToolCalls((message as { content?: unknown }).content);
+      const toolCalls = countAssistantToolCalls((message as { content?: unknown }).content);
+      snapshot.toolCallCount += toolCalls;
+      // Reset tool result fragments when a new tool-call round starts,
+      // so only the final round's results are included in the output.
+      if (toolCalls > 0) {
+        snapshot.toolResultFragments = [];
+      }
       const text = extractSubagentOutputText(message).trim();
       if (!text) {
         continue;
@@ -186,6 +203,7 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
         snapshot.latestSilentText = text;
         snapshot.latestAssistantText = undefined;
         snapshot.assistantFragments = [];
+        snapshot.toolResultFragments = [];
         continue;
       }
       snapshot.latestSilentText = undefined;
@@ -196,6 +214,9 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
     const text = extractSubagentOutputText(message).trim();
     if (text) {
       snapshot.latestRawText = text;
+      if (role === "toolResult" || role === "tool") {
+        snapshot.toolResultFragments.push(text);
+      }
     }
   }
   return snapshot;
@@ -230,6 +251,17 @@ function selectSubagentOutputText(
 ): string | undefined {
   if (snapshot.latestSilentText) {
     return snapshot.latestSilentText;
+  }
+  // When tool calls were executed and we have tool result output, include it
+  // alongside the assistant text. The assistant text may be a summary that
+  // omits the actual exec stdout/stderr the parent needs.
+  if (
+    snapshot.latestAssistantText &&
+    snapshot.toolCallCount > 0 &&
+    snapshot.toolResultFragments.length > 0
+  ) {
+    const toolOutput = snapshot.toolResultFragments.join("\n\n");
+    return `${toolOutput}\n\n${snapshot.latestAssistantText}`;
   }
   if (snapshot.latestAssistantText) {
     return snapshot.latestAssistantText;

--- a/src/agents/subagent-announce.capture-completion-reply.test.ts
+++ b/src/agents/subagent-announce.capture-completion-reply.test.ts
@@ -119,4 +119,123 @@ describe("captureSubagentCompletionReply", () => {
 
     expect(result).toBe("Mapped the modules.");
   });
+
+  it("includes exec tool result output alongside final assistant summary", async () => {
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-1",
+              name: "exec",
+              arguments: { command: "wc -c file.json" },
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: "123 file.json" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "The file has 123 bytes." }],
+        },
+      ],
+    });
+
+    const result = await captureSubagentCompletionReply("agent:main:subagent:child");
+
+    expect(result).toContain("123 file.json");
+    expect(result).toContain("The file has 123 bytes.");
+  });
+
+  it("resets tool results after intermediate assistant summary", async () => {
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call-1", name: "exec", arguments: {} }],
+        },
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: "first command output" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "First round done." }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call-2", name: "exec", arguments: {} }],
+        },
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: "second command output" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "All done." }],
+        },
+      ],
+    });
+
+    const result = await captureSubagentCompletionReply("agent:main:subagent:child");
+
+    // First round output was absorbed by "First round done." and should not reappear
+    expect(result).not.toContain("first command output");
+    expect(result).toContain("second command output");
+    expect(result).toContain("All done.");
+  });
+
+  it("includes multiple tool results from the same final round", async () => {
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "call-1", name: "exec", arguments: {} },
+            { type: "toolCall", id: "call-2", name: "exec", arguments: {} },
+          ],
+        },
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: "output A" }],
+        },
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: "output B" }],
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Final summary." }],
+        },
+      ],
+    });
+
+    const result = await captureSubagentCompletionReply("agent:main:subagent:child");
+
+    expect(result).toContain("output A");
+    expect(result).toContain("output B");
+    expect(result).toContain("Final summary.");
+  });
+
+  it("extracts tool result from nested content object", async () => {
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [
+        {
+          role: "toolResult",
+          content: {
+            content: [{ type: "text", text: "nested tool output" }],
+            details: { status: "completed" },
+          },
+        },
+      ],
+    });
+
+    const result = await captureSubagentCompletionReply("agent:main:subagent:child");
+
+    expect(result).toBe("nested tool output");
+  });
 });


### PR DESCRIPTION
## Summary

- When a sub-agent runs exec commands, `selectSubagentOutputText` prioritized the assistant's summary text over raw tool result stdout/stderr — if the LLM's final response didn't echo the output verbatim, the parent session lost the actual data
- Now accumulates all tool result texts and combines them with the assistant summary, so the parent always receives exec stdout/stderr
- Also handles a nested content array format in `extractToolResultText` that could silently return empty string

## Context

I had no idea why I was being tagged in an OpenClaw issue as I've never previously contributed here — turns out the reporter wrote `@exec` as a topic tag at the bottom of the issue. But I was bored tonight, so here's a fix.

Fixes #57965.

## Test plan

- [x] New test: exec tool result included alongside final assistant summary
- [x] New test: multiple exec tool results all preserved in output
- [x] New test: nested `AgentToolResult` content object extracted correctly
- [x] Existing `subagent-announce.capture-completion-reply.test.ts` — 7/7 pass
- [x] Existing `subagent-announce.test.ts` — 5/5 pass
- [x] Existing `subagent-announce.timeout.test.ts` + dispatch + queue — 29/29 pass
- [x] `pnpm build`, `pnpm check`, `pnpm tsgo` all clean

> This fix was developed with assistance from Claude Opus 4.6.