### PR TITLE
fix: surface actual error instead of misleading pinned write message

### DIFF
--- a/src/infra/fs-pinned-write-helper.ts
+++ b/src/infra/fs-pinned-write-helper.ts
@@ -153,7 +153,7 @@ function parsePinnedIdentity(stdout: string): FileIdentityStat {
 }
 
 function resolvePython3InstallHint(stderr: string): string {
-  if (stderr && /xcrun|command.?line.?tools|xcode/i.test(stderr)) {
+  if (process.platform === "darwin" && stderr && /xcrun|command.?line.?tools|xcode/i.test(stderr)) {
     return " (install Xcode Command Line Tools: xcode-select --install)";
   }
   if (process.platform === "linux" && /no such file|not found|ENOENT/i.test(stderr)) {

--- a/src/infra/fs-pinned-write-helper.ts
+++ b/src/infra/fs-pinned-write-helper.ts
@@ -152,6 +152,16 @@ function parsePinnedIdentity(stdout: string): FileIdentityStat {
   return { dev, ino };
 }
 
+function resolvePython3InstallHint(stderr: string): string {
+  if (stderr && /xcrun|command.?line.?tools|xcode/i.test(stderr)) {
+    return " (install Xcode Command Line Tools: xcode-select --install)";
+  }
+  if (process.platform === "linux" && /no such file|not found|ENOENT/i.test(stderr)) {
+    return " (install python3, e.g. apt install python3 or dnf install python3)";
+  }
+  return "";
+}
+
 export async function runPinnedWriteHelper(params: {
   rootPath: string;
   relativeParentPath: string;
@@ -211,9 +221,12 @@ export async function runPinnedWriteHelper(params: {
 
     const [code, signal] = await exitPromise;
     if (code !== 0) {
+      const detail = stderr.trim();
+      const installHint = resolvePython3InstallHint(detail);
       throw new Error(
-        stderr.trim() ||
-          `Pinned write helper failed with code ${code ?? "null"} (${signal ?? "?"})`,
+        detail
+          ? `python3 helper failed: ${detail}${installHint}`
+          : `python3 helper failed with code ${code ?? "null"} (${signal ?? "?"}); ensure python3 is installed`,
       );
     }
     return parsePinnedIdentity(stdout);

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -869,9 +869,14 @@ function normalizePinnedWriteError(error: unknown): Error {
   if (error instanceof SafeOpenError) {
     return error;
   }
-  return new SafeOpenError("invalid-path", "path is not a regular file under root", {
-    cause: error instanceof Error ? error : undefined,
-  });
+  const causeMessage = error instanceof Error ? error.message : String(error);
+  return new SafeOpenError(
+    "invalid-path",
+    `pinned write failed: ${causeMessage || "unknown error"}`,
+    {
+      cause: error instanceof Error ? error : undefined,
+    },
+  );
 }
 
 function normalizePinnedPathError(error: unknown): Error {


### PR DESCRIPTION
## Summary

- `normalizePinnedWriteError` was replacing all non-`SafeOpenError` errors with a generic `"path is not a regular file under root"` message, making failures like missing python3 nearly impossible to diagnose
- Preserve the original error message through `normalizePinnedWriteError` so the actual cause is visible to the user
- Add platform-specific install hints when python3 is missing (macOS: `xcode-select --install`, Linux: `apt install python3` / `dnf install python3`)

## Context

When python3 is unavailable (e.g. macOS without Xcode Command Line Tools), plugin installation fails with:

```
failed to extract archive: SafeOpenError: path is not a regular file under root
```

After this fix, users will see:

```
failed to extract archive: SafeOpenError: pinned write failed: python3 helper failed:
xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools),
missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun
(install Xcode Command Line Tools: xcode-select --install)
```

## Test plan

- [ ] Verify on macOS without Xcode CLT that plugin install shows the python3/xcrun error with install hint
- [ ] Verify on Linux without python3 that the error message mentions python3 and suggests apt/dnf
- [ ] Verify normal plugin install (with python3 present) still works as before
- [ ] Verify that `SafeOpenError` instances pass through `normalizePinnedWriteError` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)