### PR TITLE
fix(agents): handle LiveSessionModelSwitchError in subagent execution

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -415,4 +415,49 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     });
     expect(lifecycleEndCalls.length).toBeGreaterThanOrEqual(1);
   });
+
+  it("propagates authProfileId from the switch error to the retried session entry", async () => {
+    let invocation = 0;
+    let capturedAuthProfileProvider: string | undefined;
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      invocation += 1;
+      if (invocation === 1) {
+        // First invocation: switch includes an auth profile change.
+        throw new LiveSessionModelSwitchError({
+          provider: "openai",
+          model: "gpt-5.4",
+          authProfileId: "profile-openai-prod",
+          authProfileIdSource: "user",
+        });
+      }
+      // Second invocation: succeed with the switched model.
+      const result = await params.run(params.provider, params.model);
+      return {
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [],
+      };
+    });
+
+    state.runAgentAttemptMock.mockImplementation(async (...args: unknown[]) => {
+      const attemptParams = args[0] as { authProfileProvider?: string } | undefined;
+      capturedAuthProfileProvider = attemptParams?.authProfileProvider;
+      return makeSuccessResult("openai", "gpt-5.4");
+    });
+
+    const agentCommand = await getAgentCommand();
+    await agentCommand({
+      message: "hello",
+      to: "+1234567890",
+      senderIsOwner: true,
+    });
+
+    // The retried attempt must receive the switched provider for auth profile
+    // validation, not the original default provider.
+    expect(capturedAuthProfileProvider).toBe("openai");
+
+    // runWithModelFallback should have been called twice.
+    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1,0 +1,418 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LiveSessionModelSwitchError } from "./live-model-switch.js";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks – these must be declared before any vi.mock() calls so the
+// mock factories can reference them.
+// ---------------------------------------------------------------------------
+const state = vi.hoisted(() => ({
+  runWithModelFallbackMock: vi.fn(),
+  runAgentAttemptMock: vi.fn(),
+  emitAgentEventMock: vi.fn(),
+  registerAgentRunContextMock: vi.fn(),
+  clearAgentRunContextMock: vi.fn(),
+  updateSessionStoreAfterAgentRunMock: vi.fn(),
+  deliverAgentCommandResultMock: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+vi.mock("./model-fallback.js", () => ({
+  runWithModelFallback: (params: unknown) => state.runWithModelFallbackMock(params),
+}));
+
+vi.mock("./command/attempt-execution.js", () => ({
+  buildAcpResult: vi.fn(),
+  createAcpVisibleTextAccumulator: vi.fn(),
+  emitAcpAssistantDelta: vi.fn(),
+  emitAcpLifecycleEnd: vi.fn(),
+  emitAcpLifecycleError: vi.fn(),
+  emitAcpLifecycleStart: vi.fn(),
+  persistAcpTurnTranscript: vi.fn(),
+  persistSessionEntry: vi.fn(),
+  prependInternalEventContext: (_body: string) => _body,
+  runAgentAttempt: (...args: unknown[]) => state.runAgentAttemptMock(...args),
+  sessionFileHasContent: vi.fn(async () => false),
+}));
+
+vi.mock("./command/delivery.js", () => ({
+  deliverAgentCommandResult: (...args: unknown[]) => state.deliverAgentCommandResultMock(...args),
+}));
+
+vi.mock("./command/run-context.js", () => ({
+  resolveAgentRunContext: () => ({
+    messageChannel: "test",
+    accountId: "acct",
+    groupId: undefined,
+    groupChannel: undefined,
+    groupSpace: undefined,
+    currentChannelId: undefined,
+    currentThreadTs: undefined,
+    replyToMode: undefined,
+    hasRepliedRef: { current: false },
+  }),
+}));
+
+vi.mock("./command/session-store.js", () => ({
+  updateSessionStoreAfterAgentRun: (...args: unknown[]) =>
+    state.updateSessionStoreAfterAgentRunMock(...args),
+}));
+
+vi.mock("./command/session.js", () => ({
+  resolveSession: () => ({
+    sessionId: "session-1",
+    sessionKey: "agent:main",
+    sessionEntry: { sessionId: "session-1", updatedAt: Date.now() },
+    sessionStore: {},
+    storePath: "/tmp/store.json",
+    isNewSession: true,
+    persistedThinking: undefined,
+    persistedVerbose: undefined,
+  }),
+}));
+
+vi.mock("./command/types.js", () => ({}));
+
+vi.mock("../acp/policy.js", () => ({
+  resolveAcpAgentPolicyError: () => null,
+  resolveAcpDispatchPolicyError: () => null,
+}));
+
+vi.mock("../acp/runtime/errors.js", () => ({
+  toAcpRuntimeError: vi.fn(),
+}));
+
+vi.mock("../acp/runtime/session-identifiers.js", () => ({
+  resolveAcpSessionCwd: () => "/tmp",
+}));
+
+vi.mock("../auto-reply/thinking.js", () => ({
+  formatThinkingLevels: () => "low, medium, high",
+  formatXHighModelHint: () => "model-x",
+  normalizeThinkLevel: (v?: string) => v || undefined,
+  normalizeVerboseLevel: (v?: string) => v || undefined,
+  supportsXHighThinking: () => false,
+}));
+
+vi.mock("../cli/command-format.js", () => ({
+  formatCliCommand: (cmd: string) => cmd,
+}));
+
+vi.mock("../cli/command-secret-gateway.js", () => ({
+  resolveCommandSecretRefsViaGateway: async (params: { config: unknown }) => ({
+    resolvedConfig: params.config,
+    diagnostics: [],
+  }),
+}));
+
+vi.mock("../cli/command-secret-targets.js", () => ({
+  getAgentRuntimeCommandSecretTargetIds: () => [],
+}));
+
+vi.mock("../cli/deps.js", () => ({
+  createDefaultDeps: () => ({}),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => ({}),
+  readConfigFileSnapshotForWrite: async () => ({
+    snapshot: { valid: false },
+  }),
+  setRuntimeConfigSnapshot: vi.fn(),
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  resolveAgentIdFromSessionKey: () => "default",
+  mergeSessionEntry: (a: unknown, b: unknown) => ({ ...(a as object), ...(b as object) }),
+  updateSessionStore: vi.fn(
+    async (_path: string, fn: (store: Record<string, unknown>) => unknown) => {
+      const store: Record<string, unknown> = {};
+      return fn(store);
+    },
+  ),
+}));
+
+vi.mock("../config/sessions/transcript.js", () => ({
+  resolveSessionTranscriptFile: async () => ({
+    sessionFile: "/tmp/session.jsonl",
+    sessionEntry: { sessionId: "session-1", updatedAt: Date.now() },
+  }),
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  clearAgentRunContext: (...args: unknown[]) => state.clearAgentRunContextMock(...args),
+  emitAgentEvent: (...args: unknown[]) => state.emitAgentEventMock(...args),
+  registerAgentRunContext: (...args: unknown[]) => state.registerAgentRunContextMock(...args),
+}));
+
+vi.mock("../infra/outbound/session-context.js", () => ({
+  buildOutboundSessionContext: () => ({}),
+}));
+
+vi.mock("../infra/skills-remote.js", () => ({
+  getRemoteSkillEligibility: () => ({ eligible: false }),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock("../routing/session-key.js", () => ({
+  normalizeAgentId: (id: string) => id,
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {
+    error: vi.fn(),
+    log: vi.fn(),
+  },
+}));
+
+vi.mock("../sessions/level-overrides.js", () => ({
+  applyVerboseOverride: vi.fn(),
+}));
+
+vi.mock("../sessions/model-overrides.js", () => ({
+  applyModelOverrideToSessionEntry: () => ({ updated: false }),
+}));
+
+vi.mock("../sessions/send-policy.js", () => ({
+  resolveSendPolicy: () => "allow",
+}));
+
+vi.mock("../terminal/ansi.js", () => ({
+  sanitizeForLog: (s: string) => s,
+}));
+
+vi.mock("../utils/message-channel.js", () => ({
+  resolveMessageChannel: () => "test",
+}));
+
+vi.mock("./agent-scope.js", () => ({
+  listAgentIds: () => ["default"],
+  resolveAgentDir: () => "/tmp/agent",
+  resolveEffectiveModelFallbacks: () => undefined,
+  resolveSessionAgentId: () => "default",
+  resolveAgentSkillsFilter: () => undefined,
+  resolveAgentWorkspaceDir: () => "/tmp/workspace",
+}));
+
+vi.mock("./auth-profiles.js", () => ({
+  ensureAuthProfileStore: () => ({ profiles: {} }),
+}));
+
+vi.mock("./auth-profiles/session-override.js", () => ({
+  clearSessionAuthProfileOverride: vi.fn(),
+}));
+
+vi.mock("./defaults.js", () => ({
+  DEFAULT_MODEL: "claude",
+  DEFAULT_PROVIDER: "anthropic",
+}));
+
+vi.mock("./lanes.js", () => ({
+  AGENT_LANE_SUBAGENT: "subagent",
+}));
+
+vi.mock("./model-catalog.js", () => ({
+  loadModelCatalog: async () => [],
+}));
+
+vi.mock("./model-selection.js", () => ({
+  buildAllowedModelSet: () => ({
+    allowedKeys: new Set<string>(),
+    allowedCatalog: [],
+    allowAny: true,
+  }),
+  modelKey: (p: string, m: string) => `${p}/${m}`,
+  normalizeModelRef: (p: string, m: string) => ({ provider: p, model: m }),
+  parseModelRef: (m: string, p: string) => ({ provider: p, model: m }),
+  resolveConfiguredModelRef: () => ({ provider: "anthropic", model: "claude" }),
+  resolveDefaultModelForAgent: () => ({ provider: "anthropic", model: "claude" }),
+  resolveThinkingDefault: () => "low",
+}));
+
+vi.mock("./skills.js", () => ({
+  buildWorkspaceSkillSnapshot: () => ({}),
+}));
+
+vi.mock("./skills/refresh.js", () => ({
+  getSkillsSnapshotVersion: () => 0,
+}));
+
+vi.mock("./spawned-context.js", () => ({
+  normalizeSpawnedRunMetadata: (meta: unknown) => meta ?? {},
+}));
+
+vi.mock("./timeout.js", () => ({
+  resolveAgentTimeoutMs: () => 30_000,
+}));
+
+vi.mock("./workspace.js", () => ({
+  ensureAgentWorkspace: async () => ({ dir: "/tmp/workspace" }),
+}));
+
+// ACP session manager mock – resolveSession returns null (non-ACP path).
+vi.mock("../acp/control-plane/manager.js", () => ({
+  getAcpSessionManager: () => ({
+    resolveSession: () => null,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+async function getAgentCommand() {
+  return (await import("./agent-command.js")).agentCommand;
+}
+
+type FallbackRunnerParams = {
+  provider: string;
+  model: string;
+  run: (provider: string, model: string) => Promise<unknown>;
+};
+
+function makeSuccessResult(provider: string, model: string) {
+  return {
+    payloads: [{ text: "ok" }],
+    meta: {
+      durationMs: 100,
+      aborted: false,
+      stopReason: "end_turn",
+      agentMeta: { provider, model },
+    },
+  };
+}
+
+describe("agentCommand – LiveSessionModelSwitchError retry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.deliverAgentCommandResultMock.mockResolvedValue(undefined);
+    state.updateSessionStoreAfterAgentRunMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("retries with the switched provider/model when LiveSessionModelSwitchError is thrown", async () => {
+    let invocation = 0;
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      invocation += 1;
+      if (invocation === 1) {
+        // First invocation: simulate the embedded runner detecting a live
+        // session model switch and throwing LiveSessionModelSwitchError.
+        throw new LiveSessionModelSwitchError({
+          provider: "openai",
+          model: "gpt-5.4",
+        });
+      }
+      // Second invocation: succeed with the switched model.
+      const result = await params.run(params.provider, params.model);
+      return {
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [],
+      };
+    });
+
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+
+    const agentCommand = await getAgentCommand();
+    await agentCommand({
+      message: "hello",
+      to: "+1234567890",
+      senderIsOwner: true,
+    });
+
+    // runWithModelFallback should have been called twice:
+    // 1st time with the default provider/model (throws LiveSessionModelSwitchError)
+    // 2nd time with the switched provider/model
+    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(2);
+
+    const secondCall = state.runWithModelFallbackMock.mock.calls[1]?.[0] as
+      | FallbackRunnerParams
+      | undefined;
+    expect(secondCall?.provider).toBe("openai");
+    expect(secondCall?.model).toBe("gpt-5.4");
+  });
+
+  it("propagates non-LiveSessionModelSwitchError errors without retrying", async () => {
+    state.runWithModelFallbackMock.mockRejectedValueOnce(new Error("some other failure"));
+
+    const agentCommand = await getAgentCommand();
+    await expect(
+      agentCommand({
+        message: "hello",
+        to: "+1234567890",
+        senderIsOwner: true,
+      }),
+    ).rejects.toThrow("some other failure");
+
+    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits lifecycle error event for non-switch errors", async () => {
+    state.runWithModelFallbackMock.mockRejectedValueOnce(new Error("provider down"));
+
+    const agentCommand = await getAgentCommand();
+    await expect(
+      agentCommand({
+        message: "hello",
+        to: "+1234567890",
+        senderIsOwner: true,
+      }),
+    ).rejects.toThrow("provider down");
+
+    // Verify that a lifecycle error event was emitted.
+    const lifecycleErrorCalls = state.emitAgentEventMock.mock.calls.filter((call: unknown[]) => {
+      const arg = call[0] as { stream?: string; data?: { phase?: string } };
+      return arg?.stream === "lifecycle" && arg?.data?.phase === "error";
+    });
+    expect(lifecycleErrorCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("resets lifecycleEnded flag between retry iterations", async () => {
+    let invocation = 0;
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      invocation += 1;
+      if (invocation === 1) {
+        throw new LiveSessionModelSwitchError({
+          provider: "openai",
+          model: "gpt-5.4",
+        });
+      }
+      const result = await params.run(params.provider, params.model);
+      return {
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [],
+      };
+    });
+
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+
+    const agentCommand = await getAgentCommand();
+    await agentCommand({
+      message: "hello",
+      to: "+1234567890",
+      senderIsOwner: true,
+    });
+
+    // After successful retry, a lifecycle "end" event should be emitted
+    // (not an "error" event from the first iteration's switch).
+    const lifecycleEndCalls = state.emitAgentEventMock.mock.calls.filter((call: unknown[]) => {
+      const arg = call[0] as { stream?: string; data?: { phase?: string } };
+      return arg?.stream === "lifecycle" && arg?.data?.phase === "end";
+    });
+    expect(lifecycleEndCalls.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -501,4 +501,51 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       hasSessionModelOverride: true,
     });
   });
+
+  it("does not flip hasSessionModelOverride on auth-only switch with same model", async () => {
+    let invocation = 0;
+    state.runWithModelFallbackMock.mockImplementation(
+      async (params: FallbackRunnerParams) => {
+        invocation += 1;
+        if (invocation === 1) {
+          // Auth-only switch: same default provider/model, only authProfileId changes.
+          throw new LiveSessionModelSwitchError({
+            provider: "anthropic",
+            model: "claude",
+            authProfileId: "profile-99",
+            authProfileIdSource: "admin",
+          });
+        }
+        const result = await params.run(params.provider, params.model);
+        return {
+          result,
+          provider: params.provider,
+          model: params.model,
+          attempts: [],
+        };
+      },
+    );
+    state.runAgentAttemptMock.mockResolvedValue(
+      makeSuccessResult("anthropic", "claude"),
+    );
+
+    resolveEffectiveModelFallbacksMock.mockClear();
+
+    const agentCommand = await getAgentCommand();
+    await agentCommand({
+      message: "hello",
+      to: "+1234567890",
+      senderIsOwner: true,
+    });
+
+    // Both calls should see hasSessionModelOverride: false because the model
+    // did not actually change — only the auth profile was switched.
+    expect(resolveEffectiveModelFallbacksMock).toHaveBeenCalledTimes(2);
+    expect(resolveEffectiveModelFallbacksMock.mock.calls[0][0]).toMatchObject({
+      hasSessionModelOverride: false,
+    });
+    expect(resolveEffectiveModelFallbacksMock.mock.calls[1][0]).toMatchObject({
+      hasSessionModelOverride: false,
+    });
+  });
 });

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -194,10 +194,11 @@ vi.mock("../utils/message-channel.js", () => ({
   resolveMessageChannel: () => "test",
 }));
 
+const resolveEffectiveModelFallbacksMock = vi.fn().mockReturnValue(undefined);
 vi.mock("./agent-scope.js", () => ({
   listAgentIds: () => ["default"],
   resolveAgentDir: () => "/tmp/agent",
-  resolveEffectiveModelFallbacks: () => undefined,
+  resolveEffectiveModelFallbacks: resolveEffectiveModelFallbacksMock,
   resolveSessionAgentId: () => "default",
   resolveAgentSkillsFilter: () => undefined,
   resolveAgentWorkspaceDir: () => "/tmp/workspace",
@@ -459,5 +460,45 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
     // runWithModelFallback should have been called twice.
     expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("updates hasSessionModelOverride for fallback resolution after switch", async () => {
+    let invocation = 0;
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      invocation += 1;
+      if (invocation === 1) {
+        throw new LiveSessionModelSwitchError({
+          provider: "openai",
+          model: "gpt-5.4",
+        });
+      }
+      const result = await params.run(params.provider, params.model);
+      return {
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [],
+      };
+    });
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+
+    resolveEffectiveModelFallbacksMock.mockClear();
+
+    const agentCommand = await getAgentCommand();
+    await agentCommand({
+      message: "hello",
+      to: "+1234567890",
+      senderIsOwner: true,
+    });
+
+    // First call: no session override (initial state).
+    expect(resolveEffectiveModelFallbacksMock).toHaveBeenCalledTimes(2);
+    expect(resolveEffectiveModelFallbacksMock.mock.calls[0][0]).toMatchObject({
+      hasSessionModelOverride: false,
+    });
+    // Second call (retry): session now has a model override from the switch.
+    expect(resolveEffectiveModelFallbacksMock.mock.calls[1][0]).toMatchObject({
+      hasSessionModelOverride: true,
+    });
   });
 });

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -629,7 +629,7 @@ async function agentCommandInternal(
         model = normalizedStored.model;
       }
     }
-    const providerForAuthProfileValidation = provider;
+    let providerForAuthProfileValidation = provider;
     if (hasExplicitRunOverride) {
       const explicitRef = explicitModelOverride
         ? explicitProviderOverride
@@ -836,6 +836,17 @@ async function agentCommandInternal(
           model = err.model;
           fallbackProvider = err.provider;
           fallbackModel = err.model;
+          // Keep auth-profile validation in sync so the next attempt resolves
+          // the correct session-level auth profile for the new provider.
+          providerForAuthProfileValidation = err.provider;
+          // Forward auth-profile fields carried by the switch request so the
+          // retried run uses the right credentials (mirrors the main runner).
+          if (sessionEntry) {
+            sessionEntry.authProfileOverride = err.authProfileId;
+            sessionEntry.authProfileOverrideSource = err.authProfileId
+              ? err.authProfileIdSource
+              : undefined;
+          }
           // Reset lifecycle tracking for the retry iteration.
           lifecycleEnded = false;
           log.info(

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -66,6 +66,7 @@ import { resolveSession } from "./command/session.js";
 import type { AgentCommandIngressOpts, AgentCommandOpts } from "./command/types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
+import { LiveSessionModelSwitchError } from "./live-model-switch.js";
 import { loadModelCatalog } from "./model-catalog.js";
 import { runWithModelFallback } from "./model-fallback.js";
 import {
@@ -732,109 +733,131 @@ async function agentCommandInternal(
     let result: Awaited<ReturnType<typeof runAgentAttempt>>;
     let fallbackProvider = provider;
     let fallbackModel = model;
-    try {
-      const runContext = resolveAgentRunContext(opts);
-      const messageChannel = resolveMessageChannel(
-        runContext.messageChannel,
-        opts.replyChannel ?? opts.channel,
-      );
-      const spawnedBy = normalizedSpawned.spawnedBy ?? sessionEntry?.spawnedBy;
-      // Keep fallback candidate resolution centralized so session model overrides,
-      // per-agent overrides, and default fallbacks stay consistent across callers.
-      const effectiveFallbacksOverride = resolveEffectiveModelFallbacks({
-        cfg,
-        agentId: sessionAgentId,
-        hasSessionModelOverride: Boolean(storedModelOverride),
-      });
+    // Retry loop: when the embedded runner detects a live session model switch
+    // (e.g. a subagent whose persisted session targets a different provider/model),
+    // it throws LiveSessionModelSwitchError.  Catch it and restart the full
+    // runWithModelFallback cycle with the updated provider/model, mirroring the
+    // same retry logic used by the main auto-reply runner
+    // (see: agent-runner-execution.ts).
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        const runContext = resolveAgentRunContext(opts);
+        const messageChannel = resolveMessageChannel(
+          runContext.messageChannel,
+          opts.replyChannel ?? opts.channel,
+        );
+        const spawnedBy = normalizedSpawned.spawnedBy ?? sessionEntry?.spawnedBy;
+        // Keep fallback candidate resolution centralized so session model overrides,
+        // per-agent overrides, and default fallbacks stay consistent across callers.
+        const effectiveFallbacksOverride = resolveEffectiveModelFallbacks({
+          cfg,
+          agentId: sessionAgentId,
+          hasSessionModelOverride: Boolean(storedModelOverride),
+        });
 
-      // Track model fallback attempts so retries on an existing session don't
-      // re-inject the original prompt as a duplicate user message.
-      let fallbackAttemptIndex = 0;
-      const fallbackResult = await runWithModelFallback({
-        cfg,
-        provider,
-        model,
-        runId,
-        agentDir,
-        fallbacksOverride: effectiveFallbacksOverride,
-        run: async (providerOverride, modelOverride, runOptions) => {
-          const isFallbackRetry = fallbackAttemptIndex > 0;
-          fallbackAttemptIndex += 1;
-          return runAgentAttempt({
-            providerOverride,
-            modelOverride,
-            cfg,
-            sessionEntry,
-            sessionId,
-            sessionKey,
-            sessionAgentId,
-            sessionFile,
-            workspaceDir,
-            body,
-            isFallbackRetry,
-            resolvedThinkLevel,
-            timeoutMs,
+        // Track model fallback attempts so retries on an existing session don't
+        // re-inject the original prompt as a duplicate user message.
+        let fallbackAttemptIndex = 0;
+        const fallbackResult = await runWithModelFallback({
+          cfg,
+          provider,
+          model,
+          runId,
+          agentDir,
+          fallbacksOverride: effectiveFallbacksOverride,
+          run: async (providerOverride, modelOverride, runOptions) => {
+            const isFallbackRetry = fallbackAttemptIndex > 0;
+            fallbackAttemptIndex += 1;
+            return runAgentAttempt({
+              providerOverride,
+              modelOverride,
+              cfg,
+              sessionEntry,
+              sessionId,
+              sessionKey,
+              sessionAgentId,
+              sessionFile,
+              workspaceDir,
+              body,
+              isFallbackRetry,
+              resolvedThinkLevel,
+              timeoutMs,
+              runId,
+              opts,
+              runContext,
+              spawnedBy,
+              messageChannel,
+              skillsSnapshot,
+              resolvedVerboseLevel,
+              agentDir,
+              authProfileProvider: providerForAuthProfileValidation,
+              sessionStore,
+              storePath,
+              allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+              sessionHasHistory: !isNewSession || (await sessionFileHasContent(sessionFile)),
+              onAgentEvent: (evt) => {
+                // Track lifecycle end for fallback emission below.
+                if (
+                  evt.stream === "lifecycle" &&
+                  typeof evt.data?.phase === "string" &&
+                  (evt.data.phase === "end" || evt.data.phase === "error")
+                ) {
+                  lifecycleEnded = true;
+                }
+              },
+            });
+          },
+        });
+        result = fallbackResult.result;
+        fallbackProvider = fallbackResult.provider;
+        fallbackModel = fallbackResult.model;
+        if (!lifecycleEnded) {
+          const stopReason = result.meta.stopReason;
+          if (stopReason && stopReason !== "end_turn") {
+            console.error(`[agent] run ${runId} ended with stopReason=${stopReason}`);
+          }
+          emitAgentEvent({
             runId,
-            opts,
-            runContext,
-            spawnedBy,
-            messageChannel,
-            skillsSnapshot,
-            resolvedVerboseLevel,
-            agentDir,
-            authProfileProvider: providerForAuthProfileValidation,
-            sessionStore,
-            storePath,
-            allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
-            sessionHasHistory: !isNewSession || (await sessionFileHasContent(sessionFile)),
-            onAgentEvent: (evt) => {
-              // Track lifecycle end for fallback emission below.
-              if (
-                evt.stream === "lifecycle" &&
-                typeof evt.data?.phase === "string" &&
-                (evt.data.phase === "end" || evt.data.phase === "error")
-              ) {
-                lifecycleEnded = true;
-              }
+            stream: "lifecycle",
+            data: {
+              phase: "end",
+              startedAt,
+              endedAt: Date.now(),
+              aborted: result.meta.aborted ?? false,
+              stopReason,
             },
           });
-        },
-      });
-      result = fallbackResult.result;
-      fallbackProvider = fallbackResult.provider;
-      fallbackModel = fallbackResult.model;
-      if (!lifecycleEnded) {
-        const stopReason = result.meta.stopReason;
-        if (stopReason && stopReason !== "end_turn") {
-          console.error(`[agent] run ${runId} ended with stopReason=${stopReason}`);
         }
-        emitAgentEvent({
-          runId,
-          stream: "lifecycle",
-          data: {
-            phase: "end",
-            startedAt,
-            endedAt: Date.now(),
-            aborted: result.meta.aborted ?? false,
-            stopReason,
-          },
-        });
+        break;
+      } catch (err) {
+        if (err instanceof LiveSessionModelSwitchError) {
+          provider = err.provider;
+          model = err.model;
+          fallbackProvider = err.provider;
+          fallbackModel = err.model;
+          // Reset lifecycle tracking for the retry iteration.
+          lifecycleEnded = false;
+          log.info(
+            `Live session model switch in subagent run ${runId}: switching to ${err.provider}/${err.model}`,
+          );
+          continue;
+        }
+        if (!lifecycleEnded) {
+          emitAgentEvent({
+            runId,
+            stream: "lifecycle",
+            data: {
+              phase: "error",
+              startedAt,
+              endedAt: Date.now(),
+              error: String(err),
+            },
+          });
+        }
+        throw err;
       }
-    } catch (err) {
-      if (!lifecycleEnded) {
-        emitAgentEvent({
-          runId,
-          stream: "lifecycle",
-          data: {
-            phase: "error",
-            startedAt,
-            endedAt: Date.now(),
-            error: String(err),
-          },
-        });
-      }
-      throw err;
-    }
+    } // end while
 
     // Update token+model fields in the session store.
     if (sessionStore && sessionKey) {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -619,7 +619,7 @@ async function agentCommandInternal(
     }
 
     const storedProviderOverride = sessionEntry?.providerOverride?.trim();
-    const storedModelOverride = sessionEntry?.modelOverride?.trim();
+    let storedModelOverride = sessionEntry?.modelOverride?.trim();
     if (storedModelOverride) {
       const candidateProvider = storedProviderOverride || defaultProvider;
       const normalizedStored = normalizeModelRef(candidateProvider, storedModelOverride);
@@ -847,6 +847,9 @@ async function agentCommandInternal(
               ? err.authProfileIdSource
               : undefined;
           }
+          // After a live switch the session effectively has a model override,
+          // so fallback candidate resolution picks up default fallbacks too.
+          storedModelOverride = err.model;
           // Reset lifecycle tracking for the retry iteration.
           lifecycleEnded = false;
           log.info(

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -847,9 +847,13 @@ async function agentCommandInternal(
               ? err.authProfileIdSource
               : undefined;
           }
-          // After a live switch the session effectively has a model override,
-          // so fallback candidate resolution picks up default fallbacks too.
-          storedModelOverride = err.model;
+          // Only update storedModelOverride when the model actually changed
+          // (or was already overridden).  Auth-only switches that keep the same
+          // provider/model should not flip hasSessionModelOverride to true,
+          // because that would alter fallback candidate resolution.
+          if (storedModelOverride || err.model !== model) {
+            storedModelOverride = err.model;
+          }
           // Reset lifecycle tracking for the retry iteration.
           lifecycleEnded = false;
           log.info(

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -832,6 +832,9 @@ async function agentCommandInternal(
         break;
       } catch (err) {
         if (err instanceof LiveSessionModelSwitchError) {
+          // Capture the pre-switch model before mutating, so the guard below
+          // can detect whether the model actually changed.
+          const previousModel = model;
           provider = err.provider;
           model = err.model;
           fallbackProvider = err.provider;
@@ -851,7 +854,7 @@ async function agentCommandInternal(
           // (or was already overridden).  Auth-only switches that keep the same
           // provider/model should not flip hasSessionModelOverride to true,
           // because that would alter fallback candidate resolution.
-          if (storedModelOverride || err.model !== model) {
+          if (storedModelOverride || err.model !== previousModel) {
             storedModelOverride = err.model;
           }
           // Reset lifecycle tracking for the retry iteration.


### PR DESCRIPTION
### Summary

- **Problem**: When a subagent is configured with a different provider/model than the parent agent (e.g., parent uses Anthropic, subagent uses OpenAI), the subagent fails immediately with a `LiveSessionModelSwitchError`. This occurs in `src/agents/agent-command.ts` where the error is caught but not handled, causing it to be rethrown and aborting the execution.
- **Root Cause**: The `runWithModelFallback` function throws a `LiveSessionModelSwitchError` when it detects a live session model switch (e.g., when the persisted session targets a different provider/model). While the main auto-reply runner (`src/auto-reply/reply/agent-runner-execution.ts`) has a `while` loop and a `catch` block to handle this error by updating the provider/model and retrying, the subagent execution path (`agentCommandInternal` in `src/agents/agent-command.ts`) lacks this retry mechanism. Consequently, the error escapes the fallback loop and crashes the subagent.
- **Fix**: Introduced a `while (true)` retry loop around the `runWithModelFallback` call in `agentCommandInternal` (`src/agents/agent-command.ts`), mirroring the exact logic used in the main runner. When `LiveSessionModelSwitchError` is caught, the provider and model variables are updated, the `lifecycleEnded` flag is reset, and the loop continues to retry the execution with the correct model. This ensures subagents can seamlessly switch models just like the main agent.
- **What changed**:
  - `src/agents/agent-command.ts`: Added `LiveSessionModelSwitchError` import. Wrapped the `runWithModelFallback` execution in a `while (true)` loop. Added a `catch` branch specifically for `LiveSessionModelSwitchError` to update model state and `continue`.
  - `src/agents/agent-command.live-model-switch.test.ts`: Added comprehensive unit tests to verify the retry logic, error propagation, and lifecycle event emission.
- **What did NOT change (scope boundary)**: The core model fallback logic (`runWithModelFallback`) and the main agent runner (`agent-runner-execution.ts`) remain untouched. The fix is strictly localized to the subagent command execution path.

### Reproduction

1. Configure a parent agent to use `anthropic/claude`.
2. Configure a subagent to use `openai/gpt-4o`.
3. Trigger the subagent from the parent agent.
4. Observe the subagent crash with `LiveSessionModelSwitchError` before the fix. After the fix, it successfully switches models and replies.

### Risk / Mitigation

- **Risk**: Infinite loops if the model switch error is thrown repeatedly without making progress.
- **Mitigation**: The `LiveSessionModelSwitchError` carries the target provider and model, which are explicitly applied to the next iteration. The underlying `runWithModelFallback` and `runAgentAttempt` logic ensures that once the correct model is applied, the switch error is not thrown again. Unit tests specifically verify that the retry loop terminates successfully after the switch.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Agents

### Linked Issue/PR

Fixes #57998