### PR TITLE
daemon: set macOS LaunchAgent ProcessType and WorkingDirectory

### DIFF
--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -6,6 +6,7 @@ import fs from "node:fs/promises";
 export const LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS = 1;
 // launchd stores plist integer values in decimal; 0o077 renders as 63 (owner-only files).
 export const LAUNCH_AGENT_UMASK_DECIMAL = 0o077;
+export const LAUNCH_AGENT_PROCESS_TYPE = "Interactive";
 
 const plistEscape = (value: string): string =>
   value
@@ -106,12 +107,13 @@ export function buildLaunchAgentPlist({
   const argsXml = programArguments
     .map((arg) => `\n      <string>${plistEscape(arg)}</string>`)
     .join("");
-  const workingDirXml = workingDirectory
-    ? `\n    <key>WorkingDirectory</key>\n    <string>${plistEscape(workingDirectory)}</string>`
+  const effectiveWorkingDirectory = workingDirectory?.trim();
+  const workingDirXml = effectiveWorkingDirectory
+    ? `\n    <key>WorkingDirectory</key>\n    <string>${plistEscape(effectiveWorkingDirectory)}</string>`
     : "";
   const commentXml = comment?.trim()
     ? `\n    <key>Comment</key>\n    <string>${plistEscape(comment.trim())}</string>`
     : "";
   const envXml = renderEnvDict(environment);
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ThrottleInterval</key>\n    <integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>\n    <key>Umask</key>\n    <integer>${LAUNCH_AGENT_UMASK_DECIMAL}</integer>\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    ${workingDirXml}\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n  <dict>\n    <key>Label</key>\n    <string>${plistEscape(label)}</string>\n    ${commentXml}\n    <key>RunAtLoad</key>\n    <true/>\n    <key>KeepAlive</key>\n    <true/>\n    <key>ThrottleInterval</key>\n    <integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>\n    <key>ProcessType</key>\n    <string>${plistEscape(LAUNCH_AGENT_PROCESS_TYPE)}</string>\n    <key>Umask</key>\n    <integer>${LAUNCH_AGENT_UMASK_DECIMAL}</integer>\n    ${workingDirXml}\n    <key>ProgramArguments</key>\n    <array>${argsXml}\n    </array>\n    <key>StandardOutPath</key>\n    <string>${plistEscape(stdoutPath)}</string>\n    <key>StandardErrorPath</key>\n    <string>${plistEscape(stderrPath)}</string>${envXml}\n  </dict>\n</plist>\n`;
 }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -1,6 +1,7 @@
 import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  LAUNCH_AGENT_PROCESS_TYPE,
   LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS,
   LAUNCH_AGENT_UMASK_DECIMAL,
 } from "./launchd-plist.js";
@@ -522,6 +523,23 @@ describe("launchd install", () => {
     expect(plist).toContain(`<integer>${LAUNCH_AGENT_UMASK_DECIMAL}</integer>`);
     expect(plist).toContain("<key>ThrottleInterval</key>");
     expect(plist).toContain(`<integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>`);
+    expect(plist).toContain("<key>ProcessType</key>");
+    expect(plist).toContain(`<string>${LAUNCH_AGENT_PROCESS_TYPE}</string>`);
+  });
+
+  it("preserves an explicit working directory in the generated plist", async () => {
+    const env = createDefaultLaunchdEnv();
+    await installLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+      workingDirectory: "/Users/test/project",
+    });
+
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const plist = state.files.get(plistPath) ?? "";
+    expect(plist).toContain("<key>WorkingDirectory</key>");
+    expect(plist).toContain("<string>/Users/test/project</string>");
   });
 
   it("rewrites the plist before bootstrap during restart fallback", async () => {


### PR DESCRIPTION
## Summary
- set generated macOS LaunchAgent plists to `ProcessType=Interactive`
- always emit a `WorkingDirectory`, defaulting to `/` when no explicit directory is provided
- cover the new plist defaults in launchd install tests

## Testing
- pnpm exec vitest run src/daemon/launchd.test.ts
- pnpm lint

Closes #58061
Related to #54861