### PR TITLE
feat(browser): add local-browser-bridge adapter

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -18,7 +18,7 @@ Beginner view:
 - Think of it as a **separate, agent-only browser**.
 - The `openclaw` profile does **not** touch your personal browser profile.
 - The agent can **open tabs, read pages, click, and type** in a safe lane.
-- The built-in `user` profile attaches to your real signed-in Chrome session via Chrome MCP.
+- The built-in `user` profile attaches to your real signed-in browser session.
 
 ## What you get
 
@@ -122,20 +122,42 @@ Typical symptoms:
 - `browser.request` is missing.
 - The agent reports the browser tool as unavailable or missing.
 
-## Profiles: `openclaw` vs `user`
+## Profiles: `openclaw` vs `user` vs `chrome-relay`
 
 - `openclaw`: managed, isolated browser (no extension required).
-- `user`: built-in Chrome MCP attach profile for your **real signed-in Chrome**
-  session.
+- `user`: built-in Chrome MCP attach profile for your **real signed-in browser** session. If `OPENCLAW_LOCAL_BROWSER_BRIDGE_URL` is set and reachable, the agent browser tool and `openclaw browser` CLI can route `user` through `local-browser-bridge` as **Safari actionable** (`safari-direct`) for `status`/`tabs`/`open`/`navigate`.
+- `chrome-relay`: explicit Chrome extension relay flow. If `OPENCLAW_LOCAL_BROWSER_BRIDGE_URL` is set and reachable, the agent browser tool and `openclaw browser` CLI can also route `chrome-relay` through `local-browser-bridge` as **Chrome shared-tab read-only** (`chrome-relay`) for `status`/`tabs`.
 
 For agent browser tool calls:
 
 - Default: use the isolated `openclaw` browser.
-- Prefer `profile="user"` when existing logged-in sessions matter and the user
-  is at the computer to click/approve any attach prompt.
+- Prefer `profile="user"` when existing logged-in sessions matter and the user is at the computer to click/approve any attach prompt.
+- Use `profile="chrome-relay"` only when the user explicitly wants the Chrome extension / toolbar-button attach flow.
 - `profile` is the explicit override when you want a specific browser mode.
 
 Set `browser.defaultProfile: "openclaw"` if you want managed mode by default.
+
+### Experimental local-browser-bridge adapter
+
+If `OPENCLAW_LOCAL_BROWSER_BRIDGE_URL` is set (default bridge URL expectation:
+`http://127.0.0.1:3000`) and the service is reachable, OpenClaw has a minimal
+bridge-backed path:
+
+- `profile="user"` → Safari actionable (`safari-direct`) via local-browser-bridge
+- `profile="chrome-relay"` → Chrome shared-tab read-only via local-browser-bridge
+
+Current OpenClaw wiring is intentionally narrow and truthful:
+
+- supported through the agent browser tool and `openclaw browser` CLI:
+  `status`, `tabs`, `open`, `navigate`
+- Safari runtime path: `open`/`navigate` only
+- Chrome relay path: `status`/`tabs` only
+- Chrome relay rejects write actions like `open`, `navigate`, `focus`, `close`,
+  `snapshot`, `act`, and `screenshot`
+- not yet wired through this adapter path: session attach/resume UX
+
+This is a consumer seam for the bridge contract, not a full replacement for the
+existing managed-browser / Chrome MCP / extension-relay implementations.
 
 ## Configuration
 
@@ -173,6 +195,10 @@ Browser settings live in `~/.openclaw/openclaw.json`.
         attachOnly: true,
         userDataDir: "~/Library/Application Support/BraveSoftware/Brave-Browser",
         color: "#FB542B",
+      "chrome-relay": {
+        driver: "extension",
+        cdpUrl: "http://127.0.0.1:18792",
+        color: "#00AA00",
       },
       remote: { cdpUrl: "http://10.0.0.42:9222", color: "#00AA00" },
     },
@@ -379,6 +405,7 @@ Defaults:
 - The `openclaw` profile is auto-created if missing.
 - The `user` profile is built-in for Chrome MCP existing-session attach.
 - Existing-session profiles are opt-in beyond `user`; create them with `--driver existing-session`.
+- The `chrome-relay` profile is built-in for the Chrome extension relay (points at `http://127.0.0.1:18792` by default).
 - Local CDP ports allocate from **18800–18899** by default.
 - Deleting a profile moves its local data directory to Trash.
 
@@ -431,6 +458,8 @@ Then in the matching browser:
 3. Keep the browser running and approve the connection prompt when OpenClaw attaches.
 
 Common inspect pages:
+- CLI: `openclaw browser --browser-profile chrome-relay tabs`
+- Agent tool: `browser` with `profile="chrome-relay"`
 
 - Chrome: `chrome://inspect/#remote-debugging`
 - Brave: `brave://inspect/#remote-debugging`

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -454,6 +454,7 @@ Then in the matching browser:
 3. Keep the browser running and approve the connection prompt when OpenClaw attaches.
 
 Common inspect pages:
+
 - CLI: `openclaw browser --browser-profile chrome-relay tabs`
 - Agent tool: `browser` with `profile="chrome-relay"`
 

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -195,10 +195,6 @@ Browser settings live in `~/.openclaw/openclaw.json`.
         attachOnly: true,
         userDataDir: "~/Library/Application Support/BraveSoftware/Brave-Browser",
         color: "#FB542B",
-      "chrome-relay": {
-        driver: "extension",
-        cdpUrl: "http://127.0.0.1:18792",
-        color: "#00AA00",
       },
       remote: { cdpUrl: "http://10.0.0.42:9222", color: "#00AA00" },
     },

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -615,6 +615,23 @@ describe("browser tool local-browser-bridge adapter", () => {
     ).rejects.toThrow("read-only in v1");
     expect(browserActionsMocks.browserNavigate).not.toHaveBeenCalled();
   });
+  it("falls through to the normal browser path for unsupported bridge actions", async () => {
+    vi.stubEnv("OPENCLAW_LOCAL_BROWSER_BRIDGE_URL", "http://127.0.0.1:3000");
+    const tool = createBrowserTool();
+
+    await tool.execute?.("call-1", {
+      action: "act",
+      profile: "user",
+      request: { kind: "hover", targetId: "tab-1", ref: "btn-1" },
+    });
+
+    expect(browserActionsMocks.browserAct).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ kind: "hover", targetId: "tab-1", ref: "btn-1" }),
+      expect.objectContaining({ profile: "user" }),
+    );
+  });
+
 });
 
 describe("browser tool act compatibility", () => {

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -160,6 +160,7 @@ function mockSingleBrowserProxyNode() {
 
 function resetBrowserToolMocks() {
   vi.clearAllMocks();
+  vi.unstubAllEnvs();
   configMocks.loadConfig.mockReturnValue({ browser: {} });
   browserConfigMocks.resolveBrowserConfig.mockReturnValue({
     enabled: true,
@@ -559,6 +560,60 @@ describe("browser tool url alias support", () => {
       baseUrl: undefined,
       profile: undefined,
     });
+  });
+});
+
+describe("browser tool local-browser-bridge adapter", () => {
+  registerBrowserToolAfterEachReset();
+
+  it("routes profile=user status through local-browser-bridge", async () => {
+    vi.stubEnv("OPENCLAW_LOCAL_BROWSER_BRIDGE_URL", "http://127.0.0.1:3000");
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ capabilities: { navigate: true } }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            diagnostics: {
+              browser: "safari",
+              attach: { mode: "direct" },
+              ready: true,
+              blockers: [],
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ sessions: [] }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createBrowserTool();
+    const result = await tool.execute?.("call-1", { action: "status", profile: "user" });
+
+    expect(browserClientMocks.browserStatus).not.toHaveBeenCalled();
+    expect(result?.details).toMatchObject({
+      adapter: "local-browser-bridge",
+      profile: "user",
+      route: "safari-direct",
+      browser: "safari",
+      attachMode: "direct",
+    });
+  });
+
+  it("rejects write actions for profile=chrome-relay through local-browser-bridge", async () => {
+    vi.stubEnv("OPENCLAW_LOCAL_BROWSER_BRIDGE_URL", "http://127.0.0.1:3000");
+    const tool = createBrowserTool();
+
+    await expect(
+      tool.execute?.("call-1", {
+        action: "navigate",
+        profile: "chrome-relay",
+        url: "https://example.com",
+      }),
+    ).rejects.toThrow("read-only in v1");
+    expect(browserActionsMocks.browserNavigate).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { executeLocalBrowserBridgeAction } from "./browser/local-browser-bridge.js";
 import {
   executeActAction,
   executeConsoleAction,
@@ -379,8 +380,10 @@ export function createBrowserTool(opts?: {
     description: [
       "Control the browser via OpenClaw's browser control server (status/start/stop/profiles/tabs/open/snapshot/screenshot/actions).",
       "Browser choice: omit profile by default for the isolated OpenClaw-managed browser (`openclaw`).",
-      'For the logged-in user browser on the local host, use profile="user". A supported Chromium-based browser (v144+) must be running. Use only when existing logins/cookies matter and the user is present.',
+      'For the logged-in user browser on the local host, prefer profile="user". Use it only when existing logins/cookies matter and the user is present to click/approve any browser attach prompt.',
+      'Use profile="chrome-relay" only for the Chrome extension / Browser Relay / toolbar-button attach-tab flow, or when the user explicitly asks for the extension relay.',
       'When a node-hosted browser proxy is available, the tool may auto-route to it. Pin a node with node=<id|name> or target="node".',
+      'User-browser flows need user interaction: profile="user" may require approving a browser attach prompt; profile="chrome-relay" needs the user to click the OpenClaw Browser Relay toolbar icon on the tab (badge ON). If user presence is unclear, ask first.',
       "When using refs from snapshot (e.g. e12), keep the same tab: prefer passing targetId from the snapshot response into subsequent actions (act/click/type/etc).",
       'For stable, self-resolving refs across calls, use snapshot with refs="aria" (Playwright aria-ref ids). Default refs="role" are role+name-based.',
       "Use snapshot+act for UI automation. Avoid act:wait by default; use only in exceptional cases when no reliable UI state exists.",
@@ -398,8 +401,8 @@ export function createBrowserTool(opts?: {
       if (requestedNode && target && target !== "node") {
         throw new Error('node is only supported with target="node".');
       }
-      // User-browser profiles (existing-session) are host-only.
-      const isUserBrowserProfile = shouldPreferHostForProfile(profile);
+      // User-browser profiles are host-only.
+      const isUserBrowserProfile = shouldPreferHostForProfile(profile) || profile === "chrome-relay";
       if (isUserBrowserProfile) {
         if (requestedNode || target === "node") {
           throw new Error(`profile="${profile}" only supports the local host browser.`);
@@ -452,6 +455,16 @@ export function createBrowserTool(opts?: {
             return proxy.result;
           }
         : null;
+      if (!proxyRequest && resolvedTarget !== "sandbox") {
+        const directBridgeResult = await executeLocalBrowserBridgeAction({
+          action,
+          profile: profile ?? undefined,
+          input: params,
+        });
+        if (directBridgeResult) {
+          return jsonResult(directBridgeResult);
+        }
+      }
 
       switch (action) {
         case "status":

--- a/extensions/browser/src/browser/bridge-server.auth.test.ts
+++ b/extensions/browser/src/browser/bridge-server.auth.test.ts
@@ -5,6 +5,9 @@ import {
   DEFAULT_OPENCLAW_BROWSER_COLOR,
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
 } from "./constants.js";
+import { getBrowserTestFetch } from "./test-fetch.js";
+
+const stableFetch = getBrowserTestFetch();
 
 function buildResolvedConfig(): ResolvedBrowserConfig {
   return {
@@ -47,10 +50,10 @@ describe("startBrowserBridgeServer auth", () => {
     });
     servers.push({ stop: () => stopBrowserBridgeServer(bridge.server) });
 
-    const unauth = await fetch(`${bridge.baseUrl}/`);
+    const unauth = await stableFetch(`${bridge.baseUrl}/`);
     expect(unauth.status).toBe(401);
 
-    const authed = await fetch(`${bridge.baseUrl}/`, { headers });
+    const authed = await stableFetch(`${bridge.baseUrl}/`, { headers });
     expect(authed.status).toBe(200);
   }
 
@@ -95,7 +98,7 @@ describe("startBrowserBridgeServer auth", () => {
     });
     servers.push({ stop: () => stopBrowserBridgeServer(bridge.server) });
 
-    const res = await fetch(`${bridge.baseUrl}/sandbox/novnc?token=valid-token`);
+    const res = await stableFetch(`${bridge.baseUrl}/sandbox/novnc?token=valid-token`);
     expect(res.status).toBe(200);
     expect(res.headers.get("location")).toBeNull();
     expect(res.headers.get("cache-control")).toContain("no-store");

--- a/extensions/browser/src/browser/local-browser-bridge.ts
+++ b/extensions/browser/src/browser/local-browser-bridge.ts
@@ -1,0 +1,320 @@
+type LocalBrowserBridgeBrowser = "safari" | "chrome";
+type LocalBrowserBridgeAttachMode = "direct" | "relay";
+type LocalBrowserBridgeRouteName = "safari-direct" | "chrome-relay";
+type LocalBrowserBridgeKind = "safari-actionable" | "chrome-readonly";
+type LocalBrowserBridgeAction = "status" | "tabs" | "open" | "navigate";
+
+export type LocalBrowserBridgeRoute = {
+  browser: LocalBrowserBridgeBrowser;
+  attachMode: LocalBrowserBridgeAttachMode;
+  route: LocalBrowserBridgeRouteName;
+  kind: LocalBrowserBridgeKind;
+};
+
+type LocalBrowserBridgeSession = {
+  browser?: unknown;
+  attach?: {
+    mode?: unknown;
+  };
+};
+
+type LocalBrowserBridgeResponseRecord = Record<string, unknown>;
+type LocalBrowserBridgeRequestInit = Omit<RequestInit, "signal">;
+
+function asRecord(value: unknown): LocalBrowserBridgeResponseRecord | null {
+  return value && typeof value === "object" ? (value as LocalBrowserBridgeResponseRecord) : null;
+}
+
+function readSessions(value: unknown): LocalBrowserBridgeSession[] {
+  const record = asRecord(value);
+  return Array.isArray(record?.sessions) ? (record.sessions as LocalBrowserBridgeSession[]) : [];
+}
+
+function readTargetUrl(input: Record<string, unknown>): string {
+  const targetUrl = typeof input.targetUrl === "string" ? input.targetUrl.trim() : "";
+  if (targetUrl) {
+    return targetUrl;
+  }
+  const url = typeof input.url === "string" ? input.url.trim() : "";
+  if (url) {
+    return url;
+  }
+  throw new Error("targetUrl is required");
+}
+
+export function getLocalBrowserBridgeBaseUrl(): string | null {
+  const raw = process.env.OPENCLAW_LOCAL_BROWSER_BRIDGE_URL?.trim();
+  if (!raw) {
+    return null;
+  }
+  return raw.replace(/\/$/, "");
+}
+
+export function resolveLocalBrowserBridgeRoute(profile?: string): LocalBrowserBridgeRoute | null {
+  if (profile === "user") {
+    return {
+      browser: "safari",
+      attachMode: "direct",
+      route: "safari-direct",
+      kind: "safari-actionable",
+    };
+  }
+  if (profile === "chrome-relay") {
+    return {
+      browser: "chrome",
+      attachMode: "relay",
+      route: "chrome-relay",
+      kind: "chrome-readonly",
+    };
+  }
+  return null;
+}
+
+export function resolveLocalBrowserBridgeRequestAction(params: {
+  method: "GET" | "POST" | "DELETE";
+  path: string;
+}): LocalBrowserBridgeAction | null {
+  if (params.method === "GET" && params.path === "/") {
+    return "status";
+  }
+  if (params.method === "GET" && params.path === "/tabs") {
+    return "tabs";
+  }
+  if (params.method === "POST" && params.path === "/tabs/open") {
+    return "open";
+  }
+  if (params.method === "POST" && params.path === "/navigate") {
+    return "navigate";
+  }
+  return null;
+}
+
+export async function fetchLocalBrowserBridgeJson(
+  path: string,
+  init?: LocalBrowserBridgeRequestInit,
+  timeoutMs?: number,
+): Promise<unknown> {
+  const baseUrl = getLocalBrowserBridgeBaseUrl();
+  if (!baseUrl) {
+    throw new Error("OPENCLAW_LOCAL_BROWSER_BRIDGE_URL is not set.");
+  }
+  const controller = new AbortController();
+  const timer =
+    typeof timeoutMs === "number" && Number.isFinite(timeoutMs)
+      ? setTimeout(() => controller.abort(), timeoutMs)
+      : undefined;
+  const headers = new Headers(init?.headers);
+  if (!headers.has("Accept")) {
+    headers.set("Accept", "application/json");
+  }
+  try {
+    const response = await fetch(`${baseUrl}${path}`, {
+      ...init,
+      headers,
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    const payload = text ? (JSON.parse(text) as unknown) : undefined;
+    const payloadRecord = asRecord(payload);
+    if (!response.ok) {
+      throw new Error(
+        typeof payloadRecord?.error === "string"
+          ? payloadRecord.error
+          : typeof payloadRecord?.message === "string"
+            ? payloadRecord.message
+            : `local-browser-bridge request failed: ${response.status}`,
+      );
+    }
+    return payload;
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+export function summarizeLocalBrowserBridgeDiagnostics(profile: string, diagnostics: unknown) {
+  const diagnosticsRecord = asRecord(diagnostics);
+  const details = asRecord(diagnosticsRecord?.diagnostics) ?? diagnosticsRecord;
+  const blockers = Array.isArray(details?.blockers) ? details.blockers : [];
+  const ready = typeof details?.ready === "boolean" ? details.ready : blockers.length === 0;
+  return {
+    profile,
+    browser: details?.browser ?? null,
+    attachMode: asRecord(details?.attach)?.mode ?? null,
+    route:
+      details?.browser === "safari"
+        ? "safari-direct"
+        : profile === "chrome-relay"
+          ? "chrome-relay"
+          : null,
+    ready,
+    blockers,
+    diagnostics: details,
+  };
+}
+
+async function runLocalBrowserBridgeAction(params: {
+  action: LocalBrowserBridgeAction;
+  profile: string;
+  route: LocalBrowserBridgeRoute;
+  input: Record<string, unknown>;
+  timeoutMs?: number;
+}) {
+  const { action, profile, route, input, timeoutMs } = params;
+  switch (action) {
+    case "status": {
+      const [capabilities, diagnostics, sessions] = await Promise.all([
+        fetchLocalBrowserBridgeJson(
+          `/v1/capabilities?browser=${encodeURIComponent(route.browser)}`,
+          undefined,
+          timeoutMs,
+        ),
+        fetchLocalBrowserBridgeJson(
+          `/v1/diagnostics?browser=${encodeURIComponent(route.browser)}`,
+          undefined,
+          timeoutMs,
+        ),
+        fetchLocalBrowserBridgeJson(`/v1/sessions`, undefined, timeoutMs).catch(() => ({
+          sessions: [],
+        })),
+      ]);
+      const matchingSessions = readSessions(sessions).filter(
+        (session) =>
+          session.browser === route.browser &&
+          (route.attachMode === "relay" ? session.attach?.mode === "relay" : true),
+      );
+      const capabilitiesRecord = asRecord(capabilities);
+      return {
+        ok: true,
+        adapter: "local-browser-bridge",
+        profile,
+        route: route.route,
+        kind: route.kind,
+        browser: route.browser,
+        attachMode: route.attachMode,
+        status: summarizeLocalBrowserBridgeDiagnostics(profile, diagnostics),
+        matchingSessions,
+        capabilities: capabilitiesRecord?.capabilities ?? capabilities,
+      };
+    }
+    case "tabs": {
+      const tabsPayload = asRecord(
+        await fetchLocalBrowserBridgeJson(
+          `/v1/tabs?browser=${encodeURIComponent(route.browser)}`,
+          undefined,
+          timeoutMs,
+        ),
+      );
+      return {
+        ok: true,
+        adapter: "local-browser-bridge",
+        profile,
+        route: route.route,
+        tabs: Array.isArray(tabsPayload?.tabs) ? tabsPayload.tabs : [],
+      };
+    }
+    case "open":
+    case "navigate": {
+      if (route.browser === "chrome") {
+        throw new Error(
+          `profile="${profile}" is backed by local-browser-bridge Chrome relay, which is read-only in v1. Use tabs/status only.`,
+        );
+      }
+      const url = readTargetUrl(input);
+      const navigation = asRecord(
+        await fetchLocalBrowserBridgeJson(
+          "/v1/navigate",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ browser: route.browser, url }),
+          },
+          timeoutMs,
+        ),
+      );
+      return {
+        ok: true,
+        adapter: "local-browser-bridge",
+        profile,
+        route: route.route,
+        ...navigation,
+        url: typeof navigation?.url === "string" ? navigation.url : url,
+      };
+    }
+  }
+}
+
+export async function executeLocalBrowserBridgeAction(params: {
+  action: string;
+  profile?: string;
+  input: Record<string, unknown>;
+  timeoutMs?: number;
+}): Promise<Record<string, unknown> | null> {
+  if (!getLocalBrowserBridgeBaseUrl()) {
+    return null;
+  }
+  const profile = params.profile?.trim();
+  const route = resolveLocalBrowserBridgeRoute(profile);
+  if (!profile || !route) {
+    return null;
+  }
+  if (
+    params.action !== "status" &&
+    params.action !== "tabs" &&
+    params.action !== "open" &&
+    params.action !== "navigate"
+  ) {
+    return null;
+  }
+  return await runLocalBrowserBridgeAction({
+    action: params.action,
+    profile,
+    route,
+    input: params.input,
+    timeoutMs: params.timeoutMs,
+  });
+}
+
+export async function executeLocalBrowserBridgeRequest(params: {
+  profile?: string;
+  request: {
+    method: "GET" | "POST" | "DELETE";
+    path: string;
+    body?: unknown;
+  };
+  timeoutMs?: number;
+}): Promise<Record<string, unknown> | null> {
+  if (!getLocalBrowserBridgeBaseUrl()) {
+    return null;
+  }
+  const profile = params.profile?.trim();
+  const route = resolveLocalBrowserBridgeRoute(profile);
+  if (!profile || !route) {
+    return null;
+  }
+  const action = resolveLocalBrowserBridgeRequestAction(params.request);
+  if (!action) {
+    return null;
+  }
+  const input = asRecord(params.request.body) ?? {};
+  const payload = await runLocalBrowserBridgeAction({
+    action,
+    profile,
+    route,
+    input,
+    timeoutMs: params.timeoutMs,
+  });
+  if (action !== "status") {
+    return payload;
+  }
+  return {
+    ...payload,
+    enabled: true,
+    running: Boolean(asRecord(payload.status)?.ready),
+    transport: route.attachMode === "relay" ? "chrome-mcp" : "local-browser-bridge",
+    chosenBrowser: route.browser,
+    detectedBrowser: route.browser,
+    color: profile === "chrome-relay" ? "#4285F4" : "#0A84FF",
+  };
+}

--- a/extensions/browser/src/browser/relay-attach-ux.ts
+++ b/extensions/browser/src/browser/relay-attach-ux.ts
@@ -1,0 +1,38 @@
+type RelayBranch = "click-toolbar-button" | "use-current-shared-tab";
+
+type AttachUxCopy = {
+  prompt: string;
+  scopeNote: string;
+};
+
+function getRelayAttachUxCopy(branch: RelayBranch): AttachUxCopy {
+  if (branch === "use-current-shared-tab") {
+    return {
+      prompt: "Click the OpenClaw Browser Relay toolbar button on the Chrome tab you want to share, then retry on that current shared tab.",
+      scopeNote: "Chrome relay is read-only in v1 and only exposes the tab currently shared through the toolbar button.",
+    };
+  }
+  return {
+    prompt: "Click the OpenClaw Browser Relay toolbar button on the Chrome tab you want to share, then retry.",
+    scopeNote: "Chrome relay is read-only in v1 and only exposes the tab currently shared through the toolbar button.",
+  };
+}
+
+function appendRelayUx(base: string, branch: RelayBranch): string {
+  const ux = getRelayAttachUxCopy(branch);
+  return `${base} ${ux.prompt} ${ux.scopeNote}`;
+}
+
+export function formatChromeRelayAttachRequiredError(profileName: string): string {
+  return appendRelayUx(
+    `tab not found (no attached Chrome tabs for profile "${profileName}").`,
+    "click-toolbar-button",
+  );
+}
+
+export function formatChromeRelayStaleTargetError(): string {
+  return appendRelayUx(
+    "tab not found (the requested Chrome relay target is no longer the currently shared tab).",
+    "use-current-shared-tab",
+  );
+}

--- a/extensions/browser/src/browser/server-context.selection.ts
+++ b/extensions/browser/src/browser/server-context.selection.ts
@@ -6,6 +6,10 @@ import { BrowserTabNotFoundError, BrowserTargetAmbiguousError } from "./errors.j
 import { getBrowserProfileCapabilities } from "./profile-capabilities.js";
 import type { PwAiModule } from "./pw-ai-module.js";
 import { getPwAiModule } from "./pw-ai-module.js";
+import {
+  formatChromeRelayAttachRequiredError,
+  formatChromeRelayStaleTargetError,
+} from "./relay-attach-ux.js";
 import type { BrowserTab, ProfileRuntimeState } from "./server-context.types.js";
 import { resolveTargetIdFromTabs } from "./target-id.js";
 
@@ -38,6 +42,9 @@ export function createProfileSelectionOps({
     const profileState = getProfileState();
     const tabs1 = await listTabs();
     if (tabs1.length === 0) {
+      if (profile.name === "chrome-relay") {
+        throw new Error(formatChromeRelayAttachRequiredError(profile.name));
+      }
       await openTab("about:blank");
     }
 
@@ -72,6 +79,9 @@ export function createProfileSelectionOps({
       throw new BrowserTargetAmbiguousError();
     }
     if (!chosen) {
+      if (profile.name === "chrome-relay" && targetId?.trim() && candidates.length > 1) {
+        throw new Error(formatChromeRelayStaleTargetError());
+      }
       throw new BrowserTabNotFoundError();
     }
     profileState.lastTargetId = chosen.targetId;

--- a/extensions/browser/src/cli/browser-cli-shared.test.ts
+++ b/extensions/browser/src/cli/browser-cli-shared.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const gatewayMocks = vi.hoisted(() => ({
+  callGatewayFromCli: vi.fn(async () => ({ ok: true, via: "gateway" })),
+}));
+
+vi.mock("./core-api.js", () => ({
+  callGatewayFromCli: gatewayMocks.callGatewayFromCli,
+}));
+
+import { callBrowserRequest } from "./browser-cli-shared.js";
+
+describe("browser cli local-browser-bridge adapter", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("routes profile=user status through local-browser-bridge before gateway", async () => {
+    vi.stubEnv("OPENCLAW_LOCAL_BROWSER_BRIDGE_URL", "http://127.0.0.1:3000");
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ capabilities: { navigate: true } }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            diagnostics: {
+              browser: "safari",
+              attach: { mode: "direct" },
+              ready: true,
+              blockers: [],
+            },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ sessions: [] }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await callBrowserRequest(
+      { browserProfile: "user" },
+      {
+        method: "GET",
+        path: "/",
+      },
+      { timeoutMs: 1234 },
+    );
+
+    expect(gatewayMocks.callGatewayFromCli).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      adapter: "local-browser-bridge",
+      profile: "user",
+      route: "safari-direct",
+      running: true,
+      chosenBrowser: "safari",
+    });
+  });
+
+  it("falls back to the gateway for unsupported bridge-backed request paths", async () => {
+    vi.stubEnv("OPENCLAW_LOCAL_BROWSER_BRIDGE_URL", "http://127.0.0.1:3000");
+
+    const result = await callBrowserRequest(
+      { browserProfile: "user" },
+      {
+        method: "POST",
+        path: "/act",
+        body: { kind: "click" },
+      },
+      { timeoutMs: 1234 },
+    );
+
+    expect(gatewayMocks.callGatewayFromCli).toHaveBeenCalledOnce();
+    expect(result).toEqual({ ok: true, via: "gateway" });
+  });
+
+  it("rejects write actions for profile=chrome-relay", async () => {
+    vi.stubEnv("OPENCLAW_LOCAL_BROWSER_BRIDGE_URL", "http://127.0.0.1:3000");
+
+    await expect(
+      callBrowserRequest(
+        { browserProfile: "chrome-relay" },
+        {
+          method: "POST",
+          path: "/navigate",
+          body: { url: "https://example.com" },
+        },
+        { timeoutMs: 1234 },
+      ),
+    ).rejects.toThrow("read-only in v1");
+    expect(gatewayMocks.callGatewayFromCli).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/browser/src/cli/browser-cli-shared.ts
+++ b/extensions/browser/src/cli/browser-cli-shared.ts
@@ -1,3 +1,4 @@
+import { executeLocalBrowserBridgeRequest } from "../browser/local-browser-bridge.js";
 import { callGatewayFromCli, type GatewayRpcOpts } from "./core-api.js";
 
 export type BrowserParentOpts = GatewayRpcOpts & {
@@ -42,6 +43,26 @@ export async function callBrowserRequest<T>(
       ? resolvedTimeoutMs
       : undefined;
   const timeout = typeof resolvedTimeout === "number" ? String(resolvedTimeout) : opts.timeout;
+  const directPayload = await executeLocalBrowserBridgeRequest({
+    profile:
+      typeof params.query?.profile === "string"
+        ? params.query.profile
+        : typeof params.body === "object" &&
+            params.body &&
+            "profile" in params.body &&
+            typeof (params.body as { profile?: unknown }).profile === "string"
+          ? (params.body as { profile: string }).profile
+          : opts.browserProfile,
+    request: {
+      method: params.method,
+      path: params.path,
+      body: params.body,
+    },
+    timeoutMs: resolvedTimeout,
+  });
+  if (directPayload !== null) {
+    return directPayload as T;
+  }
   const payload = await callGatewayFromCli(
     "browser.request",
     { ...opts, timeout },


### PR DESCRIPTION
## Summary
- add an experimental `local-browser-bridge` adapter for host-only browser profiles
- route `profile=\"user\"` through Safari actionable bridge mode and `profile=\"chrome-relay\"` through Chrome read-only bridge mode when `OPENCLAW_LOCAL_BROWSER_BRIDGE_URL` is set
- wire both the browser CLI shared path and the agent browser tool path through the same bridge seam
- document the adapter behavior and add regression coverage for CLI + tool routing

## Details
This keeps the product contract truthful:
- `user` via bridge => Safari actionable (`safari-direct`)
- `chrome-relay` via bridge => Chrome read-only (`chrome-relay`)

Unsupported actions are still surfaced explicitly rather than being treated as silently available.

## Validation
- `pnpm exec vitest run src/cli/browser-cli-shared.test.ts src/agents/tools/browser-tool.test.ts`
- `pnpm build:strict-smoke`
- `OPENCLAW_LOCAL_BROWSER_BRIDGE_URL=http://127.0.0.1:3000 openclaw browser --browser-profile user status --json`
- `OPENCLAW_LOCAL_BROWSER_BRIDGE_URL=http://127.0.0.1:3000 openclaw browser --browser-profile user tabs --json`
- `OPENCLAW_LOCAL_BROWSER_BRIDGE_URL=http://127.0.0.1:3000 openclaw browser --browser-profile chrome-relay status --json`
- `OPENCLAW_LOCAL_BROWSER_BRIDGE_URL=http://127.0.0.1:3000 openclaw browser --browser-profile chrome-relay tabs --json`

## Notes
- Chrome relay tabs inspection still depends on a local Chrome DevTools HTTP endpoint being available.
- This PR focuses on the bridge seam and truthful routing; it does not broaden unsupported browser actions.
