### PR TITLE
Keep sessions_send delivery pending after wait timeout

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -895,7 +895,11 @@ describe("sessions tools", () => {
 
     expect(initialWaitCount).toBe(2);
     expect(
-      calls.filter((call) => call.method === "agent.wait" && call.params?.runId === "run-1"),
+      calls.filter(
+        (call) =>
+          call.method === "agent.wait" &&
+          (call.params as { runId?: string } | undefined)?.runId === "run-1",
+      ),
     ).toHaveLength(2);
   });
 
@@ -968,7 +972,11 @@ describe("sessions tools", () => {
     await vi.waitFor(
       () => {
         expect(
-          calls.filter((call) => call.method === "agent.wait" && call.params?.runId === "run-1"),
+          calls.filter(
+            (call) =>
+              call.method === "agent.wait" &&
+              (call.params as { runId?: string } | undefined)?.runId === "run-1",
+          ),
         ).toHaveLength(2);
       },
       { timeout: 2_000, interval: 5 },

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -795,6 +795,114 @@ describe("sessions tools", () => {
     expect(sendCallCount).toBe(0);
   });
 
+  it("sessions_send keeps delayed announce delivery alive after a wait timeout", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    const requesterKey = "discord:group:req";
+    const targetKey = "discord:group:target";
+    let initialWaitCount = 0;
+    let targetLatestReply: string | undefined;
+    let announceDeliveredMessage: string | undefined;
+
+    openClawToolsTesting.setDepsForTest({
+      callGateway: (opts: unknown) => callGatewayMock(opts),
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+          agentToAgent: { maxPingPongTurns: 0 },
+        },
+      },
+    });
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as {
+        method?: string;
+        params?: {
+          runId?: string;
+          sessionKey?: string;
+          message?: string;
+          extraSystemPrompt?: string;
+          to?: string;
+        };
+      };
+      calls.push(request);
+      if (request.method === "agent") {
+        if (request.params?.extraSystemPrompt?.includes("Agent-to-agent announce step")) {
+          return { runId: "announce-run", status: "accepted", acceptedAt: 2002 };
+        }
+        return { runId: "run-1", status: "accepted", acceptedAt: 2001 };
+      }
+      if (request.method === "agent.wait") {
+        if (request.params?.runId === "run-1") {
+          initialWaitCount += 1;
+          if (initialWaitCount === 1) {
+            return { runId: "run-1", status: "timeout", error: "still running" };
+          }
+          targetLatestReply = "late reply";
+          return { runId: "run-1", status: "ok" };
+        }
+        if (request.params?.runId === "announce-run") {
+          targetLatestReply = "announce-ready";
+          return { runId: "announce-run", status: "ok" };
+        }
+        return { runId: request.params?.runId ?? "unknown", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        if (request.params?.sessionKey === targetKey) {
+          return {
+            messages: targetLatestReply
+              ? [
+                  {
+                    role: "assistant",
+                    content: [{ type: "text", text: targetLatestReply }],
+                    timestamp: 20,
+                  },
+                ]
+              : [],
+          };
+        }
+        return { messages: [] };
+      }
+      if (request.method === "send") {
+        announceDeliveredMessage = request.params?.message;
+        return { messageId: "m-announce" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: requesterKey,
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-timeout", {
+      sessionKey: targetKey,
+      message: "delayed reply",
+      timeoutSeconds: 1,
+    });
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-1",
+      delivery: { status: "pending", mode: "announce" },
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(announceDeliveredMessage).toBe("announce-ready");
+      },
+      { timeout: 2_000, interval: 5 },
+    );
+
+    expect(initialWaitCount).toBe(2);
+    expect(
+      calls.filter((call) => call.method === "agent.wait" && call.params?.runId === "run-1"),
+    ).toHaveLength(2);
+  });
+
   it("sessions_send resolves sessionId inputs", async () => {
     const sessionId = "sess-send";
     const targetKey = "agent:main:discord:channel:123";

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -803,17 +803,6 @@ describe("sessions tools", () => {
     let targetLatestReply: string | undefined;
     let announceDeliveredMessage: string | undefined;
 
-    openClawToolsTesting.setDepsForTest({
-      callGateway: (opts: unknown) => callGatewayMock(opts),
-      config: {
-        ...TEST_CONFIG,
-        session: {
-          ...TEST_CONFIG.session,
-          agentToAgent: { maxPingPongTurns: 0 },
-        },
-      },
-    });
-
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as {
         method?: string;
@@ -873,6 +862,13 @@ describe("sessions tools", () => {
     const tool = createOpenClawTools({
       agentSessionKey: requesterKey,
       agentChannel: "discord",
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+          agentToAgent: { maxPingPongTurns: 0 },
+        },
+      },
     }).find((candidate) => candidate.name === "sessions_send");
     expect(tool).toBeDefined();
     if (!tool) {
@@ -901,6 +897,88 @@ describe("sessions tools", () => {
     expect(
       calls.filter((call) => call.method === "agent.wait" && call.params?.runId === "run-1"),
     ).toHaveLength(2);
+  });
+
+  it("sessions_send stops after one delayed wait timeout", async () => {
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    const requesterKey = "discord:group:req";
+    const targetKey = "discord:group:target";
+    let initialWaitCount = 0;
+    let sendCount = 0;
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as {
+        method?: string;
+        params?: {
+          runId?: string;
+          extraSystemPrompt?: string;
+        };
+      };
+      calls.push(request);
+      if (request.method === "agent") {
+        if (request.params?.extraSystemPrompt?.includes("Agent-to-agent announce step")) {
+          return { runId: "announce-run", status: "accepted", acceptedAt: 2002 };
+        }
+        return { runId: "run-1", status: "accepted", acceptedAt: 2001 };
+      }
+      if (request.method === "agent.wait") {
+        if (request.params?.runId === "run-1") {
+          initialWaitCount += 1;
+          return { runId: "run-1", status: "timeout", error: "still running" };
+        }
+        return { runId: request.params?.runId ?? "unknown", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return { messages: [] };
+      }
+      if (request.method === "send") {
+        sendCount += 1;
+        return { messageId: "m-announce" };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: requesterKey,
+      agentChannel: "discord",
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+          agentToAgent: { maxPingPongTurns: 0 },
+        },
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-timeout-twice", {
+      sessionKey: targetKey,
+      message: "delayed reply",
+      timeoutSeconds: 1,
+    });
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-1",
+      delivery: { status: "pending", mode: "announce" },
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(
+          calls.filter((call) => call.method === "agent.wait" && call.params?.runId === "run-1"),
+        ).toHaveLength(2);
+      },
+      { timeout: 2_000, interval: 5 },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(initialWaitCount).toBe(2);
+    expect(sendCount).toBe(0);
+    expect(calls.filter((call) => call.method === "agent")).toHaveLength(1);
   });
 
   it("sessions_send resolves sessionId inputs", async () => {

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -45,6 +45,9 @@ export async function runSessionsSendA2AFlow(params: {
     let primaryReply = params.roundOneReply;
     let latestReply = params.roundOneReply;
     if (!primaryReply && params.waitRunId) {
+      // Keep the delayed-delivery path bounded: after the original wait times out,
+      // we do at most one follow-up wait here. If that also times out or produces
+      // no reply, the announce flow exits without retrying again.
       const wait = await waitForAgentRun({
         runId: params.waitRunId,
         timeoutMs: Math.min(params.announceTimeoutMs, 60_000),

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -375,11 +375,12 @@ export function createSessionsSendTool(opts?: {
       });
 
       if (result.status === "timeout") {
+        startA2AFlow(undefined, runId);
         return jsonResult({
           runId,
-          status: "timeout",
-          error: result.error,
+          status: "accepted",
           sessionKey: displayKey,
+          delivery,
         });
       }
       if (result.status === "error") {


### PR DESCRIPTION
## Summary
- treat `sessions_send` wait timeouts as pending delivery instead of an immediate hard failure
- keep the agent-to-agent announce flow alive so delayed replies can still be surfaced
- add regression coverage for the delayed-reply timeout path

## Problem
`sessions_send` currently returns `status: "timeout"` as soon as the initial `agent.wait` times out. In the agent-to-agent path, that can be premature: the target run may still finish moments later, but the calling agent has already received a hard timeout and may emit a user-facing failure like `DELEGATION_FAILED:socrates:timeout`.

## Reproduction
1. Use `sessions_send` from one agent to another with `timeoutSeconds > 0`.
2. Let the target run exceed the initial wait window but still complete shortly after.
3. Observe that the caller receives a timeout immediately even though the target eventually produces a valid reply.

## Expected
If the target run is still in flight after the initial wait window, `sessions_send` should keep delivery pending and allow the follow-up announce flow to finish when the delayed reply arrives.

## Actual
The tool returned `status: "timeout"` right away, which encouraged the caller to post a failure even though the target reply could still be delivered successfully.

## Fix
When the initial `agent.wait` times out, keep the tool result in `accepted`/pending-delivery state and start the existing announce flow with the in-flight `runId`. The announce flow performs its own follow-up wait and can still fetch and relay the delayed reply.

The same pending-delivery treatment now also applies when the wait RPC itself hits a gateway timeout after the target run has already started.

## Validation
- `vitest --root /tmp/openclaw-sessions-send-timeout run src/agents/openclaw-tools.sessions.test.ts -t "sessions_send keeps delayed announce delivery alive after a wait timeout"`
- `vitest --root /tmp/openclaw-sessions-send-timeout run src/agents/openclaw-tools.sessions.test.ts`
