### PR TITLE
Secrets: hard-fail unsupported SecretRef policy and fix gateway restart token drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/forum topics: restore reply routing to the active topic and keep ACP `sessions_spawn(..., thread=true, mode="session")` bound to that same topic instead of falling back to root chat or losing follow-up routing. (#56060) Thanks @one27001.
 - Config/SecretRef + Control UI: harden SecretRef redaction round-trip restore, block unsafe raw fallback (force Form mode when raw is unavailable), and preflight submitted-config SecretRefs before config write RPC persistence. (#58044) Thanks @joshavant.
 - Config/Telegram: migrate removed `channels.telegram.groupMentionsOnly` into `channels.telegram.groups["*"].requireMention` on load so legacy configs no longer crash at startup. (#55336) thanks @jameslcowan.
+- Gateway/SecretRef: resolve restart token drift checks with merged service/runtime env sources and hard-fail unsupported mutable SecretRef plus OAuth-profile combinations so restart warnings and policy enforcement match runtime behavior. (#58141) Thanks @joshavant.
 
 ## 2026.3.28
 

--- a/docs/auth-credential-semantics.md
+++ b/docs/auth-credential-semantics.md
@@ -44,6 +44,13 @@ Token credentials (`type: "token"`) support inline `token` and/or `tokenRef`.
 2. For eligible profiles, token material may be resolved from inline value or `tokenRef`.
 3. Unresolvable refs produce `unresolved_ref` in `models status --probe` output.
 
+## OAuth SecretRef Policy Guard
+
+- SecretRef input is for static credentials only.
+- If a profile credential is `type: "oauth"`, SecretRef objects are not supported for that profile credential material.
+- If `auth.profiles.<id>.mode` is `"oauth"`, SecretRef-backed `keyRef`/`tokenRef` input for that profile is rejected.
+- Violations are hard failures in startup/reload auth resolution paths.
+
 ## Legacy-Compatible Messaging
 
 For script compatibility, probe errors keep this first line unchanged:

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -113,6 +113,10 @@ openclaw config set --batch-json '[
 openclaw config set --batch-file ./config-set.batch.json --dry-run
 ```
 
+Policy note:
+
+- SecretRef assignments are rejected on unsupported runtime-mutable surfaces (for example `hooks.token`, `commands.ownerDisplaySecret`, Discord thread-binding webhook tokens, and WhatsApp creds JSON). See [SecretRef Credential Surface](/reference/secretref-credential-surface).
+
 Batch parsing always uses the batch payload (`--batch-json`/`--batch-file`) as the source of truth.
 `--strict-json` / `--json` do not change batch parsing behavior.
 
@@ -204,6 +208,7 @@ Dry-run behavior:
 
 - Builder mode: runs SecretRef resolvability checks for changed refs/providers.
 - JSON mode (`--strict-json`, `--json`, or batch mode): runs schema validation plus SecretRef resolvability checks.
+- Policy validation also runs for known unsupported SecretRef target surfaces.
 - Exec SecretRef checks are skipped by default during dry-run to avoid command side effects.
 - Use `--allow-exec` with `--dry-run` to opt in to exec SecretRef checks (this may execute provider commands).
 - `--allow-exec` is dry-run only and errors if used without `--dry-run`.
@@ -289,6 +294,7 @@ Failure example:
 If dry-run fails:
 
 - `config schema validation failed`: your post-change config shape is invalid; fix path/value or provider/ref object shape.
+- `Config policy validation failed: unsupported SecretRef usage`: move that credential back to plaintext/string input and keep SecretRefs on supported surfaces only.
 - `SecretRef assignment(s) could not be resolved`: referenced provider/ref currently cannot resolve (missing env var, invalid file pointer, exec provider failure, or provider/source mismatch).
 - `Dry run note: skipped <n> exec SecretRef resolvability check(s)`: dry-run skipped exec refs; rerun with `--allow-exec` if you need exec resolvability validation.
 - For batch mode, fix failing entries and rerun `--dry-run` before writing.

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -209,6 +209,7 @@ Dry-run behavior:
 - Builder mode: runs SecretRef resolvability checks for changed refs/providers.
 - JSON mode (`--strict-json`, `--json`, or batch mode): runs schema validation plus SecretRef resolvability checks.
 - Policy validation also runs for known unsupported SecretRef target surfaces.
+- Policy checks evaluate the full post-change config, so parent-object writes (for example setting `hooks` as an object) cannot bypass unsupported-surface validation.
 - Exec SecretRef checks are skipped by default during dry-run to avoid command side effects.
 - Use `--allow-exec` with `--dry-run` to opt in to exec SecretRef checks (this may execute provider commands).
 - `--allow-exec` is dry-run only and errors if used without `--dry-run`.

--- a/docs/cli/daemon.md
+++ b/docs/cli/daemon.md
@@ -44,6 +44,8 @@ Notes:
 - If a required auth SecretRef is unresolved in this command path, `daemon status --json` reports `rpc.authWarning` when probe connectivity/auth fails; pass `--token`/`--password` explicitly or resolve the secret source first.
 - If the probe succeeds, unresolved auth-ref warnings are suppressed to avoid false positives.
 - On Linux systemd installs, `status` token-drift checks include both `Environment=` and `EnvironmentFile=` unit sources.
+- Drift checks resolve `gateway.auth.token` SecretRefs using merged runtime env (service command env first, then process env fallback).
+- If `gateway.auth.mode` disables token auth (`password`, `none`, `trusted-proxy`), token-drift checks skip config token resolution for that mode.
 - When token auth requires a token and `gateway.auth.token` is SecretRef-managed, `install` validates that the SecretRef is resolvable but does not persist the resolved token into service environment metadata.
 - If token auth requires a token and the configured token SecretRef is unresolved, install fails closed.
 - If both `gateway.auth.token` and `gateway.auth.password` are configured and `gateway.auth.mode` is unset, install is blocked until mode is set explicitly.

--- a/docs/cli/daemon.md
+++ b/docs/cli/daemon.md
@@ -45,7 +45,7 @@ Notes:
 - If the probe succeeds, unresolved auth-ref warnings are suppressed to avoid false positives.
 - On Linux systemd installs, `status` token-drift checks include both `Environment=` and `EnvironmentFile=` unit sources.
 - Drift checks resolve `gateway.auth.token` SecretRefs using merged runtime env (service command env first, then process env fallback).
-- If `gateway.auth.mode` disables token auth (`password`, `none`, `trusted-proxy`), token-drift checks skip config token resolution for that mode.
+- If token auth is not effectively active (explicit `gateway.auth.mode` of `password`/`none`/`trusted-proxy`, or mode unset with password fallback active), token-drift checks skip config token resolution.
 - When token auth requires a token and `gateway.auth.token` is SecretRef-managed, `install` validates that the SecretRef is resolvable but does not persist the resolved token into service environment metadata.
 - If token auth requires a token and the configured token SecretRef is unresolved, install fails closed.
 - If both `gateway.auth.token` and `gateway.auth.password` are configured and `gateway.auth.mode` is unset, install is blocked until mode is set explicitly.

--- a/docs/cli/daemon.md
+++ b/docs/cli/daemon.md
@@ -45,7 +45,7 @@ Notes:
 - If the probe succeeds, unresolved auth-ref warnings are suppressed to avoid false positives.
 - On Linux systemd installs, `status` token-drift checks include both `Environment=` and `EnvironmentFile=` unit sources.
 - Drift checks resolve `gateway.auth.token` SecretRefs using merged runtime env (service command env first, then process env fallback).
-- If token auth is not effectively active (explicit `gateway.auth.mode` of `password`/`none`/`trusted-proxy`, or mode unset with password fallback active), token-drift checks skip config token resolution.
+- If token auth is not effectively active (explicit `gateway.auth.mode` of `password`/`none`/`trusted-proxy`, or mode unset where password can win and no token candidate can win), token-drift checks skip config token resolution.
 - When token auth requires a token and `gateway.auth.token` is SecretRef-managed, `install` validates that the SecretRef is resolvable but does not persist the resolved token into service environment metadata.
 - If token auth requires a token and the configured token SecretRef is unresolved, install fails closed.
 - If both `gateway.auth.token` and `gateway.auth.password` are configured and `gateway.auth.mode` is unset, install is blocked until mode is set explicitly.

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -116,6 +116,8 @@ Notes:
 - If the probe succeeds, unresolved auth-ref warnings are suppressed to avoid false positives.
 - Use `--require-rpc` in scripts and automation when a listening service is not enough and you need the Gateway RPC itself to be healthy.
 - On Linux systemd installs, service auth drift checks read both `Environment=` and `EnvironmentFile=` values from the unit (including `%h`, quoted paths, multiple files, and optional `-` files).
+- Drift checks resolve `gateway.auth.token` SecretRefs using merged runtime env (service command env first, then process env fallback).
+- If `gateway.auth.mode` disables token auth (`password`, `none`, `trusted-proxy`), token-drift checks skip config token resolution for that mode.
 
 ### `gateway probe`
 

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -117,7 +117,7 @@ Notes:
 - Use `--require-rpc` in scripts and automation when a listening service is not enough and you need the Gateway RPC itself to be healthy.
 - On Linux systemd installs, service auth drift checks read both `Environment=` and `EnvironmentFile=` values from the unit (including `%h`, quoted paths, multiple files, and optional `-` files).
 - Drift checks resolve `gateway.auth.token` SecretRefs using merged runtime env (service command env first, then process env fallback).
-- If `gateway.auth.mode` disables token auth (`password`, `none`, `trusted-proxy`), token-drift checks skip config token resolution for that mode.
+- If token auth is not effectively active (explicit `gateway.auth.mode` of `password`/`none`/`trusted-proxy`, or mode unset with password fallback active), token-drift checks skip config token resolution.
 
 ### `gateway probe`
 

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -117,7 +117,7 @@ Notes:
 - Use `--require-rpc` in scripts and automation when a listening service is not enough and you need the Gateway RPC itself to be healthy.
 - On Linux systemd installs, service auth drift checks read both `Environment=` and `EnvironmentFile=` values from the unit (including `%h`, quoted paths, multiple files, and optional `-` files).
 - Drift checks resolve `gateway.auth.token` SecretRefs using merged runtime env (service command env first, then process env fallback).
-- If token auth is not effectively active (explicit `gateway.auth.mode` of `password`/`none`/`trusted-proxy`, or mode unset with password fallback active), token-drift checks skip config token resolution.
+- If token auth is not effectively active (explicit `gateway.auth.mode` of `password`/`none`/`trusted-proxy`, or mode unset where password can win and no token candidate can win), token-drift checks skip config token resolution.
 
 ### `gateway probe`
 

--- a/docs/gateway/authentication.md
+++ b/docs/gateway/authentication.md
@@ -105,6 +105,7 @@ Auth profile refs are also supported for static credentials:
 
 - `api_key` credentials can use `keyRef: { source, provider, id }`
 - `token` credentials can use `tokenRef: { source, provider, id }`
+- OAuth-mode profiles do not support SecretRef credentials; if `auth.profiles.<id>.mode` is set to `"oauth"`, SecretRef-backed `keyRef`/`tokenRef` input for that profile is rejected.
 
 Automation-friendly check (exit `1` when expired/missing, `2` when expiring):
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -3012,7 +3012,8 @@ Notes:
 ```
 
 - Per-agent profiles are stored at `<agentDir>/auth-profiles.json`.
-- `auth-profiles.json` supports value-level refs (`keyRef` for `api_key`, `tokenRef` for `token`).
+- `auth-profiles.json` supports value-level refs (`keyRef` for `api_key`, `tokenRef` for `token`) for static credential modes.
+- OAuth-mode profiles (`auth.profiles.<id>.mode = "oauth"`) do not support SecretRef-backed auth-profile credentials.
 - Static runtime credentials come from in-memory resolved snapshots; legacy static `auth.json` entries are scrubbed when discovered.
 - Legacy OAuth imports from `~/.openclaw/credentials/oauth.json`.
 - See [OAuth](/concepts/oauth).

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -20,6 +20,7 @@ Secrets are resolved into an in-memory runtime snapshot.
 - Resolution is eager during activation, not lazy on request paths.
 - Startup fails fast when an effectively active SecretRef cannot be resolved.
 - Reload uses atomic swap: full success, or keep the last-known-good snapshot.
+- SecretRef policy violations (for example OAuth-mode auth profiles combined with SecretRef input) fail activation before runtime swap.
 - Runtime requests read from the active in-memory snapshot only.
 - After the first successful config activation/load, runtime code paths keep reading that active in-memory snapshot until a successful reload swaps it.
 - Outbound delivery paths also read from that active snapshot (for example Discord reply/thread delivery and Telegram action sends); they do not re-resolve SecretRefs on each send.

--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -99,8 +99,8 @@ Scope intent:
 
 ### `auth-profiles.json` targets (`secrets configure` + `secrets apply` + `secrets audit`)
 
-- `profiles.*.keyRef` (`type: "api_key"`)
-- `profiles.*.tokenRef` (`type: "token"`)
+- `profiles.*.keyRef` (`type: "api_key"`; unsupported when `auth.profiles.<id>.mode = "oauth"`)
+- `profiles.*.tokenRef` (`type: "token"`; unsupported when `auth.profiles.<id>.mode = "oauth"`)
 
 [//]: # "secretref-supported-list-end"
 
@@ -109,6 +109,7 @@ Notes:
 - Auth-profile plan targets require `agentId`.
 - Plan entries target `profiles.*.key` / `profiles.*.token` and write sibling refs (`keyRef` / `tokenRef`).
 - Auth-profile refs are included in runtime resolution and audit coverage.
+- OAuth policy guard: `auth.profiles.<id>.mode = "oauth"` cannot be combined with SecretRef inputs for that profile. Startup/reload and auth-profile resolution fail fast when this policy is violated.
 - For SecretRef-managed model providers, generated `agents/*/agent/models.json` entries persist non-secret markers (not resolved secret values) for `apiKey`/header surfaces.
 - Marker persistence is source-authoritative: OpenClaw writes markers from the active source config snapshot (pre-resolution), not from resolved runtime secret values.
 - For web search:
@@ -128,8 +129,10 @@ Out-of-scope credentials include:
 - `hooks.gmail.pushToken`
 - `hooks.mappings[].sessionKey`
 - `auth-profiles.oauth.*`
-- `discord.threadBindings.*.webhookToken`
-- `whatsapp.creds.json`
+- `channels.discord.threadBindings.webhookToken`
+- `channels.discord.accounts.*.threadBindings.webhookToken`
+- `channels.whatsapp.creds.json`
+- `channels.whatsapp.accounts.*.creds.json`
 
 [//]: # "secretref-unsupported-list-end"
 

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -9,8 +9,10 @@
     "hooks.gmail.pushToken",
     "hooks.mappings[].sessionKey",
     "auth-profiles.oauth.*",
-    "discord.threadBindings.*.webhookToken",
-    "whatsapp.creds.json"
+    "channels.discord.threadBindings.webhookToken",
+    "channels.discord.accounts.*.threadBindings.webhookToken",
+    "channels.whatsapp.creds.json",
+    "channels.whatsapp.accounts.*.creds.json"
   ],
   "entries": [
     {

--- a/src/agents/auth-profiles/oauth.test.ts
+++ b/src/agents/auth-profiles/oauth.test.ts
@@ -364,6 +364,26 @@ describe("resolveApiKeyForProfile secret refs", () => {
     });
   });
 
+  it("hard-fails when oauth mode is combined with token SecretRef input", async () => {
+    const profileId = "anthropic:oauth-secretref-token";
+    await expect(
+      resolveApiKeyForProfile({
+        cfg: cfgFor(profileId, "anthropic", "oauth"),
+        store: {
+          version: 1,
+          profiles: {
+            [profileId]: {
+              type: "token",
+              provider: "anthropic",
+              tokenRef: { source: "env", provider: "default", id: "ANTHROPIC_TOKEN" },
+            },
+          },
+        },
+        profileId,
+      }),
+    ).rejects.toThrow(/mode is "oauth"/i);
+  });
+
   it("resolves inline ${ENV} api_key values", async () => {
     const profileId = "openai:inline-env";
     const previous = process.env.OPENAI_API_KEY;

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -17,6 +17,7 @@ import { AUTH_STORE_LOCK_OPTIONS, log } from "./constants.js";
 import { resolveTokenExpiryState } from "./credential-state.js";
 import { formatAuthDoctorHint } from "./doctor.js";
 import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
+import { assertNoOAuthSecretRefPolicyViolations } from "./policy.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./store.js";
 import type { AuthProfileStore, OAuthCredential } from "./types.js";
@@ -339,6 +340,12 @@ export async function resolveApiKeyForProfile(
   const refResolveCache: SecretRefResolveCache = {};
   const configForRefResolution = cfg ?? loadConfig();
   const refDefaults = configForRefResolution.secrets?.defaults;
+  assertNoOAuthSecretRefPolicyViolations({
+    store,
+    cfg: configForRefResolution,
+    profileIds: [profileId],
+    context: `auth profile ${profileId}`,
+  });
 
   if (cred.type === "api_key") {
     const key = await resolveProfileSecretString({

--- a/src/agents/auth-profiles/policy.ts
+++ b/src/agents/auth-profiles/policy.ts
@@ -1,0 +1,142 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import { coerceSecretRef, resolveSecretInputRef } from "../../config/types.secrets.js";
+import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
+
+type SecretDefaults = NonNullable<OpenClawConfig["secrets"]>["defaults"];
+
+type OAuthSecretRefPolicyViolation = {
+  profileId: string;
+  path: string;
+  reason: string;
+};
+
+function pushViolation(
+  violations: OAuthSecretRefPolicyViolation[],
+  profileId: string,
+  field: string,
+  reason: string,
+): void {
+  violations.push({
+    profileId,
+    path: `profiles.${profileId}.${field}`,
+    reason,
+  });
+}
+
+function hasSecretRefInput(params: {
+  value: unknown;
+  refValue?: unknown;
+  defaults: SecretDefaults | undefined;
+}): boolean {
+  return (
+    resolveSecretInputRef({
+      value: params.value,
+      refValue: params.refValue,
+      defaults: params.defaults,
+    }).ref !== null
+  );
+}
+
+function collectTypeOAuthSecretRefViolations(params: {
+  profileId: string;
+  credential: AuthProfileCredential;
+  defaults: SecretDefaults | undefined;
+  violations: OAuthSecretRefPolicyViolation[];
+}): void {
+  if (params.credential.type !== "oauth") {
+    return;
+  }
+  const reason =
+    'SecretRef is not allowed for type="oauth" auth profiles (OAuth credentials are runtime-mutable).';
+  const record = params.credential as Record<string, unknown>;
+  for (const field of ["access", "refresh", "token", "tokenRef", "key", "keyRef"] as const) {
+    if (coerceSecretRef(record[field], params.defaults) === null) {
+      continue;
+    }
+    pushViolation(params.violations, params.profileId, field, reason);
+  }
+}
+
+function collectOAuthModeSecretRefViolations(params: {
+  profileId: string;
+  credential: AuthProfileCredential;
+  defaults: SecretDefaults | undefined;
+  configuredMode?: "api_key" | "oauth" | "token";
+  violations: OAuthSecretRefPolicyViolation[];
+}): void {
+  if (params.configuredMode !== "oauth") {
+    return;
+  }
+  const reason =
+    `SecretRef is not allowed when auth.profiles.${params.profileId}.mode is "oauth" ` +
+    "(OAuth credentials are runtime-mutable).";
+  if (params.credential.type === "api_key") {
+    if (
+      hasSecretRefInput({
+        value: params.credential.key,
+        refValue: params.credential.keyRef,
+        defaults: params.defaults,
+      })
+    ) {
+      pushViolation(params.violations, params.profileId, "key", reason);
+    }
+    return;
+  }
+  if (params.credential.type === "token") {
+    if (
+      hasSecretRefInput({
+        value: params.credential.token,
+        refValue: params.credential.tokenRef,
+        defaults: params.defaults,
+      })
+    ) {
+      pushViolation(params.violations, params.profileId, "token", reason);
+    }
+  }
+}
+
+export function collectOAuthSecretRefPolicyViolations(params: {
+  store: AuthProfileStore;
+  cfg?: OpenClawConfig;
+  profileIds?: Iterable<string>;
+}): OAuthSecretRefPolicyViolation[] {
+  const defaults = params.cfg?.secrets?.defaults;
+  const profileFilter = params.profileIds ? new Set(params.profileIds) : null;
+  const violations: OAuthSecretRefPolicyViolation[] = [];
+  for (const [profileId, credential] of Object.entries(params.store.profiles)) {
+    if (profileFilter && !profileFilter.has(profileId)) {
+      continue;
+    }
+    collectTypeOAuthSecretRefViolations({
+      profileId,
+      credential,
+      defaults,
+      violations,
+    });
+    collectOAuthModeSecretRefViolations({
+      profileId,
+      credential,
+      defaults,
+      configuredMode: params.cfg?.auth?.profiles?.[profileId]?.mode,
+      violations,
+    });
+  }
+  return violations;
+}
+
+export function assertNoOAuthSecretRefPolicyViolations(params: {
+  store: AuthProfileStore;
+  cfg?: OpenClawConfig;
+  profileIds?: Iterable<string>;
+  context?: string;
+}): void {
+  const violations = collectOAuthSecretRefPolicyViolations(params);
+  if (violations.length === 0) {
+    return;
+  }
+  const lines = [
+    `${params.context ?? "auth-profiles"} policy validation failed: OAuth + SecretRef is not supported.`,
+    ...violations.map((violation) => `- ${violation.path}: ${violation.reason}`),
+  ];
+  throw new Error(lines.join("\n"));
+}

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -620,6 +620,33 @@ describe("config cli", () => {
       });
     });
 
+    it("fails early when unsupported mutable paths are assigned SecretRef objects (builder mode)", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "hooks.token",
+          "--ref-provider",
+          "default",
+          "--ref-source",
+          "env",
+          "--ref-id",
+          "HOOK_TOKEN",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining("Config policy validation failed: unsupported SecretRef usage"),
+      );
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining("hooks.token"));
+    });
+
     it("supports provider builder mode under secrets.providers.<alias>", async () => {
       const resolved: OpenClawConfig = {
         gateway: { port: 18789 },
@@ -705,6 +732,58 @@ describe("config cli", () => {
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
       expect(mockError).toHaveBeenCalledWith(
         expect.stringContaining("Dry run failed: config schema validation failed."),
+      );
+    });
+
+    it("fails dry-run when unsupported mutable paths receive SecretRef objects in value/json mode", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "hooks.token",
+          '{"source":"env","provider":"default","id":"HOOK_TOKEN"}',
+          "--strict-json",
+          "--dry-run",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining("Dry run failed: config schema validation failed."),
+      );
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining("hooks.token"));
+    });
+
+    it("aggregates policy failures across batch entries", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "--batch-json",
+          '[{"path":"hooks.token","ref":{"source":"env","provider":"default","id":"HOOK_TOKEN"}},{"path":"commands.ownerDisplaySecret","ref":{"source":"env","provider":"default","id":"OWNER_DISPLAY_SECRET"}}]',
+          "--dry-run",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining("hooks.token"));
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining("commands.ownerDisplaySecret"),
       );
     });
 

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -647,6 +647,29 @@ describe("config cli", () => {
       expect(mockError).toHaveBeenCalledWith(expect.stringContaining("hooks.token"));
     });
 
+    it("fails early when parent-object writes include unsupported SecretRef objects", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "hooks",
+          '{"token":{"source":"env","provider":"default","id":"HOOK_TOKEN"}}',
+          "--strict-json",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining("Config policy validation failed: unsupported SecretRef usage"),
+      );
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining("hooks.token"));
+    });
+
     it("supports provider builder mode under secrets.providers.<alias>", async () => {
       const resolved: OpenClawConfig = {
         gateway: { port: 18789 },
@@ -785,6 +808,41 @@ describe("config cli", () => {
       expect(mockError).toHaveBeenCalledWith(
         expect.stringContaining("commands.ownerDisplaySecret"),
       );
+    });
+
+    it("does not duplicate policy errors in --dry-run --json mode for parent-object writes", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "hooks",
+          '{"token":{"source":"env","provider":"default","id":"HOOK_TOKEN"}}',
+          "--strict-json",
+          "--dry-run",
+          "--json",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      const raw = mockLog.mock.calls.at(-1)?.[0];
+      expect(typeof raw).toBe("string");
+      const payload = JSON.parse(String(raw)) as {
+        ok: boolean;
+        checks: { schema: boolean; resolvability: boolean; resolvabilityComplete: boolean };
+        errors?: Array<{ kind: string; message: string; ref?: string }>;
+      };
+      expect(payload.ok).toBe(false);
+      expect(payload.checks.schema).toBe(true);
+      const hooksTokenErrors =
+        payload.errors?.filter(
+          (entry) => entry.kind === "schema" && entry.message.includes("hooks.token"),
+        ) ?? [];
+      expect(hooksTokenErrors).toHaveLength(1);
     });
 
     it("logs a dry-run note when value mode performs no validation checks", async () => {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1345,6 +1345,46 @@ describe("config cli", () => {
       ).toBe(true);
     });
 
+    it("keeps distinct resolvability failures when messages are identical but refs differ", async () => {
+      const resolved: OpenClawConfig = {
+        gateway: { port: 18789 },
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+      };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand([
+          "config",
+          "set",
+          "--batch-json",
+          '[{"path":"channels.discord.token","ref":{"source":"exec","provider":"default","id":"DISCORD_BOT_TOKEN"}},{"path":"channels.telegram.botToken","ref":{"source":"exec","provider":"default","id":"TELEGRAM_BOT_TOKEN"}}]',
+          "--dry-run",
+          "--json",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      const raw = mockLog.mock.calls.at(-1)?.[0];
+      expect(typeof raw).toBe("string");
+      const payload = JSON.parse(String(raw)) as {
+        ok: boolean;
+        errors?: Array<{ kind: string; message: string; ref?: string }>;
+      };
+      expect(payload.ok).toBe(false);
+      const resolvabilityErrors =
+        payload.errors?.filter((entry) => entry.kind === "resolvability") ?? [];
+      expect(resolvabilityErrors).toHaveLength(2);
+      expect(
+        resolvabilityErrors.some((entry) => entry.ref === "exec:default:DISCORD_BOT_TOKEN"),
+      ).toBe(true);
+      expect(
+        resolvabilityErrors.some((entry) => entry.ref === "exec:default:TELEGRAM_BOT_TOKEN"),
+      ).toBe(true);
+    });
+
     it("aggregates schema and resolvability failures in --dry-run --json mode", async () => {
       const resolved: OpenClawConfig = {
         gateway: { port: 18789 },

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -15,7 +15,10 @@ import {
   type SecretRef,
   type SecretRefSource,
 } from "../config/types.secrets.js";
-import { validateConfigObjectRaw } from "../config/validation.js";
+import {
+  collectUnsupportedSecretRefPolicyIssues,
+  validateConfigObjectRaw,
+} from "../config/validation.js";
 import { SecretProviderSchema } from "../config/zod-schema.core.js";
 import { danger, info, success } from "../globals.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
@@ -90,6 +93,7 @@ const CONFIG_SET_DESCRIPTION = [
   CONFIG_SET_EXAMPLE_PROVIDER,
   CONFIG_SET_EXAMPLE_BATCH,
 ].join("\n");
+const CONFIG_SET_POLICY_ERROR_MAX_ISSUES = 5;
 
 class ConfigSetDryRunValidationError extends Error {
   constructor(readonly result: ConfigSetDryRunResult) {
@@ -177,6 +181,82 @@ function hasOwnPathKey(value: Record<string, unknown>, key: string): boolean {
 
 function formatDoctorHint(message: string): string {
   return `Run \`${formatCliCommand("openclaw doctor")}\` ${message}`;
+}
+
+function isUnsupportedSecretRefPolicyPath(path: PathSegment[]): boolean {
+  if (path.length === 0) {
+    return false;
+  }
+
+  if (path.length === 2 && path[0] === "commands" && path[1] === "ownerDisplaySecret") {
+    return true;
+  }
+  if (path.length === 2 && path[0] === "hooks" && path[1] === "token") {
+    return true;
+  }
+  if (path.length === 3 && path[0] === "hooks" && path[1] === "gmail" && path[2] === "pushToken") {
+    return true;
+  }
+  if (
+    path.length >= 4 &&
+    path[0] === "hooks" &&
+    path[1] === "mappings" &&
+    isIndexSegment(path[2] ?? "") &&
+    path[3] === "sessionKey"
+  ) {
+    return true;
+  }
+  if (
+    path.length === 4 &&
+    path[0] === "channels" &&
+    path[1] === "discord" &&
+    path[2] === "threadBindings" &&
+    path[3] === "webhookToken"
+  ) {
+    return true;
+  }
+  if (
+    path.length === 6 &&
+    path[0] === "channels" &&
+    path[1] === "discord" &&
+    path[2] === "accounts" &&
+    path[4] === "threadBindings" &&
+    path[5] === "webhookToken"
+  ) {
+    return true;
+  }
+  if (
+    path.length === 4 &&
+    path[0] === "channels" &&
+    path[1] === "whatsapp" &&
+    path[2] === "creds" &&
+    path[3] === "json"
+  ) {
+    return true;
+  }
+  if (
+    path.length === 6 &&
+    path[0] === "channels" &&
+    path[1] === "whatsapp" &&
+    path[2] === "accounts" &&
+    path[4] === "creds" &&
+    path[5] === "json"
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function formatUnsupportedSecretRefPolicyFailureMessage(issues: string[]): string {
+  const lines = [
+    "Config policy validation failed: unsupported SecretRef usage was detected.",
+    ...issues.slice(0, CONFIG_SET_POLICY_ERROR_MAX_ISSUES).map((issue) => `- ${issue}`),
+  ];
+  if (issues.length > CONFIG_SET_POLICY_ERROR_MAX_ISSUES) {
+    lines.push(`- ... ${issues.length - CONFIG_SET_POLICY_ERROR_MAX_ISSUES} more`);
+  }
+  return lines.join("\n");
 }
 
 function validatePathSegments(path: PathSegment[]): void {
@@ -992,6 +1072,15 @@ export async function runConfigSet(opts: {
       operations,
     });
     const nextConfig = next as OpenClawConfig;
+    const shouldRunPolicyValidation = operations.some((operation) =>
+      isUnsupportedSecretRefPolicyPath(operation.requestedPath),
+    );
+    const policyIssues = shouldRunPolicyValidation
+      ? collectUnsupportedSecretRefPolicyIssues(nextConfig)
+      : [];
+    const policyIssueLines = formatConfigIssueLines(policyIssues, "", { normalizeRoot: true }).map(
+      (line) => line.trim(),
+    );
 
     if (opts.cliOptions.dryRun) {
       const hasJsonMode = operations.some((operation) => operation.inputMode === "json");
@@ -1008,6 +1097,14 @@ export async function runConfigSet(opts: {
         allowExecInDryRun: Boolean(opts.cliOptions.allowExec),
       });
       const errors: ConfigSetDryRunError[] = [];
+      if (policyIssueLines.length > 0) {
+        errors.push(
+          ...policyIssueLines.map((message) => ({
+            kind: "schema" as const,
+            message,
+          })),
+        );
+      }
       if (hasJsonMode) {
         errors.push(...collectDryRunSchemaErrors(nextConfig));
       }
@@ -1031,7 +1128,7 @@ export async function runConfigSet(opts: {
         configPath: shortenHomePath(snapshot.path),
         inputModes: [...new Set(operations.map((operation) => operation.inputMode))],
         checks: {
-          schema: hasJsonMode,
+          schema: hasJsonMode || shouldRunPolicyValidation,
           resolvability: hasJsonMode || hasBuilderMode,
           resolvabilityComplete:
             (hasJsonMode || hasBuilderMode) && selectedDryRunRefs.skippedExecRefs.length === 0,
@@ -1075,6 +1172,9 @@ export async function runConfigSet(opts: {
         );
       }
       return;
+    }
+    if (policyIssueLines.length > 0) {
+      throw new Error(formatUnsupportedSecretRefPolicyFailureMessage(policyIssueLines));
     }
 
     await replaceConfigFile({

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -183,71 +183,6 @@ function formatDoctorHint(message: string): string {
   return `Run \`${formatCliCommand("openclaw doctor")}\` ${message}`;
 }
 
-function isUnsupportedSecretRefPolicyPath(path: PathSegment[]): boolean {
-  if (path.length === 0) {
-    return false;
-  }
-
-  if (path.length === 2 && path[0] === "commands" && path[1] === "ownerDisplaySecret") {
-    return true;
-  }
-  if (path.length === 2 && path[0] === "hooks" && path[1] === "token") {
-    return true;
-  }
-  if (path.length === 3 && path[0] === "hooks" && path[1] === "gmail" && path[2] === "pushToken") {
-    return true;
-  }
-  if (
-    path.length >= 4 &&
-    path[0] === "hooks" &&
-    path[1] === "mappings" &&
-    isIndexSegment(path[2] ?? "") &&
-    path[3] === "sessionKey"
-  ) {
-    return true;
-  }
-  if (
-    path.length === 4 &&
-    path[0] === "channels" &&
-    path[1] === "discord" &&
-    path[2] === "threadBindings" &&
-    path[3] === "webhookToken"
-  ) {
-    return true;
-  }
-  if (
-    path.length === 6 &&
-    path[0] === "channels" &&
-    path[1] === "discord" &&
-    path[2] === "accounts" &&
-    path[4] === "threadBindings" &&
-    path[5] === "webhookToken"
-  ) {
-    return true;
-  }
-  if (
-    path.length === 4 &&
-    path[0] === "channels" &&
-    path[1] === "whatsapp" &&
-    path[2] === "creds" &&
-    path[3] === "json"
-  ) {
-    return true;
-  }
-  if (
-    path.length === 6 &&
-    path[0] === "channels" &&
-    path[1] === "whatsapp" &&
-    path[2] === "accounts" &&
-    path[4] === "creds" &&
-    path[5] === "json"
-  ) {
-    return true;
-  }
-
-  return false;
-}
-
 function formatUnsupportedSecretRefPolicyFailureMessage(issues: string[]): string {
   const lines = [
     "Config policy validation failed: unsupported SecretRef usage was detected.",
@@ -991,6 +926,20 @@ function collectDryRunSchemaErrors(config: OpenClawConfig): ConfigSetDryRunError
   }));
 }
 
+function dedupeDryRunErrors(errors: ConfigSetDryRunError[]): ConfigSetDryRunError[] {
+  const deduped: ConfigSetDryRunError[] = [];
+  const seen = new Set<string>();
+  for (const error of errors) {
+    const key = `${error.kind}\u0000${error.message}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(error);
+  }
+  return deduped;
+}
+
 function formatDryRunFailureMessage(params: {
   errors: ConfigSetDryRunError[];
   skippedExecRefs: number;
@@ -1072,12 +1021,7 @@ export async function runConfigSet(opts: {
       operations,
     });
     const nextConfig = next as OpenClawConfig;
-    const shouldRunPolicyValidation = operations.some((operation) =>
-      isUnsupportedSecretRefPolicyPath(operation.requestedPath),
-    );
-    const policyIssues = shouldRunPolicyValidation
-      ? collectUnsupportedSecretRefPolicyIssues(nextConfig)
-      : [];
+    const policyIssues = collectUnsupportedSecretRefPolicyIssues(nextConfig);
     const policyIssueLines = formatConfigIssueLines(policyIssues, "", { normalizeRoot: true }).map(
       (line) => line.trim(),
     );
@@ -1097,7 +1041,7 @@ export async function runConfigSet(opts: {
         allowExecInDryRun: Boolean(opts.cliOptions.allowExec),
       });
       const errors: ConfigSetDryRunError[] = [];
-      if (policyIssueLines.length > 0) {
+      if (!hasJsonMode && policyIssueLines.length > 0) {
         errors.push(
           ...policyIssueLines.map((message) => ({
             kind: "schema" as const,
@@ -1122,28 +1066,29 @@ export async function runConfigSet(opts: {
           })),
         );
       }
+      const dedupedErrors = dedupeDryRunErrors(errors);
       const dryRunResult: ConfigSetDryRunResult = {
-        ok: errors.length === 0,
+        ok: dedupedErrors.length === 0,
         operations: operations.length,
         configPath: shortenHomePath(snapshot.path),
         inputModes: [...new Set(operations.map((operation) => operation.inputMode))],
         checks: {
-          schema: hasJsonMode || shouldRunPolicyValidation,
+          schema: hasJsonMode || policyIssueLines.length > 0,
           resolvability: hasJsonMode || hasBuilderMode,
           resolvabilityComplete:
             (hasJsonMode || hasBuilderMode) && selectedDryRunRefs.skippedExecRefs.length === 0,
         },
         refsChecked: selectedDryRunRefs.refsToResolve.length,
         skippedExecRefs: selectedDryRunRefs.skippedExecRefs.length,
-        ...(errors.length > 0 ? { errors } : {}),
+        ...(dedupedErrors.length > 0 ? { errors: dedupedErrors } : {}),
       };
-      if (errors.length > 0) {
+      if (dedupedErrors.length > 0) {
         if (opts.cliOptions.json) {
           throw new ConfigSetDryRunValidationError(dryRunResult);
         }
         throw new Error(
           formatDryRunFailureMessage({
-            errors,
+            errors: dedupedErrors,
             skippedExecRefs: selectedDryRunRefs.skippedExecRefs.length,
           }),
         );

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -930,7 +930,10 @@ function dedupeDryRunErrors(errors: ConfigSetDryRunError[]): ConfigSetDryRunErro
   const deduped: ConfigSetDryRunError[] = [];
   const seen = new Set<string>();
   for (const error of errors) {
-    const key = `${error.kind}\u0000${error.message}`;
+    const key =
+      error.kind === "resolvability"
+        ? `${error.kind}\u0000${error.ref ?? ""}\u0000${error.message}`
+        : `${error.kind}\u0000${error.message}`;
     if (seen.has(key)) {
       continue;
     }

--- a/src/cli/daemon-cli/gateway-token-drift.test.ts
+++ b/src/cli/daemon-cli/gateway-token-drift.test.ts
@@ -3,8 +3,8 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { resolveGatewayTokenForDriftCheck } from "./gateway-token-drift.js";
 
 describe("resolveGatewayTokenForDriftCheck", () => {
-  it("prefers persisted config token over shell env", () => {
-    const token = resolveGatewayTokenForDriftCheck({
+  it("prefers persisted config token over shell env", async () => {
+    const token = await resolveGatewayTokenForDriftCheck({
       cfg: {
         gateway: {
           mode: "local",
@@ -21,31 +21,32 @@ describe("resolveGatewayTokenForDriftCheck", () => {
     expect(token).toBe("config-token");
   });
 
-  it("does not fall back to caller env for unresolved config token refs", () => {
-    expect(() =>
-      resolveGatewayTokenForDriftCheck({
-        cfg: {
-          secrets: {
-            providers: {
-              default: { source: "env" },
-            },
+  it("resolves env-backed local gateway token refs from the provided env", async () => {
+    const token = await resolveGatewayTokenForDriftCheck({
+      cfg: {
+        secrets: {
+          providers: {
+            default: { source: "env" },
           },
-          gateway: {
-            mode: "local",
-            auth: {
-              token: { source: "env", provider: "default", id: "OPENCLAW_GATEWAY_TOKEN" },
-            },
+        },
+        gateway: {
+          mode: "local",
+          auth: {
+            mode: "token",
+            token: { source: "env", provider: "default", id: "SERVICE_GATEWAY_TOKEN" },
           },
-        } as OpenClawConfig,
-        env: {
-          OPENCLAW_GATEWAY_TOKEN: "env-token",
-        } as NodeJS.ProcessEnv,
-      }),
-    ).toThrow(/gateway\.auth\.token/i);
+        },
+      } as OpenClawConfig,
+      env: {
+        SERVICE_GATEWAY_TOKEN: "service-token",
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(token).toBe("service-token");
   });
 
-  it("does not fall back to gateway.remote token for unresolved local token refs", () => {
-    expect(() =>
+  it("throws when an active local token ref is unresolved", async () => {
+    await expect(
       resolveGatewayTokenForDriftCheck({
         cfg: {
           secrets: {
@@ -66,6 +67,26 @@ describe("resolveGatewayTokenForDriftCheck", () => {
         } as OpenClawConfig,
         env: {} as NodeJS.ProcessEnv,
       }),
-    ).toThrow(/gateway\.auth\.token/i);
+    ).rejects.toThrow(/gateway\.auth\.token/i);
+  });
+
+  it("returns undefined when token auth is disabled by mode", async () => {
+    const token = await resolveGatewayTokenForDriftCheck({
+      cfg: {
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+        gateway: {
+          auth: {
+            mode: "password",
+            token: { source: "env", provider: "default", id: "MISSING_LOCAL_TOKEN" },
+          },
+        },
+      } as OpenClawConfig,
+      env: {} as NodeJS.ProcessEnv,
+    });
+    expect(token).toBeUndefined();
   });
 });

--- a/src/cli/daemon-cli/gateway-token-drift.test.ts
+++ b/src/cli/daemon-cli/gateway-token-drift.test.ts
@@ -89,4 +89,26 @@ describe("resolveGatewayTokenForDriftCheck", () => {
     });
     expect(token).toBeUndefined();
   });
+
+  it("returns undefined when password fallback is active with mode unset", async () => {
+    const token = await resolveGatewayTokenForDriftCheck({
+      cfg: {
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+        gateway: {
+          auth: {
+            token: { source: "env", provider: "default", id: "MISSING_LOCAL_TOKEN" },
+          },
+        },
+      } as OpenClawConfig,
+      env: {
+        OPENCLAW_GATEWAY_PASSWORD: "env-password",
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(token).toBeUndefined();
+  });
 });

--- a/src/cli/daemon-cli/gateway-token-drift.test.ts
+++ b/src/cli/daemon-cli/gateway-token-drift.test.ts
@@ -90,17 +90,12 @@ describe("resolveGatewayTokenForDriftCheck", () => {
     expect(token).toBeUndefined();
   });
 
-  it("returns undefined when password fallback is active with mode unset", async () => {
+  it("returns undefined when password fallback is active with mode unset and no token candidate", async () => {
     const token = await resolveGatewayTokenForDriftCheck({
       cfg: {
-        secrets: {
-          providers: {
-            default: { source: "env" },
-          },
-        },
         gateway: {
           auth: {
-            token: { source: "env", provider: "default", id: "MISSING_LOCAL_TOKEN" },
+            password: "config-password",
           },
         },
       } as OpenClawConfig,
@@ -110,5 +105,27 @@ describe("resolveGatewayTokenForDriftCheck", () => {
     });
 
     expect(token).toBeUndefined();
+  });
+
+  it("does not skip token resolution when mode is unset and token can win", async () => {
+    await expect(
+      resolveGatewayTokenForDriftCheck({
+        cfg: {
+          secrets: {
+            providers: {
+              default: { source: "env" },
+            },
+          },
+          gateway: {
+            auth: {
+              token: { source: "env", provider: "default", id: "MISSING_LOCAL_TOKEN" },
+            },
+          },
+        } as OpenClawConfig,
+        env: {
+          OPENCLAW_GATEWAY_PASSWORD: "env-password",
+        } as NodeJS.ProcessEnv,
+      }),
+    ).rejects.toThrow(/gateway\.auth\.token/i);
   });
 });

--- a/src/cli/daemon-cli/gateway-token-drift.ts
+++ b/src/cli/daemon-cli/gateway-token-drift.ts
@@ -1,10 +1,41 @@
 import type { OpenClawConfig } from "../../config/config.js";
-import { resolveGatewayDriftCheckCredentialsFromConfig } from "../../gateway/credentials.js";
+import { resolveSecretInputRef } from "../../config/types.secrets.js";
+import { trimToUndefined } from "../../gateway/credential-planner.js";
+import { GatewaySecretRefUnavailableError } from "../../gateway/credentials.js";
+import { resolveConfiguredSecretInputString } from "../../gateway/resolve-configured-secret-input-string.js";
 
-export function resolveGatewayTokenForDriftCheck(params: {
+function authModeDisablesToken(mode: string | undefined): boolean {
+  return mode === "password" || mode === "none" || mode === "trusted-proxy";
+}
+
+export async function resolveGatewayTokenForDriftCheck(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
-}) {
-  void params.env;
-  return resolveGatewayDriftCheckCredentialsFromConfig({ cfg: params.cfg }).token;
+}): Promise<string | undefined> {
+  const mode = params.cfg.gateway?.auth?.mode;
+  if (authModeDisablesToken(mode)) {
+    return undefined;
+  }
+
+  const tokenInput = params.cfg.gateway?.auth?.token;
+  const tokenRef = resolveSecretInputRef({
+    value: tokenInput,
+    defaults: params.cfg.secrets?.defaults,
+  }).ref;
+  if (!tokenRef) {
+    return trimToUndefined(tokenInput);
+  }
+
+  const env = params.env ?? process.env;
+  const resolved = await resolveConfiguredSecretInputString({
+    config: params.cfg,
+    env,
+    value: tokenInput,
+    path: "gateway.auth.token",
+    unresolvedReasonStyle: "detailed",
+  });
+  if (resolved.value) {
+    return resolved.value;
+  }
+  throw new GatewaySecretRefUnavailableError("gateway.auth.token");
 }

--- a/src/cli/daemon-cli/gateway-token-drift.ts
+++ b/src/cli/daemon-cli/gateway-token-drift.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../../config/config.js";
-import { hasConfiguredSecretInput, resolveSecretInputRef } from "../../config/types.secrets.js";
-import { trimToUndefined } from "../../gateway/credential-planner.js";
+import { resolveSecretInputRef } from "../../config/types.secrets.js";
+import { createGatewayCredentialPlan, trimToUndefined } from "../../gateway/credential-planner.js";
 import { GatewaySecretRefUnavailableError } from "../../gateway/credentials.js";
 import { resolveConfiguredSecretInputString } from "../../gateway/resolve-configured-secret-input-string.js";
 
@@ -12,13 +12,14 @@ function isPasswordFallbackActive(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
 }): boolean {
-  if (params.cfg.gateway?.auth?.mode !== undefined) {
+  const plan = createGatewayCredentialPlan({
+    config: params.cfg,
+    env: params.env,
+  });
+  if (plan.authMode !== undefined) {
     return false;
   }
-  if (trimToUndefined(params.env.OPENCLAW_GATEWAY_PASSWORD)) {
-    return true;
-  }
-  return hasConfiguredSecretInput(params.cfg.gateway?.auth?.password, params.cfg.secrets?.defaults);
+  return plan.passwordCanWin && !plan.tokenCanWin;
 }
 
 export async function resolveGatewayTokenForDriftCheck(params: {

--- a/src/cli/daemon-cli/gateway-token-drift.ts
+++ b/src/cli/daemon-cli/gateway-token-drift.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "../../config/config.js";
-import { resolveSecretInputRef } from "../../config/types.secrets.js";
+import { hasConfiguredSecretInput, resolveSecretInputRef } from "../../config/types.secrets.js";
 import { trimToUndefined } from "../../gateway/credential-planner.js";
 import { GatewaySecretRefUnavailableError } from "../../gateway/credentials.js";
 import { resolveConfiguredSecretInputString } from "../../gateway/resolve-configured-secret-input-string.js";
@@ -8,12 +8,29 @@ function authModeDisablesToken(mode: string | undefined): boolean {
   return mode === "password" || mode === "none" || mode === "trusted-proxy";
 }
 
+function isPasswordFallbackActive(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  if (params.cfg.gateway?.auth?.mode !== undefined) {
+    return false;
+  }
+  if (trimToUndefined(params.env.OPENCLAW_GATEWAY_PASSWORD)) {
+    return true;
+  }
+  return hasConfiguredSecretInput(params.cfg.gateway?.auth?.password, params.cfg.secrets?.defaults);
+}
+
 export async function resolveGatewayTokenForDriftCheck(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): Promise<string | undefined> {
+  const env = params.env ?? process.env;
   const mode = params.cfg.gateway?.auth?.mode;
   if (authModeDisablesToken(mode)) {
+    return undefined;
+  }
+  if (isPasswordFallbackActive({ cfg: params.cfg, env })) {
     return undefined;
   }
 
@@ -26,7 +43,6 @@ export async function resolveGatewayTokenForDriftCheck(params: {
     return trimToUndefined(tokenInput);
   }
 
-  const env = params.env ?? process.env;
   const resolved = await resolveConfiguredSecretInputString({
     config: params.cfg,
     env,

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import {
   defaultRuntime,
   resetLifecycleRuntimeLogs,
@@ -8,7 +9,7 @@ import {
   stubEmptyGatewayEnv,
 } from "./test-helpers/lifecycle-core-harness.js";
 
-const loadConfig = vi.fn(() => ({
+const loadConfig = vi.fn<() => OpenClawConfig>(() => ({
   gateway: {
     auth: {
       token: "config-token",
@@ -117,6 +118,38 @@ describe("runServiceRestart token drift", () => {
     expect(payload.warnings).toEqual(
       expect.arrayContaining([expect.stringContaining("gateway install --force")]),
     );
+  });
+
+  it("resolves config token SecretRefs using service command env before drift checks", async () => {
+    loadConfig.mockReturnValue({
+      secrets: {
+        providers: {
+          default: { source: "env" },
+        },
+      },
+      gateway: {
+        auth: {
+          mode: "token",
+          token: {
+            source: "env",
+            provider: "default",
+            id: "SERVICE_GATEWAY_TOKEN",
+          },
+        },
+      },
+    });
+    service.readCommand.mockResolvedValue({
+      programArguments: [],
+      environment: {
+        OPENCLAW_GATEWAY_TOKEN: "service-token",
+        SERVICE_GATEWAY_TOKEN: "service-token",
+      },
+    });
+
+    await runServiceRestart(createServiceRunArgs(true));
+
+    const payload = readJsonLog<{ warnings?: string[] }>();
+    expect(payload.warnings).toBeUndefined();
   });
 
   it("skips drift warning when disabled", async () => {

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -152,6 +152,39 @@ describe("runServiceRestart token drift", () => {
     expect(payload.warnings).toBeUndefined();
   });
 
+  it("prefers service command env over process env for SecretRef token drift resolution", async () => {
+    loadConfig.mockReturnValue({
+      secrets: {
+        providers: {
+          default: { source: "env" },
+        },
+      },
+      gateway: {
+        auth: {
+          mode: "token",
+          token: {
+            source: "env",
+            provider: "default",
+            id: "SERVICE_GATEWAY_TOKEN",
+          },
+        },
+      },
+    });
+    service.readCommand.mockResolvedValue({
+      programArguments: [],
+      environment: {
+        OPENCLAW_GATEWAY_TOKEN: "service-token",
+        SERVICE_GATEWAY_TOKEN: "service-token",
+      },
+    });
+    vi.stubEnv("SERVICE_GATEWAY_TOKEN", "process-token");
+
+    await runServiceRestart(createServiceRunArgs(true));
+
+    const payload = readJsonLog<{ warnings?: string[] }>();
+    expect(payload.warnings).toBeUndefined();
+  });
+
   it("skips drift warning when disabled", async () => {
     await runServiceRestart({
       serviceNoun: "Node",

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -400,7 +400,11 @@ export async function runServiceRestart(params: {
       const command = await params.service.readCommand(process.env);
       const serviceToken = command?.environment?.OPENCLAW_GATEWAY_TOKEN;
       const cfg = await readBestEffortConfig();
-      const configToken = resolveGatewayTokenForDriftCheck({ cfg, env: process.env });
+      const driftEnv = {
+        ...process.env,
+        ...command?.environment,
+      };
+      const configToken = await resolveGatewayTokenForDriftCheck({ cfg, env: driftEnv });
       const driftIssue = checkTokenDrift({ serviceToken, configToken });
       if (driftIssue) {
         const warning = driftIssue.detail

--- a/src/config/validation.policy.test.ts
+++ b/src/config/validation.policy.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObjectRaw } from "./validation.js";
+
+describe("config validation SecretRef policy guards", () => {
+  it("surfaces a policy error for hooks.token SecretRef objects", () => {
+    const result = validateConfigObjectRaw({
+      hooks: {
+        token: {
+          source: "env",
+          provider: "default",
+          id: "HOOK_TOKEN",
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const issue = result.issues.find((entry) => entry.path === "hooks.token");
+      expect(issue).toBeDefined();
+      expect(issue?.message).toContain("SecretRef objects are not supported at hooks.token");
+      expect(issue?.message).toContain(
+        "https://docs.openclaw.ai/reference/secretref-credential-surface",
+      );
+      expect(
+        result.issues.some(
+          (entry) =>
+            entry.path === "hooks.token" &&
+            entry.message.includes("Invalid input: expected string, received object"),
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("keeps standard schema errors for non-SecretRef objects", () => {
+    const result = validateConfigObjectRaw({
+      hooks: {
+        token: {
+          unexpected: "value",
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const issue = result.issues.find((entry) => entry.path === "hooks.token");
+      expect(issue).toBeDefined();
+      expect(issue?.message).toBe("Invalid input: expected string, received object");
+    }
+  });
+
+  it("allows env-template strings on unsupported mutable paths", () => {
+    const result = validateConfigObjectRaw({
+      hooks: {
+        token: "${HOOK_TOKEN}",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("replaces derived unrecognized-key errors with policy guidance for discord thread binding webhookToken", () => {
+    const result = validateConfigObjectRaw({
+      channels: {
+        discord: {
+          threadBindings: {
+            webhookToken: {
+              source: "env",
+              provider: "default",
+              id: "DISCORD_THREAD_BINDING_WEBHOOK_TOKEN",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const policyIssue = result.issues.find(
+        (entry) => entry.path === "channels.discord.threadBindings.webhookToken",
+      );
+      expect(policyIssue).toBeDefined();
+      expect(policyIssue?.message).toContain(
+        "SecretRef objects are not supported at channels.discord.threadBindings.webhookToken",
+      );
+      expect(
+        result.issues.some(
+          (entry) =>
+            entry.path === "channels.discord.threadBindings" &&
+            entry.message.includes('Unrecognized key: "webhookToken"'),
+        ),
+      ).toBe(false);
+    }
+  });
+});

--- a/src/config/validation.policy.test.ts
+++ b/src/config/validation.policy.test.ts
@@ -91,4 +91,39 @@ describe("config validation SecretRef policy guards", () => {
       ).toBe(false);
     }
   });
+
+  it("preserves unrelated unknown-key errors when policy and typos coexist", () => {
+    const result = validateConfigObjectRaw({
+      channels: {
+        discord: {
+          threadBindings: {
+            webhookToken: {
+              source: "env",
+              provider: "default",
+              id: "DISCORD_THREAD_BINDING_WEBHOOK_TOKEN",
+            },
+            webhookTokne: "typo",
+          },
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(
+        result.issues.some(
+          (entry) =>
+            entry.path === "channels.discord.threadBindings.webhookToken" &&
+            entry.message.includes("SecretRef objects are not supported"),
+        ),
+      ).toBe(true);
+      expect(
+        result.issues.some(
+          (entry) =>
+            entry.path === "channels.discord.threadBindings" &&
+            entry.message.includes("webhookTokne"),
+        ),
+      ).toBe(true);
+    }
+  });
 });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -31,6 +31,7 @@ import {
 import { findLegacyConfigIssues } from "./legacy.js";
 import { materializeRuntimeConfig } from "./materialize.js";
 import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
+import { coerceSecretRef } from "./types.secrets.js";
 import { OpenClawSchema } from "./zod-schema.js";
 
 const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth", "google-gemini-cli-auth"]);
@@ -45,6 +46,7 @@ type AllowedValuesCollection = {
 type JsonSchemaLike = Record<string, unknown>;
 
 const CUSTOM_EXPECTED_ONE_OF_RE = /expected one of ((?:"[^"]+"(?:\|"?[^"]+"?)*)+)/i;
+const SECRETREF_POLICY_DOC_URL = "https://docs.openclaw.ai/reference/secretref-credential-surface";
 const bundledChannelSchemaById = new Map<string, unknown>(
   GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.map(
     (entry) => [entry.channelId, entry.schema] as const,
@@ -256,6 +258,183 @@ function collectAllowedValuesFromUnknownIssue(issue: unknown): unknown[] {
   return collection.values;
 }
 
+function isObjectSecretRefCandidate(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  return coerceSecretRef(value) !== null;
+}
+
+function formatUnsupportedMutableSecretRefMessage(path: string): string {
+  return [
+    `SecretRef objects are not supported at ${path}.`,
+    "This credential is runtime-mutable or runtime-managed and must stay a plain string value.",
+    'Use a plain string (env template strings like "${MY_VAR}" are allowed).',
+    `See ${SECRETREF_POLICY_DOC_URL}.`,
+  ].join(" ");
+}
+
+function pushUnsupportedMutableSecretRefIssue(
+  issues: ConfigValidationIssue[],
+  path: string,
+  value: unknown,
+): void {
+  if (!isObjectSecretRefCandidate(value)) {
+    return;
+  }
+  issues.push({
+    path,
+    message: formatUnsupportedMutableSecretRefMessage(path),
+  });
+}
+
+function collectUnsupportedMutableSecretRefIssues(raw: unknown): ConfigValidationIssue[] {
+  if (!isRecord(raw)) {
+    return [];
+  }
+
+  const issues: ConfigValidationIssue[] = [];
+
+  const commands = isRecord(raw.commands) ? raw.commands : null;
+  if (commands) {
+    pushUnsupportedMutableSecretRefIssue(
+      issues,
+      "commands.ownerDisplaySecret",
+      commands.ownerDisplaySecret,
+    );
+  }
+
+  const hooks = isRecord(raw.hooks) ? raw.hooks : null;
+  if (hooks) {
+    pushUnsupportedMutableSecretRefIssue(issues, "hooks.token", hooks.token);
+
+    const gmail = isRecord(hooks.gmail) ? hooks.gmail : null;
+    if (gmail) {
+      pushUnsupportedMutableSecretRefIssue(issues, "hooks.gmail.pushToken", gmail.pushToken);
+    }
+
+    const mappings = hooks.mappings;
+    if (Array.isArray(mappings)) {
+      for (const [index, mapping] of mappings.entries()) {
+        if (!isRecord(mapping)) {
+          continue;
+        }
+        pushUnsupportedMutableSecretRefIssue(
+          issues,
+          `hooks.mappings.${index}.sessionKey`,
+          mapping.sessionKey,
+        );
+      }
+    }
+  }
+
+  const channels = isRecord(raw.channels) ? raw.channels : null;
+  if (channels) {
+    const discord = isRecord(channels.discord) ? channels.discord : null;
+    if (discord) {
+      const threadBindings = isRecord(discord.threadBindings) ? discord.threadBindings : null;
+      if (threadBindings) {
+        pushUnsupportedMutableSecretRefIssue(
+          issues,
+          "channels.discord.threadBindings.webhookToken",
+          threadBindings.webhookToken,
+        );
+      }
+      const accounts = isRecord(discord.accounts) ? discord.accounts : null;
+      if (accounts) {
+        for (const [accountId, account] of Object.entries(accounts)) {
+          if (!isRecord(account)) {
+            continue;
+          }
+          const accountThreadBindings = isRecord(account.threadBindings)
+            ? account.threadBindings
+            : null;
+          if (!accountThreadBindings) {
+            continue;
+          }
+          pushUnsupportedMutableSecretRefIssue(
+            issues,
+            `channels.discord.accounts.${accountId}.threadBindings.webhookToken`,
+            accountThreadBindings.webhookToken,
+          );
+        }
+      }
+    }
+
+    const whatsapp = isRecord(channels.whatsapp) ? channels.whatsapp : null;
+    if (whatsapp) {
+      const creds = isRecord(whatsapp.creds) ? whatsapp.creds : null;
+      if (creds) {
+        pushUnsupportedMutableSecretRefIssue(issues, "channels.whatsapp.creds.json", creds.json);
+      }
+      const accounts = isRecord(whatsapp.accounts) ? whatsapp.accounts : null;
+      if (accounts) {
+        for (const [accountId, account] of Object.entries(accounts)) {
+          if (!isRecord(account)) {
+            continue;
+          }
+          const accountCreds = isRecord(account.creds) ? account.creds : null;
+          if (!accountCreds) {
+            continue;
+          }
+          pushUnsupportedMutableSecretRefIssue(
+            issues,
+            `channels.whatsapp.accounts.${accountId}.creds.json`,
+            accountCreds.json,
+          );
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+function isUnsupportedMutableSecretRefSchemaIssue(params: {
+  issue: ConfigValidationIssue;
+  policyIssue: ConfigValidationIssue;
+}): boolean {
+  const { issue, policyIssue } = params;
+  if (issue.path === policyIssue.path) {
+    return /expected string, received object/i.test(issue.message);
+  }
+
+  if (!issue.path || !policyIssue.path || !policyIssue.path.startsWith(`${issue.path}.`)) {
+    return false;
+  }
+
+  const remainder = policyIssue.path.slice(issue.path.length + 1);
+  const childKey = remainder.split(".")[0];
+  if (!childKey) {
+    return false;
+  }
+
+  if (!/Unrecognized key/i.test(issue.message)) {
+    return false;
+  }
+  return issue.message.includes(`"${childKey}"`);
+}
+
+function mergeUnsupportedMutableSecretRefIssues(
+  policyIssues: ConfigValidationIssue[],
+  schemaIssues: ConfigValidationIssue[],
+): ConfigValidationIssue[] {
+  if (policyIssues.length === 0) {
+    return schemaIssues;
+  }
+  const filteredSchemaIssues = schemaIssues.filter(
+    (issue) =>
+      !policyIssues.some((policyIssue) =>
+        isUnsupportedMutableSecretRefSchemaIssue({ issue, policyIssue }),
+      ),
+  );
+  return [...policyIssues, ...filteredSchemaIssues];
+}
+
+export function collectUnsupportedSecretRefPolicyIssues(raw: unknown): ConfigValidationIssue[] {
+  return collectUnsupportedMutableSecretRefIssues(raw);
+}
+
 function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
   const record = toIssueRecord(issue);
   const path = formatConfigPath(toConfigPathSegments(record?.path));
@@ -365,6 +544,7 @@ export function validateConfigObjectRaw(
   raw: unknown,
 ): { ok: true; config: OpenClawConfig } | { ok: false; issues: ConfigValidationIssue[] } {
   const normalizedRaw = normalizeLegacyWebSearchConfig(raw);
+  const policyIssues = collectUnsupportedSecretRefPolicyIssues(normalizedRaw);
   const legacyIssues = findLegacyConfigIssues(normalizedRaw);
   if (legacyIssues.length > 0) {
     return {
@@ -377,10 +557,14 @@ export function validateConfigObjectRaw(
   }
   const validated = OpenClawSchema.safeParse(normalizedRaw);
   if (!validated.success) {
+    const schemaIssues = validated.error.issues.map((issue) => mapZodIssueToConfigIssue(issue));
     return {
       ok: false,
-      issues: validated.error.issues.map((issue) => mapZodIssueToConfigIssue(issue)),
+      issues: mergeUnsupportedMutableSecretRefIssues(policyIssues, schemaIssues),
     };
+  }
+  if (policyIssues.length > 0) {
+    return { ok: false, issues: policyIssues };
   }
   const validatedConfig = validated.data as OpenClawConfig;
   const duplicates = findDuplicateAgentDirs(validatedConfig);

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -11,6 +11,7 @@ import {
 import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
 import { hasKind } from "../plugins/slots.js";
+import { collectUnsupportedSecretRefConfigCandidates } from "../secrets/unsupported-surface-policy.js";
 import {
   hasAvatarUriScheme,
   isAvatarDataUrl,
@@ -289,102 +290,9 @@ function pushUnsupportedMutableSecretRefIssue(
 }
 
 function collectUnsupportedMutableSecretRefIssues(raw: unknown): ConfigValidationIssue[] {
-  if (!isRecord(raw)) {
-    return [];
-  }
-
   const issues: ConfigValidationIssue[] = [];
-
-  const commands = isRecord(raw.commands) ? raw.commands : null;
-  if (commands) {
-    pushUnsupportedMutableSecretRefIssue(
-      issues,
-      "commands.ownerDisplaySecret",
-      commands.ownerDisplaySecret,
-    );
-  }
-
-  const hooks = isRecord(raw.hooks) ? raw.hooks : null;
-  if (hooks) {
-    pushUnsupportedMutableSecretRefIssue(issues, "hooks.token", hooks.token);
-
-    const gmail = isRecord(hooks.gmail) ? hooks.gmail : null;
-    if (gmail) {
-      pushUnsupportedMutableSecretRefIssue(issues, "hooks.gmail.pushToken", gmail.pushToken);
-    }
-
-    const mappings = hooks.mappings;
-    if (Array.isArray(mappings)) {
-      for (const [index, mapping] of mappings.entries()) {
-        if (!isRecord(mapping)) {
-          continue;
-        }
-        pushUnsupportedMutableSecretRefIssue(
-          issues,
-          `hooks.mappings.${index}.sessionKey`,
-          mapping.sessionKey,
-        );
-      }
-    }
-  }
-
-  const channels = isRecord(raw.channels) ? raw.channels : null;
-  if (channels) {
-    const discord = isRecord(channels.discord) ? channels.discord : null;
-    if (discord) {
-      const threadBindings = isRecord(discord.threadBindings) ? discord.threadBindings : null;
-      if (threadBindings) {
-        pushUnsupportedMutableSecretRefIssue(
-          issues,
-          "channels.discord.threadBindings.webhookToken",
-          threadBindings.webhookToken,
-        );
-      }
-      const accounts = isRecord(discord.accounts) ? discord.accounts : null;
-      if (accounts) {
-        for (const [accountId, account] of Object.entries(accounts)) {
-          if (!isRecord(account)) {
-            continue;
-          }
-          const accountThreadBindings = isRecord(account.threadBindings)
-            ? account.threadBindings
-            : null;
-          if (!accountThreadBindings) {
-            continue;
-          }
-          pushUnsupportedMutableSecretRefIssue(
-            issues,
-            `channels.discord.accounts.${accountId}.threadBindings.webhookToken`,
-            accountThreadBindings.webhookToken,
-          );
-        }
-      }
-    }
-
-    const whatsapp = isRecord(channels.whatsapp) ? channels.whatsapp : null;
-    if (whatsapp) {
-      const creds = isRecord(whatsapp.creds) ? whatsapp.creds : null;
-      if (creds) {
-        pushUnsupportedMutableSecretRefIssue(issues, "channels.whatsapp.creds.json", creds.json);
-      }
-      const accounts = isRecord(whatsapp.accounts) ? whatsapp.accounts : null;
-      if (accounts) {
-        for (const [accountId, account] of Object.entries(accounts)) {
-          if (!isRecord(account)) {
-            continue;
-          }
-          const accountCreds = isRecord(account.creds) ? account.creds : null;
-          if (!accountCreds) {
-            continue;
-          }
-          pushUnsupportedMutableSecretRefIssue(
-            issues,
-            `channels.whatsapp.accounts.${accountId}.creds.json`,
-            accountCreds.json,
-          );
-        }
-      }
-    }
+  for (const candidate of collectUnsupportedSecretRefConfigCandidates(raw)) {
+    pushUnsupportedMutableSecretRefIssue(issues, candidate.path, candidate.value);
   }
 
   return issues;

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -320,7 +320,11 @@ function isUnsupportedMutableSecretRefSchemaIssue(params: {
   if (!/Unrecognized key/i.test(issue.message)) {
     return false;
   }
-  return issue.message.includes(`"${childKey}"`);
+  const unrecognizedKeys = [...issue.message.matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+  if (unrecognizedKeys.length === 0) {
+    return false;
+  }
+  return unrecognizedKeys.length === 1 && unrecognizedKeys[0] === childKey;
 }
 
 function mergeUnsupportedMutableSecretRefIssues(

--- a/src/secrets/credential-matrix.ts
+++ b/src/secrets/credential-matrix.ts
@@ -1,4 +1,5 @@
 import { listSecretTargetRegistryEntries } from "./target-registry.js";
+import { UNSUPPORTED_SECRETREF_SURFACE_PATTERNS } from "./unsupported-surface-policy.js";
 
 type CredentialMatrixEntry = {
   id: string;
@@ -19,18 +20,6 @@ export type SecretRefCredentialMatrixDocument = {
   excludedMutableOrRuntimeManaged: string[];
   entries: CredentialMatrixEntry[];
 };
-
-const EXCLUDED_MUTABLE_OR_RUNTIME_MANAGED = [
-  "commands.ownerDisplaySecret",
-  "hooks.token",
-  "hooks.gmail.pushToken",
-  "hooks.mappings[].sessionKey",
-  "auth-profiles.oauth.*",
-  "channels.discord.threadBindings.webhookToken",
-  "channels.discord.accounts.*.threadBindings.webhookToken",
-  "channels.whatsapp.creds.json",
-  "channels.whatsapp.accounts.*.creds.json",
-];
 
 export function buildSecretRefCredentialMatrix(): SecretRefCredentialMatrixDocument {
   const entries: CredentialMatrixEntry[] = listSecretTargetRegistryEntries()
@@ -54,7 +43,7 @@ export function buildSecretRefCredentialMatrix(): SecretRefCredentialMatrixDocum
     pathSyntax: 'Dot path with "*" for map keys and "[]" for arrays.',
     scope:
       "Credentials that are strictly user-supplied and not minted/rotated by OpenClaw runtime.",
-    excludedMutableOrRuntimeManaged: [...EXCLUDED_MUTABLE_OR_RUNTIME_MANAGED],
+    excludedMutableOrRuntimeManaged: [...UNSUPPORTED_SECRETREF_SURFACE_PATTERNS],
     entries,
   };
 }

--- a/src/secrets/credential-matrix.ts
+++ b/src/secrets/credential-matrix.ts
@@ -26,8 +26,10 @@ const EXCLUDED_MUTABLE_OR_RUNTIME_MANAGED = [
   "hooks.gmail.pushToken",
   "hooks.mappings[].sessionKey",
   "auth-profiles.oauth.*",
-  "discord.threadBindings.*.webhookToken",
-  "whatsapp.creds.json",
+  "channels.discord.threadBindings.webhookToken",
+  "channels.discord.accounts.*.threadBindings.webhookToken",
+  "channels.whatsapp.creds.json",
+  "channels.whatsapp.accounts.*.creds.json",
 ];
 
 export function buildSecretRefCredentialMatrix(): SecretRefCredentialMatrixDocument {

--- a/src/secrets/runtime-auth-collectors.ts
+++ b/src/secrets/runtime-auth-collectors.ts
@@ -1,4 +1,5 @@
 import type { AuthProfileCredential, AuthProfileStore } from "../agents/auth-profiles.js";
+import { assertNoOAuthSecretRefPolicyViolations } from "../agents/auth-profiles/policy.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import {
   pushAssignment,
@@ -103,6 +104,12 @@ export function collectAuthStoreAssignments(params: {
   context: ResolverContext;
   agentDir: string;
 }): void {
+  assertNoOAuthSecretRefPolicyViolations({
+    store: params.store,
+    cfg: params.context.sourceConfig,
+    context: `auth-profiles ${params.agentDir}`,
+  });
+
   const defaults = params.context.sourceConfig.secrets?.defaults;
   for (const [profileId, profile] of Object.entries(params.store.profiles)) {
     if (profile.type === "api_key") {

--- a/src/secrets/runtime-auth-profiles-oauth-policy.test.ts
+++ b/src/secrets/runtime-auth-profiles-oauth-policy.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { AuthProfileStore } from "../agents/auth-profiles.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { prepareSecretsRuntimeSnapshot } from "./runtime.js";
+
+function withAuthProfileMode(mode: "api_key" | "oauth" | "token"): OpenClawConfig {
+  return {
+    auth: {
+      profiles: {
+        "anthropic:default": {
+          provider: "anthropic",
+          mode,
+        },
+      },
+    },
+    secrets: {
+      providers: {
+        default: { source: "env" },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+describe("secrets runtime oauth auth-profile SecretRef policy", () => {
+  it("fails startup snapshot when oauth mode profile uses token SecretRef", async () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "anthropic:default": {
+          type: "token",
+          provider: "anthropic",
+          tokenRef: { source: "env", provider: "default", id: "ANTHROPIC_TOKEN" },
+        },
+      },
+    };
+
+    await expect(
+      prepareSecretsRuntimeSnapshot({
+        config: withAuthProfileMode("oauth"),
+        env: { ANTHROPIC_TOKEN: "token-value" } as NodeJS.ProcessEnv,
+        loadAuthStore: () => store,
+        loadablePluginOrigins: new Map(),
+        agentDirs: ["/tmp/openclaw-secrets-runtime-main"],
+      }),
+    ).rejects.toThrow(/OAuth \+ SecretRef is not supported/i);
+  });
+
+  it("keeps token SecretRef support when the profile mode is token", async () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "anthropic:default": {
+          type: "token",
+          provider: "anthropic",
+          tokenRef: { source: "env", provider: "default", id: "ANTHROPIC_TOKEN" },
+        },
+      },
+    };
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config: withAuthProfileMode("token"),
+      env: { ANTHROPIC_TOKEN: "token-value" } as NodeJS.ProcessEnv,
+      loadAuthStore: () => store,
+      loadablePluginOrigins: new Map(),
+      agentDirs: ["/tmp/openclaw-secrets-runtime-main"],
+    });
+
+    const resolved = snapshot.authStores[0]?.store.profiles["anthropic:default"];
+    expect(resolved).toMatchObject({
+      type: "token",
+      token: "token-value",
+    });
+  });
+});

--- a/src/secrets/runtime.integration.test.ts
+++ b/src/secrets/runtime.integration.test.ts
@@ -255,6 +255,97 @@ describe("secrets runtime snapshot integration", () => {
     });
   });
 
+  it("fails fast at startup when gateway auth SecretRef is active and unresolved", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+        OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE: "1",
+        OPENCLAW_VERSION: undefined,
+      },
+      async () => {
+        await expect(
+          prepareSecretsRuntimeSnapshot({
+            config: asConfig({
+              gateway: {
+                auth: {
+                  mode: "token",
+                  token: {
+                    source: "env",
+                    provider: "default",
+                    id: "MISSING_GATEWAY_AUTH_TOKEN",
+                  },
+                },
+              },
+            }),
+            env: {},
+            agentDirs: ["/tmp/openclaw-agent-main"],
+            loadAuthStore: () => ({ version: 1, profiles: {} }),
+          }),
+        ).rejects.toThrow(/MISSING_GATEWAY_AUTH_TOKEN/i);
+      },
+    );
+  });
+
+  it(
+    "keeps last-known-good runtime snapshot active when reload introduces unresolved active gateway auth refs",
+    async () => {
+      await withTempHome("openclaw-secrets-runtime-gateway-auth-reload-lkg-", async (home) => {
+        const initialTokenRef = {
+          source: "env",
+          provider: "default",
+          id: "GATEWAY_AUTH_TOKEN",
+        } as const;
+        const missingTokenRef = {
+          source: "env",
+          provider: "default",
+          id: "MISSING_GATEWAY_AUTH_TOKEN",
+        } as const;
+
+        const prepared = await prepareSecretsRuntimeSnapshot({
+          config: asConfig({
+            gateway: {
+              auth: {
+                mode: "token",
+                token: initialTokenRef,
+              },
+            },
+          }),
+          env: {
+            GATEWAY_AUTH_TOKEN: "gateway-runtime-token",
+          },
+          agentDirs: ["/tmp/openclaw-agent-main"],
+          loadAuthStore: () => ({ version: 1, profiles: {} }),
+        });
+
+        activateSecretsRuntimeSnapshot(prepared);
+        expect(loadConfig().gateway?.auth?.token).toBe("gateway-runtime-token");
+
+        await expect(
+          writeConfigFile({
+            ...loadConfig(),
+            gateway: {
+              auth: {
+                mode: "token",
+                token: missingTokenRef,
+              },
+            },
+          }),
+        ).rejects.toThrow(/runtime snapshot refresh failed: .*MISSING_GATEWAY_AUTH_TOKEN/i);
+
+        const activeAfterFailure = getActiveSecretsRuntimeSnapshot();
+        expect(activeAfterFailure).not.toBeNull();
+        expect(loadConfig().gateway?.auth?.token).toBe("gateway-runtime-token");
+        expect(activeAfterFailure?.sourceConfig.gateway?.auth?.token).toEqual(initialTokenRef);
+
+        const persistedConfig = JSON.parse(
+          await fs.readFile(path.join(home, ".openclaw", "openclaw.json"), "utf8"),
+        ) as OpenClawConfig;
+        expect(persistedConfig.gateway?.auth?.token).toEqual(missingTokenRef);
+      });
+    },
+    SECRETS_RUNTIME_INTEGRATION_TIMEOUT_MS,
+  );
+
   it(
     "keeps last-known-good web runtime snapshot when reload introduces unresolved active web refs",
     async () => {

--- a/src/secrets/unsupported-surface-policy.test.ts
+++ b/src/secrets/unsupported-surface-policy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectUnsupportedSecretRefConfigCandidates,
+  UNSUPPORTED_SECRETREF_SURFACE_PATTERNS,
+} from "./unsupported-surface-policy.js";
+
+describe("unsupported SecretRef surface policy metadata", () => {
+  it("exposes the canonical unsupported surface patterns", () => {
+    expect(UNSUPPORTED_SECRETREF_SURFACE_PATTERNS).toEqual([
+      "commands.ownerDisplaySecret",
+      "hooks.token",
+      "hooks.gmail.pushToken",
+      "hooks.mappings[].sessionKey",
+      "auth-profiles.oauth.*",
+      "channels.discord.threadBindings.webhookToken",
+      "channels.discord.accounts.*.threadBindings.webhookToken",
+      "channels.whatsapp.creds.json",
+      "channels.whatsapp.accounts.*.creds.json",
+    ]);
+  });
+
+  it("discovers concrete config candidates for unsupported mutable surfaces", () => {
+    const candidates = collectUnsupportedSecretRefConfigCandidates({
+      commands: { ownerDisplaySecret: { source: "env", provider: "default", id: "OWNER" } },
+      hooks: {
+        token: { source: "env", provider: "default", id: "HOOK_TOKEN" },
+        gmail: { pushToken: { source: "env", provider: "default", id: "GMAIL_PUSH" } },
+        mappings: [{ sessionKey: { source: "env", provider: "default", id: "S0" } }],
+      },
+      channels: {
+        discord: {
+          threadBindings: {
+            webhookToken: { source: "env", provider: "default", id: "DISCORD_WEBHOOK" },
+          },
+          accounts: {
+            ops: {
+              threadBindings: {
+                webhookToken: {
+                  source: "env",
+                  provider: "default",
+                  id: "DISCORD_WEBHOOK_OPS",
+                },
+              },
+            },
+          },
+        },
+        whatsapp: {
+          creds: { json: { source: "env", provider: "default", id: "WHATSAPP_JSON" } },
+          accounts: {
+            ops: {
+              creds: {
+                json: { source: "env", provider: "default", id: "WHATSAPP_JSON_OPS" },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(candidates.map((candidate) => candidate.path).toSorted()).toEqual(
+      [
+        "commands.ownerDisplaySecret",
+        "hooks.token",
+        "hooks.gmail.pushToken",
+        "hooks.mappings.0.sessionKey",
+        "channels.discord.threadBindings.webhookToken",
+        "channels.discord.accounts.ops.threadBindings.webhookToken",
+        "channels.whatsapp.creds.json",
+        "channels.whatsapp.accounts.ops.creds.json",
+      ].toSorted(),
+    );
+  });
+});

--- a/src/secrets/unsupported-surface-policy.ts
+++ b/src/secrets/unsupported-surface-policy.ts
@@ -1,0 +1,128 @@
+import { isRecord } from "../utils.js";
+
+export const UNSUPPORTED_SECRETREF_SURFACE_PATTERNS = [
+  "commands.ownerDisplaySecret",
+  "hooks.token",
+  "hooks.gmail.pushToken",
+  "hooks.mappings[].sessionKey",
+  "auth-profiles.oauth.*",
+  "channels.discord.threadBindings.webhookToken",
+  "channels.discord.accounts.*.threadBindings.webhookToken",
+  "channels.whatsapp.creds.json",
+  "channels.whatsapp.accounts.*.creds.json",
+] as const;
+
+export type UnsupportedSecretRefConfigCandidate = {
+  path: string;
+  value: unknown;
+};
+
+export function collectUnsupportedSecretRefConfigCandidates(
+  raw: unknown,
+): UnsupportedSecretRefConfigCandidate[] {
+  if (!isRecord(raw)) {
+    return [];
+  }
+
+  const candidates: UnsupportedSecretRefConfigCandidate[] = [];
+
+  const commands = isRecord(raw.commands) ? raw.commands : null;
+  if (commands) {
+    candidates.push({
+      path: "commands.ownerDisplaySecret",
+      value: commands.ownerDisplaySecret,
+    });
+  }
+
+  const hooks = isRecord(raw.hooks) ? raw.hooks : null;
+  if (hooks) {
+    candidates.push({ path: "hooks.token", value: hooks.token });
+
+    const gmail = isRecord(hooks.gmail) ? hooks.gmail : null;
+    if (gmail) {
+      candidates.push({
+        path: "hooks.gmail.pushToken",
+        value: gmail.pushToken,
+      });
+    }
+
+    const mappings = hooks.mappings;
+    if (Array.isArray(mappings)) {
+      for (const [index, mapping] of mappings.entries()) {
+        if (!isRecord(mapping)) {
+          continue;
+        }
+        candidates.push({
+          path: `hooks.mappings.${index}.sessionKey`,
+          value: mapping.sessionKey,
+        });
+      }
+    }
+  }
+
+  const channels = isRecord(raw.channels) ? raw.channels : null;
+  if (!channels) {
+    return candidates;
+  }
+
+  const discord = isRecord(channels.discord) ? channels.discord : null;
+  if (discord) {
+    const threadBindings = isRecord(discord.threadBindings) ? discord.threadBindings : null;
+    if (threadBindings) {
+      candidates.push({
+        path: "channels.discord.threadBindings.webhookToken",
+        value: threadBindings.webhookToken,
+      });
+    }
+    const accounts = isRecord(discord.accounts) ? discord.accounts : null;
+    if (accounts) {
+      for (const [accountId, account] of Object.entries(accounts)) {
+        if (!isRecord(account)) {
+          continue;
+        }
+        const accountThreadBindings = isRecord(account.threadBindings)
+          ? account.threadBindings
+          : null;
+        if (!accountThreadBindings) {
+          continue;
+        }
+        candidates.push({
+          path: `channels.discord.accounts.${accountId}.threadBindings.webhookToken`,
+          value: accountThreadBindings.webhookToken,
+        });
+      }
+    }
+  }
+
+  const whatsapp = isRecord(channels.whatsapp) ? channels.whatsapp : null;
+  if (!whatsapp) {
+    return candidates;
+  }
+
+  const creds = isRecord(whatsapp.creds) ? whatsapp.creds : null;
+  if (creds) {
+    candidates.push({
+      path: "channels.whatsapp.creds.json",
+      value: creds.json,
+    });
+  }
+  const accounts = isRecord(whatsapp.accounts) ? whatsapp.accounts : null;
+  if (!accounts) {
+    return candidates;
+  }
+  for (const [accountId, account] of Object.entries(accounts)) {
+    if (!isRecord(account)) {
+      continue;
+    }
+    const accountCreds = isRecord(account.creds) ? account.creds : null;
+    if (!accountCreds) {
+      continue;
+    }
+    candidates.push({
+      path: `channels.whatsapp.accounts.${accountId}.creds.json`,
+      value: accountCreds.json,
+    });
+  }
+
+  return candidates;
+}


### PR DESCRIPTION
## Summary

- Problem: Gateway service restart drift checks produced false-positive token drift/unavailable warnings when `gateway.auth.token` used SecretRef, and unsupported runtime-mutable SecretRef surfaces were not consistently hard-failed early.
- Why it matters: operators saw noisy or misleading drift warnings, and invalid SecretRef policy combinations could survive until later runtime paths.
- What changed: implemented service-env-aware SecretRef drift resolution in restart checks, added explicit unsupported SecretRef policy validation for mutable config/auth surfaces, and enforced OAuth + SecretRef hard-fail in auth-profile runtime resolution paths.
- What did NOT change (scope boundary): this PR does not implement/install-path fixes for `gateway install --force` file/plist SecretRef handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55029
- Closes #57211
- Related #53742
- Related #57261
- Related #55448
- Related #57411
- [x] This PR fixes a bug or regression

## C2 Cluster Coverage Matrix

Fully addressed:

- #55029 (restart drift-check cannot verify env-backed SecretRef token)
  - Addressed by service-env-aware token SecretRef resolution in restart drift check.
- #57211 (restart false-positive token drift warning for SecretRef token)
  - Addressed by active-mode-aware token resolution and warning suppression when resolved values match.
- #55448 (open PR in same area)
  - Addressed/superseded by this PR’s restart drift-check fix path and tests.
- #57411 (open PR in same area)
  - Addressed/superseded by this PR’s restart false-positive warning fix path and tests.

Partially addressed:

- #53742
  - Addressed: restart/doctor drift-loop symptom caused by SecretRef drift-check resolution behavior.
  - Not addressed: `gateway install --force` plaintext projection concern in LaunchAgent plist handling.
- #57261
  - Addressed: drift-check SecretRef resolution behavior during restart evaluation.
  - Not addressed: install-path failure behavior for file-backed `gateway.auth.token` SecretRef.

Additional post-review blocker fix:

- Parent-path bypass in `config set` policy hard-fail (setting parent objects like `hooks`/`channels.discord` with nested unsupported SecretRef values).
  - Addressed by commit `6316fd3584`: removed requested-path gating and now runs unsupported SecretRef policy validation unconditionally on post-mutation config before write.
  - Regression coverage: `src/cli/config-cli.test.ts`
    - `fails early when parent-object writes include unsupported SecretRef objects`
    - `does not duplicate policy errors in --dry-run --json mode for parent-object writes`

## Root Cause / Regression History (if applicable)

- Root cause: drift-check token resolution used config-only/empty-env paths that did not mirror actual service runtime env inputs for SecretRef-backed tokens.
- Missing detection / guardrail: no restart-focused tests covered merged service command env + SecretRef token resolution and no early policy gate for unsupported mutable SecretRef paths.
- Prior context (`git blame`, prior PR, issue, or refactor if known): open bug threads #55029/#57211 and open PRs #55448/#57411 identified the restart drift check path.
- Why this regressed now: SecretRef support expansion outpaced drift-check parity and policy hard-fail coverage for runtime-mutable surfaces.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/cli/daemon-cli/gateway-token-drift.test.ts`
  - `src/cli/daemon-cli/lifecycle-core.test.ts`
  - `src/config/validation.policy.test.ts`
  - `src/secrets/runtime-auth-profiles-oauth-policy.test.ts`
  - `src/secrets/runtime.integration.test.ts`
- Scenario the test should lock in: restart drift check resolves SecretRef token using service env and avoids false drift warnings; unsupported mutable SecretRef policy fails early; OAuth + SecretRef profile combinations hard-fail in startup/reload/auth resolution.
- Why this is the smallest reliable guardrail: these tests hit the exact drift and policy seams without unrelated end-to-end harness overhead.
- Existing test that already covers this (if any): updated lifecycle/drift tests now cover merged-env restart behavior.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `openclaw gateway restart` drift checks now resolve `gateway.auth.token` SecretRefs with merged service+process env inputs and reduce false-positive drift warnings.
- Drift checks skip config token resolution when `gateway.auth.mode` disables token auth (`password`, `none`, `trusted-proxy`).
- Unsupported runtime-mutable SecretRef assignments fail early with policy guidance in config validation/config-set paths.
- OAuth-mode auth-profile + SecretRef combinations now hard-fail in runtime/auth resolution paths.

## Diagram (if applicable)

```text
Before:
[gateway restart] -> [config token drift check with incomplete env] -> [SecretRef unavailable/false drift warning]

After:
[gateway restart] -> [drift check with merged service env + mode-aware token resolution] -> [accurate drift result]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:
  - Risk: stricter policy can reject previously accepted-but-invalid SecretRef configs.
  - Mitigation: deterministic error messages + docs updates clarify supported vs unsupported SecretRef surfaces.

## Repro + Verification

### Environment

- OS: macOS + Linux test fixtures
- Runtime/container: local Node/Bun test harness
- Model/provider: N/A
- Integration/channel (if any): gateway/daemon CLI and auth-profile runtime paths
- Relevant config (redacted): `gateway.auth.token` SecretRef via env/file provider, auth profile mode combinations

### Steps

1. Configure `gateway.auth.token` as SecretRef and set service env token source.
2. Run restart/drift-check paths.
3. Attempt unsupported mutable SecretRef assignments and OAuth+SecretRef mode combinations.

### Expected

- Accurate/noisy-free drift behavior in restart path for resolvable SecretRef token.
- Early hard-fail for unsupported policy combinations.

### Actual

- Matches expected in scoped tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Scoped verification command (pass):

- `pnpm test -- src/config/validation.policy.test.ts src/cli/config-cli.test.ts src/cli/daemon-cli/gateway-token-drift.test.ts src/cli/daemon-cli/lifecycle-core.test.ts src/agents/auth-profiles/oauth.test.ts src/secrets/runtime-auth-profiles-oauth-policy.test.ts src/secrets/runtime.integration.test.ts src/commands/doctor-gateway-services.test.ts src/secrets/target-registry.test.ts`

## Human Verification (required)

- Verified scenarios: restart drift-check SecretRef resolution, lifecycle drift warning behavior, unsupported mutable SecretRef validation, OAuth+SecretRef hard-fail behavior, docs/matrix sync.
- Edge cases checked: token mode disabled (`password`), unresolved active refs, reload keeps last-known-good snapshot.
- What you did **not** verify: full unrelated repo-wide suite (known unrelated skills/test lane failures remain out of this branch scope).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes (for valid supported configs)
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: stricter policy gating may break previously tolerated but philosophically invalid config shapes.
  - Mitigation: explicit policy errors point to canonical SecretRef surface docs; behavior is intentional hard-fail for unsupported mutable/OAuth combinations.
- Risk: restart drift behavior change could alter warning visibility for edge deployments.
  - Mitigation: added targeted tests for merged env and mode-gated token resolution.

