### PR TITLE
feat(slack): add message search support via search.messages API

### DIFF
--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -13,6 +13,7 @@ import {
   readSlackMessages,
   removeOwnSlackReactions,
   removeSlackReaction,
+  searchSlackMessages,
   sendSlackMessage,
   unpinSlackMessage,
 } from "./actions.js";
@@ -57,6 +58,7 @@ export const slackActionRuntime = {
   recordSlackThreadParticipation,
   removeOwnSlackReactions,
   removeSlackReaction,
+  searchSlackMessages,
   sendSlackMessage,
   unpinSlackMessage,
 };
@@ -440,6 +442,32 @@ export async function handleSlackAction(
       ? await slackActionRuntime.getSlackMemberInfo(userId, readOpts)
       : await slackActionRuntime.getSlackMemberInfo(userId);
     return jsonResult({ ok: true, info });
+  }
+
+  if (action === "searchMessages") {
+    if (!isActionEnabled("messages")) {
+      throw new Error("Slack messages are disabled.");
+    }
+    if (!userToken) {
+      throw new Error(
+        "Slack search requires a User Token (xoxp-) with search:read scope. " +
+          "Set channels.slack.userToken in your config.",
+      );
+    }
+    const query = readStringParam(params, "query", { required: true });
+    const count = readNumberParam(params, "count", { integer: true });
+    const sort = readStringParam(params, "sort") as "score" | "timestamp" | undefined;
+    const sortDir = readStringParam(params, "sortDir") as "asc" | "desc" | undefined;
+    const page = readNumberParam(params, "page", { integer: true });
+    const result = await slackActionRuntime.searchSlackMessages(query, {
+      ...(accountId ? { accountId } : {}),
+      token: userToken,
+      count: count ?? undefined,
+      sort: sort ?? undefined,
+      sortDir: sortDir ?? undefined,
+      page: page ?? undefined,
+    });
+    return jsonResult({ ok: true, ...result });
   }
 
   if (action === "emojiList") {

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -467,7 +467,17 @@ export async function handleSlackAction(
       sortDir: sortDir ?? undefined,
       page: page ?? undefined,
     });
-    return jsonResult({ ok: true, ...result });
+    // Wrap matches in `results.messages` so the CLI text formatter renders
+    // them via the shared search-results path (extractDiscordSearchResultsMessages).
+    return jsonResult({
+      ok: true,
+      results: {
+        messages: result.matches,
+      },
+      total: result.total,
+      page: result.page,
+      pages: result.pages,
+    });
   }
 
   if (action === "emojiList") {

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -286,6 +286,60 @@ export async function listSlackPins(
   return (result.items ?? []) as SlackPin[];
 }
 
+export type SlackSearchMatch = {
+  ts?: string;
+  text?: string;
+  user?: string;
+  username?: string;
+  channel?: { id?: string; name?: string };
+  permalink?: string;
+  thread_ts?: string;
+};
+
+export type SlackSearchResult = {
+  matches: SlackSearchMatch[];
+  total: number;
+  page: number;
+  pages: number;
+};
+
+export async function searchSlackMessages(
+  query: string,
+  opts: SlackActionClientOpts & {
+    count?: number;
+    sort?: "score" | "timestamp";
+    sortDir?: "asc" | "desc";
+    page?: number;
+  } = {},
+): Promise<SlackSearchResult> {
+  // search.messages は User Token (xoxp-) でのみ動作する
+  const client = await getClient(opts);
+  const result = await client.search.messages({
+    query,
+    count: opts.count,
+    sort: opts.sort,
+    sort_dir: opts.sortDir,
+    page: opts.page,
+  });
+  const messages = result.messages;
+  const paging = messages?.paging as { page?: number; pages?: number } | undefined;
+  const rawMatches = (messages?.matches ?? []) as Array<Record<string, unknown>>;
+  return {
+    matches: rawMatches.map((m) => ({
+      ts: m.ts as string | undefined,
+      text: m.text as string | undefined,
+      username: m.username as string | undefined,
+      user: m.user as string | undefined,
+      channel: m.channel as { id?: string; name?: string } | undefined,
+      permalink: m.permalink as string | undefined,
+      thread_ts: m.thread_ts as string | undefined,
+    })),
+    total: messages?.total ?? 0,
+    page: paging?.page ?? 1,
+    pages: paging?.pages ?? 1,
+  };
+}
+
 type SlackFileInfoSummary = {
   id?: string;
   name?: string;

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -312,7 +312,7 @@ export async function searchSlackMessages(
     page?: number;
   } = {},
 ): Promise<SlackSearchResult> {
-  // search.messages は User Token (xoxp-) でのみ動作する
+  // search.messages requires a User Token (xoxp-), not a Bot Token
   const client = await getClient(opts);
   const result = await client.search.messages({
     query,

--- a/extensions/slack/src/message-action-dispatch.ts
+++ b/extensions/slack/src/message-action-dispatch.ts
@@ -181,6 +181,29 @@ export async function handleSlackMessageAction(params: {
     return await invoke({ action: "emojiList", limit, accountId }, cfg);
   }
 
+  if (action === "search") {
+    const query = readStringParam(actionParams, "query", { required: true });
+    const count = readNumberParam(actionParams, "limit", { integer: true });
+    const sort = readStringParam(actionParams, "sort") as "score" | "timestamp" | undefined;
+    const sortDir = readStringParam(actionParams, "sortDir") as "asc" | "desc" | undefined;
+    const page = readNumberParam(actionParams, "page", { integer: true });
+    const channelId = readStringParam(actionParams, "channelId");
+    // channelId がある場合、Slack の search query に "in:<channel>" を付与する
+    const fullQuery = channelId ? `${query} in:<${channelId}>` : query;
+    return await invoke(
+      {
+        action: "searchMessages",
+        query: fullQuery,
+        count: count ?? undefined,
+        sort: sort ?? undefined,
+        sortDir: sortDir ?? undefined,
+        page: page ?? undefined,
+        accountId,
+      },
+      cfg,
+    );
+  }
+
   if (action === "download-file") {
     const fileId = readStringParam(actionParams, "fileId", { required: true });
     const channelId =

--- a/extensions/slack/src/message-action-dispatch.ts
+++ b/extensions/slack/src/message-action-dispatch.ts
@@ -189,7 +189,7 @@ export async function handleSlackMessageAction(params: {
     const page = readNumberParam(actionParams, "page", { integer: true });
     const channelId = readStringParam(actionParams, "channelId");
     // channelId がある場合、Slack の search query に "in:<channel>" を付与する
-    const fullQuery = channelId ? `${query} in:<${channelId}>` : query;
+    const fullQuery = channelId ? `${query} in:${channelId}` : query;
     return await invoke(
       {
         action: "searchMessages",

--- a/extensions/slack/src/message-action-dispatch.ts
+++ b/extensions/slack/src/message-action-dispatch.ts
@@ -188,7 +188,7 @@ export async function handleSlackMessageAction(params: {
     const sortDir = readStringParam(actionParams, "sortDir") as "asc" | "desc" | undefined;
     const page = readNumberParam(actionParams, "page", { integer: true });
     const channelId = readStringParam(actionParams, "channelId");
-    // channelId がある場合、Slack の search query に "in:<channel>" を付与する
+    // Scope search to a specific channel when channelId is provided
     const fullQuery = channelId ? `${query} in:${channelId}` : query;
     return await invoke(
       {

--- a/extensions/slack/src/message-actions.ts
+++ b/extensions/slack/src/message-actions.ts
@@ -35,6 +35,10 @@ export function listSlackMessageActions(cfg: OpenClawConfig): ChannelMessageActi
     actions.add("delete");
     actions.add("download-file");
     actions.add("upload-file");
+    // search requires a User Token (xoxp-) — only advertise when at least one account has it
+    if (accounts.some((account) => account.userToken?.trim())) {
+      actions.add("search");
+    }
   }
   if (isActionEnabled("pins")) {
     actions.add("pin");

--- a/extensions/slack/src/message-actions.ts
+++ b/extensions/slack/src/message-actions.ts
@@ -35,8 +35,10 @@ export function listSlackMessageActions(cfg: OpenClawConfig): ChannelMessageActi
     actions.add("delete");
     actions.add("download-file");
     actions.add("upload-file");
-    // search requires a User Token (xoxp-) — only advertise when at least one account has it
-    if (accounts.some((account) => account.userToken?.trim())) {
+    // search requires a User Token (xoxp-) — check ALL enabled accounts (not just
+    // bot-token accounts) so user-token-only setups can still discover search.
+    const allAccounts = listEnabledSlackAccounts(cfg);
+    if (allAccounts.some((account) => account.userToken?.trim())) {
       actions.add("search");
     }
   }

--- a/src/cli/program/message/register.permissions-search.ts
+++ b/src/cli/program/message/register.permissions-search.ts
@@ -17,7 +17,7 @@ export function registerMessagePermissionsCommand(message: Command, helpers: Mes
 export function registerMessageSearchCommand(message: Command, helpers: MessageCliHelpers) {
   helpers
     .withMessageBase(message.command("search").description("Search messages"))
-    .option("--guild-id <id>", "Guild id (Discord)")
+    .option("--guild-id <id>", "Guild id (required for Discord)")
     .requiredOption("--query <text>", "Search query")
     .option("--channel-id <id>", "Channel id")
     .option("--channel-ids <id>", "Channel id (repeat)", collectOption, [] as string[])

--- a/src/cli/program/message/register.permissions-search.ts
+++ b/src/cli/program/message/register.permissions-search.ts
@@ -16,14 +16,16 @@ export function registerMessagePermissionsCommand(message: Command, helpers: Mes
 
 export function registerMessageSearchCommand(message: Command, helpers: MessageCliHelpers) {
   helpers
-    .withMessageBase(message.command("search").description("Search Discord messages"))
-    .requiredOption("--guild-id <id>", "Guild id")
+    .withMessageBase(message.command("search").description("Search messages"))
+    .option("--guild-id <id>", "Guild id (Discord)")
     .requiredOption("--query <text>", "Search query")
     .option("--channel-id <id>", "Channel id")
     .option("--channel-ids <id>", "Channel id (repeat)", collectOption, [] as string[])
     .option("--author-id <id>", "Author id")
     .option("--author-ids <id>", "Author id (repeat)", collectOption, [] as string[])
     .option("--limit <n>", "Result limit")
+    .option("--sort <type>", "Sort by (score, timestamp)")
+    .option("--sort-dir <dir>", "Sort direction (asc, desc)")
     .action(async (opts) => {
       await helpers.runMessageAction("search", opts);
     });


### PR DESCRIPTION
## Summary

Add Slack message search support using the `search.messages` Web API. Addresses #38716 and #54224.

## Changes

| File | Change |
|------|--------|
| `extensions/slack/src/actions.ts` | `searchSlackMessages()` function + `SlackSearchMatch`/`SlackSearchResult` types |
| `extensions/slack/src/action-runtime.ts` | `searchMessages` action handler with User Token guard |
| `extensions/slack/src/message-action-dispatch.ts` | `search` → `searchMessages` dispatch + optional `in:<channel>` query scoping |
| `extensions/slack/src/message-actions.ts` | Advertise `search` only when a User Token is configured |
| `src/cli/program/message/register.permissions-search.ts` | Make `--guild-id` optional (was required, Discord-only), add `--sort`/`--sort-dir` |

## Requirements

- **User Token** (`xoxp-`) with `search:read` scope — Bot Tokens cannot call `search.messages`
- Set via `openclaw config set channels.slack.userToken <token>`

## Usage

```bash
# Basic search
openclaw message search --channel slack --query "deployment"

# With options
openclaw message search --channel slack --query "bug fix" --limit 10 --sort timestamp --sort-dir desc

# Scoped to a channel
openclaw message search --channel slack --query "release" --channel-id C0AB51884E6
```

## Design decisions

- **User Token gating**: `search` is only advertised as an available action when at least one Slack account has a User Token configured, preventing confusing runtime errors
- **`in:<channel>` scoping**: When `--channel-id` is provided, it's appended to the query as `in:<id>` (Slack search accepts both channel names and IDs)
- **Follows existing patterns**: Parameter reading, dispatch flow, and response format match `read`/`react`/`pin` etc.
- **`--guild-id` made optional**: Was previously `requiredOption` which blocked Slack usage; Discord search still works the same way

## Testing

- ✅ TypeScript type check (`tsgo --noEmit`) — 0 errors
- ✅ oxlint — 0 warnings/errors
- ⏳ Runtime test pending User Token configuration
