### PR TITLE
fix: add retry logic for Windows EPERM errors in atomic file writes

### DIFF
--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -1,11 +1,17 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { setTimeout as sleep } from "node:timers/promises";
+import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "./backoff.ts";
 
 const MAX_RETRIES = 5;
-const RETRY_BASE_DELAY_MS = 50;
 const IS_WINDOWS = process.platform === "win32";
+
+const EPERM_BACKOFF: BackoffPolicy = {
+  initialMs: 100,
+  maxMs: 1_600,
+  factor: 2,
+  jitter: 0.25,
+};
 
 export async function readJsonFile<T>(filePath: string): Promise<T | null> {
   try {
@@ -42,8 +48,8 @@ export async function writeTextAtomic(
     mkdirOptions.mode = options.ensureDirMode;
   }
   const parentDir = path.dirname(filePath);
+  await fs.mkdir(parentDir, mkdirOptions);
   for (let attempt = 1; attempt <= MAX_RETRIES + 1; attempt++) {
-    await fs.mkdir(parentDir, mkdirOptions);
     const tmp = `${filePath}.${randomUUID()}.tmp`;
     try {
       const tmpHandle = await fs.open(tmp, "w", mode);
@@ -85,8 +91,8 @@ export async function writeTextAtomic(
         err.code === "EPERM" &&
         attempt < MAX_RETRIES + 1
       ) {
-        const delay = 2 ** attempt * RETRY_BASE_DELAY_MS;
-        await sleep(delay);
+        const delay = computeBackoff(EPERM_BACKOFF, attempt);
+        await sleepWithAbort(delay);
         continue;
       }
       throw err;

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -49,7 +49,7 @@ export async function writeTextAtomic(
   }
   const parentDir = path.dirname(filePath);
   await fs.mkdir(parentDir, mkdirOptions);
-  for (let attempt = 1; attempt <= MAX_RETRIES + 1; attempt++) {
+  for (let attempt = 0; attempt < MAX_RETRIES + 1; attempt++) {
     const tmp = `${filePath}.${randomUUID()}.tmp`;
     try {
       const tmpHandle = await fs.open(tmp, "w", mode);
@@ -89,9 +89,9 @@ export async function writeTextAtomic(
         typeof err === "object" &&
         "code" in err &&
         err.code === "EPERM" &&
-        attempt < MAX_RETRIES + 1
+        attempt < MAX_RETRIES
       ) {
-        const delay = computeBackoff(EPERM_BACKOFF, attempt);
+        const delay = computeBackoff(EPERM_BACKOFF, attempt + 1);
         await sleepWithAbort(delay);
         continue;
       }

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const MAX_RETRIES = 5;
+const RETRY_BASE_DELAY_MS = 50;
+const IS_WINDOWS = process.platform === "win32";
 
 export async function readJsonFile<T>(filePath: string): Promise<T | null> {
   try {
@@ -36,40 +41,58 @@ export async function writeTextAtomic(
   if (typeof options?.ensureDirMode === "number") {
     mkdirOptions.mode = options.ensureDirMode;
   }
-  await fs.mkdir(path.dirname(filePath), mkdirOptions);
   const parentDir = path.dirname(filePath);
-  const tmp = `${filePath}.${randomUUID()}.tmp`;
-  try {
-    const tmpHandle = await fs.open(tmp, "w", mode);
+  for (let attempt = 1; attempt <= MAX_RETRIES + 1; attempt++) {
+    await fs.mkdir(parentDir, mkdirOptions);
+    const tmp = `${filePath}.${randomUUID()}.tmp`;
     try {
-      await tmpHandle.writeFile(payload, { encoding: "utf8" });
-      await tmpHandle.sync();
-    } finally {
-      await tmpHandle.close().catch(() => undefined);
-    }
-    try {
-      await fs.chmod(tmp, mode);
-    } catch {
-      // best-effort; ignore on platforms without chmod
-    }
-    await fs.rename(tmp, filePath);
-    try {
-      const dirHandle = await fs.open(parentDir, "r");
+      const tmpHandle = await fs.open(tmp, "w", mode);
       try {
-        await dirHandle.sync();
+        await tmpHandle.writeFile(payload, { encoding: "utf8" });
+        await tmpHandle.sync();
       } finally {
-        await dirHandle.close().catch(() => undefined);
+        await tmpHandle.close().catch(() => undefined);
       }
-    } catch {
-      // best-effort; some platforms/filesystems do not support syncing directories.
+      try {
+        await fs.chmod(tmp, mode);
+      } catch {
+        // best-effort; ignore on platforms without chmod
+      }
+      await fs.rename(tmp, filePath);
+      try {
+        const dirHandle = await fs.open(parentDir, "r");
+        try {
+          await dirHandle.sync();
+        } finally {
+          await dirHandle.close().catch(() => undefined);
+        }
+      } catch {
+        // best-effort; some platforms/filesystems do not support syncing directories.
+      }
+      try {
+        await fs.chmod(filePath, mode);
+      } catch {
+        // best-effort; ignore on platforms without chmod
+      }
+      return;
+    } catch (err) {
+      // Only retry on Windows; other platforms should fail fast
+      if (
+        IS_WINDOWS &&
+        err &&
+        typeof err === "object" &&
+        "code" in err &&
+        err.code === "EPERM" &&
+        attempt < MAX_RETRIES + 1
+      ) {
+        const delay = 2 ** attempt * RETRY_BASE_DELAY_MS;
+        await sleep(delay);
+        continue;
+      }
+      throw err;
+    } finally {
+      await fs.rm(tmp, { force: true }).catch(() => undefined);
     }
-    try {
-      await fs.chmod(filePath, mode);
-    } catch {
-      // best-effort; ignore on platforms without chmod
-    }
-  } finally {
-    await fs.rm(tmp, { force: true }).catch(() => undefined);
   }
 }
 


### PR DESCRIPTION
- Fix Windows EPERM error on atomic file writes
- Add exponential backoff retry logic for file lock race conditions
- Handle concurrent writes to pending.json on Windows platforms

fixed #52093
dont know if this is too aggressive to have 5 retries and maximum 3100ms retry time,maybe need core member to tweak a bit