### PR TITLE
fix(config): DATABASE_URL missing warning fires 3310+ times per run causing log spam and stack overflow

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1720,9 +1720,13 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       const legacyResolution = resolveLegacyConfigForRead(resolvedConfig, effectiveParsed);
       const effectiveConfigRaw = legacyResolution.effectiveConfigRaw;
       for (const w of readResolution.envWarnings) {
-        deps.logger.warn(
-          `Config (${configPath}): missing env var "${w.varName}" at ${w.configPath} - feature using this value will be unavailable`,
-        );
+        const dedupeKey = `${w.varName}:${w.configPath}`;
+        if (!emittedEnvVarWarnings.has(dedupeKey)) {
+          emittedEnvVarWarnings.add(dedupeKey);
+          deps.logger.warn(
+            `Config (${configPath}): missing env var "${w.varName}" at ${w.configPath} - feature using this value will be unavailable`,
+          );
+        }
       }
       warnOnConfigMiskeys(effectiveConfigRaw, deps.logger);
       if (typeof effectiveConfigRaw !== "object" || effectiveConfigRaw === null) {
@@ -2381,6 +2385,7 @@ let runtimeConfigSnapshot: OpenClawConfig | null = null;
 let runtimeConfigSourceSnapshot: OpenClawConfig | null = null;
 let runtimeConfigSnapshotRefreshHandler: RuntimeConfigSnapshotRefreshHandler | null = null;
 const configWriteListeners = new Set<(event: ConfigWriteNotification) => void>();
+const emittedEnvVarWarnings = new Set<string>();
 
 function notifyConfigWriteListeners(event: ConfigWriteNotification): void {
   for (const listener of configWriteListeners) {
@@ -2419,6 +2424,7 @@ export function resetConfigRuntimeState(): void {
 }
 
 export function clearRuntimeConfigSnapshot(): void {
+  emittedEnvVarWarnings.clear();
   resetConfigRuntimeState();
 }
 

--- a/src/logging/config.ts
+++ b/src/logging/config.ts
@@ -6,15 +6,25 @@ type LoggingConfig = OpenClawConfig["logging"];
 
 const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
 
+let readingLoggingConfig = false;
+
 export function shouldSkipMutatingLoggingConfigRead(argv: string[] = process.argv): boolean {
   const [primary, secondary] = getCommandPathWithRootOptions(argv, 2);
   return primary === "config" && (secondary === "schema" || secondary === "validate");
+}
+
+export function isReadingLoggingConfig(): boolean {
+  return readingLoggingConfig;
 }
 
 export function readLoggingConfig(): LoggingConfig | undefined {
   if (shouldSkipMutatingLoggingConfigRead()) {
     return undefined;
   }
+  if (readingLoggingConfig) {
+    return undefined;
+  }
+  readingLoggingConfig = true;
   try {
     const loaded = requireConfig?.("../config/config.js") as
       | {
@@ -29,5 +39,7 @@ export function readLoggingConfig(): LoggingConfig | undefined {
     return logging as LoggingConfig;
   } catch {
     return undefined;
+  } finally {
+    readingLoggingConfig = false;
   }
 }

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -2,7 +2,11 @@ import util from "node:util";
 import type { OpenClawConfig } from "../config/types.js";
 import { isVerbose } from "../global-state.js";
 import { stripAnsi } from "../terminal/ansi.js";
-import { readLoggingConfig, shouldSkipMutatingLoggingConfigRead } from "./config.js";
+import {
+  isReadingLoggingConfig,
+  readLoggingConfig,
+  shouldSkipMutatingLoggingConfigRead,
+} from "./config.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, normalizeLogLevel } from "./levels.js";
 import { getLogger, type LoggerSettings } from "./logger.js";
@@ -72,7 +76,14 @@ function resolveConsoleSettings(): ConsoleSettings {
   }
 
   let cfg: OpenClawConfig["logging"] | undefined =
-    (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
+    (loggingState.overrideSettings as LoggerSettings | null) ?? undefined;
+  if (!cfg) {
+    if (loggingState.resolvingConsoleSettings || isReadingLoggingConfig()) {
+      cfg = undefined;
+    } else {
+      cfg = readLoggingConfig();
+    }
+  }
   if (!cfg && !shouldSkipMutatingLoggingConfigRead()) {
     if (loggingState.resolvingConsoleSettings) {
       cfg = undefined;

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -6,7 +6,11 @@ import {
   POSIX_OPENCLAW_TMP_DIR,
   resolvePreferredOpenClawTmpDir,
 } from "../infra/tmp-openclaw-dir.js";
-import { readLoggingConfig, shouldSkipMutatingLoggingConfigRead } from "./config.js";
+import {
+  isReadingLoggingConfig,
+  readLoggingConfig,
+  shouldSkipMutatingLoggingConfigRead,
+} from "./config.js";
 import type { ConsoleStyle } from "./console.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
@@ -114,8 +118,11 @@ function resolveSettings(): ResolvedSettings {
   }
 
   let cfg: OpenClawConfig["logging"] | undefined =
-    (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
-  if (!cfg && !shouldSkipMutatingLoggingConfigRead()) {
+    (loggingState.overrideSettings as LoggerSettings | null) ?? undefined;
+  if (!cfg && !isReadingLoggingConfig()) {
+    cfg = readLoggingConfig();
+  }
+  if (!cfg && !shouldSkipMutatingLoggingConfigRead() && !isReadingLoggingConfig()) {
     try {
       const loaded = requireConfig?.("../config/config.js") as
         | {


### PR DESCRIPTION
## Fix: Eliminate infinite config-read loop when `DATABASE_URL` is unset

### Problem

When the `DATABASE_URL` environment variable is not set, config validation emits a warning on **every** config read — producing **3,310+ duplicate warnings** in a single session.

The root cause is a re-entrant config read cycle:


The logging system calls into the config layer, which tries to log a warning, which re-enters the config layer, and so on — creating an infinite loop of redundant warnings and wasted work.

### Solution

Two complementary fixes:

1. **Deduplicate env-var-missing warnings** — emit once per process per missing key, not once per read.
2. **Guard the logging path against re-entrant config reads** — break the cycle at the point where logging re-enters config resolution.

### Changes

| File | Change |
|---|---|
| `src/config/io.ts` | Deduplicate env-var-missing warnings using an `emittedEnvVarWarnings` Set, cleared on `clearRuntimeConfigSnapshot()` |
| `src/logging/config.ts` | Add re-entrancy guard to `readLoggingConfig()` with a `readingLoggingConfig` flag and `isReadingLoggingConfig()` accessor |
| `src/logging/console.ts` | Check `isReadingLoggingConfig()` before calling `readLoggingConfig()` in `resolveConsoleSettings()` (previously only the `loadConfigFallback` path was guarded) |
| `src/logging/logger.ts` | Guard both `readLoggingConfig()` and `loadConfig()` fallback paths in `resolveSettings()` |

### Before / After

**Before:** Missing `DATABASE_URL` → 3,310+ warnings per session, potential perf hit from re-entrant config reads.

**After:** Missing `DATABASE_URL` → 1 warning per process. No re-entrant reads.

---

Closes #58080
