### PR TITLE
fix(agents): persist generic CLI transcript for completion capture

### DIFF
--- a/src/agents/command/attempt-execution.cli-transcript.test.ts
+++ b/src/agents/command/attempt-execution.cli-transcript.test.ts
@@ -1,0 +1,138 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { persistCliTurnTranscript } from "./attempt-execution.js";
+
+const chatHistoryMock = vi.fn<(sessionKey: string) => Promise<{ messages?: Array<unknown> }>>(
+  async (_sessionKey: string) => ({ messages: [] }),
+);
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: vi.fn(async (request: unknown) => {
+    const typed = request as { method?: string; params?: { sessionKey?: string } };
+    if (typed.method === "chat.history") {
+      return await chatHistoryMock(typed.params?.sessionKey ?? "");
+    }
+    return {};
+  }),
+}));
+
+type TranscriptRecord = {
+  type?: string;
+  message?: unknown;
+};
+
+function extractAssistantText(message: unknown): string {
+  if (!message || typeof message !== "object") {
+    return "";
+  }
+  const msg = message as { content?: unknown };
+  const content = msg.content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .flatMap((block) => {
+      if (!block || typeof block !== "object") {
+        return [] as string[];
+      }
+      const typed = block as { type?: unknown; text?: unknown };
+      if (typed.type === "text" && typeof typed.text === "string") {
+        return [typed.text];
+      }
+      return [] as string[];
+    })
+    .join("\n")
+    .trim();
+}
+
+async function readTranscriptMessages(sessionFile: string): Promise<unknown[]> {
+  try {
+    const raw = await fs.readFile(sessionFile, "utf-8");
+    const messages: unknown[] = [];
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(line) as TranscriptRecord;
+        if (parsed.type === "message" && parsed.message) {
+          messages.push(parsed.message);
+        }
+      } catch {
+        // Ignore non-message or malformed lines in this narrow regression test.
+      }
+    }
+    return messages;
+  } catch {
+    return [];
+  }
+}
+
+describe("persistCliTurnTranscript", () => {
+  let tempDir = "";
+  let sessionFile = "";
+  let captureSubagentCompletionReply: (typeof import("../subagent-announce.js"))["captureSubagentCompletionReply"];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ captureSubagentCompletionReply } = await import("../subagent-announce.js"));
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-transcript-"));
+    sessionFile = path.join(tempDir, "session.jsonl");
+    chatHistoryMock.mockReset().mockImplementation(async () => ({
+      messages: await readTranscriptMessages(sessionFile),
+    }));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("writes CLI assistant output into transcript history so completion capture can read it", async () => {
+    const expectedText = "ROUTE_OK\nroute=cli-transcript-test";
+
+    await persistCliTurnTranscript({
+      body: "Probe prompt for CLI transcript persistence",
+      result: {
+        payloads: [{ text: expectedText }],
+        meta: {
+          durationMs: 12,
+          stopReason: "stop",
+          agentMeta: {
+            sessionId: "cli-session-1",
+            provider: "google-gemini-cli",
+            model: "gemini-2.5-flash",
+            usage: {
+              input: 11,
+              output: 7,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: 18,
+            },
+          },
+        },
+      },
+      sessionId: "validation-session-1",
+      sessionKey: undefined,
+      sessionFile,
+      sessionEntry: undefined,
+      sessionAgentId: "main",
+      sessionCwd: tempDir,
+      provider: "google-gemini-cli",
+      model: "gemini-2.5-flash",
+    });
+
+    const transcriptMessages = await readTranscriptMessages(sessionFile);
+    expect(transcriptMessages).toHaveLength(2);
+    expect((transcriptMessages[0] as { role?: unknown }).role).toBe("user");
+    expect((transcriptMessages[1] as { role?: unknown }).role).toBe("assistant");
+    expect(extractAssistantText(transcriptMessages[1])).toBe(expectedText);
+
+    const captured = await captureSubagentCompletionReply("agent:main:subagent:child");
+    expect(captured).toBe(expectedText);
+  });
+});

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -301,6 +301,85 @@ export async function persistAcpTurnTranscript(params: {
   return sessionEntry;
 }
 
+export async function persistCliTurnTranscript(params: {
+  body: string;
+  result: Awaited<ReturnType<typeof runCliAgent>>;
+  sessionId: string;
+  sessionKey?: string;
+  sessionFile: string;
+  sessionEntry: SessionEntry | undefined;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  sessionAgentId: string;
+  threadId?: string | number;
+  sessionCwd: string;
+  provider: string;
+  model: string;
+}): Promise<SessionEntry | undefined> {
+  const promptText = params.body;
+  const payloadText = params.result.payloads
+    ?.map((payload) => (typeof payload?.text === "string" ? payload.text : ""))
+    .filter((text): text is string => Boolean(text?.trim()))
+    .join("\n\n");
+  const replyText = normalizeReplyPayload({ text: payloadText ?? "" })?.text ?? "";
+
+  if (!promptText && !replyText) {
+    return params.sessionEntry;
+  }
+
+  const resolved = params.sessionKey
+    ? await resolveSessionTranscriptFile({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        sessionEntry: params.sessionEntry,
+        sessionStore: params.sessionStore,
+        storePath: params.storePath,
+        agentId: params.sessionAgentId,
+        threadId: params.threadId,
+      })
+    : {
+        sessionFile: params.sessionFile,
+        sessionEntry: params.sessionEntry,
+      };
+
+  const hadSessionFile = await fs
+    .access(resolved.sessionFile)
+    .then(() => true)
+    .catch(() => false);
+  const sessionManager = SessionManager.open(resolved.sessionFile);
+  await prepareSessionManagerForRun({
+    sessionManager,
+    sessionFile: resolved.sessionFile,
+    hadSessionFile,
+    sessionId: params.sessionId,
+    cwd: params.sessionCwd,
+  });
+
+  if (promptText) {
+    sessionManager.appendMessage({
+      role: "user",
+      content: promptText,
+      timestamp: Date.now(),
+    });
+  }
+
+  if (replyText) {
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: replyText }],
+      api: "openai-responses",
+      provider: params.provider,
+      model: params.result.meta.agentMeta?.model ?? params.model,
+      usage: ACP_TRANSCRIPT_USAGE,
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+  }
+
+  emitSessionTranscriptUpdate(resolved.sessionFile);
+  return resolved.sessionEntry;
+}
+
 export function runAgentAttempt(params: {
   providerOverride: string;
   modelOverride: string;
@@ -346,6 +425,32 @@ export function runAgentAttempt(params: {
       : undefined;
   if (isCliProvider(params.providerOverride, params.cfg)) {
     const cliSessionBinding = getCliSessionBinding(params.sessionEntry, params.providerOverride);
+    const persistCliTranscript = async (result: Awaited<ReturnType<typeof runCliAgent>>) => {
+      try {
+        params.sessionEntry = await persistCliTurnTranscript({
+          body: effectivePrompt,
+          result,
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          sessionFile: params.sessionFile,
+          sessionEntry: params.sessionEntry,
+          sessionStore: params.sessionStore,
+          storePath: params.storePath,
+          sessionAgentId: params.sessionAgentId,
+          threadId: params.opts.threadId,
+          sessionCwd: params.workspaceDir,
+          provider: params.providerOverride,
+          model: params.modelOverride,
+        });
+      } catch (error) {
+        log.warn(
+          `CLI transcript persistence failed for ${params.sessionKey ?? params.sessionId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+      return result;
+    };
     const runCliWithSession = (nextCliSessionId: string | undefined) =>
       runCliAgent({
         sessionId: params.sessionId,
@@ -371,65 +476,67 @@ export function runAgentAttempt(params: {
         imageOrder: params.isFallbackRetry ? undefined : params.opts.imageOrder,
         streamParams: params.opts.streamParams,
       });
-    return runCliWithSession(cliSessionBinding?.sessionId).catch(async (err) => {
-      if (
-        err instanceof FailoverError &&
-        err.reason === "session_expired" &&
-        cliSessionBinding?.sessionId &&
-        params.sessionKey &&
-        params.sessionStore &&
-        params.storePath
-      ) {
-        log.warn(
-          `CLI session expired, clearing from session store: provider=${sanitizeForLog(params.providerOverride)} sessionKey=${params.sessionKey}`,
-        );
+    return runCliWithSession(cliSessionBinding?.sessionId)
+      .catch(async (err) => {
+        if (
+          err instanceof FailoverError &&
+          err.reason === "session_expired" &&
+          cliSessionBinding?.sessionId &&
+          params.sessionKey &&
+          params.sessionStore &&
+          params.storePath
+        ) {
+          log.warn(
+            `CLI session expired, clearing from session store: provider=${sanitizeForLog(params.providerOverride)} sessionKey=${params.sessionKey}`,
+          );
 
-        const entry = params.sessionStore[params.sessionKey];
-        if (entry) {
-          const updatedEntry = { ...entry };
-          clearCliSession(updatedEntry, params.providerOverride);
-          updatedEntry.updatedAt = Date.now();
+          const entry = params.sessionStore[params.sessionKey];
+          if (entry) {
+            const updatedEntry = { ...entry };
+            clearCliSession(updatedEntry, params.providerOverride);
+            updatedEntry.updatedAt = Date.now();
 
-          await persistSessionEntry({
-            sessionStore: params.sessionStore,
-            sessionKey: params.sessionKey,
-            storePath: params.storePath,
-            entry: updatedEntry,
-          });
+            await persistSessionEntry({
+              sessionStore: params.sessionStore,
+              sessionKey: params.sessionKey,
+              storePath: params.storePath,
+              entry: updatedEntry,
+            });
 
-          params.sessionEntry = updatedEntry;
-        }
-
-        return runCliWithSession(undefined).then(async (result) => {
-          if (
-            result.meta.agentMeta?.cliSessionBinding?.sessionId &&
-            params.sessionKey &&
-            params.sessionStore &&
-            params.storePath
-          ) {
-            const entry = params.sessionStore[params.sessionKey];
-            if (entry) {
-              const updatedEntry = { ...entry };
-              setCliSessionBinding(
-                updatedEntry,
-                params.providerOverride,
-                result.meta.agentMeta.cliSessionBinding,
-              );
-              updatedEntry.updatedAt = Date.now();
-
-              await persistSessionEntry({
-                sessionStore: params.sessionStore,
-                sessionKey: params.sessionKey,
-                storePath: params.storePath,
-                entry: updatedEntry,
-              });
-            }
+            params.sessionEntry = updatedEntry;
           }
-          return result;
-        });
-      }
-      throw err;
-    });
+
+          return runCliWithSession(undefined).then(async (result) => {
+            if (
+              result.meta.agentMeta?.cliSessionBinding?.sessionId &&
+              params.sessionKey &&
+              params.sessionStore &&
+              params.storePath
+            ) {
+              const entry = params.sessionStore[params.sessionKey];
+              if (entry) {
+                const updatedEntry = { ...entry };
+                setCliSessionBinding(
+                  updatedEntry,
+                  params.providerOverride,
+                  result.meta.agentMeta.cliSessionBinding,
+                );
+                updatedEntry.updatedAt = Date.now();
+
+                await persistSessionEntry({
+                  sessionStore: params.sessionStore,
+                  sessionKey: params.sessionKey,
+                  storePath: params.storePath,
+                  entry: updatedEntry,
+                });
+              }
+            }
+            return result;
+          });
+        }
+        throw err;
+      })
+      .then(persistCliTranscript);
   }
 
   return runEmbeddedPiAgent({


### PR DESCRIPTION
## Summary

- Problem: generic CLI-backed runs can produce valid final text but still surface `(no output)` in subagent completion announce because the final CLI text is not persisted into transcript/history.
- Why it matters: completion capture reads `chat.history` / transcript-backed history, so successful generic CLI runs can look empty to the parent even when the CLI backend actually succeeded.
- What changed: add `persistCliTurnTranscript(...)` beside ACP transcript persistence and call it after successful generic CLI runs; add a regression test that verifies completion capture can read the persisted CLI text.
- What did NOT change (scope boundary): no change to Gemini shim behavior, no new CLI backend routing policy, no change to Claude-specific history import behavior, no live config changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #58176
- Related #7324
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `runCliAgent()` returned successful CLI text in the transient result/payload path, but generic CLI-backed runs did not persist that text into the child session transcript/history path used by completion capture.
- Missing detection / guardrail: there was no regression test connecting successful CLI transcript persistence to `captureSubagentCompletionReply(...)`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): generic CLI path differed from ACP path, which already had explicit transcript persistence; Claude CLI also had a separate history import path, masking this class of problem for Claude-backed runs.
- Why this regressed now: generic CLI-backed subagent completion depended on transcript/history visibility, but the CLI execution path never wrote the final assistant turn into transcript history.
- If unknown, what was ruled out: ruled out Gemini invocation/argv failure and shim JSON normalization failure; isolated validation showed completion capture starts working once the CLI turn is written into transcript history.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/command/attempt-execution.cli-transcript.test.ts`
- Scenario the test should lock in: after a successful generic CLI turn is persisted, `captureSubagentCompletionReply(...)` should return the expected final assistant text instead of `(no output)` / empty history.
- Why this is the smallest reliable guardrail: it tests the exact contract edge between CLI transcript persistence and completion capture without requiring a full live gateway or provider-backed run.
- Existing test that already covers this (if any): `src/agents/subagent-announce.capture-completion-reply.test.ts` covers capture behavior, but not the CLI transcript persistence path that feeds it.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Generic CLI-backed subagent completions should now surface the final text correctly when the CLI run succeeded, instead of sometimes announcing `(no output)` because transcript/history was empty.

## Diagram (if applicable)

```text
Before:
[successful generic CLI run] -> [transient payload text only] -> [no transcript entry] -> [completion capture reads empty history] -> [(no output)]

After:
[successful generic CLI run] -> [persist CLI transcript] -> [completion capture reads transcript history] -> [final text delivered]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 22.04 arm64
- Runtime/container: isolated source checkout of `v2026.3.28`
- Model/provider: generic CLI path (provider-independent validation, originally motivated by Gemini CLI)
- Integration/channel (if any): subagent completion capture path
- Relevant config (redacted): none required for the narrow regression test

### Steps

1. Run a successful generic CLI-backed turn that returns non-empty final text.
2. Persist the CLI turn into session transcript/history.
3. Call `captureSubagentCompletionReply(...)` for that session.

### Expected

- completion capture returns the persisted final assistant text

### Actual

- before this patch, generic CLI-backed completion could read empty history and surface `(no output)`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - isolated source-checkout contract validation proved that persisting the CLI transcript is sufficient for completion capture to return the expected text
  - targeted tests passed in the isolated `v2026.3.28` checkout:
    - `pnpm exec vitest run src/agents/command/attempt-execution.cli-transcript.test.ts src/agents/subagent-announce.capture-completion-reply.test.ts`
  - after cherry-picking the fix onto current `main`, the same targeted tests passed again on the PR branch:
    - `pnpm exec vitest run src/agents/command/attempt-execution.cli-transcript.test.ts src/agents/subagent-announce.capture-completion-reply.test.ts`
- Edge cases checked:
  - existing `captureSubagentCompletionReply(...)` tests still passed unchanged
  - patch remains generic to non-Claude CLI providers and does not depend on Gemini-specific shim behavior
- What you did **not** verify:
  - full live gateway end-to-end subagent announce in a production runtime
  - public/upstream CI matrix

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: transcript persistence could duplicate or slightly alter CLI-visible text formatting in edge cases.
  - Mitigation: persist only normalized reply text, keep the change scoped to successful CLI turns, and cover the behavior with a regression test.
- Risk: this fixes transcript/history visibility but does not address unrelated provider-side or announce-scheduling failures.
  - Mitigation: scope the PR explicitly to transcript persistence and keep provider-specific routing/shim changes out of this patch.
