### PR TITLE
fix(line): bound preverify webhook concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,7 @@ Docs: https://docs.openclaw.ai
 - Subagents/announcements: preserve the requester agent id for inline deterministic tool spawns so named agents without channel bindings can still announce completions through the correct owner session. (#55437) Thanks @kAIborg24.
 - Telegram/Anthropic streaming: replace raw invalid stream-order provider errors with a safe retry message so internal `message_start/message_stop` failures do not leak into chats. (#55408) Thanks @imydal.
 - Plugins/context engines: retry strict legacy `assemble()` calls without the new `prompt` field when older engines reject it, preserving prompt-aware retrieval compatibility for pre-prompt plugins. (#50848) thanks @danhdoan.
+- LINE/webhooks: cap shared concurrent pre-verify webhook body reads so excess requests are rejected before entering the LINE body handler. Thanks @nexrin and @vincentkoc.
 - CLI/update status: explicitly say `up to date` when the local version already matches npm latest, while keeping the availability logic unchanged. (#51409) Thanks @dongzhenye.
 - Daemon/Linux: stop flagging non-gateway systemd services as duplicate gateways just because their unit files mention OpenClaw, reducing false-positive doctor/log noise. (#45328) Thanks @gregretkowski.
 - Feishu: close WebSocket connections on monitor stop/abort so ghost connections no longer persist, preventing duplicate event processing and resource leaks across restart cycles. (#52844) Thanks @schumilin.

--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -1,7 +1,10 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { WEBHOOK_IN_FLIGHT_DEFAULTS } from "openclaw/plugin-sdk/webhook-request-guards";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type LineNodeWebhookHandler = (req: IncomingMessage, res: ServerResponse) => Promise<void>;
 
 const {
   createLineBotMock,
@@ -13,13 +16,15 @@ const {
     account: { accountId: "default" },
     handleWebhook: vi.fn(),
   })),
-  createLineNodeWebhookHandlerMock: vi.fn(() => vi.fn()),
+  createLineNodeWebhookHandlerMock: vi.fn<() => LineNodeWebhookHandler>(() =>
+    vi.fn<LineNodeWebhookHandler>(async () => {}),
+  ),
   registerPluginHttpRouteMock: vi.fn(),
   unregisterHttpMock: vi.fn(),
 }));
 
 let monitorLineProvider: typeof import("./monitor.js").monitorLineProvider;
-let innerLineWebhookHandlerMock: ReturnType<typeof vi.fn>;
+let innerLineWebhookHandlerMock: ReturnType<typeof vi.fn<LineNodeWebhookHandler>>;
 
 vi.mock("./bot.js", () => ({
   createLineBot: createLineBotMock,
@@ -91,8 +96,10 @@ describe("monitorLineProvider lifecycle", () => {
       account: { accountId: "default" },
       handleWebhook: vi.fn(),
     });
-    innerLineWebhookHandlerMock = vi.fn(async () => {});
-    createLineNodeWebhookHandlerMock.mockReset().mockReturnValue(innerLineWebhookHandlerMock);
+    innerLineWebhookHandlerMock = vi.fn<LineNodeWebhookHandler>(async () => {});
+    createLineNodeWebhookHandlerMock
+      .mockReset()
+      .mockImplementation(() => innerLineWebhookHandlerMock);
     unregisterHttpMock.mockReset();
     registerPluginHttpRouteMock.mockReset().mockReturnValue(unregisterHttpMock);
     ({ monitorLineProvider } = await import("./monitor.js"));
@@ -166,6 +173,7 @@ describe("monitorLineProvider lifecycle", () => {
   });
 
   it("rejects webhook requests above the shared in-flight limit before body handling", async () => {
+    const limit = WEBHOOK_IN_FLIGHT_DEFAULTS.maxInFlightPerKey;
     const releaseRequests: Array<() => void> = [];
     let reachLimit!: () => void;
     const reachedLimit = new Promise<void>((resolve) => {
@@ -174,7 +182,7 @@ describe("monitorLineProvider lifecycle", () => {
 
     innerLineWebhookHandlerMock.mockImplementation(
       async (_req: IncomingMessage, res: ServerResponse) => {
-        if (releaseRequests.length === 7) {
+        if (releaseRequests.length === limit - 1) {
           reachLimit();
         }
         await new Promise<void>((resolve) => {
@@ -202,7 +210,7 @@ describe("monitorLineProvider lifecycle", () => {
         headers: {},
       }) as IncomingMessage;
 
-    const firstEight = Array.from({ length: 8 }, () =>
+    const firstRequests = Array.from({ length: limit }, () =>
       route!.handler(createPostRequest(), createRouteResponse()),
     );
     await reachedLimit;
@@ -210,12 +218,12 @@ describe("monitorLineProvider lifecycle", () => {
     const overflowResponse = createRouteResponse();
     await route!.handler(createPostRequest(), overflowResponse);
 
-    expect(innerLineWebhookHandlerMock).toHaveBeenCalledTimes(8);
+    expect(innerLineWebhookHandlerMock).toHaveBeenCalledTimes(limit);
     expect(overflowResponse.statusCode).toBe(429);
     expect(overflowResponse.end).toHaveBeenCalledWith("Too Many Requests");
 
     releaseRequests.splice(0).forEach((release) => release());
-    await Promise.all(firstEight);
+    await Promise.all(firstRequests);
     monitor.stop();
   });
 

--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -1,17 +1,25 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createLineBotMock, registerPluginHttpRouteMock, unregisterHttpMock } = vi.hoisted(() => ({
+const {
+  createLineBotMock,
+  createLineNodeWebhookHandlerMock,
+  registerPluginHttpRouteMock,
+  unregisterHttpMock,
+} = vi.hoisted(() => ({
   createLineBotMock: vi.fn(() => ({
     account: { accountId: "default" },
     handleWebhook: vi.fn(),
   })),
+  createLineNodeWebhookHandlerMock: vi.fn(() => vi.fn()),
   registerPluginHttpRouteMock: vi.fn(),
   unregisterHttpMock: vi.fn(),
 }));
 
 let monitorLineProvider: typeof import("./monitor.js").monitorLineProvider;
+let innerLineWebhookHandlerMock: ReturnType<typeof vi.fn>;
 
 vi.mock("./bot.js", () => ({
   createLineBot: createLineBotMock,
@@ -42,7 +50,7 @@ vi.mock("openclaw/plugin-sdk/webhook-ingress", () => ({
 }));
 
 vi.mock("./webhook-node.js", () => ({
-  createLineNodeWebhookHandler: vi.fn(() => vi.fn()),
+  createLineNodeWebhookHandler: createLineNodeWebhookHandlerMock,
 }));
 
 vi.mock("./auto-reply-delivery.js", () => ({
@@ -83,10 +91,24 @@ describe("monitorLineProvider lifecycle", () => {
       account: { accountId: "default" },
       handleWebhook: vi.fn(),
     });
+    innerLineWebhookHandlerMock = vi.fn(async () => {});
+    createLineNodeWebhookHandlerMock.mockReset().mockReturnValue(innerLineWebhookHandlerMock);
     unregisterHttpMock.mockReset();
     registerPluginHttpRouteMock.mockReset().mockReturnValue(unregisterHttpMock);
     ({ monitorLineProvider } = await import("./monitor.js"));
   });
+
+  const createRouteResponse = () => {
+    const resObj = {
+      statusCode: 0,
+      headersSent: false,
+      setHeader: vi.fn(),
+      end: vi.fn(() => {
+        resObj.headersSent = true;
+      }),
+    };
+    return resObj as unknown as ServerResponse & { end: ReturnType<typeof vi.fn> };
+  };
 
   it("waits for abort before resolving", async () => {
     const abort = new AbortController();
@@ -141,6 +163,60 @@ describe("monitorLineProvider lifecycle", () => {
     monitor.stop();
     monitor.stop();
     expect(unregisterHttpMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects webhook requests above the shared in-flight limit before body handling", async () => {
+    const releaseRequests: Array<() => void> = [];
+    let reachLimit!: () => void;
+    const reachedLimit = new Promise<void>((resolve) => {
+      reachLimit = resolve;
+    });
+
+    innerLineWebhookHandlerMock.mockImplementation(
+      async (_req: IncomingMessage, res: ServerResponse) => {
+        if (releaseRequests.length === 7) {
+          reachLimit();
+        }
+        await new Promise<void>((resolve) => {
+          releaseRequests.push(resolve);
+        });
+        res.statusCode = 200;
+        res.end();
+      },
+    );
+
+    const monitor = await monitorLineProvider({
+      channelAccessToken: "token",
+      channelSecret: "secret", // pragma: allowlist secret
+      config: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+    });
+
+    const route = registerPluginHttpRouteMock.mock.calls[0]?.[0] as
+      | { handler: (req: IncomingMessage, res: ServerResponse) => Promise<void> }
+      | undefined;
+    expect(route).toBeDefined();
+    const createPostRequest = () =>
+      ({
+        method: "POST",
+        headers: {},
+      }) as IncomingMessage;
+
+    const firstEight = Array.from({ length: 8 }, () =>
+      route!.handler(createPostRequest(), createRouteResponse()),
+    );
+    await reachedLimit;
+
+    const overflowResponse = createRouteResponse();
+    await route!.handler(createPostRequest(), overflowResponse);
+
+    expect(innerLineWebhookHandlerMock).toHaveBeenCalledTimes(8);
+    expect(overflowResponse.statusCode).toBe(429);
+    expect(overflowResponse.end).toHaveBeenCalledWith("Too Many Requests");
+
+    releaseRequests.splice(0).forEach((release) => release());
+    await Promise.all(firstEight);
+    monitor.stop();
   });
 
   it("rejects startup when channel secret is missing", async () => {

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -288,7 +288,13 @@ export async function monitorLineProvider(
   });
 
   const normalizedPath = normalizePluginHttpPath(webhookPath, "/line/webhook") ?? "/line/webhook";
-  const lineWebhookHandler = createLineNodeWebhookHandler({ channelSecret: secret, bot, runtime });
+  const createScopedLineWebhookHandler = (onRequestAuthenticated?: () => void) =>
+    createLineNodeWebhookHandler({
+      channelSecret: secret,
+      bot,
+      runtime,
+      onRequestAuthenticated,
+    });
   const unregisterHttp = registerPluginHttpRoute({
     path: normalizedPath,
     auth: "plugin",
@@ -298,14 +304,13 @@ export async function monitorLineProvider(
     log: (msg) => logVerbose(msg),
     handler: async (req, res) => {
       if (req.method !== "POST") {
-        await lineWebhookHandler(req, res);
+        await createScopedLineWebhookHandler()(req, res);
         return;
       }
 
       const requestLifecycle = beginWebhookRequestPipelineOrReject({
         req,
         res,
-        allowMethods: ["POST"],
         inFlightLimiter: lineWebhookInFlightLimiter,
         inFlightKey: `line:${resolvedAccountId}`,
       });
@@ -314,7 +319,7 @@ export async function monitorLineProvider(
       }
 
       try {
-        await lineWebhookHandler(req, res);
+        await createScopedLineWebhookHandler(requestLifecycle.release)(req, res);
       } finally {
         requestLifecycle.release();
       }

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -15,6 +15,10 @@ import {
   normalizePluginHttpPath,
   registerPluginHttpRoute,
 } from "openclaw/plugin-sdk/webhook-ingress";
+import {
+  beginWebhookRequestPipelineOrReject,
+  createWebhookInFlightLimiter,
+} from "openclaw/plugin-sdk/webhook-request-guards";
 import { deliverLineAutoReply } from "./auto-reply-delivery.js";
 import { createLineBot } from "./bot.js";
 import { processLineMessage } from "./markdown-to-line.js";
@@ -64,6 +68,7 @@ const runtimeState = new Map<
     lastOutboundAt?: number | null;
   }
 >();
+const lineWebhookInFlightLimiter = createWebhookInFlightLimiter();
 
 function recordChannelRuntimeState(params: {
   channel: string;
@@ -283,6 +288,7 @@ export async function monitorLineProvider(
   });
 
   const normalizedPath = normalizePluginHttpPath(webhookPath, "/line/webhook") ?? "/line/webhook";
+  const lineWebhookHandler = createLineNodeWebhookHandler({ channelSecret: secret, bot, runtime });
   const unregisterHttp = registerPluginHttpRoute({
     path: normalizedPath,
     auth: "plugin",
@@ -290,7 +296,29 @@ export async function monitorLineProvider(
     pluginId: "line",
     accountId: resolvedAccountId,
     log: (msg) => logVerbose(msg),
-    handler: createLineNodeWebhookHandler({ channelSecret: secret, bot, runtime }),
+    handler: async (req, res) => {
+      if (req.method !== "POST") {
+        await lineWebhookHandler(req, res);
+        return;
+      }
+
+      const requestLifecycle = beginWebhookRequestPipelineOrReject({
+        req,
+        res,
+        allowMethods: ["POST"],
+        inFlightLimiter: lineWebhookInFlightLimiter,
+        inFlightKey: `line:${resolvedAccountId}`,
+      });
+      if (!requestLifecycle.ok) {
+        return;
+      }
+
+      try {
+        await lineWebhookHandler(req, res);
+      } finally {
+        requestLifecycle.release();
+      }
+    },
   });
 
   logVerbose(`line: registered webhook handler at ${normalizedPath}`);

--- a/extensions/line/src/webhook-node.test.ts
+++ b/extensions/line/src/webhook-node.test.ts
@@ -286,6 +286,42 @@ describe("createLineNodeWebhookHandler", () => {
     );
   });
 
+  it("releases authenticated requests before event processing completes", async () => {
+    const rawBody = JSON.stringify({ events: [{ type: "message" }] });
+    let releaseAuthenticated!: () => void;
+    const bot = {
+      handleWebhook: vi.fn(
+        async () =>
+          await new Promise<void>((resolve) => {
+            releaseAuthenticated = resolve;
+          }),
+      ),
+    };
+    const onRequestAuthenticated = vi.fn();
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const handler = createLineNodeWebhookHandler({
+      channelSecret: SECRET,
+      bot,
+      runtime,
+      readBody: async () => rawBody,
+      onRequestAuthenticated,
+    });
+
+    const { res } = createRes();
+    const request = runSignedPost({ handler, rawBody, secret: SECRET, res });
+
+    await vi.waitFor(() => {
+      expect(onRequestAuthenticated).toHaveBeenCalledTimes(1);
+      expect(bot.handleWebhook).toHaveBeenCalledTimes(1);
+    });
+
+    expect(res.headersSent).toBe(false);
+    releaseAuthenticated();
+    await request;
+
+    expect(res.statusCode).toBe(200);
+  });
+
   it("returns 500 when event processing fails and does not acknowledge with 200", async () => {
     const rawBody = JSON.stringify({ events: [{ type: "message" }] });
     const { secret } = createPostWebhookTestHarness(rawBody);

--- a/extensions/line/src/webhook-node.ts
+++ b/extensions/line/src/webhook-node.ts
@@ -31,6 +31,7 @@ export function createLineNodeWebhookHandler(params: {
   runtime: RuntimeEnv;
   readBody?: ReadBodyFn;
   maxBodyBytes?: number;
+  onRequestAuthenticated?: () => void;
 }): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
   const maxBodyBytes = params.maxBodyBytes ?? LINE_WEBHOOK_MAX_BODY_BYTES;
   const readBody = params.readBody ?? readLineWebhookRequestBody;
@@ -95,6 +96,8 @@ export function createLineNodeWebhookHandler(params: {
         res.end(JSON.stringify({ error: "Invalid webhook payload" }));
         return;
       }
+
+      params.onRequestAuthenticated?.();
 
       if (body.events && body.events.length > 0) {
         logVerbose(`line: received ${body.events.length} webhook events`);


### PR DESCRIPTION
## Summary

- Problem: LINE webhook requests could pile up in the body handler before signature verification.
- Why it matters: excess concurrent requests could consume shared webhook capacity before verification and normal handling.
- What changed: added a shared in-flight limiter around the LINE POST webhook path before entering the LINE node handler, with regression coverage for over-limit rejection.
- What did NOT change (scope boundary): this does not change signature verification semantics or message processing behavior after a request is admitted.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the LINE plugin webhook route passed POST requests straight into the node webhook handler, so there was no shared pre-handler admission control on concurrent body reads.
- Missing detection / guardrail: no integration test asserted that over-limit requests were rejected before entering the body handler.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: the route had no explicit pre-handler concurrency guard.
- If unknown, what was ruled out: ruled out later-stage handler logic as the admission point.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/line/src/monitor.lifecycle.test.ts`
- Scenario the test should lock in: reject requests beyond the shared in-flight limit before body handling starts.
- Why this is the smallest reliable guardrail: it exercises the actual registered route handler and admission path without needing external webhook infrastructure.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Excess concurrent LINE webhook requests now receive `429 Too Many Requests` before entering the LINE body handler.

## Diagram (if applicable)

```text
Before:
[POST webhook burst] -> [LINE body handler] -> [verification + processing]

After:
[POST webhook burst] -> [shared in-flight gate]
                           -> [admit] -> [LINE body handler]
                           -> [reject 429]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): LINE
- Relevant config (redacted): channel secret configured

### Steps

1. Register the LINE webhook route.
2. Send more concurrent POST requests than the shared in-flight allowance.
3. Observe admitted requests continue and overflow requests reject before body handling.

### Expected

- Overflow POST requests are rejected with `429 Too Many Requests` before entering the LINE node webhook handler.

### Actual

- Verified by regression test coverage on the registered route handler.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran the focused LINE lifecycle test file locally.
- Edge cases checked: non-POST requests still delegate directly; POST overflow rejects without incrementing the inner handler call count past admitted requests.
- What you did **not** verify: full repo-wide `pnpm check` completion on this host.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a too-low shared limit could reject legitimate burst traffic.
  - Mitigation: the plugin uses the shared webhook request guard path and only applies it to POST requests entering the body handler.
