### PR TITLE
fix(discord): suppress reconnect-exhausted error during health-monitor stale-socket restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/gateway: ignore abort-time reconnect-exhausted events during stale-socket health-monitor restart cleanup, so expected Carbon reconnect exhaustion does not reject the channel lifecycle. Carries forward #58216. Thanks @Perttulands.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -550,9 +550,6 @@ describe("runDiscordGatewayLifecycle", () => {
       "reconnect-exhausted",
       "Max reconnect attempts (0) reached after code 1005",
     );
-    gateway.disconnect.mockImplementation(() => {
-      lifecycleHandler?.(reconnectExhaustedEvent);
-    });
     waitForDiscordGatewayStopMock.mockImplementationOnce((params) => {
       return new Promise<void>((resolve, reject) => {
         let settled = false;
@@ -578,7 +575,7 @@ describe("runDiscordGatewayLifecycle", () => {
 
         lifecycleHandler = (event) => {
           if ((params.onGatewayEvent?.(event) ?? "stop") === "stop") {
-            finishReject(event.err);
+            finishReject(new Error("unexpected lifecycle stop for abort-time reconnect"));
           }
         };
         params.gatewaySupervisor?.attachLifecycle(lifecycleHandler);
@@ -588,7 +585,14 @@ describe("runDiscordGatewayLifecycle", () => {
           onAbort();
           return;
         }
-        params.abortSignal?.addEventListener("abort", onAbort, { once: true });
+        params.abortSignal?.addEventListener(
+          "abort",
+          () => {
+            lifecycleHandler?.(reconnectExhaustedEvent);
+            onAbort();
+          },
+          { once: true },
+        );
       });
     });
 

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -539,6 +539,75 @@ describe("runDiscordGatewayLifecycle", () => {
     );
   });
 
+  it("suppresses reconnect-exhausted fired during abort-driven disconnect", async () => {
+    const abortController = new AbortController();
+    const { emitter, gateway } = createGatewayHarness();
+    gateway.isConnected = true;
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    let lifecycleHandler: ((event: DiscordGatewayEvent) => void) | undefined;
+    const reconnectExhaustedEvent = createGatewayEvent(
+      "reconnect-exhausted",
+      "Max reconnect attempts (0) reached after code 1005",
+    );
+    gateway.disconnect.mockImplementation(() => {
+      lifecycleHandler?.(reconnectExhaustedEvent);
+    });
+    waitForDiscordGatewayStopMock.mockImplementationOnce((params) => {
+      return new Promise<void>((resolve, reject) => {
+        let settled = false;
+        const finishResolve = () => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          try {
+            params.gateway?.disconnect?.();
+          } finally {
+            resolve();
+          }
+        };
+        const finishReject = (err: unknown) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          reject(err);
+        };
+        const onAbort = () => finishResolve();
+
+        lifecycleHandler = (event) => {
+          if ((params.onGatewayEvent?.(event) ?? "stop") === "stop") {
+            finishReject(event.err);
+          }
+        };
+        params.gatewaySupervisor?.attachLifecycle(lifecycleHandler);
+        params.registerForceStop?.(finishReject);
+
+        if (params.abortSignal?.aborted) {
+          onAbort();
+          return;
+        }
+        params.abortSignal?.addEventListener("abort", onAbort, { once: true });
+      });
+    });
+
+    const { lifecycleParams, runtimeLog, runtimeError } = createLifecycleHarness({ gateway });
+    lifecycleParams.abortSignal = abortController.signal;
+
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+    await vi.waitFor(() => expect(waitForDiscordGatewayStopMock).toHaveBeenCalledTimes(1));
+    abortController.abort();
+
+    await expect(lifecyclePromise).resolves.toBeUndefined();
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("ignoring expected reconnect-exhausted during shutdown"),
+    );
+    expect(runtimeError).not.toHaveBeenCalledWith(
+      expect.stringContaining("discord gateway reconnect-exhausted"),
+    );
+  });
+
   it("pushes disconnected status when Carbon schedules a reconnect", async () => {
     const { emitter, gateway } = createGatewayHarness();
     gateway.isConnected = true;

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -431,7 +431,7 @@ export async function runDiscordGatewayLifecycle(params: {
       params.runtime.log?.(
         `discord: ignoring expected reconnect-exhausted during shutdown: ${event.message}`,
       );
-      return "stop";
+      return "continue";
     }
     if (event.shouldStopLifecycle) {
       lifecycleStopping = true;

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -424,6 +424,15 @@ export async function runDiscordGatewayLifecycle(params: {
       );
       return "stop";
     }
+    const isExpectedShutdownReconnectExhausted =
+      (lifecycleStopping || params.abortSignal?.aborted === true) &&
+      event.type === "reconnect-exhausted";
+    if (isExpectedShutdownReconnectExhausted) {
+      params.runtime.log?.(
+        `discord: ignoring expected reconnect-exhausted during shutdown: ${event.message}`,
+      );
+      return "stop";
+    }
     if (event.shouldStopLifecycle) {
       lifecycleStopping = true;
     }
@@ -438,11 +447,17 @@ export async function runDiscordGatewayLifecycle(params: {
   };
   const drainPendingGatewayErrors = (): "continue" | "stop" =>
     params.gatewaySupervisor.drainPending((event) => {
+      const isExpectedShutdownReconnectExhausted =
+        event.type === "reconnect-exhausted" &&
+        (lifecycleStopping || params.abortSignal?.aborted === true);
       const decision = handleGatewayEvent(event);
       if (decision !== "stop") {
         return "continue";
       }
       if (event.type === "disallowed-intents") {
+        return "stop";
+      }
+      if (isExpectedShutdownReconnectExhausted) {
         return "stop";
       }
       throw new DiscordGatewayLifecycleError(event);


### PR DESCRIPTION
## Problem

When the channel health monitor detects a stale Discord socket (no events for 30 minutes) and triggers a channel restart, the process crashes with:

```
[health-monitor] [discord:default] health-monitor: restarting (reason: stale-socket)
[openclaw] Uncaught exception: Error: Max reconnect attempts (0) reached after code 1005
```

With `systemd Restart=always`, this creates a crashloop cycling every ~35 minutes (30min stale threshold + 5min startup grace). In our setup, 6 Discord-connected agents accumulated 44-51 restarts each over 3.5 days.

## Root Cause

Race condition in the shutdown sequence:

1. Health monitor calls `stopChannel` → fires abort signal
2. `reconnectController.onAbort` fires → sets `gateway.options.reconnect = { maxAttempts: 0 }` → calls `gateway.disconnect()`
3. Carbon/`@buape/carbon` fires `reconnect-exhausted` error **synchronously** during disconnect
4. `handleGatewayEvent` checks `lifecycleStopping` to suppress the expected error — but `lifecycleStopping` is set in the `finally` block of `runDiscordGatewayLifecycle`, which hasn't run yet
5. Error treated as unexpected → rejects the lifecycle promise → uncaught exception → process.exit(1)

## Fix

Add `params.abortSignal?.aborted` check alongside `lifecycleStopping` in `handleGatewayEvent`. This matches the existing pattern already used in `drainPendingGatewayErrors` (which correctly handles the queued-event variant of this race).

The one-line change:

```diff
- if (lifecycleStopping && event.type === "reconnect-exhausted") {
+ if ((lifecycleStopping || params.abortSignal?.aborted) && event.type === "reconnect-exhausted") {
```

## Tests

- Updated existing test "suppresses reconnect-exhausted already queued before shutdown" to verify the abort-aware suppression path
- Added new test "suppresses reconnect-exhausted fired as live event when abortSignal is aborted but lifecycleStopping is not yet true"
- All 23 tests in `provider.lifecycle.test.ts` pass