### PR TITLE
fix(gateway): clear throttled launchd state before re-bootstrap in restart handoff

### DIFF
--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -40,4 +40,44 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
     expect(args[1]).not.toContain("sleep 1");
     expect(unrefMock).toHaveBeenCalledTimes(1);
   });
+
+  it("bootout before bootstrap in kickstart mode to clear throttle state", () => {
+    const env = { HOME: "/Users/test", OPENCLAW_PROFILE: "default" };
+    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+
+    scheduleDetachedLaunchdRestartHandoff({ env, mode: "kickstart", waitForPid: 9876 });
+
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    const script = args[1];
+    // bootout must appear before bootstrap so any stale registration and
+    // ThrottleInterval state is cleared before re-registering the service.
+    const bootoutIndex = script.indexOf('launchctl bootout "$domain" "$plist_path"');
+    const bootstrapIndex = script.indexOf('launchctl bootstrap "$domain" "$plist_path"');
+    expect(bootoutIndex).toBeGreaterThanOrEqual(0);
+    expect(bootstrapIndex).toBeGreaterThan(bootoutIndex);
+  });
+
+  it("bootout before bootstrap in start-after-exit mode to clear throttle state", () => {
+    const env = { HOME: "/Users/test", OPENCLAW_PROFILE: "default" };
+    spawnMock.mockReturnValue({ pid: 5555, unref: unrefMock });
+
+    const result = scheduleDetachedLaunchdRestartHandoff({
+      env,
+      mode: "start-after-exit",
+      waitForPid: 1234,
+    });
+
+    expect(result).toEqual({ ok: true, pid: 5555 });
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    const script = args[1];
+    expect(args[6]).toBe("1234");
+    // start-after-exit should also clear throttle state via bootout before bootstrap.
+    const bootoutIndex = script.indexOf('launchctl bootout "$domain" "$plist_path"');
+    const bootstrapIndex = script.indexOf('launchctl bootstrap "$domain" "$plist_path"');
+    expect(bootoutIndex).toBeGreaterThanOrEqual(0);
+    expect(bootstrapIndex).toBeGreaterThan(bootoutIndex);
+    // Should attempt start first, then fall back to the bootstrap path.
+    expect(script).toContain('launchctl start "$service_target"');
+    expect(script).toContain('launchctl kickstart -k "$service_target"');
+  });
 });

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -77,6 +77,7 @@ plist_path="$3"
 ${waitForCallerPid}
 if ! launchctl kickstart -k "$service_target" >/dev/null 2>&1; then
   launchctl enable "$service_target" >/dev/null 2>&1
+  launchctl bootout "$domain" "$plist_path" >/dev/null 2>&1 || true
   if launchctl bootstrap "$domain" "$plist_path" >/dev/null 2>&1; then
     launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
   fi
@@ -90,9 +91,8 @@ plist_path="$3"
 ${waitForCallerPid}
 if ! launchctl start "$service_target" >/dev/null 2>&1; then
   launchctl enable "$service_target" >/dev/null 2>&1
+  launchctl bootout "$domain" "$plist_path" >/dev/null 2>&1 || true
   if launchctl bootstrap "$domain" "$plist_path" >/dev/null 2>&1; then
-    launchctl start "$service_target" >/dev/null 2>&1 || launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
-  else
     launchctl kickstart -k "$service_target" >/dev/null 2>&1 || true
   fi
 fi


### PR DESCRIPTION
Fixes #58254

## Problem

After an auto-update, the Openclaw gateway fails to restart on macOS and must be manually started with `openclaw gateway start`.

**Root cause — update/restart race leading to launchd ThrottleInterval:**

1. The update flow calls `installLaunchAgent`, which runs `bootout` + `bootstrap` on the new plist
2. Because `RunAtLoad=true`, launchd immediately tries to start the freshly bootstrapped service
3. The old gateway process is still running and holding the port — the new process fails to bind → **launchd enters ThrottleInterval** for that service label
4. The old process receives SIGUSR1 (config-change restart), calls `restartGatewayProcessWithFreshPid()`, and schedules a `start-after-exit` handoff
5. The handoff script waits for the old PID to exit, then tries `launchctl start` → fails (service booted out by step 1)
6. Falls back to `launchctl bootstrap` → **fails** (service is *already* registered from step 1's bootstrap)
7. Since bootstrap failed, the `else` branch tries `launchctl kickstart -k` → **silently fails** because launchd is still throttling from step 3
8. Gateway stays down; no further restart attempts

The same throttle trap can hit the `kickstart` handoff mode if a similar race occurs during an explicit `openclaw gateway restart` issued from inside a launchd-managed process.

## Fix

Add a `launchctl bootout` step **before** `launchctl bootstrap` in both handoff modes. This unconditionally clears any existing service registration and its associated throttle state, so the subsequent `bootstrap` always starts from a clean slate and `kickstart -k` can proceed without throttle interference.

**`kickstart` mode** — adds `bootout` before the fallback `bootstrap`:
```
bootout || true → bootstrap → kickstart -k
```

**`start-after-exit` mode** — same pattern, and simplifies the post-bootstrap branch (both old branches called `kickstart -k`, now unified):
```
bootout || true → bootstrap → kickstart -k
```

## Changes

- `src/daemon/launchd-restart-handoff.ts` — 4-line change to `buildLaunchdRestartScript`
- `src/daemon/launchd-restart-handoff.test.ts` — adds coverage for `start-after-exit` mode and asserts `bootout` is present in both modes

## Testing

- [x] Unit tests: `pnpm vitest run src/daemon/launchd-restart-handoff.test.ts` — all 3 tests pass (added 2 new cases)
- [ ] Integration test on a real macOS auto-update cycle (verified against local logs; full end-to-end tested by the original reporter)

---

**AI-assisted** (Claude Sonnet 4.6 via Cowork). The bug was diagnosed from system logs and source inspection. I reviewed and understand all changed code. Prompts available on request.