### PR TITLE
fix(mattermost): add groups property to config schema (#57618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Docs: https://docs.openclaw.ai
 - Cron: send failure notifications through the job's primary delivery channel using the same session context as successful delivery when no explicit `failureDestination` is configured. (#60622) Thanks @artwalker.
 - Gateway/auth: serialize async shared-secret auth attempts per client so concurrent Tailscale-capable failures cannot overrun the intended auth rate-limit budget. Thanks @Telecaster2147.- Doctor/config: compare normalized `talk` configs by deep structural equality instead of key-order-sensitive serialization so `openclaw doctor --fix` stops repeatedly reporting/applying no-op `talk.provider/providers` normalization. (#59911) Thanks @ejames-dev.
 - Gateway/device auth: reuse cached device-token scopes only for cached-token reconnects, while keeping explicit `deviceToken` scope requests and empty-cache fallbacks intact so reconnects preserve `operator.read` without breaking explicit auth flows. (#46032) Thanks @caicongyang.
+- Mattermost/config schema: accept `groups.*.requireMention` again so existing Mattermost configs no longer fail strict validation after upgrade. (#58271) Thanks @MoerAI.
 
 ## 2026.4.2
 

--- a/extensions/mattermost/src/config-schema-core.ts
+++ b/extensions/mattermost/src/config-schema-core.ts
@@ -12,10 +12,6 @@ const MattermostGroupSchema = z
   .object({
     /** Whether mentions are required to trigger the bot in this group. */
     requireMention: z.boolean().optional(),
-    /** Whether the bot is enabled in this group. */
-    enabled: z.boolean().optional(),
-    /** Allowlist of sender IDs permitted to interact in this group. */
-    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   })
   .strict();
 

--- a/extensions/mattermost/src/config-schema-core.ts
+++ b/extensions/mattermost/src/config-schema-core.ts
@@ -8,6 +8,17 @@ import {
 import { z } from "openclaw/plugin-sdk/zod";
 import { buildSecretInputSchema } from "./secret-input.js";
 
+const MattermostGroupSchema = z
+  .object({
+    /** Whether mentions are required to trigger the bot in this group. */
+    requireMention: z.boolean().optional(),
+    /** Whether the bot is enabled in this group. */
+    enabled: z.boolean().optional(),
+    /** Allowlist of sender IDs permitted to interact in this group. */
+    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  })
+  .strict();
+
 function requireMattermostOpenAllowFrom(params: {
   policy?: string;
   allowFrom?: Array<string | number>;
@@ -98,6 +109,8 @@ const MattermostAccountSchemaBase = z
         allowedSourceIps: z.array(z.string()).optional(),
       })
       .optional(),
+    /** Per-group configuration (keyed by Mattermost channel ID or "*" for default). */
+    groups: z.record(z.string(), MattermostGroupSchema.optional()).optional(),
     /** Allow fetching from private/internal IP addresses (e.g. localhost). Required for self-hosted Mattermost on LAN/VPN. */
     allowPrivateNetwork: z.boolean().optional(),
     /** Retry configuration for DM channel creation */

--- a/extensions/mattermost/src/config-schema.test.ts
+++ b/extensions/mattermost/src/config-schema.test.ts
@@ -29,6 +29,39 @@ describe("MattermostConfigSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts groups with requireMention", () => {
+    const result = MattermostConfigSchema.safeParse({
+      groups: {
+        "*": { requireMention: true },
+        "channel-123": { requireMention: false },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts groups on account", () => {
+    const result = MattermostConfigSchema.safeParse({
+      accounts: {
+        main: {
+          baseUrl: "https://chat.example.com",
+          groups: {
+            "*": { requireMention: true },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown properties inside groups entry", () => {
+    const result = MattermostConfigSchema.safeParse({
+      groups: {
+        "*": { requireMention: true, unknownProp: "bad" },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("rejects unsupported direct-message reply threading config", () => {
     const result = MattermostConfigSchema.safeParse({
       dm: {

--- a/extensions/mattermost/src/config-schema.ts
+++ b/extensions/mattermost/src/config-schema.ts
@@ -12,10 +12,6 @@ const MattermostGroupSchema = z
   .object({
     /** Whether mentions are required to trigger the bot in this group. */
     requireMention: z.boolean().optional(),
-    /** Whether the bot is enabled in this group. */
-    enabled: z.boolean().optional(),
-    /** Allowlist of sender IDs permitted to interact in this group. */
-    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   })
   .strict();
 

--- a/extensions/mattermost/src/config-schema.ts
+++ b/extensions/mattermost/src/config-schema.ts
@@ -8,6 +8,17 @@ import {
 } from "./config-runtime.js";
 import { buildSecretInputSchema } from "./secret-input.js";
 
+const MattermostGroupSchema = z
+  .object({
+    /** Whether mentions are required to trigger the bot in this group. */
+    requireMention: z.boolean().optional(),
+    /** Whether the bot is enabled in this group. */
+    enabled: z.boolean().optional(),
+    /** Allowlist of sender IDs permitted to interact in this group. */
+    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+  })
+  .strict();
+
 function requireMattermostOpenAllowFrom(params: {
   policy?: string;
   allowFrom?: Array<string | number>;
@@ -98,6 +109,8 @@ const MattermostAccountSchemaBase = z
         allowedSourceIps: z.array(z.string()).optional(),
       })
       .optional(),
+    /** Per-group configuration (keyed by Mattermost channel ID or "*" for default). */
+    groups: z.record(z.string(), MattermostGroupSchema.optional()).optional(),
     /** Allow fetching from private/internal IP addresses (e.g. localhost). Required for self-hosted Mattermost on LAN/VPN. */
     allowPrivateNetwork: z.boolean().optional(),
     /** Retry configuration for DM channel creation */


### PR DESCRIPTION
## Summary
Fixes #57618 — Mattermost channel config validation rejects `groups` property with "must NOT have additional properties" after upgrading to v2026.3.28.

## Root Cause
The Mattermost config schema (`MattermostAccountSchemaBase`) uses `.strict()` to reject unknown properties, but the `groups` property was never declared in the schema despite being used in runtime code (`monitor.ts`, `monitor.test.ts`). Other channel plugins (IRC, Matrix, Feishu, BlueBubbles, Zalo, LINE) all include `groups` in their schemas.

## Changes
- `extensions/mattermost/src/config-schema-core.ts`: Add `MattermostGroupSchema` (with `requireMention`, `enabled`, `allowFrom` fields) and `groups` record to `MattermostAccountSchemaBase`
- `extensions/mattermost/src/config-schema.ts`: Same schema addition (test-facing schema)
- `extensions/mattermost/src/config-schema.test.ts`: Add 3 test cases for groups acceptance/rejection

## Test
```
pnpm test -- extensions/mattermost/src/config-schema.test.ts
# 8 tests passed (8)
```

Closes #57618