### PR TITLE
fix(sandbox): add { once: true } to Docker abort signal listener

### DIFF
--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -91,7 +91,7 @@ export function execDockerRaw(
       if (signal.aborted) {
         handleAbort();
       } else {
-        signal.addEventListener("abort", handleAbort);
+        signal.addEventListener("abort", handleAbort, { once: true });
       }
     }
 


### PR DESCRIPTION
## Summary

- Add `{ once: true }` to the abort signal listener in `execDockerRaw()` (`src/agents/sandbox/docker.ts:94`) to align with every other abort listener in the codebase (15+ instances all use `{ once: true }`).
- Without this, the listener accumulates on the `AbortSignal` in long-running sessions with many tool calls, causing memory pressure. With `{ once: true }`, the listener auto-removes after firing, preventing buildup.
- The existing `removeEventListener` calls in the `error`/`close` handlers are retained for the normal (non-abort) exit path; they become harmless no-ops if the listener already auto-removed.

## Test plan

- [x] Verified all existing Docker sandbox tests pass (`docker.windows.test.ts`, `docker.config-hash-recreate.test.ts` — 9/9 tests green)
- [x] Confirmed this is the only abort listener in the codebase missing `{ once: true }` via codebase-wide grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)