### PR TITLE
test: add coverage for link-understanding module

### DIFF
--- a/src/link-understanding/apply.test.ts
+++ b/src/link-understanding/apply.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/config.js";
+
+// Mock runner and format dependencies.
+vi.mock("./runner.js", () => ({
+  runLinkUnderstanding: vi.fn(),
+}));
+
+vi.mock("./format.js", async () => {
+  const actual = await vi.importActual<typeof import("./format.js")>("./format.js");
+  return { ...actual };
+});
+
+vi.mock("../auto-reply/reply/inbound-context.js", () => ({
+  finalizeInboundContext: vi.fn(),
+}));
+
+import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
+import { applyLinkUnderstanding } from "./apply.js";
+import { runLinkUnderstanding } from "./runner.js";
+
+const mockRunLinkUnderstanding = vi.mocked(runLinkUnderstanding);
+const mockFinalizeInboundContext = vi.mocked(finalizeInboundContext);
+
+function makeCtx(overrides?: Partial<MsgContext>): MsgContext {
+  return {
+    Body: "check https://example.com",
+    SessionKey: "test-session",
+    ...overrides,
+  };
+}
+
+function makeCfg(): OpenClawConfig {
+  return {
+    tools: {
+      links: { enabled: true, models: [{ command: "curl", args: ["{{LinkUrl}}"] }] },
+    },
+  } as OpenClawConfig;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("applyLinkUnderstanding", () => {
+  it("returns result with no side effects when outputs is empty", async () => {
+    mockRunLinkUnderstanding.mockResolvedValue({ urls: ["https://example.com"], outputs: [] });
+    const ctx = makeCtx();
+    const originalBody = ctx.Body;
+    const result = await applyLinkUnderstanding({ ctx, cfg: makeCfg() });
+
+    expect(result).toEqual({ urls: ["https://example.com"], outputs: [] });
+    expect(ctx.Body).toBe(originalBody);
+    expect(ctx.LinkUnderstanding).toBeUndefined();
+    expect(mockFinalizeInboundContext).not.toHaveBeenCalled();
+  });
+
+  it("updates ctx.Body and ctx.LinkUnderstanding when outputs are present", async () => {
+    mockRunLinkUnderstanding.mockResolvedValue({
+      urls: ["https://example.com"],
+      outputs: ["summary of page"],
+    });
+    const ctx = makeCtx({ Body: "check https://example.com" });
+    const result = await applyLinkUnderstanding({ ctx, cfg: makeCfg() });
+
+    expect(result.outputs).toEqual(["summary of page"]);
+    expect(ctx.LinkUnderstanding).toEqual(["summary of page"]);
+    expect(ctx.Body).toBe("check https://example.com\n\nsummary of page");
+  });
+
+  it("appends to existing LinkUnderstanding array", async () => {
+    mockRunLinkUnderstanding.mockResolvedValue({
+      urls: ["https://b.com"],
+      outputs: ["new output"],
+    });
+    const ctx = makeCtx({ LinkUnderstanding: ["existing output"] });
+    await applyLinkUnderstanding({ ctx, cfg: makeCfg() });
+
+    expect(ctx.LinkUnderstanding).toEqual(["existing output", "new output"]);
+  });
+
+  it("calls finalizeInboundContext with forceBody flags when outputs exist", async () => {
+    mockRunLinkUnderstanding.mockResolvedValue({
+      urls: ["https://example.com"],
+      outputs: ["summary"],
+    });
+    const ctx = makeCtx();
+    await applyLinkUnderstanding({ ctx, cfg: makeCfg() });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(ctx, {
+      forceBodyForAgent: true,
+      forceBodyForCommands: true,
+    });
+  });
+
+  it("handles multiple outputs correctly", async () => {
+    mockRunLinkUnderstanding.mockResolvedValue({
+      urls: ["https://a.com", "https://b.com"],
+      outputs: ["first summary", "second summary"],
+    });
+    const ctx = makeCtx({ Body: "links" });
+    await applyLinkUnderstanding({ ctx, cfg: makeCfg() });
+
+    expect(ctx.LinkUnderstanding).toEqual(["first summary", "second summary"]);
+    expect(ctx.Body).toBe("links\n\nfirst summary\nsecond summary");
+  });
+
+  it("passes cfg and ctx to runLinkUnderstanding", async () => {
+    mockRunLinkUnderstanding.mockResolvedValue({ urls: [], outputs: [] });
+    const ctx = makeCtx();
+    const cfg = makeCfg();
+    await applyLinkUnderstanding({ ctx, cfg });
+
+    expect(mockRunLinkUnderstanding).toHaveBeenCalledWith({ cfg, ctx });
+  });
+});

--- a/src/link-understanding/format.test.ts
+++ b/src/link-understanding/format.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { formatLinkUnderstandingBody } from "./format.js";
+
+describe("formatLinkUnderstandingBody", () => {
+  it("returns empty string when body is undefined and outputs is empty", () => {
+    expect(formatLinkUnderstandingBody({ outputs: [] })).toBe("");
+  });
+
+  it("returns body unchanged when outputs is empty", () => {
+    expect(formatLinkUnderstandingBody({ body: "hello world", outputs: [] })).toBe("hello world");
+  });
+
+  it("returns body when outputs are only whitespace", () => {
+    expect(formatLinkUnderstandingBody({ body: "hello", outputs: ["  ", "\n", ""] })).toBe("hello");
+  });
+
+  it("returns joined outputs when body is undefined", () => {
+    expect(formatLinkUnderstandingBody({ outputs: ["summary A", "summary B"] })).toBe(
+      "summary A\nsummary B",
+    );
+  });
+
+  it("returns joined outputs when body is empty string", () => {
+    expect(formatLinkUnderstandingBody({ body: "", outputs: ["summary A"] })).toBe("summary A");
+  });
+
+  it("appends outputs after body separated by double newline", () => {
+    expect(
+      formatLinkUnderstandingBody({ body: "check this link", outputs: ["link summary"] }),
+    ).toBe("check this link\n\nlink summary");
+  });
+
+  it("trims body and output whitespace", () => {
+    expect(formatLinkUnderstandingBody({ body: "  body  ", outputs: ["  output  "] })).toBe(
+      "body\n\noutput",
+    );
+  });
+
+  it("filters out empty outputs after trimming", () => {
+    expect(formatLinkUnderstandingBody({ body: "body", outputs: ["real output", "", "  "] })).toBe(
+      "body\n\nreal output",
+    );
+  });
+
+  it("handles multiple non-empty outputs", () => {
+    expect(
+      formatLinkUnderstandingBody({
+        body: "message",
+        outputs: ["first", "second", "third"],
+      }),
+    ).toBe("message\n\nfirst\nsecond\nthird");
+  });
+});

--- a/src/link-understanding/runner.test.ts
+++ b/src/link-understanding/runner.test.ts
@@ -1,0 +1,444 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { LinkModelConfig, LinkToolsConfig } from "../config/types.tools.js";
+
+// Mock external dependencies.
+vi.mock("../process/exec.js", () => ({
+  runExec: vi.fn(),
+}));
+
+vi.mock("../globals.js", () => ({
+  logVerbose: vi.fn(),
+  shouldLogVerbose: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../media-understanding/scope.js", () => ({
+  resolveMediaUnderstandingScope: vi.fn().mockReturnValue("allow"),
+  normalizeMediaUnderstandingChatType: vi.fn().mockReturnValue(undefined),
+}));
+
+// Use the real resolve for timeout logic.
+vi.mock("../media-understanding/resolve.js", async () => {
+  const actual = await vi.importActual<typeof import("../media-understanding/resolve.js")>(
+    "../media-understanding/resolve.js",
+  );
+  return { ...actual };
+});
+
+// Use the real templating module.
+vi.mock("../auto-reply/templating.js", async () => {
+  const actual = await vi.importActual<typeof import("../auto-reply/templating.js")>(
+    "../auto-reply/templating.js",
+  );
+  return { ...actual };
+});
+
+import { shouldLogVerbose } from "../globals.js";
+import { resolveMediaUnderstandingScope } from "../media-understanding/scope.js";
+import { runExec } from "../process/exec.js";
+import { runLinkUnderstanding } from "./runner.js";
+
+const mockRunExec = vi.mocked(runExec);
+const mockShouldLogVerbose = vi.mocked(shouldLogVerbose);
+const mockResolveScope = vi.mocked(resolveMediaUnderstandingScope);
+
+function makeCtx(overrides?: Partial<MsgContext>): MsgContext {
+  return {
+    Body: "check https://example.com",
+    SessionKey: "test-session",
+    ...overrides,
+  };
+}
+
+function makeCfg(linksCfg?: LinkToolsConfig): OpenClawConfig {
+  return {
+    tools: {
+      links: linksCfg,
+    },
+  } as OpenClawConfig;
+}
+
+function makeCliEntry(overrides?: Partial<LinkModelConfig>): LinkModelConfig {
+  return {
+    type: "cli",
+    command: "curl",
+    args: ["{{LinkUrl}}"],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mockResolveScope.mockReturnValue("allow");
+  mockShouldLogVerbose.mockReturnValue(false);
+});
+
+describe("runLinkUnderstanding", () => {
+  // ── Config gating ──────────────────────────────────────────────────
+
+  describe("config gating", () => {
+    it("returns empty result when tools.links is undefined", async () => {
+      const result = await runLinkUnderstanding({
+        cfg: { tools: {} } as OpenClawConfig,
+        ctx: makeCtx(),
+      });
+      expect(result).toEqual({ urls: [], outputs: [] });
+    });
+
+    it("returns empty result when links config enabled is false", async () => {
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: false }),
+        ctx: makeCtx(),
+      });
+      expect(result).toEqual({ urls: [], outputs: [] });
+    });
+
+    it("returns empty result when scope decision is deny", async () => {
+      mockResolveScope.mockReturnValue("deny");
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx(),
+      });
+      expect(result).toEqual({ urls: [], outputs: [] });
+    });
+  });
+
+  // ── Message / URL extraction ───────────────────────────────────────
+
+  describe("URL extraction", () => {
+    it("returns empty result when message has no links", async () => {
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: "no links here" }),
+      });
+      expect(result).toEqual({ urls: [], outputs: [] });
+    });
+
+    it("uses explicit message param over context Body", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "output", stderr: "" });
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: "https://ignored.com" }),
+        message: "see https://override.com",
+      });
+      expect(result.urls).toEqual(["https://override.com"]);
+    });
+
+    it("falls back to CommandBody when message is undefined", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "output", stderr: "" });
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: undefined, CommandBody: "see https://cmd.com" }),
+      });
+      expect(result.urls).toEqual(["https://cmd.com"]);
+    });
+
+    it("falls back to RawBody when CommandBody is undefined", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "output", stderr: "" });
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: undefined, CommandBody: undefined, RawBody: "see https://raw.com" }),
+      });
+      expect(result.urls).toEqual(["https://raw.com"]);
+    });
+
+    it("respects maxLinks from config", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "output", stderr: "" });
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, maxLinks: 1, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: "https://a.com https://b.com https://c.com" }),
+      });
+      expect(result.urls).toEqual(["https://a.com"]);
+    });
+
+    it("returns URLs with empty outputs when no model entries are configured", async () => {
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [] }),
+        ctx: makeCtx({ Body: "see https://example.com" }),
+      });
+      expect(result).toEqual({ urls: ["https://example.com"], outputs: [] });
+    });
+
+    it("returns URLs with empty outputs when models key is missing", async () => {
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true }),
+        ctx: makeCtx({ Body: "see https://example.com" }),
+      });
+      expect(result).toEqual({ urls: ["https://example.com"], outputs: [] });
+    });
+  });
+
+  // ── CLI entry execution ────────────────────────────────────────────
+
+  describe("CLI entry execution", () => {
+    it("invokes runExec with correct command and templated args", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "page summary", stderr: "" });
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      expect(result.outputs).toEqual(["page summary"]);
+      expect(mockRunExec).toHaveBeenCalledWith("curl", ["https://example.com"], expect.any(Object));
+    });
+
+    it("passes timeout from entry config", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "ok", stderr: "" });
+      await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry({ timeoutSeconds: 10 })] }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      const callOpts = mockRunExec.mock.calls[0]?.[2];
+      expect(callOpts).toMatchObject({ timeoutMs: 10_000 });
+    });
+
+    it("uses global link timeout when entry timeout is not set", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "ok", stderr: "" });
+      await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, timeoutSeconds: 15, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      const callOpts = mockRunExec.mock.calls[0]?.[2];
+      expect(callOpts).toMatchObject({ timeoutMs: 15_000 });
+    });
+
+    it("falls back to DEFAULT_LINK_TIMEOUT_SECONDS (30s) when no timeout configured", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "ok", stderr: "" });
+      await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      const callOpts = mockRunExec.mock.calls[0]?.[2];
+      expect(callOpts).toMatchObject({ timeoutMs: 30_000 });
+    });
+
+    it("skips entry when command is empty/whitespace", async () => {
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry({ command: "   " })] }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      expect(result.urls).toEqual(["https://example.com"]);
+      expect(result.outputs).toEqual([]);
+      expect(mockRunExec).not.toHaveBeenCalled();
+    });
+
+    it("skips entry when type is not cli", async () => {
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({
+          enabled: true,
+          models: [{ type: "provider" as unknown as "cli", command: "curl" }],
+        }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      expect(result.outputs).toEqual([]);
+      expect(mockRunExec).not.toHaveBeenCalled();
+    });
+
+    it("treats missing type as cli (default)", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "output", stderr: "" });
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({
+          enabled: true,
+          models: [{ command: "my-tool", args: ["{{LinkUrl}}"] }],
+        }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      expect(result.outputs).toEqual(["output"]);
+      expect(mockRunExec).toHaveBeenCalledWith(
+        "my-tool",
+        ["https://example.com"],
+        expect.any(Object),
+      );
+    });
+
+    it("does not template the command itself, only args", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "output", stderr: "" });
+      await runLinkUnderstanding({
+        cfg: makeCfg({
+          enabled: true,
+          models: [{ command: "{{LinkUrl}}", args: ["{{LinkUrl}}"] }],
+        }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      // Command should be passed as-is, args should be templated.
+      expect(mockRunExec).toHaveBeenCalledWith(
+        "{{LinkUrl}}",
+        ["https://example.com"],
+        expect.any(Object),
+      );
+    });
+
+    it("returns null output when stdout is empty", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "", stderr: "" });
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      expect(result.urls).toEqual(["https://example.com"]);
+      expect(result.outputs).toEqual([]);
+    });
+
+    it("returns null output when stdout is whitespace only", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "   \n  ", stderr: "" });
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      expect(result.outputs).toEqual([]);
+    });
+
+    it("trims stdout before returning", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "  page content  \n", stderr: "" });
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      expect(result.outputs).toEqual(["page content"]);
+    });
+  });
+
+  // ── Fallback / error handling ──────────────────────────────────────
+
+  describe("fallback and error handling", () => {
+    it("falls back to next entry when first entry throws", async () => {
+      const entries: LinkModelConfig[] = [
+        makeCliEntry({ command: "fail-tool" }),
+        makeCliEntry({ command: "ok-tool" }),
+      ];
+      mockRunExec
+        .mockRejectedValueOnce(new Error("command not found"))
+        .mockResolvedValueOnce({ stdout: "fallback output", stderr: "" });
+
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: entries }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      expect(result.outputs).toEqual(["fallback output"]);
+    });
+
+    it("returns empty outputs when all entries fail", async () => {
+      const entries: LinkModelConfig[] = [
+        makeCliEntry({ command: "fail-1" }),
+        makeCliEntry({ command: "fail-2" }),
+      ];
+      mockRunExec
+        .mockRejectedValueOnce(new Error("fail 1"))
+        .mockRejectedValueOnce(new Error("fail 2"));
+
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: entries }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      expect(result.urls).toEqual(["https://example.com"]);
+      expect(result.outputs).toEqual([]);
+    });
+
+    it("stops trying entries once one succeeds", async () => {
+      const entries: LinkModelConfig[] = [
+        makeCliEntry({ command: "good" }),
+        makeCliEntry({ command: "never-called" }),
+      ];
+      mockRunExec.mockResolvedValueOnce({ stdout: "first wins", stderr: "" });
+
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: entries }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      expect(result.outputs).toEqual(["first wins"]);
+      expect(mockRunExec).toHaveBeenCalledTimes(1);
+    });
+
+    it("continues to next URL even when first URL produces no output", async () => {
+      mockRunExec
+        .mockResolvedValueOnce({ stdout: "", stderr: "" })
+        .mockResolvedValueOnce({ stdout: "second url output", stderr: "" });
+
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: "https://a.com https://b.com" }),
+      });
+      expect(result.urls).toEqual(["https://a.com", "https://b.com"]);
+      expect(result.outputs).toEqual(["second url output"]);
+    });
+
+    it("processes each URL with all configured entries", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "output", stderr: "" });
+
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: "https://a.com https://b.com" }),
+      });
+      expect(result.urls).toEqual(["https://a.com", "https://b.com"]);
+      expect(result.outputs).toEqual(["output", "output"]);
+      expect(mockRunExec).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── Verbose logging ────────────────────────────────────────────────
+
+  describe("verbose logging", () => {
+    it("does not throw when verbose logging is enabled", async () => {
+      mockShouldLogVerbose.mockReturnValue(true);
+      mockRunExec.mockResolvedValue({ stdout: "ok", stderr: "" });
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      expect(result.outputs).toEqual(["ok"]);
+    });
+
+    it("logs exhaustion when verbose and all entries fail", async () => {
+      mockShouldLogVerbose.mockReturnValue(true);
+      mockRunExec.mockRejectedValue(new Error("fail"));
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      expect(result.outputs).toEqual([]);
+    });
+
+    it("logs scope denial when verbose", async () => {
+      mockShouldLogVerbose.mockReturnValue(true);
+      mockResolveScope.mockReturnValue("deny");
+      const result = await runLinkUnderstanding({
+        cfg: makeCfg({ enabled: true, models: [makeCliEntry()] }),
+        ctx: makeCtx(),
+      });
+      expect(result).toEqual({ urls: [], outputs: [] });
+    });
+  });
+
+  // ── Template context ───────────────────────────────────────────────
+
+  describe("template context", () => {
+    it("passes LinkUrl in template context for arg substitution", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "ok", stderr: "" });
+      await runLinkUnderstanding({
+        cfg: makeCfg({
+          enabled: true,
+          models: [
+            { command: "fetch", args: ["--url", "{{LinkUrl}}", "--session", "{{SessionKey}}"] },
+          ],
+        }),
+        ctx: makeCtx({ Body: "https://target.com", SessionKey: "sess-123" }),
+      });
+      expect(mockRunExec).toHaveBeenCalledWith(
+        "fetch",
+        ["--url", "https://target.com", "--session", "sess-123"],
+        expect.any(Object),
+      );
+    });
+
+    it("passes empty args when entry.args is undefined", async () => {
+      mockRunExec.mockResolvedValue({ stdout: "ok", stderr: "" });
+      await runLinkUnderstanding({
+        cfg: makeCfg({
+          enabled: true,
+          models: [{ command: "fetch" }],
+        }),
+        ctx: makeCtx({ Body: "https://example.com" }),
+      });
+      expect(mockRunExec).toHaveBeenCalledWith("fetch", [], expect.any(Object));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add **46 new tests** across 3 test files for the previously untested `src/link-understanding/` module (`runner.ts`, `format.ts`, `apply.ts`)
- The `runner.ts` orchestrator handles user-controlled URLs with external command execution and configurable timeouts — a potential SSRF/injection surface that had zero test coverage
- Tests cover config gating, URL extraction fallback chain, CLI entry execution with templated args, timeout resolution, error handling with entry fallback, verbose logging paths, output formatting, and apply-side context mutation

## New test files
| File | Tests | Covers |
|------|-------|--------|
| `runner.test.ts` | 31 | Config gating (disabled/deny/missing), URL extraction from message/CommandBody/RawBody/Body fallback, maxLinks, CLI entry execution, timeout resolution (entry → global → default 30s), empty/whitespace command skipping, non-cli type skipping, template context (LinkUrl, SessionKey), stdout trimming, fallback across entries on error, verbose logging |
| `format.test.ts` | 9 | Body+outputs formatting, empty/undefined body, whitespace-only outputs, multiple outputs joining |
| `apply.test.ts` | 6 | No-op when outputs empty, ctx.Body mutation, ctx.LinkUnderstanding accumulation, finalizeInboundContext delegation |

## Test plan
- [x] `pnpm test -- src/link-understanding/` — all 56 tests pass (46 new + 10 existing in `detect.test.ts`)
- [x] `pnpm format` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)