### PR TITLE
docs: improve AGENTS.md with project overview and quick reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,25 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 # Repository Guidelines
+
+**OpenClaw** is a multi-channel AI gateway that connects messaging platforms (WhatsApp, Telegram, Discord, Slack, Signal, iMessage, Matrix, and more) to AI agents. TypeScript (ESM), pnpm monorepo, Node 22+.
+
+## Quick Reference
+
+```bash
+pnpm install                # install deps
+pnpm check                  # lint + format + typecheck (local dev gate)
+pnpm test                   # run all tests (vitest, forks pool)
+pnpm test -- <path>         # run scoped test (e.g. src/foo/bar.test.ts)
+pnpm test -- <path> -t "name"  # run single test by name
+pnpm build                  # full build (required before push if touching SDK/packaging/lazy-loading)
+pnpm format:fix             # auto-fix formatting (oxfmt)
+pnpm lint:fix               # auto-fix lint (oxlint)
+pnpm dev                    # run CLI in dev mode
+pnpm tsgo                   # typecheck only
+```
 
 - Repo: https://github.com/openclaw/openclaw
 - In chat replies, file references must be repo-root relative only (example: `src/telegram/index.ts:80`); never absolute paths or `~/...`.
@@ -9,7 +30,7 @@
 - Source code: `src/` (CLI wiring in `src/cli`, commands in `src/commands`, web provider in `src/provider-web.ts`, infra in `src/infra`, media pipeline in `src/media`).
 - Tests: colocated `*.test.ts`.
 - Docs: `docs/` (images, queue, Pi config). Built output lives in `dist/`.
-- Nomenclature: use "plugin" / "plugins" in docs, UI, changelogs, and contributor guidance. The bundled workspace plugin tree remains the internal package layout to avoid repo-wide churn from a rename.
+- Nomenclature: use "plugin" / "plugins" in docs, UI, changelogs, and contributor guidance. The bundled workspace plugin tree (`extensions/`) remains the internal package layout to avoid repo-wide churn from a rename.
 - Bundled plugin naming: for repo-owned workspace plugins, keep the canonical plugin id aligned across `openclaw.plugin.json:id`, the default workspace folder name, and package names anchored to the same id (`@openclaw/<id>` or approved suffix forms like `-provider`, `-plugin`, `-speech`, `-sandbox`, `-media-understanding`). Keep `openclaw.install.npmSpec` equal to the package name and `openclaw.channel.id` equal to the plugin id when present. Exceptions must be explicit and covered by the repo invariant test.
 - Plugins: live in the bundled workspace plugin tree (workspace packages). Keep plugin-only deps in the extension `package.json`; do not add them to the root `package.json` unless core uses them.
 - Plugins: install runs `npm install --omit=dev` in plugin dir; runtime deps must live in `dependencies`. Avoid `workspace:*` in `dependencies` (npm install breaks); put `openclaw` in `devDependencies` or `peerDependencies` instead (runtime resolves `openclaw/plugin-sdk` via jiti alias).
@@ -272,7 +293,7 @@
   - Only ask when changes are semantic (logic/data/behavior).
 - **Multi-agent safety:** focus reports on your edits; avoid guard-rail disclaimers unless truly blocked; when multiple agents touch the same file, continue if safe; end with a brief “other files present” note only if relevant.
 - Bug investigations: read source code of relevant npm dependencies and all related local code before concluding; aim for high-confidence root cause.
-- Code style: add brief comments for tricky logic; keep files under ~500 LOC when feasible (split/refactor as needed).
+- Code style: add brief comments for tricky logic; keep files under ~700 LOC when feasible (split/refactor as needed).
 - Tool schema guardrails (google-antigravity): avoid `Type.Union` in tool input schemas; no `anyOf`/`oneOf`/`allOf`. Use `stringEnum`/`optionalStringEnum` (Type.Unsafe enum) for string lists, and `Type.Optional(...)` instead of `... | null`. Keep top-level tool schema as `type: "object"` with `properties`.
 - Tool schema guardrails: avoid raw `format` property names in tool schemas; some validators treat `format` as a reserved keyword and reject the schema.
 - Never send streaming/partial replies to external messaging surfaces (WhatsApp, Telegram); only final replies should be delivered there. Streaming/tool events may still go to internal UIs/control channel.


### PR DESCRIPTION
## Summary
- Add Claude Code header and one-line project description for faster onboarding
- Add consolidated quick-reference command block near the top
- Clarify `extensions/` as the bundled plugin tree path
- Unify file LOC guidance to ~700 (was ~500 in one section, ~700 in another)

## Test plan
- [ ] Verify CLAUDE.md symlink still resolves correctly
- [ ] Confirm no content duplication with existing sections

🤖 Generated with [Claude Code](https://claude.ai/claude-code)