### PR TITLE
fix(cron): include run timestamp in delivery idempotency key for persistent sessions

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -283,7 +283,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
     expect(enqueueSystemEvent).toHaveBeenCalledWith("Morning briefing complete.", {
       sessionKey: "agent:main:main",
-      contextKey: "cron-direct-delivery:v1:run-123:telegram::123456:",
+      contextKey: expect.stringMatching(/^cron-direct-delivery:v2:run-123:\d+:telegram::123456:$/),
     });
   });
 

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -214,6 +214,7 @@ function getCompletedDirectCronDelivery(
 
 function buildDirectCronDeliveryIdempotencyKey(params: {
   runSessionId: string;
+  runStartedAt: number;
   delivery: SuccessfulDeliveryTarget;
 }): string {
   const threadId =
@@ -222,7 +223,10 @@ function buildDirectCronDeliveryIdempotencyKey(params: {
       : String(params.delivery.threadId);
   const accountId = params.delivery.accountId?.trim() ?? "";
   const normalizedTo = normalizeDeliveryTarget(params.delivery.channel, params.delivery.to);
-  return `cron-direct-delivery:v1:${params.runSessionId}:${params.delivery.channel}:${accountId}:${normalizedTo}:${threadId}`;
+  // Include runStartedAt so persistent sessions (which reuse sessionId) get a
+  // unique key per cron run. Without this, the 24h idempotency cache prevents
+  // delivery on all runs after the first.
+  return `cron-direct-delivery:v2:${params.runSessionId}:${params.runStartedAt}:${params.delivery.channel}:${accountId}:${normalizedTo}:${threadId}`;
 }
 
 function shouldQueueCronAwareness(job: CronJob, deliveryBestEffort: boolean): boolean {
@@ -368,6 +372,7 @@ export async function dispatchCronDelivery(
     const identity = resolveAgentOutboundIdentity(params.cfgWithAgentDefaults, params.agentId);
     const deliveryIdempotencyKey = buildDirectCronDeliveryIdempotencyKey({
       runSessionId: params.runSessionId,
+      runStartedAt: params.runStartedAt,
       delivery,
     });
     try {


### PR DESCRIPTION
## Summary

- **Problem**: Persistent sessions (`sessionTarget: "session:xxx"`) reuse the same `sessionId` across cron runs. The delivery idempotency key was built from `sessionId + channel + to`, making it identical across runs. After the first successful delivery, the 24h idempotency cache blocked all subsequent deliveries — marking them `delivered=true` without actually sending.
- **Why it matters**: Cron jobs using persistent sessions (for cross-run memory/context) only deliver their first result. All subsequent runs appear successful but never reach the user. This silently breaks the primary use case for persistent session cron jobs.
- **What changed**: Added `runStartedAt` timestamp to `buildDirectCronDeliveryIdempotencyKey` so each cron run gets a unique cache key. Bumped key version from `v1` to `v2`.
- **What did NOT change**: Isolated sessions already get unique `sessionId` per run, so the extra field is redundant but harmless. Cache TTL and pruning logic unchanged.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway (cron delivery)

## Linked Issue

None (discovered during production usage of `sessionTarget: "session:xxx"` cron jobs)

## User-visible / Behavior Changes

Cron jobs with persistent sessions now deliver results on every run, not just the first.

## Security Impact

- Permissions or access control? **No**
- Secrets, tokens, or credentials? **No**
- Network requests or external connections? **No**
- Command execution or tool invocation? **No**
- Data access patterns or storage? **No** (only affects in-memory idempotency cache keys)

## Repro + Verification

**Environment**: OpenClaw 2026.3.28+, cron job with `sessionTarget: "session:xxx"`

**Steps**:
1. Create a cron job with `sessionTarget: "session:my-scan"` and `delivery: {mode: "announce", channel: "telegram", to: "12345"}`
2. Wait for first cron run — delivery arrives in Telegram
3. Wait for second cron run — delivery does NOT arrive (but `lastDeliveryStatus` says `delivered`)

**Expected**: Every run delivers to Telegram.

**Actual (before fix)**: Only the first run delivers. Subsequent runs hit the idempotency cache (same key due to reused `sessionId`) and skip actual delivery.

**Actual (after fix)**: Every run gets a unique idempotency key (different `runStartedAt`) and delivers correctly.

## Evidence

- 20/20 tests pass in `delivery-dispatch.double-announce.test.ts`
- Updated test assertion from hardcoded `v1` key to regex matching `v2` with timestamp
- Root cause confirmed by tracing: `buildDirectCronDeliveryIdempotencyKey` uses `runSessionId` which is `cronSession.sessionEntry.sessionId` (line 250 of run.ts) — fixed for persistent sessions but unique per run for isolated sessions

## Human Verification

- [x] Confirmed isolated sessions unaffected (they already get unique `sessionId` via `forceNew: true`)
- [x] Confirmed `runStartedAt` is always available (`Date.now()` at run.ts line 429)
- [x] Confirmed key version bump `v1` -> `v2` prevents collisions with cached entries after deploy
- [x] Tested on production: persistent session cron delivery now works on consecutive runs

## Review Conversations

- [x] I have replied to / resolved all bot review conversations

## Compatibility / Migration

Backward compatible. Existing `v1` cache entries expire naturally (24h TTL). No config changes.

## Failure Recovery

Revert single commit. Watch for: cron delivery idempotency cache not preventing genuine retries (unlikely — same `runStartedAt` within a single run still deduplicates correctly).

## Risks and Mitigations

Low risk. The only behavioral change is that persistent session cron runs no longer share idempotency keys. Within a single run, retries still deduplicate correctly (same `runStartedAt`).

🤖 AI-assisted (Claude Code). Root cause traced through full delivery pipeline. Fix verified with existing test suite.