### PR TITLE
fix: preserve original message body on fallback retries

### DIFF
--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -16,14 +16,14 @@ describe("resolveFallbackRetryPrompt", () => {
     ).toBe(originalBody);
   });
 
-  it("returns recovery prompt for fallback retry with existing session history", () => {
+  it("preserves original body for fallback retry even with existing session history", () => {
     expect(
       resolveFallbackRetryPrompt({
         body: originalBody,
         isFallbackRetry: true,
         sessionHasHistory: true,
       }),
-    ).toBe("Continue where you left off. The previous model attempt failed or timed out.");
+    ).toBe(originalBody);
   });
 
   it("preserves original body for fallback retry when session has no history (subagent spawn)", () => {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -129,7 +129,17 @@ export function resolveFallbackRetryPrompt(params: {
   if (!params.sessionHasHistory) {
     return params.body;
   }
-  return "Continue where you left off. The previous model attempt failed or timed out.";
+  // Always preserve the original body on fallback retries. The previous logic
+  // replaced the body with a generic "Continue where you left off..." prompt,
+  // assuming the model could reconstruct context from transcript history. This
+  // breaks inter-agent messages (sessions_send) whose content IS the task —
+  // the fallback model gets a vague recovery prompt instead of the actual work
+  // item. It also fails when the first attempt dies before the SessionManager
+  // flushes the user turn, leaving the original message absent from history.
+  // Preserving the original body is safe: the fallback model may see a
+  // duplicate in transcript history, but that is strictly preferable to losing
+  // the message content entirely.
+  return params.body;
 }
 
 export function prependInternalEventContext(


### PR DESCRIPTION
## Summary

- `resolveFallbackRetryPrompt()` replaced the message body with a generic "Continue where you left off..." recovery prompt when `sessionHasHistory` was true. For inter-agent `sessions_send` messages, this silently discarded the actual task content, breaking multi-agent communication.
- Changed to always return the original body on fallback retries instead of substituting the recovery prompt.

## Changes

- `src/agents/command/attempt-execution.ts`: Modified `resolveFallbackRetryPrompt()` to always preserve the original body.
- `src/agents/command/attempt-execution.test.ts`: Updated test expectation to verify original body is preserved.

Closes #58219