### PR TITLE
session: clear model overrides on /reset and /new (#58302)

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -431,8 +431,9 @@ export async function initSessionState(params: {
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      persistedModelOverride = entry.modelOverride;
-      persistedProviderOverride = entry.providerOverride;
+      // Do not carry over modelOverride/providerOverride — /reset and /new
+      // should revert to config defaults.  The /new <model-name> hint is
+      // applied separately by applyResetModelOverride after session creation.
       persistedAuthProfileOverride = entry.authProfileOverride;
       persistedAuthProfileOverrideSource = entry.authProfileOverrideSource;
       persistedAuthProfileOverrideCompactionCount = entry.authProfileOverrideCompactionCount;
@@ -615,6 +616,10 @@ export async function initSessionState(params: {
     sessionEntry.outputTokens = undefined;
     sessionEntry.estimatedCostUsd = undefined;
     sessionEntry.contextTokens = undefined;
+    // Clear runtime model state so the store spread below does not leak the
+    // previous session's last-used model into the new session (#58302).
+    sessionEntry.model = undefined;
+    sessionEntry.modelProvider = undefined;
   }
   // Preserve per-session overrides while resetting compaction state on /new.
   sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -50,6 +50,10 @@ function stripRuntimeModelState(entry?: SessionEntry): SessionEntry | undefined 
     ...entry,
     model: undefined,
     modelProvider: undefined,
+    // Also clear user-set overrides so resolveSessionModelRef falls back to
+    // config defaults — /reset and /new should not carry the /model selection.
+    modelOverride: undefined,
+    providerOverride: undefined,
     contextTokens: undefined,
     systemPromptReport: undefined,
   };
@@ -336,8 +340,11 @@ export async function performGatewaySessionReset(params: {
       execAsk: currentEntry?.execAsk,
       execNode: currentEntry?.execNode,
       responseUsage: currentEntry?.responseUsage,
-      providerOverride: currentEntry?.providerOverride,
-      modelOverride: currentEntry?.modelOverride,
+      // Do not carry over model overrides — /reset and /new should revert to
+      // config defaults.  The /new <model-name> hint is applied separately by
+      // applyResetModelOverride after session creation.
+      providerOverride: undefined,
+      modelOverride: undefined,
       authProfileOverride: currentEntry?.authProfileOverride,
       authProfileOverrideSource: currentEntry?.authProfileOverrideSource,
       authProfileOverrideCompactionCount: currentEntry?.authProfileOverrideCompactionCount,


### PR DESCRIPTION
## Summary
- Fix `/reset` and `/new` commands not reverting model selection to config defaults
- Both gateway (`session-reset-service.ts`) and auto-reply (`session.ts`) paths were carrying over `modelOverride`/`providerOverride` from the old session into the new one

## Changes
- `stripRuntimeModelState()` now also clears `modelOverride`/`providerOverride` so `resolveSessionModelRef` falls back to config defaults
- Gateway `nextEntry` construction no longer copies `currentEntry?.providerOverride`/`modelOverride`
- Auto-reply reset path no longer persists `entry.modelOverride`/`entry.providerOverride` when `resetTriggered` is true
- Explicit `model`/`modelProvider` clearing in the `isNewSession` block prevents the store spread from leaking old runtime model state

The `/new <model-name>` hint flow (`applyResetModelOverride`) is unaffected — it runs after session creation and correctly sets overrides when a model hint is present in the body.

Closes #58302