### PR TITLE
cron: clear stale sessionFile on session rollover (#58304)

### DIFF
--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -219,6 +219,39 @@ describe("resolveCronSession", () => {
       expect(result.sessionEntry.deliveryContext).toBeUndefined();
     });
 
+    it("clears stale sessionFile when rolling to a new sessionId (#58304)", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "old-session-id",
+          updatedAt: NOW_MS - 86_400_000,
+          sessionFile: "/old/path/old-session-id.jsonl",
+        },
+        fresh: false,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.sessionId).not.toBe("old-session-id");
+      // sessionFile must be cleared so resolveSessionFilePath recomputes from
+      // the new sessionId rather than reusing the old path.
+      expect(result.sessionEntry.sessionFile).toBeUndefined();
+    });
+
+    it("clears stale sessionFile when forceNew is true (#58304)", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id",
+          updatedAt: NOW_MS - 1000,
+          systemSent: true,
+          sessionFile: "/old/path/existing-session-id.jsonl",
+        },
+        fresh: true,
+        forceNew: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.sessionFile).toBeUndefined();
+    });
+
     it("preserves delivery routing metadata when reusing fresh session", () => {
       const result = resolveWithStoredEntry({
         entry: {
@@ -246,6 +279,23 @@ describe("resolveCronSession", () => {
         to: "channel:C0XXXXXXXXX",
         threadId: "1737500000.123456",
       });
+    });
+
+    it("preserves sessionFile when reusing fresh session", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id-101",
+          updatedAt: NOW_MS - 1000,
+          systemSent: true,
+          sessionFile: "/data/sessions/existing-session-id-101.jsonl",
+        },
+        fresh: true,
+      });
+
+      expect(result.isNewSession).toBe(false);
+      expect(result.sessionEntry.sessionFile).toBe(
+        "/data/sessions/existing-session-id-101.jsonl",
+      );
     });
 
     it("creates new sessionId when entry exists but has no sessionId", () => {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -83,6 +83,10 @@ export function resolveCronSession(params: {
       lastAccountId: undefined,
       lastThreadId: undefined,
       deliveryContext: undefined,
+      // Clear stale sessionFile so resolveSessionFilePath recomputes from the
+      // new sessionId — otherwise the old path leaks and transcripts land in
+      // the previous session's file (#58304).
+      sessionFile: undefined,
     }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };


### PR DESCRIPTION
## Summary
- Fix cron session rollover preserving the old `sessionFile` path when a new `sessionId` is generated
- When a cron session expires (stale) or `forceNew` is true, the `...entry` spread carries forward the old `sessionFile`, causing the new session's transcripts to be written to the previous session's file

## Changes
- Clear `sessionFile` in the `isNewSession` spread in `resolveCronSession()` so `resolveSessionFilePath` recomputes a fresh path from the new `sessionId`
- Added 3 new tests: verifying sessionFile is cleared on stale rollover, cleared on forceNew, and preserved when reusing a fresh session

Closes #58304