### PR TITLE
fix(update-cli): respawn plugin refresh after self-update

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -29,6 +30,7 @@ const pathExists = vi.fn();
 const syncPluginsForUpdateChannel = vi.fn();
 const updateNpmInstalledPlugins = vi.fn();
 const nodeVersionSatisfiesEngine = vi.fn();
+const spawn = vi.fn();
 const { defaultRuntime: runtimeCapture, resetRuntimeCapture } = createCliRuntimeCapture();
 
 vi.mock("@clack/prompts", () => ({
@@ -76,6 +78,7 @@ vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return {
     ...actual,
+    spawn,
     spawnSync: vi.fn(() => ({
       pid: 0,
       output: [],
@@ -315,6 +318,15 @@ describe("update-cli", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetRuntimeCapture();
+    spawn.mockImplementation(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        once: EventEmitter["once"];
+      };
+      queueMicrotask(() => {
+        child.emit("exit", 0, null);
+      });
+      return child;
+    });
     vi.mocked(defaultRuntime.exit).mockImplementation(() => {});
     vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(process.cwd());
     vi.mocked(readConfigFileSnapshot).mockResolvedValue(baseSnapshot);
@@ -408,6 +420,48 @@ describe("update-cli", () => {
     vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult());
     setTty(false);
     setStdoutTty(false);
+  });
+
+  it("respawns into the updated package root before running post-update tasks", async () => {
+    const { entryPath } = setupUpdatedRootRefresh();
+
+    await updateCommand({ yes: true });
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.stringMatching(/node/),
+      [entryPath, "update", "--yes"],
+      expect.objectContaining({
+        stdio: "inherit",
+        env: expect.objectContaining({
+          OPENCLAW_UPDATE_POST_CORE: "1",
+          OPENCLAW_UPDATE_POST_CORE_CHANNEL: "dev",
+        }),
+      }),
+    );
+    expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
+    expect(runDaemonInstall).not.toHaveBeenCalled();
+    expect(runDaemonRestart).not.toHaveBeenCalled();
+  });
+
+  it("post-core resume mode skips the core update and only runs post-update tasks", async () => {
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_UPDATE_POST_CORE_CHANNEL: "stable",
+      },
+      async () => {
+        await updateCommand({ restart: false });
+      },
+    );
+
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(runCommandWithTimeout).not.toHaveBeenCalledWith(
+      ["npm", "i", "-g", expect.any(String)],
+      expect.anything(),
+    );
+    expect(syncPluginsForUpdateChannel).toHaveBeenCalledTimes(1);
+    expect(updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
+    expect(spawn).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -443,6 +443,24 @@ describe("update-cli", () => {
     expect(runDaemonRestart).not.toHaveBeenCalled();
   });
 
+  it("falls back to in-process post-update work when the fresh process exits non-zero", async () => {
+    setupUpdatedRootRefresh();
+    spawn.mockImplementationOnce(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        once: EventEmitter["once"];
+      };
+      queueMicrotask(() => {
+        child.emit("exit", 2, null);
+      });
+      return child;
+    });
+
+    await updateCommand({ yes: true });
+
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(2);
+    expect(updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
+  });
+
   it("post-core resume mode skips the core update and only runs post-update tasks", async () => {
     await withEnvAsync(
       {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -443,7 +443,7 @@ describe("update-cli", () => {
     expect(runDaemonRestart).not.toHaveBeenCalled();
   });
 
-  it("falls back to in-process post-update work when the fresh process exits non-zero", async () => {
+  it("fails the update when the fresh process exits non-zero", async () => {
     setupUpdatedRootRefresh();
     spawn.mockImplementationOnce(() => {
       const child = new EventEmitter() as EventEmitter & {
@@ -455,10 +455,12 @@ describe("update-cli", () => {
       return child;
     });
 
-    await updateCommand({ yes: true });
+    await expect(updateCommand({ yes: true })).rejects.toThrow(
+      "post-update process exited with code 2",
+    );
 
     expect(defaultRuntime.exit).toHaveBeenCalledWith(2);
-    expect(updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
+    expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
   });
 
   it("post-core resume mode skips the core update and only runs post-update tasks", async () => {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import path from "node:path";
 import { confirm, isCancel } from "@clack/prompts";
 import {
@@ -75,6 +76,8 @@ import { suppressDeprecations } from "./suppress-deprecations.js";
 
 const CLI_NAME = resolveCliName();
 const SERVICE_REFRESH_TIMEOUT_MS = 60_000;
+const POST_CORE_UPDATE_ENV = "OPENCLAW_UPDATE_POST_CORE";
+const POST_CORE_UPDATE_CHANNEL_ENV = "OPENCLAW_UPDATE_POST_CORE_CHANNEL";
 const SERVICE_REFRESH_PATH_ENV_KEYS = [
   "OPENCLAW_HOME",
   "OPENCLAW_STATE_DIR",
@@ -106,6 +109,10 @@ const UPDATE_QUIPS = [
 
 function pickUpdateQuip(): string {
   return UPDATE_QUIPS[Math.floor(Math.random() * UPDATE_QUIPS.length)] ?? "Update complete.";
+}
+
+function isPackageManagerUpdateMode(mode: UpdateRunResult["mode"]): mode is "npm" | "pnpm" | "bun" {
+  return mode === "npm" || mode === "pnpm" || mode === "bun";
 }
 
 function resolveGatewayInstallEntrypointCandidates(root?: string): string[] {
@@ -741,9 +748,73 @@ async function maybeRestartService(params: {
   }
 }
 
+async function runPostCorePluginUpdate(params: {
+  root: string;
+  channel: "stable" | "beta" | "dev";
+  configSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
+  opts: UpdateCommandOptions;
+}): Promise<void> {
+  await updatePluginsAfterCoreUpdate({
+    root: params.root,
+    channel: params.channel,
+    configSnapshot: params.configSnapshot,
+    opts: params.opts,
+  });
+}
+
+async function continuePostCoreUpdateInFreshProcess(params: {
+  root: string;
+  channel: "stable" | "beta" | "dev";
+  resultMode: "npm" | "pnpm" | "bun";
+  opts: UpdateCommandOptions;
+}): Promise<boolean> {
+  const entryPath = path.join(params.root, "dist", "entry.js");
+  if (!(await pathExists(entryPath))) {
+    return false;
+  }
+
+  const argv = [entryPath, "update"];
+  if (params.opts.json) {
+    argv.push("--json");
+  }
+  if (params.opts.restart === false) {
+    argv.push("--no-restart");
+  }
+  if (params.opts.yes) {
+    argv.push("--yes");
+  }
+
+  const child = spawn(resolveNodeRunner(), argv, {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      [POST_CORE_UPDATE_ENV]: "1",
+      [POST_CORE_UPDATE_CHANNEL_ENV]: params.channel,
+    },
+  });
+
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`post-update process terminated by signal ${signal}`));
+        return;
+      }
+      resolve(code ?? 1);
+    });
+  });
+
+  if (exitCode !== 0) {
+    defaultRuntime.exit(exitCode);
+  }
+  return true;
+}
+
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   suppressDeprecations();
   const invocationCwd = tryResolveInvocationCwd();
+  const postCoreUpdateResume = process.env[POST_CORE_UPDATE_ENV] === "1";
+  const postCoreUpdateChannel = process.env[POST_CORE_UPDATE_CHANNEL_ENV]?.trim();
 
   const timeoutMs = parseTimeoutMsOrExit(opts.timeout);
   const shouldRestart = opts.restart !== false;
@@ -752,6 +823,26 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   }
 
   const root = await resolveUpdateRoot();
+  if (postCoreUpdateResume) {
+    if (
+      postCoreUpdateChannel !== "stable" &&
+      postCoreUpdateChannel !== "beta" &&
+      postCoreUpdateChannel !== "dev"
+    ) {
+      defaultRuntime.error("Missing post-core update channel context.");
+      defaultRuntime.exit(1);
+      return;
+    }
+
+    await runPostCorePluginUpdate({
+      root,
+      channel: postCoreUpdateChannel,
+      configSnapshot: await readConfigFileSnapshot(),
+      opts,
+    });
+    return;
+  }
+
   const updateStatus = await checkUpdateStatus({
     root,
     timeoutMs: timeoutMs ?? 3500,
@@ -942,24 +1033,6 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   const { progress, stop } = createUpdateProgress(showProgress);
   const startedAt = Date.now();
 
-  let restartScriptPath: string | null = null;
-  let refreshGatewayServiceEnv = false;
-  const gatewayPort = resolveGatewayPort(
-    configSnapshot.valid ? configSnapshot.config : undefined,
-    process.env,
-  );
-  if (shouldRestart) {
-    try {
-      const loaded = await resolveGatewayService().isLoaded({ env: process.env });
-      if (loaded) {
-        restartScriptPath = await prepareRestartScript(process.env, gatewayPort);
-        refreshGatewayServiceEnv = true;
-      }
-    } catch {
-      // Ignore errors during pre-check; fallback to standard restart
-    }
-  }
-
   const result =
     updateInstallKind === "package"
       ? await runPackageInstallUpdate({
@@ -1043,12 +1116,42 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     }
   }
 
-  await updatePluginsAfterCoreUpdate({
-    root,
-    channel,
-    configSnapshot: postUpdateConfigSnapshot,
-    opts,
-  });
+  let pluginsUpdatedInFreshProcess = false;
+  if (isPackageManagerUpdateMode(result.mode)) {
+    pluginsUpdatedInFreshProcess = await continuePostCoreUpdateInFreshProcess({
+      root: result.root ?? root,
+      channel,
+      resultMode: result.mode,
+      opts,
+    });
+  }
+
+  if (!pluginsUpdatedInFreshProcess) {
+    await runPostCorePluginUpdate({
+      root,
+      channel,
+      configSnapshot: postUpdateConfigSnapshot,
+      opts,
+    });
+  }
+
+  let restartScriptPath: string | null = null;
+  let refreshGatewayServiceEnv = false;
+  const gatewayPort = resolveGatewayPort(
+    postUpdateConfigSnapshot.valid ? postUpdateConfigSnapshot.config : undefined,
+    process.env,
+  );
+  if (shouldRestart) {
+    try {
+      const loaded = await resolveGatewayService().isLoaded({ env: process.env });
+      if (loaded) {
+        restartScriptPath = await prepareRestartScript(process.env, gatewayPort);
+        refreshGatewayServiceEnv = true;
+      }
+    } catch {
+      // Ignore errors during pre-check; fallback to standard restart
+    }
+  }
 
   await tryWriteCompletionCache(root, Boolean(opts.json));
   await tryInstallShellCompletion({

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -806,7 +806,7 @@ async function continuePostCoreUpdateInFreshProcess(params: {
 
   if (exitCode !== 0) {
     defaultRuntime.exit(exitCode);
-    return false;
+    throw new Error(`post-update process exited with code ${exitCode}`);
   }
   return true;
 }

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -806,6 +806,7 @@ async function continuePostCoreUpdateInFreshProcess(params: {
 
   if (exitCode !== 0) {
     defaultRuntime.exit(exitCode);
+    return false;
   }
   return true;
 }


### PR DESCRIPTION
## Summary

- Problem: `openclaw update` could self-update the globally installed package and then keep running old lazy-import code during `Updating plugins...`.
- Why it matters: tracked npm plugins could fail immediately after a successful host update with `ERR_MODULE_NOT_FOUND` from stale `dist/install.runtime-*.js` chunk references.
- What changed: package-manager updates now hand off plugin refresh to a fresh process started from the updated `dist/entry.js`, then return to the original flow for completion cache refresh and restart logic.
- What did NOT change (scope boundary): git-update behavior, plugin install semantics, hook-pack update behavior, and restart/doctor sequencing outside the handoff are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: after a package-manager self-update, the running CLI process still held old lazy-import paths for the plugin update helpers and tried to import stale hashed chunks.
- Missing detection / guardrail: the update flow assumed it could safely continue plugin refresh inside the same process after replacing the installed package files.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the shared package/plugin update flow now refreshes plugins after core update in the same command.
- Why this regressed now: once the package install replaced hashed `dist/*` files, the old process could no longer resolve the lazy-imported chunk names it had been compiled with.
- If unknown, what was ruled out: ruled out a missing file in the affected plugin package by reproducing the same failure with a minimal tracked npm plugin install record.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/update-cli.test.ts`
- Scenario the test should lock in: package self-updates respawn into the updated entrypoint before plugin refresh, and the resumed post-core path skips re-running the core update.
- Why this is the smallest reliable guardrail: the bug is in CLI control flow around process lifetime and can be reproduced by asserting the fresh-process handoff without needing a full global install fixture.
- Existing test that already covers this (if any): existing update-cli coverage already covered the surrounding restart/service-refresh flow.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw update` no longer runs tracked npm plugin refresh inside the stale pre-update process after a package-manager self-update.
- Successful package updates continue with the same visible restart/completion behavior after the plugin-refresh handoff.

## Diagram (if applicable)

```text
Before:
openclaw update -> replace global package files -> old process runs plugin refresh -> stale chunk import fails

After:
openclaw update -> replace global package files -> updated entrypoint resumes plugin refresh -> original flow continues -> restart
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.16.0 global npm install
- Model/provider: N/A
- Integration/channel (if any): tracked npm plugin (`claworld`)
- Relevant config (redacted): `plugins.installs.<id>.source = "npm"`

### Steps

1. Install `openclaw@2026.3.23-2` into an isolated global prefix.
2. Add a tracked npm plugin install record.
3. Run `openclaw update` to upgrade to `2026.3.28`.

### Expected

- Host update finishes and tracked npm plugins refresh successfully.

### Actual

- Host update succeeds, then plugin refresh fails with `ERR_MODULE_NOT_FOUND` from stale `dist/install.runtime-*.js` imports.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced the stale-chunk failure in an isolated global install, then ran `corepack pnpm vitest src/cli/update-cli.test.ts` after implementing the fresh-process handoff.
- Edge cases checked: package-update path still preserves existing restart/service-refresh coverage; resumed post-core mode does not re-run the core update.
- What you did **not** verify: I did not run a full packaged end-to-end upgrade against a freshly built artifact from this branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: respawn handoff could silently skip plugin refresh if the updated entrypoint is missing.
  - Mitigation: the code falls back to the in-process plugin update path when `dist/entry.js` is unavailable.
- Risk: package-update flow could accidentally recurse into another core update.
  - Mitigation: the resumed mode is gated by explicit env vars and returns before any core-update work runs.
