### PR TITLE
fix: emit cli-backends.runtime as standalone build entry

### DIFF
--- a/extensions/anthropic/index.ts
+++ b/extensions/anthropic/index.ts
@@ -29,6 +29,7 @@ import { cloneFirstTemplateModel } from "openclaw/plugin-sdk/provider-model-shar
 import { fetchClaudeUsage } from "openclaw/plugin-sdk/provider-usage";
 import { buildAnthropicCliBackend } from "./cli-backend.js";
 import { buildAnthropicCliMigrationResult, hasClaudeCliAuth } from "./cli-migration.js";
+import { CLAUDE_CLI_BACKEND_ID } from "./cli-shared.js";
 import { anthropicMediaUnderstandingProvider } from "./media-understanding-provider.js";
 
 const PROVIDER_ID = "anthropic";
@@ -352,6 +353,7 @@ export default definePluginEntry({
     api.registerCliBackend(buildAnthropicCliBackend());
     api.registerProvider({
       id: PROVIDER_ID,
+      hookAliases: [CLAUDE_CLI_BACKEND_ID],
       label: "Anthropic",
       docsPath: "/providers/models",
       envVars: ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"],

--- a/scripts/test-built-plugin-singleton.mjs
+++ b/scripts/test-built-plugin-singleton.mjs
@@ -44,6 +44,14 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const smokeEntryPath = path.join(repoRoot, "dist", "plugins", "build-smoke-entry.js");
 assert.ok(fs.existsSync(smokeEntryPath), `missing build output: ${smokeEntryPath}`);
 
+// Verify CLI backend runtime is emitted as a standalone entry so that
+// `isCliProvider()` can resolve it at runtime via `require()`.
+const cliBackendsRuntimePath = path.join(repoRoot, "dist", "plugins", "cli-backends.runtime.js");
+assert.ok(
+  fs.existsSync(cliBackendsRuntimePath),
+  `missing build output: ${cliBackendsRuntimePath} — CLI backends will silently fail at runtime`,
+);
+
 const { clearPluginCommands, getPluginCommandSpecs, loadOpenClawPlugins, matchPluginCommand } =
   await import(pathToFileURL(smokeEntryPath).href);
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import { resolveThinkingDefaultForModel } from "../auto-reply/thinking.shared.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
@@ -30,9 +31,15 @@ let log: ReturnType<typeof createSubsystemLogger> | null = null;
 
 type CliBackendRuntimeModule = typeof import("../plugins/cli-backends.runtime.js");
 
+// Use a local `createRequire(import.meta.url)` so the bundler emits a require
+// anchored to this chunk's file URL.  A bare `require()` gets hoisted into a
+// shared helpers chunk whose `import.meta.url` points elsewhere, breaking the
+// relative path resolution at runtime.
+const requireFromHere = createRequire(import.meta.url);
 const CLI_BACKEND_RUNTIME_CANDIDATES = [
   "../plugins/cli-backends.runtime.js",
   "../plugins/cli-backends.runtime.ts",
+  "./plugins/cli-backends.runtime.js",
 ] as const;
 
 let cliBackendRuntimeModule: CliBackendRuntimeModule | undefined;
@@ -43,7 +50,7 @@ function loadCliBackendRuntime(): CliBackendRuntimeModule | null {
   }
   for (const candidate of CLI_BACKEND_RUNTIME_CANDIDATES) {
     try {
-      cliBackendRuntimeModule = require(candidate) as CliBackendRuntimeModule;
+      cliBackendRuntimeModule = requireFromHere(candidate) as CliBackendRuntimeModule;
       return cliBackendRuntimeModule;
     } catch {
       // Try source/runtime candidates in order.

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -87,8 +87,14 @@ export function resolveOwningPluginIdsForProvider(params: {
     env: params.env,
   });
   const pluginIds = registry.plugins
-    .filter((plugin) =>
-      plugin.providers.some((providerId) => normalizeProviderId(providerId) === normalizedProvider),
+    .filter(
+      (plugin) =>
+        plugin.providers.some(
+          (providerId) => normalizeProviderId(providerId) === normalizedProvider,
+        ) ||
+        (plugin.cliBackends ?? []).some(
+          (backendId) => normalizeProviderId(backendId) === normalizedProvider,
+        ),
     )
     .map((plugin) => plugin.id);
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -123,6 +123,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/auth-profiles.runtime": "src/agents/auth-profiles.runtime.ts",
     "agents/pi-model-discovery-runtime": "src/agents/pi-model-discovery-runtime.ts",
     "commands/status.summary.runtime": "src/commands/status.summary.runtime.ts",
+    "plugins/cli-backends.runtime": "src/plugins/cli-backends.runtime.ts",
     "plugins/provider-runtime.runtime": "src/plugins/provider-runtime.runtime.ts",
     "plugins/runtime/runtime-line.contract": "src/plugins/runtime/runtime-line.contract.ts",
     extensionAPI: "src/extensionAPI.ts",


### PR DESCRIPTION
Fixes #57326

## What's broken

The `claude-cli` provider (and all CLI backend providers) fails with **"Unknown model"** errors on every request:

```
⚠️ Agent failed before reply: All models failed (5):
  claude-cli/claude-sonnet-4-6: Unknown model (model_not_found)
  claude-cli/claude-opus-4-6: Unknown model (model_not_found)
  ...
```

This affects anyone who configured the Anthropic Claude CLI auth method via `openclaw agents add` or `openclaw configure --section model`.

## How to reproduce

1. `openclaw agents add main` → Anthropic → "Anthropic Claude CLI"
2. Send any message via TUI, Telegram, Slack, or `openclaw agent`
3. Every request fails with `Unknown model: claude-cli/...`

## Root cause

Two independent issues prevent `claude-cli` from working:

**1. CLI backend routing (commit 1):** The CLI backends runtime module is not emitted as a standalone file by the bundler — it gets inlined into another chunk. At runtime, `isCliProvider()` silently fails to load the module and always returns `false`, so `claude-cli` requests are sent to the embedded inference runner instead of the CLI runner subprocess.

**2. Provider hook resolution (commit 2):** Even when the model resolver runs for `claude-cli`, the plugin ownership lookup and provider runtime hooks don't fire because `claude-cli` is only registered as a `cliBackend`, not as a `provider` or `hookAlias` on the Anthropic plugin. This was independently diagnosed in [#57326 (comment)](https://github.com/openclaw/openclaw/issues/57326#issuecomment-4155325692).

## Fix

**Commit 1** — fix CLI backend routing:
- Register the CLI backends runtime as a standalone build entry (matching how `provider-runtime.runtime` is already registered)
- Fix the `require()` resolution pattern to anchor to the correct file location
- Add a build-smoke assertion to prevent silent regression

**Commit 2** — fix provider hook resolution (credit: [#57326 comment](https://github.com/openclaw/openclaw/issues/57326#issuecomment-4155325692)):
- Add `claude-cli` as a `hookAlias` on the Anthropic provider so `matchesProviderId()` and runtime hooks fire
- Include `cliBackends` in `resolveOwningPluginIdsForProvider()` so the plugin registry maps CLI backend IDs back to their owning plugin

May also partially address #57907.
