### PR TITLE
fix(daemon): increase launchd ThrottleInterval to prevent zombie process storm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Breaking
+
+- Daemon: increase launchd `ThrottleInterval` from 1s to 10s to prevent gateway process storms when the port isn't released before restart. This prevents 30+ zombie processes from accumulating during rapid restart cycles on macOS. (#58306)
+
 ### Changes
 
 - Android/assistant: auto-send Google Assistant App Actions prompts once chat is healthy and idle, while keeping bare assistant launches as open-only. (#59721) Thanks @obviyus.

--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs/promises";
 
 // launchd applies ThrottleInterval to any rapid relaunch, including
-// intentional gateway restarts. Keep it low so CLI restarts and forced
-// reinstalls do not stall for a full minute.
-export const LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS = 1;
+// intentional gateway restarts. Set to 10 seconds to allow time for the
+// gateway port to be released before restart, preventing zombie process storms.
+// See: https://github.com/openclaw/openclaw/issues/58306
+export const LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS = 10;
 // launchd stores plist integer values in decimal; 0o077 renders as 63 (owner-only files).
 export const LAUNCH_AGENT_UMASK_DECIMAL = 0o077;
 


### PR DESCRIPTION
## Summary

Fix crash-level bug where 30+ zombie gateway processes accumulate on macOS when the port isn't released before launchd restarts.

## Root Cause

- launchd's `ThrottleInterval=1` restarts the gateway every 1 second after crash
- Gateway port (18789) takes >1 second to be released
- Each restart fails to bind port and spawns a new zombie process
- 30+ processes accumulate within minutes, making UI permanently spin

## Fix

Increase `LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS` from 1 to 10 seconds:
- Allows sufficient time for port release before restart
- Prevents zombie process accumulation
- Trade-off: intentional CLI restarts delayed by up to 10 seconds (acceptable)

## Testing

- ✅ All existing launchd tests pass (25 tests)
- ✅ TypeScript type check passes
- ✅ All lint checks pass
- ✅ Manual testing needed: macOS with launchd KeepAlive enabled

## Related

Fixes #58306

## Changelog

Added to `CHANGELOG.md` under `## Unreleased` → `### Breaking`