### PR TITLE
fix(security): remove wildcard injection in alsoAllow and preserve plugin-only allowlists

### DIFF
--- a/src/agents/sandbox-tool-policy.ts
+++ b/src/agents/sandbox-tool-policy.ts
@@ -10,10 +10,8 @@ function unionAllow(base?: string[], extra?: string[]): string[] | undefined {
   if (!Array.isArray(extra) || extra.length === 0) {
     return base;
   }
-  // If the user is using alsoAllow without an allowlist, treat it as additive on top of
-  // an implicit allow-all policy.
   if (!Array.isArray(base) || base.length === 0) {
-    return Array.from(new Set(["*", ...extra]));
+    return Array.from(new Set(extra));
   }
   return Array.from(new Set([...base, ...extra]));
 }

--- a/src/agents/sandbox-tool-policy.ts
+++ b/src/agents/sandbox-tool-policy.ts
@@ -10,8 +10,11 @@ function unionAllow(base?: string[], extra?: string[]): string[] | undefined {
   if (!Array.isArray(extra) || extra.length === 0) {
     return base;
   }
-  if (!Array.isArray(base) || base.length === 0) {
+  if (!Array.isArray(base)) {
     return Array.from(new Set(extra));
+  }
+  if (base.length === 0) {
+    return base;
   }
   return Array.from(new Set([...base, ...extra]));
 }

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -36,7 +36,7 @@ describe("tool-policy-pipeline", () => {
     resetToolPolicyWarningCacheForTest();
   });
 
-  test("strips allowlists that would otherwise disable core tools", () => {
+  test("preserves plugin-only allowlists instead of silently stripping them", () => {
     const tools = [{ name: "exec" }, { name: "plugin_tool" }] as unknown as DummyTool[];
     const filtered = applyToolPolicyPipeline({
       // oxlint-disable-next-line typescript/no-explicit-any
@@ -53,7 +53,7 @@ describe("tool-policy-pipeline", () => {
       ],
     });
     const names = filtered.map((t) => (t as unknown as DummyTool).name).toSorted();
-    expect(names).toEqual(["exec", "plugin_tool"]);
+    expect(names).toEqual(["plugin_tool"]);
   });
 
   test("warns about unknown allowlist entries", () => {

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -129,7 +129,7 @@ export function applyToolPolicyPipeline(params: {
           })
         ) {
           const suffix = describeUnknownAllowlistSuffix({
-            strippedAllowlist: resolved.strippedAllowlist,
+            pluginOnlyAllowlist: resolved.pluginOnlyAllowlist,
             hasGatedCoreEntries: gatedCoreEntries.length > 0,
             hasOtherEntries: otherEntries.length > 0,
           });
@@ -164,11 +164,11 @@ function shouldSuppressUnavailableCoreToolWarning(params: {
 }
 
 function describeUnknownAllowlistSuffix(params: {
-  strippedAllowlist: boolean;
+  pluginOnlyAllowlist: boolean;
   hasGatedCoreEntries: boolean;
   hasOtherEntries: boolean;
 }): string {
-  const preface = params.strippedAllowlist
+  const preface = params.pluginOnlyAllowlist
     ? "Allowlist contains only plugin entries; core tools will not be available."
     : "";
   const detail =

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -169,7 +169,7 @@ function describeUnknownAllowlistSuffix(params: {
   hasOtherEntries: boolean;
 }): string {
   const preface = params.strippedAllowlist
-    ? "Ignoring allowlist so core tools remain available."
+    ? "Allowlist contains only plugin entries; core tools will not be available."
     : "";
   const detail =
     params.hasGatedCoreEntries && params.hasOtherEntries

--- a/src/agents/tool-policy.plugin-only-allowlist.test.ts
+++ b/src/agents/tool-policy.plugin-only-allowlist.test.ts
@@ -11,14 +11,14 @@ describe("stripPluginOnlyAllowlist", () => {
   it("preserves allowlist when it only targets plugin tools", () => {
     const policy = stripPluginOnlyAllowlist({ allow: ["lobster"] }, pluginGroups, coreTools);
     expect(policy.policy?.allow).toEqual(["lobster"]);
-    expect(policy.strippedAllowlist).toBe(true);
+    expect(policy.pluginOnlyAllowlist).toBe(true);
     expect(policy.unknownAllowlist).toEqual([]);
   });
 
   it("preserves allowlist when it only targets plugin groups", () => {
     const policy = stripPluginOnlyAllowlist({ allow: ["group:plugins"] }, pluginGroups, coreTools);
     expect(policy.policy?.allow).toEqual(["group:plugins"]);
-    expect(policy.strippedAllowlist).toBe(true);
+    expect(policy.pluginOnlyAllowlist).toBe(true);
     expect(policy.unknownAllowlist).toEqual([]);
   });
 
@@ -42,7 +42,7 @@ describe("stripPluginOnlyAllowlist", () => {
     const emptyPlugins: PluginToolGroups = { all: [], byPlugin: new Map() };
     const policy = stripPluginOnlyAllowlist({ allow: ["lobster"] }, emptyPlugins, coreTools);
     expect(policy.policy?.allow).toEqual(["lobster"]);
-    expect(policy.strippedAllowlist).toBe(true);
+    expect(policy.pluginOnlyAllowlist).toBe(true);
     expect(policy.unknownAllowlist).toEqual(["lobster"]);
   });
 

--- a/src/agents/tool-policy.plugin-only-allowlist.test.ts
+++ b/src/agents/tool-policy.plugin-only-allowlist.test.ts
@@ -8,15 +8,17 @@ const pluginGroups: PluginToolGroups = {
 const coreTools = new Set(["read", "write", "exec", "session_status"]);
 
 describe("stripPluginOnlyAllowlist", () => {
-  it("strips allowlist when it only targets plugin tools", () => {
+  it("preserves allowlist when it only targets plugin tools", () => {
     const policy = stripPluginOnlyAllowlist({ allow: ["lobster"] }, pluginGroups, coreTools);
-    expect(policy.policy?.allow).toBeUndefined();
+    expect(policy.policy?.allow).toEqual(["lobster"]);
+    expect(policy.strippedAllowlist).toBe(true);
     expect(policy.unknownAllowlist).toEqual([]);
   });
 
-  it("strips allowlist when it only targets plugin groups", () => {
+  it("preserves allowlist when it only targets plugin groups", () => {
     const policy = stripPluginOnlyAllowlist({ allow: ["group:plugins"] }, pluginGroups, coreTools);
-    expect(policy.policy?.allow).toBeUndefined();
+    expect(policy.policy?.allow).toEqual(["group:plugins"]);
+    expect(policy.strippedAllowlist).toBe(true);
     expect(policy.unknownAllowlist).toEqual([]);
   });
 
@@ -36,10 +38,11 @@ describe("stripPluginOnlyAllowlist", () => {
     expect(policy.unknownAllowlist).toEqual([]);
   });
 
-  it("strips allowlist with unknown entries when no core tools match", () => {
+  it("preserves allowlist with unknown entries when no core tools match", () => {
     const emptyPlugins: PluginToolGroups = { all: [], byPlugin: new Map() };
     const policy = stripPluginOnlyAllowlist({ allow: ["lobster"] }, emptyPlugins, coreTools);
-    expect(policy.policy?.allow).toBeUndefined();
+    expect(policy.policy?.allow).toEqual(["lobster"]);
+    expect(policy.strippedAllowlist).toBe(true);
     expect(policy.unknownAllowlist).toEqual(["lobster"]);
   });
 

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -186,14 +186,8 @@ export function stripPluginOnlyAllowlist(
     }
   }
   const strippedAllowlist = !hasCoreEntry;
-  // When an allowlist contains only plugin tools, we strip it to avoid accidentally
-  // disabling core tools. Users who want additive behavior should prefer `tools.alsoAllow`.
-  if (strippedAllowlist) {
-    // Note: logging happens in the caller (pi-tools/tools-invoke) after this function returns.
-    // We keep this note here for future maintainers.
-  }
   return {
-    policy: strippedAllowlist ? { ...policy, allow: undefined } : policy,
+    policy,
     unknownAllowlist: Array.from(new Set(unknownAllowlist)),
     strippedAllowlist,
   };

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -69,7 +69,7 @@ export type PluginToolGroups = {
 export type AllowlistResolution = {
   policy: ToolPolicyLike | undefined;
   unknownAllowlist: string[];
-  strippedAllowlist: boolean;
+  pluginOnlyAllowlist: boolean;
 };
 
 export function collectExplicitAllowlist(policies: Array<ToolPolicyLike | undefined>): string[] {
@@ -159,11 +159,11 @@ export function stripPluginOnlyAllowlist(
   coreTools: Set<string>,
 ): AllowlistResolution {
   if (!policy?.allow || policy.allow.length === 0) {
-    return { policy, unknownAllowlist: [], strippedAllowlist: false };
+    return { policy, unknownAllowlist: [], pluginOnlyAllowlist: false };
   }
   const normalized = normalizeToolList(policy.allow);
   if (normalized.length === 0) {
-    return { policy, unknownAllowlist: [], strippedAllowlist: false };
+    return { policy, unknownAllowlist: [], pluginOnlyAllowlist: false };
   }
   const pluginIds = new Set(groups.byPlugin.keys());
   const pluginTools = new Set(groups.all);
@@ -185,11 +185,11 @@ export function stripPluginOnlyAllowlist(
       unknownAllowlist.push(entry);
     }
   }
-  const strippedAllowlist = !hasCoreEntry;
+  const pluginOnlyAllowlist = !hasCoreEntry;
   return {
     policy,
     unknownAllowlist: Array.from(new Set(unknownAllowlist)),
-    strippedAllowlist,
+    pluginOnlyAllowlist,
   };
 }
 


### PR DESCRIPTION
## Summary

Two fail-open bugs in the tool policy system silently grant unrestricted tool access when operators intend to restrict it:

1. **`unionAllow` wildcard injection** — `alsoAllow` without `allow` injects `"*"` into the allow list, turning `{ alsoAllow: ["web_search"] }` into `["*", "web_search"]` (all tools allowed).
2. **`stripPluginOnlyAllowlist` silent removal** — when an allowlist contains only plugin tool names, the entire allowlist is silently removed, converting a restrictive policy to allow-all.

## What changed

| File | Change |
|------|--------|
| `src/agents/sandbox-tool-policy.ts` | Removed `"*"` injection in `unionAllow`. When `alsoAllow` is used without `allow`, the extra entries are now the complete allowlist. |
| `src/agents/tool-policy.ts` | `stripPluginOnlyAllowlist` now preserves the allowlist instead of stripping it. The `strippedAllowlist` flag is still returned for caller-side logging. |
| `src/agents/tool-policy.plugin-only-allowlist.test.ts` | Updated assertions: plugin-only allowlists are now preserved, not stripped. |
| `src/agents/tool-policy-pipeline.test.ts` | Updated assertion: pipeline now restricts to the configured allowlist instead of allowing all tools. |

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| `{ alsoAllow: ["exec"] }` without `allow` | `["*", "exec"]` — all tools | `["exec"]` — only exec |
| `{ allow: ["my-plugin-tool"] }` | `{ allow: undefined }` — all tools | `{ allow: ["my-plugin-tool"] }` — preserved |

## Breaking changes

- Configs using `alsoAllow` without `allow` previously got implicit allow-all behavior. They will now be restricted to only the `alsoAllow` entries. This is the intended behavior per the API semantics.
- Configs with plugin-only allowlists will now restrict core tools. Operators should add core tool names to `allow` if needed.

## Testing

- [x] `pnpm build` passes
- [x] `pnpm check` passes (0 warnings, 0 errors)
- [x] `pnpm test` passes (1 pre-existing failure in `src/cli/cli-utils.test.ts` unrelated to this change — `os.networkInterfaces()` sandbox error, also fails on `main`)
- [x] All 22 tool policy tests pass: `tool-policy.plugin-only-allowlist.test.ts`, `tool-policy-pipeline.test.ts`, `sandbox/tool-policy.test.ts`

## AI-assisted disclosure

- [x] This PR was AI-assisted (Cursor with Claude)
- [x] Fully tested (`pnpm build && pnpm check && pnpm test`)
- [x] I understand what the code does — the fix removes implicit wildcard injection and preserves operator-configured allowlists
- [ ] Codex review pending (will run `codex review --base origin/main` if available)

## Security context

- **CWE-862**: Missing Authorization
- **CWE-863**: Incorrect Authorization

This change touches `src/agents/sandbox-tool-policy.ts` which is covered by `CODEOWNERS` (`@openclaw/secops`). Secops review is required.

## References

- Vulnerability report: [GHSA-3jp7-2r46-23w8](https://github.com/openclaw/openclaw/security/advisories/GHSA-3jp7-2r46-23w8)
- Affected file: `src/agents/sandbox-tool-policy.ts` (CODEOWNERS: `@openclaw/secops`)

Made with [Cursor](https://cursor.com)