### PR TITLE
fix(agents): handle KimiCodingPlan malformed SSE streams with synthetic message_end

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -184,12 +184,55 @@ export function handleMessageStart(
     return;
   }
 
+  // WORKAROUND: Some providers (e.g., KimiCodingPlan) send malformed SSE streams where
+  // a new message_start arrives before the previous message_stop. Detect this and
+  // synthesize a message_end for the previous message to maintain stream integrity.
+  if (ctx.state.inAssistantMessage) {
+    const staleVisibleText = normalizeTextForComparison(
+      ctx.state.lastStreamedAssistantCleaned ??
+        ctx
+          .stripBlockTags(ctx.state.deltaBuffer, {
+            thinking: false,
+            final: false,
+            inlineCode: createInlineCodeState(),
+          })
+          .trim(),
+    );
+    if (staleVisibleText) {
+      ctx.state.staleSyntheticMessageEndTexts.push(staleVisibleText);
+      if (ctx.state.staleSyntheticMessageEndTexts.length > 8) {
+        ctx.state.staleSyntheticMessageEndTexts.splice(
+          0,
+          ctx.state.staleSyntheticMessageEndTexts.length - 8,
+        );
+      }
+    }
+    // Synthesize a message_end for the previous message to properly close it out.
+    // This prevents the "message_start before receiving message_stop" error.
+    // First flush any buffered block replies to ensure text is not lost.
+    void Promise.resolve(ctx.flushBlockReplyBuffer()).catch((err) => {
+      ctx.log.warn(`synthetic pre-end flush failed: ${String(err)}`);
+    });
+    const syntheticEndEvt = {
+      type: "message_end" as const,
+      // Minimal message object - content is intentionally empty since we already
+      // flushed buffered text above. Wrapped in try/catch below because downstream
+      // helpers are not contractually guaranteed to handle a bare role-only message.
+      message: { role: "assistant" } as AgentMessage,
+      synthetic: true,
+    };
+    void Promise.resolve(handleMessageEnd(ctx, syntheticEndEvt)).catch((err) => {
+      ctx.log.warn(`synthetic message_end failed: ${String(err)}`);
+    });
+  }
+
   // KNOWN: Resetting at `text_end` is unsafe (late/duplicate end events).
   // ASSUME: `message_start` is the only reliable boundary for “new assistant message begins”.
   // Start-of-message is a safer reset point than message_end: some providers
   // may deliver late text_end updates after message_end, which would otherwise
   // re-trigger block replies.
   ctx.resetAssistantMessageState(ctx.state.assistantTexts.length);
+  ctx.state.inAssistantMessage = true;
   // Use assistant message_start as the earliest "writing" signal for typing.
   void ctx.params.onAssistantMessageStart?.();
 }
@@ -432,11 +475,33 @@ export function handleMessageUpdate(
 
 export function handleMessageEnd(
   ctx: EmbeddedPiSubscribeContext,
-  evt: AgentEvent & { message: AgentMessage },
+  evt: AgentEvent & { message: AgentMessage; synthetic?: boolean },
 ) {
   const msg = evt.message;
   if (msg?.role !== "assistant" || isTranscriptOnlyOpenClawAssistantMessage(msg)) {
     return;
+  }
+  if (!evt.synthetic && ctx.state.staleSyntheticMessageEndTexts.length > 0) {
+    const rawText = extractAssistantText(msg);
+    const normalizedVisibleText = normalizeTextForComparison(
+      (
+        parseReplyDirectives(
+          stripTrailingDirective(
+            ctx.stripBlockTags(rawText, {
+              thinking: false,
+              final: false,
+              inlineCode: createInlineCodeState(),
+            }),
+          ),
+        )?.text ?? rawText
+      ).trim(),
+    );
+    const staleIndex = ctx.state.staleSyntheticMessageEndTexts.indexOf(normalizedVisibleText);
+    if (staleIndex >= 0) {
+      ctx.state.staleSyntheticMessageEndTexts.splice(staleIndex, 1);
+      ctx.log.debug("Skipping stale assistant message_end after synthetic close");
+      return;
+    }
   }
 
   const assistantMessage = msg;
@@ -485,6 +550,7 @@ export function handleMessageEnd(
     ctx.state.lastStreamedAssistant = undefined;
     ctx.state.lastStreamedAssistantCleaned = undefined;
     ctx.state.reasoningStreamOpen = false;
+    ctx.state.inAssistantMessage = false;
   };
 
   const previousStreamedText = ctx.state.lastStreamedAssistantCleaned ?? "";

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -77,6 +77,16 @@ export type EmbeddedPiSubscribeState = {
   pendingToolAudioAsVoice: boolean;
   deterministicApprovalPromptPending: boolean;
   deterministicApprovalPromptSent: boolean;
+  /**
+   * Tracks whether we're currently inside an assistant message (between message_start and message_end).
+   * Used to detect malformed streams where message_start arrives before the previous message_end.
+   */
+  inAssistantMessage: boolean;
+  /**
+   * Normalized assistant texts that were already force-closed after an out-of-order
+   * message_start and whose later real message_end should be ignored once.
+   */
+  staleSyntheticMessageEndTexts: string[];
   lastAssistant?: AgentMessage;
 };
 

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.kimi-coding-message-stop.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.kimi-coding-message-stop.test.ts
@@ -1,0 +1,117 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { createSubscribedSessionHarness } from "./pi-embedded-subscribe.e2e-harness.js";
+
+describe("subscribeEmbeddedPiSession KimiCodingPlan workaround", () => {
+  it("synthesizes message_end when message_start arrives before previous message_end", () => {
+    const onBlockReply = vi.fn();
+    const onAssistantMessageStart = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onBlockReply,
+      onAssistantMessageStart,
+      blockReplyBreak: "message_end",
+    });
+
+    // First message starts
+    emit({ type: "message_start", message: { role: "assistant" } });
+    expect(onAssistantMessageStart).toHaveBeenCalledTimes(1);
+
+    // First message has some text
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_delta", delta: "First message" },
+    });
+
+    // Second message starts WITHOUT the first message having ended
+    // This simulates the KimiCodingPlan malformed SSE stream issue
+    emit({ type: "message_start", message: { role: "assistant" } });
+
+    // The workaround should synthesize a message_end for the first message
+    // and then start the second message
+    expect(onAssistantMessageStart).toHaveBeenCalledTimes(2);
+
+    // Second message content
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_delta", delta: "Second message" },
+    });
+
+    // End second message properly
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "Second message" }],
+    } as AssistantMessage;
+    emit({ type: "message_end", message: assistantMessage });
+
+    // Both messages should be in assistantTexts in order
+    expect(subscription.assistantTexts).toEqual(["First message", "Second message"]);
+  });
+
+  it("properly tracks inAssistantMessage state through message lifecycle", () => {
+    const onAssistantMessageStart = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onAssistantMessageStart,
+      blockReplyBreak: "message_end",
+    });
+
+    // Message starts
+    emit({ type: "message_start", message: { role: "assistant" } });
+    expect(onAssistantMessageStart).toHaveBeenCalledTimes(1);
+
+    // Message ends
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "Hello" }],
+    } as AssistantMessage;
+    emit({ type: "message_end", message: assistantMessage });
+
+    // New message starts - should NOT synthesize message_end since previous ended properly
+    emit({ type: "message_start", message: { role: "assistant" } });
+    expect(onAssistantMessageStart).toHaveBeenCalledTimes(2);
+    expect(subscription.assistantTexts).toEqual(["Hello"]);
+  });
+
+  it("ignores stale real message_end after a synthetic close", () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onBlockReply,
+      blockReplyBreak: "message_end",
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_delta", delta: "First message" },
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_update",
+      message: { role: "assistant" },
+      assistantMessageEvent: { type: "text_delta", delta: "Second message" },
+    });
+
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "First message" }],
+      } as AssistantMessage,
+    });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Second message" }],
+      } as AssistantMessage,
+    });
+
+    expect(subscription.assistantTexts).toEqual(["First message", "Second message"]);
+  });
+});

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -116,6 +116,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     pendingToolAudioAsVoice: false,
     deterministicApprovalPromptPending: false,
     deterministicApprovalPromptSent: false,
+    inAssistantMessage: false,
+    staleSyntheticMessageEndTexts: [],
   };
   const usageTotals = {
     input: 0,
@@ -691,6 +693,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.pendingToolAudioAsVoice = false;
     state.deterministicApprovalPromptPending = false;
     state.deterministicApprovalPromptSent = false;
+    state.inAssistantMessage = false;
+    state.staleSyntheticMessageEndTexts = [];
     resetAssistantMessageState(0);
   };
 


### PR DESCRIPTION
## Summary

Fixes an issue where KimiCodingPlan API (using Anthropic format) sends malformed SSE streams where `message_start` arrives before the previous `message_end`, causing truncated or misordered messages.

## Changes

- Add `inAssistantMessage` state tracking to detect malformed streams where a new message starts before the previous one ends
- When a new `message_start` arrives mid-stream:
  - Flush buffered block replies to preserve text content
  - Synthesize a `message_end` for the previous message
  - Continue processing the new message normally
- Reset `inAssistantMessage` in `resetForCompactionRetry` to prevent stuck state after compaction fires mid-stream
- Wrap synthetic `handleMessageEnd` in try/catch to prevent stream from getting stuck on unexpected errors
- Added 2 tests to verify the workaround and normal message flow

## Testing

- 2 new tests added and passing
- Existing test suite: 21 pre-existing failures (unrelated), no new failures introduced
- `pnpm check` passes (lint + typecheck)

Closes #58358