### PR TITLE
fix(memory): resolve plugin registry before multimodal validation

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -364,6 +364,13 @@ export function resolveMemorySearchConfig(
   cfg: OpenClawConfig,
   agentId: string,
 ): ResolvedMemorySearchConfig | null {
+  // Ensure built-in providers are registered before mergeConfig resolves
+  // provider adapters and their defaultModel values.
+  resolveRuntimePluginRegistry({
+    config: cfg,
+    workspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
+  });
+
   const defaults = cfg.agents?.defaults?.memorySearch;
   const overrides = resolveAgentConfig(cfg, agentId)?.memorySearch;
   const resolved = mergeConfig(defaults, overrides, agentId);
@@ -371,14 +378,6 @@ export function resolveMemorySearchConfig(
     return null;
   }
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
-  if (multimodalActive && !getMemoryEmbeddingProvider(resolved.provider)) {
-    // Ensure built-in providers are registered before validation in CLI/Status flows.
-    // Use agent-specific workspace if available to avoid loading a conflicting registry later.
-    resolveRuntimePluginRegistry({
-      config: cfg,
-      workspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
-    });
-  }
   const multimodalProvider =
     resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider);
   if (

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -366,17 +366,31 @@ export function resolveMemorySearchConfig(
 ): ResolvedMemorySearchConfig | null {
   // Ensure built-in providers are registered before mergeConfig resolves
   // provider adapters and their defaultModel values.
-  resolveRuntimePluginRegistry({
-    config: cfg,
-    workspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
-  });
-
   const defaults = cfg.agents?.defaults?.memorySearch;
   const overrides = resolveAgentConfig(cfg, agentId)?.memorySearch;
+
+  // 1. Fast path: check if enabled and multimodal at all before triggering side effects.
+  const isEnabled = overrides?.enabled ?? defaults?.enabled ?? true;
+  const isMultimodal = isMemoryMultimodalEnabled(
+    normalizeMemoryMultimodalSettings({
+      enabled: overrides?.multimodal?.enabled ?? defaults?.multimodal?.enabled,
+    }),
+  );
+
+  if (isEnabled && isMultimodal) {
+    // 2. Heavy path: Ensure built-in providers are registered before mergeConfig resolves
+    // provider adapters and their defaultModel values.
+    resolveRuntimePluginRegistry({
+      config: cfg,
+      workspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
+    });
+  }
+
   const resolved = mergeConfig(defaults, overrides, agentId);
   if (!resolved.enabled) {
     return null;
   }
+
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
   const multimodalProvider =
     resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider);

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -8,6 +8,7 @@ import {
   normalizeMemoryMultimodalSettings,
   type MemoryMultimodalSettings,
 } from "../plugin-sdk/memory-core-host-multimodal.js";
+import { resolveRuntimePluginRegistry } from "../plugins/loader.js";
 import { getMemoryEmbeddingProvider } from "../plugins/memory-embedding-providers.js";
 import { clampInt, clampNumber, resolveUserPath } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope.js";
@@ -370,6 +371,10 @@ export function resolveMemorySearchConfig(
     return null;
   }
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
+  if (multimodalActive) {
+    // Ensure built-in providers are registered before validation in CLI/Status flows
+    resolveRuntimePluginRegistry({ config: cfg });
+  }
   const multimodalProvider =
     resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider);
   if (

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -11,7 +11,7 @@ import {
 import { resolveRuntimePluginRegistry } from "../plugins/loader.js";
 import { getMemoryEmbeddingProvider } from "../plugins/memory-embedding-providers.js";
 import { clampInt, clampNumber, resolveUserPath } from "../utils.js";
-import { resolveAgentConfig } from "./agent-scope.js";
+import { resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
 
 export type ResolvedMemorySearchConfig = {
   enabled: boolean;
@@ -371,9 +371,13 @@ export function resolveMemorySearchConfig(
     return null;
   }
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
-  if (multimodalActive) {
-    // Ensure built-in providers are registered before validation in CLI/Status flows
-    resolveRuntimePluginRegistry({ config: cfg });
+  if (multimodalActive && !getMemoryEmbeddingProvider(resolved.provider)) {
+    // Ensure built-in providers are registered before validation in CLI/Status flows.
+    // Use agent-specific workspace if available to avoid loading a conflicting registry later.
+    resolveRuntimePluginRegistry({
+      config: cfg,
+      workspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
+    });
   }
   const multimodalProvider =
     resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider);


### PR DESCRIPTION
### Problem
In v2026.3.28, when `multimodal: true` is enabled, `openclaw status` (and other CLI flows) fails with a fatal error: `agents.*.memorySearch.multimodal requires a provider adapter...`. 

This happens because `resolveMemorySearchConfig` attempts to validate the provider adapter before the `memory-core` plugin (which registers the adapter) is fully initialized in the runtime.

### Fix
Explicitly call `resolveRuntimePluginRegistry({ config: cfg })` within `resolveMemorySearchConfig` if multimodal is active, ensuring all built-in and configured adapters are registered before the validation check occurs.

Verified with `./openclaw.mjs status` after the patch.