### PR TITLE
fix: handle 429 errors for model failover

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -1017,6 +1017,16 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (leadingStatus?.code === 410) {
     return classifyFailoverReasonFromHttpStatus(leadingStatus.code, leadingStatus.rest);
   }
+
+  // Handle Kimi-style JSON error payloads like:
+  // {"type":"error","error":{"type":"quota_exceeded","message":"..."}}
+  // These need explicit handling because the error type is in the JSON body,
+  // not just in the message text.
+  const quotaExceededMatch = trimmed.match(/"type"\s*:\s*"quota_exceeded"/i);
+  if (quotaExceededMatch) {
+    return "rate_limit";
+  }
+
   const reasonFrom402Text = classifyFailoverReasonFrom402Text(raw);
   if (reasonFrom402Text) {
     return reasonFrom402Text;


### PR DESCRIPTION
## Summary

Handle 429 (Rate Limit Exceeded) errors in Kimi Anthropic-format responses to trigger model failover and prevent infinite message processing loops.

## Changes

- Added 429 error handling in model failover logic
- Model is now marked as unavailable when quota is exceeded

## Testing

Existing tests pass.

Fixes openclaw/openclaw#58442