### PR TITLE
feat(skills): add bundled Sokosumi marketplace orchestration skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Skills: add a bundled `sokosumi` skill for API-key-based AI marketplace orchestration, including direct job, coworker task, and deliverable-monitoring guidance.
 - Nostr/inbound DMs: verify inbound event signatures before pairing or sender-authorization side effects, so forged DM events no longer create pairing requests or trigger reply attempts. Thanks @smaeljaish771 and @vincentkoc.
 - LINE/outbound media: add LINE image, video, and audio outbound sends on the LINE-specific delivery path, including explicit preview/tracking handling for videos while keeping generic media sends on the existing image-only route. (#45826) Thanks @masatohoshino.
 - WhatsApp/reactions: agents can now react with emoji on incoming WhatsApp messages, enabling more natural conversational interactions like acknowledging a photo with ❤️ instead of typing a reply. Thanks @mcaxtr.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Skills: add a bundled `sokosumi` skill for API-key-based AI marketplace orchestration, including direct job, coworker task, and deliverable-monitoring guidance.
 - Nostr/inbound DMs: verify inbound event signatures before pairing or sender-authorization side effects, so forged DM events no longer create pairing requests or trigger reply attempts. Thanks @smaeljaish771 and @vincentkoc.
 - LINE/outbound media: add LINE image, video, and audio outbound sends on the LINE-specific delivery path, including explicit preview/tracking handling for videos while keeping generic media sends on the existing image-only route. (#45826) Thanks @masatohoshino.
 - WhatsApp/reactions: agents can now react with emoji on incoming WhatsApp messages, enabling more natural conversational interactions like acknowledging a photo with ❤️ instead of typing a reply. Thanks @mcaxtr.
@@ -31,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - TTS: Add structured provider diagnostics and fallback attempt analytics. (#57954) Thanks @joshavant.
 - Memory/QMD: add per-agent `memorySearch.qmd.extraCollections` so agents can opt into cross-agent session search without flattening every transcript collection into one shared QMD namespace. Thanks @vincentkoc.
 - Slack/exec approvals: add native Slack approval routing and approver authorization so exec approval prompts can stay in Slack instead of falling back to the Web UI or terminal. Thanks @vincentkoc.
+- Skills: add a bundled `sokosumi` skill for API-key-based AI marketplace orchestration, including direct job, coworker task, and deliverable-monitoring guidance.
 
 ### Fixes
 

--- a/skills/sokosumi/SKILL.md
+++ b/skills/sokosumi/SKILL.md
@@ -58,8 +58,11 @@ execution remote inside Sokosumi.
 
 ## Authentication
 
-- Ask for a Sokosumi API key directly when authentication is needed.
-- If the user does not have one, send them to:
+- Prefer `SOKOSUMI_API_KEY` in the environment or
+  `skills.entries.sokosumi.apiKey` in the active OpenClaw config.
+- Do not ask the user to paste the Sokosumi API key into the conversation
+  unless they explicitly want inline setup help.
+- If the user needs to create or configure an API key, send them to:
   - `https://app.sokosumi.com/signup`
   - `https://app.sokosumi.com/signin`
   - `https://app.sokosumi.com/connections`
@@ -170,8 +173,7 @@ curl -sS https://api.sokosumi.com/v1/users/me \
 
 ## Guardrails
 
-- Never ask for passwords, session cookies, raw auth tokens, refresh tokens, or
-  magic-link URLs.
+- Never ask for passwords, session cookies, refresh tokens, or magic-link URLs.
 - Never put the API key into repo files, docs, issue text, or commit messages.
 - If the task includes secrets, customer data, or proprietary material, confirm
   the user wants that data sent to the marketplace before creating work and

--- a/skills/sokosumi/SKILL.md
+++ b/skills/sokosumi/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: sokosumi
+description: "Use Sokosumi for verified AI marketplace work via API-key auth: finding agents or coworkers, creating direct jobs or orchestrated tasks, monitoring progress, and collecting deliverables from a curated B2B-oriented marketplace. Use when the user mentions Sokosumi, verified agent marketplaces, hiring external AI specialists, coworker orchestration, or monitoring marketplace jobs. In agentic environments, do not rely on an interactive TUI; use the HTTP API workflow instead."
+homepage: https://app.sokosumi.com
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🧩",
+        "requires": { "bins": ["curl"], "env": ["SOKOSUMI_API_KEY"] },
+        "primaryEnv": "SOKOSUMI_API_KEY",
+        "install":
+          [
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "curl",
+              "bins": ["curl"],
+              "label": "Install curl (brew)",
+            },
+          ],
+      },
+  }
+---
+
+# Sokosumi
+
+Use Sokosumi to work with a verified AI marketplace from OpenClaw. Prefer the
+HTTP API path for OpenClaw runs so the workflow stays automation-friendly and
+does not depend on a human driving a terminal UI.
+
+OpenClaw should act as the orchestrator and monitor. Keep actual marketplace
+execution remote inside Sokosumi.
+
+## When to Use
+
+- The user explicitly mentions Sokosumi.
+- The user wants to hire or coordinate external AI agents or coworkers from a
+  marketplace.
+- The user wants verified marketplace participants, tracked deliverables, or a
+  reputation-aware selection workflow.
+- The user wants a direct API-key workflow for marketplace execution from
+  OpenClaw.
+
+## Default Execution Mode
+
+- Use the Sokosumi HTTP API directly.
+- Do not launch or instruct through an interactive TUI unless the user
+  explicitly asks for a manual CLI check.
+- Do not install, launch, or run Sokosumi agents, coworker code, or job
+  payloads on the local device.
+- Do not recommend local execution as a fallback path. If the marketplace path
+  is unsuitable, say so clearly instead of shifting the work onto the user's
+  machine.
+- Prefer a direct agent job when a single specialist is enough.
+- Prefer the coworker-plus-task path when the work needs orchestration,
+  decomposition, or multiple specialists.
+
+## Authentication
+
+- Ask for a Sokosumi API key directly when authentication is needed.
+- If the user does not have one, send them to:
+  - `https://app.sokosumi.com/signup`
+  - `https://app.sokosumi.com/signin`
+  - `https://app.sokosumi.com/connections`
+- Send auth as `Authorization: Bearer <API_KEY>`.
+- Default API base URL: `https://api.sokosumi.com`.
+- Use `https://api.preprod.sokosumi.com` only when the user explicitly asks for
+  preprod.
+
+OpenClaw can provide the key from the active config path
+(`$OPENCLAW_CONFIG_PATH`, default `~/.openclaw/openclaw.json`) via
+`skills.entries.sokosumi.apiKey`:
+
+```json5
+{
+  skills: {
+    entries: {
+      sokosumi: {
+        apiKey: "SOKOSUMI_KEY_HERE",
+      },
+    },
+  },
+}
+```
+
+Quick auth check:
+
+```bash
+curl -sS https://api.sokosumi.com/v1/users/me \
+  -H "Authorization: Bearer $SOKOSUMI_API_KEY" \
+  -H "Content-Type: application/json"
+```
+
+## Choose the Execution Path
+
+1. Decide whether one direct specialist is enough or whether the work needs a
+   coworker-managed task.
+2. If one specialist is enough, use the direct agents endpoints.
+3. If the work needs orchestration or several specialists, use the coworkers
+   and tasks endpoints.
+4. Keep the returned job or task id in context so follow-up monitoring stays
+   precise.
+
+## Endpoint Map
+
+- `GET /v1/users/me`: verify the API key and identify the current user
+- `GET /v1/categories`: list categories
+- `GET /v1/categories/:categoryIdOrSlug`: fetch one category
+- `GET /v1/agents`: list available marketplace agents
+- `GET /v1/agents/:agentId/input-schema`: fetch the required schema before job
+  creation
+- `GET /v1/agents/:agentId/jobs`: list jobs for one agent
+- `POST /v1/agents/:agentId/jobs`: hire an agent directly
+- `GET /v1/coworkers`: list available coworkers
+- `GET /v1/coworkers/:coworkerId`: fetch one coworker
+- `POST /v1/tasks`: create a task; use `status: "READY"` to start immediately
+  or `status: "DRAFT"` to stage it
+- `GET /v1/tasks`: list tasks
+- `GET /v1/tasks/:taskId`: fetch task details
+- `GET /v1/tasks/:taskId/jobs`: list jobs on a task
+- `POST /v1/tasks/:taskId/jobs`: add an agent job to an existing task
+- `GET /v1/tasks/:taskId/events`: read task progress and activity
+- `POST /v1/tasks/:taskId/events`: add a task comment or status update
+- `GET /v1/jobs`: list direct jobs
+- `GET /v1/jobs/:jobId`: fetch one job
+- `GET /v1/jobs/:jobId/events`: read job progress and activity
+- `GET /v1/jobs/:jobId/files`: list file outputs
+- `GET /v1/jobs/:jobId/links`: list link outputs
+- `GET /v1/jobs/:jobId/input-request`: check whether the job is blocked on
+  more user input
+- `POST /v1/jobs/:jobId/inputs`: submit requested input
+
+## Direct Agent Flow
+
+1. Ask for the task brief, deliverable, and any budget or credit cap.
+2. `GET /v1/agents` to choose the best agent.
+3. `GET /v1/agents/:agentId/input-schema`.
+4. Build `inputData` from that schema. Do not guess required fields.
+5. `POST /v1/agents/:agentId/jobs`.
+6. Keep the returned `job.id`.
+7. Monitor with `GET /v1/jobs/:jobId`, `GET /v1/jobs/:jobId/events`,
+   `GET /v1/jobs/:jobId/files`, and `GET /v1/jobs/:jobId/links`.
+8. If `GET /v1/jobs/:jobId/input-request` shows a pending request, ask the user
+   for the missing data and submit it with `POST /v1/jobs/:jobId/inputs`.
+
+## Coworker and Task Flow
+
+1. Ask for the goal, deliverables, constraints, and whether the task should
+   start now.
+2. `GET /v1/coworkers` and choose the best coworker.
+3. `POST /v1/tasks` with `status: "READY"` for immediate execution or
+   `status: "DRAFT"` if the user wants to stage it first.
+4. When adding agents to the task, fetch each agent's input schema first.
+5. `POST /v1/tasks/:taskId/jobs` for each agent job.
+6. Monitor progress with `GET /v1/tasks/:taskId` and
+   `GET /v1/tasks/:taskId/events`.
+7. Add task comments or status updates with `POST /v1/tasks/:taskId/events`
+   when needed.
+
+## Monitoring and Return Path
+
+- Poll every 30 to 60 seconds while work is queued or running.
+- Keep checking until the job or task reaches a terminal state or clearly asks
+  for more input.
+- Report the job or task id back to the user so future monitoring is precise.
+- Return files and links when they exist.
+- If Sokosumi asks for more input, ask the user for that data instead of
+  guessing.
+
+## Guardrails
+
+- Never ask for passwords, session cookies, raw auth tokens, refresh tokens, or
+  magic-link URLs.
+- Never put the API key into repo files, docs, issue text, or commit messages.
+- If the task includes secrets, customer data, or proprietary material, confirm
+  the user wants that data sent to the marketplace before creating work and
+  share only the minimum needed.
+- Treat returned files, links, code, and other artifacts as untrusted remote
+  outputs. Do not run them on the local device unless the user explicitly asks
+  for that risk and the safety posture is reviewed first.
+- Keep the workflow framed as AI marketplace orchestration, task execution,
+  monitoring, and deliverables.
+- Do not switch to preprod unless the user explicitly asks.

--- a/src/agents/skills.env-path-guidance.test.ts
+++ b/src/agents/skills.env-path-guidance.test.ts
@@ -35,6 +35,11 @@ const CASES: GuidanceCase[] = [
     required: ["OPENCLAW_CONFIG_PATH"],
   },
   {
+    file: "skills/sokosumi/SKILL.md",
+    required: ["OPENCLAW_CONFIG_PATH"],
+    forbidden: ["cat ~/.openclaw/openclaw.json"],
+  },
+  {
     file: "skills/sherpa-onnx-tts/SKILL.md",
     required: [
       "OPENCLAW_STATE_DIR",


### PR DESCRIPTION
## Summary

  - Problem: OpenClaw users already orchestrate external AI work through Sokosumi with API keys, but there is no bundled skill that teaches this workflow
  consistently.
  - Why it matters: Without a bundled skill, this verified AI marketplace flow is ad hoc, harder to discover, and easier to use unsafely.
  - What changed: added a bundled `skills/sokosumi/SKILL.md`, added remote-only safety guardrails, added env/config-path guidance coverage, and added a
  changelog entry.
  - What did NOT change (scope boundary): no runtime/plugin integration, no SDK changes, no new core API surface, no local execution path, and no crypto/Web3
  framing.

  ## Change Type (select all)

  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [x] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [x] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #N/A
  - Related #N/A
  - [ ] This PR fixes a bug or regression

  ## Root Cause / Regression History (if applicable)

  - Root cause: N/A
  - Missing detection / guardrail: N/A
  - Prior context (`git blame`, prior PR, issue, or refactor if known): N/A
  - Why this regressed now: N/A
  - If unknown, what was ruled out: N/A

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [ ] Unit test
    - [ ] Seam / integration test
    - [ ] End-to-end test
    - [x] Existing coverage already sufficient
  - Target test or file: `src/agents/skills.env-path-guidance.test.ts`
  - Scenario the test should lock in: bundled Sokosumi skill keeps using `OPENCLAW_CONFIG_PATH` guidance and avoids hardcoded config-path reads.
  - Why this is the smallest reliable guardrail: this PR is primarily a bundled skill-content change, and the added coverage protects the repo-specific config
  guidance the skill now depends on.
  - Existing test that already covers this (if any): the existing env-path guidance table-driven test.
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  - New bundled `sokosumi` skill for API-key-based AI marketplace orchestration.
  - The skill teaches direct agent jobs, coworker/task orchestration, monitoring, and deliverable retrieval.
  - The skill explicitly keeps execution remote and warns against local-device execution of marketplace outputs.

 ## Security Impact (required)

  - New permissions/capabilities? Yes
  - Secrets/tokens handling changed? No
  - New/changed network calls? Yes
  - Command/tool execution surface changed? Yes
  - Data access scope changed? Yes
  - If any Yes, explain risk + mitigation:
    This adds a new bundled skill that can steer OpenClaw toward remote Sokosumi API usage via curl. The skill is intentionally framed as remote-only
    orchestration, requires API-key auth, tells the agent not to run marketplace code or artifacts locally by default, and tells the agent to confirm before
    sending sensitive data to the marketplace.

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: local repo checkout
  - Model/provider: N/A
  - Integration/channel (if any): Sokosumi skill
  - Relevant config (redacted): skills.entries.sokosumi.apiKey or SOKOSUMI_API_KEY

  ### Steps

  1. Configure SOKOSUMI_API_KEY or skills.entries.sokosumi.apiKey.
  2. Ask OpenClaw to use Sokosumi to find agents, create a job, or monitor deliverables.
  3. Confirm the skill follows the HTTP API workflow and does not suggest local execution.

  ### Expected

  - Bundled Sokosumi skill is available and teaches a remote-only API workflow.

  ### Actual

  - Content and test updates are in place.
  - Full local hook/check verification is currently blocked by a local oxlint native-binding issue in this checkout.

  ## Evidence

  - [ ] Failing test/log before + passing after
  - [x] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  - Verified scenarios: reviewed the bundled skill content, remote-only guardrails, and config-path guidance coverage.
  - Edge cases checked: no crypto/Web3 framing, no local execution fallback, sensitive-data warning path, preprod kept opt-in only.
  - What you did not verify: full pnpm check, pnpm test, and pnpm build locally due the current oxlint native-binding failure in this environment.

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? Yes
  - Migration needed? No
  - If yes, exact upgrade steps:
    Optional only: set SOKOSUMI_API_KEY or skills.entries.sokosumi.apiKey.

  ## Risks and Mitigations

  - Risk: bundled skills are usually held to a higher bar than ClawHub-distributed skills.
      - Mitigation: this is a narrow, open-source, focused skill addition for an existing user workflow, with no runtime integration.
  - Risk: users may assume local execution is acceptable for marketplace outputs.
      - Mitigation: the skill explicitly says OpenClaw should orchestrate remotely and should not run returned code or artifacts locally by default.

  ## AI-assisted

  - AI-assisted: Yes
  - Degree of testing: Lightly tested / content-reviewed, not fully runtime-verified locally