### PR TITLE
build(release): reuse preflight artifacts for npm publish

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -28,6 +28,7 @@ env:
 
 jobs:
   preflight_openclaw_npm:
+    if: ${{ inputs.preflight_run_id == '' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -142,7 +143,76 @@ jobs:
   publish_openclaw_npm:
     # npm trusted publishing + provenance requires a GitHub-hosted runner.
     needs: [preflight_openclaw_npm, validate_publish_dispatch_ref]
-    if: ${{ !inputs.preflight_only }}
+    if: ${{ !inputs.preflight_only && inputs.preflight_run_id == '' }}
+    runs-on: ubuntu-latest
+    environment: npm-release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Validate tag input format
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*((-beta\.[1-9][0-9]*)|(-[1-9][0-9]*))?$ ]]; then
+            echo "Invalid release tag format: ${RELEASE_TAG}"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          install-bun: "false"
+          use-sticky-disk: "false"
+          install-deps: "false"
+
+      - name: Ensure version is not already published
+        run: |
+          set -euo pipefail
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          if npm view "openclaw@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
+            echo "openclaw@${PACKAGE_VERSION} is already published on npm."
+            exit 1
+          fi
+
+          echo "Publishing openclaw@${PACKAGE_VERSION}"
+
+      - name: Download prepared npm tarball
+        uses: actions/download-artifact@v8
+        with:
+          name: openclaw-npm-preflight-${{ inputs.tag }}
+          path: preflight-tarball
+
+      - name: Resolve publish tarball
+        id: publish_tarball
+        run: |
+          set -euo pipefail
+          TARBALL_PATH="$(find preflight-tarball -maxdepth 1 -type f -name '*.tgz' -print | sort | tail -n 1)"
+          if [[ -z "$TARBALL_PATH" ]]; then
+            echo "Prepared preflight tarball not found." >&2
+            ls -la preflight-tarball >&2 || true
+            exit 1
+          fi
+          echo "path=$TARBALL_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Publish
+        env:
+          OPENCLAW_PREPACK_PREPARED: "1"
+        run: bash scripts/openclaw-npm-publish.sh --publish "${{ steps.publish_tarball.outputs.path }}"
+
+  publish_openclaw_npm_from_preflight:
+    needs: [validate_publish_dispatch_ref]
+    if: ${{ !inputs.preflight_only && inputs.preflight_run_id != '' }}
     runs-on: ubuntu-latest
     environment: npm-release
     permissions:
@@ -173,6 +243,7 @@ jobs:
           pnpm-version: ${{ env.PNPM_VERSION }}
           install-bun: "false"
           use-sticky-disk: "false"
+          install-deps: "false"
 
       - name: Ensure version is not already published
         run: |
@@ -187,7 +258,6 @@ jobs:
           echo "Publishing openclaw@${PACKAGE_VERSION}"
 
       - name: Download prepared npm tarball
-        if: ${{ inputs.preflight_run_id != '' }}
         uses: actions/download-artifact@v8
         with:
           name: openclaw-npm-preflight-${{ inputs.tag }}
@@ -196,30 +266,8 @@ jobs:
           run-id: ${{ inputs.preflight_run_id }}
           github-token: ${{ github.token }}
 
-      - name: Build
-        if: ${{ inputs.preflight_run_id == '' }}
-        run: pnpm build
-
-      - name: Build Control UI
-        if: ${{ inputs.preflight_run_id == '' }}
-        run: pnpm ui:build
-
-      - name: Validate release tag and package metadata
-        env:
-          RELEASE_TAG: ${{ inputs.tag }}
-          RELEASE_MAIN_REF: origin/main
-        run: |
-          set -euo pipefail
-          RELEASE_SHA=$(git rev-parse HEAD)
-          export RELEASE_SHA RELEASE_TAG RELEASE_MAIN_REF
-          # Fetch the full main ref so merge-base ancestry checks keep working
-          # for older tagged commits that are still contained in main.
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          pnpm release:openclaw:npm:check
-
       - name: Resolve publish tarball
         id: publish_tarball
-        if: ${{ inputs.preflight_run_id != '' }}
         run: |
           set -euo pipefail
           TARBALL_PATH="$(find preflight-tarball -maxdepth 1 -type f -name '*.tgz' -print | sort | tail -n 1)"

--- a/scripts/openclaw-npm-publish.sh
+++ b/scripts/openclaw-npm-publish.sh
@@ -13,8 +13,8 @@ fi
 package_version="$(node -p "require('./package.json').version")"
 current_beta_version="$(npm view openclaw dist-tags.beta 2>/dev/null || true)"
 mapfile -t publish_plan < <(
-  PACKAGE_VERSION="${package_version}" CURRENT_BETA_VERSION="${current_beta_version}" node --import tsx --input-type=module <<'EOF'
-import { resolveNpmPublishPlan } from "./scripts/openclaw-npm-release-check.ts";
+  PACKAGE_VERSION="${package_version}" CURRENT_BETA_VERSION="${current_beta_version}" node --input-type=module <<'EOF'
+import { resolveNpmPublishPlan } from "./scripts/lib/npm-publish-plan.mjs";
 
 const plan = resolveNpmPublishPlan(
   process.env.PACKAGE_VERSION ?? "",


### PR DESCRIPTION
## Summary

- Problem: the npm release workflow rebuilt and revalidated the same tagged commit in both preflight and publish, and the newer `preflight_run_id` tarball path was only partially wired.
- Why it matters: release ops were paying repeated install/build latency for the same immutable tag, and the "promote an existing preflight" path still fell back to duplicated work.
- What changed: preflight now remains the authoritative build/validation step, publish consumes the prepared tarball, and the publish script now resolves publish tags without requiring repo dependencies.
- What did NOT change (scope boundary): this PR does not change macOS release flow, approval requirements, tag policy, or release notes/appcast handling.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the release workflow evolved toward artifact reuse, but publish still rebuilt the tag and still installed repo deps because the publish script depended on `tsx` and root workspace state.
- Missing detection / guardrail: no workflow-level check asserted that `preflight_run_id` promotion avoided `pnpm install` / rebuild work.
- Prior context (`git blame`, prior PR, issue, or refactor if known): `ad06d5ab4d` introduced prepared tarball support in the workflow, but the seam remained incomplete.
- Why this regressed now: the release path was incrementally hardened for safety, but the expensive steps were never collapsed after artifact prep existed.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `.github/workflows/openclaw-npm-release.yml`, `scripts/openclaw-npm-publish.sh`
- Scenario the test should lock in: publish path can run from a prepared tarball without workspace dependency install or rebuild.
- Why this is the smallest reliable guardrail: the behavior lives at workflow/script seam level, not in app runtime code.
- Existing test that already covers this (if any): none directly.
- If no new test is added, why not: the repo does not currently have workflow simulation coverage for this path; I verified via script syntax, YAML parse, and targeted logic checks.

## User-visible / Behavior Changes

None for end users. Maintainers get a faster, less duplicated npm release path.

## Diagram (if applicable)

```text
Before:
[tag] -> [preflight build/validate] -> [publish job installs deps again] -> [build again] -> [validate again] -> [publish]

After:
[tag] -> [preflight build/validate/pack tarball] -> [publish job downloads tarball] -> [publish]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local worktree
- Model/provider: N/A
- Integration/channel (if any): GitHub Actions release workflow
- Relevant config (redacted): N/A

### Steps

1. Inspect current `openclaw-npm-release.yml` and `openclaw-npm-publish.sh`.
2. Patch publish to consume preflight tarballs in both same-run and `preflight_run_id` flows, and remove repo dependency install from publish jobs.
3. Verify shell syntax, publish-plan resolution, and YAML parsing locally.

### Expected

- Publish jobs do not rebuild the same tagged commit after preflight.
- Existing `preflight_run_id` promotion path works without a second install/build.

### Actual

- Local verification matched expected behavior.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `bash -n scripts/openclaw-npm-publish.sh`; `node --input-type=module` publish-plan resolution from `scripts/lib/npm-publish-plan.mjs`; Ruby YAML parse of `.github/workflows/openclaw-npm-release.yml`; repo `pnpm check` via commit hook.
- Edge cases checked: stable vs beta publish-plan resolution; same-run publish and explicit `preflight_run_id` paths in workflow conditions.
- What you did **not** verify: full GitHub Actions execution against a real tag and trusted-publishing environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: artifact download assumptions drift from the preflight job output naming.
  - Mitigation: publish path resolves the tarball explicitly and fails closed if the artifact is missing.
- Risk: removing install from publish job could break if publish script still depended on workspace tooling.
  - Mitigation: publish script now imports the plain `.mjs` publish-plan helper and only needs checkout + Node/npm.
