### PR TITLE
fix(otel): Add openclaw_agent label to token metrics

### DIFF
--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -375,6 +375,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const recordModelUsage = (evt: Extract<DiagnosticEventPayload, { type: "model.usage" }>) => {
         const attrs = {
           "openclaw.channel": evt.channel ?? "unknown",
+          "openclaw.agent": evt.agent ?? "unknown",
           "openclaw.provider": evt.provider ?? "unknown",
           "openclaw.model": evt.model ?? "unknown",
         };
@@ -508,13 +509,16 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
       const addSessionIdentityAttrs = (
         spanAttrs: Record<string, string | number>,
-        evt: { sessionKey?: string; sessionId?: string },
+        evt: { sessionKey?: string; sessionId?: string; agent?: string },
       ) => {
         if (evt.sessionKey) {
           spanAttrs["openclaw.sessionKey"] = evt.sessionKey;
         }
         if (evt.sessionId) {
           spanAttrs["openclaw.sessionId"] = evt.sessionId;
+        }
+        if (evt.agent) {
+          spanAttrs["openclaw.agent"] = evt.agent;
         }
       };
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -611,9 +611,11 @@ export async function runReplyAgent(params: {
       const costConfig = resolveModelCostConfig({
         provider: providerUsed,
         model: modelUsed,
+        agent: agentId,
         config: cfg,
       });
       const costUsd = estimateUsageCost({ usage, cost: costConfig });
+      const agentId = sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined;
       emitDiagnosticEvent({
         type: "model.usage",
         sessionKey,
@@ -621,6 +623,7 @@ export async function runReplyAgent(params: {
         channel: replyToChannel,
         provider: providerUsed,
         model: modelUsed,
+        agent: agentId,
         usage: {
           input,
           output,
@@ -650,6 +653,7 @@ export async function runReplyAgent(params: {
         ? resolveModelCostConfig({
             provider: providerUsed,
             model: modelUsed,
+        agent: agentId,
             config: cfg,
           })
         : undefined;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -608,6 +608,7 @@ export async function runReplyAgent(params: {
       const cacheWrite = usage.cacheWrite ?? 0;
       const promptTokens = input + cacheRead + cacheWrite;
       const totalTokens = usage.total ?? promptTokens + output;
+      const agentId = sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined;
       const costConfig = resolveModelCostConfig({
         provider: providerUsed,
         model: modelUsed,
@@ -615,7 +616,6 @@ export async function runReplyAgent(params: {
         config: cfg,
       });
       const costUsd = estimateUsageCost({ usage, cost: costConfig });
-      const agentId = sessionKey ? resolveAgentIdFromSessionKey(sessionKey) : undefined;
       emitDiagnosticEvent({
         type: "model.usage",
         sessionKey,

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -14,6 +14,7 @@ export type DiagnosticUsageEvent = DiagnosticBaseEvent & {
   channel?: string;
   provider?: string;
   model?: string;
+  agent?: string;
   usage: {
     input?: number;
     output?: number;


### PR DESCRIPTION
## Changes

- Add agent field to DiagnosticUsageEvent type
- Add agentId to model.usage diagnostic event in agent-runner.ts  
- Add openclaw.agent label to OTEL metrics in diagnostics-otel plugin
- Update addSessionIdentityAttrs to include agent field

## Problem

OTEL token metrics were missing the `openclaw_agent` label, causing custom models to not be visible in Grafana token list.

## Solution

This fix adds the agent identifier to the model.usage diagnostic event and ensures it's properly included in the OTEL metrics as the `openclaw.agent` label.

## Testing

- Verify custom models appear in Grafana token list
- Verify dashboard panels show data for custom models
- Verify fallback model usage is tracked