### PR TITLE
fix(session): prevent heartbeat/cron/exec events from triggering session reset (#58409)

### DIFF
--- a/src/auto-reply/reply/session.heartbeat-no-reset.test.ts
+++ b/src/auto-reply/reply/session.heartbeat-no-reset.test.ts
@@ -1,0 +1,228 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { saveSessionStore } from "../../config/sessions/store.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { MsgContext } from "../templating.js";
+import { initSessionState } from "./session.js";
+
+describe("initSessionState - heartbeat should not trigger session reset", () => {
+  let tempDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp("/tmp/openclaw-test-");
+    storePath = path.join(tempDir, "sessions.json");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const createBaseConfig = (): OpenClawConfig => ({
+    agents: {
+      defaults: {
+        workspace: tempDir,
+      },
+      list: [
+        {
+          id: "main",
+          workspace: tempDir,
+        },
+      ],
+    },
+    session: {
+      store: storePath,
+      reset: {
+        mode: "idle",
+        idleMinutes: 5, // 5 minutes idle timeout
+      },
+    },
+    channels: {},
+    gateway: {
+      port: 18789,
+      mode: "local",
+      bind: "loopback",
+      auth: { mode: "token", token: "test" },
+    },
+    plugins: {
+      entries: {},
+    },
+  });
+
+  const createBaseCtx = (overrides?: Partial<MsgContext>): MsgContext => ({
+    Body: "test message",
+    From: "user123",
+    To: "bot123",
+    SessionKey: "main:user123",
+    Provider: "telegram",
+    Surface: "telegram",
+    ChatType: "direct",
+    CommandAuthorized: true,
+    ...overrides,
+  });
+
+  it("should NOT reset session when Provider is 'heartbeat'", async () => {
+    // Setup: Create a session entry that is "stale" (older than idle timeout)
+    const now = Date.now();
+    const staleTime = now - 10 * 60 * 1000; // 10 minutes ago (exceeds 5min idle timeout)
+
+    const initialStore: Record<string, SessionEntry> = {
+      "main:user123": {
+        sessionId: "original-session-id-12345",
+        updatedAt: staleTime,
+        systemSent: true,
+      },
+    };
+    await saveSessionStore(storePath, initialStore);
+
+    const cfg = createBaseConfig();
+    const ctx = createBaseCtx({
+      Provider: "heartbeat", // Heartbeat provider should NOT trigger reset
+      Body: "HEARTBEAT_OK",
+    });
+
+    const result = await initSessionState({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // Assert: Session should NOT be reset (same sessionId)
+    expect(result.isNewSession).toBe(false);
+    expect(result.resetTriggered).toBe(false);
+    expect(result.sessionId).toBe("original-session-id-12345");
+    expect(result.sessionEntry.sessionId).toBe("original-session-id-12345");
+  });
+
+  it("should reset session when Provider is NOT 'heartbeat' and session is stale", async () => {
+    // Setup: Create a session entry that is "stale" (older than idle timeout)
+    const now = Date.now();
+    const staleTime = now - 10 * 60 * 1000; // 10 minutes ago (exceeds 5min idle timeout)
+
+    const initialStore: Record<string, SessionEntry> = {
+      "main:user123": {
+        sessionId: "original-session-id-12345",
+        updatedAt: staleTime,
+        systemSent: true,
+      },
+    };
+    await saveSessionStore(storePath, initialStore);
+
+    const cfg = createBaseConfig();
+    const ctx = createBaseCtx({
+      Provider: "telegram", // Regular provider - SHOULD trigger reset if stale
+      Body: "test message",
+    });
+
+    const result = await initSessionState({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // Assert: Session SHOULD be reset (new sessionId) because it's stale
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false); // Not a manual reset, but idle reset
+    expect(result.sessionId).not.toBe("original-session-id-12345");
+  });
+
+  it("should preserve session when Provider is 'heartbeat' even with daily reset mode", async () => {
+    // Setup: Create a session entry from yesterday (would trigger daily reset)
+    const now = Date.now();
+    const yesterday = now - 25 * 60 * 60 * 1000; // 25 hours ago
+
+    const initialStore: Record<string, SessionEntry> = {
+      "main:user123": {
+        sessionId: "original-session-id-67890",
+        updatedAt: yesterday,
+        systemSent: true,
+      },
+    };
+    await saveSessionStore(storePath, initialStore);
+
+    const cfg = createBaseConfig();
+    cfg.session!.reset = {
+      mode: "daily",
+      atHour: 4, // 4 AM daily reset
+    };
+
+    const ctx = createBaseCtx({
+      Provider: "heartbeat",
+      Body: "HEARTBEAT_OK",
+    });
+
+    const result = await initSessionState({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // Assert: Session should NOT be reset even though it's past daily reset time
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe("original-session-id-67890");
+  });
+
+  it("should handle cron-event provider same as heartbeat (no reset)", async () => {
+    // Setup: Create a stale session
+    const now = Date.now();
+    const staleTime = now - 10 * 60 * 1000;
+
+    const initialStore: Record<string, SessionEntry> = {
+      "main:user123": {
+        sessionId: "cron-session-id-abcde",
+        updatedAt: staleTime,
+        systemSent: true,
+      },
+    };
+    await saveSessionStore(storePath, initialStore);
+
+    const cfg = createBaseConfig();
+    const ctx = createBaseCtx({
+      Provider: "cron-event", // Cron events should also NOT trigger reset
+      Body: "cron job output",
+    });
+
+    const result = await initSessionState({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // Assert: Session should NOT be reset for cron events either
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe("cron-session-id-abcde");
+  });
+
+  it("should handle exec-event provider same as heartbeat (no reset)", async () => {
+    // Setup: Create a stale session
+    const now = Date.now();
+    const staleTime = now - 10 * 60 * 1000;
+
+    const initialStore: Record<string, SessionEntry> = {
+      "main:user123": {
+        sessionId: "exec-session-id-fghij",
+        updatedAt: staleTime,
+        systemSent: true,
+      },
+    };
+    await saveSessionStore(storePath, initialStore);
+
+    const cfg = createBaseConfig();
+    const ctx = createBaseCtx({
+      Provider: "exec-event", // Exec events should also NOT trigger reset
+      Body: "exec completion",
+    });
+
+    const result = await initSessionState({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // Assert: Session should NOT be reset for exec events either
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe("exec-session-id-fghij");
+  });
+});

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -383,8 +383,16 @@ export async function initSessionState(params: {
     resetType,
     resetOverride: channelReset,
   });
+  // Heartbeat, cron-event, and exec-event runs should NEVER trigger session resets.
+  // These are automated system events, not user interactions that should affect
+  // session continuity. Forcing freshEntry=true prevents accidental data loss.
+  // See #58409 for details on silent session reset bug.
+  const isSystemEvent =
+    ctx.Provider === "heartbeat" || ctx.Provider === "cron-event" || ctx.Provider === "exec-event";
   const freshEntry = entry
-    ? evaluateSessionFreshness({ updatedAt: entry.updatedAt, now, policy: resetPolicy }).fresh
+    ? isSystemEvent
+      ? true
+      : evaluateSessionFreshness({ updatedAt: entry.updatedAt, now, policy: resetPolicy }).fresh
     : false;
   // Capture the current session entry before any reset so its transcript can be
   // archived afterward.  We need to do this for both explicit resets (/new, /reset)


### PR DESCRIPTION
## Summary

Fixes #58409 - Heartbeat system causes silent session reset leading to user data loss.

## Problem

The heartbeat system (and similar automated events like cron-event and exec-event) triggered the session initialization logic, which evaluated session freshness based on idle/daily reset policies. When a session was considered 'stale' (e.g., idle for more than the configured timeout), it was silently reset, causing:

- Complete loss of conversation context (8,000+ messages in reported case)
- 1.2MB+ of data moved to .reset backup files
- No warning to users
- No automatic recovery mechanism

## Root Cause

In `src/auto-reply/reply/session.ts`, the `initSessionState` function evaluates session freshness for ALL requests, including automated system events. The freshness check uses idle/daily reset policies that are appropriate for user interactions but should NOT apply to system-initiated check-ins.

## Solution

Detect system event providers (`heartbeat`, `cron-event`, `exec-event`) and force `freshEntry=true` to skip reset policy evaluation for these automated events.

### Code Changes

```typescript
// Before
const freshEntry = entry
  ? evaluateSessionFreshness({ updatedAt: entry.updatedAt, now, policy: resetPolicy }).fresh
  : false;

// After
const isSystemEvent = ctx.Provider === "heartbeat" || ctx.Provider === "cron-event" || ctx.Provider === "exec-event";
const freshEntry = entry
  ? isSystemEvent
    ? true
    : evaluateSessionFreshness({ updatedAt: entry.updatedAt, now, policy: resetPolicy }).fresh
  : false;
```

## Testing

Added comprehensive test coverage in `src/auto-reply/reply/session.heartbeat-no-reset.test.ts`:

- ✅ Heartbeat provider does NOT trigger session reset
- ✅ Regular provider DOES trigger reset when session is stale (expected behavior preserved)
- ✅ Daily reset mode does NOT affect heartbeat runs
- ✅ Cron-event provider does NOT trigger reset
- ✅ Exec-event provider does NOT trigger reset

All tests pass:
```
✓ src/auto-reply/reply/session.heartbeat-no-reset.test.ts (5 tests) 270ms
```

## Impact

- **Users with heartbeat enabled**: No longer at risk of silent data loss
- **Cron job users**: Automated jobs preserve session continuity
- **Exec event tracking**: Command completion events don't disrupt sessions
- **Regular users**: No change in behavior - idle/daily resets still work as expected

## Verification

To verify the fix works:

1. Enable heartbeat with short interval:
   ```bash
   openclaw config set agents.defaults.heartbeat '{"every":"5m"}' --json
   ```

2. Set aggressive idle reset:
   ```bash
   openclaw config set session.reset '{"mode":"idle","idleMinutes":2}' --json
   ```

3. Have an active conversation, then wait for heartbeat to trigger

4. Verify session is NOT reset (context preserved)

## Related Issues

- #58409 - [CRITICAL] Heartbeat System Causes Silent Session Reset - User Data Loss
- #58377 - LiveSessionModelSwitchError in cron triggers retry loop
- #58379 - Session death loop on overloaded fallback