### PR TITLE
feat(mistral): add Voxtral TTS support

### DIFF
--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -128,6 +128,7 @@ The media transcription path uses `/v1/audio/transcriptions`. The default audio 
             mistral: {
               voice: "gb_oliver_excited",
               model: "voxtral-mini-tts-2603",
+              speed: 1.0,
               apiKey: "mistral_api_key",
               baseUrl: "https://api.mistral.ai/v1",
             },
@@ -138,6 +139,10 @@ The media transcription path uses `/v1/audio/transcriptions`. The default audio 
     ```
 
     `openclaw onboard --auth-choice mistral-api-key` makes the same key available to Mistral TTS. Set `messages.tts.provider` to `"mistral"` or use `/tts provider mistral`; no separate TTS API key is required. TTS path uses `/v1/audio/speech`.
+
+    - TTS base URL defaults to `https://api.mistral.ai/v1` and inherits `models.providers.mistral.baseUrl` when set. Override with `messages.tts.providers.mistral.baseUrl` or `MISTRAL_TTS_BASE_URL`.
+    - `speed` adjusts playback rate (e.g. `1.0` = normal). Omit to use the Voxtral API default.
+    - Model-driven directives support `voice` / `mistralVoiceId` and `model` / `mistralModelId` overrides per reply.
 
   </Accordion>
 

--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -128,7 +128,6 @@ The media transcription path uses `/v1/audio/transcriptions`. The default audio 
             mistral: {
               voice: "gb_oliver_excited",
               model: "voxtral-mini-tts-2603",
-              speed: 1.0,
               apiKey: "mistral_api_key",
               baseUrl: "https://api.mistral.ai/v1",
             },
@@ -141,7 +140,6 @@ The media transcription path uses `/v1/audio/transcriptions`. The default audio 
     `openclaw onboard --auth-choice mistral-api-key` makes the same key available to Mistral TTS. Set `messages.tts.provider` to `"mistral"` or use `/tts provider mistral`; no separate TTS API key is required. TTS path uses `/v1/audio/speech`.
 
     - TTS base URL defaults to `https://api.mistral.ai/v1` and inherits `models.providers.mistral.baseUrl` when set. Override with `messages.tts.providers.mistral.baseUrl` or `MISTRAL_TTS_BASE_URL`.
-    - `speed` adjusts playback rate (e.g. `1.0` = normal). Omit to use the Voxtral API default.
     - Model-driven directives support `voice` / `mistralVoiceId` and `model` / `mistralModelId` overrides per reply.
 
   </Accordion>

--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -1,15 +1,16 @@
 ---
-summary: "Use Mistral models and Voxtral transcription with OpenClaw"
+summary: "Use Mistral models plus Voxtral speech with OpenClaw"
 read_when:
   - You want to use Mistral models in OpenClaw
   - You need Mistral API key onboarding and model refs
+  - You want Voxtral transcription or text-to-speech
 title: "Mistral"
 ---
 
 # Mistral
 
-OpenClaw supports Mistral for both text/image model routing (`mistral/...`) and
-audio transcription via Voxtral in media understanding.
+OpenClaw supports Mistral for text/image model routing (`mistral/...`), audio
+transcription via Voxtral in media understanding, and Voxtral text-to-speech.
 Mistral can also be used for memory embeddings (`memorySearch.provider = "mistral"`).
 
 - Provider: `mistral`
@@ -114,8 +115,34 @@ The media transcription path uses `/v1/audio/transcriptions`. The default audio 
 
   </Accordion>
 
+  <Accordion title="Text-to-speech (Voxtral)">
+    See the [Voxtral TTS documentation](https://docs.mistral.ai/capabilities/audio/text_to_speech) for available models and voices.
+
+    ```json5
+    {
+      messages: {
+        tts: {
+          auto: "always",
+          provider: "mistral",
+          providers: {
+            mistral: {
+              voice: "gb_oliver_excited",
+              model: "voxtral-mini-tts-2603",
+              apiKey: "mistral_api_key",
+              baseUrl: "https://api.mistral.ai/v1",
+            },
+          },
+        },
+      },
+    }
+    ```
+
+    `openclaw onboard --auth-choice mistral-api-key` makes the same key available to Mistral TTS. Set `messages.tts.provider` to `"mistral"` or use `/tts provider mistral`; no separate TTS API key is required. TTS path uses `/v1/audio/speech`.
+
+  </Accordion>
+
   <Accordion title="Auth and base URL">
-    - Mistral auth uses `MISTRAL_API_KEY`.
+    - Mistral auth uses `MISTRAL_API_KEY` for models, Voxtral transcription, and Voxtral TTS.
     - Provider base URL defaults to `https://api.mistral.ai/v1`.
     - Onboarding default model is `mistral/mistral-large-latest`.
     - Z.AI uses Bearer auth with your API key.

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -9,7 +9,7 @@ title: "Text-to-Speech"
 
 # Text-to-speech (TTS)
 
-OpenClaw can convert outbound replies into audio using ElevenLabs, Microsoft, MiniMax, or OpenAI.
+OpenClaw can convert outbound replies into audio using ElevenLabs, Microsoft, MiniMax, OpenAI, or Mistral.
 It works anywhere OpenClaw can send audio.
 
 ## Supported services
@@ -18,6 +18,7 @@ It works anywhere OpenClaw can send audio.
 - **Microsoft** (primary or fallback provider; current bundled implementation uses `node-edge-tts`)
 - **MiniMax** (primary or fallback provider; uses the T2A v2 API)
 - **OpenAI** (primary or fallback provider; also used for summaries)
+- **Mistral** (primary or fallback provider; uses Voxtral TTS and can reuse your Mistral provider auth)
 
 ### Microsoft speech notes
 
@@ -34,17 +35,22 @@ or ElevenLabs.
 
 ## Optional keys
 
-If you want OpenAI, ElevenLabs, or MiniMax:
+If you want OpenAI, ElevenLabs, MiniMax, or Mistral:
 
 - `ELEVENLABS_API_KEY` (or `XI_API_KEY`)
 - `MINIMAX_API_KEY`
 - `OPENAI_API_KEY`
+- `MISTRAL_API_KEY`
 
 Microsoft speech does **not** require an API key.
 
 If multiple providers are configured, the selected provider is used first and the others are fallback options.
 Auto-summary uses the configured `summaryModel` (or `agents.defaults.model.primary`),
 so that provider must also be authenticated if you enable summaries.
+
+If you already configured an API key for models from OpenAI, Mistral or MiniMax,
+OpenClaw can reuse that same auth for TTS. You do not need to copy the
+key into `messages.tts.providers.<provider>.apiKey` unless you want a TTS-specific override.
 
 ## Service links
 
@@ -116,6 +122,25 @@ Full schema is in [Gateway configuration](/gateway/configuration).
             useSpeakerBoost: true,
             speed: 1.0,
           },
+        },
+      },
+    },
+  },
+}
+```
+
+### Mistral with shared provider auth
+
+```json5
+{
+  messages: {
+    tts: {
+      auto: "always",
+      provider: "mistral",
+      providers: {
+        mistral: {
+          model: "voxtral-mini-tts-2603",
+          voice: "gb_oliver_excited",
         },
       },
     },

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -132,6 +132,10 @@ Full schema is in [Gateway configuration](/gateway/configuration).
 
 ### Mistral with shared provider auth
 
+Reuses the Mistral API key already configured for models. OpenAI TTS is
+disabled so it does not appear in the fallback order even though
+`OPENAI_API_KEY` is set.
+
 ```json5
 {
   messages: {
@@ -142,6 +146,9 @@ Full schema is in [Gateway configuration](/gateway/configuration).
         mistral: {
           model: "voxtral-mini-tts-2603",
           voice: "gb_oliver_excited",
+        },
+        openai: {
+          enabled: false,
         },
       },
     },
@@ -297,6 +304,7 @@ Then run:
 - `providers.mistral.baseUrl`: override Mistral TTS endpoint (default `https://api.mistral.ai/v1`, env: `MISTRAL_TTS_BASE_URL`; also inherits `models.providers.mistral.baseUrl` when set).
 - `providers.mistral.model`: Voxtral TTS model (default `voxtral-mini-tts-2603`).
 - `providers.mistral.voice`: Voxtral voice name (e.g. `gb_oliver_excited`). See [Voxtral TTS docs](https://docs.mistral.ai/capabilities/audio/text_to_speech) for available voices.
+- `providers.openai.enabled`: allow OpenAI TTS usage (default `true`). Set to `false` to exclude OpenAI from TTS and fallback while keeping the API key available for models.
 - `providers.microsoft.enabled`: allow Microsoft speech usage (default `true`; no API key).
 - `providers.microsoft.voice`: Microsoft neural voice name (e.g. `en-US-MichelleNeural`).
 - `providers.microsoft.lang`: language code (e.g. `en-US`).

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -44,7 +44,7 @@ If you want OpenAI, ElevenLabs, MiniMax, or Mistral:
 
 Microsoft speech does **not** require an API key.
 
-If multiple providers are configured, the selected provider is used first and the others are fallback options.
+If multiple providers are configured, the selected provider is tried first. If it fails, OpenClaw automatically falls back through the remaining configured providers in `autoSelectOrder` (openai → mistral → elevenlabs → microsoft → minimax by default). There is no explicit fallback config; any provider that passes its `isConfigured` check is eligible.
 Auto-summary uses the configured `summaryModel` (or `agents.defaults.model.primary`),
 so that provider must also be authenticated if you enable summaries.
 

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -297,7 +297,6 @@ Then run:
 - `providers.mistral.baseUrl`: override Mistral TTS endpoint (default `https://api.mistral.ai/v1`, env: `MISTRAL_TTS_BASE_URL`; also inherits `models.providers.mistral.baseUrl` when set).
 - `providers.mistral.model`: Voxtral TTS model (default `voxtral-mini-tts-2603`).
 - `providers.mistral.voice`: Voxtral voice name (e.g. `gb_oliver_excited`). See [Voxtral TTS docs](https://docs.mistral.ai/capabilities/audio/text_to_speech) for available voices.
-- `providers.mistral.speed`: playback speed multiplier (e.g. `1.0` = normal).
 - `providers.microsoft.enabled`: allow Microsoft speech usage (default `true`; no API key).
 - `providers.microsoft.voice`: Microsoft neural voice name (e.g. `en-US-MichelleNeural`).
 - `providers.microsoft.lang`: language code (e.g. `en-US`).

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -58,6 +58,7 @@ key into `messages.tts.providers.<provider>.apiKey` unless you want a TTS-specif
 - [OpenAI Audio API reference](https://platform.openai.com/docs/api-reference/audio)
 - [ElevenLabs Text to Speech](https://elevenlabs.io/docs/api-reference/text-to-speech)
 - [ElevenLabs Authentication](https://elevenlabs.io/docs/api-reference/authentication)
+- [Mistral Voxtral TTS](https://docs.mistral.ai/capabilities/audio/text_to_speech)
 - [MiniMax T2A v2 API](https://platform.minimaxi.com/document/T2A%20V2)
 - [node-edge-tts](https://github.com/SchneeHertz/node-edge-tts)
 - [Microsoft Speech output formats](https://learn.microsoft.com/azure/ai-services/speech-service/rest-text-to-speech#audio-outputs)
@@ -263,7 +264,7 @@ Then run:
   - `tagged` only sends audio when the reply includes `[[tts:key=value]]` directives or a `[[tts:text]]...[[/tts:text]]` block.
 - `enabled`: legacy toggle (doctor migrates this to `auto`).
 - `mode`: `"final"` (default) or `"all"` (includes tool/block replies).
-- `provider`: speech provider id such as `"elevenlabs"`, `"microsoft"`, `"minimax"`, or `"openai"` (fallback is automatic).
+- `provider`: speech provider id such as `"elevenlabs"`, `"microsoft"`, `"minimax"`, `"mistral"`, or `"openai"` (fallback is automatic).
 - If `provider` is **unset**, OpenClaw uses the first configured speech provider in registry auto-select order.
 - Legacy `provider: "edge"` still works and is normalized to `microsoft`.
 - `summaryModel`: optional cheap model for auto-summary; defaults to `agents.defaults.model.primary`.
@@ -293,6 +294,10 @@ Then run:
 - `providers.minimax.speed`: playback speed `0.5..2.0` (default 1.0).
 - `providers.minimax.vol`: volume `(0, 10]` (default 1.0; must be greater than 0).
 - `providers.minimax.pitch`: pitch shift `-12..12` (default 0).
+- `providers.mistral.baseUrl`: override Mistral TTS endpoint (default `https://api.mistral.ai/v1`, env: `MISTRAL_TTS_BASE_URL`; also inherits `models.providers.mistral.baseUrl` when set).
+- `providers.mistral.model`: Voxtral TTS model (default `voxtral-mini-tts-2603`).
+- `providers.mistral.voice`: Voxtral voice name (e.g. `gb_oliver_excited`). See [Voxtral TTS docs](https://docs.mistral.ai/capabilities/audio/text_to_speech) for available voices.
+- `providers.mistral.speed`: playback speed multiplier (e.g. `1.0` = normal).
 - `providers.microsoft.enabled`: allow Microsoft speech usage (default `true`; no API key).
 - `providers.microsoft.voice`: Microsoft neural voice name (e.g. `en-US-MichelleNeural`).
 - `providers.microsoft.lang`: language code (e.g. `en-US`).
@@ -327,9 +332,10 @@ Here you go.
 
 Available directive keys (when enabled):
 
-- `provider` (registered speech provider id, for example `openai`, `elevenlabs`, `minimax`, or `microsoft`; requires `allowProvider: true`)
-- `voice` (OpenAI voice) or `voiceId` (ElevenLabs / MiniMax)
-- `model` (OpenAI TTS model, ElevenLabs model id, or MiniMax model)
+- `provider` (registered speech provider id, for example `openai`, `elevenlabs`, `minimax`, `mistral`, or `microsoft`; requires `allowProvider: true`)
+- `voice` (OpenAI or Mistral voice) or `voiceId` (ElevenLabs / MiniMax)
+- `mistralVoiceId` / `mistralModelId` (Mistral-specific aliases for `voice` / `model`)
+- `model` (OpenAI TTS model, ElevenLabs model id, MiniMax model, or Mistral model)
 - `stability`, `similarityBoost`, `style`, `speed`, `useSpeakerBoost`
 - `vol` / `volume` (MiniMax volume, 0-10)
 - `pitch` (MiniMax pitch, -12 to 12)
@@ -388,6 +394,7 @@ These override `messages.tts.*` for that host.
   - 48kHz / 64kbps is a good voice message tradeoff.
 - **Other channels**: MP3 (`mp3_44100_128` from ElevenLabs, `mp3` from OpenAI).
   - 44.1kHz / 128kbps is the default balance for speech clarity.
+- **Mistral**: Opus voice messages (Feishu / Matrix / Telegram / WhatsApp) or MP3 (other channels), matching the OpenAI/ElevenLabs pattern. Telephony output uses WAV decoded to s16le PCM internally.
 - **MiniMax**: MP3 (`speech-2.8-hd` model, 32kHz sample rate). Voice-note format not natively supported; use OpenAI or ElevenLabs for guaranteed Opus voice messages.
 - **Microsoft**: uses `microsoft.outputFormat` (default `audio-24khz-48kbitrate-mono-mp3`).
   - The bundled transport accepts an `outputFormat`, but not all formats are available from the service.

--- a/extensions/mistral/api.test.ts
+++ b/extensions/mistral/api.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from "vitest";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
 import {
   applyMistralModelCompat,
   MISTRAL_MODEL_TRANSPORT_PATCH,
   MISTRAL_SMALL_LATEST_ID,
   resolveMistralCompatPatch,
 } from "./api.js";
+import mistralPlugin from "./index.js";
 import { contributeMistralResolvedModelCompat } from "./provider-compat.js";
 
 function readCompat<T>(model: unknown): T | undefined {
@@ -133,6 +135,71 @@ describe("applyMistralModelCompat", () => {
 
     expect(
       contributeMistralResolvedModelCompat({
+        modelId: "mistralai/mistral-small-3.2",
+        model: {
+          provider: "openrouter",
+          api: "openai-completions",
+          baseUrl: "https://openrouter.ai/api/v1",
+        },
+      }),
+    ).toEqual(MISTRAL_MODEL_TRANSPORT_PATCH);
+  });
+});
+
+describe("mistral plugin register", () => {
+  it("registers the speech provider and wires contributeResolvedModelCompat through to native, provider-family, and hinted custom routes", () => {
+    type ContributeResolvedModelCompat = (params: {
+      modelId: string;
+      model: Record<string, unknown>;
+    }) => unknown;
+
+    let capturedContributeResolvedModelCompat: ContributeResolvedModelCompat | undefined;
+    const registerSpeechProvider = vi.fn();
+    const registerMediaUnderstandingProvider = vi.fn();
+
+    const fakeApi = {
+      registerProvider: (provider: {
+        contributeResolvedModelCompat?: ContributeResolvedModelCompat;
+      }) => {
+        capturedContributeResolvedModelCompat = provider.contributeResolvedModelCompat;
+      },
+      registerSpeechProvider,
+      registerMediaUnderstandingProvider,
+    };
+
+    mistralPlugin.register(fakeApi as unknown as OpenClawPluginApi);
+
+    expect(registerSpeechProvider).toHaveBeenCalledOnce();
+    expect(registerMediaUnderstandingProvider).toHaveBeenCalledOnce();
+    expect(capturedContributeResolvedModelCompat).toBeDefined();
+
+    // native Mistral provider route
+    expect(
+      capturedContributeResolvedModelCompat!({
+        modelId: "mistral-large-latest",
+        model: {
+          provider: "mistral",
+          api: "openai-completions",
+          baseUrl: "https://proxy.example/v1",
+        },
+      }),
+    ).toEqual(MISTRAL_MODEL_TRANSPORT_PATCH);
+
+    // hinted custom route via api.mistral.ai base URL
+    expect(
+      capturedContributeResolvedModelCompat!({
+        modelId: "custom-model",
+        model: {
+          provider: "custom-mistral-host",
+          api: "openai-completions",
+          baseUrl: "https://api.mistral.ai/v1",
+        },
+      }),
+    ).toEqual(MISTRAL_MODEL_TRANSPORT_PATCH);
+
+    // provider-family route via OpenRouter Mistral model id hint
+    expect(
+      capturedContributeResolvedModelCompat!({
         modelId: "mistralai/mistral-small-3.2",
         model: {
           provider: "openrouter",

--- a/extensions/mistral/index.ts
+++ b/extensions/mistral/index.ts
@@ -4,6 +4,7 @@ import { mistralMediaUnderstandingProvider } from "./media-understanding-provide
 import { applyMistralConfig, MISTRAL_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildMistralProvider } from "./provider-catalog.js";
 import { contributeMistralResolvedModelCompat } from "./provider-compat.js";
+import { buildMistralSpeechProvider } from "./speech-provider.js";
 
 const PROVIDER_ID = "mistral";
 export function buildMistralReplayPolicy() {
@@ -48,6 +49,7 @@ export default defineSingleProviderPluginEntry({
     buildReplayPolicy: () => buildMistralReplayPolicy(),
   },
   register(api) {
+    api.registerSpeechProvider(buildMistralSpeechProvider());
     api.registerMediaUnderstandingProvider(mistralMediaUnderstandingProvider);
   },
 });

--- a/extensions/mistral/openclaw.plugin.json
+++ b/extensions/mistral/openclaw.plugin.json
@@ -21,6 +21,7 @@
     }
   ],
   "contracts": {
+    "speechProviders": ["mistral"],
     "mediaUnderstandingProviders": ["mistral"]
   },
   "configSchema": {

--- a/extensions/mistral/package.json
+++ b/extensions/mistral/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "OpenClaw Mistral provider plugin",
   "type": "module",
+  "dependencies": {
+    "@mistralai/mistralai": "^2.2.0"
+  },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"
   },

--- a/extensions/mistral/speech-provider.test.ts
+++ b/extensions/mistral/speech-provider.test.ts
@@ -1,0 +1,466 @@
+import * as providerAuthRuntime from "openclaw/plugin-sdk/provider-auth-runtime";
+import {
+  parseTtsDirectives,
+  type SpeechProviderPlugin,
+  type SpeechSynthesisRequest,
+} from "openclaw/plugin-sdk/speech";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildMistralSpeechProvider, decodeMistralWavToS16le } from "./speech-provider.js";
+
+/** Build a minimal RIFF/WAVE buffer with f32le mono audio at the given sample rate. */
+function buildF32leWav(samples: Float32Array, sampleRate: number): Buffer {
+  const dataBytes = samples.length * 4;
+  const buf = Buffer.alloc(44 + dataBytes);
+  buf.write("RIFF", 0, "ascii");
+  buf.writeUInt32LE(36 + dataBytes, 4);
+  buf.write("WAVE", 8, "ascii");
+  buf.write("fmt ", 12, "ascii");
+  buf.writeUInt32LE(16, 16); // fmt chunk size
+  buf.writeUInt16LE(3, 20); // audioFormat: IEEE float
+  buf.writeUInt16LE(1, 22); // channels: mono
+  buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(sampleRate * 4, 28); // byte rate
+  buf.writeUInt16LE(4, 32); // block align
+  buf.writeUInt16LE(32, 34); // bits per sample
+  buf.write("data", 36, "ascii");
+  buf.writeUInt32LE(dataBytes, 40);
+  for (let i = 0; i < samples.length; i++) {
+    buf.writeFloatLE(samples[i], 44 + i * 4);
+  }
+  return buf;
+}
+
+/** Build a minimal RIFF/WAVE buffer with s16le mono audio at the given sample rate. */
+function buildS16leWav(samples: Int16Array, sampleRate: number): Buffer {
+  const dataBytes = samples.length * 2;
+  const buf = Buffer.alloc(44 + dataBytes);
+  buf.write("RIFF", 0, "ascii");
+  buf.writeUInt32LE(36 + dataBytes, 4);
+  buf.write("WAVE", 8, "ascii");
+  buf.write("fmt ", 12, "ascii");
+  buf.writeUInt32LE(16, 16);
+  buf.writeUInt16LE(1, 20); // audioFormat: PCM integer
+  buf.writeUInt16LE(1, 22); // channels: mono
+  buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(sampleRate * 2, 28);
+  buf.writeUInt16LE(2, 32);
+  buf.writeUInt16LE(16, 34);
+  buf.write("data", 36, "ascii");
+  buf.writeUInt32LE(dataBytes, 40);
+  for (let i = 0; i < samples.length; i++) {
+    buf.writeInt16LE(samples[i], 44 + i * 2);
+  }
+  return buf;
+}
+
+function insertChunkBeforeData(buffer: Buffer, chunkId: string, payload: Buffer): Buffer {
+  const padBytes = payload.length % 2;
+  const chunk = Buffer.alloc(8 + payload.length + padBytes);
+  chunk.write(chunkId, 0, "ascii");
+  chunk.writeUInt32LE(payload.length, 4);
+  payload.copy(chunk, 8);
+
+  const wavWithChunk = Buffer.concat([buffer.subarray(0, 36), chunk, buffer.subarray(36)]);
+  wavWithChunk.writeUInt32LE(wavWithChunk.length - 8, 4);
+  return wavWithChunk;
+}
+
+describe("mistral speech provider", () => {
+  const originalFetch = globalThis.fetch;
+  const provider = buildMistralSpeechProvider();
+
+  function buildSynthesisRequest(
+    overrides: Partial<SpeechSynthesisRequest> = {},
+  ): SpeechSynthesisRequest {
+    return {
+      text: "hello",
+      cfg: {
+        auth: {
+          profiles: {
+            "mistral:default": {
+              provider: "mistral",
+              mode: "api_key",
+            },
+          },
+        },
+      } as never,
+      providerConfig: {
+        baseUrl: "https://api.mistral.ai/v1",
+        model: "voxtral-mini-tts-2603",
+        voice: "",
+      },
+      target: "voice-note",
+      timeoutMs: 5000,
+      ...overrides,
+    };
+  }
+
+  const modelOverridePolicy = {
+    enabled: true,
+    allowText: false,
+    allowProvider: false,
+    allowVoice: true,
+    allowModelId: true,
+    allowVoiceSettings: false,
+    allowNormalization: false,
+    allowSeed: false,
+  } as const;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    delete process.env.MISTRAL_API_KEY;
+    delete process.env.MISTRAL_TTS_BASE_URL;
+  });
+
+  it("treats configured Mistral auth profiles as TTS-ready", () => {
+    expect(
+      provider.isConfigured({
+        cfg: {
+          auth: {
+            profiles: {
+              "mistral:default": {
+                provider: "mistral",
+                mode: "api_key",
+              },
+            },
+          },
+        } as never,
+        providerConfig: {},
+        timeoutMs: 5000,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats auth.order with a Mistral profile list as TTS-ready", () => {
+    expect(
+      provider.isConfigured({
+        cfg: {
+          auth: {
+            order: {
+              mistral: ["mistral:default"],
+            },
+          },
+        } as never,
+        providerConfig: {},
+        timeoutMs: 5000,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat an empty auth.order Mistral list as TTS-ready", () => {
+    expect(
+      provider.isConfigured({
+        cfg: {
+          auth: {
+            order: {
+              mistral: [],
+            },
+          },
+        } as never,
+        providerConfig: {},
+        timeoutMs: 5000,
+      }),
+    ).toBe(false);
+  });
+
+  it("reuses the Mistral model provider baseUrl when no TTS override is configured", () => {
+    const providerConfig = provider.resolveConfig?.({
+      cfg: {
+        models: {
+          providers: {
+            mistral: {
+              baseUrl: "https://custom.mistral.example/v1",
+            },
+          },
+        },
+      } as never,
+      rawConfig: {},
+      timeoutMs: 5000,
+    });
+
+    expect(providerConfig).toMatchObject({
+      baseUrl: "https://custom.mistral.example/v1",
+      model: "voxtral-mini-tts-2603",
+    });
+  });
+
+  it("maps Talk config modelId and voiceId onto the Mistral TTS config shape", () => {
+    const talkConfig = provider.resolveTalkConfig?.({
+      cfg: {
+        models: {
+          providers: {
+            mistral: {
+              baseUrl: "https://base.mistral.example/v1",
+            },
+          },
+        },
+      } as never,
+      baseTtsConfig: {},
+      talkProviderConfig: {
+        apiKey: "talk-mistral-key",
+        baseUrl: "https://talk.mistral.example/v1",
+        modelId: "voxtral-custom-tts",
+        voiceId: "voice_123",
+        speed: 1.1,
+      },
+      timeoutMs: 5000,
+    });
+
+    expect(talkConfig).toMatchObject({
+      apiKey: "talk-mistral-key",
+      baseUrl: "https://talk.mistral.example/v1",
+      model: "voxtral-custom-tts",
+      voice: "voice_123",
+      speed: 1.1,
+    });
+  });
+
+  it("maps Talk request overrides onto Mistral speech overrides", () => {
+    const talkOverrides = provider.resolveTalkOverrides?.({
+      talkProviderConfig: {},
+      params: {
+        modelId: "voxtral-live-tts",
+        voiceId: "voice_override",
+        speed: 1.25,
+      },
+    });
+
+    expect(talkOverrides).toEqual({
+      model: "voxtral-live-tts",
+      voice: "voice_override",
+      speed: 1.25,
+    });
+  });
+
+  it("accepts provider-specific camelCase directive aliases for Mistral", () => {
+    const result = parseTtsDirectives(
+      "Hello [[tts:mistralVoiceId=voice_abc mistralModelId=voxtral-live-tts]] world",
+      modelOverridePolicy,
+      { providers: [provider] },
+    );
+    const mistralOverrides = result.overrides.providerOverrides?.mistral as
+      | { voice?: string; model?: string }
+      | undefined;
+
+    expect(mistralOverrides).toEqual({
+      voice: "voice_abc",
+      model: "voxtral-live-tts",
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("does not swallow bare model directives meant for a later provider", () => {
+    const laterProvider: SpeechProviderPlugin = {
+      id: "elevenlabs",
+      label: "ElevenLabs",
+      autoSelectOrder: 20,
+      isConfigured: () => true,
+      parseDirectiveToken: ({ key, value }) =>
+        key === "model" ? { handled: true, overrides: { modelId: value } } : { handled: false },
+      synthesize: async () => ({
+        audioBuffer: Buffer.from("audio"),
+        outputFormat: "mp3",
+        fileExtension: ".mp3",
+        voiceCompatible: false,
+      }),
+    };
+
+    const result = parseTtsDirectives(
+      "Hello [[tts:provider=elevenlabs model=eleven_v3]] world",
+      {
+        ...modelOverridePolicy,
+        allowProvider: true,
+      },
+      { providers: [provider, laterProvider] },
+    );
+
+    expect(result.overrides.provider).toBe("elevenlabs");
+    expect(result.overrides.providerOverrides?.mistral).toBeUndefined();
+    expect(result.overrides.providerOverrides?.elevenlabs).toEqual({
+      modelId: "eleven_v3",
+    });
+  });
+
+  it("prefers provider auth resolution over the raw env fallback", async () => {
+    const audio = Buffer.from("fake-opus-audio");
+    process.env.MISTRAL_API_KEY = "env-mistral-key";
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "resolved-profile-key",
+      source: "profile:mistral:default",
+      mode: "api-key",
+      profileId: "mistral:default",
+    });
+    const fetchMock = vi.fn(async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.model).toBe("voxtral-mini-tts-2603");
+      expect(body.voice_id).toBeUndefined();
+      expect(body.response_format).toBe("opus");
+      expect(init?.headers).toMatchObject({
+        Authorization: "Bearer resolved-profile-key",
+      });
+      return new Response(JSON.stringify({ audio_data: audio.toString("base64") }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await provider.synthesize(buildSynthesisRequest());
+
+    expect(result.audioBuffer.equals(audio)).toBe(true);
+    expect(result.outputFormat).toBe("opus");
+    expect(result.fileExtension).toBe(".opus");
+    expect(result.voiceCompatible).toBe(true);
+  });
+
+  it("surfaces Mistral API error details from non-2xx responses", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "resolved-profile-key",
+      source: "profile:mistral:default",
+      mode: "api-key",
+      profileId: "mistral:default",
+    });
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          error: {
+            message: "bad credentials",
+            type: "invalid_request",
+            code: "bad_auth",
+          },
+        }),
+        {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }) as unknown as typeof fetch;
+
+    await expect(provider.synthesize(buildSynthesisRequest())).rejects.toThrow(
+      "Mistral TTS API error (401): bad credentials [type=invalid_request, code=bad_auth]",
+    );
+  });
+
+  it("throws when Voxtral omits audio_data from the response envelope", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "resolved-profile-key",
+      source: "profile:mistral:default",
+      mode: "api-key",
+      profileId: "mistral:default",
+    });
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(JSON.stringify({ id: "tts_123" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    await expect(provider.synthesize(buildSynthesisRequest())).rejects.toThrow(
+      "Mistral TTS response missing audio_data",
+    );
+  });
+
+  it("synthesizes telephony audio by requesting WAV and decoding f32le to s16le", async () => {
+    const samples = new Float32Array([0.5, -0.5, 0.25]);
+    const wavBuf = buildF32leWav(samples, 24_000);
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "resolved-profile-key",
+      source: "profile:mistral:default",
+      mode: "api-key",
+      profileId: "mistral:default",
+    });
+    const fetchMock = vi.fn(async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.response_format).toBe("wav");
+      return new Response(JSON.stringify({ audio_data: wavBuf.toString("base64") }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await provider.synthesizeTelephony!({
+      text: "hello",
+      cfg: {
+        auth: {
+          profiles: {
+            "mistral:default": { provider: "mistral", mode: "api_key" },
+          },
+        },
+      } as never,
+      providerConfig: {
+        baseUrl: "https://api.mistral.ai/v1",
+        model: "voxtral-mini-tts-2603",
+        voice: "",
+      },
+      timeoutMs: 5000,
+    });
+
+    expect(result.outputFormat).toBe("pcm");
+    expect(result.sampleRate).toBe(24_000);
+    // 3 f32 samples → 3 s16 samples = 6 bytes
+    expect(result.audioBuffer.byteLength).toBe(6);
+  });
+
+  it("throws when no Mistral API key can be resolved", async () => {
+    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
+      source: "env: MISTRAL_API_KEY",
+      mode: "api-key",
+    });
+
+    await expect(
+      provider.synthesize(
+        buildSynthesisRequest({
+          cfg: {} as never,
+        }),
+      ),
+    ).rejects.toThrow('No API key resolved for provider "mistral" (auth mode: api-key).');
+  });
+});
+
+describe("decodeMistralWavToS16le", () => {
+  it("converts f32le mono WAV to s16le and returns the sample rate from the header", () => {
+    const samples = new Float32Array([1.0, -1.0, 0.5, 0.0]);
+    const wav = buildF32leWav(samples, 24_000);
+    const { audioBuffer, sampleRate } = decodeMistralWavToS16le(wav);
+    expect(sampleRate).toBe(24_000);
+    expect(audioBuffer.byteLength).toBe(samples.length * 2);
+    expect(audioBuffer.readInt16LE(0)).toBe(32767);
+    expect(audioBuffer.readInt16LE(2)).toBe(-32767);
+  });
+
+  it("finds the data chunk after an odd-sized metadata chunk", () => {
+    const samples = new Float32Array([1.0, -1.0]);
+    const wav = insertChunkBeforeData(buildF32leWav(samples, 24_000), "LIST", Buffer.from("abc"));
+    const { audioBuffer, sampleRate } = decodeMistralWavToS16le(wav);
+    expect(sampleRate).toBe(24_000);
+    expect(audioBuffer.byteLength).toBe(samples.length * 2);
+    expect(audioBuffer.readInt16LE(0)).toBe(32767);
+    expect(audioBuffer.readInt16LE(2)).toBe(-32767);
+  });
+
+  it("passes through s16le mono WAV unchanged and returns the correct sample rate", () => {
+    const samples = new Int16Array([1000, -2000, 0, 32767]);
+    const wav = buildS16leWav(samples, 16_000);
+    const { audioBuffer, sampleRate } = decodeMistralWavToS16le(wav);
+    expect(sampleRate).toBe(16_000);
+    expect(audioBuffer.byteLength).toBe(samples.length * 2);
+    expect(audioBuffer.readInt16LE(0)).toBe(1000);
+    expect(audioBuffer.readInt16LE(6)).toBe(32767);
+  });
+
+  it("throws on a truncated buffer", () => {
+    expect(() => decodeMistralWavToS16le(Buffer.alloc(10))).toThrow(
+      "Mistral TTS WAV response too short",
+    );
+  });
+
+  it("throws on a non-WAV buffer", () => {
+    const buf = Buffer.alloc(44);
+    buf.write("NOPE", 0, "ascii");
+    expect(() => decodeMistralWavToS16le(buf)).toThrow(
+      "Mistral TTS WAV response is not a valid RIFF/WAVE file",
+    );
+  });
+});

--- a/extensions/mistral/speech-provider.test.ts
+++ b/extensions/mistral/speech-provider.test.ts
@@ -164,6 +164,41 @@ describe("mistral speech provider", () => {
     ).toBe(false);
   });
 
+  it("gates profile metadata on an explicit empty auth.order Mistral entry", () => {
+    // auth.order.mistral=[] is authoritative: resolveAuthProfileOrder returns []
+    // even when profiles exist, so synthesis would fail. isConfigured must agree.
+    expect(
+      provider.isConfigured({
+        cfg: {
+          auth: {
+            profiles: {
+              "mistral:default": { provider: "mistral", mode: "api_key" },
+            },
+            order: {
+              mistral: [],
+            },
+          },
+        } as never,
+        providerConfig: {},
+        timeoutMs: 5000,
+      }),
+    ).toBe(false);
+  });
+
+  it("treats no cfg-level Mistral metadata as TTS-ready for auth-store-only credentials", () => {
+    // When cfg has no Mistral profiles and no Mistral auth.order entry,
+    // resolveApiKeyForProvider falls through to the auth store. isConfigured
+    // must return true so the provider is not skipped for users whose only
+    // credentials live in auth-profiles.json.
+    expect(
+      provider.isConfigured({
+        cfg: {} as never,
+        providerConfig: {},
+        timeoutMs: 5000,
+      }),
+    ).toBe(true);
+  });
+
   it("reuses the Mistral model provider baseUrl when no TTS override is configured", () => {
     const providerConfig = provider.resolveConfig?.({
       cfg: {

--- a/extensions/mistral/speech-provider.test.ts
+++ b/extensions/mistral/speech-provider.test.ts
@@ -1,3 +1,4 @@
+import { Mistral } from "@mistralai/mistralai";
 import * as providerAuthRuntime from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   parseTtsDirectives,
@@ -6,6 +7,8 @@ import {
 } from "openclaw/plugin-sdk/speech";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildMistralSpeechProvider, decodeMistralWavToS16le } from "./speech-provider.js";
+
+vi.mock("@mistralai/mistralai", () => ({ Mistral: vi.fn() }));
 
 /** Build a minimal RIFF/WAVE buffer with f32le mono audio at the given sample rate. */
 function buildF32leWav(samples: Float32Array, sampleRate: number): Buffer {
@@ -66,8 +69,14 @@ function insertChunkBeforeData(buffer: Buffer, chunkId: string, payload: Buffer)
 }
 
 describe("mistral speech provider", () => {
-  const originalFetch = globalThis.fetch;
   const provider = buildMistralSpeechProvider();
+
+  function mockMistralComplete(impl: () => Promise<unknown>) {
+    const mockComplete = vi.fn(impl);
+    vi.mocked(Mistral).mockImplementation(function () {
+      return { audio: { speech: { complete: mockComplete } } } as unknown as Mistral;
+    });
+  }
 
   function buildSynthesisRequest(
     overrides: Partial<SpeechSynthesisRequest> = {},
@@ -107,7 +116,7 @@ describe("mistral speech provider", () => {
   } as const;
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    vi.mocked(Mistral).mockReset();
     vi.restoreAllMocks();
     delete process.env.MISTRAL_API_KEY;
     delete process.env.MISTRAL_TTS_BASE_URL;
@@ -322,23 +331,20 @@ describe("mistral speech provider", () => {
       mode: "api-key",
       profileId: "mistral:default",
     });
-    const fetchMock = vi.fn(async (_url, init) => {
-      const body = JSON.parse(String(init?.body));
-      expect(body.model).toBe("voxtral-mini-tts-2603");
-      expect(body.voice_id).toBeUndefined();
-      expect(body.response_format).toBe("opus");
-      expect(init?.headers).toMatchObject({
-        Authorization: "Bearer resolved-profile-key",
-      });
-      return new Response(JSON.stringify({ audio_data: audio.toString("base64") }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
+    const mockComplete = vi.fn().mockResolvedValue({ audioData: audio.toString("base64") });
+    vi.mocked(Mistral).mockImplementation(function (opts) {
+      expect(opts?.apiKey).toBe("resolved-profile-key");
+      expect(opts?.serverURL).toBe("https://api.mistral.ai");
+      return { audio: { speech: { complete: mockComplete } } } as unknown as Mistral;
     });
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     const result = await provider.synthesize(buildSynthesisRequest());
 
+    expect(mockComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "voxtral-mini-tts-2603", responseFormat: "opus" }),
+      expect.anything(),
+    );
+    expect(mockComplete.mock.calls[0][0].voiceId).toBeUndefined();
     expect(result.audioBuffer.equals(audio)).toBe(true);
     expect(result.outputFormat).toBe("opus");
     expect(result.fileExtension).toBe(".opus");
@@ -352,43 +358,16 @@ describe("mistral speech provider", () => {
       mode: "api-key",
       profileId: "mistral:default",
     });
-    globalThis.fetch = vi.fn(async () => {
-      return new Response(
-        JSON.stringify({
-          error: {
-            message: "bad credentials",
-            type: "invalid_request",
-            code: "bad_auth",
-          },
-        }),
-        {
-          status: 401,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
-    }) as unknown as typeof fetch;
+    const sdkError = Object.assign(new Error("SDK error"), {
+      statusCode: 401,
+      body: JSON.stringify({
+        error: { message: "bad credentials", type: "invalid_request", code: "bad_auth" },
+      }),
+    });
+    mockMistralComplete(() => Promise.reject(sdkError));
 
     await expect(provider.synthesize(buildSynthesisRequest())).rejects.toThrow(
       "Mistral TTS API error (401): bad credentials [type=invalid_request, code=bad_auth]",
-    );
-  });
-
-  it("throws when Voxtral omits audio_data from the response envelope", async () => {
-    vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "resolved-profile-key",
-      source: "profile:mistral:default",
-      mode: "api-key",
-      profileId: "mistral:default",
-    });
-    globalThis.fetch = vi.fn(async () => {
-      return new Response(JSON.stringify({ id: "tts_123" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-    }) as unknown as typeof fetch;
-
-    await expect(provider.synthesize(buildSynthesisRequest())).rejects.toThrow(
-      "Mistral TTS response missing audio_data",
     );
   });
 
@@ -401,15 +380,13 @@ describe("mistral speech provider", () => {
       mode: "api-key",
       profileId: "mistral:default",
     });
-    const fetchMock = vi.fn(async (_url, init) => {
-      const body = JSON.parse(String(init?.body));
-      expect(body.response_format).toBe("wav");
-      return new Response(JSON.stringify({ audio_data: wavBuf.toString("base64") }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
+    const mockComplete = vi.fn().mockImplementation(async (req: { responseFormat: string }) => {
+      expect(req.responseFormat).toBe("wav");
+      return { audioData: wavBuf.toString("base64") };
     });
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    vi.mocked(Mistral).mockImplementation(function () {
+      return { audio: { speech: { complete: mockComplete } } } as unknown as Mistral;
+    });
 
     const result = await provider.synthesizeTelephony!({
       text: "hello",

--- a/extensions/mistral/speech-provider.test.ts
+++ b/extensions/mistral/speech-provider.test.ts
@@ -237,7 +237,6 @@ describe("mistral speech provider", () => {
         baseUrl: "https://talk.mistral.example/v1",
         modelId: "voxtral-custom-tts",
         voiceId: "voice_123",
-        speed: 1.1,
       },
       timeoutMs: 5000,
     });
@@ -247,7 +246,6 @@ describe("mistral speech provider", () => {
       baseUrl: "https://talk.mistral.example/v1",
       model: "voxtral-custom-tts",
       voice: "voice_123",
-      speed: 1.1,
     });
   });
 
@@ -257,14 +255,12 @@ describe("mistral speech provider", () => {
       params: {
         modelId: "voxtral-live-tts",
         voiceId: "voice_override",
-        speed: 1.25,
       },
     });
 
     expect(talkOverrides).toEqual({
       model: "voxtral-live-tts",
       voice: "voice_override",
-      speed: 1.25,
     });
   });
 

--- a/extensions/mistral/speech-provider.test.ts
+++ b/extensions/mistral/speech-provider.test.ts
@@ -56,6 +56,18 @@ function buildS16leWav(samples: Int16Array, sampleRate: number): Buffer {
   return buf;
 }
 
+function insertChunkBeforeFmt(buffer: Buffer, chunkId: string, payload: Buffer): Buffer {
+  const padBytes = payload.length % 2;
+  const chunk = Buffer.alloc(8 + payload.length + padBytes);
+  chunk.write(chunkId, 0, "ascii");
+  chunk.writeUInt32LE(payload.length, 4);
+  payload.copy(chunk, 8);
+  // Insert after the 12-byte RIFF/WAVE header, before the fmt chunk
+  const result = Buffer.concat([buffer.subarray(0, 12), chunk, buffer.subarray(12)]);
+  result.writeUInt32LE(result.length - 8, 4); // update RIFF size
+  return result;
+}
+
 function insertChunkBeforeData(buffer: Buffer, chunkId: string, payload: Buffer): Buffer {
   const padBytes = payload.length % 2;
   const chunk = Buffer.alloc(8 + payload.length + padBytes);
@@ -440,6 +452,16 @@ describe("decodeMistralWavToS16le", () => {
   it("converts f32le mono WAV to s16le and returns the sample rate from the header", () => {
     const samples = new Float32Array([1.0, -1.0, 0.5, 0.0]);
     const wav = buildF32leWav(samples, 24_000);
+    const { audioBuffer, sampleRate } = decodeMistralWavToS16le(wav);
+    expect(sampleRate).toBe(24_000);
+    expect(audioBuffer.byteLength).toBe(samples.length * 2);
+    expect(audioBuffer.readInt16LE(0)).toBe(32767);
+    expect(audioBuffer.readInt16LE(2)).toBe(-32767);
+  });
+
+  it("finds the fmt chunk when a JUNK chunk precedes it", () => {
+    const samples = new Float32Array([1.0, -1.0]);
+    const wav = insertChunkBeforeFmt(buildF32leWav(samples, 24_000), "JUNK", Buffer.alloc(4));
     const { audioBuffer, sampleRate } = decodeMistralWavToS16le(wav);
     expect(sampleRate).toBe(24_000);
     expect(audioBuffer.byteLength).toBe(samples.length * 2);

--- a/extensions/mistral/speech-provider.test.ts
+++ b/extensions/mistral/speech-provider.test.ts
@@ -194,18 +194,27 @@ describe("mistral speech provider", () => {
     ).toBe(false);
   });
 
-  it("treats no cfg-level Mistral metadata as TTS-ready for auth-store-only credentials", () => {
-    // When cfg has no Mistral profiles and no Mistral auth.order entry,
-    // resolveApiKeyForProvider falls through to the auth store. isConfigured
-    // must return true so the provider is not skipped for users whose only
-    // credentials live in auth-profiles.json.
+  it("does not treat absent cfg-level Mistral metadata as TTS-ready", () => {
+    // No explicit auth signal means isConfigured returns false. The "none" case
+    // is not treated as a positive signal — credentials may exist in the auth
+    // store but that is resolved at synthesis time, not here.
     expect(
       provider.isConfigured({
         cfg: {} as never,
         providerConfig: {},
         timeoutMs: 5000,
       }),
-    ).toBe(true);
+    ).toBe(false);
+
+    // Same when cfg is undefined — callers that omit cfg (e.g. getTtsProvider)
+    // must not see Mistral as auto-selectable without a real auth signal.
+    expect(
+      provider.isConfigured({
+        cfg: undefined as never,
+        providerConfig: {},
+        timeoutMs: 5000,
+      }),
+    ).toBe(false);
   });
 
   it("reuses the Mistral model provider baseUrl when no TTS override is configured", () => {

--- a/extensions/mistral/speech-provider.ts
+++ b/extensions/mistral/speech-provider.ts
@@ -22,21 +22,15 @@ type MistralTtsProviderConfig = {
   baseUrl: string;
   model: string;
   voice: string;
-  speed?: number;
 };
 
 type MistralTtsProviderOverrides = {
   model?: string;
   voice?: string;
-  speed?: number;
 };
 
 function normalizeProviderId(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim().toLowerCase() : undefined;
-}
-
-function asNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function hasConfiguredSecret(value: unknown): boolean {
@@ -112,7 +106,6 @@ function normalizeMistralProviderConfig(
     ),
     model: trimToUndefined(raw?.model) ?? DEFAULT_MISTRAL_TTS_MODEL,
     voice: trimToUndefined(raw?.voice) ?? "",
-    speed: asNumber(raw?.speed),
   };
 }
 
@@ -126,7 +119,6 @@ function readMistralProviderConfig(
     baseUrl: normalizeMistralTtsBaseUrl(trimToUndefined(config.baseUrl) ?? normalized.baseUrl),
     model: trimToUndefined(config.model) ?? normalized.model,
     voice: trimToUndefined(config.voice) ?? normalized.voice,
-    speed: asNumber(config.speed) ?? normalized.speed,
   };
 }
 
@@ -139,7 +131,6 @@ function readMistralOverrides(
   return {
     model: trimToUndefined(overrides.model),
     voice: trimToUndefined(overrides.voice),
-    speed: asNumber(overrides.speed),
   };
 }
 
@@ -332,11 +323,10 @@ async function mistralTTS(params: {
   baseUrl: string;
   model: string;
   voice: string;
-  speed?: number;
   responseFormat: "mp3" | "opus" | "pcm" | "wav";
   timeoutMs: number;
 }): Promise<Buffer> {
-  const { text, apiKey, baseUrl, model, voice, speed, responseFormat, timeoutMs } = params;
+  const { text, apiKey, baseUrl, model, voice, responseFormat, timeoutMs } = params;
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -353,7 +343,6 @@ async function mistralTTS(params: {
         input: text,
         ...(voice ? { voice_id: voice } : {}),
         response_format: responseFormat,
-        ...(speed != null && { speed }),
       }),
       signal: controller.signal,
     });
@@ -405,9 +394,6 @@ export function buildMistralSpeechProvider(): SpeechProviderPlugin {
         ...(trimToUndefined(talkProviderConfig.voiceId) == null
           ? {}
           : { voice: trimToUndefined(talkProviderConfig.voiceId) }),
-        ...(asNumber(talkProviderConfig.speed) == null
-          ? {}
-          : { speed: asNumber(talkProviderConfig.speed) }),
       };
     },
     resolveTalkOverrides: ({ params }) => ({
@@ -417,7 +403,6 @@ export function buildMistralSpeechProvider(): SpeechProviderPlugin {
       ...(trimToUndefined(params.modelId) == null
         ? {}
         : { model: trimToUndefined(params.modelId) }),
-      ...(asNumber(params.speed) == null ? {} : { speed: asNumber(params.speed) }),
     }),
     isConfigured: ({ cfg, providerConfig }) => {
       const config = readMistralProviderConfig(providerConfig, cfg);
@@ -446,7 +431,6 @@ export function buildMistralSpeechProvider(): SpeechProviderPlugin {
         baseUrl: config.baseUrl,
         model: config.model,
         voice: config.voice,
-        speed: config.speed,
         responseFormat: "wav",
         timeoutMs: req.timeoutMs,
       });
@@ -467,7 +451,6 @@ export function buildMistralSpeechProvider(): SpeechProviderPlugin {
         baseUrl: config.baseUrl,
         model: overrides.model ?? config.model,
         voice: overrides.voice ?? config.voice,
-        speed: overrides.speed ?? config.speed,
         responseFormat,
         timeoutMs: req.timeoutMs,
       });

--- a/extensions/mistral/speech-provider.ts
+++ b/extensions/mistral/speech-provider.ts
@@ -1,0 +1,476 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { requireApiKey, resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import type {
+  SpeechDirectiveTokenParseContext,
+  SpeechProviderConfig,
+  SpeechProviderOverrides,
+  SpeechProviderPlugin,
+} from "openclaw/plugin-sdk/speech";
+import {
+  asObject,
+  readResponseTextLimited,
+  trimToUndefined,
+  truncateErrorDetail,
+} from "openclaw/plugin-sdk/speech";
+import { MISTRAL_BASE_URL } from "./model-definitions.js";
+
+const DEFAULT_MISTRAL_TTS_MODEL = "voxtral-mini-tts-2603";
+
+type MistralTtsProviderConfig = {
+  apiKey?: string;
+  baseUrl: string;
+  model: string;
+  voice: string;
+  speed?: number;
+};
+
+type MistralTtsProviderOverrides = {
+  model?: string;
+  voice?: string;
+  speed?: number;
+};
+
+function normalizeProviderId(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim().toLowerCase() : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function hasConfiguredSecret(value: unknown): boolean {
+  return (typeof value === "string" && value.trim().length > 0) || asObject(value) != null;
+}
+
+function normalizeMistralTtsBaseUrl(baseUrl?: string): string {
+  const trimmed = baseUrl?.trim();
+  return trimmed ? trimmed.replace(/\/+$/, "") : MISTRAL_BASE_URL;
+}
+
+function findMistralModelProviderConfig(cfg?: OpenClawConfig): Record<string, unknown> | undefined {
+  const providers = asObject(cfg?.models?.providers);
+  if (!providers) {
+    return undefined;
+  }
+  for (const [providerId, providerConfig] of Object.entries(providers)) {
+    if (normalizeProviderId(providerId) === "mistral") {
+      return asObject(providerConfig);
+    }
+  }
+  return undefined;
+}
+
+function hasConfiguredMistralAuthProfileMetadata(cfg?: OpenClawConfig): boolean {
+  const profiles = asObject(cfg?.auth?.profiles);
+  return Boolean(
+    profiles &&
+    Object.values(profiles).some(
+      (profile) => normalizeProviderId(asObject(profile)?.provider) === "mistral",
+    ),
+  );
+}
+
+function hasConfiguredMistralAuthOrder(cfg?: OpenClawConfig): boolean {
+  const order = asObject(cfg?.auth?.order);
+  if (!order) {
+    return false;
+  }
+  // auth.order keys are provider IDs; check if any key normalizes to "mistral"
+  // and has at least one profile ID entry, matching what resolveAuthProfileOrder does.
+  return Object.entries(order).some(([providerId, profileIds]) => {
+    if (normalizeProviderId(providerId) !== "mistral") {
+      return false;
+    }
+    return Array.isArray(profileIds) && profileIds.length > 0;
+  });
+}
+
+function normalizeMistralProviderConfig(
+  rawConfig: Record<string, unknown>,
+  cfg?: OpenClawConfig,
+): MistralTtsProviderConfig {
+  const providers = asObject(rawConfig.providers);
+  const raw = asObject(providers?.mistral) ?? asObject(rawConfig.mistral);
+  const modelProvider = findMistralModelProviderConfig(cfg);
+  return {
+    apiKey: normalizeResolvedSecretInputString({
+      value: raw?.apiKey,
+      path: "messages.tts.providers.mistral.apiKey",
+    }),
+    baseUrl: normalizeMistralTtsBaseUrl(
+      trimToUndefined(raw?.baseUrl) ??
+        trimToUndefined(process.env.MISTRAL_TTS_BASE_URL) ??
+        trimToUndefined(modelProvider?.baseUrl),
+    ),
+    model: trimToUndefined(raw?.model) ?? DEFAULT_MISTRAL_TTS_MODEL,
+    voice: trimToUndefined(raw?.voice) ?? "",
+    speed: asNumber(raw?.speed),
+  };
+}
+
+function readMistralProviderConfig(
+  config: SpeechProviderConfig,
+  cfg?: OpenClawConfig,
+): MistralTtsProviderConfig {
+  const normalized = normalizeMistralProviderConfig({}, cfg);
+  return {
+    apiKey: trimToUndefined(config.apiKey) ?? normalized.apiKey,
+    baseUrl: normalizeMistralTtsBaseUrl(trimToUndefined(config.baseUrl) ?? normalized.baseUrl),
+    model: trimToUndefined(config.model) ?? normalized.model,
+    voice: trimToUndefined(config.voice) ?? normalized.voice,
+    speed: asNumber(config.speed) ?? normalized.speed,
+  };
+}
+
+function readMistralOverrides(
+  overrides: SpeechProviderOverrides | undefined,
+): MistralTtsProviderOverrides {
+  if (!overrides) {
+    return {};
+  }
+  return {
+    model: trimToUndefined(overrides.model),
+    voice: trimToUndefined(overrides.voice),
+    speed: asNumber(overrides.speed),
+  };
+}
+
+function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
+  handled: boolean;
+  overrides?: SpeechProviderOverrides;
+  warnings?: string[];
+} {
+  switch (ctx.key) {
+    case "mistralvoice":
+    case "mistralvoiceid":
+    case "mistral_voice":
+    case "mistral_voice_id":
+      if (!ctx.policy.allowVoice) {
+        return { handled: true };
+      }
+      if (!ctx.value.trim()) {
+        return { handled: true, warnings: [`invalid Mistral voice "${ctx.value}"`] };
+      }
+      return { handled: true, overrides: { voice: ctx.value.trim() } };
+    case "mistralmodel":
+    case "mistralmodelid":
+    case "mistral_model":
+      if (!ctx.policy.allowModelId) {
+        return { handled: true };
+      }
+      if (!ctx.value.trim()) {
+        return { handled: true, warnings: [`invalid Mistral model "${ctx.value}"`] };
+      }
+      return { handled: true, overrides: { model: ctx.value.trim() } };
+    default:
+      return { handled: false };
+  }
+}
+
+function decodeBase64Audio(value: string): Buffer {
+  return Buffer.from(value, "base64");
+}
+
+type WavChunkInfo = {
+  audioData: Buffer;
+  sampleRate: number;
+  numChannels: number;
+  bitsPerSample: number;
+  /** 1 = PCM integer, 3 = IEEE float */
+  audioFormat: number;
+};
+
+function getRiffChunkSpan(chunkSize: number): number {
+  // RIFF chunks are word-aligned, so odd-length payloads include a 1-byte pad.
+  return 8 + chunkSize + (chunkSize % 2);
+}
+
+function parseWavChunk(buffer: Buffer): WavChunkInfo {
+  if (buffer.length < 44) {
+    throw new Error("Mistral TTS WAV response too short");
+  }
+  if (buffer.toString("ascii", 0, 4) !== "RIFF" || buffer.toString("ascii", 8, 12) !== "WAVE") {
+    throw new Error("Mistral TTS WAV response is not a valid RIFF/WAVE file");
+  }
+  if (buffer.toString("ascii", 12, 16) !== "fmt ") {
+    throw new Error("Mistral TTS WAV response missing fmt chunk");
+  }
+  const fmtSize = buffer.readUInt32LE(16);
+  const audioFormat = buffer.readUInt16LE(20);
+  const numChannels = buffer.readUInt16LE(22);
+  const sampleRate = buffer.readUInt32LE(24);
+  const bitsPerSample = buffer.readUInt16LE(34);
+
+  // Scan for the data chunk (there may be additional chunks between fmt and data)
+  let offset = 12 + getRiffChunkSpan(fmtSize);
+  while (offset + 8 <= buffer.length) {
+    const chunkId = buffer.toString("ascii", offset, offset + 4);
+    const chunkSize = buffer.readUInt32LE(offset + 4);
+    if (chunkId === "data") {
+      const audioData = buffer.subarray(offset + 8, offset + 8 + chunkSize);
+      return { audioData, sampleRate, numChannels, bitsPerSample, audioFormat };
+    }
+    offset += getRiffChunkSpan(chunkSize);
+  }
+  throw new Error("Mistral TTS WAV response missing data chunk");
+}
+
+/**
+ * Decode a Mistral WAV response to mono s16le PCM.
+ * Handles f32le (audioFormat=3) and s16le (audioFormat=1) WAV sources.
+ * Returns the raw s16le buffer and the sample rate from the WAV header.
+ */
+export function decodeMistralWavToS16le(buffer: Buffer): {
+  audioBuffer: Buffer;
+  sampleRate: number;
+} {
+  const { audioData, sampleRate, numChannels, bitsPerSample, audioFormat } = parseWavChunk(buffer);
+
+  if (audioFormat === 3 && bitsPerSample === 32) {
+    // f32le → s16le (mix to mono if needed)
+    const samplesPerFrame = numChannels;
+    const frames = Math.floor(audioData.length / (4 * samplesPerFrame));
+    const output = Buffer.alloc(frames * 2);
+    for (let i = 0; i < frames; i++) {
+      let sum = 0;
+      for (let ch = 0; ch < samplesPerFrame; ch++) {
+        sum += audioData.readFloatLE((i * samplesPerFrame + ch) * 4);
+      }
+      const sample = Math.round((sum / samplesPerFrame) * 32767);
+      output.writeInt16LE(Math.max(-32768, Math.min(32767, sample)), i * 2);
+    }
+    return { audioBuffer: output, sampleRate };
+  }
+
+  if (audioFormat === 1 && bitsPerSample === 16) {
+    // Already s16le — mix to mono if needed
+    if (numChannels === 1) {
+      return { audioBuffer: audioData, sampleRate };
+    }
+    const frames = Math.floor(audioData.length / (2 * numChannels));
+    const output = Buffer.alloc(frames * 2);
+    for (let i = 0; i < frames; i++) {
+      let sum = 0;
+      for (let ch = 0; ch < numChannels; ch++) {
+        sum += audioData.readInt16LE((i * numChannels + ch) * 2);
+      }
+      output.writeInt16LE(Math.round(sum / numChannels), i * 2);
+    }
+    return { audioBuffer: output, sampleRate };
+  }
+
+  throw new Error(
+    `Mistral TTS WAV: unsupported format (audioFormat=${audioFormat}, bitsPerSample=${bitsPerSample})`,
+  );
+}
+
+function formatMistralErrorPayload(payload: unknown): string | undefined {
+  const root = asObject(payload);
+  const subject = asObject(root?.error) ?? root;
+  if (!subject) {
+    return undefined;
+  }
+  const message =
+    trimToUndefined(subject.message) ??
+    trimToUndefined(subject.detail) ??
+    trimToUndefined(root?.message);
+  const type = trimToUndefined(subject.type);
+  const code = trimToUndefined(subject.code);
+  const metadata = [type ? `type=${type}` : undefined, code ? `code=${code}` : undefined]
+    .filter((value): value is string => Boolean(value))
+    .join(", ");
+  if (message && metadata) {
+    return `${truncateErrorDetail(message)} [${metadata}]`;
+  }
+  if (message) {
+    return truncateErrorDetail(message);
+  }
+  if (metadata) {
+    return `[${metadata}]`;
+  }
+  return undefined;
+}
+
+async function extractMistralErrorDetail(response: Response): Promise<string | undefined> {
+  const rawBody = trimToUndefined(await readResponseTextLimited(response));
+  if (!rawBody) {
+    return undefined;
+  }
+  try {
+    return formatMistralErrorPayload(JSON.parse(rawBody)) ?? truncateErrorDetail(rawBody);
+  } catch {
+    return truncateErrorDetail(rawBody);
+  }
+}
+
+async function resolveMistralApiKey(params: {
+  cfg: OpenClawConfig;
+  providerConfig: MistralTtsProviderConfig;
+}): Promise<string> {
+  const configuredApiKey = params.providerConfig.apiKey;
+  if (configuredApiKey) {
+    return configuredApiKey;
+  }
+  const auth = await resolveApiKeyForProvider({
+    provider: "mistral",
+    cfg: params.cfg,
+  });
+  return requireApiKey(auth, "mistral");
+}
+
+async function mistralTTS(params: {
+  text: string;
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  voice: string;
+  speed?: number;
+  responseFormat: "mp3" | "opus" | "pcm" | "wav";
+  timeoutMs: number;
+}): Promise<Buffer> {
+  const { text, apiKey, baseUrl, model, voice, speed, responseFormat, timeoutMs } = params;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(`${baseUrl}/audio/speech`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        input: text,
+        ...(voice ? { voice_id: voice } : {}),
+        response_format: responseFormat,
+        ...(speed != null && { speed }),
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const detail = await extractMistralErrorDetail(response);
+      throw new Error(`Mistral TTS API error (${response.status})${detail ? `: ${detail}` : ""}`);
+    }
+
+    // Voxtral returns synthesized audio inside a JSON envelope instead of
+    // streaming raw audio bytes directly like the OpenAI TTS endpoint.
+    const payload = (await response.json()) as Record<string, unknown>;
+    const audioData = trimToUndefined(payload.audio_data);
+    if (!audioData) {
+      throw new Error("Mistral TTS response missing audio_data");
+    }
+    return decodeBase64Audio(audioData);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function buildMistralSpeechProvider(): SpeechProviderPlugin {
+  return {
+    id: "mistral",
+    label: "Mistral",
+    autoSelectOrder: 15,
+    models: [DEFAULT_MISTRAL_TTS_MODEL],
+    resolveConfig: ({ cfg, rawConfig }) => normalizeMistralProviderConfig(rawConfig, cfg),
+    parseDirectiveToken,
+    resolveTalkConfig: ({ cfg, baseTtsConfig, talkProviderConfig }) => {
+      const base = normalizeMistralProviderConfig(baseTtsConfig, cfg);
+      return {
+        ...base,
+        ...(talkProviderConfig.apiKey === undefined
+          ? {}
+          : {
+              apiKey: normalizeResolvedSecretInputString({
+                value: talkProviderConfig.apiKey,
+                path: "talk.providers.mistral.apiKey",
+              }),
+            }),
+        ...(trimToUndefined(talkProviderConfig.baseUrl) == null
+          ? {}
+          : { baseUrl: normalizeMistralTtsBaseUrl(trimToUndefined(talkProviderConfig.baseUrl)) }),
+        ...(trimToUndefined(talkProviderConfig.modelId) == null
+          ? {}
+          : { model: trimToUndefined(talkProviderConfig.modelId) }),
+        ...(trimToUndefined(talkProviderConfig.voiceId) == null
+          ? {}
+          : { voice: trimToUndefined(talkProviderConfig.voiceId) }),
+        ...(asNumber(talkProviderConfig.speed) == null
+          ? {}
+          : { speed: asNumber(talkProviderConfig.speed) }),
+      };
+    },
+    resolveTalkOverrides: ({ params }) => ({
+      ...(trimToUndefined(params.voiceId) == null
+        ? {}
+        : { voice: trimToUndefined(params.voiceId) }),
+      ...(trimToUndefined(params.modelId) == null
+        ? {}
+        : { model: trimToUndefined(params.modelId) }),
+      ...(asNumber(params.speed) == null ? {} : { speed: asNumber(params.speed) }),
+    }),
+    isConfigured: ({ cfg, providerConfig }) => {
+      const config = readMistralProviderConfig(providerConfig, cfg);
+      return (
+        Boolean(config.apiKey) ||
+        Boolean(trimToUndefined(process.env.MISTRAL_API_KEY)) ||
+        hasConfiguredSecret(findMistralModelProviderConfig(cfg)?.apiKey) ||
+        hasConfiguredMistralAuthProfileMetadata(cfg) ||
+        hasConfiguredMistralAuthOrder(cfg)
+      );
+    },
+    synthesizeTelephony: async (req) => {
+      const config = readMistralProviderConfig(req.providerConfig, req.cfg);
+      const apiKey = await resolveMistralApiKey({
+        cfg: req.cfg,
+        providerConfig: config,
+      });
+      // Request WAV instead of PCM because:
+      // 1. Mistral's response_format=pcm returns f32le, but the telephony pipeline expects s16le.
+      //    Feeding f32le directly caused completely distorted inbound greeting audio.
+      // 2. The WAV header is self-describing, so decodeMistralWavToS16le can read the actual
+      //    sample rate and bit depth rather than hardcoding assumptions, and handles stereo→mono
+      //    mixing. We do the f32le→s16le conversion ourselves to avoid a second lossy step.
+      const wavBuffer = await mistralTTS({
+        text: req.text,
+        apiKey,
+        baseUrl: config.baseUrl,
+        model: config.model,
+        voice: config.voice,
+        speed: config.speed,
+        responseFormat: "wav",
+        timeoutMs: req.timeoutMs,
+      });
+      const { audioBuffer, sampleRate } = decodeMistralWavToS16le(wavBuffer);
+      return { audioBuffer, outputFormat: "pcm", sampleRate };
+    },
+    synthesize: async (req) => {
+      const config = readMistralProviderConfig(req.providerConfig, req.cfg);
+      const overrides = readMistralOverrides(req.providerOverrides);
+      const apiKey = await resolveMistralApiKey({
+        cfg: req.cfg,
+        providerConfig: config,
+      });
+      const responseFormat = req.target === "voice-note" ? "opus" : "mp3";
+      const audioBuffer = await mistralTTS({
+        text: req.text,
+        apiKey,
+        baseUrl: config.baseUrl,
+        model: overrides.model ?? config.model,
+        voice: overrides.voice ?? config.voice,
+        speed: overrides.speed ?? config.speed,
+        responseFormat,
+        timeoutMs: req.timeoutMs,
+      });
+      return {
+        audioBuffer,
+        outputFormat: responseFormat,
+        fileExtension: responseFormat === "opus" ? ".opus" : ".mp3",
+        voiceCompatible: req.target === "voice-note",
+      };
+    },
+  };
+}

--- a/extensions/mistral/speech-provider.ts
+++ b/extensions/mistral/speech-provider.ts
@@ -177,31 +177,45 @@ function getRiffChunkSpan(chunkSize: number): number {
 }
 
 function parseWavChunk(buffer: Buffer): WavChunkInfo {
-  if (buffer.length < 44) {
+  if (buffer.length < 12) {
     throw new Error("Mistral TTS WAV response too short");
   }
   if (buffer.toString("ascii", 0, 4) !== "RIFF" || buffer.toString("ascii", 8, 12) !== "WAVE") {
     throw new Error("Mistral TTS WAV response is not a valid RIFF/WAVE file");
   }
-  if (buffer.toString("ascii", 12, 16) !== "fmt ") {
-    throw new Error("Mistral TTS WAV response missing fmt chunk");
-  }
-  const fmtSize = buffer.readUInt32LE(16);
-  const audioFormat = buffer.readUInt16LE(20);
-  const numChannels = buffer.readUInt16LE(22);
-  const sampleRate = buffer.readUInt32LE(24);
-  const bitsPerSample = buffer.readUInt16LE(34);
 
-  // Scan for the data chunk (there may be additional chunks between fmt and data)
-  let offset = 12 + getRiffChunkSpan(fmtSize);
+  // Scan all chunks from byte 12 — fmt may not be first (e.g. JUNK/LIST may precede it)
+  let fmt:
+    | { audioFormat: number; numChannels: number; sampleRate: number; bitsPerSample: number }
+    | undefined;
+  let offset = 12;
   while (offset + 8 <= buffer.length) {
     const chunkId = buffer.toString("ascii", offset, offset + 4);
     const chunkSize = buffer.readUInt32LE(offset + 4);
-    if (chunkId === "data") {
+    if (chunkId === "fmt ") {
+      // fmt chunk data layout: audioFormat(2) numChannels(2) sampleRate(4)
+      //   byteRate(4) blockAlign(2) bitsPerSample(2) — 16 bytes minimum
+      if (chunkSize < 16 || buffer.length < offset + 24) {
+        throw new Error("Mistral TTS WAV response fmt chunk too short");
+      }
+      fmt = {
+        audioFormat: buffer.readUInt16LE(offset + 8),
+        numChannels: buffer.readUInt16LE(offset + 10),
+        sampleRate: buffer.readUInt32LE(offset + 12),
+        bitsPerSample: buffer.readUInt16LE(offset + 22),
+      };
+    } else if (chunkId === "data") {
+      if (!fmt) {
+        throw new Error("Mistral TTS WAV response data chunk before fmt chunk");
+      }
       const audioData = buffer.subarray(offset + 8, offset + 8 + chunkSize);
-      return { audioData, sampleRate, numChannels, bitsPerSample, audioFormat };
+      return { audioData, ...fmt };
     }
     offset += getRiffChunkSpan(chunkSize);
+  }
+
+  if (!fmt) {
+    throw new Error("Mistral TTS WAV response missing fmt chunk");
   }
   throw new Error("Mistral TTS WAV response missing data chunk");
 }

--- a/extensions/mistral/speech-provider.ts
+++ b/extensions/mistral/speech-provider.ts
@@ -1,3 +1,4 @@
+import { Mistral } from "@mistralai/mistralai";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { requireApiKey, resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
@@ -7,12 +8,7 @@ import type {
   SpeechProviderOverrides,
   SpeechProviderPlugin,
 } from "openclaw/plugin-sdk/speech";
-import {
-  asObject,
-  readResponseTextLimited,
-  trimToUndefined,
-  truncateErrorDetail,
-} from "openclaw/plugin-sdk/speech";
+import { asObject, trimToUndefined, truncateErrorDetail } from "openclaw/plugin-sdk/speech";
 import { MISTRAL_BASE_URL } from "./model-definitions.js";
 
 const DEFAULT_MISTRAL_TTS_MODEL = "voxtral-mini-tts-2603";
@@ -166,10 +162,6 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
   }
 }
 
-function decodeBase64Audio(value: string): Buffer {
-  return Buffer.from(value, "base64");
-}
-
 type WavChunkInfo = {
   audioData: Buffer;
   sampleRate: number;
@@ -290,18 +282,6 @@ function formatMistralErrorPayload(payload: unknown): string | undefined {
   return undefined;
 }
 
-async function extractMistralErrorDetail(response: Response): Promise<string | undefined> {
-  const rawBody = trimToUndefined(await readResponseTextLimited(response));
-  if (!rawBody) {
-    return undefined;
-  }
-  try {
-    return formatMistralErrorPayload(JSON.parse(rawBody)) ?? truncateErrorDetail(rawBody);
-  } catch {
-    return truncateErrorDetail(rawBody);
-  }
-}
-
 async function resolveMistralApiKey(params: {
   cfg: OpenClawConfig;
   providerConfig: MistralTtsProviderConfig;
@@ -317,6 +297,21 @@ async function resolveMistralApiKey(params: {
   return requireApiKey(auth, "mistral");
 }
 
+function isMistralSdkError(err: unknown): err is { statusCode: number; body: string } {
+  return (
+    err != null &&
+    typeof err === "object" &&
+    typeof (err as Record<string, unknown>).statusCode === "number" &&
+    typeof (err as Record<string, unknown>).body === "string"
+  );
+}
+
+function toMistralSdkServerUrl(baseUrl: string): string {
+  // The SDK appends /v1/audio/speech to its serverURL. Our baseUrl config
+  // includes /v1 as part of the REST API path prefix, so strip the suffix.
+  return baseUrl.replace(/\/v1$/, "");
+}
+
 async function mistralTTS(params: {
   text: string;
   apiKey: string;
@@ -327,41 +322,32 @@ async function mistralTTS(params: {
   timeoutMs: number;
 }): Promise<Buffer> {
   const { text, apiKey, baseUrl, model, voice, responseFormat, timeoutMs } = params;
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
+  const client = new Mistral({ apiKey, serverURL: toMistralSdkServerUrl(baseUrl) });
   try {
-    const response = await fetch(`${baseUrl}/audio/speech`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
+    const response = await client.audio.speech.complete(
+      {
         model,
         input: text,
-        ...(voice ? { voice_id: voice } : {}),
-        response_format: responseFormat,
-      }),
-      signal: controller.signal,
-    });
-
-    if (!response.ok) {
-      const detail = await extractMistralErrorDetail(response);
-      throw new Error(`Mistral TTS API error (${response.status})${detail ? `: ${detail}` : ""}`);
+        ...(voice ? { voiceId: voice } : {}),
+        responseFormat,
+      },
+      { timeoutMs },
+    );
+    // SDK returns audioData as a base64 string; decode to binary
+    return Buffer.from(response.audioData, "base64");
+  } catch (err) {
+    if (isMistralSdkError(err)) {
+      let detail: string | undefined;
+      try {
+        detail = formatMistralErrorPayload(JSON.parse(err.body)) ?? truncateErrorDetail(err.body);
+      } catch {
+        detail = truncateErrorDetail(err.body);
+      }
+      throw new Error(`Mistral TTS API error (${err.statusCode})${detail ? `: ${detail}` : ""}`, {
+        cause: err,
+      });
     }
-
-    // Voxtral returns synthesized audio inside a JSON envelope instead of
-    // streaming raw audio bytes directly like the OpenAI TTS endpoint.
-    const payload = (await response.json()) as Record<string, unknown>;
-    const audioData = trimToUndefined(payload.audio_data);
-    if (!audioData) {
-      throw new Error("Mistral TTS response missing audio_data");
-    }
-    return decodeBase64Audio(audioData);
-  } finally {
-    clearTimeout(timeout);
+    throw err;
   }
 }
 

--- a/extensions/mistral/speech-provider.ts
+++ b/extensions/mistral/speech-provider.ts
@@ -58,9 +58,9 @@ function findMistralModelProviderConfig(cfg?: OpenClawConfig): Record<string, un
  *   credentials will be tried regardless of what auth.profiles contains.
  * - "configured": auth.order has a non-empty Mistral entry, or auth.profiles
  *   contains at least one Mistral profile.
- * - "none": no cfg-level Mistral metadata at all. resolveApiKeyForProvider will
- *   fall through to the auth store (auth-profiles.json), so the provider should
- *   be considered potentially configured.
+ * - "none": no cfg-level Mistral metadata at all (including when cfg is undefined).
+ *   Not treated as a positive signal for isConfigured; credentials may still
+ *   exist in the auth store but that is resolved at synthesis time.
  */
 function resolveMistralCfgAuthKind(cfg?: OpenClawConfig): "empty-order" | "configured" | "none" {
   const order = asObject(cfg?.auth?.order);
@@ -396,7 +396,7 @@ export function buildMistralSpeechProvider(): SpeechProviderPlugin {
         Boolean(config.apiKey) ||
         Boolean(trimToUndefined(process.env.MISTRAL_API_KEY)) ||
         hasConfiguredSecret(findMistralModelProviderConfig(cfg)?.apiKey) ||
-        resolveMistralCfgAuthKind(cfg) !== "empty-order"
+        resolveMistralCfgAuthKind(cfg) === "configured"
       );
     },
     synthesizeTelephony: async (req) => {

--- a/extensions/mistral/speech-provider.ts
+++ b/extensions/mistral/speech-provider.ts
@@ -61,29 +61,36 @@ function findMistralModelProviderConfig(cfg?: OpenClawConfig): Record<string, un
   return undefined;
 }
 
-function hasConfiguredMistralAuthProfileMetadata(cfg?: OpenClawConfig): boolean {
+/**
+ * Classifies the cfg-level Mistral auth state for the `isConfigured` gate:
+ * - "empty-order": auth.order has an explicit Mistral entry with an empty array.
+ *   resolveAuthProfileOrder treats this as authoritative and returns [], so no
+ *   credentials will be tried regardless of what auth.profiles contains.
+ * - "configured": auth.order has a non-empty Mistral entry, or auth.profiles
+ *   contains at least one Mistral profile.
+ * - "none": no cfg-level Mistral metadata at all. resolveApiKeyForProvider will
+ *   fall through to the auth store (auth-profiles.json), so the provider should
+ *   be considered potentially configured.
+ */
+function resolveMistralCfgAuthKind(cfg?: OpenClawConfig): "empty-order" | "configured" | "none" {
+  const order = asObject(cfg?.auth?.order);
+  if (order) {
+    for (const [key, val] of Object.entries(order)) {
+      if (normalizeProviderId(key) === "mistral") {
+        return Array.isArray(val) && val.length > 0 ? "configured" : "empty-order";
+      }
+    }
+  }
   const profiles = asObject(cfg?.auth?.profiles);
-  return Boolean(
+  if (
     profiles &&
     Object.values(profiles).some(
       (profile) => normalizeProviderId(asObject(profile)?.provider) === "mistral",
-    ),
-  );
-}
-
-function hasConfiguredMistralAuthOrder(cfg?: OpenClawConfig): boolean {
-  const order = asObject(cfg?.auth?.order);
-  if (!order) {
-    return false;
+    )
+  ) {
+    return "configured";
   }
-  // auth.order keys are provider IDs; check if any key normalizes to "mistral"
-  // and has at least one profile ID entry, matching what resolveAuthProfileOrder does.
-  return Object.entries(order).some(([providerId, profileIds]) => {
-    if (normalizeProviderId(providerId) !== "mistral") {
-      return false;
-    }
-    return Array.isArray(profileIds) && profileIds.length > 0;
-  });
+  return "none";
 }
 
 function normalizeMistralProviderConfig(
@@ -418,8 +425,7 @@ export function buildMistralSpeechProvider(): SpeechProviderPlugin {
         Boolean(config.apiKey) ||
         Boolean(trimToUndefined(process.env.MISTRAL_API_KEY)) ||
         hasConfiguredSecret(findMistralModelProviderConfig(cfg)?.apiKey) ||
-        hasConfiguredMistralAuthProfileMetadata(cfg) ||
-        hasConfiguredMistralAuthOrder(cfg)
+        resolveMistralCfgAuthKind(cfg) !== "empty-order"
       );
     },
     synthesizeTelephony: async (req) => {

--- a/extensions/openai/speech-provider.test.ts
+++ b/extensions/openai/speech-provider.test.ts
@@ -45,6 +45,7 @@ describe("buildOpenAISpeechProvider", () => {
     });
 
     expect(resolved).toEqual({
+      enabled: true,
       apiKey: "sk-test",
       baseUrl: "https://example.com/v1",
       model: "tts-1",
@@ -191,5 +192,16 @@ describe("buildOpenAISpeechProvider", () => {
     expect(result.outputFormat).toBe("wav");
     expect(result.fileExtension).toBe(".wav");
     expect(result.voiceCompatible).toBe(false);
+  });
+
+  it("reports not configured when enabled is false, even with an API key", () => {
+    const provider = buildOpenAISpeechProvider();
+    expect(
+      provider.isConfigured({
+        cfg: {} as never,
+        providerConfig: { apiKey: "sk-test", enabled: false },
+        timeoutMs: 5_000,
+      }),
+    ).toBe(false);
   });
 });

--- a/extensions/openai/speech-provider.test.ts
+++ b/extensions/openai/speech-provider.test.ts
@@ -93,6 +93,19 @@ describe("buildOpenAISpeechProvider", () => {
     });
   });
 
+  it("does not handle directive tokens when enabled is false", () => {
+    const provider = buildOpenAISpeechProvider();
+
+    expect(
+      provider.parseDirectiveToken?.({
+        key: "voice",
+        value: "alloy",
+        policy: { allowVoice: true, allowModelId: true },
+        providerConfig: { enabled: false, apiKey: "sk-test" },
+      } as never),
+    ).toEqual({ handled: false });
+  });
+
   it("preserves talk responseFormat overrides", () => {
     const provider = buildOpenAISpeechProvider();
 

--- a/extensions/openai/speech-provider.ts
+++ b/extensions/openai/speech-provider.ts
@@ -157,7 +157,10 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
   // Don't claim ownership of directive tokens when this provider is disabled —
   // otherwise a disabled OpenAI provider would silently consume voice= tokens
   // before providers like Mistral get a chance to handle them.
-  if (!readOpenAIProviderConfig(ctx.providerConfig ?? {}).enabled) {
+  // Read `enabled` directly rather than through readOpenAIProviderConfig so
+  // stale/invalid OpenAI-specific fields on a disabled config cannot throw
+  // and turn this guard into a hard failure.
+  if (asObjectRecord(ctx.providerConfig)?.enabled === false) {
     return { handled: false };
   }
   const baseUrl = trimToUndefined(asObjectRecord(ctx.providerConfig)?.baseUrl);

--- a/extensions/openai/speech-provider.ts
+++ b/extensions/openai/speech-provider.ts
@@ -5,6 +5,7 @@ import type {
   SpeechProviderOverrides,
   SpeechProviderPlugin,
 } from "openclaw/plugin-sdk/speech";
+import { asBoolean } from "openclaw/plugin-sdk/speech";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -30,6 +31,7 @@ const OPENAI_SPEECH_RESPONSE_FORMATS = ["mp3", "opus", "wav"] as const;
 type OpenAiSpeechResponseFormat = (typeof OPENAI_SPEECH_RESPONSE_FORMATS)[number];
 
 type OpenAITtsProviderConfig = {
+  enabled: boolean;
   apiKey?: string;
   baseUrl: string;
   model: string;
@@ -101,6 +103,7 @@ function normalizeOpenAIProviderConfig(
 ): OpenAITtsProviderConfig {
   const raw = resolveOpenAIProviderConfigRecord(rawConfig);
   return {
+    enabled: asBoolean(raw?.enabled) ?? true,
     apiKey: normalizeResolvedSecretInputString({
       value: raw?.apiKey,
       path: "messages.tts.providers.openai.apiKey",
@@ -121,6 +124,7 @@ function normalizeOpenAIProviderConfig(
 function readOpenAIProviderConfig(config: SpeechProviderConfig): OpenAITtsProviderConfig {
   const normalized = normalizeOpenAIProviderConfig({});
   return {
+    enabled: asBoolean(config.enabled) ?? normalized.enabled,
     apiKey: trimToUndefined(config.apiKey) ?? normalized.apiKey,
     baseUrl: trimToUndefined(config.baseUrl) ?? normalized.baseUrl,
     model: trimToUndefined(config.model) ?? normalized.model,
@@ -227,8 +231,10 @@ export function buildOpenAISpeechProvider(): SpeechProviderPlugin {
       ...(asFiniteNumber(params.speed) == null ? {} : { speed: asFiniteNumber(params.speed) }),
     }),
     listVoices: async () => OPENAI_TTS_VOICES.map((voice) => ({ id: voice, name: voice })),
-    isConfigured: ({ providerConfig }) =>
-      Boolean(readOpenAIProviderConfig(providerConfig).apiKey || process.env.OPENAI_API_KEY),
+    isConfigured: ({ providerConfig }) => {
+      const config = readOpenAIProviderConfig(providerConfig);
+      return config.enabled && Boolean(config.apiKey || process.env.OPENAI_API_KEY);
+    },
     synthesize: async (req) => {
       const config = readOpenAIProviderConfig(req.providerConfig);
       const overrides = readOpenAIOverrides(req.providerOverrides);

--- a/extensions/openai/speech-provider.ts
+++ b/extensions/openai/speech-provider.ts
@@ -154,6 +154,12 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
   overrides?: SpeechProviderOverrides;
   warnings?: string[];
 } {
+  // Don't claim ownership of directive tokens when this provider is disabled —
+  // otherwise a disabled OpenAI provider would silently consume voice= tokens
+  // before providers like Mistral get a chance to handle them.
+  if (!readOpenAIProviderConfig(ctx.providerConfig ?? {}).enabled) {
+    return { handled: false };
+  }
   const baseUrl = trimToUndefined(asObjectRecord(ctx.providerConfig)?.baseUrl);
   switch (ctx.key) {
     case "voice":

--- a/package.json
+++ b/package.json
@@ -1375,6 +1375,7 @@
     "@mariozechner/pi-coding-agent": "0.66.1",
     "@mariozechner/pi-tui": "0.66.1",
     "@matrix-org/matrix-sdk-crypto-wasm": "18.0.0",
+    "@mistralai/mistralai": "^2.2.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@mozilla/readability": "^0.6.0",
     "@sinclair/typebox": "0.34.49",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@matrix-org/matrix-sdk-crypto-wasm':
         specifier: 18.0.0
         version: 18.0.0
+      '@mistralai/mistralai':
+        specifier: ^2.2.0
+        version: 2.2.0
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -838,6 +841,10 @@ importers:
         version: link:../../packages/plugin-sdk
 
   extensions/mistral:
+    dependencies:
+      '@mistralai/mistralai':
+        specifier: ^2.2.0
+        version: 2.2.0
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -2566,6 +2573,9 @@ packages:
 
   '@mistralai/mistralai@1.14.1':
     resolution: {integrity: sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==}
+
+  '@mistralai/mistralai@2.2.0':
+    resolution: {integrity: sha512-JQUGIXjFWnw/J9LpTSf/ZXwVW3Sh8FBAcfTo5QvAHqkl4CfSiIwnjRJhMoAFcP6ncCe84YPU1ncDGX+p3OXnfg==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -9668,6 +9678,15 @@ snapshots:
       - debug
 
   '@mistralai/mistralai@1.14.1':
+    dependencies:
+      ws: 8.20.0
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@mistralai/mistralai@2.2.0':
     dependencies:
       ws: 8.20.0
       zod: 4.3.6

--- a/src/tts/provider-registry.test.ts
+++ b/src/tts/provider-registry.test.ts
@@ -113,17 +113,20 @@ describe("speech provider registry", () => {
 
     expect(listSpeechProviders(cfg).map((provider) => provider.id)).toEqual(["microsoft"]);
     expect(getSpeechProvider("edge", cfg)?.id).toBe("microsoft");
-    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith({
-      config: {
-        plugins: {
-          entries: {
-            elevenlabs: { enabled: true },
-            microsoft: { enabled: true },
-            openai: { enabled: true },
-          },
-        },
-      },
-    });
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            entries: expect.objectContaining({
+              elevenlabs: { enabled: true },
+              microsoft: { enabled: true },
+              mistral: { enabled: true },
+              openai: { enabled: true },
+            }),
+          }),
+        }),
+      }),
+    );
   });
 
   it("returns no providers when neither plugins nor active registry provide speech support", () => {

--- a/src/tts/provider-registry.test.ts
+++ b/src/tts/provider-registry.test.ts
@@ -8,6 +8,7 @@ const loadPluginManifestRegistryMock = vi.fn(() => ({
   plugins: [
     { id: "elevenlabs", origin: "bundled", contracts: { speechProviders: [{}] } },
     { id: "microsoft", origin: "bundled", contracts: { speechProviders: [{}] } },
+    { id: "mistral", origin: "bundled", contracts: { speechProviders: [{}] } },
     { id: "openai", origin: "bundled", contracts: { speechProviders: [{}] } },
   ],
 }));

--- a/test/helpers/plugins/plugin-registration-contract-cases.ts
+++ b/test/helpers/plugins/plugin-registration-contract-cases.ts
@@ -79,6 +79,7 @@ export const pluginRegistrationContractCases = {
   },
   mistral: {
     pluginId: "mistral",
+    speechProviderIds: ["mistral"],
     mediaUnderstandingProviderIds: ["mistral"],
   },
   moonshot: {


### PR DESCRIPTION
## Summary

This PR adds [Voxtral TTS](https://mistral.ai/news/voxtral-tts) support through the `mistral` speech provider.

- Reuses existing Mistral onboarding, auth-profile resolution, and base URL config so the same `MISTRAL_API_KEY` setup can power models, transcription, and TTS.
- **Built on the official `@mistralai/mistralai` v2 SDK** (`client.audio.speech.complete()`) — no raw HTTP, no manual JSON-envelope parsing or base64 decode. Upgraded workspace-wide from 1.14.1 → 2.2.0 (pi-ai only uses `chat.stream()`, stable across v1→v2).
- **Added `enabled` flag to the OpenAI TTS provider** — lets users keep OpenAI as a model provider while explicitly opting it out of the automatic TTS fallback order.
- Documents setup/examples for Mistral/Voxtral TTS and adds focused provider/registration coverage.
- What did NOT change (scope boundary): this stays focused on the Voxtral TTS provider path and does not change unrelated TTS providers.
- Specifically, there is a pre-existing issue with speech directive parsing at the architectural level, which is not solved in this PR.

I have a followup branch ready for Voxtral STT, for which this PR is a prerequisite.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #58117
- Related #60131
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Prior context (`git blame`, prior PR, issue, or refactor if known): N/A
- Why this regressed now: N/A
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this: N/A
- Target test or file: N/A
- Scenario the test should lock in: N/A
- Why this is the smallest reliable guardrail: N/A
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Adds `mistral` as a TTS provider using Voxtral TTS.
- Lets the Mistral TTS path reuse existing Mistral auth/base URL resolution instead of needing a separate TTS-only setup path.
- Adds Mistral/Voxtral TTS setup examples to the provider and TTS docs.
- Adds `messages.tts.providers.openai.enabled` flag — set to `false` to disable OpenAI as an automatic TTS fallback while keeping OpenAI configured as a model provider.

## Diagram

```mermaid
flowchart TD
    explicit["/tts provider mistral"] --> mistral
    autoselect["TTS auto-select<br/>(openai.enabled = false)"] --> mistral

    mistral[mistral speech provider] --> auth[resolve config and auth]
    auth --> sdk["@mistralai/mistralai v2 SDK<br/>client.audio.speech.complete()"]
    sdk --> api["POST /v1/audio/speech"]
    api --> audio["audio ✓"]
    api -- "error / timeout" --> fallback{"openai.enabled?"}
    fallback -- "true (default)" --> openai["OpenAI TTS fallback"]
    fallback -- "false" --> other["other providers in fallback order"]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this adds a new Mistral TTS network path (via the official `@mistralai/mistralai` SDK) and reuses existing Mistral auth/profile resolution for that provider; focused plugin tests cover auth reuse, registration, and request shaping.

## Repro + Verification

### Environment

- OS: Linux (local checkout)
- Runtime/container: Node + `npx pnpm`
- Model/provider: Mistral / Voxtral TTS
- Integration/channel (if any): core TTS provider path
- Relevant config (redacted): existing `auth.profiles.mistral:*` or `models.providers.mistral` plus `messages.tts.provider = "mistral"`

### Steps

1. Configure Mistral via onboarding or an auth profile using `MISTRAL_API_KEY`.
2. Set `messages.tts.provider` to `mistral` or use `/tts provider mistral`.
3. Request speech synthesis.

### Expected

- OpenClaw recognizes Mistral as a TTS provider and synthesizes audio through Voxtral TTS.

### Actual

- Prior to this branch, there was no Voxtral TTS support on the Mistral provider path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Voxtral TTS in Telegram voice notes
- Voxtral TTS in voice-call (with Twilio)
- Using a real `MISTRAL_API_KEY` and configured voice id.
- Edge cases checked: auth-profile reuse, provider base URL reuse, Mistral plugin registration, docs/examples for Voxtral TTS, SDK v2 usage (serverURL handling, error reformatting), and OpenAI `enabled` flag behaviour in auto-select.
- What you did **not** verify: broader live coverage beyond one real key + voice id path (for example additional voices).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Risks and Mitigations

- Risk: the Voxtral TTS provider could drift from manifest/runtime ownership expectations.
  - Mitigation: the PR adds Mistral plugin registration and contract coverage for the speech provider.
- Risk: upgrading `@mistralai/mistralai` 1.14.1 → 2.2.0 workspace-wide could break `@mariozechner/pi-ai` model calls.
  - Mitigation: pi-ai only uses `new Mistral()` + `chat.stream()`, both unchanged in v2; verified in code review of pi-ai's `dist/providers/mistral.js`.