### PR TITLE
routing: support wildcard peer bindings (peer.id="*") for multi-agent routing

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -922,6 +922,145 @@ describe("role-based agent routing", () => {
   });
 });
 
+describe("wildcard peer bindings (peer.id=*)", () => {
+  test("peer.id=* matches any direct peer and routes to the bound agent", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "second-ana" }] },
+      bindings: [
+        {
+          agentId: "second-ana",
+          match: {
+            channel: "telegram",
+            accountId: "second-ana",
+            peer: { kind: "direct", id: "*" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      accountId: "second-ana",
+      peer: { kind: "direct", id: "12345678" },
+    });
+    expect(route.agentId).toBe("second-ana");
+    expect(route.sessionKey).toContain("agent:second-ana:");
+    expect(route.matchedBy).toBe("binding.account");
+  });
+
+  test("peer.id=* does not match group peers when kind is direct", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "main", default: true }, { id: "dm-only" }] },
+      bindings: [
+        {
+          agentId: "dm-only",
+          match: {
+            channel: "telegram",
+            accountId: "bot1",
+            peer: { kind: "direct", id: "*" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "telegram",
+      accountId: "bot1",
+      peer: { kind: "group", id: "group-999" },
+    });
+    expect(route.agentId).toBe("main");
+    expect(route.matchedBy).toBe("default");
+  });
+
+  test("exact peer binding wins over wildcard peer binding", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "exact" }, { id: "wild" }] },
+      bindings: [
+        {
+          agentId: "wild",
+          match: {
+            channel: "whatsapp",
+            accountId: "biz",
+            peer: { kind: "direct", id: "*" },
+          },
+        },
+        {
+          agentId: "exact",
+          match: {
+            channel: "whatsapp",
+            accountId: "biz",
+            peer: { kind: "direct", id: "+1000" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "whatsapp",
+      accountId: "biz",
+      peer: { kind: "direct", id: "+1000" },
+    });
+    expect(route.agentId).toBe("exact");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+
+  test("wildcard peer binding wins over default fallback for unmatched peers", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "exact" }, { id: "wild" }] },
+      bindings: [
+        {
+          agentId: "wild",
+          match: {
+            channel: "whatsapp",
+            accountId: "biz",
+            peer: { kind: "direct", id: "*" },
+          },
+        },
+        {
+          agentId: "exact",
+          match: {
+            channel: "whatsapp",
+            accountId: "biz",
+            peer: { kind: "direct", id: "+1000" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "whatsapp",
+      accountId: "biz",
+      peer: { kind: "direct", id: "+9999" },
+    });
+    expect(route.agentId).toBe("wild");
+    expect(route.matchedBy).toBe("binding.account");
+  });
+
+  test("group wildcard peer matches any group peer", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "grp" }] },
+      bindings: [
+        {
+          agentId: "grp",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "group", id: "*" },
+          },
+        },
+      ],
+    };
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "group", id: "g-42" },
+    });
+    expect(route.agentId).toBe("grp");
+    expect(route.matchedBy).toBe("binding.account");
+  });
+});
+
 describe("binding evaluation cache scalability", () => {
   test("does not rescan full bindings after channel/account cache rollover (#36915)", () => {
     const bindingCount = 2_205;

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -945,7 +945,7 @@ describe("wildcard peer bindings (peer.id=*)", () => {
     });
     expect(route.agentId).toBe("second-ana");
     expect(route.sessionKey).toContain("agent:second-ana:");
-    expect(route.matchedBy).toBe("binding.account");
+    expect(route.matchedBy).toBe("binding.peer.wildcard");
   });
 
   test("peer.id=* does not match group peers when kind is direct", () => {
@@ -1033,7 +1033,7 @@ describe("wildcard peer bindings (peer.id=*)", () => {
       peer: { kind: "direct", id: "+9999" },
     });
     expect(route.agentId).toBe("wild");
-    expect(route.matchedBy).toBe("binding.account");
+    expect(route.matchedBy).toBe("binding.peer.wildcard");
   });
 
   test("group wildcard peer matches any group peer", () => {
@@ -1057,7 +1057,7 @@ describe("wildcard peer bindings (peer.id=*)", () => {
       peer: { kind: "group", id: "g-42" },
     });
     expect(route.agentId).toBe("grp");
-    expect(route.matchedBy).toBe("binding.account");
+    expect(route.matchedBy).toBe("binding.peer.wildcard");
   });
 });
 

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -50,6 +50,7 @@ export type ResolvedAgentRoute = {
   matchedBy:
     | "binding.peer"
     | "binding.peer.parent"
+    | "binding.peer.wildcard"
     | "binding.guild+roles"
     | "binding.guild"
     | "binding.team"
@@ -214,6 +215,7 @@ const MAX_RESOLVED_ROUTE_CACHE_KEYS = 4000;
 
 type EvaluatedBindingsIndex = {
   byPeer: Map<string, EvaluatedBinding[]>;
+  byPeerWildcard: EvaluatedBinding[];
   byGuildWithRoles: Map<string, EvaluatedBinding[]>;
   byGuild: Map<string, EvaluatedBinding[]>;
   byTeam: Map<string, EvaluatedBinding[]>;
@@ -369,6 +371,7 @@ function collectPeerIndexedBindings(
 
 function buildEvaluatedBindingsIndex(bindings: EvaluatedBinding[]): EvaluatedBindingsIndex {
   const byPeer = new Map<string, EvaluatedBinding[]>();
+  const byPeerWildcard: EvaluatedBinding[] = [];
   const byGuildWithRoles = new Map<string, EvaluatedBinding[]>();
   const byGuild = new Map<string, EvaluatedBinding[]>();
   const byTeam = new Map<string, EvaluatedBinding[]>();
@@ -380,6 +383,10 @@ function buildEvaluatedBindingsIndex(bindings: EvaluatedBinding[]): EvaluatedBin
       for (const key of peerLookupKeys(binding.match.peer.kind, binding.match.peer.id)) {
         pushToIndexMap(byPeer, key, binding);
       }
+      continue;
+    }
+    if (binding.match.peer.state === "wildcard-kind") {
+      byPeerWildcard.push(binding);
       continue;
     }
     if (binding.match.guildId && binding.match.roles) {
@@ -403,6 +410,7 @@ function buildEvaluatedBindingsIndex(bindings: EvaluatedBinding[]): EvaluatedBin
 
   return {
     byPeer,
+    byPeerWildcard,
     byGuildWithRoles,
     byGuild,
     byTeam,
@@ -752,6 +760,13 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       scopePeer: parentPeer && parentPeer.id ? parentPeer : null,
       candidates: collectPeerIndexedBindings(bindingsIndex, parentPeer),
       predicate: (candidate) => candidate.match.peer.state === "valid",
+    },
+    {
+      matchedBy: "binding.peer.wildcard",
+      enabled: Boolean(peer),
+      scopePeer: peer,
+      candidates: bindingsIndex.byPeerWildcard,
+      predicate: (candidate) => candidate.match.peer.state === "wildcard-kind",
     },
     {
       matchedBy: "binding.guild+roles",

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -168,6 +168,7 @@ export function pickFirstExistingAgentId(cfg: OpenClawConfig, agentId: string): 
 type NormalizedPeerConstraint =
   | { state: "none" }
   | { state: "invalid" }
+  | { state: "wildcard-kind"; kind: ChatType }
   | { state: "valid"; kind: ChatType; id: string };
 
 type NormalizedBindingMatch = {
@@ -481,6 +482,9 @@ function normalizePeerConstraint(
   if (!kind || !id) {
     return { state: "invalid" };
   }
+  if (id === "*") {
+    return { state: "wildcard-kind", kind };
+  }
   return { state: "valid", kind, id };
 }
 
@@ -594,6 +598,11 @@ function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope)
       return false;
     }
   }
+  if (match.peer.state === "wildcard-kind") {
+    if (!scope.peer || !peerKindMatches(match.peer.kind, scope.peer.kind)) {
+      return false;
+    }
+  }
   if (match.guildId && match.guildId !== scope.guildId) {
     return false;
   }
@@ -699,6 +708,9 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     }
     if (value.state === "invalid") {
       return "invalid";
+    }
+    if (value.state === "wildcard-kind") {
+      return `${value.kind}:*`;
     }
     return `${value.kind}:${value.id}`;
   };


### PR DESCRIPTION
## Summary

Fixes #58546.

Bindings with `peer: { kind: "direct", id: "*" }` were silently ignored because `"*"` was treated as a literal peer ID. The binding was indexed exclusively in the `byPeer` map under key `"direct:*"`, which never matched actual incoming peer IDs (e.g. `"direct:12345678"`). This caused multi-agent routing to fall through to the default agent (`"main"`), breaking setups where a named Telegram account should route all DMs to a specific agent.

### Root cause

`normalizePeerConstraint` normalized `{ kind: "direct", id: "*" }` to `{ state: "valid", kind: "direct", id: "*" }` — the same state as any concrete peer. `buildEvaluatedBindingsIndex` then placed it in the `byPeer` index under key `"direct:*"` and skipped all other categories. `collectPeerIndexedBindings` only looked up exact peer IDs, so the wildcard binding was never found.

### Fix

- Add a `"wildcard-kind"` state to `NormalizedPeerConstraint` for bindings where `peer.id === "*"`
- Wildcard-kind bindings skip the `byPeer` index and fall through to `byAccount`/`byChannel` tiers
- `matchesBindingScope` checks only peer kind (not ID) for wildcard-kind constraints
- Exact peer bindings still take priority (higher tier) over wildcard peer bindings

### Test plan

- [x] `peer.id=*` matches any direct peer and routes to the bound agent
- [x] `peer.id=*` does NOT match group peers when kind is `direct`
- [x] Exact peer binding wins over wildcard peer binding (tier priority)
- [x] Wildcard peer binding wins over default fallback for unmatched peers
- [x] Group wildcard peer matches any group peer
- [x] All 50 existing + new routing tests pass
- [x] All 76 tests across 5 routing test files pass

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
