### PR TITLE
fix(msteams): tighten html attachment fallback

### DIFF
--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -388,11 +388,14 @@ const GRAPH_MEDIA_SUCCESS_CASES: GraphMediaSuccessCase[] = [
       };
     },
     expectedLength: 2,
+    assert: ({ fetchMock }) => {
+      const calledUrls = fetchMock.mock.calls.map(([calledUrl]) => String(calledUrl));
+      expect(calledUrls).not.toContain(`${DEFAULT_MESSAGE_URL}/attachments`);
+    },
   }),
 ];
 type GraphFetchMockOptions = {
   hostedContents?: unknown[];
-  attachments?: unknown[];
   messageAttachments?: unknown[];
   onShareRequest?: (url: string) => Response | Promise<Response>;
   onUnhandled?: (url: string) => Response | Promise<Response> | undefined;
@@ -409,7 +412,6 @@ const buildShareReferenceGraphFetchOptions = (params: {
   onShareRequest?: GraphFetchMockOptions["onShareRequest"];
   onUnhandled?: GraphFetchMockOptions["onUnhandled"];
 }) => ({
-  attachments: [params.referenceAttachment],
   messageAttachments: [params.referenceAttachment],
   ...(params.onShareRequest ? { onShareRequest: params.onShareRequest } : {}),
   ...(params.onUnhandled ? { onUnhandled: params.onUnhandled } : {}),
@@ -427,16 +429,11 @@ type GraphEndpointResponseHandler = {
 };
 const createGraphEndpointResponseHandlers = (params: {
   hostedContents: unknown[];
-  attachments: unknown[];
   messageAttachments: unknown[];
 }): GraphEndpointResponseHandler[] => [
   {
     suffix: "/hostedContents",
     buildResponse: () => createGraphCollectionResponse(params.hostedContents),
-  },
-  {
-    suffix: "/attachments",
-    buildResponse: () => createGraphCollectionResponse(params.attachments),
   },
   {
     suffix: "/messages/123",
@@ -453,11 +450,9 @@ const resolveGraphEndpointResponse = (
 
 const createGraphFetchMock = (options: GraphFetchMockOptions = {}) => {
   const hostedContents = options.hostedContents ?? [];
-  const attachments = options.attachments ?? [];
   const messageAttachments = options.messageAttachments ?? [];
   const endpointHandlers = createGraphEndpointResponseHandlers({
     hostedContents,
-    attachments,
     messageAttachments,
   });
   return vi.fn(async (url: string) => {
@@ -714,9 +709,6 @@ describe("msteams attachments", () => {
         }
         if (url === `${DEFAULT_MESSAGE_URL}/hostedContents`) {
           return createGraphCollectionResponse([]);
-        }
-        if (url === `${DEFAULT_MESSAGE_URL}/attachments`) {
-          return createGraphCollectionResponse([referenceAttachment]);
         }
         if (url.startsWith(GRAPH_SHARES_URL_PREFIX)) {
           return createRedirectResponse(escapedUrl);

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -261,6 +261,8 @@ export async function downloadMSTeamsGraphMedia(params: {
   const fetchFn = params.fetchFn ?? fetch;
   const sharePointMedia: MSTeamsInboundMedia[] = [];
   const downloadedReferenceUrls = new Set<string>();
+  let messageAttachments: GraphAttachment[] = [];
+  let messageStatus: number | undefined;
   try {
     const { response: msgRes, release } = await fetchWithSsrFGuard({
       url: messageUrl,
@@ -272,6 +274,7 @@ export async function downloadMSTeamsGraphMedia(params: {
       auditContext: "msteams.graph.message",
     });
     try {
+      messageStatus = msgRes.status;
       if (msgRes.ok) {
         const msgData = (await msgRes.json()) as {
           body?: { content?: string; contentType?: string };
@@ -282,10 +285,11 @@ export async function downloadMSTeamsGraphMedia(params: {
             name?: string;
           }>;
         };
+        messageAttachments = Array.isArray(msgData.attachments) ? msgData.attachments : [];
 
         // Extract SharePoint file attachments (contentType: "reference")
         // Download any file type, not just images
-        const spAttachments = (msgData.attachments ?? []).filter(
+        const spAttachments = messageAttachments.filter(
           (a) => a.contentType === "reference" && a.contentUrl && a.name,
         );
         for (const att of spAttachments) {
@@ -350,14 +354,7 @@ export async function downloadMSTeamsGraphMedia(params: {
     ssrfPolicy,
   });
 
-  const attachments = await fetchGraphCollection<GraphAttachment>({
-    url: `${messageUrl}/attachments`,
-    accessToken,
-    fetchFn: params.fetchFn,
-    ssrfPolicy,
-  });
-
-  const normalizedAttachments = attachments.items.map(normalizeGraphAttachment);
+  const normalizedAttachments = messageAttachments.map(normalizeGraphAttachment);
   const filteredAttachments =
     sharePointMedia.length > 0
       ? normalizedAttachments.filter((att) => {
@@ -387,7 +384,7 @@ export async function downloadMSTeamsGraphMedia(params: {
     hostedCount: hosted.count,
     attachmentCount: filteredAttachments.length + sharePointMedia.length,
     hostedStatus: hosted.status,
-    attachmentStatus: attachments.status,
+    attachmentStatus: messageStatus,
     messageUrl,
   };
 }

--- a/extensions/msteams/src/monitor-handler/inbound-media.test.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-media.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MSTeamsHtmlAttachmentSummary, MSTeamsInboundMedia } from "../attachments.js";
+
+const {
+  buildMSTeamsGraphMessageUrlsMock,
+  downloadMSTeamsAttachmentsMock,
+  downloadMSTeamsGraphMediaMock,
+} = vi.hoisted(() => ({
+  buildMSTeamsGraphMessageUrlsMock: vi.fn(),
+  downloadMSTeamsAttachmentsMock: vi.fn(),
+  downloadMSTeamsGraphMediaMock: vi.fn(),
+}));
+
+vi.mock("../attachments.js", async () => {
+  const actual = await vi.importActual<typeof import("../attachments.js")>("../attachments.js");
+  return {
+    ...actual,
+    buildMSTeamsGraphMessageUrls: buildMSTeamsGraphMessageUrlsMock,
+    downloadMSTeamsAttachments: downloadMSTeamsAttachmentsMock,
+    downloadMSTeamsGraphMedia: downloadMSTeamsGraphMediaMock,
+  };
+});
+
+import { resolveMSTeamsInboundMedia } from "./inbound-media.js";
+
+const TOKEN_PROVIDER = {
+  getAccessToken: vi.fn(async () => "token"),
+};
+
+const DOWNLOADED_MEDIA: MSTeamsInboundMedia[] = [
+  {
+    path: "/tmp/report.pdf",
+    contentType: "application/pdf",
+    placeholder: "<media:document>",
+  },
+];
+
+function createHtmlSummary(
+  overrides: Partial<MSTeamsHtmlAttachmentSummary>,
+): MSTeamsHtmlAttachmentSummary {
+  return {
+    htmlAttachments: 1,
+    imgTags: 0,
+    dataImages: 0,
+    cidImages: 0,
+    srcHosts: [],
+    attachmentTags: 0,
+    attachmentIds: [],
+    ...overrides,
+  };
+}
+
+function buildParams(params: {
+  attachments: Array<{ contentType?: string | null; content?: unknown }>;
+  htmlSummary?: MSTeamsHtmlAttachmentSummary;
+}) {
+  return {
+    attachments: params.attachments,
+    htmlSummary: params.htmlSummary,
+    maxBytes: 1024,
+    tokenProvider: TOKEN_PROVIDER,
+    conversationType: "channel",
+    conversationId: "19:thread@thread.tacv2",
+    conversationMessageId: "123",
+    activity: {
+      id: "123",
+      replyToId: "root-1",
+      channelData: {
+        team: { id: "team-1" },
+        channel: { id: "channel-1" },
+      },
+    },
+    log: {},
+  };
+}
+
+describe("resolveMSTeamsInboundMedia", () => {
+  beforeEach(() => {
+    buildMSTeamsGraphMessageUrlsMock.mockReset();
+    downloadMSTeamsAttachmentsMock.mockReset();
+    downloadMSTeamsGraphMediaMock.mockReset();
+    TOKEN_PROVIDER.getAccessToken.mockClear();
+
+    downloadMSTeamsAttachmentsMock.mockResolvedValue([]);
+    buildMSTeamsGraphMessageUrlsMock.mockReturnValue([
+      "https://graph.microsoft.com/v1.0/teams/team-1/channels/channel-1/messages/root-1/replies/123",
+    ]);
+    downloadMSTeamsGraphMediaMock.mockResolvedValue({
+      media: DOWNLOADED_MEDIA,
+      attachmentStatus: 200,
+    });
+  });
+
+  it("skips graph fallback for mention-only html attachments", async () => {
+    const media = await resolveMSTeamsInboundMedia(
+      buildParams({
+        attachments: [{ contentType: "text/html", content: "<div><at>Bot</at> hello</div>" }],
+        htmlSummary: createHtmlSummary({ attachmentTags: 0 }),
+      }),
+    );
+
+    expect(media).toEqual([]);
+    expect(buildMSTeamsGraphMessageUrlsMock).not.toHaveBeenCalled();
+    expect(downloadMSTeamsGraphMediaMock).not.toHaveBeenCalled();
+  });
+
+  it("uses graph fallback when html attachments include attachment tags", async () => {
+    const media = await resolveMSTeamsInboundMedia(
+      buildParams({
+        attachments: [
+          { contentType: "text/html", content: '<div><attachment id="att-1"></attachment></div>' },
+        ],
+        htmlSummary: createHtmlSummary({ attachmentTags: 1, attachmentIds: ["att-1"] }),
+      }),
+    );
+
+    expect(buildMSTeamsGraphMessageUrlsMock).toHaveBeenCalledOnce();
+    expect(downloadMSTeamsGraphMediaMock).toHaveBeenCalledOnce();
+    expect(media).toEqual(DOWNLOADED_MEDIA);
+  });
+});

--- a/extensions/msteams/src/monitor-handler/inbound-media.test.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-media.test.ts
@@ -104,6 +104,18 @@ describe("resolveMSTeamsInboundMedia", () => {
     expect(downloadMSTeamsGraphMediaMock).not.toHaveBeenCalled();
   });
 
+  it("skips graph fallback for mention-only html attachments when htmlSummary is omitted", async () => {
+    const media = await resolveMSTeamsInboundMedia(
+      buildParams({
+        attachments: [{ contentType: "text/html", content: "<div><at>Bot</at> hello</div>" }],
+      }),
+    );
+
+    expect(media).toEqual([]);
+    expect(buildMSTeamsGraphMessageUrlsMock).not.toHaveBeenCalled();
+    expect(downloadMSTeamsGraphMediaMock).not.toHaveBeenCalled();
+  });
+
   it("uses graph fallback when html attachments include attachment tags", async () => {
     const media = await resolveMSTeamsInboundMedia(
       buildParams({
@@ -111,6 +123,20 @@ describe("resolveMSTeamsInboundMedia", () => {
           { contentType: "text/html", content: '<div><attachment id="att-1"></attachment></div>' },
         ],
         htmlSummary: createHtmlSummary({ attachmentTags: 1, attachmentIds: ["att-1"] }),
+      }),
+    );
+
+    expect(buildMSTeamsGraphMessageUrlsMock).toHaveBeenCalledOnce();
+    expect(downloadMSTeamsGraphMediaMock).toHaveBeenCalledOnce();
+    expect(media).toEqual(DOWNLOADED_MEDIA);
+  });
+
+  it("uses graph fallback for cid-hosted html images without attachment tags", async () => {
+    const media = await resolveMSTeamsInboundMedia(
+      buildParams({
+        attachments: [
+          { contentType: "text/html", content: '<div><img src="cid:image-1" /></div>' },
+        ],
       }),
     );
 

--- a/extensions/msteams/src/monitor-handler/inbound-media.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-media.ts
@@ -2,6 +2,7 @@ import {
   buildMSTeamsGraphMessageUrls,
   downloadMSTeamsAttachments,
   downloadMSTeamsGraphMedia,
+  summarizeMSTeamsHtmlAttachments,
   type MSTeamsAccessTokenProvider,
   type MSTeamsAttachmentLike,
   type MSTeamsHtmlAttachmentSummary,
@@ -50,13 +51,15 @@ export async function resolveMSTeamsInboundMedia(params: {
     authAllowHosts: params.authAllowHosts,
     preserveFilenames,
   });
+  const effectiveHtmlSummary = htmlSummary ?? summarizeMSTeamsHtmlAttachments(attachments);
 
   if (mediaList.length === 0) {
     const onlyHtmlAttachments =
       attachments.length > 0 &&
       attachments.every((att) => String(att.contentType ?? "").startsWith("text/html"));
+    const hasAttachmentTags = (effectiveHtmlSummary?.attachmentTags ?? 0) > 0;
 
-    if (onlyHtmlAttachments) {
+    if (onlyHtmlAttachments && hasAttachmentTags) {
       const messageUrls = buildMSTeamsGraphMessageUrls({
         conversationType,
         conversationId,
@@ -115,12 +118,12 @@ export async function resolveMSTeamsInboundMedia(params: {
 
   if (mediaList.length > 0) {
     log.debug?.("downloaded attachments", { count: mediaList.length });
-  } else if (htmlSummary?.imgTags) {
+  } else if (effectiveHtmlSummary?.imgTags) {
     log.debug?.("inline images detected but none downloaded", {
-      imgTags: htmlSummary.imgTags,
-      srcHosts: htmlSummary.srcHosts,
-      dataImages: htmlSummary.dataImages,
-      cidImages: htmlSummary.cidImages,
+      imgTags: effectiveHtmlSummary.imgTags,
+      srcHosts: effectiveHtmlSummary.srcHosts,
+      dataImages: effectiveHtmlSummary.dataImages,
+      cidImages: effectiveHtmlSummary.cidImages,
     });
   }
 

--- a/extensions/msteams/src/monitor-handler/inbound-media.ts
+++ b/extensions/msteams/src/monitor-handler/inbound-media.ts
@@ -57,9 +57,10 @@ export async function resolveMSTeamsInboundMedia(params: {
     const onlyHtmlAttachments =
       attachments.length > 0 &&
       attachments.every((att) => String(att.contentType ?? "").startsWith("text/html"));
-    const hasAttachmentTags = (effectiveHtmlSummary?.attachmentTags ?? 0) > 0;
+    const hasGraphMediaHints =
+      (effectiveHtmlSummary?.attachmentTags ?? 0) > 0 || (effectiveHtmlSummary?.cidImages ?? 0) > 0;
 
-    if (onlyHtmlAttachments && hasAttachmentTags) {
+    if (onlyHtmlAttachments && hasGraphMediaHints) {
       const messageUrls = buildMSTeamsGraphMessageUrls({
         conversationType,
         conversationId,


### PR DESCRIPTION
## Summary

- Problem: Teams mention-only `text/html` attachments still triggered Graph media fallback, and the Graph media path still attempted `${messageUrl}/attachments` instead of using the message body's `attachments` array.
- Why it matters: mention-only messages generated noisy fallback attempts and misleading empty-fetch diagnostics, while legitimate Graph attachment handling depended on a redundant and undocumented fetch path.
- What changed: gate the Graph fallback on real `<attachment>` tags in HTML attachments, reuse `chatMessage.attachments` from the fetched message body, and add regression tests for both behaviors.
- What did NOT change (scope boundary): this PR does not change message ID candidate selection or broader Teams file-download auth behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #58617
- Related #58617
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `resolveMSTeamsInboundMedia()` treated any all-`text/html` attachment set as a Graph-media fallback candidate, even though Teams mention markup also arrives as `text/html` and does not imply a downloadable file.
- Missing detection / guardrail: there was no regression test ensuring mention-only HTML skips Graph fallback, and no test asserting Graph media reuses `chatMessage.attachments` from the message resource.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #58617 documents the observed behavior; I did not trace a single introducing PR with confidence.
- Why this regressed now: Teams channel mentions and file-card markup share the same `text/html` transport shape, so the broader fallback condition matched both.
- If unknown, what was ruled out: this PR does not assume a universal message-id mismatch because the current code already tries several message-id candidates.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/msteams/src/monitor-handler/inbound-media.test.ts`, `extensions/msteams/src/attachments.test.ts`
- Scenario the test should lock in: mention-only HTML attachments must not trigger Graph fallback, and Graph media downloads must source attachments from the fetched message body rather than `${messageUrl}/attachments`.
- Why this is the smallest reliable guardrail: both decisions are local branching rules with stable inputs and do not need a full Teams roundtrip to validate.
- Existing test that already covers this (if any): existing attachment tests covered SharePoint reference downloads but not the fallback trigger condition or the redundant `/attachments` fetch.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Teams mention-only channel messages stop triggering empty Graph media fallback attempts.
- Teams Graph media downloads now rely on the message body's attachment data instead of a redundant follow-up fetch.

## Diagram (if applicable)

```text
Before:
mention-only html -> onlyHtmlAttachments=true -> Graph fallback -> empty fetch noise
file html -> onlyHtmlAttachments=true -> Graph fallback -> attachment handling

After:
mention-only html -> attachmentTags=0 -> no Graph fallback
file html with <attachment> -> attachmentTags>0 -> Graph fallback -> attachment handling
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 15.3 / darwin 25.3.0
- Runtime/container: Node 22+ via repo scripts
- Model/provider: N/A
- Integration/channel (if any): `msteams`
- Relevant config (redacted): default test config

### Steps

1. Send a Teams channel message that contains only mention HTML attachments.
2. Observe the inbound media resolution path.
3. Send a Teams channel file message that resolves through Graph message attachments.

### Expected

- Mention-only HTML does not trigger Graph media fallback.
- Graph file handling uses the fetched message body's `attachments` array.

### Actual

- Before this change, mention-only HTML could enter Graph fallback.
- Before this change, Graph media also tried `${messageUrl}/attachments`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `pnpm test:extension msteams` successfully; verified the new unit coverage for mention-only HTML and the updated Graph attachment path; ran `pnpm build` successfully.
- Edge cases checked: mention-only HTML skips fallback, HTML with `<attachment>` tags still falls back, SharePoint reference attachments still merge with hosted content without calling `${messageUrl}/attachments`.
- What you did **not** verify: live Teams channel traffic against a real tenant.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Teams file-card HTML without `<attachment>` tags would no longer trigger Graph fallback.
  - Mitigation: the fallback now keys off the explicit attachment markup Teams uses for file cards, and the direct attachment downloader remains unchanged for normal attachment payloads.
- Risk: repo-wide `pnpm check` is currently blocked by unrelated existing `tsgo` failures in `extensions/diffs/src/language-hints.test.ts`.
  - Mitigation: this PR still includes a green `pnpm test:extension msteams` lane and a green `pnpm build` run for the touched surface.

## AI Assistance

- [x] AI-assisted
- Testing: lightly tested on the touched surface (`pnpm test:extension msteams`, `pnpm build`; `pnpm check` blocked by unrelated existing `tsgo` failures in `extensions/diffs/src/language-hints.test.ts`)
- Prompts/session logs: available on request
- Confirmed understanding: yes

Made with [Cursor](https://cursor.com)