### PR TITLE
Matrix: add native exec approvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Android/assistant: auto-send Google Assistant App Actions prompts once chat is healthy and idle, while keeping bare assistant launches as open-only. (#59721) Thanks @obviyus.
+- Matrix/exec approvals: add Matrix-native exec approval prompts with account-scoped approvers, channel-or-DM delivery, and room-thread aware resolution handling. (#58635) Thanks @gumadeiras.
 
 ### Fixes
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -629,6 +629,36 @@ If an unapproved Matrix user keeps messaging you before approval, OpenClaw reuse
 
 See [Pairing](/channels/pairing) for the shared DM pairing flow and storage layout.
 
+## Exec approvals
+
+Matrix can act as an exec approval client for a Matrix account.
+
+- `channels.matrix.execApprovals.enabled`
+- `channels.matrix.execApprovals.approvers` (optional; falls back to `channels.matrix.dm.allowFrom`)
+- `channels.matrix.execApprovals.target` (`dm` | `channel` | `both`, default: `dm`)
+- `channels.matrix.execApprovals.agentFilter`
+- `channels.matrix.execApprovals.sessionFilter`
+
+Matrix becomes an exec approval client when `enabled` is true and at least one approver can be resolved. Approvers must be Matrix user IDs such as `@owner:example.org`.
+
+Delivery rules:
+
+- `target: "dm"` sends approval prompts to approver DMs
+- `target: "channel"` sends the prompt back to the originating Matrix room or DM
+- `target: "both"` sends to approver DMs and the originating Matrix room or DM
+
+Matrix uses text approval prompts today. Approvers resolve them with `/approve <id> allow-once`, `/approve <id> allow-always`, or `/approve <id> deny`.
+
+Only resolved approvers can approve or deny. Channel delivery includes the command text, so only enable `channel` or `both` in trusted rooms.
+
+Matrix approval prompts reuse the shared core approval planner. The Matrix-specific surface is transport only: room/DM routing and message send/update/delete behavior.
+
+Per-account override:
+
+- `channels.matrix.accounts.<account>.execApprovals`
+
+Related docs: [Exec approvals](/tools/exec-approvals)
+
 ## Multi-account example
 
 ```json5
@@ -773,6 +803,9 @@ Live directory lookup uses the logged-in Matrix account:
 - `dm`: DM policy block (`enabled`, `policy`, `allowFrom`, `threadReplies`).
 - `dm.allowFrom` entries should be full Matrix user IDs unless you already resolved them through live directory lookup.
 - `dm.threadReplies`: DM-only thread policy override (`off`, `inbound`, `always`). It overrides the top-level `threadReplies` setting for both reply placement and session isolation in DMs.
+- `execApprovals`: Matrix-native exec approval delivery (`enabled`, `approvers`, `target`, `agentFilter`, `sessionFilter`).
+- `execApprovals.approvers`: Matrix user IDs allowed to approve exec requests. Optional when `dm.allowFrom` already identifies the approvers.
+- `execApprovals.target`: `dm | channel | both` (default: `dm`).
 - `accounts`: named per-account overrides. Top-level `channels.matrix` values act as defaults for these entries.
 - `groups`: per-room policy map. Prefer room IDs or aliases; unresolved room names are ignored at runtime. Session/group identity uses the stable room ID after resolution, while human-readable labels still come from room names.
 - `rooms`: legacy alias for `groups`.

--- a/extensions/matrix/src/approval-auth.ts
+++ b/extensions/matrix/src/approval-auth.ts
@@ -2,23 +2,24 @@ import {
   createResolvedApproverActionAuthAdapter,
   resolveApprovalApprovers,
 } from "openclaw/plugin-sdk/approval-runtime";
+import { normalizeMatrixApproverId } from "./exec-approvals.js";
 import { resolveMatrixAccount } from "./matrix/accounts.js";
-import { normalizeMatrixUserId } from "./matrix/monitor/allowlist.js";
 import type { CoreConfig } from "./types.js";
 
-function normalizeMatrixApproverId(value: string | number): string | undefined {
-  const normalized = normalizeMatrixUserId(String(value));
-  return normalized || undefined;
+export function getMatrixApprovalAuthApprovers(params: {
+  cfg: CoreConfig;
+  accountId?: string | null;
+}): string[] {
+  const account = resolveMatrixAccount(params);
+  return resolveApprovalApprovers({
+    allowFrom: account.config.dm?.allowFrom,
+    normalizeApprover: normalizeMatrixApproverId,
+  });
 }
 
 export const matrixApprovalAuth = createResolvedApproverActionAuthAdapter({
   channelLabel: "Matrix",
-  resolveApprovers: ({ cfg, accountId }) => {
-    const account = resolveMatrixAccount({ cfg: cfg as CoreConfig, accountId });
-    return resolveApprovalApprovers({
-      allowFrom: account.config.dm?.allowFrom,
-      normalizeApprover: normalizeMatrixApproverId,
-    });
-  },
+  resolveApprovers: ({ cfg, accountId }) =>
+    getMatrixApprovalAuthApprovers({ cfg: cfg as CoreConfig, accountId }),
   normalizeSenderId: (value) => normalizeMatrixApproverId(value),
 });

--- a/extensions/matrix/src/approval-native.test.ts
+++ b/extensions/matrix/src/approval-native.test.ts
@@ -195,6 +195,30 @@ describe("matrix native approval adapter", () => {
     ).toEqual({ authorized: true });
   });
 
+  it("requires Matrix DM approvers before enabling plugin approval auth", () => {
+    const cfg = buildConfig({
+      dm: { allowFrom: [] },
+      execApprovals: {
+        enabled: true,
+        approvers: ["@exec:example.org"],
+        target: "both",
+      },
+    });
+
+    expect(
+      matrixApprovalCapability.authorizeActorAction?.({
+        cfg,
+        accountId: "default",
+        senderId: "@exec:example.org",
+        action: "approve",
+        approvalKind: "plugin",
+      }),
+    ).toEqual({
+      authorized: false,
+      reason: "❌ Matrix plugin approvals are not enabled for this bot account.",
+    });
+  });
+
   it("disables matrix-native plugin approval delivery", () => {
     const capabilities = matrixNativeApprovalAdapter.native?.describeDeliveryCapabilities({
       cfg: buildConfig(),

--- a/extensions/matrix/src/approval-native.test.ts
+++ b/extensions/matrix/src/approval-native.test.ts
@@ -1,0 +1,141 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { describe, expect, it } from "vitest";
+import { matrixApprovalCapability, matrixNativeApprovalAdapter } from "./approval-native.js";
+
+function buildConfig(
+  overrides?: Partial<NonNullable<NonNullable<OpenClawConfig["channels"]>["matrix"]>>,
+): OpenClawConfig {
+  return {
+    channels: {
+      matrix: {
+        homeserver: "https://matrix.example.org",
+        userId: "@bot:example.org",
+        accessToken: "tok",
+        execApprovals: {
+          enabled: true,
+          approvers: ["@owner:example.org"],
+          target: "both",
+        },
+        ...overrides,
+      },
+    },
+  } as OpenClawConfig;
+}
+
+describe("matrix native approval adapter", () => {
+  it("describes native matrix approval delivery capabilities", () => {
+    const capabilities = matrixNativeApprovalAdapter.native?.describeDeliveryCapabilities({
+      cfg: buildConfig(),
+      accountId: "default",
+      approvalKind: "exec",
+      request: {
+        id: "req-1",
+        request: {
+          command: "echo hi",
+          turnSourceChannel: "matrix",
+          turnSourceTo: "room:!ops:example.org",
+          turnSourceAccountId: "default",
+          sessionKey: "agent:main:matrix:channel:!ops:example.org",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 1000,
+      },
+    });
+
+    expect(capabilities).toEqual({
+      enabled: true,
+      preferredSurface: "both",
+      supportsOriginSurface: true,
+      supportsApproverDmSurface: true,
+      notifyOriginWhenDmOnly: false,
+    });
+  });
+
+  it("resolves origin targets from matrix turn source", async () => {
+    const target = await matrixNativeApprovalAdapter.native?.resolveOriginTarget?.({
+      cfg: buildConfig(),
+      accountId: "default",
+      approvalKind: "exec",
+      request: {
+        id: "req-1",
+        request: {
+          command: "echo hi",
+          turnSourceChannel: "matrix",
+          turnSourceTo: "room:!ops:example.org",
+          turnSourceThreadId: "$thread",
+          turnSourceAccountId: "default",
+          sessionKey: "agent:main:matrix:channel:!ops:example.org",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 1000,
+      },
+    });
+
+    expect(target).toEqual({
+      to: "room:!ops:example.org",
+      threadId: "$thread",
+    });
+  });
+
+  it("resolves approver dm targets", async () => {
+    const targets = await matrixNativeApprovalAdapter.native?.resolveApproverDmTargets?.({
+      cfg: buildConfig(),
+      accountId: "default",
+      approvalKind: "exec",
+      request: {
+        id: "req-1",
+        request: {
+          command: "echo hi",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 1000,
+      },
+    });
+
+    expect(targets).toEqual([{ to: "user:@owner:example.org" }]);
+  });
+
+  it("keeps plugin approval auth independent from exec approvers", () => {
+    const cfg = buildConfig({
+      dm: { allowFrom: ["@owner:example.org"] },
+      execApprovals: {
+        enabled: true,
+        approvers: ["@exec:example.org"],
+        target: "both",
+      },
+    });
+
+    expect(
+      matrixApprovalCapability.authorizeActorAction?.({
+        cfg,
+        accountId: "default",
+        senderId: "@owner:example.org",
+        action: "approve",
+        approvalKind: "plugin",
+      }),
+    ).toEqual({ authorized: true });
+
+    expect(
+      matrixApprovalCapability.authorizeActorAction?.({
+        cfg,
+        accountId: "default",
+        senderId: "@exec:example.org",
+        action: "approve",
+        approvalKind: "plugin",
+      }),
+    ).toEqual({
+      authorized: false,
+      reason: "❌ You are not authorized to approve plugin requests on Matrix.",
+    });
+
+    expect(
+      matrixApprovalCapability.authorizeActorAction?.({
+        cfg,
+        accountId: "default",
+        senderId: "@exec:example.org",
+        action: "approve",
+        approvalKind: "exec",
+      }),
+    ).toEqual({ authorized: true });
+  });
+});

--- a/extensions/matrix/src/approval-native.test.ts
+++ b/extensions/matrix/src/approval-native.test.ts
@@ -138,4 +138,30 @@ describe("matrix native approval adapter", () => {
       }),
     ).toEqual({ authorized: true });
   });
+
+  it("disables matrix-native plugin approval delivery", () => {
+    const capabilities = matrixNativeApprovalAdapter.native?.describeDeliveryCapabilities({
+      cfg: buildConfig(),
+      accountId: "default",
+      approvalKind: "plugin",
+      request: {
+        id: "plugin:req-1",
+        request: {
+          title: "Plugin Approval Required",
+          description: "Allow plugin access",
+          pluginId: "git-tools",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 1000,
+      },
+    });
+
+    expect(capabilities).toEqual({
+      enabled: false,
+      preferredSurface: "approver-dm",
+      supportsOriginSurface: false,
+      supportsApproverDmSurface: false,
+      notifyOriginWhenDmOnly: false,
+    });
+  });
 });

--- a/extensions/matrix/src/approval-native.test.ts
+++ b/extensions/matrix/src/approval-native.test.ts
@@ -95,6 +95,62 @@ describe("matrix native approval adapter", () => {
     expect(targets).toEqual([{ to: "user:@owner:example.org" }]);
   });
 
+  it("keeps plugin forwarding fallback active when native delivery is exec-only", () => {
+    const shouldSuppress = matrixNativeApprovalAdapter.delivery?.shouldSuppressForwardingFallback;
+    if (!shouldSuppress) {
+      throw new Error("delivery suppression helper unavailable");
+    }
+
+    expect(
+      shouldSuppress({
+        cfg: buildConfig(),
+        approvalKind: "plugin",
+        target: {
+          channel: "matrix",
+          to: "room:!ops:example.org",
+          accountId: "default",
+        },
+        request: {
+          id: "req-1",
+          request: {
+            command: "echo hi",
+            turnSourceChannel: "matrix",
+            turnSourceTo: "room:!ops:example.org",
+            turnSourceAccountId: "default",
+          },
+          createdAtMs: 0,
+          expiresAtMs: 1000,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves room-id case when matching Matrix origin targets", async () => {
+    const target = await matrixNativeApprovalAdapter.native?.resolveOriginTarget?.({
+      cfg: buildConfig(),
+      accountId: "default",
+      approvalKind: "exec",
+      request: {
+        id: "req-1",
+        request: {
+          command: "echo hi",
+          turnSourceChannel: "matrix",
+          turnSourceTo: "room:!Ops:Example.org",
+          turnSourceThreadId: "$thread",
+          turnSourceAccountId: "default",
+          sessionKey: "agent:main:matrix:channel:!Ops:Example.org",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 1000,
+      },
+    });
+
+    expect(target).toEqual({
+      to: "room:!Ops:Example.org",
+      threadId: "$thread",
+    });
+  });
+
   it("keeps plugin approval auth independent from exec approvers", () => {
     const cfg = buildConfig({
       dm: { allowFrom: ["@owner:example.org"] },

--- a/extensions/matrix/src/approval-native.ts
+++ b/extensions/matrix/src/approval-native.ts
@@ -5,12 +5,10 @@ import {
   createApproverRestrictedNativeApprovalCapability,
   splitChannelApprovalCapability,
 } from "openclaw/plugin-sdk/approval-runtime";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { ExecApprovalRequest, PluginApprovalRequest } from "openclaw/plugin-sdk/infra-runtime";
 import { getMatrixApprovalAuthApprovers, matrixApprovalAuth } from "./approval-auth.js";
 import {
   getMatrixExecApprovalApprovers,
-  isMatrixExecApprovalApprover,
   isMatrixExecApprovalAuthorizedSender,
   isMatrixExecApprovalClientEnabled,
   resolveMatrixExecApprovalTarget,
@@ -114,8 +112,6 @@ const matrixNativeApprovalCapability = createApproverRestrictedNativeApprovalCap
     getMatrixExecApprovalApprovers({ cfg, accountId }).length > 0,
   isExecAuthorizedSender: ({ cfg, accountId, senderId }) =>
     isMatrixExecApprovalAuthorizedSender({ cfg, accountId, senderId }),
-  isPluginAuthorizedSender: ({ cfg, accountId, senderId }) =>
-    isMatrixExecApprovalApprover({ cfg, accountId, senderId }),
   isNativeDeliveryEnabled: ({ cfg, accountId }) =>
     isMatrixExecApprovalClientEnabled({ cfg, accountId }),
   resolveNativeDeliveryMode: ({ cfg, accountId }) =>
@@ -126,6 +122,39 @@ const matrixNativeApprovalCapability = createApproverRestrictedNativeApprovalCap
   resolveOriginTarget: resolveMatrixOriginTarget,
   resolveApproverDmTargets: resolveMatrixApproverDmTargets,
 });
+
+const splitMatrixApprovalCapability = splitChannelApprovalCapability(
+  matrixNativeApprovalCapability,
+);
+const matrixBaseNativeApprovalAdapter = splitMatrixApprovalCapability.native;
+const matrixExecOnlyNativeApprovalAdapter = matrixBaseNativeApprovalAdapter && {
+  describeDeliveryCapabilities: (
+    params: Parameters<typeof matrixBaseNativeApprovalAdapter.describeDeliveryCapabilities>[0],
+  ) =>
+    params.approvalKind === "plugin"
+      ? {
+          enabled: false,
+          preferredSurface: "approver-dm" as const,
+          supportsOriginSurface: false,
+          supportsApproverDmSurface: false,
+          notifyOriginWhenDmOnly: false,
+        }
+      : matrixBaseNativeApprovalAdapter.describeDeliveryCapabilities(params),
+  resolveOriginTarget: async (
+    params: Parameters<NonNullable<typeof matrixBaseNativeApprovalAdapter.resolveOriginTarget>>[0],
+  ) =>
+    params.approvalKind === "plugin"
+      ? null
+      : ((await matrixBaseNativeApprovalAdapter.resolveOriginTarget?.(params)) ?? null),
+  resolveApproverDmTargets: async (
+    params: Parameters<
+      NonNullable<typeof matrixBaseNativeApprovalAdapter.resolveApproverDmTargets>
+    >[0],
+  ) =>
+    params.approvalKind === "plugin"
+      ? []
+      : ((await matrixBaseNativeApprovalAdapter.resolveApproverDmTargets?.(params)) ?? []),
+};
 
 export const matrixApprovalCapability = createChannelApprovalCapability({
   authorizeActorAction: (params) =>
@@ -148,9 +177,17 @@ export const matrixApprovalCapability = createChannelApprovalCapability({
   },
   approvals: {
     delivery: matrixNativeApprovalCapability.delivery,
-    native: matrixNativeApprovalCapability.native,
+    native: matrixExecOnlyNativeApprovalAdapter,
     render: matrixNativeApprovalCapability.render,
   },
 });
 
-export const matrixNativeApprovalAdapter = splitChannelApprovalCapability(matrixApprovalCapability);
+export const matrixNativeApprovalAdapter = {
+  auth: {
+    authorizeActorAction: matrixApprovalCapability.authorizeActorAction,
+    getActionAvailabilityState: matrixApprovalCapability.getActionAvailabilityState,
+  },
+  delivery: matrixApprovalCapability.delivery,
+  render: matrixApprovalCapability.render,
+  native: matrixExecOnlyNativeApprovalAdapter,
+};

--- a/extensions/matrix/src/approval-native.ts
+++ b/extensions/matrix/src/approval-native.ts
@@ -21,6 +21,13 @@ import type { CoreConfig } from "./types.js";
 
 type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
 type MatrixOriginTarget = { to: string; threadId?: string };
+const MATRIX_PLUGIN_NATIVE_DELIVERY_DISABLED = {
+  enabled: false,
+  preferredSurface: "approver-dm" as const,
+  supportsOriginSurface: false,
+  supportsApproverDmSurface: false,
+  notifyOriginWhenDmOnly: false,
+};
 
 function normalizeComparableTarget(value: string): string {
   const target = resolveMatrixTargetIdentity(value);
@@ -78,6 +85,10 @@ function matrixTargetsMatch(a: MatrixOriginTarget, b: MatrixOriginTarget): boole
     normalizeComparableTarget(a.to) === normalizeComparableTarget(b.to) &&
     (a.threadId ?? "") === (b.threadId ?? "")
   );
+}
+
+function hasMatrixPluginApprovers(params: { cfg: CoreConfig; accountId?: string | null }): boolean {
+  return getMatrixApprovalAuthApprovers(params).length > 0;
 }
 
 const resolveMatrixOriginTarget = createChannelNativeOriginTargetResolver({
@@ -146,13 +157,7 @@ const matrixExecOnlyNativeApprovalAdapter = matrixBaseNativeApprovalAdapter && {
     params: Parameters<typeof matrixBaseNativeApprovalAdapter.describeDeliveryCapabilities>[0],
   ) =>
     params.approvalKind === "plugin"
-      ? {
-          enabled: false,
-          preferredSurface: "approver-dm" as const,
-          supportsOriginSurface: false,
-          supportsApproverDmSurface: false,
-          notifyOriginWhenDmOnly: false,
-        }
+      ? MATRIX_PLUGIN_NATIVE_DELIVERY_DISABLED
       : matrixBaseNativeApprovalAdapter.describeDeliveryCapabilities(params),
   resolveOriginTarget: async (
     params: Parameters<NonNullable<typeof matrixBaseNativeApprovalAdapter.resolveOriginTarget>>[0],
@@ -172,36 +177,30 @@ const matrixExecOnlyNativeApprovalAdapter = matrixBaseNativeApprovalAdapter && {
 
 export const matrixApprovalCapability = createChannelApprovalCapability({
   authorizeActorAction: (params) => {
-    if (params.approvalKind === "plugin") {
-      if (
-        getMatrixApprovalAuthApprovers({
-          cfg: params.cfg as CoreConfig,
-          accountId: params.accountId,
-        }).length === 0
-      ) {
-        return {
-          authorized: false,
-          reason: "❌ Matrix plugin approvals are not enabled for this bot account.",
-        } as const;
-      }
-      return matrixApprovalAuth.authorizeActorAction(params);
+    if (params.approvalKind !== "plugin") {
+      return matrixNativeApprovalCapability.authorizeActorAction?.(params) ?? { authorized: true };
     }
-    return matrixNativeApprovalCapability.authorizeActorAction?.(params) ?? { authorized: true };
-  },
-  getActionAvailabilityState: (params) => {
     if (
-      getMatrixApprovalAuthApprovers({
+      !hasMatrixPluginApprovers({
         cfg: params.cfg as CoreConfig,
         accountId: params.accountId,
-      }).length > 0
+      })
     ) {
-      return { kind: "enabled" } as const;
+      return {
+        authorized: false,
+        reason: "❌ Matrix plugin approvals are not enabled for this bot account.",
+      } as const;
     }
-    return (
-      matrixNativeApprovalCapability.getActionAvailabilityState?.(params) ??
-      ({ kind: "disabled" } as const)
-    );
+    return matrixApprovalAuth.authorizeActorAction(params);
   },
+  getActionAvailabilityState: (params) =>
+    hasMatrixPluginApprovers({
+      cfg: params.cfg as CoreConfig,
+      accountId: params.accountId,
+    })
+      ? ({ kind: "enabled" } as const)
+      : (matrixNativeApprovalCapability.getActionAvailabilityState?.(params) ??
+        ({ kind: "disabled" } as const)),
   approvals: {
     delivery: matrixDeliveryAdapter,
     native: matrixExecOnlyNativeApprovalAdapter,

--- a/extensions/matrix/src/approval-native.ts
+++ b/extensions/matrix/src/approval-native.ts
@@ -27,7 +27,10 @@ function normalizeComparableTarget(value: string): string {
   if (!target) {
     return value.trim().toLowerCase();
   }
-  return `${target.kind}:${target.id}`.toLowerCase();
+  if (target.kind === "user") {
+    return `user:${normalizeMatrixUserId(target.id)}`;
+  }
+  return `${target.kind.toLowerCase()}:${target.id}`;
 }
 
 function resolveMatrixNativeTarget(raw: string): string | null {
@@ -127,6 +130,17 @@ const splitMatrixApprovalCapability = splitChannelApprovalCapability(
   matrixNativeApprovalCapability,
 );
 const matrixBaseNativeApprovalAdapter = splitMatrixApprovalCapability.native;
+const matrixBaseDeliveryAdapter = splitMatrixApprovalCapability.delivery;
+type MatrixForwardingSuppressionParams = Parameters<
+  NonNullable<NonNullable<typeof matrixBaseDeliveryAdapter>["shouldSuppressForwardingFallback"]>
+>[0];
+const matrixDeliveryAdapter = matrixBaseDeliveryAdapter && {
+  ...matrixBaseDeliveryAdapter,
+  shouldSuppressForwardingFallback: (params: MatrixForwardingSuppressionParams) =>
+    params.approvalKind === "plugin"
+      ? false
+      : (matrixBaseDeliveryAdapter.shouldSuppressForwardingFallback?.(params) ?? false),
+};
 const matrixExecOnlyNativeApprovalAdapter = matrixBaseNativeApprovalAdapter && {
   describeDeliveryCapabilities: (
     params: Parameters<typeof matrixBaseNativeApprovalAdapter.describeDeliveryCapabilities>[0],
@@ -176,7 +190,7 @@ export const matrixApprovalCapability = createChannelApprovalCapability({
     );
   },
   approvals: {
-    delivery: matrixNativeApprovalCapability.delivery,
+    delivery: matrixDeliveryAdapter,
     native: matrixExecOnlyNativeApprovalAdapter,
     render: matrixNativeApprovalCapability.render,
   },
@@ -187,7 +201,7 @@ export const matrixNativeApprovalAdapter = {
     authorizeActorAction: matrixApprovalCapability.authorizeActorAction,
     getActionAvailabilityState: matrixApprovalCapability.getActionAvailabilityState,
   },
-  delivery: matrixApprovalCapability.delivery,
+  delivery: matrixDeliveryAdapter,
   render: matrixApprovalCapability.render,
   native: matrixExecOnlyNativeApprovalAdapter,
 };

--- a/extensions/matrix/src/approval-native.ts
+++ b/extensions/matrix/src/approval-native.ts
@@ -171,10 +171,23 @@ const matrixExecOnlyNativeApprovalAdapter = matrixBaseNativeApprovalAdapter && {
 };
 
 export const matrixApprovalCapability = createChannelApprovalCapability({
-  authorizeActorAction: (params) =>
-    params.approvalKind === "plugin"
-      ? matrixApprovalAuth.authorizeActorAction(params)
-      : (matrixNativeApprovalCapability.authorizeActorAction?.(params) ?? { authorized: true }),
+  authorizeActorAction: (params) => {
+    if (params.approvalKind === "plugin") {
+      if (
+        getMatrixApprovalAuthApprovers({
+          cfg: params.cfg as CoreConfig,
+          accountId: params.accountId,
+        }).length === 0
+      ) {
+        return {
+          authorized: false,
+          reason: "❌ Matrix plugin approvals are not enabled for this bot account.",
+        } as const;
+      }
+      return matrixApprovalAuth.authorizeActorAction(params);
+    }
+    return matrixNativeApprovalCapability.authorizeActorAction?.(params) ?? { authorized: true };
+  },
   getActionAvailabilityState: (params) => {
     if (
       getMatrixApprovalAuthApprovers({

--- a/extensions/matrix/src/approval-native.ts
+++ b/extensions/matrix/src/approval-native.ts
@@ -1,0 +1,156 @@
+import {
+  createChannelApprovalCapability,
+  createChannelApproverDmTargetResolver,
+  createChannelNativeOriginTargetResolver,
+  createApproverRestrictedNativeApprovalCapability,
+  splitChannelApprovalCapability,
+} from "openclaw/plugin-sdk/approval-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { ExecApprovalRequest, PluginApprovalRequest } from "openclaw/plugin-sdk/infra-runtime";
+import { getMatrixApprovalAuthApprovers, matrixApprovalAuth } from "./approval-auth.js";
+import {
+  getMatrixExecApprovalApprovers,
+  isMatrixExecApprovalApprover,
+  isMatrixExecApprovalAuthorizedSender,
+  isMatrixExecApprovalClientEnabled,
+  resolveMatrixExecApprovalTarget,
+  shouldHandleMatrixExecApprovalRequest,
+} from "./exec-approvals.js";
+import { listMatrixAccountIds } from "./matrix/accounts.js";
+import { normalizeMatrixUserId } from "./matrix/monitor/allowlist.js";
+import { resolveMatrixTargetIdentity } from "./matrix/target-ids.js";
+import type { CoreConfig } from "./types.js";
+
+type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+type MatrixOriginTarget = { to: string; threadId?: string };
+
+function normalizeComparableTarget(value: string): string {
+  const target = resolveMatrixTargetIdentity(value);
+  if (!target) {
+    return value.trim().toLowerCase();
+  }
+  return `${target.kind}:${target.id}`.toLowerCase();
+}
+
+function resolveMatrixNativeTarget(raw: string): string | null {
+  const target = resolveMatrixTargetIdentity(raw);
+  if (!target) {
+    return null;
+  }
+  return target.kind === "user" ? `user:${target.id}` : `room:${target.id}`;
+}
+
+function normalizeThreadId(value?: string | number | null): string | undefined {
+  const trimmed = value == null ? "" : String(value).trim();
+  return trimmed || undefined;
+}
+
+function resolveTurnSourceMatrixOriginTarget(request: ApprovalRequest): MatrixOriginTarget | null {
+  const turnSourceChannel = request.request.turnSourceChannel?.trim().toLowerCase() || "";
+  const turnSourceTo = request.request.turnSourceTo?.trim() || "";
+  const target = resolveMatrixNativeTarget(turnSourceTo);
+  if (turnSourceChannel !== "matrix" || !target) {
+    return null;
+  }
+  return {
+    to: target,
+    threadId: normalizeThreadId(request.request.turnSourceThreadId),
+  };
+}
+
+function resolveSessionMatrixOriginTarget(sessionTarget: {
+  to: string;
+  threadId?: string | number | null;
+}): MatrixOriginTarget | null {
+  const target = resolveMatrixNativeTarget(sessionTarget.to);
+  if (!target) {
+    return null;
+  }
+  return {
+    to: target,
+    threadId: normalizeThreadId(sessionTarget.threadId),
+  };
+}
+
+function matrixTargetsMatch(a: MatrixOriginTarget, b: MatrixOriginTarget): boolean {
+  return (
+    normalizeComparableTarget(a.to) === normalizeComparableTarget(b.to) &&
+    (a.threadId ?? "") === (b.threadId ?? "")
+  );
+}
+
+const resolveMatrixOriginTarget = createChannelNativeOriginTargetResolver({
+  channel: "matrix",
+  shouldHandleRequest: ({ cfg, accountId, request }) =>
+    shouldHandleMatrixExecApprovalRequest({
+      cfg,
+      accountId,
+      request,
+    }),
+  resolveTurnSourceTarget: resolveTurnSourceMatrixOriginTarget,
+  resolveSessionTarget: resolveSessionMatrixOriginTarget,
+  targetsMatch: matrixTargetsMatch,
+});
+
+const resolveMatrixApproverDmTargets = createChannelApproverDmTargetResolver({
+  shouldHandleRequest: ({ cfg, accountId, request }) =>
+    shouldHandleMatrixExecApprovalRequest({
+      cfg,
+      accountId,
+      request,
+    }),
+  resolveApprovers: getMatrixExecApprovalApprovers,
+  mapApprover: (approver) => {
+    const normalized = normalizeMatrixUserId(approver);
+    return normalized ? { to: `user:${normalized}` } : null;
+  },
+});
+
+const matrixNativeApprovalCapability = createApproverRestrictedNativeApprovalCapability({
+  channel: "matrix",
+  channelLabel: "Matrix",
+  listAccountIds: listMatrixAccountIds,
+  hasApprovers: ({ cfg, accountId }) =>
+    getMatrixExecApprovalApprovers({ cfg, accountId }).length > 0,
+  isExecAuthorizedSender: ({ cfg, accountId, senderId }) =>
+    isMatrixExecApprovalAuthorizedSender({ cfg, accountId, senderId }),
+  isPluginAuthorizedSender: ({ cfg, accountId, senderId }) =>
+    isMatrixExecApprovalApprover({ cfg, accountId, senderId }),
+  isNativeDeliveryEnabled: ({ cfg, accountId }) =>
+    isMatrixExecApprovalClientEnabled({ cfg, accountId }),
+  resolveNativeDeliveryMode: ({ cfg, accountId }) =>
+    resolveMatrixExecApprovalTarget({ cfg, accountId }),
+  requireMatchingTurnSourceChannel: true,
+  resolveSuppressionAccountId: ({ target, request }) =>
+    target.accountId?.trim() || request.request.turnSourceAccountId?.trim() || undefined,
+  resolveOriginTarget: resolveMatrixOriginTarget,
+  resolveApproverDmTargets: resolveMatrixApproverDmTargets,
+});
+
+export const matrixApprovalCapability = createChannelApprovalCapability({
+  authorizeActorAction: (params) =>
+    params.approvalKind === "plugin"
+      ? matrixApprovalAuth.authorizeActorAction(params)
+      : (matrixNativeApprovalCapability.authorizeActorAction?.(params) ?? { authorized: true }),
+  getActionAvailabilityState: (params) => {
+    if (
+      getMatrixApprovalAuthApprovers({
+        cfg: params.cfg as CoreConfig,
+        accountId: params.accountId,
+      }).length > 0
+    ) {
+      return { kind: "enabled" } as const;
+    }
+    return (
+      matrixNativeApprovalCapability.getActionAvailabilityState?.(params) ??
+      ({ kind: "disabled" } as const)
+    );
+  },
+  approvals: {
+    delivery: matrixNativeApprovalCapability.delivery,
+    native: matrixNativeApprovalCapability.native,
+    render: matrixNativeApprovalCapability.render,
+  },
+});
+
+export const matrixNativeApprovalAdapter = splitChannelApprovalCapability(matrixApprovalCapability);

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -35,8 +35,9 @@ import {
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
 import { matrixMessageActions } from "./actions.js";
-import { matrixApprovalAuth } from "./approval-auth.js";
+import { matrixApprovalCapability } from "./approval-native.js";
 import { MatrixConfigSchema } from "./config-schema.js";
+import { shouldSuppressLocalMatrixExecApprovalPrompt } from "./exec-approvals.js";
 import {
   resolveMatrixGroupRequireMention,
   resolveMatrixGroupToolPolicy,
@@ -312,7 +313,7 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
             },
           }),
       },
-      auth: matrixApprovalAuth,
+      approvalCapability: matrixApprovalCapability,
       groups: {
         resolveRequireMention: resolveMatrixGroupRequireMention,
         resolveToolPolicy: resolveMatrixGroupToolPolicy,
@@ -558,6 +559,12 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
       chunker: chunkTextForOutbound,
       chunkerMode: "markdown",
       textChunkLimit: 4000,
+      shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload }) =>
+        shouldSuppressLocalMatrixExecApprovalPrompt({
+          cfg,
+          accountId,
+          payload,
+        }),
       ...createRuntimeOutboundDelegates({
         getRuntime: loadMatrixChannelRuntime,
         sendText: {

--- a/extensions/matrix/src/config-schema.ts
+++ b/extensions/matrix/src/config-schema.ts
@@ -31,6 +31,16 @@ const matrixThreadBindingsSchema = z
   })
   .optional();
 
+const matrixExecApprovalsSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    approvers: AllowFromListSchema,
+    agentFilter: z.array(z.string()).optional(),
+    sessionFilter: z.array(z.string()).optional(),
+    target: z.enum(["dm", "channel", "both"]).optional(),
+  })
+  .optional();
+
 const matrixRoomSchema = z
   .object({
     account: z.string().optional(),
@@ -90,6 +100,7 @@ export const MatrixConfigSchema = z.object({
   dm: buildNestedDmConfigSchema({
     threadReplies: z.enum(["off", "inbound", "always"]).optional(),
   }),
+  execApprovals: matrixExecApprovalsSchema,
   groups: z.object({}).catchall(matrixRoomSchema).optional(),
   rooms: z.object({}).catchall(matrixRoomSchema).optional(),
   actions: matrixActionSchema,

--- a/extensions/matrix/src/exec-approvals-handler.test.ts
+++ b/extensions/matrix/src/exec-approvals-handler.test.ts
@@ -17,23 +17,6 @@ const baseRequest = {
   expiresAtMs: 61_000,
 };
 
-const pluginRequest = {
-  id: "plugin:9f1c7d5d-b1fb-46ef-ac45-662723b65bb7",
-  request: {
-    title: "Plugin Approval Required",
-    description: "Allow plugin access",
-    pluginId: "git-tools",
-    agentId: "main",
-    sessionKey: "agent:main:matrix:channel:!ops:example.org",
-    turnSourceChannel: "matrix",
-    turnSourceTo: "room:!ops:example.org",
-    turnSourceThreadId: "$thread",
-    turnSourceAccountId: "default",
-  },
-  createdAtMs: 1000,
-  expiresAtMs: 61_000,
-};
-
 function createHandler(cfg: OpenClawConfig, accountId = "default") {
   const client = {} as never;
   const sendMessage = vi
@@ -204,34 +187,6 @@ describe("MatrixExecApprovalHandler", () => {
       "!ops:example.org",
       "$m1",
       expect.stringContaining("Exec approval: Allowed once"),
-      expect.objectContaining({
-        accountId: "default",
-      }),
-    );
-  });
-
-  it("delivers plugin approvals through the shared native delivery planner", async () => {
-    const cfg = {
-      channels: {
-        matrix: {
-          homeserver: "https://matrix.example.org",
-          userId: "@bot:example.org",
-          accessToken: "tok",
-          execApprovals: {
-            enabled: true,
-            approvers: ["@owner:example.org"],
-            target: "dm",
-          },
-        },
-      },
-    } as OpenClawConfig;
-    const { handler, sendMessage } = createHandler(cfg);
-
-    await handler.handleRequested(pluginRequest);
-
-    expect(sendMessage).toHaveBeenCalledWith(
-      "room:!dm-owner:example.org",
-      expect.stringContaining("Plugin Approval Required"),
       expect.objectContaining({
         accountId: "default",
       }),

--- a/extensions/matrix/src/exec-approvals-handler.test.ts
+++ b/extensions/matrix/src/exec-approvals-handler.test.ts
@@ -223,4 +223,37 @@ describe("MatrixExecApprovalHandler", () => {
       }),
     );
   });
+
+  it("honors request decision constraints in pending approval text", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "tok",
+          execApprovals: {
+            enabled: true,
+            approvers: ["@owner:example.org"],
+            target: "channel",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { handler, sendMessage } = createHandler(cfg);
+
+    await handler.handleRequested({
+      ...baseRequest,
+      request: {
+        ...baseRequest.request,
+        ask: "always",
+        allowedDecisions: ["allow-once", "deny"],
+      },
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "room:!ops:example.org",
+      expect.not.stringContaining("allow-always"),
+      expect.anything(),
+    );
+  });
 });

--- a/extensions/matrix/src/exec-approvals-handler.test.ts
+++ b/extensions/matrix/src/exec-approvals-handler.test.ts
@@ -1,0 +1,271 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MatrixExecApprovalHandler } from "./exec-approvals-handler.js";
+
+const baseRequest = {
+  id: "9f1c7d5d-b1fb-46ef-ac45-662723b65bb7",
+  request: {
+    command: "npm view diver name version description",
+    agentId: "main",
+    sessionKey: "agent:main:matrix:channel:!ops:example.org",
+    turnSourceChannel: "matrix",
+    turnSourceTo: "room:!ops:example.org",
+    turnSourceThreadId: "$thread",
+    turnSourceAccountId: "default",
+  },
+  createdAtMs: 1000,
+  expiresAtMs: 61_000,
+};
+
+const pluginRequest = {
+  id: "plugin:9f1c7d5d-b1fb-46ef-ac45-662723b65bb7",
+  request: {
+    title: "Plugin Approval Required",
+    description: "Allow plugin access",
+    pluginId: "git-tools",
+    agentId: "main",
+    sessionKey: "agent:main:matrix:channel:!ops:example.org",
+    turnSourceChannel: "matrix",
+    turnSourceTo: "room:!ops:example.org",
+    turnSourceThreadId: "$thread",
+    turnSourceAccountId: "default",
+  },
+  createdAtMs: 1000,
+  expiresAtMs: 61_000,
+};
+
+function createHandler(cfg: OpenClawConfig, accountId = "default") {
+  const client = {} as never;
+  const sendMessage = vi
+    .fn()
+    .mockResolvedValueOnce({ messageId: "$m1", roomId: "!ops:example.org" })
+    .mockResolvedValue({ messageId: "$m2", roomId: "!dm-owner:example.org" });
+  const editMessage = vi.fn().mockResolvedValue({ eventId: "$edit1" });
+  const deleteMessage = vi.fn().mockResolvedValue(undefined);
+  const repairDirectRooms = vi.fn().mockResolvedValue({
+    activeRoomId: "!dm-owner:example.org",
+  });
+  const handler = new MatrixExecApprovalHandler(
+    {
+      client,
+      accountId,
+      cfg,
+    },
+    {
+      nowMs: () => 1000,
+      sendMessage,
+      editMessage,
+      deleteMessage,
+      repairDirectRooms,
+    },
+  );
+  return { client, handler, sendMessage, editMessage, deleteMessage, repairDirectRooms };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("MatrixExecApprovalHandler", () => {
+  it("sends approval prompts to the originating matrix room when target=channel", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "tok",
+          execApprovals: {
+            enabled: true,
+            approvers: ["@owner:example.org"],
+            target: "channel",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { handler, sendMessage } = createHandler(cfg);
+
+    await handler.handleRequested(baseRequest);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "room:!ops:example.org",
+      expect.stringContaining("/approve 9f1c7d5d-b1fb-46ef-ac45-662723b65bb7 allow-once"),
+      expect.objectContaining({
+        accountId: "default",
+        threadId: "$thread",
+      }),
+    );
+  });
+
+  it("falls back to approver dms when channel routing is unavailable", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "tok",
+          execApprovals: {
+            enabled: true,
+            approvers: ["@owner:example.org"],
+            target: "channel",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { client, handler, sendMessage, repairDirectRooms } = createHandler(cfg);
+
+    await handler.handleRequested({
+      ...baseRequest,
+      request: {
+        ...baseRequest.request,
+        turnSourceChannel: "slack",
+        turnSourceTo: "channel:C1",
+        turnSourceAccountId: null,
+        turnSourceThreadId: null,
+      },
+    });
+
+    expect(repairDirectRooms).toHaveBeenCalledWith({
+      client,
+      remoteUserId: "@owner:example.org",
+      encrypted: false,
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      "room:!dm-owner:example.org",
+      expect.stringContaining("/approve 9f1c7d5d-b1fb-46ef-ac45-662723b65bb7 allow-once"),
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
+  });
+
+  it("does not double-send when the origin room is the approver dm", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "tok",
+          execApprovals: {
+            enabled: true,
+            approvers: ["@owner:example.org"],
+            target: "dm",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { handler, sendMessage } = createHandler(cfg);
+
+    await handler.handleRequested({
+      ...baseRequest,
+      request: {
+        ...baseRequest.request,
+        sessionKey: "agent:main:matrix:direct:!dm-owner:example.org",
+        turnSourceTo: "room:!dm-owner:example.org",
+        turnSourceThreadId: undefined,
+      },
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      "room:!dm-owner:example.org",
+      expect.stringContaining("/approve 9f1c7d5d-b1fb-46ef-ac45-662723b65bb7 allow-once"),
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
+  });
+
+  it("edits tracked approval messages when resolved", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "tok",
+          execApprovals: {
+            enabled: true,
+            approvers: ["@owner:example.org"],
+            target: "both",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { handler, editMessage } = createHandler(cfg);
+
+    await handler.handleRequested(baseRequest);
+    await handler.handleResolved({
+      id: baseRequest.id,
+      decision: "allow-once",
+      resolvedBy: "matrix:@owner:example.org",
+      ts: 2000,
+    });
+
+    expect(editMessage).toHaveBeenCalledWith(
+      "!ops:example.org",
+      "$m1",
+      expect.stringContaining("Exec approval: Allowed once"),
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
+  });
+
+  it("delivers plugin approvals through the shared native delivery planner", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "tok",
+          execApprovals: {
+            enabled: true,
+            approvers: ["@owner:example.org"],
+            target: "dm",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { handler, sendMessage } = createHandler(cfg);
+
+    await handler.handleRequested(pluginRequest);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "room:!dm-owner:example.org",
+      expect.stringContaining("Plugin Approval Required"),
+      expect.objectContaining({
+        accountId: "default",
+      }),
+    );
+  });
+
+  it("deletes tracked approval messages when they expire", async () => {
+    vi.useFakeTimers();
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "tok",
+          execApprovals: {
+            enabled: true,
+            approvers: ["@owner:example.org"],
+            target: "both",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { handler, deleteMessage } = createHandler(cfg);
+
+    await handler.handleRequested(baseRequest);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(deleteMessage).toHaveBeenCalledWith(
+      "!ops:example.org",
+      "$m1",
+      expect.objectContaining({
+        accountId: "default",
+        reason: "approval expired",
+      }),
+    );
+  });
+});

--- a/extensions/matrix/src/exec-approvals-handler.ts
+++ b/extensions/matrix/src/exec-approvals-handler.ts
@@ -1,7 +1,5 @@
 import {
   buildExecApprovalPendingReplyPayload,
-  buildPluginApprovalPendingReplyPayload,
-  buildPluginApprovalResolvedMessage,
   getExecApprovalApproverDmNoticeText,
   resolveExecApprovalCommandDisplay,
 } from "openclaw/plugin-sdk/approval-runtime";
@@ -11,10 +9,6 @@ import {
   type ExecApprovalChannelRuntime,
   type ExecApprovalRequest,
   type ExecApprovalResolved,
-} from "openclaw/plugin-sdk/infra-runtime";
-import type {
-  PluginApprovalRequest,
-  PluginApprovalResolved,
 } from "openclaw/plugin-sdk/infra-runtime";
 import { matrixNativeApprovalAdapter } from "./approval-native.js";
 import {
@@ -29,9 +23,8 @@ import { sendMessageMatrix } from "./matrix/send.js";
 import { resolveMatrixTargetIdentity } from "./matrix/target-ids.js";
 import type { CoreConfig } from "./types.js";
 
-type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
-type ApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;
-type ApprovalKind = "exec" | "plugin";
+type ApprovalRequest = ExecApprovalRequest;
+type ApprovalResolved = ExecApprovalResolved;
 type PendingMessage = {
   roomId: string;
   messageId: string;
@@ -67,17 +60,7 @@ function normalizeThreadId(value?: string | number | null): string | undefined {
   return trimmed || undefined;
 }
 
-function resolveApprovalKind(request: ApprovalRequest): ApprovalKind {
-  return request.id.startsWith("plugin:") ? "plugin" : "exec";
-}
-
 function buildPendingApprovalText(params: { request: ApprovalRequest; nowMs: number }): string {
-  if (resolveApprovalKind(params.request) === "plugin") {
-    return buildPluginApprovalPendingReplyPayload({
-      request: params.request as PluginApprovalRequest,
-      nowMs: params.nowMs,
-    }).text!;
-  }
   return buildExecApprovalPendingReplyPayload({
     approvalId: params.request.id,
     approvalSlug: params.request.id.slice(0, 8),
@@ -96,12 +79,7 @@ function buildResolvedApprovalText(params: {
   request: ApprovalRequest;
   resolved: ApprovalResolved;
 }): string {
-  if (resolveApprovalKind(params.request) === "plugin") {
-    return buildPluginApprovalResolvedMessage(params.resolved as PluginApprovalResolved);
-  }
-  const command = resolveExecApprovalCommandDisplay(
-    (params.request as ExecApprovalRequest).request,
-  ).commandText;
+  const command = resolveExecApprovalCommandDisplay(params.request.request).commandText;
   const decisionLabel =
     params.resolved.decision === "allow-once"
       ? "Allowed once"
@@ -140,7 +118,7 @@ export class MatrixExecApprovalHandler {
       cfg: this.opts.cfg,
       accountId: this.opts.accountId,
       gatewayUrl: this.opts.gatewayUrl,
-      eventKinds: ["exec", "plugin"],
+      eventKinds: ["exec"],
       nowMs: this.nowMs,
       nativeAdapter: matrixNativeApprovalAdapter.native,
       isConfigured: () =>

--- a/extensions/matrix/src/exec-approvals-handler.ts
+++ b/extensions/matrix/src/exec-approvals-handler.ts
@@ -1,0 +1,282 @@
+import {
+  buildExecApprovalPendingReplyPayload,
+  buildPluginApprovalPendingReplyPayload,
+  buildPluginApprovalResolvedMessage,
+  getExecApprovalApproverDmNoticeText,
+  resolveExecApprovalCommandDisplay,
+} from "openclaw/plugin-sdk/approval-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  createChannelNativeApprovalRuntime,
+  type ExecApprovalChannelRuntime,
+  type ExecApprovalRequest,
+  type ExecApprovalResolved,
+} from "openclaw/plugin-sdk/infra-runtime";
+import type {
+  PluginApprovalRequest,
+  PluginApprovalResolved,
+} from "openclaw/plugin-sdk/infra-runtime";
+import { matrixNativeApprovalAdapter } from "./approval-native.js";
+import {
+  isMatrixExecApprovalClientEnabled,
+  shouldHandleMatrixExecApprovalRequest,
+} from "./exec-approvals.js";
+import { resolveMatrixAccount } from "./matrix/accounts.js";
+import { deleteMatrixMessage, editMatrixMessage } from "./matrix/actions/messages.js";
+import { repairMatrixDirectRooms } from "./matrix/direct-management.js";
+import type { MatrixClient } from "./matrix/sdk.js";
+import { sendMessageMatrix } from "./matrix/send.js";
+import { resolveMatrixTargetIdentity } from "./matrix/target-ids.js";
+import type { CoreConfig } from "./types.js";
+
+type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+type ApprovalResolved = ExecApprovalResolved | PluginApprovalResolved;
+type ApprovalKind = "exec" | "plugin";
+type PendingMessage = {
+  roomId: string;
+  messageId: string;
+};
+
+type PreparedMatrixTarget = {
+  to: string;
+  roomId: string;
+  threadId?: string;
+};
+
+export type MatrixExecApprovalHandlerOpts = {
+  client: MatrixClient;
+  accountId: string;
+  cfg: OpenClawConfig;
+  gatewayUrl?: string;
+};
+
+export type MatrixExecApprovalHandlerDeps = {
+  nowMs?: () => number;
+  sendMessage?: typeof sendMessageMatrix;
+  editMessage?: typeof editMatrixMessage;
+  deleteMessage?: typeof deleteMatrixMessage;
+  repairDirectRooms?: typeof repairMatrixDirectRooms;
+};
+
+function isHandlerConfigured(params: { cfg: OpenClawConfig; accountId: string }): boolean {
+  return isMatrixExecApprovalClientEnabled(params);
+}
+
+function normalizeThreadId(value?: string | number | null): string | undefined {
+  const trimmed = value == null ? "" : String(value).trim();
+  return trimmed || undefined;
+}
+
+function resolveApprovalKind(request: ApprovalRequest): ApprovalKind {
+  return request.id.startsWith("plugin:") ? "plugin" : "exec";
+}
+
+function buildPendingApprovalText(params: { request: ApprovalRequest; nowMs: number }): string {
+  if (resolveApprovalKind(params.request) === "plugin") {
+    return buildPluginApprovalPendingReplyPayload({
+      request: params.request as PluginApprovalRequest,
+      nowMs: params.nowMs,
+    }).text!;
+  }
+  return buildExecApprovalPendingReplyPayload({
+    approvalId: params.request.id,
+    approvalSlug: params.request.id.slice(0, 8),
+    approvalCommandId: params.request.id,
+    command: resolveExecApprovalCommandDisplay((params.request as ExecApprovalRequest).request)
+      .commandText,
+    cwd: (params.request as ExecApprovalRequest).request.cwd ?? undefined,
+    host: (params.request as ExecApprovalRequest).request.host === "node" ? "node" : "gateway",
+    nodeId: (params.request as ExecApprovalRequest).request.nodeId ?? undefined,
+    expiresAtMs: params.request.expiresAtMs,
+    nowMs: params.nowMs,
+  }).text!;
+}
+
+function buildResolvedApprovalText(params: {
+  request: ApprovalRequest;
+  resolved: ApprovalResolved;
+}): string {
+  if (resolveApprovalKind(params.request) === "plugin") {
+    return buildPluginApprovalResolvedMessage(params.resolved as PluginApprovalResolved);
+  }
+  const command = resolveExecApprovalCommandDisplay(
+    (params.request as ExecApprovalRequest).request,
+  ).commandText;
+  const decisionLabel =
+    params.resolved.decision === "allow-once"
+      ? "Allowed once"
+      : params.resolved.decision === "allow-always"
+        ? "Allowed always"
+        : "Denied";
+  return [`Exec approval: ${decisionLabel}`, "", "Command", "```", command, "```"].join("\n");
+}
+
+export class MatrixExecApprovalHandler {
+  private readonly runtime: ExecApprovalChannelRuntime<ApprovalRequest, ApprovalResolved>;
+  private readonly nowMs: () => number;
+  private readonly sendMessage: typeof sendMessageMatrix;
+  private readonly editMessage: typeof editMatrixMessage;
+  private readonly deleteMessage: typeof deleteMatrixMessage;
+  private readonly repairDirectRooms: typeof repairMatrixDirectRooms;
+
+  constructor(
+    private readonly opts: MatrixExecApprovalHandlerOpts,
+    deps: MatrixExecApprovalHandlerDeps = {},
+  ) {
+    this.nowMs = deps.nowMs ?? Date.now;
+    this.sendMessage = deps.sendMessage ?? sendMessageMatrix;
+    this.editMessage = deps.editMessage ?? editMatrixMessage;
+    this.deleteMessage = deps.deleteMessage ?? deleteMatrixMessage;
+    this.repairDirectRooms = deps.repairDirectRooms ?? repairMatrixDirectRooms;
+    this.runtime = createChannelNativeApprovalRuntime<
+      PendingMessage,
+      PreparedMatrixTarget,
+      string,
+      ApprovalRequest,
+      ApprovalResolved
+    >({
+      label: "matrix/exec-approvals",
+      clientDisplayName: `Matrix Exec Approvals (${this.opts.accountId})`,
+      cfg: this.opts.cfg,
+      accountId: this.opts.accountId,
+      gatewayUrl: this.opts.gatewayUrl,
+      eventKinds: ["exec", "plugin"],
+      nowMs: this.nowMs,
+      nativeAdapter: matrixNativeApprovalAdapter.native,
+      isConfigured: () =>
+        isHandlerConfigured({ cfg: this.opts.cfg, accountId: this.opts.accountId }),
+      shouldHandle: (request) =>
+        shouldHandleMatrixExecApprovalRequest({
+          cfg: this.opts.cfg,
+          accountId: this.opts.accountId,
+          request,
+        }),
+      buildPendingContent: ({ request, nowMs }) =>
+        buildPendingApprovalText({
+          request,
+          nowMs,
+        }),
+      sendOriginNotice: async ({ originTarget }) => {
+        const preparedTarget = await this.prepareTarget(originTarget);
+        if (!preparedTarget) {
+          return;
+        }
+        await this.sendMessage(preparedTarget.to, getExecApprovalApproverDmNoticeText(), {
+          cfg: this.opts.cfg as CoreConfig,
+          accountId: this.opts.accountId,
+          client: this.opts.client,
+          threadId: preparedTarget.threadId,
+        });
+      },
+      prepareTarget: async ({ plannedTarget }) => {
+        const preparedTarget = await this.prepareTarget(plannedTarget.target);
+        if (!preparedTarget) {
+          return null;
+        }
+        return {
+          dedupeKey: `${preparedTarget.roomId}:${preparedTarget.threadId ?? ""}`,
+          target: preparedTarget,
+        };
+      },
+      deliverTarget: async ({ preparedTarget, pendingContent }) => {
+        const result = await this.sendMessage(preparedTarget.to, pendingContent, {
+          cfg: this.opts.cfg as CoreConfig,
+          accountId: this.opts.accountId,
+          client: this.opts.client,
+          threadId: preparedTarget.threadId,
+        });
+        return {
+          roomId: result.roomId,
+          messageId: result.messageId,
+        };
+      },
+      finalizeResolved: async ({ request, resolved, entries }) => {
+        await this.finalizeResolved(request, resolved, entries);
+      },
+      finalizeExpired: async ({ entries }) => {
+        await this.clearPending(entries);
+      },
+    });
+  }
+
+  async start(): Promise<void> {
+    await this.runtime.start();
+  }
+
+  async stop(): Promise<void> {
+    await this.runtime.stop();
+  }
+
+  async handleRequested(request: ApprovalRequest): Promise<void> {
+    await this.runtime.handleRequested(request);
+  }
+
+  async handleResolved(resolved: ApprovalResolved): Promise<void> {
+    await this.runtime.handleResolved(resolved);
+  }
+
+  private async prepareTarget(rawTarget: {
+    to: string;
+    threadId?: string | number | null;
+  }): Promise<PreparedMatrixTarget | null> {
+    const target = resolveMatrixTargetIdentity(rawTarget.to);
+    if (!target) {
+      return null;
+    }
+    const threadId = normalizeThreadId(rawTarget.threadId);
+    if (target.kind === "user") {
+      const account = resolveMatrixAccount({
+        cfg: this.opts.cfg as CoreConfig,
+        accountId: this.opts.accountId,
+      });
+      const repaired = await this.repairDirectRooms({
+        client: this.opts.client,
+        remoteUserId: target.id,
+        encrypted: account.config.encryption === true,
+      });
+      if (!repaired.activeRoomId) {
+        return null;
+      }
+      return {
+        to: `room:${repaired.activeRoomId}`,
+        roomId: repaired.activeRoomId,
+        threadId,
+      };
+    }
+    return {
+      to: `room:${target.id}`,
+      roomId: target.id,
+      threadId,
+    };
+  }
+
+  private async finalizeResolved(
+    request: ApprovalRequest,
+    resolved: ApprovalResolved,
+    entries: PendingMessage[],
+  ): Promise<void> {
+    const text = buildResolvedApprovalText({ request, resolved });
+    await Promise.allSettled(
+      entries.map(async (entry) => {
+        await this.editMessage(entry.roomId, entry.messageId, text, {
+          cfg: this.opts.cfg as CoreConfig,
+          accountId: this.opts.accountId,
+          client: this.opts.client,
+        });
+      }),
+    );
+  }
+
+  private async clearPending(entries: PendingMessage[]): Promise<void> {
+    await Promise.allSettled(
+      entries.map(async (entry) => {
+        await this.deleteMessage(entry.roomId, entry.messageId, {
+          cfg: this.opts.cfg as CoreConfig,
+          accountId: this.opts.accountId,
+          client: this.opts.client,
+          reason: "approval expired",
+        });
+      }),
+    );
+  }
+}

--- a/extensions/matrix/src/exec-approvals-handler.ts
+++ b/extensions/matrix/src/exec-approvals-handler.ts
@@ -65,11 +65,15 @@ function buildPendingApprovalText(params: { request: ApprovalRequest; nowMs: num
     approvalId: params.request.id,
     approvalSlug: params.request.id.slice(0, 8),
     approvalCommandId: params.request.id,
+    ask: params.request.request.ask ?? undefined,
+    agentId: params.request.request.agentId ?? undefined,
+    allowedDecisions: params.request.request.allowedDecisions,
     command: resolveExecApprovalCommandDisplay((params.request as ExecApprovalRequest).request)
       .commandText,
     cwd: (params.request as ExecApprovalRequest).request.cwd ?? undefined,
     host: (params.request as ExecApprovalRequest).request.host === "node" ? "node" : "gateway",
     nodeId: (params.request as ExecApprovalRequest).request.nodeId ?? undefined,
+    sessionKey: params.request.request.sessionKey ?? undefined,
     expiresAtMs: params.request.expiresAtMs,
     nowMs: params.nowMs,
   }).text!;

--- a/extensions/matrix/src/exec-approvals.test.ts
+++ b/extensions/matrix/src/exec-approvals.test.ts
@@ -159,6 +159,51 @@ describe("matrix exec approvals", () => {
     ).toBe(false);
   });
 
+  it("suppresses local prompts for generic exec payloads when metadata matches filters", () => {
+    const payload = {
+      channelData: {
+        execApproval: {
+          approvalId: "req-1",
+          approvalSlug: "req-1",
+          approvalKind: "exec",
+          agentId: "ops-agent",
+          sessionKey: "agent:ops-agent:matrix:channel:!ops:example.org",
+        },
+      },
+    };
+
+    expect(
+      shouldSuppressLocalMatrixExecApprovalPrompt({
+        cfg: buildConfig({
+          enabled: true,
+          approvers: ["@owner:example.org"],
+          agentFilter: ["ops-agent"],
+          sessionFilter: ["matrix:channel:"],
+        }),
+        payload,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress local prompts for plugin approval payloads", () => {
+    const payload = {
+      channelData: {
+        execApproval: {
+          approvalId: "plugin:req-1",
+          approvalSlug: "plugin:r",
+          approvalKind: "plugin",
+        },
+      },
+    };
+
+    expect(
+      shouldSuppressLocalMatrixExecApprovalPrompt({
+        cfg: buildConfig({ enabled: true, approvers: ["@owner:example.org"] }),
+        payload,
+      }),
+    ).toBe(false);
+  });
+
   it("normalizes prefixed approver ids", () => {
     expect(normalizeMatrixApproverId("matrix:@owner:example.org")).toBe("@owner:example.org");
     expect(normalizeMatrixApproverId("user:@owner:example.org")).toBe("@owner:example.org");

--- a/extensions/matrix/src/exec-approvals.test.ts
+++ b/extensions/matrix/src/exec-approvals.test.ts
@@ -1,0 +1,169 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { describe, expect, it } from "vitest";
+import {
+  getMatrixExecApprovalApprovers,
+  isMatrixExecApprovalApprover,
+  isMatrixExecApprovalAuthorizedSender,
+  isMatrixExecApprovalClientEnabled,
+  isMatrixExecApprovalTargetRecipient,
+  normalizeMatrixApproverId,
+  resolveMatrixExecApprovalTarget,
+  shouldHandleMatrixExecApprovalRequest,
+  shouldSuppressLocalMatrixExecApprovalPrompt,
+} from "./exec-approvals.js";
+
+function buildConfig(
+  execApprovals?: NonNullable<NonNullable<OpenClawConfig["channels"]>["matrix"]>["execApprovals"],
+  channelOverrides?: Partial<NonNullable<NonNullable<OpenClawConfig["channels"]>["matrix"]>>,
+): OpenClawConfig {
+  return {
+    channels: {
+      matrix: {
+        homeserver: "https://matrix.example.org",
+        userId: "@bot:example.org",
+        accessToken: "tok",
+        ...channelOverrides,
+        execApprovals,
+      },
+    },
+  } as OpenClawConfig;
+}
+
+describe("matrix exec approvals", () => {
+  it("requires enablement and an explicit or inferred approver", () => {
+    expect(isMatrixExecApprovalClientEnabled({ cfg: buildConfig() })).toBe(false);
+    expect(isMatrixExecApprovalClientEnabled({ cfg: buildConfig({ enabled: true }) })).toBe(false);
+    expect(
+      isMatrixExecApprovalClientEnabled({
+        cfg: buildConfig({ enabled: true }, { dm: { allowFrom: ["@owner:example.org"] } }),
+      }),
+    ).toBe(true);
+    expect(
+      isMatrixExecApprovalClientEnabled({
+        cfg: buildConfig({ enabled: true, approvers: ["@owner:example.org"] }),
+      }),
+    ).toBe(true);
+  });
+
+  it("prefers explicit approvers when configured", () => {
+    const cfg = buildConfig(
+      { enabled: true, approvers: ["user:@override:example.org"] },
+      { dm: { allowFrom: ["@owner:example.org"] } },
+    );
+
+    expect(getMatrixExecApprovalApprovers({ cfg })).toEqual(["@override:example.org"]);
+    expect(isMatrixExecApprovalApprover({ cfg, senderId: "@override:example.org" })).toBe(true);
+    expect(isMatrixExecApprovalApprover({ cfg, senderId: "@owner:example.org" })).toBe(false);
+  });
+
+  it("defaults target to dm", () => {
+    expect(
+      resolveMatrixExecApprovalTarget({
+        cfg: buildConfig({ enabled: true, approvers: ["@owner:example.org"] }),
+      }),
+    ).toBe("dm");
+  });
+
+  it("matches matrix target recipients from generic approval forwarding targets", () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "tok",
+        },
+      },
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [
+            { channel: "matrix", to: "user:@target:example.org" },
+            { channel: "matrix", to: "room:!ops:example.org" },
+          ],
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(isMatrixExecApprovalTargetRecipient({ cfg, senderId: "@target:example.org" })).toBe(
+      true,
+    );
+    expect(isMatrixExecApprovalTargetRecipient({ cfg, senderId: "@other:example.org" })).toBe(
+      false,
+    );
+    expect(isMatrixExecApprovalAuthorizedSender({ cfg, senderId: "@target:example.org" })).toBe(
+      true,
+    );
+  });
+
+  it("suppresses local prompts only when the native client is enabled", () => {
+    const payload = {
+      channelData: {
+        execApproval: {
+          approvalId: "req-1",
+          approvalSlug: "req-1",
+        },
+      },
+    };
+
+    expect(
+      shouldSuppressLocalMatrixExecApprovalPrompt({
+        cfg: buildConfig({ enabled: true, approvers: ["@owner:example.org"] }),
+        payload,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSuppressLocalMatrixExecApprovalPrompt({
+        cfg: buildConfig(),
+        payload,
+      }),
+    ).toBe(false);
+  });
+
+  it("normalizes prefixed approver ids", () => {
+    expect(normalizeMatrixApproverId("matrix:@owner:example.org")).toBe("@owner:example.org");
+    expect(normalizeMatrixApproverId("user:@owner:example.org")).toBe("@owner:example.org");
+  });
+
+  it("applies agent and session filters to request handling", () => {
+    const cfg = buildConfig({
+      enabled: true,
+      approvers: ["@owner:example.org"],
+      agentFilter: ["ops-agent"],
+      sessionFilter: ["matrix:channel:", "ops$"],
+    });
+
+    expect(
+      shouldHandleMatrixExecApprovalRequest({
+        cfg,
+        request: {
+          id: "req-1",
+          request: {
+            command: "echo hi",
+            agentId: "ops-agent",
+            sessionKey: "agent:ops-agent:matrix:channel:!room:example.org:ops",
+          },
+          createdAtMs: 0,
+          expiresAtMs: 1000,
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldHandleMatrixExecApprovalRequest({
+        cfg,
+        request: {
+          id: "req-2",
+          request: {
+            command: "echo hi",
+            agentId: "other-agent",
+            sessionKey: "agent:other-agent:matrix:channel:!room:example.org:ops",
+          },
+          createdAtMs: 0,
+          expiresAtMs: 1000,
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/extensions/matrix/src/exec-approvals.test.ts
+++ b/extensions/matrix/src/exec-approvals.test.ts
@@ -32,6 +32,11 @@ function buildConfig(
 describe("matrix exec approvals", () => {
   it("requires enablement and an explicit or inferred approver", () => {
     expect(isMatrixExecApprovalClientEnabled({ cfg: buildConfig() })).toBe(false);
+    expect(
+      isMatrixExecApprovalClientEnabled({
+        cfg: buildConfig(undefined, { dm: { allowFrom: ["@owner:example.org"] } }),
+      }),
+    ).toBe(false);
     expect(isMatrixExecApprovalClientEnabled({ cfg: buildConfig({ enabled: true }) })).toBe(false);
     expect(
       isMatrixExecApprovalClientEnabled({
@@ -54,6 +59,13 @@ describe("matrix exec approvals", () => {
     expect(getMatrixExecApprovalApprovers({ cfg })).toEqual(["@override:example.org"]);
     expect(isMatrixExecApprovalApprover({ cfg, senderId: "@override:example.org" })).toBe(true);
     expect(isMatrixExecApprovalApprover({ cfg, senderId: "@owner:example.org" })).toBe(false);
+  });
+
+  it("ignores wildcard allowlist entries when inferring exec approvers", () => {
+    const cfg = buildConfig({ enabled: true }, { dm: { allowFrom: ["*"] } });
+
+    expect(getMatrixExecApprovalApprovers({ cfg })).toEqual([]);
+    expect(isMatrixExecApprovalClientEnabled({ cfg })).toBe(false);
   });
 
   it("defaults target to dm", () => {
@@ -102,6 +114,8 @@ describe("matrix exec approvals", () => {
         execApproval: {
           approvalId: "req-1",
           approvalSlug: "req-1",
+          agentId: "ops-agent",
+          sessionKey: "agent:ops-agent:matrix:channel:!ops:example.org",
         },
       },
     };
@@ -116,6 +130,30 @@ describe("matrix exec approvals", () => {
     expect(
       shouldSuppressLocalMatrixExecApprovalPrompt({
         cfg: buildConfig(),
+        payload,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps local prompts when filters exclude the request", () => {
+    const payload = {
+      channelData: {
+        execApproval: {
+          approvalId: "req-1",
+          approvalSlug: "req-1",
+          agentId: "other-agent",
+          sessionKey: "agent:other-agent:matrix:channel:!ops:example.org",
+        },
+      },
+    };
+
+    expect(
+      shouldSuppressLocalMatrixExecApprovalPrompt({
+        cfg: buildConfig({
+          enabled: true,
+          approvers: ["@owner:example.org"],
+          agentFilter: ["ops-agent"],
+        }),
         payload,
       }),
     ).toBe(false);

--- a/extensions/matrix/src/exec-approvals.ts
+++ b/extensions/matrix/src/exec-approvals.ts
@@ -117,6 +117,9 @@ export function shouldSuppressLocalMatrixExecApprovalPrompt(params: {
   if (!metadata) {
     return false;
   }
+  if (metadata.approvalKind !== "exec") {
+    return false;
+  }
   const request = buildFilterCheckRequest({
     metadata,
   });

--- a/extensions/matrix/src/exec-approvals.ts
+++ b/extensions/matrix/src/exec-approvals.ts
@@ -1,0 +1,72 @@
+import {
+  createChannelExecApprovalProfile,
+  isChannelExecApprovalTargetRecipient,
+  resolveApprovalRequestAccountId,
+  resolveApprovalApprovers,
+} from "openclaw/plugin-sdk/approval-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { ExecApprovalRequest, PluginApprovalRequest } from "openclaw/plugin-sdk/infra-runtime";
+import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
+import { resolveMatrixAccount } from "./matrix/accounts.js";
+import { normalizeMatrixUserId } from "./matrix/monitor/allowlist.js";
+
+type ApprovalRequest = ExecApprovalRequest | PluginApprovalRequest;
+
+export function normalizeMatrixApproverId(value: string | number): string | undefined {
+  const normalized = normalizeMatrixUserId(String(value));
+  return normalized || undefined;
+}
+
+export function getMatrixExecApprovalApprovers(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): string[] {
+  const account = resolveMatrixAccount(params).config;
+  return resolveApprovalApprovers({
+    explicit: account.execApprovals?.approvers,
+    allowFrom: account.dm?.allowFrom,
+    normalizeApprover: normalizeMatrixApproverId,
+  });
+}
+
+export function isMatrixExecApprovalTargetRecipient(params: {
+  cfg: OpenClawConfig;
+  senderId?: string | null;
+  accountId?: string | null;
+}): boolean {
+  return isChannelExecApprovalTargetRecipient({
+    ...params,
+    channel: "matrix",
+    normalizeSenderId: normalizeMatrixApproverId,
+    matchTarget: ({ target, normalizedSenderId }) =>
+      normalizeMatrixApproverId(target.to) === normalizedSenderId,
+  });
+}
+
+const matrixExecApprovalProfile = createChannelExecApprovalProfile({
+  resolveConfig: (params) => resolveMatrixAccount(params).config.execApprovals,
+  resolveApprovers: getMatrixExecApprovalApprovers,
+  normalizeSenderId: normalizeMatrixApproverId,
+  isTargetRecipient: isMatrixExecApprovalTargetRecipient,
+  matchesRequestAccount: (params) => {
+    const turnSourceChannel = params.request.request.turnSourceChannel?.trim().toLowerCase() || "";
+    const boundAccountId = resolveApprovalRequestAccountId({
+      cfg: params.cfg,
+      request: params.request,
+      channel: turnSourceChannel === "matrix" ? null : "matrix",
+    });
+    return (
+      !boundAccountId ||
+      !params.accountId ||
+      normalizeAccountId(boundAccountId) === normalizeAccountId(params.accountId)
+    );
+  },
+});
+
+export const isMatrixExecApprovalClientEnabled = matrixExecApprovalProfile.isClientEnabled;
+export const isMatrixExecApprovalApprover = matrixExecApprovalProfile.isApprover;
+export const isMatrixExecApprovalAuthorizedSender = matrixExecApprovalProfile.isAuthorizedSender;
+export const resolveMatrixExecApprovalTarget = matrixExecApprovalProfile.resolveTarget;
+export const shouldHandleMatrixExecApprovalRequest = matrixExecApprovalProfile.shouldHandleRequest;
+export const shouldSuppressLocalMatrixExecApprovalPrompt =
+  matrixExecApprovalProfile.shouldSuppressLocalPrompt;

--- a/extensions/matrix/src/exec-approvals.ts
+++ b/extensions/matrix/src/exec-approvals.ts
@@ -91,19 +91,14 @@ export const resolveMatrixExecApprovalTarget = matrixExecApprovalProfile.resolve
 export const shouldHandleMatrixExecApprovalRequest = matrixExecApprovalProfile.shouldHandleRequest;
 
 function buildFilterCheckRequest(params: {
-  approvalId: string;
-  payload: ReplyPayload;
-}): ExecApprovalRequest | null {
-  const metadata = getExecApprovalReplyMetadata(params.payload);
-  if (!metadata) {
-    return null;
-  }
+  metadata: NonNullable<ReturnType<typeof getExecApprovalReplyMetadata>>;
+}): ExecApprovalRequest {
   return {
-    id: params.approvalId,
+    id: params.metadata.approvalId,
     request: {
       command: "",
-      agentId: metadata.agentId ?? null,
-      sessionKey: metadata.sessionKey ?? null,
+      agentId: params.metadata.agentId ?? null,
+      sessionKey: params.metadata.sessionKey ?? null,
     },
     createdAtMs: 0,
     expiresAtMs: 0,
@@ -123,12 +118,8 @@ export function shouldSuppressLocalMatrixExecApprovalPrompt(params: {
     return false;
   }
   const request = buildFilterCheckRequest({
-    approvalId: metadata.approvalId,
-    payload: params.payload,
+    metadata,
   });
-  if (!request) {
-    return false;
-  }
   return shouldHandleMatrixExecApprovalRequest({
     cfg: params.cfg,
     accountId: params.accountId,

--- a/extensions/matrix/src/exec-approvals.ts
+++ b/extensions/matrix/src/exec-approvals.ts
@@ -1,11 +1,13 @@
 import {
   createChannelExecApprovalProfile,
+  getExecApprovalReplyMetadata,
   isChannelExecApprovalTargetRecipient,
   resolveApprovalRequestAccountId,
   resolveApprovalApprovers,
 } from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { ExecApprovalRequest, PluginApprovalRequest } from "openclaw/plugin-sdk/infra-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
 import { resolveMatrixAccount } from "./matrix/accounts.js";
 import { normalizeMatrixUserId } from "./matrix/monitor/allowlist.js";
@@ -17,6 +19,25 @@ export function normalizeMatrixApproverId(value: string | number): string | unde
   return normalized || undefined;
 }
 
+function normalizeMatrixExecApproverId(value: string | number): string | undefined {
+  const normalized = normalizeMatrixApproverId(value);
+  return normalized === "*" ? undefined : normalized;
+}
+
+function resolveMatrixExecApprovalConfig(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}) {
+  const config = resolveMatrixAccount(params).config.execApprovals;
+  if (!config) {
+    return { enabled: false } as const;
+  }
+  return {
+    ...config,
+    enabled: config.enabled === true,
+  };
+}
+
 export function getMatrixExecApprovalApprovers(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
@@ -25,7 +46,7 @@ export function getMatrixExecApprovalApprovers(params: {
   return resolveApprovalApprovers({
     explicit: account.execApprovals?.approvers,
     allowFrom: account.dm?.allowFrom,
-    normalizeApprover: normalizeMatrixApproverId,
+    normalizeApprover: normalizeMatrixExecApproverId,
   });
 }
 
@@ -44,7 +65,7 @@ export function isMatrixExecApprovalTargetRecipient(params: {
 }
 
 const matrixExecApprovalProfile = createChannelExecApprovalProfile({
-  resolveConfig: (params) => resolveMatrixAccount(params).config.execApprovals,
+  resolveConfig: resolveMatrixExecApprovalConfig,
   resolveApprovers: getMatrixExecApprovalApprovers,
   normalizeSenderId: normalizeMatrixApproverId,
   isTargetRecipient: isMatrixExecApprovalTargetRecipient,
@@ -68,5 +89,49 @@ export const isMatrixExecApprovalApprover = matrixExecApprovalProfile.isApprover
 export const isMatrixExecApprovalAuthorizedSender = matrixExecApprovalProfile.isAuthorizedSender;
 export const resolveMatrixExecApprovalTarget = matrixExecApprovalProfile.resolveTarget;
 export const shouldHandleMatrixExecApprovalRequest = matrixExecApprovalProfile.shouldHandleRequest;
-export const shouldSuppressLocalMatrixExecApprovalPrompt =
-  matrixExecApprovalProfile.shouldSuppressLocalPrompt;
+
+function buildFilterCheckRequest(params: {
+  approvalId: string;
+  payload: ReplyPayload;
+}): ExecApprovalRequest | null {
+  const metadata = getExecApprovalReplyMetadata(params.payload);
+  if (!metadata) {
+    return null;
+  }
+  return {
+    id: params.approvalId,
+    request: {
+      command: "",
+      agentId: metadata.agentId ?? null,
+      sessionKey: metadata.sessionKey ?? null,
+    },
+    createdAtMs: 0,
+    expiresAtMs: 0,
+  };
+}
+
+export function shouldSuppressLocalMatrixExecApprovalPrompt(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  payload: ReplyPayload;
+}): boolean {
+  if (!matrixExecApprovalProfile.shouldSuppressLocalPrompt(params)) {
+    return false;
+  }
+  const metadata = getExecApprovalReplyMetadata(params.payload);
+  if (!metadata) {
+    return false;
+  }
+  const request = buildFilterCheckRequest({
+    approvalId: metadata.approvalId,
+    payload: params.payload,
+  });
+  if (!request) {
+    return false;
+  }
+  return shouldHandleMatrixExecApprovalRequest({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    request,
+  });
+}

--- a/extensions/matrix/src/matrix/account-config.ts
+++ b/extensions/matrix/src/matrix/account-config.ts
@@ -121,7 +121,7 @@ export function resolveMatrixAccountConfig(params: {
       | undefined,
     accountId,
     normalizeAccountId,
-    nestedObjectKeys: ["dm", "actions"],
+    nestedObjectKeys: ["dm", "actions", "execApprovals"],
   });
   const accountConfig = findMatrixAccountConfig(params.cfg, accountId);
   const groups = mergeMatrixRoomEntries(

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -1,4 +1,5 @@
 import { format } from "node:util";
+import { MatrixExecApprovalHandler } from "../../exec-approvals-handler.js";
 import {
   GROUP_POLICY_BLOCKED_LABEL,
   resolveThreadBindingIdleTimeoutMsForChannel,
@@ -10,8 +11,8 @@ import {
 } from "../../runtime-api.js";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { CoreConfig, ReplyToMode } from "../../types.js";
-import { resolveConfiguredMatrixBotUserIds } from "../accounts.js";
 import { resolveMatrixAccountConfig } from "../account-config.js";
+import { resolveConfiguredMatrixBotUserIds } from "../accounts.js";
 import { setActiveMatrixClient } from "../active-client.js";
 import {
   isBunRuntime,
@@ -145,6 +146,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   setActiveMatrixClient(client, auth.accountId);
   let cleanedUp = false;
   let threadBindingManager: { accountId: string; stop: () => void } | null = null;
+  let execApprovalsHandler: MatrixExecApprovalHandler | null = null;
   const inboundDeduper = await createMatrixInboundEventDeduper({
     auth,
     env: process.env,
@@ -164,6 +166,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
       client.stopSyncWithoutPersist();
       await client.drainPendingDecryptions("matrix monitor shutdown");
       await waitForInFlightRoomMessages();
+      await execApprovalsHandler?.stop();
       threadBindingManager?.stop();
       await inboundDeduper.stop();
       await releaseSharedClientInstance(client, "persist");
@@ -342,6 +345,13 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
 
     // Shared client is already started via resolveSharedMatrixClient.
     logger.info(`matrix: logged in as ${auth.userId}`);
+
+    execApprovalsHandler = new MatrixExecApprovalHandler({
+      client,
+      accountId: effectiveAccountId,
+      cfg,
+    });
+    await execApprovalsHandler.start();
 
     await runMatrixStartupMaintenance({
       client,

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -64,6 +64,21 @@ export type MatrixThreadBindingsConfig = {
   spawnAcpSessions?: boolean;
 };
 
+export type MatrixExecApprovalTarget = "dm" | "channel" | "both";
+
+export type MatrixExecApprovalConfig = {
+  /** If true, deliver exec approvals through Matrix-native prompts. */
+  enabled?: boolean;
+  /** Optional approver Matrix user IDs. Falls back to dm.allowFrom. */
+  approvers?: Array<string | number>;
+  /** Optional agent allowlist for approval delivery. */
+  agentFilter?: string[];
+  /** Optional session allowlist for approval delivery. */
+  sessionFilter?: string[];
+  /** Where approval prompts should go. Default: dm. */
+  target?: MatrixExecApprovalTarget;
+};
+
 /** Per-account Matrix config (excludes the accounts field to prevent recursion). */
 export type MatrixAccountConfig = Omit<MatrixConfig, "accounts">;
 
@@ -154,6 +169,8 @@ export type MatrixConfig = {
   autoJoinAllowlist?: Array<string | number>;
   /** Direct message policy + allowlist overrides. */
   dm?: MatrixDmConfig;
+  /** Matrix-native exec approval delivery config. */
+  execApprovals?: MatrixExecApprovalConfig;
   /** Room config allowlist keyed by room ID or alias (names resolved to IDs when possible). */
   groups?: Record<string, MatrixRoomConfig>;
   /** Room config allowlist keyed by room ID or alias. Legacy; use groups. */

--- a/extensions/slack/src/approval-native.test.ts
+++ b/extensions/slack/src/approval-native.test.ts
@@ -309,6 +309,7 @@ describe("slack native approval adapter", () => {
     expect(
       shouldSuppress({
         cfg: buildConfig(),
+        approvalKind: "exec",
         target: { channel: "slack", to: "channel:C123ROOM", accountId: "default" },
         request: {
           id: "approval-1",
@@ -326,6 +327,7 @@ describe("slack native approval adapter", () => {
     expect(
       shouldSuppress({
         cfg: buildConfig(),
+        approvalKind: "exec",
         target: { channel: "slack", to: "channel:C123ROOM", accountId: "default" },
         request: {
           id: "approval-1",

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -512,6 +512,7 @@ export type ChannelApprovalDeliveryAdapter = {
   hasConfiguredDmRoute?: (params: { cfg: OpenClawConfig }) => boolean;
   shouldSuppressForwardingFallback?: (params: {
     cfg: OpenClawConfig;
+    approvalKind: ChannelApprovalKind;
     target: ChannelApprovalForwardTarget;
     request: ExecApprovalRequest;
   }) => boolean;

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -483,6 +483,31 @@ describe("exec approval forwarder", () => {
     );
   });
 
+  it("stores exec metadata on generic forwarded fallback payloads", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        payloads: [
+          expect.objectContaining({
+            channelData: expect.objectContaining({
+              execApproval: expect.objectContaining({
+                approvalId: "req-1",
+                approvalKind: "exec",
+                agentId: "main",
+                sessionKey: "agent:main:main",
+              }),
+            }),
+          }),
+        ],
+      }),
+    );
+  });
+
   it("formats single-line commands as inline code", async () => {
     vi.useFakeTimers();
     const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -169,6 +169,7 @@ function buildSyntheticApprovalRequest(routeRequest: ApprovalRouteRequest): Exec
 }
 
 function shouldSkipForwardingFallback(params: {
+  approvalKind: "exec" | "plugin";
   target: ExecApprovalForwardTarget;
   cfg: OpenClawConfig;
   routeRequest: ApprovalRouteRequest;
@@ -181,6 +182,7 @@ function shouldSkipForwardingFallback(params: {
   return (
     adapter?.delivery?.shouldSuppressForwardingFallback?.({
       cfg: params.cfg,
+      approvalKind: params.approvalKind,
       target: params.target,
       request: buildSyntheticApprovalRequest(params.routeRequest),
     }) ?? false
@@ -502,8 +504,15 @@ function createApprovalHandlers<
             resolveSessionTarget: params.resolveSessionTarget,
           })
         : []),
-    ].filter((target) => !shouldSkipForwardingFallback({ target, cfg, routeRequest }));
-
+    ].filter(
+      (target) =>
+        !shouldSkipForwardingFallback({
+          approvalKind: params.strategy.kind,
+          target,
+          cfg,
+          routeRequest,
+        }),
+    );
     if (filteredTargets.length === 0) {
       return false;
     }
@@ -598,7 +607,15 @@ function createApprovalHandlers<
                 resolveSessionTarget: params.resolveSessionTarget,
               })
             : []),
-        ].filter((target) => !shouldSkipForwardingFallback({ target, cfg, routeRequest }));
+        ].filter(
+          (target) =>
+            !shouldSkipForwardingFallback({
+              approvalKind: params.strategy.kind,
+              target,
+              cfg,
+              routeRequest,
+            }),
+        );
       }
     }
     if (!targets?.length) {

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -353,7 +353,9 @@ function buildExecPendingPayload(params: {
     approvalId: params.request.id,
     approvalSlug: params.request.id.slice(0, 8),
     text: buildRequestMessage(params.request, params.nowMs),
+    agentId: params.request.request.agentId ?? null,
     allowedDecisions: resolveExecApprovalRequestAllowedDecisions(params.request.request),
+    sessionKey: params.request.request.sessionKey ?? null,
   });
 }
 

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -85,6 +85,7 @@ describe("exec approval reply helpers", () => {
     ).toEqual({
       approvalId: "req-1",
       approvalSlug: "slug-1",
+      approvalKind: "exec",
       agentId: "agent-1",
       allowedDecisions: ["allow-once", "deny", "allow-always"],
       sessionKey: "session-1",
@@ -108,6 +109,7 @@ describe("exec approval reply helpers", () => {
       execApproval: {
         approvalId: "req-1",
         approvalSlug: "slug-1",
+        approvalKind: "exec",
         agentId: undefined,
         allowedDecisions: ["allow-once", "allow-always", "deny"],
         sessionKey: undefined,
@@ -157,6 +159,7 @@ describe("exec approval reply helpers", () => {
       execApproval: {
         approvalId: "req-ask-always",
         approvalSlug: "slug-always",
+        approvalKind: "exec",
         allowedDecisions: ["allow-once", "deny"],
       },
     });
@@ -200,6 +203,7 @@ describe("exec approval reply helpers", () => {
       execApproval: {
         approvalId: "req-meta",
         approvalSlug: "slug-meta",
+        approvalKind: "exec",
         agentId: "ops-agent",
         allowedDecisions: ["allow-once", "allow-always", "deny"],
         sessionKey: "agent:ops-agent:matrix:channel:!room:example.org",

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -76,14 +76,18 @@ describe("exec approval reply helpers", () => {
           execApproval: {
             approvalId: " req-1 ",
             approvalSlug: " slug-1 ",
+            agentId: " agent-1 ",
             allowedDecisions: ["allow-once", "bad", "deny", "allow-always", 3],
+            sessionKey: " session-1 ",
           },
         },
       }),
     ).toEqual({
       approvalId: "req-1",
       approvalSlug: "slug-1",
+      agentId: "agent-1",
       allowedDecisions: ["allow-once", "deny", "allow-always"],
+      sessionKey: "session-1",
     });
   });
 
@@ -104,7 +108,9 @@ describe("exec approval reply helpers", () => {
       execApproval: {
         approvalId: "req-1",
         approvalSlug: "slug-1",
+        agentId: undefined,
         allowedDecisions: ["allow-once", "allow-always", "deny"],
+        sessionKey: undefined,
       },
     });
     expect(payload.interactive).toEqual({
@@ -177,6 +183,27 @@ describe("exec approval reply helpers", () => {
           ],
         },
       ],
+    });
+  });
+
+  it("stores agent and session metadata for downstream suppression checks", () => {
+    const payload = buildExecApprovalPendingReplyPayload({
+      approvalId: "req-meta",
+      approvalSlug: "slug-meta",
+      agentId: "ops-agent",
+      sessionKey: "agent:ops-agent:matrix:channel:!room:example.org",
+      command: "echo ok",
+      host: "gateway",
+    });
+
+    expect(payload.channelData).toEqual({
+      execApproval: {
+        approvalId: "req-meta",
+        approvalSlug: "slug-meta",
+        agentId: "ops-agent",
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+        sessionKey: "agent:ops-agent:matrix:channel:!room:example.org",
+      },
     });
   });
 

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -15,6 +15,7 @@ export type ExecApprovalUnavailableReason =
 export type ExecApprovalReplyMetadata = {
   approvalId: string;
   approvalSlug: string;
+  approvalKind: "exec" | "plugin";
   agentId?: string;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
   sessionKey?: string;
@@ -229,6 +230,7 @@ export function getExecApprovalReplyMetadata(
   if (!approvalId || !approvalSlug) {
     return null;
   }
+  const approvalKind = record.approvalKind === "plugin" ? "plugin" : "exec";
   const allowedDecisions = Array.isArray(record.allowedDecisions)
     ? record.allowedDecisions.filter(
         (value): value is ExecApprovalReplyDecision =>
@@ -242,6 +244,7 @@ export function getExecApprovalReplyMetadata(
   return {
     approvalId,
     approvalSlug,
+    approvalKind,
     agentId,
     allowedDecisions,
     sessionKey,
@@ -307,6 +310,7 @@ export function buildExecApprovalPendingReplyPayload(
       execApproval: {
         approvalId: params.approvalId,
         approvalSlug: params.approvalSlug,
+        approvalKind: "exec",
         agentId: params.agentId?.trim() || undefined,
         allowedDecisions,
         sessionKey: params.sessionKey?.trim() || undefined,

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -15,7 +15,9 @@ export type ExecApprovalUnavailableReason =
 export type ExecApprovalReplyMetadata = {
   approvalId: string;
   approvalSlug: string;
+  agentId?: string;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
+  sessionKey?: string;
 };
 
 export type ExecApprovalActionDescriptor = {
@@ -31,11 +33,13 @@ export type ExecApprovalPendingReplyParams = {
   approvalSlug: string;
   approvalCommandId?: string;
   ask?: string | null;
+  agentId?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
   command: string;
   cwd?: string;
   host: ExecHost;
   nodeId?: string;
+  sessionKey?: string | null;
   expiresAtMs?: number;
   nowMs?: number;
 };
@@ -231,10 +235,16 @@ export function getExecApprovalReplyMetadata(
           value === "allow-once" || value === "allow-always" || value === "deny",
       )
     : undefined;
+  const agentId =
+    typeof record.agentId === "string" ? record.agentId.trim() || undefined : undefined;
+  const sessionKey =
+    typeof record.sessionKey === "string" ? record.sessionKey.trim() || undefined : undefined;
   return {
     approvalId,
     approvalSlug,
+    agentId,
     allowedDecisions,
+    sessionKey,
   };
 }
 
@@ -297,7 +307,9 @@ export function buildExecApprovalPendingReplyPayload(
       execApproval: {
         approvalId: params.approvalId,
         approvalSlug: params.approvalSlug,
+        agentId: params.agentId?.trim() || undefined,
         allowedDecisions,
+        sessionKey: params.sessionKey?.trim() || undefined,
       },
     },
   };

--- a/src/plugin-sdk/approval-delivery-helpers.test.ts
+++ b/src/plugin-sdk/approval-delivery-helpers.test.ts
@@ -165,6 +165,7 @@ describe("createApproverRestrictedNativeApprovalAdapter", () => {
     expect(
       shouldSuppressForwardingFallback({
         cfg: {} as never,
+        approvalKind: "exec",
         target: { channel: "telegram", to: "target-1" },
         request: {
           request: {
@@ -179,6 +180,7 @@ describe("createApproverRestrictedNativeApprovalAdapter", () => {
     expect(
       shouldSuppressForwardingFallback({
         cfg: {} as never,
+        approvalKind: "exec",
         target: { channel: "telegram", to: "target-1" },
         request: {
           request: {
@@ -193,6 +195,7 @@ describe("createApproverRestrictedNativeApprovalAdapter", () => {
     expect(
       shouldSuppressForwardingFallback({
         cfg: {} as never,
+        approvalKind: "exec",
         target: { channel: "slack", to: "target-1" },
         request: {
           request: {
@@ -208,6 +211,21 @@ describe("createApproverRestrictedNativeApprovalAdapter", () => {
       cfg: {} as never,
       accountId: "topic-1",
     });
+
+    expect(
+      shouldSuppressForwardingFallback({
+        cfg: {} as never,
+        approvalKind: "plugin",
+        target: { channel: "telegram", to: "target-1" },
+        request: {
+          request: {
+            command: "pwd",
+            turnSourceChannel: "telegram",
+            turnSourceAccountId: "topic-1",
+          },
+        } as never,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/plugin-sdk/approval-delivery-helpers.test.ts
+++ b/src/plugin-sdk/approval-delivery-helpers.test.ts
@@ -225,7 +225,7 @@ describe("createApproverRestrictedNativeApprovalAdapter", () => {
           },
         } as never,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });
 

--- a/src/plugin-sdk/approval-delivery-helpers.ts
+++ b/src/plugin-sdk/approval-delivery-helpers.ts
@@ -18,6 +18,7 @@ type ApprovalAdapterParams = {
 
 type DeliverySuppressionParams = {
   cfg: OpenClawConfig;
+  approvalKind: ApprovalKind;
   target: { channel: string; accountId?: string | null };
   request: { request: { turnSourceChannel?: string | null; turnSourceAccountId?: string | null } };
 };
@@ -126,6 +127,9 @@ function buildApproverRestrictedNativeApprovalCapability(
             (resolvedAccountId === undefined
               ? input.target.accountId?.trim()
               : resolvedAccountId.trim()) || undefined;
+          if (input.approvalKind === "plugin") {
+            return false;
+          }
           return params.isNativeDeliveryEnabled({ cfg: input.cfg, accountId });
         },
       },

--- a/src/plugin-sdk/approval-delivery-helpers.ts
+++ b/src/plugin-sdk/approval-delivery-helpers.ts
@@ -127,9 +127,6 @@ function buildApproverRestrictedNativeApprovalCapability(
             (resolvedAccountId === undefined
               ? input.target.accountId?.trim()
               : resolvedAccountId.trim()) || undefined;
-          if (input.approvalKind === "plugin") {
-            return false;
-          }
           return params.isNativeDeliveryEnabled({ cfg: input.cfg, accountId });
         },
       },

--- a/src/plugin-sdk/approval-renderers.test.ts
+++ b/src/plugin-sdk/approval-renderers.test.ts
@@ -89,9 +89,12 @@ describe("plugin-sdk/approval-renderers", () => {
       },
       channelDataExpected: {
         execApproval: {
+          agentId: undefined,
           approvalId: "plugin-approval-123",
+          approvalKind: "plugin",
           approvalSlug: "custom-slug",
           allowedDecisions: ["allow-once", "allow-always", "deny"],
+          sessionKey: undefined,
           state: "pending",
         },
         telegram: {

--- a/src/plugin-sdk/approval-renderers.ts
+++ b/src/plugin-sdk/approval-renderers.ts
@@ -13,10 +13,13 @@ import {
 const DEFAULT_ALLOWED_DECISIONS = ["allow-once", "allow-always", "deny"] as const;
 
 export function buildApprovalPendingReplyPayload(params: {
+  approvalKind?: "exec" | "plugin";
   approvalId: string;
   approvalSlug: string;
   text: string;
+  agentId?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
+  sessionKey?: string | null;
   channelData?: Record<string, unknown>;
 }): ReplyPayload {
   const allowedDecisions = params.allowedDecisions ?? DEFAULT_ALLOWED_DECISIONS;
@@ -30,7 +33,10 @@ export function buildApprovalPendingReplyPayload(params: {
       execApproval: {
         approvalId: params.approvalId,
         approvalSlug: params.approvalSlug,
+        approvalKind: params.approvalKind ?? "exec",
+        agentId: params.agentId?.trim() || undefined,
         allowedDecisions,
+        sessionKey: params.sessionKey?.trim() || undefined,
         state: "pending",
       },
       ...params.channelData,
@@ -66,6 +72,7 @@ export function buildPluginApprovalPendingReplyPayload(params: {
   channelData?: Record<string, unknown>;
 }): ReplyPayload {
   return buildApprovalPendingReplyPayload({
+    approvalKind: "plugin",
     approvalId: params.request.id,
     approvalSlug: params.approvalSlug ?? params.request.id.slice(0, 8),
     text: params.text ?? buildPluginApprovalRequestMessage(params.request, params.nowMs),


### PR DESCRIPTION
## Summary
- add explicit opt-in Matrix native exec approval config, routing, and runtime handling
- keep Matrix plugin approvals on the existing DM auth and forwarding path while preventing hidden or duplicate prompts
- carry approval kind and request routing metadata through shared fallback payloads so Matrix filter-aware local suppression matches the real exec request

## Testing
- pnpm test -- extensions/matrix/src/approval-native.test.ts extensions/matrix/src/exec-approvals.test.ts extensions/matrix/src/exec-approvals-handler.test.ts extensions/slack/src/approval-native.test.ts src/plugin-sdk/approval-delivery-helpers.test.ts src/infra/exec-approval-reply.test.ts src/infra/exec-approval-forwarder.test.ts src/plugin-sdk/approval-renderers.test.ts
- pnpm check
- pnpm build
