### PR TITLE
Webchat: preserve rewritten stream snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Tasks/gateway: re-check the current task record before maintenance marks runs lost or prunes them, so a task heartbeat or cleanup update that lands during a sweep no longer gets overwritten by stale snapshot state.
 - Tasks/gateway: keep the task registry maintenance sweep from stalling the gateway event loop under synchronous SQLite pressure, so upgraded gateways stop hanging about a minute after startup. (#58670) Thanks @openperf
 - Channels/WhatsApp: pass inbound message timestamp to model context so the AI can see when WhatsApp messages were sent. (#58590) Thanks @Maninae
+- Web UI/OpenResponses: preserve rewritten stream snapshots in webchat and keep OpenResponses final streamed text aligned when models rewind earlier output. (#58641) Thanks @neeravmakwana
 
 ## 2026.3.31
 

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -69,11 +69,13 @@ describe("buildAssistantStreamData", () => {
       buildAssistantStreamData({
         text: "hello",
         delta: "he",
+        replace: true,
         mediaUrl: "https://example.com/a.png",
       }),
     ).toEqual({
       text: "hello",
       delta: "he",
+      replace: true,
       mediaUrls: ["https://example.com/a.png"],
     });
   });

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -153,13 +153,15 @@ export function hasAssistantVisibleReply(params: {
 export function buildAssistantStreamData(params: {
   text?: string;
   delta?: string;
+  replace?: boolean;
   mediaUrls?: string[];
   mediaUrl?: string;
-}): { text: string; delta: string; mediaUrls?: string[] } {
+}): { text: string; delta: string; replace?: true; mediaUrls?: string[] } {
   const mediaUrls = resolveSendableOutboundReplyParts(params).mediaUrls;
   return {
     text: params.text ?? "",
     delta: params.delta ?? "",
+    replace: params.replace ? true : undefined,
     mediaUrls: mediaUrls.length ? mediaUrls : undefined,
   };
 }
@@ -310,13 +312,15 @@ export function handleMessageUpdate(
 
     let shouldEmit = false;
     let deltaText = "";
+    let replace = false;
     if (!hasAssistantVisibleReply({ text: cleanedText, mediaUrls, audioAsVoice: hasAudio })) {
       shouldEmit = false;
-    } else if (previousCleaned && !cleanedText.startsWith(previousCleaned)) {
-      shouldEmit = false;
     } else {
-      deltaText = cleanedText.slice(previousCleaned.length);
-      shouldEmit = Boolean(deltaText || hasMedia || hasAudio);
+      replace = Boolean(previousCleaned && !cleanedText.startsWith(previousCleaned));
+      deltaText = replace ? "" : cleanedText.slice(previousCleaned.length);
+      shouldEmit = replace
+        ? cleanedText !== previousCleaned || hasMedia || hasAudio
+        : Boolean(deltaText || hasMedia || hasAudio);
     }
 
     ctx.state.lastStreamedAssistant = next;
@@ -330,6 +334,7 @@ export function handleMessageUpdate(
       const data = buildAssistantStreamData({
         text: cleanedText,
         delta: deltaText,
+        replace,
         mediaUrls,
       });
       emitAgentEvent({

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -316,7 +316,7 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(payloads).toHaveLength(1);
   });
 
-  it("skips agent events when cleaned text rewinds mid-stream", () => {
+  it("emits a replacement snapshot when cleaned text rewinds mid-stream", () => {
     const { emit, onAgentEvent } = createAgentEventHarness();
 
     emit({ type: "message_start", message: { role: "assistant" } });
@@ -324,8 +324,13 @@ describe("subscribeEmbeddedPiSession", () => {
     emitAssistantTextDelta(emit, " https://example.com/a.png\nCaption");
 
     const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
-    expect(payloads).toHaveLength(1);
+    expect(payloads).toHaveLength(2);
     expect(payloads[0]?.text).toBe("MEDIA:");
+    expect(payloads[0]?.delta).toBe("MEDIA:");
+    expect(payloads[0]?.replace).toBeUndefined();
+    expect(payloads[1]?.text).toBe("Caption");
+    expect(payloads[1]?.delta).toBe("");
+    expect(payloads[1]?.replace).toBe(true);
   });
 
   it("emits agent events when media arrives without text", () => {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -920,6 +920,11 @@ export async function handleOpenResponsesHttpRequest(
     }
 
     if (evt.stream === "assistant") {
+      const text = evt.data?.text;
+      const replace = evt.data?.replace === true;
+      if (replace && typeof text === "string") {
+        accumulatedText = text;
+      }
       const content = resolveAssistantStreamDeltaText(evt);
       if (!content) {
         return;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -134,6 +134,25 @@ describe("handleChatEvent", () => {
     expect(state.chatMessages).toEqual([]);
   });
 
+  it("replaces the stream when a delta snapshot gets shorter", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Alpha beta",
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Alpha" }],
+      },
+    };
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(state.chatStream).toBe("Alpha");
+  });
+
   it("returns final for another run when payload has no message", () => {
     const state = createActiveStreamingState();
     const payload: ChatEventPayload = {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -295,10 +295,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (payload.state === "delta") {
     const next = extractText(payload.message);
     if (typeof next === "string" && !isSilentReplyStream(next)) {
-      const current = state.chatStream ?? "";
-      if (!current || next.length >= current.length) {
-        state.chatStream = next;
-      }
+      state.chatStream = next;
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);


### PR DESCRIPTION
#### Summary

Fix the webchat streaming path so assistant text revisions are treated as replacement snapshots instead of being silently dropped. This keeps rewritten structured replies, including table-like output, visible during streaming and after history refresh.

#### Repro Steps

1. Use a model that rewrites earlier characters while producing structured output.
2. Request a response with table-like or aligned multiline text.
3. Observe that the streaming path can rewind from an earlier snapshot to a shorter corrected one.
4. Before this change, the agent stream suppressed that correction and the webchat controller also rejected shorter replacement snapshots.

#### Root Cause

The assistant streaming pipeline assumed visible text only ever grew monotonically.

- `src/agents/pi-embedded-subscribe.handlers.messages.ts` dropped updates when cleaned text no longer started with the previous cleaned snapshot.
- `ui/src/ui/controllers/chat.ts` ignored chat deltas when the next visible snapshot was shorter than the current one.
- `src/gateway/openresponses-http.ts` also needed to keep its accumulated text in sync when replacement snapshots occur.

#### Behavior Changes

- Emit assistant replacement snapshots instead of suppressing rewritten stream updates.
- Let the webchat controller replace the current stream with shorter corrected snapshots.
- Keep OpenResponses' accumulated text aligned with replacement snapshots.
- Add regressions for the rewind case in both the agent stream and the webchat controller.

#### Codebase and GitHub Search

- Related issue: [#58631](https://github.com/openclaw/openclaw/issues/58631)
- Code paths reviewed: `src/agents/pi-embedded-subscribe.handlers.messages.ts`, `ui/src/ui/controllers/chat.ts`, `ui/src/ui/chat/message-extract.ts`, `ui/src/ui/chat/grouped-render.ts`, `ui/src/ui/markdown.ts`, `src/gateway/openresponses-http.ts`
- Existing tests reviewed: `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.e2e.test.ts`, `ui/src/ui/controllers/chat.test.ts`, `ui/src/ui/markdown.test.ts`

#### Tests

- Passed: `pnpm exec vitest run --config vitest.config.ts src/ui/controllers/chat.test.ts src/ui/chat/message-extract.test.ts src/ui/markdown.test.ts`
- Failed outside this change: `pnpm check` currently reports repo-wide format-check failures across many files.
- Failed outside this change: `pnpm build` currently fails in `vendor/a2ui/renderers/lit/src/0.8/model.test.ts` during `canvas:a2ui:bundle` with missing Node builtin type names.
- Failed outside this change: `pnpm exec vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.e2e.test.ts` currently aborts before running tests with `getOAuthProviders is not a function`.

#### Manual Testing

Not run locally beyond the targeted automated regression coverage above.

**Sign-Off**

- Models used: GPT-5.4
- Submitter effort: investigated the reported repro path, implemented a focused fix, and ran targeted validation.
- Agent notes: AI-assisted change; lightly tested with targeted UI regressions and issue/code-path review. lobster-biscuit

Made with [Cursor](https://cursor.com)