### PR TITLE
fix(reply-runtime): preserve final answer in /reasoning on with block replies

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1290,6 +1290,7 @@ export async function runEmbeddedPiAgent(
 
           const payloads = buildEmbeddedRunPayloads({
             assistantTexts: attempt.assistantTexts,
+            assistantTextBaseline: attempt.assistantTextBaseline,
             toolMetas: attempt.toolMetas,
             lastAssistant: attempt.lastAssistant,
             lastToolError: attempt.lastToolError,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -419,64 +419,64 @@ export async function runEmbeddedAttempt(
       ? []
       : (() => {
           const allTools = createOpenClawCodingTools({
-          agentId: sessionAgentId,
-          trigger: params.trigger,
-          memoryFlushWritePath: params.memoryFlushWritePath,
-          exec: {
-            ...params.execOverrides,
-            elevated: params.bashElevated,
-          },
-          sandbox,
-          messageProvider: params.messageChannel ?? params.messageProvider,
-          agentAccountId: params.agentAccountId,
-          messageTo: params.messageTo,
-          messageThreadId: params.messageThreadId,
-          groupId: params.groupId,
-          groupChannel: params.groupChannel,
-          groupSpace: params.groupSpace,
-          spawnedBy: params.spawnedBy,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          senderUsername: params.senderUsername,
-          senderE164: params.senderE164,
-          senderIsOwner: params.senderIsOwner,
-          allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-          sessionKey: sandboxSessionKey,
-          sessionId: params.sessionId,
-          runId: params.runId,
-          agentDir,
-          workspaceDir: effectiveWorkspace,
-          // When sandboxing uses a copied workspace (`ro` or `none`), effectiveWorkspace points
-          // at the sandbox copy. Spawned subagents should inherit the real workspace instead.
-          spawnWorkspaceDir: resolveAttemptSpawnWorkspaceDir({
+            agentId: sessionAgentId,
+            trigger: params.trigger,
+            memoryFlushWritePath: params.memoryFlushWritePath,
+            exec: {
+              ...params.execOverrides,
+              elevated: params.bashElevated,
+            },
             sandbox,
-            resolvedWorkspace,
-          }),
-          config: params.config,
-          abortSignal: runAbortController.signal,
-          modelProvider: params.model.provider,
-          modelId: params.modelId,
-          modelCompat: params.model.compat,
-          modelApi: params.model.api,
-          modelContextWindowTokens: params.model.contextWindow,
-          modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
-          currentChannelId: params.currentChannelId,
-          currentThreadTs: params.currentThreadTs,
-          currentMessageId: params.currentMessageId,
-          replyToMode: params.replyToMode,
-          hasRepliedRef: params.hasRepliedRef,
-          modelHasVision,
-          requireExplicitMessageTarget:
-            params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
-          disableMessageTool: params.disableMessageTool,
-          onYield: (message) => {
-            yieldDetected = true;
-            yieldMessage = message;
-            queueYieldInterruptForSession?.();
-            runAbortController.abort("sessions_yield");
-            abortSessionForYield?.();
-          },
-        });
+            messageProvider: params.messageChannel ?? params.messageProvider,
+            agentAccountId: params.agentAccountId,
+            messageTo: params.messageTo,
+            messageThreadId: params.messageThreadId,
+            groupId: params.groupId,
+            groupChannel: params.groupChannel,
+            groupSpace: params.groupSpace,
+            spawnedBy: params.spawnedBy,
+            senderId: params.senderId,
+            senderName: params.senderName,
+            senderUsername: params.senderUsername,
+            senderE164: params.senderE164,
+            senderIsOwner: params.senderIsOwner,
+            allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+            sessionKey: sandboxSessionKey,
+            sessionId: params.sessionId,
+            runId: params.runId,
+            agentDir,
+            workspaceDir: effectiveWorkspace,
+            // When sandboxing uses a copied workspace (`ro` or `none`), effectiveWorkspace points
+            // at the sandbox copy. Spawned subagents should inherit the real workspace instead.
+            spawnWorkspaceDir: resolveAttemptSpawnWorkspaceDir({
+              sandbox,
+              resolvedWorkspace,
+            }),
+            config: params.config,
+            abortSignal: runAbortController.signal,
+            modelProvider: params.model.provider,
+            modelId: params.modelId,
+            modelCompat: params.model.compat,
+            modelApi: params.model.api,
+            modelContextWindowTokens: params.model.contextWindow,
+            modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
+            currentChannelId: params.currentChannelId,
+            currentThreadTs: params.currentThreadTs,
+            currentMessageId: params.currentMessageId,
+            replyToMode: params.replyToMode,
+            hasRepliedRef: params.hasRepliedRef,
+            modelHasVision,
+            requireExplicitMessageTarget:
+              params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
+            disableMessageTool: params.disableMessageTool,
+            onYield: (message) => {
+              yieldDetected = true;
+              yieldMessage = message;
+              queueYieldInterruptForSession?.();
+              runAbortController.abort("sessions_yield");
+              abortSessionForYield?.();
+            },
+          });
           if (params.toolsAllow && params.toolsAllow.length > 0) {
             const allowSet = new Set(params.toolsAllow);
             return allTools.filter((tool) => allowSet.has(tool.name));
@@ -621,7 +621,7 @@ export async function runEmbeddedAttempt(
     const promptMode = resolvePromptModeForSession(params.sessionKey);
 
     // When toolsAllow is set, use minimal prompt and strip skills catalog
-    const effectivePromptMode = params.toolsAllow?.length ? "minimal" as const : promptMode;
+    const effectivePromptMode = params.toolsAllow?.length ? ("minimal" as const) : promptMode;
     const effectiveSkillsPrompt = params.toolsAllow?.length ? undefined : skillsPrompt;
     const docsPath = await resolveOpenClawDocsPath({
       workspaceDir: effectiveWorkspace,
@@ -1284,6 +1284,7 @@ export async function runEmbeddedAttempt(
         getMessagingToolSentMediaUrls,
         getMessagingToolSentTargets,
         getSuccessfulCronAdds,
+        getAssistantTextBaseline,
         didSendViaMessagingTool,
         getLastToolError,
         getUsageTotals,
@@ -1859,6 +1860,7 @@ export async function runEmbeddedAttempt(
         systemPromptReport,
         messagesSnapshot,
         assistantTexts,
+        assistantTextBaseline: getAssistantTextBaseline?.(),
         toolMetas: toolMetasNormalized,
         lastAssistant,
         lastToolError: getLastToolError?.(),

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -65,6 +65,46 @@ describe("buildEmbeddedRunPayloads reasoning-on fallback", () => {
     expect(texts).toContain("Earlier block reply text");
     expect(texts).not.toContain("Final answer");
   });
+
+  it("does not duplicate when multi-chunk assistantTexts already covers the full answer", () => {
+    const lastAssistant = makeAssistantMessageFixture({
+      stopReason: "stop",
+      errorMessage: undefined,
+      content: [{ type: "text", text: "Part 1\nPart 2" }],
+    });
+
+    // Block-reply chunking split the answer into two entries.
+    // Concatenating them reproduces the fallback text.
+    const payloads = buildPayloads({
+      assistantTexts: ["Part 1", "Part 2"],
+      lastAssistant,
+      reasoningLevel: "on",
+    });
+
+    const answerPayloads = payloads.filter((p) => !p.isReasoning);
+    const answerTexts = answerPayloads.map((p) => p.text).filter(Boolean);
+    // Each chunk should appear once; the combined fallback must NOT be appended
+    expect(answerTexts).toEqual(["Part 1", "Part 2"]);
+  });
+
+  it("appends fallback when multi-chunk assistantTexts differ from the final answer", () => {
+    const lastAssistant = makeAssistantMessageFixture({
+      stopReason: "stop",
+      errorMessage: undefined,
+      content: [{ type: "text", text: "Completely different final answer" }],
+    });
+
+    const payloads = buildPayloads({
+      assistantTexts: ["Part 1", "Part 2"],
+      lastAssistant,
+      reasoningLevel: "on",
+    });
+
+    const answerPayloads = payloads.filter((p) => !p.isReasoning);
+    const answerTexts = answerPayloads.map((p) => p.text).filter(Boolean);
+    // Chunks are preserved and the different fallback is appended
+    expect(answerTexts).toEqual(["Part 1", "Part 2", "Completely different final answer"]);
+  });
 });
 
 describe("buildEmbeddedRunPayloads tool-error warnings", () => {

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -1,5 +1,71 @@
 import { describe, expect, it } from "vitest";
+import { makeAssistantMessageFixture } from "../../test-helpers/assistant-message-fixtures.js";
 import { buildPayloads, expectSingleToolErrorPayload } from "./payloads.test-helpers.js";
+
+describe("buildEmbeddedRunPayloads reasoning-on fallback", () => {
+  it("includes fallback answer when reasoning is on and assistantTexts has earlier content", () => {
+    const lastAssistant = makeAssistantMessageFixture({
+      stopReason: "stop",
+      errorMessage: undefined,
+      content: [
+        { type: "thinking", thinking: "Because it helps" },
+        { type: "text", text: "Final answer" },
+      ],
+    });
+
+    // assistantTexts has earlier block-reply text but NOT the final answer
+    const payloads = buildPayloads({
+      assistantTexts: ["Earlier block reply text"],
+      lastAssistant,
+      reasoningLevel: "on",
+    });
+
+    const texts = payloads.map((p) => p.text);
+    // The earlier text should still be present
+    expect(texts).toContain("Earlier block reply text");
+    // The final answer must be appended from fallback
+    expect(texts).toContain("Final answer");
+  });
+
+  it("does not duplicate when assistantTexts already contains the final answer", () => {
+    const lastAssistant = makeAssistantMessageFixture({
+      stopReason: "stop",
+      errorMessage: undefined,
+      content: [{ type: "text", text: "Final answer" }],
+    });
+
+    const payloads = buildPayloads({
+      assistantTexts: ["Final answer"],
+      lastAssistant,
+      reasoningLevel: "on",
+    });
+
+    const answerPayloads = payloads.filter((p) => !p.isReasoning);
+    // Should not duplicate the answer
+    const answerTexts = answerPayloads.map((p) => p.text).filter(Boolean);
+    const finalCount = answerTexts.filter((t) => t === "Final answer").length;
+    expect(finalCount).toBe(1);
+  });
+
+  it("does not append fallback when reasoning is off", () => {
+    const lastAssistant = makeAssistantMessageFixture({
+      stopReason: "stop",
+      errorMessage: undefined,
+      content: [{ type: "text", text: "Final answer" }],
+    });
+
+    const payloads = buildPayloads({
+      assistantTexts: ["Earlier block reply text"],
+      lastAssistant,
+      reasoningLevel: "off",
+    });
+
+    const texts = payloads.map((p) => p.text);
+    // Should only contain assistantTexts, not the fallback
+    expect(texts).toContain("Earlier block reply text");
+    expect(texts).not.toContain("Final answer");
+  });
+});
 
 describe("buildEmbeddedRunPayloads tool-error warnings", () => {
   function expectNoPayloads(params: Parameters<typeof buildPayloads>[0]) {

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -105,6 +105,34 @@ describe("buildEmbeddedRunPayloads reasoning-on fallback", () => {
     // Chunks are preserved and the different fallback is appended
     expect(answerTexts).toEqual(["Part 1", "Part 2", "Completely different final answer"]);
   });
+
+  it("does not duplicate when assistantTexts contains earlier messages plus current message chunks", () => {
+    const lastAssistant = makeAssistantMessageFixture({
+      stopReason: "stop",
+      errorMessage: undefined,
+      content: [{ type: "text", text: "Part 1\nPart 2" }],
+    });
+
+    // Simulates multi-turn run where assistantTexts accumulated across messages:
+    // - entries 0-1 belong to a previous assistant message (tool call confirmation)
+    // - entries 2-3 belong to the current final answer (baseline = 2)
+    const payloads = buildPayloads({
+      assistantTexts: ["Tool result acknowledged", "Calling next tool...", "Part 1", "Part 2"],
+      assistantTextBaseline: 2,
+      lastAssistant,
+      reasoningLevel: "on",
+    });
+
+    const answerPayloads = payloads.filter((p) => !p.isReasoning);
+    const answerTexts = answerPayloads.map((p) => p.text).filter(Boolean);
+    // All four entries should be present; the combined fallback must NOT be appended
+    expect(answerTexts).toEqual([
+      "Tool result acknowledged",
+      "Calling next tool...",
+      "Part 1",
+      "Part 2",
+    ]);
+  });
 });
 
 describe("buildEmbeddedRunPayloads tool-error warnings", () => {

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -106,6 +106,27 @@ describe("buildEmbeddedRunPayloads reasoning-on fallback", () => {
     expect(answerTexts).toEqual(["Part 1", "Part 2", "Completely different final answer"]);
   });
 
+  it("does not duplicate when multi-chunk hard-split covers a long unbroken answer", () => {
+    const lastAssistant = makeAssistantMessageFixture({
+      stopReason: "stop",
+      errorMessage: undefined,
+      // A long line with no whitespace — chunker hard-splits at maxChars
+      content: [{ type: "text", text: "ABCDEFGHIJKLMNOPQRSTUVWXYZ" }],
+    });
+
+    // Block-reply chunker hard-split the unbroken text; no separator between chunks
+    const payloads = buildPayloads({
+      assistantTexts: ["ABCDEFGHIJ", "KLMNOPQRSTUVWXYZ"],
+      lastAssistant,
+      reasoningLevel: "on",
+    });
+
+    const answerPayloads = payloads.filter((p) => !p.isReasoning);
+    const answerTexts = answerPayloads.map((p) => p.text).filter(Boolean);
+    // Chunks preserved; fallback must NOT be appended
+    expect(answerTexts).toEqual(["ABCDEFGHIJ", "KLMNOPQRSTUVWXYZ"]);
+  });
+
   it("does not duplicate when assistantTexts contains earlier messages plus current message chunks", () => {
     const lastAssistant = makeAssistantMessageFixture({
       stopReason: "stop",

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -272,7 +272,12 @@ export function buildEmbeddedRunPayloads(params: {
     (currentMessageSources.some((t) => normalizeTextForComparison(t) === normalizedFallback) ||
       // ... then check whether concatenating all chunks reproduces the fallback,
       // which handles multi-chunk block replies that split a single answer.
-      normalizeTextForComparison(currentMessageSources.join("\n")) === normalizedFallback),
+      // EmbeddedBlockChunker may strip whitespace at split boundaries, so we
+      // check both no-separator (hard splits) and single-space (soft splits).
+      // normalizeTextForComparison collapses all whitespace to single spaces,
+      // so join(" ") matches when original had whitespace that chunker ate.
+      normalizeTextForComparison(currentMessageSources.join("")) === normalizedFallback ||
+      normalizeTextForComparison(currentMessageSources.join(" ")) === normalizedFallback),
   );
   const needsFallbackAppend =
     !suppressAssistantArtifacts &&

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -251,25 +251,27 @@ export function buildEmbeddedRunPayloads(params: {
     return isRawApiErrorPayload(trimmed);
   };
   // When reasoning is on and assistantTexts contains earlier block-reply content,
-  // the final answer may not be represented. Ensure fallbackAnswerText is appended
-  // when it is not already covered by assistantTexts.
-  const rawAnswerSources = params.assistantTexts.length ? params.assistantTexts : [];
+  // the final answer may not be represented. Append fallbackAnswerText when it
+  // is not already covered — either as a single matching entry or as the
+  // concatenation of all chunked entries.
+  const rawAnswerSources = params.assistantTexts;
   const normalizedFallback = fallbackAnswerText
     ? normalizeTextForComparison(fallbackAnswerText)
     : "";
-  const fallbackAlreadyCovered =
+  const fallbackAlreadyCovered = Boolean(
     normalizedFallback &&
     rawAnswerSources.length > 0 &&
     // Check per-element exact match first (single chunk covers the full answer) ...
     (rawAnswerSources.some((t) => normalizeTextForComparison(t) === normalizedFallback) ||
       // ... then check whether concatenating all chunks reproduces the fallback,
       // which handles multi-chunk block replies that split a single answer.
-      normalizeTextForComparison(rawAnswerSources.join("\n")) === normalizedFallback);
+      normalizeTextForComparison(rawAnswerSources.join("\n")) === normalizedFallback),
+  );
   const needsFallbackAppend =
     !suppressAssistantArtifacts &&
     rawAnswerSources.length > 0 &&
     params.reasoningLevel === "on" &&
-    normalizedFallback &&
+    Boolean(normalizedFallback) &&
     !fallbackAlreadyCovered;
   const answerTexts = suppressAssistantArtifacts
     ? []

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -254,14 +254,23 @@ export function buildEmbeddedRunPayloads(params: {
   // the final answer may not be represented. Ensure fallbackAnswerText is appended
   // when it is not already covered by assistantTexts.
   const rawAnswerSources = params.assistantTexts.length ? params.assistantTexts : [];
+  const normalizedFallback = fallbackAnswerText
+    ? normalizeTextForComparison(fallbackAnswerText)
+    : "";
+  const fallbackAlreadyCovered =
+    normalizedFallback &&
+    rawAnswerSources.length > 0 &&
+    // Check per-element exact match first (single chunk covers the full answer) ...
+    (rawAnswerSources.some((t) => normalizeTextForComparison(t) === normalizedFallback) ||
+      // ... then check whether concatenating all chunks reproduces the fallback,
+      // which handles multi-chunk block replies that split a single answer.
+      normalizeTextForComparison(rawAnswerSources.join("\n")) === normalizedFallback);
   const needsFallbackAppend =
     !suppressAssistantArtifacts &&
     rawAnswerSources.length > 0 &&
     params.reasoningLevel === "on" &&
-    fallbackAnswerText &&
-    !rawAnswerSources.some(
-      (t) => normalizeTextForComparison(t) === normalizeTextForComparison(fallbackAnswerText),
-    );
+    normalizedFallback &&
+    !fallbackAlreadyCovered;
   const answerTexts = suppressAssistantArtifacts
     ? []
     : (rawAnswerSources.length

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -250,10 +250,24 @@ export function buildEmbeddedRunPayloads(params: {
     }
     return isRawApiErrorPayload(trimmed);
   };
+  // When reasoning is on and assistantTexts contains earlier block-reply content,
+  // the final answer may not be represented. Ensure fallbackAnswerText is appended
+  // when it is not already covered by assistantTexts.
+  const rawAnswerSources = params.assistantTexts.length ? params.assistantTexts : [];
+  const needsFallbackAppend =
+    !suppressAssistantArtifacts &&
+    rawAnswerSources.length > 0 &&
+    params.reasoningLevel === "on" &&
+    fallbackAnswerText &&
+    !rawAnswerSources.some(
+      (t) => normalizeTextForComparison(t) === normalizeTextForComparison(fallbackAnswerText),
+    );
   const answerTexts = suppressAssistantArtifacts
     ? []
-    : (params.assistantTexts.length
-        ? params.assistantTexts
+    : (rawAnswerSources.length
+        ? needsFallbackAppend
+          ? [...rawAnswerSources, fallbackAnswerText]
+          : rawAnswerSources
         : fallbackAnswerText
           ? [fallbackAnswerText]
           : []

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -90,6 +90,7 @@ function resolveToolErrorWarningPolicy(params: {
 
 export function buildEmbeddedRunPayloads(params: {
   assistantTexts: string[];
+  assistantTextBaseline?: number;
   toolMetas: ToolMetaEntry[];
   lastAssistant: AssistantMessage | undefined;
   lastToolError?: LastToolError;
@@ -254,18 +255,24 @@ export function buildEmbeddedRunPayloads(params: {
   // the final answer may not be represented. Append fallbackAnswerText when it
   // is not already covered — either as a single matching entry or as the
   // concatenation of all chunked entries.
+  //
+  // Only compare entries from the current assistant message (baseline onward)
+  // to avoid false negatives when assistantTexts accumulates across messages.
   const rawAnswerSources = params.assistantTexts;
+  const currentMessageSources = params.assistantTextBaseline
+    ? rawAnswerSources.slice(params.assistantTextBaseline)
+    : rawAnswerSources;
   const normalizedFallback = fallbackAnswerText
     ? normalizeTextForComparison(fallbackAnswerText)
     : "";
   const fallbackAlreadyCovered = Boolean(
     normalizedFallback &&
-    rawAnswerSources.length > 0 &&
+    currentMessageSources.length > 0 &&
     // Check per-element exact match first (single chunk covers the full answer) ...
-    (rawAnswerSources.some((t) => normalizeTextForComparison(t) === normalizedFallback) ||
+    (currentMessageSources.some((t) => normalizeTextForComparison(t) === normalizedFallback) ||
       // ... then check whether concatenating all chunks reproduces the fallback,
       // which handles multi-chunk block replies that split a single answer.
-      normalizeTextForComparison(rawAnswerSources.join("\n")) === normalizedFallback),
+      normalizeTextForComparison(currentMessageSources.join("\n")) === normalizedFallback),
   );
   const needsFallbackAppend =
     !suppressAssistantArtifacts &&

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -44,6 +44,9 @@ export type EmbeddedRunAttemptResult = {
   systemPromptReport?: SessionSystemPromptReport;
   messagesSnapshot: AgentMessage[];
   assistantTexts: string[];
+  /** Index in assistantTexts where the current assistant message starts.
+   * Entries before this belong to earlier assistant messages in the same run. */
+  assistantTextBaseline?: number;
   toolMetas: Array<{ toolName: string; meta?: string }>;
   lastAssistant: AssistantMessage | undefined;
   lastToolError?: {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -708,6 +708,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     getMessagingToolSentMediaUrls: () => messagingToolSentMediaUrls.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),
     getSuccessfulCronAdds: () => state.successfulCronAdds,
+    getAssistantTextBaseline: () => state.assistantTextBaseline,
     // Returns true if any messaging tool successfully sent a message.
     // Used to suppress agent's confirmation text (e.g., "Respondi no Telegram!")
     // which is generated AFTER the tool sends the actual answer.

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -214,7 +214,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       pushAssistantText(text);
     }
 
-    state.assistantTextBaseline = assistantTexts.length;
+    // NOTE: We intentionally do NOT update assistantTextBaseline here.
+    // The baseline must remain pointing to the start of the current assistant
+    // message so that buildEmbeddedRunPayloads can correctly scope its fallback
+    // deduplication to entries from this message only. The baseline will be
+    // updated by resetAssistantMessageState when the next assistant message starts.
   };
 
   // ── Messaging tool duplicate detection ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- When `/reasoning on` is active and the channel registers `onBlockReply` (e.g. DingTalk AI cards), the final assistant answer could be lost in the assembled reply payload
- Root cause: `finalizeAssistantTexts` skips both branches when `includeReasoning + onBlockReply + addedDuringMessage` are all true, leaving `assistantTexts` with only earlier block-reply content. `buildEmbeddedRunPayloads` then ignores `fallbackAnswerText` because `assistantTexts` is non-empty
- Fix: in `buildEmbeddedRunPayloads`, when `reasoningLevel === "on"` and `assistantTexts` does not already contain the final answer (compared via `normalizeTextForComparison`), append `fallbackAnswerText` to the answer sources

## Test plan

- [x] New test: `includes fallback answer when reasoning is on and assistantTexts has earlier content` — verifies the core bug fix
- [x] New test: `does not duplicate when assistantTexts already contains the final answer` — verifies deduplication
- [x] New test: `does not append fallback when reasoning is off` — verifies no impact on non-reasoning modes
- [x] All existing payloads tests pass (41 tests)
- [x] All previously passing subscribe tests remain green
- [ ] Manual verification on DingTalk AI card channel with `/reasoning on`

Closes #58627