### PR TITLE
fix(diffs): ship viewer runtime asset

### DIFF
--- a/dist/extensions/assets/viewer-runtime.js
+++ b/dist/extensions/assets/viewer-runtime.js
@@ -1,0 +1,23 @@
+const DIFFS_TAG_NAME = "diffs-container";
+
+if (typeof HTMLElement !== "undefined" && customElements.get(DIFFS_TAG_NAME) == null) {
+  class DiffsContainerElement extends HTMLElement {
+    constructor() {
+      super();
+      if (this.shadowRoot != null) return;
+
+      const template = this.querySelector(':scope > template[shadowrootmode="open"]');
+      if (!(template instanceof HTMLTemplateElement)) return;
+
+      const shadowRoot = this.attachShadow({ mode: "open" });
+      shadowRoot.append(template.content.cloneNode(true));
+      template.remove();
+    }
+  }
+
+  customElements.define(DIFFS_TAG_NAME, DiffsContainerElement);
+}
+
+document.documentElement.dataset.openclawDiffsReady = "true";
+
+export const DiffsContainerLoaded = true;

--- a/src/plugins/diffs-bundled-assets.test.ts
+++ b/src/plugins/diffs-bundled-assets.test.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const diffsPluginIndexPath = path.join(repoRoot, "dist/extensions/diffs/index.js");
+const viewerRuntimePath = path.join(repoRoot, "dist/extensions/assets/viewer-runtime.js");
+
+describe("bundled diffs viewer assets", () => {
+  test("references the shipped viewer runtime asset from the bundled diffs plugin", async () => {
+    const pluginIndex = await fs.readFile(diffsPluginIndexPath, "utf8");
+
+    expect(pluginIndex).toContain("../assets/viewer-runtime.js");
+    expect(pluginIndex).toContain('import "${VIEWER_RUNTIME_RELATIVE_IMPORT_PATH}?v=${hash}";');
+  });
+
+  test("ships the expected viewer runtime asset", async () => {
+    const viewerRuntime = await fs.readFile(viewerRuntimePath, "utf8");
+
+    expect(viewerRuntime).toContain('const DIFFS_TAG_NAME = "diffs-container";');
+    expect(viewerRuntime).toContain('shadowrootmode="open"');
+    expect(viewerRuntime).toContain(
+      'document.documentElement.dataset.openclawDiffsReady = "true";',
+    );
+  });
+});


### PR DESCRIPTION
#### Summary

Ship the missing `dist/extensions/assets/viewer-runtime.js` file that the bundled `diffs` plugin already resolves at runtime, and add a regression test that checks the shipped asset boundary.

#### Repro Steps

1. Install the published package with the bundled `diffs` plugin enabled.
2. Invoke the `diffs` tool so the viewer route tries to load `/plugins/diffs/assets/viewer-runtime.js`.
3. Observe the missing-file failure because `dist/extensions/assets/viewer-runtime.js` was not present in the packed artifact.

#### Root Cause

The bundled plugin loader in `dist/extensions/diffs/index.js` already resolves `../assets/viewer-runtime.js`, but the runtime asset was absent from `dist/extensions/assets/`, so packaged installs failed at asset load time.

#### Behavior Changes

- The packaged `diffs` viewer now ships the runtime asset at the exact path the bundled plugin already loads.
- The runtime asset sets the ready marker and includes a declarative shadow DOM fallback so the prerendered diff HTML still upgrades if the browser does not hydrate the shadow root automatically.
- Added a regression test that asserts the bundled plugin still points at the shipped runtime asset and that the runtime asset file is present.

#### Codebase and GitHub Search

- Searched the bundled `diffs` plugin for `viewer-runtime.js`, `getServedViewerAsset`, and `loadViewerAssets` to confirm the failing runtime path.
- Checked `npm pack --json --dry-run --ignore-scripts` output to verify the packaged file list before and after the fix.
- Confirmed the reported behavior against [Issue #58598](https://github.com/openclaw/openclaw/issues/58598).

#### Tests

- `node --input-type=module -e '...` to verify the bundled plugin still resolves `../assets/viewer-runtime.js` and that the shipped asset contains the ready marker plus the shadow DOM fallback.
- `npm pack --json --dry-run --ignore-scripts` to verify the tarball now contains `dist/extensions/assets/viewer-runtime.js`.
- `pnpm exec vitest run src/plugins/diffs-bundled-assets.test.ts --config vitest.unit.config.ts` currently fails before executing tests because of an unrelated repo import error: `getOAuthProviders is not a function` from `src/agents/auth-profiles/oauth.ts`.

#### Manual Testing (omit if N/A)

N/A

#### Evidence (omit if N/A)

- `npm pack --json --dry-run --ignore-scripts` now includes `dist/extensions/assets/viewer-runtime.js`. lobster-biscuit

**Sign-Off**

- Models used: GPT-5.4
- Submitter effort: Investigated the packaged artifact, reproduced the missing shipped asset boundary, and kept the fix scoped to the runtime file the bundle already expects.
- Agent notes: The tracked source for this bundled extension is not present in this checkout, so the fix is intentionally scoped to the shipped runtime artifact plus a regression check around that packaged boundary.

Made with [Cursor](https://cursor.com)