### PR TITLE
fix: grant default operator scopes when gateway auth mode is none (#58357)

### DIFF
--- a/src/gateway/http-utils.request-context.test.ts
+++ b/src/gateway/http-utils.request-context.test.ts
@@ -100,6 +100,21 @@ describe("resolveTrustedHttpOperatorScopes", () => {
 
     expect(scopes).toEqual([]);
   });
+
+  it("restores default operator scopes for auth-none without scope header", () => {
+    const scopes = resolveTrustedHttpOperatorScopes(createReq(), {
+      authMethod: "none",
+      trustDeclaredOperatorScopes: true,
+    });
+
+    expect(scopes).toEqual([
+      "operator.admin",
+      "operator.read",
+      "operator.write",
+      "operator.approvals",
+      "operator.pairing",
+    ]);
+  });
 });
 
 describe("resolveHttpSenderIsOwner", () => {
@@ -154,6 +169,36 @@ describe("resolveOpenAiCompatibleHttpOperatorScopes", () => {
 
     expect(scopes).toEqual(["operator.write"]);
   });
+
+  it("restores default operator scopes for auth-none", () => {
+    const scopes = resolveOpenAiCompatibleHttpOperatorScopes(createReq(), {
+      authMethod: "none",
+      trustDeclaredOperatorScopes: true,
+    });
+
+    expect(scopes).toEqual([
+      "operator.admin",
+      "operator.read",
+      "operator.write",
+      "operator.approvals",
+      "operator.pairing",
+    ]);
+  });
+
+  it("restores default operator scopes for auth-none even without scope header", () => {
+    const scopes = resolveOpenAiCompatibleHttpOperatorScopes(createReq({}), {
+      authMethod: "none",
+      trustDeclaredOperatorScopes: true,
+    });
+
+    expect(scopes).toEqual([
+      "operator.admin",
+      "operator.read",
+      "operator.write",
+      "operator.approvals",
+      "operator.pairing",
+    ]);
+  });
 });
 
 describe("resolveOpenAiCompatibleHttpSenderIsOwner", () => {
@@ -181,6 +226,15 @@ describe("resolveOpenAiCompatibleHttpSenderIsOwner", () => {
         createReq({ "x-openclaw-scopes": "operator.admin" }),
         { authMethod: "trusted-proxy", trustDeclaredOperatorScopes: true },
       ),
+    ).toBe(true);
+  });
+
+  it("treats auth-none as owner on the compat surface", () => {
+    expect(
+      resolveOpenAiCompatibleHttpSenderIsOwner(createReq(), {
+        authMethod: "none",
+        trustDeclaredOperatorScopes: true,
+      }),
     ).toBe(true);
   });
 });

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -155,10 +155,7 @@ export function resolveOpenAiCompatibleHttpOperatorScopes(
   req: IncomingMessage,
   requestAuth: AuthorizedGatewayHttpRequest,
 ): string[] {
-  if (
-    usesSharedSecretGatewayMethod(requestAuth.authMethod) ||
-    requestAuth.authMethod === "none"
-  ) {
+  if (usesSharedSecretGatewayMethod(requestAuth.authMethod) || requestAuth.authMethod === "none") {
     // Shared-secret HTTP bearer auth is a documented trusted-operator surface
     // for the compat APIs and direct /tools/invoke. This is designed-as-is:
     // token/password auth proves possession of the gateway operator secret, not
@@ -185,10 +182,7 @@ export function resolveOpenAiCompatibleHttpSenderIsOwner(
   req: IncomingMessage,
   requestAuth: AuthorizedGatewayHttpRequest,
 ): boolean {
-  if (
-    usesSharedSecretGatewayMethod(requestAuth.authMethod) ||
-    requestAuth.authMethod === "none"
-  ) {
+  if (usesSharedSecretGatewayMethod(requestAuth.authMethod) || requestAuth.authMethod === "none") {
     // Shared-secret HTTP bearer auth also carries owner semantics on the compat
     // APIs and direct /tools/invoke. This is intentional: there is no separate
     // per-request owner primitive on that shared-secret path, so owner-only

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -127,8 +127,14 @@ export function resolveTrustedHttpOperatorScopes(
   req: IncomingMessage,
   authOrRequest?:
     | SharedSecretGatewayAuth
-    | Pick<AuthorizedGatewayHttpRequest, "trustDeclaredOperatorScopes">,
+    | Pick<AuthorizedGatewayHttpRequest, "authMethod" | "trustDeclaredOperatorScopes">,
 ): string[] {
+  // auth-none means no security boundary at all — grant default operator
+  // scopes so unauthenticated HTTP callers are not rejected by scope gates.
+  if (authOrRequest && "authMethod" in authOrRequest && authOrRequest.authMethod === "none") {
+    return [...CLI_DEFAULT_OPERATOR_SCOPES];
+  }
+
   if (!shouldTrustDeclaredHttpOperatorScopes(req, authOrRequest)) {
     // Gateway bearer auth only proves possession of the shared secret. Do not
     // let HTTP clients self-assert operator scopes through request headers.
@@ -149,11 +155,18 @@ export function resolveOpenAiCompatibleHttpOperatorScopes(
   req: IncomingMessage,
   requestAuth: AuthorizedGatewayHttpRequest,
 ): string[] {
-  if (usesSharedSecretGatewayMethod(requestAuth.authMethod)) {
+  if (
+    usesSharedSecretGatewayMethod(requestAuth.authMethod) ||
+    requestAuth.authMethod === "none"
+  ) {
     // Shared-secret HTTP bearer auth is a documented trusted-operator surface
     // for the compat APIs and direct /tools/invoke. This is designed-as-is:
     // token/password auth proves possession of the gateway operator secret, not
     // a narrower per-request scope identity, so restore the normal defaults.
+    //
+    // auth-none means no security boundary is configured at all, so HTTP
+    // requests should receive the same default operator scopes that the CLI
+    // and other first-party callers get.
     return [...CLI_DEFAULT_OPERATOR_SCOPES];
   }
   return resolveTrustedHttpOperatorScopes(req, requestAuth);
@@ -163,7 +176,7 @@ export function resolveHttpSenderIsOwner(
   req: IncomingMessage,
   authOrRequest?:
     | SharedSecretGatewayAuth
-    | Pick<AuthorizedGatewayHttpRequest, "trustDeclaredOperatorScopes">,
+    | Pick<AuthorizedGatewayHttpRequest, "authMethod" | "trustDeclaredOperatorScopes">,
 ): boolean {
   return resolveTrustedHttpOperatorScopes(req, authOrRequest).includes(ADMIN_SCOPE);
 }
@@ -172,11 +185,16 @@ export function resolveOpenAiCompatibleHttpSenderIsOwner(
   req: IncomingMessage,
   requestAuth: AuthorizedGatewayHttpRequest,
 ): boolean {
-  if (usesSharedSecretGatewayMethod(requestAuth.authMethod)) {
+  if (
+    usesSharedSecretGatewayMethod(requestAuth.authMethod) ||
+    requestAuth.authMethod === "none"
+  ) {
     // Shared-secret HTTP bearer auth also carries owner semantics on the compat
     // APIs and direct /tools/invoke. This is intentional: there is no separate
     // per-request owner primitive on that shared-secret path, so owner-only
     // tool policy follows the documented trusted-operator contract.
+    //
+    // auth-none has no security boundary, so grant owner semantics as well.
     return true;
   }
   return resolveHttpSenderIsOwner(req, requestAuth);


### PR DESCRIPTION
## Summary

Fixes #58357 — HTTP `/v1/chat/completions` returns `403 missing scope: operator.write` when gateway runs with `--auth none`.

## Root Cause

`resolveOpenAiCompatibleHttpOperatorScopes` only checked `usesSharedSecretGatewayMethod(requestAuth.authMethod)` which returns `false` for `authMethod === "none"`, causing it to fall through to `resolveTrustedHttpOperatorScopes` which returns `[]` when no `x-openclaw-scopes` header is present.

## Changes

- **`src/gateway/http-utils.ts`**: Added `|| requestAuth.authMethod === "none"` to three scope/owner resolution functions so auth-none requests receive `CLI_DEFAULT_OPERATOR_SCOPES` and owner semantics, matching the behavior of shared-secret methods.
- **`src/gateway/http-utils.request-context.test.ts`**: Added 4 test cases covering auth-none scope resolution on both compat and non-compat endpoints.

## Test Evidence

All 17 tests in `http-utils.request-context.test.ts` pass including 4 new auth-none cases.