### PR TITLE
fix: strip SecretRef marker values from getApiKeyAndHeaders result (#58087)

### DIFF
--- a/src/agents/pi-model-discovery.auth.test.ts
+++ b/src/agents/pi-model-discovery.auth.test.ts
@@ -477,4 +477,96 @@ describe("discoverAuthStorage", () => {
       expect(model?.compat?.toolCallArgumentsEncoding).toBe("html-entities");
     });
   });
+
+  it("strips secretref-managed marker values from getApiKeyAndHeaders result", async () => {
+    await withAgentDir(async (agentDir) => {
+      await writeModelsJson(agentDir, {
+        providers: {
+          "custom-provider": {
+            api: "openai-completions",
+            baseUrl: "https://api.example.com/v1",
+            apiKey: "EXAMPLE_API_KEY",
+            headers: {
+              "x-custom-header": "secretref-managed",
+              "x-normal-header": "normal-value",
+            },
+            models: [
+              {
+                id: "test-model",
+                name: "Test Model",
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 128000,
+                maxTokens: 4096,
+              },
+            ],
+          },
+        },
+      });
+
+      process.env.EXAMPLE_API_KEY = "sk-test-key";
+      try {
+        const authStorage = discoverAuthStorage(agentDir);
+        const modelRegistry = discoverModels(authStorage, agentDir);
+        const model = modelRegistry.find("custom-provider", "test-model");
+        expect(model).toBeTruthy();
+        const auth = await modelRegistry.getApiKeyAndHeaders(model!);
+        expect(auth.ok).toBe(true);
+        if (auth.ok) {
+          // The "secretref-managed" marker should be stripped
+          expect(auth.headers?.["x-custom-header"]).toBeUndefined();
+          // Normal headers should be preserved
+          expect(auth.headers?.["x-normal-header"]).toBe("normal-value");
+        }
+      } finally {
+        delete process.env.EXAMPLE_API_KEY;
+      }
+    });
+  });
+
+  it("strips secretref-env header marker values from getApiKeyAndHeaders result", async () => {
+    await withAgentDir(async (agentDir) => {
+      await writeModelsJson(agentDir, {
+        providers: {
+          "custom-provider": {
+            api: "openai-completions",
+            baseUrl: "https://api.example.com/v1",
+            apiKey: "EXAMPLE_API_KEY",
+            headers: {
+              "x-env-header": "secretref-env:MY_SECRET_VAR",
+              "x-keep-header": "real-value",
+            },
+            models: [
+              {
+                id: "test-model",
+                name: "Test Model",
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 128000,
+                maxTokens: 4096,
+              },
+            ],
+          },
+        },
+      });
+
+      process.env.EXAMPLE_API_KEY = "sk-test-key";
+      try {
+        const authStorage = discoverAuthStorage(agentDir);
+        const modelRegistry = discoverModels(authStorage, agentDir);
+        const model = modelRegistry.find("custom-provider", "test-model");
+        expect(model).toBeTruthy();
+        const auth = await modelRegistry.getApiKeyAndHeaders(model!);
+        expect(auth.ok).toBe(true);
+        if (auth.ok) {
+          // The "secretref-env:" marker should be stripped
+          expect(auth.headers?.["x-env-header"]).toBeUndefined();
+          // Normal headers should be preserved
+          expect(auth.headers?.["x-keep-header"]).toBe("real-value");
+        }
+      } finally {
+        delete process.env.EXAMPLE_API_KEY;
+      }
+    });
+  });
 });

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -15,6 +15,7 @@ import {
 import type { ProviderRuntimeModel } from "../plugins/types.js";
 import { ensureAuthProfileStore } from "./auth-profiles.js";
 import { PROVIDER_ENV_API_KEY_CANDIDATES } from "./model-auth-env-vars.js";
+import { isSecretRefHeaderValueMarker } from "./model-auth-markers.js";
 import { resolveEnvApiKey } from "./model-auth-env.js";
 import { resolvePiCredentialMapFromStore, type PiCredentialMap } from "./pi-auth-credentials.js";
 
@@ -134,6 +135,30 @@ function createOpenClawModelRegistry(
     getAvailable().map((entry: Model<Api>) => normalizeRegistryModel(entry, agentDir));
   registry.find = (provider: string, modelId: string) =>
     normalizeRegistryModel(find(provider, modelId), agentDir);
+
+  // Sanitize headers returned by getApiKeyAndHeaders to strip SecretRef
+  // marker values (e.g. "secretref-managed") that the upstream registry
+  // may have stored from models.json provider/model header entries.
+  const getApiKeyAndHeaders = registry.getApiKeyAndHeaders.bind(registry);
+  registry.getApiKeyAndHeaders = async (model: Model<Api>) => {
+    const result = await getApiKeyAndHeaders(model);
+    if (!result.ok || !result.headers) {
+      return result;
+    }
+    const sanitized: Record<string, string> = {};
+    let kept = 0;
+    for (const [key, value] of Object.entries(result.headers)) {
+      if (typeof value === "string" && isSecretRefHeaderValueMarker(value)) {
+        continue;
+      }
+      sanitized[key] = value;
+      kept++;
+    }
+    return {
+      ...result,
+      headers: kept > 0 ? sanitized : undefined,
+    };
+  };
 
   return registry;
 }

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -15,8 +15,8 @@ import {
 import type { ProviderRuntimeModel } from "../plugins/types.js";
 import { ensureAuthProfileStore } from "./auth-profiles.js";
 import { PROVIDER_ENV_API_KEY_CANDIDATES } from "./model-auth-env-vars.js";
-import { isSecretRefHeaderValueMarker } from "./model-auth-markers.js";
 import { resolveEnvApiKey } from "./model-auth-env.js";
+import { isSecretRefHeaderValueMarker } from "./model-auth-markers.js";
 import { resolvePiCredentialMapFromStore, type PiCredentialMap } from "./pi-auth-credentials.js";
 
 const PiAuthStorageClass = PiCodingAgent.AuthStorage;


### PR DESCRIPTION
## Summary

Fixes #58087 — SecretRef-backed model provider headers sent as literal `"secretref-managed"` in API requests, causing 401 failures on custom providers.

## Root Cause

The `@mariozechner/pi-coding-agent` library's `ModelRegistry.getApiKeyAndHeaders()` spreads `providerHeaders` and `modelHeaders` from its internal Maps **after** `model.headers`. These Map values contain raw markers like `"secretref-managed"` from `models.json`, which overwrite the already-resolved secret values.

## Changes

- **`src/agents/pi-model-discovery.ts`**: Override `getApiKeyAndHeaders` on the `OpenClawModelRegistry` instance to post-process the result, stripping any header values matching `isSecretRefHeaderValueMarker()` before they reach the HTTP client.
- **`src/agents/pi-model-discovery.auth.test.ts`**: Added 2 test cases verifying marker stripping for both `secretref-managed` and `secretref-env:*` header values.

## Test Evidence

All 11 tests in `pi-model-discovery.auth.test.ts` pass including 2 new marker-stripping cases.