### PR TITLE
fix(acpx): repair queue owner session recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/exec approvals: route topic-aware exec approval followups through Telegram-owned threading and approval-target parsing, so forum-topic approvals stay in the originating topic instead of falling back to the root chat. (#58783)
 - Agents/failover: unify structured and raw provider error classification so provider-specific `400`/`422` payloads no longer get forced into generic format failures before retry, billing, or compaction logic can inspect them. (#58856) Thanks @aaron-he-zhu.
 - Auth profiles/store: coerce misplaced SecretRef objects out of plaintext `key` and `token` fields during store load so agents without ACP runtime stop crashing on `.trim()` after upgrade. (#58923) Thanks @openperf.
+- ACPX/runtime: repair `queue owner unavailable` session recovery by replacing dead named sessions and resuming the backend session when ACPX exposes a stable session id, so the first ACP prompt no longer inherits a dead handle. (#58669) Thanks @neeravmakwana
 
 ## 2026.3.31
 

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -47,6 +47,7 @@ async function expectSessionEnsureFallback(params: {
   env?: Record<string, string>;
   expectNewAfterStatus: boolean;
   expectedRecordId?: string;
+  expectedResumeSessionId?: string | null;
 }) {
   const previousEnv = new Map<string, string | undefined>();
   for (const [key, value] of Object.entries(params.env ?? {})) {
@@ -77,6 +78,17 @@ async function expectSessionEnsureFallback(params: {
       expect(newIndex).toBeGreaterThan(statusIndex);
     } else {
       expect(newIndex).toBe(-1);
+    }
+    const newEntry = newIndex >= 0 ? logs[newIndex] : null;
+    const newArgs = ((newEntry?.args as string[]) ?? []).slice();
+    const resumeFlagIndex = newArgs.indexOf("--resume-session");
+    if (params.expectedResumeSessionId === undefined) {
+      // No assertion requested for resume behavior.
+    } else if (params.expectedResumeSessionId === null) {
+      expect(resumeFlagIndex).toBe(-1);
+    } else {
+      expect(resumeFlagIndex).toBeGreaterThanOrEqual(0);
+      expect(newArgs[resumeFlagIndex + 1]).toBe(params.expectedResumeSessionId);
     }
   } finally {
     for (const [key, value] of previousEnv.entries()) {
@@ -241,14 +253,15 @@ describe("AcpxRuntime", () => {
     expect(resumeArgs[resumeFlagIndex + 1]).toBe(resumeSessionId);
   });
 
-  it("retains dead named sessions when status only reports queue owner unavailable", async () => {
+  it("repairs dead named sessions when status only reports queue owner unavailable", async () => {
     await expectSessionEnsureFallback({
       sessionKey: "agent:codex:acp:dead-session",
       env: {
         MOCK_ACPX_STATUS_STATUS: "dead",
         MOCK_ACPX_STATUS_SUMMARY: "queue owner unavailable",
       },
-      expectNewAfterStatus: false,
+      expectNewAfterStatus: true,
+      expectedResumeSessionId: "sid-agent:codex:acp:dead-session",
     });
   });
 
@@ -275,7 +288,7 @@ describe("AcpxRuntime", () => {
     });
   });
 
-  it("retains the named session after ensure failure when status only reports queue owner unavailable", async () => {
+  it("repairs the named session after ensure failure when status only reports queue owner unavailable", async () => {
     await expectSessionEnsureFallback({
       sessionKey: "agent:codex:acp:ensure-fallback-dead",
       env: {
@@ -283,8 +296,22 @@ describe("AcpxRuntime", () => {
         MOCK_ACPX_STATUS_STATUS: "dead",
         MOCK_ACPX_STATUS_SUMMARY: "queue owner unavailable",
       },
-      expectNewAfterStatus: false,
+      expectNewAfterStatus: true,
       expectedRecordId: "rec-agent:codex:acp:ensure-fallback-dead",
+      expectedResumeSessionId: "sid-agent:codex:acp:ensure-fallback-dead",
+    });
+  });
+
+  it("falls back to a fresh named session when queue owner recovery has no resumable id", async () => {
+    await expectSessionEnsureFallback({
+      sessionKey: "agent:codex:acp:dead-session-no-ids",
+      env: {
+        MOCK_ACPX_STATUS_STATUS: "dead",
+        MOCK_ACPX_STATUS_SUMMARY: "queue owner unavailable",
+        MOCK_ACPX_STATUS_NO_IDS: "1",
+      },
+      expectNewAfterStatus: true,
+      expectedResumeSessionId: null,
     });
   });
 

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -71,15 +71,17 @@ async function expectSessionEnsureFallback(params: {
     const logs = await readMockRuntimeLogEntries(logPath);
     const ensureIndex = logs.findIndex((entry) => entry.kind === "ensure");
     const statusIndex = logs.findIndex((entry) => entry.kind === "status");
-    const newIndex = logs.findIndex((entry) => entry.kind === "new");
+    const newEntries = logs.filter((entry) => entry.kind === "new");
+    const newEntry = newEntries[0] ?? null;
+    const newIndex = newEntry ? logs.indexOf(newEntry) : -1;
     expect(ensureIndex).toBeGreaterThanOrEqual(0);
     expect(statusIndex).toBeGreaterThan(ensureIndex);
     if (params.expectNewAfterStatus) {
+      expect(newEntries).toHaveLength(1);
       expect(newIndex).toBeGreaterThan(statusIndex);
     } else {
-      expect(newIndex).toBe(-1);
+      expect(newEntries).toHaveLength(0);
     }
-    const newEntry = newIndex >= 0 ? logs[newIndex] : null;
     const newArgs = ((newEntry?.args as string[]) ?? []).slice();
     const resumeFlagIndex = newArgs.indexOf("--resume-session");
     if (params.expectedResumeSessionId === undefined) {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -129,6 +129,10 @@ function shouldRetainNamedSessionForDeadStatus(detail: AcpxJsonObject | undefine
   return summary?.includes("queue owner unavailable") ?? false;
 }
 
+function resolveResumeSessionIdFromDetail(detail: AcpxJsonObject | undefined): string | undefined {
+  return asOptionalString(detail?.acpxSessionId) ?? asOptionalString(detail?.agentSessionId);
+}
+
 function formatAcpxControlErrorMessage(params: {
   code?: string;
   message: string;
@@ -350,6 +354,27 @@ export class AcpxRuntime implements AcpRuntime {
     });
   }
 
+  private async replaceDeadNamedSession(params: {
+    detail: AcpxJsonObject | undefined;
+    sessionName: string;
+    agent: string;
+    cwd: string;
+    logContext: string;
+  }): Promise<AcpxJsonObject[]> {
+    const resumeSessionId = resolveResumeSessionIdFromDetail(params.detail);
+    this.logger?.warn?.(
+      resumeSessionId
+        ? `acpx ensureSession repairing dead named session by resuming backend session: session=${params.sessionName} cwd=${params.cwd} resumeSessionId=${resumeSessionId} ${params.logContext}`
+        : `acpx ensureSession repairing dead named session with fresh session owner: session=${params.sessionName} cwd=${params.cwd} ${params.logContext}`,
+    );
+    return await this.createNamedSession({
+      agent: params.agent,
+      cwd: params.cwd,
+      sessionName: params.sessionName,
+      ...(resumeSessionId ? { resumeSessionId } : {}),
+    });
+  }
+
   private async shouldReplaceEnsuredSession(params: {
     sessionName: string;
     agent: string;
@@ -388,10 +413,14 @@ export class AcpxRuntime implements AcpRuntime {
     if (status === "dead") {
       const summary = summarizeLogText(asOptionalString(detail?.summary) ?? "");
       if (shouldRetainNamedSessionForDeadStatus(detail)) {
-        this.logger?.warn?.(
-          `acpx ensureSession retaining dead named session with recoverable status: session=${params.sessionName} cwd=${params.cwd} status=${status} summary=${summary || "<empty>"}`,
-        );
-        return false;
+        await this.replaceDeadNamedSession({
+          detail,
+          sessionName: params.sessionName,
+          agent: params.agent,
+          cwd: params.cwd,
+          logContext: `status=${status} summary=${summary || "<empty>"}`,
+        });
+        return true;
       }
       this.logger?.warn?.(
         `acpx ensureSession replacing dead named session: session=${params.sessionName} cwd=${params.cwd} status=${status} summary=${summary || "<empty>"}`,
@@ -451,10 +480,13 @@ export class AcpxRuntime implements AcpRuntime {
     if (status === "dead") {
       const summary = summarizeLogText(asOptionalString(detail?.summary) ?? "");
       if (shouldRetainNamedSessionForDeadStatus(detail)) {
-        this.logger?.warn?.(
-          `acpx ensureSession retaining dead named session after ensure failure with recoverable status: session=${params.sessionName} cwd=${params.cwd} status=${status} summary=${summary || "<empty>"}`,
-        );
-        return events;
+        return await this.replaceDeadNamedSession({
+          detail,
+          sessionName: params.sessionName,
+          agent: params.agent,
+          cwd: params.cwd,
+          logContext: `status=${status} summary=${summary || "<empty>"}`,
+        });
       }
       this.logger?.warn?.(
         `acpx ensureSession replacing dead named session after ensure failure: session=${params.sessionName} cwd=${params.cwd}`,

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -74,6 +74,11 @@ type AcpxHealthCheckResult =
           };
     };
 
+type EnsureFailureRecoveryResult = {
+  events: AcpxJsonObject[];
+  skipPostEnsureReplacement: boolean;
+};
+
 function formatPermissionModeGuidance(): string {
   return "Configure plugins.entries.acpx.config.permissionMode to one of: approve-reads, approve-all, deny-all.";
 }
@@ -379,7 +384,7 @@ export class AcpxRuntime implements AcpRuntime {
     sessionName: string;
     agent: string;
     cwd: string;
-  }): Promise<boolean> {
+  }): Promise<{ replace: boolean; replacementEvents?: AcpxJsonObject[] }> {
     const args = await this.buildVerbArgs({
       agent: params.agent,
       cwd: params.cwd,
@@ -397,7 +402,7 @@ export class AcpxRuntime implements AcpRuntime {
       this.logger?.warn?.(
         `acpx ensureSession status probe failed: session=${params.sessionName} cwd=${params.cwd} error=${summarizeLogText(error instanceof Error ? error.message : String(error)) || "<empty>"}`,
       );
-      return false;
+      return { replace: false };
     }
 
     const noSession = events.some((event) => toAcpxErrorEvent(event)?.code === "NO_SESSION");
@@ -405,7 +410,7 @@ export class AcpxRuntime implements AcpRuntime {
       this.logger?.warn?.(
         `acpx ensureSession replacing missing named session: session=${params.sessionName} cwd=${params.cwd}`,
       );
-      return true;
+      return { replace: true };
     }
 
     const detail = events.find((event) => !toAcpxErrorEvent(event));
@@ -413,22 +418,24 @@ export class AcpxRuntime implements AcpRuntime {
     if (status === "dead") {
       const summary = summarizeLogText(asOptionalString(detail?.summary) ?? "");
       if (shouldRetainNamedSessionForDeadStatus(detail)) {
-        await this.replaceDeadNamedSession({
-          detail,
-          sessionName: params.sessionName,
-          agent: params.agent,
-          cwd: params.cwd,
-          logContext: `status=${status} summary=${summary || "<empty>"}`,
-        });
-        return true;
+        return {
+          replace: true,
+          replacementEvents: await this.replaceDeadNamedSession({
+            detail,
+            sessionName: params.sessionName,
+            agent: params.agent,
+            cwd: params.cwd,
+            logContext: `status=${status} summary=${summary || "<empty>"}`,
+          }),
+        };
       }
       this.logger?.warn?.(
         `acpx ensureSession replacing dead named session: session=${params.sessionName} cwd=${params.cwd} status=${status} summary=${summary || "<empty>"}`,
       );
-      return true;
+      return { replace: true };
     }
 
-    return false;
+    return { replace: false };
   }
 
   private async recoverEnsureFailure(params: {
@@ -436,7 +443,7 @@ export class AcpxRuntime implements AcpRuntime {
     agent: string;
     cwd: string;
     error: unknown;
-  }): Promise<AcpxJsonObject[] | null> {
+  }): Promise<EnsureFailureRecoveryResult | null> {
     const errorMessage = summarizeLogText(
       params.error instanceof Error ? params.error.message : String(params.error),
     );
@@ -468,11 +475,14 @@ export class AcpxRuntime implements AcpRuntime {
       this.logger?.warn?.(
         `acpx ensureSession creating named session after ensure failure and missing status: session=${params.sessionName} cwd=${params.cwd}`,
       );
-      return await this.createNamedSession({
-        agent: params.agent,
-        cwd: params.cwd,
-        sessionName: params.sessionName,
-      });
+      return {
+        events: await this.createNamedSession({
+          agent: params.agent,
+          cwd: params.cwd,
+          sessionName: params.sessionName,
+        }),
+        skipPostEnsureReplacement: true,
+      };
     }
 
     const detail = events.find((event) => !toAcpxErrorEvent(event));
@@ -480,29 +490,38 @@ export class AcpxRuntime implements AcpRuntime {
     if (status === "dead") {
       const summary = summarizeLogText(asOptionalString(detail?.summary) ?? "");
       if (shouldRetainNamedSessionForDeadStatus(detail)) {
-        return await this.replaceDeadNamedSession({
-          detail,
-          sessionName: params.sessionName,
-          agent: params.agent,
-          cwd: params.cwd,
-          logContext: `status=${status} summary=${summary || "<empty>"}`,
-        });
+        return {
+          events: await this.replaceDeadNamedSession({
+            detail,
+            sessionName: params.sessionName,
+            agent: params.agent,
+            cwd: params.cwd,
+            logContext: `status=${status} summary=${summary || "<empty>"}`,
+          }),
+          skipPostEnsureReplacement: true,
+        };
       }
       this.logger?.warn?.(
         `acpx ensureSession replacing dead named session after ensure failure: session=${params.sessionName} cwd=${params.cwd}`,
       );
-      return await this.createNamedSession({
-        agent: params.agent,
-        cwd: params.cwd,
-        sessionName: params.sessionName,
-      });
+      return {
+        events: await this.createNamedSession({
+          agent: params.agent,
+          cwd: params.cwd,
+          sessionName: params.sessionName,
+        }),
+        skipPostEnsureReplacement: true,
+      };
     }
 
     if (status === "alive" || findSessionIdentifierEvent(events)) {
       this.logger?.warn?.(
         `acpx ensureSession reusing live named session after ensure failure: session=${params.sessionName} cwd=${params.cwd} status=${status || "unknown"}`,
       );
-      return events;
+      return {
+        events,
+        skipPostEnsureReplacement: false,
+      };
     }
 
     return null;
@@ -521,6 +540,7 @@ export class AcpxRuntime implements AcpRuntime {
     const mode = input.mode;
     const resumeSessionId = asTrimmedString(input.resumeSessionId);
     let events: AcpxJsonObject[];
+    let skipPostEnsureReplacement = false;
     if (resumeSessionId) {
       events = await this.createNamedSession({
         agent,
@@ -549,7 +569,8 @@ export class AcpxRuntime implements AcpRuntime {
         if (!recovered) {
           throw error;
         }
-        events = recovered;
+        events = recovered.events;
+        skipPostEnsureReplacement = recovered.skipPostEnsureReplacement;
       }
     }
     if (events.length === 0) {
@@ -559,26 +580,27 @@ export class AcpxRuntime implements AcpRuntime {
     }
     let ensuredEvent = findSessionIdentifierEvent(events);
 
-    if (
-      ensuredEvent &&
-      !resumeSessionId &&
-      (await this.shouldReplaceEnsuredSession({
+    if (ensuredEvent && !resumeSessionId && !skipPostEnsureReplacement) {
+      const replacement = await this.shouldReplaceEnsuredSession({
         sessionName,
         agent,
         cwd,
-      }))
-    ) {
-      events = await this.createNamedSession({
-        agent,
-        cwd,
-        sessionName,
       });
-      if (events.length === 0) {
-        this.logger?.warn?.(
-          `acpx ensureSession returned no events after replacing dead session: session=${sessionName} agent=${agent} cwd=${cwd}`,
-        );
+      if (replacement.replace) {
+        events =
+          replacement.replacementEvents ??
+          (await this.createNamedSession({
+            agent,
+            cwd,
+            sessionName,
+          }));
+        if (events.length === 0) {
+          this.logger?.warn?.(
+            `acpx ensureSession returned no events after replacing dead session: session=${sessionName} agent=${agent} cwd=${cwd}`,
+          );
+        }
+        ensuredEvent = findSessionIdentifierEvent(events);
       }
-      ensuredEvent = findSessionIdentifierEvent(events);
     }
 
     if (!ensuredEvent && !resumeSessionId) {

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -201,10 +201,11 @@ if (command === "status") {
   }
   const status = process.env.MOCK_ACPX_STATUS_STATUS || (sessionFromOption ? "alive" : "no-session");
   const summary = process.env.MOCK_ACPX_STATUS_SUMMARY || "";
+  const omitStatusIds = process.env.MOCK_ACPX_STATUS_NO_IDS === "1";
   emitJson({
-    acpxRecordId: sessionFromOption ? "rec-" + sessionFromOption : null,
-    acpxSessionId: sessionFromOption ? "sid-" + sessionFromOption : null,
-    agentSessionId: sessionFromOption ? "inner-" + sessionFromOption : null,
+    acpxRecordId: sessionFromOption && !omitStatusIds ? "rec-" + sessionFromOption : null,
+    acpxSessionId: sessionFromOption && !omitStatusIds ? "sid-" + sessionFromOption : null,
+    agentSessionId: sessionFromOption && !omitStatusIds ? "inner-" + sessionFromOption : null,
     status,
     ...(summary ? { summary } : {}),
     pid: 4242,
@@ -426,6 +427,7 @@ export async function cleanupMockRuntimeFixtures(): Promise<void> {
   delete process.env.MOCK_ACPX_ENSURE_EXIT_1;
   delete process.env.MOCK_ACPX_ENSURE_STDERR;
   delete process.env.MOCK_ACPX_STATUS_STATUS;
+  delete process.env.MOCK_ACPX_STATUS_NO_IDS;
   delete process.env.MOCK_ACPX_STATUS_SUMMARY;
   sharedMockCliScriptPath = null;
   logFileSequence = 0;


### PR DESCRIPTION
## Summary

- Problem: ACP gateway sessions could keep a named session in `status=dead` when acpx reported `queue owner unavailable`, then hand that dead handle to the first prompt.
- Why it matters: `sessions_spawn` could still fail on the first turn for Claude and intermittently for other ACP agents even though the runtime logged that the dead session was "recoverable".
- What changed: the acpx runtime now repairs that dead named session by creating a replacement owner, resuming the backend session when a stable session id is available, and falling back to a fresh named session when it is not.
- What did NOT change (scope boundary): this does not change unrelated ACP status handling, config defaults, or non-queue-owner dead-session recovery.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #58659
- Related #56855
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `extensions/acpx/src/runtime.ts` treated `status=dead` with `summary~="queue owner unavailable"` as a session to keep, so `ensureSession()` could return a dead handle that then failed on the first `prompt`.
- Missing detection / guardrail: the regression tests only asserted that OpenClaw stopped replacing those dead sessions in a loop; they did not assert that the repaired session was usable for the next turn.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the queue-owner path was special-cased in `1c95c41c37` to avoid an infinite replace loop.
- Why this regressed now: the earlier fix avoided the loop but still left the queue-owner recovery path returning the dead named session instead of repairing it.
- If unknown, what was ruled out: ruled out a simple TTL-only fix because the reported failure still reproduces after increasing `queueOwnerTtlSeconds`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/acpx/src/runtime.test.ts`
- Scenario the test should lock in: when status reports `dead` plus `queue owner unavailable`, the runtime should repair the named session, resume when a stable session id exists, and fall back to a fresh named session when it does not.
- Why this is the smallest reliable guardrail: the bug lives entirely in the ACPX runtime control-flow around `sessions ensure`, `status`, and `sessions new`.
- Existing test that already covers this (if any): the prior dead-session tests covered the queue-owner branch but asserted the wrong behavior for this issue.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- ACP sessions that hit `queue owner unavailable` during initialization now repair the dead named session instead of returning a dead handle to the first turn.
- When ACPX exposes a stable session id for that dead session, OpenClaw resumes it to preserve continuity.

## Diagram (if applicable)

```text
Before:
[sessions ensure] -> [status=dead queue owner unavailable] -> [retain dead session] -> [first prompt fails]

After:
[sessions ensure] -> [status=dead queue owner unavailable] -> [repair named session owner] -> [first prompt uses repaired session]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 25.3.0
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: ACPX mock runtime in tests; issue repro targets Claude and Codex ACP agents
- Integration/channel (if any): ACP gateway sessions
- Relevant config (redacted): `acpx.permissionMode=approve-all`, `acpx.nonInteractivePermissions=deny`, `acpx.queueOwnerTtlSeconds=30`

### Steps

1. Create or ensure an ACP named session.
2. Return `status=dead` with `summary=queue owner unavailable` from `status --session`.
3. Continue initialization and attempt the first turn.

### Expected

- The runtime repairs the dead named session before returning the handle.
- If a stable session id is present, the repair resumes that session.
- If no stable session id is present, the runtime falls back to a fresh named session.

### Actual

- Before this change, the runtime kept the dead named session and the first prompt could still fail with `ACP_TURN_FAILED`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: updated the queue-owner recovery tests, added the no-resumable-id fallback case, ran `pnpm test -- extensions/acpx/src/runtime.test.ts -t "queue owner unavailable|ensure fallback|no resumable id"`, ran `pnpm test:extension acpx`, and ran `pnpm build`.
- Edge cases checked: dead queue-owner status after `sessions ensure`, dead queue-owner status after ensure failure fallback, and missing ids in the status payload.
- What you did **not** verify: a live Claude/Codex gateway repro in this environment, and `pnpm check` still reports unrelated pre-existing type failures in `extensions/diffs/src/language-hints.test.ts` and `src/plugins/contracts/plugin-sdk-subpaths.test.ts`.
- AI assistance / testing note: prepared with AI assistance, manually reviewed before opening, and validated with the focused ACPX test lanes above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: some ACPX backends may report queue-owner failures without stable ids, which forces a fresh named session instead of a resume.
  - Mitigation: the runtime only takes that fallback when `status` provides no resumable id at all, and the new regression test locks in that branch.

Made with [Cursor](https://cursor.com)