### PR TITLE
fix(tasks): prevent synchronous task registry sweep from blocking event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram/local Bot API: preserve media MIME types for absolute-path downloads so local audio files still trigger transcription and other MIME-based handling. (#54603) Thanks @jzakirov
+- Tasks/gateway: keep the task registry maintenance sweep from stalling the gateway event loop under synchronous SQLite pressure, so upgraded gateways stop hanging about a minute after startup. (#58670) Thanks @openperf
 
 ## 2026.3.31
 

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -384,7 +384,9 @@ export async function tasksMaintenanceCommand(
   runtime: RuntimeEnv,
 ) {
   const auditBefore = getInspectableTaskAuditSummary();
-  const maintenance = opts.apply ? runTaskRegistryMaintenance() : previewTaskRegistryMaintenance();
+  const maintenance = opts.apply
+    ? await runTaskRegistryMaintenance()
+    : previewTaskRegistryMaintenance();
   const summary = getInspectableTaskRegistrySummary();
   const auditAfter = opts.apply ? getInspectableTaskAuditSummary() : auditBefore;
 

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -205,6 +205,16 @@ function yieldToEventLoop(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
+function startScheduledSweep() {
+  if (sweepInProgress) {
+    return;
+  }
+  sweepInProgress = true;
+  void sweepTaskRegistry().finally(() => {
+    sweepInProgress = false;
+  });
+}
+
 export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintenanceSummary> {
   ensureTaskRegistryReady();
   const now = Date.now();
@@ -256,32 +266,15 @@ export async function sweepTaskRegistry(): Promise<TaskRegistryMaintenanceSummar
 
 export function startTaskRegistryMaintenance() {
   ensureTaskRegistryReady();
-  // Defer the first sweep to avoid blocking the critical startup window.
-  // Use setTimeout instead of running synchronously at startup.
   deferredSweep = setTimeout(() => {
     deferredSweep = null;
-    if (sweepInProgress) {
-      return;
-    }
-    sweepInProgress = true;
-    void sweepTaskRegistry().finally(() => {
-      sweepInProgress = false;
-    });
+    startScheduledSweep();
   }, 5_000);
+  deferredSweep.unref?.();
   if (sweeper) {
     return;
   }
-  sweeper = setInterval(() => {
-    // Prevent overlapping sweeps — if a previous async sweep is still
-    // running, skip this tick entirely.
-    if (sweepInProgress) {
-      return;
-    }
-    sweepInProgress = true;
-    void sweepTaskRegistry().finally(() => {
-      sweepInProgress = false;
-    });
-  }, TASK_SWEEP_INTERVAL_MS);
+  sweeper = setInterval(startScheduledSweep, TASK_SWEEP_INTERVAL_MS);
   sweeper.unref?.();
 }
 

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -20,7 +20,15 @@ const TASK_RECONCILE_GRACE_MS = 5 * 60_000;
 const TASK_RETENTION_MS = 7 * 24 * 60 * 60_000;
 const TASK_SWEEP_INTERVAL_MS = 60_000;
 
+/**
+ * Number of tasks to process before yielding to the event loop.
+ * Keeps the main thread responsive during large sweeps.
+ */
+const SWEEP_YIELD_BATCH_SIZE = 25;
+
 let sweeper: NodeJS.Timeout | null = null;
+let deferredSweep: NodeJS.Timeout | null = null;
+let sweepInProgress = false;
 
 export type TaskRegistryMaintenanceSummary = {
   reconciled: number;
@@ -188,22 +196,41 @@ export function previewTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary
   return { reconciled, cleanupStamped, pruned };
 }
 
-export function runTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary {
+/**
+ * Yield control back to the event loop so that pending I/O callbacks,
+ * timers, and incoming requests can be processed between batches of
+ * synchronous task-registry maintenance work.
+ */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintenanceSummary> {
   ensureTaskRegistryReady();
   const now = Date.now();
   let reconciled = 0;
   let cleanupStamped = 0;
   let pruned = 0;
-  for (const task of listTaskRecords()) {
+  const tasks = listTaskRecords();
+  let processed = 0;
+  for (const task of tasks) {
     if (shouldMarkLost(task, now)) {
       const next = markTaskLost(task, now);
       if (next.status === "lost") {
         reconciled += 1;
       }
+      processed += 1;
+      if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
+        await yieldToEventLoop();
+      }
       continue;
     }
     if (shouldPruneTerminalTask(task, now) && deleteTaskRecordById(task.taskId)) {
       pruned += 1;
+      processed += 1;
+      if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
+        await yieldToEventLoop();
+      }
       continue;
     }
     if (
@@ -215,32 +242,59 @@ export function runTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary {
     ) {
       cleanupStamped += 1;
     }
+    processed += 1;
+    if (processed % SWEEP_YIELD_BATCH_SIZE === 0) {
+      await yieldToEventLoop();
+    }
   }
   return { reconciled, cleanupStamped, pruned };
 }
 
-export function sweepTaskRegistry(): TaskRegistryMaintenanceSummary {
+export async function sweepTaskRegistry(): Promise<TaskRegistryMaintenanceSummary> {
   return runTaskRegistryMaintenance();
 }
 
 export function startTaskRegistryMaintenance() {
   ensureTaskRegistryReady();
-  void sweepTaskRegistry();
+  // Defer the first sweep to avoid blocking the critical startup window.
+  // Use setTimeout instead of running synchronously at startup.
+  deferredSweep = setTimeout(() => {
+    deferredSweep = null;
+    if (sweepInProgress) {
+      return;
+    }
+    sweepInProgress = true;
+    void sweepTaskRegistry().finally(() => {
+      sweepInProgress = false;
+    });
+  }, 5_000);
   if (sweeper) {
     return;
   }
   sweeper = setInterval(() => {
-    void sweepTaskRegistry();
+    // Prevent overlapping sweeps — if a previous async sweep is still
+    // running, skip this tick entirely.
+    if (sweepInProgress) {
+      return;
+    }
+    sweepInProgress = true;
+    void sweepTaskRegistry().finally(() => {
+      sweepInProgress = false;
+    });
   }, TASK_SWEEP_INTERVAL_MS);
   sweeper.unref?.();
 }
 
 export function stopTaskRegistryMaintenanceForTests() {
-  if (!sweeper) {
-    return;
+  if (deferredSweep) {
+    clearTimeout(deferredSweep);
+    deferredSweep = null;
   }
-  clearInterval(sweeper);
-  sweeper = null;
+  if (sweeper) {
+    clearInterval(sweeper);
+    sweeper = null;
+  }
+  sweepInProgress = false;
 }
 
 export function getReconciledTaskById(taskId: string): TaskRecord | undefined {

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -404,7 +404,7 @@ function openTaskRegistryDatabase(): TaskRegistryDatabase {
   const { DatabaseSync } = requireNodeSqlite();
   const db = new DatabaseSync(pathname);
   db.exec(`PRAGMA journal_mode = WAL;`);
-  db.exec(`PRAGMA synchronous = FULL;`);
+  db.exec(`PRAGMA synchronous = NORMAL;`);
   db.exec(`PRAGMA busy_timeout = 5000;`);
   ensureSchema(db);
   ensureTaskRegistryPermissions(pathname);
@@ -455,7 +455,6 @@ export function saveTaskRegistryStateToSqlite(snapshot: TaskRegistryStoreSnapsho
 export function upsertTaskRegistryRecordToSqlite(task: TaskRecord) {
   const store = openTaskRegistryDatabase();
   store.statements.upsertRow.run(bindTaskRecord(task));
-  ensureTaskRegistryPermissions(store.path);
 }
 
 export function upsertTaskWithDeliveryStateToSqlite(params: {
@@ -476,7 +475,6 @@ export function deleteTaskRegistryRecordFromSqlite(taskId: string) {
   const store = openTaskRegistryDatabase();
   store.statements.deleteRow.run(taskId);
   store.statements.deleteDeliveryState.run(taskId);
-  ensureTaskRegistryPermissions(store.path);
 }
 
 export function deleteTaskAndDeliveryStateFromSqlite(taskId: string) {
@@ -489,13 +487,11 @@ export function deleteTaskAndDeliveryStateFromSqlite(taskId: string) {
 export function upsertTaskDeliveryStateToSqlite(state: TaskDeliveryState) {
   const store = openTaskRegistryDatabase();
   store.statements.replaceDeliveryState.run(bindTaskDeliveryState(state));
-  ensureTaskRegistryPermissions(store.path);
 }
 
 export function deleteTaskDeliveryStateFromSqlite(taskId: string) {
   const store = openTaskRegistryDatabase();
   store.statements.deleteDeliveryState.run(taskId);
-  ensureTaskRegistryPermissions(store.path);
 }
 
 export function closeTaskRegistrySqliteStore() {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -36,6 +36,8 @@ import {
   previewTaskRegistryMaintenance,
   reconcileInspectableTasks,
   runTaskRegistryMaintenance,
+  startTaskRegistryMaintenance,
+  stopTaskRegistryMaintenanceForTests,
   sweepTaskRegistry,
 } from "./task-registry.maintenance.js";
 import { configureTaskRegistryRuntime } from "./task-registry.store.js";
@@ -1116,6 +1118,40 @@ describe("task-registry", () => {
         pruned: 0,
       });
       expect(getTaskById("task-missing-cleanup")?.cleanupAfter).toBeGreaterThan(now);
+    });
+  });
+
+  it("cancels the deferred maintenance sweep during test teardown", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      vi.useFakeTimers();
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const now = Date.now();
+
+      const task = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:acp:missing",
+        runId: "run-deferred-maintenance-stop",
+        task: "Missing child",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+      setTaskTimingById({
+        taskId: task.taskId,
+        lastEventAt: now - 10 * 60_000,
+      });
+
+      startTaskRegistryMaintenance();
+      stopTaskRegistryMaintenanceForTests();
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      await flushAsyncWork();
+
+      expect(getTaskById(task.taskId)).toMatchObject({
+        status: "running",
+      });
     });
   });
 

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1026,7 +1026,7 @@ describe("task-registry", () => {
         lastEventAt: now - 10 * 60_000,
       });
 
-      expect(runTaskRegistryMaintenance()).toEqual({
+      expect(await runTaskRegistryMaintenance()).toEqual({
         reconciled: 1,
         cleanupStamped: 0,
         pruned: 0,
@@ -1061,7 +1061,7 @@ describe("task-registry", () => {
         lastEventAt: Date.now() - 8 * 24 * 60 * 60_000,
       });
 
-      expect(sweepTaskRegistry()).toEqual({
+      expect(await sweepTaskRegistry()).toEqual({
         reconciled: 0,
         cleanupStamped: 0,
         pruned: 1,
@@ -1110,7 +1110,7 @@ describe("task-registry", () => {
         pruned: 0,
       });
 
-      expect(runTaskRegistryMaintenance()).toEqual({
+      expect(await runTaskRegistryMaintenance()).toEqual({
         reconciled: 0,
         cleanupStamped: 1,
         pruned: 0,


### PR DESCRIPTION
### Summary

- **Problem**: After upgrading to 2026.3.31, the gateway becomes completely unresponsive within 30-60 seconds of startup. The process hangs and requires `SIGKILL` to terminate. This is caused by the task registry maintenance sweep in `src/tasks/task-registry.maintenance.ts` and `src/tasks/task-registry.store.sqlite.ts`.
- **Root Cause**: The task registry maintenance sweep (`sweepTaskRegistry`) runs every 60 seconds on the main thread. It performs synchronous SQLite I/O using `node:sqlite` `DatabaseSync` with `PRAGMA synchronous = FULL`. Furthermore, after every single row upsert/delete, it redundantly calls `ensureTaskRegistryPermissions()` which performs 5-7 synchronous filesystem syscalls (`mkdirSync`, `chmodSync`, `existsSync`). When combined with a large number of tasks or other plugins (like LCM) doing sync I/O, this blocks the Node.js event loop entirely.
- **Fix**: 
  1. Changed `PRAGMA synchronous = FULL` to `NORMAL` in `task-registry.store.sqlite.ts`. Since the task registry is a reconstructable cache, `FULL` (which forces an fsync on every commit) is overkill and `NORMAL` is the recommended safe default for WAL mode.
  2. Removed redundant `ensureTaskRegistryPermissions()` calls from individual row operations (they are still correctly enforced at database open and batch transaction boundaries).
  3. Refactored `sweepTaskRegistry` and `runTaskRegistryMaintenance` to be `async`, and introduced `yieldToEventLoop()` (via `setImmediate`) every 25 tasks to prevent the sweep from monopolizing the event loop.
  4. Deferred the initial sweep at startup using `setTimeout` to avoid blocking the critical startup window.
- **What changed**: 
  - `src/tasks/task-registry.store.sqlite.ts`: Changed PRAGMA sync setting and removed redundant permission checks.
  - `src/tasks/task-registry.maintenance.ts`: Made sweep functions async, added yielding, and deferred initial sweep.
  - `src/commands/tasks.ts`: Added `await` to `runTaskRegistryMaintenance` call.
  - `src/tasks/task-registry.test.ts`: Updated tests to `await` the now-async maintenance functions.
- **What did NOT change (scope boundary)**: The actual logic for determining which tasks are lost or pruned remains unchanged. The SQLite schema and data structures are untouched. No changes were made to the plugin loader or other subsystems.

### Reproduction

1. Start the gateway on version 2026.3.31 with a populated task registry and the LCM plugin enabled.
2. Wait for approximately 60 seconds.
3. Observe that the gateway becomes unreachable on localhost and cannot handle `SIGTERM`.

### Risk / Mitigation

- **Risk**: Making the sweep asynchronous could theoretically allow overlapping sweeps if a sweep takes longer than 60 seconds.
- **Mitigation**: Added a `sweepInProgress` boolean flag in `startTaskRegistryMaintenance` to skip the interval tick if the previous async sweep is still running, preventing any overlap. Tests were updated to ensure the async behavior is correctly awaited.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Tasks

### Linked Issue/PR

Fixes #58651