### PR TITLE
fix(feishu): prevent timing side-channel in webhook signature comparison

### DIFF
--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -37,10 +37,19 @@ function isFeishuWebhookPayload(value: unknown): value is Record<string, unknown
 function timingSafeEqualString(left: string, right: string): boolean {
   const leftBuffer = Buffer.from(left, "utf8");
   const rightBuffer = Buffer.from(right, "utf8");
-  if (leftBuffer.length !== rightBuffer.length) {
-    return false;
-  }
-  return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+
+  // Pad to equal length before constant-time comparison to prevent
+  // leaking length information via early-return timing.
+  const maxLen = Math.max(leftBuffer.length, rightBuffer.length);
+  const paddedLeft = Buffer.alloc(maxLen);
+  const paddedRight = Buffer.alloc(maxLen);
+  leftBuffer.copy(paddedLeft);
+  rightBuffer.copy(paddedRight);
+
+  // Call timingSafeEqual unconditionally to ensure constant-time execution
+  // regardless of length mismatch (avoids early-return timing leak).
+  const timingResult = crypto.timingSafeEqual(paddedLeft, paddedRight);
+  return leftBuffer.length === rightBuffer.length && timingResult;
 }
 
 function buildFeishuWebhookEnvelope(

--- a/extensions/feishu/src/monitor.webhook-e2e.test.ts
+++ b/extensions/feishu/src/monitor.webhook-e2e.test.ts
@@ -116,6 +116,48 @@ describe("Feishu webhook signed-request e2e", () => {
     );
   });
 
+  it("still runs timingSafeEqual for malformed short signatures", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+    const timingSafeEqualSpy = vi.spyOn(crypto, "timingSafeEqual");
+
+    await withRunningWebhookMonitor(
+      {
+        accountId: "short-signature-compare-path",
+        path: "/hook-e2e-short-signature-compare-path",
+        verificationToken: "verify_token",
+        encryptKey: "encrypt_key",
+      },
+      monitorFeishuProvider,
+      async (url) => {
+        const payload = { type: "url_verification", challenge: "challenge-token" };
+        const headers = signFeishuPayload({
+          encryptKey: "encrypt_key",
+          rawBody: JSON.stringify(payload),
+        });
+        headers["x-lark-signature"] = headers["x-lark-signature"].slice(0, 12);
+
+        const response = await fetch(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(payload),
+        });
+
+        expect(response.status).toBe(401);
+        expect(await response.text()).toBe("Invalid signature");
+      },
+    );
+
+    expect(timingSafeEqualSpy).toHaveBeenCalledOnce();
+    const [leftBuffer, rightBuffer] = timingSafeEqualSpy.mock.calls[0] ?? [];
+    expect(Buffer.isBuffer(leftBuffer)).toBe(true);
+    expect(Buffer.isBuffer(rightBuffer)).toBe(true);
+    if (!Buffer.isBuffer(leftBuffer) || !Buffer.isBuffer(rightBuffer)) {
+      throw new TypeError("Expected crypto.timingSafeEqual to receive Buffer arguments");
+    }
+    expect(leftBuffer).toHaveLength(rightBuffer.length);
+    timingSafeEqualSpy.mockRestore();
+  });
+
   it("rejects malformed short signatures with 401", async () => {
     probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
 


### PR DESCRIPTION
## Summary

Removes the early-return length check in `timingSafeEqualString` and pads both buffers to equal length before calling `crypto.timingSafeEqual` unconditionally. This closes a timing side-channel where short signatures took a measurably different code path than same-length-but-wrong signatures.

## Changes

- **`extensions/feishu/src/signature.ts`**: Pad both buffers to `maxLen` before `timingSafeEqual`; gate the final `true` result on the original length check so correctness is preserved.
- **`extensions/feishu/src/monitor.webhook-e2e.test.ts`**: Add a focused regression test that spies on `crypto.timingSafeEqual` and asserts it is called even for truncated signatures, with both buffers equal in length. Spy is restored via `mockRestore()` after the test to avoid polluting subsequent tests.

## Security rationale

- **Equal lengths**: padding is a no-op; `timingSafeEqual` behaves exactly as before.
- **Unequal lengths**: the padded comparison always returns `false` (shorter buffer has zeros where the longer has real content), and the length check also fails — result is correctly `false` with no timing shortcut.
- The length of a SHA-256 hex digest (64 chars) is publicly known, so the practical gain is modest, but removing the early-exit branch is good hygiene and aligns with the pattern used in other extensions (LINE, Nextcloud Talk).