### PR TITLE
fix: treat gateway.auth and gateway.controlUi as no-op in reload plan (#58620)

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -34,6 +34,14 @@ type ReloadAction =
 const BASE_RELOAD_RULES: ReloadRule[] = [
   { prefix: "gateway.remote", kind: "none" },
   { prefix: "gateway.reload", kind: "none" },
+  // Auth config (token, mode) is resolved once during prepareGatewayStartupConfig.
+  // Startup may auto-generate gateway.auth.token and persist it, which the file
+  // watcher would otherwise see as a restart-worthy change under the catch-all
+  // "gateway" prefix, causing a self-induced restart loop (#58620).
+  { prefix: "gateway.auth", kind: "none" },
+  // Control UI allowed-origins may be seeded at startup; treat as no-op to avoid
+  // the same self-induced restart loop.
+  { prefix: "gateway.controlUi", kind: "none" },
   {
     prefix: "gateway.channelHealthCheckMinutes",
     kind: "hot",

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -199,6 +199,24 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toContain("diagnostics.stuckSessionWarnMs");
   });
 
+  it("treats gateway.auth.token as no-op (#58620)", () => {
+    const plan = buildGatewayReloadPlan(["gateway.auth.token"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("gateway.auth.token");
+  });
+
+  it("treats gateway.auth.mode as no-op (#58620)", () => {
+    const plan = buildGatewayReloadPlan(["gateway.auth.mode"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("gateway.auth.mode");
+  });
+
+  it("treats gateway.controlUi.allowedOrigins as no-op (#58620)", () => {
+    const plan = buildGatewayReloadPlan(["gateway.controlUi.allowedOrigins"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("gateway.controlUi.allowedOrigins");
+  });
+
   it("defaults unknown paths to restart", () => {
     const plan = buildGatewayReloadPlan(["unknownField"]);
     expect(plan.restartGateway).toBe(true);
@@ -227,6 +245,16 @@ describe("buildGatewayReloadPlan", () => {
       path: "gateway.remote.url",
       expectRestartGateway: false,
       expectNoopPath: "gateway.remote.url",
+    },
+    {
+      path: "gateway.auth.token",
+      expectRestartGateway: false,
+      expectNoopPath: "gateway.auth.token",
+    },
+    {
+      path: "gateway.controlUi.allowedOrigins",
+      expectRestartGateway: false,
+      expectNoopPath: "gateway.controlUi.allowedOrigins",
     },
     {
       path: "unknownField",


### PR DESCRIPTION
## Summary

Fixes #58620.

At startup, `ensureGatewayStartupAuth` auto-generates and persists `gateway.auth.token` to the config file. Similarly, `maybeSeedControlUiAllowedOriginsAtStartup` writes `gateway.controlUi.allowedOrigins`. The config file watcher (started later) detects these writes and matches them against the catch-all `{ prefix: "gateway", kind: "restart" }` rule in `BASE_RELOAD_RULES_TAIL`, triggering a full gateway restart — which regenerates the token — creating an infinite restart loop.

## Changes

- Added `{ prefix: "gateway.auth", kind: "none" }` and `{ prefix: "gateway.controlUi", kind: "none" }` rules to `BASE_RELOAD_RULES` in `src/gateway/config-reload-plan.ts`. These take precedence over the catch-all gateway restart rule in TAIL, preventing the self-induced restart loop.
- Added test coverage for `gateway.auth.token`, `gateway.auth.mode`, and `gateway.controlUi.allowedOrigins` paths to verify they are classified as no-op.

## Test plan

- `pnpm test -- src/gateway/config-reload.test.ts` — all 30 tests pass