### PR TITLE
feat: guard memory writes for non-main sessions (cron/isolated/subagent)

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -551,6 +551,65 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
   };
 }
 
+/**
+ * Guard that prevents non-main sessions (cron, isolated agent turns, subagents)
+ * from writing to MEMORY.md or the memory/ directory. This protects long-term
+ * curated memory from being overwritten by sessions that lack full conversational context.
+ *
+ * Main sessions (trigger: undefined or "human") retain full write access.
+ * Memory flush runs use their own dedicated guard (wrapToolMemoryFlushAppendOnlyWrite).
+ */
+export function wrapToolMemoryWriteGuard(
+  tool: AnyAgentTool,
+  options: {
+    trigger?: string;
+    root: string;
+    containerWorkdir?: string;
+  },
+): AnyAgentTool {
+  // Only guard non-main sessions
+  const isMainSession = !options.trigger || options.trigger === "human";
+  if (isMainSession) {
+    return tool;
+  }
+
+  const MEMORY_FILE_NAMES = new Set(["MEMORY.md", "memory.md"]);
+  const MEMORY_DIR_PREFIX = "memory/";
+
+  return {
+    ...tool,
+    execute: async (toolCallId, args, signal, onUpdate) => {
+      const normalized = normalizeToolParams(args);
+      const record =
+        normalized ??
+        (args && typeof args === "object" ? (args as Record<string, unknown>) : undefined);
+      const filePath =
+        typeof record?.path === "string" && record.path.trim() ? record.path : undefined;
+
+      if (filePath) {
+        const resolvedPath = resolveToolPathAgainstWorkspaceRoot({
+          filePath,
+          root: options.root,
+          containerWorkdir: options.containerWorkdir,
+        });
+        const relativePath = path.relative(options.root, resolvedPath);
+        const fileName = path.basename(resolvedPath);
+        const isInMemoryDir = relativePath.startsWith(MEMORY_DIR_PREFIX);
+        const isMemoryFile = MEMORY_FILE_NAMES.has(fileName);
+
+        if (isMemoryFile || isInMemoryDir) {
+          throw new Error(
+            `Memory write blocked: non-main sessions (trigger: ${options.trigger ?? "unknown"}) ` +
+              `cannot write to ${relativePath}. Use a main session to update memory files.`,
+          );
+        }
+      }
+
+      return tool.execute(toolCallId, normalized ?? args, signal, onUpdate);
+    },
+  };
+}
+
 export function wrapToolWorkspaceRootGuardWithOptions(
   tool: AnyAgentTool,
   root: string,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -41,6 +41,7 @@ import {
   wrapToolMemoryFlushAppendOnlyWrite,
   wrapToolWorkspaceRootGuard,
   wrapToolWorkspaceRootGuardWithOptions,
+  wrapToolMemoryWriteGuard,
   wrapToolParamNormalization,
 } from "./pi-tools.read.js";
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
@@ -427,14 +428,24 @@ export function createOpenClawCodingTools(options?: {
         return [];
       }
       const wrapped = createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      const withRootGuard = workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped;
+      const withMemoryGuard = wrapToolMemoryWriteGuard(withRootGuard, {
+        trigger: options?.trigger,
+        root: workspaceRoot,
+      });
+      return [withMemoryGuard];
     }
     if (tool.name === "edit") {
       if (sandboxRoot) {
         return [];
       }
       const wrapped = createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      const withRootGuard = workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped;
+      const withMemoryGuard = wrapToolMemoryWriteGuard(withRootGuard, {
+        trigger: options?.trigger,
+        root: workspaceRoot,
+      });
+      return [withMemoryGuard];
     }
     return [tool];
   });


### PR DESCRIPTION
## Summary

Add a runtime guard that prevents non-main session types (cron, isolated agent turns, subagents) from writing to MEMORY.md or the memory/ directory, preserving the integrity of long-term curated memory.

## Problem

After a system restart, cron jobs reconnect with a fresh context. If a cron job's prompt references memory-related instructions (e.g., "review and update memory"), it can overwrite or append to MEMORY.md without the full conversational context that a main session has. This can lead to:

- Duplicated or stale entries in long-term memory
- Loss of nuanced context that only a live session possesses
- Memory entries that lack proper curation

## Solution

A lightweight tool-wrapper guard that checks the session trigger before allowing writes to memory files:

- **Main sessions** (trigger: undefined or "human"): full read/write access to MEMORY.md and memory/
- **Non-main sessions** (cron, isolated, subagent): writes to MEMORY.md and memory/ are blocked with a clear error message
- **Memory flush runs**: continue to use their own dedicated guard (wrapToolMemoryFlushAppendOnlyWrite)

The guard follows the existing tool-wrapper pattern used by wrapToolMemoryFlushAppendOnlyWrite and wrapToolWorkspaceRootGuard.

## Changes

- **src/agents/pi-tools.read.ts**: new `wrapToolMemoryWriteGuard` function (59 lines)
- **src/agents/pi-tools.ts**: apply guard to write and edit tools in createOpenClawCodingTools (import + 2 wrapping sites)

## Behavior

- Non-main sessions attempting to write to MEMORY.md or memory/ files will get: `Memory write blocked: non-main sessions (trigger: cron) cannot write to MEMORY.md. Use a main session to update memory files.`
- Non-main sessions can still READ memory files normally
- No changes to main session behavior
- No config changes required — the guard activates automatically based on session trigger

## Risk

- Low: guard is additive, doesn't change existing behavior for main sessions
- If a cron job legitimately needs to update memory, it can queue a write intent for the next main session pickup
