### PR TITLE
CLI: improve channels list usage fetch warnings

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -95,7 +95,6 @@ Notes:
 
 - Run `openclaw status --deep` for a broad probe.
 - Use `openclaw doctor` for guided fixes.
-- `openclaw channels list` warns when the usage snapshot cannot be fetched. For Claude, this usually means the current auth is missing `user:profile` access. Use `--no-usage`, provide a claude.ai session key (`CLAUDE_WEB_SESSION_KEY` / `CLAUDE_WEB_COOKIE`), or re-auth via Claude Code CLI.
 - `openclaw channels list` warns when the usage snapshot cannot be fetched. For Claude, this usually means the current auth is missing `user:profile` access. Use `--no-usage`, provide a claude.ai session key (`CLAUDE_WEB_SESSION_KEY` / `CLAUDE_WEB_COOKIE`), or re-auth via Claude CLI.
 - `openclaw channels status` falls back to config-only summaries when the gateway is unreachable. If a supported channel credential is configured via SecretRef but unavailable in the current command path, it reports that account as configured with degraded notes instead of showing it as not configured.
 

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -95,7 +95,8 @@ Notes:
 
 - Run `openclaw status --deep` for a broad probe.
 - Use `openclaw doctor` for guided fixes.
-- `openclaw channels list` prints `Claude: HTTP 403 ... user:profile` → usage snapshot needs the `user:profile` scope. Use `--no-usage`, or provide a claude.ai session key (`CLAUDE_WEB_SESSION_KEY` / `CLAUDE_WEB_COOKIE`), or re-auth via Claude CLI.
+- `openclaw channels list` warns when the usage snapshot cannot be fetched. For Claude, this usually means the current auth is missing `user:profile` access. Use `--no-usage`, provide a claude.ai session key (`CLAUDE_WEB_SESSION_KEY` / `CLAUDE_WEB_COOKIE`), or re-auth via Claude Code CLI.
+- `openclaw channels list` warns when the usage snapshot cannot be fetched. For Claude, this usually means the current auth is missing `user:profile` access. Use `--no-usage`, provide a claude.ai session key (`CLAUDE_WEB_SESSION_KEY` / `CLAUDE_WEB_COOKIE`), or re-auth via Claude CLI.
 - `openclaw channels status` falls back to config-only summaries when the gateway is unreachable. If a supported channel credential is configured via SecretRef but unavailable in the current command path, it reports that account as configured with degraded notes instead of showing it as not configured.
 
 ## Capabilities probe

--- a/docs/tools/video-generation.md
+++ b/docs/tools/video-generation.md
@@ -182,7 +182,7 @@ openclaw config set agents.defaults.videoGenerationModel.primary "qwen/wan2.6-t2
 - [Tools Overview](/tools)
 - [Background Tasks](/automation/tasks) -- task tracking for async video generation
 - [Alibaba Model Studio](/providers/alibaba)
-- [BytePlus](/concepts/model-providers#byteplus-international)
+- [BytePlus (International)](/concepts/model-providers#byteplus-international)
 - [ComfyUI](/providers/comfy)
 - [fal](/providers/fal)
 - [Google (Gemini)](/providers/google)

--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -138,8 +138,8 @@ describe("minimax provider hooks", () => {
       registerMediaUnderstandingProvider() {},
       registerImageGenerationProvider() {},
       registerMusicGenerationProvider() {},
-      registerVideoGenerationProvider() {},
       registerSpeechProvider() {},
+      registerVideoGenerationProvider() {},
       registerWebSearchProvider(provider: unknown) {
         webSearchProviders.push(provider);
       },

--- a/src/commands/channels.list.usage-errors.test.ts
+++ b/src/commands/channels.list.usage-errors.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
@@ -70,7 +70,7 @@ function createChannelsListTestPlugin(): ChannelPlugin {
 describe("channelsListCommand usage snapshot failures", () => {
   const runtime = createTestRuntime();
 
-  beforeAll(() => {
+  beforeEach(() => {
     setActivePluginRegistry(
       createTestRegistry([
         {
@@ -80,9 +80,6 @@ describe("channelsListCommand usage snapshot failures", () => {
         },
       ]),
     );
-  });
-
-  beforeEach(() => {
     runtime.log.mockReset();
     runtime.error.mockReset();
     runtime.exit.mockReset();
@@ -100,6 +97,10 @@ describe("channelsListCommand usage snapshot failures", () => {
       targetStatesByPath: {},
       hadUnresolvedTargets: false,
     });
+  });
+
+  afterAll(() => {
+    setActivePluginRegistry(createTestRegistry());
   });
 
   it("renders usage output when the usage snapshot loads successfully", async () => {

--- a/src/commands/channels.list.usage-errors.test.ts
+++ b/src/commands/channels.list.usage-errors.test.ts
@@ -1,0 +1,158 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { configMocks } from "./channels.mock-harness.js";
+import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
+
+const authMocks = vi.hoisted(() => ({
+  loadAuthProfileStore: vi.fn(),
+}));
+
+const usageMocks = vi.hoisted(() => ({
+  loadProviderUsageSummary: vi.fn(),
+  formatUsageReportLines: vi.fn(),
+}));
+
+const secretMocks = vi.hoisted(() => ({
+  resolveCommandSecretRefsViaGateway: vi.fn(),
+}));
+
+vi.mock("../agents/auth-profiles.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/auth-profiles.js")>();
+  return {
+    ...actual,
+    loadAuthProfileStore: authMocks.loadAuthProfileStore,
+  };
+});
+
+vi.mock("../infra/provider-usage.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/provider-usage.js")>();
+  return {
+    ...actual,
+    loadProviderUsageSummary: usageMocks.loadProviderUsageSummary,
+    formatUsageReportLines: usageMocks.formatUsageReportLines,
+  };
+});
+
+vi.mock("../cli/command-secret-gateway.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../cli/command-secret-gateway.js")>();
+  return {
+    ...actual,
+    resolveCommandSecretRefsViaGateway: secretMocks.resolveCommandSecretRefsViaGateway,
+  };
+});
+
+import { channelsListCommand } from "./channels.js";
+
+function createChannelsListTestPlugin(): ChannelPlugin {
+  return {
+    ...createChannelTestPluginBase({
+      id: "discord",
+      label: "Discord",
+      docsPath: "/channels/discord",
+    }),
+    config: {
+      listAccountIds: () => ["default"],
+      defaultAccountId: () => "default",
+      resolveAccount: () => ({
+        name: "Primary",
+        configured: true,
+        enabled: true,
+        tokenSource: "config",
+      }),
+      isConfigured: () => true,
+      isEnabled: () => true,
+    },
+  } as ChannelPlugin;
+}
+
+describe("channelsListCommand usage snapshot failures", () => {
+  const runtime = createTestRuntime();
+
+  beforeAll(() => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          plugin: createChannelsListTestPlugin(),
+          source: "test",
+        },
+      ]),
+    );
+  });
+
+  beforeEach(() => {
+    runtime.log.mockReset();
+    runtime.error.mockReset();
+    runtime.exit.mockReset();
+    configMocks.readConfigFileSnapshot.mockResolvedValue(baseConfigSnapshot);
+    authMocks.loadAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {},
+    });
+    usageMocks.formatUsageReportLines.mockReturnValue(["Usage summary", "Claude: 12 requests"]);
+    usageMocks.loadProviderUsageSummary.mockReset();
+    secretMocks.resolveCommandSecretRefsViaGateway.mockReset();
+    secretMocks.resolveCommandSecretRefsViaGateway.mockResolvedValue({
+      resolvedConfig: baseConfigSnapshot.config,
+      diagnostics: [],
+      targetStatesByPath: {},
+      hadUnresolvedTargets: false,
+    });
+  });
+
+  it("renders usage output when the usage snapshot loads successfully", async () => {
+    usageMocks.loadProviderUsageSummary.mockResolvedValue({ providers: [] });
+
+    await channelsListCommand({}, runtime);
+
+    const joined = runtime.log.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(joined).toContain("Chat channels:");
+    expect(joined).toContain("Discord");
+    expect(joined).toContain("Usage summary");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("shows actionable Claude guidance for known scope failures", async () => {
+    usageMocks.loadProviderUsageSummary.mockRejectedValue(
+      new Error("Claude: HTTP 403 forbidden for /api/organizations user:profile"),
+    );
+
+    await channelsListCommand({}, runtime);
+
+    const joined = runtime.log.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(joined).toContain("Chat channels:");
+    expect(joined).toContain("Discord");
+    expect(joined).toContain("Usage snapshot unavailable for Claude.");
+    expect(joined).toContain("user:profile");
+    expect(joined).toContain("openclaw channels list --no-usage");
+    expect(joined).toContain("CLAUDE_WEB_SESSION_KEY / CLAUDE_WEB_COOKIE");
+    expect(joined).not.toContain("Error: Claude: HTTP 403 forbidden");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("shows a generic warning and preserves main output for unknown usage failures", async () => {
+    usageMocks.loadProviderUsageSummary.mockRejectedValue(new Error("socket hang up"));
+
+    await channelsListCommand({}, runtime);
+
+    const joined = runtime.log.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(joined).toContain("Chat channels:");
+    expect(joined).toContain("Discord");
+    expect(joined).toContain("Usage snapshot unavailable.");
+    expect(joined).toContain("The channel and auth summary above is still valid.");
+    expect(joined).toContain("Error: socket hang up");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("skips usage loading entirely when usage is disabled", async () => {
+    await channelsListCommand({ usage: false }, runtime);
+
+    expect(usageMocks.loadProviderUsageSummary).not.toHaveBeenCalled();
+    const joined = runtime.log.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(joined).toContain("Chat channels:");
+    expect(joined).not.toContain("Usage summary");
+    expect(joined).not.toContain("Usage snapshot unavailable");
+  });
+});

--- a/src/commands/channels/list.ts
+++ b/src/commands/channels/list.ts
@@ -6,6 +6,7 @@ import type { ChannelAccountSnapshot, ChannelPlugin } from "../../channels/plugi
 import { withProgress } from "../../cli/progress.js";
 import { formatUsageReportLines, loadProviderUsageSummary } from "../../infra/provider-usage.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+import { describeUnknownError } from "../../secrets/shared.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import { formatChannelAccountLabel, requireValidConfig } from "./shared.js";
@@ -14,6 +15,36 @@ export type ChannelsListOptions = {
   json?: boolean;
   usage?: boolean;
 };
+
+function classifyUsageSnapshotFailure(error: unknown): {
+  lines: string[];
+  rawError?: string;
+} {
+  const message = describeUnknownError(error).trim();
+  const normalized = message.toLowerCase();
+  const isClaudeScopeFailure =
+    normalized.includes("claude") &&
+    (normalized.includes("403") || normalized.includes("user:profile"));
+
+  if (isClaudeScopeFailure) {
+    return {
+      lines: [
+        "Usage snapshot unavailable for Claude.",
+        "This usually means the current auth does not have the required user:profile access.",
+        "Try openclaw channels list --no-usage, re-auth via Claude Code CLI, or set CLAUDE_WEB_SESSION_KEY / CLAUDE_WEB_COOKIE.",
+      ],
+    };
+  }
+
+  return {
+    lines: [
+      "Usage snapshot unavailable.",
+      "The channel and auth summary above is still valid.",
+      "Try openclaw channels list --no-usage, re-auth the affected provider, or retry with the required credentials in this command path.",
+    ],
+    rawError: message || undefined,
+  };
+}
 
 const colorValue = (value: string) => {
   if (value === "none") {
@@ -96,7 +127,15 @@ async function loadUsageWithProgress(
       async () => await loadProviderUsageSummary(),
     );
   } catch (err) {
-    runtime.error(String(err));
+    const classified = classifyUsageSnapshotFailure(err);
+    runtime.log("");
+    runtime.log(theme.warn("Usage:"));
+    for (const line of classified.lines) {
+      runtime.log(theme.warn(`- ${line}`));
+    }
+    if (classified.rawError) {
+      runtime.log(theme.muted(`  Error: ${classified.rawError}`));
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- improve `openclaw channels list` usage-fetch failures with actionable CLI warnings
- add targeted coverage for Claude scope failures, generic usage failures, successful usage output, and `--no-usage`
- update the channels CLI docs to match the new warning behavior

## Why
`openclaw channels list` could previously surface raw usage-fetch errors such as Claude `403` scope failures. This change keeps the command output usable and gives users concrete next steps instead of a bare backend-style error.

## Testing
- `pnpm test -- src/commands/channels.list.usage-errors.test.ts`
- `pnpm test -- src/commands/channels.adds-non-default-telegram-account.test.ts`
- `pnpm check`
