### PR TITLE
docs: clarify channels login docs for plugin channels

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -479,7 +479,7 @@ Subcommands:
   - When adding a non-default account to a channel still using single-account top-level config, OpenClaw moves account-scoped values into `channels.<channel>.accounts.default` before writing the new account.
   - Non-interactive `channels add` does not auto-create/upgrade bindings; channel-only bindings continue to match the default account.
 - `channels remove`: disable by default; pass `--delete` to remove config entries without prompts.
-- `channels login`: interactive channel login (WhatsApp Web only).
+- `channels login`: interactive channel login for channels that implement a login flow (for example WhatsApp Web and QR-login plugins).
 - `channels logout`: log out of a channel session (if supported).
 
 Common options:
@@ -490,7 +490,7 @@ Common options:
 
 `channels login` options:
 
-- `--channel <channel>` (default `whatsapp`; supports `whatsapp`/`web`)
+- `--channel <channel>` (default `whatsapp`; built-in supports `whatsapp`/`web`, and installed plugins may add more login-capable channel ids)
 - `--account <id>`
 - `--verbose`
 

--- a/docs/zh-CN/cli/index.md
+++ b/docs/zh-CN/cli/index.md
@@ -432,7 +432,7 @@ openclaw [--dev] [--profile <name>] <command>
   - 当向仍使用单账户顶层配置的渠道添加非默认账户时，OpenClaw 会先将账户作用域值移动到 `channels.<channel>.accounts.default`，再写入新账户。
   - 非交互式 `channels add` 不会自动创建 / 升级绑定；仅渠道绑定会继续匹配默认账户。
 - `channels remove`：默认执行禁用；传入 `--delete` 可在无提示下删除配置项。
-- `channels login`：对实现了登录流程的渠道执行交互式登录（例如 WhatsApp Web 和支持扫码登录的插件渠道）。
+- `channels login`：交互式渠道登录（仅 WhatsApp Web）。
 - `channels logout`：登出某个渠道会话（如支持）。
 
 通用选项：
@@ -443,7 +443,7 @@ openclaw [--dev] [--profile <name>] <command>
 
 `channels login` 选项：
 
-- `--channel <channel>`（默认 `whatsapp`；内置支持 `whatsapp`/`web`，安装的插件还可以增加更多支持登录的渠道 id）
+- `--channel <channel>`（默认 `whatsapp`；支持 `whatsapp`/`web`）
 - `--account <id>`
 - `--verbose`
 

--- a/docs/zh-CN/cli/index.md
+++ b/docs/zh-CN/cli/index.md
@@ -432,7 +432,7 @@ openclaw [--dev] [--profile <name>] <command>
   - 当向仍使用单账户顶层配置的渠道添加非默认账户时，OpenClaw 会先将账户作用域值移动到 `channels.<channel>.accounts.default`，再写入新账户。
   - 非交互式 `channels add` 不会自动创建 / 升级绑定；仅渠道绑定会继续匹配默认账户。
 - `channels remove`：默认执行禁用；传入 `--delete` 可在无提示下删除配置项。
-- `channels login`：交互式渠道登录（仅 WhatsApp Web）。
+- `channels login`：对实现了登录流程的渠道执行交互式登录（例如 WhatsApp Web 和支持扫码登录的插件渠道）。
 - `channels logout`：登出某个渠道会话（如支持）。
 
 通用选项：
@@ -443,7 +443,7 @@ openclaw [--dev] [--profile <name>] <command>
 
 `channels login` 选项：
 
-- `--channel <channel>`（默认 `whatsapp`；支持 `whatsapp`/`web`）
+- `--channel <channel>`（默认 `whatsapp`；内置支持 `whatsapp`/`web`，安装的插件还可以增加更多支持登录的渠道 id）
 - `--account <id>`
 - `--verbose`
 


### PR DESCRIPTION
## Summary
- update the CLI reference to describe `channels login` as a generic login entry point for login-capable channels, not WhatsApp-only
- clarify that built-in `whatsapp`/`web` are the built-in ids while installed plugins may add more login-capable channel ids
- keep the English and Simplified Chinese docs aligned

## Why
The current CLI reference still says `channels login` is WhatsApp Web only, but plugin docs such as Zalo Personal already document `openclaw channels login --channel zalouser`, so the existing wording is now misleading.

## Testing
- docs only; no code changes
