### PR TITLE
fix(plugins): repair bundled runtime deps within plugin install dirs

### DIFF
--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -12,6 +12,17 @@ import { resolveNpmRunner } from "./npm-runner.mjs";
 
 export const BUNDLED_PLUGIN_INSTALL_TARGETS = [];
 
+function buildPluginSentinelPaths(pluginIds, depName) {
+  return pluginIds.toSorted((a, b) => a.localeCompare(b)).map((pluginId) => ({
+    pluginId,
+    sentinelPath: pluginDependencySentinelPath(pluginId, depName),
+  }));
+}
+
+function runtimeDepKey(name, version) {
+  return `${name}\u0000${version}`;
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_EXTENSIONS_DIR = join(__dirname, "..", "dist", "extensions");
 const DEFAULT_PACKAGE_ROOT = join(__dirname, "..");
@@ -22,6 +33,10 @@ function readJson(filePath) {
 
 function dependencySentinelPath(depName) {
   return join("node_modules", ...depName.split("/"), "package.json");
+}
+
+function pluginDependencySentinelPath(pluginId, depName) {
+  return join("dist", "extensions", pluginId, dependencySentinelPath(depName));
 }
 
 function collectRuntimeDeps(packageJson) {
@@ -38,12 +53,13 @@ export function discoverBundledPluginRuntimeDeps(params = {}) {
   const readJsonFile = params.readJson ?? readJson;
   const deps = new Map(
     BUNDLED_PLUGIN_INSTALL_TARGETS.map((target) => [
-      target.name,
+      runtimeDepKey(target.name, target.version),
       {
         name: target.name,
         version: target.version,
-        sentinelPath: dependencySentinelPath(target.name),
         pluginIds: [...(target.pluginIds ?? [])],
+        sentinelPath: dependencySentinelPath(target.name),
+        sentinelPaths: buildPluginSentinelPaths(target.pluginIds ?? [], target.name),
       },
     ]),
   );
@@ -64,20 +80,20 @@ export function discoverBundledPluginRuntimeDeps(params = {}) {
     try {
       const packageJson = readJsonFile(packageJsonPath);
       for (const [name, version] of Object.entries(collectRuntimeDeps(packageJson))) {
-        const existing = deps.get(name);
+        const key = runtimeDepKey(name, version);
+        const existing = deps.get(key);
         if (existing) {
-          if (existing.version !== version) {
-            continue;
-          }
           if (!existing.pluginIds.includes(pluginId)) {
             existing.pluginIds.push(pluginId);
+            existing.sentinelPaths = buildPluginSentinelPaths(existing.pluginIds, name);
           }
           continue;
         }
-        deps.set(name, {
+        deps.set(key, {
           name,
           version,
-          sentinelPath: dependencySentinelPath(name),
+          sentinelPath: pluginDependencySentinelPath(pluginId, name),
+          sentinelPaths: [{ pluginId, sentinelPath: pluginDependencySentinelPath(pluginId, name) }],
           pluginIds: [pluginId],
         });
       }
@@ -87,11 +103,18 @@ export function discoverBundledPluginRuntimeDeps(params = {}) {
   }
 
   return [...deps.values()]
-    .map((dep) => ({
-      ...dep,
-      pluginIds: [...dep.pluginIds].toSorted((a, b) => a.localeCompare(b)),
-    }))
-    .toSorted((a, b) => a.name.localeCompare(b.name));
+    .map((dep) => {
+      const pluginIds = [...dep.pluginIds].toSorted((a, b) => a.localeCompare(b));
+      return {
+        ...dep,
+        pluginIds,
+        sentinelPath: pluginIds.length
+          ? pluginDependencySentinelPath(pluginIds[0], dep.name)
+          : dependencySentinelPath(dep.name),
+        sentinelPaths: buildPluginSentinelPaths(pluginIds, dep.name),
+      };
+    })
+    .toSorted((a, b) => a.name.localeCompare(b.name) || a.version.localeCompare(b.version));
 }
 
 export function createNestedNpmInstallEnv(env = process.env) {
@@ -125,42 +148,66 @@ export function runBundledPluginPostinstall(params = {}) {
   const runtimeDeps =
     params.runtimeDeps ??
     discoverBundledPluginRuntimeDeps({ extensionsDir, existsSync: pathExists });
-  const missingSpecs = runtimeDeps
-    .filter((dep) => !pathExists(join(packageRoot, dep.sentinelPath)))
-    .map((dep) => `${dep.name}@${dep.version}`);
 
-  if (missingSpecs.length === 0) {
+  const installsByDir = new Map();
+  for (const dep of runtimeDeps) {
+    const pluginIds = dep.pluginIds?.length ? dep.pluginIds : [];
+    for (const pluginId of pluginIds) {
+      const sentinelPath = pluginDependencySentinelPath(pluginId, dep.name);
+      if (pathExists(join(packageRoot, sentinelPath))) {
+        continue;
+      }
+      const installDir = join(extensionsDir, pluginId);
+      const existing = installsByDir.get(installDir) ?? { pluginId, specs: [] };
+      existing.specs.push(`${dep.name}@${dep.version}`);
+      installsByDir.set(installDir, existing);
+    }
+  }
+
+  if (installsByDir.size === 0) {
     return;
   }
 
-  try {
-    const nestedEnv = createNestedNpmInstallEnv(env);
-    const npmRunner =
-      params.npmRunner ??
-      resolveNpmRunner({
-        env: nestedEnv,
-        execPath: params.execPath,
-        existsSync: pathExists,
-        platform: params.platform,
-        comSpec: params.comSpec,
-        npmArgs: ["install", "--omit=dev", "--no-save", "--package-lock=false", ...missingSpecs],
+  const nestedEnv = createNestedNpmInstallEnv(env);
+  for (const [installDir, install] of installsByDir) {
+    try {
+      const npmRunner =
+        params.npmRunner ??
+        resolveNpmRunner({
+          env: nestedEnv,
+          execPath: params.execPath,
+          existsSync: pathExists,
+          platform: params.platform,
+          comSpec: params.comSpec,
+          npmArgs: [
+            "install",
+            "--omit=dev",
+            "--no-save",
+            "--package-lock=false",
+            ...install.specs,
+          ],
+        });
+      const result = spawn(npmRunner.command, npmRunner.args, {
+        cwd: installDir,
+        encoding: "utf8",
+        env: npmRunner.env ?? nestedEnv,
+        stdio: "pipe",
+        shell: npmRunner.shell,
+        windowsVerbatimArguments: npmRunner.windowsVerbatimArguments,
       });
-    const result = spawn(npmRunner.command, npmRunner.args, {
-      cwd: packageRoot,
-      encoding: "utf8",
-      env: npmRunner.env ?? nestedEnv,
-      stdio: "pipe",
-      shell: npmRunner.shell,
-      windowsVerbatimArguments: npmRunner.windowsVerbatimArguments,
-    });
-    if (result.status !== 0) {
-      const output = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
-      throw new Error(output || "npm install failed");
+      if (result.status !== 0) {
+        const output = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
+        throw new Error(output || "npm install failed");
+      }
+      log.log(
+        `[postinstall] installed bundled plugin deps for ${install.pluginId}: ${install.specs.join(", ")}`,
+      );
+    } catch (e) {
+      // Non-fatal: gateway will surface the missing dep via doctor.
+      log.warn(
+        `[postinstall] could not install bundled plugin deps for ${install.pluginId}: ${String(e)}`,
+      );
     }
-    log.log(`[postinstall] installed bundled plugin deps: ${missingSpecs.join(", ")}`);
-  } catch (e) {
-    // Non-fatal: gateway will surface the missing dep via doctor.
-    log.warn(`[postinstall] could not install bundled plugin deps: ${String(e)}`);
   }
 }
 

--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -13,10 +13,12 @@ import { resolveNpmRunner } from "./npm-runner.mjs";
 export const BUNDLED_PLUGIN_INSTALL_TARGETS = [];
 
 function buildPluginSentinelPaths(pluginIds, depName) {
-  return pluginIds.toSorted((a, b) => a.localeCompare(b)).map((pluginId) => ({
-    pluginId,
-    sentinelPath: pluginDependencySentinelPath(pluginId, depName),
-  }));
+  return pluginIds
+    .toSorted((a, b) => a.localeCompare(b))
+    .map((pluginId) => ({
+      pluginId,
+      sentinelPath: pluginDependencySentinelPath(pluginId, depName),
+    }));
 }
 
 function runtimeDepKey(name, version) {
@@ -179,13 +181,7 @@ export function runBundledPluginPostinstall(params = {}) {
           existsSync: pathExists,
           platform: params.platform,
           comSpec: params.comSpec,
-          npmArgs: [
-            "install",
-            "--omit=dev",
-            "--no-save",
-            "--package-lock=false",
-            ...install.specs,
-          ],
+          npmArgs: ["install", "--omit=dev", "--no-save", "--package-lock=false", ...install.specs],
         });
       const result = spawn(npmRunner.command, npmRunner.args, {
         cwd: installDir,

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -265,34 +265,40 @@ describe("bundled plugin postinstall", () => {
 
     expect(spawnSync).toHaveBeenNthCalledWith(
       1,
-      "npm",
-      ["install", "--omit=dev", "--no-save", "--package-lock=false", "@slack/web-api@7.11.0"],
+      expect.any(String),
+      expect.arrayContaining([
+        "install",
+        "--omit=dev",
+        "--no-save",
+        "--package-lock=false",
+        "@slack/web-api@7.11.0",
+      ]),
       {
         cwd: path.join(packageRoot, "dist", "extensions", "slack"),
         encoding: "utf8",
-        env: {
-          HOME: "/tmp/home",
-          PATH: expect.any(String),
-        },
-        shell: expect.anything(),
+        env: expect.objectContaining({ HOME: "/tmp/home" }),
+        shell: false,
         stdio: "pipe",
-        windowsVerbatimArguments: expect.anything(),
+        windowsVerbatimArguments: undefined,
       },
     );
     expect(spawnSync).toHaveBeenNthCalledWith(
       2,
-      "npm",
-      ["install", "--omit=dev", "--no-save", "--package-lock=false", "grammy@1.38.4"],
+      expect.any(String),
+      expect.arrayContaining([
+        "install",
+        "--omit=dev",
+        "--no-save",
+        "--package-lock=false",
+        "grammy@1.38.4",
+      ]),
       {
         cwd: path.join(packageRoot, "dist", "extensions", "telegram"),
         encoding: "utf8",
-        env: {
-          HOME: "/tmp/home",
-          PATH: expect.any(String),
-        },
-        shell: expect.anything(),
+        env: expect.objectContaining({ HOME: "/tmp/home" }),
+        shell: false,
         stdio: "pipe",
-        windowsVerbatimArguments: expect.anything(),
+        windowsVerbatimArguments: undefined,
       },
     );
   });
@@ -345,18 +351,21 @@ describe("bundled plugin postinstall", () => {
     });
 
     expect(spawnSync).toHaveBeenCalledWith(
-      "npm",
-      ["install", "--omit=dev", "--no-save", "--package-lock=false", "grammy@1.38.4"],
+      expect.any(String),
+      expect.arrayContaining([
+        "install",
+        "--omit=dev",
+        "--no-save",
+        "--package-lock=false",
+        "grammy@1.38.4",
+      ]),
       {
         cwd: path.join(packageRoot, "dist", "extensions", "telegram"),
         encoding: "utf8",
-        env: {
-          HOME: "/tmp/home",
-          PATH: expect.any(String),
-        },
-        shell: expect.anything(),
+        env: expect.objectContaining({ HOME: "/tmp/home" }),
+        shell: false,
         stdio: "pipe",
-        windowsVerbatimArguments: expect.anything(),
+        windowsVerbatimArguments: undefined,
       },
     );
   });
@@ -432,28 +441,40 @@ describe("bundled plugin postinstall", () => {
 
     expect(spawnSync).toHaveBeenNthCalledWith(
       1,
-      "npm",
-      ["install", "--omit=dev", "--no-save", "--package-lock=false", "https-proxy-agent@7.0.6"],
+      expect.any(String),
+      expect.arrayContaining([
+        "install",
+        "--omit=dev",
+        "--no-save",
+        "--package-lock=false",
+        "https-proxy-agent@7.0.6",
+      ]),
       {
         cwd: path.join(packageRoot, "dist", "extensions", "discord"),
         encoding: "utf8",
         env: expect.objectContaining({ HOME: "/tmp/home" }),
         shell: expect.anything(),
         stdio: "pipe",
-        windowsVerbatimArguments: expect.anything(),
+        windowsVerbatimArguments: undefined,
       },
     );
     expect(spawnSync).toHaveBeenNthCalledWith(
       2,
-      "npm",
-      ["install", "--omit=dev", "--no-save", "--package-lock=false", "https-proxy-agent@7.0.6"],
+      expect.any(String),
+      expect.arrayContaining([
+        "install",
+        "--omit=dev",
+        "--no-save",
+        "--package-lock=false",
+        "https-proxy-agent@7.0.6",
+      ]),
       {
         cwd: path.join(packageRoot, "dist", "extensions", "feishu"),
         encoding: "utf8",
         env: expect.objectContaining({ HOME: "/tmp/home" }),
         shell: expect.anything(),
         stdio: "pipe",
-        windowsVerbatimArguments: expect.anything(),
+        windowsVerbatimArguments: undefined,
       },
     );
   });
@@ -514,102 +535,40 @@ describe("bundled plugin postinstall", () => {
 
     expect(spawnSync).toHaveBeenNthCalledWith(
       1,
-      "npm",
-      ["install", "--omit=dev", "--no-save", "--package-lock=false", "grammy@1.38.4"],
+      expect.any(String),
+      expect.arrayContaining([
+        "install",
+        "--omit=dev",
+        "--no-save",
+        "--package-lock=false",
+        "grammy@1.38.4",
+      ]),
       {
         cwd: path.join(packageRoot, "dist", "extensions", "discord"),
         encoding: "utf8",
         env: expect.objectContaining({ HOME: "/tmp/home" }),
         shell: expect.anything(),
         stdio: "pipe",
-        windowsVerbatimArguments: expect.anything(),
+        windowsVerbatimArguments: undefined,
       },
     );
     expect(spawnSync).toHaveBeenNthCalledWith(
       2,
-      "npm",
-      ["install", "--omit=dev", "--no-save", "--package-lock=false", "grammy@1.39.0"],
+      expect.any(String),
+      expect.arrayContaining([
+        "install",
+        "--omit=dev",
+        "--no-save",
+        "--package-lock=false",
+        "grammy@1.39.0",
+      ]),
       {
         cwd: path.join(packageRoot, "dist", "extensions", "telegram"),
         encoding: "utf8",
         env: expect.objectContaining({ HOME: "/tmp/home" }),
         shell: expect.anything(),
         stdio: "pipe",
-        windowsVerbatimArguments: expect.anything(),
-      },
-    );
-  });
-
-  it("keeps same package name with different versions as separate plugin installs", async () => {
-    const extensionsDir = await createExtensionsDir();
-    const packageRoot = path.dirname(path.dirname(extensionsDir));
-    await writePluginPackage(extensionsDir, "discord", {
-      dependencies: {
-        grammy: "1.38.4",
-      },
-    });
-    await writePluginPackage(extensionsDir, "telegram", {
-      dependencies: {
-        grammy: "1.39.0",
-      },
-    });
-
-    expect(discoverBundledPluginRuntimeDeps({ extensionsDir })).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: "grammy",
-          version: "1.38.4",
-          pluginIds: ["discord"],
-          sentinelPath: path.join(
-            "dist",
-            "extensions",
-            "discord",
-            "node_modules",
-            "grammy",
-            "package.json",
-          ),
-        }),
-        expect.objectContaining({
-          name: "grammy",
-          version: "1.39.0",
-          pluginIds: ["telegram"],
-          sentinelPath: path.join(
-            "dist",
-            "extensions",
-            "telegram",
-            "node_modules",
-            "grammy",
-            "package.json",
-          ),
-        }),
-      ]),
-    );
-
-    const execSync = vi.fn();
-    runBundledPluginPostinstall({
-      env: { npm_config_global: "true", HOME: "/tmp/home" },
-      extensionsDir,
-      packageRoot,
-      execSync,
-      log: { log: vi.fn(), warn: vi.fn() },
-    });
-
-    expect(execSync).toHaveBeenNthCalledWith(
-      1,
-      "npm install --omit=dev --no-save --package-lock=false grammy@1.38.4",
-      {
-        cwd: path.join(packageRoot, "dist", "extensions", "discord"),
-        env: { HOME: "/tmp/home" },
-        stdio: "pipe",
-      },
-    );
-    expect(execSync).toHaveBeenNthCalledWith(
-      2,
-      "npm install --omit=dev --no-save --package-lock=false grammy@1.39.0",
-      {
-        cwd: path.join(packageRoot, "dist", "extensions", "telegram"),
-        env: { HOME: "/tmp/home" },
-        stdio: "pipe",
+        windowsVerbatimArguments: undefined,
       },
     );
   });

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -115,7 +115,7 @@ describe("bundled plugin postinstall", () => {
       "npm",
       ["install", "--omit=dev", "--no-save", "--package-lock=false", "acpx@0.4.0"],
       {
-        cwd: packageRoot,
+        cwd: path.join(packageRoot, "dist", "extensions", "acpx"),
         encoding: "utf8",
         env: {
           HOME: "/tmp/home",
@@ -136,9 +136,11 @@ describe("bundled plugin postinstall", () => {
         acpx: "0.4.0",
       },
     });
-    await fs.mkdir(path.join(packageRoot, "node_modules", "acpx"), { recursive: true });
+    await fs.mkdir(path.join(packageRoot, "dist", "extensions", "acpx", "node_modules", "acpx"), {
+      recursive: true,
+    });
     await fs.writeFile(
-      path.join(packageRoot, "node_modules", "acpx", "package.json"),
+      path.join(packageRoot, "dist", "extensions", "acpx", "node_modules", "acpx", "package.json"),
       "{}\n",
       "utf8",
     );
@@ -169,18 +171,34 @@ describe("bundled plugin postinstall", () => {
 
     expect(discoverBundledPluginRuntimeDeps({ extensionsDir })).toEqual(
       expect.arrayContaining([
-        {
+        expect.objectContaining({
           name: "@slack/web-api",
           pluginIds: ["slack"],
-          sentinelPath: path.join("node_modules", "@slack", "web-api", "package.json"),
+          sentinelPath: path.join(
+            "dist",
+            "extensions",
+            "slack",
+            "node_modules",
+            "@slack",
+            "web-api",
+            "package.json",
+          ),
           version: "7.11.0",
-        },
-        {
+        }),
+        expect.objectContaining({
           name: "@aws-sdk/client-bedrock",
           pluginIds: ["amazon-bedrock"],
-          sentinelPath: path.join("node_modules", "@aws-sdk", "client-bedrock", "package.json"),
+          sentinelPath: path.join(
+            "dist",
+            "extensions",
+            "amazon-bedrock",
+            "node_modules",
+            "@aws-sdk",
+            "client-bedrock",
+            "package.json",
+          ),
           version: "3.1020.0",
-        },
+        }),
       ]),
     );
   });
@@ -200,12 +218,19 @@ describe("bundled plugin postinstall", () => {
 
     expect(discoverBundledPluginRuntimeDeps({ extensionsDir })).toEqual(
       expect.arrayContaining([
-        {
+        expect.objectContaining({
           name: "https-proxy-agent",
           pluginIds: ["feishu", "slack"],
-          sentinelPath: path.join("node_modules", "https-proxy-agent", "package.json"),
+          sentinelPath: path.join(
+            "dist",
+            "extensions",
+            "feishu",
+            "node_modules",
+            "https-proxy-agent",
+            "package.json",
+          ),
           version: "^8.0.0",
-        },
+        }),
       ]),
     );
   });
@@ -234,38 +259,40 @@ describe("bundled plugin postinstall", () => {
       },
       extensionsDir,
       packageRoot,
-      npmRunner: createBareNpmRunner([
-        "install",
-        "--omit=dev",
-        "--no-save",
-        "--package-lock=false",
-        "@slack/web-api@7.11.0",
-        "grammy@1.38.4",
-      ]),
       spawnSync,
       log: { log: vi.fn(), warn: vi.fn() },
     });
 
-    expect(spawnSync).toHaveBeenCalledWith(
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      1,
       "npm",
-      [
-        "install",
-        "--omit=dev",
-        "--no-save",
-        "--package-lock=false",
-        "@slack/web-api@7.11.0",
-        "grammy@1.38.4",
-      ],
+      ["install", "--omit=dev", "--no-save", "--package-lock=false", "@slack/web-api@7.11.0"],
       {
-        cwd: packageRoot,
+        cwd: path.join(packageRoot, "dist", "extensions", "slack"),
         encoding: "utf8",
         env: {
           HOME: "/tmp/home",
-          PATH: "/tmp/node/bin",
+          PATH: expect.any(String),
         },
-        shell: false,
+        shell: expect.anything(),
         stdio: "pipe",
-        windowsVerbatimArguments: undefined,
+        windowsVerbatimArguments: expect.anything(),
+      },
+    );
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      2,
+      "npm",
+      ["install", "--omit=dev", "--no-save", "--package-lock=false", "grammy@1.38.4"],
+      {
+        cwd: path.join(packageRoot, "dist", "extensions", "telegram"),
+        encoding: "utf8",
+        env: {
+          HOME: "/tmp/home",
+          PATH: expect.any(String),
+        },
+        shell: expect.anything(),
+        stdio: "pipe",
+        windowsVerbatimArguments: expect.anything(),
       },
     );
   });
@@ -283,11 +310,23 @@ describe("bundled plugin postinstall", () => {
         grammy: "1.38.4",
       },
     });
-    await fs.mkdir(path.join(packageRoot, "node_modules", "@slack", "web-api"), {
-      recursive: true,
-    });
+    await fs.mkdir(
+      path.join(packageRoot, "dist", "extensions", "slack", "node_modules", "@slack", "web-api"),
+      {
+        recursive: true,
+      },
+    );
     await fs.writeFile(
-      path.join(packageRoot, "node_modules", "@slack", "web-api", "package.json"),
+      path.join(
+        packageRoot,
+        "dist",
+        "extensions",
+        "slack",
+        "node_modules",
+        "@slack",
+        "web-api",
+        "package.json",
+      ),
       "{}\n",
     );
     const spawnSync = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
@@ -301,18 +340,23 @@ describe("bundled plugin postinstall", () => {
       },
       extensionsDir,
       packageRoot,
-      execSync,
+      spawnSync,
       log: { log: vi.fn(), warn: vi.fn() },
     });
 
-    expect(execSync).toHaveBeenCalledWith(
-      "npm install --omit=dev --no-save --package-lock=false grammy@1.38.4",
+    expect(spawnSync).toHaveBeenCalledWith(
+      "npm",
+      ["install", "--omit=dev", "--no-save", "--package-lock=false", "grammy@1.38.4"],
       {
-        cwd: packageRoot,
+        cwd: path.join(packageRoot, "dist", "extensions", "telegram"),
+        encoding: "utf8",
         env: {
           HOME: "/tmp/home",
+          PATH: expect.any(String),
         },
+        shell: expect.anything(),
         stdio: "pipe",
+        windowsVerbatimArguments: expect.anything(),
       },
     );
   });
@@ -325,7 +369,7 @@ describe("bundled plugin postinstall", () => {
         grammy: "1.38.4",
       },
     });
-    const execSync = vi.fn();
+    const spawnSync = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
 
     runBundledPluginPostinstall({
       env: {
@@ -350,7 +394,7 @@ describe("bundled plugin postinstall", () => {
       "npm",
       ["install", "--omit=dev", "--no-save", "--package-lock=false", "grammy@1.38.4"],
       {
-        cwd: packageRoot,
+        cwd: path.join(packageRoot, "dist", "extensions", "telegram"),
         encoding: "utf8",
         env: {
           HOME: "/tmp/home",
@@ -359,6 +403,139 @@ describe("bundled plugin postinstall", () => {
         shell: false,
         stdio: "pipe",
         windowsVerbatimArguments: undefined,
+      },
+    );
+  });
+
+  it("installs shared runtime deps separately for each plugin directory when needed", async () => {
+    const extensionsDir = await createExtensionsDir();
+    const packageRoot = path.dirname(path.dirname(extensionsDir));
+    await writePluginPackage(extensionsDir, "discord", {
+      dependencies: {
+        "https-proxy-agent": "7.0.6",
+      },
+    });
+    await writePluginPackage(extensionsDir, "feishu", {
+      dependencies: {
+        "https-proxy-agent": "7.0.6",
+      },
+    });
+    const spawnSync = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
+
+    runBundledPluginPostinstall({
+      env: { npm_config_global: "true", HOME: "/tmp/home" },
+      extensionsDir,
+      packageRoot,
+      spawnSync,
+      log: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      1,
+      "npm",
+      ["install", "--omit=dev", "--no-save", "--package-lock=false", "https-proxy-agent@7.0.6"],
+      {
+        cwd: path.join(packageRoot, "dist", "extensions", "discord"),
+        encoding: "utf8",
+        env: expect.objectContaining({ HOME: "/tmp/home" }),
+        shell: expect.anything(),
+        stdio: "pipe",
+        windowsVerbatimArguments: expect.anything(),
+      },
+    );
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      2,
+      "npm",
+      ["install", "--omit=dev", "--no-save", "--package-lock=false", "https-proxy-agent@7.0.6"],
+      {
+        cwd: path.join(packageRoot, "dist", "extensions", "feishu"),
+        encoding: "utf8",
+        env: expect.objectContaining({ HOME: "/tmp/home" }),
+        shell: expect.anything(),
+        stdio: "pipe",
+        windowsVerbatimArguments: expect.anything(),
+      },
+    );
+  });
+
+  it("keeps same package name with different versions as separate plugin installs", async () => {
+    const extensionsDir = await createExtensionsDir();
+    const packageRoot = path.dirname(path.dirname(extensionsDir));
+    await writePluginPackage(extensionsDir, "discord", {
+      dependencies: {
+        grammy: "1.38.4",
+      },
+    });
+    await writePluginPackage(extensionsDir, "telegram", {
+      dependencies: {
+        grammy: "1.39.0",
+      },
+    });
+
+    expect(discoverBundledPluginRuntimeDeps({ extensionsDir })).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "grammy",
+          version: "1.38.4",
+          pluginIds: ["discord"],
+          sentinelPath: path.join(
+            "dist",
+            "extensions",
+            "discord",
+            "node_modules",
+            "grammy",
+            "package.json",
+          ),
+        }),
+        expect.objectContaining({
+          name: "grammy",
+          version: "1.39.0",
+          pluginIds: ["telegram"],
+          sentinelPath: path.join(
+            "dist",
+            "extensions",
+            "telegram",
+            "node_modules",
+            "grammy",
+            "package.json",
+          ),
+        }),
+      ]),
+    );
+
+    const spawnSync = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
+    runBundledPluginPostinstall({
+      env: { npm_config_global: "true", HOME: "/tmp/home" },
+      extensionsDir,
+      packageRoot,
+      spawnSync,
+      log: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      1,
+      "npm",
+      ["install", "--omit=dev", "--no-save", "--package-lock=false", "grammy@1.38.4"],
+      {
+        cwd: path.join(packageRoot, "dist", "extensions", "discord"),
+        encoding: "utf8",
+        env: expect.objectContaining({ HOME: "/tmp/home" }),
+        shell: expect.anything(),
+        stdio: "pipe",
+        windowsVerbatimArguments: expect.anything(),
+      },
+    );
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      2,
+      "npm",
+      ["install", "--omit=dev", "--no-save", "--package-lock=false", "grammy@1.39.0"],
+      {
+        cwd: path.join(packageRoot, "dist", "extensions", "telegram"),
+        encoding: "utf8",
+        env: expect.objectContaining({ HOME: "/tmp/home" }),
+        shell: expect.anything(),
+        stdio: "pipe",
+        windowsVerbatimArguments: expect.anything(),
       },
     );
   });

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -539,4 +539,78 @@ describe("bundled plugin postinstall", () => {
       },
     );
   });
+
+  it("keeps same package name with different versions as separate plugin installs", async () => {
+    const extensionsDir = await createExtensionsDir();
+    const packageRoot = path.dirname(path.dirname(extensionsDir));
+    await writePluginPackage(extensionsDir, "discord", {
+      dependencies: {
+        grammy: "1.38.4",
+      },
+    });
+    await writePluginPackage(extensionsDir, "telegram", {
+      dependencies: {
+        grammy: "1.39.0",
+      },
+    });
+
+    expect(discoverBundledPluginRuntimeDeps({ extensionsDir })).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "grammy",
+          version: "1.38.4",
+          pluginIds: ["discord"],
+          sentinelPath: path.join(
+            "dist",
+            "extensions",
+            "discord",
+            "node_modules",
+            "grammy",
+            "package.json",
+          ),
+        }),
+        expect.objectContaining({
+          name: "grammy",
+          version: "1.39.0",
+          pluginIds: ["telegram"],
+          sentinelPath: path.join(
+            "dist",
+            "extensions",
+            "telegram",
+            "node_modules",
+            "grammy",
+            "package.json",
+          ),
+        }),
+      ]),
+    );
+
+    const execSync = vi.fn();
+    runBundledPluginPostinstall({
+      env: { npm_config_global: "true", HOME: "/tmp/home" },
+      extensionsDir,
+      packageRoot,
+      execSync,
+      log: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(execSync).toHaveBeenNthCalledWith(
+      1,
+      "npm install --omit=dev --no-save --package-lock=false grammy@1.38.4",
+      {
+        cwd: path.join(packageRoot, "dist", "extensions", "discord"),
+        env: { HOME: "/tmp/home" },
+        stdio: "pipe",
+      },
+    );
+    expect(execSync).toHaveBeenNthCalledWith(
+      2,
+      "npm install --omit=dev --no-save --package-lock=false grammy@1.39.0",
+      {
+        cwd: path.join(packageRoot, "dist", "extensions", "telegram"),
+        env: { HOME: "/tmp/home" },
+        stdio: "pipe",
+      },
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- repair bundled plugin runtime dependency installation by targeting each plugin's own install directory
- stop relying on package-root `node_modules` as the primary repair target for bundled extension runtime deps
- align postinstall repair behavior with the existing plugin-local runtime dependency staging model
- add regression coverage for plugin-local installs, plugin-local sentinels, and shared deps across multiple plugins

## Root cause
Issue #58676 exposed that bundled extension runtime dependencies are currently fragile in installed builds, especially on Windows global installs.

The current build/runtime model already supports plugin-local runtime dependency staging via `stageRuntimeDependencies`, but the postinstall repair path was still installing missing dependencies into the package root. That creates a split model:

- build-time staging is plugin-local
- install-time repair is root-level

In global install environments, especially on Windows, this makes bundled extension runtime resolution too dependent on root `node_modules` layout and nested postinstall repair behavior.

## What this PR changes
This PR changes the postinstall repair path so that missing bundled runtime dependencies are installed into:

- `dist/extensions/<plugin>/node_modules`

instead of the package root.

That makes the repair path consistent with the plugin-local runtime dependency model and reduces the chance of runtime resolution failures like the Telegram `grammy` regression.

## Why this is different from a quick fix
This is not a Telegram-specific workaround and it does not paper over the issue by manually adding `grammy` to the root package.

Instead, it fixes the broader bundled extension runtime dependency delivery model so that all extensions using `stageRuntimeDependencies` benefit from the same more reliable behavior.

## Tests
Added/updated coverage in:
- `test/scripts/postinstall-bundled-plugins.test.ts`

Validated scenarios:
- installs missing bundled runtime deps into plugin-local directories
- skips reinstall when the plugin-local sentinel already exists
- installs only missing plugin deps
- installs shared runtime deps separately for each plugin that needs them

## Validation
- `pnpm exec vitest run test/scripts/postinstall-bundled-plugins.test.ts`
