### PR TITLE
feat: add atlas delivery coordinator tools

### DIFF
--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -1,10 +1,10 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../src/config/config.js";
 import { buildPluginApi } from "../../src/plugins/api-builder.js";
 import type { PluginRuntime } from "../../src/plugins/runtime/types.js";
-import type { ProviderPlugin } from "../../src/plugins/types.js";
 import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
 import amazonBedrockPlugin from "./index.js";
 

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -46,7 +46,10 @@ if [ "${#format_files[@]}" -gt 0 ]; then
   "$RUN_NODE_TOOL" oxfmt --write --no-error-on-unmatched-pattern "${format_files[@]}"
 fi
 
-git add -- "${files[@]}"
+# Some upstream-tracked paths are intentionally matched by broad ignore rules
+# (for example generated screenshots, vendored files, or bundled binaries).
+# Re-stage them forcefully after fixers so merges don't fail at commit time.
+git add -f -- "${files[@]}"
 
 # This hook is also exercised from lightweight temp repos in tests, where the
 # staged-file safety behavior matters but the full OpenClaw workspace does not

--- a/skills/atlas-delivery/SKILL.md
+++ b/skills/atlas-delivery/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: atlas-delivery
+description: "Atlas-backed delivery coordination for Homio product work. Use when a user asks to change, fix, verify, preview, or inspect Atlas-managed behavior and the right flow is: clarify the goal, inspect repo state through atlas_inspect, then hand execution to Atlas via atlas_execution. NOT for direct code editing, direct PR promises, or owning live workspaces."
+metadata: { "openclaw": { "emoji": "🛰️" } }
+---
+
+# Atlas Delivery
+
+Use this skill when the user describes a product problem or desired change and `Atlas`
+should execute the implementation, verification, preview, or MR flow.
+
+## Core Role Split
+
+`OpenClaw` is the coordinator:
+
+- understand the business problem;
+- turn it into a short actionable brief;
+- inspect Atlas-managed repo state in readonly mode;
+- submit the brief to Atlas;
+- track status and translate it back into simple user language.
+
+`Atlas` is the execution owner:
+
+- code changes;
+- tests and verify runs;
+- preview stand;
+- MR evidence;
+- durable task/runtime state.
+
+Do not promise to push code, create a PR directly, or own a live workspace yourself.
+
+## Workflow
+
+1. Clarify the request until the goal, scope, and acceptance criteria are actionable.
+2. If the ask is broad, split it into something like `MVP -> verify -> polish`.
+3. If AKG or prior-memory retrieval tools are available in this deployment, use them first.
+4. Use `atlas_inspect` before proposing execution:
+   - `context` for repo/head/base context
+   - `search` for anchors
+   - `file` for exact implementation reading
+   - `changed_files` / `diff` when comparing branches
+   - `git_status` only when workspace dirtiness matters
+   - for Homio product work, default to repo `homio/core` unless the user explicitly names another repo
+5. Show the user a short brief:
+   - what you understood
+   - what will change
+   - what will not change
+   - how Atlas will verify it
+6. Once there are no critical unknowns, submit to Atlas with `atlas_execution`.
+7. Track work through `get`, `events`, and `artifacts`.
+8. Explain progress as human stages, not internal ids:
+   - understood
+   - preparing
+   - executing
+   - verifying
+   - preview ready
+9. When verify fails but the task is still actionable, iterate up to 3 times through Atlas.
+10. If Atlas returns `no_files_changed`, stop auto-retrying and clarify the brief/spec.
+11. If Atlas is unavailable or returns infrastructure failures (for example 503), do not propose a local/manual fallback path. Report Atlas as blocked and keep execution ownership in Atlas.
+
+## Submit Rules
+
+For `atlas_execution action="submit"`:
+
+- always provide `brief`
+- always provide `intent`
+- prefer a clear `title`
+- default to repo `homio/core` unless the user explicitly provided a different repo
+- do not ask which repo or branch to use unless `homio/core` is actually ambiguous or contradicted by evidence
+- include `acceptanceCriteria` when known
+- include `verifyPlan` when you already know how it should be checked
+- include `stagePlan` when the task was split into phases
+
+For Telegram-topic work:
+
+- ensure Atlas sees the real topic coordinates
+- if the current conversation context already includes Telegram `chatId/threadId`, let the tool infer them
+- do not invent fake thread ids
+
+For Bitrix-linked work:
+
+- keep Bitrix as a linked work item, not as the owner of execution state
+- only pass `bitrixTaskId` when it is actually known
+
+## Communication Rules
+
+- Hide Atlas internal ids from the user unless explicitly asked.
+- Report outcomes in terms of behavior, verification, preview URL, and what to check.
+- When preview is ready, tell the user what page/flow to open and what should now be true.
+- If Atlas is waiting on approval, say what decision is needed and why.
+- Do not ask the user for repo/branch defaults in ordinary Homio implementation requests.
+- Do not suggest “Option B: do it locally outside Atlas” when Atlas is temporarily unavailable.
+
+## Read Next
+
+If you need the exact meaning of every Atlas tool action, lifecycle state, artifact kind,
+transport rule, or runtime endpoint, read:
+
+- `references/atlas-contract.md`

--- a/skills/atlas-delivery/references/atlas-contract.md
+++ b/skills/atlas-delivery/references/atlas-contract.md
@@ -1,0 +1,278 @@
+# Atlas Contract Reference
+
+This file is the detailed contract for the `atlas-delivery` skill. Read it when you need
+the exact meaning of Atlas functions or when a task depends on transport, artifact, or
+status semantics.
+
+## 1. Boundary
+
+`OpenClaw` owns:
+
+- user clarification
+- business framing
+- brief construction
+- readonly inspection
+- execution tracking
+- user-facing narration
+
+`Atlas` owns:
+
+- mutable repo work
+- branch/workspace/stand lifecycle
+- verify execution
+- preview publishing
+- MR evidence
+- durable runtime state
+
+Never collapse these boundaries by promising direct code pushes or by treating local chat
+state as the source of truth.
+
+## 2. Atlas Auth And Base URL
+
+The current OpenClaw client resolves Atlas from:
+
+- `OPENCLAW_ATLAS_WEB_BASE_URL`, else `ATLAS_WEB_BASE_URL`
+- `OPENCLAW_ATLAS_A2A_TOKEN`, else `ATLAS_A2A_TOKEN`, else `ATLAS_WEB_LOGS_TOKEN`
+
+If these are missing, report configuration failure instead of emulating Atlas locally.
+
+Default Homio assumption:
+
+- unless the user explicitly says otherwise, implementation work targets `homio/core`
+- do not ask “which repo?” or “which branch?” in ordinary Homio delivery flows unless the default is contradicted by evidence
+
+## 3. OpenClaw Tool Surface
+
+### `atlas_inspect`
+
+Readonly inspection against a commit-pinned Atlas snapshot.
+
+Actions:
+
+- `context`
+  - Atlas endpoint: `GET /api/runtime/inspect/context`
+  - use to resolve repo, requested ref, `headSha`, optional `baseRef/baseSha`, and changed files against a base
+- `tree`
+  - Atlas endpoint: `GET /api/runtime/inspect/tree`
+  - use to browse tracked paths at the resolved snapshot
+- `file`
+  - Atlas endpoint: `GET /api/runtime/inspect/file`
+  - use to read one tracked file from the snapshot
+- `search`
+  - Atlas endpoint: `GET /api/runtime/inspect/search`
+  - use to find anchors before reading full files
+- `changed_files`
+  - Atlas endpoint: `GET /api/runtime/inspect/changed-files`
+  - requires `baseRef` and `headRef`
+- `diff`
+  - Atlas endpoint: `GET /api/runtime/inspect/diff`
+  - requires `baseRef` and `headRef`
+- `git_status`
+  - Atlas endpoint: `GET /api/runtime/inspect/git-status`
+  - use only when workspace dirtiness matters
+
+Important invariants:
+
+- this is readonly
+- Atlas resolves a real git repo under the trusted inspect root
+- invalid repo/path/ref inputs return structured errors
+- this is not a live workspace mount
+
+### `atlas_execution`
+
+Atlas execution and lifecycle access.
+
+Actions:
+
+- `agent_card`
+  - Atlas endpoint: `GET /api/a2a/agent-card`
+  - use to confirm capabilities
+- `submit`
+  - Atlas endpoint: `POST /api/a2a/tasks`
+  - use only after the brief is actionable
+- `list`
+  - Atlas endpoint: `GET /api/a2a/tasks`
+  - use to find related tasks or recover status
+- `get`
+  - Atlas endpoint: `GET /api/a2a/tasks/{id}`
+  - primary source of truth for task state
+- `events`
+  - Atlas endpoint: `GET /api/a2a/tasks/{id}/events`
+  - use to explain lifecycle transitions
+- `artifacts`
+  - Atlas endpoint: `GET /api/a2a/tasks/{id}/artifacts`
+  - use to fetch evidence
+
+Important invariants:
+
+- `brief` is required for `submit`
+- `telegram-topic` submit requires real `sourceChatId` and `sourceThreadId`
+- `409 conflict` means Atlas already has an active execution for the same topic/thread; attach to that task instead of creating another one
+- `atlas_execution` is mutating and must not be exposed through generic HTTP tool invoke or subagent execution
+
+## 4. Submit Envelope Meaning
+
+The current OpenClaw submit path sends:
+
+- `executionSpec.kind = "ExecutionSpec"`
+- `executionSpec.taskId`
+- `executionSpec.intent`
+- `executionSpec.repo`
+- `executionSpec.summary`
+- `executionSpec.target.taskId`
+- `executionSpec.target.env`
+- `executionSpec.target.branch`
+- top-level `atlasTaskId`
+- `executionSpec.metadata.title`
+- `executionSpec.metadata.brief`
+- `executionSpec.metadata.acceptanceCriteria`
+- `executionSpec.metadata.nonGoals`
+- `executionSpec.metadata.verifyPlan`
+- `executionSpec.metadata.stagePlan`
+- `executionSpec.metadata.linkedTargetTaskId` when the user-facing linked work item differs from the Atlas-owned task id
+
+It also sends source identity:
+
+- `source.agent = "openclaw"`
+- `source.transport`
+- `source.chatId`
+- `source.threadId`
+- `source.messageId`
+
+And extra linkage:
+
+- `sessionId`
+- `branch`
+- `envName`
+- `metadata.workThreadId`
+- `metadata.bitrixTaskId`
+- `metadata.linkedTargetTaskId`
+
+Important invariant:
+
+- `targetTaskId` is not the same thing as `atlasTaskId`
+- Atlas-owned execution identity must remain canonical and separate from linked external work items such as Bitrix
+
+## 5. Source Transport Inference
+
+If transport is not explicitly provided, the current tool infers it this way:
+
+1. explicit transport wins
+2. if the agent channel is Telegram and chat/thread context exists -> `telegram-topic`
+3. if the agent channel is Bitrix or `bitrixTaskId` is present -> `bitrix`
+4. otherwise -> `openclaw`
+
+Telegram context may come in either form:
+
+- `telegram:group-or-channel:chat:topic:thread`
+- split context like `agentTo="telegram:-100777"` plus `agentThreadId="4401"`
+
+Do not infer `bitrix` from a generic `targetTaskId` alone.
+
+## 6. Task Response Meaning
+
+Atlas task responses can include:
+
+- `task`
+- `runtimeSession`
+- `workThread`
+- `artifacts`
+- `latestArtifactByKind`
+
+Treat `latestArtifactByKind` as the fastest source of truth for:
+
+- `WorkspaceLease`
+- `PreviewLink`
+- `VerifyReport`
+- `MergeRequestArtifact`
+
+Do not infer completion from chat messages if Atlas artifacts disagree.
+
+## 7. Lifecycle States
+
+Common task states:
+
+- `queued`
+- `claimed`
+- `running`
+- `waiting_approval`
+- `completed`
+- `failed`
+- `cancelled`
+
+Translate them for the user as:
+
+- `queued/claimed` -> preparing
+- `running` -> executing
+- `waiting_approval` -> needs your decision
+- `completed` -> ready for review
+- `failed` -> Atlas could not complete execution
+
+## 8. Error Policy
+
+### `no_files_changed`
+
+Treat this as a brief/spec failure, not an implementation success and not a blind-retry case.
+Explain that Atlas found nothing actionable to change, then clarify the intended behavior.
+
+### Verify failure
+
+When the goal is still clear and the failure looks fixable, allow up to 3 Atlas iterations.
+After that, surface the blocker with evidence.
+
+### `409 a2a_active_topic_execution_exists`
+
+Do not create a parallel execution. Reuse or inspect the existing task.
+
+### Missing Atlas config
+
+If base URL or token is missing, say Atlas delivery is not configured and stop. Do not fall
+back to direct repo mutation.
+
+### Atlas infrastructure failure
+
+If Atlas is temporarily unavailable or returns infrastructure errors such as `503`, report that
+Atlas is blocked. Do not propose a local/manual bypass path that would move execution ownership
+out of Atlas.
+
+## 9. Atlas Runtime Endpoints Outside The Current Tool Surface
+
+These Atlas functions exist even if there is not yet a dedicated OpenClaw wrapper for each:
+
+- `GET /api/runtime/work-threads`
+- `POST /api/runtime/work-threads/ensure`
+- `GET /api/runtime/work-threads/by-topic`
+- `POST /api/runtime/work-threads/link-bitrix`
+- `POST /api/runtime/work-threads/unlink-bitrix`
+- `POST /api/runtime/telegram-topic`
+
+Meaning:
+
+- `work_threads` are the canonical thread-level entity across Telegram, Bitrix, transport bindings, and A2A
+- `by-topic` resolves a canonical work thread from `(chat_id, thread_id)`
+- `ensure` upserts the canonical work thread
+- `link-bitrix` and `unlink-bitrix` manage Bitrix as a linked work item
+- `telegram-topic` creates/records a Telegram topic on the Atlas side
+
+Current coordinator rule:
+
+- know these functions exist
+- prefer the wrapped tool surface
+- do not fabricate raw HTTP calls unless the deployment explicitly exposes them as allowed tools
+
+## 10. User-Facing Output
+
+The user should usually see:
+
+1. the brief
+2. current stage
+3. result of verification
+4. preview link and what to check
+5. next suggested iteration only if it is clearly useful
+
+The user should not need to see:
+
+- `A2A task id`
+- `work_thread id`
+- raw branch or lease bookkeeping
+- callback plumbing

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -130,10 +130,7 @@ function applyWhamCooldownResult(params: {
       : 0;
   return {
     ...params.computed,
-    cooldownUntil: Math.max(
-      existingActiveCooldownUntil,
-      params.now + params.whamResult.cooldownMs,
-    ),
+    cooldownUntil: Math.max(existingActiveCooldownUntil, params.now + params.whamResult.cooldownMs),
   };
 }
 

--- a/src/agents/openclaw-atlas-matrix.e2e.test.ts
+++ b/src/agents/openclaw-atlas-matrix.e2e.test.ts
@@ -1,0 +1,620 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import "./test-helpers/fast-core-tools.js";
+import { createOpenClawTools } from "./openclaw-tools.js";
+
+const atlasDir = "/Users/s1z0v/kd-projects/Homio/atlas";
+const token = "openclaw-atlas-matrix-token";
+const slots = ["ai01", "ai02", "ai03", "ai04", "ai05"] as const;
+const spawnedChildren = new Set<ChildProcess>();
+
+type MatrixTransport = "telegram-topic" | "bitrix";
+
+type MatrixCase = {
+  slot: (typeof slots)[number];
+  transport: MatrixTransport;
+  index: number;
+  a2aTaskId: string;
+  atlasTaskId: string;
+  branch: string;
+  title: string;
+  summary: string;
+  telegramChatId: string;
+  telegramTopicId: string;
+  bitrixTaskId: string;
+  bitrixChatId: string;
+};
+
+function mkTempDir(prefix: string) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function mkTempDb() {
+  return path.join(mkTempDir("openclaw-atlas-db-"), "mini-app.db");
+}
+
+function mkAutoenvStatePath() {
+  const dir = mkTempDir("openclaw-atlas-autoenv-");
+  const statePath = path.join(dir, "ai.json");
+  const initialState = Object.fromEntries(slots.map((slot) => [slot, {}]));
+  fs.writeFileSync(statePath, JSON.stringify(initialState, null, 2), "utf-8");
+  return statePath;
+}
+
+function createInspectRepoRoot() {
+  const root = mkTempDir("openclaw-atlas-inspect-root-");
+  const repoDir = path.join(root, "demo");
+  fs.mkdirSync(path.join(repoDir, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(repoDir, "src", "button.tsx"),
+    'export const loginButtonLabel = "Sign in";\n',
+    "utf-8",
+  );
+  execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "OpenClaw Matrix"], {
+    cwd: repoDir,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.email", "openclaw-matrix@example.test"], {
+    cwd: repoDir,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["add", "."], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoDir, stdio: "ignore" });
+  return { root, repoDir };
+}
+
+function spawnMiniApp(opts: {
+  port: number;
+  metricsPort: number;
+  dbPath: string;
+  autoenvStatePath: string;
+  inspectRepoRoot: string;
+}) {
+  const child = spawn(process.execPath, ["--import", "tsx", "scripts/mini-app/server.ts"], {
+    cwd: atlasDir,
+    env: {
+      ...process.env,
+      ATLAS_A2A_TOKEN: token,
+      ATLAS_WEB_LOGS_TOKEN: token,
+      ATLAS_WEB_DB_PATH: opts.dbPath,
+      ATLAS_WEB_PORT: String(opts.port),
+      ATLAS_WEB_METRICS_PORT: String(opts.metricsPort),
+      ATLAS_AUTOENV_STATE: opts.autoenvStatePath,
+      ATLAS_INSPECT_REPO_ROOT: opts.inspectRepoRoot,
+      ATLAS_INSPECT_REPO_NAMESPACE: "homio",
+    },
+    stdio: "ignore",
+  });
+  spawnedChildren.add(child);
+  return child;
+}
+
+async function stopChild(child: ChildProcess) {
+  if (child.exitCode !== null) {
+    spawnedChildren.delete(child);
+    return;
+  }
+  child.kill("SIGTERM");
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  if (child.exitCode === null) {
+    child.kill("SIGKILL");
+  }
+  spawnedChildren.delete(child);
+}
+
+afterEach(async () => {
+  for (const child of spawnedChildren) {
+    await stopChild(child);
+  }
+});
+
+async function waitForHealth(baseUrl: string, timeoutMs = 8000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const response = await fetch(`${baseUrl}/health`);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // retry
+    }
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  throw new Error(`mini-app did not become healthy within ${timeoutMs}ms`);
+}
+
+async function api(
+  baseUrl: string,
+  pathname: string,
+  init?: {
+    method?: string;
+    body?: Record<string, unknown> | null;
+  },
+) {
+  const response = await fetch(`${baseUrl}${pathname}`, {
+    method: init?.method || "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(init?.body ? { "Content-Type": "application/json" } : {}),
+    },
+    body: init?.body ? JSON.stringify(init.body) : undefined,
+  });
+  const text = await response.text();
+  let payload: unknown = null;
+  try {
+    payload = text ? JSON.parse(text) : null;
+  } catch {
+    payload = text;
+  }
+  return { response, payload };
+}
+
+async function expectOk<T = unknown>(
+  baseUrl: string,
+  pathname: string,
+  init?: {
+    method?: string;
+    body?: Record<string, unknown> | null;
+  },
+) {
+  const { response, payload } = await api(baseUrl, pathname, init);
+  assert.equal(
+    response.status,
+    200,
+    `${init?.method || "GET"} ${pathname} failed: ${JSON.stringify(payload)}`,
+  );
+  return payload as T;
+}
+
+function buildMatrixCase(
+  slot: (typeof slots)[number],
+  transport: MatrixTransport,
+  index: number,
+): MatrixCase {
+  const suffix = `${transport === "telegram-topic" ? "tg" : "bx"}-${slot}`;
+  return {
+    slot,
+    transport,
+    index,
+    a2aTaskId: `openclaw-a2a-${suffix}`,
+    atlasTaskId: `openclaw-atlas-${suffix}`,
+    branch: `feature/openclaw-matrix/${suffix}`,
+    title: `OpenClaw ${transport} ${slot}`,
+    summary: `OpenClaw local full contour ${transport} ${slot}`,
+    telegramChatId: `-10091${100 + index}`,
+    telegramTopicId: `${8100 + index}`,
+    bitrixTaskId: `bitrix-${suffix}`,
+    bitrixChatId: `chat-${suffix}`,
+  };
+}
+
+function createAtlasToolsContext(taskCase: MatrixCase) {
+  if (taskCase.transport === "telegram-topic") {
+    return createOpenClawTools({
+      agentChannel: "telegram",
+      agentTo:
+        taskCase.index % 2 === 0
+          ? `telegram:${taskCase.telegramChatId}`
+          : `telegram:group:${taskCase.telegramChatId}:topic:${taskCase.telegramTopicId}`,
+      agentThreadId: taskCase.telegramTopicId,
+    });
+  }
+  return createOpenClawTools({
+    agentChannel: "bitrix",
+    agentTo: `bitrix:${taskCase.bitrixChatId}`,
+  });
+}
+
+async function publishLifecycleArtifacts(baseUrl: string, taskCase: MatrixCase, a2aTaskId: string) {
+  const leasePayload = await expectOk<{ artifact?: { kind?: string } }>(
+    baseUrl,
+    `/api/a2a/tasks/${encodeURIComponent(a2aTaskId)}/artifacts`,
+    {
+      method: "POST",
+      body: {
+        kind: "WorkspaceLease",
+        payload: {
+          kind: "WorkspaceLease",
+          workspaceId: `ws-${taskCase.slot}-${taskCase.a2aTaskId}`,
+          taskId: a2aTaskId,
+          slotId: taskCase.slot,
+          branch: taskCase.branch,
+          headSha: `facefeed${taskCase.index}`,
+          accessMode: "read_only",
+          transport: {
+            kind: "workspace_projection",
+            endpoint: `a2a+atlas://workspace/${taskCase.slot}/${taskCase.a2aTaskId}`,
+          },
+        },
+      },
+    },
+  );
+  assert.equal(leasePayload?.artifact?.kind, "WorkspaceLease");
+
+  const previewPayload = await expectOk<{ artifact?: { kind?: string } }>(
+    baseUrl,
+    `/api/a2a/tasks/${encodeURIComponent(a2aTaskId)}/artifacts`,
+    {
+      method: "POST",
+      body: {
+        kind: "PreviewLink",
+        payload: {
+          kind: "PreviewLink",
+          envName: taskCase.slot,
+          branch: taskCase.branch,
+          url: `https://${taskCase.slot}.example.test/openclaw/${taskCase.index}`,
+        },
+      },
+    },
+  );
+  assert.equal(previewPayload?.artifact?.kind, "PreviewLink");
+
+  const verifyPayload = await expectOk<{ artifact?: { kind?: string } }>(
+    baseUrl,
+    `/api/a2a/tasks/${encodeURIComponent(a2aTaskId)}/artifacts`,
+    {
+      method: "POST",
+      body: {
+        kind: "VerifyReport",
+        payload: {
+          kind: "VerifyReport",
+          verifyKind: "ui",
+          status: "passed",
+          summary: {
+            passed: 3,
+            failed: 0,
+            slot: taskCase.slot,
+          },
+          reviewUrls: [`https://review.example.test/${taskCase.a2aTaskId}`],
+          primaryScreenshot: `.atlas/verifier/${taskCase.a2aTaskId}.png`,
+        },
+      },
+    },
+  );
+  assert.equal(verifyPayload?.artifact?.kind, "VerifyReport");
+
+  const mrPayload = await expectOk<{ artifact?: { kind?: string } }>(
+    baseUrl,
+    `/api/a2a/tasks/${encodeURIComponent(a2aTaskId)}/artifacts`,
+    {
+      method: "POST",
+      body: {
+        kind: "MergeRequestArtifact",
+        payload: {
+          kind: "MergeRequestArtifact",
+          url: `https://gitlab.example.test/${taskCase.a2aTaskId}/merge_requests/${taskCase.index}`,
+          iid: `${taskCase.index}`,
+          title: `${taskCase.title} MR`,
+        },
+      },
+    },
+  );
+  assert.equal(mrPayload?.artifact?.kind, "MergeRequestArtifact");
+}
+
+async function runMatrixTask(baseUrl: string, taskCase: MatrixCase) {
+  if (taskCase.transport === "bitrix" && taskCase.index % 2 === 0) {
+    const topicPayload = await expectOk<{ workThread?: { bitrixTaskId?: string } }>(
+      baseUrl,
+      "/api/runtime/telegram-topic",
+      {
+        method: "POST",
+        body: {
+          taskId: taskCase.atlasTaskId,
+          branch: taskCase.branch,
+          forumChatId: taskCase.telegramChatId,
+          telegramTopicId: taskCase.telegramTopicId,
+          bitrixTaskId: taskCase.bitrixTaskId,
+          bitrixChatId: taskCase.bitrixChatId,
+          title: taskCase.title,
+          summary: taskCase.summary,
+        },
+      },
+    );
+    assert.equal(topicPayload?.workThread?.bitrixTaskId, taskCase.bitrixTaskId);
+  }
+
+  const previousBaseUrl = process.env.OPENCLAW_ATLAS_WEB_BASE_URL;
+  const previousToken = process.env.OPENCLAW_ATLAS_A2A_TOKEN;
+  process.env.OPENCLAW_ATLAS_WEB_BASE_URL = baseUrl;
+  process.env.OPENCLAW_ATLAS_A2A_TOKEN = token;
+  try {
+    const tools = createAtlasToolsContext(taskCase);
+    const inspectTool = tools.find((candidate) => candidate.name === "atlas_inspect");
+    const executionTool = tools.find((candidate) => candidate.name === "atlas_execution");
+    if (!inspectTool || !executionTool) {
+      throw new Error("atlas tools are missing");
+    }
+
+    const contextResult = await inspectTool.execute(`inspect-context-${taskCase.index}`, {
+      action: "context",
+      repo: "homio/demo",
+      ref: "HEAD",
+    });
+    const contextDetails = contextResult.details as { ok?: boolean; result?: { headSha?: string } };
+    expect(contextDetails.ok).toBe(true);
+    expect(String(contextDetails.result?.headSha || "")).toHaveLength(40);
+
+    const fileResult = await inspectTool.execute(`inspect-file-${taskCase.index}`, {
+      action: "file",
+      repo: "homio/demo",
+      ref: "HEAD",
+      path: "src/button.tsx",
+    });
+    const fileDetails = fileResult.details as { ok?: boolean; result?: { content?: string } };
+    expect(fileDetails.ok).toBe(true);
+    expect(fileDetails.result?.content).toContain("Sign in");
+
+    const submitArgs: Record<string, string> = {
+      action: "submit",
+      taskId: taskCase.a2aTaskId,
+      atlasTaskId: taskCase.atlasTaskId,
+      title: taskCase.title,
+      summary: taskCase.summary,
+      repo: "homio/demo",
+      intent: "deploy_preview",
+      branch: taskCase.branch,
+      envName: taskCase.slot,
+      brief: `Prepare preview for ${taskCase.title}.`,
+      acceptanceCriteria: `Preview opens on ${taskCase.slot} and artifacts are published.`,
+      verifyPlan: "Publish VerifyReport after preview bind.",
+      stagePlan: "brief -> execute -> verify -> preview",
+    };
+    if (taskCase.transport === "bitrix") {
+      submitArgs.bitrixTaskId = taskCase.bitrixTaskId;
+    }
+
+    const submitResult = await executionTool.execute(`submit-${taskCase.index}`, submitArgs);
+    const submitDetails = submitResult.details as {
+      ok?: boolean;
+      result?: { task?: { id?: string }; workThread?: { id?: string | null } };
+    };
+    expect(submitDetails.ok).toBe(true);
+    expect(
+      submitDetails.result?.task?.id || (submitDetails.result as { id?: string } | undefined)?.id,
+    ).toBe(taskCase.a2aTaskId);
+    const workThreadId = String(submitDetails.result?.workThread?.id || "").trim() || null;
+    expect(workThreadId).toBeTruthy();
+
+    await expectOk(baseUrl, "/api/slots/lock", {
+      method: "POST",
+      body: {
+        slot: taskCase.slot,
+        taskId: taskCase.atlasTaskId,
+        branch: taskCase.branch,
+      },
+    });
+
+    const claimed = await expectOk<{ task?: { id?: string; claimToken?: string | null } }>(
+      baseUrl,
+      "/api/a2a/tasks/claim",
+      {
+        method: "POST",
+        body: {
+          claimedBy: "openclaw-matrix",
+          sourceAgent: "openclaw",
+          repo: "homio/demo",
+        },
+      },
+    );
+    assert.equal(claimed?.task?.id, taskCase.a2aTaskId);
+
+    await expectOk(baseUrl, `/api/a2a/tasks/${encodeURIComponent(taskCase.a2aTaskId)}/status`, {
+      method: "POST",
+      body: {
+        status: "running",
+        claimToken: claimed?.task?.claimToken || null,
+        metadata: {
+          executor: {
+            stage: "deploying_preview",
+          },
+          workThreadId,
+        },
+      },
+    });
+
+    await publishLifecycleArtifacts(baseUrl, taskCase, taskCase.a2aTaskId);
+
+    await expectOk(baseUrl, `/api/a2a/tasks/${encodeURIComponent(taskCase.a2aTaskId)}/status`, {
+      method: "POST",
+      body: {
+        status: "completed",
+        metadata: {
+          executor: {
+            stage: "completed",
+          },
+          workThreadId,
+        },
+      },
+    });
+
+    const getResult = await executionTool.execute(`get-${taskCase.index}`, {
+      action: "get",
+      taskId: taskCase.a2aTaskId,
+    });
+    const getDetails = getResult.details as {
+      ok?: boolean;
+      result?: {
+        task?: { atlasTaskId?: string | null; status?: string | null };
+        latestArtifactByKind?: Record<string, { kind?: string }>;
+        workThread?: { id?: string | null };
+      };
+    };
+    expect(getDetails.ok).toBe(true);
+    expect(getDetails.result?.task?.atlasTaskId).toBe(taskCase.atlasTaskId);
+    expect(getDetails.result?.task?.status).toBe("completed");
+    expect(getDetails.result?.latestArtifactByKind?.WorkspaceLease?.kind).toBe("WorkspaceLease");
+    expect(getDetails.result?.latestArtifactByKind?.PreviewLink?.kind).toBe("PreviewLink");
+    expect(getDetails.result?.latestArtifactByKind?.VerifyReport?.kind).toBe("VerifyReport");
+    expect(getDetails.result?.latestArtifactByKind?.MergeRequestArtifact?.kind).toBe(
+      "MergeRequestArtifact",
+    );
+    if (workThreadId) {
+      expect(getDetails.result?.workThread?.id).toBe(workThreadId);
+    }
+
+    const eventsResult = await executionTool.execute(`events-${taskCase.index}`, {
+      action: "events",
+      taskId: taskCase.a2aTaskId,
+      limit: 20,
+    });
+    const eventsDetails = eventsResult.details as {
+      ok?: boolean;
+      result?: { events?: Array<{ eventType?: string }> };
+    };
+    expect(eventsDetails.ok).toBe(true);
+    expect(eventsDetails.result?.events?.some((event) => event.eventType === "task.created")).toBe(
+      true,
+    );
+    expect(
+      eventsDetails.result?.events?.some((event) => event.eventType === "artifact.published"),
+    ).toBe(true);
+
+    const artifactsResult = await executionTool.execute(`artifacts-${taskCase.index}`, {
+      action: "artifacts",
+      taskId: taskCase.a2aTaskId,
+      limit: 20,
+    });
+    const artifactsDetails = artifactsResult.details as {
+      ok?: boolean;
+      result?: { artifacts?: Array<{ kind?: string }> };
+    };
+    expect(artifactsDetails.ok).toBe(true);
+    expect(artifactsDetails.result?.artifacts?.map((artifact) => artifact.kind)).toEqual(
+      expect.arrayContaining([
+        "WorkspaceLease",
+        "PreviewLink",
+        "VerifyReport",
+        "MergeRequestArtifact",
+      ]),
+    );
+
+    await expectOk(baseUrl, "/api/slots/unlock", {
+      method: "POST",
+      body: {
+        slot: taskCase.slot,
+        branch: taskCase.branch,
+      },
+    });
+
+    return {
+      slot: taskCase.slot,
+      transport: taskCase.transport,
+      a2aTaskId: taskCase.a2aTaskId,
+      atlasTaskId: taskCase.atlasTaskId,
+      workThreadId,
+    };
+  } finally {
+    if (previousBaseUrl === undefined) {
+      delete process.env.OPENCLAW_ATLAS_WEB_BASE_URL;
+    } else {
+      process.env.OPENCLAW_ATLAS_WEB_BASE_URL = previousBaseUrl;
+    }
+    if (previousToken === undefined) {
+      delete process.env.OPENCLAW_ATLAS_A2A_TOKEN;
+    } else {
+      process.env.OPENCLAW_ATLAS_A2A_TOKEN = previousToken;
+    }
+  }
+}
+
+describe("OpenClaw -> Atlas full contour matrix", () => {
+  it("runs 10 local delivery tasks through atlas_inspect, atlas_execution, slots, and artifacts", async () => {
+    const port = 26000 + Math.floor(Math.random() * 1000);
+    const metricsPort = port + 1;
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const dbPath = mkTempDb();
+    const autoenvStatePath = mkAutoenvStatePath();
+    const inspectRepo = createInspectRepoRoot();
+    const child = spawnMiniApp({
+      port,
+      metricsPort,
+      dbPath,
+      autoenvStatePath,
+      inspectRepoRoot: inspectRepo.root,
+    });
+
+    await waitForHealth(baseUrl);
+
+    const previousBaseUrl = process.env.OPENCLAW_ATLAS_WEB_BASE_URL;
+    const previousToken = process.env.OPENCLAW_ATLAS_A2A_TOKEN;
+    try {
+      const results: Array<{
+        slot: string;
+        transport: MatrixTransport;
+        a2aTaskId: string;
+        atlasTaskId: string;
+        workThreadId: string | null;
+      }> = [];
+
+      let index = 1;
+      for (const slot of slots) {
+        for (const transport of ["telegram-topic", "bitrix"] as const) {
+          const taskCase = buildMatrixCase(slot, transport, index++);
+          results.push(await runMatrixTask(baseUrl, taskCase));
+        }
+      }
+
+      expect(results).toHaveLength(10);
+      expect(new Set(results.map((item) => item.a2aTaskId)).size).toBe(10);
+      expect(new Set(results.map((item) => item.atlasTaskId)).size).toBe(10);
+
+      const listTool = createOpenClawTools().find(
+        (candidate) => candidate.name === "atlas_execution",
+      );
+      if (!listTool) {
+        throw new Error("missing atlas_execution tool");
+      }
+      process.env.OPENCLAW_ATLAS_WEB_BASE_URL = baseUrl;
+      process.env.OPENCLAW_ATLAS_A2A_TOKEN = token;
+      const listResult = await listTool.execute("list-matrix", {
+        action: "list",
+        repo: "homio/demo",
+        limit: 20,
+      });
+      const listDetails = listResult.details as {
+        ok?: boolean;
+        result?: { tasks?: Array<{ status?: string | null }> };
+      };
+      expect(listDetails.ok).toBe(true);
+      expect(listDetails.result?.tasks).toHaveLength(10);
+      expect(listDetails.result?.tasks?.filter((task) => task.status === "completed").length).toBe(
+        10,
+      );
+
+      const slotsPayload = await expectOk<{
+        slots: Array<{ status?: string | null }>;
+      }>(baseUrl, "/api/slots");
+      expect(slotsPayload?.slots).toHaveLength(slots.length);
+      for (const slotRow of slotsPayload.slots) {
+        expect(String(slotRow.status || "").trim()).toBe("free");
+      }
+
+      const autoenvState = JSON.parse(fs.readFileSync(autoenvStatePath, "utf-8")) as Record<
+        string,
+        Record<string, unknown>
+      >;
+      for (const slot of slots) {
+        expect(Object.keys(autoenvState[slot] || {})).toHaveLength(0);
+      }
+    } finally {
+      if (previousBaseUrl === undefined) {
+        delete process.env.OPENCLAW_ATLAS_WEB_BASE_URL;
+      } else {
+        process.env.OPENCLAW_ATLAS_WEB_BASE_URL = previousBaseUrl;
+      }
+      if (previousToken === undefined) {
+        delete process.env.OPENCLAW_ATLAS_A2A_TOKEN;
+      } else {
+        process.env.OPENCLAW_ATLAS_A2A_TOKEN = previousToken;
+      }
+      await stopChild(child);
+    }
+  }, 120000);
+});

--- a/src/agents/openclaw-tools.atlas.e2e.test.ts
+++ b/src/agents/openclaw-tools.atlas.e2e.test.ts
@@ -1,0 +1,1152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "./test-helpers/fast-core-tools.js";
+import { createOpenClawTools } from "./openclaw-tools.js";
+
+type FetchCall = [unknown, RequestInit?];
+
+function requestUrlFromCall(call: FetchCall | undefined): string {
+  const value = call?.[0];
+  if (value instanceof URL) {
+    return value.toString();
+  }
+  return typeof value === "string" ? value : "";
+}
+
+function parseRequestBody<T>(body: unknown): T {
+  if (typeof body === "string") {
+    return JSON.parse(body) as T;
+  }
+  if (body && typeof body === "object") {
+    return body as T;
+  }
+  return {} as T;
+}
+
+describe("Atlas-backed OpenClaw tools", () => {
+  beforeEach(() => {
+    process.env.OPENCLAW_ATLAS_WEB_BASE_URL = "https://atlas.example.test";
+    process.env.OPENCLAW_ATLAS_A2A_TOKEN = "atlas-test-token";
+  });
+
+  afterEach(() => {
+    delete process.env.OPENCLAW_ATLAS_WEB_BASE_URL;
+    delete process.env.OPENCLAW_ATLAS_A2A_TOKEN;
+    vi.unstubAllGlobals();
+  });
+
+  it("exposes atlas inspect and execution tools", () => {
+    const names = createOpenClawTools().map((tool) => tool.name);
+    expect(names).toContain("atlas_inspect");
+    expect(names).toContain("atlas_execution");
+  });
+
+  it("atlas_inspect reads snapshot file content through Atlas API", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            repo: "homio/core",
+            headSha: "abc123",
+            path: "src/button.tsx",
+            content: 'export const label = "Sign in";\n',
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_inspect");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_inspect tool");
+    }
+
+    const result = await tool.execute("call-atlas-inspect", {
+      action: "file",
+      repo: "homio/core",
+      ref: "abc123",
+      path: "src/button.tsx",
+    });
+
+    const details = result.details as {
+      ok?: boolean;
+      action?: string;
+      result?: { content?: string; headSha?: string };
+    };
+    expect(details.ok).toBe(true);
+    expect(details.action).toBe("file");
+    expect(details.result?.headSha).toBe("abc123");
+    expect(details.result?.content).toContain("Sign in");
+
+    const call = fetchMock.mock.calls[0] as unknown as FetchCall;
+    const [, init] = call;
+    const requestUrl = requestUrlFromCall(call);
+    expect(requestUrl).toContain("/api/runtime/inspect/file");
+    expect(requestUrl).toContain("repo=homio%2Fcore");
+    expect(requestUrl).toContain("path=src%2Fbutton.tsx");
+    expect(init).toBeDefined();
+    const headers = new Headers(init?.headers);
+    expect(headers.get("Authorization")).toBe("Bearer atlas-test-token");
+  });
+
+  it("atlas_execution submits execution briefs and surfaces 409 conflicts without throwing", async () => {
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const href = String(url);
+      if (href.includes("/api/runtime/work-threads/by-topic")) {
+        return new Response(JSON.stringify({ workThread: { id: "wt-conflict" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (init?.method === "POST" && href.includes("/api/a2a/tasks")) {
+        return new Response(
+          JSON.stringify({
+            error: "a2a_active_topic_execution_exists",
+            conflict: true,
+            existingTaskId: "existing-task-1",
+          }),
+          { status: 409, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-submit", {
+      action: "submit",
+      taskId: "atlas-task-1",
+      title: "Login button polish",
+      repo: "homio/core",
+      intent: "implement_feature",
+      branch: "feature/login-button",
+      envName: "ai02",
+      sourceTransport: "telegram-topic",
+      sourceChatId: "-100777",
+      sourceThreadId: "4401",
+      brief: "Improve the login button copy and color.",
+      acceptanceCriteria: "Button says Войти and the visual contrast passes.",
+      verifyPlan: "Add/update a focused UI test and run verify before preview.",
+    });
+
+    const details = result.details as {
+      ok?: boolean;
+      conflict?: boolean;
+      result?: { existingTaskId?: string };
+    };
+    expect(details.ok).toBe(false);
+    expect(details.conflict).toBe(true);
+    expect(details.result?.existingTaskId).toBe("existing-task-1");
+
+    const submitCall = fetchMock.mock.calls.find(
+      ([requestUrl, requestInit]) =>
+        String(requestUrl).includes("/api/a2a/tasks") && requestInit?.method === "POST",
+    );
+    expect(submitCall).toBeDefined();
+    const [, init] = submitCall as unknown as FetchCall;
+    expect(init).toBeDefined();
+    const body = parseRequestBody<{
+      executionSpec?: {
+        taskId?: string;
+        repo?: string;
+        metadata?: Record<string, unknown>;
+        target?: { env?: string; branch?: string };
+      };
+      source?: { transport?: string; chatId?: string; threadId?: string };
+      metadata?: Record<string, unknown>;
+    }>(init?.body);
+    expect(body.executionSpec?.taskId).toBe("atlas-task-1");
+    expect(body.executionSpec?.repo).toBe("homio/core");
+    expect(body.executionSpec?.target?.env).toBe("ai02");
+    expect(body.executionSpec?.target?.branch).toBe("feature/login-button");
+    expect(body.executionSpec?.metadata?.brief).toBe("Improve the login button copy and color.");
+    expect(body.source?.transport).toBe("telegram-topic");
+    expect(body.source?.chatId).toBe("-100777");
+    expect(body.source?.threadId).toBe("4401");
+    expect(body.metadata?.verifyPlan).toBe(
+      "Add/update a focused UI test and run verify before preview.",
+    );
+  });
+
+  it("atlas_execution infers telegram-topic source from tool context", async () => {
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const href = String(url);
+      if (href.includes("/api/runtime/work-threads/by-topic")) {
+        return new Response(JSON.stringify({ workThread: { id: "wt-ctx" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (init?.method === "POST" && href.includes("/api/a2a/tasks")) {
+        return new Response(JSON.stringify({ id: "atlas-task-ctx" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools({
+      agentChannel: "telegram",
+      agentTo: "telegram:group:-100777:topic:4401",
+      agentThreadId: "4401",
+    }).find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-submit-context", {
+      action: "submit",
+      taskId: "atlas-task-ctx",
+      title: "Login button polish",
+      repo: "homio/core",
+      intent: "implement_feature",
+      brief: "Improve the login button copy and color.",
+    });
+
+    const details = result.details as { ok?: boolean; result?: { id?: string } };
+    expect(details.ok).toBe(true);
+    expect(details.result?.id).toBe("atlas-task-ctx");
+
+    const submitCall = fetchMock.mock.calls.find(
+      ([requestUrl, requestInit]) =>
+        String(requestUrl).includes("/api/a2a/tasks") && requestInit?.method === "POST",
+    );
+    expect(submitCall).toBeDefined();
+    const [, init] = submitCall as unknown as FetchCall;
+    expect(init).toBeDefined();
+    const body = parseRequestBody<{
+      source?: { transport?: string; chatId?: string; threadId?: string };
+    }>(init?.body);
+    expect(body.source?.transport).toBe("telegram-topic");
+    expect(body.source?.chatId).toBe("-100777");
+    expect(body.source?.threadId).toBe("4401");
+  });
+
+  it("atlas_execution infers telegram chat from split target + thread context", async () => {
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const href = String(url);
+      if (href.includes("/api/runtime/work-threads/by-topic")) {
+        return new Response(JSON.stringify({ workThread: { id: "wt-split-ctx" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (init?.method === "POST" && href.includes("/api/a2a/tasks")) {
+        return new Response(JSON.stringify({ id: "atlas-task-split-ctx" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools({
+      agentChannel: "telegram",
+      agentTo: "telegram:-100777",
+      agentThreadId: "4401",
+    }).find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-submit-split-context", {
+      action: "submit",
+      taskId: "atlas-task-split-ctx",
+      title: "Login button polish",
+      repo: "homio/core",
+      intent: "implement_feature",
+      brief: "Improve the login button copy and color.",
+    });
+
+    const details = result.details as { ok?: boolean; result?: { id?: string } };
+    expect(details.ok).toBe(true);
+    expect(details.result?.id).toBe("atlas-task-split-ctx");
+
+    const submitCall = fetchMock.mock.calls.find(
+      ([requestUrl, requestInit]) =>
+        String(requestUrl).includes("/api/a2a/tasks") && requestInit?.method === "POST",
+    );
+    expect(submitCall).toBeDefined();
+    const [, init] = submitCall as unknown as FetchCall;
+    expect(init).toBeDefined();
+    const body = parseRequestBody<{
+      source?: { transport?: string; chatId?: string; threadId?: string };
+    }>(init?.body);
+    expect(body.source?.transport).toBe("telegram-topic");
+    expect(body.source?.chatId).toBe("-100777");
+    expect(body.source?.threadId).toBe("4401");
+  });
+
+  it("atlas_execution defaults to openclaw transport when no source context exists", async () => {
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return new Response(JSON.stringify({ id: "atlas-task-openclaw" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-submit-openclaw", {
+      action: "submit",
+      taskId: "atlas-task-openclaw",
+      title: "Login button polish",
+      repo: "homio/core",
+      intent: "implement_feature",
+      brief: "Improve the login button copy and color.",
+    });
+
+    const details = result.details as { ok?: boolean; result?: { id?: string } };
+    expect(details.ok).toBe(true);
+    expect(details.result?.id).toBe("atlas-task-openclaw");
+
+    const submitCall = fetchMock.mock.calls.find(
+      ([requestUrl, requestInit]) =>
+        String(requestUrl).includes("/api/a2a/tasks") && requestInit?.method === "POST",
+    );
+    expect(submitCall).toBeDefined();
+    const [, init] = submitCall as unknown as FetchCall;
+    expect(init).toBeDefined();
+    const body = parseRequestBody<{
+      source?: { transport?: string; chatId?: string | null; threadId?: string | null };
+    }>(init?.body);
+    expect(body.source?.transport).toBe("openclaw");
+    expect(body.source?.chatId ?? null).toBeNull();
+    expect(body.source?.threadId ?? null).toBeNull();
+  });
+
+  it("atlas_execution infers bitrix transport when task context is bitrix-linked", async () => {
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const href = String(url);
+      if (href.includes("/api/runtime/work-threads?")) {
+        return new Response(JSON.stringify({ workThreads: [{ id: "wt-bitrix" }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (init?.method === "POST" && href.includes("/api/a2a/tasks")) {
+        return new Response(JSON.stringify({ id: "atlas-task-bitrix" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools({
+      agentChannel: "bitrix",
+    }).find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-submit-bitrix", {
+      action: "submit",
+      taskId: "atlas-task-bitrix",
+      title: "Bitrix-linked polish",
+      repo: "homio/core",
+      intent: "implement_feature",
+      brief: "Improve the login button copy and color.",
+      bitrixTaskId: "bitrix-12345",
+    });
+
+    const details = result.details as { ok?: boolean; result?: { id?: string } };
+    expect(details.ok).toBe(true);
+    expect(details.result?.id).toBe("atlas-task-bitrix");
+
+    const submitCall = fetchMock.mock.calls.find(
+      ([requestUrl, requestInit]) =>
+        String(requestUrl).includes("/api/a2a/tasks") && requestInit?.method === "POST",
+    );
+    expect(submitCall).toBeDefined();
+    const [, init] = submitCall as unknown as FetchCall;
+    expect(init).toBeDefined();
+    const body = parseRequestBody<{
+      source?: { transport?: string };
+    }>(init?.body);
+    expect(body.source?.transport).toBe("bitrix");
+  });
+
+  it("atlas_execution infers bitrix chat id from bitrix target context", async () => {
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return new Response(JSON.stringify({ id: "atlas-task-bitrix-chat" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ workThreads: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools({
+      agentChannel: "bitrix",
+      agentTo: "bitrix:chat-441",
+    }).find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-submit-bitrix-chat", {
+      action: "submit",
+      taskId: "atlas-task-bitrix-chat",
+      title: "Bitrix chat inference",
+      repo: "homio/core",
+      intent: "implement_feature",
+      brief: "Use existing bitrix context.",
+      bitrixTaskId: "bitrix-441",
+    });
+
+    const details = result.details as { ok?: boolean; result?: { id?: string } };
+    expect(details.ok).toBe(true);
+    expect(details.result?.id).toBe("atlas-task-bitrix-chat");
+
+    const [, init] = fetchMock.mock.calls.at(-1) as unknown as FetchCall;
+    expect(init).toBeDefined();
+    const body = parseRequestBody<{
+      source?: { transport?: string; chatId?: string | null };
+    }>(init?.body);
+    expect(body.source?.transport).toBe("bitrix");
+    expect(body.source?.chatId).toBe("chat-441");
+  });
+
+  it("atlas_execution keeps atlasTaskId distinct from bitrixTaskId when no explicit atlas task exists", async () => {
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const href = String(url);
+      if (href.includes("/api/runtime/work-threads?")) {
+        return new Response(JSON.stringify({ workThreads: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (href.includes("/api/runtime/work-threads/ensure")) {
+        return new Response(JSON.stringify({ workThread: { id: "wt-bitrix-separate" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (init?.method === "POST" && href.includes("/api/a2a/tasks")) {
+        return new Response(JSON.stringify({ id: "a2a-task-bitrix-separate" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools({
+      agentChannel: "bitrix",
+      agentTo: "bitrix:chat-777",
+    }).find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-submit-bitrix-separate", {
+      action: "submit",
+      taskId: "a2a-task-bitrix-separate",
+      title: "Bitrix linked intake",
+      repo: "homio/core",
+      intent: "implement_feature",
+      branch: "feature/bitrix-separate-id",
+      brief: "Keep Atlas ownership separate from linked Bitrix work.",
+      bitrixTaskId: "bitrix-777",
+    });
+
+    const details = result.details as { ok?: boolean; result?: { id?: string } };
+    expect(details.ok).toBe(true);
+    expect(details.result?.id).toBe("a2a-task-bitrix-separate");
+
+    const ensureBody = parseRequestBody<{
+      atlasTaskId?: string | null;
+      bitrixTaskId?: string | null;
+    }>(fetchMock.mock.calls[1]?.[1]?.body);
+    expect(ensureBody.atlasTaskId).toBe("a2a-task-bitrix-separate");
+    expect(ensureBody.bitrixTaskId).toBe("bitrix-777");
+
+    const submitCall = fetchMock.mock.calls.find(
+      ([requestUrl, requestInit]) =>
+        String(requestUrl).includes("/api/a2a/tasks") && requestInit?.method === "POST",
+    );
+    expect(submitCall).toBeDefined();
+    const [, submitInit] = submitCall as unknown as FetchCall;
+    expect(submitInit).toBeDefined();
+    const submitBody = parseRequestBody<{
+      executionSpec?: { taskId?: string; target?: { taskId?: string | null } };
+      metadata?: Record<string, unknown>;
+    }>(submitInit?.body);
+    expect(submitBody.executionSpec?.taskId).toBe("a2a-task-bitrix-separate");
+    expect(submitBody.executionSpec?.target?.taskId).toBe("a2a-task-bitrix-separate");
+    expect(submitBody.metadata?.bitrixTaskId).toBe("bitrix-777");
+  });
+
+  it("atlas_execution ensures a bitrix work thread when fallback intake has no topic yet", async () => {
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const href = String(url);
+      if (href.includes("/api/runtime/work-threads?")) {
+        return new Response(JSON.stringify({ workThreads: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (href.includes("/api/runtime/work-threads/ensure")) {
+        return new Response(JSON.stringify({ workThread: { id: "wt-bitrix-fallback" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (init?.method === "POST" && href.includes("/api/a2a/tasks")) {
+        return new Response(JSON.stringify({ id: "atlas-task-bitrix-fallback" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools({
+      agentChannel: "bitrix",
+      agentTo: "bitrix:chat-991",
+    }).find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-submit-bitrix-fallback", {
+      action: "submit",
+      taskId: "a2a-task-bitrix-fallback",
+      atlasTaskId: "atlas-task-bitrix-fallback",
+      title: "Bitrix fallback intake",
+      repo: "homio/core",
+      intent: "implement_feature",
+      branch: "feature/bitrix-fallback",
+      envName: "ai03",
+      brief: "Create a canonical work thread before any telegram topic exists.",
+      bitrixTaskId: "bitrix-991",
+    });
+
+    const details = result.details as { ok?: boolean; result?: { id?: string } };
+    expect(details.ok).toBe(true);
+    expect(details.result?.id).toBe("atlas-task-bitrix-fallback");
+
+    expect(requestUrlFromCall(fetchMock.mock.calls[0] as unknown as FetchCall)).toContain(
+      "/api/runtime/work-threads?",
+    );
+    expect(requestUrlFromCall(fetchMock.mock.calls[1] as unknown as FetchCall)).toContain(
+      "/api/runtime/work-threads/ensure",
+    );
+
+    const ensureBody = parseRequestBody<{
+      ownerTransport?: string;
+      atlasTaskId?: string | null;
+      bitrixTaskId?: string | null;
+      bitrixChatId?: string | null;
+    }>(fetchMock.mock.calls[1]?.[1]?.body);
+    expect(ensureBody.ownerTransport).toBe("bitrix");
+    expect(ensureBody.atlasTaskId).toBe("atlas-task-bitrix-fallback");
+    expect(ensureBody.bitrixTaskId).toBe("bitrix-991");
+    expect(ensureBody.bitrixChatId).toBe("chat-991");
+
+    const submitCall = fetchMock.mock.calls.find(
+      ([requestUrl, requestInit]) =>
+        String(requestUrl).includes("/api/a2a/tasks") && requestInit?.method === "POST",
+    );
+    expect(submitCall).toBeDefined();
+    const [, submitInit] = submitCall as unknown as FetchCall;
+    expect(submitInit).toBeDefined();
+    const submitBody = parseRequestBody<{
+      metadata?: Record<string, unknown>;
+      executionSpec?: { metadata?: Record<string, unknown> };
+    }>(submitInit?.body);
+    expect(submitBody.metadata?.workThreadId).toBe("wt-bitrix-fallback");
+    expect(submitBody.executionSpec?.metadata?.workThreadId).toBe("wt-bitrix-fallback");
+  });
+
+  it("atlas_execution does not infer bitrix from generic targetTaskId alone", async () => {
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return new Response(JSON.stringify({ id: "atlas-task-generic-target" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-submit-generic-target", {
+      action: "submit",
+      taskId: "atlas-task-generic-target",
+      title: "Generic linked work item",
+      repo: "homio/core",
+      intent: "implement_feature",
+      brief: "Improve the login button copy and color.",
+      targetTaskId: "external-work-item-77",
+    });
+
+    const details = result.details as { ok?: boolean; result?: { id?: string } };
+    expect(details.ok).toBe(true);
+    expect(details.result?.id).toBe("atlas-task-generic-target");
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as FetchCall;
+    expect(init).toBeDefined();
+    const body = parseRequestBody<{
+      atlasTaskId?: string | null;
+      source?: { transport?: string };
+      executionSpec?: {
+        taskId?: string | null;
+        target?: { taskId?: string | null };
+        metadata?: Record<string, unknown>;
+      };
+      metadata?: Record<string, unknown>;
+    }>(init?.body);
+    expect(body.atlasTaskId).toBe("atlas-task-generic-target");
+    expect(body.executionSpec?.taskId).toBe("atlas-task-generic-target");
+    expect(body.executionSpec?.target?.taskId).toBe("atlas-task-generic-target");
+    expect(body.executionSpec?.metadata?.linkedTargetTaskId).toBe("external-work-item-77");
+    expect(body.metadata?.linkedTargetTaskId).toBe("external-work-item-77");
+    expect(body.source?.transport).toBe("openclaw");
+  });
+
+  it("atlas_execution resolves telegram work thread before submit and preserves distinct atlasTaskId", async () => {
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const href = String(url);
+      if (href.includes("/api/runtime/work-threads/by-topic")) {
+        return new Response(JSON.stringify({ workThread: null }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (href.includes("/api/runtime/work-threads/ensure")) {
+        return new Response(JSON.stringify({ workThread: { id: "wt-telegram-1" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (init?.method === "POST" && href.includes("/api/a2a/tasks")) {
+        return new Response(JSON.stringify({ id: "a2a-task-telegram-1" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools({
+      agentChannel: "telegram",
+      agentTo: "telegram:group:-100901:topic:4411",
+      agentThreadId: "4411",
+    }).find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-submit-telegram-thread", {
+      action: "submit",
+      taskId: "a2a-task-telegram-1",
+      atlasTaskId: "atlas-task-telegram-1",
+      title: "Telegram thread sync",
+      summary: "Keep canonical topic identity",
+      repo: "homio/core",
+      intent: "implement_feature",
+      branch: "feature/telegram-thread-sync",
+      envName: "ai02",
+      brief: "Submit through the canonical telegram work thread.",
+    });
+
+    const details = result.details as { ok?: boolean; result?: { id?: string } };
+    expect(details.ok).toBe(true);
+    expect(details.result?.id).toBe("a2a-task-telegram-1");
+
+    expect(requestUrlFromCall(fetchMock.mock.calls[0] as unknown as FetchCall)).toContain(
+      "/api/runtime/work-threads/by-topic",
+    );
+    expect(requestUrlFromCall(fetchMock.mock.calls[1] as unknown as FetchCall)).toContain(
+      "/api/runtime/work-threads/ensure",
+    );
+
+    const ensureBody = parseRequestBody<{
+      atlasTaskId?: string;
+      branch?: string;
+      telegramChatId?: string;
+      telegramTopicId?: string;
+    }>(fetchMock.mock.calls[1]?.[1]?.body);
+    expect(ensureBody.atlasTaskId).toBe("atlas-task-telegram-1");
+    expect(ensureBody.branch).toBe("feature/telegram-thread-sync");
+    expect(ensureBody.telegramChatId).toBe("-100901");
+    expect(ensureBody.telegramTopicId).toBe("4411");
+
+    const [, submitInit] = fetchMock.mock.calls[2] as unknown as FetchCall;
+    expect(submitInit).toBeDefined();
+    const submitBody = parseRequestBody<{
+      atlasTaskId?: string | null;
+      executionSpec?: {
+        taskId?: string;
+        target?: { taskId?: string | null };
+        metadata?: Record<string, unknown>;
+      };
+      metadata?: Record<string, unknown>;
+      source?: { transport?: string; chatId?: string | null; threadId?: string | null };
+    }>(submitInit?.body);
+    expect(submitBody.atlasTaskId).toBe("atlas-task-telegram-1");
+    expect(submitBody.executionSpec?.taskId).toBe("a2a-task-telegram-1");
+    expect(submitBody.executionSpec?.target?.taskId).toBe("atlas-task-telegram-1");
+    expect(submitBody.executionSpec?.metadata?.workThreadId).toBe("wt-telegram-1");
+    expect(submitBody.metadata?.workThreadId).toBe("wt-telegram-1");
+    expect(submitBody.source?.transport).toBe("telegram-topic");
+    expect(submitBody.source?.chatId).toBe("-100901");
+    expect(submitBody.source?.threadId).toBe("4411");
+  });
+
+  it("atlas_execution rejects submit without a brief before calling Atlas", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    await expect(
+      tool.execute("call-atlas-submit-missing-brief", {
+        action: "submit",
+        taskId: "atlas-task-2",
+        intent: "implement_feature",
+        sourceTransport: "bitrix",
+      }),
+    ).rejects.toThrow("brief required");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("atlas_execution rejects telegram-topic submit without topic coordinates", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    await expect(
+      tool.execute("call-atlas-submit-missing-topic", {
+        action: "submit",
+        taskId: "atlas-task-3",
+        intent: "implement_feature",
+        brief: "Polish the login button.",
+        sourceTransport: "telegram-topic",
+        sourceChatId: "-100777",
+      }),
+    ).rejects.toThrow("sourceThreadId required for telegram-topic submissions");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("atlas_execution list does not add an implicit homio/core repo filter", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ tasks: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-list-unfiltered", {
+      action: "list",
+      limit: 10,
+    });
+
+    const details = result.details as { ok?: boolean; result?: { tasks?: unknown[] } };
+    expect(details.ok).toBe(true);
+    expect(details.result?.tasks).toEqual([]);
+
+    const requestUrl = requestUrlFromCall(fetchMock.mock.calls[0] as unknown as FetchCall);
+    expect(requestUrl).toContain("/api/a2a/tasks");
+    expect(requestUrl).not.toContain("repo=homio%2Fcore");
+  });
+
+  it("atlas_execution list forwards atlas and transport filters when provided", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ tasks: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-list-filtered", {
+      action: "list",
+      atlasTaskId: "atlas-task-filter-1",
+      sourceTransport: "telegram-topic",
+      sourceChatId: "-100777",
+      sourceThreadId: "4401",
+      repo: "homio/core",
+      limit: 10,
+    });
+
+    const details = result.details as { ok?: boolean; result?: { tasks?: unknown[] } };
+    expect(details.ok).toBe(true);
+    expect(details.result?.tasks).toEqual([]);
+
+    const requestUrl = requestUrlFromCall(fetchMock.mock.calls[0] as unknown as FetchCall);
+    expect(requestUrl).toContain("atlas_task_id=atlas-task-filter-1");
+    expect(requestUrl).toContain("source_transport=telegram-topic");
+    expect(requestUrl).toContain("source_chat_id=-100777");
+    expect(requestUrl).toContain("source_thread_id=4401");
+    expect(requestUrl).toContain("repo=homio%2Fcore");
+  });
+
+  it("atlas_execution get resolves A2A task id from atlasTaskId when needed", async () => {
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const href = String(url);
+      if (href.includes("/api/a2a/tasks?")) {
+        return new Response(JSON.stringify({ tasks: [{ id: "a2a-from-atlas-1" }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (href.endsWith("/api/a2a/tasks/a2a-from-atlas-1")) {
+        return new Response(
+          JSON.stringify({
+            task: {
+              id: "a2a-from-atlas-1",
+              atlasTaskId: "atlas-task-recovery-1",
+              status: "running",
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-get-by-atlas-task-id", {
+      action: "get",
+      atlasTaskId: "atlas-task-recovery-1",
+      repo: "homio/core",
+    });
+
+    const details = result.details as {
+      ok?: boolean;
+      result?: { task?: { id?: string; atlasTaskId?: string; status?: string } };
+    };
+    expect(details.ok).toBe(true);
+    expect(details.result?.task?.id).toBe("a2a-from-atlas-1");
+    expect(details.result?.task?.atlasTaskId).toBe("atlas-task-recovery-1");
+
+    const lookupUrl = requestUrlFromCall(fetchMock.mock.calls[0] as unknown as FetchCall);
+    expect(lookupUrl).toContain("/api/a2a/tasks?");
+    expect(lookupUrl).toContain("atlas_task_id=atlas-task-recovery-1");
+    expect(lookupUrl).toContain("repo=homio%2Fcore");
+    const getUrl = requestUrlFromCall(fetchMock.mock.calls[1] as unknown as FetchCall);
+    expect(getUrl).toContain("/api/a2a/tasks/a2a-from-atlas-1");
+  });
+
+  it("atlas_execution prefers an active A2A task when atlasTaskId lookup returns history", async () => {
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const href = String(url);
+      if (href.includes("/api/a2a/tasks?")) {
+        return new Response(
+          JSON.stringify({
+            tasks: [
+              {
+                id: "a2a-completed-old",
+                status: "completed",
+                createdAt: "2026-04-01T01:00:00.000Z",
+              },
+              {
+                id: "a2a-running-new",
+                status: "running",
+                createdAt: "2026-04-01T02:00:00.000Z",
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (href.endsWith("/api/a2a/tasks/a2a-running-new")) {
+        return new Response(
+          JSON.stringify({
+            task: { id: "a2a-running-new", atlasTaskId: "atlas-task-history-1", status: "running" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-get-by-atlas-history", {
+      action: "get",
+      atlasTaskId: "atlas-task-history-1",
+    });
+
+    const details = result.details as {
+      ok?: boolean;
+      result?: { task?: { id?: string; status?: string } };
+    };
+    expect(details.ok).toBe(true);
+    expect(details.result?.task?.id).toBe("a2a-running-new");
+    expect(details.result?.task?.status).toBe("running");
+  });
+
+  it("atlas_execution events resolves A2A task id from atlasTaskId when needed", async () => {
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const href = String(url);
+      if (href.includes("/api/a2a/tasks?")) {
+        return new Response(JSON.stringify({ tasks: [{ id: "a2a-from-atlas-events" }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (href.includes("/api/a2a/tasks/a2a-from-atlas-events/events")) {
+        return new Response(JSON.stringify({ events: [{ eventType: "task.created" }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-events-by-atlas-task-id", {
+      action: "events",
+      atlasTaskId: "atlas-task-recovery-events",
+      limit: 5,
+    });
+
+    const details = result.details as {
+      ok?: boolean;
+      result?: { events?: Array<{ eventType?: string }> };
+    };
+    expect(details.ok).toBe(true);
+    expect(details.result?.events?.[0]?.eventType).toBe("task.created");
+  });
+
+  it("atlas_execution get resolves A2A task id from topic source coordinates when ids are absent", async () => {
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const href = String(url);
+      if (href.includes("/api/a2a/tasks?")) {
+        return new Response(
+          JSON.stringify({ tasks: [{ id: "a2a-from-topic-1", status: "running" }] }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (href.endsWith("/api/a2a/tasks/a2a-from-topic-1")) {
+        return new Response(
+          JSON.stringify({
+            task: {
+              id: "a2a-from-topic-1",
+              sourceChatId: "-100777",
+              sourceThreadId: "4401",
+              status: "running",
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-get-by-topic-coords", {
+      action: "get",
+      sourceTransport: "telegram-topic",
+      sourceChatId: "-100777",
+      sourceThreadId: "4401",
+      repo: "homio/core",
+    });
+
+    const details = result.details as {
+      ok?: boolean;
+      result?: { task?: { id?: string; sourceChatId?: string; sourceThreadId?: string } };
+    };
+    expect(details.ok).toBe(true);
+    expect(details.result?.task?.id).toBe("a2a-from-topic-1");
+
+    const lookupUrl = requestUrlFromCall(fetchMock.mock.calls[0] as unknown as FetchCall);
+    expect(lookupUrl).toContain("source_transport=telegram-topic");
+    expect(lookupUrl).toContain("source_chat_id=-100777");
+    expect(lookupUrl).toContain("source_thread_id=4401");
+  });
+
+  it("atlas_execution get can recover from telegram tool context without explicit ids", async () => {
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const href = String(url);
+      if (href.includes("/api/a2a/tasks?")) {
+        return new Response(
+          JSON.stringify({ tasks: [{ id: "a2a-from-context-1", status: "running" }] }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+      if (href.endsWith("/api/a2a/tasks/a2a-from-context-1")) {
+        return new Response(
+          JSON.stringify({
+            task: {
+              id: "a2a-from-context-1",
+              sourceChatId: "-100888",
+              sourceThreadId: "5501",
+              status: "running",
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools({
+      agentChannel: "telegram",
+      agentTo: "telegram:group:-100888:topic:5501",
+      agentThreadId: "5501",
+    }).find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    const result = await tool.execute("call-atlas-get-by-context", {
+      action: "get",
+      repo: "homio/core",
+    });
+
+    const details = result.details as { ok?: boolean; result?: { task?: { id?: string } } };
+    expect(details.ok).toBe(true);
+    expect(details.result?.task?.id).toBe("a2a-from-context-1");
+  });
+
+  it("atlas_execution rejects conflicting taskId and atlasTaskId instead of silently trusting taskId", async () => {
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const href = String(url);
+      if (href.endsWith("/api/a2a/tasks/a2a-explicit-1")) {
+        return new Response(
+          JSON.stringify({
+            task: { id: "a2a-explicit-1", atlasTaskId: "atlas-task-other", status: "running" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    await expect(
+      tool.execute("call-atlas-get-conflicting-ids", {
+        action: "get",
+        taskId: "a2a-explicit-1",
+        atlasTaskId: "atlas-task-expected",
+      }),
+    ).rejects.toThrow("taskId a2a-explicit-1 does not match atlasTaskId atlas-task-expected");
+  });
+
+  it("atlas_execution rejects source-based recovery without full topic coordinates", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "atlas_execution");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing atlas_execution tool");
+    }
+
+    await expect(
+      tool.execute("call-atlas-get-ambiguous-source", {
+        action: "get",
+        sourceTransport: "telegram-topic",
+        sourceChatId: "-100777",
+      }),
+    ).rejects.toThrow("sourceChatId and sourceThreadId required for source-based task recovery");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -14,15 +14,11 @@ const listTasksForRelatedSessionKeyForOwnerMock = vi.hoisted(() =>
       [] as Array<Record<string, unknown>>,
   ),
 );
-const resolveEnvApiKeyMock = vi.hoisted(
-  () => vi.fn((_provider?: string, _env?: NodeJS.ProcessEnv) => null),
+const resolveEnvApiKeyMock = vi.hoisted(() =>
+  vi.fn((_provider?: string, _env?: NodeJS.ProcessEnv) => null),
 );
-const resolveUsableCustomProviderApiKeyMock = vi.hoisted(
-  () =>
-    vi.fn(
-      (_params?: { provider?: string }) =>
-        null as { apiKey: string; source: string } | null,
-    ),
+const resolveUsableCustomProviderApiKeyMock = vi.hoisted(() =>
+  vi.fn((_params?: { provider?: string }) => null as { apiKey: string; source: string } | null),
 );
 
 const createMockConfig = () => ({

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -779,8 +779,8 @@ describe("sessions tools", () => {
     let lastWaitedRunId: string | undefined;
     const replyByRunId = new Map<string, string>();
     const requesterKey = "discord:group:req";
-    const targetKey = "discord:group:target";
-    let sendParams: { to?: string; channel?: string; message?: string } = {};
+    const targetKey = "discord:group:target:thread:42";
+    let sendParams: { to?: string; channel?: string; message?: string; threadId?: string } = {};
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: unknown };
       calls.push(request);
@@ -827,12 +827,13 @@ describe("sessions tools", () => {
       }
       if (request.method === "send") {
         const params = request.params as
-          | { to?: string; channel?: string; message?: string }
+          | { to?: string; channel?: string; message?: string; threadId?: string }
           | undefined;
         sendParams = {
           to: params?.to,
           channel: params?.channel,
           message: params?.message,
+          threadId: params?.threadId,
         };
         return { messageId: "m-announce" };
       }
@@ -887,6 +888,7 @@ describe("sessions tools", () => {
       to: "group:target",
       channel: "discord",
       message: "announce now",
+      threadId: "42",
     });
   });
 

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -13,6 +13,8 @@ import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import type { SpawnedToolContext } from "./spawned-context.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
 import { createAgentsListTool } from "./tools/agents-list-tool.js";
+import { createAtlasExecutionTool } from "./tools/atlas-execution-tool.js";
+import { createAtlasInspectTool } from "./tools/atlas-inspect-tool.js";
 import { createCanvasTool } from "./tools/canvas-tool.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { createCronTool } from "./tools/cron-tool.js";
@@ -182,6 +184,12 @@ export function createOpenClawTools(
         requesterSenderId: options?.requesterSenderId ?? undefined,
       });
   const tools: AnyAgentTool[] = [
+    createAtlasInspectTool(),
+    createAtlasExecutionTool({
+      agentChannel: options?.agentChannel,
+      agentTo: options?.agentTo,
+      agentThreadId: options?.agentThreadId,
+    }),
     createCanvasTool({ config: options?.config }),
     createNodesTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -551,20 +551,18 @@ function coerceText(value: unknown): string {
   if (value == null) {
     return "";
   }
-  if (
-    typeof value === "number" ||
-    typeof value === "boolean" ||
-    typeof value === "bigint" ||
-    typeof value === "symbol"
-  ) {
-    return String(value);
-  }
   if (typeof value === "object") {
     try {
       return JSON.stringify(value) ?? "";
     } catch {
       return "";
     }
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return `${value}`;
+  }
+  if (typeof value === "symbol") {
+    return value.description ? `Symbol(${value.description})` : "Symbol()";
   }
   return "";
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -419,64 +419,64 @@ export async function runEmbeddedAttempt(
       ? []
       : (() => {
           const allTools = createOpenClawCodingTools({
-          agentId: sessionAgentId,
-          trigger: params.trigger,
-          memoryFlushWritePath: params.memoryFlushWritePath,
-          exec: {
-            ...params.execOverrides,
-            elevated: params.bashElevated,
-          },
-          sandbox,
-          messageProvider: params.messageChannel ?? params.messageProvider,
-          agentAccountId: params.agentAccountId,
-          messageTo: params.messageTo,
-          messageThreadId: params.messageThreadId,
-          groupId: params.groupId,
-          groupChannel: params.groupChannel,
-          groupSpace: params.groupSpace,
-          spawnedBy: params.spawnedBy,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          senderUsername: params.senderUsername,
-          senderE164: params.senderE164,
-          senderIsOwner: params.senderIsOwner,
-          allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-          sessionKey: sandboxSessionKey,
-          sessionId: params.sessionId,
-          runId: params.runId,
-          agentDir,
-          workspaceDir: effectiveWorkspace,
-          // When sandboxing uses a copied workspace (`ro` or `none`), effectiveWorkspace points
-          // at the sandbox copy. Spawned subagents should inherit the real workspace instead.
-          spawnWorkspaceDir: resolveAttemptSpawnWorkspaceDir({
+            agentId: sessionAgentId,
+            trigger: params.trigger,
+            memoryFlushWritePath: params.memoryFlushWritePath,
+            exec: {
+              ...params.execOverrides,
+              elevated: params.bashElevated,
+            },
             sandbox,
-            resolvedWorkspace,
-          }),
-          config: params.config,
-          abortSignal: runAbortController.signal,
-          modelProvider: params.model.provider,
-          modelId: params.modelId,
-          modelCompat: params.model.compat,
-          modelApi: params.model.api,
-          modelContextWindowTokens: params.model.contextWindow,
-          modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
-          currentChannelId: params.currentChannelId,
-          currentThreadTs: params.currentThreadTs,
-          currentMessageId: params.currentMessageId,
-          replyToMode: params.replyToMode,
-          hasRepliedRef: params.hasRepliedRef,
-          modelHasVision,
-          requireExplicitMessageTarget:
-            params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
-          disableMessageTool: params.disableMessageTool,
-          onYield: (message) => {
-            yieldDetected = true;
-            yieldMessage = message;
-            queueYieldInterruptForSession?.();
-            runAbortController.abort("sessions_yield");
-            abortSessionForYield?.();
-          },
-        });
+            messageProvider: params.messageChannel ?? params.messageProvider,
+            agentAccountId: params.agentAccountId,
+            messageTo: params.messageTo,
+            messageThreadId: params.messageThreadId,
+            groupId: params.groupId,
+            groupChannel: params.groupChannel,
+            groupSpace: params.groupSpace,
+            spawnedBy: params.spawnedBy,
+            senderId: params.senderId,
+            senderName: params.senderName,
+            senderUsername: params.senderUsername,
+            senderE164: params.senderE164,
+            senderIsOwner: params.senderIsOwner,
+            allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+            sessionKey: sandboxSessionKey,
+            sessionId: params.sessionId,
+            runId: params.runId,
+            agentDir,
+            workspaceDir: effectiveWorkspace,
+            // When sandboxing uses a copied workspace (`ro` or `none`), effectiveWorkspace points
+            // at the sandbox copy. Spawned subagents should inherit the real workspace instead.
+            spawnWorkspaceDir: resolveAttemptSpawnWorkspaceDir({
+              sandbox,
+              resolvedWorkspace,
+            }),
+            config: params.config,
+            abortSignal: runAbortController.signal,
+            modelProvider: params.model.provider,
+            modelId: params.modelId,
+            modelCompat: params.model.compat,
+            modelApi: params.model.api,
+            modelContextWindowTokens: params.model.contextWindow,
+            modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
+            currentChannelId: params.currentChannelId,
+            currentThreadTs: params.currentThreadTs,
+            currentMessageId: params.currentMessageId,
+            replyToMode: params.replyToMode,
+            hasRepliedRef: params.hasRepliedRef,
+            modelHasVision,
+            requireExplicitMessageTarget:
+              params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
+            disableMessageTool: params.disableMessageTool,
+            onYield: (message) => {
+              yieldDetected = true;
+              yieldMessage = message;
+              queueYieldInterruptForSession?.();
+              runAbortController.abort("sessions_yield");
+              abortSessionForYield?.();
+            },
+          });
           if (params.toolsAllow && params.toolsAllow.length > 0) {
             const allowSet = new Set(params.toolsAllow);
             return allTools.filter((tool) => allowSet.has(tool.name));
@@ -621,7 +621,7 @@ export async function runEmbeddedAttempt(
     const promptMode = resolvePromptModeForSession(params.sessionKey);
 
     // When toolsAllow is set, use minimal prompt and strip skills catalog
-    const effectivePromptMode = params.toolsAllow?.length ? "minimal" as const : promptMode;
+    const effectivePromptMode = params.toolsAllow?.length ? ("minimal" as const) : promptMode;
     const effectiveSkillsPrompt = params.toolsAllow?.length ? undefined : skillsPrompt;
     const docsPath = await resolveOpenClawDocsPath({
       workspaceDir: effectiveWorkspace,

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -45,20 +45,18 @@ const coerceText = (value: unknown): string => {
   if (value == null) {
     return "";
   }
-  if (
-    typeof value === "number" ||
-    typeof value === "boolean" ||
-    typeof value === "bigint" ||
-    typeof value === "symbol"
-  ) {
-    return String(value);
-  }
   if (typeof value === "object") {
     try {
       return JSON.stringify(value) ?? "";
     } catch {
       return "";
     }
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return `${value}`;
+  }
+  if (typeof value === "symbol") {
+    return value.description ? `Symbol(${value.description})` : "Symbol()";
   }
   return "";
 };

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -145,9 +145,10 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
     expect(isToolAllowedByPolicyName("sessions_history", policy)).toBe(true);
   });
 
-  it("depth-1 orchestrator still denies gateway and cron but allows memory tools", () => {
+  it("depth-1 orchestrator still denies gateway, atlas_execution, and cron but allows memory tools", () => {
     const policy = resolveSubagentToolPolicy(baseCfg, 1);
     expect(isToolAllowedByPolicyName("gateway", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("atlas_execution", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("cron", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("memory_search", policy)).toBe(true);
     expect(isToolAllowedByPolicyName("memory_get", policy)).toBe(true);
@@ -187,6 +188,11 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
   it("depth-1 leaf (maxSpawnDepth=1) denies sessions_list", () => {
     const policy = resolveSubagentToolPolicy(leafCfg, 1);
     expect(isToolAllowedByPolicyName("sessions_list", policy)).toBe(false);
+  });
+
+  it("leaf subagents also deny atlas_execution", () => {
+    const policy = resolveSubagentToolPolicy(leafCfg, 1);
+    expect(isToolAllowedByPolicyName("atlas_execution", policy)).toBe(false);
   });
 
   it("uses stored leaf role for flat depth-1 session keys", () => {

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -28,6 +28,9 @@ const SUBAGENT_TOOL_DENY_ALWAYS = [
   // System admin - dangerous from subagent
   "gateway",
   "agents_list",
+  // Atlas execution must stay coordinator-owned; subagents can inspect context but must not
+  // independently submit code-changing work into Atlas.
+  "atlas_execution",
   // Interactive setup - not a task
   "whatsapp_login",
   // Status/scheduling - main agent coordinates

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -18,6 +18,8 @@ export const DEFAULT_TOOL_ALLOW = [
   "edit",
   "apply_patch",
   "image",
+  "atlas_inspect",
+  "atlas_execution",
   "sessions_list",
   "sessions_history",
   "sessions_send",

--- a/src/agents/skills.atlas-delivery.e2e.test.ts
+++ b/src/agents/skills.atlas-delivery.e2e.test.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter } from "./skills/frontmatter.js";
+
+describe("atlas-delivery bundled skill", () => {
+  it("describes Atlas-backed coordination instead of direct code ownership", () => {
+    const skillPath = path.join(process.cwd(), "skills", "atlas-delivery", "SKILL.md");
+    const raw = fs.readFileSync(skillPath, "utf-8");
+    const frontmatter = parseFrontmatter(raw);
+    const description = String(frontmatter.description || "");
+    const normalizedRaw = raw.toLowerCase();
+
+    expect(description.toLowerCase()).toContain("atlas");
+    expect(description.toLowerCase()).toContain("atlas_inspect");
+    expect(description.toLowerCase()).toContain("atlas_execution");
+    expect(description.toLowerCase()).toContain("not for direct code editing");
+    expect(normalizedRaw).toContain("show the user a short brief");
+    expect(raw).toContain("Do not promise to push code");
+    expect(raw).toContain("no_files_changed");
+    expect(raw).toContain("homio/core");
+    expect(raw).toContain("do not ask which repo or branch to use");
+    expect(raw).toContain("do not propose a local/manual fallback path");
+  });
+
+  it("ships the detailed Atlas contract reference", () => {
+    const referencePath = path.join(
+      process.cwd(),
+      "skills",
+      "atlas-delivery",
+      "references",
+      "atlas-contract.md",
+    );
+    const raw = fs.readFileSync(referencePath, "utf-8");
+
+    expect(raw).toContain("atlas_inspect");
+    expect(raw).toContain("atlas_execution");
+    expect(raw).toContain("/api/a2a/tasks");
+    expect(raw).toContain("/api/runtime/work-threads/by-topic");
+    expect(raw).toContain("OpenClaw");
+    expect(raw).toContain("Atlas");
+    expect(raw).toContain("implementation work targets `homio/core`");
+    expect(raw).toContain("returns infrastructure errors such as `503`");
+  });
+});

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -394,6 +394,17 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
+  it("hardens Atlas delivery defaults for Homio and blocks local bypass advice", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["atlas_inspect", "atlas_execution"],
+    });
+
+    expect(prompt).toContain("default to repo `homio/core`");
+    expect(prompt).toContain("Do not ask the user which repo or branch to use");
+    expect(prompt).toContain("do not offer a local/manual bypass flow");
+  });
+
   it("includes workspace notes when provided", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -144,6 +144,49 @@ function buildMessagingSection(params: {
   ];
 }
 
+function buildAtlasSection(params: { isMinimal: boolean; availableTools: Set<string> }) {
+  if (params.isMinimal) {
+    return [];
+  }
+  const hasInspect = params.availableTools.has("atlas_inspect");
+  const hasExecution = params.availableTools.has("atlas_execution");
+  if (!hasInspect && !hasExecution) {
+    return [];
+  }
+  const lines = ["## Atlas Delivery"];
+  if (hasInspect) {
+    lines.push(
+      "- For Atlas-managed implementation work, inspect repo state through atlas_inspect before proposing changes.",
+    );
+  }
+  if (hasExecution) {
+    lines.push("- Always produce a short execution brief before Atlas work starts.");
+    lines.push(
+      "- For Homio implementation work, default to repo `homio/core` unless the user explicitly names a different repo.",
+    );
+    lines.push(
+      "- Do not ask the user which repo or branch to use unless there is real evidence the default `homio/core` flow is wrong or multiple repos are genuinely plausible.",
+    );
+    lines.push(
+      "- If the request is vague, first break it into something like MVP -> verify -> polish and clarify the goal until the brief is actionable.",
+    );
+    lines.push(
+      "- Once the goal is clear and no critical unknowns remain, submit the brief to Atlas via atlas_execution without waiting for an extra OK.",
+    );
+    lines.push(
+      "- Treat `no_files_changed` as an unclear brief/spec problem: clarify the goal instead of blind retries.",
+    );
+    lines.push(
+      "- If Atlas is unavailable or returns infrastructure errors (for example 503), do not offer a local/manual bypass flow. Report Atlas as blocked and keep the execution path Atlas-owned.",
+    );
+    lines.push(
+      "- Hide Atlas internal ids from the user. Explain work as human stages: understood, preparing, executing, verifying, preview ready.",
+    );
+  }
+  lines.push("");
+  return lines;
+}
+
 function buildVoiceSection(params: { isMinimal: boolean; ttsHint?: string }) {
   if (params.isMinimal) {
     return [];
@@ -248,6 +291,10 @@ export function buildAgentSystemPrompt(params: {
     canvas: "Present/eval/snapshot the Canvas",
     nodes: "List/describe/notify/camera/screen on paired nodes",
     cron: "Manage cron jobs and wake events (use for reminders; when scheduling a reminder, write the systemEvent text as something that will read like a reminder when it fires, and mention that it is a reminder depending on the time gap between setting and firing; include recent context in reminder text if appropriate)",
+    atlas_inspect:
+      "Inspect Atlas-managed repositories through a commit-pinned readonly view (context, tree, file, search, diff, changed files, git status)",
+    atlas_execution:
+      "Submit execution briefs to Atlas and inspect Atlas task status, events, and artifacts",
     message: "Send messages and channel actions",
     gateway: "Restart, apply config, or run updates on the running OpenClaw process",
     agents_list: acpSpawnRuntimeEnabled
@@ -283,6 +330,8 @@ export function buildAgentSystemPrompt(params: {
     "canvas",
     "nodes",
     "cron",
+    "atlas_inspect",
+    "atlas_execution",
     "message",
     "gateway",
     "agents_list",
@@ -477,6 +526,10 @@ export function buildAgentSystemPrompt(params: {
     "",
     ...skillsSection,
     ...memorySection,
+    ...buildAtlasSection({
+      isMinimal,
+      availableTools,
+    }),
     // Skip self-update for subagent/none modes
     hasGateway && !isMinimal ? "## OpenClaw Self-Update" : "",
     hasGateway && !isMinimal

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -33,6 +33,7 @@ const CORE_TOOL_SECTION_ORDER: Array<{ id: string; label: string }> = [
   { id: "ui", label: "UI" },
   { id: "messaging", label: "Messaging" },
   { id: "automation", label: "Automation" },
+  { id: "atlas", label: "Atlas" },
   { id: "nodes", label: "Nodes" },
   { id: "agents", label: "Agents" },
   { id: "media", label: "Media" },
@@ -226,6 +227,22 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     includeInOpenClawGroup: true,
   },
   {
+    id: "atlas_inspect",
+    label: "atlas_inspect",
+    description: "Inspect Atlas-managed repo snapshots",
+    sectionId: "atlas",
+    profiles: ["coding"],
+    includeInOpenClawGroup: true,
+  },
+  {
+    id: "atlas_execution",
+    label: "atlas_execution",
+    description: "Submit and track Atlas execution tasks",
+    sectionId: "atlas",
+    profiles: ["coding"],
+    includeInOpenClawGroup: true,
+  },
+  {
     id: "nodes",
     label: "nodes",
     description: "Nodes + devices",
@@ -303,6 +320,9 @@ function buildCoreToolGroupMap() {
   );
   return {
     "group:openclaw": openclawTools,
+    "group:atlas": CORE_TOOL_DEFINITIONS.filter((tool) => tool.sectionId === "atlas").map(
+      (tool) => tool.id,
+    ),
     ...Object.fromEntries(sectionToolMap.entries()),
   };
 }

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -12,6 +12,7 @@ const MUTATING_TOOL_NAMES = new Set([
   "canvas",
   "nodes",
   "session_status",
+  "atlas_execution",
 ]);
 
 const READ_ONLY_ACTIONS = new Set([
@@ -135,6 +136,10 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
       );
     case "session_status":
       return typeof record?.model === "string" && record.model.trim().length > 0;
+    case "atlas_inspect":
+      return false;
+    case "atlas_execution":
+      return action == null || !READ_ONLY_ACTIONS.has(action);
     default: {
       if (normalized === "cron" || normalized === "gateway" || normalized === "canvas") {
         return action == null || !READ_ONLY_ACTIONS.has(action);

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -224,4 +224,14 @@ describe("resolveSandboxToolPolicyForAgent", () => {
     expect(resolved.allow).toEqual(["read"]);
     expect(resolved.deny).toEqual(["image"]);
   });
+
+  it("defaults include Atlas inspect and execution tools for sandboxed coordinator flows", () => {
+    const resolved = resolveSandboxToolPolicyForAgent(undefined, undefined);
+    expect(resolved.allow).toContain("atlas_inspect");
+    expect(resolved.allow).toContain("atlas_execution");
+
+    const policy: SandboxToolPolicy = { allow: resolved.allow, deny: resolved.deny };
+    expect(isToolAllowed(policy, "atlas_inspect")).toBe(true);
+    expect(isToolAllowed(policy, "atlas_execution")).toBe(true);
+  });
 });

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -14,7 +14,6 @@ export {
   TOOL_GROUPS,
 } from "./tool-policy-shared.js";
 export type { ToolProfileId } from "./tool-policy-shared.js";
-
 // Keep tool-policy browser-safe: do not import tools/common at runtime.
 function wrapOwnerOnlyToolExecution(tool: AnyAgentTool, senderIsOwner: boolean): AnyAgentTool {
   if (tool.ownerOnly !== true || senderIsOwner || !tool.execute) {

--- a/src/agents/tools/atlas-client.ts
+++ b/src/agents/tools/atlas-client.ts
@@ -1,0 +1,96 @@
+type AtlasRequestOptions = {
+  method?: "GET" | "POST";
+  query?: Record<string, string | number | boolean | null | undefined>;
+  body?: unknown;
+};
+
+export class AtlasHttpError extends Error {
+  readonly status: number;
+  readonly payload: unknown;
+
+  constructor(status: number, message: string, payload: unknown) {
+    super(message);
+    this.name = "AtlasHttpError";
+    this.status = status;
+    this.payload = payload;
+  }
+}
+
+function resolveAtlasBaseUrl() {
+  const baseUrl = String(
+    process.env.OPENCLAW_ATLAS_WEB_BASE_URL || process.env.ATLAS_WEB_BASE_URL || "",
+  ).trim();
+  if (!baseUrl) {
+    throw new Error(
+      "Atlas base URL is not configured. Set OPENCLAW_ATLAS_WEB_BASE_URL or ATLAS_WEB_BASE_URL.",
+    );
+  }
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function resolveAtlasToken() {
+  return String(
+    process.env.OPENCLAW_ATLAS_A2A_TOKEN ||
+      process.env.ATLAS_A2A_TOKEN ||
+      process.env.ATLAS_WEB_LOGS_TOKEN ||
+      "",
+  ).trim();
+}
+
+function buildAtlasUrl(
+  pathname: string,
+  query?: Record<string, string | number | boolean | null | undefined>,
+) {
+  const url = new URL(`${resolveAtlasBaseUrl()}${pathname}`);
+  for (const [key, value] of Object.entries(query || {})) {
+    if (value == null) {
+      continue;
+    }
+    const normalized =
+      typeof value === "boolean" ? (value ? "true" : "false") : String(value).trim();
+    if (!normalized) {
+      continue;
+    }
+    url.searchParams.set(key, normalized);
+  }
+  return url;
+}
+
+export async function atlasJsonRequest<T>(
+  pathname: string,
+  options: AtlasRequestOptions = {},
+): Promise<T> {
+  const method = options.method || "GET";
+  const url = buildAtlasUrl(pathname, options.query);
+  const headers = new Headers();
+  const token = resolveAtlasToken();
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  if (options.body !== undefined) {
+    headers.set("Content-Type", "application/json");
+  }
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+  });
+  const text = await response.text();
+  const payload = text ? safeJsonParse(text) : null;
+  if (!response.ok) {
+    const errorMessage =
+      payload && typeof payload === "object" && "error" in payload && payload.error
+        ? String(payload.error)
+        : text || `${method} ${pathname} failed with ${response.status}`;
+    throw new AtlasHttpError(response.status, errorMessage, payload);
+  }
+  return payload as T;
+}
+
+function safeJsonParse(value: string) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return { raw: value };
+  }
+}

--- a/src/agents/tools/atlas-execution-tool.ts
+++ b/src/agents/tools/atlas-execution-tool.ts
@@ -1,0 +1,628 @@
+import crypto from "node:crypto";
+import { Type } from "@sinclair/typebox";
+import { stringEnum } from "../schema/typebox.js";
+import { AtlasHttpError, atlasJsonRequest } from "./atlas-client.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readNumberParam, readStringParam } from "./common.js";
+
+const ATLAS_EXECUTION_ACTIONS = [
+  "agent_card",
+  "submit",
+  "get",
+  "list",
+  "events",
+  "artifacts",
+] as const;
+
+const AtlasExecutionToolSchema = Type.Object({
+  action: stringEnum(ATLAS_EXECUTION_ACTIONS),
+  taskId: Type.Optional(Type.String()),
+  atlasTaskId: Type.Optional(Type.String()),
+  title: Type.Optional(Type.String()),
+  summary: Type.Optional(Type.String()),
+  repo: Type.Optional(Type.String()),
+  intent: Type.Optional(Type.String()),
+  branch: Type.Optional(Type.String()),
+  envName: Type.Optional(Type.String()),
+  targetTaskId: Type.Optional(Type.String()),
+  sourceTransport: Type.Optional(Type.String()),
+  sourceChatId: Type.Optional(Type.String()),
+  sourceThreadId: Type.Optional(Type.String()),
+  sourceMessageId: Type.Optional(Type.String()),
+  sessionId: Type.Optional(Type.String()),
+  workThreadId: Type.Optional(Type.String()),
+  bitrixTaskId: Type.Optional(Type.String()),
+  brief: Type.Optional(Type.String()),
+  acceptanceCriteria: Type.Optional(Type.String()),
+  nonGoals: Type.Optional(Type.String()),
+  verifyPlan: Type.Optional(Type.String()),
+  stagePlan: Type.Optional(Type.String()),
+  status: Type.Optional(Type.String()),
+  limit: Type.Optional(Type.Number({ minimum: 1 })),
+});
+
+type AtlasExecutionToolContext = {
+  agentChannel?: string;
+  agentTo?: string;
+  agentThreadId?: string | number;
+};
+
+function asNullableText(value: string | number | undefined | null): string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return normalized || undefined;
+}
+
+function parseTelegramTarget(raw?: string): { chatId?: string; threadId?: string } {
+  const value = asNullableText(raw);
+  if (!value) {
+    return {};
+  }
+  const directMatch = value.match(/^(?:telegram:)?(?:group|channel):([^:]+):topic:(\d+)$/i);
+  if (directMatch) {
+    return { chatId: directMatch[1], threadId: directMatch[2] };
+  }
+  const groupOnlyMatch = value.match(/^(?:telegram:)?(?:group|channel):([^:]+)$/i);
+  if (groupOnlyMatch) {
+    return { chatId: groupOnlyMatch[1] };
+  }
+  const prefixedPeerMatch = value.match(/^telegram:([^:]+)$/i);
+  if (prefixedPeerMatch) {
+    return { chatId: prefixedPeerMatch[1] };
+  }
+  const suffixMatch = value.match(/^([^:]+):topic:(\d+)$/i);
+  if (suffixMatch) {
+    return { chatId: suffixMatch[1], threadId: suffixMatch[2] };
+  }
+  return {};
+}
+
+function parseBitrixTarget(raw?: string): { chatId?: string } {
+  const value = asNullableText(raw);
+  if (!value) {
+    return {};
+  }
+  const prefixedMatch = value.match(/^bitrix:(.+)$/i);
+  if (prefixedMatch) {
+    return { chatId: asNullableText(prefixedMatch[1]) };
+  }
+  if (!value.includes(":")) {
+    return { chatId: value };
+  }
+  return {};
+}
+
+function inferAtlasSourceContext(params: {
+  explicitTransport?: string;
+  explicitChatId?: string;
+  explicitThreadId?: string;
+  bitrixTaskId?: string;
+  context?: AtlasExecutionToolContext;
+}) {
+  const channel = asNullableText(params.context?.agentChannel)?.toLowerCase();
+  const parsedTelegramTarget = parseTelegramTarget(params.context?.agentTo);
+  const parsedBitrixTarget = parseBitrixTarget(params.context?.agentTo);
+  const chatId =
+    params.explicitChatId ||
+    (channel === "bitrix" ? parsedBitrixTarget.chatId : undefined) ||
+    parsedTelegramTarget.chatId;
+  const threadId =
+    params.explicitThreadId ||
+    asNullableText(params.context?.agentThreadId) ||
+    parsedTelegramTarget.threadId;
+  const explicitTransport = asNullableText(params.explicitTransport);
+
+  if (explicitTransport) {
+    return {
+      sourceTransport: explicitTransport,
+      sourceChatId: chatId,
+      sourceThreadId: threadId,
+    };
+  }
+
+  if (channel === "telegram" && (chatId || threadId)) {
+    return {
+      sourceTransport: "telegram-topic",
+      sourceChatId: chatId,
+      sourceThreadId: threadId,
+    };
+  }
+
+  if (channel === "bitrix" || params.bitrixTaskId) {
+    return {
+      sourceTransport: "bitrix",
+      sourceChatId: chatId,
+      sourceThreadId: threadId,
+    };
+  }
+
+  return {
+    sourceTransport: "openclaw",
+    sourceChatId: chatId,
+    sourceThreadId: threadId,
+  };
+}
+
+async function resolveAtlasWorkThreadId(params: {
+  repo: string;
+  branch?: string;
+  envName?: string;
+  atlasTaskId?: string;
+  title?: string;
+  summary?: string;
+  sourceTransport?: string;
+  sourceChatId?: string;
+  sourceThreadId?: string;
+  bitrixTaskId?: string;
+  workThreadId?: string;
+}) {
+  const explicitWorkThreadId = asNullableText(params.workThreadId);
+  if (explicitWorkThreadId) {
+    return explicitWorkThreadId;
+  }
+
+  const sourceTransport = asNullableText(params.sourceTransport)?.toLowerCase();
+  const sourceChatId = asNullableText(params.sourceChatId);
+  const sourceThreadId = asNullableText(params.sourceThreadId);
+  const bitrixTaskId = asNullableText(params.bitrixTaskId);
+  const atlasTaskId = asNullableText(params.atlasTaskId);
+
+  if (
+    /^(telegram-topic|telegram_topic|telegram)$/i.test(String(sourceTransport || "")) &&
+    sourceChatId &&
+    sourceThreadId
+  ) {
+    const lookup = await atlasJsonRequest<{ workThread?: { id?: string | null } | null }>(
+      "/api/runtime/work-threads/by-topic",
+      {
+        query: {
+          chat_id: sourceChatId,
+          thread_id: sourceThreadId,
+        },
+      },
+    );
+    const existingId = asNullableText(lookup?.workThread?.id);
+    if (existingId) {
+      return existingId;
+    }
+    const ensured = await atlasJsonRequest<{ workThread?: { id?: string | null } | null }>(
+      "/api/runtime/work-threads/ensure",
+      {
+        method: "POST",
+        body: {
+          repo: params.repo,
+          status: "active",
+          ownerTransport: "telegram",
+          telegramChatId: sourceChatId,
+          telegramTopicId: sourceThreadId,
+          atlasTaskId: atlasTaskId || null,
+          branch: asNullableText(params.branch) || null,
+          envName: asNullableText(params.envName) || null,
+          bitrixTaskId: bitrixTaskId || null,
+          title: asNullableText(params.title) || null,
+          summary: asNullableText(params.summary) || asNullableText(params.title) || null,
+          metadata: {
+            sourceAgent: "openclaw",
+          },
+        },
+      },
+    );
+    return asNullableText(ensured?.workThread?.id);
+  }
+
+  if (bitrixTaskId) {
+    const payload = await atlasJsonRequest<{ workThreads?: Array<{ id?: string | null }> }>(
+      "/api/runtime/work-threads",
+      {
+        query: {
+          bitrix_task_id: bitrixTaskId,
+          limit: 1,
+        },
+      },
+    );
+    const existingId = asNullableText(payload?.workThreads?.[0]?.id);
+    if (existingId) {
+      return existingId;
+    }
+    const ensured = await atlasJsonRequest<{ workThread?: { id?: string | null } | null }>(
+      "/api/runtime/work-threads/ensure",
+      {
+        method: "POST",
+        body: {
+          repo: params.repo,
+          status: "active",
+          ownerTransport: "bitrix",
+          atlasTaskId: atlasTaskId || null,
+          branch: asNullableText(params.branch) || null,
+          envName: asNullableText(params.envName) || null,
+          bitrixTaskId: bitrixTaskId,
+          bitrixChatId: sourceChatId || null,
+          title: asNullableText(params.title) || null,
+          summary: asNullableText(params.summary) || asNullableText(params.title) || null,
+          metadata: {
+            sourceAgent: "openclaw",
+          },
+        },
+      },
+    );
+    return asNullableText(ensured?.workThread?.id);
+  }
+
+  return undefined;
+}
+
+async function resolveA2ATaskId(params: {
+  taskId?: string;
+  atlasTaskId?: string;
+  repo?: string;
+  sourceTransport?: string;
+  sourceChatId?: string;
+  sourceThreadId?: string;
+}): Promise<string> {
+  const explicitTaskId = asNullableText(params.taskId);
+  if (explicitTaskId) {
+    await assertA2ATaskIdentity(explicitTaskId, {
+      atlasTaskId: params.atlasTaskId,
+      sourceTransport: params.sourceTransport,
+      sourceChatId: params.sourceChatId,
+      sourceThreadId: params.sourceThreadId,
+    });
+    return explicitTaskId;
+  }
+  const atlasTaskId = asNullableText(params.atlasTaskId);
+  const sourceTransport = asNullableText(params.sourceTransport);
+  const sourceChatId = asNullableText(params.sourceChatId);
+  const sourceThreadId = asNullableText(params.sourceThreadId);
+  const isTopicScopedSource = /^(telegram-topic|telegram_topic|telegram)$/i.test(
+    String(sourceTransport || ""),
+  );
+  if (!atlasTaskId && !isTopicScopedSource) {
+    throw new Error("taskId required");
+  }
+  if (!atlasTaskId && (!sourceChatId || !sourceThreadId)) {
+    throw new Error("sourceChatId and sourceThreadId required for source-based task recovery");
+  }
+  const payload = await atlasJsonRequest<{
+    tasks?: Array<{ id?: string | null; status?: string | null; createdAt?: string | null }>;
+  }>("/api/a2a/tasks", {
+    query: {
+      atlas_task_id: atlasTaskId,
+      source_transport: sourceTransport,
+      source_chat_id: sourceChatId,
+      source_thread_id: sourceThreadId,
+      repo: asNullableText(params.repo),
+      limit: 20,
+    },
+  });
+  const resolvedTaskId = selectPreferredA2ATaskId(payload?.tasks || []);
+  if (!resolvedTaskId) {
+    if (atlasTaskId) {
+      throw new Error(`a2a task not found for atlasTaskId ${atlasTaskId}`);
+    }
+    throw new Error("a2a task not found for the provided source context");
+  }
+  return resolvedTaskId;
+}
+
+async function assertA2ATaskIdentity(
+  taskId: string,
+  expected: {
+    atlasTaskId?: string;
+    sourceTransport?: string;
+    sourceChatId?: string;
+    sourceThreadId?: string;
+  },
+): Promise<void> {
+  const expectedAtlasTaskId = asNullableText(expected.atlasTaskId);
+  const expectedSourceTransport = asNullableText(expected.sourceTransport);
+  const expectedSourceChatId = asNullableText(expected.sourceChatId);
+  const expectedSourceThreadId = asNullableText(expected.sourceThreadId);
+  if (
+    !expectedAtlasTaskId &&
+    !expectedSourceTransport &&
+    !expectedSourceChatId &&
+    !expectedSourceThreadId
+  ) {
+    return;
+  }
+  const payload = await atlasJsonRequest<{
+    task?: {
+      id?: string | null;
+      atlasTaskId?: string | null;
+      sourceTransport?: string | null;
+      sourceChatId?: string | null;
+      sourceThreadId?: string | null;
+    } | null;
+  }>(`/api/a2a/tasks/${encodeURIComponent(taskId)}`);
+  const task = payload?.task;
+  if (!task?.id) {
+    throw new Error(`a2a task not found for taskId ${taskId}`);
+  }
+  if (expectedAtlasTaskId && asNullableText(task.atlasTaskId) !== expectedAtlasTaskId) {
+    throw new Error(`taskId ${taskId} does not match atlasTaskId ${expectedAtlasTaskId}`);
+  }
+  if (expectedSourceTransport && asNullableText(task.sourceTransport) !== expectedSourceTransport) {
+    throw new Error(`taskId ${taskId} does not match sourceTransport ${expectedSourceTransport}`);
+  }
+  if (expectedSourceChatId && asNullableText(task.sourceChatId) !== expectedSourceChatId) {
+    throw new Error(`taskId ${taskId} does not match sourceChatId ${expectedSourceChatId}`);
+  }
+  if (expectedSourceThreadId && asNullableText(task.sourceThreadId) !== expectedSourceThreadId) {
+    throw new Error(`taskId ${taskId} does not match sourceThreadId ${expectedSourceThreadId}`);
+  }
+}
+
+function getA2ATaskStatusPriority(status?: string | null): number {
+  switch (
+    String(status || "")
+      .trim()
+      .toLowerCase()
+  ) {
+    case "running":
+      return 5;
+    case "waiting_approval":
+      return 4;
+    case "claimed":
+      return 3;
+    case "queued":
+      return 2;
+    case "completed":
+      return 1;
+    case "failed":
+    case "cancelled":
+    default:
+      return 0;
+  }
+}
+
+function selectPreferredA2ATaskId(
+  tasks: Array<{ id?: string | null; status?: string | null; createdAt?: string | null }>,
+): string | undefined {
+  const sorted = tasks.toSorted((left, right) => {
+    const byStatus = getA2ATaskStatusPriority(right.status) - getA2ATaskStatusPriority(left.status);
+    if (byStatus !== 0) {
+      return byStatus;
+    }
+    const leftCreatedAt = Date.parse(String(left.createdAt || "")) || 0;
+    const rightCreatedAt = Date.parse(String(right.createdAt || "")) || 0;
+    return rightCreatedAt - leftCreatedAt;
+  });
+  for (const task of sorted) {
+    const id = asNullableText(task.id);
+    if (id) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+export function createAtlasExecutionTool(context?: AtlasExecutionToolContext): AnyAgentTool {
+  return {
+    label: "Atlas Execution",
+    name: "atlas_execution",
+    description:
+      "Submit an execution brief to Atlas, then inspect Atlas task status, events, and artifacts. Use this after clarifying the goal and acceptance criteria; Atlas owns code changes, tests, preview, and MR evidence.",
+    parameters: AtlasExecutionToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const action = readStringParam(params, "action", { required: true });
+      const taskId = readStringParam(params, "taskId");
+      const atlasTaskIdParam = readStringParam(params, "atlasTaskId");
+      const explicitRepo = readStringParam(params, "repo");
+      const limit = readNumberParam(params, "limit", { integer: true });
+      const recoverySource = inferAtlasSourceContext({
+        explicitTransport: readStringParam(params, "sourceTransport"),
+        explicitChatId: readStringParam(params, "sourceChatId"),
+        explicitThreadId: readStringParam(params, "sourceThreadId"),
+        bitrixTaskId: readStringParam(params, "bitrixTaskId"),
+        context,
+      });
+
+      if (action === "agent_card") {
+        const result = await atlasJsonRequest("/api/a2a/agent-card");
+        return jsonResult({ ok: true, action, result });
+      }
+
+      if (action === "list") {
+        const result = await atlasJsonRequest("/api/a2a/tasks", {
+          query: {
+            status: readStringParam(params, "status"),
+            atlas_task_id: atlasTaskIdParam,
+            source_transport: readStringParam(params, "sourceTransport"),
+            source_chat_id: readStringParam(params, "sourceChatId"),
+            source_thread_id: readStringParam(params, "sourceThreadId"),
+            repo: explicitRepo,
+            limit,
+          },
+        });
+        return jsonResult({ ok: true, action, result });
+      }
+
+      if (action === "get") {
+        const resolvedTaskId = await resolveA2ATaskId({
+          taskId,
+          atlasTaskId: atlasTaskIdParam,
+          repo: explicitRepo,
+          sourceTransport: recoverySource.sourceTransport,
+          sourceChatId: recoverySource.sourceChatId,
+          sourceThreadId: recoverySource.sourceThreadId,
+        });
+        const result = await atlasJsonRequest(
+          `/api/a2a/tasks/${encodeURIComponent(resolvedTaskId)}`,
+        );
+        return jsonResult({ ok: true, action, result });
+      }
+
+      if (action === "events") {
+        const resolvedTaskId = await resolveA2ATaskId({
+          taskId,
+          atlasTaskId: atlasTaskIdParam,
+          repo: explicitRepo,
+          sourceTransport: recoverySource.sourceTransport,
+          sourceChatId: recoverySource.sourceChatId,
+          sourceThreadId: recoverySource.sourceThreadId,
+        });
+        const result = await atlasJsonRequest(
+          `/api/a2a/tasks/${encodeURIComponent(resolvedTaskId)}/events`,
+          {
+            query: {
+              limit,
+            },
+          },
+        );
+        return jsonResult({ ok: true, action, result });
+      }
+
+      if (action === "artifacts") {
+        const resolvedTaskId = await resolveA2ATaskId({
+          taskId,
+          atlasTaskId: atlasTaskIdParam,
+          repo: explicitRepo,
+          sourceTransport: recoverySource.sourceTransport,
+          sourceChatId: recoverySource.sourceChatId,
+          sourceThreadId: recoverySource.sourceThreadId,
+        });
+        const result = await atlasJsonRequest(
+          `/api/a2a/tasks/${encodeURIComponent(resolvedTaskId)}/artifacts`,
+          {
+            query: {
+              limit,
+            },
+          },
+        );
+        return jsonResult({ ok: true, action, result });
+      }
+
+      if (action === "submit") {
+        const repo = explicitRepo || "homio/core";
+        const requiredTaskId = taskId || crypto.randomUUID();
+        const explicitAtlasTaskId = readStringParam(params, "atlasTaskId");
+        const intent = readStringParam(params, "intent", { required: true });
+        const title = readStringParam(params, "title");
+        const summary = readStringParam(params, "summary");
+        const branch = readStringParam(params, "branch");
+        const envName = readStringParam(params, "envName");
+        const linkedTargetTaskId = readStringParam(params, "targetTaskId");
+        const inferredSource = inferAtlasSourceContext({
+          explicitTransport: readStringParam(params, "sourceTransport"),
+          explicitChatId: readStringParam(params, "sourceChatId"),
+          explicitThreadId: readStringParam(params, "sourceThreadId"),
+          bitrixTaskId: readStringParam(params, "bitrixTaskId"),
+          context,
+        });
+        const sourceTransport = inferredSource.sourceTransport;
+        const sourceChatId = inferredSource.sourceChatId;
+        const sourceThreadId = inferredSource.sourceThreadId;
+        const sourceMessageId = readStringParam(params, "sourceMessageId");
+        const sessionId = readStringParam(params, "sessionId");
+        const workThreadId = readStringParam(params, "workThreadId");
+        const bitrixTaskId = readStringParam(params, "bitrixTaskId");
+        const brief = readStringParam(params, "brief");
+        const acceptanceCriteria = readStringParam(params, "acceptanceCriteria");
+        const nonGoals = readStringParam(params, "nonGoals");
+        const verifyPlan = readStringParam(params, "verifyPlan");
+        const stagePlan = readStringParam(params, "stagePlan");
+        const atlasTaskId = explicitAtlasTaskId || requiredTaskId;
+
+        if (!brief) {
+          throw new Error("brief required");
+        }
+        if (sourceTransport === "telegram-topic") {
+          if (!sourceChatId) {
+            throw new Error("sourceChatId required for telegram-topic submissions");
+          }
+          if (!sourceThreadId) {
+            throw new Error("sourceThreadId required for telegram-topic submissions");
+          }
+        }
+
+        const resolvedWorkThreadId = await resolveAtlasWorkThreadId({
+          repo,
+          branch,
+          envName,
+          atlasTaskId,
+          title,
+          summary,
+          sourceTransport,
+          sourceChatId,
+          sourceThreadId,
+          bitrixTaskId,
+          workThreadId,
+        });
+
+        const body = {
+          executionSpec: {
+            kind: "ExecutionSpec",
+            taskId: requiredTaskId,
+            intent,
+            repo,
+            summary: summary || title || brief || null,
+            target: {
+              taskId: atlasTaskId || null,
+              env: envName || null,
+              branch: branch || null,
+            },
+            metadata: {
+              title: title || null,
+              brief: brief || null,
+              acceptanceCriteria: acceptanceCriteria || null,
+              nonGoals: nonGoals || null,
+              verifyPlan: verifyPlan || null,
+              stagePlan: stagePlan || null,
+              workThreadId: resolvedWorkThreadId || null,
+              bitrixTaskId: bitrixTaskId || null,
+              linkedTargetTaskId: linkedTargetTaskId || null,
+            },
+          },
+          atlasTaskId: atlasTaskId || null,
+          source: {
+            agent: "openclaw",
+            transport: sourceTransport,
+            chatId: sourceChatId || null,
+            threadId: sourceThreadId || null,
+            messageId: sourceMessageId || null,
+          },
+          sessionId: sessionId || null,
+          branch: branch || null,
+          envName: envName || null,
+          metadata: {
+            workThreadId: resolvedWorkThreadId || null,
+            bitrixTaskId: bitrixTaskId || null,
+            brief: brief || null,
+            acceptanceCriteria: acceptanceCriteria || null,
+            nonGoals: nonGoals || null,
+            verifyPlan: verifyPlan || null,
+            stagePlan: stagePlan || null,
+            title: title || null,
+            linkedTargetTaskId: linkedTargetTaskId || null,
+          },
+        };
+
+        try {
+          const result = await atlasJsonRequest("/api/a2a/tasks", {
+            method: "POST",
+            body,
+          });
+          return jsonResult({ ok: true, action, result });
+        } catch (error) {
+          if (error instanceof AtlasHttpError && error.status === 409) {
+            return jsonResult({
+              ok: false,
+              conflict: true,
+              action,
+              result: error.payload,
+            });
+          }
+          throw error;
+        }
+      }
+
+      throw new Error(`Unsupported atlas_execution action: ${action}`);
+    },
+  };
+}

--- a/src/agents/tools/atlas-inspect-tool.ts
+++ b/src/agents/tools/atlas-inspect-tool.ts
@@ -1,0 +1,155 @@
+import { Type } from "@sinclair/typebox";
+import { stringEnum } from "../schema/typebox.js";
+import { atlasJsonRequest } from "./atlas-client.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readNumberParam, readStringParam } from "./common.js";
+
+const ATLAS_INSPECT_ACTIONS = [
+  "context",
+  "tree",
+  "file",
+  "search",
+  "changed_files",
+  "diff",
+  "git_status",
+] as const;
+
+const AtlasInspectToolSchema = Type.Object({
+  action: stringEnum(ATLAS_INSPECT_ACTIONS),
+  repo: Type.Optional(Type.String()),
+  repoDir: Type.Optional(Type.String()),
+  ref: Type.Optional(Type.String()),
+  branch: Type.Optional(Type.String()),
+  baseRef: Type.Optional(Type.String()),
+  headRef: Type.Optional(Type.String()),
+  path: Type.Optional(Type.String()),
+  query: Type.Optional(Type.String()),
+  recursive: Type.Optional(Type.Boolean()),
+  limit: Type.Optional(Type.Number({ minimum: 1 })),
+  contextLines: Type.Optional(Type.Number({ minimum: 0 })),
+  maxBytes: Type.Optional(Type.Number({ minimum: 1024 })),
+});
+
+export function createAtlasInspectTool(): AnyAgentTool {
+  return {
+    label: "Atlas Inspect",
+    name: "atlas_inspect",
+    description:
+      "Read Atlas-managed repositories through a commit-pinned readonly inspect plane. Use this to resolve repo/head, read files, search code, inspect diffs, and review changed files without touching the live workspace.",
+    parameters: AtlasInspectToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const action = readStringParam(params, "action", { required: true });
+      const repo = readStringParam(params, "repo");
+      const repoDir = readStringParam(params, "repoDir");
+      const ref = readStringParam(params, "ref");
+      const branch = readStringParam(params, "branch");
+      const baseRef = readStringParam(params, "baseRef");
+      const headRef = readStringParam(params, "headRef");
+      const targetPath = readStringParam(params, "path");
+      const query = readStringParam(params, "query");
+      const limit = readNumberParam(params, "limit", { integer: true });
+      const contextLines = readNumberParam(params, "contextLines", { integer: true });
+      const maxBytes = readNumberParam(params, "maxBytes", { integer: true });
+      const recursive = typeof params.recursive === "boolean" ? params.recursive : undefined;
+
+      const baseQuery = {
+        repo,
+        repo_dir: repoDir,
+        ref,
+        branch,
+      };
+
+      if (action === "context") {
+        const result = await atlasJsonRequest("/api/runtime/inspect/context", {
+          query: {
+            ...baseQuery,
+            base_ref: baseRef,
+          },
+        });
+        return jsonResult({ ok: true, action, result });
+      }
+      if (action === "tree") {
+        const result = await atlasJsonRequest("/api/runtime/inspect/tree", {
+          query: {
+            ...baseQuery,
+            path: targetPath,
+            recursive,
+            limit,
+          },
+        });
+        return jsonResult({ ok: true, action, result });
+      }
+      if (action === "file") {
+        const pathValue = targetPath;
+        if (!pathValue) {
+          throw new Error("path required");
+        }
+        const result = await atlasJsonRequest("/api/runtime/inspect/file", {
+          query: {
+            ...baseQuery,
+            path: pathValue,
+            max_bytes: maxBytes,
+          },
+        });
+        return jsonResult({ ok: true, action, result });
+      }
+      if (action === "search") {
+        if (!query) {
+          throw new Error("query required");
+        }
+        const result = await atlasJsonRequest("/api/runtime/inspect/search", {
+          query: {
+            ...baseQuery,
+            q: query,
+            path: targetPath,
+            limit,
+          },
+        });
+        return jsonResult({ ok: true, action, result });
+      }
+      if (action === "changed_files") {
+        if (!baseRef || !headRef) {
+          throw new Error("baseRef and headRef required");
+        }
+        const result = await atlasJsonRequest("/api/runtime/inspect/changed-files", {
+          query: {
+            repo,
+            repo_dir: repoDir,
+            base_ref: baseRef,
+            head_ref: headRef,
+          },
+        });
+        return jsonResult({ ok: true, action, result });
+      }
+      if (action === "diff") {
+        if (!baseRef || !headRef) {
+          throw new Error("baseRef and headRef required");
+        }
+        const result = await atlasJsonRequest("/api/runtime/inspect/diff", {
+          query: {
+            repo,
+            repo_dir: repoDir,
+            base_ref: baseRef,
+            head_ref: headRef,
+            path: targetPath,
+            context: contextLines,
+            max_bytes: maxBytes,
+          },
+        });
+        return jsonResult({ ok: true, action, result });
+      }
+      if (action === "git_status") {
+        const result = await atlasJsonRequest("/api/runtime/inspect/git-status", {
+          query: {
+            repo,
+            repo_dir: repoDir,
+          },
+        });
+        return jsonResult({ ok: true, action, result });
+      }
+
+      throw new Error(`Unsupported atlas_inspect action: ${action}`);
+    },
+  };
+}

--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -53,8 +53,22 @@ export async function resolveAnnounceTarget(params: {
       (typeof deliveryContext?.accountId === "string" ? deliveryContext.accountId : undefined) ??
       (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined) ??
       (typeof origin?.accountId === "string" ? origin.accountId : undefined);
+    const threadIdRaw =
+      (typeof deliveryContext?.threadId === "string" ||
+      typeof deliveryContext?.threadId === "number"
+        ? deliveryContext.threadId
+        : undefined) ??
+      ((match as { lastThreadId?: unknown } | undefined)?.lastThreadId as
+        | string
+        | number
+        | undefined) ??
+      fallback?.threadId;
+    const threadId =
+      threadIdRaw == null || String(threadIdRaw).trim() === ""
+        ? undefined
+        : String(threadIdRaw).trim();
     if (channel && to) {
-      return { channel, to, accountId };
+      return { channel, to, accountId, threadId };
     }
   } catch {
     // ignore

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -85,6 +85,7 @@ export type SessionListRow = {
   lastChannel?: string;
   lastTo?: string;
   lastAccountId?: string;
+  lastThreadId?: string | number;
   transcriptPath?: string;
   messages?: unknown[];
 };

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -137,6 +137,7 @@ export async function runSessionsSendA2AFlow(params: {
             message: announceReply.trim(),
             channel: announceTarget.channel,
             accountId: announceTarget.accountId,
+            threadId: announceTarget.threadId,
             idempotencyKey: crypto.randomUUID(),
           },
           timeoutMs: 10_000,

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -297,6 +297,33 @@ describe("resolveAnnounceTarget", () => {
       accountId: "work",
     });
   });
+
+  it("preserves threadId from sessions.list delivery context when session lookup is preferred", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:whatsapp:group:123@g.us",
+          deliveryContext: {
+            channel: "whatsapp",
+            to: "123@g.us",
+            accountId: "work",
+            threadId: 77,
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:whatsapp:group:123@g.us",
+      displayKey: "agent:main:whatsapp:group:123@g.us",
+    });
+    expect(target).toEqual({
+      channel: "whatsapp",
+      to: "123@g.us",
+      accountId: "work",
+      threadId: "77",
+    });
+  });
 });
 
 describe("sessions_list gating", () => {

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -101,9 +101,30 @@ vi.mock("../agents/openclaw-tools.js", () => {
       }),
     },
     {
+      name: "context_probe",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({
+        ok: true,
+        route: {
+          agentTo: lastCreateOpenClawToolsContext?.agentTo,
+          agentThreadId: lastCreateOpenClawToolsContext?.agentThreadId,
+        },
+      }),
+    },
+    {
       name: "sessions_send",
       parameters: { type: "object", properties: {} },
       execute: async () => ({ ok: true }),
+    },
+    {
+      name: "atlas_inspect",
+      parameters: { type: "object", properties: { action: { type: "string" } } },
+      execute: async () => ({ ok: true, action: "file", result: { content: "snapshot" } }),
+    },
+    {
+      name: "atlas_execution",
+      parameters: { type: "object", properties: { action: { type: "string" } } },
+      execute: async () => ({ ok: true, action: "submit", result: { taskId: "atlas-task-1" } }),
     },
     {
       name: "gateway",
@@ -568,13 +589,12 @@ describe("POST /tools/invoke", () => {
     expect(body.error.type).toBe("not_found");
   });
 
-  it("propagates message target/thread headers into tools context for sessions_spawn", async () => {
+  it("propagates message target/thread headers into tools context for allowed tools", async () => {
     cfg = {
       ...cfg,
       agents: {
-        list: [{ id: "main", default: true, tools: { allow: ["sessions_spawn"] } }],
+        list: [{ id: "main", default: true, tools: { allow: ["context_probe"] } }],
       },
-      gateway: { tools: { allow: ["sessions_spawn"] } },
     };
 
     const res = await invokeTool({
@@ -584,7 +604,7 @@ describe("POST /tools/invoke", () => {
         "x-openclaw-message-to": "channel:24514",
         "x-openclaw-thread-id": "thread-24514",
       },
-      tool: "sessions_spawn",
+      tool: "context_probe",
       sessionKey: "main",
     });
 
@@ -606,6 +626,23 @@ describe("POST /tools/invoke", () => {
     expect(res.status).toBe(404);
   });
 
+  it("keeps sessions_send denied via HTTP even when gateway.tools.allow includes it", async () => {
+    cfg = {
+      ...cfg,
+      agents: {
+        list: [{ id: "main", default: true, tools: { allow: ["sessions_send"] } }],
+      },
+      gateway: { tools: { allow: ["sessions_send"] } },
+    };
+
+    const res = await invokeToolAuthed({
+      tool: "sessions_send",
+      sessionKey: "main",
+    });
+
+    expect(res.status).toBe(404);
+  });
+
   it("denies gateway tool via HTTP", async () => {
     setMainAllowedTools({ allow: ["gateway"] });
 
@@ -615,6 +652,48 @@ describe("POST /tools/invoke", () => {
     });
 
     expect(res.status).toBe(404);
+  });
+
+  it("allows atlas_inspect via HTTP when agent policy allows it", async () => {
+    cfg = {
+      ...cfg,
+      agents: {
+        list: [{ id: "main", default: true, tools: { allow: ["atlas_inspect"] } }],
+      },
+    };
+
+    const res = await invokeToolAuthed({
+      tool: "atlas_inspect",
+      args: { action: "file", repo: "homio/core", path: "src/button.tsx" },
+      sessionKey: "main",
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.result?.action).toBe("file");
+    expect(body.result?.result?.content).toBe("snapshot");
+  });
+
+  it("keeps atlas_execution denied via HTTP even when explicitly allowed in gateway config", async () => {
+    cfg = {
+      ...cfg,
+      agents: {
+        list: [{ id: "main", default: true, tools: { allow: ["atlas_execution"] } }],
+      },
+      gateway: { tools: { allow: ["atlas_execution"] } },
+    };
+
+    const res = await invokeToolAuthed({
+      tool: "atlas_execution",
+      args: { action: "submit", taskId: "atlas-task-1" },
+      sessionKey: "main",
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error?.type).toBe("not_found");
   });
 
   it("allows gateway tool via HTTP when explicitly enabled in gateway.tools.allow", async () => {
@@ -736,10 +815,14 @@ describe("POST /tools/invoke", () => {
 
   it("requires operator.write scope for HTTP tool invocation", async () => {
     allowAgentsListForMain();
+    vi.mocked(authorizeHttpGatewayConnect).mockResolvedValueOnce({
+      ok: true,
+      method: "trusted-proxy",
+    });
 
     const res = await invokeTool({
       port: sharedPort,
-      headers: {},
+      headers: { "x-openclaw-scopes": "operator.read" },
       tool: "agents_list",
       sessionKey: "main",
     });

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -25,7 +25,10 @@ import { logWarn } from "../logger.js";
 import { isTestDefaultMemorySlotDisabled } from "../plugins/config-state.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { isSubagentSessionKey } from "../routing/session-key.js";
-import { DEFAULT_GATEWAY_HTTP_TOOL_DENY } from "../security/dangerous-tools.js";
+import {
+  DEFAULT_GATEWAY_HTTP_TOOL_DENY,
+  NON_OVERRIDABLE_GATEWAY_HTTP_TOOL_DENY,
+} from "../security/dangerous-tools.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
@@ -320,8 +323,9 @@ export async function handleToolsInvokeHttpRequest(
 
   // Gateway HTTP-specific deny list — applies to ALL sessions via HTTP.
   const gatewayToolsCfg = cfg.gateway?.tools;
+  const nonOverridableGatewayDeny = new Set<string>(NON_OVERRIDABLE_GATEWAY_HTTP_TOOL_DENY);
   const defaultGatewayDeny: string[] = DEFAULT_GATEWAY_HTTP_TOOL_DENY.filter(
-    (name) => !gatewayToolsCfg?.allow?.includes(name),
+    (name) => nonOverridableGatewayDeny.has(name) || !gatewayToolsCfg?.allow?.includes(name),
   );
   const gatewayDenyNames = defaultGatewayDeny.concat(
     Array.isArray(gatewayToolsCfg?.deny) ? gatewayToolsCfg.deny : [],

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -371,11 +371,12 @@ describe("security audit", () => {
     cases: readonly T[],
     run: (testCase: T, tmp: string) => Promise<void>,
   ) => {
-    await Promise.all(
-      cases.map(async (testCase) => {
-        await withChannelSecurityStateDir(async (tmp) => run(testCase, tmp));
-      }),
-    );
+    // These cases intentionally share one state dir to verify fallback behavior.
+    // Run them serially so Windows does not race on rm/mkdir for the shared
+    // credentials directory between concurrent cases.
+    for (const testCase of cases) {
+      await withChannelSecurityStateDir(async (tmp) => run(testCase, tmp));
+    }
   };
 
   const runSharedExtensionsAudit = async (config: OpenClawConfig) => {

--- a/src/security/dangerous-tools.ts
+++ b/src/security/dangerous-tools.ts
@@ -25,6 +25,8 @@ export const DEFAULT_GATEWAY_HTTP_TOOL_DENY = [
   "sessions_spawn",
   // Cross-session injection — message injection across sessions
   "sessions_send",
+  // Atlas execution bridge — triggers external code execution / deploy workflow
+  "atlas_execution",
   // Persistent automation control plane — can create/update/remove scheduled runs
   "cron",
   // Gateway control plane — prevents gateway reconfiguration via HTTP
@@ -34,3 +36,35 @@ export const DEFAULT_GATEWAY_HTTP_TOOL_DENY = [
   // Interactive setup — requires terminal QR scan, hangs on HTTP
   "whatsapp_login",
 ] as const;
+
+/**
+ * Subset of HTTP-denied tools that must stay blocked even if `gateway.tools.allow`
+ * is configured. These tools bypass the intended OpenClaw coordinator flow or
+ * enable interactive/execution behavior that is unsafe on a generic HTTP surface.
+ */
+export const NON_OVERRIDABLE_GATEWAY_HTTP_TOOL_DENY = [
+  "sessions_spawn",
+  "sessions_send",
+  "atlas_execution",
+  "whatsapp_login",
+] as const;
+
+/**
+ * ACP tools that should always require explicit user approval.
+ * ACP is an automation surface; we never want "silent yes" for mutating/execution tools.
+ */
+export const DANGEROUS_ACP_TOOL_NAMES = [
+  "exec",
+  "spawn",
+  "shell",
+  "sessions_spawn",
+  "sessions_send",
+  "atlas_execution",
+  "gateway",
+  "fs_write",
+  "fs_delete",
+  "fs_move",
+  "apply_patch",
+] as const;
+
+export const DANGEROUS_ACP_TOOLS = new Set<string>(DANGEROUS_ACP_TOOL_NAMES);

--- a/src/shared/chat-content.ts
+++ b/src/shared/chat-content.ts
@@ -15,20 +15,18 @@ export function extractTextFromChatContent(
     if (value == null) {
       return "";
     }
-    if (
-      typeof value === "number" ||
-      typeof value === "boolean" ||
-      typeof value === "bigint" ||
-      typeof value === "symbol"
-    ) {
-      return String(value);
-    }
     if (typeof value === "object") {
       try {
         return JSON.stringify(value) ?? "";
       } catch {
         return "";
       }
+    }
+    if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+      return `${value}`;
+    }
+    if (typeof value === "symbol") {
+      return value.description ? `Symbol(${value.description})` : "Symbol()";
     }
     return "";
   };


### PR DESCRIPTION
## Summary
- add Atlas-backed inspect and execution tools for OpenClaw
- add atlas delivery skill and policy/prompt coverage
- add end-to-end atlas delivery matrix tests

## Validation
- pnpm exec vitest run --config vitest.e2e.config.ts src/agents/openclaw-atlas-matrix.e2e.test.ts src/agents/openclaw-tools.atlas.e2e.test.ts src/agents/skills.atlas-delivery.e2e.test.ts src/agents/system-prompt.e2e.test.ts
