### PR TITLE
fix: catch per-stage errors in HTTP request pipeline to prevent cascade 500s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Channels/WhatsApp: pass inbound message timestamp to model context so the AI can see when WhatsApp messages were sent. (#58590) Thanks @Maninae
 - Web UI/OpenResponses: preserve rewritten stream snapshots in webchat and keep OpenResponses final streamed text aligned when models rewind earlier output. (#58641) Thanks @neeravmakwana
 - MiniMax/plugins: auto-enable the bundled MiniMax plugin for API-key auth/config so MiniMax image generation and other plugin-owned capabilities load without manual plugin allowlisting. (#57127) Thanks @tars90percent.
+- Gateway/HTTP: skip failing HTTP request stages so one broken facade no longer forces every HTTP endpoint to return 500. (#58746) Thanks @yelog
 
 ## 2026.3.31
 

--- a/src/gateway/server-http.stages.test.ts
+++ b/src/gateway/server-http.stages.test.ts
@@ -64,6 +64,10 @@ describe("runGatewayHttpRequestStages", () => {
 
     expect(result).toBe(true);
     expect(stageC).toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('stage "async-broken" threw'),
+      expect.any(Error),
+    );
 
     consoleSpy.mockRestore();
   });

--- a/src/gateway/server-http.stages.test.ts
+++ b/src/gateway/server-http.stages.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { runGatewayHttpRequestStages } from "./server-http.js";
+
+describe("runGatewayHttpRequestStages", () => {
+  it("returns true when a stage handles the request", async () => {
+    const stages = [
+      { name: "a", run: () => false },
+      { name: "b", run: () => true },
+      { name: "c", run: () => false },
+    ];
+    expect(await runGatewayHttpRequestStages(stages)).toBe(true);
+  });
+
+  it("returns false when no stage handles the request", async () => {
+    const stages = [
+      { name: "a", run: () => false },
+      { name: "b", run: () => false },
+    ];
+    expect(await runGatewayHttpRequestStages(stages)).toBe(false);
+  });
+
+  it("skips a throwing stage and continues to subsequent stages", async () => {
+    const stageC = vi.fn(() => true);
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const stages = [
+      { name: "a", run: () => false },
+      {
+        name: "broken-facade",
+        run: () => {
+          throw new Error("Cannot find module '@slack/bolt'");
+        },
+      },
+      { name: "c", run: stageC },
+    ];
+
+    const result = await runGatewayHttpRequestStages(stages);
+
+    expect(result).toBe(true);
+    expect(stageC).toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('stage "broken-facade" threw'),
+      expect.any(Error),
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it("skips a rejecting async stage and continues", async () => {
+    const stageC = vi.fn(() => true);
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const stages = [
+      {
+        name: "async-broken",
+        run: async () => {
+          throw new Error("ERR_MODULE_NOT_FOUND");
+        },
+      },
+      { name: "c", run: stageC },
+    ];
+
+    const result = await runGatewayHttpRequestStages(stages);
+
+    expect(result).toBe(true);
+    expect(stageC).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  it("returns false when the only non-throwing stages do not handle", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const stages = [
+      {
+        name: "broken",
+        run: () => {
+          throw new Error("load failed");
+        },
+      },
+      { name: "unmatched", run: () => false },
+    ];
+
+    const result = await runGatewayHttpRequestStages(stages);
+
+    expect(result).toBe(false);
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -314,12 +314,21 @@ type GatewayHttpRequestStage = {
   run: () => Promise<boolean> | boolean;
 };
 
-async function runGatewayHttpRequestStages(
+export async function runGatewayHttpRequestStages(
   stages: readonly GatewayHttpRequestStage[],
 ): Promise<boolean> {
   for (const stage of stages) {
-    if (await stage.run()) {
-      return true;
+    try {
+      if (await stage.run()) {
+        return true;
+      }
+    } catch (err) {
+      // Log and skip the failing stage so subsequent stages (control-ui,
+      // gateway-probes, etc.) remain reachable.  A common trigger is a
+      // bundled-plugin facade that fails to load because an optional
+      // dependency is missing (e.g. @slack/bolt after the lazy-facade
+      // refactor).
+      console.error(`[gateway-http] stage "${stage.name}" threw — skipping:`, err);
     }
   }
   return false;
@@ -1013,7 +1022,8 @@ export function createGatewayHttpServer(opts: {
       res.statusCode = 404;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
       res.end("Not Found");
-    } catch {
+    } catch (err) {
+      console.error("[gateway-http] unhandled error in request handler:", err);
       res.statusCode = 500;
       res.setHeader("Content-Type", "text/plain; charset=utf-8");
       res.end("Internal Server Error");


### PR DESCRIPTION
## Summary

Fixes #58689, fixes #58697.

When a bundled-plugin HTTP facade fails to load (e.g. `@slack/bolt` missing after the lazy-facade refactor in `8e0ab35b0e`), the thrown error propagates through `runGatewayHttpRequestStages` and kills the entire HTTP request pipeline. All subsequent stages — including control-ui, gateway-probes, and plugin routes — become unreachable, causing every HTTP endpoint to return 500 Internal Server Error. WebSocket connections are unaffected because they use a separate code path.

## Changes

- **`src/gateway/server-http.ts`**: Wrap each stage's `run()` call in `runGatewayHttpRequestStages` with a try/catch. A throwing stage is logged via `console.error` and skipped (treated as "not handled"), allowing subsequent stages to execute normally. Also added error logging to the outer catch block in `handleRequest` which was previously a bare `catch {}` that silently returned 500 with no diagnostic output.

- **`src/gateway/server-http.stages.test.ts`**: Unit tests for `runGatewayHttpRequestStages` covering: normal handling, no-match fallthrough, sync throw skip-and-continue, async rejection skip-and-continue, and correct error logging.

## Root Cause

Commit `8e0ab35b0e` refactored bundled plugin loading to use lazy facades. The Slack HTTP handler is loaded via `loadBundledPluginPublicSurfaceModuleSync` → jiti, which transitively imports `@slack/bolt` and `@slack/web-api` as external (no longer bundled) packages. When these packages are missing (postinstall failed, pnpm/yarn global install, Windows), jiti throws `ERR_MODULE_NOT_FOUND`. Since `runGatewayHttpRequestStages` had no per-stage error handling, the error propagated to the outer catch block (which also had no logging), returning a silent 500 for every request.