### PR TITLE
fix: suppress direct announce delivery for completion-message flows (double-post fix)

### DIFF
--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -484,14 +484,15 @@ async function sendSubagentAnnounceDirectly(params: {
     const sessionOnlyOrigin = effectiveDirectOrigin?.channel
       ? effectiveDirectOrigin
       : requesterSessionOrigin;
-    const deliveryTarget = !params.requesterIsSubagent
-      ? resolveExternalBestEffortDeliveryTarget({
-          channel: effectiveDirectOrigin?.channel,
-          to: effectiveDirectOrigin?.to,
-          accountId: effectiveDirectOrigin?.accountId,
-          threadId: effectiveDirectOrigin?.threadId,
-        })
-      : { deliver: false };
+    const deliveryTarget =
+      !params.requesterIsSubagent && !params.expectsCompletionMessage
+        ? resolveExternalBestEffortDeliveryTarget({
+            channel: effectiveDirectOrigin?.channel,
+            to: effectiveDirectOrigin?.to,
+            accountId: effectiveDirectOrigin?.accountId,
+            threadId: effectiveDirectOrigin?.threadId,
+          })
+        : { deliver: false };
     const normalizedSessionOnlyOriginChannel = !params.requesterIsSubagent
       ? normalizeMessageChannel(sessionOnlyOrigin?.channel)
       : undefined;

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -1708,7 +1708,7 @@ describe("subagent announce formatting", () => {
     });
   });
 
-  it("uses direct completion delivery when explicit channel+to route is available", async () => {
+  it("keeps completion direct announces session-only even when explicit channel+to route is available", async () => {
     sessionStore = {
       "agent:main:main": {
         sessionId: "requester-session-direct-route",
@@ -1734,7 +1734,7 @@ describe("subagent announce formatting", () => {
         sessionKey: "agent:main:main",
         channel: "discord",
         to: "channel:12345",
-        deliver: true,
+        deliver: false,
       },
     });
   });


### PR DESCRIPTION
## Bug
When a sub-agent completes with `expectsCompletionMessage=true` and the requester is a live parent session (not a sub-agent), two independent delivery paths both fire:

1. **Direct announce path** — `sendSubagentAnnounceDirectly()` calls `callGateway({ method: "agent", deliver: true })`. The gateway auto-delivers the LLM response to the external channel (for example Slack).
2. **Parent session wake** — that same `callGateway({ method: "agent" })` call also wakes the parent session, which processes the completion event through its normal session flow and delivers its own reply to the same channel/thread.

Both paths independently generate and send a response, which produces duplicate external posts a few seconds apart.

## Fix
In `sendSubagentAnnounceDirectly()`, completion-message flows now suppress transport auto-delivery on the direct announce path by setting `deliver: false` whenever the requester is a live parent session.

The `callGateway({ method: "agent" })` call still fires and wakes the parent session. This only disables the gateway auto-send leg, so the parent session still handles delivery through its normal flow.

## What's not affected
- `expectsCompletionMessage=false` flows (fire-and-forget) — unchanged
- Sub-agent chains (`requesterIsSubagent=true`) — already suppressed
- `bestEffortDeliver` — does not override `deliver: false`
- Queue fallback path — still has `deliver: true` for transient failures

## Validation
- Updated the direct-announce condition in `src/agents/subagent-announce-delivery.ts`
- Updated the explicit-route regression expectation in `src/agents/subagent-announce.format.e2e.test.ts`
- Ran `NODE_OPTIONS=--max-old-space-size=8192 pnpm tsc --noEmit`
- Ran `pnpm vitest run src/agents/subagent-announce.test.ts src/agents/subagent-announce-dispatch.test.ts`