### PR TITLE
fix(plugins): treat context-engine plugins as capabilities in status/inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/context engines: run opt-in turn maintenance as idle-aware background work so the next foreground turn no longer waits on proactive maintenance. (#65233) thanks @100yenadmin
 
+- Plugins/status: report the registered context-engine IDs in `plugins inspect` instead of the owning plugin ID, so non-matching engine IDs and multi-engine plugins are classified correctly. (#58766) thanks @zhuisDEV
 ## 2026.4.12
 
 ### Changes

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2608,6 +2608,12 @@ module.exports = { id: "throws-after-import", register() {} };`,
         selectCount: () => 1,
         duplicateMessage:
           "context engine already registered: shared-context-engine-loader-test (plugin:context-engine-owner-a)",
+        assertPrimaryOwner: (registry: ReturnType<typeof loadOpenClawPlugins>) => {
+          expect(
+            registry.plugins.find((entry) => entry.id === "context-engine-owner-a")
+              ?.contextEngineIds,
+          ).toEqual(["shared-context-engine-loader-test"]);
+        },
         assert: expectDuplicateRegistrationResult,
       },
       {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -733,6 +733,7 @@ function createPluginRecord(params: {
     musicGenerationProviderIds: [],
     webFetchProviderIds: [],
     webSearchProviderIds: [],
+    contextEngineIds: [],
     memoryEmbeddingProviderIds: [],
     agentHarnessIds: [],
     gatewayMethods: [],

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -246,6 +246,7 @@ export type PluginRecord = {
   musicGenerationProviderIds: string[];
   webFetchProviderIds: string[];
   webSearchProviderIds: string[];
+  contextEngineIds?: string[];
   memoryEmbeddingProviderIds: string[];
   agentHarnessIds: string[];
   gatewayMethods: string[];

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1220,6 +1220,10 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                     source: record.source,
                     message: `context engine already registered: ${id} (${result.existingOwner})`,
                   });
+                  return;
+                }
+                if (!record.contextEngineIds?.includes(id)) {
+                  record.contextEngineIds = [...(record.contextEngineIds ?? []), id];
                 }
               },
               registerCompactionProvider: (

--- a/src/plugins/status.test-helpers.ts
+++ b/src/plugins/status.test-helpers.ts
@@ -59,6 +59,7 @@ export function createPluginRecord(
     musicGenerationProviderIds: [],
     webFetchProviderIds: [],
     webSearchProviderIds: [],
+    contextEngineIds: [],
     memoryEmbeddingProviderIds: [],
     agentHarnessIds: [],
     gatewayMethods: [],

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -663,6 +663,7 @@ describe("plugin status reports", () => {
           id: "moon",
           name: "Moon",
           kind: "context-engine",
+          contextEngineIds: ["moon-engine"],
           hookCount: 1,
         }),
       ],
@@ -676,7 +677,7 @@ describe("plugin status reports", () => {
       capabilityMode: "plain",
       capabilityKinds: ["context-engine"],
     });
-    expect(inspect.capabilities).toEqual([{ kind: "context-engine", ids: ["moon"] }]);
+    expect(inspect.capabilities).toEqual([{ kind: "context-engine", ids: ["moon-engine"] }]);
     expect(inspect.compatibility).toEqual([]);
     expectNoCompatibilityWarnings();
   });

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -676,6 +676,7 @@ describe("plugin status reports", () => {
       capabilityMode: "plain",
       capabilityKinds: ["context-engine"],
     });
+    expect(inspect.capabilities).toEqual([{ kind: "context-engine", ids: ["moon"] }]);
     expect(inspect.compatibility).toEqual([]);
     expectNoCompatibilityWarnings();
   });

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -656,6 +656,30 @@ describe("plugin status reports", () => {
     expect(inspect.capabilities).toEqual([{ kind: "cli-backend", ids: ["claude-cli"] }]);
   });
 
+  it("treats a context-engine plugin as a plain capability", () => {
+    setPluginLoadResult({
+      plugins: [
+        createPluginRecord({
+          id: "moon",
+          name: "Moon",
+          kind: "context-engine",
+          hookCount: 1,
+        }),
+      ],
+      hooks: [createCustomHook({ pluginId: "moon", events: ["message"] })],
+    });
+
+    const inspect = expectInspectReport("moon");
+
+    expectInspectShape(inspect, {
+      shape: "plain-capability",
+      capabilityMode: "plain",
+      capabilityKinds: ["context-engine"],
+    });
+    expect(inspect.compatibility).toEqual([]);
+    expectNoCompatibilityWarnings();
+  });
+
   it("builds compatibility warnings for legacy compatibility paths", () => {
     setPluginLoadResult({
       plugins: [

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -21,6 +21,7 @@ import {
   resolvePluginRuntimeLoadContext,
 } from "./runtime/load-context.js";
 import { loadPluginMetadataRegistrySnapshot } from "./runtime/metadata-registry-loader.js";
+import { hasKind } from "./slots.js";
 import type { PluginHookName } from "./types.js";
 
 export type PluginStatusReport = PluginRegistry & {
@@ -37,6 +38,7 @@ export type PluginCapabilityKind =
   | "image-generation"
   | "web-search"
   | "agent-harness"
+  | "context-engine"
   | "channel";
 
 export type PluginInspectShape =
@@ -249,6 +251,10 @@ function buildCapabilityEntries(plugin: PluginRegistry["plugins"][number]) {
     { kind: "image-generation" as const, ids: plugin.imageGenerationProviderIds },
     { kind: "web-search" as const, ids: plugin.webSearchProviderIds },
     { kind: "agent-harness" as const, ids: plugin.agentHarnessIds },
+    {
+      kind: "context-engine" as const,
+      ids: plugin.status === "loaded" && hasKind(plugin.kind, "context-engine") ? [plugin.id] : [],
+    },
     { kind: "channel" as const, ids: plugin.channelIds },
   ].filter((entry) => entry.ids.length > 0);
 }

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -253,7 +253,10 @@ function buildCapabilityEntries(plugin: PluginRegistry["plugins"][number]) {
     { kind: "agent-harness" as const, ids: plugin.agentHarnessIds },
     {
       kind: "context-engine" as const,
-      ids: plugin.status === "loaded" && hasKind(plugin.kind, "context-engine") ? [plugin.id] : [],
+      ids:
+        plugin.status === "loaded" && hasKind(plugin.kind, "context-engine")
+          ? (plugin.contextEngineIds ?? [])
+          : [],
     },
     { kind: "channel" as const, ids: plugin.channelIds },
   ].filter((entry) => entry.ids.length > 0);


### PR DESCRIPTION
Summary: include context-engine plugins in buildCapabilityEntries so status/plugins inspect does not misclassify loaded context-engine plugins as hook-only. Adds regression coverage in src/plugins/status.test.ts. Validation: pnpm -C /Users/lilac/gh/openclaw exec vitest run --config vitest.unit.config.ts src/plugins/status.test.ts.