### PR TITLE
Improve gateway:watch errors when dependency package configs are corrupted

### DIFF
--- a/scripts/watch-node.d.mts
+++ b/scripts/watch-node.d.mts
@@ -23,4 +23,16 @@ export function runWatchMain(params?: {
   args?: string[];
   env?: NodeJS.ProcessEnv;
   now?: () => number;
+  loadChokidar?: () => Promise<{
+    watch: (
+      paths: string[],
+      options: {
+        ignoreInitial: boolean;
+        ignored: (watchPath: string) => boolean;
+      },
+    ) => {
+      on: (event: "add" | "change" | "unlink" | "error", cb: (arg?: unknown) => void) => void;
+      close?: () => Promise<void> | void;
+    };
+  }>;
 }): Promise<number>;

--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -3,7 +3,6 @@ import { spawn } from "node:child_process";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
-import chokidar from "chokidar";
 import { isRestartRelevantRunNodePath, runNodeWatchedPaths } from "./run-node.mjs";
 
 const WATCH_NODE_RUNNER = "scripts/run-node.mjs";
@@ -27,7 +26,54 @@ const resolveRepoPath = (filePath, cwd) => {
 const isIgnoredWatchPath = (filePath, cwd) =>
   !isRestartRelevantRunNodePath(resolveRepoPath(filePath, cwd));
 
+const isInvalidPackageConfigError = (err) =>
+  err?.code === "ERR_INVALID_PACKAGE_CONFIG" &&
+  String(err?.message ?? "").includes("node_modules/");
+
+const extractInvalidPackageConfigPath = (err) => {
+  const message = String(err?.message ?? "");
+  const match = message.match(/Invalid package config (.+?) while importing /);
+  return match?.[1] ?? null;
+};
+
+const printFriendlyWatchStartupError = (err) => {
+  if (!isInvalidPackageConfigError(err)) {
+    console.error(err);
+    return;
+  }
+
+  const packageConfigPath = extractInvalidPackageConfigPath(err);
+
+  console.error("");
+  console.error(
+    "[openclaw] gateway:watch could not start because a dependency package config looks corrupted.",
+  );
+  if (packageConfigPath) {
+    console.error(`[openclaw] Invalid package config: ${packageConfigPath}`);
+  }
+  console.error("[openclaw] This usually means a file in node_modules is empty or truncated.");
+  console.error("[openclaw] Recommended recovery:");
+  console.error("[openclaw]   rm -rf node_modules");
+  console.error("[openclaw]   pnpm store prune");
+  console.error("[openclaw]   pnpm install");
+  console.error("");
+  console.error("[openclaw] Original error:");
+  console.error(err);
+};
+
+const loadChokidar = async () => {
+  try {
+    const mod = await import("chokidar");
+    return mod.default ?? mod;
+  } catch (err) {
+    printFriendlyWatchStartupError(err);
+    throw err;
+  }
+};
+
 export async function runWatchMain(params = {}) {
+  const chokidarModule = params.chokidar ?? (await loadChokidar());
+
   const deps = {
     spawn: params.spawn ?? spawn,
     process: params.process ?? process,
@@ -36,7 +82,7 @@ export async function runWatchMain(params = {}) {
     env: params.env ? { ...params.env } : { ...process.env },
     now: params.now ?? Date.now,
     createWatcher:
-      params.createWatcher ?? ((watchPaths, options) => chokidar.watch(watchPaths, options)),
+      params.createWatcher ?? ((watchPaths, options) => chokidarModule.watch(watchPaths, options)),
     watchPaths: params.watchPaths ?? runNodeWatchedPaths,
   };
 
@@ -145,7 +191,9 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   void runWatchMain()
     .then((code) => process.exit(code))
     .catch((err) => {
-      console.error(err);
+      if (!isInvalidPackageConfigError(err)) {
+        console.error(err);
+      }
       process.exit(1);
     });
 }

--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -62,17 +62,21 @@ const printFriendlyWatchStartupError = (err) => {
 };
 
 const loadChokidar = async () => {
-  try {
-    const mod = await import("chokidar");
-    return mod.default ?? mod;
-  } catch (err) {
-    printFriendlyWatchStartupError(err);
-    throw err;
-  }
+  const mod = await import("chokidar");
+  return mod.default ?? mod;
 };
 
 export async function runWatchMain(params = {}) {
-  const chokidarModule = params.chokidar ?? (await loadChokidar());
+  let createWatcher = params.createWatcher;
+  if (!createWatcher) {
+    try {
+      const chokidarModule = params.chokidar ?? (await (params.loadChokidar ?? loadChokidar)());
+      createWatcher = (watchPaths, options) => chokidarModule.watch(watchPaths, options);
+    } catch (err) {
+      printFriendlyWatchStartupError(err);
+      throw err;
+    }
+  }
 
   const deps = {
     spawn: params.spawn ?? spawn,
@@ -81,8 +85,7 @@ export async function runWatchMain(params = {}) {
     args: params.args ?? process.argv.slice(2),
     env: params.env ? { ...params.env } : { ...process.env },
     now: params.now ?? Date.now,
-    createWatcher:
-      params.createWatcher ?? ((watchPaths, options) => chokidarModule.watch(watchPaths, options)),
+    createWatcher,
     watchPaths: params.watchPaths ?? runNodeWatchedPaths,
   };
 

--- a/src/infra/watch-node.test.ts
+++ b/src/infra/watch-node.test.ts
@@ -222,4 +222,46 @@ describe("watch-node script", () => {
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
     expect(watcher.close).toHaveBeenCalledTimes(1);
   });
+  it("prints recovery guidance when chokidar fails with invalid package config", async () => {
+    const error = Object.assign(
+      new Error(
+        'Invalid package config /tmp/openclaw/node_modules/chokidar/package.json while importing "chokidar" from /tmp/openclaw/scripts/watch-node.mjs.',
+      ),
+      { code: "ERR_INVALID_PACKAGE_CONFIG" },
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fakeProcess = createFakeProcess();
+
+    await expect(
+      runWatchMain({
+        args: ["gateway", "--force"],
+        cwd: "/tmp/openclaw",
+        loadChokidar: vi.fn(async () => {
+          throw error;
+        }),
+        process: fakeProcess,
+      }),
+    ).rejects.toBe(error);
+
+    expect(errorSpy).toHaveBeenCalledWith("");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[openclaw] gateway:watch could not start because a dependency package config looks corrupted.",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[openclaw] Invalid package config: /tmp/openclaw/node_modules/chokidar/package.json",
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[openclaw] This usually means a file in node_modules is empty or truncated.",
+    );
+    expect(errorSpy).toHaveBeenCalledWith("[openclaw] Recommended recovery:");
+    expect(errorSpy).toHaveBeenCalledWith("[openclaw]   rm -rf node_modules");
+    expect(errorSpy).toHaveBeenCalledWith("[openclaw]   pnpm store prune");
+    expect(errorSpy).toHaveBeenCalledWith("[openclaw]   pnpm install");
+    expect(errorSpy).toHaveBeenCalledWith("");
+    expect(errorSpy).toHaveBeenCalledWith("[openclaw] Original error:");
+    expect(errorSpy).toHaveBeenCalledWith(error);
+
+    errorSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

Improve `gateway:watch` startup diagnostics when a dependency under `node_modules` has an invalid or truncated `package.json`.

## What changed

- Load `chokidar` dynamically instead of at module import time
- Detect `ERR_INVALID_PACKAGE_CONFIG` errors coming from `node_modules`
- Print a friendlier recovery message before exiting
- Keep the original error attached for debugging context

## Why

Before this change, `pnpm gateway:watch` could fail very early with a raw Node error like:

`ERR_INVALID_PACKAGE_CONFIG`

That made it unclear that the real issue was a corrupted dependency file under `node_modules`, and gave no recovery guidance.

Now the command explains the likely cause and suggests:

- `rm -rf node_modules`
- `pnpm store prune`
- `pnpm install`

## Manual verification

1. Installed dependencies normally
2. Corrupted `node_modules/chokidar/package.json` by truncating it to 0 bytes
3. Ran `pnpm gateway:watch`
4. Confirmed the new friendly error message appeared with recovery steps
5. Restored `package.json`
6. Re-ran `pnpm gateway:watch`
7. Confirmed normal startup still worked