### PR TITLE
fix: restore bundled runtime dependency provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Memory/QMD: prefer `--mask` over `--glob` when creating QMD collections so default memory collections keep their intended patterns and stop colliding on restart. (#58643) Thanks @GitZhangChi.
 - Gateway/HTTP: skip failing HTTP request stages so one broken facade no longer forces every HTTP endpoint to return 500. (#58746) Thanks @yelog
 - Sessions/model switching: keep `/model` changes queued behind busy runs instead of interrupting the active turn, and retarget queued followups so later work picks up the new model as soon as the current turn finishes.
+- Plugins/bundled runtimes: restore externalized bundled plugin runtime dependency staging across packed installs, Docker builds, and local runtime staging so bundled plugins keep their declared runtime deps after the 2026.3.31 externalization change. (#58782)
 
 ## 2026.3.31
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches
-COPY scripts/postinstall-bundled-plugins.mjs ./scripts/postinstall-bundled-plugins.mjs
+COPY scripts/postinstall-bundled-plugins.mjs scripts/npm-runner.mjs ./scripts/
 
 COPY --from=ext-deps /out/ ./${OPENCLAW_BUNDLED_PLUGIN_DIR}/
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "!docs/.generated/**",
     "!docs/.i18n/zh-CN.tm.jsonl",
     "skills/",
+    "scripts/npm-runner.mjs",
     "scripts/postinstall-bundled-plugins.mjs"
   ],
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1227,6 +1227,7 @@
     "oxfmt": "0.43.0",
     "oxlint": "^1.58.0",
     "oxlint-tsgolint": "^0.18.1",
+    "semver": "7.7.4",
     "signal-utils": "0.21.1",
     "tsdown": "0.21.7",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       oxlint-tsgolint:
         specifier: ^0.18.1
         version: 0.18.1
+      semver:
+        specifier: 7.7.4
+        version: 7.7.4
       signal-utils:
         specifier: 0.21.1
         version: 0.21.1(signal-polyfill@0.2.2)

--- a/scripts/docker/cleanup-smoke/Dockerfile
+++ b/scripts/docker/cleanup-smoke/Dockerfile
@@ -19,7 +19,7 @@ COPY ui/package.json ./ui/package.json
 COPY packages ./packages
 COPY extensions ./extensions
 COPY patches ./patches
-COPY scripts/postinstall-bundled-plugins.mjs ./scripts/postinstall-bundled-plugins.mjs
+COPY scripts/postinstall-bundled-plugins.mjs scripts/npm-runner.mjs ./scripts/
 RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
   corepack enable \
   && pnpm install --frozen-lockfile

--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -22,7 +22,7 @@ COPY --chown=appuser:appuser package.json pnpm-lock.yaml pnpm-workspace.yaml .np
 COPY --chown=appuser:appuser ui/package.json ./ui/package.json
 COPY --chown=appuser:appuser extensions ./extensions
 COPY --chown=appuser:appuser patches ./patches
-COPY --chown=appuser:appuser scripts/postinstall-bundled-plugins.mjs ./scripts/postinstall-bundled-plugins.mjs
+COPY --chown=appuser:appuser scripts/postinstall-bundled-plugins.mjs scripts/npm-runner.mjs ./scripts/
 
 RUN --mount=type=cache,id=openclaw-pnpm-store,target=/home/appuser/.local/share/pnpm/store,sharing=locked \
     pnpm install --frozen-lockfile

--- a/scripts/npm-runner.mjs
+++ b/scripts/npm-runner.mjs
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>^%\r\n]/;
+const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>%\r\n]/;
 
 function resolvePathEnvKey(env) {
   return Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
@@ -11,10 +11,11 @@ function escapeForCmdExe(arg) {
   if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(arg)) {
     throw new Error(`unsafe Windows cmd.exe argument detected: ${JSON.stringify(arg)}`);
   }
-  if (!arg.includes(" ") && !arg.includes('"')) {
-    return arg;
+  const escaped = arg.replace(/\^/g, "^^");
+  if (!escaped.includes(" ") && !escaped.includes('"')) {
+    return escaped;
   }
-  return `"${arg.replace(/"/g, '""')}"`;
+  return `"${escaped.replace(/"/g, '""')}"`;
 }
 
 function buildCmdExeCommandLine(command, args) {

--- a/scripts/npm-runner.mjs
+++ b/scripts/npm-runner.mjs
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>^%\r\n]/;
+
+function resolvePathEnvKey(env) {
+  return Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+}
+
+function escapeForCmdExe(arg) {
+  if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(arg)) {
+    throw new Error(`unsafe Windows cmd.exe argument detected: ${JSON.stringify(arg)}`);
+  }
+  if (!arg.includes(" ") && !arg.includes('"')) {
+    return arg;
+  }
+  return `"${arg.replace(/"/g, '""')}"`;
+}
+
+function buildCmdExeCommandLine(command, args) {
+  return [escapeForCmdExe(command), ...args.map(escapeForCmdExe)].join(" ");
+}
+
+function resolveToolchainNpmRunner(params) {
+  const npmCliCandidates = [
+    params.pathImpl.resolve(params.nodeDir, "../lib/node_modules/npm/bin/npm-cli.js"),
+    params.pathImpl.resolve(params.nodeDir, "node_modules/npm/bin/npm-cli.js"),
+  ];
+  const npmCliPath = npmCliCandidates.find((candidate) => params.existsSync(candidate));
+  if (npmCliPath) {
+    return {
+      command:
+        params.platform === "win32"
+          ? params.pathImpl.join(params.nodeDir, "node.exe")
+          : params.pathImpl.join(params.nodeDir, "node"),
+      args: [npmCliPath, ...params.npmArgs],
+      shell: false,
+    };
+  }
+  if (params.platform !== "win32") {
+    return null;
+  }
+  const npmExePath = params.pathImpl.resolve(params.nodeDir, "npm.exe");
+  if (params.existsSync(npmExePath)) {
+    return {
+      command: npmExePath,
+      args: params.npmArgs,
+      shell: false,
+    };
+  }
+  const npmCmdPath = params.pathImpl.resolve(params.nodeDir, "npm.cmd");
+  if (params.existsSync(npmCmdPath)) {
+    return {
+      command: params.comSpec,
+      args: ["/d", "/s", "/c", buildCmdExeCommandLine(npmCmdPath, params.npmArgs)],
+      shell: false,
+      windowsVerbatimArguments: true,
+    };
+  }
+  return null;
+}
+
+export function resolveNpmRunner(params = {}) {
+  const execPath = params.execPath ?? process.execPath;
+  const npmArgs = params.npmArgs ?? [];
+  const existsSync = params.existsSync ?? fs.existsSync;
+  const env = params.env ?? process.env;
+  const platform = params.platform ?? process.platform;
+  const comSpec = params.comSpec ?? env.ComSpec ?? "cmd.exe";
+  const pathImpl = platform === "win32" ? path.win32 : path.posix;
+  const nodeDir = pathImpl.dirname(execPath);
+  const npmToolchain = resolveToolchainNpmRunner({
+    comSpec,
+    existsSync,
+    nodeDir,
+    npmArgs,
+    pathImpl,
+    platform,
+  });
+  if (npmToolchain) {
+    return npmToolchain;
+  }
+  if (platform === "win32") {
+    const expectedPaths = [
+      pathImpl.resolve(nodeDir, "../lib/node_modules/npm/bin/npm-cli.js"),
+      pathImpl.resolve(nodeDir, "node_modules/npm/bin/npm-cli.js"),
+      pathImpl.resolve(nodeDir, "npm.exe"),
+      pathImpl.resolve(nodeDir, "npm.cmd"),
+    ];
+    throw new Error(
+      `failed to resolve a toolchain-local npm next to ${execPath}. ` +
+        `Checked: ${expectedPaths.join(", ")}. ` +
+        "OpenClaw refuses to shell out to bare npm on Windows; install a Node.js toolchain that bundles npm or run with a matching Node installation.",
+    );
+  }
+  const pathKey = resolvePathEnvKey(env);
+  const currentPath = env[pathKey];
+  return {
+    command: "npm",
+    args: npmArgs,
+    shell: false,
+    env: {
+      ...env,
+      [pathKey]:
+        typeof currentPath === "string" && currentPath.length > 0
+          ? `${nodeDir}${path.delimiter}${currentPath}`
+          : nodeDir,
+    },
+  };
+}

--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -4,10 +4,11 @@
 // so runtime dependencies declared in dist/extensions/*/package.json must also
 // resolve from the package root node_modules after a global install.
 // This script is a no-op outside of a global npm install context.
-import { execSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { resolveNpmRunner } from "./npm-runner.mjs";
 
 export const BUNDLED_PLUGIN_INSTALL_TARGETS = [];
 
@@ -107,7 +108,7 @@ export function runBundledPluginPostinstall(params = {}) {
   }
   const extensionsDir = params.extensionsDir ?? DEFAULT_EXTENSIONS_DIR;
   const packageRoot = params.packageRoot ?? DEFAULT_PACKAGE_ROOT;
-  const exec = params.execSync ?? execSync;
+  const spawn = params.spawnSync ?? spawnSync;
   const pathExists = params.existsSync ?? existsSync;
   const log = params.log ?? console;
   const runtimeDeps =
@@ -122,11 +123,28 @@ export function runBundledPluginPostinstall(params = {}) {
   }
 
   try {
-    exec(`npm install --omit=dev --no-save --package-lock=false ${missingSpecs.join(" ")}`, {
+    const nestedEnv = createNestedNpmInstallEnv(env);
+    const npmRunner =
+      params.npmRunner ??
+      resolveNpmRunner({
+        env: nestedEnv,
+        execPath: params.execPath,
+        existsSync: pathExists,
+        platform: params.platform,
+        comSpec: params.comSpec,
+        npmArgs: ["install", "--omit=dev", "--no-save", "--package-lock=false", ...missingSpecs],
+      });
+    const result = spawn(npmRunner.command, npmRunner.args, {
       cwd: packageRoot,
-      env: createNestedNpmInstallEnv(env),
+      env: npmRunner.env ?? nestedEnv,
       stdio: "pipe",
+      shell: npmRunner.shell,
+      windowsVerbatimArguments: npmRunner.windowsVerbatimArguments,
     });
+    if (result.status !== 0) {
+      const output = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
+      throw new Error(output || "npm install failed");
+    }
     log.log(`[postinstall] installed bundled plugin deps: ${missingSpecs.join(", ")}`);
   } catch (e) {
     // Non-fatal: gateway will surface the missing dep via doctor.

--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -136,6 +136,7 @@ export function runBundledPluginPostinstall(params = {}) {
       });
     const result = spawn(npmRunner.command, npmRunner.args, {
       cwd: packageRoot,
+      encoding: "utf8",
       env: npmRunner.env ?? nestedEnv,
       stdio: "pipe",
       shell: npmRunner.shell,

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -23,6 +23,8 @@ const requiredPathGroups = [
   ["dist/entry.js", "dist/entry.mjs"],
   ...listPluginSdkDistArtifacts(),
   ...listBundledPluginPackArtifacts(),
+  "scripts/npm-runner.mjs",
+  "scripts/postinstall-bundled-plugins.mjs",
   "dist/plugin-sdk/compat.js",
   "dist/plugin-sdk/root-alias.cjs",
   "dist/build-info.json",

--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -45,6 +45,108 @@ function dependencyNodeModulesPath(nodeModulesDir, depName) {
   return path.join(nodeModulesDir, ...depName.split("/"));
 }
 
+function readInstalledDependencyVersion(nodeModulesDir, depName) {
+  const packageJsonPath = path.join(
+    dependencyNodeModulesPath(nodeModulesDir, depName),
+    "package.json",
+  );
+  if (!fs.existsSync(packageJsonPath)) {
+    return null;
+  }
+  const version = readJson(packageJsonPath).version;
+  return typeof version === "string" ? version : null;
+}
+
+function parseSemver(version) {
+  const match =
+    /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(
+      version.trim(),
+    );
+  if (!match) {
+    return null;
+  }
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+    patch: Number.parseInt(match[3], 10),
+    prerelease: match[4] ?? null,
+  };
+}
+
+function dependencyVersionSatisfied(spec, installedVersion) {
+  if (spec === installedVersion) {
+    return true;
+  }
+  if (!spec.startsWith("^")) {
+    return false;
+  }
+  const minimum = parseSemver(spec.slice(1));
+  const installed = parseSemver(installedVersion);
+  if (!minimum || !installed) {
+    return false;
+  }
+  if (minimum.major === 0) {
+    return (
+      installed.major === 0 &&
+      installed.minor === minimum.minor &&
+      (installed.patch > minimum.patch ||
+        (installed.patch === minimum.patch &&
+          (installed.prerelease === minimum.prerelease ||
+            (minimum.prerelease === null && installed.prerelease === null))))
+    );
+  }
+  if (installed.major !== minimum.major) {
+    return false;
+  }
+  if (installed.minor < minimum.minor) {
+    return false;
+  }
+  if (installed.minor > minimum.minor) {
+    return true;
+  }
+  if (installed.patch < minimum.patch) {
+    return false;
+  }
+  if (installed.patch > minimum.patch) {
+    return true;
+  }
+  return installed.prerelease === minimum.prerelease;
+}
+
+function collectInstalledRuntimeClosure(rootNodeModulesDir, dependencySpecs) {
+  const packageCache = new Map();
+  const closure = new Set();
+  const queue = Object.entries(dependencySpecs);
+
+  while (queue.length > 0) {
+    const [depName, spec] = queue.shift();
+    const installedVersion = readInstalledDependencyVersion(rootNodeModulesDir, depName);
+    if (installedVersion === null || !dependencyVersionSatisfied(spec, installedVersion)) {
+      return null;
+    }
+    if (closure.has(depName)) {
+      continue;
+    }
+
+    const packageJsonPath = path.join(
+      dependencyNodeModulesPath(rootNodeModulesDir, depName),
+      "package.json",
+    );
+    const packageJson = packageCache.get(depName) ?? readJson(packageJsonPath);
+    packageCache.set(depName, packageJson);
+    closure.add(depName);
+
+    for (const [childName, childSpec] of Object.entries(packageJson.dependencies ?? {})) {
+      queue.push([childName, childSpec]);
+    }
+    for (const [childName, childSpec] of Object.entries(packageJson.optionalDependencies ?? {})) {
+      queue.push([childName, childSpec]);
+    }
+  }
+
+  return [...closure];
+}
+
 function listBundledPluginRuntimeDirs(repoRoot) {
   const extensionsRoot = path.join(repoRoot, "dist", "extensions");
   if (!fs.existsSync(extensionsRoot)) {
@@ -135,22 +237,17 @@ function readRuntimeDepsStamp(stampPath) {
 
 function stageInstalledRootRuntimeDeps(params) {
   const { fingerprint, packageJson, pluginDir, repoRoot } = params;
-  const dependencyNames = [
-    ...Object.keys(packageJson.dependencies ?? {}),
-    ...Object.keys(packageJson.optionalDependencies ?? {}),
-  ];
+  const dependencySpecs = {
+    ...packageJson.dependencies,
+    ...packageJson.optionalDependencies,
+  };
   const rootNodeModulesDir = path.join(repoRoot, "node_modules");
-  if (dependencyNames.length === 0 || !fs.existsSync(rootNodeModulesDir)) {
+  if (Object.keys(dependencySpecs).length === 0 || !fs.existsSync(rootNodeModulesDir)) {
     return false;
   }
 
-  const missingRootDeps = dependencyNames.filter(
-    (depName) =>
-      !fs.existsSync(
-        path.join(dependencyNodeModulesPath(rootNodeModulesDir, depName), "package.json"),
-      ),
-  );
-  if (missingRootDeps.length > 0) {
+  const dependencyNames = collectInstalledRuntimeClosure(rootNodeModulesDir, dependencySpecs);
+  if (dependencyNames === null) {
     return false;
   }
 

--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -4,8 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-
-const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>^%\r\n]/;
+import { resolveNpmRunner } from "./npm-runner.mjs";
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
@@ -40,6 +39,10 @@ function replaceDir(targetPath, sourcePath) {
   }
   fs.cpSync(sourcePath, targetPath, { recursive: true, force: true });
   removePathIfExists(sourcePath);
+}
+
+function dependencyNodeModulesPath(nodeModulesDir, depName) {
+  return path.join(nodeModulesDir, ...depName.split("/"));
 }
 
 function listBundledPluginRuntimeDirs(repoRoot) {
@@ -130,114 +133,64 @@ function readRuntimeDepsStamp(stampPath) {
   }
 }
 
-export function resolveNpmRunner(params = {}) {
-  const execPath = params.execPath ?? process.execPath;
-  const npmArgs = params.npmArgs ?? [];
-  const existsSync = params.existsSync ?? fs.existsSync;
-  const env = params.env ?? process.env;
-  const platform = params.platform ?? process.platform;
-  const comSpec = params.comSpec ?? env.ComSpec ?? "cmd.exe";
-  const pathImpl = platform === "win32" ? path.win32 : path.posix;
-  const nodeDir = pathImpl.dirname(execPath);
-  const npmToolchain = resolveToolchainNpmRunner({
-    comSpec,
-    existsSync,
-    nodeDir,
-    npmArgs,
-    pathImpl,
-    platform,
-  });
-  if (npmToolchain) {
-    return npmToolchain;
-  }
-  if (platform === "win32") {
-    const expectedPaths = [
-      pathImpl.resolve(nodeDir, "../lib/node_modules/npm/bin/npm-cli.js"),
-      pathImpl.resolve(nodeDir, "node_modules/npm/bin/npm-cli.js"),
-      pathImpl.resolve(nodeDir, "npm.exe"),
-      pathImpl.resolve(nodeDir, "npm.cmd"),
-    ];
-    throw new Error(
-      `failed to resolve a toolchain-local npm next to ${execPath}. ` +
-        `Checked: ${expectedPaths.join(", ")}. ` +
-        "OpenClaw refuses to shell out to bare npm on Windows; install a Node.js toolchain that bundles npm or run with a matching Node installation.",
-    );
-  }
-  const pathKey = resolvePathEnvKey(env);
-  const currentPath = env[pathKey];
-  return {
-    command: "npm",
-    args: npmArgs,
-    shell: false,
-    env: {
-      ...env,
-      [pathKey]:
-        typeof currentPath === "string" && currentPath.length > 0
-          ? `${nodeDir}${path.delimiter}${currentPath}`
-          : nodeDir,
-    },
-  };
-}
-
-function resolveToolchainNpmRunner(params) {
-  const npmCliCandidates = [
-    params.pathImpl.resolve(params.nodeDir, "../lib/node_modules/npm/bin/npm-cli.js"),
-    params.pathImpl.resolve(params.nodeDir, "node_modules/npm/bin/npm-cli.js"),
+function stageInstalledRootRuntimeDeps(params) {
+  const { fingerprint, packageJson, pluginDir, repoRoot } = params;
+  const dependencyNames = [
+    ...Object.keys(packageJson.dependencies ?? {}),
+    ...Object.keys(packageJson.optionalDependencies ?? {}),
   ];
-  const npmCliPath = npmCliCandidates.find((candidate) => params.existsSync(candidate));
-  if (npmCliPath) {
-    return {
-      command:
-        params.platform === "win32"
-          ? params.pathImpl.join(params.nodeDir, "node.exe")
-          : params.pathImpl.join(params.nodeDir, "node"),
-      args: [npmCliPath, ...params.npmArgs],
-      shell: false,
-    };
+  const rootNodeModulesDir = path.join(repoRoot, "node_modules");
+  if (dependencyNames.length === 0 || !fs.existsSync(rootNodeModulesDir)) {
+    return false;
   }
-  if (params.platform !== "win32") {
-    return null;
-  }
-  const npmExePath = params.pathImpl.resolve(params.nodeDir, "npm.exe");
-  if (params.existsSync(npmExePath)) {
-    return {
-      command: npmExePath,
-      args: params.npmArgs,
-      shell: false,
-    };
-  }
-  const npmCmdPath = params.pathImpl.resolve(params.nodeDir, "npm.cmd");
-  if (params.existsSync(npmCmdPath)) {
-    return {
-      command: params.comSpec,
-      args: ["/d", "/s", "/c", buildCmdExeCommandLine(npmCmdPath, params.npmArgs)],
-      shell: false,
-      windowsVerbatimArguments: true,
-    };
-  }
-  return null;
-}
 
-function resolvePathEnvKey(env) {
-  return Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
-}
-
-function escapeForCmdExe(arg) {
-  if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(arg)) {
-    throw new Error(`unsafe Windows cmd.exe argument detected: ${JSON.stringify(arg)}`);
+  const missingRootDeps = dependencyNames.filter(
+    (depName) =>
+      !fs.existsSync(
+        path.join(dependencyNodeModulesPath(rootNodeModulesDir, depName), "package.json"),
+      ),
+  );
+  if (missingRootDeps.length > 0) {
+    return false;
   }
-  if (!arg.includes(" ") && !arg.includes('"')) {
-    return arg;
-  }
-  return `"${arg.replace(/"/g, '""')}"`;
-}
 
-function buildCmdExeCommandLine(command, args) {
-  return [escapeForCmdExe(command), ...args.map(escapeForCmdExe)].join(" ");
+  const nodeModulesDir = path.join(pluginDir, "node_modules");
+  const stampPath = resolveRuntimeDepsStampPath(pluginDir);
+  const stagedNodeModulesDir = path.join(
+    makeTempDir(
+      os.tmpdir(),
+      `openclaw-runtime-deps-${sanitizeTempPrefixSegment(path.basename(pluginDir))}-`,
+    ),
+    "node_modules",
+  );
+
+  try {
+    for (const depName of dependencyNames) {
+      const sourcePath = dependencyNodeModulesPath(rootNodeModulesDir, depName);
+      const targetPath = dependencyNodeModulesPath(stagedNodeModulesDir, depName);
+      fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+      fs.cpSync(sourcePath, targetPath, { recursive: true, force: true, dereference: true });
+    }
+
+    replaceDir(nodeModulesDir, stagedNodeModulesDir);
+    writeJson(stampPath, {
+      fingerprint,
+      generatedAt: new Date().toISOString(),
+    });
+    return true;
+  } finally {
+    removePathIfExists(path.dirname(stagedNodeModulesDir));
+  }
 }
 
 function installPluginRuntimeDeps(params) {
-  const { fingerprint, packageJson, pluginDir, pluginId } = params;
+  const { fingerprint, packageJson, pluginDir, pluginId, repoRoot } = params;
+  if (
+    repoRoot &&
+    stageInstalledRootRuntimeDeps({ fingerprint, packageJson, pluginDir, repoRoot })
+  ) {
+    return;
+  }
   const nodeModulesDir = path.join(pluginDir, "node_modules");
   const stampPath = resolveRuntimeDepsStampPath(pluginDir);
   const tempInstallDir = makeTempDir(
@@ -333,6 +286,7 @@ export function stageBundledPluginRuntimeDeps(params = {}) {
         packageJson,
         pluginDir,
         pluginId,
+        repoRoot,
       },
     });
   }

--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import semverSatisfies from "semver/functions/satisfies.js";
 import { resolveNpmRunner } from "./npm-runner.mjs";
 
 function readJson(filePath) {
@@ -57,60 +58,8 @@ function readInstalledDependencyVersion(nodeModulesDir, depName) {
   return typeof version === "string" ? version : null;
 }
 
-function parseSemver(version) {
-  const match =
-    /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(
-      version.trim(),
-    );
-  if (!match) {
-    return null;
-  }
-  return {
-    major: Number.parseInt(match[1], 10),
-    minor: Number.parseInt(match[2], 10),
-    patch: Number.parseInt(match[3], 10),
-    prerelease: match[4] ?? null,
-  };
-}
-
 function dependencyVersionSatisfied(spec, installedVersion) {
-  if (spec === installedVersion) {
-    return true;
-  }
-  if (!spec.startsWith("^")) {
-    return false;
-  }
-  const minimum = parseSemver(spec.slice(1));
-  const installed = parseSemver(installedVersion);
-  if (!minimum || !installed) {
-    return false;
-  }
-  if (minimum.major === 0) {
-    return (
-      installed.major === 0 &&
-      installed.minor === minimum.minor &&
-      (installed.patch > minimum.patch ||
-        (installed.patch === minimum.patch &&
-          (installed.prerelease === minimum.prerelease ||
-            (minimum.prerelease === null && installed.prerelease === null))))
-    );
-  }
-  if (installed.major !== minimum.major) {
-    return false;
-  }
-  if (installed.minor < minimum.minor) {
-    return false;
-  }
-  if (installed.minor > minimum.minor) {
-    return true;
-  }
-  if (installed.patch < minimum.patch) {
-    return false;
-  }
-  if (installed.patch > minimum.patch) {
-    return true;
-  }
-  return installed.prerelease === minimum.prerelease;
+  return semverSatisfies(installedVersion, spec, { includePrerelease: false });
 }
 
 function collectInstalledRuntimeClosure(rootNodeModulesDir, dependencySpecs) {

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -261,6 +261,8 @@ describe("collectMissingPackPaths", () => {
       expect.arrayContaining([
         "dist/channel-catalog.json",
         "dist/control-ui/index.html",
+        "scripts/npm-runner.mjs",
+        "scripts/postinstall-bundled-plugins.mjs",
         bundledDistPluginFile("matrix", "helper-api.js"),
         bundledDistPluginFile("matrix", "runtime-api.js"),
         bundledDistPluginFile("matrix", "thread-bindings-runtime.js"),
@@ -282,6 +284,8 @@ describe("collectMissingPackPaths", () => {
         "dist/control-ui/index.html",
         ...requiredBundledPluginPackPaths,
         ...requiredPluginSdkPackPaths,
+        "scripts/npm-runner.mjs",
+        "scripts/postinstall-bundled-plugins.mjs",
         "dist/plugin-sdk/root-alias.cjs",
         "dist/build-info.json",
         "dist/channel-catalog.json",

--- a/test/scripts/npm-runner.test.ts
+++ b/test/scripts/npm-runner.test.ts
@@ -85,6 +85,27 @@ describe("resolveNpmRunner", () => {
     });
   });
 
+  it("escapes caret semver specs when invoking npm.cmd through cmd.exe", () => {
+    const execPath = "C:\\nodejs\\node.exe";
+    const npmCmdPath = path.win32.resolve(path.win32.dirname(execPath), "npm.cmd");
+
+    const runner = resolveNpmRunner({
+      comSpec: "C:\\Windows\\System32\\cmd.exe",
+      execPath,
+      env: {},
+      existsSync: (candidate) => candidate === npmCmdPath,
+      npmArgs: ["install", "@slack/bolt@^4.6.0"],
+      platform: "win32",
+    });
+
+    expect(runner).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/c", `${npmCmdPath} install @slack/bolt@^^4.6.0`],
+      shell: false,
+      windowsVerbatimArguments: true,
+    });
+  });
+
   it("prefixes PATH with the active node dir when falling back to bare npm", () => {
     expect(
       resolveNpmRunner({

--- a/test/scripts/npm-runner.test.ts
+++ b/test/scripts/npm-runner.test.ts
@@ -1,0 +1,120 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveNpmRunner } from "../../scripts/npm-runner.mjs";
+
+describe("resolveNpmRunner", () => {
+  it("anchors npm staging to the active node toolchain when npm-cli.js exists", () => {
+    const execPath = "/Users/test/.nodenv/versions/24.13.0/bin/node";
+    const expectedNpmCliPath = path.posix.resolve(
+      path.posix.dirname(execPath),
+      "../lib/node_modules/npm/bin/npm-cli.js",
+    );
+
+    const runner = resolveNpmRunner({
+      execPath,
+      env: {},
+      existsSync: (candidate) => candidate === expectedNpmCliPath,
+      platform: "darwin",
+    });
+
+    expect(runner).toEqual({
+      command: execPath,
+      args: [expectedNpmCliPath],
+      shell: false,
+    });
+  });
+
+  it("anchors Windows npm staging to the adjacent npm-cli.js without a shell", () => {
+    const execPath = "C:\\nodejs\\node.exe";
+    const expectedNpmCliPath = path.win32.resolve(
+      path.win32.dirname(execPath),
+      "node_modules/npm/bin/npm-cli.js",
+    );
+
+    const runner = resolveNpmRunner({
+      execPath,
+      env: {},
+      existsSync: (candidate) => candidate === expectedNpmCliPath,
+      platform: "win32",
+    });
+
+    expect(runner).toEqual({
+      command: execPath,
+      args: [expectedNpmCliPath],
+      shell: false,
+    });
+  });
+
+  it("uses an adjacent npm.exe on Windows without a shell", () => {
+    const execPath = "C:\\nodejs\\node.exe";
+    const expectedNpmExePath = path.win32.resolve(path.win32.dirname(execPath), "npm.exe");
+
+    const runner = resolveNpmRunner({
+      execPath,
+      env: {},
+      existsSync: (candidate) => candidate === expectedNpmExePath,
+      npmArgs: ["install", "--silent"],
+      platform: "win32",
+    });
+
+    expect(runner).toEqual({
+      command: expectedNpmExePath,
+      args: ["install", "--silent"],
+      shell: false,
+    });
+  });
+
+  it("wraps an adjacent npm.cmd via cmd.exe without enabling shell mode", () => {
+    const execPath = "C:\\nodejs\\node.exe";
+    const npmCmdPath = path.win32.resolve(path.win32.dirname(execPath), "npm.cmd");
+
+    const runner = resolveNpmRunner({
+      comSpec: "C:\\Windows\\System32\\cmd.exe",
+      execPath,
+      env: {},
+      existsSync: (candidate) => candidate === npmCmdPath,
+      npmArgs: ["install", "--omit=dev"],
+      platform: "win32",
+    });
+
+    expect(runner).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/c", `${npmCmdPath} install --omit=dev`],
+      shell: false,
+      windowsVerbatimArguments: true,
+    });
+  });
+
+  it("prefixes PATH with the active node dir when falling back to bare npm", () => {
+    expect(
+      resolveNpmRunner({
+        execPath: "/tmp/node",
+        env: {
+          PATH: "/usr/bin:/bin",
+        },
+        existsSync: () => false,
+        platform: "linux",
+      }),
+    ).toEqual({
+      command: "npm",
+      args: [],
+      shell: false,
+      env: {
+        PATH: `/tmp${path.delimiter}/usr/bin:/bin`,
+      },
+    });
+  });
+
+  it("fails closed on Windows when no toolchain-local npm CLI exists", () => {
+    expect(() =>
+      resolveNpmRunner({
+        execPath: "C:\\node\\node.exe",
+        env: {
+          Path: "C:\\Windows\\System32",
+        },
+        existsSync: () => false,
+        platform: "win32",
+      }),
+    ).toThrow("OpenClaw refuses to shell out to bare npm on Windows");
+  });
+});

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -38,6 +38,18 @@ async function writePluginPackage(
 }
 
 describe("bundled plugin postinstall", () => {
+  function createBareNpmRunner(args: string[]) {
+    return {
+      command: "npm",
+      args,
+      env: {
+        HOME: "/tmp/home",
+        PATH: "/tmp/node/bin",
+      },
+      shell: false as const,
+    };
+  }
+
   it("clears global npm config before nested installs", () => {
     expect(
       createNestedNpmInstallEnv({
@@ -86,6 +98,13 @@ describe("bundled plugin postinstall", () => {
       },
       extensionsDir,
       packageRoot,
+      npmRunner: createBareNpmRunner([
+        "install",
+        "--omit=dev",
+        "--no-save",
+        "--package-lock=false",
+        "acpx@0.4.0",
+      ]),
       spawnSync,
       log: { log: vi.fn(), warn: vi.fn() },
     });
@@ -95,9 +114,10 @@ describe("bundled plugin postinstall", () => {
       ["install", "--omit=dev", "--no-save", "--package-lock=false", "acpx@0.4.0"],
       {
         cwd: packageRoot,
+        encoding: "utf8",
         env: {
           HOME: "/tmp/home",
-          PATH: expect.any(String),
+          PATH: "/tmp/node/bin",
         },
         shell: false,
         stdio: "pipe",
@@ -211,6 +231,14 @@ describe("bundled plugin postinstall", () => {
       },
       extensionsDir,
       packageRoot,
+      npmRunner: createBareNpmRunner([
+        "install",
+        "--omit=dev",
+        "--no-save",
+        "--package-lock=false",
+        "@slack/web-api@7.11.0",
+        "grammy@1.38.4",
+      ]),
       spawnSync,
       log: { log: vi.fn(), warn: vi.fn() },
     });
@@ -227,9 +255,10 @@ describe("bundled plugin postinstall", () => {
       ],
       {
         cwd: packageRoot,
+        encoding: "utf8",
         env: {
           HOME: "/tmp/home",
-          PATH: expect.any(String),
+          PATH: "/tmp/node/bin",
         },
         shell: false,
         stdio: "pipe",
@@ -268,6 +297,13 @@ describe("bundled plugin postinstall", () => {
       },
       extensionsDir,
       packageRoot,
+      npmRunner: createBareNpmRunner([
+        "install",
+        "--omit=dev",
+        "--no-save",
+        "--package-lock=false",
+        "grammy@1.38.4",
+      ]),
       spawnSync,
       log: { log: vi.fn(), warn: vi.fn() },
     });
@@ -277,9 +313,10 @@ describe("bundled plugin postinstall", () => {
       ["install", "--omit=dev", "--no-save", "--package-lock=false", "grammy@1.38.4"],
       {
         cwd: packageRoot,
+        encoding: "utf8",
         env: {
           HOME: "/tmp/home",
-          PATH: expect.any(String),
+          PATH: "/tmp/node/bin",
         },
         shell: false,
         stdio: "pipe",

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -57,15 +57,15 @@ describe("bundled plugin postinstall", () => {
         acpx: "0.4.0",
       },
     });
-    const execSync = vi.fn();
+    const spawnSync = vi.fn();
 
     runBundledPluginPostinstall({
       env: { npm_config_global: "false" },
       extensionsDir,
-      execSync,
+      spawnSync,
     });
 
-    expect(execSync).not.toHaveBeenCalled();
+    expect(spawnSync).not.toHaveBeenCalled();
   });
 
   it("runs nested local installs with sanitized env when the sentinel package is missing", async () => {
@@ -76,7 +76,7 @@ describe("bundled plugin postinstall", () => {
         acpx: "0.4.0",
       },
     });
-    const execSync = vi.fn();
+    const spawnSync = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
 
     runBundledPluginPostinstall({
       env: {
@@ -86,18 +86,22 @@ describe("bundled plugin postinstall", () => {
       },
       extensionsDir,
       packageRoot,
-      execSync,
+      spawnSync,
       log: { log: vi.fn(), warn: vi.fn() },
     });
 
-    expect(execSync).toHaveBeenCalledWith(
-      "npm install --omit=dev --no-save --package-lock=false acpx@0.4.0",
+    expect(spawnSync).toHaveBeenCalledWith(
+      "npm",
+      ["install", "--omit=dev", "--no-save", "--package-lock=false", "acpx@0.4.0"],
       {
         cwd: packageRoot,
         env: {
           HOME: "/tmp/home",
+          PATH: expect.any(String),
         },
+        shell: false,
         stdio: "pipe",
+        windowsVerbatimArguments: undefined,
       },
     );
   });
@@ -116,16 +120,16 @@ describe("bundled plugin postinstall", () => {
       "{}\n",
       "utf8",
     );
-    const execSync = vi.fn();
+    const spawnSync = vi.fn();
 
     runBundledPluginPostinstall({
       env: { npm_config_global: "true" },
       extensionsDir,
       packageRoot,
-      execSync,
+      spawnSync,
     });
 
-    expect(execSync).not.toHaveBeenCalled();
+    expect(spawnSync).not.toHaveBeenCalled();
   });
 
   it("discovers bundled plugin runtime deps from extension manifests", async () => {
@@ -197,7 +201,7 @@ describe("bundled plugin postinstall", () => {
         grammy: "1.38.4",
       },
     });
-    const execSync = vi.fn();
+    const spawnSync = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
 
     runBundledPluginPostinstall({
       env: {
@@ -207,18 +211,29 @@ describe("bundled plugin postinstall", () => {
       },
       extensionsDir,
       packageRoot,
-      execSync,
+      spawnSync,
       log: { log: vi.fn(), warn: vi.fn() },
     });
 
-    expect(execSync).toHaveBeenCalledWith(
-      "npm install --omit=dev --no-save --package-lock=false @slack/web-api@7.11.0 grammy@1.38.4",
+    expect(spawnSync).toHaveBeenCalledWith(
+      "npm",
+      [
+        "install",
+        "--omit=dev",
+        "--no-save",
+        "--package-lock=false",
+        "@slack/web-api@7.11.0",
+        "grammy@1.38.4",
+      ],
       {
         cwd: packageRoot,
         env: {
           HOME: "/tmp/home",
+          PATH: expect.any(String),
         },
+        shell: false,
         stdio: "pipe",
+        windowsVerbatimArguments: undefined,
       },
     );
   });
@@ -243,7 +258,7 @@ describe("bundled plugin postinstall", () => {
       path.join(packageRoot, "node_modules", "@slack", "web-api", "package.json"),
       "{}\n",
     );
-    const execSync = vi.fn();
+    const spawnSync = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
 
     runBundledPluginPostinstall({
       env: {
@@ -253,18 +268,22 @@ describe("bundled plugin postinstall", () => {
       },
       extensionsDir,
       packageRoot,
-      execSync,
+      spawnSync,
       log: { log: vi.fn(), warn: vi.fn() },
     });
 
-    expect(execSync).toHaveBeenCalledWith(
-      "npm install --omit=dev --no-save --package-lock=false grammy@1.38.4",
+    expect(spawnSync).toHaveBeenCalledWith(
+      "npm",
+      ["install", "--omit=dev", "--no-save", "--package-lock=false", "grammy@1.38.4"],
       {
         cwd: packageRoot,
         env: {
           HOME: "/tmp/home",
+          PATH: expect.any(String),
         },
+        shell: false,
         stdio: "pipe",
+        windowsVerbatimArguments: undefined,
       },
     );
   });

--- a/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
@@ -224,6 +224,86 @@ describe("stageBundledPluginRuntimeDeps", () => {
     ).toBe("module.exports = 'nested';\n");
   });
 
+  it("falls back when a ^0.0.x root dependency exceeds the patch ceiling", () => {
+    const { pluginDir, repoRoot } = createBundledPluginFixture({
+      packageJson: {
+        name: "@openclaw/fixture-plugin",
+        version: "1.0.0",
+        dependencies: { tiny: "^0.0.3" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      },
+    });
+    const rootDepDir = path.join(repoRoot, "node_modules", "tiny");
+    fs.mkdirSync(rootDepDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(rootDepDir, "package.json"),
+      '{ "name": "tiny", "version": "0.0.5" }\n',
+      "utf8",
+    );
+
+    let installCount = 0;
+    stageBundledPluginRuntimeDeps({
+      cwd: repoRoot,
+      installPluginRuntimeDepsImpl: ({ fingerprint }: { fingerprint: string }) => {
+        installCount += 1;
+        const nodeModulesDir = path.join(pluginDir, "node_modules", "tiny");
+        fs.mkdirSync(nodeModulesDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(nodeModulesDir, "package.json"),
+          '{ "name": "tiny", "version": "0.0.3" }\n',
+          "utf8",
+        );
+        fs.writeFileSync(
+          path.join(pluginDir, ".openclaw-runtime-deps-stamp.json"),
+          `${JSON.stringify({ fingerprint }, null, 2)}\n`,
+          "utf8",
+        );
+      },
+    });
+
+    expect(installCount).toBe(1);
+  });
+
+  it("falls back when a stable caret range only matches a prerelease root build", () => {
+    const { pluginDir, repoRoot } = createBundledPluginFixture({
+      packageJson: {
+        name: "@openclaw/fixture-plugin",
+        version: "1.0.0",
+        dependencies: { direct: "^1.2.3" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      },
+    });
+    const rootDepDir = path.join(repoRoot, "node_modules", "direct");
+    fs.mkdirSync(rootDepDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(rootDepDir, "package.json"),
+      '{ "name": "direct", "version": "1.3.0-beta.1" }\n',
+      "utf8",
+    );
+
+    let installCount = 0;
+    stageBundledPluginRuntimeDeps({
+      cwd: repoRoot,
+      installPluginRuntimeDepsImpl: ({ fingerprint }: { fingerprint: string }) => {
+        installCount += 1;
+        const nodeModulesDir = path.join(pluginDir, "node_modules", "direct");
+        fs.mkdirSync(nodeModulesDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(nodeModulesDir, "package.json"),
+          '{ "name": "direct", "version": "1.2.3" }\n',
+          "utf8",
+        );
+        fs.writeFileSync(
+          path.join(pluginDir, ".openclaw-runtime-deps-stamp.json"),
+          `${JSON.stringify({ fingerprint }, null, 2)}\n`,
+          "utf8",
+        );
+      },
+    });
+
+    expect(installCount).toBe(1);
+  });
+
   it("retries transient runtime dependency staging failures before surfacing an error", () => {
     const { pluginDir, repoRoot } = createBundledPluginFixture({
       packageJson: {

--- a/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
@@ -2,127 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import {
-  resolveNpmRunner,
-  stageBundledPluginRuntimeDeps,
-} from "../../scripts/stage-bundled-plugin-runtime-deps.mjs";
-
-describe("resolveNpmRunner", () => {
-  it("anchors npm staging to the active node toolchain when npm-cli.js exists", () => {
-    const execPath = "/Users/test/.nodenv/versions/24.13.0/bin/node";
-    const expectedNpmCliPath = path.posix.resolve(
-      path.posix.dirname(execPath),
-      "../lib/node_modules/npm/bin/npm-cli.js",
-    );
-
-    const runner = resolveNpmRunner({
-      execPath,
-      env: {},
-      existsSync: (candidate: string) => candidate === expectedNpmCliPath,
-      platform: "darwin",
-    });
-
-    expect(runner).toEqual({
-      command: execPath,
-      args: [expectedNpmCliPath],
-      shell: false,
-    });
-  });
-
-  it("anchors Windows npm staging to the adjacent npm-cli.js without a shell", () => {
-    const execPath = "C:\\nodejs\\node.exe";
-    const expectedNpmCliPath = path.win32.resolve(
-      path.win32.dirname(execPath),
-      "node_modules/npm/bin/npm-cli.js",
-    );
-
-    const runner = resolveNpmRunner({
-      execPath,
-      env: {},
-      existsSync: (candidate: string) => candidate === expectedNpmCliPath,
-      platform: "win32",
-    });
-
-    expect(runner).toEqual({
-      command: execPath,
-      args: [expectedNpmCliPath],
-      shell: false,
-    });
-  });
-
-  it("uses an adjacent npm.exe on Windows without a shell", () => {
-    const execPath = "C:\\nodejs\\node.exe";
-    const expectedNpmExePath = path.win32.resolve(path.win32.dirname(execPath), "npm.exe");
-
-    const runner = resolveNpmRunner({
-      execPath,
-      env: {},
-      existsSync: (candidate: string) => candidate === expectedNpmExePath,
-      npmArgs: ["install", "--silent"],
-      platform: "win32",
-    });
-
-    expect(runner).toEqual({
-      command: expectedNpmExePath,
-      args: ["install", "--silent"],
-      shell: false,
-    });
-  });
-
-  it("wraps an adjacent npm.cmd via cmd.exe without enabling shell mode", () => {
-    const execPath = "C:\\nodejs\\node.exe";
-    const npmCmdPath = path.win32.resolve(path.win32.dirname(execPath), "npm.cmd");
-
-    const runner = resolveNpmRunner({
-      comSpec: "C:\\Windows\\System32\\cmd.exe",
-      execPath,
-      env: {},
-      existsSync: (candidate: string) => candidate === npmCmdPath,
-      npmArgs: ["install", "--omit=dev"],
-      platform: "win32",
-    });
-
-    expect(runner).toEqual({
-      command: "C:\\Windows\\System32\\cmd.exe",
-      args: ["/d", "/s", "/c", `${npmCmdPath} install --omit=dev`],
-      shell: false,
-      windowsVerbatimArguments: true,
-    });
-  });
-
-  it("prefixes PATH with the active node dir when falling back to bare npm", () => {
-    expect(
-      resolveNpmRunner({
-        execPath: "/tmp/node",
-        env: {
-          PATH: "/usr/bin:/bin",
-        },
-        existsSync: () => false,
-        platform: "linux",
-      }),
-    ).toEqual({
-      command: "npm",
-      args: [],
-      shell: false,
-      env: {
-        PATH: `/tmp${path.delimiter}/usr/bin:/bin`,
-      },
-    });
-  });
-
-  it("fails closed on Windows when no toolchain-local npm CLI exists", () => {
-    expect(() =>
-      resolveNpmRunner({
-        execPath: "C:\\node\\node.exe",
-        env: {
-          Path: "C:\\Windows\\System32",
-        },
-        existsSync: () => false,
-        platform: "win32",
-      }),
-    ).toThrow("OpenClaw refuses to shell out to bare npm on Windows");
-  });
-});
+import { stageBundledPluginRuntimeDeps } from "../../scripts/stage-bundled-plugin-runtime-deps.mjs";
 
 describe("stageBundledPluginRuntimeDeps", () => {
   function createBundledPluginFixture(params: {
@@ -227,6 +107,28 @@ describe("stageBundledPluginRuntimeDeps", () => {
 
     expect(installCount).toBe(2);
     expect(fs.readFileSync(path.join(pluginDir, "node_modules", "marker.txt"), "utf8")).toBe("2\n");
+  });
+
+  it("stages runtime deps from the root node_modules when already installed", () => {
+    const { pluginDir, repoRoot } = createBundledPluginFixture({
+      packageJson: {
+        name: "@openclaw/fixture-plugin",
+        version: "1.0.0",
+        dependencies: { "left-pad": "1.3.0" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      },
+    });
+    const rootDepDir = path.join(repoRoot, "node_modules", "left-pad");
+    fs.mkdirSync(rootDepDir, { recursive: true });
+    fs.writeFileSync(path.join(rootDepDir, "package.json"), '{ "name": "left-pad" }\n', "utf8");
+    fs.writeFileSync(path.join(rootDepDir, "index.js"), "module.exports = 1;\n", "utf8");
+
+    stageBundledPluginRuntimeDeps({ cwd: repoRoot });
+
+    expect(
+      fs.readFileSync(path.join(pluginDir, "node_modules", "left-pad", "index.js"), "utf8"),
+    ).toBe("module.exports = 1;\n");
+    expect(fs.existsSync(path.join(pluginDir, ".openclaw-runtime-deps-stamp.json"))).toBe(true);
   });
 
   it("retries transient runtime dependency staging failures before surfacing an error", () => {

--- a/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
@@ -120,7 +120,11 @@ describe("stageBundledPluginRuntimeDeps", () => {
     });
     const rootDepDir = path.join(repoRoot, "node_modules", "left-pad");
     fs.mkdirSync(rootDepDir, { recursive: true });
-    fs.writeFileSync(path.join(rootDepDir, "package.json"), '{ "name": "left-pad" }\n', "utf8");
+    fs.writeFileSync(
+      path.join(rootDepDir, "package.json"),
+      '{ "name": "left-pad", "version": "1.3.0" }\n',
+      "utf8",
+    );
     fs.writeFileSync(path.join(rootDepDir, "index.js"), "module.exports = 1;\n", "utf8");
 
     stageBundledPluginRuntimeDeps({ cwd: repoRoot });
@@ -129,6 +133,95 @@ describe("stageBundledPluginRuntimeDeps", () => {
       fs.readFileSync(path.join(pluginDir, "node_modules", "left-pad", "index.js"), "utf8"),
     ).toBe("module.exports = 1;\n");
     expect(fs.existsSync(path.join(pluginDir, ".openclaw-runtime-deps-stamp.json"))).toBe(true);
+  });
+
+  it("stages hoisted transitive runtime deps from the root node_modules", () => {
+    const { pluginDir, repoRoot } = createBundledPluginFixture({
+      packageJson: {
+        name: "@openclaw/fixture-plugin",
+        version: "1.0.0",
+        dependencies: { direct: "1.0.0" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      },
+    });
+    const directDir = path.join(repoRoot, "node_modules", "direct");
+    const transitiveDir = path.join(repoRoot, "node_modules", "transitive");
+    fs.mkdirSync(directDir, { recursive: true });
+    fs.mkdirSync(transitiveDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(directDir, "package.json"),
+      '{ "name": "direct", "version": "1.0.0", "dependencies": { "transitive": "^1.2.0" } }\n',
+      "utf8",
+    );
+    fs.writeFileSync(path.join(directDir, "index.js"), "module.exports = 'direct';\n", "utf8");
+    fs.writeFileSync(
+      path.join(transitiveDir, "package.json"),
+      '{ "name": "transitive", "version": "1.2.3" }\n',
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(transitiveDir, "index.js"),
+      "module.exports = 'transitive';\n",
+      "utf8",
+    );
+
+    stageBundledPluginRuntimeDeps({ cwd: repoRoot });
+
+    expect(
+      fs.readFileSync(path.join(pluginDir, "node_modules", "direct", "index.js"), "utf8"),
+    ).toBe("module.exports = 'direct';\n");
+    expect(
+      fs.readFileSync(path.join(pluginDir, "node_modules", "transitive", "index.js"), "utf8"),
+    ).toBe("module.exports = 'transitive';\n");
+  });
+
+  it("falls back to staging installs when the root dependency version is incompatible", () => {
+    const { pluginDir, repoRoot } = createBundledPluginFixture({
+      packageJson: {
+        name: "@openclaw/fixture-plugin",
+        version: "1.0.0",
+        dependencies: { "left-pad": "^1.3.0" },
+        openclaw: { bundle: { stageRuntimeDependencies: true } },
+      },
+    });
+    const rootDepDir = path.join(repoRoot, "node_modules", "left-pad");
+    fs.mkdirSync(rootDepDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(rootDepDir, "package.json"),
+      '{ "name": "left-pad", "version": "2.0.0" }\n',
+      "utf8",
+    );
+    fs.writeFileSync(path.join(rootDepDir, "index.js"), "module.exports = 'root';\n", "utf8");
+
+    let installCount = 0;
+    stageBundledPluginRuntimeDeps({
+      cwd: repoRoot,
+      installPluginRuntimeDepsImpl: ({ fingerprint }: { fingerprint: string }) => {
+        installCount += 1;
+        const nodeModulesDir = path.join(pluginDir, "node_modules", "left-pad");
+        fs.mkdirSync(nodeModulesDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(nodeModulesDir, "package.json"),
+          '{ "name": "left-pad", "version": "1.3.0" }\n',
+          "utf8",
+        );
+        fs.writeFileSync(
+          path.join(nodeModulesDir, "index.js"),
+          "module.exports = 'nested';\n",
+          "utf8",
+        );
+        fs.writeFileSync(
+          path.join(pluginDir, ".openclaw-runtime-deps-stamp.json"),
+          `${JSON.stringify({ fingerprint }, null, 2)}\n`,
+          "utf8",
+        );
+      },
+    });
+
+    expect(installCount).toBe(1);
+    expect(
+      fs.readFileSync(path.join(pluginDir, "node_modules", "left-pad", "index.js"), "utf8"),
+    ).toBe("module.exports = 'nested';\n");
   });
 
   it("retries transient runtime dependency staging failures before surfacing an error", () => {


### PR DESCRIPTION
## Summary
- restore bundled plugin runtime dependency provisioning after the 2026.3.31 externalization change
- share npm runner resolution across staging and global postinstall paths
- stage bundled runtime deps from root `node_modules` before falling back to nested installs

## Verification
- `pnpm test -- test/scripts/npm-runner.test.ts test/scripts/postinstall-bundled-plugins.test.ts test/scripts/stage-bundled-plugin-runtime-deps.test.ts`
- `pnpm build`
