### PR TITLE
fix(hooks): emit inbound senderAgentId for managed senders

### DIFF
--- a/extensions/discord/src/accounts.ts
+++ b/extensions/discord/src/accounts.ts
@@ -21,6 +21,8 @@ const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("di
 export const listDiscordAccountIds = listAccountIds;
 export const resolveDefaultDiscordAccountId = resolveDefaultAccountId;
 
+const discordManagedAccountIdByBotUserId = new Map<string, string>();
+
 export function resolveDiscordAccountConfig(
   cfg: OpenClawConfig,
   accountId: string,
@@ -91,3 +93,31 @@ export function listEnabledDiscordAccounts(cfg: OpenClawConfig): ResolvedDiscord
     .map((accountId) => resolveDiscordAccount({ cfg, accountId }))
     .filter((account) => account.enabled);
 }
+
+export function rememberDiscordManagedBotIdentity(params: {
+  accountId?: string | null;
+  botUserId?: string | null;
+}) {
+  const accountId = normalizeAccountId(params.accountId);
+  const botUserId = params.botUserId?.trim();
+  if (!accountId || !botUserId) {
+    return;
+  }
+  discordManagedAccountIdByBotUserId.set(botUserId, accountId);
+}
+
+export function resolveDiscordManagedAccountIdByBotUserId(
+  botUserId?: string | null,
+): string | undefined {
+  const normalizedBotUserId = botUserId?.trim();
+  if (!normalizedBotUserId) {
+    return undefined;
+  }
+  return discordManagedAccountIdByBotUserId.get(normalizedBotUserId);
+}
+
+export const __testing = {
+  resetManagedBotIdentityMap() {
+    discordManagedAccountIdByBotUserId.clear();
+  },
+};

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -81,6 +81,8 @@ let createBaseDiscordMessageContext: typeof import("./message-handler.test-harne
 let createDiscordDirectMessageContextOverrides: typeof import("./message-handler.test-harness.js").createDiscordDirectMessageContextOverrides;
 let threadBindingTesting: typeof import("./thread-bindings.js").__testing;
 let createThreadBindingManager: typeof import("./thread-bindings.js").createThreadBindingManager;
+let discordAccountTesting: typeof import("../accounts.js").__testing;
+let rememberDiscordManagedBotIdentity: typeof import("../accounts.js").rememberDiscordManagedBotIdentity;
 let processDiscordMessage: typeof import("./message-handler.process.js").processDiscordMessage;
 
 const sendModule = await import("../send.js");
@@ -204,6 +206,8 @@ beforeAll(async () => {
   vi.useRealTimers();
   ({ createBaseDiscordMessageContext, createDiscordDirectMessageContextOverrides } =
     await import("./message-handler.test-harness.js"));
+  ({ __testing: discordAccountTesting, rememberDiscordManagedBotIdentity } =
+    await import("../accounts.js"));
   ({ __testing: threadBindingTesting, createThreadBindingManager } =
     await import("./thread-bindings.js"));
   ({ processDiscordMessage } = await import("./message-handler.process.js"));
@@ -224,6 +228,7 @@ beforeEach(() => {
   recordInboundSession.mockResolvedValue(undefined);
   readSessionUpdatedAt.mockReturnValue(undefined);
   resolveStorePath.mockReturnValue("/tmp/openclaw-discord-process-test-sessions.json");
+  discordAccountTesting.resetManagedBotIdentityMap();
   threadBindingTesting.resetThreadBindingsForTests();
 });
 
@@ -245,11 +250,21 @@ function getLastRouteUpdate():
 }
 
 function getLastDispatchCtx():
-  | { SessionKey?: string; MessageThreadId?: string | number }
+  | {
+      SessionKey?: string;
+      MessageThreadId?: string | number;
+      SenderManagedAccountId?: string;
+    }
   | undefined {
   const callArgs = dispatchInboundMessage.mock.calls.at(-1) as unknown[] | undefined;
   const params = callArgs?.[0] as
-    | { ctx?: { SessionKey?: string; MessageThreadId?: string | number } }
+    | {
+        ctx?: {
+          SessionKey?: string;
+          MessageThreadId?: string | number;
+          SenderManagedAccountId?: string;
+        };
+      }
     | undefined;
   return params?.ctx;
 }
@@ -289,6 +304,34 @@ function expectSinglePreviewEdit() {
 }
 
 describe("processDiscordMessage ack reactions", () => {
+  it("adds SenderManagedAccountId when the sender is another configured Discord bot", async () => {
+    rememberDiscordManagedBotIdentity({
+      accountId: "ops",
+      botUserId: "bot-peer",
+    });
+    const ctx = await createBaseContext({
+      author: {
+        id: "bot-peer",
+        username: "ops-bot",
+        discriminator: "0",
+        globalName: "Ops Bot",
+      },
+      sender: {
+        id: "bot-peer",
+        label: "ops-bot",
+        name: "Ops Bot",
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(getLastDispatchCtx()).toEqual(
+      expect.objectContaining({
+        SenderManagedAccountId: "ops",
+      }),
+    );
+  });
+
   it("skips ack reactions for group-mentions when mentions are not required", async () => {
     const ctx = await createBaseContext({
       shouldRequireMention: false,

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -36,7 +36,10 @@ import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtim
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-runtime";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-runtime";
-import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
+import {
+  resolveDiscordManagedAccountIdByBotUserId,
+  resolveDiscordMaxLinesPerMessage,
+} from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import { resolveDiscordDraftStreamingChunking } from "../draft-chunking.js";
 import { createDiscordDraftStream } from "../draft-stream.js";
@@ -373,6 +376,7 @@ export async function processDiscordMessage(
           timestamp: entry.timestamp,
         }))
       : undefined;
+  const senderManagedAccountId = resolveDiscordManagedAccountIdByBotUserId(sender.id);
 
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
@@ -387,6 +391,7 @@ export async function processDiscordMessage(
     ChatType: isDirectMessage ? "direct" : "channel",
     ConversationLabel: fromLabel,
     SenderName: senderName,
+    SenderManagedAccountId: senderManagedAccountId,
     SenderId: sender.id,
     SenderUsername: senderUsername,
     SenderTag: senderTag,

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -40,7 +40,10 @@ import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { createNonExitingRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { summarizeStringEntries } from "openclaw/plugin-sdk/text-runtime";
-import { resolveDiscordAccount } from "../accounts.js";
+import {
+  rememberDiscordManagedBotIdentity,
+  resolveDiscordAccount,
+} from "../accounts.js";
 import { fetchDiscordApplicationId } from "../probe.js";
 import { normalizeDiscordToken } from "../token.js";
 import { createDiscordVoiceCommand } from "../voice/command.js";
@@ -966,6 +969,10 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
           gateway: lifecycleGateway,
           details,
         }),
+    });
+    rememberDiscordManagedBotIdentity({
+      accountId: account.accountId,
+      botUserId,
     });
     let voiceManager: DiscordVoiceManager | null = null;
 

--- a/extensions/matrix/src/matrix/accounts.ts
+++ b/extensions/matrix/src/matrix/accounts.ts
@@ -59,13 +59,21 @@ export function resolveConfiguredMatrixBotUserIds(params: {
   accountId?: string | null;
   env?: NodeJS.ProcessEnv;
 }): Set<string> {
+  return new Set(resolveConfiguredMatrixBotAccountIdsByUserId(params).keys());
+}
+
+export function resolveConfiguredMatrixBotAccountIdsByUserId(params: {
+  cfg: CoreConfig;
+  accountId?: string | null;
+  env?: NodeJS.ProcessEnv;
+}): Map<string, string> {
   const env = params.env ?? process.env;
   const currentAccountId = normalizeAccountId(params.accountId);
   const accountIds = new Set(resolveConfiguredMatrixAccountIds(params.cfg, env));
   if (resolveMatrixAccount({ cfg: params.cfg, accountId: DEFAULT_ACCOUNT_ID, env }).configured) {
     accountIds.add(DEFAULT_ACCOUNT_ID);
   }
-  const ids = new Set<string>();
+  const accountIdByUserId = new Map<string, string>();
 
   for (const accountId of accountIds) {
     if (normalizeAccountId(accountId) === currentAccountId) {
@@ -80,11 +88,11 @@ export function resolveConfiguredMatrixBotUserIds(params: {
       env,
     });
     if (userId) {
-      ids.add(userId);
+      accountIdByUserId.set(userId, normalizeAccountId(accountId));
     }
   }
 
-  return ids;
+  return accountIdByUserId;
 }
 
 export function resolveMatrixAccount(params: {

--- a/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
@@ -26,6 +26,7 @@ type MatrixHandlerTestHarnessOptions = {
   roomsConfig?: Record<string, MatrixRoomConfig>;
   accountAllowBots?: boolean | "mentions";
   configuredBotUserIds?: Set<string>;
+  configuredBotAccountIdsByUserId?: Map<string, string>;
   mentionRegexes?: RegExp[];
   groupPolicy?: "open" | "allowlist" | "disabled";
   replyToMode?: ReplyToMode;
@@ -209,6 +210,7 @@ export function createMatrixHandlerTestHarness(
     roomsConfig: options.roomsConfig,
     accountAllowBots: options.accountAllowBots,
     configuredBotUserIds: options.configuredBotUserIds,
+    configuredBotAccountIdsByUserId: options.configuredBotAccountIdsByUserId,
     groupPolicy: options.groupPolicy ?? "open",
     replyToMode: options.replyToMode ?? "off",
     threadReplies: options.threadReplies ?? "inbound",

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -303,14 +303,17 @@ describe("matrix monitor handler pairing account scope", () => {
   });
 
   it("accepts room messages from configured Matrix bot accounts when allowBots is true", async () => {
+    const finalizeInboundContext = vi.fn((ctx) => ctx);
     const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
       isDirectMessage: false,
       accountAllowBots: true,
       configuredBotUserIds: new Set(["@ops:example.org"]),
+      configuredBotAccountIdsByUserId: new Map([["@ops:example.org", "ops"]]),
       roomsConfig: {
         "!room:example.org": { requireMention: false },
       },
       getMemberDisplayName: async () => "ops-bot",
+      finalizeInboundContext,
     });
 
     await handler(
@@ -323,6 +326,11 @@ describe("matrix monitor handler pairing account scope", () => {
     );
 
     expect(recordInboundSession).toHaveBeenCalled();
+    expect(finalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderManagedAccountId: "ops",
+      }),
+    );
   });
 
   it("does not treat unconfigured Matrix users as bots when allowBots is off", async () => {

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -78,6 +78,7 @@ export type MatrixMonitorHandlerParams = {
   roomsConfig?: Record<string, MatrixRoomConfig>;
   accountAllowBots?: boolean | "mentions";
   configuredBotUserIds?: ReadonlySet<string>;
+  configuredBotAccountIdsByUserId?: ReadonlyMap<string, string>;
   groupPolicy: "open" | "allowlist" | "disabled";
   replyToMode: ReplyToMode;
   threadReplies: "off" | "inbound" | "always";
@@ -196,6 +197,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     roomsConfig,
     accountAllowBots,
     configuredBotUserIds = new Set<string>(),
+    configuredBotAccountIdsByUserId = new Map<string, string>(),
     groupPolicy,
     replyToMode,
     threadReplies,
@@ -422,7 +424,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             })
           : undefined;
         const roomConfig = roomConfigInfo?.config;
-        const allowBotsMode = resolveMatrixAllowBotsMode(roomConfig?.allowBots ?? accountAllowBots);
+        const allowBotsMode = resolveMatrixAllowBotsMode(
+          roomConfig?.allowBots ?? accountAllowBots,
+        );
         const isConfiguredBotSender = configuredBotUserIds.has(senderId);
         const roomMatchMeta = roomConfigInfo
           ? `matchKey=${roomConfigInfo.matchKey ?? "none"} matchSource=${
@@ -991,6 +995,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         body: textWithId,
       });
       const groupSystemPrompt = roomConfig?.systemPrompt?.trim() || undefined;
+      const senderManagedAccountId = configuredBotAccountIdsByUserId.get(senderId);
       const ctxPayload = core.channel.reply.finalizeInboundContext({
         Body: body,
         RawBody: bodyText,
@@ -1003,6 +1008,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         ChatType: isDirectMessage ? "direct" : "channel",
         ConversationLabel: envelopeFrom,
         SenderName: senderName,
+        SenderManagedAccountId: senderManagedAccountId,
         SenderId: senderId,
         SenderUsername: senderId.split(":")[0]?.replace(/^@/, ""),
         GroupSubject: isRoom ? (roomName ?? roomId) : undefined,

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -10,7 +10,11 @@ import {
 } from "../../runtime-api.js";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { CoreConfig, ReplyToMode } from "../../types.js";
-import { resolveConfiguredMatrixBotUserIds, resolveMatrixAccount } from "../accounts.js";
+import {
+  resolveConfiguredMatrixBotAccountIdsByUserId,
+  resolveConfiguredMatrixBotUserIds,
+  resolveMatrixAccount,
+} from "../accounts.js";
 import { setActiveMatrixClient } from "../active-client.js";
 import {
   isBunRuntime,
@@ -92,6 +96,10 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   let roomsConfig = accountConfig.groups ?? accountConfig.rooms;
   let needsRoomAliasesForConfig = false;
   const configuredBotUserIds = resolveConfiguredMatrixBotUserIds({
+    cfg,
+    accountId: effectiveAccountId,
+  });
+  const configuredBotAccountIdsByUserId = resolveConfiguredMatrixBotAccountIdsByUserId({
     cfg,
     accountId: effectiveAccountId,
   });
@@ -260,6 +268,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     roomsConfig,
     accountAllowBots,
     configuredBotUserIds,
+    configuredBotAccountIdsByUserId,
     groupPolicy,
     replyToMode,
     threadReplies,

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2222,6 +2222,51 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("emits senderAgentId when inbound sender maps to a managed account binding", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+    const cfg = {
+      bindings: [{ agentId: "ops-agent", match: { channel: "telegram", accountId: "ops" } }],
+    } as OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:999",
+      SessionKey: "agent:ops-agent:thread-1",
+      AccountId: "default",
+      SenderId: "user-1",
+      SenderManagedAccountId: "ops",
+      MessageSid: "msg-managed-1",
+      CommandBody: "hello",
+      RawBody: "hello",
+      Body: "hello",
+    });
+
+    const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(hookMocks.runner.runMessageReceived).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          senderAgentId: "ops-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledWith(
+      "message",
+      "received",
+      expect.any(String),
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          senderAgentId: "ops-agent",
+        }),
+      }),
+    );
+  });
+
   it("does not broadcast inbound claims without a core-owned plugin binding", async () => {
     setNoAbort();
     hookMocks.runner.hasHooks.mockImplementation(

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -21,6 +21,7 @@ import {
   toInternalMessageReceivedContext,
   toPluginMessageContext,
   toPluginMessageReceivedEvent,
+  withResolvedInboundSenderAgentId,
 } from "../../hooks/message-hook-mappers.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import {
@@ -233,7 +234,10 @@ export async function dispatchReplyFromConfig(params: {
     typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp) ? ctx.Timestamp : undefined;
   const messageIdForHook =
     ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
-  const hookContext = deriveInboundMessageHookContext(ctx, { messageId: messageIdForHook });
+  const hookContext = withResolvedInboundSenderAgentId(
+    deriveInboundMessageHookContext(ctx, { messageId: messageIdForHook }),
+    cfg,
+  );
   const { isGroup, groupId } = hookContext;
   const inboundClaimContext = toPluginInboundClaimContext(hookContext);
   const inboundClaimEvent = toPluginInboundClaimEvent(hookContext, {

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -13,6 +13,7 @@ import {
   toPluginMessageContext,
   toPluginMessageReceivedEvent,
   toPluginMessageSentEvent,
+  withResolvedInboundSenderAgentId,
 } from "./message-hook-mappers.js";
 
 function makeInboundCtx(overrides: Partial<FinalizedMsgContext> = {}): FinalizedMsgContext {
@@ -125,6 +126,35 @@ describe("message hook mappers", () => {
         senderE164: "+15551234567",
       }),
     });
+  });
+
+  it("resolves senderAgentId from senderManagedAccountId using bindings", () => {
+    const cfg = {
+      bindings: [{ agentId: "ops-agent", match: { channel: "telegram", accountId: "ops" } }],
+    } as OpenClawConfig;
+    const canonical = withResolvedInboundSenderAgentId(
+      deriveInboundMessageHookContext(
+        makeInboundCtx({
+          SenderManagedAccountId: "ops",
+        }),
+      ),
+      cfg,
+    );
+
+    expect(toPluginMessageReceivedEvent(canonical)).toEqual(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          senderAgentId: "ops-agent",
+        }),
+      }),
+    );
+    expect(toInternalMessageReceivedContext(canonical)).toEqual(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          senderAgentId: "ops-agent",
+        }),
+      }),
+    );
   });
 
   it("normalizes Discord channel targets for inbound claim contexts", () => {

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -1,5 +1,6 @@
 import type { FinalizedMsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveBoundAgentIdForChannelAccount } from "../routing/bindings.js";
 import type {
   PluginHookInboundClaimContext,
   PluginHookInboundClaimEvent,
@@ -28,6 +29,8 @@ export type CanonicalInboundMessageHookContext = {
   messageId?: string;
   senderId?: string;
   senderName?: string;
+  senderManagedAccountId?: string;
+  senderAgentId?: string;
   senderUsername?: string;
   senderE164?: string;
   provider?: string;
@@ -109,6 +112,7 @@ export function deriveInboundMessageHookContext(
       ctx.MessageSidLast,
     senderId: ctx.SenderId,
     senderName: ctx.SenderName,
+    senderManagedAccountId: ctx.SenderManagedAccountId,
     senderUsername: ctx.SenderUsername,
     senderE164: ctx.SenderE164,
     provider: ctx.Provider,
@@ -125,6 +129,21 @@ export function deriveInboundMessageHookContext(
     isGroup,
     groupId: isGroup ? conversationId : undefined,
   };
+}
+
+export function withResolvedInboundSenderAgentId(
+  canonical: CanonicalInboundMessageHookContext,
+  cfg: OpenClawConfig,
+): CanonicalInboundMessageHookContext {
+  if (canonical.senderAgentId) {
+    return canonical;
+  }
+  const senderAgentId = resolveBoundAgentIdForChannelAccount(
+    cfg,
+    canonical.channelId,
+    canonical.senderManagedAccountId,
+  );
+  return senderAgentId ? { ...canonical, senderAgentId } : canonical;
 }
 
 export function buildCanonicalSentMessageHookContext(params: {
@@ -311,6 +330,7 @@ export function toPluginMessageReceivedEvent(
       originatingTo: canonical.originatingTo,
       messageId: canonical.messageId,
       senderId: canonical.senderId,
+      senderAgentId: canonical.senderAgentId,
       senderName: canonical.senderName,
       senderUsername: canonical.senderUsername,
       senderE164: canonical.senderE164,
@@ -348,6 +368,7 @@ export function toInternalMessageReceivedContext(
       surface: canonical.surface,
       threadId: canonical.threadId,
       senderId: canonical.senderId,
+      senderAgentId: canonical.senderAgentId,
       senderName: canonical.senderName,
       senderUsername: canonical.senderUsername,
       senderE164: canonical.senderE164,

--- a/src/routing/bindings.ts
+++ b/src/routing/bindings.ts
@@ -112,3 +112,30 @@ export function resolvePreferredAccountId(params: {
   }
   return params.defaultAccountId;
 }
+
+export function resolveBoundAgentIdForChannelAccount(
+  cfg: OpenClawConfig,
+  channelId: string,
+  accountId?: string | null,
+): string | null {
+  const normalizedChannel = normalizeBindingChannelId(channelId);
+  if (!normalizedChannel) {
+    return null;
+  }
+  const normalizedAccountId = normalizeAccountId(accountId);
+  if (!normalizedAccountId) {
+    return null;
+  }
+  for (const binding of listBindings(cfg)) {
+    const resolved = resolveNormalizedBindingMatch(binding);
+    if (
+      !resolved ||
+      resolved.channelId !== normalizedChannel ||
+      resolved.accountId !== normalizedAccountId
+    ) {
+      continue;
+    }
+    return resolved.agentId;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- Problem: `message_received` hooks can see provider-native sender identity, but arbiter ultimately needs the managed sender's `agentId` to distinguish managed-agent echoes from true external-user messages.
- Why it matters: Without a resolved inbound `senderAgentId`, arbiter can misclassify managed-agent messages as user traffic, which weakens quiet-mode handling, backfill accuracy, and stale-run cancellation.
- What changed: Provider-side inbound normalization now marks managed senders where the provider can see its own self/account identity, and the shared hook dispatch path resolves and emits `metadata.senderAgentId` before plugin/internal `message_received` hooks fire.
- What did NOT change (scope boundary): This rebuild intentionally drops the old outbound `message_sent` metadata expansion from `#58144`. The scope is narrowed to inbound `message_received` metadata that arbiter actually consumes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The previous hook contract stopped at provider/account identity, so downstream consumers had to reconstruct `accountId -> agentId` themselves or could not recover managed-agent identity at all.
- Missing detection / guardrail: Coverage existed for hook payload content, but not for managed-sender resolution across provider inbound normalization and shared hook dispatch.
- Prior context: The earlier `#58144` branch widened metadata in the mapper layer, but review showed that producer-side managed sender identity still was not sourced on real inbound traffic.
- Why this regressed now: Not a new regression; this was latent and became visible as arbiter logic started depending on accurate managed-sender attribution.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/hooks/message-hook-mappers.test.ts`, `src/auto-reply/reply/dispatch-from-config.test.ts`, `extensions/matrix/src/matrix/monitor/handler.test.ts`, `extensions/discord/src/monitor/message-handler.process.test.ts`
- Scenario the test should lock in: Inbound managed senders from Discord/Matrix produce `senderManagedAccountId` in canonical context and the shared dispatch path emits `metadata.senderAgentId` after binding lookup.
- Why this is the smallest reliable guardrail: The failure spans provider-side sender normalization and the shared hook-dispatch boundary, so targeted unit/seam coverage across those files locks the exact path without needing live provider traffic.
- Existing test that already covers this (if any): None prior to this PR.
- If no new test is added, why not: New tests are added in this PR.

## User-visible / Behavior Changes

`message_received` hook consumers, including arbiter, now receive `metadata.senderAgentId` for managed inbound senders when the provider can identify that sender as one of our configured accounts. No config changes.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows Server 2022 / Linux (CI)
- Runtime/container: Node 22+
- Model/provider: N/A (gateway/integration fix)
- Integration/channel (if any): Inbound Discord and Matrix message monitoring, shared hook dispatch
- Relevant config (redacted): Standard gateway config with managed channel bindings for Discord and/or Matrix

### Steps

1. Receive an inbound message from a sender that matches one of our managed provider accounts.
2. Inspect the canonical inbound hook context and emitted `message_received` hook metadata.
3. Verify the shared dispatch layer emits `metadata.senderAgentId` matching the currently bound agent.

### Expected

- Hook consumers receive `metadata.senderAgentId` for managed inbound senders.

### Actual

- Before fix: provider inbound code could not surface managed sender identity all the way to hook consumers, so `message_received` hooks usually lacked a resolvable managed sender.
- After fix: provider-side managed sender detection feeds the shared dispatch path, which emits `senderAgentId` directly.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New tests in the touched provider and hook-dispatch paths verify managed-sender propagation and final `senderAgentId` emission.

## Human Verification (required)

- Verified scenarios: `git diff --check` and `pnpm exec vitest run --configLoader native --pool=threads src/hooks/message-hook-mappers.test.ts src/auto-reply/reply/dispatch-from-config.test.ts extensions/matrix/src/matrix/monitor/handler.test.ts extensions/discord/src/monitor/message-handler.process.test.ts`
- Edge cases checked: sender remains optional for non-managed inbound traffic; binding lookup stays channel/account scoped.
- What you did **not** verify: Live Discord/Matrix traffic against real provider endpoints.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in the superseded branch lineage.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; inbound hook payloads return to the prior state without `metadata.senderAgentId`.
- Files/config to restore: No config changes; only code files.
- Known bad symptoms reviewers should watch for: Managed-agent echoes still showing up as external user messages in arbiter-driven flows.

## Risks and Mitigations

- Risk: Multiple bindings for the same `channelId/accountId` pair would make `senderAgentId` resolution ambiguous.
  - Mitigation: The shared helper resolves against the current binding config, which is already the source of truth for account-to-agent ownership.

## FAQ / Known review points

### Q: Why emit `senderAgentId` instead of relying on `SenderManagedAccountId`?
A: Arbiter ultimately needs the managed sender's `agentId`, not the intermediate managed `accountId`. This branch resolves that once in the shared hook layer so consumers do not duplicate `accountId -> agentId` lookup logic.

### Q: Why keep `SenderManagedAccountId` in canonical inbound context at all?
A: Providers naturally know provider-native sender identity first. They can cheaply mark "this sender is managed account X" during inbound normalization, and the shared dispatch path then resolves the current bound `agentId`.

### Q: Why not keep the old outbound `message_sent` metadata changes from `#58144`?
A: Latest `upstream/main` already moved the outbound delivery code, and arbiter does not consume `message_sent`. This rebuild intentionally narrows scope to inbound `message_received` metadata that arbiter actually reads.