### PR TITLE
feat(plugins): add registerStreamFnWrapper for per-call stream wrapping

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -25,6 +25,7 @@ import {
   extractModelCompat,
   resolveToolCallArgumentsEncoding,
 } from "../../../plugins/provider-model-compat.js";
+import { getActivePluginRegistry } from "../../../plugins/runtime.js";
 import {
   resolveProviderSystemPromptContribution,
   resolveProviderTextTransforms,
@@ -1614,6 +1615,14 @@ export async function runEmbeddedAttempt(
       activeSession.agent.streamFn = wrapStreamFnHandleSensitiveStopReason(
         activeSession.agent.streamFn,
       );
+
+      // Apply plugin-registered streamFn wrappers (e.g. per-call model routing).
+      const pluginStreamFnWrappers = getActivePluginRegistry()?.streamFnWrappers;
+      if (pluginStreamFnWrappers?.length) {
+        for (const wrapper of pluginStreamFnWrappers) {
+          activeSession.agent.streamFn = wrapper(activeSession.agent.streamFn);
+        }
+      }
 
       let idleTimeoutTrigger: ((error: Error) => void) | undefined;
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -25,12 +25,12 @@ import {
   extractModelCompat,
   resolveToolCallArgumentsEncoding,
 } from "../../../plugins/provider-model-compat.js";
-import { getActivePluginRegistry } from "../../../plugins/runtime.js";
 import {
   resolveProviderSystemPromptContribution,
   resolveProviderTextTransforms,
   transformProviderSystemPrompt,
 } from "../../../plugins/provider-runtime.js";
+import { getActivePluginRegistry } from "../../../plugins/runtime.js";
 import { getPluginToolMeta } from "../../../plugins/tools.js";
 import { isAcpSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
 import { normalizeOptionalLowercaseString } from "../../../shared/string-coerce.js";
@@ -1620,7 +1620,12 @@ export async function runEmbeddedAttempt(
       const pluginStreamFnWrappers = getActivePluginRegistry()?.streamFnWrappers;
       if (pluginStreamFnWrappers?.length) {
         for (const wrapper of pluginStreamFnWrappers) {
-          activeSession.agent.streamFn = wrapper(activeSession.agent.streamFn);
+          try {
+            activeSession.agent.streamFn = wrapper(activeSession.agent.streamFn);
+          } catch (err) {
+            // Isolate wrapper failures — skip the failing wrapper rather than stalling the attempt.
+            log.warn("plugin streamFn wrapper failed; skipping", { err });
+          }
         }
       }
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1624,7 +1624,7 @@ export async function runEmbeddedAttempt(
             activeSession.agent.streamFn = wrapper(activeSession.agent.streamFn);
           } catch (err) {
             // Isolate wrapper failures — skip the failing wrapper rather than stalling the attempt.
-            log.warn("plugin streamFn wrapper failed; skipping", { err });
+            log.warn(`plugin streamFn wrapper failed; skipping: ${String(err)}`);
           }
         }
       }

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -99,6 +99,7 @@ const createRegistry = (diagnostics: PluginDiagnostic[]): PluginRegistry => ({
   gatewayDiscoveryServices: [],
   conversationBindingResolvedHandlers: [],
   diagnostics,
+  streamFnWrappers: [],
 });
 
 type ServerPluginsModule = typeof import("./server-plugins.js");

--- a/src/gateway/test-helpers.plugin-registry.ts
+++ b/src/gateway/test-helpers.plugin-registry.ts
@@ -35,6 +35,7 @@ function createStubPluginRegistry(): PluginRegistry {
     commands: [],
     conversationBindingResolvedHandlers: [],
     diagnostics: [],
+    streamFnWrappers: [],
   };
 }
 

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -53,6 +53,7 @@ export type BuildPluginApiParams = {
       | "registerCodexAppServerExtensionFactory"
       | "registerDetachedTaskRuntime"
       | "registerMemoryCapability"
+      | "registerStreamFnWrapper"
       | "registerMemoryPromptSection"
       | "registerMemoryPromptSupplement"
       | "registerMemoryCorpusSupplement"
@@ -110,6 +111,7 @@ const noopRegisterCodexAppServerExtensionFactory: OpenClawPluginApi["registerCod
   () => {};
 const noopRegisterDetachedTaskRuntime: OpenClawPluginApi["registerDetachedTaskRuntime"] = () => {};
 const noopRegisterMemoryCapability: OpenClawPluginApi["registerMemoryCapability"] = () => {};
+const noopRegisterStreamFnWrapper: OpenClawPluginApi["registerStreamFnWrapper"] = () => {};
 const noopRegisterMemoryPromptSection: OpenClawPluginApi["registerMemoryPromptSection"] = () => {};
 const noopRegisterMemoryPromptSupplement: OpenClawPluginApi["registerMemoryPromptSupplement"] =
   () => {};
@@ -184,6 +186,7 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     registerDetachedTaskRuntime:
       handlers.registerDetachedTaskRuntime ?? noopRegisterDetachedTaskRuntime,
     registerMemoryCapability: handlers.registerMemoryCapability ?? noopRegisterMemoryCapability,
+    registerStreamFnWrapper: handlers.registerStreamFnWrapper ?? noopRegisterStreamFnWrapper,
     registerMemoryPromptSection:
       handlers.registerMemoryPromptSection ?? noopRegisterMemoryPromptSection,
     registerMemoryPromptSupplement:

--- a/src/plugins/registry-empty.ts
+++ b/src/plugins/registry-empty.ts
@@ -36,5 +36,6 @@ export function createEmptyPluginRegistry(): PluginRegistry {
     commands: [],
     conversationBindingResolvedHandlers: [],
     diagnostics: [],
+    streamFnWrappers: [],
   };
 }

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -1,3 +1,4 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import type { AgentHarness } from "../agents/harness/types.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
@@ -326,6 +327,8 @@ export type PluginRegistry = {
   commands: PluginCommandRegistration[];
   conversationBindingResolvedHandlers: PluginConversationBindingResolvedHandlerRegistration[];
   diagnostics: PluginDiagnostic[];
+  /** Plugin-registered streamFn wrappers applied after provider wrappers. */
+  streamFnWrappers: Array<(streamFn: StreamFn) => StreamFn>;
 };
 
 export type PluginRegistryParams = {

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import {
   getRegisteredAgentHarness,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import {
   getRegisteredAgentHarness,
@@ -1491,6 +1492,9 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   return;
                 }
                 registerMemoryCapability(record.id, capability);
+              },
+              registerStreamFnWrapper: (wrapper: PluginRegistry["streamFnWrappers"][number]) => {
+                registry.streamFnWrappers.push(wrapper);
               },
               registerMemoryPromptSection: (builder) => {
                 if (!hasKind(record.kind, "memory")) {

--- a/src/plugins/status.test-helpers.ts
+++ b/src/plugins/status.test-helpers.ts
@@ -143,6 +143,7 @@ export function createPluginLoadResult(
     services: [],
     commands: [],
     conversationBindingResolvedHandlers: [],
+    streamFnWrappers: [],
     ...rest,
     gatewayDiscoveryServices: rest.gatewayDiscoveryServices ?? [],
     realtimeTranscriptionProviders: realtimeTranscriptionProviders ?? [],

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2132,6 +2132,11 @@ export type OpenClawPluginApi = {
     capability: import("./memory-state.js").MemoryPluginCapability,
   ) => void;
   /**
+   * Register a streamFn wrapper applied to every LLM API call within a turn.
+   * Wrappers are applied after provider-specific wrappers.
+   */
+  registerStreamFnWrapper: (wrapper: (streamFn: StreamFn) => StreamFn) => void;
+  /**
    * Register the system prompt section builder for this memory plugin (exclusive slot).
    * @deprecated Use registerMemoryCapability({ promptBuilder }) instead.
    */

--- a/src/test-utils/channel-plugins.ts
+++ b/src/test-utils/channel-plugins.ts
@@ -52,6 +52,7 @@ export const createTestRegistry = (channels: TestChannelRegistration[] = []): Pl
   commands: [],
   conversationBindingResolvedHandlers: [],
   diagnostics: [],
+  streamFnWrappers: [],
 });
 
 export const createChannelTestPluginBase = (params: {

--- a/test/helpers/plugins/plugin-api.ts
+++ b/test/helpers/plugins/plugin-api.ts
@@ -46,6 +46,7 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
     registerCodexAppServerExtensionFactory() {},
     registerDetachedTaskRuntime() {},
     registerMemoryCapability() {},
+    registerStreamFnWrapper() {},
     registerMemoryPromptSection() {},
     registerMemoryPromptSupplement() {},
     registerMemoryCorpusSupplement() {},


### PR DESCRIPTION
## Summary

- Add `registerStreamFnWrapper` to the Plugin SDK, allowing any plugin to wrap the per-call `streamFn`
- Wrappers fire for every LLM API call within a turn (tool-use loops, retries, etc.)
- Applied after all provider and core wrappers, before idle timeout detection

## Motivation

Only provider plugins can currently wrap `streamFn` via `wrapStreamFn` on their provider runtime. Non-provider plugins (context engines, channel plugins, orchestration plugins) that need per-call interception have no API path. This adds a generic `registerStreamFnWrapper` method following the same composition pattern used by core wrappers in `attempt.ts`.

**Use case:** A plugin that routes different calls within the same turn to different models — e.g. using a cheaper model for mechanical tool-result processing and a more capable model for intent classification and final synthesis. The wrapper inspects `context.messages` to detect the call phase and swaps `model.id`
accordingly.

## Changes

| File | Change |
|------|--------|
| `src/plugins/types.ts` | Add `streamFnWrappers` to `PluginRegistry`, `registerStreamFnWrapper` to `OpenClawPluginApi` |
| `src/plugins/registry.ts` | Handler implementation in `createApi` (inside `registrationMode === "full"` block) |
| `src/plugins/registry-empty.ts` | Empty array default |
| `src/plugins/api-builder.ts` | Noop + wiring for `buildPluginApi` |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Apply wrappers after core wrapper chain |
| Test helpers (6 files) | Add `streamFnWrappers: []` to mock registries and `registerStreamFnWrapper() {}` to mock API objects |

## Design decisions

- **Placement:** Wrappers are applied after `wrapStreamFnHandleSensitiveStopReason` and before idle timeout detection. This means plugin wrappers see every call but don't interfere with core safety wrappers or timeout handling.
- **Registration mode:** Only available in `registrationMode === "full"`, consistent with other registration methods.
- **Composition:** Wrappers stack in registration order — later wrappers are outermost. Same `(streamFn) => streamFn` pattern as core wrappers.
- **No attribution metadata:** Kept simple for the initial implementation. `record.id`/`record.source` are available in the registration scope if debugging metadata is needed later.

## Test plan

- [ ] `pnpm build` passes (no new TS errors)
- [ ] Register a wrapper via `api.registerStreamFnWrapper`, confirm it fires for each LLM API call within a multi-tool turn
- [ ] Verify wrapper receives correct `(model, context, options)` signature
- [ ] Verify multiple wrappers compose correctly
- [ ] Verify wrapper is not called when `registrationMode !== "full"`
