### PR TITLE
fix(line): resolve dist runtime contract path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/HTTP: skip failing HTTP request stages so one broken facade no longer forces every HTTP endpoint to return 500. (#58746) Thanks @yelog
 - Sessions/model switching: keep `/model` changes queued behind busy runs instead of interrupting the active turn, and retarget queued followups so later work picks up the new model as soon as the current turn finishes.
 - Plugins/bundled runtimes: restore externalized bundled plugin runtime dependency staging across packed installs, Docker builds, and local runtime staging so bundled plugins keep their declared runtime deps after the 2026.3.31 externalization change. (#58782)
+- LINE/runtime: resolve the packaged runtime contract from the built `dist/plugins/runtime` layout so LINE channels start correctly again after global npm installs on `2026.3.31`. (#58799) Thanks @vincentkoc.
 
 ## 2026.3.31
 

--- a/src/plugins/runtime/local-runtime-module.test.ts
+++ b/src/plugins/runtime/local-runtime-module.test.ts
@@ -1,0 +1,76 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadSiblingRuntimeModuleSync } from "./local-runtime-module.js";
+
+const tempDirs = new Set<string>();
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-runtime-module-"));
+  tempDirs.add(dir);
+  return dir;
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+describe("loadSiblingRuntimeModuleSync", () => {
+  it("loads a sibling runtime module from the caller directory", () => {
+    const root = createTempDir();
+    const moduleUrl = pathToFileURL(
+      path.join(root, "src", "plugins", "runtime", "runtime-line.js"),
+    ).href;
+
+    writeFile(
+      path.join(root, "src", "plugins", "runtime", "runtime-line.contract.js"),
+      "module.exports = { runtimeLine: { source: 'sibling' } };",
+    );
+
+    const loaded = loadSiblingRuntimeModuleSync<{ runtimeLine: { source: string } }>({
+      moduleUrl,
+      relativeBase: "./runtime-line.contract",
+    });
+
+    expect(loaded.runtimeLine.source).toBe("sibling");
+  });
+
+  it("falls back to the built plugins/runtime dist layout", () => {
+    const root = createTempDir();
+    const moduleUrl = pathToFileURL(path.join(root, "dist", "runtime-9DLN_Ai5.js")).href;
+
+    writeFile(
+      path.join(root, "dist", "plugins", "runtime", "runtime-line.contract.js"),
+      "module.exports = { runtimeLine: { source: 'dist-runtime' } };",
+    );
+
+    const loaded = loadSiblingRuntimeModuleSync<{ runtimeLine: { source: string } }>({
+      moduleUrl,
+      relativeBase: "./runtime-line.contract",
+    });
+
+    expect(loaded.runtimeLine.source).toBe("dist-runtime");
+  });
+
+  it("throws when no candidate runtime module exists", () => {
+    const root = createTempDir();
+    const moduleUrl = pathToFileURL(path.join(root, "dist", "runtime-9DLN_Ai5.js")).href;
+
+    expect(() =>
+      loadSiblingRuntimeModuleSync({
+        moduleUrl,
+        relativeBase: "./runtime-line.contract",
+      }),
+    ).toThrow("Unable to resolve runtime module ./runtime-line.contract");
+  });
+});

--- a/src/plugins/runtime/local-runtime-module.ts
+++ b/src/plugins/runtime/local-runtime-module.ts
@@ -13,10 +13,15 @@ const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
 
 function resolveSiblingRuntimeModulePath(moduleUrl: string, relativeBase: string): string {
   const baseDir = path.dirname(fileURLToPath(moduleUrl));
-  for (const ext of RUNTIME_MODULE_EXTENSIONS) {
-    const candidate = path.resolve(baseDir, `${relativeBase}${ext}`);
-    if (fs.existsSync(candidate)) {
-      return candidate;
+  const baseName = relativeBase.replace(/^\.\//, "");
+  const candidateDirs = [baseDir, path.resolve(baseDir, "plugins", "runtime")];
+
+  for (const dir of candidateDirs) {
+    for (const ext of RUNTIME_MODULE_EXTENSIONS) {
+      const candidate = path.resolve(dir, `${baseName}${ext}`);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
     }
   }
   throw new Error(`Unable to resolve runtime module ${relativeBase} from ${moduleUrl}`);


### PR DESCRIPTION
## Summary
- teach the local runtime module resolver to fall back to the built `dist/plugins/runtime/*` layout
- add a focused resolver test that reproduces the packaged LINE startup failure

## Testing
- `pnpm test -- src/plugins/runtime/local-runtime-module.test.ts`
- `pnpm check`
- `pnpm build`

Fixes #58719
Fixes #58708
