### PR TITLE
fix(status): filter stale task rows from status cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/local Bot API: preserve media MIME types for absolute-path downloads so local audio files still trigger transcription and other MIME-based handling. (#54603) Thanks @jzakirov
 - Tasks/gateway: re-check the current task record before maintenance marks runs lost or prunes them, so a task heartbeat or cleanup update that lands during a sweep no longer gets overwritten by stale snapshot state.
 - Tasks/gateway: keep the task registry maintenance sweep from stalling the gateway event loop under synchronous SQLite pressure, so upgraded gateways stop hanging about a minute after startup. (#58670) Thanks @openperf
+- Tasks/status: hide stale completed background tasks from `/status` and `session_status`, prefer live task context, and show recent failures only when no active work remains. (#58661) Thanks @vincentkoc
 - Channels/WhatsApp: pass inbound message timestamp to model context so the AI can see when WhatsApp messages were sent. (#58590) Thanks @Maninae
 - Web UI/OpenResponses: preserve rewritten stream snapshots in webchat and keep OpenResponses final streamed text aligned when models rewind earlier output. (#58641) Thanks @neeravmakwana
 - MiniMax/plugins: auto-enable the bundled MiniMax plugin for API-key auth/config so MiniMax image generation and other plugin-owned capabilities load without manual plugin allowlisting. (#57127) Thanks @tars90percent.

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -515,6 +515,52 @@ describe("session_status tool", () => {
     expect(text).toContain("permission denied");
   });
 
+  it("prefers failure context over newer success context in session_status output", async () => {
+    resetSessionStore({
+      "agent:main:main": {
+        sessionId: "sess-main",
+        updatedAt: Date.now(),
+      },
+    });
+    listTasksForRelatedSessionKeyForOwnerMock.mockReturnValue([
+      {
+        taskId: "task-failed",
+        runtime: "cron",
+        requesterSessionKey: "agent:main:main",
+        task: "failing task",
+        status: "failed",
+        deliveryStatus: "pending",
+        notifyPolicy: "done_only",
+        createdAt: Date.now() - 60_000,
+        endedAt: Date.now() - 30_000,
+        error: "permission denied",
+      },
+      {
+        taskId: "task-succeeded",
+        runtime: "subagent",
+        requesterSessionKey: "agent:main:main",
+        task: "successful task",
+        status: "succeeded",
+        deliveryStatus: "delivered",
+        notifyPolicy: "done_only",
+        createdAt: Date.now() - 10_000,
+        endedAt: Date.now(),
+        terminalSummary: "all done",
+      },
+    ]);
+
+    const tool = createSessionStatusTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("tc-failed-priority", { sessionKey: "agent:main:main" });
+    const firstContent = result.content?.[0];
+    const text = (firstContent as { text: string } | undefined)?.text ?? "";
+
+    expect(text).toContain("📌 Tasks: 1 recent failure");
+    expect(text).toContain("failing task");
+    expect(text).toContain("permission denied");
+    expect(text).not.toContain("successful task");
+    expect(text).not.toContain("all done");
+  });
+
   it("resolves a literal current sessionId in session_status", async () => {
     resetSessionStore({
       main: {

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 import { resolvePreferredSessionKeyForSessionIdMatches } from "../sessions/session-id-resolution.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+import { buildTaskStatusSnapshot } from "../tasks/task-status.js";
 
 const loadSessionStoreMock = vi.fn();
 const updateSessionStoreMock = vi.fn();
@@ -35,6 +37,7 @@ const createMockConfig = () => ({
 });
 
 let mockConfig: Record<string, unknown> = createMockConfig();
+const TASK_STATUS_SNAPSHOT_NOW = 1_000_000_000_000;
 
 function createScopedSessionStores() {
   return new Map<string, Record<string, unknown>>([
@@ -209,29 +212,10 @@ async function loadFreshOpenClawToolsForSessionStatusTest() {
     buildTaskStatusSnapshotForRelatedSessionKeyForOwner: (params: {
       relatedSessionKey: string;
       callerOwnerKey: string;
-    }) => {
-      const tasks = listTasksForRelatedSessionKeyForOwnerMock(params) as Array<
-        {
-          status?: string;
-        } & Record<string, unknown>
-      >;
-      const active = tasks.filter((task) => task.status === "queued" || task.status === "running");
-      const recentTerminal = active.length > 0 ? [] : tasks;
-      const recentFailureCount = recentTerminal.filter(
-        (task) => task.status === "failed" || task.status === "timed_out" || task.status === "lost",
-      ).length;
-      const visible = active.length > 0 ? active : recentTerminal;
-      const latest = visible[0] as Record<string, unknown> | undefined;
-      return {
-        latest,
-        visible,
-        active,
-        recentTerminal,
-        activeCount: active.length,
-        totalCount: visible.length,
-        recentFailureCount,
-      };
-    },
+    }) =>
+      buildTaskStatusSnapshot(listTasksForRelatedSessionKeyForOwnerMock(params) as TaskRecord[], {
+        now: TASK_STATUS_SNAPSHOT_NOW,
+      }),
   }));
   ({ createSessionStatusTool } = await import("./tools/session-status-tool.js"));
 }

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -14,15 +14,11 @@ const listTasksForRelatedSessionKeyForOwnerMock = vi.hoisted(() =>
       [] as Array<Record<string, unknown>>,
   ),
 );
-const resolveEnvApiKeyMock = vi.hoisted(
-  () => vi.fn((_provider?: string, _env?: NodeJS.ProcessEnv) => null),
+const resolveEnvApiKeyMock = vi.hoisted(() =>
+  vi.fn((_provider?: string, _env?: NodeJS.ProcessEnv) => null),
 );
-const resolveUsableCustomProviderApiKeyMock = vi.hoisted(
-  () =>
-    vi.fn(
-      (_params?: { provider?: string }) =>
-        null as { apiKey: string; source: string } | null,
-    ),
+const resolveUsableCustomProviderApiKeyMock = vi.hoisted(() =>
+  vi.fn((_params?: { provider?: string }) => null as { apiKey: string; source: string } | null),
 );
 
 const createMockConfig = () => ({
@@ -210,6 +206,32 @@ async function loadFreshOpenClawToolsForSessionStatusTest() {
       relatedSessionKey: string;
       callerOwnerKey: string;
     }) => listTasksForRelatedSessionKeyForOwnerMock(params),
+    buildTaskStatusSnapshotForRelatedSessionKeyForOwner: (params: {
+      relatedSessionKey: string;
+      callerOwnerKey: string;
+    }) => {
+      const tasks = listTasksForRelatedSessionKeyForOwnerMock(params) as Array<
+        {
+          status?: string;
+        } & Record<string, unknown>
+      >;
+      const active = tasks.filter((task) => task.status === "queued" || task.status === "running");
+      const recentTerminal = active.length > 0 ? [] : tasks;
+      const recentFailureCount = recentTerminal.filter(
+        (task) => task.status === "failed" || task.status === "timed_out" || task.status === "lost",
+      ).length;
+      const visible = active.length > 0 ? active : recentTerminal;
+      const latest = visible[0] as Record<string, unknown> | undefined;
+      return {
+        latest,
+        visible,
+        active,
+        recentTerminal,
+        activeCount: active.length,
+        totalCount: visible.length,
+        recentFailureCount,
+      };
+    },
   }));
   ({ createSessionStatusTool } = await import("./tools/session-status-tool.js"));
 }
@@ -433,6 +455,80 @@ describe("session_status tool", () => {
     expect(text).toContain("acp");
     expect(text).toContain("Summarize inbox backlog");
     expect(text).toContain("Indexing the latest threads");
+  });
+
+  it("hides stale completed task rows from session_status output", async () => {
+    resetSessionStore({
+      "agent:main:main": {
+        sessionId: "sess-main",
+        updatedAt: Date.now(),
+      },
+    });
+    listTasksForRelatedSessionKeyForOwnerMock.mockReturnValue([
+      {
+        taskId: "task-stale",
+        runtime: "cron",
+        requesterSessionKey: "agent:main:main",
+        task: "stale completed task",
+        status: "succeeded",
+        deliveryStatus: "delivered",
+        notifyPolicy: "done_only",
+        createdAt: Date.now() - 15 * 60_000,
+        terminalSummary: "finished long ago",
+      },
+      {
+        taskId: "task-live",
+        runtime: "subagent",
+        requesterSessionKey: "agent:main:main",
+        task: "live task",
+        status: "running",
+        deliveryStatus: "pending",
+        notifyPolicy: "done_only",
+        createdAt: Date.now() - 5_000,
+        progressSummary: "still working",
+      },
+    ]);
+
+    const tool = createSessionStatusTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("tc-stale", { sessionKey: "agent:main:main" });
+    const firstContent = result.content?.[0];
+    const text = (firstContent as { text: string } | undefined)?.text ?? "";
+
+    expect(text).toContain("📌 Tasks: 1 active");
+    expect(text).toContain("live task");
+    expect(text).not.toContain("stale completed task");
+    expect(text).not.toContain("finished long ago");
+  });
+
+  it("shows recent failure context in session_status output when no task is active", async () => {
+    resetSessionStore({
+      "agent:main:main": {
+        sessionId: "sess-main",
+        updatedAt: Date.now(),
+      },
+    });
+    listTasksForRelatedSessionKeyForOwnerMock.mockReturnValue([
+      {
+        taskId: "task-failed",
+        runtime: "cron",
+        requesterSessionKey: "agent:main:main",
+        task: "failing task",
+        status: "failed",
+        deliveryStatus: "pending",
+        notifyPolicy: "done_only",
+        createdAt: Date.now() - 5_000,
+        error: "permission denied",
+      },
+    ]);
+
+    const tool = createSessionStatusTool({ agentSessionKey: "agent:main:main" });
+    const result = await tool.execute("tc-failed", { sessionKey: "agent:main:main" });
+    const firstContent = result.content?.[0];
+    const text = (firstContent as { text: string } | undefined)?.text ?? "";
+
+    expect(text).toContain("📌 Tasks: 1 recent failure");
+    expect(text).toContain("failing task");
+    expect(text).toContain("permission denied");
   });
 
   it("resolves a literal current sessionId in session_status", async () => {

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -22,7 +22,7 @@ import {
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
-import { listTasksForRelatedSessionKeyForOwner } from "../../tasks/task-owner-access.js";
+import { buildTaskStatusSnapshotForRelatedSessionKeyForOwner } from "../../tasks/task-owner-access.js";
 import { loadModelCatalog } from "../model-catalog.js";
 import {
   buildAllowedModelSet,
@@ -119,25 +119,19 @@ function formatSessionTaskLine(params: {
   relatedSessionKey: string;
   callerOwnerKey: string;
 }): string | undefined {
-  const tasks = listTasksForRelatedSessionKeyForOwner({
+  const snapshot = buildTaskStatusSnapshotForRelatedSessionKeyForOwner({
     relatedSessionKey: params.relatedSessionKey,
     callerOwnerKey: params.callerOwnerKey,
   });
-  if (tasks.length === 0) {
+  const latest = snapshot.latest;
+  if (!latest) {
     return undefined;
   }
-  const latest = tasks[0];
-  const active = tasks.filter(
-    (task) => task.status === "queued" || task.status === "running",
-  ).length;
-  const failed = tasks.filter(
-    (task) => task.status === "failed" || task.status === "timed_out" || task.status === "lost",
-  ).length;
   const headline =
-    active > 0
-      ? `${active} active`
-      : failed > 0
-        ? `${failed} recent failure${failed === 1 ? "" : "s"}`
+    snapshot.activeCount > 0
+      ? `${snapshot.activeCount} active`
+      : snapshot.recentFailureCount > 0
+        ? `${snapshot.recentFailureCount} recent failure${snapshot.recentFailureCount === 1 ? "" : "s"}`
         : `latest ${latest.status.replaceAll("_", " ")}`;
   const title = latest.label?.trim() || latest.task.trim();
   const detail =

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -123,8 +123,8 @@ function formatSessionTaskLine(params: {
     relatedSessionKey: params.relatedSessionKey,
     callerOwnerKey: params.callerOwnerKey,
   });
-  const latest = snapshot.latest;
-  if (!latest) {
+  const task = snapshot.focus;
+  if (!task) {
     return undefined;
   }
   const headline =
@@ -132,13 +132,13 @@ function formatSessionTaskLine(params: {
       ? `${snapshot.activeCount} active`
       : snapshot.recentFailureCount > 0
         ? `${snapshot.recentFailureCount} recent failure${snapshot.recentFailureCount === 1 ? "" : "s"}`
-        : `latest ${latest.status.replaceAll("_", " ")}`;
-  const title = latest.label?.trim() || latest.task.trim();
+        : `latest ${task.status.replaceAll("_", " ")}`;
+  const title = task.label?.trim() || task.task.trim();
   const detail =
-    latest.status === "running" || latest.status === "queued"
-      ? latest.progressSummary?.trim()
-      : latest.error?.trim() || latest.terminalSummary?.trim();
-  const parts = [headline, latest.runtime, title, detail].filter(Boolean);
+    task.status === "running" || task.status === "queued"
+      ? task.progressSummary?.trim()
+      : task.error?.trim() || task.terminalSummary?.trim();
+  const parts = [headline, task.runtime, title, detail].filter(Boolean);
   return parts.length ? `📌 Tasks: ${parts.join(" · ")}` : undefined;
 }
 

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -4,7 +4,12 @@ import {
   resetSubagentRegistryForTests,
 } from "../../agents/subagent-registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { createQueuedTaskRun, createRunningTaskRun } from "../../tasks/task-executor.js";
+import {
+  completeTaskRunByRunId,
+  createQueuedTaskRun,
+  createRunningTaskRun,
+  failTaskRunByRunId,
+} from "../../tasks/task-executor.js";
 import { resetTaskRegistryForTests } from "../../tasks/task-registry.js";
 import { buildStatusReply } from "./commands-status.js";
 import { buildCommandTestParams } from "./commands.test-harness.js";
@@ -204,6 +209,57 @@ describe("buildStatusReply subagent summary", () => {
 
     expect(reply?.text).toContain("📌 Tasks: 2 active · 2 total");
     expect(reply?.text).toMatch(/📌 Tasks: 2 active · 2 total · (subagent|cron) · /);
+  });
+
+  it("hides stale completed task rows from the session task line", async () => {
+    createRunningTaskRun({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      childSessionKey: "agent:main:subagent:status-task-live",
+      runId: "run-status-task-live",
+      task: "live background task",
+      progressSummary: "still working",
+    });
+    createQueuedTaskRun({
+      runtime: "cron",
+      requesterSessionKey: "agent:main:main",
+      childSessionKey: "agent:main:subagent:status-task-stale-done",
+      runId: "run-status-task-stale-done",
+      task: "stale completed task",
+    });
+    completeTaskRunByRunId({
+      runId: "run-status-task-stale-done",
+      endedAt: Date.now() - 10 * 60_000,
+      terminalSummary: "done a while ago",
+    });
+
+    const reply = await buildStatusReplyForTest({});
+
+    expect(reply?.text).toContain("📌 Tasks: 1 active · 1 total");
+    expect(reply?.text).toContain("live background task");
+    expect(reply?.text).not.toContain("stale completed task");
+    expect(reply?.text).not.toContain("done a while ago");
+  });
+
+  it("shows a recent failure when no active tasks remain", async () => {
+    createRunningTaskRun({
+      runtime: "acp",
+      requesterSessionKey: "agent:main:main",
+      childSessionKey: "agent:main:acp:status-task-failed",
+      runId: "run-status-task-failed",
+      task: "failed background task",
+    });
+    failTaskRunByRunId({
+      runId: "run-status-task-failed",
+      endedAt: Date.now(),
+      error: "approval denied",
+    });
+
+    const reply = await buildStatusReplyForTest({});
+
+    expect(reply?.text).toContain("📌 Tasks: 1 recent failure");
+    expect(reply?.text).toContain("failed background task");
+    expect(reply?.text).toContain("approval denied");
   });
 
   it("falls back to same-agent task counts without details when the current session has none", async () => {

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -262,6 +262,41 @@ describe("buildStatusReply subagent summary", () => {
     expect(reply?.text).toContain("approval denied");
   });
 
+  it("prefers failure context over newer success context when showing recent failures", async () => {
+    createRunningTaskRun({
+      runtime: "acp",
+      requesterSessionKey: "agent:main:main",
+      childSessionKey: "agent:main:acp:status-task-failed-priority",
+      runId: "run-status-task-failed-priority",
+      task: "failed background task",
+    });
+    failTaskRunByRunId({
+      runId: "run-status-task-failed-priority",
+      endedAt: Date.now() - 30_000,
+      error: "approval denied",
+    });
+    createRunningTaskRun({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      childSessionKey: "agent:main:subagent:status-task-succeeded-later",
+      runId: "run-status-task-succeeded-later",
+      task: "later successful task",
+    });
+    completeTaskRunByRunId({
+      runId: "run-status-task-succeeded-later",
+      endedAt: Date.now(),
+      terminalSummary: "all done",
+    });
+
+    const reply = await buildStatusReplyForTest({});
+
+    expect(reply?.text).toContain("📌 Tasks: 1 recent failure");
+    expect(reply?.text).toContain("failed background task");
+    expect(reply?.text).toContain("approval denied");
+    expect(reply?.text).not.toContain("later successful task");
+    expect(reply?.text).not.toContain("all done");
+  });
+
   it("falls back to same-agent task counts without details when the current session has none", async () => {
     createRunningTaskRun({
       runtime: "subagent",

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -23,6 +23,7 @@ import {
 } from "../../infra/provider-usage.js";
 import type { MediaUnderstandingDecision } from "../../media-understanding/types.js";
 import { listTasksForAgentId, listTasksForSessionKey } from "../../tasks/task-registry.js";
+import { buildTaskStatusSnapshot } from "../../tasks/task-status.js";
 import { normalizeGroupActivation } from "../group-activation.js";
 import { resolveSelectedAndActiveModel } from "../model-runtime.js";
 import { buildStatusMessage } from "../status.js";
@@ -56,15 +57,17 @@ function shouldLoadUsageSummary(params: {
 }
 
 function formatSessionTaskLine(sessionKey: string): string | undefined {
-  const tasks = listTasksForSessionKey(sessionKey);
-  if (tasks.length === 0) {
+  const snapshot = buildTaskStatusSnapshot(listTasksForSessionKey(sessionKey));
+  const latest = snapshot.latest;
+  if (!latest) {
     return undefined;
   }
-  const latest = tasks[0];
-  const active = tasks.filter(
-    (task) => task.status === "queued" || task.status === "running",
-  ).length;
-  const headline = `${active} active · ${tasks.length} total`;
+  const headline =
+    snapshot.activeCount > 0
+      ? `${snapshot.activeCount} active · ${snapshot.totalCount} total`
+      : snapshot.recentFailureCount > 0
+        ? `${snapshot.recentFailureCount} recent failure${snapshot.recentFailureCount === 1 ? "" : "s"}`
+        : "recently finished";
   const title = latest.label?.trim() || latest.task.trim();
   const detail =
     latest.status === "running" || latest.status === "queued"
@@ -75,14 +78,11 @@ function formatSessionTaskLine(sessionKey: string): string | undefined {
 }
 
 function formatAgentTaskCountsLine(agentId: string): string | undefined {
-  const tasks = listTasksForAgentId(agentId);
-  if (tasks.length === 0) {
+  const snapshot = buildTaskStatusSnapshot(listTasksForAgentId(agentId));
+  if (snapshot.totalCount === 0) {
     return undefined;
   }
-  const active = tasks.filter(
-    (task) => task.status === "queued" || task.status === "running",
-  ).length;
-  return `📌 Tasks: ${active} active · ${tasks.length} total · agent-local`;
+  return `📌 Tasks: ${snapshot.activeCount} active · ${snapshot.totalCount} total · agent-local`;
 }
 
 export async function buildStatusReply(params: {

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -58,8 +58,8 @@ function shouldLoadUsageSummary(params: {
 
 function formatSessionTaskLine(sessionKey: string): string | undefined {
   const snapshot = buildTaskStatusSnapshot(listTasksForSessionKey(sessionKey));
-  const latest = snapshot.latest;
-  if (!latest) {
+  const task = snapshot.focus;
+  if (!task) {
     return undefined;
   }
   const headline =
@@ -68,12 +68,12 @@ function formatSessionTaskLine(sessionKey: string): string | undefined {
       : snapshot.recentFailureCount > 0
         ? `${snapshot.recentFailureCount} recent failure${snapshot.recentFailureCount === 1 ? "" : "s"}`
         : "recently finished";
-  const title = latest.label?.trim() || latest.task.trim();
+  const title = task.label?.trim() || task.task.trim();
   const detail =
-    latest.status === "running" || latest.status === "queued"
-      ? latest.progressSummary?.trim()
-      : latest.error?.trim() || latest.terminalSummary?.trim();
-  const parts = [headline, latest.runtime, title, detail].filter(Boolean);
+    task.status === "running" || task.status === "queued"
+      ? task.progressSummary?.trim()
+      : task.error?.trim() || task.terminalSummary?.trim();
+  const parts = [headline, task.runtime, title, detail].filter(Boolean);
   return parts.length ? `📌 Tasks: ${parts.join(" · ")}` : undefined;
 }
 

--- a/src/tasks/task-owner-access.ts
+++ b/src/tasks/task-owner-access.ts
@@ -5,6 +5,7 @@ import {
   resolveTaskForLookupToken,
 } from "./task-registry.js";
 import type { TaskRecord } from "./task-registry.types.js";
+import { buildTaskStatusSnapshot } from "./task-status.js";
 
 function normalizeOwnerKey(ownerKey?: string): string | undefined {
   const trimmed = ownerKey?.trim();
@@ -40,6 +41,18 @@ export function listTasksForRelatedSessionKeyForOwner(params: {
 }): TaskRecord[] {
   return listTasksForRelatedSessionKey(params.relatedSessionKey).filter((task) =>
     canOwnerAccessTask(task, params.callerOwnerKey),
+  );
+}
+
+export function buildTaskStatusSnapshotForRelatedSessionKeyForOwner(params: {
+  relatedSessionKey: string;
+  callerOwnerKey: string;
+}) {
+  return buildTaskStatusSnapshot(
+    listTasksForRelatedSessionKeyForOwner({
+      relatedSessionKey: params.relatedSessionKey,
+      callerOwnerKey: params.callerOwnerKey,
+    }),
   );
 }
 

--- a/src/tasks/task-status.ts
+++ b/src/tasks/task-status.ts
@@ -1,0 +1,64 @@
+import { reconcileTaskRecordForOperatorInspection } from "./task-registry.maintenance.js";
+import type { TaskRecord } from "./task-registry.types.js";
+
+const ACTIVE_TASK_STATUSES = new Set(["queued", "running"]);
+const FAILURE_TASK_STATUSES = new Set(["failed", "timed_out", "lost"]);
+export const TASK_STATUS_RECENT_WINDOW_MS = 5 * 60_000;
+
+function isActiveTask(task: TaskRecord): boolean {
+  return ACTIVE_TASK_STATUSES.has(task.status);
+}
+
+function isFailureTask(task: TaskRecord): boolean {
+  return FAILURE_TASK_STATUSES.has(task.status);
+}
+
+function resolveTaskReferenceAt(task: TaskRecord): number {
+  if (isActiveTask(task)) {
+    return task.lastEventAt ?? task.startedAt ?? task.createdAt;
+  }
+  return task.endedAt ?? task.lastEventAt ?? task.startedAt ?? task.createdAt;
+}
+
+function isExpiredTask(task: TaskRecord, now: number): boolean {
+  return typeof task.cleanupAfter === "number" && task.cleanupAfter <= now;
+}
+
+function isRecentTerminalTask(task: TaskRecord, now: number): boolean {
+  if (isActiveTask(task)) {
+    return false;
+  }
+  return now - resolveTaskReferenceAt(task) <= TASK_STATUS_RECENT_WINDOW_MS;
+}
+
+export type TaskStatusSnapshot = {
+  latest?: TaskRecord;
+  visible: TaskRecord[];
+  active: TaskRecord[];
+  recentTerminal: TaskRecord[];
+  activeCount: number;
+  totalCount: number;
+  recentFailureCount: number;
+};
+
+export function buildTaskStatusSnapshot(
+  tasks: TaskRecord[],
+  opts?: { now?: number },
+): TaskStatusSnapshot {
+  const now = opts?.now ?? Date.now();
+  const reconciled = tasks
+    .map((task) => reconcileTaskRecordForOperatorInspection(task))
+    .filter((task) => !isExpiredTask(task, now));
+  const active = reconciled.filter(isActiveTask);
+  const recentTerminal = reconciled.filter((task) => isRecentTerminalTask(task, now));
+  const visible = active.length > 0 ? [...active, ...recentTerminal] : recentTerminal;
+  return {
+    latest: active[0] ?? recentTerminal[0],
+    visible,
+    active,
+    recentTerminal,
+    activeCount: active.length,
+    totalCount: visible.length,
+    recentFailureCount: recentTerminal.filter(isFailureTask).length,
+  };
+}

--- a/src/tasks/task-status.ts
+++ b/src/tasks/task-status.ts
@@ -33,6 +33,7 @@ function isRecentTerminalTask(task: TaskRecord, now: number): boolean {
 
 export type TaskStatusSnapshot = {
   latest?: TaskRecord;
+  focus?: TaskRecord;
   visible: TaskRecord[];
   active: TaskRecord[];
   recentTerminal: TaskRecord[];
@@ -52,8 +53,11 @@ export function buildTaskStatusSnapshot(
   const active = reconciled.filter(isActiveTask);
   const recentTerminal = reconciled.filter((task) => isRecentTerminalTask(task, now));
   const visible = active.length > 0 ? [...active, ...recentTerminal] : recentTerminal;
+  const focus =
+    active[0] ?? recentTerminal.find((task) => isFailureTask(task)) ?? recentTerminal[0];
   return {
     latest: active[0] ?? recentTerminal[0],
+    focus,
     visible,
     active,
     recentTerminal,


### PR DESCRIPTION
## Summary

- Problem: `/status` and `session_status` were reading raw retained task rows, so stale completed tasks could keep showing up as if they were still the relevant session context.
- Why it matters: users checking current status can miss active work, or see misleading stale task context after cleanup has not swept yet.
- What changed: added a cleanup-aware task status snapshot, routed both status surfaces through it, preferred active tasks, and only surfaced recent failures when no active work remains.
- What did NOT change (scope boundary): this does not change task creation, retention policy, or maintenance sweep behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #58661
- Related #54226
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: both status surfaces built their task line from raw retained registry rows instead of a cleanup-aware view.
- Missing detection / guardrail: there was no shared status-specific snapshot helper that excluded expired rows and prioritized active tasks.
- Prior context (`git blame`, prior PR, issue, or refactor if known): task status surfaces were added before a dedicated status snapshot layer existed.
- Why this regressed now: task retention and task-linked status became useful enough that stale completed rows were visible to users in normal `/status` checks.
- If unknown, what was ruled out: this was not a task maintenance sweep failure alone; the UI path itself was reading the wrong view.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/commands-status.test.ts`, `src/agents/openclaw-tools.session-status.test.ts`
- Scenario the test should lock in: stale completed tasks should not headline status when no active visible work remains, and recent failures should only surface when active tasks are absent.
- Why this is the smallest reliable guardrail: both user-visible status surfaces share the same summary semantics, and these tests assert those semantics directly.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `/status` prefers active session-linked tasks over stale completed rows.
- `session_status` follows the same cleanup-aware task view.
- Recent failures are still visible, but only when there is no active work to show.
- Changelog entry included under `Unreleased > Fixes`. Thanks @vincentkoc.

## Diagram (if applicable)

```text
Before:
[/status] -> [raw retained tasks] -> [stale completed row may headline]

After:
[/status] -> [cleanup-aware task snapshot] -> [active tasks first | else recent failure | else recent completion]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local worktree
- Model/provider: N/A
- Integration/channel (if any): chat `/status`, `session_status`
- Relevant config (redacted): default local dev config

### Steps

1. Create retained completed task rows and at least one active task linked to a session.
2. Run the chat `/status` path or the `session_status` tool.
3. Compare the task headline before and after the snapshot filtering.

### Expected

- Active task context is shown first.
- Expired/stale completed rows do not headline status.
- Recent failures only appear when no active work remains.

### Actual

- Verified by targeted tests below.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `/status` active-vs-stale behavior, `session_status` active-vs-recent-failure behavior.
- Edge cases checked: expired retained rows excluded even before maintenance sweep; recent failures still visible when there is no active work.
- What you did **not** verify: live channel smoke across every chat transport.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: status hides a terminal task a user still wanted to inspect.
  - Mitigation: `openclaw tasks` remains the full ledger/operator surface; this change only narrows the status summary view.

AI-assisted: yes. Targeted tests and local `pnpm check` run.
