### PR TITLE
Improve gateway health URL override credential error

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -85,6 +85,7 @@ vi.mock("./client.js", () => ({
 
 const { __testing, buildGatewayConnectionDetails, callGateway, callGatewayCli, callGatewayScoped } =
   await import("./call.js");
+const { ensureExplicitGatewayAuth } = __testing;
 
 class StubGatewayClient {
   constructor(opts: {
@@ -169,6 +170,19 @@ function makeRemotePasswordGatewayConfig(remotePassword: string, localPassword =
     },
   };
 }
+
+describe("ensureExplicitGatewayAuth", () => {
+  it("mentions explicit credential flags for CLI url overrides", () => {
+    expect(() =>
+      ensureExplicitGatewayAuth({
+        urlOverride: "ws://127.0.0.1:18789",
+        urlOverrideSource: "cli",
+        errorHint: "Fix: pass --token or --password (or gatewayToken in tools).",
+        configPath: "/tmp/openclaw.json",
+      }),
+    ).toThrowError(/gateway url override requires explicit credentials \(--token or --password\)/);
+  });
+});
 
 describe("callGateway url resolution", () => {
   const envSnapshot = captureEnv([

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -166,6 +166,7 @@ export const __testing = {
     gatewayCallDeps.createGatewayClient =
       createGatewayClient ?? defaultGatewayCallDeps.createGatewayClient;
   },
+  ensureExplicitGatewayAuth,
   resetDepsForTests(): void {
     gatewayCallDeps.createGatewayClient = defaultGatewayCallDeps.createGatewayClient;
     gatewayCallDeps.loadConfig = defaultGatewayCallDeps.loadConfig;
@@ -236,7 +237,7 @@ export function ensureExplicitGatewayAuth(params: {
     return;
   }
   const message = [
-    "gateway url override requires explicit credentials",
+    "gateway url override requires explicit credentials (--token or --password)",
     params.errorHint,
     params.configPath ? `Config: ${params.configPath}` : undefined,
   ]


### PR DESCRIPTION
## Summary

Make the gateway URL override credential error more actionable by telling users which explicit flags to pass.

## What changed

- Updated the URL override credential error to mention `--token` or `--password`
- Added a focused test covering the CLI URL override error message

## Why

When `gateway health --url ...` is used without explicit credentials, the current error explains that explicit credentials are required, but does not immediately tell the user which flags to provide.

This change makes the recovery path clearer by explicitly mentioning `--token` and `--password`.

## Manual verification

1. Located the `ensureExplicitGatewayAuth` error path in `src/gateway/call.ts`
2. Updated the error text to mention `--token` or `--password`
3. Added a focused test in `src/gateway/call.test.ts`
4. Ran the targeted Vitest case for the new assertion
5. Ran the repo checks during commit