### PR TITLE
dispatch: broadcast inbound_claim to global plugin listeners

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -415,6 +415,21 @@ export async function dispatchReplyFromConfig(params: {
     }
   }
 
+  // Broadcast inbound_claim to global plugin listeners (fixes #48434).
+  // Allows plugins like listen-only to observe all unbound inbound messages
+  // without requiring a conversation binding.
+  if (hookRunner?.hasHooks("inbound_claim")) {
+    const broadcastResult = await hookRunner.runInboundClaim(
+      inboundClaimEvent,
+      inboundClaimContext,
+    );
+    if (broadcastResult?.handled) {
+      markIdle("plugin_broadcast_claim");
+      recordProcessed("completed", { reason: "plugin-broadcast-handled" });
+      return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
+    }
+  }
+
   // Trigger plugin hooks (fire-and-forget)
   if (hookRunner?.hasHooks("message_received")) {
     fireAndForgetHook(


### PR DESCRIPTION
## Problem

`inbound_claim` currently only fires for plugin-bound conversations (via `runInboundClaimForPluginOutcome`). Plugins that register global handlers — e.g. listen-only observers, spam filters, rate limiters — are never invoked for unbound inbound events.

Reported in #48434.

## Change

After the `if (pluginOwnedBinding)` block in `dispatch-from-config.ts`, add a single broadcast call to `hookRunner.runInboundClaim()`. This iterates all registered global listeners regardless of conversation binding. If any listener returns `{ handled: true }`, dispatch stops early (same early-return pattern used for plugin-bound handling).

```
+  // Broadcast inbound_claim to global plugin listeners (fixes #48434).
+  if (hookRunner) {
+    const broadcastResult = await hookRunner.runInboundClaim(
+      inboundClaimEvent,
+      inboundClaimContext,
+    );
+    if (broadcastResult?.handled) {
+      markIdle("plugin_broadcast_claim");
+      recordProcessed("completed", { reason: "plugin-broadcast-handled" });
+      return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
+    }
+  }
```

## Why this is safe

- All supporting infrastructure (`runInboundClaim`, types, runners, event mappers, tests) already exists from PR #45318 — this is purely a missing call-site.
- Backward-compatible: plugins that don't register a global handler are unaffected. The existing plugin-bound flow runs first and is unchanged.
- No new dependencies.

## Testing

Existing tests in `dispatch-from-config.test.ts` and `wired-hooks-inbound-claim.test.ts` cover the runner. I've validated the broadcast path locally against the `openclaw-listen-only` plugin (https://github.com/flowolforg/openclaw-listen-only) on a Telegram group chat.

Closes #48434