### PR TITLE
fix(errors): include provider name in overload and rate-limit messages

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -828,11 +828,15 @@ export async function runAgentTurnWithFallback(params: {
         (isRateLimitErrorMessage(errorCandidate) || isOverloadedErrorMessage(errorCandidate))
       ) {
         const isOverloaded = isOverloadedErrorMessage(errorCandidate);
+        const trimmedProvider = fallbackProvider?.trim();
+        const providerLabel = trimmedProvider
+          ? `${trimmedProvider.charAt(0).toUpperCase()}${trimmedProvider.slice(1)} API`
+          : undefined;
         runResult.payloads = [
           {
             text: isOverloaded
-              ? "⚠️ The AI service is temporarily overloaded. Please try again in a moment."
-              : "⚠️ API rate limit reached — the model couldn't generate a response. Please try again in a moment.",
+              ? `⚠️ ${providerLabel ?? "The AI service"} is temporarily overloaded. Please try again in a moment.`
+              : `⚠️ ${providerLabel ?? "API"} rate limit reached — the model couldn't generate a response. Please try again in a moment.`,
             isError: true,
           },
         ];


### PR DESCRIPTION
## Summary

When the AI provider returns a 529 overload or 429 rate-limit error mid-turn, OpenClaw surfaced a generic message with no indication of which provider was the bottleneck.

- Derives a display label from  (the provider that actually ran) and injects it into the user-facing overload/rate-limit message.
- Falls back to the original generic text when no provider context is available (e.g. during startup before any run completes).

**Before**


**After**


Fixes #58871