### PR TITLE
CLI/plugins: stop forced-unsafe installs from falling back to hook packs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/native commands: keep Telegram command-sync cache process-local so gateway restarts re-register the menu instead of trusting stale on-disk sync state after Telegram cleared commands out-of-band. (#66730) Thanks @nightq.
 - Audio/self-hosted STT: restore `models.providers.*.request.allowPrivateNetwork` for audio transcription so private or LAN speech-to-text endpoints stop tripping SSRF blocks after the v2026.4.14 regression. (#66692) Thanks @jhsmith409.
 - QQBot/cron: guard against undefined `event.content` in `parseFaceTags` and `filterInternalMarkers` so cron-triggered agent turns with no content payload no longer crash with `TypeError: Cannot read properties of undefined (reading 'startsWith')`. (#66302) Thanks @xinmotlanthua.
+- CLI/plugins: stop `--dangerously-force-unsafe-install` plugin installs from falling back to hook-pack installs after security scan failures, while still preserving non-security fallback behavior for real hook packs. (#58909) Thanks @hxy91819.
 
 ## 2026.4.14
 
@@ -1043,7 +1044,6 @@ Docs: https://docs.openclaw.ai
 - Tools/web_search (Kimi): replay native Moonshot `$web_search` arguments verbatim, disable thinking for `kimi-k2.5`, and add Moonshot region/model setup prompts so bundled Kimi web search works again. (#59356) Thanks @Innocent-children.
 - Auth/OpenAI Codex: persist plugin-refreshed OAuth credentials to `auth-profiles.json` before returning them, so rotated Codex refresh tokens survive restart and stop falling into `refresh_token_reused` loops. (#53082)
 - Discord/gateway: hand reconnect ownership back to Carbon, keep runtime status aligned with close/reconnect state, and force-stop sockets that open without reaching READY so Discord monitors recover promptly instead of waiting on stale health timeouts. (#59019) Thanks @obviyus
-- CLI/plugins: stop `--dangerously-force-unsafe-install` plugin installs from falling back to hook-pack installs after security scan failures, while still preserving non-security fallback behavior for real hook packs. (#58909) Thanks @hxy91819.
 
 ## 2026.3.31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1041,6 +1041,9 @@ Docs: https://docs.openclaw.ai
 - ACPX/runtime: repair `queue owner unavailable` session recovery by replacing dead named sessions and resuming the backend session when ACPX exposes a stable session id, so the first ACP prompt no longer inherits a dead handle. (#58669) Thanks @neeravmakwana
 - ACPX/runtime: retry dead-session queue-owner repair without `--resume-session` when the reported ACPX session id is stale, so recovery still creates a fresh named session instead of failing session init. Thanks @obviyus.
 - Tools/web_search (Kimi): replay native Moonshot `$web_search` arguments verbatim, disable thinking for `kimi-k2.5`, and add Moonshot region/model setup prompts so bundled Kimi web search works again. (#59356) Thanks @Innocent-children.
+- Auth/OpenAI Codex: persist plugin-refreshed OAuth credentials to `auth-profiles.json` before returning them, so rotated Codex refresh tokens survive restart and stop falling into `refresh_token_reused` loops. (#53082)
+- Discord/gateway: hand reconnect ownership back to Carbon, keep runtime status aligned with close/reconnect state, and force-stop sockets that open without reaching READY so Discord monitors recover promptly instead of waiting on stale health timeouts. (#59019) Thanks @obviyus
+- CLI/plugins: stop `--dangerously-force-unsafe-install` plugin installs from falling back to hook-pack installs after security scan failures, while still preserving non-security fallback behavior for real hook packs. (#58909) Thanks @hxy91819.
 
 ## 2026.3.31
 

--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -252,6 +252,8 @@ vi.mock("./prompt.js", () => ({
 vi.mock("../plugins/install.js", () => ({
   PLUGIN_INSTALL_ERROR_CODE: {
     NPM_PACKAGE_NOT_FOUND: "npm_package_not_found",
+    SECURITY_SCAN_BLOCKED: "security_scan_blocked",
+    SECURITY_SCAN_FAILED: "security_scan_failed",
   },
   installPluginFromNpmSpec: ((
     ...args: Parameters<(typeof import("../plugins/install.js"))["installPluginFromNpmSpec"]>

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -11,6 +11,7 @@ import {
   enablePluginInConfig,
   installHooksFromPath,
   installHooksFromNpmSpec,
+  installHooksFromPath,
   installPluginFromClawHub,
   installPluginFromMarketplace,
   installPluginFromNpmSpec,
@@ -676,6 +677,235 @@ describe("plugins cli install", () => {
         mode: "update",
       }),
     );
+  });
+
+  it("passes the install logger to the --link dry-run probe", async () => {
+    const localPluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-link-plugin-"));
+    const cfg = {
+      plugins: {
+        entries: {},
+        load: {
+          paths: [],
+        },
+      },
+    } as OpenClawConfig;
+    const enabledCfg = createEnabledPluginConfig("demo");
+
+    loadConfig.mockReturnValue(cfg);
+    installPluginFromPath.mockImplementation(
+      async (params: {
+        logger?: { warn?: (message: string) => void };
+        path: string;
+        dryRun?: boolean;
+        dangerouslyForceUnsafeInstall?: boolean;
+      }) => {
+        params.logger?.warn?.(
+          'WARNING: Plugin "demo" forced despite dangerous code patterns via --dangerously-force-unsafe-install: index.js:1',
+        );
+        return {
+          ok: true,
+          pluginId: "demo",
+          targetDir: localPluginDir,
+          version: "1.0.0",
+          extensions: [],
+        };
+      },
+    );
+    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
+    recordPluginInstall.mockReturnValue(enabledCfg);
+    applyExclusiveSlotSelection.mockReturnValue({
+      config: enabledCfg,
+      warnings: [],
+    });
+
+    try {
+      await runPluginsCommand([
+        "plugins",
+        "install",
+        localPluginDir,
+        "--link",
+        "--dangerously-force-unsafe-install",
+      ]);
+    } finally {
+      fs.rmSync(localPluginDir, { recursive: true, force: true });
+    }
+
+    expect(installPluginFromPath).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: localPluginDir,
+        dryRun: true,
+        dangerouslyForceUnsafeInstall: true,
+        logger: expect.objectContaining({
+          info: expect.any(Function),
+          warn: expect.any(Function),
+        }),
+      }),
+    );
+    expect(
+      runtimeLogs.some((line) =>
+        line.includes(
+          "forced despite dangerous code patterns via --dangerously-force-unsafe-install",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not fall back to hook pack for local path when dangerous force unsafe install is set", async () => {
+    const localPluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-plugin-"));
+    const cfg = {} as OpenClawConfig;
+    const pluginInstallError = "plugin blocked by security scan";
+
+    loadConfig.mockReturnValue(cfg);
+    installPluginFromPath.mockResolvedValue({
+      ok: false,
+      error: pluginInstallError,
+      code: "security_scan_blocked",
+    });
+
+    try {
+      await expect(
+        runPluginsCommand([
+          "plugins",
+          "install",
+          localPluginDir,
+          "--dangerously-force-unsafe-install",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+    } finally {
+      fs.rmSync(localPluginDir, { recursive: true, force: true });
+    }
+
+    expect(installHooksFromPath).not.toHaveBeenCalled();
+    expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
+  });
+
+  it("does not fall back to hook pack for npm installs when dangerous force unsafe install is set", async () => {
+    const cfg = {} as OpenClawConfig;
+    const pluginInstallError = "plugin blocked by security scan";
+
+    loadConfig.mockReturnValue(cfg);
+    installPluginFromClawHub.mockResolvedValue({
+      ok: false,
+      error: "ClawHub /api/v1/packages/demo failed (404): Package not found",
+      code: "package_not_found",
+    });
+    installPluginFromNpmSpec.mockResolvedValue({
+      ok: false,
+      error: pluginInstallError,
+      code: "security_scan_blocked",
+    });
+
+    await expect(
+      runPluginsCommand(["plugins", "install", "demo", "--dangerously-force-unsafe-install"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(installHooksFromNpmSpec).not.toHaveBeenCalled();
+    expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
+  });
+
+  it("still falls back to local hook pack when dangerous force unsafe install is set for non-security errors", async () => {
+    const localHookDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-hook-pack-"));
+    const cfg = {} as OpenClawConfig;
+    const installedCfg = {
+      hooks: {
+        internal: {
+          installs: {
+            "demo-hooks": {
+              source: "path",
+              sourcePath: localHookDir,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    loadConfig.mockReturnValue(cfg);
+    installPluginFromPath.mockResolvedValue({
+      ok: false,
+      error: "package.json missing openclaw.plugin.json",
+      code: "missing_openclaw_extensions",
+    });
+    installHooksFromPath.mockResolvedValue({
+      ok: true,
+      hookPackId: "demo-hooks",
+      hooks: ["command-audit"],
+      targetDir: "/tmp/hooks/demo-hooks",
+      version: "1.2.3",
+    });
+    recordHookInstall.mockReturnValue(installedCfg);
+
+    try {
+      await runPluginsCommand([
+        "plugins",
+        "install",
+        localHookDir,
+        "--dangerously-force-unsafe-install",
+      ]);
+    } finally {
+      fs.rmSync(localHookDir, { recursive: true, force: true });
+    }
+
+    expect(installHooksFromPath).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: localHookDir,
+      }),
+    );
+    expect(runtimeLogs.some((line) => line.includes("Installed hook pack: demo-hooks"))).toBe(true);
+  });
+
+  it("still falls back to npm hook pack when dangerous force unsafe install is set for non-security errors", async () => {
+    const cfg = {} as OpenClawConfig;
+    const installedCfg = {
+      hooks: {
+        internal: {
+          installs: {
+            "demo-hooks": {
+              source: "npm",
+              spec: "@acme/demo-hooks@1.2.3",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    loadConfig.mockReturnValue(cfg);
+    installPluginFromClawHub.mockResolvedValue({
+      ok: false,
+      error: "ClawHub /api/v1/packages/@acme/demo-hooks failed (404): Package not found",
+      code: "package_not_found",
+    });
+    installPluginFromNpmSpec.mockResolvedValue({
+      ok: false,
+      error: "package.json missing openclaw.plugin.json",
+      code: "missing_openclaw_extensions",
+    });
+    installHooksFromNpmSpec.mockResolvedValue({
+      ok: true,
+      hookPackId: "demo-hooks",
+      hooks: ["command-audit"],
+      targetDir: "/tmp/hooks/demo-hooks",
+      version: "1.2.3",
+      npmResolution: {
+        name: "@acme/demo-hooks",
+        spec: "@acme/demo-hooks@1.2.3",
+        integrity: "sha256-demo",
+      },
+    });
+    recordHookInstall.mockReturnValue(installedCfg);
+
+    await runPluginsCommand([
+      "plugins",
+      "install",
+      "@acme/demo-hooks",
+      "--dangerously-force-unsafe-install",
+    ]);
+
+    expect(installHooksFromNpmSpec).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "@acme/demo-hooks",
+      }),
+    );
+    expect(runtimeLogs.some((line) => line.includes("Installed hook pack: demo-hooks"))).toBe(true);
   });
 
   it("does not fall back to npm when ClawHub rejects a real package", async () => {

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -779,6 +779,35 @@ describe("plugins cli install", () => {
     expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
   });
 
+  it("does not fall back to hook pack for local path when security scan fails under dangerous force unsafe install", async () => {
+    const localPluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-plugin-"));
+    const cfg = {} as OpenClawConfig;
+    const pluginInstallError = "plugin security scan failed";
+
+    loadConfig.mockReturnValue(cfg);
+    installPluginFromPath.mockResolvedValue({
+      ok: false,
+      error: pluginInstallError,
+      code: "security_scan_failed",
+    });
+
+    try {
+      await expect(
+        runPluginsCommand([
+          "plugins",
+          "install",
+          localPluginDir,
+          "--dangerously-force-unsafe-install",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+    } finally {
+      fs.rmSync(localPluginDir, { recursive: true, force: true });
+    }
+
+    expect(installHooksFromPath).not.toHaveBeenCalled();
+    expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
+  });
+
   it("does not fall back to hook pack for npm installs when dangerous force unsafe install is set", async () => {
     const cfg = {} as OpenClawConfig;
     const pluginInstallError = "plugin blocked by security scan";
@@ -793,6 +822,30 @@ describe("plugins cli install", () => {
       ok: false,
       error: pluginInstallError,
       code: "security_scan_blocked",
+    });
+
+    await expect(
+      runPluginsCommand(["plugins", "install", "demo", "--dangerously-force-unsafe-install"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(installHooksFromNpmSpec).not.toHaveBeenCalled();
+    expect(runtimeErrors.at(-1)).toContain(pluginInstallError);
+  });
+
+  it("does not fall back to hook pack for npm installs when security scan fails under dangerous force unsafe install", async () => {
+    const cfg = {} as OpenClawConfig;
+    const pluginInstallError = "plugin security scan failed";
+
+    loadConfig.mockReturnValue(cfg);
+    installPluginFromClawHub.mockResolvedValue({
+      ok: false,
+      error: "ClawHub /api/v1/packages/demo failed (404): Package not found",
+      code: "package_not_found",
+    });
+    installPluginFromNpmSpec.mockResolvedValue({
+      ok: false,
+      error: pluginInstallError,
+      code: "security_scan_failed",
     });
 
     await expect(

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -9,7 +9,6 @@ import {
   buildPluginDiagnosticsReport,
   clearPluginManifestRegistryCache,
   enablePluginInConfig,
-  installHooksFromPath,
   installHooksFromNpmSpec,
   installHooksFromPath,
   installPluginFromClawHub,
@@ -692,25 +691,26 @@ describe("plugins cli install", () => {
     const enabledCfg = createEnabledPluginConfig("demo");
 
     loadConfig.mockReturnValue(cfg);
-    installPluginFromPath.mockImplementation(
-      async (params: {
-        logger?: { warn?: (message: string) => void };
-        path: string;
-        dryRun?: boolean;
-        dangerouslyForceUnsafeInstall?: boolean;
-      }) => {
-        params.logger?.warn?.(
-          'WARNING: Plugin "demo" forced despite dangerous code patterns via --dangerously-force-unsafe-install: index.js:1',
-        );
-        return {
-          ok: true,
-          pluginId: "demo",
-          targetDir: localPluginDir,
-          version: "1.0.0",
-          extensions: [],
-        };
-      },
-    );
+    installPluginFromPath.mockImplementation(async (...args: unknown[]) => {
+      const [params] = args as [
+        {
+          logger?: { warn?: (message: string) => void };
+          path: string;
+          dryRun?: boolean;
+          dangerouslyForceUnsafeInstall?: boolean;
+        },
+      ];
+      params.logger?.warn?.(
+        'WARNING: Plugin "demo" forced despite dangerous code patterns via --dangerously-force-unsafe-install: index.js:1',
+      );
+      return {
+        ok: true,
+        pluginId: "demo",
+        targetDir: localPluginDir,
+        version: "1.0.0",
+        extensions: [],
+      };
+    });
     enablePluginInConfig.mockReturnValue({ config: enabledCfg });
     recordPluginInstall.mockReturnValue(enabledCfg);
     applyExclusiveSlotSelection.mockReturnValue({

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -9,7 +9,11 @@ import { extractErrorCode, formatErrorMessage } from "../infra/errors.js";
 import { type BundledPluginSource, findBundledPluginSource } from "../plugins/bundled-sources.js";
 import { formatClawHubSpecifier, installPluginFromClawHub } from "../plugins/clawhub.js";
 import type { InstallSafetyOverrides } from "../plugins/install-security-scan.js";
-import { installPluginFromNpmSpec, installPluginFromPath } from "../plugins/install.js";
+import {
+  PLUGIN_INSTALL_ERROR_CODE,
+  installPluginFromNpmSpec,
+  installPluginFromPath,
+} from "../plugins/install.js";
 import { clearPluginManifestRegistryCache } from "../plugins/manifest-registry.js";
 import {
   installPluginFromMarketplace,
@@ -191,6 +195,17 @@ async function tryInstallHookPackFromNpmSpec(params: {
   return { ok: true };
 }
 
+function shouldExitOnForcedUnsafeInstall(params: {
+  forceUnsafeInstall: boolean;
+  code?: string;
+}): boolean {
+  return (
+    params.forceUnsafeInstall &&
+    (params.code === PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED ||
+      params.code === PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_FAILED)
+  );
+}
+
 function isAllowedBundledRecoveryIssue(
   issue: { path?: string; message?: string },
   request: PluginInstallRequestContext,
@@ -345,6 +360,7 @@ export async function runPluginInstallCommand(params: {
   }
 
   const resolved = request.resolvedPath ?? request.normalizedSpec;
+  const forceUnsafeInstall = opts.dangerouslyForceUnsafeInstall === true;
 
   if (fs.existsSync(resolved)) {
     if (opts.link) {
@@ -352,10 +368,16 @@ export async function runPluginInstallCommand(params: {
       const merged = Array.from(new Set([...existing, resolved]));
       const probe = await installPluginFromPath({
         ...safetyOverrides,
+        mode: installMode,
         path: resolved,
         dryRun: true,
+        logger: createPluginInstallLogger(),
       });
       if (!probe.ok) {
+        if (shouldExitOnForcedUnsafeInstall({ forceUnsafeInstall, code: probe.code })) {
+          defaultRuntime.error(probe.error);
+          return defaultRuntime.exit(1);
+        }
         const hookFallback = await tryInstallHookPackFromLocalPath({
           config: cfg,
           installMode,
@@ -402,6 +424,10 @@ export async function runPluginInstallCommand(params: {
       logger: createPluginInstallLogger(),
     });
     if (!result.ok) {
+      if (shouldExitOnForcedUnsafeInstall({ forceUnsafeInstall, code: result.code })) {
+        defaultRuntime.error(result.error);
+        return defaultRuntime.exit(1);
+      }
       const hookFallback = await tryInstallHookPackFromLocalPath({
         config: cfg,
         installMode,
@@ -547,6 +573,10 @@ export async function runPluginInstallCommand(params: {
     logger: createPluginInstallLogger(),
   });
   if (!result.ok) {
+    if (shouldExitOnForcedUnsafeInstall({ forceUnsafeInstall, code: result.code })) {
+      defaultRuntime.error(result.error);
+      return defaultRuntime.exit(1);
+    }
     const bundledFallbackPlan = resolveBundledInstallPlanForNpmFailure({
       rawSpec: raw,
       code: result.code,


### PR DESCRIPTION
## Summary

- Problem: after #58879 fixed install-layer passthrough for `dangerouslyForceUnsafeInstall`, the CLI could still fall back to hook-pack installation when plugin install returned `SECURITY_SCAN_BLOCKED` or `SECURITY_SCAN_FAILED`.
- Why it matters: that made a security failure look like a generic package-shape failure and could surface a misleading `package.json missing openclaw.hooks` error instead of failing closed on the real security result.
- What changed: `src/cli/plugins-install-command.ts` now stops the install flow on those security result codes when `--dangerously-force-unsafe-install` is set, across local-path installs, `--link` probing, and npm-spec installs.
- What else changed: targeted regression coverage was added in `src/cli/plugins-cli.install.test.ts`, and the shared CLI test helper now recognizes the security result codes used by the new cases.
- Scope boundary: this PR does not change plugin security-scan policy, and it does not change the existing non-security hook-pack fallback behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #58723
- Related #58879
- Supersedes #58742
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the CLI treated `security_scan_blocked` and `security_scan_failed` like ordinary plugin-install failures and continued into hook-pack fallback instead of failing closed.
- Missing detection / guardrail: there was no CLI-level branch that distinguished security result codes from genuine “not a plugin, maybe a hook pack” failures.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #58879 fixed the install-layer passthrough bug for archive and npm-spec paths, but it did not change the CLI fallback path after those results came back.
- Why this regressed now: once security scan outcomes were propagated correctly, the older broad fallback path became visible and handled them too permissively.
- If unknown, what was ruled out: ruled out plugin security policy bugs and hook-pack installer bugs; the problem was the CLI branching after installer result propagation.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/plugins-cli.install.test.ts`
- Scenario the test should lock in: when plugin install returns `security_scan_blocked` or `security_scan_failed` for local-path or npm installs with `--dangerously-force-unsafe-install`, the command should surface the plugin error and must not call hook-pack fallback; non-security failures should still fall back.
- Why this is the smallest reliable guardrail: the behavior is CLI control flow around installer result codes, so command-level unit tests exercise the real decision point without requiring a live registry or end-to-end setup.
- Existing test that already covers this (if any): none before this PR covered the security-failure vs non-security-failure fallback split.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw plugins install <path-or-spec> --dangerously-force-unsafe-install` now stops on plugin security-scan blocked/failed results instead of falling through to hook-pack installation.
- Genuine non-security hook-pack fallback behavior is unchanged.
- `--link` probing now threads the install logger through the forced-unsafe path so warning output matches the full install path.

## Diagram (if applicable)

```text
Before:
[plugins install --dangerously-force-unsafe-install]
  -> [plugin install returns security_scan_blocked/security_scan_failed]
  -> [CLI falls back to hook-pack install]
  -> [misleading hook-pack error]

After:
[plugins install --dangerously-force-unsafe-install]
  -> [plugin install returns security_scan_blocked/security_scan_failed]
  -> [CLI exits with the plugin security error]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this narrows the CLI install path by preventing hook-pack fallback after security-scan failures. Mitigation is explicit result-code gating plus regression tests that preserve the intended non-security fallback path.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): none required; exercised via CLI tests

### Steps

1. Run `pnpm test -- src/cli/plugins-cli.install.test.ts`.
2. Verify local-path and npm `--dangerously-force-unsafe-install` security-failure cases do not call hook-pack fallback.
3. Verify non-security plugin install failures still fall back when appropriate.
4. Run `pnpm check`.

### Expected

- Security-scan blocked/failed plugin installs fail closed and do not continue into hook-pack fallback.
- Non-security plugin install failures still fall back when appropriate.

### Actual

- After this change, the CLI follows the expected fail-closed behavior for security failures while preserving the existing non-security fallback path.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted test run:
```text
Test Files  1 passed (1)
Tests      18 passed (18)
```

Repo checks:
```text
pnpm check
-> success
```

## Human Verification (required)

- Verified scenarios: ran `pnpm test -- src/cli/plugins-cli.install.test.ts` and `pnpm check`; inspected the CLI control flow for local-path, `--link`, and npm install branches.
- Edge cases checked: security-scan blocked local-path installs do not fall back; security-scan failed local-path installs do not fall back; security-scan blocked npm installs do not fall back; security-scan failed npm installs do not fall back; non-security failures still fall back; `--link` probing receives the install logger on the forced-unsafe path.
- What you did **not** verify: a committed repository end-to-end test or shipped remote regression harness in this PR. Any out-of-tree remote smoke verification is tracked separately in PR comments.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: future security-related plugin install result codes could be added without being included in the fail-closed guard.
  - Mitigation: the guard is centralized and the regression tests lock in the intended branching behavior for the current result codes.
- Risk: users who previously saw hook-pack fallback after a security failure will now get an earlier hard failure.
  - Mitigation: that stricter behavior is intentional, aligns with the security model, and non-security fallback behavior remains covered by tests.
