### PR TITLE
fix: ignore dotted backup plugin directories during discovery

### DIFF
--- a/src/plugins/discovery.test.ts
+++ b/src/plugins/discovery.test.ts
@@ -135,6 +135,10 @@ describe("discoverOpenClawPlugins", () => {
     mkdirSafe(backupDir);
     fs.writeFileSync(path.join(backupDir, "index.ts"), "export default function () {}", "utf-8");
 
+    const backupDotDir = path.join(globalExt, "openclaw-codex-app-server.backup.20260401-113050");
+    mkdirSafe(backupDotDir);
+    fs.writeFileSync(path.join(backupDotDir, "index.ts"), "export default function () {}", "utf-8");
+
     const disabledDir = path.join(globalExt, "telegram.disabled.20260222");
     mkdirSafe(disabledDir);
     fs.writeFileSync(path.join(disabledDir, "index.ts"), "export default function () {}", "utf-8");
@@ -152,6 +156,7 @@ describe("discoverOpenClawPlugins", () => {
     const ids = candidates.map((candidate) => candidate.idHint);
     expect(ids).toContain("live");
     expect(ids).not.toContain("feishu.backup-20260222");
+    expect(ids).not.toContain("openclaw-codex-app-server.backup.20260401-113050");
     expect(ids).not.toContain("telegram.disabled.20260222");
     expect(ids).not.toContain("discord.bak");
   });

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -299,7 +299,7 @@ function shouldIgnoreScannedDirectory(dirName: string): boolean {
   if (normalized.endsWith(".bak")) {
     return true;
   }
-  if (normalized.includes(".backup-")) {
+  if (normalized.includes(".backup-") || normalized.includes(".backup.")) {
     return true;
   }
   if (normalized.includes(".disabled")) {


### PR DESCRIPTION
## Summary
Ignore extension directories like:
- `plugin.backup-20260222`
- `plugin.backup.20260401-113050`

when auto-discovering plugins.

## Why
During a real cockpit recovery, I created a runtime backup directory named like:

`openclaw-codex-app-server.backup.20260401-113050`

OpenClaw scanned that directory as another plugin root, detected the same plugin id again, and produced a confusing duplicate-plugin situation during diagnosis/reload.

The current ignore logic already skips:
- `*.bak`
- `*.backup-*`
- `*.disabled*`

but it does **not** skip the dotted timestamp style `*.backup.*`, which is a very natural backup naming pattern.

## Change
- extend `shouldIgnoreScannedDirectory()` to also ignore names containing `.backup.`
- add a regression test covering `openclaw-codex-app-server.backup.20260401-113050`

## Verification
```bash
npx vitest run src/plugins/discovery.test.ts
```

Passed locally: 26/26 tests.
