### PR TITLE
Channels: add human takeover cooldown and docs

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -267,6 +267,25 @@ Now create some channels on your Discord server and start chatting. Your agent c
 - Group DMs are ignored by default (`channels.discord.dm.groupEnabled=false`).
 - Native slash commands run in isolated command sessions (`agent:<agentId>:discord:slash:<userId>`), while still carrying `CommandTargetSessionKey` to the routed conversation session.
 
+## Human takeover cooldown
+
+Enable owner-triggered cooldown so manual owner messages temporarily pause auto-replies in the same session:
+
+```json5
+{
+  channels: {
+    discord: {
+      humanTakeover: {
+        enabled: true,
+        cooldownSeconds: 300,
+      },
+    },
+  },
+}
+```
+
+Owner detection follows configured owner allowlist (`channels.discord.allowFrom` / `channels.discord.dm.allowFrom`).
+
 ## Forum channels
 
 Discord forum and media channels only accept thread posts. OpenClaw supports two ways to create them:

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -121,6 +121,23 @@ Token resolution order is account-aware. In practice, config values win over env
 
     For one-owner bots, prefer `dmPolicy: "allowlist"` with explicit numeric `allowFrom` IDs to keep access policy durable in config (instead of depending on previous pairing approvals).
 
+    Human takeover (owner cooldown):
+
+    ```json5
+    {
+      channels: {
+        telegram: {
+          humanTakeover: {
+            enabled: true,
+            cooldownSeconds: 300,
+          },
+        },
+      },
+    }
+    ```
+
+    When enabled, owner messages trigger a temporary cooldown window where auto-replies are skipped for the same conversation session.
+
     ### Finding your Telegram user ID
 
     Safer (no third-party bot):

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -167,6 +167,23 @@ OpenClaw recommends running WhatsApp on a separate number when possible. (The ch
     - if no allowlist is configured, the linked self number is allowed by default
     - outbound `fromMe` DMs are never auto-paired
 
+    Human takeover (owner cooldown):
+
+    ```json5
+    {
+      channels: {
+        whatsapp: {
+          humanTakeover: {
+            enabled: true,
+            cooldownSeconds: 300,
+          },
+        },
+      },
+    }
+    ```
+
+    When enabled, owner/manual outbound messages trigger a temporary cooldown where auto-replies are skipped for the same session.
+
   </Tab>
 
   <Tab title="Group policy + allowlists">

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -44,7 +44,11 @@ import { resolveDiscordDraftStreamingChunking } from "../draft-chunking.js";
 import { createDiscordDraftStream } from "../draft-stream.js";
 import { reactMessageDiscord, removeReactionDiscord } from "../send.js";
 import { editMessageDiscord } from "../send.messages.js";
-import { allowListMatches, normalizeDiscordAllowList, normalizeDiscordSlug } from "./allow-list.js";
+import {
+  normalizeDiscordAllowList,
+  normalizeDiscordSlug,
+  resolveDiscordAllowListMatch,
+} from "./allow-list.js";
 import { resolveTimestampMs } from "./format.js";
 import { buildDiscordInboundAccessContext } from "./inbound-context.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
@@ -139,24 +143,26 @@ export async function processDiscordMessage(
     channelConfig: cfg.channels?.discord,
     accountConfig: discordConfig,
   });
+  // Human takeover owner detection follows account-level owner config only.
+  // Guild/channel allowlists are for access control and are not treated as owner identity.
   const ownerAllowRaw = discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom;
   const ownerAllowList = normalizeDiscordAllowList(ownerAllowRaw, ["discord:", "user:", "pk:"]);
-  const takeoverDecision = decideHumanTakeover({
-    sessionKey: boundSessionKey ?? baseSessionKey,
-    enabled: humanTakeover.enabled,
-    cooldownMs: humanTakeover.cooldownMs,
-    isOwnerMessage: Boolean(
-      ownerAllowList &&
-      allowListMatches(
-        ownerAllowList,
-        {
+  const ownerMatch = ownerAllowList
+    ? resolveDiscordAllowListMatch({
+        allowList: ownerAllowList,
+        candidate: {
           id: sender.id,
           name: sender.name,
           tag: sender.tag,
         },
-        { allowNameMatching: isDangerousNameMatchingEnabled(discordConfig ?? {}) },
-      ),
-    ),
+        allowNameMatching: isDangerousNameMatchingEnabled(discordConfig ?? {}),
+      })
+    : { allowed: false };
+  const takeoverDecision = decideHumanTakeover({
+    sessionKey: boundSessionKey ?? baseSessionKey,
+    enabled: humanTakeover.enabled,
+    cooldownMs: humanTakeover.cooldownMs,
+    isOwnerMessage: ownerMatch.allowed && ownerMatch.matchSource !== "wildcard",
     isCommandLike: Boolean((baseText ?? messageText ?? "").trim().startsWith("/")),
   });
   if (takeoverDecision.skipAutoReply) {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -10,7 +10,9 @@ import {
   type StatusReactionAdapter,
 } from "openclaw/plugin-sdk/channel-feedback";
 import {
+  decideHumanTakeover,
   formatInboundEnvelope,
+  resolveHumanTakeoverConfig,
   resolveEnvelopeFormatOptions,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
@@ -42,7 +44,7 @@ import { resolveDiscordDraftStreamingChunking } from "../draft-chunking.js";
 import { createDiscordDraftStream } from "../draft-stream.js";
 import { reactMessageDiscord, removeReactionDiscord } from "../send.js";
 import { editMessageDiscord } from "../send.messages.js";
-import { normalizeDiscordSlug } from "./allow-list.js";
+import { allowListMatches, normalizeDiscordAllowList, normalizeDiscordSlug } from "./allow-list.js";
 import { resolveTimestampMs } from "./format.js";
 import { buildDiscordInboundAccessContext } from "./inbound-context.js";
 import type { DiscordMessagePreflightContext } from "./message-handler.preflight.js";
@@ -130,6 +132,43 @@ export async function processDiscordMessage(
     abortSignal,
   } = ctx;
   if (isProcessAborted(abortSignal)) {
+    return;
+  }
+
+  const humanTakeover = resolveHumanTakeoverConfig({
+    channelConfig: cfg.channels?.discord,
+    accountConfig: discordConfig,
+  });
+  const ownerAllowRaw = discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom;
+  const ownerAllowList = normalizeDiscordAllowList(ownerAllowRaw, ["discord:", "user:", "pk:"]);
+  const takeoverDecision = decideHumanTakeover({
+    sessionKey: boundSessionKey ?? baseSessionKey,
+    enabled: humanTakeover.enabled,
+    cooldownMs: humanTakeover.cooldownMs,
+    isOwnerMessage: Boolean(
+      ownerAllowList &&
+      allowListMatches(
+        ownerAllowList,
+        {
+          id: sender.id,
+          name: sender.name,
+          tag: sender.tag,
+        },
+        { allowNameMatching: isDangerousNameMatchingEnabled(discordConfig ?? {}) },
+      ),
+    ),
+    isCommandLike: Boolean((baseText ?? messageText ?? "").trim().startsWith("/")),
+  });
+  if (takeoverDecision.skipAutoReply) {
+    if (takeoverDecision.reason === "owner-message") {
+      logVerbose(
+        `discord: skipping auto-reply; human takeover activated (${Math.ceil((takeoverDecision.remainingMs ?? 0) / 1000)}s)`,
+      );
+    } else {
+      logVerbose(
+        `discord: skipping auto-reply; human takeover cooldown active (${Math.ceil((takeoverDecision.remainingMs ?? 0) / 1000)}s left)`,
+      );
+    }
     return;
   }
 

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -5,7 +5,9 @@ import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-h
 import { shouldDebounceTextInbound } from "openclaw/plugin-sdk/channel-inbound";
 import {
   createInboundDebouncer,
+  decideHumanTakeover,
   resolveInboundDebounceMs,
+  resolveHumanTakeoverConfig,
 } from "openclaw/plugin-sdk/channel-inbound";
 import {
   buildCommandsMessagePaginated,
@@ -145,6 +147,15 @@ export const registerTelegramHandlers = ({
   let textFragmentProcessing: Promise<void> = Promise.resolve();
 
   const debounceMs = resolveInboundDebounceMs({ cfg, channel: "telegram" });
+  const humanTakeover = resolveHumanTakeoverConfig({
+    channelConfig: cfg.channels?.telegram,
+    accountConfig: telegramCfg,
+  });
+  const ownerAllowFrom = normalizeDmAllowFromWithStore({
+    allowFrom,
+    storeAllowFrom: [],
+    dmPolicy: "allowlist",
+  });
   const FORWARD_BURST_DEBOUNCE_MS = 80;
   type TelegramDebounceLane = "default" | "forward";
   type TelegramDebounceEntry = {
@@ -1069,9 +1080,29 @@ export const registerTelegramHandlers = ({
         ]
       : [];
     const senderId = msg.from?.id ? String(msg.from.id) : "";
+    const senderUsername = msg.from?.username ?? "";
     const conversationThreadId = resolvedThreadId ?? dmThreadId;
     const conversationKey =
       conversationThreadId != null ? `${chatId}:topic:${conversationThreadId}` : String(chatId);
+    const takeoverDecision = decideHumanTakeover({
+      sessionKey: `telegram:${accountId ?? "default"}:${conversationKey}`,
+      enabled: humanTakeover.enabled,
+      cooldownMs: humanTakeover.cooldownMs,
+      isOwnerMessage: isSenderAllowed({ allow: ownerAllowFrom, senderId, senderUsername }),
+      isCommandLike: Boolean((msg.text ?? msg.caption ?? "").trim().startsWith("/")),
+    });
+    if (takeoverDecision.skipAutoReply) {
+      if (takeoverDecision.reason === "owner-message") {
+        logVerbose(
+          `Skipping telegram auto-reply: human takeover activated for ${conversationKey} (${Math.ceil((takeoverDecision.remainingMs ?? 0) / 1000)}s)`,
+        );
+      } else {
+        logVerbose(
+          `Skipping telegram auto-reply: human takeover cooldown active for ${conversationKey} (${Math.ceil((takeoverDecision.remainingMs ?? 0) / 1000)}s left)`,
+        );
+      }
+      return;
+    }
     const debounceLane = resolveTelegramDebounceLane(msg);
     const debounceKey = senderId
       ? `telegram:${accountId ?? "default"}:${conversationKey}:${senderId}:${debounceLane}`

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -42,6 +42,7 @@ import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
   isSenderAllowed,
   normalizeDmAllowFromWithStore,
+  resolveSenderAllowMatch,
   type NormalizedAllowFrom,
 } from "./bot-access.js";
 import { defaultTelegramBotDeps } from "./bot-deps.js";
@@ -1082,13 +1083,31 @@ export const registerTelegramHandlers = ({
     const senderId = msg.from?.id ? String(msg.from.id) : "";
     const senderUsername = msg.from?.username ?? "";
     const isDirectChat = msg.chat.type === "private";
-    const isLinkedOwnerSender = isSenderAllowed({
+    const ownerSenderMatch = resolveSenderAllowMatch({
       allow: ownerAllowFrom,
       senderId,
       senderUsername,
     });
+    const isLinkedOwnerSender =
+      ownerSenderMatch.allowed && ownerSenderMatch.matchSource !== "wildcard";
     const isOwnerDirectChat = isLinkedOwnerSender && isDirectChat;
     const shouldTriggerTakeover = isLinkedOwnerSender && !isDirectChat;
+    const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
+    const isForum = await resolveTelegramForumFlag({
+      chatId,
+      chatType: msg.chat.type,
+      isGroup,
+      isForum: msg.chat.is_forum,
+      getChat,
+    });
+    const takeoverSession = resolveTelegramSessionState({
+      chatId,
+      isGroup,
+      isForum,
+      messageThreadId: msg.message_thread_id,
+      resolvedThreadId,
+      senderId,
+    });
     const conversationThreadId = resolvedThreadId ?? dmThreadId;
     const conversationKey =
       conversationThreadId != null ? `${chatId}:topic:${conversationThreadId}` : String(chatId);
@@ -1098,7 +1117,7 @@ export const registerTelegramHandlers = ({
       );
     }
     const takeoverDecision = decideHumanTakeover({
-      sessionKey: `telegram:${accountId ?? "default"}:${conversationKey}`,
+      sessionKey: takeoverSession.sessionKey,
       enabled: humanTakeover.enabled,
       cooldownMs: humanTakeover.cooldownMs,
       isOwnerMessage: shouldTriggerTakeover,

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1081,16 +1081,34 @@ export const registerTelegramHandlers = ({
       : [];
     const senderId = msg.from?.id ? String(msg.from.id) : "";
     const senderUsername = msg.from?.username ?? "";
+    const isDirectChat = msg.chat.type === "private";
+    const isLinkedOwnerSender = isSenderAllowed({
+      allow: ownerAllowFrom,
+      senderId,
+      senderUsername,
+    });
+    const isOwnerDirectChat = isLinkedOwnerSender && isDirectChat;
+    const shouldTriggerTakeover = isLinkedOwnerSender && !isDirectChat;
     const conversationThreadId = resolvedThreadId ?? dmThreadId;
     const conversationKey =
       conversationThreadId != null ? `${chatId}:topic:${conversationThreadId}` : String(chatId);
+    if (humanTakeover.enabled) {
+      logVerbose(
+        `telegram human takeover check session=${conversationKey} chatType=${msg.chat.type} sender=${senderId || "unknown"} ownerSender=${String(isLinkedOwnerSender)} ownerDirectChat=${String(isOwnerDirectChat)} trigger=${String(shouldTriggerTakeover)}`,
+      );
+    }
     const takeoverDecision = decideHumanTakeover({
       sessionKey: `telegram:${accountId ?? "default"}:${conversationKey}`,
       enabled: humanTakeover.enabled,
       cooldownMs: humanTakeover.cooldownMs,
-      isOwnerMessage: isSenderAllowed({ allow: ownerAllowFrom, senderId, senderUsername }),
+      isOwnerMessage: shouldTriggerTakeover,
       isCommandLike: Boolean((msg.text ?? msg.caption ?? "").trim().startsWith("/")),
     });
+    if (humanTakeover.enabled) {
+      logVerbose(
+        `telegram human takeover decision session=${conversationKey} ownerMessage=${String(shouldTriggerTakeover)} skip=${String(takeoverDecision.skipAutoReply)} reason=${takeoverDecision.reason ?? "none"} remainingMs=${String(takeoverDecision.remainingMs ?? 0)}`,
+      );
+    }
     if (takeoverDecision.skipAutoReply) {
       if (takeoverDecision.reason === "owner-message") {
         logVerbose(

--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -24,6 +24,7 @@ export type ResolvedWhatsAppAccount = {
   isLegacyAuthDir: boolean;
   selfChatMode?: boolean;
   allowFrom?: string[];
+  humanTakeover?: WhatsAppAccountConfig["humanTakeover"];
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
   dmPolicy?: DmPolicy;
@@ -148,6 +149,7 @@ export function resolveWhatsAppAccount(params: {
     selfChatMode: merged.selfChatMode,
     dmPolicy: merged.dmPolicy,
     allowFrom: merged.allowFrom,
+    humanTakeover: merged.humanTakeover,
     groupAllowFrom: merged.groupAllowFrom,
     groupPolicy: merged.groupPolicy,
     textChunkLimit: merged.textChunkLimit,

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -219,6 +219,11 @@ export async function processMessage(params: {
   }
 
   const sender = getSenderIdentity(params.msg);
+  const self = getSelfIdentity(params.msg);
+  const normalizedSelfE164 = self.e164 ? normalizeE164(self.e164) : null;
+  const isDirectSelfChat =
+    params.msg.chatType !== "group" &&
+    Boolean(normalizedSelfE164 && sender.e164 && normalizeE164(sender.e164) === normalizedSelfE164);
   const normalizedOwnerAllowFrom = new Set(
     (account.allowFrom ?? [])
       .map((entry) => normalizeE164(String(entry)))
@@ -226,11 +231,17 @@ export async function processMessage(params: {
   );
   const senderE164 = sender.e164 ? normalizeE164(sender.e164) : null;
   const ownerTriggeredTakeover =
-    Boolean(params.msg.fromMe) || Boolean(senderE164 && normalizedOwnerAllowFrom.has(senderE164));
+    !isDirectSelfChat &&
+    (Boolean(params.msg.fromMe) || Boolean(senderE164 && normalizedOwnerAllowFrom.has(senderE164)));
   const humanTakeover = resolveHumanTakeoverConfig({
     channelConfig: params.cfg.channels?.whatsapp,
     accountConfig: account,
   });
+  if (humanTakeover.enabled && shouldLogVerbose()) {
+    logVerbose(
+      `WhatsApp human takeover check session=${params.route.sessionKey} fromMe=${String(Boolean(params.msg.fromMe))} isDirectSelfChat=${String(isDirectSelfChat)} sender=${senderE164 ?? "unknown"} ownerAllowlisted=${String(Boolean(senderE164 && normalizedOwnerAllowFrom.has(senderE164)))}`,
+    );
+  }
   const takeoverDecision = decideHumanTakeover({
     sessionKey: params.route.sessionKey,
     enabled: humanTakeover.enabled,
@@ -238,6 +249,11 @@ export async function processMessage(params: {
     isOwnerMessage: ownerTriggeredTakeover,
     isCommandLike: params.msg.body.trim().startsWith("/"),
   });
+  if (humanTakeover.enabled && shouldLogVerbose()) {
+    logVerbose(
+      `WhatsApp human takeover decision session=${params.route.sessionKey} ownerMessage=${String(ownerTriggeredTakeover)} skip=${String(takeoverDecision.skipAutoReply)} reason=${takeoverDecision.reason ?? "none"} remainingMs=${String(takeoverDecision.remainingMs ?? 0)}`,
+    );
+  }
   if (takeoverDecision.skipAutoReply) {
     if (takeoverDecision.reason === "owner-message") {
       logVerbose(
@@ -287,7 +303,6 @@ export async function processMessage(params: {
     whatsappInboundLog.debug(`Inbound body: ${elide(combinedBody, 400)}`);
   }
 
-  const self = getSelfIdentity(params.msg);
   const replyTo = getReplyContext(params.msg);
   const dmRouteTarget =
     params.msg.chatType !== "group"

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -242,12 +242,16 @@ export async function processMessage(params: {
       `WhatsApp human takeover check session=${params.route.sessionKey} fromMe=${String(Boolean(params.msg.fromMe))} isDirectSelfChat=${String(isDirectSelfChat)} sender=${senderE164 ?? "unknown"} ownerAllowlisted=${String(Boolean(senderE164 && normalizedOwnerAllowFrom.has(senderE164)))}`,
     );
   }
+  const messageLooksCommandLike = params.msg.body.trim().startsWith("/");
+  // fromMe DM events can pass inbound access control when takeover is enabled.
+  // Treat owner-authored slash messages as manual intervention, not inbound commands.
+  const commandLikeForTakeover = messageLooksCommandLike && !Boolean(params.msg.fromMe);
   const takeoverDecision = decideHumanTakeover({
     sessionKey: params.route.sessionKey,
     enabled: humanTakeover.enabled,
     cooldownMs: humanTakeover.cooldownMs,
     isOwnerMessage: ownerTriggeredTakeover,
-    isCommandLike: params.msg.body.trim().startsWith("/"),
+    isCommandLike: commandLikeForTakeover,
   });
   if (humanTakeover.enabled && shouldLogVerbose()) {
     logVerbose(

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -1,5 +1,7 @@
 import { resolveIdentityNamePrefix } from "openclaw/plugin-sdk/agent-runtime";
 import {
+  decideHumanTakeover,
+  resolveHumanTakeoverConfig,
   resolveInboundSessionEnvelopeContext,
   toLocationContext,
 } from "openclaw/plugin-sdk/channel-inbound";
@@ -158,6 +160,10 @@ export async function processMessage(params: {
   groupHistory?: GroupHistoryEntry[];
   suppressGroupHistoryClear?: boolean;
 }) {
+  const account = resolveWhatsAppAccount({
+    cfg: params.cfg,
+    accountId: params.msg.accountId,
+  });
   const conversationId = params.msg.conversationId ?? params.msg.from;
   const { storePath, envelopeOptions, previousTimestamp } = resolveInboundSessionEnvelopeContext({
     cfg: params.cfg,
@@ -212,6 +218,39 @@ export async function processMessage(params: {
     return false;
   }
 
+  const sender = getSenderIdentity(params.msg);
+  const normalizedOwnerAllowFrom = new Set(
+    (account.allowFrom ?? [])
+      .map((entry) => normalizeE164(String(entry)))
+      .filter((entry): entry is string => Boolean(entry)),
+  );
+  const senderE164 = sender.e164 ? normalizeE164(sender.e164) : null;
+  const ownerTriggeredTakeover =
+    Boolean(params.msg.fromMe) || Boolean(senderE164 && normalizedOwnerAllowFrom.has(senderE164));
+  const humanTakeover = resolveHumanTakeoverConfig({
+    channelConfig: params.cfg.channels?.whatsapp,
+    accountConfig: account,
+  });
+  const takeoverDecision = decideHumanTakeover({
+    sessionKey: params.route.sessionKey,
+    enabled: humanTakeover.enabled,
+    cooldownMs: humanTakeover.cooldownMs,
+    isOwnerMessage: ownerTriggeredTakeover,
+    isCommandLike: params.msg.body.trim().startsWith("/"),
+  });
+  if (takeoverDecision.skipAutoReply) {
+    if (takeoverDecision.reason === "owner-message") {
+      logVerbose(
+        `Skipping auto-reply: human takeover activated for ${params.route.sessionKey} (${Math.ceil((takeoverDecision.remainingMs ?? 0) / 1000)}s)`,
+      );
+    } else {
+      logVerbose(
+        `Skipping auto-reply: human takeover cooldown active for ${params.route.sessionKey} (${Math.ceil((takeoverDecision.remainingMs ?? 0) / 1000)}s left)`,
+      );
+    }
+    return false;
+  }
+
   // Send ack reaction immediately upon message receipt (post-gating)
   maybeSendAckReaction({
     cfg: params.cfg,
@@ -248,7 +287,6 @@ export async function processMessage(params: {
     whatsappInboundLog.debug(`Inbound body: ${elide(combinedBody, 400)}`);
   }
 
-  const sender = getSenderIdentity(params.msg);
   const self = getSelfIdentity(params.msg);
   const replyTo = getReplyContext(params.msg);
   const dmRouteTarget =

--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -149,9 +149,21 @@ export async function checkInboundAccessControl(params: {
   // DM access control (secure defaults): "pairing" (default) / "allowlist" / "open" / "disabled".
   if (!params.group) {
     if (params.isFromMe && !isSamePhone) {
-      logVerbose("Skipping outbound DM (fromMe); no pairing reply needed.");
+      const humanTakeoverEnabled = account.humanTakeover?.enabled === true;
+      if (!humanTakeoverEnabled) {
+        logVerbose("Skipping outbound DM (fromMe); no pairing reply needed.");
+        return {
+          allowed: false,
+          shouldMarkRead: false,
+          isSelfChat,
+          resolvedAccountId: account.accountId,
+        };
+      }
+      logVerbose(
+        "Allowing outbound DM (fromMe) through inbound pipeline to activate human takeover cooldown.",
+      );
       return {
-        allowed: false,
+        allowed: true,
         shouldMarkRead: false,
         isSelfChat,
         resolvedAccountId: account.accountId,

--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -72,7 +72,9 @@ export async function checkInboundAccessControl(params: {
   const dmAllowFrom = configuredAllowFrom.length > 0 ? configuredAllowFrom : defaultAllowFrom;
   const groupAllowFrom =
     account.groupAllowFrom ?? (configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined);
-  const isSamePhone = params.from === params.selfE164;
+  const normalizedFrom = normalizeE164(params.from);
+  const normalizedSelf = params.selfE164 ? normalizeE164(params.selfE164) : null;
+  const isSamePhone = Boolean(normalizedSelf && normalizedFrom === normalizedSelf);
   const isSelfChat = account.selfChatMode ?? isSelfChatMode(params.selfE164, configuredAllowFrom);
   const pairingGraceMs =
     typeof params.pairingGraceMs === "number" && params.pairingGraceMs > 0

--- a/src/channels/human-takeover.test.ts
+++ b/src/channels/human-takeover.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  decideHumanTakeover,
+  resetHumanTakeoverState,
+  resolveHumanTakeoverConfig,
+} from "./human-takeover.js";
+
+describe("human takeover", () => {
+  afterEach(() => {
+    resetHumanTakeoverState();
+  });
+
+  it("resolves disabled by default", () => {
+    expect(resolveHumanTakeoverConfig({})).toEqual({
+      enabled: false,
+      cooldownMs: 300_000,
+    });
+  });
+
+  it("activates cooldown on owner non-command message", () => {
+    const decision = decideHumanTakeover({
+      sessionKey: "session-a",
+      enabled: true,
+      cooldownMs: 60_000,
+      isOwnerMessage: true,
+      nowMs: 1_000,
+    });
+    expect(decision.skipAutoReply).toBe(true);
+    expect(decision.activated).toBe(true);
+
+    const activeDecision = decideHumanTakeover({
+      sessionKey: "session-a",
+      enabled: true,
+      cooldownMs: 60_000,
+      isOwnerMessage: false,
+      nowMs: 10_000,
+    });
+    expect(activeDecision.skipAutoReply).toBe(true);
+    expect(activeDecision.reason).toBe("cooldown-active");
+  });
+
+  it("does not activate on owner command messages", () => {
+    const decision = decideHumanTakeover({
+      sessionKey: "session-b",
+      enabled: true,
+      cooldownMs: 60_000,
+      isOwnerMessage: true,
+      isCommandLike: true,
+      nowMs: 1_000,
+    });
+    expect(decision.skipAutoReply).toBe(false);
+
+    const followUp = decideHumanTakeover({
+      sessionKey: "session-b",
+      enabled: true,
+      cooldownMs: 60_000,
+      isOwnerMessage: false,
+      nowMs: 2_000,
+    });
+    expect(followUp.skipAutoReply).toBe(false);
+  });
+});

--- a/src/channels/human-takeover.test.ts
+++ b/src/channels/human-takeover.test.ts
@@ -59,4 +59,83 @@ describe("human takeover", () => {
     });
     expect(followUp.skipAutoReply).toBe(false);
   });
+
+  it("expires cooldown after active window", () => {
+    decideHumanTakeover({
+      sessionKey: "session-expire",
+      enabled: true,
+      cooldownMs: 10_000,
+      isOwnerMessage: true,
+      nowMs: 1_000,
+    });
+
+    const afterExpiry = decideHumanTakeover({
+      sessionKey: "session-expire",
+      enabled: true,
+      cooldownMs: 10_000,
+      isOwnerMessage: false,
+      nowMs: 11_001,
+    });
+
+    expect(afterExpiry.skipAutoReply).toBe(false);
+    expect(afterExpiry.activated).toBe(false);
+  });
+
+  it("extends cooldown when owner sends another message", () => {
+    decideHumanTakeover({
+      sessionKey: "session-extend",
+      enabled: true,
+      cooldownMs: 10_000,
+      isOwnerMessage: true,
+      nowMs: 1_000,
+    });
+
+    decideHumanTakeover({
+      sessionKey: "session-extend",
+      enabled: true,
+      cooldownMs: 10_000,
+      isOwnerMessage: true,
+      nowMs: 9_000,
+    });
+
+    const stillActive = decideHumanTakeover({
+      sessionKey: "session-extend",
+      enabled: true,
+      cooldownMs: 10_000,
+      isOwnerMessage: false,
+      nowMs: 15_000,
+    });
+    expect(stillActive.skipAutoReply).toBe(true);
+    expect(stillActive.reason).toBe("cooldown-active");
+
+    const expiredAfterExtension = decideHumanTakeover({
+      sessionKey: "session-extend",
+      enabled: true,
+      cooldownMs: 10_000,
+      isOwnerMessage: false,
+      nowMs: 19_001,
+    });
+    expect(expiredAfterExtension.skipAutoReply).toBe(false);
+  });
+
+  it("keeps cooldown state isolated per session", () => {
+    decideHumanTakeover({
+      sessionKey: "session-a",
+      enabled: true,
+      cooldownMs: 60_000,
+      isOwnerMessage: true,
+      nowMs: 1_000,
+    });
+
+    const otherSession = decideHumanTakeover({
+      sessionKey: "session-b",
+      enabled: true,
+      cooldownMs: 60_000,
+      isOwnerMessage: false,
+      nowMs: 2_000,
+    });
+
+    expect(otherSession.skipAutoReply).toBe(false);
+    expect(otherSession.activated).toBe(false);
+  });
 });

--- a/src/channels/human-takeover.ts
+++ b/src/channels/human-takeover.ts
@@ -79,7 +79,6 @@ export function decideHumanTakeover(params: {
     }
     const nextActiveUntil = nowMs + params.cooldownMs;
     humanTakeoverCooldownBySession.set(params.sessionKey, nextActiveUntil);
-    pruneHumanTakeoverState(nowMs);
     return {
       skipAutoReply: true,
       activated: true,

--- a/src/channels/human-takeover.ts
+++ b/src/channels/human-takeover.ts
@@ -1,0 +1,106 @@
+import type { HumanTakeoverConfig } from "../config/types.base.js";
+
+const DEFAULT_HUMAN_TAKEOVER_COOLDOWN_SECONDS = 300;
+const HUMAN_TAKEOVER_MAX_TRACKED_SESSIONS = 5000;
+const humanTakeoverCooldownBySession = new Map<string, number>();
+
+function pruneHumanTakeoverState(nowMs: number): void {
+  for (const [sessionKey, activeUntil] of humanTakeoverCooldownBySession) {
+    if (activeUntil <= nowMs) {
+      humanTakeoverCooldownBySession.delete(sessionKey);
+    }
+  }
+
+  if (humanTakeoverCooldownBySession.size <= HUMAN_TAKEOVER_MAX_TRACKED_SESSIONS) {
+    return;
+  }
+
+  const overflow = humanTakeoverCooldownBySession.size - HUMAN_TAKEOVER_MAX_TRACKED_SESSIONS;
+  const oldestByExpiry = [...humanTakeoverCooldownBySession.entries()]
+    .toSorted((a, b) => a[1] - b[1])
+    .slice(0, overflow);
+  for (const [sessionKey] of oldestByExpiry) {
+    humanTakeoverCooldownBySession.delete(sessionKey);
+  }
+}
+
+export type ResolvedHumanTakeoverConfig = {
+  enabled: boolean;
+  cooldownMs: number;
+};
+
+export type HumanTakeoverDecision = {
+  skipAutoReply: boolean;
+  activated: boolean;
+  reason?: "owner-message" | "cooldown-active";
+  remainingMs?: number;
+};
+
+export function resolveHumanTakeoverConfig(params: {
+  channelConfig?: { humanTakeover?: HumanTakeoverConfig } | null;
+  accountConfig?: { humanTakeover?: HumanTakeoverConfig } | null;
+  defaultCooldownSeconds?: number;
+}): ResolvedHumanTakeoverConfig {
+  const configured = params.accountConfig?.humanTakeover ?? params.channelConfig?.humanTakeover;
+  const enabled = configured?.enabled === true;
+  const cooldownSecondsRaw =
+    configured?.cooldownSeconds ??
+    params.defaultCooldownSeconds ??
+    DEFAULT_HUMAN_TAKEOVER_COOLDOWN_SECONDS;
+  const cooldownSeconds =
+    Number.isFinite(cooldownSecondsRaw) && cooldownSecondsRaw > 0
+      ? Math.floor(cooldownSecondsRaw)
+      : DEFAULT_HUMAN_TAKEOVER_COOLDOWN_SECONDS;
+
+  return {
+    enabled,
+    cooldownMs: cooldownSeconds * 1000,
+  };
+}
+
+export function decideHumanTakeover(params: {
+  sessionKey: string;
+  enabled: boolean;
+  cooldownMs: number;
+  isOwnerMessage: boolean;
+  isCommandLike?: boolean;
+  nowMs?: number;
+}): HumanTakeoverDecision {
+  if (!params.sessionKey || !params.enabled || params.cooldownMs <= 0) {
+    return { skipAutoReply: false, activated: false };
+  }
+
+  const nowMs = params.nowMs ?? Date.now();
+  pruneHumanTakeoverState(nowMs);
+
+  if (params.isOwnerMessage) {
+    if (params.isCommandLike) {
+      return { skipAutoReply: false, activated: false };
+    }
+    const nextActiveUntil = nowMs + params.cooldownMs;
+    humanTakeoverCooldownBySession.set(params.sessionKey, nextActiveUntil);
+    pruneHumanTakeoverState(nowMs);
+    return {
+      skipAutoReply: true,
+      activated: true,
+      reason: "owner-message",
+      remainingMs: params.cooldownMs,
+    };
+  }
+
+  const cooldownUntil = humanTakeoverCooldownBySession.get(params.sessionKey) ?? 0;
+  if (cooldownUntil > nowMs) {
+    return {
+      skipAutoReply: true,
+      activated: false,
+      reason: "cooldown-active",
+      remainingMs: cooldownUntil - nowMs,
+    };
+  }
+
+  return { skipAutoReply: false, activated: false };
+}
+
+export function resetHumanTakeoverState(): void {
+  humanTakeoverCooldownBySession.clear();
+}

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -8,6 +8,13 @@ export type ReplyToMode = "off" | "first" | "all";
 export type GroupPolicy = "open" | "disabled" | "allowlist";
 export type DmPolicy = "pairing" | "allowlist" | "open" | "disabled";
 
+export type HumanTakeoverConfig = {
+  /** Enable owner-triggered human takeover for this channel/account. */
+  enabled?: boolean;
+  /** Cooldown duration in seconds after owner messages. Default: 300. */
+  cooldownSeconds?: number;
+};
+
 export type OutboundRetryConfig = {
   /** Max retry attempts for outbound requests (default: 3). */
   attempts?: number;

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -3,6 +3,7 @@ import type {
   BlockStreamingCoalesceConfig,
   DmPolicy,
   GroupPolicy,
+  HumanTakeoverConfig,
   MarkdownConfig,
   OutboundRetryConfig,
   ReplyToMode,
@@ -301,6 +302,8 @@ export type DiscordAccountConfig = {
    * Legacy key: channels.discord.dm.allowFrom.
    */
   allowFrom?: string[];
+  /** Owner-triggered human takeover cooldown controls. */
+  humanTakeover?: HumanTakeoverConfig;
   /** Default delivery target for CLI --deliver when no explicit --reply-to is provided. */
   defaultTo?: string;
   dm?: DiscordDmConfig;

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -3,6 +3,7 @@ import type {
   BlockStreamingCoalesceConfig,
   DmPolicy,
   GroupPolicy,
+  HumanTakeoverConfig,
   MarkdownConfig,
   OutboundRetryConfig,
   ReplyToMode,
@@ -120,6 +121,8 @@ export type TelegramAccountConfig = {
   direct?: Record<string, TelegramDirectConfig>;
   /** DM allowlist (numeric Telegram user IDs). Onboarding can resolve @username to IDs. */
   allowFrom?: Array<string | number>;
+  /** Owner-triggered human takeover cooldown controls. */
+  humanTakeover?: HumanTakeoverConfig;
   /** Default delivery target for CLI `--deliver` when no explicit `--reply-to` is provided. */
   defaultTo?: string | number;
   /** Optional allowlist for Telegram group senders (numeric Telegram user IDs). */

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -3,6 +3,7 @@ import type {
   BlockStreamingCoalesceConfig,
   DmPolicy,
   GroupPolicy,
+  HumanTakeoverConfig,
   MarkdownConfig,
 } from "./types.base.js";
 import type {
@@ -50,6 +51,8 @@ type WhatsAppSharedConfig = {
   selfChatMode?: boolean;
   /** Optional allowlist for WhatsApp direct chats (E.164). */
   allowFrom?: string[];
+  /** Owner-triggered human takeover cooldown controls. */
+  humanTakeover?: HumanTakeoverConfig;
   /** Default delivery target for CLI `--deliver` when no explicit `--reply-to` is provided (E.164 or group JID). */
   defaultTo?: string;
   /** Optional allowlist for WhatsApp group senders (E.164). */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -337,6 +337,14 @@ export const GroupPolicySchema = z.enum(["open", "disabled", "allowlist"]);
 
 export const DmPolicySchema = z.enum(["pairing", "allowlist", "open", "disabled"]);
 
+export const HumanTakeoverSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    cooldownSeconds: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
 export const BlockStreamingCoalesceSchema = z
   .object({
     minChars: z.number().int().positive().optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -25,6 +25,7 @@ import {
   ExecutableTokenSchema,
   GroupPolicySchema,
   HexColorSchema,
+  HumanTakeoverSchema,
   MarkdownConfigSchema,
   MSTeamsReplyStyleSchema,
   ProviderCommandsSchema,
@@ -199,6 +200,7 @@ export const TelegramAccountSchemaBase = z
     replyToMode: ReplyToModeSchema.optional(),
     groups: z.record(z.string(), TelegramGroupSchema.optional()).optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    humanTakeover: HumanTakeoverSchema,
     defaultTo: z.union([z.string(), z.number()]).optional(),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
@@ -530,6 +532,7 @@ export const DiscordAccountSchema = z
     // inheritance in multi-account setups (shallow merge works; nested dm object doesn't).
     dmPolicy: DmPolicySchema.optional(),
     allowFrom: DiscordIdListSchema.optional(),
+    humanTakeover: HumanTakeoverSchema,
     defaultTo: z.string().optional(),
     dm: DiscordDmSchema.optional(),
     guilds: z.record(z.string(), DiscordGuildSchema.optional()).optional(),

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -9,6 +9,7 @@ import {
   DmConfigSchema,
   DmPolicySchema,
   GroupPolicySchema,
+  HumanTakeoverSchema,
   MarkdownConfigSchema,
 } from "./zod-schema.core.js";
 
@@ -45,6 +46,7 @@ const WhatsAppSharedSchema = z.object({
   dmPolicy: DmPolicySchema.optional().default("pairing"),
   selfChatMode: z.boolean().optional(),
   allowFrom: z.array(z.string()).optional(),
+  humanTakeover: HumanTakeoverSchema,
   defaultTo: z.string().optional(),
   groupAllowFrom: z.array(z.string()).optional(),
   groupPolicy: GroupPolicySchema.optional().default("allowlist"),

--- a/src/plugin-sdk/channel-inbound.ts
+++ b/src/plugin-sdk/channel-inbound.ts
@@ -35,6 +35,15 @@ export {
   resolveMentionGating,
   resolveMentionGatingWithBypass,
 } from "../channels/mention-gating.js";
+export {
+  decideHumanTakeover,
+  resolveHumanTakeoverConfig,
+  resetHumanTakeoverState,
+} from "../channels/human-takeover.js";
+export type {
+  HumanTakeoverDecision,
+  ResolvedHumanTakeoverConfig,
+} from "../channels/human-takeover.js";
 export type { NormalizedLocation } from "../channels/location.js";
 export { formatLocationText, toLocationContext } from "../channels/location.js";
 export { logInboundDrop } from "../channels/logging.js";


### PR DESCRIPTION
This pull request introduces a new "human takeover" feature for Discord, Telegram, and WhatsApp channels, allowing owner-triggered cooldowns that temporarily pause auto-replies in a conversation after a manual (owner) message. The implementation includes configuration options, core logic, and integration into each channel's message handling flow. Documentation and tests are updated accordingly.

**Human Takeover Feature Implementation**

* Core logic and configuration:
  * Added `HumanTakeoverConfig` type and support for owner-triggered human takeover cooldowns to the base config (`src/config/types.base.ts`, `src/config/types.discord.ts`, `src/config/types.telegram.ts`, `extensions/whatsapp/src/accounts.ts`) [[1]](diffhunk://#diff-6e190c314827cdeb61a5ef3293fe971068c94ae8442c236dc205f6c94eddda9fR11-R17) [[2]](diffhunk://#diff-154055a0f819456d559e7414a66383c47793db4b9e2fca48bbbdc74022195ae5R6) [[3]](diffhunk://#diff-154055a0f819456d559e7414a66383c47793db4b9e2fca48bbbdc74022195ae5R305-R306) [[4]](diffhunk://#diff-c42b2f2a547284d06601e67c9df38e2409ec418619bc08571aa1d4ccc1f83bd1R6) [[5]](diffhunk://#diff-12d9574aeb9de91b19eda6d5faf30337701d015b59c054614de9d8b4957f2267R27) [[6]](diffhunk://#diff-12d9574aeb9de91b19eda6d5faf30337701d015b59c054614de9d8b4957f2267R152).
  * Implemented core logic for resolving config, tracking cooldown state per session, and making takeover decisions (`src/channels/human-takeover.ts`).
  * Added unit tests for the human takeover logic (`src/channels/human-takeover.test.ts`).

**Channel Integrations**

* Discord:
  * Integrated human takeover checks into the Discord message handler, including owner detection and cooldown logic (`extensions/discord/src/monitor/message-handler.process.ts`) [[1]](diffhunk://#diff-2f3c4c45615b18cb84f835e47f32d2df771ae23c294097a8a5a8c859b0159c93R13-R15) [[2]](diffhunk://#diff-2f3c4c45615b18cb84f835e47f32d2df771ae23c294097a8a5a8c859b0159c93L45-R47) [[3]](diffhunk://#diff-2f3c4c45615b18cb84f835e47f32d2df771ae23c294097a8a5a8c859b0159c93R138-R174).
* Telegram:
  * Integrated human takeover logic into the Telegram bot handler, using allowlists and session keys (`extensions/telegram/src/bot-handlers.runtime.ts`) [[1]](diffhunk://#diff-d9095e01d65cedc92b7801dd99e04e15d253f7446d2f9732296fe7b9b5500f35R8-R10) [[2]](diffhunk://#diff-d9095e01d65cedc92b7801dd99e04e15d253f7446d2f9732296fe7b9b5500f35R150-R158) [[3]](diffhunk://#diff-d9095e01d65cedc92b7801dd99e04e15d253f7446d2f9732296fe7b9b5500f35R1083-R1105).
* WhatsApp:
  * Integrated human takeover and outbound DM logic, including allowlist normalization and session-based cooldowns (`extensions/whatsapp/src/auto-reply/monitor/process-message.ts`, `extensions/whatsapp/src/inbound/access-control.ts`) [[1]](diffhunk://#diff-62285dba5233540219637c8674ae407fe1989dad047ac4e14b3a4a80f929b6d6R3-R4) [[2]](diffhunk://#diff-62285dba5233540219637c8674ae407fe1989dad047ac4e14b3a4a80f929b6d6R163-R166) [[3]](diffhunk://#diff-62285dba5233540219637c8674ae407fe1989dad047ac4e14b3a4a80f929b6d6R221-R253) [[4]](diffhunk://#diff-62285dba5233540219637c8674ae407fe1989dad047ac4e14b3a4a80f929b6d6L251) [[5]](diffhunk://#diff-02b382ca29a70cbbfbea01ec2cb9117eebe4c953eec457db3ff790b4b88651fcR152-R153) [[6]](diffhunk://#diff-02b382ca29a70cbbfbea01ec2cb9117eebe4c953eec457db3ff790b4b88651fcR162-R171).

**Documentation Updates**

* Added documentation for the human takeover feature and configuration examples to Discord, Telegram, and WhatsApp channel docs (`docs/channels/discord.md`, `docs/channels/telegram.md`, `docs/channels/whatsapp.md`) [[1]](diffhunk://#diff-fcadb488f6eeb9fcd9874b7255cbc2c52a436127cbfb6c293d3d99036c7e5136R270-R288) [[2]](diffhunk://#diff-ef4d52c59e8d27cfb16b402964664241087bfa6eeb9aef06777a87a0e7bb03baR124-R140) [[3]](diffhunk://#diff-cd0b2f4417e5a176c54e31e6bca731ffd18e10d54ba53233aecbb3b1fa8e5962R170-R186)


Closes #35208