### PR TITLE
fix(auth): ensure credential key and token fields are strings during store load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/retries: keep non-idempotent sends on the strict safe-send path, retry wrapped pre-connect failures, and preserve `429` / `retry_after` backoff for safe delivery retries. (#51895) Thanks @chinar-amrutkar
 - Agents/Anthropic: preserve thinking blocks and signatures across replay, cache-control patching, and context pruning so compacted Anthropic sessions continue working instead of failing on later turns. (#58916) Thanks @obviyus
 - Agents/failover: unify structured and raw provider error classification so provider-specific `400`/`422` payloads no longer get forced into generic format failures before retry, billing, or compaction logic can inspect them. (#58856) Thanks @aaron-he-zhu.
+- Auth profiles/store: coerce misplaced SecretRef objects out of plaintext `key` and `token` fields during store load so agents without ACP runtime stop crashing on `.trim()` after upgrade. (#58923) Thanks @openperf.
 
 ## 2026.3.31
 

--- a/src/agents/auth-profiles.ensureauthprofilestore.test.ts
+++ b/src/agents/auth-profiles.ensureauthprofilestore.test.ts
@@ -326,7 +326,6 @@ describe("ensureAuthProfileStore", () => {
           `${JSON.stringify(invalidStore, null, 2)}\n`,
           "utf8",
         );
-
         const store = ensureAuthProfileStore(agentDir);
         expect(store.profiles).toEqual({});
         expect(warnSpy).toHaveBeenCalledTimes(1);
@@ -347,5 +346,254 @@ describe("ensureAuthProfileStore", () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  it("migrates SecretRef object in `key` to `keyRef` and clears `key` (#58861)", () => {
+    withTempAgentDir("openclaw-nonstr-key-ref-", (agentDir) => {
+      clearRuntimeAuthProfileStoreSnapshots();
+      const storeData = {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      };
+      fs.writeFileSync(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(storeData, null, 2)}\n`,
+        "utf8",
+      );
+      const store = ensureAuthProfileStore(agentDir);
+      const profile = store.profiles["openai:default"];
+      expect(profile).toBeDefined();
+      expect(profile.type).toBe("api_key");
+      if (profile.type === "api_key") {
+        // key must not be an object — that would crash `.trim()` downstream
+        expect(profile.key).toBeUndefined();
+        expect(profile.keyRef).toEqual({
+          source: "env",
+          provider: "default",
+          id: "OPENAI_API_KEY",
+        });
+      }
+    });
+  });
+
+  it("deletes non-string non-SecretRef `key` without setting keyRef (#58861)", () => {
+    withTempAgentDir("openclaw-nonstr-key-num-", (agentDir) => {
+      clearRuntimeAuthProfileStoreSnapshots();
+      const storeData = {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: 12345,
+          },
+        },
+      };
+      fs.writeFileSync(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(storeData, null, 2)}\n`,
+        "utf8",
+      );
+      const store = ensureAuthProfileStore(agentDir);
+      const profile = store.profiles["openai:default"];
+      expect(profile).toBeDefined();
+      expect(profile.type).toBe("api_key");
+      if (profile.type === "api_key") {
+        expect(profile.key).toBeUndefined();
+        expect(profile.keyRef).toBeUndefined();
+      }
+    });
+  });
+
+  it("does not overwrite existing `keyRef` when `key` contains a SecretRef (#58861)", () => {
+    withTempAgentDir("openclaw-nonstr-key-dup-", (agentDir) => {
+      clearRuntimeAuthProfileStoreSnapshots();
+      const storeData = {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: { source: "env", provider: "default", id: "WRONG_VAR" },
+            keyRef: { source: "env", provider: "default", id: "CORRECT_VAR" },
+          },
+        },
+      };
+      fs.writeFileSync(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(storeData, null, 2)}\n`,
+        "utf8",
+      );
+      const store = ensureAuthProfileStore(agentDir);
+      const profile = store.profiles["openai:default"];
+      expect(profile).toBeDefined();
+      expect(profile.type).toBe("api_key");
+      if (profile.type === "api_key") {
+        expect(profile.key).toBeUndefined();
+        expect(profile.keyRef).toEqual({
+          source: "env",
+          provider: "default",
+          id: "CORRECT_VAR",
+        });
+      }
+    });
+  });
+
+  it("overwrites malformed `keyRef` with migrated ref from `key` (#58861)", () => {
+    withTempAgentDir("openclaw-nonstr-key-malformed-ref-", (agentDir) => {
+      clearRuntimeAuthProfileStoreSnapshots();
+      const storeData = {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+            keyRef: null,
+          },
+        },
+      };
+      fs.writeFileSync(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(storeData, null, 2)}\n`,
+        "utf8",
+      );
+      const store = ensureAuthProfileStore(agentDir);
+      const profile = store.profiles["openai:default"];
+      expect(profile).toBeDefined();
+      expect(profile.type).toBe("api_key");
+      if (profile.type === "api_key") {
+        expect(profile.key).toBeUndefined();
+        expect(profile.keyRef).toEqual({
+          source: "env",
+          provider: "default",
+          id: "OPENAI_API_KEY",
+        });
+      }
+    });
+  });
+
+  it("preserves valid string `key` values unchanged (#58861)", () => {
+    withTempAgentDir("openclaw-str-key-", (agentDir) => {
+      clearRuntimeAuthProfileStoreSnapshots();
+      const storeData = {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-valid-plaintext-key",
+          },
+        },
+      };
+      fs.writeFileSync(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(storeData, null, 2)}\n`,
+        "utf8",
+      );
+      const store = ensureAuthProfileStore(agentDir);
+      const profile = store.profiles["openai:default"];
+      expect(profile).toBeDefined();
+      expect(profile.type).toBe("api_key");
+      if (profile.type === "api_key") {
+        expect(profile.key).toBe("sk-valid-plaintext-key");
+      }
+    });
+  });
+
+  it("migrates SecretRef object in `token` to `tokenRef` and clears `token` (#58861)", () => {
+    withTempAgentDir("openclaw-nonstr-token-ref-", (agentDir) => {
+      clearRuntimeAuthProfileStoreSnapshots();
+      const storeData = {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "anthropic:default": {
+            type: "token",
+            provider: "anthropic",
+            token: { source: "env", provider: "default", id: "ANTHROPIC_TOKEN" },
+          },
+        },
+      };
+      fs.writeFileSync(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(storeData, null, 2)}\n`,
+        "utf8",
+      );
+      const store = ensureAuthProfileStore(agentDir);
+      const profile = store.profiles["anthropic:default"];
+      expect(profile).toBeDefined();
+      expect(profile.type).toBe("token");
+      if (profile.type === "token") {
+        expect(profile.token).toBeUndefined();
+        expect(profile.tokenRef).toEqual({
+          source: "env",
+          provider: "default",
+          id: "ANTHROPIC_TOKEN",
+        });
+      }
+    });
+  });
+
+  it("deletes non-string non-SecretRef `token` without setting tokenRef (#58861)", () => {
+    withTempAgentDir("openclaw-nonstr-token-num-", (agentDir) => {
+      clearRuntimeAuthProfileStoreSnapshots();
+      const storeData = {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "anthropic:default": {
+            type: "token",
+            provider: "anthropic",
+            token: 99999,
+          },
+        },
+      };
+      fs.writeFileSync(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(storeData, null, 2)}\n`,
+        "utf8",
+      );
+      const store = ensureAuthProfileStore(agentDir);
+      const profile = store.profiles["anthropic:default"];
+      expect(profile).toBeDefined();
+      expect(profile.type).toBe("token");
+      if (profile.type === "token") {
+        expect(profile.token).toBeUndefined();
+        expect(profile.tokenRef).toBeUndefined();
+      }
+    });
+  });
+
+  it("preserves valid string `token` values unchanged (#58861)", () => {
+    withTempAgentDir("openclaw-str-token-", (agentDir) => {
+      clearRuntimeAuthProfileStoreSnapshots();
+      const storeData = {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "anthropic:default": {
+            type: "token",
+            provider: "anthropic",
+            token: "tok-valid-plaintext",
+          },
+        },
+      };
+      fs.writeFileSync(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(storeData, null, 2)}\n`,
+        "utf8",
+      );
+      const store = ensureAuthProfileStore(agentDir);
+      const profile = store.profiles["anthropic:default"];
+      expect(profile).toBeDefined();
+      expect(profile.type).toBe("token");
+      if (profile.type === "token") {
+        expect(profile.token).toBe("tok-valid-plaintext");
+      }
+    });
   });
 });

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { resolveOAuthPath } from "../../config/paths.js";
+import { coerceSecretRef } from "../../config/types.secrets.js";
 import { withFileLock } from "../../infra/file-lock.js";
 import { loadJsonFile, saveJsonFile } from "../../infra/json-file.js";
 import {
@@ -167,6 +168,27 @@ function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<Auth
   // apiKey → key alias for ApiKeyCredential
   if (!("key" in entry) && typeof entry["apiKey"] === "string") {
     entry["key"] = entry["apiKey"];
+  }
+  // Ensure `key` is a string.  Users sometimes write a SecretRef object into
+  // the `key` field instead of `keyRef`.  When that happens every downstream
+  // consumer that calls `cred.key?.trim()` throws a TypeError because the
+  // value is truthy (an object) but has no `.trim()` method.  Migrate the
+  // misplaced ref to `keyRef` so the secret-resolution pipeline can pick it
+  // up, and clear the invalid `key` so callers never see a non-string value.
+  if ("key" in entry && entry["key"] != null && typeof entry["key"] !== "string") {
+    const ref = coerceSecretRef(entry["key"]);
+    if (ref && !coerceSecretRef(entry["keyRef"])) {
+      entry["keyRef"] = ref;
+    }
+    delete entry["key"];
+  }
+  // Same treatment for `token` on TokenCredential entries.
+  if ("token" in entry && entry["token"] != null && typeof entry["token"] !== "string") {
+    const ref = coerceSecretRef(entry["token"]);
+    if (ref && !coerceSecretRef(entry["tokenRef"])) {
+      entry["tokenRef"] = ref;
+    }
+    delete entry["token"];
   }
   return entry as Partial<AuthProfileCredential>;
 }


### PR DESCRIPTION
### Summary

- **Problem**: Agents without ACP runtime crash on every incoming message with `TypeError: cred.key?.trim is not a function` (file: `src/agents/models-config.providers.secrets.ts`, line 134). This happens because `cred.key` can be a `SecretRef` object if users wrote it into `auth-profiles.json` instead of `keyRef`.
- **Root Cause**: `normalizeRawCredentialEntry` in `src/agents/auth-profiles/store.ts` loads credentials from `auth-profiles.json` but does not validate the type of the `key` or `token` fields. If a user writes a `SecretRef` object into the `key` field instead of `keyRef`, the object passes through unchecked. Later, `resolveApiKeyFromCredential` calls `cred.key?.trim()`, which throws a `TypeError` because the object is truthy (so `?.` does not short-circuit) but lacks a `.trim()` method.
- **Fix**: Updated `normalizeRawCredentialEntry` to validate the type of `key` and `token` at load time. If they are non-string objects, we use `coerceSecretRef` to migrate them to `keyRef`/`tokenRef` (preserving the user's intent) and delete the invalid `key`/`token` field. This ensures downstream consumers always receive a `string | undefined`, preventing the crash.
- **What changed**:
  - `src/agents/auth-profiles/store.ts`: Added type validation and SecretRef migration for `key` and `token` fields in `normalizeRawCredentialEntry`.
  - `src/agents/auth-profiles.ensureauthprofilestore.test.ts`: Added 4 test cases for non-string `key` handling: SecretRef migration, invalid type cleanup, existing `keyRef` preservation, and string passthrough.
- **What did NOT change (scope boundary)**: `resolveApiKeyFromCredential`, `resolveApiKeyForProfile`, `collectApiKeyProfileAssignment`, and all other downstream credential consumers remain unchanged. The fix is localized to the store loading normalization phase. No changes to the secrets runtime pipeline, OAuth flow, or gateway startup logic.

### Reproduction

1. Have an agent without `runtime.type: "acp"` configured (e.g., `main`, `myclaw`).
2. In `auth-profiles.json`, set a credential's `key` to an object: `{"source": "env", "provider": "default", "id": "OPENAI_API_KEY"}`.
3. Send any message to that agent via any channel (Feishu, Discord, etc.).
4. Observe error in logs: `lane task error: ... error="TypeError: cred.key?.trim is not a function"`.

### Risk / Mitigation

- **Risk**: The normalization might drop user credentials if they were intentionally using non-string formats not anticipated here.
- **Mitigation**: We specifically use `coerceSecretRef` to detect and migrate valid `SecretRef` objects to `keyRef` rather than blindly dropping them. This preserves the configuration intent. Non-SecretRef non-string values (e.g., numbers, booleans) are safely dropped as they have no valid interpretation. Four targeted tests verify: (1) SecretRef migration works, (2) invalid types are cleaned, (3) existing `keyRef` is not overwritten, (4) valid string keys are untouched.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway

### Linked Issue/PR

Fixes #58861