### PR TITLE
fix(diagnostics): use systemPrompt instead of system in stream:context

### DIFF
--- a/src/agents/cache-trace.test.ts
+++ b/src/agents/cache-trace.test.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveUserPath } from "../utils.js";
 import { createCacheTrace } from "./cache-trace.js";
@@ -226,5 +226,36 @@ describe("createCacheTrace", () => {
     const event = JSON.parse(lines[0]?.trim() ?? "{}") as Record<string, unknown>;
     expect(event.messageCount).toBe(1);
     expect(event.messageFingerprints).toHaveLength(1);
+  });
+
+  it("wrapStreamFn records systemPrompt into stream:context", () => {
+    const lines: string[] = [];
+    const trace = createCacheTrace({
+      cfg: {
+        diagnostics: {
+          cacheTrace: {
+            enabled: true,
+          },
+        },
+      },
+      env: {},
+      writer: {
+        filePath: "memory",
+        write: (line) => lines.push(line),
+      },
+    });
+
+    const innerFn = vi.fn().mockResolvedValue(undefined);
+    const wrapped = trace!.wrapStreamFn(innerFn);
+
+    void wrapped(
+      { id: "gpt-4o", provider: "openai", api: null } as never,
+      { systemPrompt: "You are helpful.", messages: [], tools: [] } as never,
+      undefined,
+    );
+
+    expect(lines.length).toBe(1);
+    const event = JSON.parse(lines[0].trim()) as Record<string, unknown>;
+    expect(event.system).toBe("You are helpful.");
   });
 });

--- a/src/agents/cache-trace.ts
+++ b/src/agents/cache-trace.ts
@@ -242,7 +242,7 @@ export function createCacheTrace(params: CacheTraceInit): CacheTrace | null {
           provider: model?.provider,
           api: model?.api,
         },
-        system: (context as { system?: unknown }).system,
+        system: (context as { systemPrompt?: unknown }).systemPrompt,
         messages: (context as { messages?: AgentMessage[] }).messages ?? [],
         options: (options ?? {}) as Record<string, unknown>,
       });


### PR DESCRIPTION
## Summary

- Problem: stream:context log entries were missing the system field because cache-trace.ts was reading context.system (undefined) instead of the correct context.systemPrompt. 
- Why it matters: This broke cache trace diagnostics visibility—the system prompt was absent from stream:context events, making debugging and analysis harder for users and maintainers.
- What changed: Updated src/agents/cache-trace.ts:245 to read context.systemPrompt instead of context.system.  
- What did NOT change (scope boundary): All other cache trace stages, log formats, and configuration options remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Field name mismatch—cache-trace.ts wrapper assumed Pi Agent's StreamFn context parameter had a system field, but the actual field name in OpenClaw's usage is systemPrompt.
- Missing detection / guardrail: The existing test suite (cache-trace.test.ts) only tested recordStage directly with manual payloads, not the wrapStreamFn integration path, so the field name mismatch went undetected.
- Prior context (`git blame`, prior PR, issue, or refactor if known): systemPrompt is the established field name used throughout the codebase (see src/agents/openai-ws-stream.ts, src/agents/openai-ws-stream.test.ts).

- Why this regressed now: Likely introduced when cache-trace.ts was first implemented—the wrapper logic read the wrong field name from day one.

- If unknown, what was ruled out: N/A


## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Any
- Model/provider:  Any (diagnostic only)
- Integration/channel (if any):  N/A
- Relevant config (redacted): OPENCLAW_CACHE_TRACE=1

### Steps

  1. Enable cache trace: OPENCLAW_CACHE_TRACE=1
  2. Run an agent command that invokes streamFn
  3. Inspect the stream:context log entry

### Expected

  Log contains "system": <system prompt value>

### Actual

Before fix: "system": missing
After fix: "system": <actual system prompt>

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
    - pnpm test -- src/agents/cache-trace.test.ts passes
    - Code change is a single-line field name fix
- Edge cases checked:  N/A 
- What you did **not** verify: End-to-end cache trace log output with real agent runs

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None
