### PR TITLE
fix: preserve non-Latin characters in normalizeHyphenSlug

### DIFF
--- a/src/shared/string-normalization.test.ts
+++ b/src/shared/string-normalization.test.ts
@@ -34,6 +34,17 @@ describe("shared/string-normalization", () => {
     expect(normalizeHyphenSlug(" ###Team@@@Room### ")).toBe("###team@@@room###");
   });
 
+  it("preserves CJK characters in slug normalization", () => {
+    // CJK
+    expect(normalizeHyphenSlug("中文-组")).toBe("中文-组");
+    // Cyrillic
+    expect(normalizeHyphenSlug("  Группа Тест  ")).toBe("группа-тест");
+    // Arabic
+    expect(normalizeHyphenSlug("مجموعة-اختبار")).toBe("مجموعة-اختبار");
+    // Mixed ASCII + CJK
+    expect(normalizeHyphenSlug("team-中文")).toBe("team-中文");
+  });
+
   it("normalizes @/# prefixed slugs used by channel allowlists", () => {
     expect(normalizeAtHashSlug(" #My_Channel + Alerts ")).toBe("my-channel-alerts");
     expect(normalizeAtHashSlug("@@Room___Name")).toBe("room-name");

--- a/src/shared/string-normalization.test.ts
+++ b/src/shared/string-normalization.test.ts
@@ -43,6 +43,8 @@ describe("shared/string-normalization", () => {
     expect(normalizeHyphenSlug("مجموعة-اختبار")).toBe("مجموعة-اختبار");
     // Mixed ASCII + CJK
     expect(normalizeHyphenSlug("team-中文")).toBe("team-中文");
+    // Devanagari (combining marks)
+    expect(normalizeHyphenSlug("नमस्ते")).toBe("नमस्ते");
   });
 
   it("normalizes @/# prefixed slugs used by channel allowlists", () => {

--- a/src/shared/string-normalization.ts
+++ b/src/shared/string-normalization.ts
@@ -12,7 +12,7 @@ export function normalizeHyphenSlug(raw?: string | null) {
     return "";
   }
   const dashed = trimmed.replace(/\s+/g, "-");
-  const cleaned = dashed.replace(/[^\p{L}\p{N}#@._+-]+/gu, "-");
+  const cleaned = dashed.replace(/[^\p{L}\p{M}\p{N}#@._+-]+/gu, "-");
   return cleaned.replace(/-{2,}/g, "-").replace(/^[-.]+|[-.]+$/g, "");
 }
 

--- a/src/shared/string-normalization.ts
+++ b/src/shared/string-normalization.ts
@@ -12,7 +12,7 @@ export function normalizeHyphenSlug(raw?: string | null) {
     return "";
   }
   const dashed = trimmed.replace(/\s+/g, "-");
-  const cleaned = dashed.replace(/[^a-z0-9#@._+-]+/g, "-");
+  const cleaned = dashed.replace(/[^\p{L}\p{N}#@._+-]+/gu, "-");
   return cleaned.replace(/-{2,}/g, "-").replace(/^[-.]+|[-.]+$/g, "");
 }
 


### PR DESCRIPTION
normalizeHyphenSlug strips all non-ASCII characters via /[^a-z0-9#@._+-]+/g, causing buildGroupDisplayName to lose CJK/Cyrillic/Arabic group names and fall back to just the provider key.

Switch to Unicode-aware character classes (\p{L}, \p{N}) so non-Latin scripts are preserved in group display names.

Fixes #58932

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause:
- Missing detection / guardrail:
- Prior context (`git blame`, prior PR, issue, or refactor if known):
- Why this regressed now:
- If unknown, what was ruled out:

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user action] -> [old state]

After:
[user action] -> [new state] -> [result]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
