### PR TITLE
feat(agents): add inter-session delivery audit log for isolation observability

### DIFF
--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -1,10 +1,14 @@
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import {
   applyInputProvenanceToUserMessage,
   type InputProvenance,
+  isInterSessionInputProvenance,
 } from "../sessions/input-provenance.js";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
+
+const log = createSubsystemLogger("agents/isolation-audit");
 
 export type GuardedSessionManager = SessionManager & {
   /** Flush any synthetic tool results for pending tool calls. Idempotent. */
@@ -29,6 +33,16 @@ export function guardSessionManager(
 ): GuardedSessionManager {
   if (typeof (sessionManager as GuardedSessionManager).flushPendingToolResults === "function") {
     return sessionManager as GuardedSessionManager;
+  }
+
+  // Audit: log inter-session message delivery for isolation observability
+  if (opts?.inputProvenance && isInterSessionInputProvenance(opts.inputProvenance)) {
+    log.info("inter_session_delivery", {
+      from: opts.inputProvenance.sourceSessionKey,
+      to: opts?.sessionKey,
+      channel: opts.inputProvenance.sourceChannel,
+      tool: opts.inputProvenance.sourceTool,
+    });
   }
 
   const hookRunner = getGlobalHookRunner();

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -31,11 +31,9 @@ export function guardSessionManager(
     allowedToolNames?: Iterable<string>;
   },
 ): GuardedSessionManager {
-  if (typeof (sessionManager as GuardedSessionManager).flushPendingToolResults === "function") {
-    return sessionManager as GuardedSessionManager;
-  }
-
   // Audit: log inter-session message delivery for isolation observability
+  // Placed before the idempotency guard to ensure every delivery is logged,
+  // even if the session manager is already guarded.
   if (opts?.inputProvenance && isInterSessionInputProvenance(opts.inputProvenance)) {
     log.info("inter_session_delivery", {
       from: opts.inputProvenance.sourceSessionKey,
@@ -43,6 +41,10 @@ export function guardSessionManager(
       channel: opts.inputProvenance.sourceChannel,
       tool: opts.inputProvenance.sourceTool,
     });
+  }
+
+  if (typeof (sessionManager as GuardedSessionManager).flushPendingToolResults === "function") {
+    return sessionManager as GuardedSessionManager;
   }
 
   const hookRunner = getGlobalHookRunner();


### PR DESCRIPTION
## Summary

Adds a structured audit log entry whenever an agent processes a message originating from a different session, directly addressing **#57175**.

### Problem

In multi-agent deployments (our 17-agent hierarchy), there is no runtime visibility into cross-session message flows. When agent A sends a message to agent B via `sessions_send`, there is no log, metric, or trace that records this inter-session delivery.

### Solution

Leverage the existing `inputProvenance` infrastructure to emit a structured audit log when an inter-session message is delivered:

```
agents/isolation-audit: inter_session_delivery {
  from: "agent:dev-lead:main",
  to: "agent:dev-frontend:main",
  channel: "feishu",
  tool: "sessions_send"
}
```

### Design Decisions

1. **Non-intrusive** — Only adds a log line, zero behavior changes
2. **Uses existing infrastructure** — Hooks into `guardSessionManager()` which already receives both `sessionKey` (target) and `inputProvenance` (source)
3. **Structured logging** — Uses `createSubsystemLogger` consistent with the codebase
4. **No schema changes** — Does not modify gateway protocol, agent params, or any types

### Changed Files

| File | Change |
|------|--------|
| `src/agents/session-tool-result-guard-wrapper.ts` | Add audit log when `inputProvenance.kind === 'inter_session'` |

### Testing

- `pnpm check` passes: **0 errors, 0 warnings**

## Linked Issue

Resolves #57175

## Security Impact

Read-only observability, no behavior changes, no new attack surface.