### PR TITLE
Fix: preserve non-ASCII group names in normalizeHyphenSlug (Resolves #58932)

### DIFF
--- a/src/shared/string-normalization.test.ts
+++ b/src/shared/string-normalization.test.ts
@@ -34,6 +34,14 @@ describe("shared/string-normalization", () => {
     expect(normalizeHyphenSlug(" ###Team@@@Room### ")).toBe("###team@@@room###");
   });
 
+  it("preserves CJK and other non-Latin Unicode characters in slugs", () => {
+    expect(normalizeHyphenSlug("技术讨论组")).toBe("技术讨论组");
+    expect(normalizeHyphenSlug("友達グループ")).toBe("友達グループ");
+    expect(normalizeHyphenSlug("Команда разработчиков")).toBe("команда-разработчиков");
+    expect(normalizeHyphenSlug("مجموعة العمل")).toBe("مجموعة-العمل");
+    expect(normalizeHyphenSlug("Tech 技术 Group")).toBe("tech-技术-group");
+  });
+
   it("normalizes @/# prefixed slugs used by channel allowlists", () => {
     expect(normalizeAtHashSlug(" #My_Channel + Alerts ")).toBe("my-channel-alerts");
     expect(normalizeAtHashSlug("@@Room___Name")).toBe("room-name");

--- a/src/shared/string-normalization.ts
+++ b/src/shared/string-normalization.ts
@@ -57,7 +57,8 @@ export function normalizeHyphenSlug(raw?: string | null) {
     return "";
   }
   const dashed = trimmed.replace(/\s+/g, "-");
-  const cleaned = dashed.replace(/[^a-z0-9#@._+-]+/g, "-");
+  // Allow Unicode letters/digits (e.g. CJK, Cyrillic, Arabic) in addition to ASCII slug chars
+  const cleaned = dashed.replace(/[^a-z0-9#@._+\-\p{L}\p{N}]+/gu, "-");
   return cleaned.replace(/-{2,}/g, "-").replace(/^[-.]+|[-.]+$/g, "");
 }
 


### PR DESCRIPTION
Fixes #58932.

`normalizeHyphenSlug` used `/[^a-z0-9#@._+-]+/g` which stripped all non-ASCII characters (CJK, Cyrillic, Arabic, etc.) to empty string. For groups with non-Latin names (e.g. Telegram "技术讨论组"), this caused `buildGroupDisplayName` to return just the provider key (e.g. `telegram`) since the normalized token was empty.

**Fix:** Updated the regex to use Unicode property escapes (`\p{L}\p{N}` with the `u` flag) so non-ASCII letters and digits are preserved:
```
/[^a-z0-9#@._+\-\p{L}\p{N}]+/gu
```

**Tests added** covering CJK (Chinese, Japanese), Cyrillic, Arabic, and mixed ASCII/Unicode group names.