### PR TITLE
fix: strip reasoning object when thinking is off to prevent 400 on mandatory-reasoning endpoints (#58880)

### DIFF
--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts
@@ -2,7 +2,13 @@ import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model } from "@mariozechner/pi-ai";
 import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { createOpenRouterWrapper } from "./proxy-stream-wrappers.js";
+import { createKilocodeWrapper, createOpenRouterWrapper } from "./proxy-stream-wrappers.js";
+
+const OR_MODEL = {
+  api: "openai-completions",
+  provider: "openrouter",
+  id: "openrouter/auto",
+} as Model<"openai-completions">;
 
 describe("proxy stream wrappers", () => {
   it("adds OpenRouter attribution headers to stream options", () => {
@@ -34,5 +40,85 @@ describe("proxy stream wrappers", () => {
         },
       },
     ]);
+  });
+
+  describe("reasoning payload normalization (thinking=off)", () => {
+    it("strips reasoning object when thinkingLevel is off (OpenRouter)", () => {
+      const payloads: Array<Record<string, unknown>> = [];
+      const base: StreamFn = (_m, _c, opts) => {
+        const p: Record<string, unknown> = {
+          reasoning: { effort: "none" },
+          reasoning_effort: "none",
+          messages: [],
+        };
+        opts?.onPayload?.(p, _m);
+        payloads.push(p);
+        return createAssistantMessageEventStream();
+      };
+
+      const wrapped = createOpenRouterWrapper(base, "off");
+      void wrapped(OR_MODEL, { messages: [] }, undefined);
+
+      expect(payloads[0]).not.toHaveProperty("reasoning");
+      expect(payloads[0]).not.toHaveProperty("reasoning_effort");
+    });
+
+    it("strips reasoning object when thinkingLevel is off (Kilocode)", () => {
+      const payloads: Array<Record<string, unknown>> = [];
+      const base: StreamFn = (_m, _c, opts) => {
+        const p: Record<string, unknown> = {
+          reasoning: { effort: "none" },
+          reasoning_effort: "none",
+          messages: [],
+        };
+        opts?.onPayload?.(p, _m);
+        payloads.push(p);
+        return createAssistantMessageEventStream();
+      };
+
+      const wrapped = createKilocodeWrapper(base, "off");
+      void wrapped(OR_MODEL, { messages: [] }, undefined);
+
+      expect(payloads[0]).not.toHaveProperty("reasoning");
+      expect(payloads[0]).not.toHaveProperty("reasoning_effort");
+    });
+
+    it("strips reasoning object when thinkingLevel is undefined", () => {
+      const payloads: Array<Record<string, unknown>> = [];
+      const base: StreamFn = (_m, _c, opts) => {
+        const p: Record<string, unknown> = {
+          reasoning: { effort: "none" },
+          messages: [],
+        };
+        opts?.onPayload?.(p, _m);
+        payloads.push(p);
+        return createAssistantMessageEventStream();
+      };
+
+      const wrapped = createOpenRouterWrapper(base, undefined);
+      void wrapped(OR_MODEL, { messages: [] }, undefined);
+
+      expect(payloads[0]).not.toHaveProperty("reasoning");
+    });
+
+    it("preserves reasoning object when thinkingLevel is high", () => {
+      const payloads: Array<Record<string, unknown>> = [];
+      const base: StreamFn = (_m, _c, opts) => {
+        const p: Record<string, unknown> = {
+          reasoning: { effort: "none" },
+          messages: [],
+        };
+        opts?.onPayload?.(p, _m);
+        payloads.push(p);
+        return createAssistantMessageEventStream();
+      };
+
+      const wrapped = createOpenRouterWrapper(base, "high");
+      void wrapped(OR_MODEL, { messages: [] }, undefined);
+
+      // Existing reasoning with effort should be preserved (not overwritten
+      // because it already has an effort key).
+      expect(payloads[0]).toHaveProperty("reasoning");
+    });
   });
 });

--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -36,6 +36,11 @@ function normalizeProxyReasoningPayload(payload: unknown, thinkingLevel?: ThinkL
   const payloadObj = payload as Record<string, unknown>;
   delete payloadObj.reasoning_effort;
   if (!thinkingLevel || thinkingLevel === "off") {
+    // When thinking is off, also strip any `reasoning` object injected by
+    // the upstream library (e.g. `{ effort: "none" }`).  Leaving it causes
+    // 400 errors on providers where reasoning is mandatory and cannot be
+    // disabled (OpenRouter, Kilocode).
+    delete payloadObj.reasoning;
     return;
   }
 


### PR DESCRIPTION
## Summary

Fixes #58880.

When `thinkingLevel` is `"off"` (or undefined), `normalizeProxyReasoningPayload` correctly deletes `reasoning_effort` but returns **without** deleting the `reasoning` object. The upstream `@mariozechner/pi-ai` library may inject `reasoning: { effort: "none" }` into the payload. This survives to the API request and causes OpenRouter to return **400 "Reasoning is mandatory for this endpoint and cannot be disabled"** for models like `anthropic/claude-sonnet-4` where reasoning cannot be turned off.

## Changes

- **`src/agents/pi-embedded-runner/proxy-stream-wrappers.ts`**: Add `delete payloadObj.reasoning` before the early return in `normalizeProxyReasoningPayload` when thinking is off/undefined.
- **`src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts`**: Add regression tests verifying both `reasoning` and `reasoning_effort` are stripped for OpenRouter and Kilocode wrappers when thinking is off, undefined, and preserved when thinking is active.

## Test plan

- `pnpm test -- src/agents/pi-embedded-runner/proxy-stream-wrappers.test.ts` — 5 tests pass
- `pnpm check` — clean