### PR TITLE
fix(discord): use safe disconnect in onAbort to prevent gateway crash

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.reconnect.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.reconnect.ts
@@ -401,8 +401,11 @@ export function createDiscordGatewayReconnectController(params: {
     if (!params.gateway) {
       return;
     }
-    params.gateway.options.reconnect = { maxAttempts: 0 };
-    params.gateway.disconnect();
+    // Use the safe disconnect helper that strips close/error listeners first.
+    // Setting maxAttempts=0 then calling gateway.disconnect() directly causes
+    // the socket close handler to throw "Max reconnect attempts (0) reached",
+    // crashing the gateway process with an uncaught exception. (#56854)
+    void disconnectGatewaySocketWithoutAutoReconnect();
   };
   const ensureStartupReady = async () => {
     if (!params.gateway || params.gateway.isConnected || shouldStop()) {

--- a/extensions/discord/src/monitor/provider.lifecycle.reconnect.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.reconnect.ts
@@ -56,6 +56,7 @@ export function createDiscordGatewayReconnectController(params: {
   let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
   let helloConnectedPollId: ReturnType<typeof setInterval> | undefined;
   let reconnectInFlight: Promise<void> | undefined;
+  let disconnectInFlight: Promise<void> | undefined;
   let consecutiveHelloStalls = 0;
 
   const shouldStop = () => params.isLifecycleStopping() || params.abortSignal?.aborted;
@@ -133,6 +134,13 @@ export function createDiscordGatewayReconnectController(params: {
     });
   };
   const disconnectGatewaySocketWithoutAutoReconnect = async () => {
+    // Deduplicate concurrent disconnect calls. If onAbort fires while a
+    // reconnect-driven disconnect is already awaiting the socket close event,
+    // a second call would strip the first call's close listener, causing the
+    // first promise to hang indefinitely and the lifecycle to time out.
+    if (disconnectInFlight) {
+      return await disconnectInFlight;
+    }
     if (!params.gateway) {
       return;
     }
@@ -143,6 +151,7 @@ export function createDiscordGatewayReconnectController(params: {
       return;
     }
 
+    const doDisconnect = async () => {
     // Carbon reconnects from the socket close handler even for intentional
     // disconnects. Drop the current socket's close/error listeners so a forced
     // reconnect does not race the old socket's automatic resume path.
@@ -267,6 +276,11 @@ export function createDiscordGatewayReconnectController(params: {
       socket.on("close", onClose);
       gateway.disconnect();
     });
+    };
+    disconnectInFlight = doDisconnect().finally(() => {
+      disconnectInFlight = undefined;
+    });
+    return await disconnectInFlight;
   };
   const reconnectGateway = async (reconnectParams: {
     resume: boolean;


### PR DESCRIPTION
## Summary

Fixes #56854

The Discord provider crashes the entire gateway with an uncaught exception when the health monitor triggers an abort. The `onAbort` handler sets `gateway.options.reconnect.maxAttempts` to `0` then calls `gateway.disconnect()`. The socket close handler sees `maxAttempts=0` and throws `"Max reconnect attempts (0) reached"`, killing the process.

### Root cause

```js
// onAbort handler (line 404)
params.gateway.options.reconnect = { maxAttempts: 0 };
params.gateway.disconnect(); // triggers close handler -> throw
```

The codebase already has `disconnectGatewaySocketWithoutAutoReconnect()` (line 135) which strips close/error listeners before disconnecting, specifically to prevent this race.

### Fix

Replace the raw `disconnect()` call in `onAbort` with `disconnectGatewaySocketWithoutAutoReconnect()`. This reuses the existing safe disconnect pattern.

### Test plan

- [ ] Gateway survives Discord health monitor restart cycles without crashing
- [ ] Intentional abort (e.g., config reload) cleanly disconnects Discord

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>