### PR TITLE
fix(hooks): deduplicate internal hook handlers on config reload

### DIFF
--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -228,7 +228,13 @@ export function registerInternalHook(eventKey: string, handler: InternalHookHand
   if (!handlers.has(eventKey)) {
     handlers.set(eventKey, []);
   }
-  handlers.get(eventKey)!.push(handler);
+  const existing = handlers.get(eventKey)!;
+  // Deduplicate: skip if the exact same handler function is already registered.
+  // Without this guard, periodic config reloads re-register the same handlers,
+  // causing hooks to fire N times after N reload cycles.
+  if (!existing.includes(handler)) {
+    existing.push(handler);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add deduplication guard in `registerInternalHook()` to prevent the same handler from being pushed multiple times during periodic config reload cycles
- After N reload cycles, previously the same hook would fire N times; now it fires exactly once

## Details

`registerInternalHook` unconditionally pushes handlers to the array without checking for duplicates. When the config reloader re-runs registration code on every cycle, handlers accumulate. The fix adds an `includes()` check before `push()`, consistent with the `indexOf()` pattern already used by `unregisterInternalHook`.

Fixes #58594

## Test plan
- [ ] Verify hooks fire exactly once after multiple config reload cycles
- [ ] Verify `unregisterInternalHook` still works correctly
- [ ] Verify new handler registrations for different event keys still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>