### PR TITLE
fix: preserve non-Latin characters in normalizeHyphenSlug and normalizeAtHashSlug

### DIFF
--- a/src/shared/string-normalization.test.ts
+++ b/src/shared/string-normalization.test.ts
@@ -34,6 +34,13 @@ describe("shared/string-normalization", () => {
     expect(normalizeHyphenSlug(" ###Team@@@Room### ")).toBe("###team@@@room###");
   });
 
+  it("preserves CJK and other non-Latin Unicode characters", () => {
+    expect(normalizeHyphenSlug("技术讨论组")).toBe("技术讨论组");
+    expect(normalizeHyphenSlug("友達グループ")).toBe("友達グループ");
+    expect(normalizeHyphenSlug("Тестовая группа")).toBe("тестовая-группа");
+    expect(normalizeHyphenSlug("  CJK 测试 Room  ")).toBe("cjk-测试-room");
+  });
+
   it("normalizes @/# prefixed slugs used by channel allowlists", () => {
     expect(normalizeAtHashSlug(" #My_Channel + Alerts ")).toBe("my-channel-alerts");
     expect(normalizeAtHashSlug("@@Room___Name")).toBe("room-name");
@@ -44,5 +51,10 @@ describe("shared/string-normalization", () => {
   it("strips repeated prefixes and collapses separator-only results", () => {
     expect(normalizeAtHashSlug("###__Room  Name__")).toBe("room-name");
     expect(normalizeAtHashSlug("@@@___")).toBe("");
+  });
+
+  it("preserves CJK characters in @/# prefixed slugs", () => {
+    expect(normalizeAtHashSlug("#技术讨论")).toBe("技术讨论");
+    expect(normalizeAtHashSlug("@テスト")).toBe("テスト");
   });
 });

--- a/src/shared/string-normalization.ts
+++ b/src/shared/string-normalization.ts
@@ -12,7 +12,7 @@ export function normalizeHyphenSlug(raw?: string | null) {
     return "";
   }
   const dashed = trimmed.replace(/\s+/g, "-");
-  const cleaned = dashed.replace(/[^a-z0-9#@._+-]+/g, "-");
+  const cleaned = dashed.replace(/[^\p{L}\p{N}#@._+-]+/gu, "-");
   return cleaned.replace(/-{2,}/g, "-").replace(/^[-.]+|[-.]+$/g, "");
 }
 
@@ -23,6 +23,6 @@ export function normalizeAtHashSlug(raw?: string | null) {
   }
   const withoutPrefix = trimmed.replace(/^[@#]+/, "");
   const dashed = withoutPrefix.replace(/[\s_]+/g, "-");
-  const cleaned = dashed.replace(/[^a-z0-9-]+/g, "-");
+  const cleaned = dashed.replace(/[^\p{L}\p{N}-]+/gu, "-");
   return cleaned.replace(/-{2,}/g, "-").replace(/^-+|-+$/g, "");
 }


### PR DESCRIPTION
## Summary

- Fix `normalizeHyphenSlug` regex `/[^a-z0-9#@._+-]+/g` which strips all non-ASCII characters, replacing it with Unicode-aware `/[^\p{L}\p{N}#@._+-]+/gu`
- Apply the same fix to `normalizeAtHashSlug` (`/[^a-z0-9-]+/g` -> `/[^\p{L}\p{N}-]+/gu`)
- Add test cases for CJK (Chinese, Japanese), Cyrillic, and mixed-script inputs

This preserves non-Latin group names (e.g. Telegram/WhatsApp groups named in Chinese, Japanese, Korean, Cyrillic, Arabic) so they display correctly in the Sessions UI instead of being reduced to just the provider key.

Fixes #58932

## Test plan

- [x] Added unit tests for CJK characters in `normalizeHyphenSlug`
- [x] Added unit tests for CJK characters in `normalizeAtHashSlug`
- [ ] Existing tests still pass (no behavioral change for ASCII inputs)
- [ ] Verify group display names with non-Latin names in Sessions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)