### PR TITLE
docs: add AxonFlow governance plugin to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -21,6 +21,20 @@ OpenClaw checks ClawHub first and falls back to npm automatically.
 
 ## Listed plugins
 
+### AxonFlow Governance
+
+Policy enforcement, approval gates, and audit trails for OpenClaw tool
+execution. Governs tool inputs before execution, scans outbound messages
+for PII and secrets before delivery, and records tool and LLM activity
+to a centralized audit trail via AxonFlow.
+
+- **npm:** `@axonflow/openclaw`
+- **repo:** [github.com/getaxonflow/axonflow-openclaw-plugin](https://github.com/getaxonflow/axonflow-openclaw-plugin)
+
+```bash
+openclaw plugins install @axonflow/openclaw
+```
+
 ### Codex App Server Bridge
 
 Independent OpenClaw bridge for Codex App Server conversations. Bind a chat to


### PR DESCRIPTION
Adds `@axonflow/openclaw` to the community plugins page.

**What it does:**
- Governs tool inputs before execution (`before_tool_call`) — blocks dangerous commands, detects PII, enforces rate limits
- Scans outbound messages for PII/secrets before delivery to Telegram/Discord/Slack (`message_sending`)
- Records tool calls and LLM activity to an audit trail (`after_tool_call`, `llm_input`, `llm_output`)
- Approval gates for configurable high-risk tools
- Fail-open/fail-closed behavior when AxonFlow is unreachable

**Why it belongs here:**
OpenClaw has gained routing, memory, integration, and observability plugins quickly. Governance — centralized policy enforcement, approval workflows, and compliance-grade audit trails — is a different category that's still underbuilt. This plugin connects OpenClaw to AxonFlow's policy engine so teams can enforce consistent rules across all tools and channels without modifying agent configuration.

**Quality bar:**
- Published on [npm](https://www.npmjs.com/package/@axonflow/openclaw) (v0.2.0) and [ClawHub](https://clawhub.ai)
- Public repo with README, CHANGELOG, starter policy docs, and E2E test script
- 86 tests, E2E verified against live AxonFlow + OpenClaw
- MIT licensed
- Actively maintained