### PR TITLE
fix: use maxBackgroundTimeoutSec for effectiveTimeout only

### DIFF
--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -16,6 +16,7 @@ export type ExecToolDefaults = {
   agentId?: string;
   backgroundMs?: number;
   timeoutSec?: number;
+  maxBackgroundTimeoutSec?: number;
   approvalRunningNoticeMs?: number;
   sandbox?: BashSandboxConfig;
   elevated?: ExecElevatedDefaults;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -446,6 +446,12 @@ export function createExecTool(
       ? defaults.timeoutSec
       : 1800;
   const defaultPathPrepend = normalizePathPrepend(defaults?.pathPrepend);
+
+  // Maximum timeout for background processes (24 hours default)
+  const maxBackgroundTimeoutSec =
+    typeof defaults?.maxBackgroundTimeoutSec === "number" && defaults.maxBackgroundTimeoutSec > 0
+      ? defaults.maxBackgroundTimeoutSec
+      : 86400;
   const {
     safeBins,
     safeBinProfiles,
@@ -782,7 +788,7 @@ export function createExecTool(
       const backgroundTimeoutBypass =
         allowBackground && explicitTimeoutSec === null && (backgroundRequested || yieldRequested);
       const effectiveTimeout = backgroundTimeoutBypass
-        ? null
+        ? maxBackgroundTimeoutSec
         : (explicitTimeoutSec ?? defaultTimeoutSec);
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const usePty = params.pty === true && !sandbox;


### PR DESCRIPTION
## Summary
This PR fixes a bug introduced in a previous attempt to address issue #3949 ("Stop button doesn't kill running tool processes"). The goal is to ensure background processes (spawned via `exec` or other tools) are correctly managed and can be aborted, without causing type errors or incorrect timeout handling.

## Problem
- The previous commit aimed to use `maxBackgroundTimeoutSec` for the `effectiveTimeout` calculation when a process is requested to run in the background. This is intended to give background processes a very long default timeout (24 hours) instead of `null`, which was causing a "timeoutSec must be a positive number" error.
- However, a `sed` command unintentionally also applied the same change to the `hostEnvResult` variable. This caused a critical type error because `hostEnvResult` is typed as `ChildProcess | null`, not a number.
- As a result, the build was broken, and the logic for handling sandbox environment variables was incorrect.

## Solution
This PR reverts the erroneous change to `hostEnvResult` and correctly applies the `maxBackgroundTimeoutSec` only to the `effectiveTimeout` variable.

### Key Changes
1.  **`src/agents/bash-tools.exec.ts`**:
    -   **Line 653**: `hostEnvResult` is now correctly set to `null` when `host === "sandbox"`. This preserves the existing behavior where sandboxed processes do not inherit the host's environment variables in the same way.
    -   **Line 791**: `effectiveTimeout` now correctly uses `maxBackgroundTimeoutSec` (a number) when `backgroundTimeoutBypass` is `true`. This resolves the type error and ensures background processes have a proper, long timeout.

### Code Diff
