### PR TITLE
fix: guard Slack HTTP stage behind channels.slack.enabled

### DIFF
--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -898,11 +898,13 @@ export function createGatewayHttpServer(opts: {
               rateLimiter,
             }),
         },
-        {
+      ];
+      if (configSnapshot.channels?.slack?.enabled === true) {
+        requestStages.push({
           name: "slack",
           run: () => handleSlackHttpRequest(req, res),
-        },
-      ];
+        });
+      }
       if (openResponsesEnabled) {
         requestStages.push({
           name: "openresponses",


### PR DESCRIPTION
## Summary
- Move `handleSlackHttpRequest` stage behind `configSnapshot.channels?.slack?.enabled === true` check in `createGatewayHttpServer()`
- Prevents HTTP 500 when `@slack/web-api` is not installed and Slack plugin is disabled (default)
- Consistent with how other optional stages (Control UI, OpenAI, OpenResponses) are already guarded

## Test plan
- [ ] Start gateway **without** `@slack/web-api` installed, Slack disabled → HTTP requests should return normally
- [ ] Start gateway **with** Slack enabled and `@slack/web-api` installed → Slack HTTP callbacks should continue to work
- [ ] Verify Control UI dashboard loads at `http://127.0.0.1:<port>/`

Fixes #58994

🤖 Generated with [Claude Code](https://claude.ai/claude-code)