### PR TITLE
fix(cron): persist fresh isolated session transcript file

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -34,7 +34,8 @@ import {
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
-  resolveSessionTranscriptPath,
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
   setSessionRuntimeModel,
   updateSessionStore,
 } from "../../config/sessions.js";
@@ -286,6 +287,19 @@ export async function runCronIsolatedAgentTurn(params: {
         : params.job.id;
     cronSession.sessionEntry.label = `Cron: ${labelSuffix}`;
   }
+  const sessionFilePathOpts = resolveSessionFilePathOptions({
+    agentId,
+    storePath: cronSession.storePath,
+  });
+  if (cronSession.isNewSession) {
+    // Fresh isolated runs should persist their canonical transcript path
+    // immediately rather than waiting for a later re-entry path to backfill it.
+    cronSession.sessionEntry.sessionFile = resolveSessionFilePath(
+      runSessionId,
+      undefined,
+      sessionFilePathOpts,
+    );
+  }
 
   const resolvedModelSelection = await resolveCronModelSelection({
     cfg: params.cfg,
@@ -460,7 +474,11 @@ export async function runCronIsolatedAgentTurn(params: {
   const runStartedAt = Date.now();
   let runEndedAt = runStartedAt;
   try {
-    const sessionFile = resolveSessionTranscriptPath(cronSession.sessionEntry.sessionId, agentId);
+    const sessionFile = resolveSessionFilePath(
+      cronSession.sessionEntry.sessionId,
+      cronSession.sessionEntry,
+      sessionFilePathOpts,
+    );
     const resolvedVerboseLevel =
       normalizeVerboseLevel(cronSession.sessionEntry.verboseLevel) ??
       normalizeVerboseLevel(agentCfg?.verboseDefault) ??

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -107,6 +107,7 @@ describe("resolveCronSession", () => {
           sessionId: "existing-session-id-123",
           updatedAt: NOW_MS - 1000,
           systemSent: true,
+          sessionFile: "/custom/sessions/existing-session-id-123.jsonl",
         },
         fresh: true,
       });
@@ -114,6 +115,9 @@ describe("resolveCronSession", () => {
       expect(result.sessionEntry.sessionId).toBe("existing-session-id-123");
       expect(result.isNewSession).toBe(false);
       expect(result.systemSent).toBe(true);
+      expect(result.sessionEntry.sessionFile).toBe(
+        "/custom/sessions/existing-session-id-123.jsonl",
+      );
       expect(clearBootstrapSnapshot).not.toHaveBeenCalled();
     });
 
@@ -145,6 +149,7 @@ describe("resolveCronSession", () => {
           sessionId: "existing-session-id-456",
           updatedAt: NOW_MS - 1000,
           systemSent: true,
+          sessionFile: "/custom/sessions/existing-session-id-456.jsonl",
           modelOverride: "sonnet-4",
           providerOverride: "anthropic",
         },
@@ -157,6 +162,7 @@ describe("resolveCronSession", () => {
       expect(result.systemSent).toBe(false);
       expect(result.sessionEntry.modelOverride).toBe("sonnet-4");
       expect(result.sessionEntry.providerOverride).toBe("anthropic");
+      expect(result.sessionEntry.sessionFile).toBeUndefined();
       expect(clearBootstrapSnapshot).toHaveBeenCalledWith("webhook:stable-key");
     });
 

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -127,6 +127,7 @@ describe("resolveCronSession", () => {
           sessionId: "old-session-id",
           updatedAt: NOW_MS - 86_400_000, // 1 day ago
           systemSent: true,
+          sessionFile: "/custom/sessions/old-session-id.jsonl",
           modelOverride: "gpt-4.1-mini",
           providerOverride: "openai",
           sendPolicy: "allow",
@@ -137,6 +138,7 @@ describe("resolveCronSession", () => {
       expect(result.sessionEntry.sessionId).not.toBe("old-session-id");
       expect(result.isNewSession).toBe(true);
       expect(result.systemSent).toBe(false);
+      expect(result.sessionEntry.sessionFile).toBeUndefined();
       expect(result.sessionEntry.modelOverride).toBe("gpt-4.1-mini");
       expect(result.sessionEntry.providerOverride).toBe("openai");
       expect(result.sessionEntry.sendPolicy).toBe("allow");

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -78,6 +78,7 @@ export function resolveCronSession(params: {
     // deliveryContext must also be cleared because normalizeSessionEntryDelivery
     // repopulates lastThreadId from deliveryContext.threadId on store writes.
     ...(isNewSession && {
+      sessionFile: undefined,
       lastChannel: undefined,
       lastTo: undefined,
       lastAccountId: undefined,


### PR DESCRIPTION
## Summary

- Problem: isolated cron reruns could carry stale transcript metadata via `sessionFile`, causing yielded isolated parent runs to resume follow-up work against an older transcript instead of the current run.
- Why it matters: subagent completion handling could be appended to the wrong transcript, so the current isolated parent run could not resume its work correctly.
- What changed: fresh isolated cron sessions now clear inherited `sessionFile`, get a new transcript path derived from the current session-store location, and the isolated runner now uses session-file-aware path resolution during execution.
- What did NOT change (scope boundary): this PR does not attempt broader cleanup of unrelated session lifecycle fields such as `status`, `startedAt`, `endedAt`, or `runtimeMs`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #49572
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `resolveCronSession()` preserved the prior session entry wholesale when rolling to a fresh isolated run. That included `sessionFile`, which is run-specific metadata and should not carry across a forced-new/stale isolated session.
- Missing detection / guardrail: no test verified that a fresh isolated cron rerun both clears stale `sessionFile` metadata and rebinds execution to the current transcript path.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: isolated cron reruns reused stored session metadata more broadly than intended.
- If unknown, what was ruled out: I ruled out incorrect parent session key routing; subagent completion announces resolved through the correct parent session key, but attached to the wrong transcript because `sessionFile` was stale.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cron/isolated-agent/session.test.ts`
- Scenario the test should lock in: reused sessions preserve their existing `sessionFile`, while fresh isolated sessions clear inherited `sessionFile` before rebinding to a new run transcript.
- Why this is the smallest reliable guardrail: the bug starts in isolated cron session metadata rollover, before downstream subagent resume behavior.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Isolated cron reruns now stay bound to the correct current transcript instead of resuming follow-up work against an older transcript after subagent completion.

## Diagram (if applicable)

```text
Before:
[isolated cron rerun] -> [new sessionId + stale sessionFile] -> [subagent completion] -> [old transcript] -> [current run stalls]

After:
[isolated cron rerun] -> [new sessionId + fresh sessionFile] -> [subagent completion] -> [current transcript] -> [current run resumes]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo-run gateway
- Model/provider: reproduced across cron runs; provider overload was also observed separately during debugging, but is not required for this bug
- Integration/channel (if any): cron with subagent completion follow-up
- Relevant config (redacted): cron job with `sessionTarget: isolated`

### Steps

1. Run an isolated cron job that yields and later resumes after subagent completion.
2. Trigger another isolated run for the same cron session key.
3. Inspect `sessions.json` and the session transcript files after the parent yields and subagents complete.

### Expected

- The fresh isolated run gets a new `sessionId` and a transcript path for the current run.
- Subagent completion follow-up resumes the current isolated parent run.

### Actual

- A fresh isolated run got a new `sessionId`, but `sessions.json` still pointed `sessionFile` at an older transcript.
- Subagent completion follow-up was appended to the stale transcript instead of the current isolated run.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Observed repro:
- In cron flow `agent:main:cron:7f60ae2b-6059-4359-9b84-d12a8c7b421d`, a new isolated parent run was created with `sessionId = b0bb0798-e28d-463c-b539-2be898592777`, but `sessions.json` still pointed `sessionFile` at the older `9d1882ae-c015-4483-bf86-29bf6805bcaf.jsonl` transcript.
- After the parent yielded and subagents finished, their completion announces resolved through the correct parent session key but were appended to the stale transcript instead of the current isolated run.
- The stale session did receive the subagent completion message, but it responded with `NO_REPLY`, with reasoning that treated it as a subagent completion from an older workflow run.

## Human Verification (required)

- Verified scenarios:
  - reproduced the stale `sessionId` / `sessionFile` mismatch on an isolated cron flow
  - verified that after the fix, fresh isolated runs no longer inherit the previous transcript file
  - verified that both the base cron key and run key point to the current transcript
  - verified that the latest cron run completed in the current transcript instead of appending follow-up work to the stale older transcript
- Edge cases checked:
  - reused sessions continue using their existing `sessionFile`
  - fresh isolated sessions derive a new transcript path from the current session-store location
- What you did **not** verify:
  - broader cleanup of unrelated session lifecycle metadata such as `status`, `startedAt`, `endedAt`, or `runtimeMs`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: isolated cron reruns might still drift if another path recomputes transcript location independently of session metadata.
  - Mitigation: the runner now uses `resolveSessionFilePath(...)` so execution and persisted metadata stay aligned.
