### PR TITLE
fix(browser): add timeout protection to listPagesViaPlaywright

### DIFF
--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -116,4 +116,46 @@ describe("pw-session connection scoping", () => {
     expect(browserA.browserClose).toHaveBeenCalledTimes(1);
     expect(browserB.browserClose).not.toHaveBeenCalled();
   });
+
+  it("listPagesViaPlaywright rejects when CDP operations hang beyond the timeout", async () => {
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    // connectOverCDP returns a browser whose CDP session never resolves,
+    // simulating a hung CDP endpoint.
+    connectOverCdpSpy.mockImplementation((async () => {
+      const context = {
+        pages: () => [
+          {
+            on: vi.fn(),
+            context: () => context,
+            title: vi.fn(async () => ""),
+            url: vi.fn(() => "about:blank"),
+          },
+        ],
+        on: vi.fn(),
+        newCDPSession: vi.fn(
+          async () =>
+            new Promise<never>(() => {
+              /* never resolves — simulates CDP hang */
+            }),
+        ),
+      } as unknown as import("playwright-core").BrowserContext;
+
+      return {
+        contexts: () => [context],
+        on: vi.fn(),
+        off: vi.fn(),
+        close: vi.fn(async () => {}),
+      } as unknown as import("playwright-core").Browser;
+    }) as never);
+
+    vi.useFakeTimers();
+    try {
+      const pending = listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
+      await vi.advanceTimersByTimeAsync(15_000);
+      await expect(pending).rejects.toThrow("listPagesViaPlaywright timed out");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -152,8 +152,9 @@ describe("pw-session connection scoping", () => {
     vi.useFakeTimers();
     try {
       const pending = listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
+      const assertion = expect(pending).rejects.toThrow("listPagesViaPlaywright timed out");
       await vi.advanceTimersByTimeAsync(15_000);
-      await expect(pending).rejects.toThrow("listPagesViaPlaywright timed out");
+      await assertion;
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -715,6 +715,8 @@ export async function forceDisconnectPlaywrightForTarget(opts: {
  * List all pages/tabs from the persistent Playwright connection.
  * Used for remote profiles where HTTP-based /json/list is ephemeral.
  */
+const LIST_PAGES_TIMEOUT_MS = 15_000;
+
 export async function listPagesViaPlaywright(opts: { cdpUrl: string }): Promise<
   Array<{
     targetId: string;
@@ -723,7 +725,27 @@ export async function listPagesViaPlaywright(opts: { cdpUrl: string }): Promise<
     type: string;
   }>
 > {
-  const { browser } = await connectBrowser(opts.cdpUrl);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error("listPagesViaPlaywright timed out")),
+      LIST_PAGES_TIMEOUT_MS,
+    );
+  });
+
+  try {
+    return await Promise.race([listPagesCore(opts.cdpUrl), timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+async function listPagesCore(
+  cdpUrl: string,
+): Promise<Array<{ targetId: string; title: string; url: string; type: string }>> {
+  const { browser } = await connectBrowser(cdpUrl);
   const pages = await getAllPages(browser);
   const results: Array<{
     targetId: string;


### PR DESCRIPTION
**Fixes #58968**

## Root cause

`listPagesViaPlaywright` calls `pageTargetId()` (which opens a CDP session and sends `Target.getTargetInfo`) and `page.title()` inside a loop. Neither has a timeout. When a browser profile's CDP endpoint is connected but not responding to protocol commands — hung tab, stalled renderer — these calls block indefinitely. The suspension propagates up to the HTTP handler for tab listing, eventually causing an HTTP 500 after the server's own timeout fires.

`connectBrowser` already has timeout protection (5–9 s per attempt, 3 retries). The post-connection enumeration did not.

## Fix

Extract the enumeration loop into a private `listPagesCore` helper, then wrap the public `listPagesViaPlaywright` in a 15-second `Promise.race` timeout — the same pattern used by the CDP socket helper already in this file. Add a focused regression test: a browser mock whose CDP session never resolves, fake-timer advance to 15 s, assert rejection with a clear message.

## Changed files

- `extensions/browser/src/browser/pw-session.ts` — timeout wrapper + extracted helper
- `extensions/browser/src/browser/pw-session.connections.test.ts` — regression test