### PR TITLE
Keep channels status JSON output on gateway failure

### DIFF
--- a/src/commands/channels.status.command-flow.test.ts
+++ b/src/commands/channels.status.command-flow.test.ts
@@ -171,4 +171,32 @@ describe("channelsStatusCommand SecretRef fallback flow", () => {
     expect(joined).not.toContain("secret unavailable in this command path");
     expect(joined).not.toContain("token:config (unavailable)");
   });
+
+  it("keeps --json output machine-readable when the gateway is unreachable", async () => {
+    callGateway.mockRejectedValue(new Error("gateway closed"));
+    requireValidConfigSnapshot.mockResolvedValue({ secretResolved: false, channels: {} });
+    resolveCommandSecretRefsViaGateway.mockResolvedValue({
+      resolvedConfig: { secretResolved: false, channels: {} },
+      diagnostics: [
+        "channels status: channels.discord.token is unavailable in this command path; continuing with degraded read-only config.",
+      ],
+      targetStatesByPath: {},
+      hadUnresolvedTargets: true,
+    });
+    const jsonWrites: unknown[] = [];
+    const { runtime, logs, errors } = createRuntimeCapture();
+    const runtimeWithJson = {
+      ...runtime,
+      writeStdout: (_value: string) => {},
+      writeJson: (value: unknown) => {
+        jsonWrites.push(value);
+      },
+    };
+
+    await channelsStatusCommand({ probe: false, json: true }, runtimeWithJson as never);
+
+    expect(jsonWrites).toHaveLength(1);
+    expect(logs).toEqual([]);
+    expect(errors).toEqual([]);
+  });
 });

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -306,9 +306,16 @@ export async function channelsStatusCommand(
     }
     runtime.log(formatGatewayChannelsStatusLines(payload).join("\n"));
   } catch (err) {
-    runtime.error(`Gateway not reachable: ${String(err)}`);
     const cfg = await requireValidConfigSnapshot(runtime);
     if (!cfg) {
+      if (opts.json) {
+        writeRuntimeJson(runtime, {
+          ok: false,
+          error: `Gateway not reachable: ${String(err)}`,
+        });
+        return;
+      }
+      runtime.error(`Gateway not reachable: ${String(err)}`);
       return;
     }
     const { resolvedConfig, diagnostics } = await resolveCommandSecretRefsViaGateway({
@@ -317,11 +324,28 @@ export async function channelsStatusCommand(
       targetIds: getChannelsCommandSecretTargetIds(),
       mode: "read_only_status",
     });
+    const snapshot = await readConfigFileSnapshot();
+    const mode = cfg.gateway?.mode === "remote" ? "remote" : "local";
+
+    if (opts.json) {
+      writeRuntimeJson(runtime, {
+        ok: false,
+        error: `Gateway not reachable: ${String(err)}`,
+        fallback: {
+          kind: "config_only",
+          path: snapshot.path,
+          mode,
+          diagnostics,
+          config: resolvedConfig,
+        },
+      });
+      return;
+    }
+
+    runtime.error(`Gateway not reachable: ${String(err)}`);
     for (const entry of diagnostics) {
       runtime.log(`[secrets] ${entry}`);
     }
-    const snapshot = await readConfigFileSnapshot();
-    const mode = cfg.gateway?.mode === "remote" ? "remote" : "local";
     runtime.log(
       (
         await formatConfigChannelsStatusLines(


### PR DESCRIPTION
## Summary

Keep `channels status --json` machine-readable when the gateway is unreachable.

## What changed

- Preserved JSON output in the gateway failure path for `channels status --json`
- Returned a structured fallback payload instead of emitting human-readable logs/errors
- Added a focused command-flow test covering the unreachable-gateway JSON case

## Why

`channels status --json` currently returns JSON only on success. When the gateway is unreachable, it falls back to human-readable output, which breaks script consumers precisely when machine-readable output is most useful.

This change keeps the JSON mode machine-readable even on gateway failure while still surfacing the config-only fallback information.

## Manual verification

1. Reproduced the gateway-unreachable path in `channelsStatusCommand`
2. Verified that `--json` now writes structured JSON instead of text fallback output
3. Added a focused test in `src/commands/channels.status.command-flow.test.ts`
4. Ran:
   - `pnpm vitest run src/commands/channels.status.command-flow.test.ts -t "keeps --json output machine-readable when the gateway is unreachable"`
   - `pnpm vitest run src/commands/channels.status.command-flow.test.ts`
5. Ran the repo checks during commit