### PR TITLE
fix(memory-lancedb): force float encoding for local embedding servers

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -276,6 +276,7 @@ describe("memory plugin e2e", () => {
       expect(embeddingsCreate).toHaveBeenCalledWith({
         model: "text-embedding-3-small",
         input: "hello dimensions",
+        encoding_format: "float",
         dimensions: 1024,
       });
     } finally {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -162,9 +162,12 @@ class Embeddings {
   }
 
   async embed(text: string): Promise<number[]> {
-    const params: { model: string; input: string; dimensions?: number } = {
+    const params: { model: string; input: string; dimensions?: number; encoding_format?: "float" | "base64" } = {
       model: this.model,
       input: text,
+      // Force float encoding: the OpenAI SDK v6+ defaults to base64 which
+      // local servers (LM Studio, Ollama, etc.) do not support correctly.
+      encoding_format: "float",
     };
     if (this.dimensions) {
       params.dimensions = this.dimensions;


### PR DESCRIPTION
## Summary

- **Problem:** The OpenAI Node SDK v6+ changed its default `encoding_format` for embeddings from `"float"` to `"base64"` for bandwidth efficiency. Local embedding servers (LM Studio, Ollama, vLLM, llama.cpp) do not support base64 encoding — they return raw float arrays regardless of the requested format. The SDK then misinterprets these floats as base64-decoded data, producing garbled vectors (e.g., 192 zero-filled dimensions instead of 768 real values).
- **Why it matters:** This silently breaks both `autoRecall` and `autoCapture` for any user running the memory-lancedb plugin against a local embedding server. Recalls return no results; captures fail with dimension mismatches or store corrupted vectors.
- **What changed:** Added `encoding_format: "float"` to the embeddings API request in `Embeddings.embed()`. Updated the existing dimensions test to assert the new parameter.
- **What did NOT change (scope boundary):** No changes to config schema, DB schema, plugin registration, or any other embedding parameter handling. The `encoding_format: "float"` is also valid and harmless for OpenAI's hosted API — it simply opts out of the base64 optimization.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: OpenAI SDK v6 changelog (base64 default for embeddings)
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** The OpenAI Node SDK v6+ sends `encoding_format: "base64"` by default. Local servers ignore this parameter and return float arrays. The SDK's response parser then attempts to base64-decode the float array, producing a shorter vector of incorrect values (768 floats → ~192 garbled values after misinterpreted base64 decoding).
- **Missing detection / guardrail:** No encoding format was explicitly specified, relying on the SDK's default which changed across major versions.
- **Prior context:** The `openai` dependency was upgraded to `^6.33.0` in the memory-lancedb extension.
- **Why this regressed now:** SDK v6 changed the default encoding format. Previous SDK versions defaulted to `"float"`.
- **If unknown, what was ruled out:** N/A — root cause confirmed via direct API testing (`curl` returns 768d, SDK returns 192d for the same request; adding `encoding_format: "float"` fixes it).

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `extensions/memory-lancedb/index.test.ts`
- **Scenario the test should lock in:** The `encoding_format: "float"` parameter is always included in embeddings API calls.
- **Why this is the smallest reliable guardrail:** A unit-level assertion on the API call params catches the issue at the source without requiring a running embedding server.
- **Existing test that already covers this:** The existing `"passes configured dimensions to OpenAI embeddings API"` test now also asserts `encoding_format: "float"`.
- **If no new test is added, why not:** Extended existing test coverage instead.

## User-visible / Behavior Changes

Memory recall and auto-capture now work correctly with local embedding servers (LM Studio, Ollama, vLLM, llama.cpp). No config changes required.

## Diagram (if applicable)

```text
Before:
[embed request] -> SDK adds encoding_format:"base64" -> local server ignores, returns floats
                -> SDK decodes floats as base64 -> garbled 192-dim vector -> recall/capture fails

After:
[embed request] -> explicit encoding_format:"float" -> local server returns floats
                -> SDK reads floats directly -> correct 768-dim vector -> recall/capture works
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same endpoint, one additional benign parameter)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu (WSL2) on Windows 11
- Runtime/container: Node 22.22.1
- Model/provider: LM Studio serving `text-embedding-nomic-embed-text-v1.5`
- Integration/channel: WhatsApp (but affects all channels using memory)
- Relevant config: `embedding.baseUrl: "http://127.0.0.1:1234/v1"`, `embedding.dimensions: 768`

### Steps

1. Configure memory-lancedb with a local embedding server (LM Studio, Ollama, etc.)
2. Send a message through any channel with `autoRecall: true`
3. Check gateway logs for memory-lancedb errors

### Expected

- Memory recall and capture succeed; vectors have correct dimensions.

### Actual

- `memory-lancedb: recall failed: Error: Embedding dimension mismatch: expected 768, got 192`
- `memory-lancedb: capture failed: Error: Embedding dimension mismatch: expected 768, got 192`

## Evidence

- Gateway logs showing repeated `Embedding dimension mismatch: expected 768, got 192` errors
- Direct API verification: `curl` returns 768d vectors; OpenAI Node SDK returns 192d for the same model/input without `encoding_format: "float"`
- After fix: LanceDB transactions resume (new `.txn` files appear in `memories.lance/_transactions/`)

## Human Verification (required)

- **Verified scenarios:** Rebuilt gateway with fix, sent WhatsApp messages, confirmed new LanceDB transactions written with correct 768-dim vectors. Gateway logs show no more dimension mismatch errors.
- **Edge cases checked:** Verified `encoding_format: "float"` is valid and harmless for OpenAI's hosted API (documented parameter). Verified LM Studio returns identical results with and without the parameter.
- **What you did not verify:** Other local servers (Ollama, vLLM) — but the fix is generic (explicit float format) and the root cause is SDK-side, not server-side.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** Marginal bandwidth increase for users on OpenAI's hosted API (float vs base64 encoding).
  - **Mitigation:** Embedding payloads are small (single text → single vector); the bandwidth difference is negligible. Correctness for local servers outweighs the optimization.