### PR TITLE
Normalize telegram topic targets in delivery resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/Telegram: preserve explicit `:topic:` delivery targets over stale session-derived thread IDs when isolated cron announces to Telegram forum topics. Carries forward #59069; refs #49704 and #43808. Thanks @roytong9.
 - Memory/Dreaming: retry Dream Diary once with the session default when a configured dreaming model is unavailable, while leaving subagent trust and allowlist errors visible instead of silently masking configuration problems. Refs #67409 and #69209. Thanks @Ghiggins18 and @everySympathy.
 - Feishu/inbound files: recover CJK filenames from plain `Content-Disposition: filename=` download headers when Feishu exposes UTF-8 bytes through Latin-1 header decoding, while leaving valid Latin-1 and JSON-derived names unchanged. (#48578, #50435, #59431) Thanks @alex-xuweilong, @lishuaigit, and @DoChaoing.
 

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -612,6 +612,19 @@ describe("resolveDeliveryTarget", () => {
     expect(result.accountId).toBe("bot-b");
   });
 
+  it("strips :topic: suffix from telegram targets when threadId is resolved", async () => {
+    setMainSessionEntry(undefined);
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "telegram",
+      to: "63448508:topic:1008013",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("63448508");
+    expect(result.threadId).toBe(1008013);
+  });
+
   it("explicit delivery.accountId overrides bindings-derived accountId", async () => {
     setMainSessionEntry(undefined);
     const cfg = makeCfg({

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -116,6 +116,14 @@ beforeEach(() => {
         },
         source: "test",
       },
+      {
+        pluginId: "telegram",
+        plugin: createOutboundTestPlugin({
+          id: "telegram",
+          outbound: createStubOutbound("Telegram"),
+        }),
+        source: "test",
+      },
     ]),
   );
 });
@@ -614,6 +622,24 @@ describe("resolveDeliveryTarget", () => {
 
   it("strips :topic: suffix from telegram targets when threadId is resolved", async () => {
     setMainSessionEntry(undefined);
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "telegram",
+      to: "63448508:topic:1008013",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("63448508");
+    expect(result.threadId).toBe(1008013);
+  });
+
+  it("prefers explicit telegram :topic: targets over session-derived threadId", async () => {
+    setLastSessionEntry({
+      sessionId: "sess-telegram-topic",
+      lastChannel: "telegram",
+      lastTo: "63448508:topic:1008013",
+      lastThreadId: "stale-thread",
+    });
 
     const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
       channel: "telegram",

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -651,6 +651,20 @@ describe("resolveDeliveryTarget", () => {
     expect(result.threadId).toBe(1008013);
   });
 
+  it("keeps explicit delivery threadId when stripping telegram :topic: targets", async () => {
+    setMainSessionEntry(undefined);
+
+    const result = await resolveDeliveryTarget(makeCfg({ bindings: [] }), AGENT_ID, {
+      channel: "telegram",
+      to: "63448508:topic:1008013",
+      threadId: "42",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.to).toBe("63448508");
+    expect(result.threadId).toBe("42");
+  });
+
   it("explicit delivery.accountId overrides bindings-derived accountId", async () => {
     setMainSessionEntry(undefined);
     const cfg = makeCfg({

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -158,11 +158,21 @@ export async function resolveDeliveryTarget(
   // or when delivering to the same recipient as the session's last conversation.
   // Session-derived threadIds are dropped when the target differs to prevent
   // stale thread IDs from leaking to a different chat.
-  const threadId =
+  let threadId =
     resolved.threadId &&
     (resolved.threadIdExplicit || (resolved.to && resolved.to === resolved.lastTo))
       ? resolved.threadId
       : undefined;
+
+  if (channel === "telegram" && typeof toCandidate === "string") {
+    const topicMatch = toCandidate.match(/:topic:(\d+)$/i);
+    if (topicMatch) {
+      if (!threadId) {
+        threadId = Number(topicMatch[1]);
+      }
+      toCandidate = toCandidate.replace(/:topic:\d+$/i, "");
+    }
+  }
 
   if (!channel) {
     return {

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -167,7 +167,9 @@ export async function resolveDeliveryTarget(
   if (channel === "telegram" && typeof toCandidate === "string") {
     const topicMatch = toCandidate.match(/:topic:(\d+)$/i);
     if (topicMatch) {
-      threadId = Number(topicMatch[1]);
+      if (jobPayload.threadId == null || jobPayload.threadId === "") {
+        threadId = Number(topicMatch[1]);
+      }
       toCandidate = toCandidate.replace(/:topic:\d+$/i, "");
     }
   }

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -167,9 +167,7 @@ export async function resolveDeliveryTarget(
   if (channel === "telegram" && typeof toCandidate === "string") {
     const topicMatch = toCandidate.match(/:topic:(\d+)$/i);
     if (topicMatch) {
-      if (!threadId) {
-        threadId = Number(topicMatch[1]);
-      }
+      threadId = Number(topicMatch[1]);
       toCandidate = toCandidate.replace(/:topic:\d+$/i, "");
     }
   }


### PR DESCRIPTION
## Summary

Normalize Telegram `:topic:` delivery targets so the base recipient and `threadId` are separated consistently during delivery target resolution.

## What changed

- Strip the `:topic:<id>` suffix from Telegram delivery targets in `resolveDeliveryTarget`
- Preserve the parsed topic id as `threadId`
- Add a focused regression test for explicit Telegram `:topic:` targets
- Keep the existing thread-session lookup behavior covered by the related tests

## Why

Some delivery-target paths were preserving the raw Telegram topic suffix in `to`, returning values like:

- `to = "63448508:topic:1008013"`
- `threadId = 1008013`

instead of normalizing them to:

- `to = "63448508"`
- `threadId = 1008013`

This made the behavior inconsistent with other Telegram topic parsing paths and with the expectations already encoded in the thread-session lookup tests.

## Manual verification

1. Reproduced the failure through:
   - `src/cron/isolated-agent.delivery-target-thread-session.test.ts`
2. Added a focused regression test in:
   - `src/cron/isolated-agent/delivery-target.test.ts`
3. Updated `src/cron/isolated-agent/delivery-target.ts` to parse and strip the `:topic:` suffix directly from Telegram targets
4. Ran:
   - `pnpm vitest run src/cron/isolated-agent/delivery-target.test.ts src/cron/isolated-agent.delivery-target-thread-session.test.ts`

## Note

The normal local commit hook currently hits an unrelated repo-wide `tsgo` failure in `extensions/matrix/src/matrix/client.test.ts`, so I validated this change with the targeted tests above.