### PR TITLE
fix: edit tool CLAUDE_PARAM_GROUPS expects edits[] array

### DIFF
--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -21,17 +21,7 @@ export const CLAUDE_PARAM_GROUPS = {
   ],
   edit: [
     { keys: ["path", "file_path", "filePath", "file"], label: "path alias" },
-    {
-      keys: ["oldText", "old_string", "old_text", "oldString"],
-      label: "oldText alias",
-      validator: hasValidEditReplacements,
-    },
-    {
-      keys: ["newText", "new_string", "new_text", "newString"],
-      label: "newText alias",
-      allowEmpty: true,
-      validator: hasValidEditReplacements,
-    },
+    { keys: ["edits"], label: "edits array" },
   ],
 } as const;
 
@@ -150,15 +140,6 @@ function normalizeEditReplacements(record: Record<string, unknown>) {
   }
 }
 
-function hasValidEditReplacements(record: Record<string, unknown>): boolean {
-  const edits = record.edits;
-  return (
-    Array.isArray(edits) &&
-    edits.length > 0 &&
-    edits.every((entry) => normalizeEditReplacement(entry) !== undefined)
-  );
-}
-
 function normalizeClaudeParamAliases(record: Record<string, unknown>) {
   for (const { original, alias } of CLAUDE_PARAM_ALIASES) {
     if (alias in record && !(original in record)) {
@@ -258,6 +239,10 @@ export function assertRequiredParams(
         }
         const value = record[key];
         if (typeof value !== "string") {
+          // For edit tool, 'edits' is an array, not a string
+          if (key === "edits" && Array.isArray(value) && value.length > 0) {
+            return true;
+          }
           return false;
         }
         if (group.allowEmpty) {


### PR DESCRIPTION
- CLAUDE_PARAM_GROUPS.edit now expects 'edits' array (not top-level oldText/newText)
- assertRequiredParams updated to handle array values for 'edits' key
- Fixes validation error: 'Missing required parameters: oldText alias, newText alias'

Root cause: pi-coding-agent uses edits[] array schema with prepareEditArguments conversion, but OpenClaw wrapper was validating top-level parameters BEFORE prepareEditArguments could run, causing cascading failures.

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause:
- Missing detection / guardrail:
- Prior context (`git blame`, prior PR, issue, or refactor if known):
- Why this regressed now:
- If unknown, what was ruled out:

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user action] -> [old state]

After:
[user action] -> [new state] -> [result]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
