### PR TITLE
fix: suppress raw JSON parse errors from leaking to Discord channels (#59076) [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/errors: suppress malformed streaming tool-call JSON fragments before they reach chat surfaces while preserving provider request-validation diagnostics. Fixes #59076; keeps #59080 as duplicate coverage. (#59118) Thanks @singleGanghood.
 - CLI/models: restore provider-filtered `models list --all --provider <id>` rows for providers without manifest/static catalog coverage, including Anthropic and Amazon Bedrock, while keeping the compatibility fallback off expensive availability and resolver paths. Thanks @shakkernerd.
 - CLI/tools: keep the Gateway `tools.*` RPC namespace out of plugin command discovery and managed proxy startup, so stray commands like `openclaw tools effective` fail quickly instead of cold-loading plugin metadata. Refs #73477. Thanks @oromeis.
 - CLI/status: keep default text `openclaw status --usage` on metadata-only channel scans unless `--deep` or `--all` is set, and send stray `openclaw tools --help` through the precomputed root-help fast path so latency-triage commands avoid plugin/runtime cold loads before printing. Refs #73477 and #74220. Thanks @oromeis and @NianJiuZst.

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -41,6 +41,14 @@ function createStalledSseResponse(params: { onCancel: (reason: unknown) => void 
       params.onCancel(reason);
     },
   });
+
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function createRawSseResponse(body: string): Response {
   return new Response(body, {
     status: 200,
     headers: { "content-type": "text/event-stream" },
@@ -337,6 +345,23 @@ describe("anthropic transport stream", () => {
       "Anthropic Messages transport requires a positive maxTokens value",
     );
     expect(guardedFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("classifies malformed Anthropic SSE data as a stable transport error", async () => {
+    guardedFetchMock.mockResolvedValueOnce(createRawSseResponse('data: {"type":\n\n'));
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe("OpenClaw transport error: malformed_streaming_fragment");
   });
 
   it("preserves Anthropic OAuth identity and tool-name remapping with transport overrides", async () => {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -9,6 +9,7 @@ import {
   type SimpleStreamOptions,
   type ThinkingLevel,
 } from "@mariozechner/pi-ai";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import {
   applyAnthropicPayloadPolicyToParams,
@@ -24,7 +25,6 @@ import {
   createWritableTransportEventStream,
   failTransportStream,
   finalizeTransportStream,
-  MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
   mergeTransportHeaders,
   sanitizeNonEmptyTransportPayloadText,
   sanitizeTransportPayloadText,

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -24,6 +24,7 @@ import {
   createWritableTransportEventStream,
   failTransportStream,
   finalizeTransportStream,
+  MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
   mergeTransportHeaders,
   sanitizeNonEmptyTransportPayloadText,
   sanitizeTransportPayloadText,
@@ -534,6 +535,17 @@ function readAnthropicSseChunk(
   });
 }
 
+function parseAnthropicSseEventData(data: string): Record<string, unknown> {
+  try {
+    return JSON.parse(data) as Record<string, unknown>;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE, { cause: error });
+    }
+    throw error;
+  }
+}
+
 async function* parseAnthropicSseBody(
   body: ReadableStream<Uint8Array>,
   signal?: AbortSignal,
@@ -558,7 +570,7 @@ async function* parseAnthropicSseBody(
           .map((line) => line.slice(5).trimStart())
           .join("\n");
         if (data && data !== "[DONE]") {
-          yield JSON.parse(data) as Record<string, unknown>;
+          yield parseAnthropicSseEventData(data);
         }
         frameEnd = buffer.indexOf("\n\n");
       }
@@ -571,7 +583,7 @@ async function* parseAnthropicSseBody(
         .map((line) => line.slice(5).trimStart())
         .join("\n");
       if (data && data !== "[DONE]") {
-        yield JSON.parse(data) as Record<string, unknown>;
+        yield parseAnthropicSseEventData(data);
       }
     }
   } finally {

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -7,6 +7,7 @@ import {
   getApiErrorPayloadFingerprint,
   formatRawAssistantErrorForUi,
   isRawApiErrorPayload,
+  sanitizeUserFacingText,
 } from "./pi-embedded-helpers.js";
 import { makeAssistantMessageFixture } from "./test-helpers/assistant-message-fixtures.js";
 
@@ -349,6 +350,40 @@ describe("formatAssistantErrorText", () => {
       "LLM request failed: provider returned an invalid streaming response. Please try again.",
     );
   });
+
+  it("sanitizes streaming JSON parse errors from Anthropic SDK (#59076)", () => {
+    const msg = makeAssistantError(
+      "Expected ',' or '}' after property value in JSON at position 334 (line 1 column 335)",
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "LLM streaming response contained a malformed fragment. Please try again.",
+    );
+  });
+
+  it("sanitizes 'Expected double-quoted property name' JSON parse errors (#59076)", () => {
+    const msg = makeAssistantError(
+      "Expected double-quoted property name in JSON at position 8912 (line 219 column 5)",
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "LLM streaming response contained a malformed fragment. Please try again.",
+    );
+  });
+
+  it("sanitizes 'Unexpected token' JSON parse errors (#59076)", () => {
+    const msg = makeAssistantError("Unexpected token < in JSON at position 0");
+    expect(formatAssistantErrorText(msg)).toBe(
+      "LLM streaming response contained a malformed fragment. Please try again.",
+    );
+  });
+
+  it("keeps provider request-validation JSON diagnostics actionable", () => {
+    const msg = makeAssistantError(
+      '{"type":"error","error":{"type":"invalid_request_error","message":"Expected value in JSON at position 12 for messages.0.content"}}',
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "LLM request rejected: Expected value in JSON at position 12 for messages.0.content",
+    );
+  });
 });
 
 describe("formatRawAssistantErrorForUi", () => {
@@ -422,5 +457,24 @@ describe("raw API error payload helpers", () => {
     expect(formatRawAssistantErrorForUi(raw)).toBe(
       "LLM error insufficient_balance: Insufficient MBT balance. Top up or upgrade your subscription to continue.",
     );
+  });
+});
+
+describe("sanitizeUserFacingText — streaming JSON parse error (#59076)", () => {
+  it("rewrites JSON parse error in error context", () => {
+    const result = sanitizeUserFacingText(
+      "Expected ',' or '}' after property value in JSON at position 334 (line 1 column 335)",
+      { errorContext: true },
+    );
+    expect(result).toBe("LLM streaming response contained a malformed fragment. Please try again.");
+  });
+
+  it("does not rewrite JSON parse error when not in error context", () => {
+    // When not in error context, the text could be legitimate assistant content
+    // mentioning JSON errors. Don't rewrite.
+    const text =
+      "Expected ',' or '}' after property value in JSON at position 334 (line 1 column 335)";
+    const result = sanitizeUserFacingText(text, { errorContext: false });
+    expect(result).toBe(text);
   });
 });

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -10,6 +10,7 @@ import {
   sanitizeUserFacingText,
 } from "./pi-embedded-helpers.js";
 import { makeAssistantMessageFixture } from "./test-helpers/assistant-message-fixtures.js";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "./transport-stream-shared.js";
 
 describe("formatAssistantErrorText", () => {
   const makeAssistantError = (errorMessage: string): AssistantMessage =>
@@ -351,28 +352,8 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
-  it("sanitizes streaming JSON parse errors from Anthropic SDK (#59076)", () => {
-    const msg = makeAssistantError(
-      "Expected ',' or '}' after property value in JSON at position 334 (line 1 column 335)",
-    );
-    expect(formatAssistantErrorText(msg)).toBe(
-      "LLM streaming response contained a malformed fragment. Please try again.",
-    );
-  });
-
-  it("sanitizes 'Expected double-quoted property name' JSON parse errors (#59076)", () => {
-    const msg = makeAssistantError(
-      "Expected double-quoted property name in JSON at position 8912 (line 219 column 5)",
-    );
-    expect(formatAssistantErrorText(msg)).toBe(
-      "LLM streaming response contained a malformed fragment. Please try again.",
-    );
-  });
-
-  it("sanitizes context-proven streaming 'Unexpected token' JSON parse errors (#59076)", () => {
-    const msg = makeAssistantError(
-      'Could not parse Anthropic SSE event content_block_delta: Unexpected token } in JSON at position 14; data={"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"}"},"index":1}',
-    );
+  it("sanitizes transport-classified malformed streaming fragments (#59076)", () => {
+    const msg = makeAssistantError(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE);
     expect(formatAssistantErrorText(msg)).toBe(
       "LLM streaming response contained a malformed fragment. Please try again.",
     );
@@ -475,19 +456,10 @@ describe("raw API error payload helpers", () => {
 });
 
 describe("sanitizeUserFacingText — streaming JSON parse error (#59076)", () => {
-  it("rewrites JSON parse error in error context", () => {
-    const result = sanitizeUserFacingText(
-      "Expected ',' or '}' after property value in JSON at position 334 (line 1 column 335)",
-      { errorContext: true },
-    );
-    expect(result).toBe("LLM streaming response contained a malformed fragment. Please try again.");
-  });
-
-  it.each([
-    "Unexpected end of JSON input",
-    "Unexpected non-whitespace character after JSON at position 4",
-  ])("rewrites plain JSON.parse error variants in error context: %s", (text) => {
-    const result = sanitizeUserFacingText(text, { errorContext: true });
+  it("rewrites transport-classified malformed streaming fragments in error context", () => {
+    const result = sanitizeUserFacingText(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE, {
+      errorContext: true,
+    });
     expect(result).toBe("LLM streaming response contained a malformed fragment. Please try again.");
   });
 

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -483,6 +483,14 @@ describe("sanitizeUserFacingText — streaming JSON parse error (#59076)", () =>
     expect(result).toBe("LLM streaming response contained a malformed fragment. Please try again.");
   });
 
+  it.each([
+    "Unexpected end of JSON input",
+    "Unexpected non-whitespace character after JSON at position 4",
+  ])("rewrites plain JSON.parse error variants in error context: %s", (text) => {
+    const result = sanitizeUserFacingText(text, { errorContext: true });
+    expect(result).toBe("LLM streaming response contained a malformed fragment. Please try again.");
+  });
+
   it("does not rewrite JSON parse error when not in error context", () => {
     // When not in error context, the text could be legitimate assistant content
     // mentioning JSON errors. Don't rewrite.

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
   formatBillingErrorMessage,
@@ -10,7 +11,6 @@ import {
   sanitizeUserFacingText,
 } from "./pi-embedded-helpers.js";
 import { makeAssistantMessageFixture } from "./test-helpers/assistant-message-fixtures.js";
-import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "./transport-stream-shared.js";
 
 describe("formatAssistantErrorText", () => {
   const makeAssistantError = (errorMessage: string): AssistantMessage =>

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -369,10 +369,24 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
-  it("sanitizes 'Unexpected token' JSON parse errors (#59076)", () => {
-    const msg = makeAssistantError("Unexpected token < in JSON at position 0");
+  it("sanitizes context-proven streaming 'Unexpected token' JSON parse errors (#59076)", () => {
+    const msg = makeAssistantError(
+      'Could not parse Anthropic SSE event content_block_delta: Unexpected token } in JSON at position 14; data={"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"}"},"index":1}',
+    );
     expect(formatAssistantErrorText(msg)).toBe(
       "LLM streaming response contained a malformed fragment. Please try again.",
+    );
+  });
+
+  it("does not broadly rewrite non-streaming 'Unexpected token' JSON parse errors", () => {
+    const msg = makeAssistantError("Unexpected token < in JSON at position 0");
+    expect(formatAssistantErrorText(msg)).toBe("Unexpected token < in JSON at position 0");
+  });
+
+  it("does not rewrite non-streaming provider JSON request-validation diagnostics", () => {
+    const msg = makeAssistantError("Expected value in JSON at position 12 for messages.0.content");
+    expect(formatAssistantErrorText(msg)).toBe(
+      "Expected value in JSON at position 12 for messages.0.content",
     );
   });
 

--- a/src/agents/pi-embedded-helpers/errors.test.ts
+++ b/src/agents/pi-embedded-helpers/errors.test.ts
@@ -19,6 +19,16 @@ describe("formatAssistantErrorText streaming JSON parse classification", () => {
     );
   });
 
+  it.each([
+    "Unexpected end of JSON input",
+    "Unexpected non-whitespace character after JSON at position 4",
+  ])("suppresses plain JSON.parse streaming fragment failures: %s", (errorMessage) => {
+    const msg = makeAssistantError(errorMessage);
+    expect(formatAssistantErrorText(msg)).toBe(
+      "LLM streaming response contained a malformed fragment. Please try again.",
+    );
+  });
+
   it("suppresses structured Anthropic tool-call delta parse failures", () => {
     const msg = makeAssistantError(
       'Could not parse Anthropic SSE event content_block_delta: Unexpected end of JSON input; data={"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\\"path\\":"},"index":0}',

--- a/src/agents/pi-embedded-helpers/errors.test.ts
+++ b/src/agents/pi-embedded-helpers/errors.test.ts
@@ -1,7 +1,7 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../../shared/assistant-error-format.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
-import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transport-stream-shared.js";
 import { formatAssistantErrorText } from "./errors.js";
 
 describe("formatAssistantErrorText streaming JSON parse classification", () => {

--- a/src/agents/pi-embedded-helpers/errors.test.ts
+++ b/src/agents/pi-embedded-helpers/errors.test.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transport-stream-shared.js";
 import { formatAssistantErrorText } from "./errors.js";
 
 describe("formatAssistantErrorText streaming JSON parse classification", () => {
@@ -10,31 +11,19 @@ describe("formatAssistantErrorText streaming JSON parse classification", () => {
       content: [{ type: "text", text: errorMessage }],
     });
 
-  it("suppresses raw streaming tool-call fragment parse failures", () => {
+  it("suppresses transport-classified malformed streaming fragments", () => {
+    const msg = makeAssistantError(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE);
+    expect(formatAssistantErrorText(msg)).toBe(
+      "LLM streaming response contained a malformed fragment. Please try again.",
+    );
+  });
+
+  it("does not suppress unclassified JSON.parse text", () => {
     const msg = makeAssistantError(
       "Expected ',' or '}' after property value in JSON at position 334 (line 1 column 335)",
     );
     expect(formatAssistantErrorText(msg)).toBe(
-      "LLM streaming response contained a malformed fragment. Please try again.",
-    );
-  });
-
-  it.each([
-    "Unexpected end of JSON input",
-    "Unexpected non-whitespace character after JSON at position 4",
-  ])("suppresses plain JSON.parse streaming fragment failures: %s", (errorMessage) => {
-    const msg = makeAssistantError(errorMessage);
-    expect(formatAssistantErrorText(msg)).toBe(
-      "LLM streaming response contained a malformed fragment. Please try again.",
-    );
-  });
-
-  it("suppresses structured Anthropic tool-call delta parse failures", () => {
-    const msg = makeAssistantError(
-      'Could not parse Anthropic SSE event content_block_delta: Unexpected end of JSON input; data={"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\\"path\\":"},"index":0}',
-    );
-    expect(formatAssistantErrorText(msg)).toBe(
-      "LLM streaming response contained a malformed fragment. Please try again.",
+      "Expected ',' or '}' after property value in JSON at position 334 (line 1 column 335)",
     );
   });
 

--- a/src/agents/pi-embedded-helpers/errors.test.ts
+++ b/src/agents/pi-embedded-helpers/errors.test.ts
@@ -1,0 +1,39 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
+import { formatAssistantErrorText } from "./errors.js";
+
+describe("formatAssistantErrorText streaming JSON parse classification", () => {
+  const makeAssistantError = (errorMessage: string): AssistantMessage =>
+    makeAssistantMessageFixture({
+      errorMessage,
+      content: [{ type: "text", text: errorMessage }],
+    });
+
+  it("suppresses raw streaming tool-call fragment parse failures", () => {
+    const msg = makeAssistantError(
+      "Expected ',' or '}' after property value in JSON at position 334 (line 1 column 335)",
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "LLM streaming response contained a malformed fragment. Please try again.",
+    );
+  });
+
+  it("suppresses structured Anthropic tool-call delta parse failures", () => {
+    const msg = makeAssistantError(
+      'Could not parse Anthropic SSE event content_block_delta: Unexpected end of JSON input; data={"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\\"path\\":"},"index":0}',
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "LLM streaming response contained a malformed fragment. Please try again.",
+    );
+  });
+
+  it("keeps non-streaming provider request-validation syntax diagnostics", () => {
+    const msg = makeAssistantError(
+      '{"type":"error","error":{"type":"invalid_request_error","message":"Expected value in JSON at position 12 for messages.0.content"}}',
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "LLM request rejected: Expected value in JSON at position 12 for messages.0.content",
+    );
+  });
+});

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -46,6 +46,7 @@ import {
   isInvalidStreamingEventOrderError,
   isLikelyHttpErrorText,
   isRawApiErrorPayload,
+  isStreamingJsonParseError,
   sanitizeUserFacingText,
 } from "./sanitize-user-facing-text.js";
 import type { FailoverReason } from "./types.js";
@@ -1137,6 +1138,10 @@ export function formatAssistantErrorText(
 
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {
     return formatRawAssistantErrorForUi(raw);
+  }
+
+  if (isStreamingJsonParseError(raw)) {
+    return "LLM streaming response contained a malformed fragment. Please try again.";
   }
 
   // Never return raw unhandled errors - log for debugging but return safe message

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -213,7 +213,19 @@ export function isStreamingJsonParseError(raw: string): boolean {
   if (!raw) {
     return false;
   }
-  return /\b(?:expected|unexpected)\b.+\bin json\b.+\bposition\b/i.test(raw);
+  const trimmed = raw.trim();
+  if (
+    /\bcould not parse anthropic sse event\b/i.test(trimmed) &&
+    /\b(?:content_block_delta|input_json_delta|partial_json|tool_use)\b/i.test(trimmed) &&
+    (/\b(?:expected|unexpected|unterminated)\b.+\bin json\b.+\bposition\b/i.test(trimmed) ||
+      /\bunexpected end of json input\b/i.test(trimmed))
+  ) {
+    return true;
+  }
+
+  return /^(?:Expected (?:',' or '\}' after property value|double-quoted property name|':' after property name|',' or '\]' after array element)|Unterminated string) in JSON at position \d+(?: \(line \d+ column \d+\))?$/i.test(
+    trimmed,
+  );
 }
 
 function hasRateLimitTpmHint(raw: string): boolean {

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -3,6 +3,7 @@ import {
   extractLeadingHttpStatus,
   formatRawAssistantErrorForUi,
   isCloudflareOrHtmlErrorPage,
+  MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
   parseApiErrorInfo,
   parseApiErrorPayload,
 } from "../../shared/assistant-error-format.js";
@@ -14,7 +15,6 @@ import {
 import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
 import { stableStringify } from "../stable-stringify.js";
-import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transport-stream-shared.js";
 import {
   isBillingErrorMessage,
   isOverloadedErrorMessage,

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -223,7 +223,7 @@ export function isStreamingJsonParseError(raw: string): boolean {
     return true;
   }
 
-  return /^(?:Expected (?:',' or '\}' after property value|double-quoted property name|':' after property name|',' or '\]' after array element)|Unterminated string) in JSON at position \d+(?: \(line \d+ column \d+\))?$/i.test(
+  return /^(?:Unexpected end of JSON input|Unexpected non-whitespace character after JSON at position \d+(?: \(line \d+ column \d+\))?|(?:Expected (?:',' or '\}' after property value|double-quoted property name|':' after property name|',' or '\]' after array element)|Unterminated string) in JSON at position \d+(?: \(line \d+ column \d+\))?)$/i.test(
     trimmed,
   );
 }

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -209,6 +209,13 @@ export function isInvalidStreamingEventOrderError(raw: string): boolean {
   );
 }
 
+export function isStreamingJsonParseError(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  return /\b(?:expected|unexpected)\b.+\bin json\b.+\bposition\b/i.test(raw);
+}
+
 function hasRateLimitTpmHint(raw: string): boolean {
   const lower = normalizeLowercaseStringOrEmpty(raw);
   return /\btpm\b/i.test(lower) || lower.includes("tokens per minute");
@@ -417,6 +424,10 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
 
     if (isRawApiErrorPayload(trimmed) || isLikelyHttpErrorText(trimmed)) {
       return formatRawAssistantErrorForUi(trimmed);
+    }
+
+    if (isStreamingJsonParseError(trimmed)) {
+      return "LLM streaming response contained a malformed fragment. Please try again.";
     }
 
     if (ERROR_PREFIX_RE.test(trimmed)) {

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -14,6 +14,7 @@ import {
 import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
 import { stableStringify } from "../stable-stringify.js";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transport-stream-shared.js";
 import {
   isBillingErrorMessage,
   isOverloadedErrorMessage,
@@ -214,18 +215,10 @@ export function isStreamingJsonParseError(raw: string): boolean {
     return false;
   }
   const trimmed = raw.trim();
-  if (
-    /\bcould not parse anthropic sse event\b/i.test(trimmed) &&
-    /\b(?:content_block_delta|input_json_delta|partial_json|tool_use)\b/i.test(trimmed) &&
-    (/\b(?:expected|unexpected|unterminated)\b.+\bin json\b.+\bposition\b/i.test(trimmed) ||
-      /\bunexpected end of json input\b/i.test(trimmed))
-  ) {
+  if (trimmed === MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE) {
     return true;
   }
-
-  return /^(?:Unexpected end of JSON input|Unexpected non-whitespace character after JSON at position \d+(?: \(line \d+ column \d+\))?|(?:Expected (?:',' or '\}' after property value|double-quoted property name|':' after property name|',' or '\]' after array element)|Unterminated string) in JSON at position \d+(?: \(line \d+ column \d+\))?)$/i.test(
-    trimmed,
-  );
+  return false;
 }
 
 function hasRateLimitTpmHint(raw: string): boolean {

--- a/src/agents/transport-stream-shared.ts
+++ b/src/agents/transport-stream-shared.ts
@@ -21,6 +21,9 @@ type TransportOutputShape = {
 
 export const EMPTY_TOOL_RESULT_TEXT = "(no output)";
 
+export const MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE =
+  "OpenClaw transport error: malformed_streaming_fragment";
+
 export function sanitizeTransportPayloadText(text: string): string {
   return text.replace(
     /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,

--- a/src/agents/transport-stream-shared.ts
+++ b/src/agents/transport-stream-shared.ts
@@ -20,10 +20,6 @@ type TransportOutputShape = {
 };
 
 export const EMPTY_TOOL_RESULT_TEXT = "(no output)";
-
-export const MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE =
-  "OpenClaw transport error: malformed_streaming_fragment";
-
 export function sanitizeTransportPayloadText(text: string): string {
   return text.replace(
     /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,

--- a/src/shared/assistant-error-format.ts
+++ b/src/shared/assistant-error-format.ts
@@ -15,6 +15,11 @@ const CLOUDFLARE_HTML_ERROR_CODES = new Set([521, 522, 523, 524, 525, 526, 530])
 const STANDALONE_HTML_ERROR_HINT_RE =
   /\bcloudflare\b|cdn-cgi\/challenge-platform|challenge-error-text|enable javascript and cookies to continue|access denied|forbidden|service unavailable|bad gateway|web server is down|captcha|attention required/i;
 
+export const MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE =
+  "OpenClaw transport error: malformed_streaming_fragment";
+export const MALFORMED_STREAMING_FRAGMENT_USER_MESSAGE =
+  "LLM streaming response contained a malformed fragment. Please try again.";
+
 type ErrorPayload = Record<string, unknown>;
 
 export type ApiErrorInfo = {
@@ -186,6 +191,10 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
   const trimmed = (raw ?? "").trim();
   if (!trimmed) {
     return "LLM request failed with an unknown error.";
+  }
+
+  if (trimmed === MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE) {
+    return MALFORMED_STREAMING_FRAGMENT_USER_MESSAGE;
   }
 
   const leadingStatus = extractLeadingHttpStatus(trimmed);

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
 import type { AgentEvent, BtwEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 
@@ -751,6 +752,42 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(String(rendered)).toContain("HTTP 401");
     expect(String(rendered)).toContain("Missing scopes: model.request");
     expect(chatLog.dropAssistant).not.toHaveBeenCalledWith("run-error-envelope");
+  });
+
+  it("renders malformed streaming fragment text when chat final only has event errorMessage", () => {
+    const { state, chatLog, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    handleChatEvent({
+      runId: "run-malformed-final",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [] },
+      errorMessage: MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
+    });
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith(
+      "LLM streaming response contained a malformed fragment. Please try again.",
+      "run-malformed-final",
+    );
+  });
+
+  it("renders malformed streaming fragment text for chat error events", () => {
+    const { state, chatLog, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    handleChatEvent({
+      runId: "run-malformed-error",
+      sessionKey: state.currentSessionKey,
+      state: "error",
+      errorMessage: MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
+    });
+
+    expect(chatLog.addSystem).toHaveBeenCalledWith(
+      "run error: LLM streaming response contained a malformed fragment. Please try again.",
+    );
   });
 
   it("shows a concise /auth hint for local auth failures", () => {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,5 +1,6 @@
 import { isAuthErrorMessage } from "../agents/pi-embedded-helpers.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
@@ -450,7 +451,8 @@ export function createEventHandlers(context: EventHandlerContext) {
       forgetLocalBtwRunId?.(evt.runId);
       const wasActiveRun = state.activeChatRunId === evt.runId;
       const errorMessage = evt.errorMessage ?? "unknown";
-      chatLog.addSystem(resolveAuthErrorHint(errorMessage) ?? `run error: ${errorMessage}`);
+      const renderedError = formatRawAssistantErrorForUi(errorMessage);
+      chatLog.addSystem(resolveAuthErrorHint(errorMessage) ?? `run error: ${renderedError}`);
       terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
       maybeRefreshHistoryForRun(evt.runId);
     }

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import {
   extractContentFromMessage,
   extractTextFromMessage,
@@ -40,6 +41,17 @@ describe("extractTextFromMessage", () => {
     expect(text).toContain("HTTP 429");
     expect(text).toContain("rate_limit_error");
     expect(text).toContain("This request would exceed your account's rate limit.");
+  });
+
+  it("renders malformed streaming fragment errors with friendly text", () => {
+    const text = extractTextFromMessage({
+      role: "assistant",
+      content: [],
+      stopReason: "error",
+      errorMessage: MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
+    });
+
+    expect(text).toBe("LLM streaming response contained a malformed fragment. Please try again.");
   });
 
   it("falls back to a generic message when errorMessage is missing", () => {
@@ -274,6 +286,16 @@ describe("extractContentFromMessage", () => {
     });
 
     expect(text).toContain("HTTP 429");
+  });
+
+  it("formats malformed streaming fragment errors when content is not an array", () => {
+    const text = extractContentFromMessage({
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
+    });
+
+    expect(text).toBe("LLM streaming response contained a malformed fragment. Please try again.");
   });
 });
 

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import { getSlashCommands, parseCommand } from "./commands.js";
 import {
   createBackspaceDeduper,
@@ -39,6 +40,16 @@ describe("resolveFinalAssistantText", () => {
         errorMessage: '401 {"error":{"message":"Missing scopes: model.request"}}',
       }),
     ).toContain("HTTP 401");
+  });
+
+  it("formats malformed streaming fragment errors when final and streamed text are empty", () => {
+    expect(
+      resolveFinalAssistantText({
+        finalText: "",
+        streamedText: "",
+        errorMessage: MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
+      }),
+    ).toBe("LLM streaming response contained a malformed fragment. Please try again.");
   });
 });
 


### PR DESCRIPTION
When streaming tool calls with long CJK text, the Anthropic SDK's SSE parser can throw SyntaxError. This error was forwarded as-is to the Discord channel instead of being caught and rewritten to a user-friendly message.

## Summary

- **Problem:** Raw JSON parse errors (e.g. `Expected ',' or '}' after property value in JSON at position 334`) from the Anthropic SDK streaming layer are leaked to Discord channels as standalone messages.
- **Why it matters:** Users see confusing, technical error messages in their Discord channels that provide no actionable information. The tool call still recovers and the response comes through, making this a cosmetic but disruptive UX issue.
- **What changed:** Added `isStreamingJsonParseError()` detector in `pi-embedded-helpers/errors.ts` that intercepts JSON parse error patterns in both `formatAssistantErrorText()` and `sanitizeUserFacingText()`, replacing them with a friendly "LLM streaming response contained a malformed fragment. Please try again." message.
- **What did NOT change (scope boundary):** No changes to the streaming pipeline itself, the Anthropic SDK, pi-ai library, or the Discord channel plugin. The fix is purely in the error formatting layer that sits between the agent runner and the channel delivery.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59076
- Related #59080 (similar error-leaking pattern after session compaction)
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** `formatAssistantErrorText()` in `pi-embedded-helpers/errors.ts` has a comprehensive pattern-matching chain for known error types (context overflow, billing, rate limit, role ordering, transport, etc.), but lacked a pattern for JSON parse errors from streaming SSE data. Unrecognized errors fall through to L949 which returns the raw error text (truncated to 600 chars).
- **Missing detection / guardrail:** No pattern existed for `SyntaxError` messages from `JSON.parse` failures in the streaming pipeline.
- **Prior context:** The error originates in `@anthropic-ai/sdk/src/core/streaming.ts` L69-75 where `JSON.parse(sse.data)` is called on each SSE event. The SDK re-throws the SyntaxError, which `pi-ai`'s `streamAnthropic` catch block (L340) captures and converts to `output.errorMessage`. This flows through the agent lifecycle handler to `formatAssistantErrorText()`.
- **Why this regressed now:** Issue reporter notes it appeared after upgrading to 2026.3.31. Likely a change in the Anthropic SDK or SSE payload format for CJK content made the SSE data parsing more fragile.
- **If unknown, what was ruled out:** The `parseStreamingJson()` function in pi-ai (used for `input_json_delta` partial JSON) is safe (triple-fallback). The problem is in the SDK's SSE layer, which parses the raw SSE `data:` line with strict `JSON.parse` before pi-ai ever sees the event.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`
- **Scenario the test should lock in:** `formatAssistantErrorText` returns a friendly message (not raw error text) when the error matches JSON parse error patterns from streaming SDKs.
- **Why this is the smallest reliable guardrail:** The `formatAssistantErrorText` function is the last-mile sanitizer before error text reaches channels. Testing at this layer catches all upstream error sources without needing to mock the full streaming pipeline.
- **Existing test that already covers this (if any):** None — this is a new error pattern class.
- **If no new test is added, why not:** 5 new tests added covering 3 JSON parse error variants + 2 `sanitizeUserFacingText` context tests.

## User-visible / Behavior Changes

- **Before:** Raw JSON parse errors like `Expected ',' or '}' after property value in JSON at position 334 (line 1 column 335)` appear as standalone Discord messages.
- **After:** These errors are rewritten to `"LLM streaming response contained a malformed fragment. Please try again."` — a clear, non-technical message that tells the user what happened and what to do.

## Diagram (if applicable)

```text
Before:
  SDK SyntaxError → pi-ai catch → errorMessage → formatAssistantErrorText (no match) → raw text → Discord channel ❌

After:
  SDK SyntaxError → pi-ai catch → errorMessage → formatAssistantErrorText (isStreamingJsonParseError ✓) → friendly text → Discord channel ✅
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Darwin 23.4.0 arm64
- Runtime/container: Node v22.18.0, pnpm 10.28.0
- Model/provider: Anthropic Claude Opus 4
- Integration/channel (if any): Discord
- Relevant config (redacted): Channel with `[skills: legal, lawclaw]` in topic (adds ~10KB of skill context with regex patterns)

### Steps

1. Create a Discord channel with `[skills: legal, lawclaw]` in the topic
2. Send a message that triggers the agent to use `Edit` or `Write` with substantial Chinese text content
3. Observe the raw JSON parse error appearing as a Discord message before the actual response

### Expected

- JSON parse errors from the streaming partial JSON parser should be caught internally and not forwarded to the Discord channel.

### Actual

- Raw error messages like `Expected ',' or '}' after property value in JSON at position 334 (line 1 column 335)` appear as standalone Discord messages.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

5 new test cases added and passing:
- `sanitizes streaming JSON parse errors from Anthropic SDK (#59076)` — verifies `Expected ',' or '}' ...` pattern
- `sanitizes 'Expected double-quoted property name' JSON parse errors (#59076)` — verifies `Expected double-quoted...` pattern
- `sanitizes 'Unexpected token' JSON parse errors (#59076)` — verifies `Unexpected token...` pattern
- `sanitizeUserFacingText: rewrites JSON parse error in error context` — verifies sanitize path
- `sanitizeUserFacingText: does not rewrite when not in error context` — ensures normal text is not affected

All 131 related tests pass. `pnpm build` succeeds. AI-generated code verified by automated test runs.

## Human Verification (required)

- **Verified scenarios:** All 5 new test cases + 126 existing tests in the error formatting suite pass. Build verification passed.
- **Edge cases checked:** (1) JSON parse error with various position/line formats, (2) `sanitizeUserFacingText` only rewrites in error context (doesn't affect normal assistant text mentioning JSON), (3) regex pattern doesn't false-positive on unrelated error messages.
- **What you did NOT verify:** Live Discord channel testing with actual CJK streaming tool calls — requires a running gateway with Discord integration and an Anthropic API key.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- **Risk:** The regex `\b(?:expected|unexpected)\b.+\bin json\b.+\bposition\b` could theoretically match an assistant message that happens to contain all three keywords in sequence (e.g., explaining JSON parsing to a user).
  - **Mitigation:** The pattern only fires inside `formatAssistantErrorText()` (which processes `stopReason: "error"` assistant messages) and inside `sanitizeUserFacingText()` only when `errorContext: true`. Normal assistant text is never routed through these error-handling paths. Additionally, the regex requires all three keywords (`expected/unexpected`, `in JSON`, `position`) in a single line, making false positives on natural language extremely unlikely.
