### PR TITLE
docs(contributing): add Development Environment section with WSL2 setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,48 @@ Welcome to the lobster tank! 🦞
 4. **Test/CI-only PRs for known `main` failures** → Don't open a PR. The Maintainer team is already tracking those failures, and PRs that only tweak tests or CI to chase them will be closed unless they are required to validate a new fix.
 5. **Questions** → Discord [#help](https://discord.com/channels/1456350064065904867/1459642797895319552) / [#users-helping-users](https://discord.com/channels/1456350064065904867/1459007081603403828)
 
+## Development Environment
+
+OpenClaw is built with **TypeScript** on **Node.js 24 LTS** and uses **pnpm** as its package manager for source development.
+
+### Prerequisites
+
+- **Node.js ≥ 22.12.0** (24.x LTS recommended). Install via [NodeSource](https://github.com/nodesource/distributions) or your preferred version manager.
+- **pnpm** — install globally with `sudo npm install -g pnpm`. The project workspace configuration requires pnpm; npm alone is not sufficient for source builds.
+
+### Windows (WSL2)
+
+Windows contributors should develop inside **WSL2 with Ubuntu** rather than native Windows. The gateway daemon, systemd integration, and Unix socket paths all assume a Linux environment.
+
+Key WSL2 setup notes:
+
+1. **Enable systemd** — add `[boot] systemd=true` to `/etc/wsl.conf` inside your Ubuntu instance and restart WSL (`wsl --shutdown` from PowerShell). The gateway daemon service requires systemd.
+2. **Resource limits** — create or edit `%UserProfile%\.wslconfig` on the Windows side to set memory and CPU limits. Without this, WSL2 claims up to 50% of host RAM, which can cause instability on machines with limited memory:
+
+```ini
+   [wsl2]
+   memory=8GB
+   processors=4
+   swap=4GB
+```
+
+3. **Keep the terminal open** — the WSL2 instance (and any running gateway) stops when you close all terminal windows. Minimize rather than close.
+4. **File system** — work inside the Linux file system (`~/openclaw`) for best performance. Accessing `/mnt/c/...` (Windows drives) from WSL2 is significantly slower.
+
+### Getting started from source
+
+```bash
+git clone https://github.com/<your-username>/openclaw.git
+cd openclaw
+git remote add upstream https://github.com/openclaw/openclaw.git
+pnpm install        # install all workspace dependencies
+pnpm ui:build       # build the Control UI (Vite + React)
+pnpm build          # full TypeScript build
+pnpm openclaw --version   # verify: should print version and commit hash
+```
+
+For day-to-day development, use `pnpm gateway:watch` (auto-reload on changes) or `pnpm openclaw <command>` to run TypeScript source directly without a full build.
+
 ## Before You PR
 
 - Test locally with your OpenClaw instance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,10 +102,11 @@ Key WSL2 setup notes:
 
 1. **Enable systemd** — add the following to `/etc/wsl.conf` inside your Ubuntu instance and restart WSL (`wsl --shutdown` from PowerShell). The gateway daemon service requires systemd:
 
-````ini
+```ini
    [boot]
    systemd=true
 ```
+
 2. **Resource limits** — create or edit `%UserProfile%\.wslconfig` on the Windows side to set memory and CPU limits. Without this, WSL2 claims up to 50% of host RAM, which can cause instability on machines with limited memory:
 
 ```ini
@@ -253,4 +254,3 @@ For issues that don't fit a specific repo, or if you're unsure, email **security
 8. **Remediation Advice**
 
 Reports without reproduction steps, demonstrated impact, and remediation advice will be deprioritized. Given the volume of AI-generated scanner findings, we must ensure we're receiving vetted reports from researchers who understand the issues.
-````

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,12 +87,12 @@ Welcome to the lobster tank! 🦞
 
 ## Development Environment
 
-OpenClaw is built with **TypeScript** on **Node.js 24 LTS** and uses **pnpm** as its package manager for source development.
+OpenClaw is built with **TypeScript** on **Node.js** (22 LTS minimum, 24 LTS recommended) and uses **pnpm** as its package manager for source development.
 
 ### Prerequisites
 
-- **Node.js ≥ 22.12.0** (24.x LTS recommended). Install via [NodeSource](https://github.com/nodesource/distributions) or your preferred version manager.
-- **pnpm** — install globally with `sudo npm install -g pnpm`. The project workspace configuration requires pnpm; npm alone is not sufficient for source builds.
+- **Node.js ≥ 22.14.0** (24.x LTS recommended). Install via [NodeSource](https://github.com/nodesource/distributions) or your preferred version manager.
+- **pnpm** — install globally with `npm install -g pnpm` (add `sudo` if Node.js was installed system-wide via NodeSource; omit it if you use nvm). The project workspace configuration requires pnpm; npm alone is not sufficient for source builds.
 
 ### Windows (WSL2)
 
@@ -100,7 +100,12 @@ Windows contributors should develop inside **WSL2 with Ubuntu** rather than nati
 
 Key WSL2 setup notes:
 
-1. **Enable systemd** — add `[boot] systemd=true` to `/etc/wsl.conf` inside your Ubuntu instance and restart WSL (`wsl --shutdown` from PowerShell). The gateway daemon service requires systemd.
+1. **Enable systemd** — add the following to `/etc/wsl.conf` inside your Ubuntu instance and restart WSL (`wsl --shutdown` from PowerShell). The gateway daemon service requires systemd:
+
+````ini
+   [boot]
+   systemd=true
+```
 2. **Resource limits** — create or edit `%UserProfile%\.wslconfig` on the Windows side to set memory and CPU limits. Without this, WSL2 claims up to 50% of host RAM, which can cause instability on machines with limited memory:
 
 ```ini
@@ -248,3 +253,4 @@ For issues that don't fit a specific repo, or if you're unsure, email **security
 8. **Remediation Advice**
 
 Reports without reproduction steps, demonstrated impact, and remediation advice will be deprioritized. Given the volume of AI-generated scanner findings, we must ensure we're receiving vetted reports from researchers who understand the issues.
+````


### PR DESCRIPTION
## Summary

Add a "Development Environment" section to CONTRIBUTING.md, covering prerequisites, Windows/WSL2 setup, and a quick-start guide for building from source.

## Problem

CONTRIBUTING.md currently jumps straight to "Before You PR" without explaining how to set up a development environment. Windows contributors in particular have no guidance on WSL2 — they must discover through trial and error that systemd needs to be enabled, .wslconfig should set resource limits, and the Linux file system should be used for performance.

## Changes

New section added between "How to Contribute" and "Before You PR":

- **Prerequisites** — Node.js ≥ 22.12.0 and pnpm requirements
- **Windows (WSL2)** — four key setup notes based on hands-on experience:
  1. Enable systemd in `/etc/wsl.conf`
  2. Set `.wslconfig` resource limits
  3. Keep terminal open (minimize, don't close)
  4. Use Linux file system for performance
- **Getting started from source** — clone → pnpm install → build → verify

## Context

These notes are based on setting up an OpenClaw development environment from scratch on a Windows 11 ThinkPad 16 (WSL2 + Ubuntu 24.04 + Node.js 24.14.0 + pnpm 10.32.1). Every tip addresses an actual friction point encountered during the process.

## AI Disclosure

This PR was developed with AI assistance (Claude). The author has reviewed all content and confirms accuracy from direct experience.