### PR TITLE
fix(config): normalize Google baseUrl for custom provider keys

### DIFF
--- a/src/agents/models-config.providers.normalize-google-baseurl.test.ts
+++ b/src/agents/models-config.providers.normalize-google-baseurl.test.ts
@@ -1,0 +1,111 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { normalizeProviders } from "./models-config.providers.normalize.js";
+
+type Providers = NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]>;
+
+function buildGoogleProvider(overrides: Partial<Providers[string]> = {}): Providers[string] {
+  return {
+    baseUrl: "https://generativelanguage.googleapis.com",
+    api: "google-generative-ai",
+    apiKey: "GEMINI_API_KEY", // pragma: allowlist secret
+    models: [
+      {
+        id: "gemini-3.1-flash-lite-preview",
+        name: "Gemini 3.1 Flash Lite",
+        input: ["text"],
+        reasoning: false,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1048576,
+        maxTokens: 65536,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("normalizeProviders google baseUrl", () => {
+  it("appends /v1beta to bare googleapis.com baseUrl for custom provider keys", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    try {
+      const providers: Providers = {
+        "my-paid-google": buildGoogleProvider(),
+      };
+
+      const normalized = normalizeProviders({ providers, agentDir });
+      expect(normalized?.["my-paid-google"]?.baseUrl).toBe(
+        "https://generativelanguage.googleapis.com/v1beta",
+      );
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not double-append /v1beta when already present", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    try {
+      const providers: Providers = {
+        "my-paid-google": buildGoogleProvider({
+          baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        }),
+      };
+
+      const normalized = normalizeProviders({ providers, agentDir });
+      expect(normalized?.["my-paid-google"]?.baseUrl).toBe(
+        "https://generativelanguage.googleapis.com/v1beta",
+      );
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves non-googleapis base URLs unchanged", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    try {
+      const providers: Providers = {
+        "my-proxy": buildGoogleProvider({
+          baseUrl: "https://my-proxy.example.com/gemini",
+        }),
+      };
+
+      const normalized = normalizeProviders({ providers, agentDir });
+      expect(normalized?.["my-proxy"]?.baseUrl).toBe("https://my-proxy.example.com/gemini");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("normalizes when api is declared on individual models", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    try {
+      const providers: Providers = {
+        "custom-google": {
+          baseUrl: "https://generativelanguage.googleapis.com",
+          apiKey: "GEMINI_API_KEY", // pragma: allowlist secret
+          models: [
+            {
+              id: "gemini-3.1-flash-lite-preview",
+              name: "Gemini 3.1 Flash Lite",
+              api: "google-generative-ai",
+              input: ["text"],
+              reasoning: false,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 1048576,
+              maxTokens: 65536,
+            },
+          ],
+        },
+      };
+
+      const normalized = normalizeProviders({ providers, agentDir });
+      expect(normalized?.["custom-google"]?.baseUrl).toBe(
+        "https://generativelanguage.googleapis.com/v1beta",
+      );
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/models-config.providers.normalize.ts
+++ b/src/agents/models-config.providers.normalize.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { normalizeGoogleApiBaseUrl } from "../infra/google-api-base-url.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
 import {
   normalizeProviderSpecificConfig,
@@ -15,6 +16,26 @@ import {
 import { enforceSourceManagedProviderSecrets } from "./models-config.providers.source-managed.js";
 
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
+
+function isGoogleGenerativeAiProvider(provider: ProviderConfig): boolean {
+  return (
+    provider.api === "google-generative-ai" ||
+    (Array.isArray(provider.models) &&
+      provider.models.some((m) => m.api === "google-generative-ai"))
+  );
+}
+
+// Normalize bare Google Generative AI base URLs that omit the /v1beta path.
+// The Google plugin handles this for known provider keys (google, google-vertex,
+// google-antigravity, google-gemini-cli), but custom provider keys with
+// api: "google-generative-ai" fall through plugin resolution and need a safety net.
+function normalizeGoogleGenerativeAiBaseUrl(provider: ProviderConfig): ProviderConfig {
+  if (!provider.baseUrl || !isGoogleGenerativeAiProvider(provider)) {
+    return provider;
+  }
+  const normalized = normalizeGoogleApiBaseUrl(provider.baseUrl);
+  return normalized !== provider.baseUrl ? { ...provider, baseUrl: normalized } : provider;
+}
 
 export function normalizeProviders(params: {
   providers: ModelsConfig["providers"];
@@ -120,6 +141,12 @@ export function normalizeProviders(params: {
     if (providerSpecificNormalized !== normalizedProvider) {
       mutated = true;
       normalizedProvider = providerSpecificNormalized;
+    }
+
+    const googleBaseUrlNormalized = normalizeGoogleGenerativeAiBaseUrl(normalizedProvider);
+    if (googleBaseUrlNormalized !== normalizedProvider) {
+      mutated = true;
+      normalizedProvider = googleBaseUrlNormalized;
     }
 
     const existing = next[normalizedKey];

--- a/src/infra/google-api-base-url.test.ts
+++ b/src/infra/google-api-base-url.test.ts
@@ -31,6 +31,14 @@ describe("normalizeGoogleApiBaseUrl", () => {
       value: "generativelanguage.googleapis.com",
       expected: "generativelanguage.googleapis.com",
     },
+    {
+      value: "https://proxy.example.com/gemini?tenant=acme",
+      expected: "https://proxy.example.com/gemini?tenant=acme",
+    },
+    {
+      value: "https://proxy.example.com/gemini#section",
+      expected: "https://proxy.example.com/gemini#section",
+    },
   ])("normalizes %s", ({ value, expected }) => {
     expect(normalizeGoogleApiBaseUrl(value)).toBe(expected);
   });

--- a/src/infra/google-api-base-url.ts
+++ b/src/infra/google-api-base-url.ts
@@ -14,13 +14,14 @@ export function normalizeGoogleApiBaseUrl(baseUrl?: string): string {
   const raw = trimTrailingSlashes(baseUrl?.trim() || DEFAULT_GOOGLE_API_BASE_URL);
   try {
     const url = new URL(raw);
-    url.hash = "";
-    url.search = "";
-    if (
-      resolveProviderEndpoint(url.toString()).endpointClass === "google-generative-ai" &&
-      trimTrailingSlashes(url.pathname || "") === ""
-    ) {
-      url.pathname = "/v1beta";
+    const isGoogleEndpoint =
+      resolveProviderEndpoint(url.toString()).endpointClass === "google-generative-ai";
+    if (isGoogleEndpoint) {
+      url.hash = "";
+      url.search = "";
+      if (trimTrailingSlashes(url.pathname || "") === "") {
+        url.pathname = "/v1beta";
+      }
     }
     return trimTrailingSlashes(url.toString());
   } catch {


### PR DESCRIPTION
## Summary
- Wire `normalizeGoogleApiBaseUrl` into the provider normalization pipeline so custom provider keys with `api: "google-generative-ai"` get their bare `generativelanguage.googleapis.com` base URL corrected to include `/v1beta`
- The Google plugin handles this for known keys (`google`, `google-vertex`, `google-antigravity`, `google-gemini-cli`), but custom keys like `my-paid-google` fall through plugin resolution and hit 404s at runtime

## Why
Users who configure a custom Google Generative AI provider (e.g. a paid tier or regional endpoint) with a bare `generativelanguage.googleapis.com` base URL get silent 404s because the embedded runner treats explicit `baseUrl` as fully-versioned and does not re-append `/v1beta`.

Supersedes #41334, which addressed the same gap but targets a file structure that has since been refactored.

Relates to #44969

## Testing
```
pnpm test -- src/agents/models-config.providers.normalize-google-baseurl.test.ts
```

4 test cases:
- Appends `/v1beta` to bare googleapis.com for custom keys
- Does not double-append when already present
- Leaves non-googleapis proxy URLs unchanged
- Normalizes when `api` is declared on individual models rather than the provider