### PR TITLE
fix(provider): strip provider prefix from model ID before API call

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -259,6 +259,18 @@ describe("model-selection", () => {
         expected: { provider: "ollama-beelink2", model: "qwen2.5-coder:7b" },
       },
       {
+        name: "keeps openrouter/auto as self-prefixed canonical model ID",
+        variants: ["openrouter/auto"],
+        defaultProvider: "openrouter",
+        expected: { provider: "openrouter", model: "openrouter/auto" },
+      },
+      {
+        name: "preserves slash-delimited OpenRouter model when defaultProvider is openrouter",
+        variants: ["anthropic/claude-sonnet-4-5"],
+        defaultProvider: "openrouter",
+        expected: { provider: "anthropic", model: "claude-sonnet-4-5" },
+      },
+      {
         name: "normalizes gemini 3.1 flash-lite ids for google-vertex",
         variants: ["google-vertex/gemini-3.1-flash-lite", "gemini-3.1-flash-lite"],
         defaultProvider: "google-vertex",

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -253,6 +253,12 @@ describe("model-selection", () => {
         expected: { provider: "openai", model: "gpt-5.4-codex-codex" },
       },
       {
+        name: "extracts ollama provider from prefixed model ref",
+        variants: ["ollama-beelink2/qwen2.5-coder:7b"],
+        defaultProvider: "anthropic",
+        expected: { provider: "ollama-beelink2", model: "qwen2.5-coder:7b" },
+      },
+      {
         name: "normalizes gemini 3.1 flash-lite ids for google-vertex",
         variants: ["google-vertex/gemini-3.1-flash-lite", "gemini-3.1-flash-lite"],
         defaultProvider: "google-vertex",

--- a/src/agents/pi-embedded-runner/run.strip-provider-prefix.test.ts
+++ b/src/agents/pi-embedded-runner/run.strip-provider-prefix.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { parseModelRef } from "../model-selection.js";
+
+const DEFAULT_PROVIDER = "anthropic";
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+
+/**
+ * Mirrors the provider-prefix stripping logic in runEmbeddedPiAgent (run.ts).
+ * Extracted here so the guard condition can be unit-tested without the full
+ * embedded-runner harness.
+ */
+function resolveProviderAndModel(params: { provider?: string; model?: string }): {
+  provider: string;
+  modelId: string;
+} {
+  let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
+  let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+
+  // Guard: only strip a provider prefix when params.provider was NOT set explicitly.
+  // This prevents slash-delimited model IDs (e.g. "anthropic/claude-sonnet-4-5"
+  // on OpenRouter) from being incorrectly split when the provider is already known.
+  if (!params.provider && modelId.includes("/")) {
+    const parsedRef = parseModelRef(modelId, provider);
+    if (parsedRef) {
+      provider = parsedRef.provider;
+      modelId = parsedRef.model;
+    }
+  }
+
+  return { provider, modelId };
+}
+
+describe("provider-prefix stripping in runEmbeddedPiAgent", () => {
+  describe("strips provider prefix when params.provider is unset", () => {
+    it("extracts provider from ollama-prefixed model ref", () => {
+      const result = resolveProviderAndModel({
+        model: "ollama-beelink2/qwen2.5-coder:7b",
+      });
+      expect(result.provider).toBe("ollama-beelink2");
+      expect(result.modelId).toBe("qwen2.5-coder:7b");
+    });
+
+    it("extracts provider from openai-prefixed model ref", () => {
+      const result = resolveProviderAndModel({
+        model: "openai/gpt-5.4",
+      });
+      expect(result.provider).toBe("openai");
+      expect(result.modelId).toBe("gpt-5.4");
+    });
+
+    it("extracts provider from anthropic-prefixed model ref", () => {
+      const result = resolveProviderAndModel({
+        model: "anthropic/claude-sonnet-4-6",
+      });
+      expect(result.provider).toBe("anthropic");
+      expect(result.modelId).toBe("claude-sonnet-4-6");
+    });
+
+    it("leaves simple model IDs (no slash) unchanged", () => {
+      const result = resolveProviderAndModel({
+        model: "claude-sonnet-4-6",
+      });
+      expect(result.provider).toBe("anthropic");
+      expect(result.modelId).toBe("claude-sonnet-4-6");
+    });
+  });
+
+  describe("preserves slash-delimited model IDs when params.provider is explicitly set", () => {
+    it("does not split OpenRouter model anthropic/claude-sonnet-4-5", () => {
+      const result = resolveProviderAndModel({
+        provider: "openrouter",
+        model: "anthropic/claude-sonnet-4-5",
+      });
+      expect(result.provider).toBe("openrouter");
+      expect(result.modelId).toBe("anthropic/claude-sonnet-4-5");
+    });
+
+    it("does not split openrouter/auto self-prefixed model ID", () => {
+      const result = resolveProviderAndModel({
+        provider: "openrouter",
+        model: "openrouter/auto",
+      });
+      expect(result.provider).toBe("openrouter");
+      expect(result.modelId).toBe("openrouter/auto");
+    });
+
+    it("does not split OpenRouter model google/gemini-2.5-pro", () => {
+      const result = resolveProviderAndModel({
+        provider: "openrouter",
+        model: "google/gemini-2.5-pro",
+      });
+      expect(result.provider).toBe("openrouter");
+      expect(result.modelId).toBe("google/gemini-2.5-pro");
+    });
+
+    it("preserves explicitly set provider even with slash-delimited model", () => {
+      const result = resolveProviderAndModel({
+        provider: "ollama-beelink2",
+        model: "library/llama3:latest",
+      });
+      expect(result.provider).toBe("ollama-beelink2");
+      expect(result.modelId).toBe("library/llama3:latest");
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -143,10 +143,15 @@ export async function runEmbeddedPiAgent(
 
       // When modelId contains a provider prefix (e.g. "ollama-beelink2/qwen2.5-coder:7b"),
       // extract the provider and model name so the API receives just the model name.
-      const parsedRef = parseModelRef(modelId, provider);
-      if (parsedRef && modelId.includes("/")) {
-        provider = parsedRef.provider;
-        modelId = parsedRef.model;
+      // Only do this when params.provider was not explicitly set — otherwise
+      // slash-delimited model IDs like "anthropic/claude-sonnet-4-5" on OpenRouter
+      // (where provider is already "openrouter") would be incorrectly split.
+      if (!params.provider && modelId.includes("/")) {
+        const parsedRef = parseModelRef(modelId, provider);
+        if (parsedRef) {
+          provider = parsedRef.provider;
+          modelId = parsedRef.model;
+        }
       }
       const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
       const fallbackConfigured = hasConfiguredModelFallbacks({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -36,6 +36,7 @@ import {
   type ResolvedProviderAuth,
   resolveAuthProfileOrder,
 } from "../model-auth.js";
+import { parseModelRef } from "../model-selection.js";
 import { normalizeProviderId } from "../model-selection.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import { disposeSessionMcpRuntime } from "../pi-bundle-mcp-tools.js";
@@ -140,6 +141,14 @@ export async function runEmbeddedPiAgent(
 
       let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
       let modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
+
+      // When modelId contains a provider prefix (e.g. "ollama-beelink2/qwen2.5-coder:7b"),
+      // extract the provider and model name so the API receives just the model name.
+      const parsedRef = parseModelRef(modelId, provider);
+      if (parsedRef && modelId.includes("/")) {
+        provider = parsedRef.provider;
+        modelId = parsedRef.model;
+      }
       const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
       const fallbackConfigured = hasConfiguredModelFallbacks({
         cfg: params.config,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -36,8 +36,7 @@ import {
   type ResolvedProviderAuth,
   resolveAuthProfileOrder,
 } from "../model-auth.js";
-import { parseModelRef } from "../model-selection.js";
-import { normalizeProviderId } from "../model-selection.js";
+import { normalizeProviderId, parseModelRef } from "../model-selection.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import { disposeSessionMcpRuntime } from "../pi-bundle-mcp-tools.js";
 import {


### PR DESCRIPTION
## Summary

- Problem: `runEmbeddedPiAgent` passes the full model path (e.g. `ollama-beelink2/qwen2.5-coder:7b`) to downstream APIs instead of just the model name (`qwen2.5-coder:7b`), causing "model not found" errors from Ollama and other OpenAI-compatible providers.
- Why it matters: Multi-provider setups (local Ollama for background agents, Claude for main) are completely broken — all Ollama-routed requests fail silently with 0-token responses.
- What changed: After `modelId` is initialized in `run.ts`, call the existing `parseModelRef()` to split `"provider/model"` into separate provider and model values. Same pattern already used in `agent-command.ts:636`.
- What did NOT change (scope boundary): No changes to `parseModelRef()` itself, model resolution, or any other provider logic. Only the entry point in `runEmbeddedPiAgent` is touched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59122
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `run.ts:142` accepts `params.model` as-is without parsing the `"provider/model"` format. The existing `parseModelRef()` function handles this correctly but was never called in the `runEmbeddedPiAgent` flow.
- Missing detection / guardrail: No test covering the case where `params.model` contains an embedded provider prefix.
- Prior context: `agent-command.ts` already uses `parseModelRef()` at line 636 for the same purpose — the embedded runner path was simply missed.
- Why this regressed now: This appears to be an original omission rather than a regression.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/runs.test.ts` or a new focused test
- Scenario the test should lock in: When `params.model` is `"ollama-beelink2/qwen2.5-coder:7b"`, the model ID sent to the API should be `"qwen2.5-coder:7b"` and the provider should be `"ollama-beelink2"`.
- Why this is the smallest reliable guardrail: The split logic is a single conditional at the entry point — a unit test on the resolved model/provider values covers it directly.
- If no new test is added, why not: The fix reuses `parseModelRef()` which has 66 passing tests in `model-selection.test.ts`. A dedicated integration test for the `runEmbeddedPiAgent` path would require significant test infrastructure setup.

## AI

- AI-assisted
- targeted local verification: `npx tsc --noEmit` (no errors in `run.ts`), `pnpm test -- src/agents/model-selection.test.ts` (66/67 pass, 1 pre-existing failure unrelated to this change)