### PR TITLE
fix(ui): set default agent via agents.list[].default instead of agents.defaultId

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1295,7 +1295,21 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  updateConfigFormValue(state, ["agents", "defaultId"], agentId);
+                  const targetIndex = ensureAgentIndex(agentId);
+                  if (targetIndex < 0) {
+                    return;
+                  }
+                  const list = (getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null)
+                    ?.agents?.list;
+                  if (Array.isArray(list)) {
+                    for (let i = 0; i < list.length; i++) {
+                      if (i === targetIndex) {
+                        updateConfigFormValue(state, ["agents", "list", i, "default"], true);
+                      } else {
+                        removeConfigFormValue(state, ["agents", "list", i, "default"]);
+                      }
+                    }
+                  }
                 },
               }),
             )


### PR DESCRIPTION
## Summary

- The "Set as default" handler in the web UI config editor was writing to `agents.defaultId`, which does not exist in the Zod config schema (`AgentsSchema`). This caused a validation error on save, silently discarding the user's intent.
- Now iterates `agents.list` to set `default: true` on the target agent and removes `default` from all other agents, matching the schema's expected shape.

## Test plan

- [ ] Open the web UI config editor with multiple agents
- [ ] Click "Set as default" on a non-default agent
- [ ] Verify the config saves without validation errors
- [ ] Verify the correct agent is now marked as default
- [ ] Verify the previous default agent no longer has the default flag

Fixes #59070

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)