### PR TITLE
fix(ms teams): preserve proactive conversation payload

### DIFF
--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -192,7 +192,11 @@ describe("msteams messenger", () => {
       activityId: "activity123",
       user: { id: "user123", name: "User" },
       agent: { id: "bot123", name: "Bot" },
-      conversation: { id: "19:abc@thread.tacv2;messageid=deadbeef" },
+      conversation: {
+        id: "19:abc@thread.tacv2;messageid=deadbeef",
+        conversationType: "channel",
+        tenantId: "tenant-123",
+      },
       channelId: "msteams",
       serviceUrl: "https://service.example.com",
     };

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -201,11 +201,6 @@ describe("msteams messenger", () => {
       serviceUrl: "https://service.example.com",
     };
 
-    async function sendAndCaptureRevokeFallbackReference(params: {
-      conversation: StoredConversationReference["conversation"];
-      activityId?: string;
-      threadId?: string;
-    }) {
     it("preserves tenant and conversation type when building proactive references", () => {
       expect(buildConversationReference(baseRef)).toEqual({
         activityId: "activity123",

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -206,6 +206,27 @@ describe("msteams messenger", () => {
       activityId?: string;
       threadId?: string;
     }) {
+    it("preserves tenant and conversation type when building proactive references", () => {
+      expect(buildConversationReference(baseRef)).toEqual({
+        activityId: "activity123",
+        user: { id: "user123", name: "User" },
+        agent: { id: "bot123", name: "Bot" },
+        tenantId: "tenant-123",
+        conversation: {
+          id: "19:abc@thread.tacv2",
+          conversationType: "channel",
+          tenantId: "tenant-123",
+        },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com",
+        locale: undefined,
+      });
+    });
+    async function sendAndCaptureRevokeFallbackReference(params: {
+      conversation: StoredConversationReference["conversation"];
+      activityId?: string;
+      threadId?: string;
+    }) {
       const proactiveSent: string[] = [];
       let capturedReference: unknown;
       const conversationRef: StoredConversationReference = {

--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -244,6 +244,91 @@ describe("createMSTeamsAdapter", () => {
       },
     });
   });
+  it("preserves the full conversation reference in proactive sendActivity calls", async () => {
+    const clientState = {
+      constructorArgs: [] as Array<{ serviceUrl: string; options: unknown }>,
+      createCalls: [] as Array<{
+        conversationId: string;
+        activity: Record<string, unknown>;
+      }>,
+    };
+
+    class AppStub {
+      async getBotToken() {
+        return {
+          toString() {
+            return "bot-token";
+          },
+        };
+      }
+    }
+
+    class ClientStub {
+      constructor(serviceUrl: string, options: unknown) {
+        clientState.constructorArgs.push({ serviceUrl, options });
+      }
+
+      conversations = {
+        activities: (conversationId: string) => ({
+          create: async (activity: Record<string, unknown>) => {
+            clientState.createCalls.push({ conversationId, activity });
+            return { id: "created" };
+          },
+        }),
+      };
+    }
+
+    const creds = {
+      appId: "app-id",
+      appPassword: "secret",
+      tenantId: "tenant-id",
+    } satisfies MSTeamsCredentials;
+    const sdk = {
+      App: AppStub as unknown as MSTeamsTeamsSdk["App"],
+      Client: ClientStub as unknown as MSTeamsTeamsSdk["Client"],
+    };
+    const app = new sdk.App({
+      clientId: creds.appId,
+      clientSecret: creds.appPassword,
+      tenantId: creds.tenantId,
+    });
+    const adapter = createMSTeamsAdapter(app, sdk);
+
+    await adapter.continueConversation(
+      creds.appId,
+      {
+        serviceUrl: "https://service.example.com/",
+        conversation: {
+          id: "19:conversation@thread.tacv2",
+          conversationType: "channel",
+          tenantId: "tenant-123",
+        },
+        agent: { id: "bot-123", name: "Bot" },
+        channelId: "msteams",
+      },
+      async (ctx) => {
+        await ctx.sendActivity({ type: "message", text: "hello" });
+      },
+    );
+
+    expect(clientState.constructorArgs).toHaveLength(1);
+    expect(clientState.constructorArgs[0]?.serviceUrl).toBe("https://service.example.com/");
+    expect(clientState.createCalls).toEqual([
+      {
+        conversationId: "19:conversation@thread.tacv2",
+        activity: {
+          type: "message",
+          text: "hello",
+          from: { id: "bot-123", name: "Bot", role: "bot" },
+          conversation: {
+            id: "19:conversation@thread.tacv2",
+            conversationType: "channel",
+            tenantId: "tenant-123",
+          },
+        },
+      },
+    ]);
+  });
 });
 
 describe("createBotFrameworkJwtValidator", () => {

--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -279,6 +279,7 @@ describe("createMSTeamsAdapter", () => {
     }
 
     const creds = {
+      type: "secret",
       appId: "app-id",
       appPassword: "secret",
       tenantId: "tenant-id",
@@ -319,6 +320,7 @@ describe("createMSTeamsAdapter", () => {
         activity: {
           type: "message",
           text: "hello",
+          channelData: { tenant: { id: "tenant-123" } },
           from: { id: "bot-123", name: "Bot", role: "bot" },
           conversation: {
             id: "19:conversation@thread.tacv2",

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -35,6 +35,12 @@ type MSTeamsBotIdentity = {
   name?: string;
 };
 
+type MSTeamsConversationDetails = {
+  id?: string;
+  conversationType?: string;
+  tenantId?: string;
+} & Record<string, unknown>;
+
 type MSTeamsSendContext = {
   sendActivity: (textOrActivity: string | object) => Promise<unknown>;
   updateActivity: (activityUpdate: object) => Promise<{ id?: string } | void>;
@@ -277,8 +283,7 @@ function normalizeOutboundActivity(textOrActivity: string | object): Record<stri
 function createSendContext(params: {
   sdk: MSTeamsTeamsSdk;
   serviceUrl?: string;
-  conversationId?: string;
-  conversationType?: string;
+  conversation?: MSTeamsConversationDetails;
   bot?: MSTeamsBotIdentity;
   replyToActivityId?: string;
   getToken: () => Promise<string | undefined>;
@@ -294,8 +299,9 @@ function createSendContext(params: {
   /** Target user's Azure AD object ID; included as the recipient on personal DMs. */
   recipientAadObjectId?: string;
 }): MSTeamsSendContext {
+  const conversationId = params.conversation?.id;
   const apiClient =
-    params.serviceUrl && params.conversationId
+    params.serviceUrl && conversationId
       ? createApiClient(params.sdk, params.serviceUrl, params.getToken)
       : undefined;
 
@@ -305,7 +311,7 @@ function createSendContext(params: {
       if (params.treatInvokeResponseAsNoop && msg.type === "invokeResponse") {
         return { id: "invokeResponse" };
       }
-      if (!apiClient || !params.conversationId) {
+      if (!apiClient || !conversationId) {
         return { id: "unknown" };
       }
 
@@ -323,19 +329,14 @@ function createSendContext(params: {
             tenant: { id: params.tenantId },
           }
         : existingChannelData;
-
-      return await apiClient.conversations.activities(params.conversationId).create({
+      return await apiClient.conversations.activities(conversationId).create({
         type: "message",
         ...msg,
         ...(channelData ? { channelData } : {}),
         from: params.bot?.id
           ? { id: params.bot.id, name: params.bot.name ?? "", role: "bot" }
           : undefined,
-        conversation: {
-          id: params.conversationId,
-          conversationType: params.conversationType ?? "personal",
-          ...(params.tenantId ? { tenantId: params.tenantId } : {}),
-        },
+        conversation: params.conversation,
         ...(params.recipientId || params.recipientAadObjectId
           ? {
               recipient: {
@@ -364,12 +365,12 @@ function createSendContext(params: {
       if (!activityId) {
         throw new Error("updateActivity requires an activity id");
       }
-      if (!params.serviceUrl || !params.conversationId) {
+      if (!params.serviceUrl || !conversationId) {
         return { id: "unknown" };
       }
       return await updateActivityViaRest({
         serviceUrl: params.serviceUrl,
-        conversationId: params.conversationId,
+        conversationId,
         activityId,
         activity: nextActivity,
         token: await params.getToken(),
@@ -380,12 +381,12 @@ function createSendContext(params: {
       if (!activityId) {
         throw new Error("deleteActivity requires an activity id");
       }
-      if (!params.serviceUrl || !params.conversationId) {
+      if (!params.serviceUrl || !conversationId) {
         return;
       }
       await deleteActivityViaRest({
         serviceUrl: params.serviceUrl,
-        conversationId: params.conversationId,
+        conversationId,
         activityId,
         token: await params.getToken(),
       });
@@ -399,11 +400,7 @@ function createProcessContext(params: {
   getToken: () => Promise<string | undefined>;
 }): MSTeamsProcessContext {
   const serviceUrl = params.activity?.serviceUrl as string | undefined;
-  const conversationId = (params.activity?.conversation as Record<string, unknown>)?.id as
-    | string
-    | undefined;
-  const conversationType = (params.activity?.conversation as Record<string, unknown>)
-    ?.conversationType as string | undefined;
+  const conversation = params.activity?.conversation as MSTeamsConversationDetails | undefined;
   const replyToActivityId = params.activity?.id as string | undefined;
   const bot: MSTeamsBotIdentity | undefined =
     params.activity?.recipient && typeof params.activity.recipient === "object"
@@ -415,8 +412,7 @@ function createProcessContext(params: {
   const sendContext = createSendContext({
     sdk: params.sdk,
     serviceUrl,
-    conversationId,
-    conversationType,
+    conversation,
     bot,
     replyToActivityId,
     getToken: params.getToken,
@@ -567,8 +563,7 @@ export function createMSTeamsAdapter(app: MSTeamsApp, sdk: MSTeamsTeamsSdk): MST
       const sendContext = createSendContext({
         sdk,
         serviceUrl,
-        conversationId,
-        conversationType: reference.conversation?.conversationType,
+        conversation: reference.conversation,
         bot: reference.agent ?? undefined,
         getToken: createBotTokenGetter(app),
         tenantId,

--- a/extensions/msteams/src/send.test.ts
+++ b/extensions/msteams/src/send.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
+import { createMSTeamsAdapter, type MSTeamsTeamsSdk } from "./sdk.js";
 import { deleteMessageMSTeams, editMessageMSTeams, sendMessageMSTeams } from "./send.js";
 
 const mockState = vi.hoisted(() => ({
@@ -189,6 +190,137 @@ describe("sendMessageMSTeams", () => {
       sharePointSiteId: undefined,
     });
     mockState.sendMSTeamsMessages.mockResolvedValue(["message-1"]);
+  });
+
+  it("uses adapter.continueConversation with the stored Teams conversation payload", async () => {
+    const clientState = {
+      createCalls: [] as Array<{
+        conversationId: string;
+        activity: Record<string, unknown>;
+      }>,
+    };
+
+    class AppStub {
+      async getBotToken() {
+        return {
+          toString() {
+            return "bot-token";
+          },
+        };
+      }
+    }
+
+    class ClientStub {
+      conversations = {
+        activities: (conversationId: string) => ({
+          create: async (activity: Record<string, unknown>) => {
+            clientState.createCalls.push({ conversationId, activity });
+            return { id: "message-transport-1" };
+          },
+        }),
+      };
+    }
+
+    const sdk = {
+      App: AppStub as unknown as MSTeamsTeamsSdk["App"],
+      Client: ClientStub as unknown as MSTeamsTeamsSdk["Client"],
+    };
+    const app = new sdk.App({
+      clientId: "app-id",
+      clientSecret: "secret",
+      tenantId: "tenant-id",
+    });
+    const adapter = createMSTeamsAdapter(app, sdk);
+    const continueConversationSpy = vi.spyOn(adapter, "continueConversation");
+
+    mockState.resolveMSTeamsSendContext.mockResolvedValue({
+      adapter,
+      appId: "app-id",
+      conversationId: "19:conversation@thread.tacv2",
+      ref: {
+        user: { id: "user-1" },
+        agent: { id: "agent-1", name: "Agent" },
+        conversation: {
+          id: "19:conversation@thread.tacv2",
+          conversationType: "channel",
+          tenantId: "tenant-123",
+        },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com/",
+      },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      conversationType: "channel",
+      tokenProvider: { getAccessToken: vi.fn(async () => "token") },
+      mediaMaxBytes: 8 * 1024,
+      sharePointSiteId: undefined,
+    });
+    mockState.sendMSTeamsMessages.mockImplementation(async (params) => {
+      const proactiveRef = {
+        serviceUrl: params.conversationRef.serviceUrl,
+        conversation: params.conversationRef.conversation,
+        agent: params.conversationRef.agent ?? params.conversationRef.bot ?? undefined,
+        channelId: params.conversationRef.channelId ?? "msteams",
+      };
+      const messageIds: string[] = [];
+      await params.adapter.continueConversation(
+        params.appId,
+        proactiveRef,
+        async (ctx: {
+          sendActivity: (activity: Record<string, unknown>) => Promise<{ id?: string }>;
+        }) => {
+          for (const message of params.messages) {
+            const response = await ctx.sendActivity({
+              type: "message",
+              text: message.text,
+            });
+            messageIds.push((response as { id?: string }).id ?? "unknown");
+          }
+        },
+      );
+      return messageIds;
+    });
+
+    await expect(
+      sendMessageMSTeams({
+        cfg: {} as OpenClawConfig,
+        to: "conversation:19:conversation@thread.tacv2",
+        text: "hello",
+      }),
+    ).resolves.toEqual({
+      messageId: "message-transport-1",
+      conversationId: "19:conversation@thread.tacv2",
+    });
+
+    expect(continueConversationSpy).toHaveBeenCalledTimes(1);
+    expect(clientState.createCalls).toEqual([
+      {
+        conversationId: "19:conversation@thread.tacv2",
+        activity: {
+          type: "message",
+          text: "hello",
+          from: { id: "agent-1", name: "Agent", role: "bot" },
+          conversation: {
+            id: "19:conversation@thread.tacv2",
+            conversationType: "channel",
+            tenantId: "tenant-123",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("wraps proactive 403 failures with the Teams send context", async () => {
+    mockState.sendMSTeamsMessages.mockRejectedValue(
+      Object.assign(new Error("Forbidden"), { statusCode: 403 }),
+    );
+
+    await expect(
+      sendMessageMSTeams({
+        cfg: {} as OpenClawConfig,
+        to: "conversation:19:conversation@thread.tacv2",
+        text: "hello",
+      }),
+    ).rejects.toThrow("msteams send failed (HTTP 403): Forbidden");
   });
 
   it("loads media through shared helper and forwards mediaLocalRoots", async () => {

--- a/extensions/msteams/src/send.test.ts
+++ b/extensions/msteams/src/send.test.ts
@@ -298,6 +298,7 @@ describe("sendMessageMSTeams", () => {
         activity: {
           type: "message",
           text: "hello",
+          channelData: { tenant: { id: "tenant-123" } },
           from: { id: "agent-1", name: "Agent", role: "bot" },
           conversation: {
             id: "19:conversation@thread.tacv2",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

  - Problem: Microsoft Teams proactive sends could return HTTP 403 after the Teams SDK migration because the proactive adapter rebuilt a reduced conversation payload instead of preserving the stored Teams
    conversation reference details.
  - Why it matters: user-facing proactive sends can silently regress after inbound capture succeeds, which breaks normal OpenClaw-to-Teams delivery for existing conversations.
  - What changed: the custom Teams SDK adapter now threads the stored conversation payload through proactive continueConversation sends, and regression coverage was added at the adapter, send-helper, and stored-
    reference layers.
  - What did NOT change (scope boundary): no config changes, no auth/token flow changes, no inbound webhook handling changes, and no broader Teams monitor/runtime cleanup beyond the proactive-send path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #58774
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

 - Root cause: the Teams SDK migration replaced the previous CloudAdapter proactive send path with a custom adapter path that rebuilt conversation as { id, conversationType }, dropping other stored Teams
    conversation metadata needed by the downstream send transport.
  - Missing detection / guardrail: there was no focused regression test for proactive ctx.sendActivity(...) using the stored conversation reference, and no higher-level send-helper test asserting the preserved
    proactive transport payload.
  - Prior context (git blame, prior PR, issue, or refactor if known): regression window appears after the Teams SDK migration introduced in v2026.3.31; v2026.3.23-2 still used @microsoft/agents-hosting
    CloudAdapter.
  - Why this regressed now: the migration kept proactive send compatibility at a high level but narrowed the outgoing conversation payload in the custom adapter implementation.
  - If unknown, what was ruled out: ruled out simple appId forwarding and token acquisition issues in the changed path; the issue is in the proactive send payload shape.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: 
      - extensions/msteams/src/sdk.test.ts
      - extensions/msteams/src/send.test.ts
      - extensions/msteams/src/messenger.test.ts
  - Scenario the test should lock in: a stored Teams conversation reference with conversation metadata is used for proactive top-level sends, the adapter forwards that payload unchanged into the SDK client send
    path, and 403 failures are still surfaced as actionable send errors.
  - Why this is the smallest reliable guardrail: the bug lives at the adapter/send seam, so adapter-only coverage plus one send-helper path catches the regression without requiring live Teams traffic.
  - Existing test that already covers this (if any): existing coverage only partially covered proactive delete behavior; it did not lock proactive sendActivity(...) payload preservation.
  - If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).
  If none, write None.

  Teams proactive sends should resume working for previously stored conversation references that require the full conversation payload, instead of failing with HTTP 403 after the SDK migration.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write N/A.

  Before:
  [stored Teams conversation ref] -> [custom proactive adapter rebuilds reduced conversation object] -> [Teams send path loses metadata] -> [HTTP 403]

  After:
  [stored Teams conversation ref] -> [custom proactive adapter preserves stored conversation payload] -> [SDK client send uses full metadata] -> [delivery succeeds]

## Security Impact (required)

  - New permissions/capabilities? (Yes/No) No
  - Secrets/tokens handling changed? (Yes/No) No
  - New/changed network calls? (Yes/No) No
  - Command/tool execution surface changed? (Yes/No) No
  - Data access scope changed? (Yes/No) No
  - If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

  - OS: macOS agent workspace
  - Runtime/container: Node 22.22.1 local shell
  - Model/provider: N/A
  - Integration/channel (if any): Microsoft Teams
  - Relevant config (redacted): stored Teams conversation reference with conversation.id, conversationType, tenantId, serviceUrl, agent, user

### Steps

  1. Store a Teams conversation reference from inbound traffic.
  2. Trigger a proactive top-level send through the MSTeams send helper.
  3. Observe the adapter path that calls continueConversation and ctx.sendActivity(...).

### Expected

 - The proactive send path preserves the stored Teams conversation payload and delivery succeeds.

### Actual

  - The post-migration adapter rebuilt a reduced conversation object, which could cause proactive sends to fail with HTTP 403.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios:
      - Ran pnpm test -- extensions/msteams/src/sdk.test.ts extensions/msteams/src/send.test.ts under Node 22 and confirmed the focused proactive-send regression coverage passes.
      - Ran local Codex review against origin/main; no findings were reported for the modified code paths.
  - Edge cases checked:
      - proactive send preserves conversation metadata
      - proactive send helper still wraps HTTP 403 errors clearly
      - stored conversation reference normalization still strips ;messageid=... while preserving conversationType and tenantId
  - What you did not verify:
      - full pnpm build / repo-wide gates due unrelated existing src/agents/skills/local-loader.ts type failures on the current base
      - full pnpm test:extension msteams in this sandbox because socket-binding tests fail with listen EPERM

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

  - Backward compatible? (Yes/No) Yes
  - Config/env changes? (Yes/No) No
  - Migration needed? (Yes/No) No
  - If yes, exact upgrade steps:

## Risks and Mitigations

  List only real risks for this PR. Add/remove entries as needed. If none, write None.

  - Risk: preserving the full stored conversation payload could include fields the send transport does not expect in some edge cases.
      - Mitigation: the change keeps the existing conversation id validation, limits the change to the proactive adapter send path, and adds focused regression coverage around the outgoing payload shape.
