### PR TITLE
fix(sessions): normalize GPT-style redundant args in sessions_spawn and sessions_send

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -114,14 +114,11 @@ export function createSessionsSendTool(opts?: {
       });
 
       const sessionKeyParam = readStringParam(params, "sessionKey");
-      const labelParam = readStringParam(params, "label")?.trim() || undefined;
-      const labelAgentIdParam = readStringParam(params, "agentId")?.trim() || undefined;
-      if (sessionKeyParam && labelParam) {
-        return jsonResult({
-          runId: crypto.randomUUID(),
-          status: "error",
-          error: "Provide either sessionKey or label (not both).",
-        });
+      let labelParam = readStringParam(params, "label")?.trim() || undefined;
+      let labelAgentIdParam = readStringParam(params, "agentId")?.trim() || undefined;
+      if (sessionKeyParam) {
+        labelParam = undefined;
+        labelAgentIdParam = undefined;
       }
 
       let sessionKey = sessionKeyParam;

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -200,7 +200,7 @@ describe("sessions_spawn tool", () => {
     );
   });
 
-  it("rejects resumeSessionId without runtime=acp", async () => {
+  it("ignores resumeSessionId without runtime=acp", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
@@ -210,8 +210,17 @@ describe("sessions_spawn tool", () => {
       resumeSessionId: "7f4a78e0-f6be-43fe-855c-c1c4fd229bc4",
     });
 
-    expect(JSON.stringify(result)).toContain("resumeSessionId is only supported for runtime=acp");
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:1",
+      runId: "run-subagent",
+    });
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "resume prior work",
+      }),
+      expect.any(Object),
+    );
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
   });
 
@@ -239,7 +248,7 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
-  it('rejects streamTo when runtime is not "acp"', async () => {
+  it('ignores streamTo when runtime is not "acp"', async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
@@ -251,12 +260,17 @@ describe("sessions_spawn tool", () => {
     });
 
     expect(result.details).toMatchObject({
-      status: "error",
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:1",
+      runId: "run-subagent",
     });
-    const details = result.details as { error?: string };
-    expect(details.error).toContain("streamTo is only supported for runtime=acp");
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "analyze file",
+      }),
+      expect.any(Object),
+    );
   });
 
   it("keeps attachment content schema unconstrained for llama.cpp grammar safety", () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -182,20 +182,6 @@ export function createSessionsSpawnTool(
           }>)
         : undefined;
 
-      if (streamTo && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `streamTo is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
-
-      if (resumeSessionId && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `resumeSessionId is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
-
       if (runtime === "acp") {
         if (Array.isArray(attachments) && attachments.length > 0) {
           return jsonResult({

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -148,7 +148,7 @@ export function createSessionsSpawnTool(
       const label = typeof params.label === "string" ? params.label.trim() : "";
       const runtime = params.runtime === "acp" ? "acp" : "subagent";
       const requestedAgentId = readStringParam(params, "agentId");
-      const resumeSessionId = readStringParam(params, "resumeSessionId");
+      let resumeSessionId = readStringParam(params, "resumeSessionId");
       const modelOverride = readStringParam(params, "model");
       const thinkingOverrideRaw = readStringParam(params, "thinking");
       const cwd = readStringParam(params, "cwd");
@@ -156,7 +156,11 @@ export function createSessionsSpawnTool(
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
-      const streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      let streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      if (runtime !== "acp") {
+        resumeSessionId = undefined;
+        streamTo = undefined;
+      }
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
         typeof params.runTimeoutSeconds === "number"

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -156,7 +156,7 @@ export function createSessionsSpawnTool(
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
-      let streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      let streamTo: "parent" | undefined = params.streamTo === "parent" ? "parent" : undefined;
       if (runtime !== "acp") {
         resumeSessionId = undefined;
         streamTo = undefined;

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -529,6 +529,50 @@ describe("sessions_send gating", () => {
     expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({ method: "sessions.resolve" });
   });
 
+  it("prefers sessionKey over label+agentId and skips label resolution", async () => {
+    const tool = createMainSessionsSendTool();
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: MAIN_AGENT_SESSION_KEY, kind: "direct" }],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-sessionkey-preferred", acceptedAt: 123 };
+      }
+      return {};
+    });
+
+    const result = await tool.execute("call-sessionkey-preferred", {
+      sessionKey: MAIN_AGENT_SESSION_KEY,
+      label: "redundant",
+      agentId: "other",
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-sessionkey-preferred",
+      sessionKey: MAIN_AGENT_SESSION_KEY,
+    });
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({
+          sessionKey: MAIN_AGENT_SESSION_KEY,
+          message: "ping",
+        }),
+      }),
+    );
+    const methods = callGatewayMock.mock.calls.map(
+      (call) => (call[0] as { method?: string })?.method,
+    );
+    expect(methods).not.toContain("sessions.resolve");
+  });
+
   it("blocks cross-agent sends when tools.agentToAgent.enabled is false", async () => {
     const tool = createMainSessionsSendTool();
 


### PR DESCRIPTION
 ## Summary

  - GPT-family models sometimes send over-specified tool args (redundant but harmless fields).
  - `sessions_spawn(runtime="subagent")` previously failed hard if ACP-only fields (`streamTo`, `resumeSessionId`) were present.
  - `sessions_send` previously failed hard if both `sessionKey` and `label` were present.
  - This PR normalizes those inputs instead of failing: ignore ACP-only fields for non-ACP runtime, and prefer `sessionKey` over `label`/`agentId`.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [x] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #N/A
  - Related #N/A
  - [x] This PR fixes a bug or regression

  ## Root Cause / Regression History (if applicable)

  - Root cause: Execution logic was stricter than real model output patterns.
  - Missing detection / guardrail: No tests for GPT-style redundant arg combinations.
  - Prior context (`git blame`, prior PR, issue, or refactor if known): Likely introduced with stricter ACP/send parameter checks.
  - Why this regressed now: ACP added optional fields and increased over-specified payload frequency.
  - If unknown, what was ruled out: Not a visibility/auth policy bug, not `sessions.resolve`, not transport.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
    - [x] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file:
    - `src/agents/tools/sessions-spawn-tool.test.ts`
    - `src/agents/tools/sessions.test.ts`
  - Scenario the test should lock in:
    - `sessions_spawn`: subagent runtime ignores `streamTo`/`resumeSessionId`.
    - `sessions_send`: `sessionKey + label(+agentId)` succeeds and skips label resolution.
  - Why this is the smallest reliable guardrail: Failure happened in tool-layer argument gating.
  - Existing test that already covers this (if any): Existing sessions tests cover baseline paths; this PR adds missing redundant-arg cases.
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  - `sessions_spawn(runtime="subagent")` no longer errors on redundant ACP-only args.
  - `sessions_send` no longer errors on `sessionKey + label`; `sessionKey` wins.

  ## Diagram (if applicable)

  ```text
  Before:
  over-specified model args -> early fail-hard -> tool run blocked

  After:
  over-specified model args -> normalize -> normal execution/policy checks

  ## Security Impact (required)

  - New permissions/capabilities? (No)
  - Secrets/tokens handling changed? (No)
  - New/changed network calls? (No)
  - Command/tool execution surface changed? (Yes)
  - Data access scope changed? (No)
  - If any Yes, explain risk + mitigation:
      - Change is normalization-only. Existing visibility/a2a/policy checks still gate execution.

  ## Repro + Verification

  ### Environment

  - OS: Linux
  - Runtime/container: Node.js v24.14.1, pnpm v10.32.1
  - Model/provider: N/A (behavior motivated by GPT-family tool-calling patterns)
  - Integration/channel (if any): N/A
  - Relevant config (redacted): default test config + mocked gateway

  ### Steps

  1. Run:
     pnpm vitest run src/agents/tools/sessions-spawn-tool.test.ts src/agents/tools/sessions.test.ts

  ### Expected

  - Redundant args are ignored; valid paths proceed.

  ### Actual

  - Passed: 2 files, 31 tests.

  ## Evidence

  - [x] Failing test/log before + passing after
  - [x] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  - Verified scenarios:
      - sessions_spawn ignores ACP-only args for subagent runtime.
      - sessions_send prefers sessionKey and does not resolve label.
  - Edge cases checked:
      - ACP path unchanged for ACP runtime.
      - Existing visibility/a2a guards still apply.
  - What you did not verify:
      - Full repository lint/check pipeline on low-resource host.

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? (Yes)
  - Config/env changes? (No)
  - Migration needed? (No)
  - If yes, exact upgrade steps: N/A

  ## Risks and Mitigations

  - Risk:
      - Some callers may rely on previous fail-hard behavior.
  - Mitigation:
      - Scope is narrow (redundant-field normalization only) and regression tests added.