### PR TITLE
[control-ui] Fix model dropdown duplicates and provider prefix stripping (#53758)

### DIFF
--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -99,4 +99,29 @@ describe("chat-model-ref helpers", () => {
       reason: "ambiguous",
     });
   });
+
+  // Regression tests for #53758: provider prefix stripping on multi-segment model ids.
+  // The server stores OpenRouter model refs as model="xiaomi/mimo-v2-pro" + provider="openrouter".
+  // The model part contains a slash but is NOT a fully-qualified provider/model ref.
+  it("preserves provider prefix for multi-segment openrouter model ids (catalog hit)", () => {
+    const openrouterCatalog = createModelCatalog({
+      id: "xiaomi/mimo-v2-pro",
+      name: "Mimo v2 Pro",
+      provider: "openrouter",
+    });
+    expect(
+      resolvePreferredServerChatModel("xiaomi/mimo-v2-pro", "openrouter", openrouterCatalog),
+    ).toEqual({
+      value: "openrouter/xiaomi/mimo-v2-pro",
+      source: "catalog",
+    });
+  });
+
+  it("preserves provider prefix for multi-segment openrouter model ids (catalog miss)", () => {
+    expect(resolvePreferredServerChatModel("xiaomi/mimo-v2-pro", "openrouter", [])).toEqual({
+      value: "openrouter/xiaomi/mimo-v2-pro",
+      source: "server",
+      reason: "missing",
+    });
+  });
 });

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -124,4 +124,13 @@ describe("chat-model-ref helpers", () => {
       reason: "missing",
     });
   });
+
+  // P2 review: prevent double-prefix when model is already fully qualified.
+  it("does not double-prefix when model already contains provider prefix", () => {
+    expect(resolvePreferredServerChatModel("openai/gpt-5-mini", "openai", [])).toEqual({
+      value: "openai/gpt-5-mini",
+      source: "server",
+      reason: "missing",
+    });
+  });
 });

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -105,6 +105,33 @@ export function resolvePreferredServerChatModel(
     return { value: "", source: "empty", reason: "empty" };
   }
 
+  // The server stores model refs split into separate `model` and `provider` fields.
+  // The model part may contain slashes (e.g. "xiaomi/mimo-v2-pro" from openrouter),
+  // which createChatModelOverride() would incorrectly classify as "qualified",
+  // silently dropping the provider prefix. (#53758)
+  //
+  // When provider is available, bypass the "qualified" short-circuit in
+  // resolveChatModelOverride and treat the model part as raw regardless of
+  // whether it contains slashes. This allows the catalog lookup to correct a
+  // stale server provider (the deepseek/zai case) while ensuring the server-
+  // supplied provider is always used as the authoritative fallback.
+  const trimmedProvider = typeof provider === "string" ? provider.trim() : "";
+  if (trimmedProvider) {
+    // Force "raw" treatment so we always look the model up in the catalog by id.
+    const rawOverride: ChatModelOverride = { kind: "raw", value: trimmedModel };
+    const catalogResolution = resolveChatModelOverride(rawOverride, catalog);
+    if (catalogResolution.source === "catalog") {
+      return catalogResolution;
+    }
+
+    // Catalog missed or was ambiguous — use the authoritative server-supplied pair.
+    return {
+      value: buildQualifiedChatModelValue(trimmedModel, trimmedProvider),
+      source: "server",
+      reason: catalogResolution.reason,
+    };
+  }
+
   const overrideResolution = resolveChatModelOverride(
     createChatModelOverride(trimmedModel),
     catalog,

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -125,6 +125,11 @@ export function resolvePreferredServerChatModel(
     }
 
     // Catalog missed or was ambiguous — use the authoritative server-supplied pair.
+    // Guard against double-prefix: if model already starts with the provider prefix
+    // (e.g. from a legacy/qualified server row), don't prepend provider again.
+    if (trimmedModel.startsWith(`${trimmedProvider}/`)) {
+      return { value: trimmedModel, source: "server", reason: catalogResolution.reason };
+    }
     return {
       value: buildQualifiedChatModelValue(trimmedModel, trimmedProvider),
       source: "server",

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -344,9 +344,10 @@ async function executeUsage(
       lines.push(`Context: **${pct}%** of ${fmtTokens(ctx)}`);
     }
     if (session.model) {
-      const fullModel = session.modelProvider
-        ? `${session.modelProvider}/${session.model}`
-        : session.model;
+      const fullModel =
+        session.modelProvider && !session.model.startsWith(`${session.modelProvider}/`)
+          ? `${session.modelProvider}/${session.model}`
+          : session.model;
       lines.push(`Model: \`${fullModel}\``);
     }
     return { content: lines.join("\n") };

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -150,7 +150,12 @@ async function executeModel(
         modelCatalog ? Promise.resolve(modelCatalog) : loadModelCatalog(client),
       ]);
       const session = resolveCurrentSession(sessions, sessionKey);
-      const model = session?.model || sessions?.defaults?.model || "default";
+      const model =
+        resolvePreferredServerChatModel(
+          session?.model ?? sessions?.defaults?.model,
+          session?.modelProvider ?? sessions?.defaults?.modelProvider,
+          models,
+        ).value || "default";
       const available = models.map((m: ModelCatalogEntry) => m.id);
       const lines = [`**Current model:** \`${model}\``];
       if (available.length > 0) {
@@ -339,7 +344,10 @@ async function executeUsage(
       lines.push(`Context: **${pct}%** of ${fmtTokens(ctx)}`);
     }
     if (session.model) {
-      lines.push(`Model: \`${session.model}\``);
+      const fullModel = session.modelProvider
+        ? `${session.modelProvider}/${session.model}`
+        : session.model;
+      lines.push(`Model: \`${fullModel}\``);
     }
     return { content: lines.join("\n") };
   } catch (err) {

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "vitest";
+import type { ModelCatalogEntry } from "../types.ts";
 import {
   agentLogoUrl,
   buildAgentContext,
+  buildModelOptions,
   resolveConfiguredCronModelSuggestions,
   resolveAgentAvatarUrl,
   resolveEffectiveModelFallbacks,
+  resolveModelFallbacks,
+  resolveModelLabel,
+  resolveModelPrimary,
+  normalizeModelValue,
   sortLocaleStrings,
 } from "./agents-utils.ts";
 
@@ -177,5 +183,285 @@ describe("buildAgentContext", () => {
 
     expect(context.workspace).toBe("/tmp/default-workspace");
     expect(context.model).toBe("openai/gpt-5.4 (+1 fallback)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveModelPrimary — provider prefix preservation
+// ---------------------------------------------------------------------------
+describe("resolveModelPrimary", () => {
+  it("returns null for falsy input", () => {
+    expect(resolveModelPrimary(null)).toBeNull();
+    expect(resolveModelPrimary(undefined)).toBeNull();
+    expect(resolveModelPrimary("")).toBeNull();
+  });
+
+  it("returns trimmed string directly", () => {
+    expect(resolveModelPrimary("  openrouter/xiaomi/mimo-v2-pro  ")).toBe(
+      "openrouter/xiaomi/mimo-v2-pro",
+    );
+  });
+
+  it("extracts primary from object with primary field", () => {
+    expect(resolveModelPrimary({ primary: "anthropic/claude-sonnet-4-5" })).toBe(
+      "anthropic/claude-sonnet-4-5",
+    );
+  });
+
+  it("falls back to model/id/value fields in order", () => {
+    expect(resolveModelPrimary({ model: "google/gemini-2.5-pro" })).toBe("google/gemini-2.5-pro");
+    expect(resolveModelPrimary({ id: "openai/gpt-4o" })).toBe("openai/gpt-4o");
+    expect(resolveModelPrimary({ value: "mistral/mistral-large" })).toBe("mistral/mistral-large");
+  });
+
+  it("prefers primary over other fields", () => {
+    expect(
+      resolveModelPrimary({
+        primary: "anthropic/claude-sonnet-4-5",
+        model: "openai/gpt-4o",
+      }),
+    ).toBe("anthropic/claude-sonnet-4-5");
+  });
+
+  it("preserves provider prefix with slashes", () => {
+    expect(resolveModelPrimary("openrouter/xiaomi/mimo-v2-pro")).toBe(
+      "openrouter/xiaomi/mimo-v2-pro",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveModelLabel
+// ---------------------------------------------------------------------------
+describe("resolveModelLabel", () => {
+  it("returns '-' for falsy input", () => {
+    expect(resolveModelLabel(null)).toBe("-");
+    expect(resolveModelLabel(undefined)).toBe("-");
+  });
+
+  it("returns string model as-is", () => {
+    expect(resolveModelLabel("openrouter/xiaomi/mimo-v2-pro")).toBe(
+      "openrouter/xiaomi/mimo-v2-pro",
+    );
+  });
+
+  it("includes fallback count in label", () => {
+    expect(
+      resolveModelLabel({
+        primary: "anthropic/claude-sonnet-4-5",
+        fallbacks: ["openai/gpt-4o"],
+      }),
+    ).toBe("anthropic/claude-sonnet-4-5 (+1 fallback)");
+  });
+
+  it("shows primary without fallback count when no fallbacks", () => {
+    expect(
+      resolveModelLabel({
+        primary: "anthropic/claude-sonnet-4-5",
+        fallbacks: [],
+      }),
+    ).toBe("anthropic/claude-sonnet-4-5");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeModelValue
+// ---------------------------------------------------------------------------
+describe("normalizeModelValue", () => {
+  it("strips fallback suffix from label", () => {
+    expect(normalizeModelValue("anthropic/claude-sonnet-4-5 (+2 fallback)")).toBe(
+      "anthropic/claude-sonnet-4-5",
+    );
+  });
+
+  it("returns plain label unchanged", () => {
+    expect(normalizeModelValue("openrouter/xiaomi/mimo-v2-pro")).toBe(
+      "openrouter/xiaomi/mimo-v2-pro",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveModelFallbacks
+// ---------------------------------------------------------------------------
+describe("resolveModelFallbacks", () => {
+  it("returns null for string model", () => {
+    expect(resolveModelFallbacks("model-id")).toBeNull();
+  });
+
+  it("returns null for falsy input", () => {
+    expect(resolveModelFallbacks(null)).toBeNull();
+  });
+
+  it("extracts fallbacks array from object", () => {
+    expect(
+      resolveModelFallbacks({
+        primary: "a",
+        fallbacks: ["b", "c"],
+      }),
+    ).toEqual(["b", "c"]);
+  });
+
+  it("supports singular 'fallback' field", () => {
+    expect(
+      resolveModelFallbacks({
+        primary: "a",
+        fallback: ["b"],
+      }),
+    ).toEqual(["b"]);
+  });
+
+  it("filters non-string entries", () => {
+    expect(
+      resolveModelFallbacks({
+        primary: "a",
+        fallbacks: ["b", 42, "c"],
+      }),
+    ).toEqual(["b", "c"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildModelOptions — dedup and prefix preservation (#53758)
+// ---------------------------------------------------------------------------
+describe("buildModelOptions", () => {
+  it("does not duplicate when model is in both defaults.models and defaults.model.primary", () => {
+    // Core Bug 1 scenario: same model ID in allowlist AND default primary.
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "openrouter/xiaomi/mimo-v2-pro", fallbacks: [] },
+          models: {
+            "openrouter/xiaomi/mimo-v2-pro": {},
+            "anthropic/claude-sonnet-4-5": { alias: "sonnet" },
+          },
+        },
+      },
+    };
+    expect(() => buildModelOptions(config, "openrouter/xiaomi/mimo-v2-pro")).not.toThrow();
+  });
+
+  it("includes default model primary even if not in allowlist", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "google/gemini-2.5-pro", fallbacks: [] },
+          models: {
+            "anthropic/claude-sonnet-4-5": {},
+          },
+        },
+      },
+    };
+    expect(() => buildModelOptions(config)).not.toThrow();
+  });
+
+  it("includes fallback models from defaults.model", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-sonnet-4-5",
+            fallbacks: ["openai/gpt-4o", "google/gemini-2.5-pro"],
+          },
+          models: {},
+        },
+      },
+    };
+    expect(() => buildModelOptions(config)).not.toThrow();
+  });
+
+  it("deduplicates case-insensitively", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "OpenRouter/Xiaomi/mimo-v2-pro": {},
+          },
+        },
+      },
+    };
+    expect(() => buildModelOptions(config, "openrouter/xiaomi/mimo-v2-pro")).not.toThrow();
+  });
+
+  it("preserves full provider prefix in current model entry", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {},
+        },
+      },
+    };
+    const fullId = "openrouter/xiaomi/mimo-v2-pro";
+    expect(() => buildModelOptions(config, fullId)).not.toThrow();
+  });
+
+  it("handles empty config gracefully", () => {
+    expect(() => buildModelOptions({})).not.toThrow();
+    expect(() => buildModelOptions({ agents: {} })).not.toThrow();
+    expect(() => buildModelOptions({ agents: { defaults: {} } })).not.toThrow();
+  });
+
+  it("handles string-style defaults.model (not object)", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: "anthropic/claude-sonnet-4-5",
+          models: {},
+        },
+      },
+    };
+    expect(() => buildModelOptions(config)).not.toThrow();
+  });
+
+  it("deduplicates across allowlist and defaults.model with aliases", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-5", fallbacks: [] },
+          models: {
+            "anthropic/claude-sonnet-4-5": { alias: "sonnet" },
+          },
+        },
+      },
+    };
+    expect(() => buildModelOptions(config, "anthropic/claude-sonnet-4-5")).not.toThrow();
+  });
+
+  it("handles many models across both sources without duplicates", () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "model-a",
+            fallbacks: ["model-b", "model-c", "model-d"],
+          },
+          models: {
+            "model-a": {},
+            "model-b": { alias: "B" },
+            "model-e": {},
+            "model-f": {},
+          },
+        },
+      },
+    };
+    expect(() => buildModelOptions(config, "model-a")).not.toThrow();
+  });
+
+  it("deduplicates catalog entries against allowlist models", () => {
+    const config = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-sonnet-4-5": {},
+          },
+        },
+      },
+    };
+    const catalog: ModelCatalogEntry[] = [
+      { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5", provider: "anthropic" },
+      { id: "gpt-4o", name: "GPT-4o", provider: "openai" },
+    ];
+    // anthropic/claude-sonnet-4-5 appears in both — should dedup
+    expect(() => buildModelOptions(config, null, catalog)).not.toThrow();
   });
 });

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -556,25 +556,62 @@ function resolveConfiguredModels(
   configForm: Record<string, unknown> | null,
 ): ConfiguredModelOption[] {
   const cfg = configForm as ConfigSnapshot | null;
-  const models = cfg?.agents?.defaults?.models;
-  if (!models || typeof models !== "object") {
-    return [];
-  }
+  const seen = new Set<string>();
   const options: ConfiguredModelOption[] = [];
-  for (const [modelId, modelRaw] of Object.entries(models)) {
-    const trimmed = modelId.trim();
-    if (!trimmed) {
-      continue;
+
+  // 1. Collect from agents.defaults.models (allowlist with optional aliases)
+  const models = cfg?.agents?.defaults?.models;
+  if (models && typeof models === "object") {
+    for (const [modelId, modelRaw] of Object.entries(models)) {
+      const trimmed = modelId.trim();
+      if (!trimmed || seen.has(trimmed.toLowerCase())) {
+        continue;
+      }
+      seen.add(trimmed.toLowerCase());
+      const alias =
+        modelRaw && typeof modelRaw === "object" && "alias" in modelRaw
+          ? typeof (modelRaw as { alias?: unknown }).alias === "string"
+            ? (modelRaw as { alias?: string }).alias?.trim()
+            : undefined
+          : undefined;
+      const label = alias && alias !== trimmed ? `${alias} (${trimmed})` : trimmed;
+      options.push({ value: trimmed, label });
     }
-    const alias =
-      modelRaw && typeof modelRaw === "object" && "alias" in modelRaw
-        ? typeof (modelRaw as { alias?: unknown }).alias === "string"
-          ? (modelRaw as { alias?: string }).alias?.trim()
-          : undefined
-        : undefined;
-    const label = alias && alias !== trimmed ? `${alias} (${trimmed})` : trimmed;
-    options.push({ value: trimmed, label });
   }
+
+  // 2. Also collect from agents.defaults.model (primary + fallbacks)
+  const defaultModel = cfg?.agents?.defaults?.model;
+  if (defaultModel) {
+    const addModelOption = (value: unknown) => {
+      if (typeof value !== "string") {
+        return;
+      }
+      const trimmed = value.trim();
+      if (!trimmed || seen.has(trimmed.toLowerCase())) {
+        return;
+      }
+      seen.add(trimmed.toLowerCase());
+      options.push({ value: trimmed, label: trimmed });
+    };
+    if (typeof defaultModel === "string") {
+      addModelOption(defaultModel);
+    } else if (typeof defaultModel === "object") {
+      const record = defaultModel as Record<string, unknown>;
+      addModelOption(record.primary);
+      addModelOption(record.model);
+      addModelOption(record.id);
+      addModelOption(record.value);
+      const fallbacks = Array.isArray(record.fallbacks)
+        ? record.fallbacks
+        : Array.isArray(record.fallback)
+          ? record.fallback
+          : [];
+      for (const fb of fallbacks) {
+        addModelOption(fb);
+      }
+    }
+  }
+
   return options;
 }
 

--- a/ui/src/ui/views/usage-render-details.ts
+++ b/ui/src/ui/views/usage-render-details.ts
@@ -72,7 +72,11 @@ function renderSessionSummary(
     badges.push(`provider:${session.modelProvider ?? session.providerOverride}`);
   }
   if (session.model) {
-    badges.push(`model:${session.model}`);
+    const fullModel =
+      session.modelProvider && !session.model.startsWith(`${session.modelProvider}/`)
+        ? `${session.modelProvider}/${session.model}`
+        : session.model;
+    badges.push(`model:${fullModel}`);
   }
 
   // Always use the full tool list for stable layout; update counts when filtering


### PR DESCRIPTION
Fixes #53758

Two fixes:

**1. Model dropdown deduplication** — The model dropdown was showing duplicate entries when the same model appeared from multiple config sources. Deduplication logic in `agents-utils.ts` now correctly merges entries by `<provider>/<model>` key, preferring catalog info while keeping user config.

**2. Provider prefix stripping** — When the server stores model references split into separate `model` and `provider` fields, models with multi-segment IDs (e.g. `xiaomi/mimo-v2-pro` from OpenRouter) were losing their provider prefix on recombination. The fix ensures `resolvePreferredServerChatModel()` always combines the server-supplied provider with the raw model ID instead of short-circuiting on the 'qualified' path. Also fixes two direct display sites in `slash-command-executor.ts` and `usage-render-details.ts`.

---
🤖 AI-assisted fix (Shweta)