### PR TITLE
fix: preserve explicit input config for vision-capable models

### DIFF
--- a/src/agents/models-config.merge.test.ts
+++ b/src/agents/models-config.merge.test.ts
@@ -10,7 +10,7 @@ import type { ProviderConfig } from "./models-config.providers.secrets.js";
 describe("models-config merge helpers", () => {
   const preservedApiKey = "AGENT_KEY"; // pragma: allowlist secret
 
-  it("refreshes implicit model metadata while preserving explicit reasoning overrides", () => {
+  it("refreshes implicit model metadata while preserving explicit input and reasoning overrides", () => {
     const merged = mergeProviderModels(
       {
         api: "openai-responses",
@@ -43,10 +43,48 @@ describe("models-config merge helpers", () => {
     expect(merged.models).toEqual([
       expect.objectContaining({
         id: "gpt-5.4",
-        input: ["text"],
+        input: ["image"],
         reasoning: false,
         contextWindow: 2_000_000,
         maxTokens: 200_000,
+      }),
+    ]);
+  });
+
+  it("preserves explicit input config when user specifies vision capabilities", () => {
+    // When a user explicitly configures input: ["text", "image"] for a vision-capable
+    // model, that config should be preserved even if the implicit provider model only
+    // advertises input: ["text"]. This is critical for MiniMax models where the registry
+    // doesn't advertise vision but the user has configured it.
+    const merged = mergeProviderModels(
+      {
+        baseUrl: "https://api.minimax.io",
+        api: "minimax-direct",
+        models: [
+          {
+            id: "MiniMax-M2.7-highspeed",
+            name: "MiniMax M2.7 Highspeed",
+            input: ["text"], // implicit provider entry
+          },
+        ],
+      } as unknown as ProviderConfig,
+      {
+        baseUrl: "https://api.minimax.io",
+        api: "minimax-direct",
+        models: [
+          {
+            id: "MiniMax-M2.7-highspeed",
+            name: "MiniMax M2.7 Highspeed",
+            input: ["text", "image"], // user's explicit vision config
+          },
+        ],
+      } as unknown as ProviderConfig,
+    );
+
+    expect(merged.models).toEqual([
+      expect.objectContaining({
+        id: "MiniMax-M2.7-highspeed",
+        input: ["text", "image"], // explicit input should be preserved
       }),
     ]);
   });

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -93,7 +93,7 @@ export function mergeProviderModels(
 
     return {
       ...explicitModel,
-      input: implicitModel.input,
+      input: explicitModel.input !== undefined ? explicitModel.input : implicitModel.input,
       reasoning: "reasoning" in explicitModel ? explicitModel.reasoning : implicitModel.reasoning,
       ...(contextWindow === undefined ? {} : { contextWindow }),
       ...(maxTokens === undefined ? {} : { maxTokens }),

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -93,7 +93,7 @@ export function mergeProviderModels(
 
     return {
       ...explicitModel,
-      input: explicitModel.input !== undefined ? explicitModel.input : implicitModel.input,
+      input: "input" in explicitModel ? explicitModel.input : implicitModel.input,
       reasoning: "reasoning" in explicitModel ? explicitModel.reasoning : implicitModel.reasoning,
       ...(contextWindow === undefined ? {} : { contextWindow }),
       ...(maxTokens === undefined ? {} : { maxTokens }),


### PR DESCRIPTION
## Summary

When merging implicit provider model metadata with explicit user config, the `input` field was incorrectly being taken from the implicit provider model, overwriting the user's explicit `input` configuration.

This broke vision capabilities for models like MiniMax-M2.7 where the user explicitly configures `input: ["text", "image"]` but the implicit provider entry only advertises `input: ["text"]`.

## Fix

In `mergeProviderModels`, check if the explicit model has `input` set before falling back to the implicit model's value — following the same pattern already used correctly for the `reasoning` field.

```typescript
// Before (buggy):
input: implicitModel.input,

// After (fixed):
input: explicitModel.input !== undefined ? explicitModel.input : implicitModel.input,
```

## Testing

- Updated existing test to validate the corrected behavior
- Added new test case: `preserves explicit input config when user specifies vision capabilities`

Fixes: The image tool now correctly recognizes MiniMax models as vision-capable when the user has configured `input: ["text", "image"]`.