### PR TITLE
fix: loopback rate limit exemption allows unlimited r (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Agents/tools: include value-shape hints in missing-parameter tool errors so dropped, empty-string, and wrong-type write payloads are easier to diagnose from logs. (#55317) Thanks @priyansh19.
 - Plugins/browser: block SSRF redirect bypass by installing a real-time Playwright route handler before `page.goto()` so navigation to private/internal IPs is intercepted and aborted mid-redirect instead of checked post-hoc. (#58771) Thanks @pgondhi987.
 - Android/assistant: keep queued App Actions prompts pending when auto-send enqueue is rejected, so transient chat-health drops do not silently lose the assistant request. Thanks @obviyus.
+- Gateway/auth: rate-limit loopback auth attempts by default so same-host ingress does not silently bypass failed-login throttling when proxy CIDRs are unset. (#258)
 
 ## 2026.4.2-beta.1
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2586,7 +2586,7 @@ See [Plugins](/tools/plugin).
         maxAttempts: 10,
         windowMs: 60000,
         lockoutMs: 300000,
-        exemptLoopback: true,
+        exemptLoopback: false,
       },
     },
     tailscale: {
@@ -2642,7 +2642,7 @@ See [Plugins](/tools/plugin).
 - `gateway.auth.mode: "trusted-proxy"`: delegate auth to an identity-aware reverse proxy and trust identity headers from `gateway.trustedProxies` (see [Trusted Proxy Auth](/gateway/trusted-proxy-auth)).
 - `gateway.auth.allowTailscale`: when `true`, Tailscale Serve identity headers can satisfy Control UI/WebSocket auth (verified via `tailscale whois`); HTTP API endpoints still require token/password auth. This tokenless flow assumes the gateway host is trusted. Defaults to `true` when `tailscale.mode = "serve"`.
 - `gateway.auth.rateLimit`: optional failed-auth limiter. Applies per client IP and per auth scope (shared-secret and device-token are tracked independently). Blocked attempts return `429` + `Retry-After`.
-  - `gateway.auth.rateLimit.exemptLoopback` defaults to `true`; set `false` when you intentionally want localhost traffic rate-limited too (for test setups or strict proxy deployments).
+  - `gateway.auth.rateLimit.exemptLoopback` defaults to `false`; set `true` only for explicitly local-only workflows that should not consume auth throttle budget.
 - Browser-origin WS auth attempts are always throttled with loopback exemption disabled (defense-in-depth against browser-based localhost brute force).
 - `tailscale.mode`: `serve` (tailnet only, loopback bind) or `funnel` (public, requires auth).
 - `controlUi.allowedOrigins`: explicit browser-origin allowlist for Gateway WebSocket connects. Required when browser clients are expected from non-loopback origins.

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -172,7 +172,7 @@ export type GatewayAuthRateLimitConfig = {
   windowMs?: number;
   /** Lockout duration in milliseconds after the limit is exceeded.  @default 300000 (5 min) */
   lockoutMs?: number;
-  /** Exempt localhost/loopback addresses from auth rate limiting.  @default true */
+  /** Exempt localhost/loopback addresses from auth rate limiting.  @default false */
   exemptLoopback?: boolean;
 };
 

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -156,13 +156,27 @@ describe("auth rate limiter", () => {
 
   // ---------- loopback exemption ----------
 
-  it.each(["127.0.0.1", "::1"])("exempts loopback address %s by default", (ip) => {
+  it.each(["127.0.0.1", "::1"])("rate-limits loopback address %s by default", (ip) => {
     limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000 });
     limiter.recordFailure(ip);
-    expect(limiter.check(ip).allowed).toBe(true);
+    expect(limiter.check(ip).allowed).toBe(false);
   });
 
-  it("rate-limits loopback when exemptLoopback is false", () => {
+  it.each(["127.0.0.1", "::1"])(
+    "still exempts loopback address %s when exemptLoopback is true",
+    (ip) => {
+      limiter = createAuthRateLimiter({
+        maxAttempts: 1,
+        windowMs: 60_000,
+        lockoutMs: 60_000,
+        exemptLoopback: true,
+      });
+      limiter.recordFailure(ip);
+      expect(limiter.check(ip).allowed).toBe(true);
+    },
+  );
+
+  it("keeps loopback rate-limited when exemptLoopback is explicitly false", () => {
     limiter = createAuthRateLimiter({
       maxAttempts: 1,
       windowMs: 60_000,

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -10,8 +10,9 @@
  * - Pure in-memory Map – no external dependencies; suitable for a single
  *   gateway process.  The Map is periodically pruned to avoid unbounded
  *   growth.
- * - Loopback addresses (127.0.0.1 / ::1) are exempt by default so that local
- *   CLI sessions are never locked out.
+ * - Loopback addresses are rate-limited by default so local same-host ingress
+ *   cannot silently bypass auth throttling. Callers can opt back into
+ *   loopback exemption for explicitly local-only workflows.
  * - The module is side-effect-free: callers create an instance via
  *   {@link createAuthRateLimiter} and pass it where needed.
  */
@@ -29,7 +30,7 @@ export interface RateLimitConfig {
   windowMs?: number;
   /** Lockout duration in milliseconds after the limit is exceeded.  @default 300_000 (5 min) */
   lockoutMs?: number;
-  /** Exempt loopback (localhost) addresses from rate limiting.  @default true */
+  /** Exempt loopback (localhost) addresses from rate limiting.  @default false */
   exemptLoopback?: boolean;
   /** Background prune interval in milliseconds; set <= 0 to disable auto-prune.  @default 60_000 */
   pruneIntervalMs?: number;
@@ -96,7 +97,7 @@ export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter
   const maxAttempts = config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
   const windowMs = config?.windowMs ?? DEFAULT_WINDOW_MS;
   const lockoutMs = config?.lockoutMs ?? DEFAULT_LOCKOUT_MS;
-  const exemptLoopback = config?.exemptLoopback ?? true;
+  const exemptLoopback = config?.exemptLoopback ?? false;
   const pruneIntervalMs = config?.pruneIntervalMs ?? PRUNE_INTERVAL_MS;
 
   const entries = new Map<string, RateLimitEntry>();

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import {
   assertGatewayAuthConfigured,
   authorizeGatewayConnect,
@@ -335,6 +335,40 @@ describe("gateway auth", () => {
     });
     expect(limiter.check).toHaveBeenCalledWith("203.0.113.77", "shared-secret");
     expect(limiter.recordFailure).toHaveBeenCalledWith("203.0.113.77", "shared-secret");
+  });
+
+  it("rate-limits same-host ingress auth failures by default when trusted proxies are unset", async () => {
+    const limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 60_000 });
+    try {
+      const req = {
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { "x-forwarded-for": "203.0.113.44" },
+      } as never;
+
+      const first = await authorizeGatewayConnect({
+        auth: { mode: "token", token: "secret", allowTailscale: false },
+        connectAuth: { token: "wrong" },
+        req,
+        trustedProxies: [],
+        rateLimiter: limiter,
+      });
+      expect(first.ok).toBe(false);
+      expect(first.reason).toBe("token_mismatch");
+
+      const second = await authorizeGatewayConnect({
+        auth: { mode: "token", token: "secret", allowTailscale: false },
+        connectAuth: { token: "wrong" },
+        req,
+        trustedProxies: [],
+        rateLimiter: limiter,
+      });
+      expect(second.ok).toBe(false);
+      expect(second.reason).toBe("rate_limited");
+      expect(second.rateLimited).toBe(true);
+      expect(second.retryAfterMs).toBeGreaterThan(0);
+    } finally {
+      limiter.dispose();
+    }
   });
 
   it("passes custom rate-limit scope to limiter operations", async () => {


### PR DESCRIPTION
## Summary

- Problem: same-host ingress traffic without `gateway.trustedProxies` was classified by the auth limiter as loopback traffic, so failed shared-secret auth attempts never consumed the throttle budget.
- Why it matters: a remote caller behind that deployment shape could keep sending wrong token or password attempts without hitting the configured auth limiter.
- What changed: the auth rate limiter now treats loopback addresses as rate-limited by default, docs/types reflect the new default, and focused regressions cover both the default loopback behavior and the same-host ingress auth path.
- What did NOT change (scope boundary): this does not change proxy IP resolution, trusted-proxy auth rules, or the explicit `exemptLoopback: true` opt-in for local-only workflows.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR


## Root Cause / Regression History (if applicable)

- Root cause: `createAuthRateLimiter()` defaulted `exemptLoopback` to `true`, so the shared auth limiter treated `127.0.0.1` and `::1` as permanently exempt even when those addresses represented a same-host proxy hop rather than a truly local caller.
- Missing detection / guardrail: coverage asserted loopback exemption but did not cover the realistic ingress shape where a remote client arrives through a same-host proxy with `gateway.trustedProxies` unset.
- Prior context (`git blame`, prior PR, issue, or refactor if known): introduced in `feat(gateway): add auth rate-limiting & brute-force protection (#15035)`.
- Why this regressed now: the limiter shipped with a local-CLI convenience default before the repo had a regression test for same-host ingress on the auth boundary.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/auth-rate-limit.test.ts` and `src/gateway/auth.test.ts`
- Scenario the test should lock in: loopback addresses are throttled by default, but `exemptLoopback: true` still preserves the opt-in local-only escape hatch; same-host ingress requests without trusted proxies get rate-limited on repeated wrong shared-secret attempts.
- Why this is the smallest reliable guardrail: the bug is the combination of the limiter default plus the existing request IP resolution path, so one unit-level default assertion and one auth-seam regression are enough to prove the real behavior without a live proxy harness.
- Existing test that already covers this (if any): browser-origin WS auth already forces `exemptLoopback: false`, but it did not cover the shared-secret default path.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `gateway.auth.rateLimit.exemptLoopback` now defaults to `false`.
- Gateways exposed through same-host ingress no longer silently skip shared-secret auth throttling unless operators explicitly opt back into `exemptLoopback: true`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux 6.8.0-101-generic x86_64
- Runtime/container: local repo worktree, `pnpm` test wrapper
- Model/provider: N/A
- Integration/channel (if any): Gateway shared-secret auth
- Relevant config (redacted): `gateway.auth.mode="token"` with `gateway.auth.rateLimit` enabled and `gateway.trustedProxies=[]`

### Steps

1. Configure Gateway shared-secret auth with auth rate limiting enabled.
2. Send a wrong token through a same-host ingress shape where the Gateway sees `remoteAddress=127.0.0.1` and `X-Forwarded-For` is present but the proxy is not declared trusted.
3. Repeat the wrong-token request.

### Expected

- The repeated request is blocked by the auth limiter instead of receiving a fresh auth attempt.

### Actual

- Before this fix, the limiter treated the request as loopback-exempt and never consumed the throttle budget.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the `authorizeGatewayConnect()` IP resolution path, confirmed the limiter default change in `createAuthRateLimiter()`, and ran focused gateway tests covering the default loopback behavior plus the same-host ingress regression.
- Edge cases checked: explicit `exemptLoopback: true` still keeps loopback exempt; explicit `exemptLoopback: false` still rate-limits loopback.
- What you did **not** verify: a live reverse-proxy deployment and the repo-wide `pnpm build` gate (service-managed after this turn).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `gateway.auth.rateLimit.exemptLoopback=true` to restore the previous local exemption behavior while debugging, or revert the limiter default change.
- Files/config to restore: `src/gateway/auth-rate-limit.ts`, `src/gateway/auth-rate-limit.test.ts`, `src/gateway/auth.test.ts`, `src/config/types.gateway.ts`, `docs/gateway/configuration-reference.md`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: intentionally local-only workflows that relied on unlimited loopback auth retries may now hit the shared auth throttle unless they opt back into loopback exemption.

## Risks and Mitigations

- Risk: operators with explicitly local-only admin workflows may be surprised that localhost auth attempts now count against the limiter by default.
  - Mitigation: keep `exemptLoopback` as an explicit opt-in, document the new default in the configuration reference, and cover the opt-in path with tests.
