### PR TITLE
feat: Add Gemini TTS speech provider

### DIFF
--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -222,9 +222,9 @@ function createLazyGoogleSpeechProvider(): SpeechProviderPlugin {
     resolveConfig: (ctx) => getProvider().resolveConfig?.(ctx) ?? {},
     resolveTalkConfig: (ctx) => getProvider().resolveTalkConfig?.(ctx) ?? {},
     resolveTalkOverrides: (ctx) => getProvider().resolveTalkOverrides?.(ctx) ?? {},
-    listVoices: async (req) => await getProvider().listVoices?.(req),
+    listVoices: (req) => getProvider().listVoices?.(req) ?? Promise.resolve([]),
     isConfigured: (req) => getProvider().isConfigured?.(req) ?? false,
-    synthesize: async (req) => await getProvider().synthesize(req),
+    synthesize: (req) => getProvider().synthesize(req),
   };
 }
 

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -1,5 +1,6 @@
 import type { ImageGenerationProvider } from "openclaw/plugin-sdk/image-generation";
 import type { MediaUnderstandingProvider } from "openclaw/plugin-sdk/media-understanding";
+import type { SpeechProviderPlugin } from "openclaw/plugin-sdk/speech";
 import {
   definePluginEntry,
   type OpenClawPluginApi,
@@ -39,6 +40,7 @@ type GoogleOauthApiKeyCredential = {
 let googleGeminiCliProviderPromise: Promise<ProviderPlugin> | null = null;
 let googleImageGenerationProviderPromise: Promise<ImageGenerationProvider> | null = null;
 let googleMediaUnderstandingProviderPromise: Promise<MediaUnderstandingProvider> | null = null;
+let googleSpeechProviderPromise: Promise<SpeechProviderPlugin> | null = null;
 
 type GoogleMediaUnderstandingProvider = MediaUnderstandingProvider & {
   describeImage: NonNullable<MediaUnderstandingProvider["describeImage"]>;
@@ -104,6 +106,16 @@ async function loadGoogleRequiredMediaUnderstandingProvider(): Promise<GoogleMed
     throw new Error("google media understanding provider missing required handlers");
   }
   return provider as GoogleMediaUnderstandingProvider;
+}
+
+
+async function loadGoogleSpeechProvider(): Promise<SpeechProviderPlugin> {
+  if (!googleSpeechProviderPromise) {
+    googleSpeechProviderPromise = import("./speech-provider.js").then((mod) =>
+      mod.buildGeminiSpeechProvider(),
+    );
+  }
+  return await googleSpeechProviderPromise;
 }
 
 function createLazyGoogleGeminiCliProvider(): ProviderPlugin {
@@ -202,6 +214,41 @@ function createLazyGoogleMediaUnderstandingProvider(): MediaUnderstandingProvide
   };
 }
 
+
+function createLazyGoogleSpeechProvider(): SpeechProviderPlugin {
+  return {
+    id: "gemini",
+    label: "Google Gemini TTS",
+    aliases: ["google-tts"],
+    autoSelectOrder: 25,
+    models: ["gemini-2.5-flash-preview-tts"],
+    resolveConfig: async (ctx) => {
+      const provider = await loadGoogleSpeechProvider();
+      return provider.resolveConfig?.(ctx) ?? {};
+    },
+    resolveTalkConfig: async (ctx) => {
+      const provider = await loadGoogleSpeechProvider();
+      return provider.resolveTalkConfig?.(ctx) ?? {};
+    },
+    resolveTalkOverrides: async (ctx) => {
+      const provider = await loadGoogleSpeechProvider();
+      return provider.resolveTalkOverrides?.(ctx) ?? {};
+    },
+    listVoices: async (req) => {
+      const provider = await loadGoogleSpeechProvider();
+      return await provider.listVoices?.(req);
+    },
+    isConfigured: async (req) => {
+      const provider = await loadGoogleSpeechProvider();
+      return provider.isConfigured?.(req) ?? false;
+    },
+    synthesize: async (req) => {
+      const provider = await loadGoogleSpeechProvider();
+      return await provider.synthesize(req);
+    },
+  };
+}
+
 export default definePluginEntry({
   id: "google",
   name: "Google Plugin",
@@ -253,6 +300,7 @@ export default definePluginEntry({
     api.registerProvider(createLazyGoogleGeminiCliProvider());
     api.registerImageGenerationProvider(createLazyGoogleImageGenerationProvider());
     api.registerMediaUnderstandingProvider(createLazyGoogleMediaUnderstandingProvider());
+    api.registerSpeechProvider(createLazyGoogleSpeechProvider());
     api.registerWebSearchProvider(createGeminiWebSearchProvider());
   },
 });

--- a/extensions/google/index.ts
+++ b/extensions/google/index.ts
@@ -20,6 +20,7 @@ import {
 import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
 import { isModernGoogleModel, resolveGoogle31ForwardCompatModel } from "./provider-models.js";
 import { createGeminiWebSearchProvider } from "./src/gemini-web-search-provider.js";
+import { buildGeminiSpeechProvider } from "./speech-provider.js";
 
 const GOOGLE_GEMINI_CLI_PROVIDER_ID = "google-gemini-cli";
 const GOOGLE_GEMINI_CLI_PROVIDER_LABEL = "Gemini CLI OAuth";
@@ -40,7 +41,6 @@ type GoogleOauthApiKeyCredential = {
 let googleGeminiCliProviderPromise: Promise<ProviderPlugin> | null = null;
 let googleImageGenerationProviderPromise: Promise<ImageGenerationProvider> | null = null;
 let googleMediaUnderstandingProviderPromise: Promise<MediaUnderstandingProvider> | null = null;
-let googleSpeechProviderPromise: Promise<SpeechProviderPlugin> | null = null;
 
 type GoogleMediaUnderstandingProvider = MediaUnderstandingProvider & {
   describeImage: NonNullable<MediaUnderstandingProvider["describeImage"]>;
@@ -106,16 +106,6 @@ async function loadGoogleRequiredMediaUnderstandingProvider(): Promise<GoogleMed
     throw new Error("google media understanding provider missing required handlers");
   }
   return provider as GoogleMediaUnderstandingProvider;
-}
-
-
-async function loadGoogleSpeechProvider(): Promise<SpeechProviderPlugin> {
-  if (!googleSpeechProviderPromise) {
-    googleSpeechProviderPromise = import("./speech-provider.js").then((mod) =>
-      mod.buildGeminiSpeechProvider(),
-    );
-  }
-  return await googleSpeechProviderPromise;
 }
 
 function createLazyGoogleGeminiCliProvider(): ProviderPlugin {
@@ -216,36 +206,25 @@ function createLazyGoogleMediaUnderstandingProvider(): MediaUnderstandingProvide
 
 
 function createLazyGoogleSpeechProvider(): SpeechProviderPlugin {
+  let cached: SpeechProviderPlugin | undefined;
+  const getProvider = () => {
+    if (!cached) {
+      cached = buildGeminiSpeechProvider();
+    }
+    return cached;
+  };
   return {
     id: "gemini",
     label: "Google Gemini TTS",
     aliases: ["google-tts"],
     autoSelectOrder: 25,
     models: ["gemini-2.5-flash-preview-tts"],
-    resolveConfig: async (ctx) => {
-      const provider = await loadGoogleSpeechProvider();
-      return provider.resolveConfig?.(ctx) ?? {};
-    },
-    resolveTalkConfig: async (ctx) => {
-      const provider = await loadGoogleSpeechProvider();
-      return provider.resolveTalkConfig?.(ctx) ?? {};
-    },
-    resolveTalkOverrides: async (ctx) => {
-      const provider = await loadGoogleSpeechProvider();
-      return provider.resolveTalkOverrides?.(ctx) ?? {};
-    },
-    listVoices: async (req) => {
-      const provider = await loadGoogleSpeechProvider();
-      return await provider.listVoices?.(req);
-    },
-    isConfigured: async (req) => {
-      const provider = await loadGoogleSpeechProvider();
-      return provider.isConfigured?.(req) ?? false;
-    },
-    synthesize: async (req) => {
-      const provider = await loadGoogleSpeechProvider();
-      return await provider.synthesize(req);
-    },
+    resolveConfig: (ctx) => getProvider().resolveConfig?.(ctx) ?? {},
+    resolveTalkConfig: (ctx) => getProvider().resolveTalkConfig?.(ctx) ?? {},
+    resolveTalkOverrides: (ctx) => getProvider().resolveTalkOverrides?.(ctx) ?? {},
+    listVoices: async (req) => await getProvider().listVoices?.(req),
+    isConfigured: (req) => getProvider().isConfigured?.(req) ?? false,
+    synthesize: async (req) => await getProvider().synthesize(req),
   };
 }
 

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -47,7 +47,8 @@
   "contracts": {
     "mediaUnderstandingProviders": ["google"],
     "imageGenerationProviders": ["google"],
-    "webSearchProviders": ["gemini"]
+    "webSearchProviders": ["gemini"],
+    "speechProviders": ["gemini"]
   },
   "configSchema": {
     "type": "object",

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -201,13 +201,24 @@ export function buildGeminiSpeechProvider(): SpeechProviderPlugin {
       const audioBuffer = Buffer.from(audioBase64, "base64");
       const mimeType =
         data.candidates?.[0]?.content?.parts?.[0]?.inlineData?.mimeType || "audio/mp3";
-      const fileExtension = mimeType.includes("webm") ? ".webm" : ".mp3";
+      
+      // Map Gemini MIME types to correct file extensions
+      let fileExtension = ".mp3";
+      if (mimeType.includes("webm")) {
+        fileExtension = ".webm";
+      } else if (mimeType.includes("wav") || mimeType.includes("pcm") || mimeType.includes("l16")) {
+        fileExtension = ".wav";
+      } else if (mimeType.includes("ogg")) {
+        fileExtension = ".ogg";
+      } else if (mimeType.includes("flac")) {
+        fileExtension = ".flac";
+      }
 
       return {
         audioBuffer,
         outputFormat: mimeType,
         fileExtension,
-        voiceCompatible: mimeType.includes("mp3"),
+        voiceCompatible: mimeType.includes("mp3") || mimeType.includes("wav"),
       };
     },
   };

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -52,6 +52,7 @@ function normalizeGeminiProviderConfig(
     }),
     baseUrl: baseUrl?.replace(/\/+$/, "") || DEFAULT_GEMINI_BASE_URL,
     modelId: trimToUndefined(raw?.modelId) ?? DEFAULT_GEMINI_TTS_MODEL,
+    voiceId: trimToUndefined(raw?.voiceId),
     timeoutMs: asNumber(raw?.timeoutMs),
   };
 }

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -52,15 +52,22 @@ function readGeminiProviderConfig(config: SpeechProviderConfig): GeminiProviderC
   };
 }
 
+// Gemini TTS pre-built voices (as of 2026)
+const GEMINI_TTS_VOICES: Array<{ id: string; name: string; gender: string }> = [
+  { id: "Aoede", name: "Aoede", gender: "female" },
+  { id: "Charon", name: "Charon", gender: "male" },
+  { id: "Fenrir", name: "Fenrir", gender: "male" },
+  { id: "Kore", name: "Kore", gender: "female" },
+  { id: "Puck", name: "Puck", gender: "male" },
+];
+
 export async function listGeminiVoices(): Promise<SpeechVoiceOption[]> {
-  return [
-    {
-      id: "default",
-      name: "Gemini Default",
-      description: "Default Gemini TTS voice",
-      locale: "en-US",
-    },
-  ];
+  return GEMINI_TTS_VOICES.map((voice) => ({
+    id: voice.id,
+    name: voice.name,
+    gender: voice.gender,
+    locale: "en-US",
+  }));
 }
 
 export function buildGeminiSpeechProvider(): SpeechProviderPlugin {
@@ -93,6 +100,9 @@ export function buildGeminiSpeechProvider(): SpeechProviderPlugin {
       ...(trimToUndefined(params.modelId) == null
         ? {}
         : { modelId: trimToUndefined(params.modelId) }),
+      ...(trimToUndefined(params.voiceId) == null
+        ? {}
+        : { voiceId: trimToUndefined(params.voiceId) }),
     }),
     listVoices: async () => await listGeminiVoices(),
     isConfigured: ({ providerConfig }) =>
@@ -108,19 +118,36 @@ export function buildGeminiSpeechProvider(): SpeechProviderPlugin {
 
       const modelId =
         trimToUndefined(req.providerOverrides?.modelId) ?? config.modelId;
+      const voiceId = trimToUndefined(req.providerOverrides?.voiceId);
       const url = `${config.baseUrl}/${modelId}:generateContent?key=${apiKey}`;
 
       const text = req.text.slice(0, 4096);
 
+      const timeoutMs = config.timeoutMs ?? req.timeoutMs;
+      const signal = timeoutMs != null ? AbortSignal.timeout(timeoutMs) : undefined;
+
+      const generationConfig: Record<string, unknown> = {
+        responseModalities: ["AUDIO"],
+      };
+
+      if (voiceId) {
+        generationConfig.speechConfig = {
+          voiceConfig: {
+            prebuiltVoiceConfig: { voiceName: voiceId },
+          },
+        };
+      }
+
+      const requestBody = {
+        contents: [{ parts: [{ text }] }],
+        generationConfig,
+      };
+
       const response = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          contents: [{ parts: [{ text }] }],
-          generationConfig: {
-            responseModalities: ["AUDIO"],
-          },
-        }),
+        body: JSON.stringify(requestBody),
+        signal,
       });
 
       if (!response.ok) {
@@ -149,7 +176,7 @@ export function buildGeminiSpeechProvider(): SpeechProviderPlugin {
 
       const audioBuffer = Buffer.from(audioBase64, "base64");
       const mimeType =
-        data.candidates[0].content.parts[0].inlineData.mimeType || "audio/mp3";
+        data.candidates?.[0]?.content?.parts?.[0]?.inlineData?.mimeType || "audio/mp3";
       const fileExtension = mimeType.includes("webm") ? ".webm" : ".mp3";
 
       return {

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -1,3 +1,4 @@
+import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import type {
   SpeechProviderConfig,
   SpeechProviderPlugin,
@@ -35,7 +36,10 @@ function normalizeGeminiProviderConfig(
   const raw = asObject(providers?.gemini) ?? asObject(rawConfig.gemini);
   const baseUrl = trimToUndefined(raw?.baseUrl);
   return {
-    apiKey: trimToUndefined(raw?.apiKey),
+    apiKey: normalizeResolvedSecretInputString({
+      value: raw?.apiKey,
+      path: "messages.tts.providers.gemini.apiKey",
+    }),
     baseUrl: baseUrl?.replace(/\/+$/, "") || DEFAULT_GEMINI_BASE_URL,
     modelId: trimToUndefined(raw?.modelId) ?? DEFAULT_GEMINI_TTS_MODEL,
     timeoutMs: asNumber(raw?.timeoutMs),
@@ -45,7 +49,11 @@ function normalizeGeminiProviderConfig(
 function readGeminiProviderConfig(config: SpeechProviderConfig): GeminiProviderConfig {
   const defaults = normalizeGeminiProviderConfig({});
   return {
-    apiKey: trimToUndefined(config.apiKey) ?? defaults.apiKey,
+    apiKey:
+      normalizeResolvedSecretInputString({
+        value: config.apiKey,
+        path: "messages.tts.providers.gemini.apiKey",
+      }) ?? defaults.apiKey,
     baseUrl: trimToUndefined(config.baseUrl)?.replace(/\/+$/, "") ?? defaults.baseUrl,
     modelId: trimToUndefined(config.modelId) ?? defaults.modelId,
     timeoutMs: asNumber(config.timeoutMs) ?? defaults.timeoutMs,
@@ -82,9 +90,14 @@ export function buildGeminiSpeechProvider(): SpeechProviderPlugin {
       const base = normalizeGeminiProviderConfig(baseTtsConfig);
       return {
         ...base,
-        ...(trimToUndefined(talkProviderConfig.apiKey) == null
+        ...(talkProviderConfig.apiKey === undefined
           ? {}
-          : { apiKey: trimToUndefined(talkProviderConfig.apiKey) }),
+          : {
+              apiKey: normalizeResolvedSecretInputString({
+                value: talkProviderConfig.apiKey,
+                path: "talk.providers.gemini.apiKey",
+              }),
+            }),
         ...(trimToUndefined(talkProviderConfig.baseUrl) == null
           ? {}
           : { baseUrl: trimToUndefined(talkProviderConfig.baseUrl) }),

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -1,0 +1,163 @@
+import type {
+  SpeechProviderConfig,
+  SpeechProviderPlugin,
+  SpeechVoiceOption,
+} from "openclaw/plugin-sdk/speech";
+
+const DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts";
+const DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models";
+
+type GeminiProviderConfig = {
+  apiKey?: string;
+  baseUrl: string;
+  modelId: string;
+  timeoutMs?: number;
+};
+
+function trimToUndefined(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function normalizeGeminiProviderConfig(
+  rawConfig: Record<string, unknown>,
+): GeminiProviderConfig {
+  const providers = asObject(rawConfig.providers);
+  const raw = asObject(providers?.gemini) ?? asObject(rawConfig.gemini);
+  const baseUrl = trimToUndefined(raw?.baseUrl);
+  return {
+    apiKey: trimToUndefined(raw?.apiKey),
+    baseUrl: baseUrl?.replace(/\/+$/, "") || DEFAULT_GEMINI_BASE_URL,
+    modelId: trimToUndefined(raw?.modelId) ?? DEFAULT_GEMINI_TTS_MODEL,
+    timeoutMs: asNumber(raw?.timeoutMs),
+  };
+}
+
+function readGeminiProviderConfig(config: SpeechProviderConfig): GeminiProviderConfig {
+  const defaults = normalizeGeminiProviderConfig({});
+  return {
+    apiKey: trimToUndefined(config.apiKey) ?? defaults.apiKey,
+    baseUrl: trimToUndefined(config.baseUrl)?.replace(/\/+$/, "") ?? defaults.baseUrl,
+    modelId: trimToUndefined(config.modelId) ?? defaults.modelId,
+    timeoutMs: asNumber(config.timeoutMs) ?? defaults.timeoutMs,
+  };
+}
+
+export async function listGeminiVoices(): Promise<SpeechVoiceOption[]> {
+  return [
+    {
+      id: "default",
+      name: "Gemini Default",
+      description: "Default Gemini TTS voice",
+      locale: "en-US",
+    },
+  ];
+}
+
+export function buildGeminiSpeechProvider(): SpeechProviderPlugin {
+  return {
+    id: "gemini",
+    label: "Google Gemini TTS",
+    aliases: ["google-tts"],
+    autoSelectOrder: 25,
+    models: [DEFAULT_GEMINI_TTS_MODEL],
+    resolveConfig: ({ rawConfig }) => normalizeGeminiProviderConfig(rawConfig),
+    resolveTalkConfig: ({ baseTtsConfig, talkProviderConfig }) => {
+      const base = normalizeGeminiProviderConfig(baseTtsConfig);
+      return {
+        ...base,
+        ...(trimToUndefined(talkProviderConfig.apiKey) == null
+          ? {}
+          : { apiKey: trimToUndefined(talkProviderConfig.apiKey) }),
+        ...(trimToUndefined(talkProviderConfig.baseUrl) == null
+          ? {}
+          : { baseUrl: trimToUndefined(talkProviderConfig.baseUrl) }),
+        ...(trimToUndefined(talkProviderConfig.modelId) == null
+          ? {}
+          : { modelId: trimToUndefined(talkProviderConfig.modelId) }),
+        ...(asNumber(talkProviderConfig.timeoutMs) == null
+          ? {}
+          : { timeoutMs: asNumber(talkProviderConfig.timeoutMs) }),
+      };
+    },
+    resolveTalkOverrides: ({ params }) => ({
+      ...(trimToUndefined(params.modelId) == null
+        ? {}
+        : { modelId: trimToUndefined(params.modelId) }),
+    }),
+    listVoices: async () => await listGeminiVoices(),
+    isConfigured: ({ providerConfig }) =>
+      Boolean(
+        readGeminiProviderConfig(providerConfig).apiKey || process.env.GEMINI_API_KEY,
+      ),
+    synthesize: async (req) => {
+      const config = readGeminiProviderConfig(req.providerConfig);
+      const apiKey = config.apiKey || process.env.GEMINI_API_KEY;
+      if (!apiKey) {
+        throw new Error("GEMINI_API_KEY not configured");
+      }
+
+      const modelId =
+        trimToUndefined(req.providerOverrides?.modelId) ?? config.modelId;
+      const url = `${config.baseUrl}/${modelId}:generateContent?key=${apiKey}`;
+
+      const text = req.text.slice(0, 4096);
+
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text }] }],
+          generationConfig: {
+            responseModalities: ["AUDIO"],
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "Unknown error");
+        throw new Error(`Gemini TTS error (${response.status}): ${errorText}`);
+      }
+
+      const data = (await response.json()) as {
+        candidates?: Array<{
+          content?: {
+            parts?: Array<{
+              inlineData?: {
+                mimeType?: string;
+                data?: string;
+              };
+            }>;
+          };
+        }>;
+      };
+
+      const audioBase64 = data.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data;
+
+      if (!audioBase64) {
+        throw new Error("No audio data in Gemini response");
+      }
+
+      const audioBuffer = Buffer.from(audioBase64, "base64");
+      const mimeType =
+        data.candidates[0].content.parts[0].inlineData.mimeType || "audio/mp3";
+      const fileExtension = mimeType.includes("webm") ? ".webm" : ".mp3";
+
+      return {
+        audioBuffer,
+        outputFormat: mimeType,
+        fileExtension,
+        voiceCompatible: mimeType.includes("mp3"),
+      };
+    },
+  };
+}

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -67,6 +67,7 @@ function readGeminiProviderConfig(config: SpeechProviderConfig): GeminiProviderC
       }) ?? defaults.apiKey,
     baseUrl: trimToUndefined(config.baseUrl)?.replace(/\/+$/, "") ?? defaults.baseUrl,
     modelId: trimToUndefined(config.modelId) ?? defaults.modelId,
+    voiceId: trimToUndefined(config.voiceId) ?? defaults.voiceId,
     timeoutMs: asNumber(config.timeoutMs) ?? defaults.timeoutMs,
   };
 }

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -4,9 +4,18 @@ import type {
   SpeechProviderPlugin,
   SpeechVoiceOption,
 } from "openclaw/plugin-sdk/speech";
+import { parseGeminiAuth } from "./api.js";
 
 const DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts";
 const DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models";
+
+function resolveGeminiApiKey(configuredKey?: string): string | undefined {
+  return (
+    configuredKey ||
+    process.env.GEMINI_API_KEY ||
+    process.env.GOOGLE_API_KEY
+  );
+}
 
 type GeminiProviderConfig = {
   apiKey?: string;
@@ -119,20 +128,18 @@ export function buildGeminiSpeechProvider(): SpeechProviderPlugin {
     }),
     listVoices: async () => await listGeminiVoices(),
     isConfigured: ({ providerConfig }) =>
-      Boolean(
-        readGeminiProviderConfig(providerConfig).apiKey || process.env.GEMINI_API_KEY,
-      ),
+      Boolean(resolveGeminiApiKey(readGeminiProviderConfig(providerConfig).apiKey)),
     synthesize: async (req) => {
       const config = readGeminiProviderConfig(req.providerConfig);
-      const apiKey = config.apiKey || process.env.GEMINI_API_KEY;
+      const apiKey = resolveGeminiApiKey(config.apiKey);
       if (!apiKey) {
-        throw new Error("GEMINI_API_KEY not configured");
+        throw new Error("Gemini API key not configured (set GEMINI_API_KEY or GOOGLE_API_KEY)");
       }
 
       const modelId =
         trimToUndefined(req.providerOverrides?.modelId) ?? config.modelId;
       const voiceId = trimToUndefined(req.providerOverrides?.voiceId);
-      const url = `${config.baseUrl}/${modelId}:generateContent?key=${apiKey}`;
+      const url = `${config.baseUrl}/${modelId}:generateContent`;
 
       const text = req.text.slice(0, 4096);
 
@@ -156,9 +163,13 @@ export function buildGeminiSpeechProvider(): SpeechProviderPlugin {
         generationConfig,
       };
 
+      const authHeaders = parseGeminiAuth(apiKey);
       const response = await fetch(url, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...authHeaders.headers,
+        },
         body: JSON.stringify(requestBody),
         signal,
       });

--- a/extensions/google/speech-provider.ts
+++ b/extensions/google/speech-provider.ts
@@ -21,6 +21,7 @@ type GeminiProviderConfig = {
   apiKey?: string;
   baseUrl: string;
   modelId: string;
+  voiceId?: string;
   timeoutMs?: number;
 };
 
@@ -113,6 +114,9 @@ export function buildGeminiSpeechProvider(): SpeechProviderPlugin {
         ...(trimToUndefined(talkProviderConfig.modelId) == null
           ? {}
           : { modelId: trimToUndefined(talkProviderConfig.modelId) }),
+        ...(trimToUndefined(talkProviderConfig.voiceId) == null
+          ? {}
+          : { voiceId: trimToUndefined(talkProviderConfig.voiceId) }),
         ...(asNumber(talkProviderConfig.timeoutMs) == null
           ? {}
           : { timeoutMs: asNumber(talkProviderConfig.timeoutMs) }),
@@ -138,7 +142,8 @@ export function buildGeminiSpeechProvider(): SpeechProviderPlugin {
 
       const modelId =
         trimToUndefined(req.providerOverrides?.modelId) ?? config.modelId;
-      const voiceId = trimToUndefined(req.providerOverrides?.voiceId);
+      const voiceId =
+        trimToUndefined(req.providerOverrides?.voiceId) ?? config.voiceId;
       const url = `${config.baseUrl}/${modelId}:generateContent`;
 
       const text = req.text.slice(0, 4096);


### PR DESCRIPTION
## Summary

Add Gemini TTS (`gemini-2.5-flash-preview-tts`) as a built-in TTS provider alongside Microsoft Edge TTS, OpenAI, and ElevenLabs.

## Why This Matters

- **Free tier available** - Gemini TTS offers a free tier via Google AI Studio
- **High quality voices** - Competitive with OpenAI/ElevenLabs
- **Already using Gemini** - Many users already have `GEMINI_API_KEY` configured for embeddings/memory search
- **Easy integration** - Same API pattern as existing Gemini models

## Implementation

### Files Changed
- `extensions/google/speech-provider.ts` (new) - Gemini TTS provider implementation
- `extensions/google/index.ts` - Register the speech provider

### Features
- Supports `GEMINI_API_KEY` environment variable or config-based API key
- Automatic 4096 character limit handling
- MP3 and WebM audio format support
- Auto-select order 25 (between Microsoft and ElevenLabs)

## Testing

```bash
# Test command (after merge)
/tts provider gemini
/tts audio Hello, this is a test of Gemini text to speech.
```

## Configuration

```yaml
messages:
  tts:
    providers:
      gemini:
        apiKey: YOUR_GEMINI_API_KEY  # or use GEMINI_API_KEY env var
        modelId: gemini-2.5-flash-preview-tts
```

Closes #55259