### PR TITLE
fix(agents): dedupe bootstrap context files by path

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -81,6 +81,37 @@ describe("resolveBootstrapFilesForRun", () => {
     expect(warnings).toHaveLength(3);
     expect(warnings[0]).toContain('missing or invalid "path" field');
   });
+
+  it("deduplicates bootstrap files by resolved path", async () => {
+    registerInternalHook("agent:bootstrap", (event) => {
+      const context = event.context as AgentBootstrapHookContext;
+      const duplicatePath = path.join(context.workspaceDir, "MEMORY.md");
+      context.bootstrapFiles = [
+        ...context.bootstrapFiles,
+        {
+          name: "MEMORY.md",
+          path: duplicatePath,
+          content: "from hook",
+          missing: false,
+        } as WorkspaceBootstrapFile,
+      ];
+    });
+
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "memory content", "utf8");
+    const warnings: string[] = [];
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      warn: (message) => warnings.push(message),
+    });
+
+    const memoryFiles = files.filter((file) => file.path === path.join(workspaceDir, "MEMORY.md"));
+    expect(memoryFiles).toHaveLength(1);
+    expect(warnings.some((message) => message.includes("skipping duplicate bootstrap file"))).toBe(
+      true,
+    );
+  });
 });
 
 describe("resolveBootstrapContextForRun", () => {

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
@@ -31,6 +32,7 @@ function sanitizeBootstrapFiles(
   warn?: (message: string) => void,
 ): WorkspaceBootstrapFile[] {
   const sanitized: WorkspaceBootstrapFile[] = [];
+  const seenPaths = new Set<string>();
   for (const file of files) {
     const pathValue = typeof file.path === "string" ? file.path.trim() : "";
     if (!pathValue) {
@@ -39,6 +41,12 @@ function sanitizeBootstrapFiles(
       );
       continue;
     }
+    const dedupePath = path.resolve(pathValue);
+    if (seenPaths.has(dedupePath)) {
+      warn?.(`skipping duplicate bootstrap file "${file.name}" (${dedupePath})`);
+      continue;
+    }
+    seenPaths.add(dedupePath);
     sanitized.push({ ...file, path: pathValue });
   }
   return sanitized;


### PR DESCRIPTION
# PR Draft: Fix #59319

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: bootstrap context assembly could inject the same file multiple times when hook-adjusted entries repeated an existing file path.
- Why it matters: duplicate bootstrap content wastes prompt budget/tokens and can dilute important context.
- What changed: added path-based deduplication in bootstrap-file sanitization and added a targeted unit test for duplicate-path behavior.
- What did NOT change (scope boundary): no change to bootstrap file discovery order, session filtering policy, or hook execution semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59319
- Related #N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `resolveBootstrapFilesForRun` sanitized invalid paths but did not deduplicate normalized file paths after hook overrides, so duplicates could survive into context injection.
- Missing detection / guardrail: no unit assertion guaranteed uniqueness of bootstrap entries by resolved path.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown from this change set; behavior existed before this fix and was reported in #59319.
- Why this regressed now: not necessarily a new regression; likely surfaced by real-world hook/config combinations that add overlapping bootstrap entries.
- If unknown, what was ruled out: ruled out malformed-path-only failure mode (that path already had tests and filtering).

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/bootstrap-files.test.ts`
- Scenario the test should lock in: when a hook appends a bootstrap file with a path that already exists in base bootstrap files, the final list contains exactly one entry for that resolved path.
- Why this is the smallest reliable guardrail: deduplication happens inside bootstrap-file sanitization, so unit-level coverage at that seam is direct and stable.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A (new test added).

## User-visible / Behavior Changes

- Bootstrap context no longer includes duplicate copies of the same file path when duplicates are introduced by hook-adjusted bootstrap entries.

## Diagram (if applicable)

```text
Before:
[base bootstrap files + hook extras] -> [sanitize only invalid paths] -> [duplicate file paths remain] -> [context includes repeated file]

After:
[base bootstrap files + hook extras] -> [sanitize invalid paths + dedupe by resolved path] -> [unique file paths] -> [context includes file once]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (darwin)
- Runtime/container: Node 22 + pnpm workspace (local dev environment)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default test config (no special secrets)

### Steps

1. Add or simulate a bootstrap hook that appends `MEMORY.md` with a path already present in bootstrap files.
2. Run `resolveBootstrapFilesForRun` with a warning collector.
3. Inspect returned files and warnings.

### Expected

- Only one entry remains for the duplicated resolved path.
- A duplicate-skip warning is emitted.

### Actual

- Matches expected after the fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Notes:
- Added/ran `src/agents/bootstrap-files.test.ts` case: `deduplicates bootstrap files by resolved path`.
- Verification commands:
  - `pnpm test -- src/agents/bootstrap-files.test.ts`
  - `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: duplicate path from hook override is dropped; warning message emitted; malformed path filtering still works.
- Edge cases checked: duplicate exact absolute path; preserved behavior for valid non-duplicate files.
- What you did **not** verify: full end-to-end prompt token accounting in a live gateway run.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: path normalization (`path.resolve`) might collapse distinct textual paths that intentionally referred to the same file via different relative forms.
  - Mitigation: this is intended; dedupe key is file path identity at injection boundary, and behavior is covered by unit test.
