### PR TITLE
Providers: add User-Agent http header when requesting llm api

### DIFF
--- a/extensions/google/media-understanding-provider.video.test.ts
+++ b/extensions/google/media-understanding-provider.video.test.ts
@@ -95,6 +95,7 @@ describe("describeGeminiVideo", () => {
     expect(headers.get("x-goog-api-key")).toBe("test-key");
     expect(headers.get("content-type")).toBe("application/json");
     expect(headers.get("x-other")).toBe("1");
+    expect(headers.get("user-agent")).toMatch(/^openclaw\/.+/);
 
     const bodyText =
       typeof seenInit?.body === "string"

--- a/src/agents/pi-embedded-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelProviderConfig } from "../../config/config.js";
+import { resolveOpenClawUserAgent } from "../../version.js";
 import { discoverModels } from "../pi-model-discovery.js";
 import { createProviderRuntimeTestMock } from "./model.provider-runtime.test-support.js";
 
@@ -281,6 +282,7 @@ describe("resolveModel forward-compat errors and overrides", () => {
     expect(result.error).toBeUndefined();
     expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
       "X-Custom-Auth": "token-123",
+      "User-Agent": resolveOpenClawUserAgent(),
     });
   });
 

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveOpenClawUserAgent } from "../../version.js";
 import { discoverModels } from "../pi-model-discovery.js";
 import { createProviderRuntimeTestMock } from "./model.provider-runtime.test-support.js";
 
@@ -428,6 +429,7 @@ describe("resolveModel", () => {
     expect(result.error).toBeUndefined();
     expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
       "X-Custom-Auth": "token-123",
+      "User-Agent": resolveOpenClawUserAgent(),
     });
   });
 
@@ -453,6 +455,7 @@ describe("resolveModel", () => {
     expect(result.error).toBeUndefined();
     expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
       "X-Custom-Auth": "token-123",
+      "User-Agent": resolveOpenClawUserAgent(),
     });
   });
 
@@ -476,6 +479,7 @@ describe("resolveModel", () => {
     expect(result.error).toBeUndefined();
     expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
       "X-Static": "tenant-a",
+      "User-Agent": resolveOpenClawUserAgent(),
     });
   });
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -12,6 +12,7 @@ import {
   runProviderDynamicModel,
   normalizeProviderResolvedModelWithPlugin,
 } from "../../plugins/provider-runtime.js";
+import { resolveOpenClawUserAgent } from "../../version.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
@@ -214,11 +215,27 @@ function normalizeResolvedModel(params: {
       runtimeHooks,
       model: compatNormalized ?? pluginNormalized ?? normalizedInputModel,
     });
-  return normalizeResolvedProviderModel({
-    provider: params.provider,
-    model:
-      fallbackTransportNormalized ?? compatNormalized ?? pluginNormalized ?? normalizedInputModel,
-  });
+  return applyDefaultOpenClawUserAgentHeader(
+    normalizeResolvedProviderModel({
+      provider: params.provider,
+      model:
+        fallbackTransportNormalized ?? compatNormalized ?? pluginNormalized ?? normalizedInputModel,
+    }),
+  );
+}
+
+function applyDefaultOpenClawUserAgentHeader<T extends Model<Api>>(model: T): T {
+  if (Object.keys(model.headers ?? {}).some((key) => key.toLowerCase() === "user-agent")) {
+    return model;
+  }
+
+  return {
+    ...model,
+    headers: {
+      ...model.headers,
+      "User-Agent": resolveOpenClawUserAgent(),
+    },
+  };
 }
 
 function resolveProviderTransport(params: {

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -12,6 +12,7 @@ import {
 import type { GuardedFetchResult } from "../infra/net/fetch-guard.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import type { LookupFn, PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
+import { resolveOpenClawUserAgent } from "../version.js";
 export { fetchWithTimeout } from "../utils/fetch-timeout.js";
 export { normalizeBaseUrl } from "../agents/provider-request-config.js";
 
@@ -64,6 +65,14 @@ export function resolveProviderHttpRequestConfig(params: {
   };
 }
 
+function withOpenClawUserAgent(headers: Headers): Headers {
+  const next = new Headers(headers);
+  if (!next.has("User-Agent")) {
+    next.set("User-Agent", resolveOpenClawUserAgent());
+  }
+  return next;
+}
+
 export async function fetchWithTimeoutGuarded(
   url: string,
   init: RequestInit,
@@ -101,7 +110,7 @@ export async function postTranscriptionRequest(params: {
     params.url,
     {
       method: "POST",
-      headers: params.headers,
+      headers: withOpenClawUserAgent(params.headers),
       body: params.body,
     },
     params.timeoutMs,
@@ -128,7 +137,7 @@ export async function postJsonRequest(params: {
     params.url,
     {
       method: "POST",
-      headers: params.headers,
+      headers: withOpenClawUserAgent(params.headers),
       body: JSON.stringify(params.body),
     },
     params.timeoutMs,

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -9,6 +9,7 @@ import {
   resolveCompatibilityHostVersion,
   readVersionFromPackageJsonForModuleUrl,
   resolveBinaryVersion,
+  resolveOpenClawUserAgent,
   resolveRuntimeServiceVersion,
   resolveUsableRuntimeVersion,
   resolveVersionFromModuleUrl,
@@ -142,6 +143,14 @@ describe("version resolution", () => {
         npm_package_version: "1.1.1",
       }),
     ).toBe("9.9.9");
+  });
+
+  it("formats the default OpenClaw user agent from the runtime version", () => {
+    expect(
+      resolveOpenClawUserAgent({
+        OPENCLAW_VERSION: "2026.4.2",
+      }),
+    ).toBe("openclaw/2026.4.2");
   });
 
   it("prefers runtime VERSION over stale OPENCLAW_VERSION for compatibility checks", () => {

--- a/src/version.ts
+++ b/src/version.ts
@@ -134,6 +134,12 @@ export function resolveRuntimeServiceVersion(
   });
 }
 
+export function resolveOpenClawUserAgent(
+  env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
+): string {
+  return `openclaw/${resolveRuntimeServiceVersion(env)}`;
+}
+
 export function resolveCompatibilityHostVersion(
   env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
   fallback = RUNTIME_SERVICE_VERSION_FALLBACK,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenClaw did not attach a consistent default `User-Agent` header across shared LLM request paths; only some OpenAI-specific traffic had attribution headers.
- Why it matters: Hosted model providers and proxies often use `User-Agent` for attribution, diagnostics, and traffic identification, and the behavior was inconsistent across transports.
- What changed: Added a shared `openclaw/{version}` helper, inject it by default into resolved LLM model headers when no explicit user agent is already set, and apply the same default in shared provider HTTP JSON/transcription helpers.
- What did NOT change (scope boundary): Explicit caller/provider `User-Agent` overrides still win, and this PR does not change provider selection, auth flow, or endpoint routing.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: We had no shared default `User-Agent` policy in the resolved model path or shared provider HTTP helpers, so only provider-specific wrappers added it.
- Missing detection / guardrail: We had tests for OpenAI attribution wrappers, but not for a shared default `User-Agent` on generic resolved model/provider-helper paths.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Existing OpenAI attribution logic already attached `User-Agent` for native OpenAI/Codex traffic.
- Why this regressed now: As more provider requests flowed through shared helpers, the lack of a shared default header remained visible.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/version.test.ts`, `src/agents/provider-attribution.test.ts`, `src/agents/pi-embedded-runner/model.test.ts`, `extensions/google/media-understanding-provider.video.test.ts`
- Scenario the test should lock in: Shared LLM/provider request paths attach `openclaw/{version}` when no explicit `User-Agent` is present, and keep explicit overrides intact.
- Why this is the smallest reliable guardrail: The behavior is pure request/header normalization and is exercised directly at the shared helper boundaries.
- Existing test that already covers this (if any): OpenAI attribution coverage existed for provider-specific wrappers.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Existing LLM/provider HTTP requests now send `User-Agent: openclaw/{version}` by default unless a provider or caller explicitly sets a different `User-Agent`.

## Diagram (if applicable)

```text
Before:
[resolved model or provider helper] -> [request may omit User-Agent]

After:
[resolved model or provider helper] -> [inject openclaw/{version} if absent] -> [request]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: No new endpoints or request destinations were added. Existing outbound model/provider calls now include a static, versioned `User-Agent`, and explicit overrides still take precedence.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25 / pnpm workspace
- Model/provider: shared provider paths, OpenAI attribution paths, Google media-understanding helper
- Integration/channel (if any): N/A
- Relevant config (redacted): default test fixtures and provider stubs

### Steps

1. Resolve a model or send a shared provider-helper request without an explicit `User-Agent`.
2. Inspect the outgoing headers.
3. Repeat with an explicit custom `User-Agent`.

### Expected

- Shared paths send `openclaw/{version}` by default.
- Explicit custom `User-Agent` values are preserved.

### Actual

- Matches expected in targeted tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Ran focused tests covering version formatting, shared model header injection, OpenAI attribution headers, websocket attribution, and Google media-understanding request headers.
- Edge cases checked: Explicit custom `User-Agent` headers remain unchanged; OpenAI originator/version attribution still applies.
- What you did **not** verify: I did not run a full repo-wide `pnpm test` or `pnpm check` gate for unrelated surfaces.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A provider integration may rely on the absence of `User-Agent`.
  - Mitigation: Explicit provider/caller `User-Agent` values are preserved, and the new default is a simple RFC-valid product/version token.
