### PR TITLE
fix(plugin-sdk): verify subpath dist exports match source re-exports

### DIFF
--- a/scripts/check-plugin-sdk-exports.mjs
+++ b/scripts/check-plugin-sdk-exports.mjs
@@ -32,24 +32,25 @@ if (!existsSync(distFile)) {
 
 const content = readFileSync(distFile, "utf-8");
 
-// Extract the final export statement from the compiled output.
-// tsdown/rolldown emits a single `export { ... }` at the end of the file.
-const exportMatch = content.match(/export\s*\{([^}]+)\}\s*;?\s*$/);
-if (!exportMatch) {
+// Extract all export blocks from the compiled output.
+// tsdown/rolldown may emit multiple `export { ... }` blocks (one per source module).
+const exportMatches = [...content.matchAll(/export\s*\{([^}]+)\}/g)];
+if (exportMatches.length === 0) {
   console.error("ERROR: Could not find export statement in dist/plugin-sdk/index.js");
   process.exit(1);
 }
 
-const exportedNames = exportMatch[1]
-  .split(",")
-  .map((s) => {
+const exportSet = new Set();
+for (const match of exportMatches) {
+  for (const s of match[1].split(",")) {
     // Handle `foo as bar` aliases — the exported name is the `bar` part
     const parts = s.trim().split(/\s+as\s+/);
-    return (parts[parts.length - 1] || "").trim();
-  })
-  .filter(Boolean);
-
-const exportSet = new Set(exportedNames);
+    const name = (parts[parts.length - 1] || "").trim();
+    if (name) {
+      exportSet.add(name);
+    }
+  }
+}
 
 const requiredRuntimeShimEntries = ["compat.js", "root-alias.cjs"];
 

--- a/scripts/check-plugin-sdk-exports.mjs
+++ b/scripts/check-plugin-sdk-exports.mjs
@@ -70,6 +70,55 @@ for (const name of requiredExports) {
   }
 }
 
+/**
+ * Extract runtime (non-type) export names from a plugin-sdk source file.
+ * Parses `export { ... } from "..."` blocks and filters out `type` exports.
+ */
+function extractSourceExportNames(sourcePath) {
+  if (!existsSync(sourcePath)) {
+    return null;
+  }
+  const src = readFileSync(sourcePath, "utf-8");
+  const names = [];
+  // Match `export { a, b, type C } from "..."` blocks
+  for (const match of src.matchAll(/export\s*\{([^}]+)\}\s*from\s*["'][^"']+["']/g)) {
+    for (const item of match[1].split(",")) {
+      const trimmed = item.trim();
+      // Skip type-only exports
+      if (trimmed.startsWith("type ")) {
+        continue;
+      }
+      // Handle `foo as bar` — the exported name is `bar`
+      const parts = trimmed.split(/\s+as\s+/);
+      const name = (parts[parts.length - 1] || "").trim();
+      if (name) {
+        names.push(name);
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * Extract exported names from a compiled dist JS file.
+ */
+function extractDistExportNames(distPath) {
+  const content = readFileSync(distPath, "utf-8");
+  const match = content.match(/export\s*\{([^}]+)\}/);
+  if (!match) {
+    return new Set();
+  }
+  return new Set(
+    match[1]
+      .split(",")
+      .map((s) => {
+        const parts = s.trim().split(/\s+as\s+/);
+        return (parts[parts.length - 1] || "").trim();
+      })
+      .filter(Boolean),
+  );
+}
+
 for (const entry of pluginSdkSubpaths) {
   const jsPath = resolve(__dirname, "..", "dist", "plugin-sdk", `${entry}.js`);
   const dtsPath = resolve(__dirname, "..", "dist", "plugin-sdk", `${entry}.d.ts`);
@@ -80,6 +129,23 @@ for (const entry of pluginSdkSubpaths) {
   if (!existsSync(dtsPath)) {
     console.error(`MISSING SUBPATH DTS: dist/plugin-sdk/${entry}.d.ts`);
     missing += 1;
+  }
+
+  // Verify that every runtime export in the source is present in the dist.
+  if (existsSync(jsPath)) {
+    const sourcePath = resolve(__dirname, "..", "src", "plugin-sdk", `${entry}.ts`);
+    const sourceNames = extractSourceExportNames(sourcePath);
+    if (sourceNames && sourceNames.length > 0) {
+      const distNames = extractDistExportNames(jsPath);
+      for (const name of sourceNames) {
+        if (!distNames.has(name)) {
+          console.error(
+            `MISSING SUBPATH EXPORT: dist/plugin-sdk/${entry}.js is missing "${name}" (present in source)`,
+          );
+          missing += 1;
+        }
+      }
+    }
   }
 }
 
@@ -117,4 +183,6 @@ if (missing > 0) {
   process.exit(1);
 }
 
-console.log(`OK: All ${requiredExports.length} required plugin-sdk exports verified.`);
+console.log(
+  `OK: All ${requiredExports.length} required root exports and ${pluginSdkSubpaths.length} subpath entries verified.`,
+);


### PR DESCRIPTION
## Summary

- Add source-vs-dist export verification to `scripts/check-plugin-sdk-exports.mjs` so the build fails when bundled plugin-sdk subpath files silently drop re-exports during tree-shaking.
- Catches the class of regression seen in v2026.4.1 where `dist/plugin-sdk/channel-targets.js` is missing runtime exports (`resolveServicePrefixedTarget`, `resolveServicePrefixedAllowTarget`, `parseChatTargetPrefixesOrThrow`, `parseChatAllowTargetPrefixes`) that are present in `src/plugin-sdk/channel-targets.ts`.

## Context

In v2026.4.1, BlueBubbles reply delivery fails at runtime:
```
[bluebubbles] final reply failed: TypeError: (0 , _channelTargets.resolveServicePrefixedTarget) is not a function
```

The source file correctly re-exports from `../channels/plugins/chat-target-prefixes.js`, but the compiled dist facade only includes exports from `channel-config.js` and `targets.js` — the `chat-target-prefixes.js` re-exports are silently dropped by the bundler.

The existing `check-plugin-sdk-exports.mjs` script only verified that subpath `.js`/`.d.ts` files exist, not that their contents match. This PR adds content-level verification: for each subpath entry, it parses the source `export { ... } from "..."` blocks (filtering type-only exports) and checks that every runtime export name appears in the dist output.

Related: #59326 (same class of bug, different symbol)

## Test plan

- [ ] `pnpm build && node scripts/check-plugin-sdk-exports.mjs` should fail on current v2026.4.1 dist (proving it catches the regression)
- [ ] After a clean rebuild that fixes the bundler config, the check should pass
- [ ] Verify no false positives on subpaths that use `export *` or barrel re-exports