### PR TITLE
fix: honor tools.exec config overrides in exec-approvals resolution

### DIFF
--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -203,10 +203,17 @@ export function resolveExecHostApprovalContext(params: {
     security: params.security,
     ask: params.ask,
   });
+  // When tools.exec.security is explicitly configured (params.security), it represents
+  // the user's intent. The host-side approval (exec-approvals.json) should refine but
+  // not silently override explicit user config. Use the resolved agent security which
+  // already incorporates the override via resolveExecApprovalsFromFile.
   const hostSecurity = minSecurity(params.security, approvals.agent.security);
-  // An explicit ask=off policy in exec-approvals.json must be able to suppress
-  // prompts even when tool/runtime defaults are stricter (for example on-miss).
-  const hostAsk = approvals.agent.ask === "off" ? "off" : maxAsk(params.ask, approvals.agent.ask);
+  // An explicit ask=off policy from either config source must suppress prompts.
+  // Check both the resolved agent ask AND the incoming config ask.
+  const hostAsk =
+    params.ask === "off" || approvals.agent.ask === "off"
+      ? "off"
+      : maxAsk(params.ask, approvals.agent.ask);
   const askFallback = approvals.agent.askFallback;
   if (hostSecurity === "deny") {
     throw new Error(`exec denied: host=${params.host} security=deny`);

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -472,14 +472,20 @@ export function resolveExecApprovalsFromFile(params: {
   const fallbackAsk = params.overrides?.ask ?? DEFAULT_ASK;
   const fallbackAskFallback = params.overrides?.askFallback ?? DEFAULT_EXEC_APPROVAL_ASK_FALLBACK;
   const fallbackAutoAllowSkills = params.overrides?.autoAllowSkills ?? DEFAULT_AUTO_ALLOW_SKILLS;
+  // When explicit overrides are provided (from tools.exec in openclaw.json), they represent the
+  // user's configured intent and must take precedence over exec-approvals.json file defaults.
+  // Previously, overrides were only used as fallbacks when exec-approvals.json had no value,
+  // which meant stale or auto-generated file defaults could silently override the user's config.
   const resolvedDefaults: Required<ExecApprovalsDefaults> = {
-    security: normalizeSecurity(defaults.security, fallbackSecurity),
-    ask: normalizeAsk(defaults.ask, fallbackAsk),
+    security: normalizeSecurity(params.overrides?.security ?? defaults.security, fallbackSecurity),
+    ask: normalizeAsk(params.overrides?.ask ?? defaults.ask, fallbackAsk),
     askFallback: normalizeSecurity(
-      defaults.askFallback ?? fallbackAskFallback,
+      params.overrides?.askFallback ?? defaults.askFallback ?? fallbackAskFallback,
       fallbackAskFallback,
     ),
-    autoAllowSkills: Boolean(defaults.autoAllowSkills ?? fallbackAutoAllowSkills),
+    autoAllowSkills: Boolean(
+      params.overrides?.autoAllowSkills ?? defaults.autoAllowSkills ?? fallbackAutoAllowSkills,
+    ),
   };
   const resolvedAgent: Required<ExecApprovalsDefaults> = {
     security: normalizeSecurity(


### PR DESCRIPTION
## Summary

Fixes #58691 — `tools.exec.security="full"` and `tools.exec.ask="off"` in `openclaw.json` are silently ignored when `exec-approvals.json` has explicit (or auto-generated) default values from a previous version or initial setup.

**Root cause:** In `resolveExecApprovalsFromFile`, the `openclaw.json` overrides were only used as **fallbacks** — if `exec-approvals.json` had any explicit value (even stale ones from a prior version), it would take precedence. Then `minSecurity` would pick the stricter value, effectively ignoring the user's explicit config.

**Fix:**
- `resolveExecApprovalsFromFile`: When explicit overrides are provided (from `tools.exec` in `openclaw.json`), they now take precedence over `exec-approvals.json` file defaults instead of being treated as mere fallbacks
- `resolveExecHostApprovalContext`: `ask="off"` from either config source now properly suppresses interactive approval prompts

This means users no longer need to duplicate the same config in both `openclaw.json` AND `exec-approvals.json` to disable exec approvals.

## Test plan

- [x] Existing exec-approvals.test.ts passes (7/7)
- [x] Existing bash-tools.test.ts passes (23/23)
- [x] All pre-commit checks pass (tsgo, lint, policy checks)
- [ ] Manual: set tools.exec.security:"full" + ask:"off" in openclaw.json only, verify no approval prompts for gateway exec
- [ ] Manual: verify cron/headless agents run without hanging on approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)