### PR TITLE
fix(memory): skip duplicate memory.md collection on case-insensitive filesystems (macOS)

### DIFF
--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -326,8 +326,8 @@ function isCaseInsensitiveFilesystem(dir: string): boolean {
     if (upper === lower) {
       return false; // conservative: assume case-sensitive when probe is inconclusive
     }
-    const { ino: inoUpper } = fs.statSync(upper);
-    const { ino: inoLower } = fs.statSync(lower);
+    const { ino: inoUpper } = fs.statSync(upper, { bigint: true });
+    const { ino: inoLower } = fs.statSync(lower, { bigint: true });
     return inoUpper === inoLower;
   } catch {
     // Cannot stat the upper/lower paths — conservatively treat as case-sensitive

--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -317,6 +317,26 @@ function resolveMcporterConfig(raw?: MemoryQmdMcporterConfig): ResolvedQmdMcport
   return parsed;
 }
 
+function isCaseInsensitiveFilesystem(dir: string): boolean {
+  try {
+    // Probe with uppercase/lowercase stat. If both resolve to the same inode,
+    // the filesystem treats them as the same path -> case-insensitive.
+    const upper = dir.toUpperCase();
+    const lower = dir.toLowerCase();
+    if (upper === lower) {
+      return false; // conservative: assume case-sensitive when probe is inconclusive
+    }
+    const { ino: inoUpper } = fs.statSync(upper);
+    const { ino: inoLower } = fs.statSync(lower);
+    return inoUpper === inoLower;
+  } catch {
+    // Cannot stat the upper/lower paths — conservatively treat as case-sensitive
+    // so both collections are registered. Note: if QMD rejects the duplicate
+    // on macOS in this rare path, the memory-root collection may silently fail.
+    return false;
+  }
+}
+
 function resolveDefaultCollections(
   include: boolean,
   workspaceDir: string,
@@ -326,9 +346,15 @@ function resolveDefaultCollections(
   if (!include) {
     return [];
   }
+  const caseInsensitive = isCaseInsensitiveFilesystem(workspaceDir);
   const entries: Array<{ path: string; pattern: string; base: string }> = [
     { path: workspaceDir, pattern: "MEMORY.md", base: "memory-root" },
-    { path: workspaceDir, pattern: "memory.md", base: "memory-alt" },
+    // On case-insensitive filesystems (macOS), "memory.md" resolves to the same
+    // file as "MEMORY.md", causing QMD to reject the duplicate collection.
+    // Skip the lower-case variant to avoid the conflict.
+    ...(caseInsensitive
+      ? []
+      : [{ path: workspaceDir, pattern: "memory.md", base: "memory-alt" }]),
     { path: path.join(workspaceDir, "memory"), pattern: "**/*.md", base: "memory-dir" },
   ];
   return entries.map((entry) => ({


### PR DESCRIPTION
## Summary

On macOS (APFS/HFS+), the filesystem is case-insensitive, so `MEMORY.md` and `memory.md` resolve to the same file. QMD rejects the second collection registration because the path is already claimed by the first one (with a broader `**/*.md` pattern after auto-expansion).

This causes memory-root to never get registered, and every `memory_search` query fails with `Collection not found: memory-root`, silently falling back to the builtin backend.

## Fix

Detect case-insensitive filesystem via **inode comparison** (`fs.statSync` on upper/lowercase variants of the workspace path) and skip the redundant `memory.md` entry on macOS. Uses a conservative approach — when detection is uncertain, preserves both collections to avoid silent data loss.

## Test Reproduction

1. Run OpenClaw on macOS with `memory.backend: "qmd"`
2. Check gateway logs for: `qmd collection add skipped for memory-root: ... A collection already exists`
3. Run `memory_search` → always falls back to builtin
4. After fix: `memory_search` returns `provider: "qmd"`

## Related Issues

Fixes #23613, Related: #21349, #20727, #20082

> This is a re-open of #58989 (branch was recreated to fix a bad tree in the git history). All prior reviews (Greptile 5/5, Codex P2 addressed) apply.