### PR TITLE
Propagate gateway subagent binding through embedded runs

### DIFF
--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -500,6 +500,7 @@ export function runAgentAttempt(params: {
     inputProvenance: params.opts.inputProvenance,
     streamParams: params.opts.streamParams,
     agentDir: params.agentDir,
+    allowGatewaySubagentBinding: true,
     allowTransientCooldownProbe: params.allowTransientCooldownProbe,
     cleanupBundleMcpOnRunEnd: params.opts.cleanupBundleMcpOnRunEnd,
     onAgentEvent: params.onAgentEvent,

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -354,6 +354,13 @@ describe("agentCommand", () => {
     expect(callArgs?.senderIsOwner).toBe(expected);
   });
 
+  it("enables gateway subagent binding for normal agent runs", async () => {
+    const callArgs = await runEmbeddedWithTempConfig({
+      args: { message: "hi", to: "+1555" },
+    });
+    expect(callArgs?.allowGatewaySubagentBinding).toBe(true);
+  });
+
   it("requires explicit senderIsOwner for ingress runs", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");
@@ -393,6 +400,7 @@ describe("agentCommand", () => {
       );
       const ingressCall = vi.mocked(runEmbeddedPiAgent).mock.calls.at(-1)?.[0];
       expect(ingressCall?.senderIsOwner).toBe(false);
+      expect(ingressCall?.allowGatewaySubagentBinding).toBe(true);
       expect(ingressCall).not.toHaveProperty("allowModelOverride");
     });
   });

--- a/src/commands/models/list.probe.runtime.test.ts
+++ b/src/commands/models/list.probe.runtime.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 
 const runEmbeddedPiAgentMock = vi.fn();
@@ -35,6 +35,10 @@ describe("runAuthProbes runtime flags", () => {
       meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "openai", model: "gpt-5.4" } },
     });
     process.env.OPENAI_API_KEY = "test-openai-key";
+  });
+
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY;
   });
 
   it("passes gateway subagent binding through auth probe runs", async () => {

--- a/src/commands/models/list.probe.runtime.test.ts
+++ b/src/commands/models/list.probe.runtime.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+const runEmbeddedPiAgentMock = vi.fn();
+const loadModelCatalogMock = vi.fn();
+
+vi.mock("../../agents/model-catalog.js", () => ({
+  loadModelCatalog: (params: unknown) => loadModelCatalogMock(params),
+}));
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+}));
+
+vi.mock("../../agents/auth-profiles.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/auth-profiles.js")>();
+  return {
+    ...actual,
+    ensureAuthProfileStore: () => ({ version: 1, profiles: {}, order: {} }),
+    listProfilesForProvider: () => [],
+  };
+});
+
+const { runAuthProbes } = await import("./list.probe.js");
+
+describe("runAuthProbes runtime flags", () => {
+  beforeEach(() => {
+    loadModelCatalogMock.mockReset();
+    loadModelCatalogMock.mockResolvedValue([
+      { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
+    ]);
+    runEmbeddedPiAgentMock.mockReset();
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "OK" }],
+      meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "openai", model: "gpt-5.4" } },
+    });
+    process.env.OPENAI_API_KEY = "test-openai-key";
+  });
+
+  it("passes gateway subagent binding through auth probe runs", async () => {
+    const summary = await runAuthProbes({
+      cfg: {} as OpenClawConfig,
+      providers: ["openai"],
+      modelCandidates: ["openai/gpt-5.4"],
+      options: {
+        timeoutMs: 5_000,
+        concurrency: 1,
+        maxTokens: 8,
+      },
+    });
+
+    expect(summary.totalTargets).toBe(1);
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowGatewaySubagentBinding: true,
+      }),
+    );
+  });
+});

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -469,6 +469,7 @@ async function probeTarget(params: {
       model: target.model.model,
       authProfileId: target.profileId,
       authProfileIdSource: target.profileId ? "user" : undefined,
+      allowGatewaySubagentBinding: true,
       timeoutMs,
       runId: `probe-${crypto.randomUUID()}`,
       lane: `auth-probe:${target.provider}:${target.profileId ?? target.source}`,

--- a/src/hooks/llm-slug-generator.test.ts
+++ b/src/hooks/llm-slug-generator.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const runEmbeddedPiAgentMock = vi.fn();
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: () => "main",
+  resolveAgentWorkspaceDir: () => "/tmp/openclaw-workspace",
+  resolveAgentDir: () => "/tmp/openclaw-workspace/agents/main/agent",
+  resolveAgentEffectiveModelPrimary: () => "openai/gpt-5.4",
+}));
+
+vi.mock("../agents/model-selection.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/model-selection.js")>();
+  return {
+    ...actual,
+    parseModelRef: vi.fn(() => ({ provider: "openai", model: "gpt-5.4" })),
+  };
+});
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+}));
+
+const { generateSlugViaLLM } = await import("./llm-slug-generator.js");
+
+describe("generateSlugViaLLM", () => {
+  beforeEach(() => {
+    runEmbeddedPiAgentMock.mockReset();
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "great-slug" }],
+      meta: { durationMs: 5, agentMeta: { sessionId: "s", provider: "openai", model: "gpt-5.4" } },
+    });
+  });
+
+  it("passes gateway subagent binding through embedded runs", async () => {
+    const slug = await generateSlugViaLLM({
+      sessionContent: "A conversation about better plugin runtime dispatch",
+      cfg: {} as OpenClawConfig,
+    });
+
+    expect(slug).toBe("great-slug");
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowGatewaySubagentBinding: true,
+      }),
+    );
+  });
+});

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -62,6 +62,7 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       prompt,
       provider,
       model,
+      allowGatewaySubagentBinding: true,
       timeoutMs: 15_000, // 15 second timeout
       runId: `slug-gen-${Date.now()}`,
     });


### PR DESCRIPTION
Propagate gateway subagent binding through embedded runs



## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Some plugin-backed workflows can still fail with `Plugin runtime subagent methods are only available during a gateway request.` because several embedded execution paths call `runEmbeddedPiAgent(...)` without explicitly preserving gateway subagent binding.
- Why it matters: In real usage this breaks gateway-triggered plugin workflows after the command has already started, so the failure shows up deep in runtime execution instead of at the plugin boundary.
- What changed: This PR adds `allowGatewaySubagentBinding: true` to the remaining embedded-agent call sites in command execution, slug generation, and auth probe flows, and adds regression tests that lock that contract in.
- What did NOT change (scope boundary): This PR does not change plugin logic, workflow logic, queue/retry behavior, or any plugin-specific fallback. It only fixes runtime flag propagation in `openclaw`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50131
- Related #51141
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Several production call sites still invoked `runEmbeddedPiAgent(...)` without `allowGatewaySubagentBinding: true`, so runtime plugin loading could fall back to the unavailable subagent stub even when the original action came from a gateway request.
- Missing detection / guardrail: There were no focused tests asserting that these embedded execution paths preserve gateway subagent binding.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Related runtime binding discussion exists in #50131, and the tool-loading side was partially addressed in #51141, but these remaining execution call sites were still unpatched.
- Why this regressed now: The runtime behavior became more visible as plugin workflows increasingly rely on `runtime.subagent`, while these older embedded run paths still assumed binding would be implicit.
- If unknown, what was ruled out: Plugin-side business logic and workflow-level queue/replay logic were ruled out; the failing condition comes from core runtime binding, not plugin logic.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/commands/agent.test.ts`
  - `src/hooks/llm-slug-generator.test.ts`
  - `src/commands/models/list.probe.runtime.test.ts`
- Scenario the test should lock in: Embedded command execution, slug generation, and auth probe paths must pass `allowGatewaySubagentBinding: true` to `runEmbeddedPiAgent(...)`.
- Why this is the smallest reliable guardrail: The bug is a runtime flag propagation gap at specific call sites, so focused unit tests on those call boundaries are the narrowest tests that directly prevent regression.
- Existing test that already covers this (if any): `src/commands/agent.test.ts` already covered command execution broadly; this PR extends it to assert the runtime flag.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Gateway-triggered plugin workflows are less likely to fail with `Plugin runtime subagent methods are only available during a gateway request.` when execution passes through embedded command runs.
- Internal auth probe and LLM slug generation flows now preserve the same runtime binding contract as the main gateway command path.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[gateway request] -> [embedded run without explicit binding] -> [plugin runtime gets unavailable subagent stub] -> [runtime error]

After:
[gateway request] -> [embedded run with allowGatewaySubagentBinding=true] -> [plugin runtime keeps gateway-bound subagent] -> [workflow continues]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local `openclaw` development checkout
- Model/provider: provider-agnostic; exercised via mocked embedded Pi agent calls
- Integration/channel (if any): gateway-triggered plugin workflows, including Discord-style command execution paths
- Relevant config (redacted): default gateway/plugin runtime configuration where plugin workflows can call `runtime.subagent`

### Steps

1. Trigger a gateway-backed plugin workflow that eventually executes through an embedded-agent path.
2. Let the command reach a code path such as normal command execution, LLM slug generation, or auth probing.
3. Observe whether plugin runtime subagent access is preserved.

### Expected

- Embedded runs preserve gateway subagent binding and plugin runtime can access `runtime.subagent` without raising the gateway-request error.

### Actual

- Before this fix, some embedded paths could still lose the binding and fail with `Plugin runtime subagent methods are only available during a gateway request.`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran targeted Vitest coverage for the three affected execution paths and confirmed all of them now pass with the explicit runtime flag in place.
- Edge cases checked: Normal command execution, ingress command path, one-off slug generation, and auth probe execution all preserve `allowGatewaySubagentBinding`.
- What you did **not** verify: I did not run a full live Discord end-to-end reproduction against a production gateway in this PR branch.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - A future embedded execution path could be added without the same runtime flag and reintroduce the bug.
  - Mitigation:
    - This PR adds focused regression tests around the known production call sites so similar omissions are easier to catch during review and CI.
