### PR TITLE
fix(feishu): prioritize message source account over defaultAccount

### DIFF
--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -30,30 +30,33 @@ function resolveImplicitToolAccountId(params: {
   executeParams?: AccountAwareParams;
   defaultAccountId?: string;
 }): string | undefined {
+  // 1. Explicit accountId from tool call parameters (highest priority)
   const explicitAccountId = normalizeOptionalAccountId(params.executeParams?.accountId);
   if (explicitAccountId) {
     return explicitAccountId;
   }
 
+  // 2. Contextual accountId from message source (e.g., which bot received the message)
+  // This takes priority over configured default to ensure correct multi-tenant behavior.
+  // See: https://github.com/openclaw/openclaw/issues/59399
+  const contextualAccountId = normalizeOptionalAccountId(params.defaultAccountId);
+  if (contextualAccountId && listFeishuAccountIds(params.api.config).includes(contextualAccountId)) {
+    const contextualAccount = resolveFeishuAccount({
+      cfg: params.api.config,
+      accountId: contextualAccountId,
+    });
+    if (contextualAccount.enabled) {
+      return contextualAccountId;
+    }
+  }
+
+  // 3. Configured defaultAccount as fallback (lowest priority)
   const configuredDefaultAccountId = readConfiguredDefaultAccountId(params.api.config);
   if (configuredDefaultAccountId) {
     return configuredDefaultAccountId;
   }
 
-  const contextualAccountId = normalizeOptionalAccountId(params.defaultAccountId);
-  if (!contextualAccountId) {
-    return undefined;
-  }
-
-  if (!listFeishuAccountIds(params.api.config).includes(contextualAccountId)) {
-    return undefined;
-  }
-
-  const contextualAccount = resolveFeishuAccount({
-    cfg: params.api.config,
-    accountId: contextualAccountId,
-  });
-  return contextualAccount.enabled ? contextualAccountId : undefined;
+  return undefined;
 }
 
 export function resolveFeishuToolAccount(params: {


### PR DESCRIPTION
Fixes #59399

## Summary

When multiple Feishu accounts are configured, the account that received the message should take priority over the configured defaultAccount.

## Before

1. Explicit accountId parameter
2. Configured defaultAccount ❌
3. Message source account

## After

1. Explicit accountId parameter
2. Message source account ✅
3. Configured defaultAccount (fallback)

## Impact

This ensures that when a user interacts with bot A, the tools operate on tenant A's resources, not tenant B's (which was configured as default).

## Test Plan

- Configure multiple Feishu accounts
- Set a defaultAccount
- Send message to non-default bot
- Verify tools use the correct account

🤖 Generated with [ClawHub](https://clawhub.ai)