### PR TITLE
feat(feishu): add ignoreAtAll configuration option

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -228,11 +228,21 @@ export function parseMergeForwardContent(params: { content: string; log?: Feishu
   return lines.join("\n");
 }
 
-export function checkBotMentioned(event: FeishuMessageLike, botOpenId?: string): boolean {
+export function checkBotMentioned(
+  event: FeishuMessageLike,
+  botOpenId?: string,
+  ignoreAtAll?: boolean,
+): boolean {
   if (!botOpenId) {
     return false;
   }
-  if ((event.message.content ?? "").includes("@_all")) {
+  // Check for @所有人 (broadcast) mention
+  const hasAtAll = (event.message.content ?? "").includes("@_all");
+  if (hasAtAll) {
+    // When ignoreAtAll is true, @所有人 does not count as a bot mention
+    if (ignoreAtAll) {
+      return false;
+    }
     return true;
   }
   const mentions = event.message.mentions ?? [];

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -131,9 +131,10 @@ export function parseFeishuMessageEvent(
   event: FeishuMessageEvent,
   botOpenId?: string,
   _botName?: string,
+  ignoreAtAll?: boolean,
 ): FeishuMessageContext {
   const rawContent = parseMessageContent(event.message.content, event.message.message_type);
-  const mentionedBot = checkBotMentioned(event, botOpenId);
+  const mentionedBot = checkBotMentioned(event, botOpenId, ignoreAtAll);
   const hasAnyMention = (event.message.mentions?.length ?? 0) > 0;
   // Strip the bot's own mention so slash commands like @Bot /help retain
   // the leading /. This applies in both p2p *and* group contexts — the
@@ -302,7 +303,12 @@ export async function handleFeishuMessage(params: {
     return;
   }
 
-  let ctx = parseFeishuMessageEvent(event, botOpenId, botName);
+  // Resolve ignoreAtAll setting for this chat
+  const chatId = event.message.chat_id?.trim();
+  const groupConfig = resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: chatId });
+  const ignoreAtAll = groupConfig?.ignoreAtAll ?? feishuCfg?.ignoreAtAll ?? false;
+
+  let ctx = parseFeishuMessageEvent(event, botOpenId, botName, ignoreAtAll);
   const isGroup = ctx.chatType === "group";
   const isDirect = !isGroup;
   const senderUserId = event.sender.sender_id.user_id?.trim() || undefined;

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -141,6 +141,11 @@ const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
+    /**
+     * When true, @所有人 (broadcast) messages do not trigger the bot.
+     * Overrides the top-level ignoreAtAll setting for this group.
+     */
+    ignoreAtAll: z.boolean().optional(),
     tools: ToolPolicySchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
@@ -164,6 +169,12 @@ const FeishuSharedConfigShape = {
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupSenderAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   requireMention: z.boolean().optional(),
+  /**
+   * When true, @所有人 (broadcast) messages do not trigger the bot.
+   * Only direct @mentions of the bot will be processed.
+   * Useful for announcement groups where bot should not respond to every broadcast.
+   */
+  ignoreAtAll: z.boolean().optional(),
   groups: z.record(z.string(), FeishuGroupSchema.optional()).optional(),
   historyLimit: z.number().int().min(0).optional(),
   dmHistoryLimit: z.number().int().min(0).optional(),


### PR DESCRIPTION
Fixes #59401

## Summary

When enabled, `@所有人` (broadcast) messages will not trigger the bot. Only direct `@mentions` of the bot will be processed.

## Configuration

Top-level:
```json
{
  "channels": {
    "feishu": {
      "ignoreAtAll": true
    }
  }
}
```

Per-group override:
```json
{
  "channels": {
    "feishu": {
      "groups": {
        "oc_xxx": {
          "ignoreAtAll": true
        }
      }
    }
  }
}
```

## Use Case

- Company announcement groups where `@所有人` messages are frequent
- Bot should not auto-reply to every broadcast
- Only respond to direct `@bot` mentions

## Test Plan

1. Enable `ignoreAtAll: true`
2. Send `@所有人` message in a group
3. Verify bot does NOT respond
4. Send `@bot` message in the same group
5. Verify bot DOES respond

🤖 Generated with [ClawHub](https://clawhub.ai)