### PR TITLE
fix(heartbeat): suppress reasoning payloads when main reply is HEARTBEAT_OK (#59381)

### DIFF
--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -913,10 +913,19 @@ describe("runHeartbeatOnce", () => {
         expectedTexts: ["Reasoning:\n_Because it helps_", "Final alert"],
       },
       {
-        name: "reasoning + HEARTBEAT_OK",
+        name: "reasoning + HEARTBEAT_OK suppresses all payloads",
         caseDir: "hb-reasoning-heartbeat-ok",
         replies: [{ text: "Reasoning:\n_Because it helps_" }, { text: "HEARTBEAT_OK" }],
-        expectedTexts: ["Reasoning:\n_Because it helps_"],
+        expectedTexts: [],
+      },
+      {
+        name: "reasoning containing HEARTBEAT_OK + final HEARTBEAT_OK suppresses all",
+        caseDir: "hb-reasoning-contains-heartbeat-ok",
+        replies: [
+          { text: "Reasoning:\nI should reply HEARTBEAT_OK since nothing changed" },
+          { text: "HEARTBEAT_OK" },
+        ],
+        expectedTexts: [],
       },
     ]),
   )(

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -773,7 +773,7 @@ export async function runHeartbeatOnce(opts: {
       normalized.shouldSkip = false;
     }
     const shouldSkipMain = normalized.shouldSkip && !normalized.hasMedia && !hasExecCompletion;
-    if (shouldSkipMain && reasoningPayloads.length === 0) {
+    if (shouldSkipMain) {
       await restoreHeartbeatUpdatedAt({
         storePath,
         sessionKey,


### PR DESCRIPTION
## Summary

Fixes #59381 — heartbeat replies sent in duplicate when reasoning text exists.

## Root cause

In `heartbeat-runner.ts`, when the model's main reply is `HEARTBEAT_OK` (nothing to report) but the model also produced reasoning text (e.g., "Reasoning: I should reply HEARTBEAT_OK since nothing changed"), the early-return path at line 776 was gated on `reasoningPayloads.length === 0`. This caused the function to fall through to the delivery path, sending the reasoning payloads to the user even though the main reply was suppressed.

When reasoning text itself contains "HEARTBEAT_OK", the user receives what appears to be a duplicate message — the reasoning text leaks through as a visible message.

## Fix

Remove the `reasoningPayloads.length === 0` guard from the early-return condition. When the main reply is HEARTBEAT_OK (the model decided nothing is worth reporting), all payloads including reasoning should be suppressed. The reasoning is the model's internal thought process about why nothing needs to be reported — it should not be delivered to the user.

Before:
```typescript
if (shouldSkipMain && reasoningPayloads.length === 0) {
```

After:
```typescript
if (shouldSkipMain) {
```

## Test changes

- Updated existing "reasoning + HEARTBEAT_OK" test case to expect 0 sends (was expecting 1 — the reasoning payload)
- Added new test case for reasoning text that itself contains "HEARTBEAT_OK" — verifies no payloads are sent

## Verification

- `pnpm check` passes clean
- `pnpm test -- src/infra/heartbeat-runner.returns-default-unset.test.ts` — all 31 tests pass