### PR TITLE
Use daemon auth for unmanaged restart probes

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -49,11 +49,15 @@ const probeGateway = vi.fn<
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 
-vi.mock("../../config/config.js", () => ({
-  loadConfig: () => loadConfig(),
-  readBestEffortConfig: async () => loadConfig(),
-  resolveGatewayPort,
-}));
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => loadConfig(),
+    readBestEffortConfig: async () => loadConfig(),
+    resolveGatewayPort,
+  };
+});
 
 vi.mock("../../infra/gateway-processes.js", () => ({
   findVerifiedGatewayListenerPidsOnPortSync: (port: number) =>
@@ -277,6 +281,32 @@ describe("runDaemonRestart health checks", () => {
     expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();
     expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
     expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("uses service command auth for unmanaged restart probes when shell env is unset", async () => {
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+    mockUnmanagedRestart({ runPostRestartCheck: true });
+
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+
+    service.readCommand.mockResolvedValue({
+      programArguments: ["openclaw", "gateway", "--port", "18789"],
+      environment: {
+        OPENCLAW_GATEWAY_TOKEN: " service-token ",
+      },
+    });
+
+    await runDaemonRestart({ json: true });
+
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: {
+          token: "service-token",
+          password: undefined,
+        },
+      }),
+    );
   });
 
   it("fails unmanaged restart when multiple gateway listeners are present", async () => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -1,6 +1,7 @@
 import { isRestartEnabled } from "../../config/commands.js";
 import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
 import { resolveGatewayService } from "../../daemon/service.js";
+import { resolveGatewayProbeAuthSafeWithSecretInputs } from "../../gateway/probe-auth.js";
 import { probeGateway } from "../../gateway/probe.js";
 import {
   findVerifiedGatewayListenerPidsOnPortSync,
@@ -50,15 +51,28 @@ function resolveGatewayPortFallback(): Promise<number> {
 }
 
 async function assertUnmanagedGatewayRestartEnabled(port: number): Promise<void> {
+  const service = resolveGatewayService();
+  const command = await service.readCommand(process.env).catch(() => null);
+  const serviceEnv = command?.environment ?? undefined;
+  const mergedEnv = {
+    ...(process.env as Record<string, string | undefined>),
+    ...(serviceEnv ?? undefined),
+  } as NodeJS.ProcessEnv;
+
   const cfg = await readBestEffortConfig().catch(() => undefined);
   const tlsEnabled = !!cfg?.gateway?.tls?.enabled;
   const scheme = tlsEnabled ? "wss" : "ws";
+  const probeAuth = cfg
+    ? await resolveGatewayProbeAuthSafeWithSecretInputs({
+        cfg,
+        mode: cfg.gateway?.mode === "remote" ? "remote" : "local",
+        env: mergedEnv,
+      })
+    : { auth: {} };
+
   const probe = await probeGateway({
     url: `${scheme}://127.0.0.1:${port}`,
-    auth: {
-      token: process.env.OPENCLAW_GATEWAY_TOKEN?.trim() || undefined,
-      password: process.env.OPENCLAW_GATEWAY_PASSWORD?.trim() || undefined,
-    },
+    auth: probeAuth.auth,
     timeoutMs: 1_000,
   }).catch(() => null);
 


### PR DESCRIPTION
Resubmitting after reducing my active PR queue below the repo limit. This is the same focused fix, with the existing lifecycle test passing locally.

## Summary

Use daemon/service-command auth when probing unmanaged gateway restarts instead of relying only on the current shell environment.

## What changed

- Updated unmanaged restart probe auth resolution in `src/cli/daemon-cli/lifecycle.ts`
- Read the daemon service command environment before probing the local gateway
- Merged service-command environment over `process.env` for probe auth resolution
- Resolved probe auth via `resolveGatewayProbeAuthSafeWithSecretInputs(...)` when config is available
- Kept a safe fallback to empty auth when config cannot be loaded
- Added a focused regression test covering the case where shell env is unset but the service command environment contains gateway auth
- Updated the test’s config mock to preserve the real module exports while overriding only the needed functions

## Why

The unmanaged restart probe path was previously reading only:

- `OPENCLAW_GATEWAY_TOKEN`
- `OPENCLAW_GATEWAY_PASSWORD`

from the current shell environment.

That could make restart health checks miss valid daemon auth that was present in the service command environment, even though other daemon-status paths already reason about daemon/service environment separately.

This change makes unmanaged restart probing use the daemon-side auth view instead of only the caller shell environment.

## Scope boundary

This PR does **not** change the broader daemon status flow or the probe auth resolver itself. It only updates the unmanaged restart probe path in `lifecycle.ts` to use the daemon/service-command environment when resolving auth.

## Manual verification

1. Added a focused test in `src/cli/daemon-cli/lifecycle.test.ts`
2. Verified that unmanaged restart probes now use service-command auth when shell env is unset
3. Ran:
   - `pnpm vitest run src/cli/daemon-cli/lifecycle.test.ts`
4. Ran the repo checks during commit