### PR TITLE
fix(fetch-guard): skip DNS pre-flight in trusted-env-proxy mode when proxy is configured

### DIFF
--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -411,4 +411,61 @@ describe("fetchWithSsrFGuard hardening", () => {
       expectEnvProxy: true,
     });
   });
+
+  it("skips local DNS pre-flight in trusted proxy mode (fake-ip compatibility)", async () => {
+    // Simulates Clash TUN fake-ip: the local resolver returns a non-routable
+    // placeholder address (198.18.x.x) for every hostname. In STRICT mode this
+    // would trigger an SSRF block; in TRUSTED_ENV_PROXY mode the DNS lookup
+    // must be skipped entirely so the proxy can resolve the real address.
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    const fakeIpLookup = vi.fn(async () => [
+      { address: "198.18.0.1", family: 4 },
+    ]) as unknown as NonNullable<Parameters<typeof fetchWithSsrFGuard>[0]["lookupFn"]>;
+
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const requestInit = init as RequestInit & { dispatcher?: unknown };
+      expect(getDispatcherClassName(requestInit.dispatcher)).toBe("EnvHttpProxyAgent");
+      return okResponse();
+    });
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://example.com/resource",
+      fetchImpl,
+      lookupFn: fakeIpLookup,
+      mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    // The fake-ip lookupFn must never be called — DNS is delegated to the proxy.
+    expect(fakeIpLookup).not.toHaveBeenCalled();
+    await result.release();
+  });
+
+  it("still blocks private IP literals in trusted proxy mode (no proxy configured)", async () => {
+    // TRUSTED_ENV_PROXY only bypasses DNS pre-flight when a proxy is actually
+    // configured. Without a proxy the SSRF guard must still apply for literal
+    // private IPs (caught by the hostname/IP pre-check inside
+    // resolvePinnedHostnameWithPolicy).
+    vi.unstubAllEnvs();
+    // Ensure no proxy env vars bleed in from other tests.
+    for (const key of [
+      "HTTP_PROXY",
+      "HTTPS_PROXY",
+      "http_proxy",
+      "https_proxy",
+      "ALL_PROXY",
+      "all_proxy",
+    ]) {
+      delete process.env[key];
+    }
+    const fetchImpl = vi.fn();
+    await expect(
+      fetchWithSsrFGuard({
+        url: "http://192.168.1.1/admin",
+        fetchImpl,
+        mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+      }),
+    ).rejects.toThrow(/private|internal|blocked/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 });

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -446,8 +446,8 @@ describe("fetchWithSsrFGuard hardening", () => {
     // configured. Without a proxy the SSRF guard must still apply for literal
     // private IPs (caught by the hostname/IP pre-check inside
     // resolvePinnedHostnameWithPolicy).
-    vi.unstubAllEnvs();
-    // Ensure no proxy env vars bleed in from other tests.
+    // Use vi.stubEnv so vitest's afterEach vi.unstubAllEnvs() restores originals
+    // — avoids permanently mutating process.env if a real proxy var is set.
     for (const key of [
       "HTTP_PROXY",
       "HTTPS_PROXY",
@@ -456,7 +456,7 @@ describe("fetchWithSsrFGuard hardening", () => {
       "ALL_PROXY",
       "all_proxy",
     ]) {
-      delete process.env[key];
+      vi.stubEnv(key, "");
     }
     const fetchImpl = vi.fn();
     await expect(

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -1,7 +1,7 @@
 import type { Dispatcher } from "undici";
 import { logWarn } from "../../logger.js";
 import { buildTimeoutAbortSignal } from "../../utils/fetch-timeout.js";
-import { hasProxyEnvConfigured } from "./proxy-env.js";
+import { hasEnvHttpProxyConfigured } from "./proxy-env.js";
 import { retainSafeHeadersForCrossOriginRedirect as retainSafeRedirectHeaders } from "./redirect-headers.js";
 import {
   closeDispatcher,
@@ -188,17 +188,29 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
     try {
       assertExplicitProxySupportsPinnedDns(parsedUrl, params.dispatcherPolicy, params.pinDns);
       await assertExplicitProxyAllowed(params.dispatcherPolicy, params.lookupFn, params.policy);
-      const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
-        lookupFn: params.lookupFn,
-        policy: params.policy,
-      });
+      // When a trusted env proxy is configured, delegate DNS resolution entirely
+      // to the proxy. Performing a local DNS pre-flight check first would fail
+      // in environments where the system resolver returns non-routable placeholder
+      // addresses (e.g. Clash TUN fake-ip mode returns 198.18.x.x), causing a
+      // spurious SSRF block even though the proxy itself would resolve correctly.
+      //
+      // Use hasEnvHttpProxyConfigured (not hasProxyEnvConfigured) so the gate
+      // matches undici's EnvHttpProxyAgent semantics exactly: ALL_PROXY/all_proxy
+      // are ignored by undici and must not cause the SSRF pre-flight to be skipped.
+      const protocol = parsedUrl.protocol === "https:" ? "https" : "http";
       const canUseTrustedEnvProxy =
-        mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasProxyEnvConfigured();
+        mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasEnvHttpProxyConfigured(protocol);
       if (canUseTrustedEnvProxy) {
         const { EnvHttpProxyAgent } = loadUndiciRuntimeDeps();
         dispatcher = new EnvHttpProxyAgent();
-      } else if (params.pinDns !== false) {
-        dispatcher = createPinnedDispatcher(pinned, params.dispatcherPolicy, params.policy);
+      } else {
+        const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
+          lookupFn: params.lookupFn,
+          policy: params.policy,
+        });
+        if (params.pinDns !== false) {
+          dispatcher = createPinnedDispatcher(pinned, params.dispatcherPolicy, params.policy);
+        }
       }
 
       const init: RequestInit & { dispatcher?: Dispatcher } = {


### PR DESCRIPTION
## Problem

In environments where the system DNS resolver returns non-routable placeholder addresses — most notably **Clash TUN fake-ip mode** (which returns `198.18.x.x` for every hostname) — `web_fetch` fails with an SSRF block even when a valid HTTP proxy is configured.

Root cause: `fetchWithSsrFGuard` always called `resolvePinnedHostnameWithPolicy` (local DNS pre-flight) _before_ checking whether a trusted env proxy was configured. In fake-ip mode the resolver returns `198.18.0.x` (IANA special-use range), which the SSRF guard correctly rejects — but the proxy never gets a chance to resolve the real address.

Execution order before this fix:
1. DNS pre-flight → gets fake `198.18.0.x` → **SSRF block ❌**
2. _(never reached)_ Check for `HTTPS_PROXY` → create `EnvHttpProxyAgent`

## Fix

Reorder the check in `fetchWithSsrFGuard`: if `TRUSTED_ENV_PROXY` mode is active **and** a proxy env var is set, create the `EnvHttpProxyAgent` dispatcher immediately and skip local DNS pinning entirely. DNS resolution is delegated to the proxy, which is the correct behaviour for an operator-controlled proxy.

When no proxy is configured, the existing `resolvePinnedHostnameWithPolicy` path is preserved in full.

## Security

- **STRICT mode**: unchanged — DNS pre-flight + SSRF guard always runs.
- **TRUSTED_ENV_PROXY + no proxy configured**: unchanged — falls through to the existing SSRF path.
- **TRUSTED_ENV_PROXY + proxy configured**: DNS delegated to proxy (same semantics as before for the `canUseTrustedEnvProxy` branch, just moved earlier to avoid the spurious pre-flight failure).

## Tests

Added two new test cases in `fetch-guard.ssrf.test.ts`:
1. **fake-ip compatibility** — verifies that the local `lookupFn` is never called in trusted proxy mode and that `EnvHttpProxyAgent` is used as the dispatcher.
2. **no proxy configured** — verifies that private IP literals are still blocked even in `TRUSTED_ENV_PROXY` mode when no proxy env var is set.

All 21 tests pass.

Closes #59395