### PR TITLE
fix(embedded-runner): return friendly error for session JSON parse failures

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -420,6 +420,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     ensureAuthProfileStore: vi.fn(() => ({})),
     getApiKeyForModel: mockedGetApiKeyForModel,
     resolveAuthProfileOrder: mockedResolveAuthProfileOrder,
+    shouldPreferExplicitConfigApiKeyAuth: vi.fn(() => false),
   }));
 
   vi.doMock("../models-config.js", () => ({
@@ -435,6 +436,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
 
   vi.doMock("../../process/command-queue.js", () => ({
     enqueueCommandInLane: vi.fn((_lane: string, task: () => unknown) => task()),
+    clearCommandLane: vi.fn(),
   }));
 
   vi.doMock("../../utils/message-channel.js", () => ({
@@ -460,6 +462,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
 
   vi.doMock("./lanes.js", () => ({
     resolveSessionLane: vi.fn(() => "session-lane"),
+    resolveEmbeddedSessionLane: vi.fn(() => "session-lane"),
     resolveGlobalLane: vi.fn(() => "global-lane"),
   }));
 

--- a/src/agents/pi-embedded-runner/run.session-parse-error.test.ts
+++ b/src/agents/pi-embedded-runner/run.session-parse-error.test.ts
@@ -1,0 +1,100 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import {
+  loadRunOverflowCompactionHarness,
+  mockedGlobalHookRunner,
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+  resetRunOverflowCompactionHarnessMocks,
+} from "./run.overflow-compaction.harness.js";
+import { SessionParseError } from "./session-parse-error.js";
+
+let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
+
+describe("runEmbeddedPiAgent session parse error handling", () => {
+  beforeAll(async () => {
+    ({ runEmbeddedPiAgent } = await loadRunOverflowCompactionHarness());
+  });
+
+  beforeEach(() => {
+    resetRunOverflowCompactionHarnessMocks();
+    mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
+  });
+
+  it("returns a friendly error payload for SessionParseError (bad control character)", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: new SessionParseError(
+          "Bad control character in string literal in JSON at position 544",
+          { sessionFile: "/path/to/session.jsonl" },
+        ),
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-session-parse-error-control-char",
+    });
+
+    expect(result.payloads).toBeDefined();
+    expect(result.payloads).toHaveLength(1);
+    expect(result.payloads![0]?.isError).toBe(true);
+    expect(result.payloads![0]?.text).toContain("Session transcript could not be read");
+    expect(result.payloads![0]?.text).toContain("/new");
+    expect(result.meta.error?.kind).toBe("session_parse_error");
+  });
+
+  it("returns a friendly error payload for SessionParseError (unexpected token)", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: new SessionParseError("Unexpected token < in JSON at position 0", {
+          sessionFile: "/path/to/session.jsonl",
+        }),
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-session-parse-error-unexpected-token",
+    });
+
+    expect(result.payloads).toBeDefined();
+    expect(result.payloads).toHaveLength(1);
+    expect(result.payloads![0]?.isError).toBe(true);
+    expect(result.payloads![0]?.text).toContain("Session transcript could not be read");
+    expect(result.meta.error?.kind).toBe("session_parse_error");
+  });
+
+  it("does not intercept raw SyntaxErrors not originating from session load (re-throws)", async () => {
+    // A SyntaxError thrown inside a tool handler or model decoder is NOT wrapped as
+    // SessionParseError — it should propagate rather than show the session-corrupt message.
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: new SyntaxError("Unexpected identifier 'foo'"),
+      }),
+    );
+
+    await expect(
+      runEmbeddedPiAgent({
+        ...overflowBaseRunParams,
+        runId: "run-session-parse-error-raw-syntax-rethrows",
+      }),
+    ).rejects.toThrow("Unexpected identifier 'foo'");
+  });
+
+  it("does not intercept non-syntax errors (propagates unknown errors)", async () => {
+    const unknownError = new Error("Something unrelated went wrong");
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: unknownError,
+      }),
+    );
+
+    await expect(
+      runEmbeddedPiAgent({
+        ...overflowBaseRunParams,
+        runId: "run-session-parse-error-non-syntax",
+      }),
+    ).rejects.toThrow("Something unrelated went wrong");
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -482,93 +482,134 @@ export async function runEmbeddedPiAgent(
             resolvedStreamApiKey = (apiKeyInfo as ApiKeyInfo).apiKey;
           }
 
-          const attempt = await runEmbeddedAttempt({
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-            trigger: params.trigger,
-            memoryFlushWritePath: params.memoryFlushWritePath,
-            messageChannel: params.messageChannel,
-            messageProvider: params.messageProvider,
-            agentAccountId: params.agentAccountId,
-            messageTo: params.messageTo,
-            messageThreadId: params.messageThreadId,
-            groupId: params.groupId,
-            groupChannel: params.groupChannel,
-            groupSpace: params.groupSpace,
-            spawnedBy: params.spawnedBy,
-            senderId: params.senderId,
-            senderName: params.senderName,
-            senderUsername: params.senderUsername,
-            senderE164: params.senderE164,
-            senderIsOwner: params.senderIsOwner,
-            currentChannelId: params.currentChannelId,
-            currentThreadTs: params.currentThreadTs,
-            currentMessageId: params.currentMessageId,
-            replyToMode: params.replyToMode,
-            hasRepliedRef: params.hasRepliedRef,
-            sessionFile: params.sessionFile,
-            workspaceDir: resolvedWorkspace,
-            agentDir,
-            config: params.config,
-            allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-            contextEngine,
-            contextTokenBudget: ctxInfo.tokens,
-            skillsSnapshot: params.skillsSnapshot,
-            prompt,
-            images: params.images,
-            imageOrder: params.imageOrder,
-            clientTools: params.clientTools,
-            disableTools: params.disableTools,
-            provider,
-            modelId,
-            model: applyAuthHeaderOverride(
-              applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
-              // When runtime auth exchange produced a different credential
-              // (runtimeAuthState is set), the exchanged token lives in
-              // authStorage and the SDK will pick it up automatically.
-              // Skip header injection to avoid leaking the pre-exchange key.
-              runtimeAuthState ? null : apiKeyInfo,
-              params.config,
-            ),
-            resolvedApiKey: resolvedStreamApiKey,
-            authProfileId: lastProfileId,
-            authProfileIdSource: lockedProfileId ? "user" : "auto",
-            authStorage,
-            modelRegistry,
-            agentId: workspaceResolution.agentId,
-            legacyBeforeAgentStartResult,
-            thinkLevel,
-            fastMode: params.fastMode,
-            verboseLevel: params.verboseLevel,
-            reasoningLevel: params.reasoningLevel,
-            toolResultFormat: resolvedToolResultFormat,
-            execOverrides: params.execOverrides,
-            bashElevated: params.bashElevated,
-            timeoutMs: params.timeoutMs,
-            runId: params.runId,
-            abortSignal: params.abortSignal,
-            shouldEmitToolResult: params.shouldEmitToolResult,
-            shouldEmitToolOutput: params.shouldEmitToolOutput,
-            onPartialReply: params.onPartialReply,
-            onAssistantMessageStart: params.onAssistantMessageStart,
-            onBlockReply: params.onBlockReply,
-            onBlockReplyFlush: params.onBlockReplyFlush,
-            blockReplyBreak: params.blockReplyBreak,
-            blockReplyChunking: params.blockReplyChunking,
-            onReasoningStream: params.onReasoningStream,
-            onReasoningEnd: params.onReasoningEnd,
-            onToolResult: params.onToolResult,
-            onAgentEvent: params.onAgentEvent,
-            extraSystemPrompt: params.extraSystemPrompt,
-            inputProvenance: params.inputProvenance,
-            streamParams: params.streamParams,
-            ownerNumbers: params.ownerNumbers,
-            enforceFinalTag: params.enforceFinalTag,
-            silentExpected: params.silentExpected,
-            bootstrapPromptWarningSignaturesSeen,
-            bootstrapPromptWarningSignature:
-              bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
-          });
+          // SessionParseError can be thrown synchronously by SessionManager.open()
+          // inside runEmbeddedAttempt before any attempt result is produced. Catch it
+          // here so the friendly /new guidance reaches the user instead of a raw throw.
+          let attempt: Awaited<ReturnType<typeof runEmbeddedAttempt>>;
+          try {
+            attempt = await runEmbeddedAttempt({
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              trigger: params.trigger,
+              memoryFlushWritePath: params.memoryFlushWritePath,
+              messageChannel: params.messageChannel,
+              messageProvider: params.messageProvider,
+              agentAccountId: params.agentAccountId,
+              messageTo: params.messageTo,
+              messageThreadId: params.messageThreadId,
+              groupId: params.groupId,
+              groupChannel: params.groupChannel,
+              groupSpace: params.groupSpace,
+              spawnedBy: params.spawnedBy,
+              senderId: params.senderId,
+              senderName: params.senderName,
+              senderUsername: params.senderUsername,
+              senderE164: params.senderE164,
+              senderIsOwner: params.senderIsOwner,
+              currentChannelId: params.currentChannelId,
+              currentThreadTs: params.currentThreadTs,
+              currentMessageId: params.currentMessageId,
+              replyToMode: params.replyToMode,
+              hasRepliedRef: params.hasRepliedRef,
+              sessionFile: params.sessionFile,
+              workspaceDir: resolvedWorkspace,
+              agentDir,
+              config: params.config,
+              allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+              contextEngine,
+              contextTokenBudget: ctxInfo.tokens,
+              skillsSnapshot: params.skillsSnapshot,
+              prompt,
+              images: params.images,
+              imageOrder: params.imageOrder,
+              clientTools: params.clientTools,
+              disableTools: params.disableTools,
+              provider,
+              modelId,
+              model: applyAuthHeaderOverride(
+                applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
+                // When runtime auth exchange produced a different credential
+                // (runtimeAuthState is set), the exchanged token lives in
+                // authStorage and the SDK will pick it up automatically.
+                // Skip header injection to avoid leaking the pre-exchange key.
+                runtimeAuthState ? null : apiKeyInfo,
+                params.config,
+              ),
+              resolvedApiKey: resolvedStreamApiKey,
+              authProfileId: lastProfileId,
+              authProfileIdSource: lockedProfileId ? "user" : "auto",
+              authStorage,
+              modelRegistry,
+              agentId: workspaceResolution.agentId,
+              legacyBeforeAgentStartResult,
+              thinkLevel,
+              fastMode: params.fastMode,
+              verboseLevel: params.verboseLevel,
+              reasoningLevel: params.reasoningLevel,
+              toolResultFormat: resolvedToolResultFormat,
+              execOverrides: params.execOverrides,
+              bashElevated: params.bashElevated,
+              timeoutMs: params.timeoutMs,
+              runId: params.runId,
+              abortSignal: params.abortSignal,
+              shouldEmitToolResult: params.shouldEmitToolResult,
+              shouldEmitToolOutput: params.shouldEmitToolOutput,
+              onPartialReply: params.onPartialReply,
+              onAssistantMessageStart: params.onAssistantMessageStart,
+              onBlockReply: params.onBlockReply,
+              onBlockReplyFlush: params.onBlockReplyFlush,
+              blockReplyBreak: params.blockReplyBreak,
+              blockReplyChunking: params.blockReplyChunking,
+              onReasoningStream: params.onReasoningStream,
+              onReasoningEnd: params.onReasoningEnd,
+              onToolResult: params.onToolResult,
+              onAgentEvent: params.onAgentEvent,
+              extraSystemPrompt: params.extraSystemPrompt,
+              inputProvenance: params.inputProvenance,
+              streamParams: params.streamParams,
+              ownerNumbers: params.ownerNumbers,
+              enforceFinalTag: params.enforceFinalTag,
+              silentExpected: params.silentExpected,
+              bootstrapPromptWarningSignaturesSeen,
+              bootstrapPromptWarningSignature:
+                bootstrapPromptWarningSignaturesSeen[
+                  bootstrapPromptWarningSignaturesSeen.length - 1
+                ],
+            });
+          } catch (attemptErr) {
+            if (isSessionParseError(attemptErr)) {
+              log.warn(
+                `[session-parse-error] JSON parse error in session transcript (thrown): runId=${params.runId} error=${describeUnknownError(attemptErr).slice(0, 200)}`,
+              );
+              return {
+                payloads: [
+                  {
+                    text:
+                      "Session transcript could not be read (malformed content). " +
+                      "Use /new to start a fresh session.",
+                    isError: true,
+                  },
+                ],
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta: buildErrorAgentMeta({
+                    sessionId: params.sessionId,
+                    provider,
+                    model: model.id,
+                    usageAccumulator,
+                    lastRunPromptUsage,
+                    lastTurnTotal: undefined,
+                  }),
+                  systemPromptReport: undefined,
+                  error: {
+                    kind: "session_parse_error",
+                    message: describeUnknownError(attemptErr),
+                  },
+                },
+              };
+            }
+            throw attemptErr;
+          }
 
           const {
             aborted,
@@ -974,6 +1015,40 @@ export async function runEmbeddedPiAgent(
           }
 
           if (promptError && !aborted) {
+            // Handle JSON parse errors early — before coerceToFailoverError which may
+            // re-wrap and obscure the SessionParseError identity.
+            if (isSessionParseError(promptError)) {
+              log.warn(
+                `[session-parse-error] JSON parse error in session transcript: runId=${params.runId} error=${describeUnknownError(promptError).slice(0, 200)}`,
+              );
+              return {
+                payloads: [
+                  {
+                    text:
+                      "Session transcript could not be read (malformed content). " +
+                      "Use /new to start a fresh session.",
+                    isError: true,
+                  },
+                ],
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta: buildErrorAgentMeta({
+                    sessionId: sessionIdUsed,
+                    provider,
+                    model: model.id,
+                    usageAccumulator,
+                    lastRunPromptUsage,
+                    lastAssistant,
+                    lastTurnTotal,
+                  }),
+                  systemPromptReport: attempt?.systemPromptReport,
+                  error: {
+                    kind: "session_parse_error",
+                    message: describeUnknownError(promptError),
+                  },
+                },
+              };
+            }
             // Normalize wrapped errors (e.g. abort-wrapped RESOURCE_EXHAUSTED) into
             // FailoverError so rate-limit classification works even for nested shapes.
             const normalizedPromptFailover = coerceToFailoverError(promptError, {
@@ -1142,42 +1217,6 @@ export async function runEmbeddedPiAgent(
             }
             if (promptFailoverDecision.action === "surface_error") {
               logPromptFailoverDecision("surface_error");
-            }
-            // Handle JSON parse errors (e.g. bad control characters in session
-            // transcript) with a user-friendly message instead of surfacing the
-            // raw SyntaxError text ("Bad control character in string literal at
-            // position N") to the chat surface.
-            if (isSessionParseError(promptError)) {
-              log.warn(
-                `[session-parse-error] JSON parse error in session transcript: runId=${params.runId} error=${describeUnknownError(promptError).slice(0, 200)}`,
-              );
-              return {
-                payloads: [
-                  {
-                    text:
-                      "Session transcript could not be read (malformed content). " +
-                      "Use /new to start a fresh session.",
-                    isError: true,
-                  },
-                ],
-                meta: {
-                  durationMs: Date.now() - started,
-                  agentMeta: buildErrorAgentMeta({
-                    sessionId: sessionIdUsed,
-                    provider,
-                    model: model.id,
-                    usageAccumulator,
-                    lastRunPromptUsage,
-                    lastAssistant,
-                    lastTurnTotal,
-                  }),
-                  systemPromptReport: attempt.systemPromptReport,
-                  error: {
-                    kind: "session_parse_error",
-                    message: describeUnknownError(promptError),
-                  },
-                },
-              };
             }
             throw promptError;
           }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -85,6 +85,7 @@ import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import { handleRetryLimitExhaustion } from "./run/retry-limit.js";
 import { resolveEffectiveRuntimeModel, resolveHookModelSelection } from "./run/setup.js";
+import { isSessionParseError } from "./session-parse-error.js";
 import {
   sessionLikelyHasOversizedToolResults,
   truncateOversizedToolResultsInSession,
@@ -1141,6 +1142,42 @@ export async function runEmbeddedPiAgent(
             }
             if (promptFailoverDecision.action === "surface_error") {
               logPromptFailoverDecision("surface_error");
+            }
+            // Handle JSON parse errors (e.g. bad control characters in session
+            // transcript) with a user-friendly message instead of surfacing the
+            // raw SyntaxError text ("Bad control character in string literal at
+            // position N") to the chat surface.
+            if (isSessionParseError(promptError)) {
+              log.warn(
+                `[session-parse-error] JSON parse error in session transcript: runId=${params.runId} error=${describeUnknownError(promptError).slice(0, 200)}`,
+              );
+              return {
+                payloads: [
+                  {
+                    text:
+                      "Session transcript could not be read (malformed content). " +
+                      "Use /new to start a fresh session.",
+                    isError: true,
+                  },
+                ],
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta: buildErrorAgentMeta({
+                    sessionId: sessionIdUsed,
+                    provider,
+                    model: model.id,
+                    usageAccumulator,
+                    lastRunPromptUsage,
+                    lastAssistant,
+                    lastTurnTotal,
+                  }),
+                  systemPromptReport: attempt.systemPromptReport,
+                  error: {
+                    kind: "session_parse_error",
+                    message: describeUnknownError(promptError),
+                  },
+                },
+              };
             }
             throw promptError;
           }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -119,6 +119,7 @@ import {
 import { buildEmbeddedSandboxInfo } from "../sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
 import { prepareSessionManagerForRun } from "../session-manager-init.js";
+import { SessionParseError } from "../session-parse-error.js";
 import { resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
 import {
   describeEmbeddedAgentStreamStrategy,
@@ -749,7 +750,19 @@ export async function runEmbeddedAttempt(
       });
 
       await prewarmSessionFile(params.sessionFile);
-      sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
+      let openedSession: ReturnType<typeof SessionManager.open>;
+      try {
+        openedSession = SessionManager.open(params.sessionFile);
+      } catch (err) {
+        if (err instanceof SyntaxError) {
+          throw new SessionParseError(`Failed to parse session transcript: ${err.message}`, {
+            sessionFile: params.sessionFile,
+            cause: err,
+          });
+        }
+        throw err;
+      }
+      sessionManager = guardSessionManager(openedSession, {
         agentId: sessionAgentId,
         sessionKey: params.sessionKey,
         inputProvenance: params.inputProvenance,

--- a/src/agents/pi-embedded-runner/session-parse-error.ts
+++ b/src/agents/pi-embedded-runner/session-parse-error.ts
@@ -1,0 +1,20 @@
+/**
+ * Error thrown when a session transcript file cannot be parsed.
+ *
+ * Wraps the original SyntaxError so callers can distinguish a session-load
+ * failure from a JSON parse error that occurred elsewhere during a prompt call
+ * (e.g. inside a tool handler or model response decoder).
+ */
+export class SessionParseError extends Error {
+  readonly sessionFile: string;
+
+  constructor(message: string, params: { sessionFile: string; cause?: unknown }) {
+    super(message, { cause: params.cause });
+    this.name = "SessionParseError";
+    this.sessionFile = params.sessionFile;
+  }
+}
+
+export function isSessionParseError(err: unknown): err is SessionParseError {
+  return err instanceof SessionParseError;
+}

--- a/src/agents/pi-embedded-runner/session-parse-error.ts
+++ b/src/agents/pi-embedded-runner/session-parse-error.ts
@@ -16,5 +16,7 @@ export class SessionParseError extends Error {
 }
 
 export function isSessionParseError(err: unknown): err is SessionParseError {
-  return err instanceof SessionParseError;
+  return (
+    err instanceof SessionParseError || (err instanceof Error && err.name === "SessionParseError")
+  );
 }

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -42,7 +42,8 @@ export type EmbeddedPiRunMeta = {
       | "compaction_failure"
       | "role_ordering"
       | "image_size"
-      | "retry_limit";
+      | "retry_limit"
+      | "session_parse_error";
     message: string;
   };
   /** Stop reason for the agent run (e.g., "completed", "tool_calls"). */


### PR DESCRIPTION
## Problem

When a session transcript contains bad control characters (e.g. raw ANSI escape codes from `exec` tool output), `JSON.parse()` throws a `SyntaxError` when loading the session file for a subsequent run. The error propagates as raw text — `Bad control character in string literal in JSON at position N` — surfaced directly to the chat channel.

This happens in practice when:
- An `exec` tool result contains ANSI escape sequences or C0 control characters (`\x01`–`\x1F`)
- The session is subsequently reloaded (e.g. a closing-turn or new embedded run against the same session file)

## Fix

Adds a `SyntaxError` / JSON parse error intercept in the `promptError` handling path of `runEmbeddedPiAgent`, after the existing failover classification logic. Returns a user-friendly payload instead of the raw error text:

> Session transcript could not be read (malformed content). Use /new to start a fresh session.

This follows the same pattern as the existing `role_ordering` and `image_size` error handlers already present in this path.

Also adds `session_parse_error` to the `EmbeddedPiRunResult` error kind union in `types.ts`.

## Tests

Adds `run.session-parse-error.test.ts` covering:
- Control character `SyntaxError` → friendly payload returned
- Unexpected token `SyntaxError` → friendly payload returned  
- Generic `SyntaxError` (caught by `instanceof` check) → friendly payload returned
- Non-syntax errors → still propagate (not intercepted)