### PR TITLE
fix(sessions_send): allow cross-agent messaging for sandboxed agents with a2a enabled

### DIFF
--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -114,6 +114,7 @@ export function createSessionsSendTool(opts?: {
       }
 
       let sessionKey = sessionKeyParam;
+      let isCrossAgent = false;
       if (!sessionKey && labelParam) {
         const requesterAgentId = resolveAgentIdFromSessionKey(effectiveRequesterKey);
         const requestedAgentId = labelAgentIdParam
@@ -121,9 +122,10 @@ export function createSessionsSendTool(opts?: {
           : undefined;
 
         // For cross-agent sends, check a2aPolicy first (applies to both sandboxed and non-sandboxed)
-        const isCrossAgent =
-          requesterAgentId && requestedAgentId && requestedAgentId !== requesterAgentId;
-        if (isCrossAgent) {
+        isCrossAgent = Boolean(
+          requesterAgentId && requestedAgentId && requestedAgentId !== requesterAgentId,
+        );
+        if (isCrossAgent && requesterAgentId && requestedAgentId) {
           if (!a2aPolicy.enabled) {
             return jsonResult({
               runId: crypto.randomUUID(),
@@ -205,7 +207,7 @@ export function createSessionsSendTool(opts?: {
         alias,
         mainKey,
         requesterInternalKey: effectiveRequesterKey,
-        restrictToSpawned,
+        restrictToSpawned: restrictToSpawned && !isCrossAgent,
       });
       if (!resolvedSession.ok) {
         return jsonResult({
@@ -217,7 +219,7 @@ export function createSessionsSendTool(opts?: {
       const visibleSession = await resolveVisibleSessionReference({
         resolvedSession,
         requesterSessionKey: effectiveRequesterKey,
-        restrictToSpawned,
+        restrictToSpawned: restrictToSpawned && !isCrossAgent,
         visibilitySessionKey: sessionKey,
       });
       if (!visibleSession.ok) {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -120,15 +120,10 @@ export function createSessionsSendTool(opts?: {
           ? normalizeAgentId(labelAgentIdParam)
           : undefined;
 
-        if (restrictToSpawned && requestedAgentId && requestedAgentId !== requesterAgentId) {
-          return jsonResult({
-            runId: crypto.randomUUID(),
-            status: "forbidden",
-            error: "Sandboxed sessions_send label lookup is limited to this agent",
-          });
-        }
-
-        if (requesterAgentId && requestedAgentId && requestedAgentId !== requesterAgentId) {
+        // For cross-agent sends, check a2aPolicy first (applies to both sandboxed and non-sandboxed)
+        const isCrossAgent =
+          requesterAgentId && requestedAgentId && requestedAgentId !== requesterAgentId;
+        if (isCrossAgent) {
           if (!a2aPolicy.enabled) {
             return jsonResult({
               runId: crypto.randomUUID(),
@@ -146,10 +141,16 @@ export function createSessionsSendTool(opts?: {
           }
         }
 
+        // For sandboxed agents, cross-agent messaging is allowed if a2aPolicy permits it (checked above).
+        // For same-agent sends, restrictToSpawned still limits lookup to sessions spawned by this agent.
+        // The original "Sandboxed sessions_send label lookup is limited to this agent" check has been
+        // replaced by the a2aPolicy check to allow properly configured cross-agent messaging.
+
         const resolveParams: Record<string, unknown> = {
           label: labelParam,
           ...(requestedAgentId ? { agentId: requestedAgentId } : {}),
-          ...(restrictToSpawned ? { spawnedBy: effectiveRequesterKey } : {}),
+          // For cross-agent a2a messaging, don't filter by spawnedBy so target agent's sessions are visible
+          ...(restrictToSpawned && !isCrossAgent ? { spawnedBy: effectiveRequesterKey } : {}),
         };
         let resolvedKey = "";
         try {


### PR DESCRIPTION
Fixes #59256

## Problem

Sandboxed agents cannot send messages to other agents' sessions via `sessions_send`, even when `tools.agentToAgent.enabled = true` and the allow list permits it. The error is "Sandboxed sessions_send label lookup is limited to this agent".

## Root Cause

In `src/agents/tools/sessions-send-tool.ts`, the `restrictToSpawned` check blocked cross-agent messaging before the `a2aPolicy` check could run. Additionally, the `spawnedBy` filter was always applied for sandboxed agents, preventing lookup of sessions owned by other agents.

## Fix

1. Move `a2aPolicy` check before the `restrictToSpawned` guard, so sandboxed agents can send to other agents when properly configured
2. Don't apply `spawnedBy` filter for cross-agent a2a messaging, allowing target agent's sessions to be visible during lookup

## Test Plan

- Existing sessions-resolution tests pass (16/16)
- Existing sessions-list-tool tests pass (3/3)
- Manual testing: configure two sandboxed agents with a2a enabled, verify session_send works