### PR TITLE
docs: fix Node.js minimum version in SECURITY.md (22.12.0 → 22.14.0)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -263,7 +263,7 @@ OpenClaw's web interface (Gateway Control UI + HTTP endpoints) is intended for *
 
 ### Node.js Version
 
-OpenClaw requires **Node.js 22.12.0 or later** (LTS). This version includes important security patches:
+OpenClaw requires **Node.js 22.14.0 or later** (LTS). This version includes important security patches:
 
 - CVE-2025-59466: async_hooks DoS vulnerability
 - CVE-2026-21636: Permission model bypass vulnerability
@@ -271,7 +271,7 @@ OpenClaw requires **Node.js 22.12.0 or later** (LTS). This version includes impo
 Verify your Node.js version:
 
 ```bash
-node --version  # Should be v22.12.0 or later
+node --version  # Should be v22.14.0 or later
 ```
 
 ### Docker Security


### PR DESCRIPTION
Fixes #59476

SECURITY.md § "Node.js Version" (lines 266, 274) referenced **22.12.0** but `src/infra/runtime-guard.ts` enforces **22.14.0** (`MIN_NODE = { major: 22, minor: 14, patch: 0 }`).

A user following the documented guidance with Node 22.12.0 would pass the SECURITY.md check but fail at startup.

### Changes

- Line 266: 22.12.0 → 22.14.0
- Line 274: v22.12.0 → v22.14.0