### PR TITLE
fix: clarify --tz help text to mention --at support (#59456)

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -77,7 +77,7 @@ export function registerCronAddCommand(cron: Command) {
       )
       .option("--every <duration>", "Run every duration (e.g. 10m, 1h)")
       .option("--cron <expr>", "Cron expression (5-field or 6-field with seconds)")
-      .option("--tz <iana>", "Timezone for cron expressions (IANA)", "")
+      .option("--tz <iana>", "Timezone for cron and --at expressions (IANA)", "")
       .option("--stagger <duration>", "Cron stagger window (e.g. 30s, 5m)")
       .option("--exact", "Disable cron staggering (set stagger to 0)", false)
       .option("--system-event <text>", "System event payload (main session)")

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -42,7 +42,7 @@ export function registerCronEditCommand(cron: Command) {
       .option("--at <when>", "Set one-shot time (ISO) or duration like 20m")
       .option("--every <duration>", "Set interval duration like 10m")
       .option("--cron <expr>", "Set cron expression")
-      .option("--tz <iana>", "Timezone for cron expressions (IANA)")
+      .option("--tz <iana>", "Timezone for cron and --at expressions (IANA)")
       .option("--stagger <duration>", "Cron stagger window (e.g. 30s, 5m)")
       .option("--exact", "Disable cron staggering (set stagger to 0)")
       .option("--system-event <text>", "Set systemEvent payload")


### PR DESCRIPTION
## Summary
The `--tz` help text in both `openclaw cron add` and `openclaw cron edit` says "Timezone for cron expressions" — implying it only applies to `--cron`. Updated to "Timezone for cron and --at expressions" so users know `--tz` also applies to `--at` datetime strings.

Fixes #59456

🤖 AI-assisted (Claude Code). I understand what the code does.

## Changes
| File | Change |
|------|--------|
| `src/cli/cron-cli/register.cron-add.ts` | `"Timezone for cron expressions (IANA)"` → `"Timezone for cron and --at expressions (IANA)"` |
| `src/cli/cron-cli/register.cron-edit.ts` | Same |

## Test plan
- [ ] Run `openclaw cron add --help` and verify updated help text
- [ ] Run `openclaw cron edit --help` and verify updated help text