### PR TITLE
fix(cli): pass --help through lazy command placeholders to subcommands

### DIFF
--- a/src/cli/program/register-lazy-command.ts
+++ b/src/cli/program/register-lazy-command.ts
@@ -20,6 +20,7 @@ export function registerLazyCommand({
   const placeholder = program.command(name).description(description);
   placeholder.allowUnknownOption(true);
   placeholder.allowExcessArguments(true);
+  placeholder.helpOption(false);
   placeholder.action(async (...actionArgs) => {
     for (const commandName of new Set(removeNames ?? [name])) {
       removeCommandByName(program, commandName);

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -130,6 +130,28 @@ describe("registerSubCliCommands", () => {
     expect(nodesAction).toHaveBeenCalledTimes(1);
   });
 
+  it("passes --help through to the real subcommand via re-parse", async () => {
+    const program = createRegisteredProgram(["node", "openclaw", "nodes", "list"], "openclaw");
+    program.exitOverride();
+
+    let helpOutput = "";
+    program.configureOutput({ writeOut: (str) => (helpOutput += str), writeErr: () => {} });
+
+    // Before fix: --help was intercepted by the placeholder and showed parent help.
+    // After fix: --help passes through to action, re-parse routes to the real subcommand.
+    try {
+      await program.parseAsync(["nodes", "list", "--help"], { from: "user" });
+    } catch (err: unknown) {
+      // Commander throws with exitOverride when outputting help — that's expected.
+      expect((err as { code?: string }).code).toBe("commander.helpDisplayed");
+    }
+
+    // The real CLI module was loaded (placeholder didn't swallow --help).
+    expect(registerNodesCli).toHaveBeenCalledTimes(1);
+    // Help output came from the real "list" subcommand, not the placeholder.
+    expect(helpOutput).toContain("list");
+  });
+
   it("replaces placeholder when registering a subcommand by name", async () => {
     const program = createRegisteredProgram(["node", "openclaw", "acp", "--help"], "openclaw");
 

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -139,12 +139,9 @@ describe("registerSubCliCommands", () => {
 
     // Before fix: --help was intercepted by the placeholder and showed parent help.
     // After fix: --help passes through to action, re-parse routes to the real subcommand.
-    try {
-      await program.parseAsync(["nodes", "list", "--help"], { from: "user" });
-    } catch (err: unknown) {
-      // Commander throws with exitOverride when outputting help — that's expected.
-      expect((err as { code?: string }).code).toBe("commander.helpDisplayed");
-    }
+    await expect(
+      program.parseAsync(["nodes", "list", "--help"], { from: "user" }),
+    ).rejects.toMatchObject({ code: "commander.helpDisplayed" });
 
     // The real CLI module was loaded (placeholder didn't swallow --help).
     expect(registerNodesCli).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

- `openclaw cron add --help` (and all other lazy-registered subcommands) showed the **parent** command help instead of the subcommand's own help
- Root cause: Commander's built-in `--help` handler fires on the lazy placeholder **before** the action callback can re-register the real command tree
- Fix: `placeholder.helpOption(false)` lets `--help` pass through to the action, which removes the placeholder, registers the real subcommand tree, and re-parses — so the correct subcommand help is displayed

Affects all lazy-registered CLI commands (cron, nodes, dns, acp, channels, etc.), not just cron.

Fixes #59449

## Test plan

- [x] Added test: `--help` passes through placeholder and triggers real subcommand registration
- [x] Existing tests pass (167 pass, 0 fail in `src/cli/program/`)
- [x] Cron CLI tests pass (42 pass, 0 fail)
- [x] Verified with isolated Commander script: without fix `action reached: false`, with fix `action reached: true`