### PR TITLE
Discord: omit temperature for Codex thread title generation on OpenAI Codex

### DIFF
--- a/extensions/discord/src/monitor/thread-title.generate.test.ts
+++ b/extensions/discord/src/monitor/thread-title.generate.test.ts
@@ -178,6 +178,42 @@ describe("generateThreadTitle", () => {
     );
   });
 
+  it("omits temperature for openai-codex responses models", async () => {
+    prepareSimpleCompletionModelForAgentMock.mockResolvedValueOnce({
+      selection: {
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+        agentDir: "/tmp/openclaw-agent",
+      },
+      model: {
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        id: "gpt-5.4",
+      },
+      auth: {
+        apiKey: "sk-test",
+        source: "env:TEST_API_KEY",
+        mode: "api-key",
+      },
+    } as Awaited<ReturnType<typeof agentRuntimeModule.prepareSimpleCompletionModelForAgent>>);
+
+    await generateThreadTitle({
+      cfg: {} as OpenClawConfig,
+      agentId: "main",
+      messageText: "Summarize deployment blockers and owner follow-ups.",
+    });
+
+    expect(completeWithPreparedSimpleCompletionModelMock).toHaveBeenCalledTimes(1);
+    expect(completeWithPreparedSimpleCompletionModelMock.mock.calls[0]?.[0]?.options).toEqual(
+      expect.objectContaining({
+        maxTokens: 24,
+      }),
+    );
+    expect(completeWithPreparedSimpleCompletionModelMock.mock.calls[0]?.[0]?.options).not.toHaveProperty(
+      "temperature",
+    );
+  });
+
   it("returns null when completion throws", async () => {
     completeWithPreparedSimpleCompletionModelMock.mockRejectedValueOnce(
       new Error("network timeout"),

--- a/extensions/discord/src/monitor/thread-title.generate.test.ts
+++ b/extensions/discord/src/monitor/thread-title.generate.test.ts
@@ -214,6 +214,40 @@ describe("generateThreadTitle", () => {
     );
   });
 
+  it("keeps temperature for openai-codex models on non-responses APIs", async () => {
+    prepareSimpleCompletionModelForAgentMock.mockResolvedValueOnce({
+      selection: {
+        provider: "openai-codex",
+        modelId: "gpt-5.4",
+        agentDir: "/tmp/openclaw-agent",
+      },
+      model: {
+        provider: "openai-codex",
+        api: "openai-responses",
+        id: "gpt-5.4",
+      },
+      auth: {
+        apiKey: "sk-test",
+        source: "env:TEST_API_KEY",
+        mode: "api-key",
+      },
+    } as Awaited<ReturnType<typeof agentRuntimeModule.prepareSimpleCompletionModelForAgent>>);
+
+    await generateThreadTitle({
+      cfg: {} as OpenClawConfig,
+      agentId: "main",
+      messageText: "Summarize deployment blockers and owner follow-ups.",
+    });
+
+    expect(completeWithPreparedSimpleCompletionModelMock).toHaveBeenCalledTimes(1);
+    expect(completeWithPreparedSimpleCompletionModelMock.mock.calls[0]?.[0]?.options).toEqual(
+      expect.objectContaining({
+        maxTokens: 24,
+        temperature: 0.2,
+      }),
+    );
+  });
+
   it("returns null when completion throws", async () => {
     completeWithPreparedSimpleCompletionModelMock.mockRejectedValueOnce(
       new Error("network timeout"),

--- a/extensions/discord/src/monitor/thread-title.ts
+++ b/extensions/discord/src/monitor/thread-title.ts
@@ -74,15 +74,6 @@ async function completeThreadTitle(params: {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), params.timeoutMs);
   try {
-    const options: NonNullable<
-      Parameters<typeof completeWithPreparedSimpleCompletionModel>[0]["options"]
-    > = {
-      maxTokens: DISCORD_THREAD_TITLE_MAX_TOKENS,
-      signal: controller.signal,
-    };
-    if (shouldSendThreadTitleTemperature(params.model)) {
-      options.temperature = DISCORD_THREAD_TITLE_TEMPERATURE;
-    }
     return await completeWithPreparedSimpleCompletionModel({
       model: params.model,
       auth: params.auth,
@@ -96,7 +87,13 @@ async function completeThreadTitle(params: {
           },
         ],
       },
-      options,
+      options: {
+        maxTokens: DISCORD_THREAD_TITLE_MAX_TOKENS,
+        ...(shouldSendThreadTitleTemperature(params.model)
+          ? { temperature: DISCORD_THREAD_TITLE_TEMPERATURE }
+          : {}),
+        signal: controller.signal,
+      },
     });
   } finally {
     clearTimeout(timer);

--- a/extensions/discord/src/monitor/thread-title.ts
+++ b/extensions/discord/src/monitor/thread-title.ts
@@ -106,7 +106,7 @@ async function completeThreadTitle(params: {
 function shouldSendThreadTitleTemperature(
   model: Parameters<typeof completeWithPreparedSimpleCompletionModel>[0]["model"],
 ): boolean {
-  return model.provider !== "openai-codex" && model.api !== "openai-codex-responses";
+  return model.api !== "openai-codex-responses";
 }
 
 function buildThreadTitleUserMessage(params: {

--- a/extensions/discord/src/monitor/thread-title.ts
+++ b/extensions/discord/src/monitor/thread-title.ts
@@ -74,6 +74,15 @@ async function completeThreadTitle(params: {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), params.timeoutMs);
   try {
+    const options: NonNullable<
+      Parameters<typeof completeWithPreparedSimpleCompletionModel>[0]["options"]
+    > = {
+      maxTokens: DISCORD_THREAD_TITLE_MAX_TOKENS,
+      signal: controller.signal,
+    };
+    if (shouldSendThreadTitleTemperature(params.model)) {
+      options.temperature = DISCORD_THREAD_TITLE_TEMPERATURE;
+    }
     return await completeWithPreparedSimpleCompletionModel({
       model: params.model,
       auth: params.auth,
@@ -87,15 +96,17 @@ async function completeThreadTitle(params: {
           },
         ],
       },
-      options: {
-        maxTokens: DISCORD_THREAD_TITLE_MAX_TOKENS,
-        temperature: DISCORD_THREAD_TITLE_TEMPERATURE,
-        signal: controller.signal,
-      },
+      options,
     });
   } finally {
     clearTimeout(timer);
   }
+}
+
+function shouldSendThreadTitleTemperature(
+  model: Parameters<typeof completeWithPreparedSimpleCompletionModel>[0]["model"],
+): boolean {
+  return model.provider !== "openai-codex" && model.api !== "openai-codex-responses";
 }
 
 function buildThreadTitleUserMessage(params: {


### PR DESCRIPTION
## Summary
- omit temperature from Discord thread title completions when the resolved model uses OpenAI Codex Responses
- keep the existing temperature behavior for other providers
- add a regression test covering the openai-codex-responses path

## Testing
- not run locally: this environment does not have pnpm installed

Closes #59525