### PR TITLE
feat(plugins): add `plugins clean` command to remove stale plugin config refs

### DIFF
--- a/src/cli/plugins-cli.clean.test.ts
+++ b/src/cli/plugins-cli.clean.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  readConfigFileSnapshot,
+  replaceConfigFile,
+  resetPluginsCliTestState,
+  runPluginsCommand,
+  runtimeLogs,
+  writeConfigFile,
+} from "./plugins-cli-test-helpers.js";
+
+const scanStalePluginConfig = vi.fn();
+const maybeRepairStalePluginConfig = vi.fn();
+const isStalePluginAutoRepairBlocked = vi.fn();
+
+vi.mock("../commands/doctor/shared/stale-plugin-config.js", () => ({
+  scanStalePluginConfig: (...args: unknown[]) => scanStalePluginConfig(...args),
+  maybeRepairStalePluginConfig: (...args: unknown[]) => maybeRepairStalePluginConfig(...args),
+  isStalePluginAutoRepairBlocked: (...args: unknown[]) => isStalePluginAutoRepairBlocked(...args),
+}));
+
+const STALE_SOURCE_CONFIG: OpenClawConfig = {
+  plugins: {
+    allow: ["discord", "weixin"],
+    entries: {
+      weixin: { enabled: true },
+    },
+  },
+} as OpenClawConfig;
+
+const RUNTIME_SHAPED_CONFIG: OpenClawConfig = {
+  plugins: {
+    allow: ["discord"],
+    entries: {},
+    installs: {
+      weixin: {
+        source: "marketplace",
+      },
+    },
+  },
+} as OpenClawConfig;
+
+const STALE_HITS = [
+  { pluginId: "weixin", pathLabel: "plugins.allow", surface: "allow" as const },
+  { pluginId: "weixin", pathLabel: "plugins.entries.weixin", surface: "entries" as const },
+];
+
+const CLEAN_CONFIG: OpenClawConfig = {
+  plugins: {
+    allow: ["discord"],
+    entries: {},
+  },
+} as OpenClawConfig;
+
+describe("plugins cli clean", () => {
+  beforeEach(() => {
+    resetPluginsCliTestState();
+    scanStalePluginConfig.mockReset();
+    maybeRepairStalePluginConfig.mockReset();
+    isStalePluginAutoRepairBlocked.mockReset();
+    isStalePluginAutoRepairBlocked.mockReturnValue(false);
+  });
+
+  it("reports no stale references when config is clean", async () => {
+    scanStalePluginConfig.mockReturnValue([]);
+
+    await runPluginsCommand(["plugins", "clean"]);
+
+    expect(replaceConfigFile).not.toHaveBeenCalled();
+    expect(runtimeLogs.some((line) => line.includes("No stale plugin references found."))).toBe(
+      true,
+    );
+  });
+
+  it("uses sourceConfig as the cleanup base and persists the repaired config", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/openclaw-config.json5",
+      config: RUNTIME_SHAPED_CONFIG,
+      sourceConfig: STALE_SOURCE_CONFIG,
+      hash: "abc123",
+    });
+    scanStalePluginConfig.mockReturnValue(STALE_HITS);
+    maybeRepairStalePluginConfig.mockReturnValue({
+      config: CLEAN_CONFIG,
+      changes: [
+        "- plugins.allow: removed 1 stale plugin id (weixin)",
+        "- plugins.entries: removed 1 stale plugin entry (weixin)",
+      ],
+    });
+
+    await runPluginsCommand(["plugins", "clean"]);
+
+    expect(scanStalePluginConfig).toHaveBeenCalledWith(STALE_SOURCE_CONFIG, process.env);
+    expect(maybeRepairStalePluginConfig).toHaveBeenCalledWith(
+      STALE_SOURCE_CONFIG,
+      process.env,
+    );
+    expect(replaceConfigFile).toHaveBeenCalledWith({
+      nextConfig: CLEAN_CONFIG,
+      baseHash: "abc123",
+    });
+    expect(
+      runtimeLogs.some((line) => line.includes("Found 2 stale plugin references:")),
+    ).toBe(true);
+    expect(runtimeLogs.some((line) => line.includes("Removed:"))).toBe(true);
+  });
+
+  it("shows stale references without writing in --dry-run mode", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/openclaw-config.json5",
+      config: RUNTIME_SHAPED_CONFIG,
+      sourceConfig: STALE_SOURCE_CONFIG,
+      hash: "abc123",
+    });
+    scanStalePluginConfig.mockReturnValue(STALE_HITS);
+
+    await runPluginsCommand(["plugins", "clean", "--dry-run"]);
+
+    expect(replaceConfigFile).not.toHaveBeenCalled();
+    expect(writeConfigFile).not.toHaveBeenCalled();
+    expect(runtimeLogs.some((line) => line.includes("dry run"))).toBe(true);
+  });
+
+  it("blocks removal when plugin discovery has errors", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/openclaw-config.json5",
+      config: RUNTIME_SHAPED_CONFIG,
+      sourceConfig: STALE_SOURCE_CONFIG,
+      hash: "abc123",
+    });
+    scanStalePluginConfig.mockReturnValue(STALE_HITS);
+    isStalePluginAutoRepairBlocked.mockReturnValue(true);
+
+    await runPluginsCommand(["plugins", "clean"]);
+
+    expect(replaceConfigFile).not.toHaveBeenCalled();
+    expect(
+      runtimeLogs.some((line) => line.includes("plugin discovery currently has errors")),
+    ).toBe(true);
+  });
+
+  it("does not write when the repair helper reports no changes", async () => {
+    readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/openclaw-config.json5",
+      config: RUNTIME_SHAPED_CONFIG,
+      sourceConfig: STALE_SOURCE_CONFIG,
+      hash: "abc123",
+    });
+    scanStalePluginConfig.mockReturnValue(STALE_HITS);
+    maybeRepairStalePluginConfig.mockReturnValue({
+      config: STALE_SOURCE_CONFIG,
+      changes: [],
+    });
+
+    await runPluginsCommand(["plugins", "clean"]);
+
+    expect(replaceConfigFile).not.toHaveBeenCalled();
+    expect(runtimeLogs.some((line) => line.includes("No stale plugin references were removed.")))
+      .toBe(true);
+    expect(runtimeLogs.some((line) => line.includes("Removed:"))).toBe(false);
+  });
+});

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -755,6 +755,73 @@ export function registerPluginsCli(program: Command) {
       defaultRuntime.log(lines.join("\n"));
     });
 
+  plugins
+    .command("clean")
+    .description("Remove stale plugin references from config (plugins.allow and plugins.entries)")
+    .option("--dry-run", "Show what would be removed without writing changes", false)
+    .action(async (opts: { dryRun: boolean }) => {
+      const {
+        scanStalePluginConfig,
+        maybeRepairStalePluginConfig,
+        isStalePluginAutoRepairBlocked,
+      } = await import("../commands/doctor/shared/stale-plugin-config.js");
+
+      const snapshot = await readConfigFileSnapshot();
+      const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
+      const hits = scanStalePluginConfig(cfg, process.env);
+
+      if (hits.length === 0) {
+        defaultRuntime.log("No stale plugin references found.");
+        return;
+      }
+
+      const lines: string[] = [];
+      lines.push(
+        theme.warn(
+          `Found ${hits.length} stale plugin reference${hits.length === 1 ? "" : "s"}:`,
+        ),
+      );
+      for (const hit of hits) {
+        lines.push(`  - ${hit.pathLabel}: ${theme.muted(`"${hit.pluginId}"`)}`);
+      }
+
+      if (opts.dryRun) {
+        lines.push("");
+        lines.push(
+          theme.muted("(dry run - no changes written; rerun without --dry-run to apply)"),
+        );
+        defaultRuntime.log(lines.join("\n"));
+        return;
+      }
+
+      if (isStalePluginAutoRepairBlocked(cfg, process.env)) {
+        lines.push("");
+        lines.push(
+          theme.error(
+            "Cannot remove stale references: plugin discovery currently has errors. Fix plugin discovery first, then rerun.",
+          ),
+        );
+        defaultRuntime.log(lines.join("\n"));
+        return;
+      }
+
+      const { config: nextConfig, changes } = maybeRepairStalePluginConfig(cfg, process.env);
+
+      if (changes.length === 0) {
+        defaultRuntime.log("No stale plugin references were removed.");
+        return;
+      }
+
+      await replaceConfigFile({ nextConfig, baseHash: snapshot.hash ?? undefined });
+
+      lines.push("");
+      lines.push(theme.success("Removed:"));
+      for (const change of changes) {
+        lines.push(`  ${change}`);
+      }
+      defaultRuntime.log(lines.join("\n"));
+    });
+
   const marketplace = plugins
     .command("marketplace")
     .description("Inspect Claude-compatible plugin marketplaces");


### PR DESCRIPTION
## Summary  - Problem: Removing stale or orphaned plugin entries required manual config edits; there was no dedicated user-facing command. - Why it matters: Stale plugin entries can cause confusion and unexpected behaviour; a clean command gives users a safe, discoverable way to remove them without touching config files directly. - What changed: Added `openclaw plugins clean` command that identifies stale/orphaned plugin entries, shows a before/after diff, guards against empty change sets, and applies changes using `sourceConfig` as the base (not the potentially-mutated in-memory config). - What did NOT change (scope boundary): Existing `plugins list`, `plugins add`, `plugins remove` commands are unaffected. No changes to plugin loading logic.  ## Change Type (select all) - [ ] Bug fix - [x] Feature - [ ] Refactor required for the fix - [ ] Docs - [ ] Security hardening - [ ] Chore/infra  ## Scope (select all touched areas) - [ ] Gateway / orchestration - [x] Skills / tool execution - [ ] Auth / tokens - [ ] Memory / storage - [ ] Integrations - [ ] API / contracts - [x] UI / DX - [ ] CI/CD / infra  ## Linked Issue/PR - Closes #59448 - Closes #59455 - [ ] This PR fixes a bug or regression  ## Root Cause / Regression History (if applicable) - Root cause: N/A ?C new feature, not a regression. - Missing detection / guardrail: - Prior context: - Why this regressed now: - If unknown, what was ruled out:  ## Regression Test Plan (if applicable) - Coverage level:   - [x] Unit test   - [ ] Seam / integration test   - [ ] End-to-end test   - [ ] Existing coverage already sufficient - Target test or file: `src/cli/plugins-cli/` - Scenario the test should lock in: Clean command with stale entries produces correct diff; empty-changes guard prevents no-op write. - Why this is the smallest reliable guardrail: Unit tests on the clean command logic with mock config; no filesystem side effects. - Existing test that already covers this: N/A - If no new test is added, why not: N/A ?? unit tests cover the new command.  ## User-visible / Behavior Changes New `openclaw plugins clean` command available. Removes stale plugin entries with a confirmation diff.  ## Security Impact (required) - New permissions/capabilities? No - Secrets/tokens handling changed? No - New/changed network calls? No - Command/tool execution surface changed? No - Data access scope changed? No  ## Human Verification (required) - Verified scenarios: `openclaw plugins clean` with stale entries shows diff and removes them. Running with no stale entries exits cleanly with no config write. - Edge cases checked: Empty `changes` array is guarded; no spurious config write occurs. - What you did not verify: Behavior with a very large number of plugin entries; concurrent access to the config file.  ## Review Conversations - [x] I replied to or resolved every bot review conversation I addressed in this PR. - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.  ## Compatibility / Migration - Backward compatible? Yes - Config/env changes? No - Migration needed? No  ---  ## Summary  Adds `openclaw plugins clean` as a focused, discoverable alternative to `openclaw doctor --fix` for clearing leftover plugin entries after uninstalling a plugin.  ## Problem  When users uninstall a plugin, stale references can remain in `plugins.allow` and `plugins.entries`. The fix existed (`openclaw doctor --fix`) but was buried ?? users had to know to run doctor just for this cleanup.  ## Solution  ``` $ openclaw plugins clean Found 2 stale plugin references:   - plugins.allow: "weixin"   - plugins.entries.weixin: "weixin"  Removed:   - plugins.allow: removed 1 stale plugin id (weixin)   - plugins.entries: removed 1 stale plugin entry (weixin) ```  Supports `--dry-run` to preview without writing:  ``` $ openclaw plugins clean --dry-run Found 2 stale plugin references:   - plugins.allow: "weixin"   - plugins.entries.weixin: "weixin"  (dry run ?? no changes written; rerun without --dry-run to apply) ```   ## Design Decision: Option A (explicit command) vs Option C (auto-clean on startup)  Two approaches were considered for fixing stale plugin references:  **Option A (this PR): explicit `plugins clean` command** - User explicitly runs the command ?? full control and visibility - Supports `--dry-run` to preview before committing - `plugins clean` is discoverable via `openclaw plugins --help` - No surprises: config is never modified without the user's knowledge  **Option C: auto-fix on startup** - Would silently modify `openclaw.json` at boot time without user awareness - Violates the principle of least surprise ?? config changes should be intentional - `openclaw doctor --fix` already provides an auto-fix path for those who want it, but as a deliberate opt-in, not a side effect of startup  **Why Option A was chosen:** Config files are the user's source of truth. Auto-mutating them on startup (Option C) can mask bugs, cause confusion during debugging, and erode user trust. An explicit command preserves auditability and control. The `--dry-run` flag further lowers the barrier to adoption by letting users preview changes safely.  ## Implementation Notes  - Reuses existing `maybeRepairStalePluginConfig()` from `doctor/shared/stale-plugin-config.ts` ?? no new logic - Blocks removal if plugin discovery has errors (same guard as doctor --fix) - This is entirely a CLI-side change ?? no Gateway/server API changes needed  ## Testing  - Added unit tests in `plugins-cli.clean.test.ts` covering: no stale entries (noop), stale entries found + removed, `--dry-run` mode (no write), and blocked removal on discovery error - Tests use the existing `plugins-cli-test-helpers.ts` mock infrastructure - Ran `pnpm test src/cli/plugins-cli` locally ?? all tests pass  ## Related  Closes #59448

