### PR TITLE
fix(tui): keep active run alive across fallback error events

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1145,7 +1145,7 @@ describe("createFollowupRunner messaging tool dedupe", () => {
                   },
                 },
               },
-            } as OpenClawConfig,
+            } as unknown as OpenClawConfig,
           },
         }),
       ),

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -650,4 +650,62 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     expect(loadHistory).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps the active run alive when an error event arrives before fallback final output", () => {
+    const { state, chatLog, loadHistory, setActivityStatus, handleChatEvent } =
+      createConcurrentRunHarness("partial");
+
+    loadHistory.mockClear();
+    setActivityStatus.mockClear();
+    chatLog.addSystem.mockClear();
+    chatLog.finalizeAssistant.mockClear();
+
+    handleChatEvent({
+      runId: "run-active",
+      sessionKey: state.currentSessionKey,
+      state: "error",
+      errorMessage: "API rate limit reached",
+    });
+
+    expect(state.activeChatRunId).toBe("run-active");
+    expect(loadHistory).not.toHaveBeenCalled();
+    expect(setActivityStatus).not.toHaveBeenCalledWith("error");
+    expect(chatLog.addSystem).toHaveBeenCalledWith(
+      "run error: API rate limit reached (waiting for fallback if configured)",
+    );
+
+    handleChatEvent({
+      runId: "run-active",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "fallback ok" }] },
+    });
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("fallback ok", "run-active");
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+    expect(state.activeChatRunId).toBeNull();
+  });
+
+  it("does not let a fallback-pending run block a newer active run", () => {
+    const { state, chatLog, handleChatEvent } = createConcurrentRunHarness("partial");
+
+    handleChatEvent({
+      runId: "run-active",
+      sessionKey: state.currentSessionKey,
+      state: "error",
+      errorMessage: "API rate limit reached",
+    });
+
+    expect(state.activeChatRunId).toBe("run-active");
+
+    handleChatEvent({
+      runId: "run-next",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: [{ type: "text", text: "new run output" }] },
+    });
+
+    expect(state.activeChatRunId).toBe("run-next");
+    expect(chatLog.updateAssistant).toHaveBeenCalledWith("new run output", "run-next");
+  });
 });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -62,6 +62,7 @@ export function createEventHandlers(context: EventHandlerContext) {
   } = context;
   const finalizedRuns = new Map<string, number>();
   const sessionRuns = new Map<string, number>();
+  const fallbackPendingRuns = new Set<string>();
   let streamAssembler = new TuiStreamAssembler();
   let lastSessionKey = state.currentSessionKey;
   let pendingHistoryRefresh = false;
@@ -96,6 +97,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     lastSessionKey = state.currentSessionKey;
     finalizedRuns.clear();
     sessionRuns.clear();
+    fallbackPendingRuns.clear();
     streamAssembler = new TuiStreamAssembler();
     pendingHistoryRefresh = false;
     state.pendingOptimisticUserMessage = false;
@@ -120,6 +122,7 @@ export function createEventHandlers(context: EventHandlerContext) {
   const noteFinalizedRun = (runId: string) => {
     finalizedRuns.set(runId, Date.now());
     sessionRuns.delete(runId);
+    fallbackPendingRuns.delete(runId);
     streamAssembler.drop(runId);
     pruneRunMap(finalizedRuns);
   };
@@ -151,6 +154,7 @@ export function createEventHandlers(context: EventHandlerContext) {
   }) => {
     streamAssembler.drop(params.runId);
     sessionRuns.delete(params.runId);
+    fallbackPendingRuns.delete(params.runId);
     clearActiveRunIfMatch(params.runId);
     flushPendingHistoryRefreshIfIdle();
     if (params.wasActiveRun) {
@@ -233,8 +237,12 @@ export function createEventHandlers(context: EventHandlerContext) {
       }
     }
     noteSessionRun(evt.runId);
-    if (!state.activeChatRunId && !isLocalBtwRunId?.(evt.runId)) {
+    if (
+      (!state.activeChatRunId || fallbackPendingRuns.has(state.activeChatRunId)) &&
+      !isLocalBtwRunId?.(evt.runId)
+    ) {
       state.activeChatRunId = evt.runId;
+      fallbackPendingRuns.delete(evt.runId);
       if (state.pendingOptimisticUserMessage) {
         noteLocalRunId?.(evt.runId);
         state.pendingOptimisticUserMessage = false;
@@ -305,6 +313,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     if (evt.state === "aborted") {
       forgetLocalBtwRunId?.(evt.runId);
+      fallbackPendingRuns.delete(evt.runId);
       const wasActiveRun = state.activeChatRunId === evt.runId;
       chatLog.addSystem("run aborted");
       terminateRun({ runId: evt.runId, wasActiveRun, status: "aborted" });
@@ -313,9 +322,17 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.state === "error") {
       forgetLocalBtwRunId?.(evt.runId);
       const wasActiveRun = state.activeChatRunId === evt.runId;
-      chatLog.addSystem(`run error: ${evt.errorMessage ?? "unknown"}`);
-      terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
-      maybeRefreshHistoryForRun(evt.runId);
+      if (wasActiveRun) {
+        fallbackPendingRuns.add(evt.runId);
+        chatLog.addSystem(
+          `run error: ${evt.errorMessage ?? "unknown"} (waiting for fallback if configured)`,
+        );
+      } else {
+        fallbackPendingRuns.delete(evt.runId);
+        chatLog.addSystem(`run error: ${evt.errorMessage ?? "unknown"}`);
+        terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
+        maybeRefreshHistoryForRun(evt.runId);
+      }
     }
     tui.requestRender();
   };


### PR DESCRIPTION
## Summary
- keep the active TUI run open when a chat error event arrives mid-run
- continue rendering the eventual final output when fallback succeeds
- add a regression test covering error-then-final fallback behavior

## Problem
TUI currently terminates the active run on , which drops stream state before model fallback finishes. When fallback succeeds later, the final output is no longer displayed.

## Fix
- only terminate non-active errored runs
- keep the active run state intact and show a waiting-for-fallback system note
- preserve the later  event so the fallback result can render normally

## Testing
- 
> openclaw@2026.3.24 test /Users/plaud/workspace/openclaw-59570
> node scripts/test-parallel.mjs -- src/tui/tui-event-handlers.test.ts

[test-parallel] start unit workers=2 filters=1

 RUN  v4.1.0 /Users/plaud/workspace/openclaw-59570


 Test Files  1 passed (1)
      Tests  22 passed (22)
   Start at  17:25:40
   Duration  2.29s (transform 786ms, setup 2.22s, import 5ms, tests 8ms, environment 0ms)

[test-parallel] done unit code=0 elapsed=2.8s

Closes #59570