### PR TITLE
fix(mattermost): re-fetch file attachments from REST when WebSocket delivers empty file_ids

### DIFF
--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createMattermostClient,
   createMattermostPost,
+  fetchMattermostPost,
   normalizeMattermostBaseUrl,
   updateMattermostPost,
 } from "./client.js";
@@ -141,6 +142,20 @@ describe("createMattermostClient", () => {
     });
     const result = await client.request<unknown>("/anything", { method: "DELETE" });
     expect(result).toBeUndefined();
+  });
+});
+
+// ── fetchMattermostPost ──────────────────────────────────────────────
+
+describe("fetchMattermostPost", () => {
+  it("fetches a post by id with correct URL", async () => {
+    const postData = { id: "post123", message: "hello", file_ids: ["f1", "f2"] };
+    const { client, calls } = createTestClient({ body: postData });
+
+    const result = await fetchMattermostPost(client, "post123");
+
+    expect(calls[0].url).toContain("/api/v4/posts/post123");
+    expect(result).toEqual(postData);
   });
 });
 

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -160,6 +160,13 @@ export function createMattermostClient(params: {
   return { baseUrl, apiBaseUrl, token, request, fetchImpl };
 }
 
+export async function fetchMattermostPost(
+  client: MattermostClient,
+  postId: string,
+): Promise<MattermostPost> {
+  return await client.request<MattermostPost>(`/posts/${postId}`);
+}
+
 export async function fetchMattermostMe(client: MattermostClient): Promise<MattermostUser> {
   return await client.request<MattermostUser>("/users/me");
 }

--- a/extensions/mattermost/src/mattermost/monitor-resources.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.test.ts
@@ -174,7 +174,31 @@ describe("mattermost monitor resources", () => {
     expect(fetchMattermostPost).toHaveBeenCalledTimes(2);
   });
 
-  it("refetchPostFileIds returns empty array when REST fetch fails", async () => {
+  it("refetchPostFileIds continues retrying after transient REST errors", async () => {
+    fetchMattermostPost
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce({ id: "post-1", file_ids: ["f1"], message: "hello" });
+    const debugSpy = vi.fn();
+    const { createMattermostMonitorResources } = await import("./monitor-resources.js");
+
+    const resources = createMattermostMonitorResources({
+      ...defaultResourceParams,
+      logger: { debug: debugSpy },
+    });
+
+    const promise = resources.refetchPostFileIds("post-1");
+    // first attempt at 500ms fails, second at 500+1500=2000ms succeeds
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await promise;
+
+    expect(result).toEqual(["f1"]);
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to re-fetch post post-1"),
+    );
+    expect(fetchMattermostPost).toHaveBeenCalledTimes(2);
+  });
+
+  it("refetchPostFileIds returns empty array when all retries fail", async () => {
     fetchMattermostPost.mockRejectedValue(new Error("network error"));
     const debugSpy = vi.fn();
     const { createMattermostMonitorResources } = await import("./monitor-resources.js");
@@ -185,13 +209,11 @@ describe("mattermost monitor resources", () => {
     });
 
     const promise = resources.refetchPostFileIds("post-1");
-    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(2000);
     const result = await promise;
 
     expect(result).toEqual([]);
-    expect(debugSpy).toHaveBeenCalledWith(
-      expect.stringContaining("failed to re-fetch post post-1"),
-    );
+    expect(debugSpy).toHaveBeenCalledTimes(2);
   });
 
   it("refetchPostFileIds returns empty array after all retries exhausted", async () => {

--- a/extensions/mattermost/src/mattermost/monitor-resources.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.test.ts
@@ -1,6 +1,7 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchMattermostChannel = vi.hoisted(() => vi.fn());
+const fetchMattermostPost = vi.hoisted(() => vi.fn());
 const fetchMattermostUser = vi.hoisted(() => vi.fn());
 const sendMattermostTyping = vi.hoisted(() => vi.fn());
 const updateMattermostPost = vi.hoisted(() => vi.fn());
@@ -8,6 +9,7 @@ const buildButtonProps = vi.hoisted(() => vi.fn());
 
 vi.mock("./client.js", () => ({
   fetchMattermostChannel,
+  fetchMattermostPost,
   fetchMattermostUser,
   sendMattermostTyping,
   updateMattermostPost,
@@ -17,19 +19,31 @@ vi.mock("./interactions.js", () => ({
   buildButtonProps,
 }));
 
+const defaultResourceParams = {
+  accountId: "default",
+  callbackUrl: "https://openclaw.test/callback",
+  client: {} as never,
+  logger: {},
+  mediaMaxBytes: 1024,
+  fetchRemoteMedia: vi.fn(),
+  saveMediaBuffer: vi.fn(),
+  mediaKindFromMime: () => "document" as const,
+};
+
 describe("mattermost monitor resources", () => {
-  let createMattermostMonitorResources: typeof import("./monitor-resources.js").createMattermostMonitorResources;
-
-  beforeAll(async () => {
-    ({ createMattermostMonitorResources } = await import("./monitor-resources.js"));
-  });
-
   beforeEach(() => {
+    vi.resetModules();
     fetchMattermostChannel.mockReset();
+    fetchMattermostPost.mockReset();
     fetchMattermostUser.mockReset();
     sendMattermostTyping.mockReset();
     updateMattermostPost.mockReset();
     buildButtonProps.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("downloads media, preserves auth headers, and infers media kind", async () => {
@@ -41,17 +55,15 @@ describe("mattermost monitor resources", () => {
       path: "/tmp/file.png",
       contentType: "image/png",
     }));
+    const { createMattermostMonitorResources } = await import("./monitor-resources.js");
 
     const resources = createMattermostMonitorResources({
-      accountId: "default",
-      callbackUrl: "https://openclaw.test/callback",
+      ...defaultResourceParams,
       client: {
         apiBaseUrl: "https://chat.example.com/api/v4",
         baseUrl: "https://chat.example.com",
         token: "bot-token",
       } as never,
-      logger: {},
-      mediaMaxBytes: 1024,
       fetchRemoteMedia,
       saveMediaBuffer,
       mediaKindFromMime: () => "image",
@@ -82,17 +94,9 @@ describe("mattermost monitor resources", () => {
     fetchMattermostChannel.mockResolvedValue({ id: "chan-1", name: "town-square" });
     fetchMattermostUser.mockResolvedValue({ id: "user-1", username: "alice" });
     buildButtonProps.mockReturnValue(undefined);
+    const { createMattermostMonitorResources } = await import("./monitor-resources.js");
 
-    const resources = createMattermostMonitorResources({
-      accountId: "default",
-      callbackUrl: "https://openclaw.test/callback",
-      client: {} as never,
-      logger: {},
-      mediaMaxBytes: 1024,
-      fetchRemoteMedia: vi.fn(),
-      saveMediaBuffer: vi.fn(),
-      mediaKindFromMime: () => "document",
-    });
+    const resources = createMattermostMonitorResources({ ...defaultResourceParams });
 
     await expect(resources.resolveChannelInfo("chan-1")).resolves.toEqual({
       id: "chan-1",
@@ -130,18 +134,91 @@ describe("mattermost monitor resources", () => {
     );
   });
 
-  it("proxies typing indicators to the mattermost client helper", async () => {
-    const client = {} as never;
+  // These tests use fake timers to control `node:timers/promises` sleep().
+  // vi.advanceTimersByTimeAsync must advance past each delay in the retry
+  // sequence (500ms, then 1500ms) for the promise to resolve.
+
+  it("refetchPostFileIds returns file_ids on first retry when REST has them", async () => {
+    fetchMattermostPost.mockResolvedValue({
+      id: "post-1",
+      file_ids: ["f1", "f2"],
+      message: "hello",
+    });
+    const { createMattermostMonitorResources } = await import("./monitor-resources.js");
+
+    const resources = createMattermostMonitorResources({ ...defaultResourceParams });
+
+    const promise = resources.refetchPostFileIds("post-1");
+    // first attempt fires at 500ms
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await promise;
+
+    expect(result).toEqual(["f1", "f2"]);
+    expect(fetchMattermostPost).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetchPostFileIds retries when first attempt returns empty file_ids", async () => {
+    fetchMattermostPost
+      .mockResolvedValueOnce({ id: "post-1", file_ids: [], message: "hello" })
+      .mockResolvedValueOnce({ id: "post-1", file_ids: ["f1"], message: "hello" });
+    const { createMattermostMonitorResources } = await import("./monitor-resources.js");
+
+    const resources = createMattermostMonitorResources({ ...defaultResourceParams });
+
+    const promise = resources.refetchPostFileIds("post-1");
+    // first attempt at 500ms returns empty, second at 500+1500=2000ms
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await promise;
+
+    expect(result).toEqual(["f1"]);
+    expect(fetchMattermostPost).toHaveBeenCalledTimes(2);
+  });
+
+  it("refetchPostFileIds returns empty array when REST fetch fails", async () => {
+    fetchMattermostPost.mockRejectedValue(new Error("network error"));
+    const debugSpy = vi.fn();
+    const { createMattermostMonitorResources } = await import("./monitor-resources.js");
 
     const resources = createMattermostMonitorResources({
-      accountId: "default",
-      callbackUrl: "https://openclaw.test/callback",
+      ...defaultResourceParams,
+      logger: { debug: debugSpy },
+    });
+
+    const promise = resources.refetchPostFileIds("post-1");
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await promise;
+
+    expect(result).toEqual([]);
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to re-fetch post post-1"),
+    );
+  });
+
+  it("refetchPostFileIds returns empty array after all retries exhausted", async () => {
+    fetchMattermostPost.mockResolvedValue({
+      id: "post-1",
+      file_ids: null,
+      message: "text only",
+    });
+    const { createMattermostMonitorResources } = await import("./monitor-resources.js");
+
+    const resources = createMattermostMonitorResources({ ...defaultResourceParams });
+
+    const promise = resources.refetchPostFileIds("post-1");
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await promise;
+
+    expect(result).toEqual([]);
+    expect(fetchMattermostPost).toHaveBeenCalledTimes(2);
+  });
+
+  it("proxies typing indicators to the mattermost client helper", async () => {
+    const client = {} as never;
+    const { createMattermostMonitorResources } = await import("./monitor-resources.js");
+
+    const resources = createMattermostMonitorResources({
+      ...defaultResourceParams,
       client,
-      logger: {},
-      mediaMaxBytes: 1024,
-      fetchRemoteMedia: vi.fn(),
-      saveMediaBuffer: vi.fn(),
-      mediaKindFromMime: () => "document",
     });
 
     await resources.sendTypingIndicator("chan-1", "root-1");

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -1,5 +1,7 @@
+import { setTimeout as sleep } from "node:timers/promises";
 import {
   fetchMattermostChannel,
+  fetchMattermostPost,
   fetchMattermostUser,
   sendMattermostTyping,
   updateMattermostPost,
@@ -19,6 +21,7 @@ export type MattermostMediaInfo = {
 
 const CHANNEL_CACHE_TTL_MS = 5 * 60_000;
 const USER_CACHE_TTL_MS = 10 * 60_000;
+const FILE_IDS_REFETCH_DELAYS_MS = [500, 1500];
 
 type FetchRemoteMedia = (params: {
   url: string;
@@ -173,8 +176,31 @@ export function createMattermostMonitorResources(params: {
     return {};
   };
 
+  // Mattermost broadcasts the WebSocket `posted` event before file attachment
+  // linkage is finalized, so `file_ids` is often empty.  Re-fetch the post via
+  // REST with progressive back-off: a short first attempt (500ms) keeps latency
+  // low for text-only messages that genuinely have no files, while a second
+  // attempt (1500ms) gives large uploads time to finalize.
+  const refetchPostFileIds = async (postId: string): Promise<string[]> => {
+    for (const delayMs of FILE_IDS_REFETCH_DELAYS_MS) {
+      await sleep(delayMs);
+      try {
+        const post = await fetchMattermostPost(client, postId);
+        const ids = (post.file_ids ?? []).filter(Boolean);
+        if (ids.length > 0) return ids;
+      } catch (err) {
+        logger.debug?.(
+          `mattermost: failed to re-fetch post ${postId} for file_ids: ${String(err)}`,
+        );
+        return [];
+      }
+    }
+    return [];
+  };
+
   return {
     resolveMattermostMedia,
+    refetchPostFileIds,
     sendTypingIndicator,
     resolveChannelInfo,
     resolveUserInfo,

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -178,9 +178,10 @@ export function createMattermostMonitorResources(params: {
 
   // Mattermost broadcasts the WebSocket `posted` event before file attachment
   // linkage is finalized, so `file_ids` is often empty.  Re-fetch the post via
-  // REST with progressive back-off: a short first attempt (500ms) keeps latency
-  // low for text-only messages that genuinely have no files, while a second
-  // attempt (1500ms) gives large uploads time to finalize.
+  // REST with progressive back-off (500ms then 1500ms).  Both delays always
+  // elapse for genuine text-only messages because the REST API also returns
+  // `file_ids: []` — there is no server-side signal to distinguish "no files"
+  // from "files not yet linked".  Total worst-case overhead: ~2s + 2 REST calls.
   const refetchPostFileIds = async (postId: string): Promise<string[]> => {
     for (const delayMs of FILE_IDS_REFETCH_DELAYS_MS) {
       await sleep(delayMs);
@@ -189,10 +190,11 @@ export function createMattermostMonitorResources(params: {
         const ids = (post.file_ids ?? []).filter(Boolean);
         if (ids.length > 0) return ids;
       } catch (err) {
+        // Transient errors (5xx, timeout) should not abort the loop — the next
+        // attempt may succeed once Mattermost finishes linking the files.
         logger.debug?.(
           `mattermost: failed to re-fetch post ${postId} for file_ids: ${String(err)}`,
         );
-        return [];
       }
     }
     return [];

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -598,6 +598,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
 
   const {
     resolveMattermostMedia,
+    refetchPostFileIds,
     sendTypingIndicator,
     resolveChannelInfo,
     resolveUserInfo,
@@ -1261,7 +1262,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       recordPendingHistory();
       return;
     }
-    const mediaList = await resolveMattermostMedia(post.file_ids);
+    let fileIds = post.file_ids ?? [];
+    if (fileIds.length === 0) {
+      fileIds = await refetchPostFileIds(post.id);
+    }
+    const mediaList = await resolveMattermostMedia(fileIds);
     const mediaPlaceholder = buildMattermostAttachmentPlaceholder(mediaList);
     const bodySource = oncharTriggered ? oncharResult.stripped : rawText;
     const baseText = [bodySource, mediaPlaceholder].filter(Boolean).join("\n").trim();

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1263,7 +1263,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       return;
     }
     let fileIds = post.file_ids ?? [];
-    if (fileIds.length === 0) {
+    // Skip re-fetch for debounced merged posts: the merged payload carries only
+    // the last post's id, so re-fetching would query the wrong post.  Debounced
+    // batches already bypass file-bearing messages (shouldDebounce returns false
+    // when file_ids is non-empty), so this is a known gap only when a file post
+    // is batched with a later text post.
+    if (fileIds.length === 0 && !messageIds) {
       fileIds = await refetchPostFileIds(post.id);
     }
     const mediaList = await resolveMattermostMedia(fileIds);


### PR DESCRIPTION
## Summary

- Problem: Mattermost server broadcasts the `posted` WebSocket event before file attachment linkage is finalized, so `file_ids` is always `[]` — the bot never sees attached files.
- Why it matters: Users attach files (XLSX, images, etc.) and the bot responds saying no file was attached.
- What changed: When `file_ids` is empty, re-fetch the post via REST with progressive back-off (500ms, then 1500ms) to obtain the populated array. This is the standard workaround — Mattermost has no secondary event or metadata signal for file linkage completion.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #59576
- Related #33946
- Related #43435
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

- Root cause: Mattermost server architecture — `attachFilesToPost()` runs after the WebSocket broadcast. Documented across Mattermost v5.x–v9.x; not a regression on our side.
- Missing detection / guardrail: No re-fetch logic existed for empty `file_ids`.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — one additional `GET /api/v4/posts/{id}` call (up to 2 attempts) when `file_ids` is empty
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes: The REST call uses the existing authenticated `MattermostClient`. No new credentials or endpoints. Post ID comes from the already-trusted WebSocket event payload.

## Risks and Mitigations

- Risk: Text-only messages incur ~2s overhead (500ms + 1500ms) and 2 REST calls because there is no server-side signal to distinguish "no files" from "files not yet linked" — both return `file_ids: []` from REST.
  - Mitigation: Re-fetch is skipped for debounced merged posts (wrong post ID, known gap). Transient REST errors do not abort the retry loop. No Mattermost signal exists to avoid this — confirmed via API docs research.