### PR TITLE
fix(embedded): suppress aborted assistant partial payload leaks

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -92,6 +92,57 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads.some((payload) => payload.text === errorJsonPretty)).toBe(false);
   });
 
+  it("suppresses aborted assistant partial text and surfaces a clean timeout error", () => {
+    const payloads = buildPayloads({
+      assistantTexts: [
+        "Need answer concise mention not fully E2E tested tomorrow.\n[[reply_to_current]] Final draft",
+      ],
+      lastAssistant: makeAssistant({
+        stopReason: "aborted",
+        errorMessage: "request timed out",
+        content: [
+          {
+            type: "text",
+            text: "Need answer concise mention not fully E2E tested tomorrow.\n[[reply_to_current]] Final draft",
+          },
+        ],
+      }),
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request timed out.",
+      isError: true,
+    });
+    expect(payloads[0]?.text).not.toContain("Need answer concise");
+    expect(payloads[0]?.text).not.toContain("[[reply_to_current]]");
+  });
+
+  it("suppresses aborted assistant reasoning text as well as partial answer text", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["partial answer that should not leak"],
+      lastAssistant: makeAssistant({
+        stopReason: "aborted",
+        errorMessage: "request timed out",
+        content: [
+          { type: "thinking", thinking: "partial hidden reasoning" },
+          { type: "text", text: "partial answer that should not leak" },
+        ],
+      }),
+      reasoningLevel: "on",
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request timed out.",
+      isError: true,
+    });
+    expect(payloads.map((payload) => payload.text).join("\n")).not.toContain(
+      "partial hidden reasoning",
+    );
+    expect(payloads.map((payload) => payload.text).join("\n")).not.toContain(
+      "partial answer that should not leak",
+    );
+  });
+
   it("suppresses raw error JSON from fallback assistant text", () => {
     const payloads = buildPayloads({
       lastAssistant: makeAssistant({ content: [{ type: "text", text: errorJsonPretty }] }),

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -146,9 +146,12 @@ export function buildEmbeddedRunPayloads(params: {
 
   const useMarkdown = params.toolResultFormat === "markdown";
   const suppressAssistantArtifacts = params.didSendDeterministicApprovalPrompt === true;
-  const lastAssistantErrored = params.lastAssistant?.stopReason === "error";
+  const lastAssistantStopReason = params.lastAssistant?.stopReason;
+  const lastAssistantErrored = lastAssistantStopReason === "error";
+  const lastAssistantAborted = lastAssistantStopReason === "aborted";
+  const lastAssistantNeedsErrorSurface = lastAssistantErrored || lastAssistantAborted;
   const errorText =
-    params.lastAssistant && lastAssistantErrored
+    params.lastAssistant && lastAssistantNeedsErrorSurface
       ? suppressAssistantArtifacts
         ? undefined
         : formatAssistantErrorText(params.lastAssistant, {
@@ -158,7 +161,7 @@ export function buildEmbeddedRunPayloads(params: {
             model: params.model,
           })
       : undefined;
-  const rawErrorMessage = lastAssistantErrored
+  const rawErrorMessage = lastAssistantNeedsErrorSurface
     ? normalizeOptionalString(params.lastAssistant?.errorMessage)
     : undefined;
   const rawErrorFingerprint = rawErrorMessage
@@ -208,18 +211,19 @@ export function buildEmbeddedRunPayloads(params: {
     }
   }
 
-  const reasoningText = suppressAssistantArtifacts
-    ? ""
-    : params.lastAssistant && params.reasoningLevel === "on"
-      ? formatReasoningMessage(extractAssistantThinking(params.lastAssistant))
-      : "";
+  const reasoningText =
+    suppressAssistantArtifacts || lastAssistantAborted
+      ? ""
+      : params.lastAssistant && params.reasoningLevel === "on"
+        ? formatReasoningMessage(extractAssistantThinking(params.lastAssistant))
+        : "";
   if (reasoningText) {
     replyItems.push({ text: reasoningText, isReasoning: true });
   }
 
   const fallbackAnswerText = params.lastAssistant ? extractAssistantText(params.lastAssistant) : "";
   const shouldSuppressRawErrorText = (text: string) => {
-    if (!lastAssistantErrored) {
+    if (!lastAssistantNeedsErrorSurface) {
       return false;
     }
     const trimmed = text.trim();
@@ -268,14 +272,15 @@ export function buildEmbeddedRunPayloads(params: {
     }
     return isRawApiErrorPayload(trimmed);
   };
-  const answerTexts = suppressAssistantArtifacts
-    ? []
-    : (params.assistantTexts.length
-        ? params.assistantTexts
-        : fallbackAnswerText
-          ? [fallbackAnswerText]
-          : []
-      ).filter((text) => !shouldSuppressRawErrorText(text));
+  const answerTexts =
+    suppressAssistantArtifacts || lastAssistantAborted
+      ? []
+      : (params.assistantTexts.length
+          ? params.assistantTexts
+          : fallbackAnswerText
+            ? [fallbackAnswerText]
+            : []
+        ).filter((text) => !shouldSuppressRawErrorText(text));
 
   let hasUserFacingAssistantReply = false;
   for (const text of answerTexts) {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1145,7 +1145,7 @@ describe("createFollowupRunner messaging tool dedupe", () => {
                   },
                 },
               },
-            } as OpenClawConfig,
+            } as unknown as OpenClawConfig,
           },
         }),
       ),


### PR DESCRIPTION
## Summary\n- stop treating aborted assistant turns as deliverable final answer text\n- surface a clean formatted error for aborted embedded runs instead\n- add regression coverage for timeout/abort leakage of commentary and reply tags\n\n## Testing\n- pnpm test -- src/agents/pi-embedded-runner/run/payloads.errors.test.ts\n- pnpm test -- src/agents/pi-embedded-runner/run/payloads.test.ts\n\nCloses #59536