### PR TITLE
fix: send TTS audio as voice message in Feishu

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -538,8 +538,10 @@ function resolveFeishuOutboundMediaKind(params: { fileName: string; contentType?
   if (
     ext === ".opus" ||
     ext === ".ogg" ||
+    ext === ".mp3" ||
     contentType === "audio/ogg" ||
-    contentType === "audio/opus"
+    contentType === "audio/opus" ||
+    contentType === "audio/mpeg"
   ) {
     return { fileType: "opus", msgType: "audio" };
   }


### PR DESCRIPTION
## Summary

Add .mp3 and audio/mpeg detection in resolveFeishuOutboundMediaKind() so that TTS-generated audio files (typically .mp3) are sent as voice messages instead of file attachments in Feishu.

## Changes

- extensions/feishu/src/media.ts: Added .mp3 extension and audio/mpeg contentType to audio detection in resolveFeishuOutboundMediaKind()

## Testing

Verified the fix locally by reviewing the updated code - the function now correctly identifies .mp3 and audio/mpeg as audio type.

Fixes openclaw/openclaw#59588