### PR TITLE
fix: prevent isolated heartbeat session key :heartbeat suffix accumulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/tailscale: start Tailscale exposure and the gateway update check before awaiting channel and plugin sidecar startup so remote operators are not locked out when startup sidecars stall.
 - QQBot/streaming: make block streaming configurable per QQ bot account via `streaming.mode` (`"partial"` | `"off"`, default `"partial"`) instead of hardcoding it off, so responses can be delivered incrementally. (#63746)
 - Dreaming/gateway: require `operator.admin` for persistent `/dreaming on|off` changes and treat missing gateway client scopes as unprivileged instead of silently allowing config writes. (#63872) Thanks @mbelinky.
+<<<<<<< HEAD
 - Matrix/multi-account: keep room-level `account` scoping, inherited room overrides, and implicit account selection consistent across top-level default auth, named accounts, and cached-credential env setups. (#58449) thanks @Daanvdplas and @gumadeiras.
 - Gateway/pairing: prefer explicit QR bootstrap auth over earlier Tailscale auth classification so iOS `/pair qr` silent bootstrap pairing does not fall through to `pairing required`. (#59232) Thanks @ngutman.
 - Config/Discord: coerce safe integer numeric Discord IDs to strings during config validation, keep unsafe or precision-losing numeric snowflakes rejected, and align `openclaw doctor` repair guidance with the same fail-closed behavior. (#45125) Thanks @moliendocode.
@@ -50,6 +51,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/streaming: preserve ordered block flushes before tool, message, and agent boundaries, add explicit `channels.matrix.blockStreaming` opt-in so Matrix `streaming: "off"` stays final-only by default, and move MiniMax plain-text final handling into the MiniMax provider runtime instead of the shared core heuristic. (#59266) thanks @gumadeiras
 - Gateway/agents: fix stale run-context TTL cleanup so the new maintenance sweep compiles and resets orphaned run sequence state correctly. (#52731) thanks @artwalker
 - Memory/lancedb: accept `dreaming` config when `memory-lancedb` owns the memory slot so Dreaming surfaces can read slot-owner settings without schema rejection. (#63874) Thanks @mbelinky.
+- Heartbeats/sessions: remove stale accumulated isolated heartbeat session keys when the next tick converges them back to the canonical sibling, so repaired sessions stop showing orphaned `:heartbeat:heartbeat` variants in session listings. (#59606) Thanks @rogerdigital.
 
 ## 2026.4.9
 

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -116,6 +116,12 @@ export type SessionEntry = {
   lastHeartbeatText?: string;
   /** Timestamp (ms) when lastHeartbeatText was delivered. */
   lastHeartbeatSentAt?: number;
+  /**
+   * Base session key for heartbeat-created isolated sessions.
+   * When present, `<base>:heartbeat` is a synthetic isolated session rather than
+   * a real user/session-scoped key that merely happens to end with `:heartbeat`.
+   */
+  heartbeatIsolatedBaseSessionKey?: string;
   /** Heartbeat task state (task name -> last run timestamp ms). */
   heartbeatTaskState?: Record<string, number>;
   sessionId: string;

--- a/src/infra/heartbeat-runner.isolated-key-stability.test.ts
+++ b/src/infra/heartbeat-runner.isolated-key-stability.test.ts
@@ -167,6 +167,15 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
       // (:heartbeat)+$ regex in a single pass, then exactly one is re-appended.
       // A deeply accumulated key converges to "<base>:heartbeat" in one call.
       expect(ctx?.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
+
+      const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+        string,
+        { heartbeatIsolatedBaseSessionKey?: string }
+      >;
+      expect(store[deeplyAccumulatedKey]).toBeUndefined();
+      expect(store[`${baseSessionKey}:heartbeat`]).toMatchObject({
+        heartbeatIsolatedBaseSessionKey: baseSessionKey,
+      });
     });
   });
 

--- a/src/infra/heartbeat-runner.isolated-key-stability.test.ts
+++ b/src/infra/heartbeat-runner.isolated-key-stability.test.ts
@@ -337,4 +337,47 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
       expect(store[isolatedSessionKey]).toBeUndefined();
     });
   });
+
+  it("converges a legacy isolated key that lacks the stored marker (single :heartbeat suffix)", async () => {
+    // Regression for: when an isolated session was created before
+    // heartbeatIsolatedBaseSessionKey was introduced, sessionKey already equals
+    // "<base>:heartbeat" but the stored entry has no marker. The fallback used to
+    // treat "<base>:heartbeat" as the new base and persist it as the marker, so
+    // the next wake re-entry would stabilise at "<base>:heartbeat:heartbeat"
+    // instead of converging back to "<base>:heartbeat".
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const legacyIsolatedKey = `${baseSessionKey}:heartbeat`;
+
+      // Legacy entry: has :heartbeat suffix but no heartbeatIsolatedBaseSessionKey marker.
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [legacyIsolatedKey]: {
+            sessionId: "sid",
+            updatedAt: 1,
+            lastChannel: "whatsapp",
+            lastProvider: "whatsapp",
+            lastTo: "+1555",
+          },
+        }),
+        "utf-8",
+      );
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: legacyIsolatedKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      // Must converge to the same canonical isolated key, not produce :heartbeat:heartbeat.
+      expect(replySpy.mock.calls[0]?.[0]?.SessionKey).toBe(legacyIsolatedKey);
+    });
+  });
 });

--- a/src/infra/heartbeat-runner.isolated-key-stability.test.ts
+++ b/src/infra/heartbeat-runner.isolated-key-stability.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as replyModule from "../auto-reply/reply.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -181,6 +182,69 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
       });
 
       expect(ctx?.SessionKey).toBe(alreadyIsolatedKey);
+    });
+  });
+
+  it("does not create an isolated session when task-based heartbeat skips for no-tasks-due", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              isolatedSession: true,
+              target: "whatsapp",
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const isolatedSessionKey = `${baseSessionKey}:heartbeat`;
+      await fs.writeFile(
+        `${tmpDir}/HEARTBEAT.md`,
+        `tasks:
+  - name: daily-check
+    interval: 1d
+    prompt: "Check status"
+`,
+        "utf-8",
+      );
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [baseSessionKey]: {
+            sessionId: "sid",
+            updatedAt: 1,
+            lastChannel: "whatsapp",
+            lastProvider: "whatsapp",
+            lastTo: "+1555",
+            heartbeatTaskState: {
+              "daily-check": 1,
+            },
+          },
+        }),
+        "utf-8",
+      );
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        sessionKey: baseSessionKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 2,
+        },
+      });
+
+      expect(result).toEqual({ status: "skipped", reason: "no-tasks-due" });
+      expect(replySpy).not.toHaveBeenCalled();
+
+      const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, unknown>;
+      expect(store[isolatedSessionKey]).toBeUndefined();
     });
   });
 });

--- a/src/infra/heartbeat-runner.isolated-key-stability.test.ts
+++ b/src/infra/heartbeat-runner.isolated-key-stability.test.ts
@@ -100,16 +100,34 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
 
       // Simulate wake-request path: key already has :heartbeat from a previous tick.
       const alreadySuffixedKey = `${baseSessionKey}:heartbeat`;
-
-      const ctx = await runIsolatedHeartbeat({
-        tmpDir,
+      await fs.writeFile(
         storePath,
+        JSON.stringify({
+          [alreadySuffixedKey]: {
+            sessionId: "sid",
+            updatedAt: 1,
+            lastChannel: "whatsapp",
+            lastProvider: "whatsapp",
+            lastTo: "+1555",
+            heartbeatIsolatedBaseSessionKey: baseSessionKey,
+          },
+        }),
+        "utf-8",
+      );
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
         cfg,
         sessionKey: alreadySuffixedKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
       });
 
       // Key must remain stable — no double :heartbeat suffix.
-      expect(ctx?.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
+      expect(replySpy.mock.calls[0]?.[0]?.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
     });
   });
 
@@ -173,15 +191,87 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
       const cfg = makeNamedIsolatedHeartbeatConfig(tmpDir, storePath, "alerts:heartbeat");
       const baseSessionKey = "agent:main:alerts:heartbeat";
       const alreadyIsolatedKey = `${baseSessionKey}:heartbeat`;
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [alreadyIsolatedKey]: {
+            sessionId: "sid",
+            updatedAt: 1,
+            lastChannel: "whatsapp",
+            lastProvider: "whatsapp",
+            lastTo: "+1555",
+            heartbeatIsolatedBaseSessionKey: baseSessionKey,
+          },
+        }),
+        "utf-8",
+      );
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: alreadyIsolatedKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(replySpy.mock.calls[0]?.[0]?.SessionKey).toBe(alreadyIsolatedKey);
+    });
+  });
+
+  it("keeps a forced real :heartbeat session distinct from the heartbeat-isolated sibling", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
+      const realSessionKey = "agent:main:alerts:heartbeat";
 
       const ctx = await runIsolatedHeartbeat({
         tmpDir,
         storePath,
         cfg,
-        sessionKey: alreadyIsolatedKey,
+        sessionKey: realSessionKey,
       });
 
-      expect(ctx?.SessionKey).toBe(alreadyIsolatedKey);
+      expect(ctx?.SessionKey).toBe(`${realSessionKey}:heartbeat`);
+    });
+  });
+
+  it("stays stable when a forced real :heartbeat session re-enters through its isolated sibling", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
+      const realSessionKey = "agent:main:alerts:heartbeat";
+      const isolatedSessionKey = `${realSessionKey}:heartbeat`;
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [isolatedSessionKey]: {
+            sessionId: "sid",
+            updatedAt: 1,
+            lastChannel: "whatsapp",
+            lastProvider: "whatsapp",
+            lastTo: "+1555",
+            heartbeatIsolatedBaseSessionKey: realSessionKey,
+          },
+        }),
+        "utf-8",
+      );
+
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: isolatedSessionKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      expect(replySpy.mock.calls[0]?.[0]?.SessionKey).toBe(isolatedSessionKey);
     });
   });
 

--- a/src/infra/heartbeat-runner.isolated-key-stability.test.ts
+++ b/src/infra/heartbeat-runner.isolated-key-stability.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as replyModule from "../auto-reply/reply.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { seedSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+
+vi.mock("./outbound/deliver.js", () => ({
+  deliverOutboundPayloads: vi.fn().mockResolvedValue(undefined),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
+  /**
+   * Simulates the wake-request feedback loop:
+   *   1. Normal heartbeat tick produces sessionKey "agent:main:main:heartbeat"
+   *   2. An exec/subagent event during that tick calls requestHeartbeatNow()
+   *      with the already-suffixed key "agent:main:main:heartbeat"
+   *   3. The wake handler passes that key back into runHeartbeatOnce(sessionKey: ...)
+   *
+   * Before the fix, step 3 would append another ":heartbeat" producing
+   * "agent:main:main:heartbeat:heartbeat". After the fix, the key remains
+   * stable at "agent:main:main:heartbeat".
+   */
+  async function runIsolatedHeartbeat(params: {
+    tmpDir: string;
+    storePath: string;
+    cfg: OpenClawConfig;
+    sessionKey: string;
+  }) {
+    await seedSessionStore(params.storePath, params.sessionKey, {
+      lastChannel: "whatsapp",
+      lastProvider: "whatsapp",
+      lastTo: "+1555",
+    });
+
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+    await runHeartbeatOnce({
+      cfg: params.cfg,
+      sessionKey: params.sessionKey,
+      deps: {
+        getQueueSize: () => 0,
+        nowMs: () => 0,
+      },
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    return replySpy.mock.calls[0]?.[0];
+  }
+
+  function makeIsolatedHeartbeatConfig(tmpDir: string, storePath: string): OpenClawConfig {
+    return {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: {
+            every: "5m",
+            target: "whatsapp",
+            isolatedSession: true,
+          },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+  }
+
+  function makeNamedIsolatedHeartbeatConfig(
+    tmpDir: string,
+    storePath: string,
+    heartbeatSession: string,
+  ): OpenClawConfig {
+    return {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: {
+            every: "5m",
+            target: "whatsapp",
+            isolatedSession: true,
+            session: heartbeatSession,
+          },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+  }
+
+  it("does not accumulate :heartbeat suffix when wake passes an already-suffixed key", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+
+      // Simulate wake-request path: key already has :heartbeat from a previous tick.
+      const alreadySuffixedKey = `${baseSessionKey}:heartbeat`;
+
+      const ctx = await runIsolatedHeartbeat({
+        tmpDir,
+        storePath,
+        cfg,
+        sessionKey: alreadySuffixedKey,
+      });
+
+      // Key must remain stable — no double :heartbeat suffix.
+      expect(ctx?.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
+    });
+  });
+
+  it("appends :heartbeat exactly once from a clean base key", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+
+      const ctx = await runIsolatedHeartbeat({
+        tmpDir,
+        storePath,
+        cfg,
+        sessionKey: baseSessionKey,
+      });
+
+      expect(ctx?.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
+    });
+  });
+
+  it("stays stable even with multiply-accumulated suffixes", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+
+      // Simulate a key that already accumulated several :heartbeat suffixes
+      // (from an unpatched gateway running for many ticks).
+      const deeplyAccumulatedKey = `${baseSessionKey}:heartbeat:heartbeat:heartbeat`;
+
+      const ctx = await runIsolatedHeartbeat({
+        tmpDir,
+        storePath,
+        cfg,
+        sessionKey: deeplyAccumulatedKey,
+      });
+
+      // After the fix, ALL trailing :heartbeat suffixes are stripped by the
+      // (:heartbeat)+$ regex in a single pass, then exactly one is re-appended.
+      // A deeply accumulated key converges to "<base>:heartbeat" in one call.
+      expect(ctx?.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
+    });
+  });
+
+  it("keeps isolated keys distinct when the configured base key already ends with :heartbeat", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeNamedIsolatedHeartbeatConfig(tmpDir, storePath, "alerts:heartbeat");
+      const baseSessionKey = "agent:main:alerts:heartbeat";
+
+      const ctx = await runIsolatedHeartbeat({
+        tmpDir,
+        storePath,
+        cfg,
+        sessionKey: baseSessionKey,
+      });
+
+      expect(ctx?.SessionKey).toBe(`${baseSessionKey}:heartbeat`);
+    });
+  });
+
+  it("stays stable for wake re-entry when the configured base key already ends with :heartbeat", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeNamedIsolatedHeartbeatConfig(tmpDir, storePath, "alerts:heartbeat");
+      const baseSessionKey = "agent:main:alerts:heartbeat";
+      const alreadyIsolatedKey = `${baseSessionKey}:heartbeat`;
+
+      const ctx = await runIsolatedHeartbeat({
+        tmpDir,
+        storePath,
+        cfg,
+        sessionKey: alreadyIsolatedKey,
+      });
+
+      expect(ctx?.SessionKey).toBe(alreadyIsolatedKey);
+    });
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -35,7 +35,11 @@ import {
 } from "../config/sessions/main-session.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
-import { saveSessionStore, updateSessionStore } from "../config/sessions/store.js";
+import {
+  archiveRemovedSessionTranscripts,
+  saveSessionStore,
+  updateSessionStore,
+} from "../config/sessions/store.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import { resolveCronSession } from "../cron/isolated-agent/session.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -353,6 +357,25 @@ function resolveIsolatedHeartbeatSessionKey(params: {
     isolatedSessionKey: `${params.sessionKey}:heartbeat`,
     isolatedBaseSessionKey: params.sessionKey,
   };
+}
+
+function resolveStaleHeartbeatIsolatedSessionKey(params: {
+  sessionKey: string;
+  isolatedSessionKey: string;
+  isolatedBaseSessionKey: string;
+}) {
+  if (params.sessionKey === params.isolatedSessionKey) {
+    return undefined;
+  }
+  const suffix = params.sessionKey.slice(params.isolatedBaseSessionKey.length);
+  if (
+    params.sessionKey.startsWith(params.isolatedBaseSessionKey) &&
+    suffix.length > 0 &&
+    /^(:heartbeat)+$/.test(suffix)
+  ) {
+    return params.sessionKey;
+  }
+  return undefined;
 }
 
 function resolveHeartbeatReasoningPayloads(
@@ -776,9 +799,46 @@ export async function runHeartbeatOnce(opts: {
       nowMs: startedAt,
       forceNew: true,
     });
+    const staleIsolatedSessionKey = resolveStaleHeartbeatIsolatedSessionKey({
+      sessionKey,
+      isolatedSessionKey,
+      isolatedBaseSessionKey,
+    });
+    const removedSessionFiles = new Map<string, string | undefined>();
+    if (staleIsolatedSessionKey) {
+      const staleEntry = cronSession.store[staleIsolatedSessionKey];
+      if (staleEntry?.sessionId) {
+        removedSessionFiles.set(staleEntry.sessionId, staleEntry.sessionFile);
+      }
+      delete cronSession.store[staleIsolatedSessionKey];
+    }
     cronSession.sessionEntry.heartbeatIsolatedBaseSessionKey = isolatedBaseSessionKey;
     cronSession.store[isolatedSessionKey] = cronSession.sessionEntry;
     await saveSessionStore(cronSession.storePath, cronSession.store);
+    if (removedSessionFiles.size > 0) {
+      try {
+        const referencedSessionIds = new Set(
+          Object.values(cronSession.store)
+            .map((sessionEntry) => sessionEntry?.sessionId)
+            .filter((sessionId): sessionId is string => Boolean(sessionId)),
+        );
+        await archiveRemovedSessionTranscripts({
+          removedSessionFiles,
+          referencedSessionIds,
+          storePath: cronSession.storePath,
+          reason: "deleted",
+          restrictToStoreDir: true,
+        });
+      } catch (err) {
+        log.warn(
+          {
+            err: String(err),
+            sessionKey: staleIsolatedSessionKey,
+          },
+          "heartbeat: failed to archive stale isolated session transcript",
+        );
+      }
+    }
     runSessionKey = isolatedSessionKey;
   }
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -332,10 +332,17 @@ function resolveIsolatedHeartbeatSessionKey(params: {
     }
   }
 
+  // Collapse repeated `:heartbeat` suffixes introduced by wake-triggered re-entry.
+  // The guard on configuredSessionKey ensures we do not strip a legitimate single
+  // `:heartbeat` suffix that is part of the user-configured base key itself
+  // (e.g. heartbeat.session: "alerts:heartbeat"). When the configured key already
+  // ends with `:heartbeat`, a forced wake passes `configuredKey:heartbeat` which
+  // must be treated as a new base rather than an existing isolated key.
   const configuredSuffix = params.sessionKey.slice(params.configuredSessionKey.length);
   if (
     params.sessionKey.startsWith(params.configuredSessionKey) &&
-    /^(:heartbeat){2,}$/.test(configuredSuffix)
+    /^(:heartbeat)+$/.test(configuredSuffix) &&
+    !params.configuredSessionKey.endsWith(":heartbeat")
   ) {
     return {
       isolatedSessionKey: `${params.configuredSessionKey}:heartbeat`,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -830,13 +830,10 @@ export async function runHeartbeatOnce(opts: {
           restrictToStoreDir: true,
         });
       } catch (err) {
-        log.warn(
-          {
-            err: String(err),
-            sessionKey: staleIsolatedSessionKey,
-          },
-          "heartbeat: failed to archive stale isolated session transcript",
-        );
+        log.warn("heartbeat: failed to archive stale isolated session transcript", {
+          err: String(err),
+          sessionKey: staleIsolatedSessionKey,
+        });
       }
     }
     runSessionKey = isolatedSessionKey;

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -674,29 +674,6 @@ export async function runHeartbeatOnce(opts: {
   // sending the full conversation history (~100K tokens) to the LLM.
   // Delivery routing still uses the main session entry (lastChannel, lastTo).
   const useIsolatedSession = heartbeat?.isolatedSession === true;
-  let runSessionKey = sessionKey;
-  let runStorePath = storePath;
-  if (useIsolatedSession) {
-    const configuredSession = resolveHeartbeatSession(cfg, agentId, heartbeat);
-    // Collapse only the repeated `:heartbeat` suffixes introduced by wake-triggered
-    // re-entry, while preserving legitimate base session keys that already end with
-    // `:heartbeat` (see https://github.com/openclaw/openclaw/issues/59493).
-    const isolatedKey = resolveIsolatedHeartbeatSessionKey({
-      sessionKey,
-      configuredSessionKey: configuredSession.sessionKey,
-    });
-    const cronSession = resolveCronSession({
-      cfg,
-      sessionKey: isolatedKey,
-      agentId,
-      nowMs: startedAt,
-      forceNew: true,
-    });
-    cronSession.store[isolatedKey] = cronSession.sessionEntry;
-    await saveSessionStore(cronSession.storePath, cronSession.store);
-    runSessionKey = isolatedKey;
-    runStorePath = cronSession.storePath;
-  }
   const delivery = resolveHeartbeatDeliveryTarget({
     cfg,
     entry,
@@ -751,6 +728,30 @@ export async function runHeartbeatOnce(opts: {
   // If no tasks are due, skip heartbeat entirely
   if (prompt === null) {
     return { status: "skipped", reason: "no-tasks-due" };
+  }
+
+  let runSessionKey = sessionKey;
+  let runStorePath = storePath;
+  if (useIsolatedSession) {
+    const configuredSession = resolveHeartbeatSession(cfg, agentId, heartbeat);
+    // Collapse only the repeated `:heartbeat` suffixes introduced by wake-triggered
+    // re-entry, while preserving legitimate base session keys that already end with
+    // `:heartbeat` (see https://github.com/openclaw/openclaw/issues/59493).
+    const isolatedKey = resolveIsolatedHeartbeatSessionKey({
+      sessionKey,
+      configuredSessionKey: configuredSession.sessionKey,
+    });
+    const cronSession = resolveCronSession({
+      cfg,
+      sessionKey: isolatedKey,
+      agentId,
+      nowMs: startedAt,
+      forceNew: true,
+    });
+    cronSession.store[isolatedKey] = cronSession.sessionEntry;
+    await saveSessionStore(cronSession.storePath, cronSession.store);
+    runSessionKey = isolatedKey;
+    runStorePath = cronSession.storePath;
   }
 
   // Update task last run times AFTER successful heartbeat completion

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -315,16 +315,37 @@ function resolveHeartbeatSession(
 function resolveIsolatedHeartbeatSessionKey(params: {
   sessionKey: string;
   configuredSessionKey: string;
+  sessionEntry?: { heartbeatIsolatedBaseSessionKey?: string };
 }) {
-  const suffix = params.sessionKey.slice(params.configuredSessionKey.length);
+  const storedBaseSessionKey = params.sessionEntry?.heartbeatIsolatedBaseSessionKey?.trim();
+  if (storedBaseSessionKey) {
+    const suffix = params.sessionKey.slice(storedBaseSessionKey.length);
+    if (
+      params.sessionKey.startsWith(storedBaseSessionKey) &&
+      suffix.length > 0 &&
+      /^(:heartbeat)+$/.test(suffix)
+    ) {
+      return {
+        isolatedSessionKey: `${storedBaseSessionKey}:heartbeat`,
+        isolatedBaseSessionKey: storedBaseSessionKey,
+      };
+    }
+  }
+
+  const configuredSuffix = params.sessionKey.slice(params.configuredSessionKey.length);
   if (
     params.sessionKey.startsWith(params.configuredSessionKey) &&
-    suffix.length > 0 &&
-    /^(:heartbeat)+$/.test(suffix)
+    /^(:heartbeat){2,}$/.test(configuredSuffix)
   ) {
-    return `${params.configuredSessionKey}:heartbeat`;
+    return {
+      isolatedSessionKey: `${params.configuredSessionKey}:heartbeat`,
+      isolatedBaseSessionKey: params.configuredSessionKey,
+    };
   }
-  return `${params.sessionKey}:heartbeat`;
+  return {
+    isolatedSessionKey: `${params.sessionKey}:heartbeat`,
+    isolatedBaseSessionKey: params.sessionKey,
+  };
 }
 
 function resolveHeartbeatReasoningPayloads(
@@ -731,27 +752,27 @@ export async function runHeartbeatOnce(opts: {
   }
 
   let runSessionKey = sessionKey;
-  let runStorePath = storePath;
   if (useIsolatedSession) {
     const configuredSession = resolveHeartbeatSession(cfg, agentId, heartbeat);
     // Collapse only the repeated `:heartbeat` suffixes introduced by wake-triggered
-    // re-entry, while preserving legitimate base session keys that already end with
-    // `:heartbeat` (see https://github.com/openclaw/openclaw/issues/59493).
-    const isolatedKey = resolveIsolatedHeartbeatSessionKey({
+    // re-entry for heartbeat-created isolated sessions. Real session keys that
+    // happen to end with `:heartbeat` still get a distinct isolated sibling.
+    const { isolatedSessionKey, isolatedBaseSessionKey } = resolveIsolatedHeartbeatSessionKey({
       sessionKey,
       configuredSessionKey: configuredSession.sessionKey,
+      sessionEntry: entry,
     });
     const cronSession = resolveCronSession({
       cfg,
-      sessionKey: isolatedKey,
+      sessionKey: isolatedSessionKey,
       agentId,
       nowMs: startedAt,
       forceNew: true,
     });
-    cronSession.store[isolatedKey] = cronSession.sessionEntry;
+    cronSession.sessionEntry.heartbeatIsolatedBaseSessionKey = isolatedBaseSessionKey;
+    cronSession.store[isolatedSessionKey] = cronSession.sessionEntry;
     await saveSessionStore(cronSession.storePath, cronSession.store);
-    runSessionKey = isolatedKey;
-    runStorePath = cronSession.storePath;
+    runSessionKey = isolatedSessionKey;
   }
 
   // Update task last run times AFTER successful heartbeat completion

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -312,6 +312,21 @@ function resolveHeartbeatSession(
   };
 }
 
+function resolveIsolatedHeartbeatSessionKey(params: {
+  sessionKey: string;
+  configuredSessionKey: string;
+}) {
+  const suffix = params.sessionKey.slice(params.configuredSessionKey.length);
+  if (
+    params.sessionKey.startsWith(params.configuredSessionKey) &&
+    suffix.length > 0 &&
+    /^(:heartbeat)+$/.test(suffix)
+  ) {
+    return `${params.configuredSessionKey}:heartbeat`;
+  }
+  return `${params.sessionKey}:heartbeat`;
+}
+
 function resolveHeartbeatReasoningPayloads(
   replyResult: ReplyPayload | ReplyPayload[] | undefined,
 ): ReplyPayload[] {
@@ -659,6 +674,29 @@ export async function runHeartbeatOnce(opts: {
   // sending the full conversation history (~100K tokens) to the LLM.
   // Delivery routing still uses the main session entry (lastChannel, lastTo).
   const useIsolatedSession = heartbeat?.isolatedSession === true;
+  let runSessionKey = sessionKey;
+  let runStorePath = storePath;
+  if (useIsolatedSession) {
+    const configuredSession = resolveHeartbeatSession(cfg, agentId, heartbeat);
+    // Collapse only the repeated `:heartbeat` suffixes introduced by wake-triggered
+    // re-entry, while preserving legitimate base session keys that already end with
+    // `:heartbeat` (see https://github.com/openclaw/openclaw/issues/59493).
+    const isolatedKey = resolveIsolatedHeartbeatSessionKey({
+      sessionKey,
+      configuredSessionKey: configuredSession.sessionKey,
+    });
+    const cronSession = resolveCronSession({
+      cfg,
+      sessionKey: isolatedKey,
+      agentId,
+      nowMs: startedAt,
+      forceNew: true,
+    });
+    cronSession.store[isolatedKey] = cronSession.sessionEntry;
+    await saveSessionStore(cronSession.storePath, cronSession.store);
+    runSessionKey = isolatedKey;
+    runStorePath = cronSession.storePath;
+  }
   const delivery = resolveHeartbeatDeliveryTarget({
     cfg,
     entry,
@@ -713,21 +751,6 @@ export async function runHeartbeatOnce(opts: {
   // If no tasks are due, skip heartbeat entirely
   if (prompt === null) {
     return { status: "skipped", reason: "no-tasks-due" };
-  }
-
-  let runSessionKey = sessionKey;
-  if (useIsolatedSession) {
-    const isolatedKey = `${sessionKey}:heartbeat`;
-    const cronSession = resolveCronSession({
-      cfg,
-      sessionKey: isolatedKey,
-      agentId,
-      nowMs: startedAt,
-      forceNew: true,
-    });
-    cronSession.store[isolatedKey] = cronSession.sessionEntry;
-    await saveSessionStore(cronSession.storePath, cronSession.store);
-    runSessionKey = isolatedKey;
   }
 
   // Update task last run times AFTER successful heartbeat completion


### PR DESCRIPTION
## Summary

- **Problem:** When `isolatedSession: true` is set in heartbeat config, each wake-triggered heartbeat tick appends another `:heartbeat` suffix to the session key, producing keys like `agent:main:main:heartbeat:heartbeat:heartbeat:...` that grow without bound.
- **Why it matters:** Session keys grow indefinitely, session store accumulates orphaned entries, and debugging/session management becomes difficult. Eventually hits string length limits.
- **What changed:** Strip all trailing `:heartbeat` suffixes before re-appending in `resolveIsolatedHeartbeatSessionKey()` (regex fix + three-branch resolution logic). Added 9 regression tests covering all key-stability scenarios.
- **What did NOT change (scope boundary):** No changes to `resolveHeartbeatSession()`, wake dispatch, or session key parsing. The fix is scoped to the single append site.
- **Note:** 535 additions, of which 383 are regression tests. Production change is ~56 lines in `heartbeat-runner.ts`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59493
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** Feedback loop between heartbeat runner and wake requests. During an isolated heartbeat run, exec/subagent completions call `requestHeartbeatNow()` with the current session key (already suffixed with `:heartbeat`). The wake handler passes this key back into `runHeartbeatOnce()`, which appends `:heartbeat` again at `heartbeat-runner.ts:590` without stripping the existing suffix.
- **Missing detection / guardrail:** No idempotency guard at the `:heartbeat` append site. `resolveHeartbeatSession()` accepts `forcedSessionKey` without normalizing away existing heartbeat suffixes.
- **Prior context:** The isolated session feature was added to reduce token cost by giving each heartbeat tick a fresh transcript. The wake-request path (`requestHeartbeatNow` → `wakeHandler` → `run()` → `runOnce()`) passes `sessionKey` through without sanitization.
- **Why this regressed now:** The interaction between `isolatedSession: true` and wake-triggered re-entry (exec events during heartbeat) was not covered by the original isolated session tests.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/infra/heartbeat-runner.isolated-key-stability.test.ts`
- **Scenarios the tests lock in (9 total):**
  1. Wake path with already-suffixed key → key stays `<base>:heartbeat` (no double suffix)
  2. Clean base key → appends `:heartbeat` exactly once
  3. Deeply accumulated key (e.g. `base:heartbeat:heartbeat:heartbeat`) → converges to `<base>:heartbeat` in one call
  4. Configured base key that legitimately ends with `:heartbeat` (e.g. `alerts:heartbeat`) → gets `alerts:heartbeat:heartbeat`, not stripped
  5. Wake re-entry for case 4 → key stays stable at `alerts:heartbeat:heartbeat`
  6. Forced real `:heartbeat` session (not from isolatedSession config) → gets `:heartbeat` appended
  7. Wake re-entry for case 6 → stable
  8. Task-based heartbeat skip (no tasks due) → no isolated session created
  9. Legacy isolated key without stored marker (created before `heartbeatIsolatedBaseSessionKey` was introduced) → converges to canonical `<base>:heartbeat` without producing `<base>:heartbeat:heartbeat`
- **Why this is the smallest reliable guardrail:** Tests exercise `runHeartbeatOnce()` directly with pre-suffixed session keys, simulating the exact wake-request feedback loop without needing a full gateway or real exec events.

## User-visible / Behavior Changes

- Isolated heartbeat sessions now use a stable key `<base>:heartbeat` across all ticks instead of accumulating suffixes.
- Existing sessions with accumulated suffixes will converge to the stable key on next heartbeat tick.
- Legacy sessions created before the `heartbeatIsolatedBaseSessionKey` marker was introduced also converge correctly.

## Diagram (if applicable)

```text
Before (feedback loop):
  tick 1: base → base:heartbeat (agent runs, exec event fires)
  wake:   requestHeartbeatNow(key="base:heartbeat")
  tick 2: base:heartbeat → base:heartbeat:heartbeat
  wake:   requestHeartbeatNow(key="base:heartbeat:heartbeat")
  tick 3: base:heartbeat:heartbeat → base:heartbeat:heartbeat:heartbeat
  ... (unbounded growth)

After (stable):
  tick 1: base → base:heartbeat (agent runs, exec event fires)
  wake:   requestHeartbeatNow(key="base:heartbeat")
  tick 2: strip trailing :heartbeat(s) → "base", append → base:heartbeat
  wake:   requestHeartbeatNow(key="base:heartbeat")
  tick 3: strip trailing :heartbeat(s) → "base", append → base:heartbeat
  ... (stable)
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux 6.8.0-106-generic (x64), Ubuntu (as reported in issue)
- Runtime/container: Node 22+
- Model/provider: Any (issue is model-agnostic)
- Integration/channel: Any channel with heartbeat
- Relevant config: `agents.defaults.heartbeat.isolatedSession: true`

### Steps

1. Configure agent heartbeat with `isolatedSession: true` and `every: "5m"`
2. Restart gateway
3. Wait for 2+ heartbeat ticks (especially with exec tool activity)
4. Run `sessions_list` and observe session keys

### Expected

- All heartbeat sessions use stable key: `agent:<agentId>:main:heartbeat`

### Actual

- Session keys accumulate `:heartbeat` suffixes on each wake-triggered tick

## Evidence

- [x] Failing test/log before + passing after

Test output (9 tests, all passing):
```
✓ does not accumulate :heartbeat suffix when wake passes an already-suffixed key
✓ appends :heartbeat exactly once from a clean base key
✓ stays stable even with multiply-accumulated suffixes
✓ keeps isolated keys distinct when the configured base key already ends with :heartbeat
✓ stays stable for wake re-entry when the configured base key already ends with :heartbeat
✓ keeps a forced real :heartbeat session distinct from the heartbeat-isolated sibling
✓ stays stable when a forced real :heartbeat session re-enters through its isolated sibling
✓ does not create an isolated session when task-based heartbeat skips for no-tasks-due
✓ converges a legacy isolated key that lacks the stored marker (single :heartbeat suffix)
```

Full heartbeat test suite: all passing.

## Human Verification (required)

- **Verified scenarios:** Ran all 9 new regression tests + full heartbeat suite, `pnpm check` (lint/typecheck/format all green)
- **Edge cases checked:**
  - Deeply accumulated keys (`base:heartbeat:heartbeat:heartbeat`) correctly converge in one call
  - Clean keys still get `:heartbeat` appended exactly once
  - Configured base keys legitimately ending with `:heartbeat` (e.g. `alerts:heartbeat`) are not incorrectly stripped — they get `alerts:heartbeat:heartbeat` as expected and stay stable
  - Legacy isolated sessions lacking the stored `heartbeatIsolatedBaseSessionKey` marker converge correctly without double-suffix regression
  - Task-based skip (no tasks due) leaves no isolated session in the store
  - Non-isolated heartbeats are unaffected
- **What I did not verify:** Live gateway with real exec events triggering wake requests (no access to a running gateway with `isolatedSession: true`)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No` — existing accumulated keys auto-converge on next tick; legacy sessions without stored marker also converge

## Risks and Mitigations

- **Risk:** Regex `(:heartbeat)+$` could theoretically match a user-chosen session key that legitimately ends with `:heartbeat`.
  - **Mitigation:** The strip only runs inside the `useIsolatedSession` branch, which already knows the key will get `:heartbeat` appended. The resolution logic has three branches: (1) stored `heartbeatIsolatedBaseSessionKey` marker takes priority; (2) suffix-strip applies only when the configured base does NOT itself end with `:heartbeat`; (3) fallback passes through. This means `alerts:heartbeat` as a configured session name correctly produces `alerts:heartbeat:heartbeat` (branch 3 fallback) rather than being erroneously stripped — confirmed by tests 4 and 5.