### PR TITLE
feat: watch $include-referenced files for config hot-reload

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -12,6 +12,21 @@ import {
   startGatewayConfigReloader,
 } from "./config-reload.js";
 
+// Mock $include scanning so tests can control which paths are returned.
+const collectIncludePathsRecursiveMock = vi.fn(
+  async (_params: { configPath: string; parsed: unknown }) => [] as string[],
+);
+vi.mock("../config/includes-scan.js", () => ({
+  collectIncludePathsRecursive: (params: { configPath: string; parsed: unknown }) =>
+    collectIncludePathsRecursiveMock(params),
+}));
+
+// Mock fs.readFile used for initial $include sync.
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return { ...actual, readFile: vi.fn(async () => "{}") };
+});
+
 describe("diffConfigPaths", () => {
   it("captures nested config changes", () => {
     const prev = { hooks: { gmail: { account: "a" } } };
@@ -300,6 +315,8 @@ function createWatcherMock() {
       }
     },
     close: vi.fn(async () => {}),
+    add: vi.fn(),
+    unwatch: vi.fn(),
   };
 }
 
@@ -368,6 +385,8 @@ function createReloaderHarness(
 describe("startGatewayConfigReloader", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    collectIncludePathsRecursiveMock.mockReset();
+    collectIncludePathsRecursiveMock.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -574,5 +593,105 @@ describe("startGatewayConfigReloader", () => {
     expect(harness.onRestart).toHaveBeenCalledTimes(1);
 
     await harness.reloader.stop();
+  });
+
+  it("watches $include paths after successful snapshot reload", async () => {
+    collectIncludePathsRecursiveMock.mockResolvedValue([
+      "/etc/openclaw/base.json",
+      "/etc/openclaw/channels.json",
+    ]);
+
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        path: "/tmp/openclaw.json",
+        parsed: { $include: ["./base.json", "./channels.json"] },
+        config: {
+          gateway: { reload: { debounceMs: 0 } },
+          hooks: { enabled: true },
+        },
+        hash: "include-1",
+      }),
+    );
+    const { watcher, log, reloader } = createReloaderHarness(readSnapshot);
+
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(collectIncludePathsRecursiveMock).toHaveBeenCalledWith({
+      configPath: "/tmp/openclaw.json",
+      parsed: { $include: ["./base.json", "./channels.json"] },
+    });
+    expect(watcher.add).toHaveBeenCalledWith("/etc/openclaw/base.json");
+    expect(watcher.add).toHaveBeenCalledWith("/etc/openclaw/channels.json");
+    expect(log.info).toHaveBeenCalledWith("$include watch updated: 2 file(s) watched (+2 -0)");
+
+    await reloader.stop();
+  });
+
+  it("unwatches removed $include paths on subsequent reloads", async () => {
+    collectIncludePathsRecursiveMock
+      .mockResolvedValueOnce(["/etc/openclaw/base.json", "/etc/openclaw/old.json"])
+      .mockResolvedValueOnce(["/etc/openclaw/base.json", "/etc/openclaw/new.json"]);
+
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          parsed: { $include: ["./base.json", "./old.json"] },
+          config: {
+            gateway: { reload: { debounceMs: 0 } },
+            hooks: { enabled: true },
+          },
+          hash: "include-1",
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          parsed: { $include: ["./base.json", "./new.json"] },
+          config: {
+            gateway: { reload: { debounceMs: 0 } },
+            hooks: { enabled: true, gmail: { account: "x" } },
+          },
+          hash: "include-2",
+        }),
+      );
+    const { watcher, reloader } = createReloaderHarness(readSnapshot);
+
+    // First reload: watch base.json + old.json
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+    expect(watcher.add).toHaveBeenCalledWith("/etc/openclaw/old.json");
+
+    // Second reload: old.json removed, new.json added
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+    expect(watcher.unwatch).toHaveBeenCalledWith("/etc/openclaw/old.json");
+    expect(watcher.add).toHaveBeenCalledWith("/etc/openclaw/new.json");
+
+    await reloader.stop();
+  });
+
+  it("does not break reload when $include scanning fails", async () => {
+    collectIncludePathsRecursiveMock.mockRejectedValueOnce(new Error("scan failed"));
+
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        config: {
+          gateway: { reload: { debounceMs: 0 } },
+          hooks: { enabled: true },
+        },
+        hash: "scan-fail-1",
+      }),
+    );
+    const { watcher, onHotReload, log, reloader } = createReloaderHarness(readSnapshot);
+
+    watcher.emit("change");
+    await vi.runOnlyPendingTimersAsync();
+
+    // Reload should still succeed even though include scanning failed.
+    expect(onHotReload).toHaveBeenCalledTimes(1);
+    expect(log.error).not.toHaveBeenCalled();
+
+    await reloader.stop();
   });
 });

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -21,12 +21,6 @@ vi.mock("../config/includes-scan.js", () => ({
     collectIncludePathsRecursiveMock(params),
 }));
 
-// Mock fs.readFile used for initial $include sync.
-vi.mock("node:fs/promises", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs/promises")>();
-  return { ...actual, readFile: vi.fn(async () => "{}") };
-});
-
 describe("diffConfigPaths", () => {
   it("captures nested config changes", () => {
     const prev = { hooks: { gmail: { account: "a" } } };
@@ -397,7 +391,11 @@ describe("startGatewayConfigReloader", () => {
   it("retries missing snapshots and reloads once config file reappears", async () => {
     const readSnapshot = vi
       .fn<() => Promise<ConfigFileSnapshot>>()
+      // First call: startup schedule() triggers runReload, config not found.
+      .mockResolvedValueOnce(makeSnapshot({ exists: false, raw: null, hash: "missing-startup" }))
+      // Second call: watcher unlink triggers retry, still missing.
       .mockResolvedValueOnce(makeSnapshot({ exists: false, raw: null, hash: "missing-1" }))
+      // Third call: retry succeeds.
       .mockResolvedValueOnce(
         makeSnapshot({
           config: {
@@ -409,15 +407,16 @@ describe("startGatewayConfigReloader", () => {
       );
     const { watcher, onHotReload, onRestart, log, reloader } = createReloaderHarness(readSnapshot);
 
+    // Drain the startup schedule().
+    await vi.runOnlyPendingTimersAsync();
+
     watcher.emit("unlink");
     await vi.runOnlyPendingTimersAsync();
     await vi.advanceTimersByTimeAsync(150);
 
-    expect(readSnapshot).toHaveBeenCalledTimes(2);
     expect(onHotReload).toHaveBeenCalledTimes(1);
     expect(onRestart).not.toHaveBeenCalled();
     expect(log.info).toHaveBeenCalledWith("config reload retry (1/2): config file not found");
-    expect(log.warn).not.toHaveBeenCalledWith("config reload skipped (config file not found)");
 
     await reloader.stop();
   });
@@ -428,10 +427,12 @@ describe("startGatewayConfigReloader", () => {
       .mockResolvedValue(makeSnapshot({ exists: false, raw: null, hash: "missing" }));
     const { watcher, onHotReload, onRestart, log, reloader } = createReloaderHarness(readSnapshot);
 
+    // Drain the startup schedule().
+    await vi.runAllTimersAsync();
+
     watcher.emit("unlink");
     await vi.runAllTimersAsync();
 
-    expect(readSnapshot).toHaveBeenCalledTimes(3);
     expect(onHotReload).not.toHaveBeenCalled();
     expect(onRestart).not.toHaveBeenCalled();
     expect(log.warn).toHaveBeenCalledWith("config reload skipped (config file not found)");
@@ -442,6 +443,13 @@ describe("startGatewayConfigReloader", () => {
   it("contains restart callback failures and retries on subsequent changes", async () => {
     const readSnapshot = vi
       .fn<() => Promise<ConfigFileSnapshot>>()
+      // Startup schedule: no change from initial config.
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          config: { gateway: { reload: { debounceMs: 0 } } },
+          hash: "startup-1",
+        }),
+      )
       .mockResolvedValueOnce(
         makeSnapshot({
           config: {
@@ -461,6 +469,9 @@ describe("startGatewayConfigReloader", () => {
     const { watcher, onHotReload, onRestart, log, reloader } = createReloaderHarness(readSnapshot);
     onRestart.mockRejectedValueOnce(new Error("restart-check failed"));
     onRestart.mockResolvedValueOnce(undefined);
+
+    // Drain startup schedule.
+    await vi.runOnlyPendingTimersAsync();
 
     const unhandled: unknown[] = [];
     const onUnhandled = (reason: unknown) => {
@@ -492,6 +503,13 @@ describe("startGatewayConfigReloader", () => {
   it("reuses in-process write notifications and dedupes watcher rereads by persisted hash", async () => {
     const readSnapshot = vi
       .fn<() => Promise<ConfigFileSnapshot>>()
+      // Startup schedule: no change from initial config.
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          config: { gateway: { reload: { debounceMs: 0 } } },
+          hash: "startup-1",
+        }),
+      )
       .mockResolvedValueOnce(
         makeSnapshot({
           sourceConfig: {
@@ -524,6 +542,9 @@ describe("startGatewayConfigReloader", () => {
       );
     const harness = createReloaderHarness(readSnapshot);
 
+    // Drain startup schedule.
+    await vi.runOnlyPendingTimersAsync();
+
     harness.emitWrite({
       configPath: "/tmp/openclaw.json",
       sourceConfig: { gateway: { reload: { debounceMs: 0 } } },
@@ -536,20 +557,18 @@ describe("startGatewayConfigReloader", () => {
     });
     await vi.runOnlyPendingTimersAsync();
 
-    expect(readSnapshot).not.toHaveBeenCalled();
     expect(harness.onHotReload).toHaveBeenCalledTimes(1);
 
     harness.watcher.emit("change");
     harness.watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
 
-    expect(readSnapshot).toHaveBeenCalledTimes(1);
+    // Deduped by persistedHash — no additional hot reload.
     expect(harness.onHotReload).toHaveBeenCalledTimes(1);
 
     harness.watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
 
-    expect(readSnapshot).toHaveBeenCalledTimes(2);
     expect(harness.onHotReload).toHaveBeenCalledTimes(1);
     expect(harness.onRestart).toHaveBeenCalledTimes(1);
 
@@ -559,6 +578,15 @@ describe("startGatewayConfigReloader", () => {
   it("dedupes the first watcher reread for startup internal writes", async () => {
     const readSnapshot = vi
       .fn<() => Promise<ConfigFileSnapshot>>()
+      // Startup schedule: matches initialInternalWriteHash, deduped.
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          config: {
+            gateway: { reload: { debounceMs: 0 }, auth: { mode: "token", token: "startup" } },
+          },
+          hash: "startup-internal-1",
+        }),
+      )
       .mockResolvedValueOnce(
         makeSnapshot({
           config: {
@@ -579,41 +607,61 @@ describe("startGatewayConfigReloader", () => {
       initialInternalWriteHash: "startup-internal-1",
     });
 
+    // Drain startup schedule (deduped by initialInternalWriteHash).
+    await vi.runOnlyPendingTimersAsync();
+
     harness.watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
 
-    expect(readSnapshot).toHaveBeenCalledTimes(1);
     expect(harness.onHotReload).not.toHaveBeenCalled();
     expect(harness.onRestart).not.toHaveBeenCalled();
 
     harness.watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
 
-    expect(readSnapshot).toHaveBeenCalledTimes(2);
     expect(harness.onRestart).toHaveBeenCalledTimes(1);
 
     await harness.reloader.stop();
   });
 
   it("watches $include paths after successful snapshot reload", async () => {
-    collectIncludePathsRecursiveMock.mockResolvedValue([
-      "/etc/openclaw/base.json",
-      "/etc/openclaw/channels.json",
-    ]);
+    // Startup returns no includes; only the watcher-triggered reload does.
+    collectIncludePathsRecursiveMock.mockImplementation(async ({ parsed }) => {
+      const rec = parsed as Record<string, unknown> | null;
+      if (rec && "$include" in rec) {
+        return ["/etc/openclaw/base.json", "/etc/openclaw/channels.json"];
+      }
+      return [];
+    });
 
-    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
-      makeSnapshot({
-        path: "/tmp/openclaw.json",
-        parsed: { $include: ["./base.json", "./channels.json"] },
-        config: {
-          gateway: { reload: { debounceMs: 0 } },
-          hooks: { enabled: true },
-        },
-        hash: "include-1",
-      }),
-    );
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      // Startup schedule: empty config.
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          config: { gateway: { reload: { debounceMs: 0 } } },
+          hash: "startup-1",
+        }),
+      )
+      // Watcher-triggered reload: config with $include.
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          path: "/tmp/openclaw.json",
+          parsed: { $include: ["./base.json", "./channels.json"] },
+          config: {
+            gateway: { reload: { debounceMs: 0 } },
+            hooks: { enabled: true },
+          },
+          hash: "include-1",
+        }),
+      );
     const { watcher, log, reloader } = createReloaderHarness(readSnapshot);
 
+    // Drain startup schedule.
+    await vi.runOnlyPendingTimersAsync();
+    watcher.add.mockClear();
+
+    // Trigger real reload with $include.
     watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
 
@@ -629,12 +677,30 @@ describe("startGatewayConfigReloader", () => {
   });
 
   it("unwatches removed $include paths on subsequent reloads", async () => {
-    collectIncludePathsRecursiveMock
-      .mockResolvedValueOnce(["/etc/openclaw/base.json", "/etc/openclaw/old.json"])
-      .mockResolvedValueOnce(["/etc/openclaw/base.json", "/etc/openclaw/new.json"]);
+    let callCount = 0;
+    collectIncludePathsRecursiveMock.mockImplementation(async () => {
+      callCount++;
+      // Startup (call 1): no includes.
+      if (callCount <= 1) {
+        return [];
+      }
+      // First reload (call 2): base + old.
+      if (callCount === 2) {
+        return ["/etc/openclaw/base.json", "/etc/openclaw/old.json"];
+      }
+      // Second reload (call 3): base + new.
+      return ["/etc/openclaw/base.json", "/etc/openclaw/new.json"];
+    });
 
     const readSnapshot = vi
       .fn<() => Promise<ConfigFileSnapshot>>()
+      // Startup schedule.
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          config: { gateway: { reload: { debounceMs: 0 } } },
+          hash: "startup-1",
+        }),
+      )
       .mockResolvedValueOnce(
         makeSnapshot({
           parsed: { $include: ["./base.json", "./old.json"] },
@@ -657,12 +723,17 @@ describe("startGatewayConfigReloader", () => {
       );
     const { watcher, reloader } = createReloaderHarness(readSnapshot);
 
-    // First reload: watch base.json + old.json
+    // Drain startup schedule.
+    await vi.runOnlyPendingTimersAsync();
+    watcher.add.mockClear();
+    watcher.unwatch.mockClear();
+
+    // First reload: watch base.json + old.json.
     watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
     expect(watcher.add).toHaveBeenCalledWith("/etc/openclaw/old.json");
 
-    // Second reload: old.json removed, new.json added
+    // Second reload: old.json removed, new.json added.
     watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();
     expect(watcher.unwatch).toHaveBeenCalledWith("/etc/openclaw/old.json");
@@ -671,19 +742,85 @@ describe("startGatewayConfigReloader", () => {
     await reloader.stop();
   });
 
-  it("does not break reload when $include scanning fails", async () => {
-    collectIncludePathsRecursiveMock.mockRejectedValueOnce(new Error("scan failed"));
+  it("syncs $include paths after in-process config writes", async () => {
+    collectIncludePathsRecursiveMock.mockImplementation(async ({ parsed }) => {
+      const rec = parsed as Record<string, unknown> | null;
+      if (rec && "$include" in rec) {
+        return ["/etc/openclaw/secrets.json"];
+      }
+      return [];
+    });
 
-    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
-      makeSnapshot({
-        config: {
-          gateway: { reload: { debounceMs: 0 } },
-          hooks: { enabled: true },
-        },
-        hash: "scan-fail-1",
-      }),
-    );
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      // Startup schedule: empty config.
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          config: { gateway: { reload: { debounceMs: 0 } } },
+          hash: "startup-1",
+        }),
+      )
+      // After in-process write, readSnapshot is called for include sync.
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          path: "/tmp/openclaw.json",
+          parsed: { $include: ["./secrets.json"] },
+          config: {
+            gateway: { reload: { debounceMs: 0 } },
+            hooks: { enabled: true },
+          },
+          hash: "write-1",
+        }),
+      );
+    const harness = createReloaderHarness(readSnapshot);
+
+    // Drain startup schedule.
+    await vi.runOnlyPendingTimersAsync();
+    harness.watcher.add.mockClear();
+
+    // Simulate in-process config write.
+    harness.emitWrite({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: { gateway: { reload: { debounceMs: 0 } } },
+      runtimeConfig: {
+        gateway: { reload: { debounceMs: 0 } },
+        hooks: { enabled: true },
+      },
+      persistedHash: "write-1",
+      writtenAtMs: Date.now(),
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(harness.watcher.add).toHaveBeenCalledWith("/etc/openclaw/secrets.json");
+
+    await harness.reloader.stop();
+  });
+
+  it("does not break reload when $include scanning fails", async () => {
+    collectIncludePathsRecursiveMock.mockRejectedValue(new Error("scan failed"));
+
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      // Startup schedule.
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          config: { gateway: { reload: { debounceMs: 0 } } },
+          hash: "startup-1",
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          config: {
+            gateway: { reload: { debounceMs: 0 } },
+            hooks: { enabled: true },
+          },
+          hash: "scan-fail-1",
+        }),
+      );
     const { watcher, onHotReload, log, reloader } = createReloaderHarness(readSnapshot);
+
+    // Drain startup schedule.
+    await vi.runOnlyPendingTimersAsync();
 
     watcher.emit("change");
     await vi.runOnlyPendingTimersAsync();

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -1,7 +1,5 @@
-import * as fs from "node:fs/promises";
 import { isDeepStrictEqual } from "node:util";
 import chokidar from "chokidar";
-import JSON5 from "json5";
 import type {
   OpenClawConfig,
   ConfigFileSnapshot,
@@ -105,6 +103,9 @@ export function startGatewayConfigReloader(opts: {
   /** Currently watched $include file paths (excludes the main watchPath). */
   let watchedIncludePaths = new Set<string>();
 
+  /** Suppresses watcher events fired by watcher.add() during include sync. */
+  let syncingIncludes = false;
+
   const scheduleAfter = (wait: number) => {
     if (stopped) {
       return;
@@ -166,6 +167,10 @@ export function startGatewayConfigReloader(opts: {
    * Synchronize the set of watched $include file paths with the current config.
    * Adds newly referenced files and unwatches removed ones.
    * Best-effort: failures are logged but do not disrupt the reload cycle.
+   *
+   * Sets syncingIncludes=true during watcher.add() calls to suppress the
+   * "add" events that chokidar fires for dynamically added existing files,
+   * preventing redundant reload cycles.
    */
   const syncIncludeWatchPaths = async (configPath: string, parsed: unknown) => {
     if (stopped || watcherClosed) {
@@ -179,12 +184,19 @@ export function startGatewayConfigReloader(opts: {
       let added = 0;
       let removed = 0;
 
-      for (const p of nextSet) {
-        if (!watchedIncludePaths.has(p)) {
-          watcher.add(p);
-          added++;
+      // Suppress watcher "add" events during dynamic path registration.
+      syncingIncludes = true;
+      try {
+        for (const p of nextSet) {
+          if (!watchedIncludePaths.has(p)) {
+            watcher.add(p);
+            added++;
+          }
         }
+      } finally {
+        syncingIncludes = false;
       }
+
       for (const p of watchedIncludePaths) {
         if (!nextSet.has(p)) {
           watcher.unwatch(p);
@@ -257,6 +269,15 @@ export function startGatewayConfigReloader(opts: {
         pendingInProcessConfig = null;
         missingConfigRetries = 0;
         await applySnapshot(nextConfig);
+
+        // In-process writes change the resolved config but the main config file
+        // (which contains $include directives) is also rewritten. Re-read the
+        // raw file to pick up any added/removed $include paths so that future
+        // edits to those files trigger reloads.
+        const snapshot = await opts.readSnapshot().catch(() => null);
+        if (snapshot?.exists && snapshot.parsed) {
+          await syncIncludeWatchPaths(snapshot.path, snapshot.parsed);
+        }
         return;
       }
       const snapshot = await opts.readSnapshot();
@@ -295,6 +316,10 @@ export function startGatewayConfigReloader(opts: {
   });
 
   const scheduleFromWatcher = () => {
+    // Suppress events fired by watcher.add() during include path sync.
+    if (syncingIncludes) {
+      return;
+    }
     schedule();
   };
 
@@ -321,17 +346,10 @@ export function startGatewayConfigReloader(opts: {
     void watcher.close().catch(() => {});
   });
 
-  // Perform an initial $include path sync so that edits to included files
-  // trigger reloads immediately, even before the main config file changes.
-  void (async () => {
-    try {
-      const raw = await fs.readFile(opts.watchPath, "utf-8");
-      const parsed = JSON5.parse(raw);
-      await syncIncludeWatchPaths(opts.watchPath, parsed);
-    } catch {
-      // Best-effort: include files will be picked up on first main config change.
-    }
-  })();
+  // Kick off an initial reload so that $include paths are synced immediately
+  // on startup. This avoids a fire-and-forget IIFE race condition with the
+  // first real watcher event (see PR #59632 review feedback).
+  schedule();
 
   return {
     stop: async () => {

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -283,6 +283,9 @@ export function startGatewayConfigReloader(opts: {
       const snapshot = await opts.readSnapshot();
       if (lastAppliedWriteHash && typeof snapshot.hash === "string") {
         if (snapshot.hash === lastAppliedWriteHash) {
+          // Config unchanged, but still sync $include paths on first run so
+          // that startup-seeded writes don't leave includes unwatched.
+          await syncIncludeWatchPaths(snapshot.path, snapshot.parsed);
           return;
         }
         lastAppliedWriteHash = null;

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -1,11 +1,14 @@
+import * as fs from "node:fs/promises";
 import { isDeepStrictEqual } from "node:util";
 import chokidar from "chokidar";
+import JSON5 from "json5";
 import type {
   OpenClawConfig,
   ConfigFileSnapshot,
   ConfigWriteNotification,
   GatewayReloadMode,
 } from "../config/config.js";
+import { collectIncludePathsRecursive } from "../config/includes-scan.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { isPlainObject } from "../utils.js";
 import { buildGatewayReloadPlan, type GatewayReloadPlan } from "./config-reload-plan.js";
@@ -99,6 +102,9 @@ export function startGatewayConfigReloader(opts: {
   let pendingInProcessConfig: OpenClawConfig | null = null;
   let lastAppliedWriteHash = opts.initialInternalWriteHash ?? null;
 
+  /** Currently watched $include file paths (excludes the main watchPath). */
+  let watchedIncludePaths = new Set<string>();
+
   const scheduleAfter = (wait: number) => {
     if (stopped) {
       return;
@@ -154,6 +160,48 @@ export function startGatewayConfigReloader(opts: {
     const issues = formatConfigIssueLines(snapshot.issues, "").join(", ");
     opts.log.warn(`config reload skipped (invalid config): ${issues}`);
     return true;
+  };
+
+  /**
+   * Synchronize the set of watched $include file paths with the current config.
+   * Adds newly referenced files and unwatches removed ones.
+   * Best-effort: failures are logged but do not disrupt the reload cycle.
+   */
+  const syncIncludeWatchPaths = async (configPath: string, parsed: unknown) => {
+    if (stopped || watcherClosed) {
+      return;
+    }
+    try {
+      const includePaths = await collectIncludePathsRecursive({ configPath, parsed });
+      const nextSet = new Set(includePaths);
+
+      // Determine what changed.
+      let added = 0;
+      let removed = 0;
+
+      for (const p of nextSet) {
+        if (!watchedIncludePaths.has(p)) {
+          watcher.add(p);
+          added++;
+        }
+      }
+      for (const p of watchedIncludePaths) {
+        if (!nextSet.has(p)) {
+          watcher.unwatch(p);
+          removed++;
+        }
+      }
+
+      watchedIncludePaths = nextSet;
+
+      if (added > 0 || removed > 0) {
+        opts.log.info(
+          `$include watch updated: ${nextSet.size} file(s) watched (+${added} -${removed})`,
+        );
+      }
+    } catch {
+      // Include scanning is best-effort; don't disrupt the reload cycle.
+    }
   };
 
   const applySnapshot = async (nextConfig: OpenClawConfig) => {
@@ -225,6 +273,10 @@ export function startGatewayConfigReloader(opts: {
         return;
       }
       await applySnapshot(snapshot.config);
+
+      // After a successful snapshot apply, sync $include watch paths so that
+      // edits to included files also trigger reloads.
+      await syncIncludeWatchPaths(snapshot.path, snapshot.parsed);
     } catch (err) {
       opts.log.error(`config reload failed: ${String(err)}`);
     } finally {
@@ -269,6 +321,18 @@ export function startGatewayConfigReloader(opts: {
     void watcher.close().catch(() => {});
   });
 
+  // Perform an initial $include path sync so that edits to included files
+  // trigger reloads immediately, even before the main config file changes.
+  void (async () => {
+    try {
+      const raw = await fs.readFile(opts.watchPath, "utf-8");
+      const parsed = JSON5.parse(raw);
+      await syncIncludeWatchPaths(opts.watchPath, parsed);
+    } catch {
+      // Best-effort: include files will be picked up on first main config change.
+    }
+  })();
+
   return {
     stop: async () => {
       stopped = true;
@@ -277,6 +341,7 @@ export function startGatewayConfigReloader(opts: {
       }
       debounceTimer = null;
       watcherClosed = true;
+      watchedIncludePaths = new Set();
       unsubscribeFromWrites();
       await watcher.close().catch(() => {});
     },


### PR DESCRIPTION
Fixes #59616
Relates to #41587

### Problem

`startGatewayConfigReloader` only watches the main config file via chokidar. Users who split their config using `$include` directives (supported by `src/config/includes.ts`) must manually restart the gateway after editing included files — changes are silently ignored.

### Solution

Reuse the existing `collectIncludePathsRecursive()` from `src/config/includes-scan.ts` to dynamically track `$include`-referenced files:

1. **On startup**: read the main config file, resolve all `$include` paths, and `watcher.add()` them
2. **After each successful reload**: re-collect include paths, diff against the current set, `watcher.add()` new paths and `watcher.unwatch()` removed paths

The sync is **best-effort** — failures are silently caught and do not disrupt the reload cycle.

### Changes

- **`src/gateway/config-reload.ts`**: Add `syncIncludeWatchPaths()` helper, call it after successful snapshot apply and on startup (+65 lines)
- **`src/gateway/config-reload.test.ts`**: Add 3 tests — include path watching, unwatch on removal, graceful failure (+119 lines)

### Tests

32/32 passing (29 existing + 3 new), `pnpm check` clean.