### PR TITLE
feat: add Chuizi.AI provider support

### DIFF
--- a/docs/providers/chuizi.md
+++ b/docs/providers/chuizi.md
@@ -1,0 +1,58 @@
+---
+summary: "Chuizi.AI setup (auth + model selection)"
+read_when:
+  - You want to use Chuizi.AI with OpenClaw
+  - You need the API key env var or CLI auth choice
+---
+
+# Chuizi.AI
+
+[Chuizi.AI](https://chuizi.ai) is a unified AI API gateway that provides access to 100+ models across 16 providers through a single OpenAI-compatible endpoint.
+
+- Provider: `chuizi`
+- Auth: `CHUIZI_API_KEY`
+- API: OpenAI-compatible
+
+## Quick start
+
+Set the API key (recommended: store it for the Gateway):
+
+```bash
+openclaw onboard --auth-choice chuizi-api-key
+```
+
+This will prompt for your API key and set `chuizi/anthropic/claude-sonnet-4-6` as the default model.
+
+## Non-interactive example
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice chuizi-api-key \
+  --chuizi-api-key "$CHUIZI_API_KEY" \
+  --skip-health \
+  --accept-risk
+```
+
+## Environment note
+
+If the Gateway runs as a daemon (launchd/systemd), make sure `CHUIZI_API_KEY`
+is available to that process (for example, in `~/.openclaw/.env` or via
+`env.shellEnv`).
+
+## Available models
+
+| Model ID                      | Name              | Type      | Context |
+| ----------------------------- | ----------------- | --------- | ------- |
+| `anthropic/claude-sonnet-4-6` | Claude Sonnet 4.6 | General   | 200K    |
+| `anthropic/claude-opus-4-6`   | Claude Opus 4.6   | Reasoning | 200K    |
+| `anthropic/claude-haiku-4-5`  | Claude Haiku 4.5  | General   | 200K    |
+| `openai/gpt-4.1`              | GPT-4.1           | General   | 200K    |
+| `openai/o4-mini`              | o4-mini           | Reasoning | 200K    |
+| `google/gemini-2.5-pro`       | Gemini 2.5 Pro    | Reasoning | 1M      |
+| `deepseek/deepseek-chat`      | DeepSeek V3.2     | General   | 128K    |
+| `deepseek/deepseek-r1`        | DeepSeek R1       | Reasoning | 128K    |
+
+Models use `provider/model` naming. Additional models (Qwen, Llama, Mistral, etc.) are accessible by passing any supported model ID.
+
+Get your API key at [app.chuizi.ai](https://app.chuizi.ai/login).

--- a/extensions/chuizi/api.ts
+++ b/extensions/chuizi/api.ts
@@ -1,0 +1,2 @@
+export { buildChuiziModelDefinition, CHUIZI_BASE_URL, CHUIZI_MODEL_CATALOG } from "./models.js";
+export { buildChuiziProvider } from "./provider-catalog.js";

--- a/extensions/chuizi/index.test.ts
+++ b/extensions/chuizi/index.test.ts
@@ -1,0 +1,52 @@
+import { resolveProviderPluginChoice } from "openclaw/plugin-sdk/testing";
+import { describe, expect, it } from "vitest";
+import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
+import chuiziPlugin from "./index.js";
+
+describe("chuizi provider plugin", () => {
+  it("registers Chuizi.AI with api-key auth wizard metadata", () => {
+    const provider = registerSingleProviderPlugin(chuiziPlugin);
+    const resolved = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "chuizi-api-key",
+    });
+
+    expect(provider.id).toBe("chuizi");
+    expect(provider.label).toBe("Chuizi.AI");
+    expect(provider.envVars).toEqual(["CHUIZI_API_KEY"]);
+    expect(provider.auth).toHaveLength(1);
+    expect(resolved).not.toBeNull();
+    expect(resolved?.provider.id).toBe("chuizi");
+    expect(resolved?.method.id).toBe("api-key");
+  });
+
+  it("builds the static Chuizi.AI model catalog", async () => {
+    const provider = registerSingleProviderPlugin(chuiziPlugin);
+    expect(provider.catalog).toBeDefined();
+
+    const catalog = await provider.catalog!.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "test-key" }),
+      resolveProviderAuth: () => ({
+        apiKey: "test-key",
+        mode: "api_key",
+        source: "env",
+      }),
+    } as never);
+
+    expect(catalog && "provider" in catalog).toBe(true);
+    if (!catalog || !("provider" in catalog)) {
+      throw new Error("expected single-provider catalog");
+    }
+
+    expect(catalog.provider.api).toBe("openai-completions");
+    expect(catalog.provider.baseUrl).toBe("https://api.chuizi.ai/v1");
+    expect(catalog.provider.models?.map((model) => model.id)).toContain(
+      "anthropic/claude-sonnet-4-6",
+    );
+    expect(
+      catalog.provider.models?.find((model) => model.id === "anthropic/claude-opus-4-6")?.reasoning,
+    ).toBe(true);
+  });
+});

--- a/extensions/chuizi/index.ts
+++ b/extensions/chuizi/index.ts
@@ -1,0 +1,38 @@
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { applyChuiziConfig, CHUIZI_DEFAULT_MODEL_REF } from "./onboard.js";
+import { buildChuiziProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "chuizi";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "Chuizi Provider",
+  description: "Bundled Chuizi.AI provider plugin",
+  provider: {
+    label: "Chuizi.AI",
+    docsPath: "/providers/chuizi",
+    auth: [
+      {
+        methodId: "api-key",
+        label: "Chuizi.AI API key",
+        hint: "API key",
+        optionKey: "chuiziApiKey",
+        flagName: "--chuizi-api-key",
+        envVar: "CHUIZI_API_KEY",
+        promptMessage: "Enter Chuizi.AI API key",
+        defaultModel: CHUIZI_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyChuiziConfig(cfg),
+        wizard: {
+          choiceId: "chuizi-api-key",
+          choiceLabel: "Chuizi.AI API key",
+          groupId: "chuizi",
+          groupLabel: "Chuizi.AI",
+          groupHint: "API key",
+        },
+      },
+    ],
+    catalog: {
+      buildProvider: buildChuiziProvider,
+    },
+  },
+});

--- a/extensions/chuizi/models.ts
+++ b/extensions/chuizi/models.ts
@@ -47,9 +47,9 @@ const GEMINI_25_PRO_COST = {
   cacheWrite: 0,
 };
 
-const ZERO_COST = {
-  input: 0,
-  output: 0,
+const O4_MINI_COST = {
+  input: 1.1,
+  output: 4.4,
   cacheRead: 0,
   cacheWrite: 0,
 };
@@ -100,7 +100,7 @@ export const CHUIZI_MODEL_CATALOG: ModelDefinitionConfig[] = [
     input: ["text", "image"],
     contextWindow: 200000,
     maxTokens: 100000,
-    cost: ZERO_COST,
+    cost: O4_MINI_COST,
   },
   // Google
   {
@@ -121,6 +121,7 @@ export const CHUIZI_MODEL_CATALOG: ModelDefinitionConfig[] = [
     contextWindow: 131072,
     maxTokens: 8192,
     cost: DEEPSEEK_V3_COST,
+    compat: { supportsUsageInStreaming: true },
   },
   {
     id: "deepseek/deepseek-r1",
@@ -130,6 +131,7 @@ export const CHUIZI_MODEL_CATALOG: ModelDefinitionConfig[] = [
     contextWindow: 131072,
     maxTokens: 65536,
     cost: DEEPSEEK_V3_COST,
+    compat: { supportsUsageInStreaming: true },
   },
 ];
 

--- a/extensions/chuizi/models.ts
+++ b/extensions/chuizi/models.ts
@@ -2,69 +2,124 @@ import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-s
 
 export const CHUIZI_BASE_URL = "https://api.chuizi.ai/v1";
 
-// Chuizi.AI pricing (per 1M tokens, USD)
-// https://chuizi.ai/pricing
+// Chuizi.AI pricing (per 1M tokens, USD).
+// Prices are upstream list prices × Chuizi's 1.05 gateway margin.
+// Reference: https://chuizi.ai/pricing
 
-const CLAUDE_SONNET_COST = {
-  input: 3,
-  output: 15,
-  cacheRead: 0.3,
-  cacheWrite: 3.75,
-};
-
-const CLAUDE_HAIKU_COST = {
-  input: 1,
-  output: 5,
-  cacheRead: 0.1,
-  cacheWrite: 1.25,
-};
-
+// ---- Anthropic ----
 const CLAUDE_OPUS_COST = {
-  input: 5,
-  output: 25,
-  cacheRead: 0.5,
-  cacheWrite: 6.25,
+  input: 15.75,
+  output: 78.75,
+  cacheRead: 1.575,
+  cacheWrite: 19.6875,
+};
+const CLAUDE_SONNET_COST = {
+  input: 3.15,
+  output: 15.75,
+  cacheRead: 0.315,
+  cacheWrite: 3.9375,
+};
+const CLAUDE_HAIKU_COST = {
+  input: 1.05,
+  output: 5.25,
+  cacheRead: 0.105,
+  cacheWrite: 1.3125,
 };
 
+// ---- OpenAI ----
+const GPT_5_COST = {
+  input: 1.3125,
+  output: 10.5,
+  cacheRead: 0.13125,
+  cacheWrite: 0,
+};
+const GPT_5_MINI_COST = {
+  input: 0.2625,
+  output: 2.1,
+  cacheRead: 0.02625,
+  cacheWrite: 0,
+};
 const GPT_4_1_COST = {
-  input: 2,
-  output: 8,
+  input: 2.1,
+  output: 8.4,
   cacheRead: 0,
   cacheWrite: 0,
 };
-
-const DEEPSEEK_V3_COST = {
-  input: 0.28,
-  output: 0.42,
+const GPT_4_1_MINI_COST = {
+  input: 0.42,
+  output: 1.68,
   cacheRead: 0,
   cacheWrite: 0,
 };
-
-const GEMINI_25_PRO_COST = {
-  input: 1.25,
-  output: 10,
-  cacheRead: 0,
-  cacheWrite: 0,
-};
-
 const O4_MINI_COST = {
-  input: 1.1,
-  output: 4.4,
+  input: 1.155,
+  output: 4.62,
+  cacheRead: 0.2888,
+  cacheWrite: 0,
+};
+
+// ---- Google ----
+const GEMINI_25_PRO_COST = {
+  input: 1.3125,
+  output: 10.5,
+  cacheRead: 0.328,
+  cacheWrite: 0,
+};
+const GEMINI_25_FLASH_COST = {
+  input: 0.315,
+  output: 2.625,
+  cacheRead: 0.0788,
+  cacheWrite: 0,
+};
+
+// ---- DeepSeek ----
+const DEEPSEEK_V3_COST = {
+  input: 0.294,
+  output: 1.176,
+  cacheRead: 0.029,
+  cacheWrite: 0,
+};
+const DEEPSEEK_R1_COST = {
+  input: 0.588,
+  output: 2.352,
+  cacheRead: 0.029,
+  cacheWrite: 0,
+};
+
+// ---- Qwen ----
+const QWEN3_MAX_COST = {
+  input: 2.52,
+  output: 10.08,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+// ---- xAI ----
+const GROK_4_COST = {
+  input: 3.15,
+  output: 15.75,
+  cacheRead: 0.7875,
+  cacheWrite: 0,
+};
+
+// ---- Moonshot ----
+const KIMI_K25_COST = {
+  input: 2.52,
+  output: 12.6,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+// ---- Zhipu ----
+const GLM_46_COST = {
+  input: 0.525,
+  output: 2.1,
   cacheRead: 0,
   cacheWrite: 0,
 };
 
 export const CHUIZI_MODEL_CATALOG: ModelDefinitionConfig[] = [
   // Anthropic
-  {
-    id: "anthropic/claude-sonnet-4-6",
-    name: "Claude Sonnet 4.6",
-    reasoning: false,
-    input: ["text", "image"],
-    contextWindow: 200000,
-    maxTokens: 16000,
-    cost: CLAUDE_SONNET_COST,
-  },
   {
     id: "anthropic/claude-opus-4-6",
     name: "Claude Opus 4.6",
@@ -75,15 +130,43 @@ export const CHUIZI_MODEL_CATALOG: ModelDefinitionConfig[] = [
     cost: CLAUDE_OPUS_COST,
   },
   {
+    id: "anthropic/claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 64000,
+    cost: CLAUDE_SONNET_COST,
+  },
+  {
     id: "anthropic/claude-haiku-4-5",
     name: "Claude Haiku 4.5",
     reasoning: false,
     input: ["text", "image"],
     contextWindow: 200000,
-    maxTokens: 8192,
+    maxTokens: 32000,
     cost: CLAUDE_HAIKU_COST,
   },
+
   // OpenAI
+  {
+    id: "openai/gpt-5",
+    name: "GPT-5",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 400000,
+    maxTokens: 128000,
+    cost: GPT_5_COST,
+  },
+  {
+    id: "openai/gpt-5-mini",
+    name: "GPT-5 mini",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 400000,
+    maxTokens: 128000,
+    cost: GPT_5_MINI_COST,
+  },
   {
     id: "openai/gpt-4.1",
     name: "GPT-4.1",
@@ -94,6 +177,15 @@ export const CHUIZI_MODEL_CATALOG: ModelDefinitionConfig[] = [
     cost: GPT_4_1_COST,
   },
   {
+    id: "openai/gpt-4.1-mini",
+    name: "GPT-4.1 mini",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 32768,
+    cost: GPT_4_1_MINI_COST,
+  },
+  {
     id: "openai/o4-mini",
     name: "o4-mini",
     reasoning: true,
@@ -102,16 +194,27 @@ export const CHUIZI_MODEL_CATALOG: ModelDefinitionConfig[] = [
     maxTokens: 100000,
     cost: O4_MINI_COST,
   },
+
   // Google
   {
     id: "google/gemini-2.5-pro",
     name: "Gemini 2.5 Pro",
     reasoning: true,
     input: ["text", "image"],
-    contextWindow: 1048576,
+    contextWindow: 2097152,
     maxTokens: 65536,
     cost: GEMINI_25_PRO_COST,
   },
+  {
+    id: "google/gemini-2.5-flash",
+    name: "Gemini 2.5 Flash",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    cost: GEMINI_25_FLASH_COST,
+  },
+
   // DeepSeek
   {
     id: "deepseek/deepseek-chat",
@@ -130,8 +233,52 @@ export const CHUIZI_MODEL_CATALOG: ModelDefinitionConfig[] = [
     input: ["text"],
     contextWindow: 131072,
     maxTokens: 65536,
-    cost: DEEPSEEK_V3_COST,
+    cost: DEEPSEEK_R1_COST,
     compat: { supportsUsageInStreaming: true },
+  },
+
+  // Qwen
+  {
+    id: "qwen/qwen3-max",
+    name: "Qwen3 Max",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 1048576,
+    maxTokens: 8192,
+    cost: QWEN3_MAX_COST,
+  },
+
+  // xAI
+  {
+    id: "xai/grok-4",
+    name: "Grok 4",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 256000,
+    maxTokens: 32768,
+    cost: GROK_4_COST,
+  },
+
+  // Moonshot
+  {
+    id: "moonshot/kimi-k2.5",
+    name: "Kimi K2.5",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 200000,
+    maxTokens: 65536,
+    cost: KIMI_K25_COST,
+  },
+
+  // Zhipu
+  {
+    id: "zhipu/glm-4.6",
+    name: "GLM-4.6",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 128000,
+    maxTokens: 32768,
+    cost: GLM_46_COST,
   },
 ];
 

--- a/extensions/chuizi/models.ts
+++ b/extensions/chuizi/models.ts
@@ -1,0 +1,143 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+export const CHUIZI_BASE_URL = "https://api.chuizi.ai/v1";
+
+// Chuizi.AI pricing (per 1M tokens, USD)
+// https://chuizi.ai/pricing
+
+const CLAUDE_SONNET_COST = {
+  input: 3,
+  output: 15,
+  cacheRead: 0.3,
+  cacheWrite: 3.75,
+};
+
+const CLAUDE_HAIKU_COST = {
+  input: 1,
+  output: 5,
+  cacheRead: 0.1,
+  cacheWrite: 1.25,
+};
+
+const CLAUDE_OPUS_COST = {
+  input: 5,
+  output: 25,
+  cacheRead: 0.5,
+  cacheWrite: 6.25,
+};
+
+const GPT_4_1_COST = {
+  input: 2,
+  output: 8,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+const DEEPSEEK_V3_COST = {
+  input: 0.28,
+  output: 0.42,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+const GEMINI_25_PRO_COST = {
+  input: 1.25,
+  output: 10,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+const ZERO_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+export const CHUIZI_MODEL_CATALOG: ModelDefinitionConfig[] = [
+  // Anthropic
+  {
+    id: "anthropic/claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 16000,
+    cost: CLAUDE_SONNET_COST,
+  },
+  {
+    id: "anthropic/claude-opus-4-6",
+    name: "Claude Opus 4.6",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 32000,
+    cost: CLAUDE_OPUS_COST,
+  },
+  {
+    id: "anthropic/claude-haiku-4-5",
+    name: "Claude Haiku 4.5",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 8192,
+    cost: CLAUDE_HAIKU_COST,
+  },
+  // OpenAI
+  {
+    id: "openai/gpt-4.1",
+    name: "GPT-4.1",
+    reasoning: false,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 32768,
+    cost: GPT_4_1_COST,
+  },
+  {
+    id: "openai/o4-mini",
+    name: "o4-mini",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 200000,
+    maxTokens: 100000,
+    cost: ZERO_COST,
+  },
+  // Google
+  {
+    id: "google/gemini-2.5-pro",
+    name: "Gemini 2.5 Pro",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    cost: GEMINI_25_PRO_COST,
+  },
+  // DeepSeek
+  {
+    id: "deepseek/deepseek-chat",
+    name: "DeepSeek V3.2",
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 8192,
+    cost: DEEPSEEK_V3_COST,
+  },
+  {
+    id: "deepseek/deepseek-r1",
+    name: "DeepSeek R1",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 131072,
+    maxTokens: 65536,
+    cost: DEEPSEEK_V3_COST,
+  },
+];
+
+export function buildChuiziModelDefinition(
+  model: (typeof CHUIZI_MODEL_CATALOG)[number],
+): ModelDefinitionConfig {
+  return {
+    ...model,
+    api: "openai-completions",
+  };
+}

--- a/extensions/chuizi/onboard.ts
+++ b/extensions/chuizi/onboard.ts
@@ -1,0 +1,28 @@
+import {
+  applyAgentDefaultModelPrimary,
+  applyProviderConfigWithModelCatalog,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { buildChuiziModelDefinition, CHUIZI_BASE_URL, CHUIZI_MODEL_CATALOG } from "./api.js";
+
+export const CHUIZI_DEFAULT_MODEL_REF = "chuizi/anthropic/claude-sonnet-4-6";
+
+export function applyChuiziProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[CHUIZI_DEFAULT_MODEL_REF] = {
+    ...models[CHUIZI_DEFAULT_MODEL_REF],
+    alias: models[CHUIZI_DEFAULT_MODEL_REF]?.alias ?? "Chuizi",
+  };
+
+  return applyProviderConfigWithModelCatalog(cfg, {
+    agentModels: models,
+    providerId: "chuizi",
+    api: "openai-completions",
+    baseUrl: CHUIZI_BASE_URL,
+    catalogModels: CHUIZI_MODEL_CATALOG.map(buildChuiziModelDefinition),
+  });
+}
+
+export function applyChuiziConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(applyChuiziProviderConfig(cfg), CHUIZI_DEFAULT_MODEL_REF);
+}

--- a/extensions/chuizi/openclaw.plugin.json
+++ b/extensions/chuizi/openclaw.plugin.json
@@ -1,0 +1,28 @@
+{
+  "id": "chuizi",
+  "enabledByDefault": true,
+  "providers": ["chuizi"],
+  "providerAuthEnvVars": {
+    "chuizi": ["CHUIZI_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "chuizi",
+      "method": "api-key",
+      "choiceId": "chuizi-api-key",
+      "choiceLabel": "Chuizi.AI API key",
+      "groupId": "chuizi",
+      "groupLabel": "Chuizi.AI",
+      "groupHint": "API key",
+      "optionKey": "chuiziApiKey",
+      "cliFlag": "--chuizi-api-key",
+      "cliOption": "--chuizi-api-key <key>",
+      "cliDescription": "Chuizi.AI API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/chuizi/package.json
+++ b/extensions/chuizi/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/chuizi-provider",
+  "version": "2026.4.1-beta.1",
+  "private": true,
+  "description": "OpenClaw Chuizi.AI provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/chuizi/provider-catalog.ts
+++ b/extensions/chuizi/provider-catalog.ts
@@ -1,0 +1,10 @@
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildChuiziModelDefinition, CHUIZI_BASE_URL, CHUIZI_MODEL_CATALOG } from "./api.js";
+
+export function buildChuiziProvider(): ModelProviderConfig {
+  return {
+    baseUrl: CHUIZI_BASE_URL,
+    api: "openai-completions",
+    models: CHUIZI_MODEL_CATALOG.map(buildChuiziModelDefinition),
+  };
+}


### PR DESCRIPTION
## Summary

Add [Chuizi.AI](https://chuizi.ai) as a bundled provider plugin. Chuizi.AI is a unified AI gateway that provides access to models from multiple providers (Anthropic, OpenAI, Google, DeepSeek, and others) through a single OpenAI-compatible endpoint.

## Changes

- `extensions/chuizi/` — New provider plugin (9 files)
  - Plugin entry using `defineSingleProviderPluginEntry`
  - Static model catalog with 8 popular models across 4 providers
  - Onboard config with `applyChuiziConfig`
  - Vitest tests (2 passing)
- `docs/providers/chuizi.md` — Provider documentation

## Provider details

| Field | Value |
|-------|-------|
| Provider ID | `chuizi` |
| Auth env var | `CHUIZI_API_KEY` |
| CLI flag | `--chuizi-api-key` |
| API | `openai-completions` |
| Base URL | `https://api.chuizi.ai/v1` |
| Default model | `anthropic/claude-sonnet-4-6` |

## Verification

- [x] `pnpm check` — all project checks pass (pre-commit hook verified)
- [x] `pnpm test extensions/chuizi/` — 2/2 tests pass
- [x] `oxlint extensions/chuizi/` — 0 warnings, 0 errors
- [x] TypeScript — 0 errors in `extensions/chuizi/`
- [x] Follows existing provider patterns (modeled after `deepseek` and `nvidia` extensions)
- [x] No changes to existing code

## Test plan

- [ ] Plugin loads and registers `chuizi` provider
- [ ] `openclaw onboard --auth-choice chuizi-api-key` prompts for API key
- [ ] Model catalog includes expected models
- [ ] Requests route to `https://api.chuizi.ai/v1` with correct auth header