### PR TITLE
fix: align secretref web-fetch matrix

### DIFF
--- a/src/secrets/credential-matrix.ts
+++ b/src/secrets/credential-matrix.ts
@@ -23,18 +23,29 @@ export type SecretRefCredentialMatrixDocument = {
 
 export function buildSecretRefCredentialMatrix(): SecretRefCredentialMatrixDocument {
   const entries: CredentialMatrixEntry[] = listSecretTargetRegistryEntries()
-    .map((entry) => ({
-      id: entry.id,
-      configFile: entry.configFile,
-      path: entry.pathPattern,
-      ...(entry.refPathPattern ? { refPath: entry.refPathPattern } : {}),
-      ...(entry.authProfileType ? { when: { type: entry.authProfileType } } : {}),
-      secretShape: entry.secretShape,
-      optIn: true as const,
-      ...(entry.id.startsWith("channels.googlechat.")
-        ? { notes: "Google Chat compatibility exception: sibling ref field remains canonical." }
-        : {}),
-    }))
+    .map((entry) => {
+      const isCanonicalFirecrawlWebFetchEntry =
+        entry.id === "plugins.entries.firecrawl.config.webFetch.apiKey";
+      const canonicalId = isCanonicalFirecrawlWebFetchEntry
+        ? "tools.web.fetch.firecrawl.apiKey"
+        : entry.id;
+      const canonicalPath = isCanonicalFirecrawlWebFetchEntry
+        ? "tools.web.fetch.firecrawl.apiKey"
+        : entry.pathPattern;
+
+      return {
+        id: canonicalId,
+        configFile: entry.configFile,
+        path: canonicalPath,
+        ...(entry.refPathPattern ? { refPath: entry.refPathPattern } : {}),
+        ...(entry.authProfileType ? { when: { type: entry.authProfileType } } : {}),
+        secretShape: entry.secretShape,
+        optIn: true as const,
+        ...(entry.id.startsWith("channels.googlechat.")
+          ? { notes: "Google Chat compatibility exception: sibling ref field remains canonical." }
+          : {}),
+      };
+    })
     .toSorted((a, b) => a.id.localeCompare(b.id));
 
   return {

--- a/src/secrets/exec-secret-ref-id-parity.test.ts
+++ b/src/secrets/exec-secret-ref-id-parity.test.ts
@@ -99,6 +99,9 @@ describe("exec SecretRef id parity", () => {
     if (id.startsWith("tools.web.fetch.")) {
       return "tools.web.fetch";
     }
+    if (id.startsWith("plugins.entries.") && id.includes(".config.webFetch.apiKey")) {
+      return "tools.web.fetch";
+    }
     if (id.startsWith("tools.web.x_search.")) {
       return "tools.web.x_search";
     }


### PR DESCRIPTION
## Summary
- classify plugin-owned Firecrawl web-fetch targets under the `tools.web.fetch` SecretRef class in the parity test
- project the canonical `tools.web.fetch.firecrawl.apiKey` surface when building the SecretRef credential matrix
- keep the runtime registry unchanged so configure/apply behavior still follows the actual plugin-owned config path

## Root cause
`buildSecretRefCredentialMatrix()` was serializing the raw registry entry for Firecrawl web-fetch instead of the documented canonical SecretRef surface. That made the matrix generator drift back to `plugins.entries.firecrawl.config.webFetch.apiKey` even though the docs and policy treat `tools.web.fetch.firecrawl.apiKey` as canonical.

## Verification
- `OPENCLAW_TEST_PROFILE=serial OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test -- src/secrets/exec-secret-ref-id-parity.test.ts src/secrets/target-registry.test.ts --reporter=verbose`
- commit hook `pnpm check`
