### PR TITLE
fix(agents): resolve model aliases in sessions_spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/device tokens: stop echoing rotated bearer tokens from shared/admin `device.token.rotate` responses while preserving the same-device token handoff needed by token-only clients before reconnect. (#66773) Thanks @MoerAI.
+- Agents/sessions_spawn: resolve configured bare model aliases for spawn model overrides using the target agent runtime default provider, carrying forward the alias-specific #69029 review fixes from #59681 without the unrelated active-session pruning path. Fixes #59681. Thanks @HowdyDooToYou.
 - Control UI/Talk: keep Google Live browser sessions on the WebSocket transport instead of falling back to WebRTC, validate browser Google Live WebSocket endpoints, cap Gateway relay sessions per browser connection, and remove stale browser-native voice buttons that did not use the configured Talk/TTS provider. Thanks @BunsDev.
 - Gateway/startup: reuse config snapshot plugin manifests for startup auto-enable before plugin bootstrap plans plugin loading. Thanks @shakkernerd.
 - Agents/subagents: enforce `subagents.allowAgents` for explicit same-agent `sessions_spawn(agentId=...)` calls instead of auto-allowing requester self-targets. Fixes #72827. Thanks @oiGaDio.

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -19,6 +19,7 @@ import {
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
   resolveSubagentConfiguredModelSelection,
+  resolveSubagentSpawnModelSelection,
   resolveThinkingDefault,
   resolveModelRefFromString,
 } from "./model-selection.js";
@@ -1531,6 +1532,74 @@ describe("resolveSubagentConfiguredModelSelection", () => {
 
     expect(resolveSubagentConfiguredModelSelection({ cfg, agentId: "research" })).toBe(
       "google/gemini-2.5-pro",
+    );
+  });
+});
+
+describe("resolveSubagentSpawnModelSelection", () => {
+  it("resolves a model alias override to its full provider/model ref", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          models: {
+            "anthropic/claude-opus-4-6": { alias: "opus" },
+            "openai/gpt-5.4": { alias: "gpt" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveSubagentSpawnModelSelection({ cfg, agentId: "main", modelOverride: "opus" }),
+    ).toBe("anthropic/claude-opus-4-6");
+  });
+
+  it("resolves alias in configured subagent model", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+          models: {
+            "openai/gpt-5.4": { alias: "gpt" },
+          },
+          subagents: { model: "gpt" },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveSubagentSpawnModelSelection({ cfg, agentId: "main" })).toBe("openai/gpt-5.4");
+  });
+
+  it("passes through already-qualified provider/model refs unchanged", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveSubagentSpawnModelSelection({
+        cfg,
+        agentId: "main",
+        modelOverride: "openai/gpt-5.4",
+      }),
+    ).toBe("openai/gpt-5.4");
+  });
+
+  it("falls back to runtime default when no override or config", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-sonnet-4-6" },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveSubagentSpawnModelSelection({ cfg, agentId: "main" })).toBe(
+      "anthropic/claude-sonnet-4-6",
     );
   });
 });

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -1555,6 +1555,33 @@ describe("resolveSubagentSpawnModelSelection", () => {
     ).toBe("anthropic/claude-opus-4-6");
   });
 
+  it("resolves bare configured aliases with the target agent runtime default provider", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.4" },
+          models: {
+            "claude-opus-4-6": { alias: "opus" },
+          },
+        },
+        list: [
+          {
+            id: "research",
+            model: "anthropic/claude-sonnet-4-6",
+          },
+        ],
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveSubagentSpawnModelSelection({
+        cfg,
+        agentId: "research",
+        modelOverride: "OPUS",
+      }),
+    ).toBe("anthropic/claude-opus-4-6");
+  });
+
   it("resolves alias in configured subagent model", () => {
     const cfg = {
       agents: {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -249,27 +249,17 @@ export function resolveSubagentConfiguredModelSelection(params: {
 }
 
 /**
- * Resolve a normalized model string through the alias index, returning a fully
- * qualified `provider/model` string.  If the value is already qualified or not
- * an alias, returns it unchanged.  Returns `undefined` for empty input.
+ * Resolve a normalized model string through a pre-built alias index, returning
+ * a fully qualified `provider/model` string.  If the value is already qualified
+ * or not a known alias, returns it unchanged.
  */
-function resolveModelThroughAliases(
-  value: string | undefined,
-  cfg: OpenClawConfig,
-): string | undefined {
-  if (!value) {
-    return undefined;
-  }
+function resolveModelThroughAliases(value: string, aliasIndex: ModelAliasIndex): string {
   // Already a provider/model ref — no alias resolution needed.
   if (value.includes("/")) {
     return value;
   }
   // Check if the value is a known alias; if so, resolve to provider/model.
   // Unknown bare strings are returned as-is (don't guess the provider).
-  const aliasIndex = buildModelAliasIndex({
-    cfg,
-    defaultProvider: DEFAULT_PROVIDER,
-  });
   const aliasKey = normalizeAliasKey(value);
   const aliasMatch = aliasIndex.byAlias.get(aliasKey);
   if (aliasMatch) {
@@ -295,7 +285,11 @@ export function resolveSubagentSpawnModelSelection(params: {
     }) ??
     normalizeModelSelection(resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model)) ??
     `${runtimeDefault.provider}/${runtimeDefault.model}`;
-  return resolveModelThroughAliases(raw, params.cfg) ?? raw;
+  const aliasIndex = buildModelAliasIndex({
+    cfg: params.cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+  });
+  return resolveModelThroughAliases(raw, aliasIndex);
 }
 
 export function buildAllowedModelSet(params: {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -248,6 +248,36 @@ export function resolveSubagentConfiguredModelSelection(params: {
   );
 }
 
+/**
+ * Resolve a normalized model string through the alias index, returning a fully
+ * qualified `provider/model` string.  If the value is already qualified or not
+ * an alias, returns it unchanged.  Returns `undefined` for empty input.
+ */
+function resolveModelThroughAliases(
+  value: string | undefined,
+  cfg: OpenClawConfig,
+): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  // Already a provider/model ref — no alias resolution needed.
+  if (value.includes("/")) {
+    return value;
+  }
+  // Check if the value is a known alias; if so, resolve to provider/model.
+  // Unknown bare strings are returned as-is (don't guess the provider).
+  const aliasIndex = buildModelAliasIndex({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+  });
+  const aliasKey = normalizeAliasKey(value);
+  const aliasMatch = aliasIndex.byAlias.get(aliasKey);
+  if (aliasMatch) {
+    return `${aliasMatch.ref.provider}/${aliasMatch.ref.model}`;
+  }
+  return value;
+}
+
 export function resolveSubagentSpawnModelSelection(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -257,15 +287,15 @@ export function resolveSubagentSpawnModelSelection(params: {
     cfg: params.cfg,
     agentId: params.agentId,
   });
-  return (
+  const raw =
     normalizeModelSelection(params.modelOverride) ??
     resolveSubagentConfiguredModelSelection({
       cfg: params.cfg,
       agentId: params.agentId,
     }) ??
     normalizeModelSelection(resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model)) ??
-    `${runtimeDefault.provider}/${runtimeDefault.model}`
-  );
+    `${runtimeDefault.provider}/${runtimeDefault.model}`;
+  return resolveModelThroughAliases(raw, params.cfg) ?? raw;
 }
 
 export function buildAllowedModelSet(params: {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -4,6 +4,7 @@ import {
   toAgentModelListLike,
 } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import {
   resolveAgentConfig,
   resolveAgentEffectiveModelPrimary,
@@ -260,7 +261,7 @@ function resolveModelThroughAliases(value: string, aliasIndex: ModelAliasIndex):
   }
   // Check if the value is a known alias; if so, resolve to provider/model.
   // Unknown bare strings are returned as-is (don't guess the provider).
-  const aliasKey = normalizeAliasKey(value);
+  const aliasKey = normalizeLowercaseStringOrEmpty(value);
   const aliasMatch = aliasIndex.byAlias.get(aliasKey);
   if (aliasMatch) {
     return `${aliasMatch.ref.provider}/${aliasMatch.ref.model}`;
@@ -287,7 +288,7 @@ export function resolveSubagentSpawnModelSelection(params: {
     `${runtimeDefault.provider}/${runtimeDefault.model}`;
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg,
-    defaultProvider: DEFAULT_PROVIDER,
+    defaultProvider: runtimeDefault.provider,
   });
   return resolveModelThroughAliases(raw, aliasIndex);
 }


### PR DESCRIPTION
Summary:

resolveSubagentSpawnModelSelection() uses normalizeModelSelection() to process the model override — but that function only trims the string. It never checks the configured model alias index. When a user passes an alias like "opus" or "gpt" to sessions_spawn, the child session gets patched with the raw alias string, which the gateway cannot resolve to any provider. The child session dies immediately.

Changes:

Added resolveModelThroughAliases() helper in src/agents/model-selection.ts that checks bare strings against buildModelAliasIndex. Already-qualified provider/model refs and unknown strings pass through unchanged.
Modified resolveSubagentSpawnModelSelection() to pass its result through resolveModelThroughAliases() before returning.

Test plan:
 4 new tests in model-selection.test.ts:
Alias override resolves to full provider/model ref
Configured subagent model alias resolves
Already-qualified refs pass through unchanged
Falls back to runtime default when no override
All 9 existing spawn model tests pass
pnpm tsgo — clean
Pre-commit hooks pass (lint, typecheck, conflict markers)

Fixes https://github.com/openclaw/openclaw/issues/57532
Refs https://github.com/openclaw/openclaw/issues/50736