### PR TITLE
fix(skills): allow managed-skill symlinks pointing to other known skill roots

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -197,6 +197,8 @@ function resolveContainedSkillPath(params: {
   rootDir: string;
   rootRealPath: string;
   candidatePath: string;
+  /** Additional root real paths that are considered safe symlink targets. */
+  allowedSymlinkTargetRoots?: string[];
 }): string | null {
   const candidateRealPath = tryRealpath(params.candidatePath);
   if (!candidateRealPath) {
@@ -204,6 +206,20 @@ function resolveContainedSkillPath(params: {
   }
   if (isPathInside(params.rootRealPath, candidateRealPath)) {
     return candidateRealPath;
+  }
+  // When a skill is a symlink pointing outside its root, check if the resolved
+  // path falls inside another known skill scan directory.  The `skills` CLI
+  // (https://github.com/nicepkg/skills) installs canonical copies under
+  // `~/.agents/skills/` and creates symlinks in agent-specific directories
+  // (e.g. `~/.openclaw/skills/X` → `~/.agents/skills/X`).  Without this
+  // allowlist the managed-skills scan emits a noisy warning for every such
+  // symlink even though the target is a legitimate skill root.
+  if (params.allowedSymlinkTargetRoots?.length) {
+    for (const allowedRoot of params.allowedSymlinkTargetRoots) {
+      if (isPathInside(allowedRoot, candidateRealPath)) {
+        return candidateRealPath;
+      }
+    }
   }
   warnEscapedSkillPath({
     source: params.source,
@@ -219,6 +235,7 @@ function filterLoadedSkillsInsideRoot(params: {
   source: string;
   rootDir: string;
   rootRealPath: string;
+  allowedSymlinkTargetRoots?: string[];
 }): Skill[] {
   return params.skills.filter((skill) => {
     const baseDirRealPath = resolveContainedSkillPath({
@@ -226,6 +243,7 @@ function filterLoadedSkillsInsideRoot(params: {
       rootDir: params.rootDir,
       rootRealPath: params.rootRealPath,
       candidatePath: skill.baseDir,
+      allowedSymlinkTargetRoots: params.allowedSymlinkTargetRoots,
     });
     if (!baseDirRealPath) {
       return false;
@@ -235,6 +253,7 @@ function filterLoadedSkillsInsideRoot(params: {
       rootDir: params.rootDir,
       rootRealPath: params.rootRealPath,
       candidatePath: skill.filePath,
+      allowedSymlinkTargetRoots: params.allowedSymlinkTargetRoots,
     });
     return Boolean(skillFileRealPath);
   });
@@ -293,7 +312,12 @@ function loadSkillEntries(
 ): SkillEntry[] {
   const limits = resolveSkillsLimits(opts?.config);
 
-  const loadSkills = (params: { dir: string; source: string }): Skill[] => {
+  const loadSkills = (params: {
+    dir: string;
+    source: string;
+    /** Additional root real paths that are considered safe symlink targets. */
+    allowedSymlinkTargetRoots?: string[];
+  }): Skill[] => {
     const rootDir = path.resolve(params.dir);
     const rootRealPath = tryRealpath(rootDir) ?? rootDir;
     const resolved = resolveNestedSkillsRoot(params.dir, {
@@ -305,6 +329,7 @@ function loadSkillEntries(
       rootDir,
       rootRealPath,
       candidatePath: baseDir,
+      allowedSymlinkTargetRoots: params.allowedSymlinkTargetRoots,
     });
     if (!baseDirRealPath) {
       return [];
@@ -318,6 +343,7 @@ function loadSkillEntries(
         rootDir,
         rootRealPath: baseDirRealPath,
         candidatePath: rootSkillMd,
+        allowedSymlinkTargetRoots: params.allowedSymlinkTargetRoots,
       });
       if (!rootSkillRealPath) {
         return [];
@@ -347,6 +373,7 @@ function loadSkillEntries(
         source: params.source,
         rootDir,
         rootRealPath: baseDirRealPath,
+        allowedSymlinkTargetRoots: params.allowedSymlinkTargetRoots,
       });
     }
 
@@ -383,6 +410,7 @@ function loadSkillEntries(
         rootDir,
         rootRealPath: baseDirRealPath,
         candidatePath: skillDir,
+        allowedSymlinkTargetRoots: params.allowedSymlinkTargetRoots,
       });
       if (!skillDirRealPath) {
         continue;
@@ -396,6 +424,7 @@ function loadSkillEntries(
         rootDir,
         rootRealPath: baseDirRealPath,
         candidatePath: skillMd,
+        allowedSymlinkTargetRoots: params.allowedSymlinkTargetRoots,
       });
       if (!skillMdRealPath) {
         continue;
@@ -426,6 +455,7 @@ function loadSkillEntries(
           source: params.source,
           rootDir,
           rootRealPath: baseDirRealPath,
+          allowedSymlinkTargetRoots: params.allowedSymlinkTargetRoots,
         }),
       );
 
@@ -470,16 +500,34 @@ function loadSkillEntries(
       source: "openclaw-extra",
     });
   });
+  const personalAgentsSkillsDir = path.resolve(os.homedir(), ".agents", "skills");
+  const projectAgentsSkillsDir = path.resolve(workspaceDir, ".agents", "skills");
+
+  // The `skills` CLI (https://github.com/nicepkg/skills) installs skill files
+  // into a canonical directory (`~/.agents/skills/`) and creates symlinks in
+  // each agent's skill directory.  For OpenClaw this means
+  // `~/.openclaw/skills/X` → `~/.agents/skills/X`.  Without an allowlist the
+  // symlink-escape check rejects every such skill with a noisy warning.
+  // Build a list of other known skill scan roots so that managed-skill symlinks
+  // pointing into them are accepted instead of rejected.
+  const allowedSymlinkTargetRoots = [
+    personalAgentsSkillsDir,
+    projectAgentsSkillsDir,
+    workspaceSkillsDir,
+    ...mergedExtraDirs.map((d) => path.resolve(resolveUserPath(d))),
+  ]
+    .map((d) => tryRealpath(d) ?? d)
+    .filter(Boolean);
+
   const managedSkills = loadSkills({
     dir: managedSkillsDir,
     source: "openclaw-managed",
+    allowedSymlinkTargetRoots,
   });
-  const personalAgentsSkillsDir = path.resolve(os.homedir(), ".agents", "skills");
   const personalAgentsSkills = loadSkills({
     dir: personalAgentsSkillsDir,
     source: "agents-skills-personal",
   });
-  const projectAgentsSkillsDir = path.resolve(workspaceDir, ".agents", "skills");
   const projectAgentsSkills = loadSkills({
     dir: projectAgentsSkillsDir,
     source: "agents-skills-project",


### PR DESCRIPTION
## Problem

The `skills` CLI (https://github.com/nicepkg/skills) installs canonical copies of skills under `~/.agents/skills/` and creates symlinks in each agent's skill directory. For OpenClaw this results in:

```
~/.openclaw/skills/lark-base → ../../.agents/skills/lark-base
~/.openclaw/skills/lark-calendar → ../../.agents/skills/lark-calendar
... (19 symlinks total)
```

The `resolveContainedSkillPath` security check rejects any skill whose `realpath` falls outside its configured root directory (`~/.openclaw/skills/`), causing ~19 noisy warnings on every skill reload:

```
[skills] Skipping skill path that resolves outside its configured root.
```

The skills are still loaded from `~/.agents/skills/` (via the `agents-skills-personal` source), so there is no functional impact — but the warnings are confusing and fill up logs.

## Solution

Add an `allowedSymlinkTargetRoots` parameter to `resolveContainedSkillPath` and `filterLoadedSkillsInsideRoot`. When loading managed skills (`~/.openclaw/skills/`), pass the other known skill scan directories as allowed symlink targets:

- `~/.agents/skills/` (personal agents skills)
- `<workspace>/.agents/skills/` (project agents skills)
- `<workspace>/skills/` (workspace skills)
- Extra dirs from config + plugin skill dirs

Symlinks pointing into any of these known roots are accepted. Symlinks to unknown/external locations still trigger the warning (security behavior preserved).

## Changes

- `src/agents/skills/workspace.ts`: Added `allowedSymlinkTargetRoots` option, threaded through all containment check call sites, computed allowlist from other scan roots when loading managed skills.

## Test Plan

- [x] `pnpm tsgo` passes
- [x] `pnpm lint` passes  
- [x] All pre-commit checks pass
- Verified locally: 19 symlinks in `~/.openclaw/skills/` pointing to `~/.agents/skills/` — warnings eliminated after this fix
