### PR TITLE
fix(cli): skip full plugin preload for channels login/logout when --channel is explicit

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -139,6 +139,14 @@ describe("registerPreActionHooks", () => {
     program.command("onboard").action(() => {});
     const channels = program.command("channels");
     channels.command("add").action(() => {});
+    channels
+      .command("login")
+      .option("--channel <channel>")
+      .action(() => {});
+    channels
+      .command("logout")
+      .option("--channel <channel>")
+      .action(() => {});
     program
       .command("plugins")
       .command("install")
@@ -246,6 +254,83 @@ describe("registerPreActionHooks", () => {
       commandPath: ["channels", "add"],
     });
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
+  });
+
+  it("skips plugin preload for channels login/logout when --channel is explicit", async () => {
+    // space-separated form: --channel whatsapp
+    await runPreAction({
+      parseArgv: ["channels", "login"],
+      processArgv: ["node", "openclaw", "channels", "login", "--channel", "whatsapp"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["channels", "login"],
+    });
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    // equals form: --channel=whatsapp
+    await runPreAction({
+      parseArgv: ["channels", "login"],
+      processArgv: ["node", "openclaw", "channels", "login", "--channel=whatsapp"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["channels", "login"],
+    });
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    await runPreAction({
+      parseArgv: ["channels", "logout"],
+      processArgv: ["node", "openclaw", "channels", "logout", "--channel", "whatsapp"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["channels", "logout"],
+    });
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    // equals form: --channel=whatsapp
+    await runPreAction({
+      parseArgv: ["channels", "logout"],
+      processArgv: ["node", "openclaw", "channels", "logout", "--channel=whatsapp"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["channels", "logout"],
+    });
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps full plugin preload for channels login/logout without --channel", async () => {
+    await runPreAction({
+      parseArgv: ["channels", "login"],
+      processArgv: ["node", "openclaw", "channels", "login"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["channels", "login"],
+    });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "all" });
+
+    vi.clearAllMocks();
+    await runPreAction({
+      parseArgv: ["channels", "logout"],
+      processArgv: ["node", "openclaw", "channels", "logout"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["channels", "logout"],
+    });
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "all" });
   });
 
   it("only allows invalid config for explicit Matrix reinstall requests", async () => {

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -77,8 +77,18 @@ function shouldLoadPluginsForCommand(commandPath: string[], jsonOutputMode: bool
   if ((primary === "status" || primary === "health") && jsonOutputMode) {
     return false;
   }
-  // Setup wizard and channels add should stay manifest-first and load selected plugins on demand.
+  // Setup wizard and channels add stay manifest-first (plugin loaded on demand).
   if (primary === "onboard" || (primary === "channels" && secondary === "add")) {
+    return false;
+  }
+  // channels login/logout with an explicit --channel skip the preload: the target plugin is loaded
+  // on demand by resolveInstallableChannelPlugin. Without --channel the auto-detection path needs
+  // listChannelPlugins(), so fall through to the normal full preload.
+  if (
+    primary === "channels" &&
+    (secondary === "login" || secondary === "logout") &&
+    process.argv.some((arg) => arg === "--channel" || arg.startsWith("--channel="))
+  ) {
     return false;
   }
   return true;


### PR DESCRIPTION
Fixes #56552

## Problem

Running `openclaw channels login --channel <plugin>` causes the CPU to spike and the QR-code fetch to take significantly longer than the actual network round-trip to the same endpoint. This frequently pushes the elapsed time past the plugin's AbortController timeout, resulting in:

```
AbortError: This operation was aborted
```

## Root cause

`shouldLoadPluginsForCommand` in the `preAction` hook triggers a full `scope: "all"` plugin load for every `channels` subcommand except `add`. This causes Jiti to compile every installed plugin from TypeScript at runtime, saturating the CPU and generating continuous GC pressure throughout the entire command execution (`--trace-gc` confirms sustained GC activity).

The GC cycles occupy the event loop, preventing network I/O completion callbacks from being processed in time. The actual network latency is inflated far beyond the plugin's `AbortController` timeout.

## Fix

When `--channel` is explicit, `channels login` and `channels logout` only need the single target plugin, which is already loaded on demand by `resolveInstallableChannelPlugin` inside `channel-auth.ts`. There is no reason to preload all plugins in `preAction`.

When `--channel` is omitted, the auto-detection path calls `listChannelPlugins()` and still requires a full preload — that behavior is unchanged.

## Changes

- `src/cli/program/preaction.ts`: skip plugin preload for `channels login`/`logout` when `--channel` is present in argv
- `src/cli/program/preaction.test.ts`: add test cases covering both the explicit-channel (no preload) and implicit-channel (full preload) paths
