### PR TITLE
fix(dedup): extend targetsMatchForSuppression to all channels, fix Slack duplicate delivery

### DIFF
--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -2,6 +2,8 @@ import { isMessagingToolDuplicate } from "../../agents/pi-embedded-helpers.js";
 import type { MessagingToolSend } from "../../agents/pi-embedded-runner.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
 import { parseExplicitTargetForChannel } from "../../channels/plugins/target-parsing.js";
+import { parseTelegramTarget } from "../../../extensions/telegram/api.js";
+import { parseSlackTarget } from "../../../extensions/slack/api.js";
 import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
 import { normalizeOptionalAccountId } from "../../routing/account-id.js";
 import type { ReplyPayload } from "../types.js";
@@ -100,28 +102,51 @@ function resolveTargetProviderForComparison(params: {
   return targetProvider;
 }
 
+function parseBuiltinTarget(
+  provider: string,
+  raw: string,
+): { to: string; threadId?: string } | null {
+  if (provider === "telegram") {
+    const result = parseTelegramTarget(raw);
+    return {
+      to: result.chatId,
+      threadId: result.messageThreadId != null ? String(result.messageThreadId) : undefined,
+    };
+  }
+  if (provider === "slack") {
+    const result = parseSlackTarget(raw, { defaultKind: "channel" });
+    if (!result) {
+      return null;
+    }
+    return { to: result.id };
+  }
+  return null;
+}
+
 function targetsMatchForSuppression(params: {
   provider: string;
   originTarget: string;
   targetKey: string;
   targetThreadId?: string;
 }): boolean {
-  if (params.provider !== "telegram") {
-    return params.targetKey === params.originTarget;
-  }
-
-  const origin = parseExplicitTargetForChannel("telegram", params.originTarget);
-  const target = parseExplicitTargetForChannel("telegram", params.targetKey);
+  // Try plugin-based parsing first (handles all registered channels including Slack).
+  const originPlugin = parseExplicitTargetForChannel(params.provider, params.originTarget);
+  const targetPlugin = parseExplicitTargetForChannel(params.provider, params.targetKey);
+  const origin = originPlugin
+    ? { to: originPlugin.to, threadId: originPlugin.threadId != null ? String(originPlugin.threadId) : undefined }
+    : parseBuiltinTarget(params.provider, params.originTarget);
+  const target = targetPlugin
+    ? { to: targetPlugin.to, threadId: targetPlugin.threadId != null ? String(targetPlugin.threadId) : undefined }
+    : parseBuiltinTarget(params.provider, params.targetKey);
   if (!origin || !target) {
     return params.targetKey === params.originTarget;
   }
-  const explicitTargetThreadId = normalizeThreadIdForComparison(params.targetThreadId);
-  const targetThreadId =
-    explicitTargetThreadId ?? (target.threadId != null ? String(target.threadId) : undefined);
-  const originThreadId = origin.threadId != null ? String(origin.threadId) : undefined;
   if (origin.to.trim().toLowerCase() !== target.to.trim().toLowerCase()) {
     return false;
   }
+  const explicitTargetThreadId = normalizeThreadIdForComparison(params.targetThreadId);
+  const targetThreadId = explicitTargetThreadId ?? target.threadId;
+  const originThreadId = origin.threadId;
   if (originThreadId && targetThreadId != null) {
     return originThreadId === targetThreadId;
   }

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -156,6 +156,36 @@ describe("shouldSuppressMessagingToolReplies", () => {
     ).toBe(true);
   });
 
+  it("suppresses slack replies when channel targets match in different normalized forms", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "slack",
+        originatingTo: "C12345678",
+        messagingToolSentTargets: [{ tool: "message", provider: "slack", to: "channel:C12345678" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("suppresses slack DM replies when user target forms differ", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "slack",
+        originatingTo: "channel:C12345678",
+        messagingToolSentTargets: [{ tool: "message", provider: "slack", to: "C12345678" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress slack replies when channel targets differ", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "slack",
+        originatingTo: "C12345678",
+        messagingToolSentTargets: [{ tool: "message", provider: "slack", to: "C99999999" }],
+      }),
+    ).toBe(false);
+  });
+
   it("suppresses telegram replies even when the active plugin registry omits telegram", () => {
     setActivePluginRegistry(createTestRegistry([]));
 

--- a/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
@@ -7,6 +7,8 @@ vi.mock("../../agents/subagent-announce.js", () => ({
 }));
 vi.mock("../../agents/subagent-registry.js", () => ({
   countActiveDescendantRuns: vi.fn().mockReturnValue(0),
+  getLatestSubagentRunByChildSessionKey: vi.fn().mockReturnValue(null),
+  listDescendantRunsForRequester: vi.fn().mockReturnValue([]),
 }));
 
 describe("matchesMessagingToolDeliveryTarget", () => {


### PR DESCRIPTION
## Summary

Fixes #59687 — Slack messages were being delivered twice when an agent both called the `message` tool and produced response text, because the dedup suppression logic (`targetsMatchForSuppression`) only performed semantic target normalization for Telegram.

### Root cause

`targetsMatchForSuppression()` had a hard-coded `if (provider !== "telegram")` guard that short-circuited to a plain string equality check for all non-Telegram channels. For Slack, the `message` tool target (e.g. `"C12345678"`) and the auto-delivery target (e.g. `"channel:c12345678"`) are semantically equivalent but string-different after normalization, so the suppression check always returned `false` → duplicate delivery.

### Fix

- Replaced the Telegram-only branch with a **generic channel-aware approach**: `parseExplicitTargetForChannel(provider, ...)` is tried for all channels via the plugin registry.
- Added **built-in fallback parsers** for Telegram and Slack that activate when the channel plugin is not registered, so Telegram topic-thread matching still works in environments without the full plugin registry (this also fixes 3 pre-existing failing tests on `main`).
- Thread-aware comparison logic (topic thread IDs) now applies uniformly to all channels.

### Tests

- All 16 pre-existing tests pass (including 3 that were failing on `main`).
- Added 3 new Slack-specific suppression tests.

## Test plan

- [ ] DM an agent bound to Slack; agent responds via `message.send` + produces response text → only one message appears in Slack
- [ ] Same test in a Slack channel thread → only one message in the thread
- [ ] Run `pnpm vitest run src/auto-reply/reply/reply-payloads.test.ts` → 19/19 pass