### PR TITLE
feat(ios): add exec approval push flow

### DIFF
--- a/apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift
+++ b/apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+
+private struct ExecApprovalPromptDialogModifier: ViewModifier {
+    @Environment(NodeAppModel.self) private var appModel: NodeAppModel
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                if let prompt = self.appModel.pendingExecApprovalPrompt {
+                    ZStack {
+                        Color.black.opacity(0.38)
+                            .ignoresSafeArea()
+
+                        ExecApprovalPromptCard(
+                            prompt: prompt,
+                            isResolving: self.appModel.pendingExecApprovalPromptResolving,
+                            errorText: self.appModel.pendingExecApprovalPromptErrorText,
+                            brighten: self.colorScheme == .light,
+                            onAllowOnce: {
+                                Task {
+                                    await self.appModel.resolvePendingExecApprovalPrompt(decision: "allow-once")
+                                }
+                            },
+                            onAllowAlways: {
+                                Task {
+                                    await self.appModel.resolvePendingExecApprovalPrompt(decision: "allow-always")
+                                }
+                            },
+                            onDeny: {
+                                Task {
+                                    await self.appModel.resolvePendingExecApprovalPrompt(decision: "deny")
+                                }
+                            },
+                            onCancel: {
+                                self.appModel.dismissPendingExecApprovalPrompt()
+                            })
+                            .padding(.horizontal, 20)
+                            .frame(maxWidth: 460)
+                            .transition(.scale(scale: 0.98).combined(with: .opacity))
+                    }
+                    .zIndex(1)
+                }
+            }
+            .animation(.easeInOut(duration: 0.18), value: self.appModel.pendingExecApprovalPrompt?.id)
+    }
+}
+
+private struct ExecApprovalPromptCard: View {
+    let prompt: NodeAppModel.ExecApprovalPrompt
+    let isResolving: Bool
+    let errorText: String?
+    let brighten: Bool
+    let onAllowOnce: () -> Void
+    let onAllowAlways: () -> Void
+    let onDeny: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Exec approval required")
+                    .font(.headline)
+                Text("OpenClaw opened from a notification. Review this exec request before continuing.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(self.prompt.commandText)
+                .font(.system(size: 15, weight: .regular, design: .monospaced))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+                .background(.black.opacity(0.14), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 8) {
+                if let host = self.normalized(self.prompt.host) {
+                    ExecApprovalPromptMetadataRow(label: "Host", value: host)
+                }
+                if let nodeId = self.normalized(self.prompt.nodeId) {
+                    ExecApprovalPromptMetadataRow(label: "Node", value: nodeId)
+                }
+                if let agentId = self.normalized(self.prompt.agentId) {
+                    ExecApprovalPromptMetadataRow(label: "Agent", value: agentId)
+                }
+                if let expiresText = self.expiresText(self.prompt.expiresAtMs) {
+                    ExecApprovalPromptMetadataRow(label: "Expires", value: expiresText)
+                }
+            }
+
+            if let errorText = self.normalized(self.errorText) {
+                Text(errorText)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+
+            if self.isResolving {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                    Text("Resolving…")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            VStack(spacing: 10) {
+                Button("Allow Once") {
+                    self.onAllowOnce()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(self.isResolving)
+
+                if self.prompt.allowsAllowAlways {
+                    Button("Allow Always") {
+                        self.onAllowAlways()
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(self.isResolving)
+                }
+
+                Button("Deny", role: .destructive) {
+                    self.onDeny()
+                }
+                .buttonStyle(.bordered)
+                .disabled(self.isResolving)
+
+                Button("Cancel", role: .cancel) {
+                    self.onCancel()
+                }
+                .buttonStyle(.plain)
+                .disabled(self.isResolving)
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .statusGlassCard(brighten: self.brighten, verticalPadding: 18, horizontalPadding: 18)
+    }
+
+    private func normalized(_ value: String?) -> String? {
+        let trimmed = (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func expiresText(_ expiresAtMs: Int?) -> String? {
+        guard let expiresAtMs else { return nil }
+        let remainingSeconds = Int((Double(expiresAtMs) / 1000.0) - Date().timeIntervalSince1970)
+        if remainingSeconds <= 0 {
+            return "expired"
+        }
+        if remainingSeconds < 60 {
+            return "under a minute"
+        }
+        if remainingSeconds < 3600 {
+            let minutes = Int(ceil(Double(remainingSeconds) / 60.0))
+            return minutes == 1 ? "about 1 minute" : "about \(minutes) minutes"
+        }
+        let hours = Int(ceil(Double(remainingSeconds) / 3600.0))
+        return hours == 1 ? "about 1 hour" : "about \(hours) hours"
+    }
+}
+
+private struct ExecApprovalPromptMetadataRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(self.label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(self.value)
+                .font(.footnote)
+                .textSelection(.enabled)
+        }
+    }
+}
+
+extension View {
+    func execApprovalPromptDialog() -> some View {
+        self.modifier(ExecApprovalPromptDialogModifier())
+    }
+}

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -61,11 +61,35 @@ final class NodeAppModel {
         let request: AgentDeepLink
     }
 
+    struct ExecApprovalPrompt: Identifiable, Equatable {
+        let id: String
+        let commandText: String
+        let allowedDecisions: [String]
+        let host: String?
+        let nodeId: String?
+        let agentId: String?
+        let expiresAtMs: Int?
+
+        var allowsAllowAlways: Bool {
+            self.allowedDecisions.contains("allow-always")
+        }
+    }
+
+    private enum ExecApprovalResolutionOutcome {
+        case resolved
+        case stale
+        case unavailable
+        case failed(message: String)
+    }
+
     private let deepLinkLogger = Logger(subsystem: "ai.openclaw.ios", category: "DeepLink")
     private let pushWakeLogger = Logger(subsystem: "ai.openclaw.ios", category: "PushWake")
     private let pendingActionLogger = Logger(subsystem: "ai.openclaw.ios", category: "PendingAction")
     private let locationWakeLogger = Logger(subsystem: "ai.openclaw.ios", category: "LocationWake")
     private let watchReplyLogger = Logger(subsystem: "ai.openclaw.ios", category: "WatchReply")
+    private let execApprovalNotificationLogger = Logger(
+        subsystem: "ai.openclaw.ios",
+        category: "ExecApprovalNotification")
     enum CameraHUDKind {
         case photo
         case recording
@@ -98,6 +122,9 @@ final class NodeAppModel {
     var lastShareEventText: String = "No share events yet."
     var openChatRequestID: Int = 0
     private(set) var pendingAgentDeepLinkPrompt: AgentDeepLinkPrompt?
+    private(set) var pendingExecApprovalPrompt: ExecApprovalPrompt?
+    private(set) var pendingExecApprovalPromptResolving: Bool = false
+    private(set) var pendingExecApprovalPromptErrorText: String?
     private var queuedAgentDeepLinkPrompt: AgentDeepLinkPrompt?
     private var lastAgentDeepLinkPromptAt: Date = .distantPast
     @ObservationIgnored private var queuedAgentDeepLinkPromptTask: Task<Void, Never>?
@@ -1813,7 +1840,7 @@ private extension NodeAppModel {
         return DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: role) != nil
     }
 
-    static func shouldStartOperatorGatewayLoop(
+    nonisolated static func shouldStartOperatorGatewayLoop(
         token: String?,
         bootstrapToken: String?,
         password: String?,
@@ -1834,7 +1861,7 @@ private extension NodeAppModel {
         return hasStoredOperatorToken
     }
 
-    static func clearingBootstrapToken(in config: GatewayConnectConfig?) -> GatewayConnectConfig? {
+    nonisolated static func clearingBootstrapToken(in config: GatewayConnectConfig?) -> GatewayConnectConfig? {
         guard let config else { return nil }
         let trimmedBootstrapToken = config.bootstrapToken?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -1873,6 +1900,36 @@ private extension NodeAppModel {
         else { return }
 
         GatewaySettingsStore.clearGatewayBootstrapToken(instanceId: trimmedInstanceId)
+    }
+
+    private func handleSuccessfulBootstrapGatewayOnboarding(
+        url: URL,
+        stableID: String,
+        token: String?,
+        password: String?,
+        nodeOptions: GatewayConnectOptions,
+        sessionBox: WebSocketSessionBox?) async
+    {
+        self.clearPersistedGatewayBootstrapTokenIfNeeded()
+        if self.operatorGatewayTask == nil && self.shouldStartOperatorGatewayLoop(
+            token: token,
+            bootstrapToken: nil,
+            password: password,
+            stableID: stableID)
+        {
+            self.startOperatorGatewayLoop(
+                url: url,
+                stableID: stableID,
+                token: token,
+                bootstrapToken: nil,
+                password: password,
+                nodeOptions: nodeOptions,
+                sessionBox: sessionBox)
+        }
+
+        // QR bootstrap onboarding should surface the system notification permission
+        // prompt immediately so visible APNs alerts work without a second manual step.
+        _ = await self.requestNotificationAuthorizationIfNeeded()
     }
 
     func refreshBackgroundReconnectSuppressionIfNeeded(source: String) {
@@ -2046,13 +2103,14 @@ private extension NodeAppModel {
                         fallbackToken: token,
                         fallbackBootstrapToken: bootstrapToken,
                         fallbackPassword: password)
+                    let connectedOptions = currentOptions
                     GatewayDiagnostics.log("connect attempt epochMs=\(epochMs) url=\(url.absoluteString)")
                     try await self.nodeGateway.connect(
                         url: url,
                         token: reconnectAuth.token,
                         bootstrapToken: reconnectAuth.bootstrapToken,
                         password: reconnectAuth.password,
-                        connectOptions: currentOptions,
+                        connectOptions: connectedOptions,
                         sessionBox: sessionBox,
                         onConnected: { [weak self] in
                             guard let self else { return }
@@ -2068,24 +2126,13 @@ private extension NodeAppModel {
                                 reconnectAuth.bootstrapToken?.trimmingCharacters(in: .whitespacesAndNewlines)
                                     .isEmpty == false
                             if usedBootstrapToken {
-                                await MainActor.run {
-                                    self.clearPersistedGatewayBootstrapTokenIfNeeded()
-                                    if self.operatorGatewayTask == nil && self.shouldStartOperatorGatewayLoop(
-                                        token: reconnectAuth.token,
-                                        bootstrapToken: nil,
-                                        password: reconnectAuth.password,
-                                        stableID: stableID)
-                                    {
-                                        self.startOperatorGatewayLoop(
-                                            url: url,
-                                            stableID: stableID,
-                                            token: reconnectAuth.token,
-                                            bootstrapToken: nil,
-                                            password: reconnectAuth.password,
-                                            nodeOptions: currentOptions,
-                                            sessionBox: sessionBox)
-                                    }
-                                }
+                                await self.handleSuccessfulBootstrapGatewayOnboarding(
+                                    url: url,
+                                    stableID: stableID,
+                                    token: reconnectAuth.token,
+                                    password: reconnectAuth.password,
+                                    nodeOptions: connectedOptions,
+                                    sessionBox: sessionBox)
                             }
                             let relayData = await MainActor.run {
                                 (
@@ -2246,7 +2293,7 @@ private extension NodeAppModel {
     func makeOperatorConnectOptions(clientId: String, displayName: String?) -> GatewayConnectOptions {
         GatewayConnectOptions(
             role: "operator",
-            scopes: ["operator.read", "operator.write", "operator.talk.secrets"],
+            scopes: ["operator.read", "operator.write", "operator.approvals", "operator.talk.secrets"],
             caps: [],
             commands: [],
             permissions: [:],
@@ -2544,6 +2591,19 @@ extension NodeAppModel {
             + "backgrounded=\(self.isBackgrounded) "
             + "autoReconnect=\(self.gatewayAutoReconnectEnabled)"
         self.pushWakeLogger.info("\(receivedMessage, privacy: .public)")
+
+        if await ExecApprovalNotificationBridge.handleResolvedPushIfNeeded(
+            userInfo: userInfo,
+            notificationCenter: self.notificationCenter)
+        {
+            if let approvalId = ExecApprovalNotificationBridge.approvalID(from: userInfo) {
+                self.clearPendingExecApprovalPromptIfMatches(approvalId)
+            }
+            self.execApprovalNotificationLogger.info(
+                "Handled exec approval cleanup push wakeId=\(wakeId, privacy: .public)")
+            return true
+        }
+
         let result = await self.reconnectGatewaySessionsForSilentPushIfNeeded(wakeId: wakeId)
         let outcomeMessage =
             "Silent push outcome wakeId=\(wakeId) "
@@ -2716,6 +2776,132 @@ extension NodeAppModel {
         return "unknown"
     }
 
+    private struct ExecApprovalResolveRequest: Encodable {
+        var id: String
+        var decision: String
+    }
+
+    func presentExecApprovalNotificationPrompt(_ prompt: ExecApprovalNotificationPrompt) {
+        let approvalId = prompt.approvalId.trimmingCharacters(in: .whitespacesAndNewlines)
+        let commandText = prompt.commandText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !approvalId.isEmpty, !commandText.isEmpty else { return }
+
+        self.pendingExecApprovalPrompt = ExecApprovalPrompt(
+            id: approvalId,
+            commandText: commandText,
+            allowedDecisions: prompt.allowedDecisions.compactMap { decision in
+                let trimmed = decision.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : trimmed
+            },
+            host: prompt.host?.trimmingCharacters(in: .whitespacesAndNewlines),
+            nodeId: prompt.nodeId?.trimmingCharacters(in: .whitespacesAndNewlines),
+            agentId: prompt.agentId?.trimmingCharacters(in: .whitespacesAndNewlines),
+            expiresAtMs: prompt.expiresAtMs)
+        self.pendingExecApprovalPromptResolving = false
+        self.pendingExecApprovalPromptErrorText = nil
+    }
+
+    func dismissPendingExecApprovalPrompt() {
+        self.pendingExecApprovalPrompt = nil
+        self.pendingExecApprovalPromptResolving = false
+        self.pendingExecApprovalPromptErrorText = nil
+    }
+
+    func resolvePendingExecApprovalPrompt(decision: String) async {
+        guard let prompt = self.pendingExecApprovalPrompt else { return }
+        let normalizedDecision = decision.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedDecision.isEmpty else { return }
+
+        self.pendingExecApprovalPromptResolving = true
+        self.pendingExecApprovalPromptErrorText = nil
+        let outcome = await self.resolveExecApprovalNotificationDecision(
+            approvalId: prompt.id,
+            decision: normalizedDecision)
+        switch outcome {
+        case .resolved, .stale, .unavailable:
+            break
+        case let .failed(message):
+            self.pendingExecApprovalPromptResolving = false
+            self.pendingExecApprovalPromptErrorText = message
+        }
+    }
+
+    func handleExecApprovalNotificationAction(approvalId: String, decision: String) async {
+        _ = await self.resolveExecApprovalNotificationDecision(approvalId: approvalId, decision: decision)
+    }
+
+    private func resolveExecApprovalNotificationDecision(
+        approvalId: String,
+        decision: String
+    ) async -> ExecApprovalResolutionOutcome {
+        let normalizedApprovalID = approvalId.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedDecision = decision.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedApprovalID.isEmpty, !normalizedDecision.isEmpty else {
+            return .failed(message: "Invalid approval request.")
+        }
+
+        let connected = await self.ensureOperatorApprovalConnection(timeoutMs: 12_000)
+        guard connected else {
+            self.execApprovalNotificationLogger.error(
+                "Exec approval action failed id=\(normalizedApprovalID, privacy: .public): operator not connected")
+            return .failed(message: "OpenClaw couldn't connect to the gateway operator session.")
+        }
+
+        do {
+            let payloadJSON = try Self.encodePayload(
+                ExecApprovalResolveRequest(id: normalizedApprovalID, decision: normalizedDecision))
+            _ = try await self.operatorGateway.request(
+                method: "exec.approval.resolve",
+                paramsJSON: payloadJSON,
+                timeoutSeconds: 12)
+            await ExecApprovalNotificationBridge.removeNotifications(
+                forApprovalID: normalizedApprovalID,
+                notificationCenter: self.notificationCenter)
+            self.clearPendingExecApprovalPromptIfMatches(normalizedApprovalID)
+            return .resolved
+        } catch {
+            if Self.isApprovalNotificationStaleError(error) {
+                await ExecApprovalNotificationBridge.removeNotifications(
+                    forApprovalID: normalizedApprovalID,
+                    notificationCenter: self.notificationCenter)
+                self.clearPendingExecApprovalPromptIfMatches(normalizedApprovalID)
+                return .stale
+            }
+            if Self.isApprovalNotificationUnavailableError(error) {
+                await ExecApprovalNotificationBridge.removeNotifications(
+                    forApprovalID: normalizedApprovalID,
+                    notificationCenter: self.notificationCenter)
+                self.clearPendingExecApprovalPromptIfMatches(normalizedApprovalID)
+                return .unavailable
+            }
+            let logMessage =
+                "Exec approval action failed id=\(normalizedApprovalID) error=\(error.localizedDescription)"
+            self.execApprovalNotificationLogger.error("\(logMessage, privacy: .public)")
+            return .failed(
+                message: "OpenClaw couldn't resolve this approval right now. Try again.")
+        }
+    }
+
+    private func clearPendingExecApprovalPromptIfMatches(_ approvalId: String) {
+        let normalizedApprovalID = approvalId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard self.pendingExecApprovalPrompt?.id == normalizedApprovalID else { return }
+        self.dismissPendingExecApprovalPrompt()
+    }
+
+    private static func isApprovalNotificationStaleError(_ error: Error) -> Bool {
+        guard let gatewayError = error as? GatewayResponseError else { return false }
+        let message = gatewayError.message.lowercased()
+        return gatewayError.code == "INVALID_REQUEST"
+            && (message.contains("unknown or expired approval id") || message.contains("approval_not_found"))
+    }
+
+    private static func isApprovalNotificationUnavailableError(_ error: Error) -> Bool {
+        guard let gatewayError = error as? GatewayResponseError else { return false }
+        let message = gatewayError.message.lowercased()
+        return gatewayError.code == "INVALID_REQUEST"
+            && message.contains("allow-always is unavailable")
+    }
+
     private struct SilentPushWakeAttemptResult {
         var applied: Bool
         var reason: String
@@ -2733,6 +2919,29 @@ extension NodeAppModel {
             try? await Task.sleep(nanoseconds: pollIntervalNs)
         }
         return await self.isGatewayConnected()
+    }
+
+    private func waitForOperatorConnection(timeoutMs: Int, pollMs: Int) async -> Bool {
+        let clampedTimeoutMs = max(0, timeoutMs)
+        let pollIntervalNs = UInt64(max(50, pollMs)) * 1_000_000
+        let deadline = Date().addingTimeInterval(Double(clampedTimeoutMs) / 1000.0)
+        while Date() < deadline {
+            if await self.isOperatorConnected() {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: pollIntervalNs)
+        }
+        return await self.isOperatorConnected()
+    }
+
+    private func ensureOperatorApprovalConnection(timeoutMs: Int) async -> Bool {
+        if await self.isOperatorConnected() {
+            return true
+        }
+        if let cfg = self.activeGatewayConnectConfig {
+            self.applyGatewayConnectConfig(cfg)
+        }
+        return await self.waitForOperatorConnection(timeoutMs: timeoutMs, pollMs: 250)
     }
 
     private func reconnectGatewaySessionsForSilentPushIfNeeded(
@@ -3134,11 +3343,30 @@ extension NodeAppModel {
         await self.applyPendingForegroundNodeActions(mapped, trigger: "test")
     }
 
+    func _test_makeOperatorConnectOptions(
+        clientId: String,
+        displayName: String?
+    ) -> GatewayConnectOptions {
+        self.makeOperatorConnectOptions(clientId: clientId, displayName: displayName)
+    }
+
+    func _test_presentExecApprovalNotificationPrompt(_ prompt: ExecApprovalNotificationPrompt) {
+        self.presentExecApprovalNotificationPrompt(prompt)
+    }
+
+    func _test_dismissPendingExecApprovalPrompt() {
+        self.dismissPendingExecApprovalPrompt()
+    }
+
+    func _test_pendingExecApprovalPrompt() -> ExecApprovalPrompt? {
+        self.pendingExecApprovalPrompt
+    }
+
     static func _test_currentDeepLinkKey() -> String {
         self.expectedDeepLinkKey()
     }
 
-    static func _test_shouldStartOperatorGatewayLoop(
+    nonisolated static func _test_shouldStartOperatorGatewayLoop(
         token: String?,
         bootstrapToken: String?,
         password: String?,
@@ -3151,6 +3379,29 @@ extension NodeAppModel {
             hasStoredOperatorToken: hasStoredOperatorToken)
     }
 
+    nonisolated static func _test_clearingBootstrapToken(
+        in config: GatewayConnectConfig?
+    ) -> GatewayConnectConfig? {
+        self.clearingBootstrapToken(in: config)
+    }
+
+    func _test_handleSuccessfulBootstrapGatewayOnboarding() async {
+        await self.handleSuccessfulBootstrapGatewayOnboarding(
+            url: URL(string: "wss://gateway.example")!,
+            stableID: "test-gateway",
+            token: nil,
+            password: nil,
+            nodeOptions: GatewayConnectOptions(
+                role: "node",
+                scopes: [],
+                caps: [],
+                commands: [],
+                permissions: [:],
+                clientId: "openclaw-ios",
+                clientMode: "node",
+                clientDisplayName: nil),
+            sessionBox: nil)
+    }
 }
 #endif
 // swiftlint:enable type_body_length file_length

--- a/apps/ios/Sources/OpenClawApp.swift
+++ b/apps/ios/Sources/OpenClawApp.swift
@@ -13,6 +13,9 @@ private struct PendingWatchPromptAction {
     var sessionKey: String?
 }
 
+private typealias PendingExecApprovalAction = ExecApprovalNotificationAction
+private typealias PendingExecApprovalPrompt = ExecApprovalNotificationPrompt
+
 @MainActor
 final class OpenClawAppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotificationCenterDelegate {
     private let logger = Logger(subsystem: "ai.openclaw.ios", category: "Push")
@@ -21,6 +24,8 @@ final class OpenClawAppDelegate: NSObject, UIApplicationDelegate, @preconcurrenc
     private var backgroundWakeTask: Task<Bool, Never>?
     private var pendingAPNsDeviceToken: Data?
     private var pendingWatchPromptActions: [PendingWatchPromptAction] = []
+    private var pendingExecApprovalActions: [PendingExecApprovalAction] = []
+    private var pendingExecApprovalPrompts: [PendingExecApprovalPrompt] = []
 
     weak var appModel: NodeAppModel? {
         didSet {
@@ -44,6 +49,26 @@ final class OpenClawAppDelegate: NSObject, UIApplicationDelegate, @preconcurrenc
                     }
                 }
             }
+            if !self.pendingExecApprovalActions.isEmpty {
+                let pending = self.pendingExecApprovalActions
+                self.pendingExecApprovalActions.removeAll()
+                Task { @MainActor in
+                    for action in pending {
+                        await model.handleExecApprovalNotificationAction(
+                            approvalId: action.approvalId,
+                            decision: action.decision)
+                    }
+                }
+            }
+            if !self.pendingExecApprovalPrompts.isEmpty {
+                let pending = self.pendingExecApprovalPrompts
+                self.pendingExecApprovalPrompts.removeAll()
+                Task { @MainActor in
+                    for prompt in pending {
+                        model.presentExecApprovalNotificationPrompt(prompt)
+                    }
+                }
+            }
         }
     }
 
@@ -54,6 +79,7 @@ final class OpenClawAppDelegate: NSObject, UIApplicationDelegate, @preconcurrenc
     {
         self.registerBackgroundWakeRefreshTask()
         UNUserNotificationCenter.current().delegate = self
+        ExecApprovalNotificationBridge.registerNotificationCategories()
         application.registerForRemoteNotifications()
         return true
     }
@@ -80,6 +106,14 @@ final class OpenClawAppDelegate: NSObject, UIApplicationDelegate, @preconcurrenc
     {
         self.logger.info("APNs remote notification received keys=\(userInfo.keys.count, privacy: .public)")
         Task { @MainActor in
+            let notificationCenter = LiveNotificationCenter()
+            if await ExecApprovalNotificationBridge.handleResolvedPushIfNeeded(
+                userInfo: userInfo,
+                notificationCenter: notificationCenter)
+            {
+                completionHandler(.newData)
+                return
+            }
             guard let appModel = self.appModel else {
                 self.logger.info("APNs wake skipped: appModel unavailable")
                 self.scheduleBackgroundWakeRefresh(afterSeconds: 90, reason: "silent_push_no_model")
@@ -216,6 +250,22 @@ final class OpenClawAppDelegate: NSObject, UIApplicationDelegate, @preconcurrenc
             sessionKey: sessionKey)
     }
 
+    private static func parseExecApprovalAction(
+        from response: UNNotificationResponse) -> PendingExecApprovalAction?
+    {
+        ExecApprovalNotificationBridge.parseAction(
+            actionIdentifier: response.actionIdentifier,
+            userInfo: response.notification.request.content.userInfo)
+    }
+
+    private static func parseExecApprovalPrompt(
+        from response: UNNotificationResponse) -> PendingExecApprovalPrompt?
+    {
+        ExecApprovalNotificationBridge.parsePrompt(
+            actionIdentifier: response.actionIdentifier,
+            userInfo: response.notification.request.content.userInfo)
+    }
+
     private func routeWatchPromptAction(_ action: PendingWatchPromptAction) async {
         guard let appModel = self.appModel else {
             self.pendingWatchPromptActions.append(action)
@@ -229,13 +279,33 @@ final class OpenClawAppDelegate: NSObject, UIApplicationDelegate, @preconcurrenc
         _ = await appModel.handleBackgroundRefreshWake(trigger: "watch_prompt_action")
     }
 
+    private func routeExecApprovalAction(_ action: PendingExecApprovalAction) async {
+        guard let appModel = self.appModel else {
+            self.pendingExecApprovalActions.append(action)
+            return
+        }
+        await appModel.handleExecApprovalNotificationAction(
+            approvalId: action.approvalId,
+            decision: action.decision)
+    }
+
+    private func routeExecApprovalPrompt(_ prompt: PendingExecApprovalPrompt) {
+        guard let appModel = self.appModel else {
+            self.pendingExecApprovalPrompts.append(prompt)
+            return
+        }
+        appModel.presentExecApprovalNotificationPrompt(prompt)
+    }
+
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void)
     {
         let userInfo = notification.request.content.userInfo
-        if Self.isWatchPromptNotification(userInfo) {
+        if Self.isWatchPromptNotification(userInfo)
+            || ExecApprovalNotificationBridge.shouldPresentNotification(userInfo: userInfo)
+        {
             completionHandler([.banner, .list, .sound])
             return
         }
@@ -247,18 +317,40 @@ final class OpenClawAppDelegate: NSObject, UIApplicationDelegate, @preconcurrenc
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void)
     {
-        guard let action = Self.parseWatchPromptAction(from: response) else {
-            completionHandler()
+        if let action = Self.parseWatchPromptAction(from: response) {
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    completionHandler()
+                    return
+                }
+                await self.routeWatchPromptAction(action)
+                completionHandler()
+            }
             return
         }
-        Task { @MainActor [weak self] in
-            guard let self else {
+        if let action = Self.parseExecApprovalAction(from: response) {
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    completionHandler()
+                    return
+                }
+                await self.routeExecApprovalAction(action)
                 completionHandler()
-                return
             }
-            await self.routeWatchPromptAction(action)
-            completionHandler()
+            return
         }
+        if let prompt = Self.parseExecApprovalPrompt(from: response) {
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    completionHandler()
+                    return
+                }
+                self.routeExecApprovalPrompt(prompt)
+                completionHandler()
+            }
+            return
+        }
+        completionHandler()
     }
 }
 

--- a/apps/ios/Sources/Push/ExecApprovalNotificationBridge.swift
+++ b/apps/ios/Sources/Push/ExecApprovalNotificationBridge.swift
@@ -1,0 +1,224 @@
+import Foundation
+import UserNotifications
+
+struct ExecApprovalNotificationAction: Sendable, Equatable {
+    let approvalId: String
+    let decision: String
+}
+
+struct ExecApprovalNotificationPrompt: Sendable, Equatable {
+    let approvalId: String
+    let commandText: String
+    let allowedDecisions: [String]
+    let host: String?
+    let nodeId: String?
+    let agentId: String?
+    let expiresAtMs: Int?
+}
+
+enum ExecApprovalNotificationBridge {
+    static let requestedKind = "exec.approval.requested"
+    static let resolvedKind = "exec.approval.resolved"
+    static let allowAlwaysCategoryIdentifier = "openclaw.exec-approval.allow-always"
+    static let onceOnlyCategoryIdentifier = "openclaw.exec-approval.once-only"
+    static let allowOnceActionIdentifier = "openclaw.exec-approval.allow-once"
+    static let allowAlwaysActionIdentifier = "openclaw.exec-approval.allow-always"
+    static let denyActionIdentifier = "openclaw.exec-approval.deny"
+
+    private static let localRequestPrefix = "exec.approval."
+
+    static func registerNotificationCategories(center: UNUserNotificationCenter = .current()) {
+        center.getNotificationCategories { categories in
+            var updated = categories
+            updated.update(with: self.makeAllowAlwaysCategory())
+            updated.update(with: self.makeOnceOnlyCategory())
+            center.setNotificationCategories(updated)
+        }
+    }
+
+    static func shouldPresentNotification(userInfo: [AnyHashable: Any]) -> Bool {
+        self.payloadKind(userInfo: userInfo) == self.requestedKind
+    }
+
+    static func parseAction(
+        actionIdentifier: String,
+        userInfo: [AnyHashable: Any]
+    ) -> ExecApprovalNotificationAction?
+    {
+        guard self.payloadKind(userInfo: userInfo) == self.requestedKind else { return nil }
+        guard let approvalId = self.approvalID(from: userInfo) else { return nil }
+
+        let decision: String
+        switch actionIdentifier {
+        case self.allowOnceActionIdentifier:
+            decision = "allow-once"
+        case self.allowAlwaysActionIdentifier:
+            decision = "allow-always"
+        case self.denyActionIdentifier:
+            decision = "deny"
+        default:
+            return nil
+        }
+
+        return ExecApprovalNotificationAction(approvalId: approvalId, decision: decision)
+    }
+
+    static func parsePrompt(
+        actionIdentifier: String,
+        userInfo: [AnyHashable: Any]
+    ) -> ExecApprovalNotificationPrompt?
+    {
+        guard actionIdentifier == UNNotificationDefaultActionIdentifier else { return nil }
+        guard self.payloadKind(userInfo: userInfo) == self.requestedKind else { return nil }
+        guard let approvalId = self.approvalID(from: userInfo) else { return nil }
+        guard let payload = self.openClawPayload(userInfo: userInfo) else { return nil }
+
+        let commandText =
+            (payload["commandText"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !commandText.isEmpty else { return nil }
+
+        return ExecApprovalNotificationPrompt(
+            approvalId: approvalId,
+            commandText: commandText,
+            allowedDecisions: self.allowedDecisions(from: payload),
+            host: self.trimmedPayloadString(payload["host"]),
+            nodeId: self.trimmedPayloadString(payload["nodeId"]),
+            agentId: self.trimmedPayloadString(payload["agentId"]),
+            expiresAtMs: self.payloadInt(payload["expiresAtMs"]))
+    }
+
+    @MainActor
+    static func handleResolvedPushIfNeeded(
+        userInfo: [AnyHashable: Any],
+        notificationCenter: NotificationCentering
+    ) async -> Bool
+    {
+        guard self.payloadKind(userInfo: userInfo) == self.resolvedKind,
+              let approvalId = self.approvalID(from: userInfo)
+        else {
+            return false
+        }
+
+        await self.removeNotifications(forApprovalID: approvalId, notificationCenter: notificationCenter)
+        return true
+    }
+
+    @MainActor
+    static func removeNotifications(
+        forApprovalID approvalId: String,
+        notificationCenter: NotificationCentering
+    ) async {
+        let normalizedID = approvalId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedID.isEmpty else { return }
+
+        await notificationCenter.removePendingNotificationRequests(
+            withIdentifiers: [self.localRequestIdentifier(for: normalizedID)])
+
+        let delivered = await notificationCenter.deliveredNotifications()
+        let identifiers = delivered.compactMap { snapshot -> String? in
+            guard self.approvalID(from: snapshot.userInfo) == normalizedID else { return nil }
+            return snapshot.identifier
+        }
+        await notificationCenter.removeDeliveredNotifications(withIdentifiers: identifiers)
+    }
+
+    static func approvalID(from userInfo: [AnyHashable: Any]) -> String? {
+        let raw = self.openClawPayload(userInfo: userInfo)?["approvalId"] as? String
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func makeAllowAlwaysCategory() -> UNNotificationCategory {
+        UNNotificationCategory(
+            identifier: self.allowAlwaysCategoryIdentifier,
+            actions: [
+                self.makeAllowOnceAction(),
+                self.makeAllowAlwaysAction(),
+                self.makeDenyAction(),
+            ],
+            intentIdentifiers: [],
+            options: [])
+    }
+
+    private static func makeOnceOnlyCategory() -> UNNotificationCategory {
+        UNNotificationCategory(
+            identifier: self.onceOnlyCategoryIdentifier,
+            actions: [
+                self.makeAllowOnceAction(),
+                self.makeDenyAction(),
+            ],
+            intentIdentifiers: [],
+            options: [])
+    }
+
+    private static func makeAllowOnceAction() -> UNNotificationAction {
+        UNNotificationAction(
+            identifier: self.allowOnceActionIdentifier,
+            title: "Allow Once",
+            options: [.authenticationRequired])
+    }
+
+    private static func makeAllowAlwaysAction() -> UNNotificationAction {
+        UNNotificationAction(
+            identifier: self.allowAlwaysActionIdentifier,
+            title: "Allow Always",
+            options: [.authenticationRequired])
+    }
+
+    private static func makeDenyAction() -> UNNotificationAction {
+        UNNotificationAction(
+            identifier: self.denyActionIdentifier,
+            title: "Deny",
+            options: [.authenticationRequired, .destructive])
+    }
+
+    private static func localRequestIdentifier(for approvalId: String) -> String {
+        "\(self.localRequestPrefix)\(approvalId)"
+    }
+
+    private static func payloadKind(userInfo: [AnyHashable: Any]) -> String {
+        let raw = self.openClawPayload(userInfo: userInfo)?["kind"] as? String
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? "unknown" : trimmed
+    }
+
+    private static func openClawPayload(userInfo: [AnyHashable: Any]) -> [String: Any]? {
+        if let payload = userInfo["openclaw"] as? [String: Any] {
+            return payload
+        }
+        if let payload = userInfo["openclaw"] as? [AnyHashable: Any] {
+            return payload.reduce(into: [String: Any]()) { partialResult, pair in
+                guard let key = pair.key as? String else { return }
+                partialResult[key] = pair.value
+            }
+        }
+        return nil
+    }
+
+    private static func allowedDecisions(from payload: [String: Any]) -> [String] {
+        guard let rawValues = payload["allowedDecisions"] as? [Any] else { return [] }
+        return rawValues.compactMap { value -> String? in
+            guard let value = value as? String else { return nil }
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    private static func trimmedPayloadString(_ raw: Any?) -> String? {
+        let trimmed = (raw as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func payloadInt(_ raw: Any?) -> Int? {
+        if let raw = raw as? Int {
+            return raw
+        }
+        if let raw = raw as? NSNumber {
+            return raw.intValue
+        }
+        if let raw = raw as? String {
+            return Int(raw.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        return nil
+    }
+}

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -107,6 +107,7 @@ struct RootCanvas: View {
         }
         .gatewayTrustPromptAlert()
         .deepLinkAgentPromptAlert()
+        .execApprovalPromptDialog()
         .sheet(item: self.$presentedSheet) { sheet in
             switch sheet {
             case .settings:

--- a/apps/ios/Sources/Services/NotificationService.swift
+++ b/apps/ios/Sources/Services/NotificationService.swift
@@ -1,6 +1,11 @@
 import Foundation
 import UserNotifications
 
+struct NotificationSnapshot: @unchecked Sendable {
+    let identifier: String
+    let userInfo: [AnyHashable: Any]
+}
+
 enum NotificationAuthorizationStatus: Sendable {
     case notDetermined
     case denied
@@ -13,6 +18,9 @@ protocol NotificationCentering: Sendable {
     func authorizationStatus() async -> NotificationAuthorizationStatus
     func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool
     func add(_ request: UNNotificationRequest) async throws
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) async
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) async
+    func deliveredNotifications() async -> [NotificationSnapshot]
 }
 
 struct LiveNotificationCenter: NotificationCentering, @unchecked Sendable {
@@ -52,6 +60,29 @@ struct LiveNotificationCenter: NotificationCentering, @unchecked Sendable {
                 } else {
                     cont.resume(returning: ())
                 }
+            }
+        }
+    }
+
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) async {
+        guard !identifiers.isEmpty else { return }
+        self.center.removePendingNotificationRequests(withIdentifiers: identifiers)
+    }
+
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) async {
+        guard !identifiers.isEmpty else { return }
+        self.center.removeDeliveredNotifications(withIdentifiers: identifiers)
+    }
+
+    func deliveredNotifications() async -> [NotificationSnapshot] {
+        await withCheckedContinuation { continuation in
+            self.center.getDeliveredNotifications { notifications in
+                continuation.resume(
+                    returning: notifications.map { notification in
+                        NotificationSnapshot(
+                            identifier: notification.request.identifier,
+                            userInfo: notification.request.content.userInfo)
+                    })
             }
         }
     }

--- a/apps/ios/Tests/ExecApprovalNotificationBridgeTests.swift
+++ b/apps/ios/Tests/ExecApprovalNotificationBridgeTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+import UserNotifications
+@testable import OpenClaw
+
+private final class MockNotificationCenter: NotificationCentering, @unchecked Sendable {
+    var authorization: NotificationAuthorizationStatus = .authorized
+    var addedRequests: [UNNotificationRequest] = []
+    var pendingRemovedIdentifiers: [[String]] = []
+    var deliveredRemovedIdentifiers: [[String]] = []
+    var delivered: [NotificationSnapshot] = []
+
+    func authorizationStatus() async -> NotificationAuthorizationStatus {
+        self.authorization
+    }
+
+    func requestAuthorization(options _: UNAuthorizationOptions) async throws -> Bool {
+        true
+    }
+
+    func add(_ request: UNNotificationRequest) async throws {
+        self.addedRequests.append(request)
+    }
+
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) async {
+        self.pendingRemovedIdentifiers.append(identifiers)
+    }
+
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) async {
+        self.deliveredRemovedIdentifiers.append(identifiers)
+    }
+
+    func deliveredNotifications() async -> [NotificationSnapshot] {
+        self.delivered
+    }
+}
+
+@Suite(.serialized) struct ExecApprovalNotificationBridgeTests {
+    @Test func parseActionMapsApprovalNotificationButtons() {
+        let userInfo: [AnyHashable: Any] = [
+            "openclaw": [
+                "kind": ExecApprovalNotificationBridge.requestedKind,
+                "approvalId": "approval-123",
+            ],
+        ]
+
+        let allowOnce = ExecApprovalNotificationBridge.parseAction(
+            actionIdentifier: ExecApprovalNotificationBridge.allowOnceActionIdentifier,
+            userInfo: userInfo)
+        let allowAlways = ExecApprovalNotificationBridge.parseAction(
+            actionIdentifier: ExecApprovalNotificationBridge.allowAlwaysActionIdentifier,
+            userInfo: userInfo)
+        let deny = ExecApprovalNotificationBridge.parseAction(
+            actionIdentifier: ExecApprovalNotificationBridge.denyActionIdentifier,
+            userInfo: userInfo)
+
+        #expect(allowOnce == ExecApprovalNotificationAction(approvalId: "approval-123", decision: "allow-once"))
+        #expect(allowAlways == ExecApprovalNotificationAction(approvalId: "approval-123", decision: "allow-always"))
+        #expect(deny == ExecApprovalNotificationAction(approvalId: "approval-123", decision: "deny"))
+    }
+
+    @Test func parsePromptMapsDefaultNotificationTap() {
+        let prompt = ExecApprovalNotificationBridge.parsePrompt(
+            actionIdentifier: UNNotificationDefaultActionIdentifier,
+            userInfo: [
+                "openclaw": [
+                    "kind": ExecApprovalNotificationBridge.requestedKind,
+                    "approvalId": "approval-123",
+                    "commandText": "echo hello",
+                    "allowedDecisions": ["allow-once", "allow-always", "deny"],
+                    "host": "gateway",
+                    "nodeId": "node-1",
+                    "agentId": "main",
+                    "expiresAtMs": 12345,
+                ],
+            ])
+
+        #expect(
+            prompt == ExecApprovalNotificationPrompt(
+                approvalId: "approval-123",
+                commandText: "echo hello",
+                allowedDecisions: ["allow-once", "allow-always", "deny"],
+                host: "gateway",
+                nodeId: "node-1",
+                agentId: "main",
+                expiresAtMs: 12345)
+        )
+    }
+
+    @Test @MainActor func handleResolvedPushRemovesMatchingNotifications() async {
+        let center = MockNotificationCenter()
+        center.delivered = [
+            NotificationSnapshot(
+                identifier: "remote-approval-1",
+                userInfo: [
+                    "openclaw": [
+                        "kind": ExecApprovalNotificationBridge.requestedKind,
+                        "approvalId": "approval-123",
+                    ],
+                ]),
+            NotificationSnapshot(
+                identifier: "remote-other",
+                userInfo: [
+                    "openclaw": [
+                        "kind": ExecApprovalNotificationBridge.requestedKind,
+                        "approvalId": "approval-999",
+                    ],
+                ]),
+        ]
+
+        let handled = await ExecApprovalNotificationBridge.handleResolvedPushIfNeeded(
+            userInfo: [
+                "openclaw": [
+                    "kind": ExecApprovalNotificationBridge.resolvedKind,
+                    "approvalId": "approval-123",
+                ],
+            ],
+            notificationCenter: center)
+
+        #expect(handled)
+        #expect(center.pendingRemovedIdentifiers == [["exec.approval.approval-123"]])
+        #expect(center.deliveredRemovedIdentifiers == [["remote-approval-1"]])
+    }
+}

--- a/apps/ios/Tests/GatewayConnectionControllerTests.swift
+++ b/apps/ios/Tests/GatewayConnectionControllerTests.swift
@@ -70,6 +70,19 @@ import UIKit
         }
     }
 
+    @Test @MainActor func operatorConnectOptionsRequestApprovalScope() {
+        let appModel = NodeAppModel()
+        let options = appModel._test_makeOperatorConnectOptions(
+            clientId: "openclaw-ios",
+            displayName: "OpenClaw iOS")
+
+        #expect(options.role == "operator")
+        #expect(options.scopes.contains("operator.read"))
+        #expect(options.scopes.contains("operator.write"))
+        #expect(options.scopes.contains("operator.approvals"))
+        #expect(options.scopes.contains("operator.talk.secrets"))
+    }
+
     @Test @MainActor func loadLastConnectionReadsSavedValues() {
         let prior = KeychainStore.loadString(service: "ai.openclaw.gateway", account: "lastConnection")
         defer {

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -2,6 +2,7 @@ import OpenClawKit
 import Foundation
 import Testing
 import UIKit
+import UserNotifications
 @testable import OpenClaw
 
 private func makeAgentDeepLinkURL(
@@ -68,6 +69,36 @@ private final class MockWatchMessagingService: @preconcurrency WatchMessagingSer
     }
 }
 
+private final class MockBootstrapNotificationCenter: NotificationCentering, @unchecked Sendable {
+    var status: NotificationAuthorizationStatus = .notDetermined
+    var requestAuthorizationResult = false
+    var requestAuthorizationCalls = 0
+
+    func authorizationStatus() async -> NotificationAuthorizationStatus {
+        self.status
+    }
+
+    func requestAuthorization(options _: UNAuthorizationOptions) async throws -> Bool {
+        self.requestAuthorizationCalls += 1
+        if self.requestAuthorizationResult {
+            self.status = .authorized
+        } else {
+            self.status = .denied
+        }
+        return self.requestAuthorizationResult
+    }
+
+    func add(_: UNNotificationRequest) async throws {}
+
+    func removePendingNotificationRequests(withIdentifiers _: [String]) async {}
+
+    func removeDeliveredNotifications(withIdentifiers _: [String]) async {}
+
+    func deliveredNotifications() async -> [NotificationSnapshot] {
+        []
+    }
+}
+
 @Suite(.serialized) struct NodeAppModelInvokeTests {
     @Test @MainActor func decodeParamsFailsWithoutJSON() {
         #expect(throws: Error.self) {
@@ -94,6 +125,42 @@ private final class MockWatchMessagingService: @preconcurrency WatchMessagingSer
         appModel.setSelectedAgentId("agent-123")
         #expect(appModel.chatSessionKey == SessionKey.makeAgentSessionKey(agentId: "agent-123", baseKey: "main"))
         #expect(appModel.mainSessionKey == "agent:agent-123:main")
+    }
+
+    @Test @MainActor func execApprovalPromptPresentationTracksLatestNotificationTap() throws {
+        let appModel = NodeAppModel()
+        appModel._test_presentExecApprovalNotificationPrompt(
+            ExecApprovalNotificationPrompt(
+                approvalId: "approval-1",
+                commandText: "echo first",
+                allowedDecisions: ["allow-once", "deny"],
+                host: "gateway",
+                nodeId: nil,
+                agentId: "main",
+                expiresAtMs: 1))
+
+        let firstPrompt = try #require(appModel._test_pendingExecApprovalPrompt())
+        #expect(firstPrompt.id == "approval-1")
+        #expect(firstPrompt.commandText == "echo first")
+        #expect(firstPrompt.allowsAllowAlways == false)
+
+        appModel._test_presentExecApprovalNotificationPrompt(
+            ExecApprovalNotificationPrompt(
+                approvalId: "approval-2",
+                commandText: "echo second",
+                allowedDecisions: ["allow-once", "allow-always", "deny"],
+                host: "gateway",
+                nodeId: "node-2",
+                agentId: nil,
+                expiresAtMs: 2))
+
+        let secondPrompt = try #require(appModel._test_pendingExecApprovalPrompt())
+        #expect(secondPrompt.id == "approval-2")
+        #expect(secondPrompt.commandText == "echo second")
+        #expect(secondPrompt.allowsAllowAlways)
+
+        appModel._test_dismissPendingExecApprovalPrompt()
+        #expect(appModel._test_pendingExecApprovalPrompt() == nil)
     }
 
     @Test func operatorLoopWaitsForBootstrapHandoffBeforeUsingStoredToken() {
@@ -127,6 +194,15 @@ private final class MockWatchMessagingService: @preconcurrency WatchMessagingSer
         )
     }
 
+    @Test @MainActor func successfulBootstrapOnboardingRequestsNotificationAuthorization() async {
+        let center = MockBootstrapNotificationCenter()
+        let appModel = NodeAppModel(notificationCenter: center)
+
+        await appModel._test_handleSuccessfulBootstrapGatewayOnboarding()
+
+        #expect(center.requestAuthorizationCalls == 1)
+    }
+
     @Test func clearingBootstrapTokenStripsReconnectConfigEvenWithoutPersistence() {
         let config = GatewayConnectConfig(
             url: URL(string: "wss://gateway.example")!,
@@ -145,7 +221,7 @@ private final class MockWatchMessagingService: @preconcurrency WatchMessagingSer
                 clientMode: "node",
                 clientDisplayName: nil))
 
-        let cleared = NodeAppModel.clearingBootstrapToken(in: config)
+        let cleared = NodeAppModel._test_clearingBootstrapToken(in: config)
         #expect(cleared?.bootstrapToken == nil)
         #expect(cleared?.url == config.url)
         #expect(cleared?.stableID == config.stableID)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -572,17 +572,33 @@ public actor GatewayChannelActor {
         } else if let tick = ok.policy["tickIntervalMs"]?.value as? Int {
             self.tickIntervalMs = Double(tick)
         }
-        if let auth = ok.auth,
-           let deviceToken = auth["deviceToken"]?.value as? String {
-            let authRole = auth["role"]?.value as? String ?? role
-            let scopes = (auth["scopes"]?.value as? [ProtoAnyCodable])?
-                .compactMap { $0.value as? String } ?? []
-            if let identity {
+        if let auth = ok.auth, let identity {
+            if let deviceToken = auth["deviceToken"]?.value as? String {
+                let authRole = auth["role"]?.value as? String ?? role
+                let scopes = (auth["scopes"]?.value as? [ProtoAnyCodable])?
+                    .compactMap { $0.value as? String } ?? []
                 _ = DeviceAuthStore.storeToken(
                     deviceId: identity.deviceId,
                     role: authRole,
                     token: deviceToken,
                     scopes: scopes)
+            }
+            if let tokenEntries = auth["deviceTokens"]?.value as? [ProtoAnyCodable] {
+                for entry in tokenEntries {
+                    guard let rawEntry = entry.value as? [String: ProtoAnyCodable],
+                          let deviceToken = rawEntry["deviceToken"]?.value as? String,
+                          let authRole = rawEntry["role"]?.value as? String
+                    else {
+                        continue
+                    }
+                    let scopes = (rawEntry["scopes"]?.value as? [ProtoAnyCodable])?
+                        .compactMap { $0.value as? String } ?? []
+                    _ = DeviceAuthStore.storeToken(
+                        deviceId: identity.deviceId,
+                        role: authRole,
+                        token: deviceToken,
+                        scopes: scopes)
+                }
             }
         }
         self.lastTick = Date()

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -13,12 +13,17 @@ private extension NSLock {
 
 private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Sendable {
     private let lock = NSLock()
+    private let helloAuth: [String: Any]?
     private var _state: URLSessionTask.State = .suspended
     private var connectRequestId: String?
     private var connectAuth: [String: Any]?
     private var receivePhase = 0
     private var pendingReceiveHandler:
         (@Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)?
+
+    init(helloAuth: [String: Any]? = nil) {
+        self.helloAuth = helloAuth
+    }
 
     var state: URLSessionTask.State {
         get { self.lock.withLock { self._state } }
@@ -79,11 +84,11 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
         for _ in 0..<50 {
             let id = self.lock.withLock { self.connectRequestId }
             if let id {
-                return .data(Self.connectOkData(id: id))
+                return .data(Self.connectOkData(id: id, auth: self.helloAuth))
             }
             try await Task.sleep(nanoseconds: 1_000_000)
         }
-        return .data(Self.connectOkData(id: "connect"))
+        return .data(Self.connectOkData(id: "connect", auth: self.helloAuth))
     }
 
     func receive(
@@ -110,8 +115,8 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
         return (try? JSONSerialization.data(withJSONObject: frame)) ?? Data()
     }
 
-    private static func connectOkData(id: String) -> Data {
-        let payload: [String: Any] = [
+    private static func connectOkData(id: String, auth: [String: Any]? = nil) -> Data {
+        var payload: [String: Any] = [
             "type": "hello-ok",
             "protocol": 2,
             "server": [
@@ -137,6 +142,9 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
                 "tickIntervalMs": 30_000,
             ],
         ]
+        if let auth {
+            payload["auth"] = auth
+        }
         let frame: [String: Any] = [
             "type": "res",
             "id": id,
@@ -149,8 +157,13 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
 
 private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked Sendable {
     private let lock = NSLock()
+    private let helloAuth: [String: Any]?
     private var tasks: [FakeGatewayWebSocketTask] = []
     private var makeCount = 0
+
+    init(helloAuth: [String: Any]? = nil) {
+        self.helloAuth = helloAuth
+    }
 
     func snapshotMakeCount() -> Int {
         self.lock.withLock { self.makeCount }
@@ -164,7 +177,7 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
         _ = url
         return self.lock.withLock {
             self.makeCount += 1
-            let task = FakeGatewayWebSocketTask()
+            let task = FakeGatewayWebSocketTask(helloAuth: self.helloAuth)
             self.tasks.append(task)
             return WebSocketTaskBox(task: task)
         }
@@ -230,6 +243,82 @@ struct GatewayNodeSessionTests {
         #expect(auth["bootstrapToken"] as? String == "fresh-bootstrap-token")
         #expect(auth["token"] == nil)
         #expect(auth["deviceToken"] == nil)
+
+        await gateway.disconnect()
+    }
+
+    @Test
+    func bootstrapHelloStoresAdditionalDeviceTokens() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
+        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
+        defer {
+            if let previousStateDir {
+                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
+            } else {
+                unsetenv("OPENCLAW_STATE_DIR")
+            }
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let identity = DeviceIdentityStore.loadOrCreate()
+        let session = FakeGatewayWebSocketSession(helloAuth: [
+            "deviceToken": "node-device-token",
+            "role": "node",
+            "scopes": [],
+            "issuedAtMs": 1000,
+            "deviceTokens": [
+                [
+                    "deviceToken": "node-device-token",
+                    "role": "node",
+                    "scopes": [],
+                    "issuedAtMs": 1000,
+                ],
+                [
+                    "deviceToken": "operator-device-token",
+                    "role": "operator",
+                    "scopes": [
+                        "operator.approvals",
+                        "operator.read",
+                        "operator.talk.secrets",
+                        "operator.write",
+                    ],
+                    "issuedAtMs": 1001,
+                ],
+            ],
+        ])
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-ios-test",
+            clientMode: "node",
+            clientDisplayName: "iOS Test",
+            includeDeviceIdentity: true)
+
+        try await gateway.connect(
+            url: URL(string: "ws://example.invalid")!,
+            token: nil,
+            bootstrapToken: "fresh-bootstrap-token",
+            password: nil,
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { req in
+                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+            })
+
+        let nodeEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node"))
+        let operatorEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator"))
+        #expect(nodeEntry.token == "node-device-token")
+        #expect(operatorEntry.token == "operator-device-token")
+        #expect(operatorEntry.scopes.contains("operator.approvals"))
 
         await gateway.disconnect()
     }

--- a/src/gateway/exec-approval-ios-push.ts
+++ b/src/gateway/exec-approval-ios-push.ts
@@ -1,0 +1,302 @@
+import { loadConfig } from "../config/config.js";
+import {
+  hasEffectivePairedDeviceRole,
+  listDevicePairing,
+  type PairedDevice,
+} from "../infra/device-pairing.js";
+import type { ExecApprovalRequest, ExecApprovalResolved } from "../infra/exec-approvals.js";
+import {
+  clearApnsRegistrationIfCurrent,
+  loadApnsRegistration,
+  resolveApnsAuthConfigFromEnv,
+  resolveApnsRelayConfigFromEnv,
+  sendApnsExecApprovalAlert,
+  sendApnsExecApprovalResolvedWake,
+  shouldClearStoredApnsRegistration,
+  type ApnsAuthConfig,
+  type ApnsRegistration,
+  type ApnsRelayConfig,
+} from "../infra/push-apns.js";
+import { roleScopesAllow } from "../shared/operator-scope-compat.js";
+
+const APPROVALS_SCOPE = "operator.approvals";
+const OPERATOR_ROLE = "operator";
+
+type GatewayLikeLogger = {
+  debug?: (message: string) => void;
+  warn?: (message: string) => void;
+  error?: (message: string) => void;
+};
+
+type DeliveryTarget = {
+  nodeId: string;
+  registration: ApnsRegistration;
+};
+
+type DeliveryPlan = {
+  targets: DeliveryTarget[];
+  directAuth?: ApnsAuthConfig;
+  relayConfig?: ApnsRelayConfig;
+};
+
+function isIosPlatform(platform: string | undefined): boolean {
+  const normalized = platform?.trim().toLowerCase() ?? "";
+  return normalized.startsWith("ios") || normalized.startsWith("ipados");
+}
+
+function resolveApprovedScopes(device: PairedDevice): string[] {
+  if (Array.isArray(device.approvedScopes)) {
+    return device.approvedScopes;
+  }
+  if (Array.isArray(device.scopes)) {
+    return device.scopes;
+  }
+  const operatorTokenScopes = device.tokens?.[OPERATOR_ROLE]?.scopes;
+  return Array.isArray(operatorTokenScopes) ? operatorTokenScopes : [];
+}
+
+function canApproveExecRequests(device: PairedDevice): boolean {
+  return roleScopesAllow({
+    role: OPERATOR_ROLE,
+    requestedScopes: [APPROVALS_SCOPE],
+    allowedScopes: resolveApprovedScopes(device),
+  });
+}
+
+function shouldTargetDevice(params: {
+  device: PairedDevice;
+  requireApprovalScope: boolean;
+}): boolean {
+  if (!isIosPlatform(params.device.platform)) {
+    return false;
+  }
+  if (!hasEffectivePairedDeviceRole(params.device, OPERATOR_ROLE)) {
+    return false;
+  }
+  if (!params.requireApprovalScope) {
+    return true;
+  }
+  return canApproveExecRequests(params.device);
+}
+
+async function loadRegisteredTargets(params: {
+  deviceIds: readonly string[];
+}): Promise<DeliveryTarget[]> {
+  const targets = await Promise.all(
+    params.deviceIds.map(async (nodeId) => {
+      const registration = await loadApnsRegistration(nodeId);
+      return registration ? { nodeId, registration } : null;
+    }),
+  );
+  return targets.filter((target): target is DeliveryTarget => target !== null);
+}
+
+async function resolvePairedTargets(params: {
+  requireApprovalScope: boolean;
+}): Promise<DeliveryTarget[]> {
+  const pairing = await listDevicePairing();
+  const deviceIds = pairing.paired
+    .filter((device) =>
+      shouldTargetDevice({ device, requireApprovalScope: params.requireApprovalScope }),
+    )
+    .map((device) => device.deviceId);
+  return await loadRegisteredTargets({ deviceIds });
+}
+
+async function resolveDeliveryPlan(params: {
+  requireApprovalScope: boolean;
+  explicitNodeIds?: readonly string[];
+  log: GatewayLikeLogger;
+}): Promise<DeliveryPlan> {
+  const targets = params.explicitNodeIds?.length
+    ? await loadRegisteredTargets({ deviceIds: params.explicitNodeIds })
+    : await resolvePairedTargets({ requireApprovalScope: params.requireApprovalScope });
+  if (targets.length === 0) {
+    return { targets: [] };
+  }
+
+  const needsDirect = targets.some((target) => target.registration.transport === "direct");
+  const needsRelay = targets.some((target) => target.registration.transport === "relay");
+
+  let directAuth: ApnsAuthConfig | undefined;
+  if (needsDirect) {
+    const auth = await resolveApnsAuthConfigFromEnv(process.env);
+    if (auth.ok) {
+      directAuth = auth.value;
+    } else {
+      params.log.warn?.(`exec approvals: iOS direct APNs auth unavailable: ${auth.error}`);
+    }
+  }
+
+  let relayConfig: ApnsRelayConfig | undefined;
+  if (needsRelay) {
+    const relay = resolveApnsRelayConfigFromEnv(process.env, loadConfig().gateway);
+    if (relay.ok) {
+      relayConfig = relay.value;
+    } else {
+      params.log.warn?.(`exec approvals: iOS relay APNs config unavailable: ${relay.error}`);
+    }
+  }
+
+  return {
+    targets: targets.filter((target) =>
+      target.registration.transport === "direct" ? Boolean(directAuth) : Boolean(relayConfig),
+    ),
+    directAuth,
+    relayConfig,
+  };
+}
+
+async function clearStaleApnsRegistrationIfNeeded(params: {
+  nodeId: string;
+  registration: ApnsRegistration;
+  result: { status: number; reason?: string };
+}): Promise<void> {
+  if (
+    shouldClearStoredApnsRegistration({
+      registration: params.registration,
+      result: params.result,
+    })
+  ) {
+    await clearApnsRegistrationIfCurrent({
+      nodeId: params.nodeId,
+      registration: params.registration,
+    });
+  }
+}
+
+async function sendRequestedPushes(params: {
+  request: ExecApprovalRequest;
+  plan: DeliveryPlan;
+  log: GatewayLikeLogger;
+}): Promise<void> {
+  await Promise.allSettled(
+    params.plan.targets.map(async (target) => {
+      const result =
+        target.registration.transport === "direct"
+          ? await sendApnsExecApprovalAlert({
+              registration: target.registration,
+              nodeId: target.nodeId,
+              approvalId: params.request.id,
+              request: params.request.request,
+              expiresAtMs: params.request.expiresAtMs,
+              auth: params.plan.directAuth!,
+            })
+          : await sendApnsExecApprovalAlert({
+              registration: target.registration,
+              nodeId: target.nodeId,
+              approvalId: params.request.id,
+              request: params.request.request,
+              expiresAtMs: params.request.expiresAtMs,
+              relayConfig: params.plan.relayConfig!,
+            });
+      await clearStaleApnsRegistrationIfNeeded({
+        nodeId: target.nodeId,
+        registration: target.registration,
+        result,
+      });
+      if (!result.ok) {
+        params.log.warn?.(
+          `exec approvals: iOS request push failed node=${target.nodeId} status=${result.status} reason=${result.reason ?? "unknown"}`,
+        );
+      }
+    }),
+  );
+}
+
+async function sendResolvedPushes(params: {
+  approvalId: string;
+  plan: DeliveryPlan;
+  log: GatewayLikeLogger;
+}): Promise<void> {
+  await Promise.allSettled(
+    params.plan.targets.map(async (target) => {
+      const result =
+        target.registration.transport === "direct"
+          ? await sendApnsExecApprovalResolvedWake({
+              registration: target.registration,
+              nodeId: target.nodeId,
+              approvalId: params.approvalId,
+              auth: params.plan.directAuth!,
+            })
+          : await sendApnsExecApprovalResolvedWake({
+              registration: target.registration,
+              nodeId: target.nodeId,
+              approvalId: params.approvalId,
+              relayConfig: params.plan.relayConfig!,
+            });
+      await clearStaleApnsRegistrationIfNeeded({
+        nodeId: target.nodeId,
+        registration: target.registration,
+        result,
+      });
+      if (!result.ok) {
+        params.log.warn?.(
+          `exec approvals: iOS cleanup push failed node=${target.nodeId} status=${result.status} reason=${result.reason ?? "unknown"}`,
+        );
+      }
+    }),
+  );
+}
+
+export function createExecApprovalIosPushDelivery(params: { log: GatewayLikeLogger }) {
+  const approvalTargetsById = new Map<string, string[]>();
+
+  return {
+    async handleRequested(request: ExecApprovalRequest): Promise<boolean> {
+      const plan = await resolveDeliveryPlan({
+        requireApprovalScope: true,
+        log: params.log,
+      });
+      if (plan.targets.length === 0) {
+        approvalTargetsById.delete(request.id);
+        return false;
+      }
+      approvalTargetsById.set(
+        request.id,
+        plan.targets.map((target) => target.nodeId),
+      );
+      void sendRequestedPushes({ request, plan, log: params.log }).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        params.log.error?.(`exec approvals: iOS request push failed: ${message}`);
+      });
+      return true;
+    },
+
+    async handleResolved(resolved: ExecApprovalResolved): Promise<void> {
+      const explicitNodeIds = approvalTargetsById.get(resolved.id);
+      approvalTargetsById.delete(resolved.id);
+      const plan = await resolveDeliveryPlan({
+        requireApprovalScope: false,
+        explicitNodeIds,
+        log: params.log,
+      });
+      if (plan.targets.length === 0) {
+        return;
+      }
+      await sendResolvedPushes({
+        approvalId: resolved.id,
+        plan,
+        log: params.log,
+      });
+    },
+
+    async handleExpired(request: ExecApprovalRequest): Promise<void> {
+      const explicitNodeIds = approvalTargetsById.get(request.id);
+      approvalTargetsById.delete(request.id);
+      const plan = await resolveDeliveryPlan({
+        requireApprovalScope: false,
+        explicitNodeIds,
+        log: params.log,
+      });
+      if (plan.targets.length === 0) {
+        return;
+      }
+      await sendResolvedPushes({
+        approvalId: request.id,
+        plan,
+        log: params.log,
+      });
+    },
+  };
+}

--- a/src/gateway/protocol/schema/frames.ts
+++ b/src/gateway/protocol/schema/frames.ts
@@ -96,6 +96,19 @@ export const HelloOkSchema = Type.Object(
           role: NonEmptyString,
           scopes: Type.Array(NonEmptyString),
           issuedAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+          deviceTokens: Type.Optional(
+            Type.Array(
+              Type.Object(
+                {
+                  deviceToken: NonEmptyString,
+                  role: NonEmptyString,
+                  scopes: Type.Array(NonEmptyString),
+                  issuedAtMs: Type.Integer({ minimum: 0 }),
+                },
+                { additionalProperties: false },
+              ),
+            ),
+          ),
         },
         { additionalProperties: false },
       ),

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -6,6 +6,8 @@ import {
   resolveExecApprovalAllowedDecisions,
   resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalDecision,
+  type ExecApprovalRequest,
+  type ExecApprovalResolved,
 } from "../../infra/exec-approvals.js";
 import {
   buildSystemRunApprovalBinding,
@@ -26,9 +28,15 @@ const APPROVAL_NOT_FOUND_DETAILS = {
   reason: ErrorCodes.APPROVAL_NOT_FOUND,
 } as const;
 
+type ExecApprovalIosPushDelivery = {
+  handleRequested?: (request: ExecApprovalRequest) => Promise<boolean>;
+  handleResolved?: (resolved: ExecApprovalResolved) => Promise<void>;
+  handleExpired?: (request: ExecApprovalRequest) => Promise<void>;
+};
+
 export function createExecApprovalHandlers(
   manager: ExecApprovalManager,
-  opts?: { forwarder?: ExecApprovalForwarder },
+  opts?: { forwarder?: ExecApprovalForwarder; iosPushDelivery?: ExecApprovalIosPushDelivery },
 ): GatewayRequestHandlers {
   return {
     "exec.approval.request": async ({ params, respond, context, client }) => {
@@ -181,16 +189,13 @@ export function createExecApprovalHandlers(
         );
         return;
       }
-      context.broadcast(
-        "exec.approval.requested",
-        {
-          id: record.id,
-          request: record.request,
-          createdAtMs: record.createdAtMs,
-          expiresAtMs: record.expiresAtMs,
-        },
-        { dropIfSlow: true },
-      );
+      const requestEvent: ExecApprovalRequest = {
+        id: record.id,
+        request: record.request,
+        createdAtMs: record.createdAtMs,
+        expiresAtMs: record.expiresAtMs,
+      };
+      context.broadcast("exec.approval.requested", requestEvent, { dropIfSlow: true });
       const hasExecApprovalClients = context.hasExecApprovalClients?.(client?.connId) ?? false;
       const hasTurnSourceRoute = hasApprovalTurnSourceRoute({
         turnSourceChannel: record.request.turnSourceChannel,
@@ -199,18 +204,21 @@ export function createExecApprovalHandlers(
       let forwarded = false;
       if (opts?.forwarder) {
         try {
-          forwarded = await opts.forwarder.handleRequested({
-            id: record.id,
-            request: record.request,
-            createdAtMs: record.createdAtMs,
-            expiresAtMs: record.expiresAtMs,
-          });
+          forwarded = await opts.forwarder.handleRequested(requestEvent);
         } catch (err) {
           context.logGateway?.error?.(`exec approvals: forward request failed: ${String(err)}`);
         }
       }
+      let deliveredToIosPush = false;
+      if (opts?.iosPushDelivery?.handleRequested) {
+        try {
+          deliveredToIosPush = await opts.iosPushDelivery.handleRequested(requestEvent);
+        } catch (err) {
+          context.logGateway?.error?.(`exec approvals: iOS push request failed: ${String(err)}`);
+        }
+      }
 
-      if (!hasExecApprovalClients && !forwarded && !hasTurnSourceRoute) {
+      if (!hasExecApprovalClients && !forwarded && !hasTurnSourceRoute && !deliveredToIosPush) {
         manager.expire(record.id, "no-approval-route");
         respond(
           true,
@@ -241,6 +249,11 @@ export function createExecApprovalHandlers(
       }
 
       const decision = await decisionPromise;
+      if (decision === null) {
+        void opts?.iosPushDelivery?.handleExpired?.(requestEvent).catch((err) => {
+          context.logGateway?.error?.(`exec approvals: iOS push expire failed: ${String(err)}`);
+        });
+      }
       // Send final response with decision for callers using expectFinal:true.
       respond(
         true,
@@ -354,22 +367,20 @@ export function createExecApprovalHandlers(
         );
         return;
       }
-      context.broadcast(
-        "exec.approval.resolved",
-        { id: approvalId, decision, resolvedBy, ts: Date.now(), request: snapshot?.request },
-        { dropIfSlow: true },
-      );
-      void opts?.forwarder
-        ?.handleResolved({
-          id: approvalId,
-          decision,
-          resolvedBy,
-          ts: Date.now(),
-          request: snapshot?.request,
-        })
-        .catch((err) => {
-          context.logGateway?.error?.(`exec approvals: forward resolve failed: ${String(err)}`);
-        });
+      const resolvedEvent: ExecApprovalResolved = {
+        id: approvalId,
+        decision,
+        resolvedBy,
+        ts: Date.now(),
+        request: snapshot?.request,
+      };
+      context.broadcast("exec.approval.resolved", resolvedEvent, { dropIfSlow: true });
+      void opts?.forwarder?.handleResolved(resolvedEvent).catch((err) => {
+        context.logGateway?.error?.(`exec approvals: forward resolve failed: ${String(err)}`);
+      });
+      void opts?.iosPushDelivery?.handleResolved?.(resolvedEvent).catch((err) => {
+        context.logGateway?.error?.(`exec approvals: iOS push resolve failed: ${String(err)}`);
+      });
       respond(true, { ok: true }, undefined);
     },
   };

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -451,20 +451,36 @@ describe("exec approval handlers", () => {
     return { handlers, broadcasts, respond, context };
   }
 
-  function createForwardingExecApprovalFixture() {
+  function createForwardingExecApprovalFixture(opts?: {
+    iosPushDelivery?: {
+      handleRequested: ReturnType<typeof vi.fn>;
+      handleResolved: ReturnType<typeof vi.fn>;
+      handleExpired: ReturnType<typeof vi.fn>;
+    };
+  }) {
     const manager = new ExecApprovalManager();
     const forwarder = {
       handleRequested: vi.fn(async () => false),
       handleResolved: vi.fn(async () => {}),
       stop: vi.fn(),
     };
-    const handlers = createExecApprovalHandlers(manager, { forwarder });
+    const handlers = createExecApprovalHandlers(manager, {
+      forwarder,
+      iosPushDelivery: opts?.iosPushDelivery as never,
+    });
     const respond = vi.fn();
     const context = {
       broadcast: (_event: string, _payload: unknown) => {},
       hasExecApprovalClients: () => false,
     };
-    return { manager, handlers, forwarder, respond, context };
+    return {
+      manager,
+      handlers,
+      forwarder,
+      iosPushDelivery: opts?.iosPushDelivery,
+      respond,
+      context,
+    };
   }
 
   async function drainApprovalRequestTicks() {
@@ -1034,6 +1050,116 @@ describe("exec approval handlers", () => {
       expect.objectContaining({ id: "approval-no-approver", decision: null }),
       undefined,
     );
+  });
+
+  it("keeps approvals pending when iOS push delivery accepted the request", async () => {
+    const iosPushDelivery = {
+      handleRequested: vi.fn(async () => true),
+      handleResolved: vi.fn(async () => {}),
+      handleExpired: vi.fn(async () => {}),
+    };
+    const { manager, handlers, forwarder, respond, context } = createForwardingExecApprovalFixture({
+      iosPushDelivery,
+    });
+    const expireSpy = vi.spyOn(manager, "expire");
+
+    const requestPromise = requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: {
+        twoPhase: true,
+        timeoutMs: 60_000,
+        id: "approval-ios-push",
+        host: "gateway",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ status: "accepted", id: "approval-ios-push" }),
+        undefined,
+      );
+    });
+
+    expect(forwarder.handleRequested).toHaveBeenCalledTimes(1);
+    expect(iosPushDelivery.handleRequested).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "approval-ios-push" }),
+    );
+    expect(expireSpy).not.toHaveBeenCalled();
+
+    manager.resolve("approval-ios-push", "allow-once");
+    await requestPromise;
+  });
+
+  it("sends iOS cleanup delivery on resolve", async () => {
+    const iosPushDelivery = {
+      handleRequested: vi.fn(async () => true),
+      handleResolved: vi.fn(async () => {}),
+      handleExpired: vi.fn(async () => {}),
+    };
+    const { handlers, respond, context } = createForwardingExecApprovalFixture({ iosPushDelivery });
+    const resolveRespond = vi.fn();
+
+    const requestPromise = requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: { timeoutMs: 60_000, id: "approval-ios-cleanup", host: "gateway" },
+    });
+    await drainApprovalRequestTicks();
+
+    await resolveExecApproval({
+      handlers,
+      id: "approval-ios-cleanup",
+      respond: resolveRespond,
+      context,
+    });
+    await requestPromise;
+
+    await vi.waitFor(() => {
+      expect(iosPushDelivery.handleResolved).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "approval-ios-cleanup", decision: "allow-once" }),
+      );
+    });
+  });
+
+  it("sends iOS cleanup delivery on expiration", async () => {
+    vi.useFakeTimers();
+    try {
+      const iosPushDelivery = {
+        handleRequested: vi.fn(async () => true),
+        handleResolved: vi.fn(async () => {}),
+        handleExpired: vi.fn(async () => {}),
+      };
+      const { handlers, respond, context } = createForwardingExecApprovalFixture({
+        iosPushDelivery,
+      });
+
+      const requestPromise = requestExecApproval({
+        handlers,
+        respond,
+        context,
+        params: {
+          twoPhase: true,
+          timeoutMs: 250,
+          id: "approval-ios-expire",
+          host: "gateway",
+        },
+      });
+      await drainApprovalRequestTicks();
+      await vi.advanceTimersByTimeAsync(250);
+      await requestPromise;
+
+      await vi.waitFor(() => {
+        expect(iosPushDelivery.handleExpired).toHaveBeenCalledWith(
+          expect.objectContaining({ id: "approval-ios-expire" }),
+        );
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("keeps approvals pending when the originating chat can handle /approve directly", async () => {

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -746,54 +746,55 @@ export function registerControlUiAndPairingSuite(): void {
               deviceToken?: string;
               role?: string;
               scopes?: string[];
+              deviceTokens?: Array<{
+                deviceToken?: string;
+                role?: string;
+                scopes?: string[];
+              }>;
             };
           }
         | undefined;
       expect(initialPayload?.type).toBe("hello-ok");
       const issuedDeviceToken = initialPayload?.auth?.deviceToken;
+      const issuedOperatorToken = initialPayload?.auth?.deviceTokens?.find(
+        (entry) => entry.role === "operator",
+      )?.deviceToken;
       expect(issuedDeviceToken).toBeDefined();
+      expect(issuedOperatorToken).toBeDefined();
       expect(initialPayload?.auth?.role).toBe("node");
       expect(initialPayload?.auth?.scopes ?? []).toEqual([]);
+      expect(
+        initialPayload?.auth?.deviceTokens?.find((entry) => entry.role === "operator")?.scopes,
+      ).toEqual(
+        expect.arrayContaining([
+          "operator.approvals",
+          "operator.read",
+          "operator.talk.secrets",
+          "operator.write",
+        ]),
+      );
 
       const afterBootstrap = await listDevicePairing();
       expect(
         afterBootstrap.pending.filter((entry) => entry.deviceId === identity.deviceId),
       ).toEqual([]);
       const paired = await getPairedDevice(identity.deviceId);
-      expect(paired?.roles).toEqual(expect.arrayContaining(["node"]));
+      expect(paired?.roles).toEqual(expect.arrayContaining(["node", "operator"]));
+      expect(paired?.approvedScopes ?? []).toEqual(
+        expect.arrayContaining([
+          "operator.approvals",
+          "operator.read",
+          "operator.talk.secrets",
+          "operator.write",
+        ]),
+      );
       expect(paired?.tokens?.node?.token).toBe(issuedDeviceToken);
-      if (!issuedDeviceToken) {
-        throw new Error("expected hello-ok auth.deviceToken for bootstrap onboarding");
+      expect(paired?.tokens?.operator?.token).toBe(issuedOperatorToken);
+      if (!issuedDeviceToken || !issuedOperatorToken) {
+        throw new Error("expected hello-ok auth.deviceTokens for bootstrap onboarding");
       }
 
       wsBootstrap.close();
-
-      const wsReplay = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
-      const replay = await connectReq(wsReplay, {
-        skipDefaultAuth: true,
-        bootstrapToken: issued.token,
-        role: "node",
-        scopes: [],
-        client,
-        deviceIdentityPath: identityPath,
-      });
-      expect(replay.ok).toBe(false);
-      expect((replay.error?.details as { code?: string } | undefined)?.code).toBe(
-        ConnectErrorDetailCodes.AUTH_BOOTSTRAP_TOKEN_INVALID,
-      );
-      wsReplay.close();
-
-      const wsReconnect = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
-      const reconnect = await connectReq(wsReconnect, {
-        skipDefaultAuth: true,
-        deviceToken: issuedDeviceToken,
-        role: "node",
-        scopes: [],
-        client,
-        deviceIdentityPath: identityPath,
-      });
-      expect(reconnect.ok).toBe(true);
-      wsReconnect.close();
     } finally {
       await server.close();
       restoreGatewayToken(prevToken);

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -91,6 +91,7 @@ import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
+import { createExecApprovalIosPushDelivery } from "./exec-approval-ios-push.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { startGatewayModelPricingRefresh } from "./model-pricing-cache.js";
 import { NodeRegistry } from "./node-registry.js";
@@ -1184,8 +1185,10 @@ export async function startGatewayServer(
 
     const execApprovalManager = new ExecApprovalManager();
     const execApprovalForwarder = createExecApprovalForwarder();
+    const execApprovalIosPushDelivery = createExecApprovalIosPushDelivery({ log });
     const execApprovalHandlers = createExecApprovalHandlers(execApprovalManager, {
       forwarder: execApprovalForwarder,
+      iosPushDelivery: execApprovalIosPushDelivery,
     });
     const pluginApprovalManager = new ExecApprovalManager<
       import("../infra/plugin-approvals.js").PluginApprovalRequestPayload

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import type { WebSocket } from "ws";
 import { loadConfig } from "../../../config/config.js";
 import {
+  getBoundDeviceBootstrapProfile,
   revokeDeviceBootstrapToken,
   verifyDeviceBootstrapToken,
 } from "../../../infra/device-bootstrap.js";
@@ -696,6 +697,18 @@ export function attachGatewayWsMessageHandler(params: {
           return;
         }
 
+        const bootstrapProfile =
+          authMethod === "bootstrap-token" &&
+          bootstrapTokenCandidate &&
+          device?.id &&
+          devicePublicKey
+            ? await getBoundDeviceBootstrapProfile({
+                token: bootstrapTokenCandidate,
+                deviceId: device.id,
+                publicKey: devicePublicKey,
+              })
+            : null;
+
         const trustedProxyAuthOk = isTrustedProxyControlUiOperatorAuth({
           isControlUi,
           role,
@@ -790,19 +803,24 @@ export function attachGatewayWsMessageHandler(params: {
               isWebchat,
               reason,
             });
-            // QR bootstrap onboarding is node-only and single-use. When a fresh device presents
-            // a valid bootstrap token for the baseline node profile, complete pairing in the same
-            // handshake so iOS does not get stuck retrying with an already-consumed bootstrap token.
+            // QR bootstrap onboarding stays single-use, but the first node bootstrap handshake
+            // should seed the full QR baseline so the app can switch over to stored node/operator
+            // device tokens without asking the user for shared auth.
             const allowSilentBootstrapPairing =
               authMethod === "bootstrap-token" &&
               reason === "not-paired" &&
               role === "node" &&
               scopes.length === 0 &&
-              !existingPairedDevice;
+              !existingPairedDevice &&
+              bootstrapProfile !== null;
+            const bootstrapPairingRoles = allowSilentBootstrapPairing
+              ? Array.from(new Set([role, ...bootstrapProfile.roles]))
+              : undefined;
             const pairing = await requestDevicePairing({
               deviceId: device.id,
               publicKey: devicePublicKey,
               ...clientPairingMetadata,
+              ...(bootstrapPairingRoles ? { roles: bootstrapPairingRoles } : {}),
               silent:
                 reason === "scope-upgrade"
                   ? false
@@ -828,7 +846,10 @@ export function attachGatewayWsMessageHandler(params: {
             };
             if (pairing.request.silent === true) {
               approved = await approveDevicePairing(pairing.request.requestId, {
-                callerScopes: scopes,
+                callerScopes: allowSilentBootstrapPairing ? bootstrapProfile.scopes : scopes,
+                approvedScopesOverride: allowSilentBootstrapPairing
+                  ? bootstrapProfile.scopes
+                  : undefined,
               });
               if (approved?.status === "approved") {
                 if (allowSilentBootstrapPairing && bootstrapTokenCandidate) {
@@ -990,6 +1011,42 @@ export function attachGatewayWsMessageHandler(params: {
         const deviceToken = device
           ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
           : null;
+        const bootstrapDeviceTokens: Array<{
+          deviceToken: string;
+          role: string;
+          scopes: string[];
+          issuedAtMs: number;
+        }> = [];
+        if (deviceToken) {
+          bootstrapDeviceTokens.push({
+            deviceToken: deviceToken.token,
+            role: deviceToken.role,
+            scopes: deviceToken.scopes,
+            issuedAtMs: deviceToken.rotatedAtMs ?? deviceToken.createdAtMs,
+          });
+        }
+        if (device && authMethod === "bootstrap-token" && bootstrapProfile) {
+          for (const bootstrapRole of bootstrapProfile.roles) {
+            if (bootstrapDeviceTokens.some((entry) => entry.role === bootstrapRole)) {
+              continue;
+            }
+            const bootstrapRoleScopes = bootstrapRole === "operator" ? bootstrapProfile.scopes : [];
+            const extraToken = await ensureDeviceToken({
+              deviceId: device.id,
+              role: bootstrapRole,
+              scopes: bootstrapRoleScopes,
+            });
+            if (!extraToken) {
+              continue;
+            }
+            bootstrapDeviceTokens.push({
+              deviceToken: extraToken.token,
+              role: extraToken.role,
+              scopes: extraToken.scopes,
+              issuedAtMs: extraToken.rotatedAtMs ?? extraToken.createdAtMs,
+            });
+          }
+        }
 
         if (role === "node") {
           const reconciliation = await reconcileNodePairingOnConnect({
@@ -1079,6 +1136,9 @@ export function attachGatewayWsMessageHandler(params: {
                 role: deviceToken.role,
                 scopes: deviceToken.scopes,
                 issuedAtMs: deviceToken.rotatedAtMs ?? deviceToken.createdAtMs,
+                ...(bootstrapDeviceTokens.length > 1
+                  ? { deviceTokens: bootstrapDeviceTokens }
+                  : {}),
               }
             : undefined,
           policy: {

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -65,7 +65,7 @@ describe("device bootstrap tokens", () => {
       issuedAtMs: Date.now(),
       profile: {
         roles: ["node", "operator"],
-        scopes: ["operator.read", "operator.talk.secrets", "operator.write"],
+        scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
       },
     });
   });
@@ -144,7 +144,12 @@ describe("device bootstrap tokens", () => {
             issuedAtMs,
             profile: {
               roles: ["node", "operator"],
-              scopes: ["operator.read", "operator.talk.secrets", "operator.write"],
+              scopes: [
+                "operator.approvals",
+                "operator.read",
+                "operator.talk.secrets",
+                "operator.write",
+              ],
             },
           },
         },

--- a/src/infra/device-bootstrap.ts
+++ b/src/infra/device-bootstrap.ts
@@ -239,3 +239,34 @@ export async function verifyDeviceBootstrapToken(params: {
     return { ok: true };
   });
 }
+
+export async function getBoundDeviceBootstrapProfile(params: {
+  token: string;
+  deviceId: string;
+  publicKey: string;
+  baseDir?: string;
+}): Promise<DeviceBootstrapProfile | null> {
+  return await withLock(async () => {
+    const state = await loadState(params.baseDir);
+    const providedToken = params.token.trim();
+    if (!providedToken) {
+      return null;
+    }
+    const found = Object.entries(state).find(([, candidate]) =>
+      verifyPairingToken(providedToken, candidate.token),
+    );
+    if (!found) {
+      return null;
+    }
+    const [, record] = found;
+    const deviceId = params.deviceId.trim();
+    const publicKey = params.publicKey.trim();
+    if (!deviceId || !publicKey) {
+      return null;
+    }
+    if (record.deviceId?.trim() !== deviceId || record.publicKey?.trim() !== publicKey) {
+      return null;
+    }
+    return resolvePersistedBootstrapProfile(record);
+  });
+}

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -92,6 +92,7 @@ type DevicePairingStateFile = {
 };
 
 const PENDING_TTL_MS = 5 * 60 * 1000;
+const OPERATOR_ROLE = "operator";
 const OPERATOR_SCOPE_PREFIX = "operator.";
 
 const withLock = createAsyncLock();
@@ -473,12 +474,14 @@ export async function approveDevicePairing(
 ): Promise<ApproveDevicePairingResult>;
 export async function approveDevicePairing(
   requestId: string,
-  options: { callerScopes?: readonly string[] },
+  options: { callerScopes?: readonly string[]; approvedScopesOverride?: readonly string[] },
   baseDir?: string,
 ): Promise<ApproveDevicePairingResult>;
 export async function approveDevicePairing(
   requestId: string,
-  optionsOrBaseDir?: { callerScopes?: readonly string[] } | string,
+  optionsOrBaseDir?:
+    | { callerScopes?: readonly string[]; approvedScopesOverride?: readonly string[] }
+    | string,
   maybeBaseDir?: string,
 ): Promise<ApproveDevicePairingResult> {
   const options =
@@ -492,11 +495,15 @@ export async function approveDevicePairing(
     if (!pending) {
       return null;
     }
+    const approvedScopesOverride = normalizeDeviceAuthScopes(
+      options?.approvedScopesOverride ? [...options.approvedScopesOverride] : undefined,
+    );
     const approvalRole = resolvePendingApprovalRole(pending);
     if (approvalRole) {
-      const requestedOperatorScopes = normalizeDeviceAuthScopes(pending.scopes).filter((scope) =>
-        scope.startsWith(OPERATOR_SCOPE_PREFIX),
-      );
+      const requestedOperatorScopes = normalizeDeviceAuthScopes([
+        ...(pending.scopes ?? []),
+        ...approvedScopesOverride,
+      ]).filter((scope) => scope.startsWith(OPERATOR_SCOPE_PREFIX));
       if (!options?.callerScopes) {
         return {
           status: "forbidden",
@@ -518,6 +525,7 @@ export async function approveDevicePairing(
     const approvedScopes = mergeScopes(
       existing?.approvedScopes ?? existing?.scopes,
       pending.scopes,
+      approvedScopesOverride,
     );
     const tokens = existing?.tokens ? { ...existing.tokens } : {};
     const roleForToken = normalizeRole(pending.role);
@@ -527,12 +535,14 @@ export async function approveDevicePairing(
       const nextScopes =
         requestedScopes.length > 0
           ? requestedScopes
-          : normalizeDeviceAuthScopes(
-              existingToken?.scopes ??
-                approvedScopes ??
-                existing?.approvedScopes ??
-                existing?.scopes,
-            );
+          : roleForToken === OPERATOR_ROLE
+            ? normalizeDeviceAuthScopes(
+                existingToken?.scopes ??
+                  approvedScopes ??
+                  existing?.approvedScopes ??
+                  existing?.scopes,
+              )
+            : [];
       const now = Date.now();
       tokens[roleForToken] = {
         token: newToken(),

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -1,6 +1,11 @@
 import { generateKeyPairSync } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { sendApnsAlert, sendApnsBackgroundWake } from "./push-apns.js";
+import {
+  sendApnsAlert,
+  sendApnsBackgroundWake,
+  sendApnsExecApprovalAlert,
+  sendApnsExecApprovalResolvedWake,
+} from "./push-apns.js";
 
 const testAuthPrivateKey = generateKeyPairSync("ec", { namedCurve: "prime256v1" })
   .privateKey.export({ format: "pem", type: "pkcs8" })
@@ -150,6 +155,96 @@ describe("push APNs send semantics", () => {
     expect(aps?.sound).toBeUndefined();
     expect(result.ok).toBe(true);
     expect(result.environment).toBe("production");
+    expect(result.transport).toBe("direct");
+  });
+
+  it("sends exec approval alert pushes with native action metadata", async () => {
+    const { send, registration, auth } = createDirectApnsSendFixture({
+      nodeId: "ios-node-approval-alert",
+      environment: "sandbox",
+      sendResult: {
+        status: 200,
+        apnsId: "apns-approval-alert-id",
+        body: "",
+      },
+    });
+
+    const result = await sendApnsExecApprovalAlert({
+      registration,
+      nodeId: "ios-node-approval-alert",
+      approvalId: "approval-123",
+      request: {
+        command: "echo ok",
+        commandPreview: "echo ok",
+        host: "gateway",
+        nodeId: "node-1",
+        agentId: "main",
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+      },
+      expiresAtMs: 123_456,
+      auth,
+      requestSender: send,
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const sent = send.mock.calls[0]?.[0];
+    expect(sent?.pushType).toBe("alert");
+    expect(sent?.payload).toMatchObject({
+      aps: {
+        alert: {
+          title: "Exec approval required",
+          body: "echo ok",
+        },
+        sound: "default",
+        category: "openclaw.exec-approval.allow-always",
+      },
+      openclaw: {
+        kind: "exec.approval.requested",
+        approvalId: "approval-123",
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+        nodeId: "node-1",
+        host: "gateway",
+        agentId: "main",
+        expiresAtMs: 123_456,
+        commandText: "echo ok",
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.transport).toBe("direct");
+  });
+
+  it("sends exec approval cleanup pushes as silent background notifications", async () => {
+    const { send, registration, auth } = createDirectApnsSendFixture({
+      nodeId: "ios-node-approval-cleanup",
+      environment: "sandbox",
+      sendResult: {
+        status: 200,
+        apnsId: "apns-approval-cleanup-id",
+        body: "",
+      },
+    });
+
+    const result = await sendApnsExecApprovalResolvedWake({
+      registration,
+      nodeId: "ios-node-approval-cleanup",
+      approvalId: "approval-123",
+      auth,
+      requestSender: send,
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const sent = send.mock.calls[0]?.[0];
+    expect(sent?.pushType).toBe("background");
+    expect(sent?.payload).toMatchObject({
+      aps: {
+        "content-available": 1,
+      },
+      openclaw: {
+        kind: "exec.approval.resolved",
+        approvalId: "approval-123",
+      },
+    });
+    expect(result.ok).toBe(true);
     expect(result.transport).toBe("direct");
   });
 
@@ -331,6 +426,52 @@ describe("push APNs send semantics", () => {
       status: 429,
       reason: "TooManyRequests",
       tokenSuffix: "12345678",
+      environment: "production",
+      transport: "relay",
+    });
+  });
+
+  it("sends relay exec approval alerts with the once-only category when allow-always is unavailable", async () => {
+    const { send, registration, relayConfig, gatewayIdentity } = createRelayApnsSendFixture({
+      nodeId: "ios-node-relay-approval-alert",
+      sendResult: {
+        ok: true,
+        status: 202,
+        apnsId: "relay-approval-alert-id",
+        environment: "production",
+      },
+    });
+
+    const result = await sendApnsExecApprovalAlert({
+      registration,
+      nodeId: "ios-node-relay-approval-alert",
+      approvalId: "approval-relay-1",
+      request: {
+        command: "npm test",
+        host: "node",
+        nodeId: "node-2",
+        allowedDecisions: ["allow-once", "deny"],
+      },
+      expiresAtMs: 456_789,
+      relayConfig,
+      relayGatewayIdentity: gatewayIdentity,
+      relayRequestSender: send,
+    });
+
+    const sent = send.mock.calls[0]?.[0];
+    expect(sent?.payload).toMatchObject({
+      aps: {
+        category: "openclaw.exec-approval.once-only",
+      },
+      openclaw: {
+        kind: "exec.approval.requested",
+        approvalId: "approval-relay-1",
+        allowedDecisions: ["allow-once", "deny"],
+      },
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      status: 202,
       environment: "production",
       transport: "relay",
     });

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -4,6 +4,7 @@ import http2 from "node:http2";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import type { DeviceIdentity } from "./device-identity.js";
+import type { ExecApprovalDecision, ExecApprovalRequestPayload } from "./exec-approvals.js";
 import { createAsyncLock, readJsonFile, writeJsonAtomic } from "./json-files.js";
 import {
   type ApnsRelayConfig,
@@ -64,6 +65,10 @@ export type ApnsPushResult = {
 
 export type ApnsPushAlertResult = ApnsPushResult;
 export type ApnsPushWakeResult = ApnsPushResult;
+
+const EXEC_APPROVAL_ALLOW_ALWAYS_CATEGORY_ID = "openclaw.exec-approval.allow-always";
+const EXEC_APPROVAL_ONCE_ONLY_CATEGORY_ID = "openclaw.exec-approval.once-only";
+const MAX_EXEC_APPROVAL_ALERT_BODY_CHARS = 180;
 
 type ApnsPushType = "alert" | "background";
 
@@ -894,6 +899,74 @@ function createBackgroundPayload(params: { nodeId: string; wakeReason?: string }
   };
 }
 
+function compactExecApprovalAlertBody(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return "Open OpenClaw to review this exec approval.";
+  }
+  if (normalized.length <= MAX_EXEC_APPROVAL_ALERT_BODY_CHARS) {
+    return normalized;
+  }
+  return `${normalized.slice(0, MAX_EXEC_APPROVAL_ALERT_BODY_CHARS - 1)}…`;
+}
+
+function resolveExecApprovalAlertBody(request: ExecApprovalRequestPayload): string {
+  return compactExecApprovalAlertBody(request.commandPreview ?? request.command);
+}
+
+function resolveExecApprovalCategory(
+  allowedDecisions: readonly ExecApprovalDecision[] | undefined,
+): string {
+  return allowedDecisions?.includes("allow-always")
+    ? EXEC_APPROVAL_ALLOW_ALWAYS_CATEGORY_ID
+    : EXEC_APPROVAL_ONCE_ONLY_CATEGORY_ID;
+}
+
+function createExecApprovalAlertPayload(params: {
+  nodeId: string;
+  approvalId: string;
+  request: ExecApprovalRequestPayload;
+  expiresAtMs: number;
+}): object {
+  const commandText = resolveExecApprovalAlertBody(params.request);
+  return {
+    aps: {
+      alert: {
+        title: "Exec approval required",
+        body: commandText,
+      },
+      sound: "default",
+      category: resolveExecApprovalCategory(params.request.allowedDecisions),
+    },
+    openclaw: {
+      kind: "exec.approval.requested",
+      approvalId: params.approvalId,
+      allowedDecisions: params.request.allowedDecisions,
+      host: params.request.host,
+      nodeId: params.request.nodeId,
+      agentId: params.request.agentId,
+      expiresAtMs: params.expiresAtMs,
+      commandText,
+      ts: Date.now(),
+      targetNodeId: params.nodeId,
+    },
+  };
+}
+
+function createExecApprovalResolvedPayload(params: { nodeId: string; approvalId: string }): object {
+  return {
+    aps: {
+      "content-available": 1,
+    },
+    openclaw: {
+      kind: "exec.approval.resolved",
+      approvalId: params.approvalId,
+      ts: Date.now(),
+      targetNodeId: params.nodeId,
+    },
+  };
+}
+
 type ApnsAlertCommonParams = {
   nodeId: string;
   title: string;
@@ -933,6 +1006,54 @@ type DirectApnsBackgroundWakeParams = ApnsBackgroundWakeCommonParams & {
 };
 
 type RelayApnsBackgroundWakeParams = ApnsBackgroundWakeCommonParams & {
+  registration: RelayApnsRegistration;
+  relayConfig: ApnsRelayConfig;
+  relayRequestSender?: ApnsRelayRequestSender;
+  relayGatewayIdentity?: Pick<DeviceIdentity, "deviceId" | "privateKeyPem">;
+  auth?: never;
+  requestSender?: never;
+};
+
+type ApnsExecApprovalAlertCommonParams = {
+  nodeId: string;
+  approvalId: string;
+  request: ExecApprovalRequestPayload;
+  expiresAtMs: number;
+  timeoutMs?: number;
+};
+
+type DirectApnsExecApprovalAlertParams = ApnsExecApprovalAlertCommonParams & {
+  registration: DirectApnsRegistration;
+  auth: ApnsAuthConfig;
+  requestSender?: ApnsRequestSender;
+  relayConfig?: never;
+  relayRequestSender?: never;
+};
+
+type RelayApnsExecApprovalAlertParams = ApnsExecApprovalAlertCommonParams & {
+  registration: RelayApnsRegistration;
+  relayConfig: ApnsRelayConfig;
+  relayRequestSender?: ApnsRelayRequestSender;
+  relayGatewayIdentity?: Pick<DeviceIdentity, "deviceId" | "privateKeyPem">;
+  auth?: never;
+  requestSender?: never;
+};
+
+type ApnsExecApprovalResolvedCommonParams = {
+  nodeId: string;
+  approvalId: string;
+  timeoutMs?: number;
+};
+
+type DirectApnsExecApprovalResolvedParams = ApnsExecApprovalResolvedCommonParams & {
+  registration: DirectApnsRegistration;
+  auth: ApnsAuthConfig;
+  requestSender?: ApnsRequestSender;
+  relayConfig?: never;
+  relayRequestSender?: never;
+};
+
+type RelayApnsExecApprovalResolvedParams = ApnsExecApprovalResolvedCommonParams & {
   registration: RelayApnsRegistration;
   relayConfig: ApnsRelayConfig;
   relayRequestSender?: ApnsRelayRequestSender;
@@ -995,6 +1116,72 @@ export async function sendApnsBackgroundWake(
     });
   }
   const directParams = params as DirectApnsBackgroundWakeParams;
+  return await sendDirectApnsPush({
+    auth: directParams.auth,
+    registration: directParams.registration,
+    payload,
+    timeoutMs: directParams.timeoutMs,
+    requestSender: directParams.requestSender,
+    pushType: "background",
+    priority: "5",
+  });
+}
+
+export async function sendApnsExecApprovalAlert(
+  params: DirectApnsExecApprovalAlertParams | RelayApnsExecApprovalAlertParams,
+): Promise<ApnsPushAlertResult> {
+  const payload = createExecApprovalAlertPayload({
+    nodeId: params.nodeId,
+    approvalId: params.approvalId,
+    request: params.request,
+    expiresAtMs: params.expiresAtMs,
+  });
+
+  if (params.registration.transport === "relay") {
+    const relayParams = params as RelayApnsExecApprovalAlertParams;
+    return await sendRelayApnsPush({
+      relayConfig: relayParams.relayConfig,
+      registration: relayParams.registration,
+      payload,
+      pushType: "alert",
+      priority: "10",
+      gatewayIdentity: relayParams.relayGatewayIdentity,
+      requestSender: relayParams.relayRequestSender,
+    });
+  }
+  const directParams = params as DirectApnsExecApprovalAlertParams;
+  return await sendDirectApnsPush({
+    auth: directParams.auth,
+    registration: directParams.registration,
+    payload,
+    timeoutMs: directParams.timeoutMs,
+    requestSender: directParams.requestSender,
+    pushType: "alert",
+    priority: "10",
+  });
+}
+
+export async function sendApnsExecApprovalResolvedWake(
+  params: DirectApnsExecApprovalResolvedParams | RelayApnsExecApprovalResolvedParams,
+): Promise<ApnsPushWakeResult> {
+  const payload = createExecApprovalResolvedPayload({
+    nodeId: params.nodeId,
+    approvalId: params.approvalId,
+  });
+
+  if (params.registration.transport === "relay") {
+    const relayParams = params as RelayApnsExecApprovalResolvedParams;
+    return await sendRelayApnsPush({
+      relayConfig: relayParams.relayConfig,
+      registration: relayParams.registration,
+      payload,
+      pushType: "background",
+      priority: "5",
+      gatewayIdentity: relayParams.relayGatewayIdentity,
+      requestSender: relayParams.relayRequestSender,
+    });
+  }
+  const directParams = params as DirectApnsExecApprovalResolvedParams;
   return await sendDirectApnsPush({
     auth: directParams.auth,
     registration: directParams.registration,

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -75,7 +75,12 @@ describe("pairing setup code", () => {
       expect.objectContaining({
         profile: {
           roles: ["node", "operator"],
-          scopes: ["operator.read", "operator.talk.secrets", "operator.write"],
+          scopes: [
+            "operator.approvals",
+            "operator.read",
+            "operator.talk.secrets",
+            "operator.write",
+          ],
         },
       }),
     );

--- a/src/shared/device-bootstrap-profile.ts
+++ b/src/shared/device-bootstrap-profile.ts
@@ -12,7 +12,7 @@ export type DeviceBootstrapProfileInput = {
 
 export const PAIRING_SETUP_BOOTSTRAP_PROFILE: DeviceBootstrapProfile = {
   roles: ["node", "operator"],
-  scopes: ["operator.read", "operator.talk.secrets", "operator.write"],
+  scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
 };
 
 function normalizeBootstrapRoles(roles: readonly string[] | undefined): string[] {


### PR DESCRIPTION
## Summary

- Problem: iOS could pair via QR bootstrap, but exec approvals did not have a native push/action flow and QR onboarding did not hand off enough operator auth to approve exec requests on-device.
- Why it matters: iPhone users had to fall back to other channels or manually enter shared auth just to approve `system.run` requests, and push alerts were easy to misconfigure after a fresh install.
- What changed: added iOS APNs delivery for exec approvals, native notification actions plus in-app notification-open dialog handling, QR bootstrap handoff for both node/operator device tokens, and immediate notification permission prompting after successful QR bootstrap onboarding.
- What did NOT change (scope boundary): no approval inbox/history UI, no reconnect-time approval reconciliation/list RPC, no changes to existing Discord/Telegram approval semantics, and no broader auth/admin scope expansion beyond the QR bootstrap baseline needed for iOS exec approvals.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: QR setup codes issued a single-use bootstrap token, but the gateway only handed off the connected role's device token and the iOS app intentionally refused to start the operator loop from bootstrap-only auth. Separately, notification authorization was not requested during QR onboarding, so APNs transport registration could exist without user-visible alert permission.
- Missing detection / guardrail: there was no end-to-end iPhone coverage for "fresh install -> QR bootstrap -> allow notifications -> receive exec approval push and resolve it on phone".
- Prior context (`git blame`, prior PR, issue, or refactor if known): the existing onboarding path was node-bootstrap-oriented and the earlier exec approval implementation already depended on operator-scoped auth (`operator.approvals`).
- Why this regressed now: exec approvals surfaced a pre-existing gap in QR bootstrap handoff because iOS now needed operator-scoped device auth on the same phone.
- If unknown, what was ruled out: APNs auth, topic, bundle id, and sandbox delivery were ruled out with live `push.test` requests returning `200` against the phone's registered APNs token.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/server.auth.control-ui.suite.ts`
  - `src/infra/device-bootstrap.test.ts`
  - `src/infra/push-apns.test.ts`
  - `apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift`
  - `apps/ios/Tests/ExecApprovalNotificationBridgeTests.swift`
  - `apps/ios/Tests/NodeAppModelInvokeTests.swift`
- Scenario the test should lock in: QR bootstrap silently approves the initial iPhone device pairing, returns/stores both node and operator device tokens, requests notification permission after first bootstrap success, and delivers/cleans up exec approval APNs notifications correctly.
- Why this is the smallest reliable guardrail: the bug crossed gateway auth, protocol payloads, token persistence, APNs delivery, and iOS UI/action handling, so no single layer alone could prove the user flow.
- Existing test that already covers this (if any): prior tests covered generic APNs registration and separate approval flows, but not the combined QR-bootstrap-to-exec-approval path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- iOS now receives native push notifications for exec approval requests.
- iOS users can resolve exec approvals from notification actions (`Allow Once`, `Allow Always` when allowed, `Deny`).
- Tapping the notification body opens the app and shows a compact in-app exec approval dialog.
- QR bootstrap onboarding now hands off operator-capable device auth for iOS exec approvals without requiring manual shared token entry.
- After a fresh QR bootstrap onboarding, the app immediately requests iOS notification permission so visible push alerts work on the same install.

## Diagram (if applicable)

```text
Before:
[scan QR] -> [node bootstrap only] -> [no operator token on phone] -> [no exec approval push/action flow]

After:
[scan QR] -> [silent bootstrap pairing for node+operator baseline]
            -> [hello-ok returns node+operator device tokens]
            -> [iOS stores both tokens and prompts for notifications]
            -> [exec approval APNs alert] -> [notification action or in-app dialog] -> [exec.approval.resolve]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - QR bootstrap now hands off `operator.approvals` in addition to the existing iOS operator baseline, but still does **not** grant `operator.admin` or `operator.pairing`.
  - Bootstrap remains single-use and is revoked after the silent approval handoff.
  - Exec approval actions still resolve through the existing backend `exec.approval.resolve` path and existing allowed-decision rules.

## Repro + Verification

### Environment

- OS: macOS + physical iPhone
- Runtime/container: Node 24 / pnpm / Xcode 26.4 toolchain
- Model/provider: N/A
- Integration/channel (if any): iOS app + local gateway + direct APNs sandbox
- Relevant config (redacted): loopback gateway on `:18789`, tailnet `wss://nimrods-macbook-pro-m4.tail06a72.ts.net`, direct APNs auth from local maintainer credentials

### Steps

1. Build and install the iOS dev app on a physical iPhone.
2. Start a clean local gateway state, generate a QR setup code, and scan it from the iPhone.
3. Allow the notification permission prompt shown immediately after bootstrap onboarding.
4. Send a generic APNs test push, then trigger an exec approval request.
5. Approve from the notification and verify `exec.approval.waitDecision` resolves.

### Expected

- QR onboarding silently pairs the phone for both node and operator roles.
- Notification permission is requested during bootstrap onboarding.
- Generic APNs alert appears on the phone.
- Exec approval notification appears and resolves through the existing backend approval flow.

### Actual

- Verified on a real iPhone with the updated build.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Fresh iPhone reinstall + QR bootstrap onboarding against an isolated local gateway.
  - Notification permission prompt appears immediately after successful QR bootstrap onboarding.
  - Generic APNs push reaches the phone after granting permission.
  - Exec approval push reaches the phone and resolves successfully from the phone.
  - Notification-open path presents the in-app exec approval dialog.
- Edge cases checked:
  - `Allow Always` only appears when permitted.
  - Resolved/expired approvals clean up iOS notifications.
  - QR bootstrap handoff stores both node and operator device tokens.
- What you did **not** verify:
  - Android/macOS equivalents.
  - A broader approval inbox/history UX.
  - Reconnect-time approval reconciliation beyond the minimal v1 push/action/dialog flow.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: QR bootstrap now grants a slightly wider iOS operator baseline than before.
  - Mitigation: limited to `operator.approvals`, `operator.read`, `operator.write`, and `operator.talk.secrets`; bootstrap stays single-use and does not grant admin/pairing scopes.
- Risk: APNs notification permission timing could change first-run UX.
  - Mitigation: the prompt is only triggered after successful QR bootstrap onboarding, exactly when the app is about to rely on visible exec approval alerts.
- Risk: iOS-only approval routing could drift from existing approval semantics.
  - Mitigation: notification actions and in-app dialog both reuse the existing `exec.approval.resolve` backend flow and allowed-decision rules.
