### PR TITLE
fix(telegram): keep allow-always approval action under callback_data limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Docs: https://docs.openclaw.ai
 - OpenShell/mirror sync: constrain mirror sync to managed roots only so user-added shell roots are no longer overwritten or removed during config synchronization. (#58515) Thanks @eleqtrizit.
 - Dotenv/workspace overrides: block workspace `.env` files from overriding `OPENCLAW_PINNED_PYTHON` and `OPENCLAW_PINNED_WRITE_PYTHON` so trusted helper interpreters cannot be redirected by repo-local env injection. (#58473) Thanks @eleqtrizit.
 - Plugins/install: accept JSON5 syntax in `openclaw.plugin.json` and bundle `plugin.json` manifests during install/validation, so third-party plugins with trailing commas, comments, or unquoted keys no longer fail to install. (#59084) Thanks @singleGanghood.
+- Telegram/exec approvals: rewrite shared `/approve … allow-always` callback payloads to `/approve … always` before Telegram button rendering so plugin approval IDs still fit Telegram's `callback_data` limit and keep the Allow Always action visible. (#59217) Thanks @jameslcowan.
 
 ## 2026.4.1-beta.1
 

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -28,6 +28,19 @@ function toTelegramButtonStyle(
   return style === "danger" || style === "success" || style === "primary" ? style : undefined;
 }
 
+function rewriteTelegramApprovalAlias(value: string): string {
+  if (!value.endsWith(" allow-always")) {
+    return value;
+  }
+  const approvePrefixMatch = value.match(
+    /^\/approve(?:@[^\s]+)?\s+[A-Za-z0-9][A-Za-z0-9._:-]*\s+allow-always$/i,
+  );
+  if (!approvePrefixMatch) {
+    return value;
+  }
+  return value.slice(0, -"allow-always".length) + "always";
+}
+
 function chunkInteractiveButtons(
   buttons: readonly InteractiveReplyButton[],
   rows: TelegramInlineButton[][],
@@ -35,6 +48,10 @@ function chunkInteractiveButtons(
   for (let i = 0; i < buttons.length; i += TELEGRAM_INTERACTIVE_ROW_SIZE) {
     const row = buttons
       .slice(i, i + TELEGRAM_INTERACTIVE_ROW_SIZE)
+      .map((button) => ({
+        ...button,
+        value: rewriteTelegramApprovalAlias(button.value),
+      }))
       .filter((button) => fitsTelegramCallbackData(button.value))
       .map((button) => ({
         text: button.label,

--- a/extensions/telegram/src/exec-approvals-handler.test.ts
+++ b/extensions/telegram/src/exec-approvals-handler.test.ts
@@ -100,7 +100,7 @@ describe("TelegramExecApprovalHandler", () => {
             },
             {
               text: "Allow Always",
-              callback_data: "/approve 9f1c7d5d-b1fb-46ef-ac45-662723b65bb7 allow-always",
+              callback_data: "/approve 9f1c7d5d-b1fb-46ef-ac45-662723b65bb7 always",
               style: "primary",
             },
             {

--- a/extensions/telegram/src/inline-buttons.test.ts
+++ b/extensions/telegram/src/inline-buttons.test.ts
@@ -100,6 +100,34 @@ describe("buildTelegramInteractiveButtons", () => {
       }),
     ).toEqual([[{ text: "Keep", callback_data: "keep", style: undefined }]]);
   });
+
+  it("rewrites /approve allow-always callbacks to always so plugin IDs fit Telegram limits", () => {
+    const pluginApprovalId = `plugin:${"a".repeat(36)}`;
+    expect(
+      buildTelegramInteractiveButtons({
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Allow Always",
+                value: `/approve ${pluginApprovalId} allow-always`,
+                style: "primary",
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual([
+      [
+        {
+          text: "Allow Always",
+          callback_data: `/approve ${pluginApprovalId} always`,
+          style: "primary",
+        },
+      ],
+    ]);
+  });
 });
 
 describe("resolveTelegramInlineButtons", () => {


### PR DESCRIPTION
## Summary

- follow up to #59217: keep canonical `allow-always` values in shared interactive payloads, but rewrite Telegram `/approve ... allow-always` callback payloads to `/approve ... always`
- preserve Telegram callback compatibility for long plugin approval IDs (`plugin:<uuid>`) so the Allow Always button is not dropped by Telegram's 64-byte `callback_data` limit
- add regression coverage for the alias rewrite path and align Telegram exec approval handler expectations
- add a changelog entry with thanks for #59217

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test -- extensions/telegram/src/inline-buttons.test.ts extensions/telegram/src/exec-approvals-handler.test.ts src/infra/exec-approval-reply.test.ts src/infra/exec-approval-forwarder.test.ts src/infra/plugin-approval-forwarder.test.ts src/plugin-sdk/approval-renderers.test.ts src/infra/outbound/deliver.test.ts`
- [x] attempted full gate (`pnpm lint && pnpm build && pnpm test`); local full test failed on unrelated env-sensitive baseline test `src/plugin-activation-boundary.test.ts` due loaded profile credentials (`gcp-vertex-credentials`)
