### PR TITLE
fix(browser): fall back to caps check when node commands list is empty

### DIFF
--- a/extensions/browser/src/gateway/browser-request.ts
+++ b/extensions/browser/src/gateway/browser-request.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   ErrorCodes,
   applyBrowserProxyPaths,
@@ -17,6 +18,8 @@ import {
   type GatewayRequestHandlers,
   type NodeSession,
 } from "../core-api.js";
+
+const logBrowserProxy = createSubsystemLogger("browser-proxy");
 
 type BrowserRequestParams = {
   method?: string;
@@ -183,11 +186,25 @@ export async function handleBrowserGatewayRequest({
 
   if (nodeTarget) {
     const allowlist = resolveNodeCommandAllowlist(cfg, nodeTarget);
-    const allowed = isNodeCommandAllowed({
-      command: "browser.proxy",
-      declaredCommands: nodeTarget.commands,
-      allowlist,
-    });
+    // When a node advertises the "browser" capability but its declared commands
+    // list is empty (handshake serialisation bug), fall back to the capability
+    // check so the browser proxy request is not rejected.
+    const hasBrowserCap =
+      Array.isArray(nodeTarget.caps) && nodeTarget.caps.includes("browser");
+    const capsFallback =
+      hasBrowserCap && nodeTarget.commands.length === 0 && allowlist.has("browser.proxy");
+    if (capsFallback) {
+      logBrowserProxy.warn(
+        `browser.proxy authorized via caps fallback — node ${nodeTarget.nodeId} declared no commands (possible handshake bug)`,
+      );
+    }
+    const allowed = capsFallback
+        ? ({ ok: true } as const)
+        : isNodeCommandAllowed({
+            command: "browser.proxy",
+            declaredCommands: nodeTarget.commands,
+            allowlist,
+          });
     if (!allowed.ok) {
       const platform = nodeTarget.platform ?? "unknown";
       const hint = `node command not allowed: ${allowed.reason} (platform: ${platform}, command: browser.proxy)`;

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -931,11 +931,25 @@ export const nodeHandlers: GatewayRequestHandlers = {
       }
       const cfg = loadConfig();
       const allowlist = resolveNodeCommandAllowlist(cfg, nodeSession);
-      const allowed = isNodeCommandAllowed({
-        command,
-        declaredCommands: nodeSession.commands,
-        allowlist,
-      });
+      // When a node advertises the "browser" capability but its declared
+      // commands list is empty (handshake serialisation bug), allow the
+      // browser.proxy command if it passes the allowlist check.
+      const hasBrowserCap =
+        Array.isArray(nodeSession.caps) && nodeSession.caps.includes("browser");
+      const capsFallback =
+        hasBrowserCap && command === "browser.proxy" && nodeSession.commands.length === 0 && allowlist.has("browser.proxy");
+      if (capsFallback) {
+        context.logGateway.warn(
+          `browser.proxy authorized via caps fallback — node ${nodeId} declared no commands (possible handshake bug)`,
+        );
+      }
+      const allowed = capsFallback
+          ? ({ ok: true } as const)
+          : isNodeCommandAllowed({
+              command,
+              declaredCommands: nodeSession.commands,
+              allowlist,
+            });
       if (!allowed.ok) {
         const hint = buildNodeCommandRejectionHint(allowed.reason, command, nodeSession);
         respond(


### PR DESCRIPTION
## Problem

When a Windows node host connects with `browserProxy.enabled=true`, it advertises the `browser` capability in `caps` and sends `commands: ["browser.proxy", ...]` during the WebSocket handshake. However, the gateway registers the node with `commands: []` (empty array) due to a serialisation/handshake issue.

This causes `isNodeCommandAllowed()` to reject all `browser.proxy` requests with:
```
node did not declare commands
```

The browser tool returns `No connected browser-capable nodes` even though the node is connected and the browser proxy is functional.

## Fix

Adds a capability-based fallback in two places:

1. **`extensions/browser/src/gateway/browser-request.ts`** — the browser proxy handler
2. **`src/gateway/server-methods/nodes.ts`** — the generic node invoke handler

When a node has the `browser` capability (`caps.includes("browser")`) and `browser.proxy` passes the gateway allowlist, the request is permitted even when `declaredCommands` is empty.

The existing `isNodeCommandAllowed` logic is preserved as the primary path — the caps fallback only activates when the commands list is missing or empty.

## Root cause

The root cause appears to be a deserialization issue where `connectParams.commands` loses its values between the handshake message and node registration. The `isBrowserNode()` helper in both files already has this same `caps.includes("browser") || commands.includes("browser.proxy")` pattern for node discovery — this PR extends the same resilience to the command authorization check.

## Testing

Tested with a Windows node host (precision414-PS) running OpenClaw v2026.3.31 with `nodeHost.browserProxy.enabled=true`. Before fix: browser tool calls fail with command rejection. After fix: browser proxy requests route correctly through the node.