### PR TITLE
fix(discord): preserve original filename in Discord attachment metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,7 @@ dist/protocol.schema.json
 # Synthing
 **/.stfolder/
 .dev-state
+state.json
 docs/superpowers/plans/2026-03-10-collapsed-side-nav.md
 docs/superpowers/specs/2026-03-10-collapsed-side-nav-design.md
 .gitignore

--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -81,7 +81,13 @@ function expectSinglePngDownload(params: {
   });
   expectDiscordCdnSsrFPolicy(call.ssrfPolicy);
   expect(saveMediaBuffer).toHaveBeenCalledTimes(1);
-  expect(saveMediaBuffer).toHaveBeenCalledWith(expect.any(Buffer), "image/png", "inbound", 512);
+  expect(saveMediaBuffer).toHaveBeenCalledWith(
+    expect.any(Buffer),
+    "image/png",
+    "inbound",
+    512,
+    params.filePathHint,
+  );
   expect(params.result).toEqual([
     {
       path: params.expectedPath,

--- a/extensions/discord/src/monitor/message-utils.ts
+++ b/extensions/discord/src/monitor/message-utils.ts
@@ -372,6 +372,7 @@ async function appendResolvedMediaFromAttachments(params: {
         fetched.contentType ?? attachment.content_type,
         "inbound",
         params.maxBytes,
+        attachment.filename,
       );
       params.out.push({
         path: saved.path,
@@ -491,6 +492,7 @@ async function appendResolvedMediaFromStickers(params: {
           fetched.contentType,
           "inbound",
           params.maxBytes,
+          candidate.fileName,
         );
         params.out.push({
           path: saved.path,


### PR DESCRIPTION
Pass attachment.filename as originalFilename to saveMediaBuffer so the
agent receives the original filename in inbound metadata instead of a
UUID-based path. Also applies to sticker assets.

Fixes #59744
