### PR TITLE
fix(mattermost): prioritize threadRootId over kind===direct for DM thread replies [fixes #59758]

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -210,6 +210,19 @@ describe("resolveMattermostEffectiveReplyToId", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("uses threadRootId for DM Thread messages (prioritize thread over kind===direct)", () => {
+    // When a DM opens a thread, threadRootId should take precedence so replies go
+    // to the existing thread instead of creating a new one.
+    expect(
+      resolveMattermostEffectiveReplyToId({
+        kind: "direct",
+        postId: "post-123",
+        replyToMode: "all",
+        threadRootId: "root-456",
+      }),
+    ).toBe("root-456");
+  });
 });
 
 describe("resolveMattermostThreadSessionContext", () => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -175,6 +175,9 @@ export function resolveMattermostEffectiveReplyToId(params: {
   threadRootId?: string | null;
 }): string | undefined {
   const threadRootId = params.threadRootId?.trim();
+  // Check threadRootId first — a DM Thread message should reply to the thread,
+  // not go to a new thread. Only fall through to kind===direct logic when there
+  // is no threadRootId.
   if (threadRootId && params.replyToMode !== "off") {
     return threadRootId;
   }


### PR DESCRIPTION
Fixes #59758

## What
In Mattermost, when a DM opens a thread and the user replies within that thread, the reply was incorrectly going to a new thread instead of staying in the existing thread.

## How
The `resolveMattermostEffectiveReplyToId` function now checks `threadRootId` first, before falling through to `kind===direct` logic. A DM Thread message should reply to the thread — only fall through to direct-message logic when there is no `threadRootId`.

Added a test case that verifies a `direct` message with a `threadRootId` correctly returns the `threadRootId`.