### PR TITLE
docs(changelog): add Brave config migration note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ Docs: https://docs.openclaw.ai
 
 ## 2026.4.1
 
+- Plugins/Brave: legacy `tools.web.search.brave` config blocks now trigger a strict "Unrecognized key" validation error. Remove `tools.web.search.brave.*` and use `plugins.entries.brave.config.webSearch.*` instead (e.g., `plugins.entries.brave.config.webSearch.mode` replaces `tools.web.search.brave.mode`). Run `openclaw doctor --fix` to migrate automatically. (#53857)
 - Plugins/runtime: stop ambient core helper and setup paths from loading non-selected bundled plugins, keep channel-setup snapshot scoping safe for custom channel plugins, and honor env-scoped plugin auth paths. (#59136) Thanks @vincentkoc.
 - Matrix/multi-account: keep room-level `account` scoping, inherited room overrides, and implicit account selection consistent across top-level default auth, named accounts, and cached-credential env setups. (#58449) thanks @Daanvdplas and @gumadeiras.
 - Gateway/pairing: prefer explicit QR bootstrap auth over earlier Tailscale auth classification so iOS `/pair qr` silent bootstrap pairing does not fall through to `pairing required`. (#59232) Thanks @ngutman.


### PR DESCRIPTION
## Summary
- Adds a migration note to the 2026.4.1 CHANGELOG entry documenting that legacy `tools.web.search.brave` config blocks now trigger strict "Unrecognized key" validation errors
- Users should migrate to `plugins.entries.brave.config.webSearch.*` or run `openclaw doctor --fix`

Refs #53857