### PR TITLE
fix(messaging): skip reply suppression for media-only messaging tool sends

### DIFF
--- a/src/agents/pi-embedded-messaging.ts
+++ b/src/agents/pi-embedded-messaging.ts
@@ -7,6 +7,7 @@ export type MessagingToolSend = {
   accountId?: string;
   to?: string;
   threadId?: string;
+  sentText?: boolean;
 };
 
 const CORE_MESSAGING_TOOLS = new Set(["sessions_send", "message"]);

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -643,11 +643,12 @@ export function handleToolExecutionStart(
         }
         // Field names vary by tool: Discord/Slack use "content", sessions_send uses "message",
         // Telegram also accepts "caption" for media sends with text.
-        const text =
+        const rawText =
           (argsRecord.content as string) ??
           (argsRecord.message as string) ??
           (argsRecord.caption as string);
-        if (text && typeof text === "string") {
+        const text = typeof rawText === "string" ? rawText.trim() : "";
+        if (text) {
           ctx.state.pendingMessagingTexts.set(toolCallId, text);
           ctx.log.debug(`Tracking pending messaging text: tool=${toolName} len=${text.length}`);
         }

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -641,8 +641,12 @@ export function handleToolExecutionStart(
         if (sendTarget) {
           ctx.state.pendingMessagingTargets.set(toolCallId, sendTarget);
         }
-        // Field names vary by tool: Discord/Slack use "content", sessions_send uses "message"
-        const text = (argsRecord.content as string) ?? (argsRecord.message as string);
+        // Field names vary by tool: Discord/Slack use "content", sessions_send uses "message",
+        // Telegram also accepts "caption" for media sends with text.
+        const text =
+          (argsRecord.content as string) ??
+          (argsRecord.message as string) ??
+          (argsRecord.caption as string);
         if (text && typeof text === "string") {
           ctx.state.pendingMessagingTexts.set(toolCallId, text);
           ctx.log.debug(`Tracking pending messaging text: tool=${toolName} len=${text.length}`);
@@ -808,7 +812,10 @@ export async function handleToolExecutionEnd(
   if (pendingTarget) {
     ctx.state.pendingMessagingTargets.delete(toolCallId);
     if (!isToolError) {
-      ctx.state.messagingToolSentTargets.push(pendingTarget);
+      ctx.state.messagingToolSentTargets.push({
+        ...pendingTarget,
+        sentText: Boolean(pendingText),
+      });
       ctx.trimMessagingToolSent();
     }
   }

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -19,7 +19,9 @@ async function expectSameTargetRepliesSuppressed(params: { provider: string; to:
     originatingChannel: "feishu",
     originatingTo: "ou_abc123",
     messagingToolSentTexts: ["different message"],
-    messagingToolSentTargets: [{ tool: "message", provider: params.provider, to: params.to }],
+    messagingToolSentTargets: [
+      { tool: "message", provider: params.provider, to: params.to, sentText: true },
+    ],
   });
 
   expect(replyPayloads).toHaveLength(0);
@@ -151,7 +153,9 @@ describe("buildReplyPayloads media filter integration", () => {
       originatingChannel: "telegram",
       originatingTo: "268300329",
       messagingToolSentTexts: ["different message"],
-      messagingToolSentTargets: [{ tool: "telegram", provider: "telegram", to: "268300329" }],
+      messagingToolSentTargets: [
+        { tool: "telegram", provider: "telegram", to: "268300329", sentText: true },
+      ],
     });
 
     expect(replyPayloads).toHaveLength(0);

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -173,26 +173,29 @@ export async function buildReplyPayloads(params: {
   const dedupeRuntime = shouldCheckMessagingToolDedupe
     ? await loadReplyPayloadsDedupeRuntime()
     : null;
+  const originTargetParams = {
+    messageProvider: resolveOriginMessageProvider({
+      originatingChannel: params.originatingChannel,
+      provider: params.messageProvider,
+    }),
+    messagingToolSentTargets,
+    originatingTo: resolveOriginMessageTo({
+      originatingTo: params.originatingTo,
+    }),
+    accountId: resolveOriginAccountId({
+      originatingAccountId: params.accountId,
+    }),
+  };
   const suppressMessagingToolReplies =
-    dedupeRuntime?.shouldSuppressMessagingToolReplies({
-      messageProvider: resolveOriginMessageProvider({
-        originatingChannel: params.originatingChannel,
-        provider: params.messageProvider,
-      }),
-      messagingToolSentTargets,
-      originatingTo: resolveOriginMessageTo({
-        originatingTo: params.originatingTo,
-      }),
-      accountId: resolveOriginAccountId({
-        originatingAccountId: params.accountId,
-      }),
-    }) ?? false;
-  // Only dedupe against messaging tool sends for the same origin target.
+    dedupeRuntime?.shouldSuppressMessagingToolReplies(originTargetParams) ?? false;
+  // Dedupe against messaging tool sends for the same origin target.
   // Cross-target sends (for example posting to another channel) must not
   // suppress the current conversation's final reply.
+  // Media dedupe uses the broader hasSentToSameOriginTarget (ignores sentText)
+  // so media-only sends still get deduped even though they don't suppress text replies.
   // If target metadata is unavailable, keep legacy dedupe behavior.
-  const dedupeMessagingToolPayloads =
-    suppressMessagingToolReplies || messagingToolSentTargets.length === 0;
+  const sentToSameOrigin = dedupeRuntime?.hasSentToSameOriginTarget(originTargetParams) ?? false;
+  const dedupeMessagingToolPayloads = sentToSameOrigin || messagingToolSentTargets.length === 0;
   const messagingToolSentMediaUrls = dedupeMessagingToolPayloads
     ? await normalizeSentMediaUrlsForDedupe({
         sentMediaUrls: params.messagingToolSentMediaUrls ?? [],

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1152,7 +1152,9 @@ describe("runReplyAgent messaging tool suppression", () => {
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "hello world!" }],
       messagingToolSentTexts: ["different message"],
-      messagingToolSentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
+      messagingToolSentTargets: [
+        { tool: "slack", provider: "slack", to: "channel:C1", sentText: true },
+      ],
       meta: {},
     });
 
@@ -1219,7 +1221,9 @@ describe("runReplyAgent messaging tool suppression", () => {
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "hello world!" }],
       messagingToolSentTexts: ["different message"],
-      messagingToolSentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
+      messagingToolSentTargets: [
+        { tool: "slack", provider: "slack", to: "channel:C1", sentText: true },
+      ],
       meta: {
         agentMeta: {
           usage: { input: 10, output: 5 },
@@ -1252,7 +1256,9 @@ describe("runReplyAgent messaging tool suppression", () => {
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "hello world!" }],
       messagingToolSentTexts: ["different message"],
-      messagingToolSentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
+      messagingToolSentTargets: [
+        { tool: "slack", provider: "slack", to: "channel:C1", sentText: true },
+      ],
       meta: {
         agentMeta: {
           usage: { input: 10, output: 5 },
@@ -1289,7 +1295,9 @@ describe("runReplyAgent messaging tool suppression", () => {
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "hello world!" }],
       messagingToolSentTexts: ["different message"],
-      messagingToolSentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
+      messagingToolSentTargets: [
+        { tool: "slack", provider: "slack", to: "channel:C1", sentText: true },
+      ],
       meta: {
         agentMeta: {
           promptTokens: 41_000,

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -50,7 +50,7 @@ describe("resolveFollowupDeliveryPayloads", () => {
         payloads: [{ text: "hello world!" }],
         messageProvider: "slack",
         originatingTo: "channel:C1",
-        sentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
+        sentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1", sentText: true }],
       }),
     ).toEqual([]);
   });
@@ -63,7 +63,7 @@ describe("resolveFollowupDeliveryPayloads", () => {
         messageProvider: "heartbeat",
         originatingChannel: "telegram",
         originatingTo: "268300329",
-        sentTargets: [{ tool: "telegram", provider: "telegram", to: "268300329" }],
+        sentTargets: [{ tool: "telegram", provider: "telegram", to: "268300329", sentText: true }],
       }),
     ).toEqual([]);
   });
@@ -78,7 +78,13 @@ describe("resolveFollowupDeliveryPayloads", () => {
         originatingTo: "268300329",
         originatingAccountId: "personal",
         sentTargets: [
-          { tool: "telegram", provider: "telegram", to: "268300329", accountId: "work" },
+          {
+            tool: "telegram",
+            provider: "telegram",
+            to: "268300329",
+            accountId: "work",
+            sentText: true,
+          },
         ],
       }),
     ).toEqual([{ text: "hello world!" }]);

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -989,6 +989,105 @@ describe("createFollowupRunner messaging tool dedupe", () => {
     };
   }
 
+  it("drops payloads already sent via messaging tool", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [{ text: "hello world!" }],
+        messagingToolSentTexts: ["hello world!"],
+      },
+    });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("delivers payloads when not duplicates", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: makeTextReplyDedupeResult(),
+    });
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses replies when a messaging tool sent via the same provider + target", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        ...makeTextReplyDedupeResult(),
+        messagingToolSentTargets: [
+          { tool: "slack", provider: "slack", to: "channel:C1", sentText: true },
+        ],
+      },
+      queued: baseQueuedRun("slack"),
+    });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("suppresses replies when provider is synthetic but originating channel matches", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        ...makeTextReplyDedupeResult(),
+        messagingToolSentTargets: [
+          { tool: "telegram", provider: "telegram", to: "268300329", sentText: true },
+        ],
+      },
+      queued: {
+        ...baseQueuedRun("heartbeat"),
+        originatingChannel: "telegram",
+        originatingTo: "268300329",
+      } as FollowupRun,
+    });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress replies for same target when account differs", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        ...makeTextReplyDedupeResult(),
+        messagingToolSentTargets: [
+          { tool: "telegram", provider: "telegram", to: "268300329", accountId: "work" },
+        ],
+      },
+      queued: {
+        ...baseQueuedRun("heartbeat"),
+        originatingChannel: "telegram",
+        originatingTo: "268300329",
+        originatingAccountId: "personal",
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "268300329",
+        accountId: "personal",
+      }),
+    );
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("drops media URL from payload when messaging tool already sent it", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [{ mediaUrl: "/tmp/img.png" }],
+        messagingToolSentMediaUrls: ["/tmp/img.png"],
+      },
+    });
+
+    // Media stripped -> payload becomes non-renderable -> not delivered.
+    expect(onBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("delivers media payload when not a duplicate", async () => {
+    const { onBlockReply } = await runMessagingCase({
+      agentResult: {
+        payloads: [{ mediaUrl: "/tmp/img.png" }],
+        messagingToolSentMediaUrls: ["/tmp/other.png"],
+      },
+    });
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+  });
   it("persists usage even when replies are suppressed", async () => {
     const storePath = "/tmp/openclaw-followup-usage.json";
     const sessionKey = "main";
@@ -1013,7 +1112,9 @@ describe("createFollowupRunner messaging tool dedupe", () => {
     const { onBlockReply } = await runMessagingCase({
       agentResult: {
         ...makeTextReplyDedupeResult(),
-        messagingToolSentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
+        messagingToolSentTargets: [
+          { tool: "slack", provider: "slack", to: "channel:C1", sentText: true },
+        ],
         meta: {
           agentMeta: {
             usage: { input: 1_000, output: 50 },

--- a/src/auto-reply/reply/reply-payloads-dedupe.runtime.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.runtime.ts
@@ -1,5 +1,6 @@
 export {
   filterMessagingToolDuplicates,
   filterMessagingToolMediaDuplicates,
+  hasSentToSameOriginTarget,
   shouldSuppressMessagingToolReplies,
 } from "./reply-payloads-dedupe.js";

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -136,6 +136,9 @@ export function shouldSuppressMessagingToolReplies(params: {
     return false;
   }
   return sentTargets.some((target) => {
+    if (!target.sentText) {
+      return false;
+    }
     const targetProvider = resolveTargetProviderForComparison({
       currentProvider: provider,
       targetProvider: target?.provider,

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -116,7 +116,7 @@ function targetsMatchForSuppression(params: {
   return params.targetKey === params.originTarget;
 }
 
-export function shouldSuppressMessagingToolReplies(params: {
+export function hasSentToSameOriginTarget(params: {
   messageProvider?: string;
   messagingToolSentTargets?: MessagingToolSend[];
   originatingTo?: string;
@@ -136,9 +136,6 @@ export function shouldSuppressMessagingToolReplies(params: {
     return false;
   }
   return sentTargets.some((target) => {
-    if (!target.sentText) {
-      return false;
-    }
     const targetProvider = resolveTargetProviderForComparison({
       currentProvider: provider,
       targetProvider: target?.provider,
@@ -161,4 +158,17 @@ export function shouldSuppressMessagingToolReplies(params: {
       targetThreadId: target.threadId,
     });
   });
+}
+
+export function shouldSuppressMessagingToolReplies(params: {
+  messageProvider?: string;
+  messagingToolSentTargets?: MessagingToolSend[];
+  originatingTo?: string;
+  accountId?: string;
+}): boolean {
+  if (!hasSentToSameOriginTarget(params)) {
+    return false;
+  }
+  const sentTargets = params.messagingToolSentTargets ?? [];
+  return sentTargets.some((target) => target.sentText);
 }

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -117,7 +117,7 @@ describe("shouldSuppressMessagingToolReplies", () => {
       shouldSuppressMessagingToolReplies({
         messageProvider: "telegram",
         originatingTo: "123",
-        messagingToolSentTargets: [{ tool: "message", provider: "", to: "123" }],
+        messagingToolSentTargets: [{ tool: "message", provider: "", to: "123", sentText: true }],
       }),
     ).toBe(true);
   });
@@ -127,7 +127,9 @@ describe("shouldSuppressMessagingToolReplies", () => {
       shouldSuppressMessagingToolReplies({
         messageProvider: "telegram",
         originatingTo: "123",
-        messagingToolSentTargets: [{ tool: "message", provider: "message", to: "123" }],
+        messagingToolSentTargets: [
+          { tool: "message", provider: "message", to: "123", sentText: true },
+        ],
       }),
     ).toBe(true);
   });
@@ -149,7 +151,7 @@ describe("shouldSuppressMessagingToolReplies", () => {
         messageProvider: "telegram",
         originatingTo: "telegram:group:-100123:topic:77",
         messagingToolSentTargets: [
-          { tool: "message", provider: "telegram", to: "-100123", threadId: "77" },
+          { tool: "message", provider: "telegram", to: "-100123", threadId: "77", sentText: true },
         ],
       }),
     ).toBe(true);
@@ -183,9 +185,21 @@ describe("shouldSuppressMessagingToolReplies", () => {
       shouldSuppressMessagingToolReplies({
         messageProvider: "telegram",
         originatingTo: "telegram:group:-100123",
-        messagingToolSentTargets: [{ tool: "message", provider: "telegram", to: "-100123" }],
+        messagingToolSentTargets: [
+          { tool: "message", provider: "telegram", to: "-100123", sentText: true },
+        ],
       }),
     ).toBe(true);
+  });
+
+  it("does not suppress when message tool sent media-only to the same channel", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "telegram",
+        originatingTo: "telegram:group:-100123",
+        messagingToolSentTargets: [{ tool: "message", provider: "telegram", to: "-100123" }],
+      }),
+    ).toBe(false);
   });
 
   it("suppresses telegram replies even when the active plugin registry omits telegram", () => {
@@ -197,7 +211,7 @@ describe("shouldSuppressMessagingToolReplies", () => {
         messageProvider: "telegram",
         originatingTo: "telegram:group:-100123:topic:77",
         messagingToolSentTargets: [
-          { tool: "message", provider: "telegram", to: "-100123", threadId: "77" },
+          { tool: "message", provider: "telegram", to: "-100123", threadId: "77", sentText: true },
         ],
       }),
     ).toBe(true);

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -8,5 +8,6 @@ export {
 export {
   filterMessagingToolDuplicates,
   filterMessagingToolMediaDuplicates,
+  hasSentToSameOriginTarget,
   shouldSuppressMessagingToolReplies,
 } from "./reply-payloads-dedupe.js";


### PR DESCRIPTION
## Summary

- `shouldSuppressMessagingToolReplies` suppressed all post-turn final replies when the `message` tool sent anything to the originating channel, including media-only sends (audio files, images). This caused the agent's final text reply to be silently dropped when it had also sent media to the same channel in the same turn.
- Added a `sentText` flag to `MessagingToolSend` that tracks whether a messaging tool call included text content. The suppression logic now only fires when text was actually sent to the same channel, allowing media-only sends to coexist with a final text reply.
- The fix is scoped to three files: the type definition, the tool commit handler, and the suppression check.

Closes #59743

## Test plan

- [x] New test: "does not suppress when message tool sent media-only to the same channel" (passes)
- [x] Updated existing suppression tests to include `sentText: true` for text-sending scenarios
- [x] `agent-runner-payloads.test.ts` (14 tests pass)
- [x] `followup-runner.test.ts` (updated expectations)
- [x] `agent-runner.misc.runreplyagent.test.ts` (updated expectations)
- [x] Note: 3 pre-existing test failures in `reply-payloads.test.ts` related to Telegram topic-origin matching are unrelated to this change (also fail on `upstream/main`)