### PR TITLE
fix(launchd): use launchctl stop for gateway stop on macOS

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -11,6 +11,7 @@ import {
   repairLaunchAgentBootstrap,
   restartLaunchAgent,
   resolveLaunchAgentPlistPath,
+  stopLaunchAgent,
 } from "./launchd.js";
 
 const state = vi.hoisted(() => ({
@@ -20,6 +21,8 @@ const state = vi.hoisted(() => ({
   bootstrapError: "",
   kickstartError: "",
   kickstartFailuresRemaining: 0,
+  stopError: "",
+  stopFailuresRemaining: 0,
   dirs: new Set<string>(),
   dirModes: new Map<string, number>(),
   files: new Map<string, string>(),
@@ -80,6 +83,10 @@ vi.mock("./exec-file.js", () => ({
     if (call[0] === "kickstart" && state.kickstartError && state.kickstartFailuresRemaining > 0) {
       state.kickstartFailuresRemaining -= 1;
       return { stdout: "", stderr: state.kickstartError, code: 1 };
+    }
+    if (call[0] === "stop" && state.stopError && state.stopFailuresRemaining > 0) {
+      state.stopFailuresRemaining -= 1;
+      return { stdout: "", stderr: state.stopError, code: 1 };
     }
     return { stdout: "", stderr: "", code: 0 };
   }),
@@ -154,6 +161,8 @@ beforeEach(() => {
   state.bootstrapError = "";
   state.kickstartError = "";
   state.kickstartFailuresRemaining = 0;
+  state.stopError = "";
+  state.stopFailuresRemaining = 0;
   state.dirs.clear();
   state.dirModes.clear();
   state.files.clear();
@@ -334,6 +343,61 @@ describe("launchd install", () => {
     expect(state.dirModes.get("/Users/test/Library")).toBe(0o755);
     expect(state.dirModes.get("/Users/test/Library/LaunchAgents")).toBe(0o755);
     expect(state.fileModes.get(plistPath)).toBe(0o644);
+  });
+
+  it("stops LaunchAgent with stop and no bootout", async () => {
+    const env = createDefaultLaunchdEnv();
+
+    await stopLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+    const serviceId = `${domain}/${label}`;
+    expect(state.launchctlCalls).toContainEqual(["stop", serviceId]);
+    expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
+  });
+
+  it("tolerates stop when LaunchAgent is not loaded", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.stopError = "Could not find service";
+    state.stopFailuresRemaining = 1;
+    const stdout = new PassThrough();
+    let output = "";
+    stdout.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+
+    await expect(
+      stopLaunchAgent({
+        env,
+        stdout,
+      }),
+    ).resolves.toBeUndefined();
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+    const serviceId = `${domain}/${label}`;
+    expect(state.launchctlCalls).toContainEqual(["stop", serviceId]);
+    expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
+    expect(output).toContain("Stopped LaunchAgent");
+  });
+
+  it("surfaces real stop failures", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.stopError = "Operation not permitted";
+    state.stopFailuresRemaining = 1;
+
+    await expect(
+      stopLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+      }),
+    ).rejects.toThrow("launchctl stop failed: Operation not permitted");
+
+    expect(state.launchctlCalls.some((call) => call[0] === "bootout")).toBe(false);
   });
 
   it("restarts LaunchAgent with kickstart and no bootout", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -451,11 +451,12 @@ function isUnsupportedGuiDomain(detail: string): boolean {
 export async function stopLaunchAgent({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env });
-  const res = await execLaunchctl(["bootout", `${domain}/${label}`]);
+  const serviceTarget = `${domain}/${label}`;
+  const res = await execLaunchctl(["stop", serviceTarget]);
   if (res.code !== 0 && !isLaunchctlNotLoaded(res)) {
-    throw new Error(`launchctl bootout failed: ${res.stderr || res.stdout}`.trim());
+    throw new Error(`launchctl stop failed: ${res.stderr || res.stdout}`.trim());
   }
-  stdout.write(`${formatLine("Stopped LaunchAgent", `${domain}/${label}`)}\n`);
+  stdout.write(`${formatLine("Stopped LaunchAgent", serviceTarget)}\n`);
 }
 
 async function writeLaunchAgentPlist({


### PR DESCRIPTION
## Summary

Fix macOS LaunchAgent stop semantics for `openclaw gateway stop`.

Previously `stopLaunchAgent()` used `launchctl bootout`, which unloads the
LaunchAgent entirely. That made `gateway stop` behave more like an unload than
a normal supervised stop, and could leave follow-up lifecycle commands in an
unexpected state.

This change switches the stop path to `launchctl stop`, which stops the managed
job while keeping the LaunchAgent loaded.

## Changes

- use `launchctl stop gui/<uid>/<label>` in `stopLaunchAgent()`
- keep “not loaded / not found” stop failures non-fatal
- preserve normal error surfacing for real `launchctl stop` failures
- add regression coverage for:
  - stop uses `stop`, not `bootout`
  - stop is tolerant when the service is already not loaded
  - stop still throws on real launchctl errors

## Why this is correct

`bootout` unloads the LaunchAgent from launchd, while `stop` only stops the
running service. For `openclaw gateway stop`, the latter matches the expected
CLI semantics.

This also keeps the stop path aligned with the existing restart behavior, which
already treats loaded vs not-loaded LaunchAgents differently.

## Testing

```bash
corepack pnpm vitest run src/daemon/launchd.test.ts
```

## Manual verification

1. Run `openclaw gateway install`
2. Run `openclaw gateway stop`
3. Confirm the gateway process stops
4. Confirm the LaunchAgent remains loaded rather than being unloaded
5. Run `openclaw gateway start` or `openclaw gateway restart`
6. Confirm the service starts again without requiring reinstall
