### PR TITLE
fix(node-host): forward systemRunPlan to system.run invoke in async approval path [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Docs: https://docs.openclaw.ai
 - Config/All Settings: keep the raw config view intact when sensitive fields are blank instead of corrupting or dropping the snapshot during redaction. (#28214) thanks @solodmd.
 - Plugins/runtime: honor explicit capability allowlists during fallback speech, media-understanding, and image-generation provider loading so bundled capability plugins do not bypass restrictive `plugins.allow` config. (#52262) Thanks @PerfectPan.
 - Hooks/tool policy: block tool calls when a `before_tool_call` hook crashes so hook failures fail closed instead of silently allowing execution. (#59822) Thanks @pgondhi987.
+- Node-host/exec approvals: forward `systemRunPlan` on `system.run` invokes so async approvals keep mutable script operand binding and drift revalidation enforced at execution time. (#59804) Thanks @pgondhi987.
 
 ## 2026.4.2
 

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -227,6 +227,7 @@ export async function executeNodeHostCommand(
       params: {
         command: runArgv,
         rawCommand: runRawCommand,
+        systemRunPlan: prepared.plan,
         cwd: runCwd,
         env: nodeEnv,
         timeoutMs: typeof params.timeoutSec === "number" ? params.timeoutSec * 1000 : undefined,

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -254,6 +254,7 @@ describe("exec approvals", () => {
   it("reuses approval id as the node runId", async () => {
     let invokeParams: unknown;
     let agentParams: unknown;
+    let preparedPlan: unknown;
 
     mockAcceptedApprovalFlow({
       onAgent: (params) => {
@@ -262,7 +263,21 @@ describe("exec approvals", () => {
       onNodeInvoke: (params) => {
         const invoke = params as { command?: string };
         if (invoke.command === "system.run.prepare") {
-          return buildPreparedSystemRunPayload(params);
+          const prepared = buildPreparedSystemRunPayload(params) as {
+            payload?: { plan?: Record<string, unknown> };
+          };
+          const basePlan = prepared.payload?.plan ?? {};
+          const planWithMutableBinding = {
+            ...basePlan,
+            mutableFileOperand: {
+              argvIndex: 1,
+              path: "/tmp/approved-script.sh",
+              sha256: "approved-script-hash",
+            },
+          };
+          prepared.payload = { ...prepared.payload, plan: planWithMutableBinding };
+          preparedPlan = planWithMutableBinding;
+          return prepared;
         }
         if (invoke.command === "system.run") {
           invokeParams = params;
@@ -300,6 +315,17 @@ describe("exec approvals", () => {
     ).toMatchObject({
       suppressNotifyOnExit: true,
     });
+    await expect
+      .poll(
+        () =>
+          (invokeParams as { params?: { systemRunPlan?: unknown } } | undefined)?.params
+            ?.systemRunPlan,
+        {
+          timeout: 2000,
+          interval: 20,
+        },
+      )
+      .toEqual(preparedPlan);
     await expect.poll(() => agentParams, { timeout: 2_000, interval: 20 }).toBeTruthy();
   });
 
@@ -359,15 +385,25 @@ describe("exec approvals", () => {
   it("preserves explicit workdir for node exec", async () => {
     const remoteWorkdir = "/Users/vv";
     let prepareCwd: string | undefined;
+    let preparedPlan: unknown;
+    let runSystemRunPlan: unknown;
 
     vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
       if (method === "node.invoke") {
-        const invoke = params as { command?: string; params?: { cwd?: string } };
+        const invoke = params as {
+          command?: string;
+          params?: { cwd?: string; systemRunPlan?: unknown };
+        };
         if (invoke.command === "system.run.prepare") {
           prepareCwd = invoke.params?.cwd;
-          return buildPreparedSystemRunPayload(params);
+          const prepared = buildPreparedSystemRunPayload(params) as {
+            payload?: { plan?: unknown };
+          };
+          preparedPlan = prepared.payload?.plan;
+          return prepared;
         }
         if (invoke.command === "system.run") {
+          runSystemRunPlan = invoke.params?.systemRunPlan;
           return { payload: { success: true, stdout: "ok" } };
         }
       }
@@ -388,6 +424,7 @@ describe("exec approvals", () => {
 
     expect(result.details.status).toBe("completed");
     expect(prepareCwd).toBe(remoteWorkdir);
+    expect(runSystemRunPlan).toEqual(preparedPlan);
   });
 
   it("does not forward the gateway default cwd to node exec when workdir is omitted", async () => {


### PR DESCRIPTION
## Summary

- **Problem:** `buildInvokeParams` in the node-host async approval execution path omitted `systemRunPlan` from the `system.run` invoke payload, even though the prepared plan was correctly registered at approval time.
- **Why it matters:** The node host only enables mutable file operand revalidation and approval-plan binding checks when `opts.params.systemRunPlan` is present. Without it, `approvalPlan` is null and script SHA-256 revalidation is skipped, allowing approval-time/execute-time script content to drift.
- **What changed:** Added `systemRunPlan: prepared.plan` to the `params` block in `buildInvokeParams` (`src/agents/bash-tools.exec-host-node.ts`). Added regression tests in `src/agents/bash-tools.exec.approval-id.test.ts` that assert the `system.run` invoke payload carries the plan returned by `system.run.prepare`, including a `mutableFileOperand`.
- **What did NOT change:** No changes to node-host plan validation logic, approval registration, allowlist evaluation, or any other exec path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** `buildInvokeParams` was introduced to consolidate invocation parameters for both the direct and async-approval paths, but `systemRunPlan` was only wired into the approval registration call, not the invocation builder.
- **Missing detection / guardrail:** No test asserted that the `system.run` payload carried `systemRunPlan`; existing tests only verified `runId` and `suppressNotifyOnExit`.
- **Prior context:** Approval registration (`registerExecApprovalRequestForHostOrThrow`) already received `prepared.plan` correctly; the gap was specifically in the downstream invocation.
- **Why this regressed now:** The plan forwarding was never implemented for the invoke side; it was an omission from the original implementation.
- **If unknown, what was ruled out:** N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/agents/bash-tools.exec.approval-id.test.ts`
- **Scenario the test should lock in:** `system.run` invocation params include `systemRunPlan` matching the plan from `system.run.prepare`, including `mutableFileOperand` fields.
- **Why this is the smallest reliable guardrail:** Tests the exact invocation boundary where the omission occurred with the minimal mock surface.
- **Existing test that already covers this:** None — gap identified and filled by this PR.

## User-visible / Behavior Changes

None directly visible to end users. Internally, the node host now receives `systemRunPlan` on every `system.run` invocation in the async approval path, enabling intended mutable file operand revalidation as designed.

## Diagram (if applicable)

```text
Before:
system.run.prepare -> prepared.plan -> approval registration (plan present)
                                    -> system.run invoke   (plan MISSING -> revalidation skipped)

After:
system.run.prepare -> prepared.plan -> approval registration (plan present)
                                    -> system.run invoke   (plan present -> revalidation runs)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes — `system.run` now receives `systemRunPlan`, enabling mutable file operand SHA-256 revalidation that was previously bypassed.
- Data access scope changed? No
- **Risk + mitigation:** The change restores intended behavior. The node host already had the validation logic gated on `systemRunPlan` presence; this PR ensures the parameter is forwarded so that gate fires as designed.

## Repro + Verification

### Environment

- OS: Linux (analysis environment)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel: node-host exec approvals (`system.run.prepare` + async approval callback)
- Relevant config: `ask=always` or `ask=on-miss` with node exec approvals enabled

### Steps

1. Review `buildInvokeParams` in `src/agents/bash-tools.exec-host-node.ts` — confirm `systemRunPlan` is present in returned params.
2. Run scoped tests: `pnpm test -- src/agents/bash-tools.exec.approval-id.test.ts`.
3. Confirm new assertions pass: `system.run` invoke payload carries `systemRunPlan` equal to the plan from `system.run.prepare`, including `mutableFileOperand`.

### Expected

- `systemRunPlan` present in `system.run` invoke params on node-host async approval path.
- Mutable file operand revalidation runs on node host when operand is present in plan.

### Actual (before fix)

- `systemRunPlan` absent from `system.run` invoke params.
- Node host `approvalPlan` was null; mutable operand SHA-256 check was skipped.

## Evidence

- [x] Failing test/log before + passing after — new regression tests added that would have failed before the one-line source fix.

## Human Verification (required)

- **Verified scenarios:** Code-level diff review confirming `systemRunPlan: prepared.plan` is now included in `buildInvokeParams` return value; confirmed `prepared` is guaranteed non-null at call site (early throw at line 119–121).
- **Edge cases checked:** Both approval-required and direct (no-ask) paths use `buildInvokeParams`; fix applies to both. `normalizeSystemRunApprovalPlan` already validates `mutableFileOperand` structure and returns null on malformed input.
- **What you did not verify:** Live end-to-end execution on a real node host with a mutable script operand.

> **AI-assisted:** This fix was generated by OpenAI Codex and reviewed by Claude.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** Node host receives `systemRunPlan` for the first time on this path; if host-side plan normalization is stricter than expected, it could reject previously-accepted invocations.
  - **Mitigation:** `normalizeSystemRunApprovalPlan` was already exercised on the approval-registration side with the same `prepared.plan` value; no new normalization paths are introduced.