### PR TITLE
fix: add proxy bootstrap to runMessageAction for CLI fetch paths

### DIFF
--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -14,6 +14,7 @@ import type {
   ChannelThreadingToolContext,
 } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { ensureGlobalUndiciEnvProxyDispatcher } from "../../infra/net/undici-global-dispatcher.js";
 import { hasInteractiveReplyBlocks, hasReplyPayloadContent } from "../../interactive/payload.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
@@ -822,6 +823,10 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
 export async function runMessageAction(
   input: RunMessageActionParams,
 ): Promise<MessageActionRunResult> {
+  // Proxy bootstrap: mirror attempt.ts pattern so outbound channel fetches
+  // (e.g. Discord REST API) respect HTTP_PROXY/HTTPS_PROXY env vars (as well as
+  // lowercase http_proxy/https_proxy and NO_PROXY, if set).
+  ensureGlobalUndiciEnvProxyDispatcher();
   const cfg = input.cfg;
   let params = { ...input.params };
   const resolvedAgentId =


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw message read` and other CLI commands using `runMessageAction()` fail with timeout when behind an HTTP proxy, because the global undici proxy dispatcher is not initialized in that code path.
- **Why it matters:** Users behind corporate/VPN proxies cannot use CLI message commands despite having `HTTP_PROXY`/`HTTPS_PROXY` set correctly.
- **What changed:** Added `ensureGlobalUndiciEnvProxyDispatcher()` call at the top of `runMessageAction()` in `src/infra/outbound/message-action-runner.ts`, matching the pattern already used in other fetch entry points.
- **What did NOT change:** No proxy logic changes, no new dependencies; this just ensures the existing bootstrap runs in this code path.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `runMessageAction()` was added without the proxy bootstrap that other fetch-based entry points already have.
- Missing detection / guardrail: No proxy-environment CI test.
- Prior context: Other entry points like gateway startup and webhook handlers already call `ensureGlobalUndiciEnvProxyDispatcher()`.
- Why this regressed now: The code path was always missing it; only noticed when testing CLI behind proxy.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] End-to-end test
- Target test or file: E2E test with `HTTP_PROXY` set, running `message read`
- Scenario the test should lock in: CLI fetch commands work through proxy
- Why this is the smallest reliable guardrail: Proxy behavior requires real network setup
- If no new test is added, why not: Proxy E2E requires network infrastructure not available in CI

## User-visible / Behavior Changes

CLI commands (`message read`, `message send`, etc.) now work correctly when `HTTP_PROXY`/`HTTPS_PROXY` environment variables are set.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (existing calls now route through configured proxy)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22
- Integration/channel: Discord
- Relevant config: `HTTP_PROXY=http://127.0.0.1:7890`

### Steps

1. Set `HTTP_PROXY` env var pointing to a local proxy
2. Run `openclaw message read --channel discord --account <name> --target channel:<id> --limit 3`
3. Before fix: timeout. After fix: messages returned.

### Expected

Messages returned via proxy.

### Actual

Messages returned successfully.

## Evidence

- [x] Trace/log snippets (CLI output showing messages returned through proxy)

## Human Verification (required)

- Verified scenarios: `message read` and `message send` through HTTP proxy
- Edge cases checked: Without proxy set (no regression)
- What you did **not** verify: SOCKS proxy, authenticated proxy
