### PR TITLE
Fixes #58115 - voice-call: prevent EADDRINUSE by sharing runtime across contexts

### DIFF
--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -34,6 +34,10 @@ const noopLogger = {
 type Registered = {
   methods: Map<string, unknown>;
   tools: unknown[];
+  service?: {
+    start: () => Promise<void>;
+    stop: () => Promise<void>;
+  };
 };
 type RegisterVoiceCall = (api: Record<string, unknown>) => void | Promise<void>;
 type RegisterCliContext = {
@@ -57,6 +61,12 @@ function captureStdout() {
 function setup(config: Record<string, unknown>): Registered {
   const methods = new Map<string, unknown>();
   const tools: unknown[] = [];
+  let service:
+    | {
+        start: () => Promise<void>;
+        stop: () => Promise<void>;
+      }
+    | undefined;
   void plugin.register({
     id: "voice-call",
     name: "Voice Call",
@@ -72,10 +82,12 @@ function setup(config: Record<string, unknown>): Registered {
     registerGatewayMethod: (method: string, handler: unknown) => methods.set(method, handler),
     registerTool: (tool: unknown) => tools.push(tool),
     registerCli: () => {},
-    registerService: () => {},
+    registerService: (registeredService: unknown) => {
+      service = registeredService as Registered["service"];
+    },
     resolvePath: (p: string) => p,
   } as unknown as Parameters<typeof plugin.register>[0]);
-  return { methods, tools };
+  return { methods, tools, service };
 }
 
 async function registerVoiceCallCli(program: Command) {
@@ -131,6 +143,18 @@ describe("voice-call plugin", () => {
   });
 
   afterEach(() => vi.restoreAllMocks());
+
+  it("claims shared runtime shutdown so multi-context stop runs once", async () => {
+    const first = setup({ provider: "mock" });
+    const second = setup({ provider: "mock" });
+
+    await first.service?.start();
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(1);
+
+    await Promise.all([first.service?.stop(), second.service?.stop()]);
+
+    expect(runtimeStub.stop).toHaveBeenCalledTimes(1);
+  });
 
   it("initiates a call via voicecall.initiate", async () => {
     const { methods } = setup({ provider: "mock" });

--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -24,6 +24,10 @@ vi.mock("./runtime-entry.js", () => ({
 import plugin from "./index.js";
 import { createVoiceCallRuntime } from "./runtime-entry.js";
 
+const VOICE_RUNTIME_KEY = Symbol.for("openclaw.voice.runtime");
+const VOICE_RUNTIME_PROMISE_KEY = Symbol.for("openclaw.voice.runtimePromise");
+const VOICE_RUNTIME_STOP_PROMISE_KEY = Symbol.for("openclaw.voice.runtimeStopPromise");
+
 const noopLogger = {
   info: vi.fn(),
   warn: vi.fn(),
@@ -140,9 +144,16 @@ describe("voice-call plugin", () => {
       },
       stop: vi.fn(async () => {}),
     };
+    vi.mocked(createVoiceCallRuntime).mockReset();
+    vi.mocked(createVoiceCallRuntime).mockImplementation(async () => runtimeStub);
   });
 
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as Record<PropertyKey, unknown>)[VOICE_RUNTIME_KEY];
+    delete (globalThis as Record<PropertyKey, unknown>)[VOICE_RUNTIME_PROMISE_KEY];
+    delete (globalThis as Record<PropertyKey, unknown>)[VOICE_RUNTIME_STOP_PROMISE_KEY];
+  });
 
   it("claims shared runtime shutdown so multi-context stop runs once", async () => {
     const first = setup({ provider: "mock" });
@@ -154,6 +165,49 @@ describe("voice-call plugin", () => {
     await Promise.all([first.service?.stop(), second.service?.stop()]);
 
     expect(runtimeStub.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not republish a runtime that stop already claimed", async () => {
+    let resolveFirstRuntime: ((runtime: typeof runtimeStub) => void) | undefined;
+    const firstRuntimePromise = new Promise<typeof runtimeStub>((resolve) => {
+      resolveFirstRuntime = resolve;
+    });
+    const firstRuntime = {
+      ...runtimeStub,
+      stop: vi.fn(async () => {}),
+    };
+    const secondRuntime = {
+      ...runtimeStub,
+      manager: {
+        ...runtimeStub.manager,
+        initiateCall: vi.fn(async () => ({ callId: "call-2", success: true })),
+      },
+      stop: vi.fn(async () => {}),
+    };
+    vi.mocked(createVoiceCallRuntime)
+      .mockImplementationOnce(async () => firstRuntimePromise)
+      .mockImplementationOnce(async () => secondRuntime);
+
+    const { methods, service } = setup({ provider: "mock" });
+    const startPromise = service!.start();
+    const stopPromise = service!.stop();
+
+    resolveFirstRuntime!(firstRuntime);
+    await Promise.all([startPromise, stopPromise]);
+
+    const handler = methods.get("voicecall.initiate") as
+      | ((ctx: {
+          params: Record<string, unknown>;
+          respond: ReturnType<typeof vi.fn>;
+        }) => Promise<void>)
+      | undefined;
+    const respond = vi.fn();
+    await handler?.({ params: { message: "Hi" }, respond });
+
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(2);
+    expect(firstRuntime.stop).toHaveBeenCalledTimes(1);
+    expect(firstRuntime.manager.initiateCall).not.toHaveBeenCalled();
+    expect(secondRuntime.manager.initiateCall).toHaveBeenCalledTimes(1);
   });
 
   it("initiates a call via voicecall.initiate", async () => {

--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -204,6 +204,45 @@ describe("voice-call plugin", () => {
     expect(secondRuntime.manager.initiateCall).toHaveBeenCalledTimes(1);
   });
 
+  it("retries runtime access during stop instead of surfacing a transient error", async () => {
+    let resolveFirstRuntime: ((runtime: VoiceCallRuntime) => void) | undefined;
+    const firstRuntimePromise = new Promise<VoiceCallRuntime>((resolve) => {
+      resolveFirstRuntime = resolve;
+    });
+    const firstRuntime = {
+      ...runtimeStub,
+      stop: vi.fn(async () => {}),
+    } as VoiceCallRuntime;
+    const secondRuntime = {
+      ...createRuntimeStub("call-2"),
+      stop: vi.fn(async () => {}),
+    } as VoiceCallRuntime;
+    vi.mocked(createVoiceCallRuntime)
+      .mockImplementationOnce(async () => firstRuntimePromise)
+      .mockImplementationOnce(async () => secondRuntime);
+
+    const { methods, service } = setup({ provider: "mock" });
+    const handler = methods.get("voicecall.initiate") as
+      | ((ctx: {
+          params: Record<string, unknown>;
+          respond: ReturnType<typeof vi.fn>;
+        }) => Promise<void>)
+      | undefined;
+
+    const startPromise = service!.start();
+    const stopPromise = service!.stop();
+    const respond = vi.fn();
+    const handlerPromise = handler?.({ params: { message: "Hi" }, respond });
+
+    resolveFirstRuntime!(firstRuntime);
+    await Promise.all([startPromise, stopPromise, handlerPromise]);
+
+    expect(createVoiceCallRuntime).toHaveBeenCalledTimes(2);
+    expect(firstRuntime.stop).toHaveBeenCalledTimes(1);
+    expect(secondRuntime.manager.initiateCall).toHaveBeenCalledTimes(1);
+    expect(respond).toHaveBeenCalledWith(true, { callId: "call-2", initiated: true });
+  });
+
   it("initiates a call via voicecall.initiate", async () => {
     const { methods } = setup({ provider: "mock" });
     const handler = methods.get("voicecall.initiate") as

--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -3,19 +3,9 @@ import os from "node:os";
 import path from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { VoiceCallRuntime } from "./runtime-entry.js";
 
-let runtimeStub: {
-  config: { toNumber?: string };
-  manager: {
-    initiateCall: ReturnType<typeof vi.fn>;
-    continueCall: ReturnType<typeof vi.fn>;
-    speak: ReturnType<typeof vi.fn>;
-    endCall: ReturnType<typeof vi.fn>;
-    getCall: ReturnType<typeof vi.fn>;
-    getCallByProviderCallId: ReturnType<typeof vi.fn>;
-  };
-  stop: ReturnType<typeof vi.fn>;
-};
+let runtimeStub: VoiceCallRuntime;
 
 vi.mock("./runtime-entry.js", () => ({
   createVoiceCallRuntime: vi.fn(async () => runtimeStub),
@@ -50,6 +40,28 @@ type RegisterCliContext = {
   workspaceDir?: string;
   logger: typeof noopLogger;
 };
+
+function createRuntimeStub(callId = "call-1"): VoiceCallRuntime {
+  return {
+    config: { toNumber: "+15550001234" } as unknown as VoiceCallRuntime["config"],
+    provider: {} as VoiceCallRuntime["provider"],
+    manager: {
+      initiateCall: vi.fn(async () => ({ callId, success: true })),
+      continueCall: vi.fn(async () => ({
+        success: true,
+        transcript: "hello",
+      })),
+      speak: vi.fn(async () => ({ success: true })),
+      endCall: vi.fn(async () => ({ success: true })),
+      getCall: vi.fn((id: string) => (id === "call-1" ? { callId: "call-1" } : undefined)),
+      getCallByProviderCallId: vi.fn(() => undefined),
+    } as unknown as VoiceCallRuntime["manager"],
+    webhookServer: {} as VoiceCallRuntime["webhookServer"],
+    webhookUrl: "http://127.0.0.1:3334/voice/webhook",
+    publicUrl: null,
+    stop: vi.fn(async () => {}),
+  };
+}
 
 function captureStdout() {
   let output = "";
@@ -129,21 +141,7 @@ describe("voice-call plugin", () => {
     noopLogger.error.mockClear();
     noopLogger.debug.mockClear();
     vi.mocked(createVoiceCallRuntime).mockClear();
-    runtimeStub = {
-      config: { toNumber: "+15550001234" },
-      manager: {
-        initiateCall: vi.fn(async () => ({ callId: "call-1", success: true })),
-        continueCall: vi.fn(async () => ({
-          success: true,
-          transcript: "hello",
-        })),
-        speak: vi.fn(async () => ({ success: true })),
-        endCall: vi.fn(async () => ({ success: true })),
-        getCall: vi.fn((id: string) => (id === "call-1" ? { callId: "call-1" } : undefined)),
-        getCallByProviderCallId: vi.fn(() => undefined),
-      },
-      stop: vi.fn(async () => {}),
-    };
+    runtimeStub = createRuntimeStub();
     vi.mocked(createVoiceCallRuntime).mockReset();
     vi.mocked(createVoiceCallRuntime).mockImplementation(async () => runtimeStub);
   });
@@ -168,22 +166,18 @@ describe("voice-call plugin", () => {
   });
 
   it("does not republish a runtime that stop already claimed", async () => {
-    let resolveFirstRuntime: ((runtime: typeof runtimeStub) => void) | undefined;
-    const firstRuntimePromise = new Promise<typeof runtimeStub>((resolve) => {
+    let resolveFirstRuntime: ((runtime: VoiceCallRuntime) => void) | undefined;
+    const firstRuntimePromise = new Promise<VoiceCallRuntime>((resolve) => {
       resolveFirstRuntime = resolve;
     });
     const firstRuntime = {
       ...runtimeStub,
       stop: vi.fn(async () => {}),
-    };
+    } as VoiceCallRuntime;
     const secondRuntime = {
-      ...runtimeStub,
-      manager: {
-        ...runtimeStub.manager,
-        initiateCall: vi.fn(async () => ({ callId: "call-2", success: true })),
-      },
+      ...createRuntimeStub("call-2"),
       stop: vi.fn(async () => {}),
-    };
+    } as VoiceCallRuntime;
     vi.mocked(createVoiceCallRuntime)
       .mockImplementationOnce(async () => firstRuntimePromise)
       .mockImplementationOnce(async () => secondRuntime);

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -157,16 +157,19 @@ export default definePluginEntry({
 
     const VOICE_RUNTIME_KEY = Symbol.for("openclaw.voice.runtime");
     const VOICE_RUNTIME_PROMISE_KEY = Symbol.for("openclaw.voice.runtimePromise");
+    const VOICE_RUNTIME_STOP_PROMISE_KEY = Symbol.for("openclaw.voice.runtimeStopPromise");
 
     const globalState = globalThis as typeof globalThis & {
       [VOICE_RUNTIME_KEY]?: VoiceCallRuntime | null;
       [VOICE_RUNTIME_PROMISE_KEY]?: Promise<VoiceCallRuntime> | null;
+      [VOICE_RUNTIME_STOP_PROMISE_KEY]?: Promise<void> | null;
     };
 
     globalState[VOICE_RUNTIME_KEY] ??= null;
     globalState[VOICE_RUNTIME_PROMISE_KEY] ??= null;
+    globalState[VOICE_RUNTIME_STOP_PROMISE_KEY] ??= null;
 
-    const ensureRuntime = async () => {
+    const ensureRuntime = async (): Promise<VoiceCallRuntime> => {
       if (!config.enabled) {
         throw new Error("Voice call disabled in plugin config");
       }
@@ -174,32 +177,56 @@ export default definePluginEntry({
         throw new Error(validation.errors.join("; "));
       }
 
-      if (globalState[VOICE_RUNTIME_KEY]) {
-        return globalState[VOICE_RUNTIME_KEY];
-      }
+      while (true) {
+        if (globalState[VOICE_RUNTIME_STOP_PROMISE_KEY]) {
+          await globalState[VOICE_RUNTIME_STOP_PROMISE_KEY];
+          continue;
+        }
 
-      if (!globalState[VOICE_RUNTIME_PROMISE_KEY]) {
-        globalState[VOICE_RUNTIME_PROMISE_KEY] = createVoiceCallRuntime({
-          config,
-          coreConfig: api.config as CoreConfig,
-          fullConfig: api.config,
-          agentRuntime: api.runtime.agent,
-          ttsRuntime: api.runtime.tts,
-          logger: api.logger,
-        });
-      }
+        if (globalState[VOICE_RUNTIME_KEY]) {
+          return globalState[VOICE_RUNTIME_KEY];
+        }
 
-      try {
-        globalState[VOICE_RUNTIME_KEY] = await globalState[VOICE_RUNTIME_PROMISE_KEY];
-      } catch (err) {
-        // Reset shared state so the next call can retry instead of caching a
-        // rejected promise or stale runtime across plugin contexts.
-        globalState[VOICE_RUNTIME_PROMISE_KEY] = null;
-        globalState[VOICE_RUNTIME_KEY] = null;
-        throw err;
-      }
+        let runtimePromise = globalState[VOICE_RUNTIME_PROMISE_KEY];
+        if (!runtimePromise) {
+          runtimePromise = createVoiceCallRuntime({
+            config,
+            coreConfig: api.config as CoreConfig,
+            fullConfig: api.config,
+            agentRuntime: api.runtime.agent,
+            ttsRuntime: api.runtime.tts,
+            logger: api.logger,
+          });
+          globalState[VOICE_RUNTIME_PROMISE_KEY] = runtimePromise;
+        }
 
-      return globalState[VOICE_RUNTIME_KEY]!;
+        try {
+          const runtime = await runtimePromise;
+          if (globalState[VOICE_RUNTIME_STOP_PROMISE_KEY]) {
+            await globalState[VOICE_RUNTIME_STOP_PROMISE_KEY];
+            if (globalState[VOICE_RUNTIME_KEY]) {
+              return globalState[VOICE_RUNTIME_KEY];
+            }
+            throw new Error("Voice call runtime changed during initialization; retry");
+          }
+          if (globalState[VOICE_RUNTIME_PROMISE_KEY] !== runtimePromise) {
+            if (globalState[VOICE_RUNTIME_KEY]) {
+              return globalState[VOICE_RUNTIME_KEY];
+            }
+            throw new Error("Voice call runtime changed during initialization; retry");
+          }
+          globalState[VOICE_RUNTIME_KEY] = runtime;
+          return runtime;
+        } catch (err) {
+          if (globalState[VOICE_RUNTIME_PROMISE_KEY] === runtimePromise) {
+            // Reset shared state so the next call can retry instead of caching a
+            // rejected promise or stale runtime across plugin contexts.
+            globalState[VOICE_RUNTIME_PROMISE_KEY] = null;
+            globalState[VOICE_RUNTIME_KEY] = null;
+          }
+          throw err;
+        }
+      }
     };
 
     const sendError = (respond: (ok: boolean, payload?: unknown) => void, err: unknown) => {
@@ -552,6 +579,10 @@ export default definePluginEntry({
         }
       },
       stop: async () => {
+        if (globalState[VOICE_RUNTIME_STOP_PROMISE_KEY]) {
+          await globalState[VOICE_RUNTIME_STOP_PROMISE_KEY];
+          return;
+        }
         // Claim shared state before awaiting so only one plugin context performs teardown.
         const capturedPromise = globalState[VOICE_RUNTIME_PROMISE_KEY];
         const capturedRuntime = globalState[VOICE_RUNTIME_KEY];
@@ -560,8 +591,18 @@ export default definePluginEntry({
         }
         globalState[VOICE_RUNTIME_PROMISE_KEY] = null;
         globalState[VOICE_RUNTIME_KEY] = null;
-        const rt = capturedRuntime ?? (await capturedPromise!);
-        await rt.stop();
+        const stopPromise = (async () => {
+          const rt = capturedRuntime ?? (await capturedPromise!);
+          await rt.stop();
+        })();
+        globalState[VOICE_RUNTIME_STOP_PROMISE_KEY] = stopPromise;
+        try {
+          await stopPromise;
+        } finally {
+          if (globalState[VOICE_RUNTIME_STOP_PROMISE_KEY] === stopPromise) {
+            globalState[VOICE_RUNTIME_STOP_PROMISE_KEY] = null;
+          }
+        }
       },
     });
   },

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -199,7 +199,7 @@ export default definePluginEntry({
         throw err;
       }
 
-      return globalState[VOICE_RUNTIME_KEY];
+      return globalState[VOICE_RUNTIME_KEY]!;
     };
 
     const sendError = (respond: (ok: boolean, payload?: unknown) => void, err: unknown) => {
@@ -552,17 +552,16 @@ export default definePluginEntry({
         }
       },
       stop: async () => {
-        if (!globalState[VOICE_RUNTIME_PROMISE_KEY] && !globalState[VOICE_RUNTIME_KEY]) {
+        // Claim shared state before awaiting so only one plugin context performs teardown.
+        const capturedPromise = globalState[VOICE_RUNTIME_PROMISE_KEY];
+        const capturedRuntime = globalState[VOICE_RUNTIME_KEY];
+        if (!capturedPromise && !capturedRuntime) {
           return;
         }
-        try {
-          const rt =
-            globalState[VOICE_RUNTIME_KEY] ?? (await globalState[VOICE_RUNTIME_PROMISE_KEY]!);
-          await rt.stop();
-        } finally {
-          globalState[VOICE_RUNTIME_PROMISE_KEY] = null;
-          globalState[VOICE_RUNTIME_KEY] = null;
-        }
+        globalState[VOICE_RUNTIME_PROMISE_KEY] = null;
+        globalState[VOICE_RUNTIME_KEY] = null;
+        const rt = capturedRuntime ?? (await capturedPromise!);
+        await rt.stop();
       },
     });
   },

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -168,6 +168,7 @@ export default definePluginEntry({
     globalState[VOICE_RUNTIME_KEY] ??= null;
     globalState[VOICE_RUNTIME_PROMISE_KEY] ??= null;
     globalState[VOICE_RUNTIME_STOP_PROMISE_KEY] ??= null;
+    const RETRY_ENSURE_RUNTIME = Symbol("voice-call.ensureRuntime.retry");
 
     const ensureRuntime = async (): Promise<VoiceCallRuntime> => {
       if (!config.enabled) {
@@ -202,22 +203,27 @@ export default definePluginEntry({
 
         try {
           const runtime = await runtimePromise;
-          if (globalState[VOICE_RUNTIME_STOP_PROMISE_KEY]) {
-            await globalState[VOICE_RUNTIME_STOP_PROMISE_KEY];
+          const stopPromise: Promise<void> | null =
+            globalState[VOICE_RUNTIME_STOP_PROMISE_KEY] ?? null;
+          if (stopPromise !== null) {
+            await Promise.resolve(stopPromise);
             if (globalState[VOICE_RUNTIME_KEY]) {
               return globalState[VOICE_RUNTIME_KEY];
             }
-            throw new Error("Voice call runtime changed during initialization; retry");
+            throw RETRY_ENSURE_RUNTIME;
           }
           if (globalState[VOICE_RUNTIME_PROMISE_KEY] !== runtimePromise) {
             if (globalState[VOICE_RUNTIME_KEY]) {
               return globalState[VOICE_RUNTIME_KEY];
             }
-            throw new Error("Voice call runtime changed during initialization; retry");
+            throw RETRY_ENSURE_RUNTIME;
           }
           globalState[VOICE_RUNTIME_KEY] = runtime;
           return runtime;
         } catch (err) {
+          if (err === RETRY_ENSURE_RUNTIME) {
+            continue;
+          }
           if (globalState[VOICE_RUNTIME_PROMISE_KEY] === runtimePromise) {
             // Reset shared state so the next call can retry instead of caching a
             // rejected promise or stale runtime across plugin contexts.

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -155,8 +155,16 @@ export default definePluginEntry({
       }
     }
 
-    let runtimePromise: Promise<VoiceCallRuntime> | null = null;
-    let runtime: VoiceCallRuntime | null = null;
+    const VOICE_RUNTIME_KEY = Symbol.for("openclaw.voice.runtime");
+    const VOICE_RUNTIME_PROMISE_KEY = Symbol.for("openclaw.voice.runtimePromise");
+
+    const globalState = globalThis as typeof globalThis & {
+      [VOICE_RUNTIME_KEY]?: VoiceCallRuntime | null;
+      [VOICE_RUNTIME_PROMISE_KEY]?: Promise<VoiceCallRuntime> | null;
+    };
+
+    globalState[VOICE_RUNTIME_KEY] ??= null;
+    globalState[VOICE_RUNTIME_PROMISE_KEY] ??= null;
 
     const ensureRuntime = async () => {
       if (!config.enabled) {
@@ -165,11 +173,13 @@ export default definePluginEntry({
       if (!validation.valid) {
         throw new Error(validation.errors.join("; "));
       }
-      if (runtime) {
-        return runtime;
+
+      if (globalState[VOICE_RUNTIME_KEY]) {
+        return globalState[VOICE_RUNTIME_KEY];
       }
-      if (!runtimePromise) {
-        runtimePromise = createVoiceCallRuntime({
+
+      if (!globalState[VOICE_RUNTIME_PROMISE_KEY]) {
+        globalState[VOICE_RUNTIME_PROMISE_KEY] = createVoiceCallRuntime({
           config,
           coreConfig: api.config as CoreConfig,
           fullConfig: api.config,
@@ -178,16 +188,18 @@ export default definePluginEntry({
           logger: api.logger,
         });
       }
+
       try {
-        runtime = await runtimePromise;
+        globalState[VOICE_RUNTIME_KEY] = await globalState[VOICE_RUNTIME_PROMISE_KEY];
       } catch (err) {
-        // Reset so the next call can retry instead of caching the
-        // rejected promise forever (which also leaves the port orphaned
-        // if the server started before the failure).  See: #32387
-        runtimePromise = null;
+        // Reset shared state so the next call can retry instead of caching a
+        // rejected promise or stale runtime across plugin contexts.
+        globalState[VOICE_RUNTIME_PROMISE_KEY] = null;
+        globalState[VOICE_RUNTIME_KEY] = null;
         throw err;
       }
-      return runtime;
+
+      return globalState[VOICE_RUNTIME_KEY];
     };
 
     const sendError = (respond: (ok: boolean, payload?: unknown) => void, err: unknown) => {
@@ -540,15 +552,16 @@ export default definePluginEntry({
         }
       },
       stop: async () => {
-        if (!runtimePromise) {
+        if (!globalState[VOICE_RUNTIME_PROMISE_KEY] && !globalState[VOICE_RUNTIME_KEY]) {
           return;
         }
         try {
-          const rt = await runtimePromise;
+          const rt =
+            globalState[VOICE_RUNTIME_KEY] ?? (await globalState[VOICE_RUNTIME_PROMISE_KEY]!);
           await rt.stop();
         } finally {
-          runtimePromise = null;
-          runtime = null;
+          globalState[VOICE_RUNTIME_PROMISE_KEY] = null;
+          globalState[VOICE_RUNTIME_KEY] = null;
         }
       },
     });


### PR DESCRIPTION
## Summary

-   Problem: `voice-call` can still hit `EADDRINUSE` on the webhook port
    after #32395 when multiple runtime contexts in the same
    `openclaw-gateway` process each create their own `VoiceCallRuntime`.
-   Why it matters: outbound/inbound voice-call flows can fail even
    though the port is already owned by the same gateway process,
    blocking call startup.
-   What changed: moved the voice-call runtime singleton from
    module-local state to process-wide shared state so all in-process
    callers reuse the same runtime/promise.
-   What did NOT change (scope boundary): no provider logic, webhook
    handler behavior, public API, config schema, or network flow was
    changed.
-  AI assisted code change with human testing the fix

## Change Type (select all)

-   [x] Bug fix
-   [ ] Feature
-   [ ] Refactor required for the fix
-   [ ] Docs
-   [ ] Security hardening
-   [ ] Chore/infra

## Scope (select all touched areas)

-   [x] Gateway / orchestration
-   [x] Skills / tool execution
-   [ ] Auth / tokens
-   [ ] Memory / storage
-   [x] Integrations
-   [ ] API / contracts
-   [ ] UI / DX
-   [ ] CI/CD / infra

## Linked Issue/PR

-   Closes #58115
-   Related #32395
-   [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

-   Root cause: the `voice-call` plugin stored `runtimePromise` /
    `runtime` in module-scoped variables, so separate plugin contexts
    could each create a new `VoiceCallRuntime`, which in turn
    constructed a new `VoiceCallWebhookServer` and attempted to bind the
    same port.
-   Missing detection / guardrail: `WebhookServer.start()` idempotence
    only protected repeated starts on the same server instance; there
    was no process-wide guard preventing multiple runtime instances.
-   Prior context (`git blame`, prior PR, issue, or refactor if known):
    #32395 fixed duplicate `start()` calls and failed runtime promise
    reset behavior, but did not fully address duplicate runtime creation
    across contexts.
-   Why this regressed now: the remaining singleton scope was narrower
    than the actual runtime lifecycle in gateway/plugin execution paths.
-   If unknown, what was ruled out: ruled out stale package/build and
    external competing processes; verified the patched `start()` logic
    from #32395 was present, and verified the port was already owned by
    the same `openclaw-gateway` process when the failure occurred.

## Regression Test Plan (if applicable)

-   Coverage level that should have caught this:
    -   [ ] Unit test
    -   [x] Seam / integration test
    -   [ ] End-to-end test
    -   [ ] Existing coverage already sufficient
-   Target test or file: `extensions/voice-call/index.ts`
    runtime/service lifecycle coverage, or a voice-call plugin
    integration test that exercises both service start and a later
    tool/gateway method call.
-   Scenario the test should lock in: start the voice-call service,
    confirm runtime creation/bind succeeds, then invoke a second path
    that calls `ensureRuntime()` and assert the existing runtime is
    reused instead of attempting a second bind.
-   Why this is the smallest reliable guardrail: the bug depends on
    lifecycle interaction between plugin registration/service startup
    and later runtime access, which is broader than a pure unit test of
    `start()`.
-   Existing test that already covers this (if any): none known.
-   If no new test is added, why not: this PR focuses on the minimal
    runtime fix; I manually reproduced the failure and verified the fix
    locally.

## User-visible / Behavior Changes

Voice-call no longer fails with `EADDRINUSE` in the reproduced
multi-context runtime scenario. No config or API changes.

## Diagram (if applicable)

``` text
Before:
[gateway/service start] -> [runtime A created] -> [bind 127.0.0.1:3334]
[later voice-call action] -> [runtime B created] -> [bind 127.0.0.1:3334] -> [EADDRINUSE]

After:
[gateway/service start] -> [shared runtime created] -> [bind 127.0.0.1:3334]
[later voice-call action] -> [reuse shared runtime] -> [no second bind]
```

## Security Impact (required)

-   New permissions/capabilities? (`No`)
-   Secrets/tokens handling changed? (`No`)
-   New/changed network calls? (`No`)
-   Command/tool execution surface changed? (`No`)
-   Data access scope changed? (`No`)
-   If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

-   OS: Ubuntu on gateway host; local dev/editing from macOS
-   Runtime/container: `openclaw-gateway`
-   Model/provider: voice-call plugin with webhook serving enabled
-   Integration/channel (if any): voice-call
-   Relevant config (redacted):
    -   `serve.port = 3334`
    -   `serve.path = /voice/webhook`

### Steps

1.  Enable `voice-call` with webhook serving on `127.0.0.1:3334`.
2.  Start `openclaw-gateway`.
3.  Trigger a voice-call path after startup that calls `ensureRuntime()`
    again.
4.  Observe the bind failure before the patch; repeat after the patch.

### Expected

-   A single `VoiceCallRuntime` / webhook server is reused within the
    process.
-   No second bind attempt occurs on the same port.

### Actual

-   Before the patch, a second runtime path attempted to bind
    `127.0.0.1:3334` again and failed with `EADDRINUSE`.
-   After the patch, the shared runtime was reused and the error did not
    recur.

## Evidence

-   [ ] Failing test/log before + passing after
-   [x] Trace/log snippets
-   [x] Screenshot/recording
-   [ ] Perf numbers (if relevant)

## Human Verification (required)

-   Verified scenarios:
    -   reproduced `EADDRINUSE: 127.0.0.1:3334`
    -   verified the port was already owned by the same
        `openclaw-gateway` process
    -   applied the patch and confirmed voice-call worked without the
        duplicate bind error
-   Edge cases checked:
    -   startup path still creates the runtime successfully
    -   later runtime access reuses the shared runtime
    -   stop path clears shared runtime state
-   What I did **not** verify:
    -   automated test coverage
    -   all voice providers/channels
    -   multi-process behavior outside this reproduced in-process case

## Review Conversations

-   [x] I replied to or resolved every bot review conversation I
    addressed in this PR.
-   [x] I left unresolved only the conversations that still need
    reviewer or maintainer judgment.

## Compatibility / Migration

-   Backward compatible? (`Yes`)
-   Config/env changes? (`No`)
-   Migration needed? (`No`)
-   If yes, exact upgrade steps: N/A

## Risks and Mitigations

-   Risk: sharing the runtime process-wide could retain a stale runtime
    longer than intended if lifecycle assumptions are wrong.
    -   Mitigation: stop logic clears the shared runtime and promise,
        preserving retry behavior and normal shutdown cleanup.
-   Risk: other contexts may have implicitly relied on isolated
    module-local runtime state.
    -   Mitigation: scope of change is limited to voice-call runtime
        reuse; no provider/config/API behavior changed.
