### PR TITLE
fix(lsp): clear request timeout on successful response and session dispose

### DIFF
--- a/src/agents/pi-bundle-lsp-runtime.ts
+++ b/src/agents/pi-bundle-lsp-runtime.ts
@@ -15,7 +15,10 @@ type LspSession = {
   serverName: string;
   process: ChildProcess;
   requestId: number;
-  pendingRequests: Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>;
+  pendingRequests: Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }
+  >;
   buffer: string;
   initialized: boolean;
   capabilities: LspServerCapabilities;
@@ -87,18 +90,18 @@ function parseLspMessages(buffer: string): { messages: unknown[]; remaining: str
 function sendRequest(session: LspSession, method: string, params?: unknown): Promise<unknown> {
   const id = ++session.requestId;
   return new Promise((resolve, reject) => {
-    session.pendingRequests.set(id, { resolve, reject });
     const message = { jsonrpc: "2.0", id, method, params };
     const encoded = encodeLspMessage(message);
     session.process.stdin?.write(encoded, "utf-8");
 
     // Timeout after 10 seconds
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       if (session.pendingRequests.has(id)) {
         session.pendingRequests.delete(id);
         reject(new Error(`LSP request ${method} timed out`));
       }
     }, 10_000);
+    session.pendingRequests.set(id, { resolve, reject, timer });
   });
 }
 
@@ -116,6 +119,7 @@ function handleIncomingData(session: LspSession, chunk: string) {
     if ("id" in record && typeof record.id === "number") {
       const pending = session.pendingRequests.get(record.id);
       if (pending) {
+        clearTimeout(pending.timer);
         session.pendingRequests.delete(record.id);
         if ("error" in record) {
           pending.reject(new Error(JSON.stringify(record.error)));
@@ -168,6 +172,7 @@ async function disposeSession(session: LspSession) {
     }
   }
   for (const [, pending] of session.pendingRequests) {
+    clearTimeout(pending.timer);
     pending.reject(new Error("LSP session disposed"));
   }
   session.pendingRequests.clear();


### PR DESCRIPTION
## Summary

- The 10-second request timeout in `sendRequest()` was never stored or cleared after a successful LSP response
- This leaks a timer on every request and accumulates stale timers under heavy LSP usage, holding closure references to session state and preventing GC
- Store the timeout handle and clear it when a response arrives in `handleIncomingData()` and during teardown in `disposeSession()`

## What was happening

`sendRequest()` sets a 10-second `setTimeout` to reject the request promise on timeout, but never stores the handle:

```typescript
// Before: fire-and-forget timer
setTimeout(() => {
  if (session.pendingRequests.has(id)) {
    session.pendingRequests.delete(id);
    reject(new Error(`LSP request ${method} timed out`));
  }
}, 10_000);
```

On success, the timer keeps running. Under heavy LSP usage (hover, go-to-definition, references), dozens of orphaned 10-second timers accumulate. On `disposeSession()`, timers aren't cleaned up either.

## Fix

- Add a `timer` field to the pending request map entry
- Store the `setTimeout` handle when creating the request
- `clearTimeout` in `handleIncomingData()` when a response arrives
- `clearTimeout` in `disposeSession()` for clean teardown

Follows the same pattern as the connection timeout fix in `stt-openai-realtime.ts` (#58586).

## Test plan

- [ ] Verify LSP tools (hover, definition, references) work normally
- [ ] Verify timeout still fires correctly when an LSP server is unresponsive
- [ ] Verify `disposeSession()` does not leave orphaned timers
- [ ] Verify repeated requests do not accumulate stale timers

🤖 Generated with [Claude Code](https://claude.ai/claude-code)