### PR TITLE
fix: cool down flaky upstream ws-stream handshakes

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -20,6 +20,7 @@ import {
   hasWsSession,
   planTurnInput,
   releaseWsSession,
+  resetWsTransportCooldownsForTests,
 } from "./openai-ws-stream.js";
 import { log } from "./pi-embedded-runner/logger.js";
 
@@ -33,8 +34,9 @@ const { MockManager } = vi.hoisted(() => {
   const { EventEmitter } = require("node:events") as typeof import("node:events");
   type AnyFn = (...args: unknown[]) => void;
 
-  // Shared mutable flag so inner class can see it
+  // Shared mutable flags so inner class can see them
   let _globalConnectShouldFail = false;
+  let _globalConnectErrorMessage = "Mock connect failure";
 
   class MockManager extends EventEmitter {
     private _listeners: AnyFn[] = [];
@@ -57,7 +59,7 @@ const { MockManager } = vi.hoisted(() => {
     async connect(_apiKey: string): Promise<void> {
       this.connectCallCount++;
       if (this.connectShouldFail || _globalConnectShouldFail) {
-        throw new Error("Mock connect failure");
+        throw new Error(_globalConnectErrorMessage);
       }
       this._connected = true;
     }
@@ -162,10 +164,18 @@ const { MockManager } = vi.hoisted(() => {
       _globalConnectShouldFail = v;
     }
 
+    static get globalConnectErrorMessage(): string {
+      return _globalConnectErrorMessage;
+    }
+    static set globalConnectErrorMessage(v: string) {
+      _globalConnectErrorMessage = v;
+    }
+
     static reset(): void {
       TrackedMockManager.lastInstance = null;
       TrackedMockManager.instances = [];
       _globalConnectShouldFail = false;
+      _globalConnectErrorMessage = "Mock connect failure";
     }
   }
 
@@ -1119,6 +1129,7 @@ describe("createOpenAIWebSocketStreamFn", () => {
 
   beforeEach(() => {
     MockManager.reset();
+    resetWsTransportCooldownsForTests();
     streamSimpleCalls.length = 0;
     openAIWsStreamTesting.setDepsForTest({
       createManager: (() => new MockManager()) as never,
@@ -1142,6 +1153,7 @@ describe("createOpenAIWebSocketStreamFn", () => {
     releaseWsSession("sess-store-default");
     releaseWsSession("sess-store-compat");
     releaseWsSession("sess-max-tokens-zero");
+    resetWsTransportCooldownsForTests();
     openAIWsStreamTesting.setDepsForTest();
   });
 
@@ -1397,6 +1409,38 @@ describe("createOpenAIWebSocketStreamFn", () => {
     } finally {
       MockManager.globalConnectShouldFail = false;
     }
+  });
+
+  it("skips repeated upstream WebSocket 5xx handshakes during auto-mode cooldown", async () => {
+    MockManager.globalConnectShouldFail = true;
+    MockManager.globalConnectErrorMessage = "Unexpected server response: 500";
+
+    const firstStreamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-fallback");
+    const firstStream = firstStreamFn(
+      modelStub as Parameters<typeof firstStreamFn>[0],
+      contextStub as Parameters<typeof firstStreamFn>[1],
+    );
+    for await (const _ev of await resolveStream(firstStream)) {
+      // consume fallback stream
+    }
+
+    expect(MockManager.instances).toHaveLength(1);
+    expect(streamSimpleCalls).toHaveLength(1);
+
+    MockManager.globalConnectShouldFail = false;
+    MockManager.globalConnectErrorMessage = "Mock connect failure";
+
+    const secondStreamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-fallback-2");
+    const secondStream = secondStreamFn(
+      modelStub as Parameters<typeof secondStreamFn>[0],
+      contextStub as Parameters<typeof secondStreamFn>[1],
+    );
+    for await (const _ev of await resolveStream(secondStream)) {
+      // consume cooldown fallback stream
+    }
+
+    expect(streamSimpleCalls).toHaveLength(2);
+    expect(MockManager.instances).toHaveLength(1);
   });
 
   it("tracks previous_response_id across turns (incremental send)", async () => {
@@ -1998,6 +2042,7 @@ describe("createOpenAIWebSocketStreamFn", () => {
 describe("releaseWsSession / hasWsSession", () => {
   beforeEach(() => {
     MockManager.reset();
+    resetWsTransportCooldownsForTests();
     openAIWsStreamTesting.setDepsForTest({
       createManager: (() => new MockManager()) as never,
       streamSimple: mockStreamSimple,
@@ -2006,6 +2051,7 @@ describe("releaseWsSession / hasWsSession", () => {
 
   afterEach(() => {
     releaseWsSession("registry-test");
+    resetWsTransportCooldownsForTests();
     openAIWsStreamTesting.setDepsForTest();
   });
 

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -8,13 +8,14 @@
  *  - Per-session `OpenAIWebSocketManager` (keyed by sessionId)
  *  - Tracks `previous_response_id` to send only incremental tool-result inputs
  *  - Falls back to `streamSimple` (HTTP) if the WebSocket connection fails
+ *  - Applies a short auto-mode cooldown after upstream WS handshake 5xx failures
  *  - Cleanup helpers for releasing sessions after the run completes
  *
  * Complexity budget & risk mitigation:
  *  - **Transport aware**: respects `transport` (`auto` | `websocket` | `sse`)
  *  - **Transparent fallback in `auto` mode**: connect/send failures fall back to
  *    the existing HTTP `streamSimple`; forced `websocket` mode surfaces WS errors
- *  - **Zero shared state**: per-session registry; session cleanup on dispose prevents leaks
+ *  - **Narrow shared state**: per-session registry plus a short model-scoped WS cooldown cache
  *  - **Full parity**: all generation options (temperature, top_p, max_output_tokens,
  *    tool_choice, reasoning) forwarded identically to the HTTP path
  *
@@ -64,8 +65,19 @@ interface WsSession {
   broken: boolean;
 }
 
+interface WsCooldownEntry {
+  untilMs: number;
+  statusCode: number;
+  reason: string;
+}
+
+const WS_CONNECT_5XX_COOLDOWN_MS = 5 * 60_000;
+
 /** Module-level registry: sessionId → WsSession */
 const wsRegistry = new Map<string, WsSession>();
+
+/** Module-level cooldowns: model fingerprint → cooldown entry */
+const wsCooldownRegistry = new Map<string, WsCooldownEntry>();
 
 type OpenAIWsStreamDeps = {
   createManager: (options?: OpenAIWebSocketManagerOptions) => OpenAIWebSocketManager;
@@ -187,6 +199,85 @@ export function hasWsSession(sessionId: string): boolean {
   return !!(s && !s.broken && s.manager.isConnected());
 }
 
+export function resetWsTransportCooldownsForTests(): void {
+  wsCooldownRegistry.clear();
+}
+
+function buildWsCooldownKey(model: {
+  api?: string;
+  provider?: string;
+  id?: string;
+  baseUrl?: string;
+}): string {
+  return [model.api ?? "", model.provider ?? "", model.id ?? "", model.baseUrl ?? ""]
+    .map((part) => String(part).trim())
+    .join("|");
+}
+
+function parseUnexpectedWebSocketStatusCode(error: unknown): number | null {
+  const text = error instanceof Error ? error.message : String(error);
+  const match = text.match(/Unexpected server response:\s*(\d{3})/i);
+  if (!match) {
+    return null;
+  }
+  const parsed = Number.parseInt(match[1] ?? "", 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function shouldApplyWsConnectCooldown(error: unknown): number | null {
+  const statusCode = parseUnexpectedWebSocketStatusCode(error);
+  if (!statusCode) {
+    return null;
+  }
+  return statusCode >= 500 && statusCode <= 599 ? statusCode : null;
+}
+
+function getActiveWsCooldown(model: {
+  api?: string;
+  provider?: string;
+  id?: string;
+  baseUrl?: string;
+}): WsCooldownEntry | null {
+  const key = buildWsCooldownKey(model);
+  const entry = wsCooldownRegistry.get(key);
+  if (!entry) {
+    return null;
+  }
+  if (entry.untilMs <= Date.now()) {
+    wsCooldownRegistry.delete(key);
+    return null;
+  }
+  return entry;
+}
+
+function recordWsConnectCooldown(
+  model: {
+    api?: string;
+    provider?: string;
+    id?: string;
+    baseUrl?: string;
+  },
+  statusCode: number,
+  reason: string,
+): WsCooldownEntry {
+  const entry: WsCooldownEntry = {
+    untilMs: Date.now() + WS_CONNECT_5XX_COOLDOWN_MS,
+    statusCode,
+    reason,
+  };
+  wsCooldownRegistry.set(buildWsCooldownKey(model), entry);
+  return entry;
+}
+
+function clearExpiredWsCooldowns(): void {
+  const now = Date.now();
+  for (const [key, entry] of wsCooldownRegistry.entries()) {
+    if (entry.untilMs <= now) {
+      wsCooldownRegistry.delete(key);
+    }
+  }
+}
+
 export {
   buildAssistantMessageFromResponse,
   convertMessagesToInputItems,
@@ -304,6 +395,17 @@ export function createOpenAIWebSocketStreamFn(
         return fallbackToHttp(model, context, options, apiKey, eventStream, opts.signal);
       }
 
+      clearExpiredWsCooldowns();
+      const activeCooldown = transport === "auto" ? getActiveWsCooldown(model) : null;
+      if (activeCooldown) {
+        releaseWsSession(sessionId);
+        log.debug(
+          `[ws-stream] session=${sessionId} skipping WebSocket during upstream cooldown; ` +
+            `status=${activeCooldown.statusCode} retryInMs=${Math.max(0, activeCooldown.untilMs - Date.now())}`,
+        );
+        return fallbackToHttp(model, context, options, apiKey, eventStream, opts.signal);
+      }
+
       // ── 1. Get or create session state ──────────────────────────────────
       let session = wsRegistry.get(sessionId);
 
@@ -337,9 +439,19 @@ export function createOpenAIWebSocketStreamFn(
           if (transport === "websocket") {
             throw connErr instanceof Error ? connErr : new Error(String(connErr));
           }
-          log.warn(
-            `[ws-stream] WebSocket connect failed for session=${sessionId}; falling back to HTTP. error=${String(connErr)}`,
-          );
+          const cooldownStatus = shouldApplyWsConnectCooldown(connErr);
+          if (cooldownStatus) {
+            const cooldown = recordWsConnectCooldown(model, cooldownStatus, String(connErr));
+            log.warn(
+              `[ws-stream] WebSocket connect failed for session=${sessionId}; ` +
+                `applying ${Math.round(WS_CONNECT_5XX_COOLDOWN_MS / 1000)}s HTTP cooldown ` +
+                `for upstream ${cooldown.statusCode}. error=${cooldown.reason}`,
+            );
+          } else {
+            log.warn(
+              `[ws-stream] WebSocket connect failed for session=${sessionId}; falling back to HTTP. error=${String(connErr)}`,
+            );
+          }
           // Fall back to HTTP immediately
           return fallbackToHttp(model, context, options, apiKey, eventStream, opts.signal);
         }
@@ -400,9 +512,19 @@ export function createOpenAIWebSocketStreamFn(
             if (transport === "websocket") {
               throw reconnectErr instanceof Error ? reconnectErr : new Error(String(reconnectErr));
             }
-            log.warn(
-              `[ws-stream] reconnect after warm-up failed for session=${sessionId}; falling back to HTTP. error=${String(reconnectErr)}`,
-            );
+            const cooldownStatus = shouldApplyWsConnectCooldown(reconnectErr);
+            if (cooldownStatus) {
+              const cooldown = recordWsConnectCooldown(model, cooldownStatus, String(reconnectErr));
+              log.warn(
+                `[ws-stream] reconnect after warm-up failed for session=${sessionId}; ` +
+                  `applying ${Math.round(WS_CONNECT_5XX_COOLDOWN_MS / 1000)}s HTTP cooldown ` +
+                  `for upstream ${cooldown.statusCode}. error=${cooldown.reason}`,
+              );
+            } else {
+              log.warn(
+                `[ws-stream] reconnect after warm-up failed for session=${sessionId}; falling back to HTTP. error=${String(reconnectErr)}`,
+              );
+            }
             return fallbackToHttp(model, context, options, apiKey, eventStream, opts.signal);
           }
         }


### PR DESCRIPTION
## Summary
- add a short auto-mode WebSocket cooldown after upstream handshake 5xx failures
- fall back to HTTP immediately during that cooldown instead of retrying the same failing WS path
- cover the cooldown behavior with a focused `openai-ws-stream` test

## Why
Some upstream WebSocket handshakes can fail with `Unexpected server response: 500`. In `auto` transport mode that can cause repeated WS reconnect attempts before falling back, even though the upstream path is temporarily unhealthy.

This change records a model-scoped cooldown when the WS connect/reconnect handshake fails with an upstream 5xx, then skips WS for a short window and uses the existing HTTP fallback path instead.

## Behavior
- `transport: auto`
  - handshake 5xx records a 5 minute cooldown
  - subsequent attempts during cooldown skip WS and go straight to HTTP fallback
- `transport: websocket`
  - still surfaces WS errors directly
- non-5xx WS failures keep the existing fallback behavior without recording the cooldown

## Test
- `/Users/openclaw/OpenClawWorkspace/repos/openclaw/node_modules/.bin/vitest run src/agents/openai-ws-stream.test.ts --maxWorkers=1`
