### PR TITLE
fix(cron): unwrap FailoverError to detect LiveSessionModelSwitchError in retry loop

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -794,6 +794,7 @@ export async function runWithModelFallback<T>(params: {
           reason: "overloaded",
           provider: candidate.provider,
           model: candidate.model,
+          cause: err,
         });
         lastError = switchNormalized;
         const described = describeFailoverError(switchNormalized);

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -7,6 +7,7 @@ import {
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionBinding } from "../../agents/cli-session.js";
+import { FailoverError } from "../../agents/failover-error.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch.js";
 import { runWithModelFallback, isFallbackSummaryError } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
@@ -643,7 +644,13 @@ export async function runAgentTurnWithFallback(params: {
 
       break;
     } catch (err) {
-      if (err instanceof LiveSessionModelSwitchError) {
+      const switchErr =
+        err instanceof LiveSessionModelSwitchError
+          ? err
+          : err instanceof FailoverError && err.cause instanceof LiveSessionModelSwitchError
+            ? err.cause
+            : undefined;
+      if (switchErr) {
         liveModelSwitchRetries += 1;
         if (liveModelSwitchRetries > MAX_LIVE_SWITCH_RETRIES) {
           // Prevent infinite loop when persisted session selection keeps
@@ -653,7 +660,7 @@ export async function runAgentTurnWithFallback(params: {
           // See: https://github.com/openclaw/openclaw/issues/58348
           defaultRuntime.error(
             `Live model switch failed after ${MAX_LIVE_SWITCH_RETRIES} retries ` +
-              `(${sanitizeForLog(err.provider)}/${sanitizeForLog(err.model)}). The requested model may be unavailable.`,
+              `(${sanitizeForLog(switchErr.provider)}/${sanitizeForLog(switchErr.model)}). The requested model may be unavailable.`,
           );
           const switchErrorText = shouldSurfaceToControlUi
             ? "⚠️ Agent failed before reply: model switch could not be completed. " +
@@ -668,14 +675,14 @@ export async function runAgentTurnWithFallback(params: {
             },
           };
         }
-        params.followupRun.run.provider = err.provider;
-        params.followupRun.run.model = err.model;
-        params.followupRun.run.authProfileId = err.authProfileId;
-        params.followupRun.run.authProfileIdSource = err.authProfileId
-          ? err.authProfileIdSource
+        params.followupRun.run.provider = switchErr.provider;
+        params.followupRun.run.model = switchErr.model;
+        params.followupRun.run.authProfileId = switchErr.authProfileId;
+        params.followupRun.run.authProfileIdSource = switchErr.authProfileId
+          ? switchErr.authProfileIdSource
           : undefined;
-        fallbackProvider = err.provider;
-        fallbackModel = err.model;
+        fallbackProvider = switchErr.provider;
+        fallbackModel = switchErr.model;
         continue;
       }
       const message = err instanceof Error ? err.message : String(err);

--- a/src/cron/isolated-agent/run.live-session-model-switch.test.ts
+++ b/src/cron/isolated-agent/run.live-session-model-switch.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FailoverError } from "../../agents/failover-error.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch.js";
 import {
   clearFastTestEnv,
@@ -267,6 +268,45 @@ describe("runCronIsolatedAgentTurn — LiveSessionModelSwitchError retry (#57206
     // Circuit breaker: max 2 retries → 3 total attempts (initial + 2 retries)
     expect(callCount).toBe(3);
     expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("retry limit reached"));
+  });
+
+  it("retries when runWithModelFallback wraps LiveSessionModelSwitchError in FailoverError (#59657)", async () => {
+    // When the fallback chain has only one candidate, runWithModelFallback
+    // wraps LiveSessionModelSwitchError into a FailoverError (with the
+    // original as `cause`) before re-throwing.  The cron retry loop must
+    // unwrap it so the model-switch retry still fires.
+    const switchError = new LiveSessionModelSwitchError({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    const wrappedError = new FailoverError(switchError.message, {
+      reason: "overloaded",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      cause: switchError,
+    });
+
+    let callCount = 0;
+    runWithModelFallbackMock.mockImplementation(
+      async (params: {
+        provider: string;
+        model: string;
+        run: (p: string, m: string) => Promise<unknown>;
+      }) => {
+        callCount++;
+        if (callCount === 1) {
+          throw wrappedError;
+        }
+        expect(params.provider).toBe("anthropic");
+        expect(params.model).toBe("claude-sonnet-4-6");
+        return makeSuccessfulRunResult("claude-sonnet-4-6");
+      },
+    );
+
+    const result = await runCronIsolatedAgentTurn(makeParams());
+
+    expect(result.status).toBe("ok");
+    expect(callCount).toBe(2);
   });
 
   it("does not retry when the thrown error is not a LiveSessionModelSwitchError", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -12,6 +12,7 @@ import { getCliSessionId, setCliSessionId } from "../../agents/cli-session.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import { FailoverError } from "../../agents/failover-error.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { resolveNestedAgentLane } from "../../agents/lanes.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch.js";
@@ -603,7 +604,13 @@ export async function runCronIsolatedAgentTurn(params: {
         await runPrompt(commandBody);
         break;
       } catch (err) {
-        if (err instanceof LiveSessionModelSwitchError) {
+        const switchErr =
+          err instanceof LiveSessionModelSwitchError
+            ? err
+            : err instanceof FailoverError && err.cause instanceof LiveSessionModelSwitchError
+              ? err.cause
+              : undefined;
+        if (switchErr) {
           modelSwitchRetries += 1;
           if (modelSwitchRetries > MAX_MODEL_SWITCH_RETRIES) {
             logWarn(
@@ -612,13 +619,15 @@ export async function runCronIsolatedAgentTurn(params: {
             throw err;
           }
           liveSelection = {
-            provider: err.provider,
-            model: err.model,
-            authProfileId: err.authProfileId,
-            authProfileIdSource: err.authProfileId ? err.authProfileIdSource : undefined,
+            provider: switchErr.provider,
+            model: switchErr.model,
+            authProfileId: switchErr.authProfileId,
+            authProfileIdSource: switchErr.authProfileId
+              ? switchErr.authProfileIdSource
+              : undefined,
           };
-          fallbackProvider = err.provider;
-          fallbackModel = err.model;
+          fallbackProvider = switchErr.provider;
+          fallbackModel = switchErr.model;
           syncSessionEntryLiveSelection();
           // Persist the corrected model before retrying so sessions_list
           // reflects the real model even if the retry also fails.


### PR DESCRIPTION
When a cron job specifies a model override and only one fallback candidate is configured, the model-switch retry loop silently fails to fire. The cron runner catches `LiveSessionModelSwitchError` by `instanceof` to trigger retries (#57206), but since #58466 `runWithModelFallback` wraps that error into a `FailoverError` before re-throwing via `throwFallbackFailureSummary`. The `instanceof` check returns false, the catch falls through, and the job crashes instead of retrying with the requested model.

The root cause is a conflict between two fixes: the cron retry loop (commit `10ac6ead6b`) expects a raw `LiveSessionModelSwitchError`, while the fallback-chain fix (#58466) converts it to `FailoverError` to prevent infinite retry loops inside `runWithModelFallback`. Both are correct in isolation — they just don't compose.

**Fix:** preserve the original `LiveSessionModelSwitchError` as `cause` on the `FailoverError` wrapper (`model-fallback.ts`), and teach the cron retry loop to unwrap it (`run.ts`). This keeps the fallback chain working as intended while letting the outer cron loop detect and retry model switches.

**Changes:**
- `model-fallback.ts`: pass `cause: err` when wrapping `LiveSessionModelSwitchError` into `FailoverError`
- `cron/isolated-agent/run.ts`: check both `err instanceof LiveSessionModelSwitchError` and `err.cause instanceof LiveSessionModelSwitchError`
- `run.live-session-model-switch.test.ts`: new test for the wrapped-error retry path

**Testing:**
```
$ npx vitest run --config vitest.unit.config.ts src/cron/isolated-agent/run
✓ 10 test files | 49 tests passed

$ npx tsgo --noEmit  # only pre-existing errors (msteams SDK, pi-coding-agent)
$ npx oxlint src/agents/model-fallback.ts src/cron/isolated-agent/run.ts
Found 0 warnings and 0 errors.
```

Fixes #59657
Refs #57112