### PR TITLE
fix(amazon-bedrock): enable assistant-first ordering fix for non-Claude models [AI-assisted]

### DIFF
--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -152,6 +152,26 @@ describe("amazon-bedrock provider plugin", () => {
     });
   });
 
+  describe("buildReplayPolicy — assistant-first ordering fix", () => {
+    it("enables assistant-first ordering fix for non-Claude models", async () => {
+      const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+      const policy = provider.buildReplayPolicy?.({
+        provider: "amazon-bedrock",
+        modelId: "amazon.nova-pro-v1:0",
+      } as never);
+      expect(policy).toMatchObject({ applyAssistantFirstOrderingFix: true });
+    });
+
+    it("does not enable assistant-first ordering fix for Claude models", async () => {
+      const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+      const policy = provider.buildReplayPolicy?.({
+        provider: "amazon-bedrock",
+        modelId: "us.anthropic.claude-sonnet-4-6-v1",
+      } as never);
+      expect(policy).not.toHaveProperty("applyAssistantFirstOrderingFix", true);
+    });
+  });
+
   describe("guardrail config schema", () => {
     it("defines discovery and guardrail objects with the expected shape", () => {
       const pluginJson = JSON.parse(

--- a/extensions/amazon-bedrock/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock/register.sync.runtime.ts
@@ -156,6 +156,16 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
     },
     resolveConfigApiKey: ({ env }) => resolveBedrockConfigApiKey(env),
     ...anthropicByModelReplayHooks,
+    buildReplayPolicy: (ctx) => {
+      const base = anthropicByModelReplayHooks.buildReplayPolicy?.(ctx);
+      // Non-Claude Bedrock models (e.g. Amazon Nova) require conversations to
+      // start with a user message.  Claude tolerates an assistant-first history,
+      // so only enable the ordering fix for non-Claude models.
+      if (ctx.modelId && !isAnthropicBedrockModel(ctx.modelId)) {
+        return { ...base, applyAssistantFirstOrderingFix: true };
+      }
+      return base;
+    },
     wrapStreamFn: ({ modelId, config, model, streamFn }) => {
       // Apply cache + guardrail wrapping.
       const wrapped = cacheWrapStreamFn({ modelId, streamFn });


### PR DESCRIPTION
## Summary

**Problem:** Non-Claude models on Amazon Bedrock (e.g. Amazon Nova Pro, Nova Micro) reject
conversations that start with an assistant message, returning:
> "A conversation must start with a user message."

This happens on `/new` or `/reset` because a delivery-mirror assistant message can end up
as the first entry in the replayed conversation history.

**Why it matters:** Bedrock users who select Amazon Nova (or any non-Claude Bedrock model)
cannot start new sessions at all.

**What changed:** Overrode the `buildReplayPolicy` hook in
`extensions/amazon-bedrock/register.sync.runtime.ts` so that non-Claude models get
`applyAssistantFirstOrderingFix: true` merged into the base Anthropic replay policy.
This activates the existing turn-ordering sanitization that prepends a synthetic
`"(session bootstrap)"` user message when history starts with an assistant turn.

**What did NOT change:** Claude models on Bedrock are unaffected — they keep the
base Anthropic replay policy without the ordering fix. No core transcript policy
code was modified.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations (channels, providers, external services)

## Linked Issue/PR

N/A — discovered during setup with `amazon-bedrock/amazon.nova-pro-v1:0`.

## Root Cause / Regression History

The Bedrock provider uses `buildProviderReplayFamilyHooks({ family: "anthropic-by-model" })`
which delegates to `buildAnthropicReplayPolicyForModel`. That helper builds a strict
Anthropic replay policy but does not set `applyAssistantFirstOrderingFix`.

Claude on Bedrock tolerates an assistant-first history, but Amazon Nova and other
non-Claude Bedrock models enforce the Converse API contract strictly: the first
message must have role `user`.

When a session is reset, a delivery-mirror assistant message can be the first entry
in the replayed history, triggering the rejection.

## Regression Test Plan

The new tests in `extensions/amazon-bedrock/index.test.ts` cover both branches:
- `buildReplayPolicy` returns a policy with `applyAssistantFirstOrderingFix: true` for Nova models
- `buildReplayPolicy` returns the base Anthropic policy (without the flag) for Claude models

## User-visible / Behavior Changes

- Amazon Nova (and other non-Claude Bedrock models) can now start new sessions via
  `/new` and `/reset` without the "must start with a user message" error.

## Security Impact (required)

- Does this change introduce new permission checks or modify existing ones? **No**
- Does it handle secrets, tokens, or credentials? **No**
- Does it add or change network calls? **No**
- Does it expand execution surface (e.g. new tools, commands, endpoints)? **No**
- Does it change data access patterns or storage? **No**

## Repro + Verification

**Environment:** Any OpenClaw instance configured with `amazon-bedrock/amazon.nova-pro-v1:0`

**Steps to reproduce:**
1. Configure OpenClaw with an Amazon Nova model on Bedrock
2. Send `/new` or `/reset`
3. Observe: "A conversation must start with a user message"

**After fix:** The synthetic `(session bootstrap)` user message is prepended,
and Nova responds normally.

## Evidence

```
$ pnpm test -- extensions/amazon-bedrock/index.test.ts
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

## Human Verification (required)

- Verified both new test cases pass (Nova → fix enabled, Claude → no-op)
- Verified existing Bedrock plugin tests remain green (guardrail injection, cache
  retention, thinking level, existing replay policy ownership)

## Review Conversations

N/A (new PR)

## Compatibility / Migration

- Backward compatible: yes
- No config changes needed
- No migration steps

## Risks and Mitigations

Low risk. The fix overrides `buildReplayPolicy` after spreading
`anthropicByModelReplayHooks`, merging the base Anthropic policy with the
ordering fix for non-Claude models only. Claude behavior is unchanged.