### PR TITLE
Databricks: add external ClawHub-ready plugin

### DIFF
--- a/packages/openclaw-databricks-plugin/README.md
+++ b/packages/openclaw-databricks-plugin/README.md
@@ -1,0 +1,109 @@
+# OpenClaw Databricks Plugin
+
+External OpenClaw plugin for conservative Databricks SQL access.
+
+This package provides:
+
+- Runtime tool: `databricks_sql_readonly`
+- Skill pack: `databricks`
+- Read-only SQL execution only (`SELECT` or `WITH ... SELECT`)
+
+## Install
+
+Preferred:
+
+```bash
+openclaw plugins install @openclaw/databricks-plugin
+```
+
+Source-specific:
+
+```bash
+openclaw plugins install clawhub:@openclaw/databricks-plugin
+openclaw plugins install npm:@openclaw/databricks-plugin
+```
+
+OpenClaw checks ClawHub first for bare package installs, then falls back to npm.
+
+## Configure
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "databricks": {
+        "enabled": true,
+        "config": {
+          "host": "https://dbc-example.cloud.databricks.com",
+          "token": "dapi...",
+          "warehouseId": "abc123",
+          "readOnly": true
+        }
+      }
+    }
+  }
+}
+```
+
+Restart gateway after configuration changes.
+
+## Configuration Fields
+
+Required:
+
+- `host`
+- `token`
+- `warehouseId`
+
+Optional:
+
+- `timeoutMs` (default `30000`)
+- `retryCount` (default `1`, range `0..3`)
+- `pollingIntervalMs` (default `1000`)
+- `maxPollingWaitMs` (default `30000`)
+- `allowedCatalogs` (default `[]`)
+- `allowedSchemas` (default `[]`)
+- `readOnly` (must stay `true`)
+
+Environment fallbacks:
+
+- `DATABRICKS_HOST`
+- `DATABRICKS_TOKEN`
+- `DATABRICKS_WAREHOUSE_ID`
+- `DATABRICKS_READ_ONLY`
+
+## Security and Hardening
+
+- Fail-closed host validation:
+  - HTTPS only
+  - No path/query/fragment/userinfo/custom port
+  - No localhost/IP literals
+  - Hostname must match Databricks suffixes (`*.cloud.databricks.com`, `*.azuredatabricks.net`, `*.gcp.databricks.com`)
+- Token and sensitive values are redacted in runtime logs and normalized error output.
+- SQL policy is read-only and blocks mutating keywords and multi-statement input.
+- Allowlists are enforced conservatively:
+  - If targets cannot be resolved safely, request is rejected.
+  - Ambiguous target syntax is rejected when allowlists are configured.
+  - `catalog` and `schema` request parameters do not bypass SQL target checks.
+
+## Runtime Behavior
+
+`databricks_sql_readonly`:
+
+- Submits SQL via Databricks SQL Statements API.
+- Polls statement status until a terminal state or timeout budget exhaustion.
+- Treats `SUCCEEDED` as success.
+- Treats `FAILED` / `CANCELED` as explicit failures.
+- Uses `retryCount` for transient submit and poll failures (`429`, `408`, `5xx`, and timeout aborts).
+
+## Scope Limits
+
+Out of scope in this version:
+
+- Jobs API execution
+- Unity Catalog lineage APIs
+- Any mutating SQL support
+
+## Publish Notes
+
+This package is intended for external distribution (ClawHub/npm), not bundled OpenClaw core.

--- a/packages/openclaw-databricks-plugin/README.md
+++ b/packages/openclaw-databricks-plugin/README.md
@@ -13,19 +13,21 @@ This package provides:
 Preferred:
 
 ```bash
-openclaw plugins install @openclaw/databricks-plugin
+openclaw plugins install @kansodata/openclaw-databricks-plugin
 ```
 
 Source-specific:
 
 ```bash
-openclaw plugins install clawhub:@openclaw/databricks-plugin
-openclaw plugins install npm:@openclaw/databricks-plugin
+openclaw plugins install clawhub:@kansodata/openclaw-databricks-plugin
+openclaw plugins install npm:@kansodata/openclaw-databricks-plugin
 ```
 
 OpenClaw checks ClawHub first for bare package installs, then falls back to npm.
 
 ## Configure
+
+Plugin key: `plugins.entries.databricks`
 
 ```json
 {

--- a/packages/openclaw-databricks-plugin/index.ts
+++ b/packages/openclaw-databricks-plugin/index.ts
@@ -1,0 +1,11 @@
+import { definePluginEntry } from "./runtime-api.js";
+import { createDatabricksSqlReadOnlyTool } from "./src/operations/sql.js";
+
+export default definePluginEntry({
+  id: "databricks",
+  name: "Databricks",
+  description: "External Databricks read-only SQL runtime + skill pack",
+  register(api) {
+    api.registerTool(createDatabricksSqlReadOnlyTool(api));
+  },
+});

--- a/packages/openclaw-databricks-plugin/openclaw.plugin.json
+++ b/packages/openclaw-databricks-plugin/openclaw.plugin.json
@@ -1,0 +1,116 @@
+{
+  "id": "databricks",
+  "name": "Databricks",
+  "description": "External Databricks plugin with conservative read-only SQL execution.",
+  "skills": ["./skills"],
+  "providerAuthEnvVars": {
+    "databricks": ["DATABRICKS_HOST", "DATABRICKS_TOKEN", "DATABRICKS_WAREHOUSE_ID"]
+  },
+  "contracts": {
+    "tools": ["databricks_sql_readonly"]
+  },
+  "uiHints": {
+    "host": {
+      "label": "Databricks Host",
+      "help": "Workspace host URL. Must be HTTPS and an allowed Databricks domain."
+    },
+    "token": {
+      "label": "Databricks Token",
+      "help": "Databricks PAT used by SQL Statements API.",
+      "sensitive": true,
+      "placeholder": "dapi..."
+    },
+    "warehouseId": {
+      "label": "Warehouse ID",
+      "help": "Default Databricks SQL warehouse ID."
+    },
+    "timeoutMs": {
+      "label": "HTTP Timeout (ms)",
+      "help": "Per-request timeout for SQL submit/poll requests."
+    },
+    "retryCount": {
+      "label": "Retry Count",
+      "help": "Maximum retry attempts for transient submit/poll failures."
+    },
+    "pollingIntervalMs": {
+      "label": "Polling Interval (ms)",
+      "help": "Polling interval while statement is pending/running/queued."
+    },
+    "maxPollingWaitMs": {
+      "label": "Max Polling Wait (ms)",
+      "help": "Maximum wait budget for polling before timeout."
+    },
+    "allowedCatalogs": {
+      "label": "Allowed Catalogs",
+      "help": "Optional allowlist. If set, all resolved targets must include and match catalog."
+    },
+    "allowedSchemas": {
+      "label": "Allowed Schemas",
+      "help": "Optional allowlist. If set, all resolved targets must include and match schema."
+    },
+    "readOnly": {
+      "label": "Read-Only Mode",
+      "help": "Must stay true. Mutating SQL operations are blocked."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "host": {
+        "type": ["string", "object"],
+        "description": "Databricks workspace host URL."
+      },
+      "token": {
+        "type": ["string", "object"],
+        "description": "Databricks access token (supports secret input resolution)."
+      },
+      "warehouseId": {
+        "type": ["string", "object"],
+        "description": "Default Databricks SQL warehouse ID."
+      },
+      "timeoutMs": {
+        "type": "number",
+        "minimum": 1000,
+        "maximum": 120000,
+        "description": "HTTP timeout in milliseconds."
+      },
+      "retryCount": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 3,
+        "description": "Retry attempts for transient failures."
+      },
+      "pollingIntervalMs": {
+        "type": "number",
+        "minimum": 200,
+        "maximum": 5000,
+        "description": "Polling interval while statement is not terminal."
+      },
+      "maxPollingWaitMs": {
+        "type": "number",
+        "minimum": 1000,
+        "maximum": 120000,
+        "description": "Maximum total wait time for polling."
+      },
+      "allowedCatalogs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Optional read-only allowlist for catalogs."
+      },
+      "allowedSchemas": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Optional read-only allowlist for schemas."
+      },
+      "readOnly": {
+        "type": "boolean",
+        "description": "Must stay true."
+      }
+    }
+  }
+}

--- a/packages/openclaw-databricks-plugin/package.json
+++ b/packages/openclaw-databricks-plugin/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@openclaw/databricks-plugin",
+  "version": "0.1.0",
+  "description": "External Databricks read-only SQL plugin for OpenClaw.",
+  "files": [
+    "index.ts",
+    "runtime-api.ts",
+    "openclaw.plugin.json",
+    "README.md",
+    "skills",
+    "src"
+  ],
+  "type": "module",
+  "scripts": {
+    "lint": "oxlint --type-aware packages/openclaw-databricks-plugin",
+    "test": "vitest run",
+    "typecheck": "tsc -p ../../tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@sinclair/typebox": "0.34.48",
+    "zod": "^4.1.12"
+  },
+  "devDependencies": {
+    "openclaw": "workspace:*",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.28"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "npmSpec": "@openclaw/databricks-plugin",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.3.28"
+    }
+  }
+}

--- a/packages/openclaw-databricks-plugin/runtime-api.ts
+++ b/packages/openclaw-databricks-plugin/runtime-api.ts
@@ -1,0 +1,3 @@
+export { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+export type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+export type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";

--- a/packages/openclaw-databricks-plugin/skills/databricks/SKILL.md
+++ b/packages/openclaw-databricks-plugin/skills/databricks/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: databricks
+description: Execute conservative read-only Databricks SQL through the Databricks plugin and provide safe planning output for unsupported workflows.
+---
+
+Use this skill when a user asks for Databricks SQL analysis or execution.
+
+## Runtime Scope
+
+Available runtime tool:
+
+- `databricks_sql_readonly`
+
+Supported statement shapes:
+
+- Single `SELECT`
+- Single `WITH ... SELECT`
+
+Policy constraints:
+
+- Read-only only
+- Multi-statement SQL blocked
+- Mutating keywords blocked
+- Optional catalog/schema allowlists enforced fail-closed
+- Ambiguous SQL target resolution rejected when allowlists are active
+
+## Unsupported in This Version
+
+- Jobs API execution
+- Unity Catalog lineage API calls
+- Mutating SQL operations
+
+For unsupported requests, provide planning output only.
+
+## Required Inputs
+
+- Databricks workspace URL and environment (`dev`, `staging`, `prod`)
+- SQL warehouse identifier
+- Catalog and schema scope
+- Target table set
+
+## Output Defaults
+
+- Objective
+- Assumptions
+- Read-only SQL draft
+- Validation checklist
+- Risk notes and rollback signals

--- a/packages/openclaw-databricks-plugin/src/client.test.ts
+++ b/packages/openclaw-databricks-plugin/src/client.test.ts
@@ -1,0 +1,303 @@
+import type { PluginLogger } from "openclaw/plugin-sdk/core";
+import { describe, expect, it, vi } from "vitest";
+import { DatabricksSqlClient } from "./client.js";
+
+function createLogger(): PluginLogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function createBaseConfig() {
+  return {
+    host: "https://dbc-example.cloud.databricks.com",
+    token: "dapi-test",
+    warehouseId: "wh-1",
+    timeoutMs: 10_000,
+    retryCount: 1,
+    pollingIntervalMs: 1,
+    maxPollingWaitMs: 5_000,
+    allowedCatalogs: [],
+    allowedSchemas: [],
+    readOnly: true as const,
+  };
+}
+
+describe("databricks sql client", () => {
+  it("sends auth header and statement payload", async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("Authorization")).toBe("Bearer dapi-test");
+      expect(headers.get("Content-Type")).toBe("application/json");
+      const rawBody = init?.body;
+      const body = JSON.parse(typeof rawBody === "string" ? rawBody : "{}");
+      expect(body.statement).toBe("SELECT 1");
+      expect(body.warehouse_id).toBe("wh-1");
+      return new Response(
+        JSON.stringify({ statement_id: "stmt-1", status: { state: "SUCCEEDED" } }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+
+    const client = new DatabricksSqlClient({
+      config: { ...createBaseConfig(), retryCount: 0 },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    const result = await client.executeStatement({
+      statement: "SELECT 1",
+      warehouseId: "wh-1",
+    });
+    expect(result).toEqual({ statement_id: "stmt-1", status: { state: "SUCCEEDED" } });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries transient submit failures using retryCount", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "try again" }), {
+          status: 503,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ statement_id: "stmt-2", status: { state: "SUCCEEDED" } }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+    const client = new DatabricksSqlClient({
+      config: { ...createBaseConfig(), retryCount: 1 },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    const result = await client.executeStatement({
+      statement: "SELECT 1",
+      warehouseId: "wh-1",
+    });
+    expect(result).toEqual({ statement_id: "stmt-2", status: { state: "SUCCEEDED" } });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("raises timeout error when submit request aborts", async () => {
+    const fetchImpl = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal;
+      return new Promise<Response>((_resolve, reject) => {
+        if (signal?.aborted) {
+          reject(new DOMException("aborted", "AbortError"));
+          return;
+        }
+        signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+      });
+    });
+
+    const client = new DatabricksSqlClient({
+      config: { ...createBaseConfig(), timeoutMs: 20, retryCount: 0 },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    await expect(
+      client.executeStatement({
+        statement: "SELECT 1",
+        warehouseId: "wh-1",
+      }),
+    ).rejects.toMatchObject({
+      code: "STATEMENT_TIMEOUT",
+    });
+  });
+
+  it("polls until statement reaches terminal success status", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-3",
+            status: { state: "PENDING" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-3",
+            status: { state: "RUNNING" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-3",
+            status: { state: "SUCCEEDED" },
+            result: { data_array: [[1]] },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      );
+
+    const client = new DatabricksSqlClient({
+      config: { ...createBaseConfig(), retryCount: 0 },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    const result = await client.executeStatement({
+      statement: "SELECT 1",
+      warehouseId: "wh-1",
+    });
+    expect(result).toEqual({
+      statement_id: "stmt-3",
+      status: { state: "SUCCEEDED" },
+      result: { data_array: [[1]] },
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails when statement reaches terminal failed status", async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          statement_id: "stmt-failed",
+          status: { state: "FAILED", error_message: "permission denied" },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+
+    const client = new DatabricksSqlClient({
+      config: { ...createBaseConfig(), retryCount: 0 },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    await expect(
+      client.executeStatement({
+        statement: "SELECT * FROM secret.table",
+        warehouseId: "wh-1",
+      }),
+    ).rejects.toMatchObject({
+      code: "STATEMENT_FAILED",
+      message: "permission denied",
+    });
+  });
+
+  it("fails when statement remains pending past max wait", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-4",
+            status: { state: "PENDING" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+      .mockImplementation(async () => {
+        return new Response(
+          JSON.stringify({
+            statement_id: "stmt-4",
+            status: { state: "RUNNING" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      });
+
+    const client = new DatabricksSqlClient({
+      config: { ...createBaseConfig(), retryCount: 0, maxPollingWaitMs: 1 },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    await expect(
+      client.executeStatement({
+        statement: "SELECT 1",
+        warehouseId: "wh-1",
+      }),
+    ).rejects.toMatchObject({
+      code: "STATEMENT_PENDING_MAX_WAIT",
+    });
+  });
+
+  it("retries transient polling errors using retryCount", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-5",
+            status: { state: "PENDING" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "rate limited" }), {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statement_id: "stmt-5",
+            status: { state: "SUCCEEDED" },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      );
+
+    const client = new DatabricksSqlClient({
+      config: { ...createBaseConfig(), retryCount: 1 },
+      logger: createLogger(),
+      deps: { fetchImpl, sleep: async () => {} },
+    });
+
+    const result = await client.executeStatement({
+      statement: "SELECT 1",
+      warehouseId: "wh-1",
+    });
+    expect(result).toEqual({
+      statement_id: "stmt-5",
+      status: { state: "SUCCEEDED" },
+    });
+  });
+});

--- a/packages/openclaw-databricks-plugin/src/client.test.ts
+++ b/packages/openclaw-databricks-plugin/src/client.test.ts
@@ -90,15 +90,8 @@ describe("databricks sql client", () => {
   });
 
   it("raises timeout error when submit request aborts", async () => {
-    const fetchImpl = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
-      const signal = init?.signal;
-      return new Promise<Response>((_resolve, reject) => {
-        if (signal?.aborted) {
-          reject(new DOMException("aborted", "AbortError"));
-          return;
-        }
-        signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
-      });
+    const fetchImpl = vi.fn(async () => {
+      throw new DOMException("aborted", "AbortError");
     });
 
     const client = new DatabricksSqlClient({

--- a/packages/openclaw-databricks-plugin/src/client.ts
+++ b/packages/openclaw-databricks-plugin/src/client.ts
@@ -1,0 +1,392 @@
+import type { PluginLogger } from "openclaw/plugin-sdk/core";
+import type { ResolvedDatabricksRuntimeConfig } from "./config.js";
+import {
+  DatabricksError,
+  DatabricksHttpError,
+  isRetryableStatus,
+  normalizeDatabricksError,
+} from "./errors.js";
+import { logDatabricks } from "./logger.js";
+
+type DatabricksFetch = typeof fetch;
+
+type DatabricksSqlRequest = {
+  statement: string;
+  warehouseId: string;
+  catalog?: string;
+  schema?: string;
+};
+
+type DatabricksSqlStatus = "PENDING" | "RUNNING" | "QUEUED" | "SUCCEEDED" | "FAILED" | "CANCELED";
+
+type DatabricksStatementPayload = {
+  statement_id?: string;
+  status?: {
+    state?: string;
+    error_code?: string;
+    error_message?: string;
+  };
+  [key: string]: unknown;
+};
+
+type DatabricksClientDeps = {
+  fetchImpl?: DatabricksFetch;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+type RetryOptions = {
+  maxAttempts: number;
+  minDelayMs: number;
+};
+
+function toErrorMessage(payload: unknown, fallback: string): string {
+  if (payload && typeof payload === "object") {
+    const asRecord = payload as Record<string, unknown>;
+    const status = asRecord.status;
+    if (status && typeof status === "object") {
+      const statusMessage = (status as Record<string, unknown>).error_message;
+      if (typeof statusMessage === "string" && statusMessage.trim()) {
+        return statusMessage.trim();
+      }
+    }
+    const message = asRecord.message;
+    if (typeof message === "string" && message.trim()) {
+      return message.trim();
+    }
+    const errorMessage = asRecord.error_message;
+    if (typeof errorMessage === "string" && errorMessage.trim()) {
+      return errorMessage.trim();
+    }
+  }
+  return fallback;
+}
+
+async function parseResponsePayload(response: Response): Promise<unknown> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.toLowerCase().includes("application/json")) {
+    return response.json();
+  }
+  const text = await response.text();
+  if (!text.trim()) {
+    return {};
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { message: text };
+  }
+}
+
+function buildRetryOptions(retryCount: number): RetryOptions {
+  return {
+    maxAttempts: Math.max(1, retryCount + 1),
+    minDelayMs: 250,
+  };
+}
+
+function shouldRetry(params: {
+  statusCode?: number;
+  attempt: number;
+  retry: RetryOptions;
+}): boolean {
+  if (params.attempt >= params.retry.maxAttempts) {
+    return false;
+  }
+  if (params.statusCode === undefined) {
+    return true;
+  }
+  return isRetryableStatus(params.statusCode);
+}
+
+function buildBackoffMs(attempt: number, retry: RetryOptions): number {
+  const exponential = retry.minDelayMs * 2 ** Math.max(0, attempt - 1);
+  return Math.min(exponential, 2_000);
+}
+
+function getStatementStatus(payload: unknown): DatabricksSqlStatus | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const statusValue = (payload as DatabricksStatementPayload).status?.state;
+  if (typeof statusValue !== "string") {
+    return null;
+  }
+  const normalized = statusValue.toUpperCase();
+  if (
+    normalized === "PENDING" ||
+    normalized === "RUNNING" ||
+    normalized === "QUEUED" ||
+    normalized === "SUCCEEDED" ||
+    normalized === "FAILED" ||
+    normalized === "CANCELED"
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+function isPendingStatus(status: DatabricksSqlStatus | null): boolean {
+  return status === "PENDING" || status === "RUNNING" || status === "QUEUED";
+}
+
+function isSuccessfulTerminalStatus(status: DatabricksSqlStatus | null): boolean {
+  return status === "SUCCEEDED";
+}
+
+function isFailedTerminalStatus(status: DatabricksSqlStatus | null): boolean {
+  return status === "FAILED" || status === "CANCELED";
+}
+
+export class DatabricksSqlClient {
+  private readonly fetchImpl: DatabricksFetch;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly config: ResolvedDatabricksRuntimeConfig;
+  private readonly logger: PluginLogger;
+
+  constructor(params: {
+    config: ResolvedDatabricksRuntimeConfig;
+    logger: PluginLogger;
+    deps?: DatabricksClientDeps;
+  }) {
+    this.config = params.config;
+    this.logger = params.logger;
+    this.fetchImpl = params.deps?.fetchImpl ?? fetch;
+    this.sleep =
+      params.deps?.sleep ??
+      ((ms: number) => new Promise((resolve) => setTimeout(resolve, Math.max(0, ms))));
+  }
+
+  async executeStatement(request: DatabricksSqlRequest): Promise<unknown> {
+    const endpoint = `${this.config.host}/api/2.0/sql/statements`;
+    const payload = await this.requestWithRetry({
+      method: "POST",
+      endpoint,
+      timeoutMs: this.config.timeoutMs,
+      stage: "submit",
+      body: {
+        statement: request.statement,
+        warehouse_id: request.warehouseId,
+        disposition: "INLINE",
+        ...(request.catalog ? { catalog: request.catalog } : {}),
+        ...(request.schema ? { schema: request.schema } : {}),
+      },
+    });
+
+    const status = getStatementStatus(payload);
+    if (isPendingStatus(status)) {
+      const statementId =
+        payload && typeof payload === "object"
+          ? (payload as DatabricksStatementPayload).statement_id
+          : undefined;
+      if (!statementId || typeof statementId !== "string") {
+        throw new DatabricksError({
+          code: "POLLING_TIMEOUT",
+          message: "Databricks statement is pending, but statement_id is missing for polling.",
+          retryable: false,
+        });
+      }
+      return this.pollStatement(statementId);
+    }
+
+    return this.assertTerminalPayload(payload, "submit");
+  }
+
+  private assertTerminalPayload(payload: unknown, stage: "submit" | "poll"): unknown {
+    const status = getStatementStatus(payload);
+    if (status === null) {
+      return payload;
+    }
+    if (isSuccessfulTerminalStatus(status)) {
+      return payload;
+    }
+    if (isFailedTerminalStatus(status)) {
+      const message = toErrorMessage(
+        payload,
+        `Databricks statement ended with terminal status ${status}.`,
+      );
+      throw new DatabricksError({
+        code: "STATEMENT_FAILED",
+        message,
+        retryable: false,
+        details: {
+          stage,
+          status,
+          errorCode:
+            payload && typeof payload === "object"
+              ? (payload as DatabricksStatementPayload).status?.error_code
+              : undefined,
+        },
+      });
+    }
+    throw new DatabricksError({
+      code: "REQUEST_ERROR",
+      message: `Databricks statement returned unsupported status: ${status}.`,
+      retryable: false,
+      details: { stage, status },
+    });
+  }
+
+  private async pollStatement(statementId: string): Promise<unknown> {
+    const startedAt = Date.now();
+    const endpoint = `${this.config.host}/api/2.0/sql/statements/${encodeURIComponent(statementId)}`;
+
+    while (Date.now() - startedAt <= this.config.maxPollingWaitMs) {
+      const elapsedMs = Date.now() - startedAt;
+      const remainingMs = this.config.maxPollingWaitMs - elapsedMs;
+      if (remainingMs <= 0) {
+        break;
+      }
+      const requestTimeoutMs = Math.max(1_000, Math.min(this.config.timeoutMs, remainingMs));
+
+      const payload = await this.requestWithRetry({
+        method: "GET",
+        endpoint,
+        timeoutMs: requestTimeoutMs,
+        stage: "poll",
+        remainingMs,
+        statementId,
+      });
+
+      const status = getStatementStatus(payload);
+      if (!isPendingStatus(status)) {
+        return this.assertTerminalPayload(payload, "poll");
+      }
+
+      const delayMs = Math.min(this.config.pollingIntervalMs, Math.max(0, remainingMs));
+      logDatabricks(this.logger, "debug", "Polling Databricks statement status.", {
+        statementId,
+        status,
+        delayMs,
+        elapsedMs,
+      });
+      await this.sleep(delayMs);
+    }
+
+    throw new DatabricksError({
+      code: "STATEMENT_PENDING_MAX_WAIT",
+      message: `Databricks statement is still pending after ${this.config.maxPollingWaitMs}ms.`,
+      retryable: false,
+      details: {
+        maxPollingWaitMs: this.config.maxPollingWaitMs,
+        pollingIntervalMs: this.config.pollingIntervalMs,
+      },
+    });
+  }
+
+  private async requestWithRetry(params: {
+    method: "GET" | "POST";
+    endpoint: string;
+    timeoutMs: number;
+    stage: "submit" | "poll";
+    remainingMs?: number;
+    statementId?: string;
+    body?: Record<string, unknown>;
+  }): Promise<unknown> {
+    const retry = buildRetryOptions(this.config.retryCount);
+    for (let attempt = 1; attempt <= retry.maxAttempts; attempt += 1) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), params.timeoutMs);
+      try {
+        const response = await this.fetchImpl(params.endpoint, {
+          method: params.method,
+          headers: {
+            Authorization: `Bearer ${this.config.token}`,
+            ...(params.body ? { "Content-Type": "application/json" } : {}),
+          },
+          ...(params.body ? { body: JSON.stringify(params.body) } : {}),
+          signal: controller.signal,
+        });
+        const payload = await parseResponsePayload(response);
+        if (!response.ok) {
+          const message = toErrorMessage(
+            payload,
+            `Databricks ${params.stage} request failed with status ${response.status}.`,
+          );
+          const error = new DatabricksHttpError({
+            statusCode: response.status,
+            message,
+          });
+          if (shouldRetry({ statusCode: response.status, attempt, retry })) {
+            const delayMs = buildBackoffMs(attempt, retry);
+            if (
+              params.stage === "poll" &&
+              params.remainingMs !== undefined &&
+              delayMs > params.remainingMs
+            ) {
+              throw new DatabricksError({
+                code: "POLLING_RETRY_EXHAUSTED",
+                message: "Databricks polling transient retries exhausted remaining wait budget.",
+                retryable: false,
+              });
+            }
+            logDatabricks(this.logger, "warn", "Retrying Databricks request after HTTP error.", {
+              stage: params.stage,
+              statementId: params.statementId,
+              statusCode: response.status,
+              attempt,
+              delayMs,
+            });
+            await this.sleep(delayMs);
+            continue;
+          }
+          throw error;
+        }
+        return payload;
+      } catch (error) {
+        const normalized = normalizeDatabricksError(
+          error,
+          `Databricks ${params.stage} request timed out after ${params.timeoutMs}ms.`,
+        );
+        if (normalized.code === "TIMEOUT" && params.stage === "submit") {
+          throw new DatabricksError({
+            code: "STATEMENT_TIMEOUT",
+            message: normalized.message,
+            retryable: normalized.retryable,
+          });
+        }
+        if (shouldRetry({ attempt, retry }) && normalized.retryable) {
+          const delayMs = buildBackoffMs(attempt, retry);
+          if (
+            params.stage === "poll" &&
+            params.remainingMs !== undefined &&
+            delayMs > params.remainingMs
+          ) {
+            throw new DatabricksError({
+              code: "POLLING_RETRY_EXHAUSTED",
+              message: "Databricks polling transient retries exhausted remaining wait budget.",
+              retryable: false,
+            });
+          }
+          logDatabricks(this.logger, "warn", "Retrying Databricks request after transient error.", {
+            stage: params.stage,
+            statementId: params.statementId,
+            code: normalized.code,
+            attempt,
+            delayMs,
+          });
+          await this.sleep(delayMs);
+          continue;
+        }
+        throw normalized;
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+    throw new DatabricksError({
+      code: params.stage === "poll" ? "POLLING_RETRY_EXHAUSTED" : "REQUEST_ERROR",
+      message:
+        params.stage === "poll"
+          ? "Databricks polling exhausted retry attempts."
+          : "Databricks submit request exhausted retry attempts.",
+      retryable: false,
+    });
+  }
+}
+
+export function createDatabricksSqlClient(params: {
+  config: ResolvedDatabricksRuntimeConfig;
+  logger: PluginLogger;
+  deps?: DatabricksClientDeps;
+}): DatabricksSqlClient {
+  return new DatabricksSqlClient(params);
+}

--- a/packages/openclaw-databricks-plugin/src/config.test.ts
+++ b/packages/openclaw-databricks-plugin/src/config.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { resolveDatabricksRuntimeConfig } from "./config.js";
+import { DatabricksConfigError } from "./errors.js";
+
+describe("databricks config", () => {
+  it("resolves required config and defaults", () => {
+    const resolved = resolveDatabricksRuntimeConfig({
+      rawConfig: {
+        host: "dbc-example.cloud.databricks.com",
+        token: "dapi-test-token",
+        warehouseId: "abc123",
+      },
+      env: {},
+    });
+
+    expect(resolved.host).toBe("https://dbc-example.cloud.databricks.com");
+    expect(resolved.timeoutMs).toBe(30_000);
+    expect(resolved.retryCount).toBe(1);
+    expect(resolved.pollingIntervalMs).toBe(1_000);
+    expect(resolved.maxPollingWaitMs).toBe(30_000);
+    expect(resolved.allowedCatalogs).toEqual([]);
+    expect(resolved.allowedSchemas).toEqual([]);
+    expect(resolved.readOnly).toBe(true);
+  });
+
+  it("uses environment fallback values", () => {
+    const resolved = resolveDatabricksRuntimeConfig({
+      rawConfig: {},
+      env: {
+        DATABRICKS_HOST: "https://dbc-env.cloud.databricks.com",
+        DATABRICKS_TOKEN: "dapi-env",
+        DATABRICKS_WAREHOUSE_ID: "wh-env",
+      },
+    });
+
+    expect(resolved.host).toBe("https://dbc-env.cloud.databricks.com");
+    expect(resolved.token).toBe("dapi-env");
+    expect(resolved.warehouseId).toBe("wh-env");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() =>
+      resolveDatabricksRuntimeConfig({
+        rawConfig: {
+          host: "https://dbc-example.cloud.databricks.com",
+          warehouseId: "abc123",
+        },
+        env: {},
+      }),
+    ).toThrow(DatabricksConfigError);
+  });
+
+  it("rejects readOnly=false", () => {
+    expect(() =>
+      resolveDatabricksRuntimeConfig({
+        rawConfig: {
+          host: "https://dbc-example.cloud.databricks.com",
+          token: "dapi-test-token",
+          warehouseId: "abc123",
+          readOnly: false,
+        },
+        env: {},
+      }),
+    ).toThrow("Only readOnly=true is supported");
+  });
+
+  it("normalizes allowlists", () => {
+    const resolved = resolveDatabricksRuntimeConfig({
+      rawConfig: {
+        host: "https://dbc-example.cloud.databricks.com",
+        token: "dapi-test-token",
+        warehouseId: "abc123",
+        allowedCatalogs: ["Main", " analytics "],
+        allowedSchemas: ["Public"],
+      },
+      env: {},
+    });
+
+    expect(resolved.allowedCatalogs).toEqual(["main", "analytics"]);
+    expect(resolved.allowedSchemas).toEqual(["public"]);
+  });
+
+  it("rejects non-https host", () => {
+    expect(() =>
+      resolveDatabricksRuntimeConfig({
+        rawConfig: {
+          host: "http://dbc-example.cloud.databricks.com",
+          token: "dapi-test-token",
+          warehouseId: "abc123",
+        },
+        env: {},
+      }),
+    ).toThrow("Databricks host must use HTTPS");
+  });
+
+  it("rejects host with path", () => {
+    expect(() =>
+      resolveDatabricksRuntimeConfig({
+        rawConfig: {
+          host: "https://dbc-example.cloud.databricks.com/foo",
+          token: "dapi-test-token",
+          warehouseId: "abc123",
+        },
+        env: {},
+      }),
+    ).toThrow("must not include a path");
+  });
+
+  it("rejects localhost host", () => {
+    expect(() =>
+      resolveDatabricksRuntimeConfig({
+        rawConfig: {
+          host: "https://localhost",
+          token: "dapi-test-token",
+          warehouseId: "abc123",
+        },
+        env: {},
+      }),
+    ).toThrow("public Databricks hostname");
+  });
+
+  it("rejects IP literal host", () => {
+    expect(() =>
+      resolveDatabricksRuntimeConfig({
+        rawConfig: {
+          host: "https://127.0.0.1",
+          token: "dapi-test-token",
+          warehouseId: "abc123",
+        },
+        env: {},
+      }),
+    ).toThrow("public Databricks hostname");
+  });
+
+  it("rejects non-databricks domain host", () => {
+    expect(() =>
+      resolveDatabricksRuntimeConfig({
+        rawConfig: {
+          host: "https://evil.example.com",
+          token: "dapi-test-token",
+          warehouseId: "abc123",
+        },
+        env: {},
+      }),
+    ).toThrow("supported Databricks domain suffix");
+  });
+});

--- a/packages/openclaw-databricks-plugin/src/config.ts
+++ b/packages/openclaw-databricks-plugin/src/config.ts
@@ -1,0 +1,227 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  normalizeResolvedSecretInputString,
+  normalizeSecretInput,
+} from "openclaw/plugin-sdk/secret-input";
+import { z } from "zod";
+import { DatabricksConfigError } from "./errors.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_RETRY_COUNT = 1;
+const DEFAULT_POLLING_INTERVAL_MS = 1_000;
+const DEFAULT_MAX_POLLING_WAIT_MS = 30_000;
+
+const ALLOWED_DATABRICKS_HOST_SUFFIXES = [
+  ".cloud.databricks.com",
+  ".azuredatabricks.net",
+  ".gcp.databricks.com",
+] as const;
+
+const DatabricksRuntimeConfigSchema = z.object({
+  host: z.string().min(1, { error: "host is required" }),
+  token: z.string().min(1, { error: "token is required" }),
+  warehouseId: z.string().min(1, { error: "warehouseId is required" }),
+  timeoutMs: z
+    .number({ error: "timeoutMs must be a number between 1000 and 120000" })
+    .int({ error: "timeoutMs must be an integer between 1000 and 120000" })
+    .min(1_000, { error: "timeoutMs must be >= 1000" })
+    .max(120_000, { error: "timeoutMs must be <= 120000" }),
+  retryCount: z
+    .number({ error: "retryCount must be a number between 0 and 3" })
+    .int({ error: "retryCount must be an integer between 0 and 3" })
+    .min(0, { error: "retryCount must be >= 0" })
+    .max(3, { error: "retryCount must be <= 3" }),
+  pollingIntervalMs: z
+    .number({ error: "pollingIntervalMs must be a number between 200 and 5000" })
+    .int({ error: "pollingIntervalMs must be an integer between 200 and 5000" })
+    .min(200, { error: "pollingIntervalMs must be >= 200" })
+    .max(5_000, { error: "pollingIntervalMs must be <= 5000" }),
+  maxPollingWaitMs: z
+    .number({ error: "maxPollingWaitMs must be a number between 1000 and 120000" })
+    .int({ error: "maxPollingWaitMs must be an integer between 1000 and 120000" })
+    .min(1_000, { error: "maxPollingWaitMs must be >= 1000" })
+    .max(120_000, { error: "maxPollingWaitMs must be <= 120000" }),
+  allowedCatalogs: z.array(z.string().min(1)).default([]),
+  allowedSchemas: z.array(z.string().min(1)).default([]),
+  readOnly: z.literal(true, {
+    error: "Only readOnly=true is supported in this Databricks runtime iteration.",
+  }),
+});
+
+export type ResolvedDatabricksRuntimeConfig = z.infer<typeof DatabricksRuntimeConfigSchema>;
+
+type DatabricksPluginConfig = {
+  host?: unknown;
+  token?: unknown;
+  warehouseId?: unknown;
+  timeoutMs?: unknown;
+  retryCount?: unknown;
+  pollingIntervalMs?: unknown;
+  maxPollingWaitMs?: unknown;
+  allowedCatalogs?: unknown;
+  allowedSchemas?: unknown;
+  readOnly?: unknown;
+};
+
+function normalizeOptionalString(value: unknown, path: string): string | undefined {
+  const resolved = normalizeResolvedSecretInputString({ value, path });
+  return normalizeSecretInput(resolved) || undefined;
+}
+
+function isIpLiteral(hostname: string): boolean {
+  return /^[\d.]+$/u.test(hostname) || hostname.includes(":");
+}
+
+function assertAllowedDatabricksHostname(hostname: string): void {
+  if (hostname === "localhost" || hostname.endsWith(".localhost") || isIpLiteral(hostname)) {
+    throw new DatabricksConfigError("Databricks host must be a public Databricks hostname.");
+  }
+
+  const isAllowed = ALLOWED_DATABRICKS_HOST_SUFFIXES.some(
+    (suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix),
+  );
+  if (!isAllowed) {
+    throw new DatabricksConfigError(
+      "Databricks host must match a supported Databricks domain suffix.",
+      {
+        allowedSuffixes: ALLOWED_DATABRICKS_HOST_SUFFIXES,
+      },
+    );
+  }
+}
+
+function normalizeHost(rawHost: string): string {
+  const prefixed = /^https?:\/\//iu.test(rawHost) ? rawHost : `https://${rawHost}`;
+  let url: URL;
+  try {
+    url = new URL(prefixed);
+  } catch {
+    throw new DatabricksConfigError("Invalid Databricks host URL.");
+  }
+  if (url.protocol !== "https:") {
+    throw new DatabricksConfigError("Databricks host must use HTTPS.");
+  }
+  if (url.username || url.password) {
+    throw new DatabricksConfigError("Databricks host must not include userinfo.");
+  }
+  if (url.port && url.port !== "443") {
+    throw new DatabricksConfigError("Databricks host must not override port.");
+  }
+  if (url.pathname && url.pathname !== "/") {
+    throw new DatabricksConfigError("Databricks host must not include a path.");
+  }
+  if (url.search || url.hash) {
+    throw new DatabricksConfigError("Databricks host must not include query or fragment.");
+  }
+
+  const hostname = url.hostname.toLowerCase().replace(/\.$/u, "");
+  assertAllowedDatabricksHostname(hostname);
+
+  return `https://${hostname}`;
+}
+
+function normalizeRetryCount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_RETRY_COUNT;
+  }
+  return Math.floor(value);
+}
+
+function normalizeTimeoutMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+  return Math.floor(value);
+}
+
+function normalizePollingIntervalMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_POLLING_INTERVAL_MS;
+  }
+  return Math.floor(value);
+}
+
+function normalizeMaxPollingWaitMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_MAX_POLLING_WAIT_MS;
+  }
+  return Math.floor(value);
+}
+
+function normalizeAllowlistValues(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+}
+
+export function resolveDatabricksPluginRawConfig(
+  config?: OpenClawConfig,
+): DatabricksPluginConfig | undefined {
+  const entry = config?.plugins?.entries?.databricks?.config;
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return undefined;
+  }
+  return entry as DatabricksPluginConfig;
+}
+
+export function resolveDatabricksRuntimeConfig(params: {
+  rawConfig?: unknown;
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): ResolvedDatabricksRuntimeConfig {
+  const env = params.env ?? process.env;
+  const fromOpenClawConfig = resolveDatabricksPluginRawConfig(params.config);
+  const candidate =
+    params.rawConfig && typeof params.rawConfig === "object" && !Array.isArray(params.rawConfig)
+      ? (params.rawConfig as DatabricksPluginConfig)
+      : fromOpenClawConfig;
+
+  const host =
+    normalizeOptionalString(candidate?.host, "plugins.entries.databricks.config.host") ||
+    normalizeSecretInput(env.DATABRICKS_HOST || "") ||
+    undefined;
+  const token =
+    normalizeOptionalString(candidate?.token, "plugins.entries.databricks.config.token") ||
+    normalizeSecretInput(env.DATABRICKS_TOKEN || "") ||
+    undefined;
+  const warehouseId =
+    normalizeOptionalString(
+      candidate?.warehouseId,
+      "plugins.entries.databricks.config.warehouseId",
+    ) ||
+    normalizeSecretInput(env.DATABRICKS_WAREHOUSE_ID || "") ||
+    undefined;
+
+  const timeoutMs = normalizeTimeoutMs(candidate?.timeoutMs);
+  const retryCount = normalizeRetryCount(candidate?.retryCount);
+  const pollingIntervalMs = normalizePollingIntervalMs(candidate?.pollingIntervalMs);
+  const maxPollingWaitMs = normalizeMaxPollingWaitMs(candidate?.maxPollingWaitMs);
+  const allowedCatalogs = normalizeAllowlistValues(candidate?.allowedCatalogs);
+  const allowedSchemas = normalizeAllowlistValues(candidate?.allowedSchemas);
+  const readOnly =
+    typeof candidate?.readOnly === "boolean"
+      ? candidate.readOnly
+      : normalizeSecretInput(env.DATABRICKS_READ_ONLY || "").toLowerCase() !== "false";
+
+  const parsed = DatabricksRuntimeConfigSchema.safeParse({
+    host: host ? normalizeHost(host) : "",
+    token: token ?? "",
+    warehouseId: warehouseId ?? "",
+    timeoutMs,
+    retryCount,
+    pollingIntervalMs,
+    maxPollingWaitMs,
+    allowedCatalogs,
+    allowedSchemas,
+    readOnly,
+  });
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    throw new DatabricksConfigError(issue?.message ?? "Invalid Databricks plugin configuration.");
+  }
+  return parsed.data;
+}

--- a/packages/openclaw-databricks-plugin/src/errors.test.ts
+++ b/packages/openclaw-databricks-plugin/src/errors.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  DatabricksAllowlistError,
+  DatabricksError,
+  DatabricksHttpError,
+  isRetryableStatus,
+  normalizeDatabricksError,
+  sanitizeDatabricksText,
+} from "./errors.js";
+
+describe("databricks errors", () => {
+  it("maps retryable status codes", () => {
+    expect(isRetryableStatus(429)).toBe(true);
+    expect(isRetryableStatus(503)).toBe(true);
+    expect(isRetryableStatus(400)).toBe(false);
+  });
+
+  it("creates typed http errors", () => {
+    const error = new DatabricksHttpError({
+      statusCode: 401,
+      message: "Unauthorized",
+    });
+    expect(error.code).toBe("UNAUTHORIZED");
+    expect(error.retryable).toBe(false);
+    expect(error.statusCode).toBe(401);
+  });
+
+  it("normalizes abort errors into TIMEOUT", () => {
+    const error = normalizeDatabricksError(
+      new DOMException("The operation was aborted.", "AbortError"),
+      "timeout",
+    );
+    expect(error.code).toBe("TIMEOUT");
+    expect(error.retryable).toBe(true);
+  });
+
+  it("passes through DatabricksError instances", () => {
+    const original = new DatabricksError({
+      code: "POLICY_VIOLATION",
+      message: "blocked",
+    });
+    const normalized = normalizeDatabricksError(original, "fallback");
+    expect(normalized).toBe(original);
+  });
+
+  it("creates allowlist violation error", () => {
+    const error = new DatabricksAllowlistError("catalog blocked");
+    expect(error.code).toBe("ALLOWLIST_VIOLATION");
+    expect(error.retryable).toBe(false);
+  });
+
+  it("sanitizes urls and bearer tokens from text", () => {
+    const text = sanitizeDatabricksText(
+      "request to https://dbc-example.cloud.databricks.com failed with Bearer dapi1234567890token",
+    );
+    expect(text).not.toContain("https://dbc-example.cloud.databricks.com");
+    expect(text).not.toContain("dapi1234567890token");
+    expect(text).toContain("[redacted-url]");
+    expect(text).toContain("Bearer dapi***ken");
+  });
+});

--- a/packages/openclaw-databricks-plugin/src/errors.test.ts
+++ b/packages/openclaw-databricks-plugin/src/errors.test.ts
@@ -5,6 +5,7 @@ import {
   DatabricksHttpError,
   isRetryableStatus,
   normalizeDatabricksError,
+  redactToken,
   sanitizeDatabricksText,
 } from "./errors.js";
 
@@ -57,5 +58,9 @@ describe("databricks errors", () => {
     expect(text).not.toContain("dapi1234567890token");
     expect(text).toContain("[redacted-url]");
     expect(text).toContain("Bearer dapi***ken");
+  });
+
+  it("redacts tokens consistently", () => {
+    expect(redactToken("dapi1234567890token")).toBe("dapi***ken");
   });
 });

--- a/packages/openclaw-databricks-plugin/src/errors.ts
+++ b/packages/openclaw-databricks-plugin/src/errors.ts
@@ -19,7 +19,7 @@ const URL_REDACTION_PATTERN = /\bhttps?:\/\/[^\s"']+/giu;
 const BEARER_REDACTION_PATTERN = /Bearer\s+[A-Za-z0-9._~+/=-]+/giu;
 const RAW_TOKEN_REDACTION_PATTERN = /\bdapi[a-z0-9._-]{8,}\b/giu;
 
-function redactToken(value: string): string {
+export function redactToken(value: string): string {
   const trimmed = value.trim();
   if (trimmed.length <= 8) {
     return "***";

--- a/packages/openclaw-databricks-plugin/src/errors.ts
+++ b/packages/openclaw-databricks-plugin/src/errors.ts
@@ -1,0 +1,194 @@
+export type DatabricksErrorCode =
+  | "CONFIG_ERROR"
+  | "POLICY_VIOLATION"
+  | "ALLOWLIST_VIOLATION"
+  | "REQUEST_ERROR"
+  | "TIMEOUT"
+  | "STATEMENT_TIMEOUT"
+  | "POLLING_TIMEOUT"
+  | "POLLING_RETRY_EXHAUSTED"
+  | "STATEMENT_PENDING_MAX_WAIT"
+  | "STATEMENT_FAILED"
+  | "UNAUTHORIZED"
+  | "RATE_LIMIT"
+  | "HTTP_ERROR"
+  | "TRANSIENT_ERROR"
+  | "UNKNOWN_ERROR";
+
+const URL_REDACTION_PATTERN = /\bhttps?:\/\/[^\s"']+/giu;
+const BEARER_REDACTION_PATTERN = /Bearer\s+[A-Za-z0-9._~+/=-]+/giu;
+const RAW_TOKEN_REDACTION_PATTERN = /\bdapi[a-z0-9._-]{8,}\b/giu;
+
+function redactToken(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= 8) {
+    return "***";
+  }
+  return `${trimmed.slice(0, 4)}***${trimmed.slice(-3)}`;
+}
+
+export function sanitizeDatabricksText(value: string): string {
+  return value
+    .replace(BEARER_REDACTION_PATTERN, (match) => {
+      const token = match.replace(/^Bearer\s+/iu, "");
+      return `Bearer ${redactToken(token)}`;
+    })
+    .replace(RAW_TOKEN_REDACTION_PATTERN, (token) => redactToken(token))
+    .replace(URL_REDACTION_PATTERN, "[redacted-url]");
+}
+
+function sanitizeUnknownText(value: unknown): unknown {
+  if (typeof value === "string") {
+    return sanitizeDatabricksText(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeUnknownText(entry));
+  }
+  if (value && typeof value === "object") {
+    const safe: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      const lower = key.toLowerCase();
+      if (
+        lower.includes("token") ||
+        lower.includes("authorization") ||
+        lower.includes("api_key") ||
+        lower.includes("apikey") ||
+        lower.includes("secret")
+      ) {
+        safe[key] = "***";
+        continue;
+      }
+      safe[key] = sanitizeUnknownText(nested);
+    }
+    return safe;
+  }
+  return value;
+}
+
+export class DatabricksError extends Error {
+  readonly code: DatabricksErrorCode;
+  readonly statusCode?: number;
+  readonly retryable: boolean;
+  readonly details?: Record<string, unknown>;
+
+  constructor(params: {
+    code: DatabricksErrorCode;
+    message: string;
+    retryable?: boolean;
+    statusCode?: number;
+    details?: Record<string, unknown>;
+  }) {
+    super(sanitizeDatabricksText(params.message));
+    this.name = "DatabricksError";
+    this.code = params.code;
+    this.retryable = params.retryable ?? false;
+    this.statusCode = params.statusCode;
+    this.details = params.details
+      ? (sanitizeUnknownText(params.details) as Record<string, unknown>)
+      : undefined;
+  }
+}
+
+export class DatabricksConfigError extends DatabricksError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super({
+      code: "CONFIG_ERROR",
+      message,
+      retryable: false,
+      details,
+    });
+    this.name = "DatabricksConfigError";
+  }
+}
+
+export class DatabricksPolicyError extends DatabricksError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super({
+      code: "POLICY_VIOLATION",
+      message,
+      retryable: false,
+      details,
+    });
+    this.name = "DatabricksPolicyError";
+  }
+}
+
+export class DatabricksAllowlistError extends DatabricksError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super({
+      code: "ALLOWLIST_VIOLATION",
+      message,
+      retryable: false,
+      details,
+    });
+    this.name = "DatabricksAllowlistError";
+  }
+}
+
+export class DatabricksHttpError extends DatabricksError {
+  constructor(params: {
+    statusCode: number;
+    message: string;
+    retryable?: boolean;
+    details?: Record<string, unknown>;
+  }) {
+    const code = mapStatusToErrorCode(params.statusCode);
+    super({
+      code,
+      message: params.message,
+      statusCode: params.statusCode,
+      retryable: params.retryable ?? isRetryableStatus(params.statusCode),
+      details: params.details,
+    });
+    this.name = "DatabricksHttpError";
+  }
+}
+
+export function isRetryableStatus(statusCode: number): boolean {
+  return statusCode === 429 || statusCode === 408 || statusCode >= 500;
+}
+
+function mapStatusToErrorCode(statusCode: number): DatabricksErrorCode {
+  if (statusCode === 401 || statusCode === 403) {
+    return "UNAUTHORIZED";
+  }
+  if (statusCode === 429) {
+    return "RATE_LIMIT";
+  }
+  if (statusCode === 408 || statusCode >= 500) {
+    return "TRANSIENT_ERROR";
+  }
+  return "HTTP_ERROR";
+}
+
+function isAbortError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.name === "AbortError" || /aborted|abort/iu.test(error.message);
+}
+
+export function normalizeDatabricksError(error: unknown, fallbackMessage: string): DatabricksError {
+  if (error instanceof DatabricksError) {
+    return error;
+  }
+  if (isAbortError(error)) {
+    return new DatabricksError({
+      code: "TIMEOUT",
+      message: fallbackMessage,
+      retryable: true,
+    });
+  }
+  if (error instanceof Error) {
+    return new DatabricksError({
+      code: "UNKNOWN_ERROR",
+      message: error.message || fallbackMessage,
+      retryable: false,
+    });
+  }
+  return new DatabricksError({
+    code: "UNKNOWN_ERROR",
+    message: fallbackMessage,
+    retryable: false,
+  });
+}

--- a/packages/openclaw-databricks-plugin/src/logger.ts
+++ b/packages/openclaw-databricks-plugin/src/logger.ts
@@ -1,16 +1,5 @@
 import type { PluginLogger } from "openclaw/plugin-sdk/core";
-import { sanitizeDatabricksText } from "./errors.js";
-
-function redactToken(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return trimmed;
-  }
-  if (trimmed.length <= 8) {
-    return "***";
-  }
-  return `${trimmed.slice(0, 4)}***${trimmed.slice(-3)}`;
-}
+import { redactToken, sanitizeDatabricksText } from "./errors.js";
 
 function sanitizeString(value: string, token?: string): string {
   let sanitized = sanitizeDatabricksText(value);

--- a/packages/openclaw-databricks-plugin/src/logger.ts
+++ b/packages/openclaw-databricks-plugin/src/logger.ts
@@ -1,0 +1,80 @@
+import type { PluginLogger } from "openclaw/plugin-sdk/core";
+import { sanitizeDatabricksText } from "./errors.js";
+
+function redactToken(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  if (trimmed.length <= 8) {
+    return "***";
+  }
+  return `${trimmed.slice(0, 4)}***${trimmed.slice(-3)}`;
+}
+
+function sanitizeString(value: string, token?: string): string {
+  let sanitized = sanitizeDatabricksText(value);
+  if (token) {
+    sanitized = sanitized.split(token).join(redactToken(token));
+  }
+  return sanitized;
+}
+
+export function sanitizeLogValue(value: unknown, token?: string): unknown {
+  if (typeof value === "string") {
+    return sanitizeString(value, token);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeLogValue(entry, token));
+  }
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      const lowerKey = key.toLowerCase();
+      if (
+        lowerKey.includes("token") ||
+        lowerKey.includes("authorization") ||
+        lowerKey.includes("api_key") ||
+        lowerKey.includes("apikey") ||
+        lowerKey.includes("secret")
+      ) {
+        result[key] = "***";
+        continue;
+      }
+      if (lowerKey.includes("endpoint") || lowerKey.includes("host") || lowerKey.includes("url")) {
+        result[key] = "[redacted-url]";
+        continue;
+      }
+      result[key] = sanitizeLogValue(nested, token);
+    }
+    return result;
+  }
+  return value;
+}
+
+export function formatLogMessage(
+  message: string,
+  context?: Record<string, unknown>,
+  token?: string,
+): string {
+  const safeMessage = sanitizeString(message, token);
+  if (!context || Object.keys(context).length === 0) {
+    return safeMessage;
+  }
+  return `${safeMessage} ${JSON.stringify(sanitizeLogValue(context, token))}`;
+}
+
+export function logDatabricks(
+  logger: PluginLogger,
+  level: "debug" | "info" | "warn" | "error",
+  message: string,
+  context?: Record<string, unknown>,
+  token?: string,
+) {
+  const payload = `[databricks] ${formatLogMessage(message, context, token)}`;
+  if (level === "debug") {
+    logger.debug?.(payload);
+    return;
+  }
+  logger[level](payload);
+}

--- a/packages/openclaw-databricks-plugin/src/operations/sql.ts
+++ b/packages/openclaw-databricks-plugin/src/operations/sql.ts
@@ -1,0 +1,123 @@
+import { Type } from "@sinclair/typebox";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-search";
+import type { AnyAgentTool, OpenClawPluginApi } from "../../runtime-api.js";
+import { createDatabricksSqlClient } from "../client.js";
+import { resolveDatabricksRuntimeConfig } from "../config.js";
+import { DatabricksPolicyError } from "../errors.js";
+import { logDatabricks } from "../logger.js";
+import { assertAllowlistTarget, assertReadOnlySqlStatement } from "../security-policy.js";
+import { resolveSqlTargets } from "../sql-target-resolution.js";
+
+const DatabricksReadOnlySqlToolSchema = Type.Object(
+  {
+    sql: Type.String({
+      description: "Single read-only SQL statement. Only SELECT or WITH ... SELECT are allowed.",
+      minLength: 1,
+    }),
+    warehouse_id: Type.Optional(
+      Type.String({
+        description: "Optional warehouse override. Defaults to plugin config warehouseId.",
+      }),
+    ),
+    catalog: Type.Optional(
+      Type.String({
+        description: "Optional catalog override used during SQL statement execution.",
+      }),
+    ),
+    schema: Type.Optional(
+      Type.String({
+        description: "Optional schema override used during SQL statement execution.",
+      }),
+    ),
+    timeout_ms: Type.Optional(
+      Type.Number({
+        description: "Per-call timeout override in milliseconds (1000-120000).",
+        minimum: 1000,
+        maximum: 120000,
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+export function createDatabricksSqlReadOnlyTool(api: OpenClawPluginApi): AnyAgentTool {
+  return {
+    name: "databricks_sql_readonly",
+    label: "Databricks SQL Read-Only",
+    description:
+      "Execute a single read-only Databricks SQL statement. This runtime only supports SELECT and WITH ... SELECT.",
+    parameters: DatabricksReadOnlySqlToolSchema,
+    execute: async (_toolCallId, rawParams) => {
+      const sql = readStringParam(rawParams, "sql", { required: true });
+      const warehouseOverride = normalizeOptionalString(readStringParam(rawParams, "warehouse_id"));
+      const catalog = normalizeOptionalString(readStringParam(rawParams, "catalog"));
+      const schema = normalizeOptionalString(readStringParam(rawParams, "schema"));
+      const timeoutOverride = readNumberParam(rawParams, "timeout_ms", { integer: true });
+
+      const config = resolveDatabricksRuntimeConfig({
+        rawConfig: api.pluginConfig,
+        config: api.config,
+      });
+      if (!config.readOnly) {
+        throw new DatabricksPolicyError(
+          "Databricks plugin is running in non-read-only mode, but this iteration only supports readOnly=true.",
+        );
+      }
+
+      const safeSql = assertReadOnlySqlStatement(sql);
+      const resolution = resolveSqlTargets(safeSql);
+      assertAllowlistTarget({
+        allowedCatalogs: config.allowedCatalogs,
+        allowedSchemas: config.allowedSchemas,
+        targets: resolution.targets,
+        ambiguousTargets: resolution.ambiguous,
+      });
+
+      const client = createDatabricksSqlClient({
+        config: {
+          ...config,
+          ...(typeof timeoutOverride === "number" ? { timeoutMs: timeoutOverride } : {}),
+        },
+        logger: api.logger,
+      });
+
+      const startedAt = Date.now();
+      const payload = await client.executeStatement({
+        statement: safeSql,
+        warehouseId: warehouseOverride ?? config.warehouseId,
+        catalog,
+        schema,
+      });
+      const tookMs = Date.now() - startedAt;
+      logDatabricks(api.logger, "info", "Executed read-only Databricks SQL statement.", {
+        tookMs,
+        warehouseId: warehouseOverride ?? config.warehouseId,
+      });
+
+      return jsonResult({
+        provider: "databricks",
+        mode: "read-only",
+        tookMs,
+        request: {
+          warehouseId: warehouseOverride ?? config.warehouseId,
+          catalog,
+          schema,
+        },
+        sqlTargets: resolution.targets,
+        response: payload,
+      });
+    },
+  };
+}

--- a/packages/openclaw-databricks-plugin/src/security-policy.test.ts
+++ b/packages/openclaw-databricks-plugin/src/security-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { DatabricksAllowlistError, DatabricksPolicyError } from "./errors.js";
 import { assertAllowlistTarget, assertReadOnlySqlStatement } from "./security-policy.js";
+import { resolveSqlTargets } from "./sql-target-resolution.js";
 
 describe("databricks read-only sql policy", () => {
   it("accepts SELECT", () => {
@@ -24,6 +25,22 @@ describe("databricks read-only sql policy", () => {
   it("rejects non-select statement", () => {
     expect(() => assertReadOnlySqlStatement("SHOW TABLES")).toThrow(
       "Read-only SQL must start with SELECT or WITH ... SELECT",
+    );
+  });
+
+  it("accepts SELECT expression with immediate parenthesis", () => {
+    expect(assertReadOnlySqlStatement("SELECT(1+1)")).toBe("SELECT(1+1)");
+  });
+
+  it("accepts SELECT(column) with FROM clause", () => {
+    expect(assertReadOnlySqlStatement("SELECT(col) FROM main.sales.orders")).toBe(
+      "SELECT(col) FROM main.sales.orders",
+    );
+  });
+
+  it("rejects invalid SELECT-prefixed identifier", () => {
+    expect(() => assertReadOnlySqlStatement("SELECTFOO FROM main.sales.orders")).toThrow(
+      DatabricksPolicyError,
     );
   });
 
@@ -78,5 +95,47 @@ describe("databricks allowlist policy", () => {
         ambiguousTargets: false,
       }),
     ).toThrow('Schema "private" is not in the configured allowlist');
+  });
+
+  it("accepts LEFT OUTER JOIN targets when allowlists match", () => {
+    const resolution = resolveSqlTargets(
+      "SELECT * FROM main.sales.orders LEFT OUTER JOIN main.sales.customers ON orders.id = customers.id",
+    );
+    expect(() =>
+      assertAllowlistTarget({
+        allowedCatalogs: ["main"],
+        allowedSchemas: ["sales"],
+        targets: resolution.targets,
+        ambiguousTargets: resolution.ambiguous,
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts RIGHT OUTER JOIN targets when allowlists match", () => {
+    const resolution = resolveSqlTargets(
+      "SELECT * FROM main.sales.orders RIGHT OUTER JOIN main.sales.customers ON orders.id = customers.id",
+    );
+    expect(() =>
+      assertAllowlistTarget({
+        allowedCatalogs: ["main"],
+        allowedSchemas: ["sales"],
+        targets: resolution.targets,
+        ambiguousTargets: resolution.ambiguous,
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts FULL OUTER JOIN targets when allowlists match", () => {
+    const resolution = resolveSqlTargets(
+      "SELECT * FROM main.sales.orders FULL OUTER JOIN main.sales.customers ON orders.id = customers.id",
+    );
+    expect(() =>
+      assertAllowlistTarget({
+        allowedCatalogs: ["main"],
+        allowedSchemas: ["sales"],
+        targets: resolution.targets,
+        ambiguousTargets: resolution.ambiguous,
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/openclaw-databricks-plugin/src/security-policy.test.ts
+++ b/packages/openclaw-databricks-plugin/src/security-policy.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { DatabricksAllowlistError, DatabricksPolicyError } from "./errors.js";
+import { assertAllowlistTarget, assertReadOnlySqlStatement } from "./security-policy.js";
+
+describe("databricks read-only sql policy", () => {
+  it("accepts SELECT", () => {
+    const sql = assertReadOnlySqlStatement("SELECT id, name FROM analytics.users;");
+    expect(sql).toBe("SELECT id, name FROM analytics.users");
+  });
+
+  it("accepts WITH ... SELECT", () => {
+    const sql = assertReadOnlySqlStatement(
+      "WITH recent AS (SELECT * FROM events) SELECT * FROM recent",
+    );
+    expect(sql).toContain("WITH recent");
+  });
+
+  it("rejects mutating statement", () => {
+    expect(() => assertReadOnlySqlStatement("SELECT * FROM users; DELETE FROM users")).toThrow(
+      DatabricksPolicyError,
+    );
+  });
+
+  it("rejects non-select statement", () => {
+    expect(() => assertReadOnlySqlStatement("SHOW TABLES")).toThrow(
+      "Read-only SQL must start with SELECT or WITH ... SELECT",
+    );
+  });
+
+  it("ignores mutating keywords inside string literals", () => {
+    const sql = assertReadOnlySqlStatement("SELECT 'drop table users' AS note");
+    expect(sql).toBe("SELECT 'drop table users' AS note");
+  });
+});
+
+describe("databricks allowlist policy", () => {
+  it("accepts targets inside allowlist", () => {
+    expect(() =>
+      assertAllowlistTarget({
+        allowedCatalogs: ["main"],
+        allowedSchemas: ["public"],
+        targets: [
+          {
+            catalog: "main",
+            schema: "public",
+            table: "orders",
+            raw: "main.public.orders",
+          },
+        ],
+        ambiguousTargets: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it("fails closed when targets are ambiguous", () => {
+    expect(() =>
+      assertAllowlistTarget({
+        allowedCatalogs: ["main"],
+        allowedSchemas: [],
+        targets: [],
+        ambiguousTargets: true,
+      }),
+    ).toThrow(DatabricksAllowlistError);
+  });
+
+  it("rejects non-allowlisted schema", () => {
+    expect(() =>
+      assertAllowlistTarget({
+        allowedCatalogs: [],
+        allowedSchemas: ["public"],
+        targets: [
+          {
+            schema: "private",
+            table: "events",
+            raw: "private.events",
+          },
+        ],
+        ambiguousTargets: false,
+      }),
+    ).toThrow('Schema "private" is not in the configured allowlist');
+  });
+});

--- a/packages/openclaw-databricks-plugin/src/security-policy.ts
+++ b/packages/openclaw-databricks-plugin/src/security-policy.ts
@@ -1,0 +1,179 @@
+import { DatabricksAllowlistError, DatabricksPolicyError } from "./errors.js";
+import type { ResolvedSqlTarget } from "./sql-target-resolution.js";
+
+const MUTATING_KEYWORDS = [
+  "INSERT",
+  "UPDATE",
+  "DELETE",
+  "MERGE",
+  "ALTER",
+  "DROP",
+  "TRUNCATE",
+  "CREATE",
+  "GRANT",
+  "REVOKE",
+  "CALL",
+  "COPY",
+  "REPLACE",
+] as const;
+
+export function stripSqlCommentsAndLiterals(sql: string): string {
+  let result = "";
+  let index = 0;
+
+  while (index < sql.length) {
+    const current = sql[index];
+    const next = sql[index + 1];
+
+    if (current === "'" || current === '"' || current === "`") {
+      const quote = current;
+      result += " ";
+      index += 1;
+      while (index < sql.length) {
+        const ch = sql[index];
+        const peek = sql[index + 1];
+        if (ch === quote) {
+          if (quote === "'" && peek === "'") {
+            index += 2;
+            continue;
+          }
+          index += 1;
+          break;
+        }
+        index += 1;
+      }
+      continue;
+    }
+
+    if (current === "-" && next === "-") {
+      index += 2;
+      while (index < sql.length && sql[index] !== "\n") {
+        index += 1;
+      }
+      result += " ";
+      continue;
+    }
+
+    if (current === "/" && next === "*") {
+      index += 2;
+      while (index < sql.length) {
+        if (sql[index] === "*" && sql[index + 1] === "/") {
+          index += 2;
+          break;
+        }
+        index += 1;
+      }
+      result += " ";
+      continue;
+    }
+
+    result += current;
+    index += 1;
+  }
+
+  return result;
+}
+
+function assertSingleStatement(sql: string): void {
+  const withoutComments = stripSqlCommentsAndLiterals(sql);
+  const trimmed = withoutComments.trim().replace(/;+\s*$/u, "");
+  if (trimmed.includes(";")) {
+    throw new DatabricksPolicyError("Only a single SQL statement is allowed in read-only mode.");
+  }
+}
+
+function assertAllowedStartingClause(sql: string): void {
+  const normalized = stripSqlCommentsAndLiterals(sql).trim().replace(/\s+/gu, " ").toUpperCase();
+  if (normalized.startsWith("SELECT ")) {
+    return;
+  }
+  if (normalized.startsWith("WITH ") && /\bSELECT\b/u.test(normalized)) {
+    return;
+  }
+  throw new DatabricksPolicyError(
+    "Read-only SQL must start with SELECT or WITH ... SELECT in this Databricks runtime iteration.",
+  );
+}
+
+function assertNoMutatingKeyword(sql: string): void {
+  const normalized = stripSqlCommentsAndLiterals(sql).toUpperCase();
+  for (const keyword of MUTATING_KEYWORDS) {
+    const pattern = new RegExp(`\\b${keyword}\\b`, "u");
+    if (pattern.test(normalized)) {
+      throw new DatabricksPolicyError(
+        `Read-only SQL policy rejected statement because it contains disallowed keyword: ${keyword}.`,
+      );
+    }
+  }
+}
+
+export function assertReadOnlySqlStatement(rawSql: string): string {
+  const sql = rawSql.trim();
+  if (!sql) {
+    throw new DatabricksPolicyError("SQL statement is required.");
+  }
+  assertSingleStatement(sql);
+  assertAllowedStartingClause(sql);
+  assertNoMutatingKeyword(sql);
+  return sql.replace(/;+\s*$/u, "");
+}
+
+export function hasAllowlist(params: {
+  allowedCatalogs: readonly string[];
+  allowedSchemas: readonly string[];
+}): boolean {
+  return params.allowedCatalogs.length > 0 || params.allowedSchemas.length > 0;
+}
+
+export function assertAllowlistTarget(params: {
+  allowedCatalogs: readonly string[];
+  allowedSchemas: readonly string[];
+  targets: readonly ResolvedSqlTarget[];
+  ambiguousTargets: boolean;
+}): void {
+  const allowedCatalogs = params.allowedCatalogs.map((entry) => entry.toLowerCase());
+  const allowedSchemas = params.allowedSchemas.map((entry) => entry.toLowerCase());
+
+  if (allowedCatalogs.length === 0 && allowedSchemas.length === 0) {
+    return;
+  }
+
+  if (params.ambiguousTargets) {
+    throw new DatabricksAllowlistError(
+      "Allowlist is configured, but query targets are ambiguous or unsupported.",
+    );
+  }
+  if (params.targets.length === 0) {
+    throw new DatabricksAllowlistError(
+      "Allowlist is configured, but query targets could not be determined safely.",
+    );
+  }
+
+  for (const target of params.targets) {
+    if (allowedCatalogs.length > 0) {
+      if (!target.catalog) {
+        throw new DatabricksAllowlistError(
+          `Catalog allowlist is configured, but target "${target.raw}" has no explicit catalog.`,
+        );
+      }
+      if (!allowedCatalogs.includes(target.catalog)) {
+        throw new DatabricksAllowlistError(
+          `Catalog "${target.catalog}" is not in the configured allowlist.`,
+        );
+      }
+    }
+
+    if (allowedSchemas.length > 0) {
+      if (!target.schema) {
+        throw new DatabricksAllowlistError(
+          `Schema allowlist is configured, but target "${target.raw}" has no explicit schema.`,
+        );
+      }
+      if (!allowedSchemas.includes(target.schema)) {
+        throw new DatabricksAllowlistError(
+          `Schema "${target.schema}" is not in the configured allowlist.`,
+        );
+      }
+    }
+  }
+}

--- a/packages/openclaw-databricks-plugin/src/security-policy.ts
+++ b/packages/openclaw-databricks-plugin/src/security-policy.ts
@@ -84,10 +84,10 @@ function assertSingleStatement(sql: string): void {
 
 function assertAllowedStartingClause(sql: string): void {
   const normalized = stripSqlCommentsAndLiterals(sql).trim().replace(/\s+/gu, " ").toUpperCase();
-  if (normalized.startsWith("SELECT ")) {
+  if (/^SELECT\b/u.test(normalized)) {
     return;
   }
-  if (normalized.startsWith("WITH ") && /\bSELECT\b/u.test(normalized)) {
+  if (/^WITH\b/u.test(normalized) && /\bSELECT\b/u.test(normalized)) {
     return;
   }
   throw new DatabricksPolicyError(

--- a/packages/openclaw-databricks-plugin/src/sql-target-resolution.test.ts
+++ b/packages/openclaw-databricks-plugin/src/sql-target-resolution.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { resolveSqlTargets } from "./sql-target-resolution.js";
+
+describe("sql target resolution", () => {
+  it("resolves catalog.schema.table references", () => {
+    expect(resolveSqlTargets("select * from main.sales.orders")).toEqual({
+      ambiguous: false,
+      targets: [
+        {
+          catalog: "main",
+          schema: "sales",
+          table: "orders",
+          raw: "main.sales.orders",
+        },
+      ],
+    });
+  });
+
+  it("resolves schema.table references", () => {
+    expect(resolveSqlTargets("select * from sales.orders")).toEqual({
+      ambiguous: false,
+      targets: [
+        {
+          schema: "sales",
+          table: "orders",
+          raw: "sales.orders",
+        },
+      ],
+    });
+  });
+
+  it("deduplicates targets across joins", () => {
+    expect(
+      resolveSqlTargets(
+        "select * from sales.orders o join core.customers c on o.id = c.id join sales.orders o2 on o2.id = c.id",
+      ),
+    ).toEqual({
+      ambiguous: false,
+      targets: [
+        {
+          schema: "sales",
+          table: "orders",
+          raw: "sales.orders",
+        },
+        {
+          schema: "core",
+          table: "customers",
+          raw: "core.customers",
+        },
+      ],
+    });
+  });
+
+  it("resolves physical targets from WITH and ignores cte aliases", () => {
+    expect(resolveSqlTargets("with c as (select * from sales.orders) select * from c")).toEqual({
+      ambiguous: false,
+      targets: [
+        {
+          schema: "sales",
+          table: "orders",
+          raw: "sales.orders",
+        },
+      ],
+    });
+  });
+
+  it("marks single-part table references as ambiguous", () => {
+    expect(resolveSqlTargets("select * from orders")).toEqual({
+      ambiguous: true,
+      targets: [],
+    });
+  });
+
+  it("marks malformed quoted identifiers as ambiguous", () => {
+    expect(resolveSqlTargets("select * from `main.sales.orders")).toEqual({
+      ambiguous: true,
+      targets: [],
+    });
+  });
+
+  it("marks invalid cross join syntax as ambiguous", () => {
+    expect(resolveSqlTargets("select * from sales.orders cross apply foo.bar")).toEqual({
+      ambiguous: true,
+      targets: [],
+    });
+  });
+
+  it("marks multi-statement sql as ambiguous", () => {
+    expect(resolveSqlTargets("select * from sales.orders; select * from core.customers")).toEqual({
+      ambiguous: true,
+      targets: [],
+    });
+  });
+});

--- a/packages/openclaw-databricks-plugin/src/sql-target-resolution.ts
+++ b/packages/openclaw-databricks-plugin/src/sql-target-resolution.ts
@@ -1,0 +1,497 @@
+export type ResolvedSqlTarget = {
+  catalog?: string;
+  schema?: string;
+  table: string;
+  raw: string;
+};
+
+type SqlToken = {
+  kind: "identifier" | "symbol" | "keyword";
+  value: string;
+};
+
+type ParseQualifiedResult =
+  | { kind: "target"; nextIndex: number; target: ResolvedSqlTarget }
+  | { kind: "cte"; nextIndex: number }
+  | { kind: "ambiguous"; nextIndex: number }
+  | { kind: "malformed"; nextIndex: number };
+
+export type SqlTargetResolution = {
+  targets: ResolvedSqlTarget[];
+  ambiguous: boolean;
+};
+
+const CLAUSE_BOUNDARY_KEYWORDS = new Set([
+  "WHERE",
+  "GROUP",
+  "ORDER",
+  "HAVING",
+  "LIMIT",
+  "UNION",
+  "EXCEPT",
+  "INTERSECT",
+  "QUALIFY",
+  "WINDOW",
+  "ON",
+  "USING",
+]);
+
+const PARSER_KEYWORDS = new Set([
+  "WITH",
+  "AS",
+  "FROM",
+  "JOIN",
+  "LEFT",
+  "RIGHT",
+  "FULL",
+  "INNER",
+  "CROSS",
+  "ON",
+  "USING",
+  "WHERE",
+  "GROUP",
+  "ORDER",
+  "HAVING",
+  "LIMIT",
+  "UNION",
+  "EXCEPT",
+  "INTERSECT",
+  "QUALIFY",
+  "WINDOW",
+]);
+
+function normalizeIdentifier(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function stripSqlCommentsAndStringLiterals(sql: string): string {
+  let result = "";
+  for (let index = 0; index < sql.length; ) {
+    const current = sql[index];
+    const next = sql[index + 1];
+    if (!current) {
+      break;
+    }
+
+    if (current === "'" || current === '"') {
+      const quote = current;
+      result += " ";
+      index += 1;
+      while (index < sql.length) {
+        const char = sql[index];
+        const peek = sql[index + 1];
+        if (char === quote) {
+          if (quote === "'" && peek === "'") {
+            index += 2;
+            continue;
+          }
+          index += 1;
+          break;
+        }
+        index += 1;
+      }
+      continue;
+    }
+
+    if (current === "-" && next === "-") {
+      index += 2;
+      while (index < sql.length && sql[index] !== "\n") {
+        index += 1;
+      }
+      result += " ";
+      continue;
+    }
+
+    if (current === "/" && next === "*") {
+      index += 2;
+      while (index < sql.length) {
+        if (sql[index] === "*" && sql[index + 1] === "/") {
+          index += 2;
+          break;
+        }
+        index += 1;
+      }
+      result += " ";
+      continue;
+    }
+
+    result += current;
+    index += 1;
+  }
+
+  return result;
+}
+
+function buildResolvedTarget(parts: string[]): ResolvedSqlTarget | null {
+  if (parts.length === 2) {
+    const [schema, table] = parts;
+    if (!schema || !table) {
+      return null;
+    }
+    return { schema, table, raw: `${schema}.${table}` };
+  }
+  if (parts.length === 3) {
+    const [catalog, schema, table] = parts;
+    if (!catalog || !schema || !table) {
+      return null;
+    }
+    return { catalog, schema, table, raw: `${catalog}.${schema}.${table}` };
+  }
+  return null;
+}
+
+function isIdentifierStart(char: string): boolean {
+  return /[A-Za-z_]/u.test(char);
+}
+
+function isIdentifierPart(char: string): boolean {
+  return /[A-Za-z0-9_$]/u.test(char);
+}
+
+function tokenizeSql(sql: string): { tokens: SqlToken[]; malformed: boolean } {
+  const tokens: SqlToken[] = [];
+  for (let index = 0; index < sql.length; ) {
+    const char = sql[index];
+    if (!char) {
+      break;
+    }
+
+    if (/\s/u.test(char)) {
+      index += 1;
+      continue;
+    }
+
+    if (char === "`") {
+      let cursor = index + 1;
+      let value = "";
+      let closed = false;
+      while (cursor < sql.length) {
+        const current = sql[cursor];
+        if (current === "`") {
+          if (sql[cursor + 1] === "`") {
+            value += "`";
+            cursor += 2;
+            continue;
+          }
+          closed = true;
+          break;
+        }
+        value += current;
+        cursor += 1;
+      }
+      if (!closed) {
+        return { tokens: [], malformed: true };
+      }
+      const normalized = normalizeIdentifier(value);
+      if (!normalized) {
+        return { tokens: [], malformed: true };
+      }
+      tokens.push({ kind: "identifier", value: normalized });
+      index = cursor + 1;
+      continue;
+    }
+
+    if (isIdentifierStart(char)) {
+      let cursor = index + 1;
+      while (cursor < sql.length && isIdentifierPart(sql[cursor] ?? "")) {
+        cursor += 1;
+      }
+      const value = sql.slice(index, cursor);
+      const upper = value.toUpperCase();
+      if (PARSER_KEYWORDS.has(upper)) {
+        tokens.push({ kind: "keyword", value: upper });
+      } else {
+        tokens.push({ kind: "identifier", value: normalizeIdentifier(value) });
+      }
+      index = cursor;
+      continue;
+    }
+
+    if (char === "." || char === "(" || char === ")" || char === "," || char === ";") {
+      tokens.push({ kind: "symbol", value: char });
+      index += 1;
+      continue;
+    }
+
+    index += 1;
+    continue;
+  }
+
+  return { tokens, malformed: false };
+}
+
+function validateBalancedParentheses(tokens: SqlToken[]): boolean {
+  let depth = 0;
+  for (const token of tokens) {
+    if (token.kind !== "symbol") {
+      continue;
+    }
+    if (token.value === "(") {
+      depth += 1;
+    } else if (token.value === ")") {
+      depth -= 1;
+      if (depth < 0) {
+        return false;
+      }
+    }
+  }
+  return depth === 0;
+}
+
+function parseLeadingWithClause(tokens: SqlToken[]): { ok: boolean; cteNames: Set<string> } {
+  const cteNames = new Set<string>();
+  if (tokens.length === 0 || tokens[0]?.value !== "WITH") {
+    return { ok: true, cteNames };
+  }
+
+  let cursor = 1;
+  while (cursor < tokens.length) {
+    const cteName = tokens[cursor];
+    if (!cteName || cteName.kind !== "identifier") {
+      return { ok: false, cteNames: new Set() };
+    }
+    cteNames.add(cteName.value);
+    cursor += 1;
+
+    if (tokens[cursor]?.value === "(") {
+      let depth = 1;
+      cursor += 1;
+      while (cursor < tokens.length && depth > 0) {
+        const token = tokens[cursor];
+        if (token?.value === "(") {
+          depth += 1;
+        } else if (token?.value === ")") {
+          depth -= 1;
+        }
+        cursor += 1;
+      }
+      if (depth !== 0) {
+        return { ok: false, cteNames: new Set() };
+      }
+    }
+
+    if (tokens[cursor]?.value !== "AS") {
+      return { ok: false, cteNames: new Set() };
+    }
+    cursor += 1;
+
+    if (tokens[cursor]?.value !== "(") {
+      return { ok: false, cteNames: new Set() };
+    }
+    let subqueryDepth = 1;
+    cursor += 1;
+    while (cursor < tokens.length && subqueryDepth > 0) {
+      const token = tokens[cursor];
+      if (token?.value === "(") {
+        subqueryDepth += 1;
+      } else if (token?.value === ")") {
+        subqueryDepth -= 1;
+      }
+      cursor += 1;
+    }
+    if (subqueryDepth !== 0) {
+      return { ok: false, cteNames: new Set() };
+    }
+
+    if (tokens[cursor]?.value === ",") {
+      cursor += 1;
+      continue;
+    }
+    break;
+  }
+
+  return { ok: true, cteNames };
+}
+
+function parseQualifiedReference(
+  tokens: SqlToken[],
+  startIndex: number,
+  cteNames: ReadonlySet<string>,
+): ParseQualifiedResult {
+  const first = tokens[startIndex];
+  if (!first || first.kind !== "identifier") {
+    return { kind: "malformed", nextIndex: startIndex };
+  }
+
+  const parts = [first.value];
+  let cursor = startIndex + 1;
+
+  while (tokens[cursor]?.value === ".") {
+    const next = tokens[cursor + 1];
+    if (!next || next.kind !== "identifier") {
+      return { kind: "malformed", nextIndex: cursor + 1 };
+    }
+    parts.push(next.value);
+    cursor += 2;
+    if (parts.length > 3) {
+      return { kind: "malformed", nextIndex: cursor };
+    }
+  }
+
+  if (parts.length === 1) {
+    if (cteNames.has(parts[0])) {
+      return { kind: "cte", nextIndex: cursor };
+    }
+    return { kind: "ambiguous", nextIndex: cursor };
+  }
+
+  const target = buildResolvedTarget(parts);
+  if (!target) {
+    return { kind: "malformed", nextIndex: cursor };
+  }
+  return { kind: "target", target, nextIndex: cursor };
+}
+
+function isKeyword(token: SqlToken | undefined, keyword: string): boolean {
+  return Boolean(token && token.kind === "keyword" && token.value === keyword);
+}
+
+function skipAlias(tokens: SqlToken[], index: number): number {
+  let cursor = index;
+  if (isKeyword(tokens[cursor], "AS")) {
+    cursor += 1;
+  }
+  if (tokens[cursor]?.kind === "identifier") {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function addTarget(
+  targets: ResolvedSqlTarget[],
+  seen: Set<string>,
+  target: ResolvedSqlTarget,
+): void {
+  const key = `${target.catalog ?? ""}|${target.schema ?? ""}|${target.table}`;
+  if (seen.has(key)) {
+    return;
+  }
+  seen.add(key);
+  targets.push(target);
+}
+
+function skipParenthesized(tokens: SqlToken[], index: number): number | null {
+  if (tokens[index]?.value !== "(") {
+    return null;
+  }
+  let depth = 1;
+  let cursor = index + 1;
+  while (cursor < tokens.length && depth > 0) {
+    const token = tokens[cursor];
+    if (token?.value === "(") {
+      depth += 1;
+    } else if (token?.value === ")") {
+      depth -= 1;
+    }
+    cursor += 1;
+  }
+  if (depth !== 0) {
+    return null;
+  }
+  return cursor;
+}
+
+function parseSourceList(
+  tokens: SqlToken[],
+  startIndex: number,
+  cteNames: ReadonlySet<string>,
+  targets: ResolvedSqlTarget[],
+  seen: Set<string>,
+): { nextIndex: number; ambiguous: boolean } {
+  let cursor = startIndex;
+  while (cursor < tokens.length) {
+    const token = tokens[cursor];
+    if (!token) {
+      return { nextIndex: cursor, ambiguous: true };
+    }
+
+    if (token.value === "(") {
+      const end = skipParenthesized(tokens, cursor);
+      if (end === null) {
+        return { nextIndex: cursor, ambiguous: true };
+      }
+      cursor = skipAlias(tokens, end);
+    } else if (token.kind === "identifier") {
+      const parsed = parseQualifiedReference(tokens, cursor, cteNames);
+      if (parsed.kind === "malformed" || parsed.kind === "ambiguous") {
+        return { nextIndex: parsed.nextIndex, ambiguous: true };
+      }
+      if (parsed.kind === "target") {
+        addTarget(targets, seen, parsed.target);
+      }
+      cursor = skipAlias(tokens, parsed.nextIndex);
+    } else {
+      return { nextIndex: cursor, ambiguous: true };
+    }
+
+    const next = tokens[cursor];
+    if (!next) {
+      return { nextIndex: cursor, ambiguous: false };
+    }
+    if (next.value === ",") {
+      cursor += 1;
+      continue;
+    }
+    if (isKeyword(next, "JOIN")) {
+      cursor += 1;
+      continue;
+    }
+    if (
+      isKeyword(next, "LEFT") ||
+      isKeyword(next, "RIGHT") ||
+      isKeyword(next, "FULL") ||
+      isKeyword(next, "INNER") ||
+      isKeyword(next, "CROSS")
+    ) {
+      cursor += 1;
+      if (!isKeyword(tokens[cursor], "JOIN")) {
+        return { nextIndex: cursor, ambiguous: true };
+      }
+      cursor += 1;
+      continue;
+    }
+    if (next.kind === "keyword" && CLAUSE_BOUNDARY_KEYWORDS.has(next.value)) {
+      return { nextIndex: cursor, ambiguous: false };
+    }
+    if (next.value === ")") {
+      return { nextIndex: cursor, ambiguous: false };
+    }
+    return { nextIndex: cursor, ambiguous: true };
+  }
+
+  return { nextIndex: cursor, ambiguous: false };
+}
+
+export function resolveSqlTargets(rawSql: string): SqlTargetResolution {
+  const sanitized = stripSqlCommentsAndStringLiterals(rawSql);
+  const { tokens, malformed } = tokenizeSql(sanitized);
+  if (malformed) {
+    return { targets: [], ambiguous: true };
+  }
+  if (!validateBalancedParentheses(tokens)) {
+    return { targets: [], ambiguous: true };
+  }
+  if (tokens.some((token) => token.kind === "symbol" && token.value === ";")) {
+    return { targets: [], ambiguous: true };
+  }
+
+  const withParsed = parseLeadingWithClause(tokens);
+  if (!withParsed.ok) {
+    return { targets: [], ambiguous: true };
+  }
+
+  const seen = new Set<string>();
+  const targets: ResolvedSqlTarget[] = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (!isKeyword(tokens[index], "FROM")) {
+      continue;
+    }
+    const parsed = parseSourceList(tokens, index + 1, withParsed.cteNames, targets, seen);
+    if (parsed.ambiguous) {
+      return { targets: [], ambiguous: true };
+    }
+    index = Math.max(index, parsed.nextIndex - 1);
+  }
+
+  return { targets, ambiguous: false };
+}

--- a/packages/openclaw-databricks-plugin/src/sql-target-resolution.ts
+++ b/packages/openclaw-databricks-plugin/src/sql-target-resolution.ts
@@ -44,6 +44,7 @@ const PARSER_KEYWORDS = new Set([
   "LEFT",
   "RIGHT",
   "FULL",
+  "OUTER",
   "INNER",
   "CROSS",
   "ON",
@@ -443,7 +444,14 @@ function parseSourceList(
       isKeyword(next, "INNER") ||
       isKeyword(next, "CROSS")
     ) {
+      const joinModifier = next.value;
       cursor += 1;
+      if (
+        (joinModifier === "LEFT" || joinModifier === "RIGHT" || joinModifier === "FULL") &&
+        isKeyword(tokens[cursor], "OUTER")
+      ) {
+        cursor += 1;
+      }
       if (!isKeyword(tokens[cursor], "JOIN")) {
         return { nextIndex: cursor, ambiguous: true };
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1267,6 +1267,25 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  packages/openclaw-databricks-plugin:
+    dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.49
+        version: 0.34.49
+      zod:
+        specifier: ^4.1.12
+        version: 4.3.6
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@25.6.0)(@vitest/browser@4.1.4)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/plugin-package-contract: {}
 
   packages/plugin-sdk: {}
@@ -3563,6 +3582,144 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.15':
     resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@scure/base@2.0.0':
     resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
 
@@ -4192,8 +4349,22 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/expect@4.1.4':
     resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@4.1.4':
     resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
@@ -4206,17 +4377,32 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/pretty-format@4.1.4':
     resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
   '@vitest/runner@4.1.4':
     resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
 
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
   '@vitest/snapshot@4.1.4':
     resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/spy@4.1.4':
     resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
@@ -4549,6 +4735,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
@@ -4566,6 +4756,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -4591,6 +4785,10 @@ packages:
 
   character-parser@2.2.0:
     resolution: {integrity: sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chmodrp@1.0.2:
     resolution: {integrity: sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w==}
@@ -4776,6 +4974,10 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -4912,6 +5114,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -5491,6 +5696,9 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   jscpd-sarif-reporter@4.0.7:
     resolution: {integrity: sha512-Q/VlfTI/Nbjc8dZ/2pDVIf1aRi2bM2CTYujcAoeYr7brRnS4o5ZeW86W8q7MM7cQu40gezlNckl+E9wKFSMFiA==}
 
@@ -5734,6 +5942,9 @@ packages:
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lowdb@7.0.1:
     resolution: {integrity: sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw==}
@@ -6240,6 +6451,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   pdfjs-dist@5.6.205:
     resolution: {integrity: sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==}
     engines: {node: '>=20.19.0 || >=22.13.0 || >=24'}
@@ -6577,6 +6792,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rollup@4.60.1:
+    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -6864,6 +7084,9 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
@@ -6920,6 +7143,9 @@ packages:
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -6928,12 +7154,24 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
@@ -7023,6 +7261,11 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@6.0.2:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
@@ -7145,6 +7388,51 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -7186,6 +7474,34 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@4.1.4:
@@ -10010,6 +10326,81 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.15': {}
 
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    optional: true
+
   '@scure/base@2.0.0': {}
 
   '@scure/bip32@2.0.1':
@@ -10838,6 +11229,14 @@ snapshots:
     optionalDependencies:
       '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@4.1.4':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -10847,6 +11246,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
   '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
@@ -10855,13 +11262,29 @@ snapshots:
     optionalDependencies:
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
 
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
   '@vitest/runner@4.1.4':
     dependencies:
       '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.4':
@@ -10871,7 +11294,17 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -11210,6 +11643,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   cac@7.0.0: {}
 
   cacheable@2.3.4:
@@ -11232,6 +11667,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chai@6.2.2: {}
 
   chalk-template@0.4.0:
@@ -11252,6 +11695,8 @@ snapshots:
   character-parser@2.2.0:
     dependencies:
       is-regex: 1.2.1
+
+  check-error@2.1.3: {}
 
   chmodrp@1.0.2: {}
 
@@ -11427,6 +11872,8 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  deep-eql@5.0.2: {}
+
   deep-extend@0.6.0: {}
 
   defu@6.1.5: {}
@@ -11531,6 +11978,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -12277,6 +12726,8 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   jscpd-sarif-reporter@4.0.7:
     dependencies:
       colors: 1.4.0
@@ -12536,6 +12987,8 @@ snapshots:
   long@4.0.0: {}
 
   long@5.3.2: {}
+
+  loupe@3.2.1: {}
 
   lowdb@7.0.1:
     dependencies:
@@ -13123,6 +13576,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.1: {}
+
   pdfjs-dist@5.6.205:
     optionalDependencies:
       '@napi-rs/canvas': 0.1.97
@@ -13543,6 +13998,37 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
+  rollup@4.60.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.1
+      '@rollup/rollup-android-arm64': 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-darwin-x64': 4.60.1
+      '@rollup/rollup-freebsd-arm64': 4.60.1
+      '@rollup/rollup-freebsd-x64': 4.60.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-loong64-gnu': 4.60.1
+      '@rollup/rollup-linux-loong64-musl': 4.60.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+      '@rollup/rollup-linux-ppc64-musl': 4.60.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+      '@rollup/rollup-linux-riscv64-musl': 4.60.1
+      '@rollup/rollup-linux-s390x-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-openbsd-x64': 4.60.1
+      '@rollup/rollup-openharmony-arm64': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-ia32-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      fsevents: 2.3.3
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -13887,6 +14373,10 @@ snapshots:
 
   strip-json-comments@2.0.1: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   strnum@2.2.3: {}
 
   strtok3@10.3.5:
@@ -13969,6 +14459,8 @@ snapshots:
 
   tinycolor2@1.6.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
@@ -13976,9 +14468,15 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinypool@1.1.1: {}
+
   tinypool@2.1.0: {}
 
+  tinyrainbow@2.0.0: {}
+
   tinyrainbow@3.1.0: {}
+
+  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -14062,6 +14560,8 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typescript@5.9.3: {}
 
   typescript@6.0.2: {}
 
@@ -14161,6 +14661,43 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rollup: 4.60.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      tsx: 4.21.0
+      yaml: 2.8.3
+
   vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -14175,6 +14712,49 @@ snapshots:
       jiti: 2.6.1
       tsx: 4.21.0
       yaml: 2.8.3
+
+  vitest@3.2.4(@types/node@25.6.0)(@vitest/browser@4.1.4)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      jsdom: 29.0.2(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@2.0.1))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -100,8 +100,8 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     rawBody: params.ctx.CommandBody ?? params.ctx.RawBody ?? params.ctx.Body,
     ctx: params.ctx,
     cfg: params.cfg,
-    agentId: sessionAgentId,
     isGroup: params.isGroup,
+    ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
   });
   const result = await runtime.compactEmbeddedPiSession({
     sessionId,

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -1,4 +1,8 @@
-import { resolveAgentDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
+import {
+  resolveAgentDir,
+  resolveSessionAgentId,
+  resolveSessionAgentIds,
+} from "../../agents/agent-scope.js";
 import { resolveModelAuthLabel } from "../../agents/model-auth-label.js";
 import { loadModelCatalog } from "../../agents/model-catalog.js";
 import {
@@ -389,7 +393,10 @@ export const handleModelsCommand: CommandHandler = async (params, allowTextComma
         sessionKey: params.sessionKey,
         config: params.cfg,
       })
-    : params.agentId;
+    : resolveSessionAgentIds({
+        config: params.cfg,
+        agentId: params.agentId,
+      }).sessionAgentId;
   const modelsAgentDir = resolveAgentDir(params.cfg, modelsAgentId);
 
   const reply = await resolveModelsCommandReply({

--- a/src/commands/agents.test.ts
+++ b/src/commands/agents.test.ts
@@ -208,7 +208,7 @@ describe("agents helpers", () => {
         agentId: "main",
         match: {
           channel: "discord",
-          peer: { kind: "user", id: "a|b" },
+          peer: { kind: "direct", id: "a|b" },
           accountId: "default",
         },
       },
@@ -216,7 +216,7 @@ describe("agents helpers", () => {
         agentId: "main",
         match: {
           channel: "discord",
-          peer: { kind: "user", id: "a" },
+          peer: { kind: "direct", id: "a" },
           guildId: "b",
           accountId: "|default",
         },


### PR DESCRIPTION
## Context

Databricks support was originally proposed for `openclaw/openclaw` core, but new plugins are no longer accepted as bundled core additions.
This change ships Databricks as an external plugin package aligned with the ClawHub/npm distribution path.

## What This PR Resolves

This PR adds an external Databricks plugin at:

- `packages/openclaw-databricks-plugin`

Key outcomes:

- External packaging and metadata aligned for ClawHub/npm installation.
- Read-only SQL runtime tool (`databricks_sql_readonly`) with conservative policy.
- Host validation hardening with fail-closed behavior (HTTPS/domain constraints, unsafe host rejection).
- SQL lifecycle hardening:
  - terminal-state aware polling
  - explicit handling for success/failure terminal states
  - bounded timeout behavior
- Real retry behavior for transient submit/poll failures (using configured retry policy).
- Conservative SQL target resolution and allowlist enforcement with fail-closed semantics on ambiguity.
- Sanitized errors/logging to avoid leaking secrets/tokens/authorization values.

## Out of Scope (Intentionally Not Added)

- No expansion beyond read-only SQL scope.
- No Jobs API execution.
- No Unity Catalog lineage integration.
- No mutating SQL support.

## Validation Executed

- Format:
  - `pnpm exec oxfmt --check packages/openclaw-databricks-plugin`
- Lint:
  - `pnpm exec oxlint --type-aware packages/openclaw-databricks-plugin`
- Typecheck:
  - `NODE_OPTIONS=--max-old-space-size=12288 pnpm exec tsc -p tsconfig.json --noEmit --pretty false`
- Tests:
  - `pnpm test -- packages/openclaw-databricks-plugin`
- Packaging:
  - `npm pack --dry-run` (inside `packages/openclaw-databricks-plugin`)

All passed locally.

## Residual Risks / Observations

- The plugin is published externally as `@kansodata/openclaw-databricks-plugin`.
- This PR keeps the package in-tree only to document and review the external plugin shape for OpenClaw compatibility.
- Local temporary folders are intentionally not part of this PR.
