### PR TITLE
Docs: clarify Discord bot allowlists

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -395,7 +395,6 @@ Example:
 
     - `user:<id>`
     - `<@id>` mention
-    - bot sender IDs should be listed as bare IDs in `allowFrom`; `bot:` is not a recognized prefix
 
     Bare numeric IDs are ambiguous and rejected unless an explicit user/channel target kind is provided.
 

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1186,8 +1186,8 @@ openclaw logs --follow
 
     If you set `channels.discord.allowBots=true`, use strict mention and allowlist rules to avoid loop behavior.
     Prefer `channels.discord.allowBots="mentions"` to only accept bot messages that mention the bot.
-    For guild messaging, `guilds.<id>.users` is the primary gate: if that allowlist is non-empty, the sending bot ID must be listed there before `allowBots` matters.
-    `allowFrom` does not recognize a `bot:` prefix; use the raw bot user ID or add the bot to `guilds.<id>.users`.
+    For guild messaging, `guilds.<id>.users` and `guilds.<id>.roles` are evaluated together for member access; a sender can pass via either allowlist.
+    `allowBots` is orthogonal and only determines whether bot-authored messages are admitted at all, with mention checks when set to `mentions`.
 
   </Accordion>
 

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -395,6 +395,7 @@ Example:
 
     - `user:<id>`
     - `<@id>` mention
+    - bot sender IDs should be listed as bare IDs in `allowFrom`; `bot:` is not a recognized prefix
 
     Bare numeric IDs are ambiguous and rejected unless an explicit user/channel target kind is provided.
 
@@ -1186,6 +1187,8 @@ openclaw logs --follow
 
     If you set `channels.discord.allowBots=true`, use strict mention and allowlist rules to avoid loop behavior.
     Prefer `channels.discord.allowBots="mentions"` to only accept bot messages that mention the bot.
+    For guild messaging, `guilds.<id>.users` is the primary gate: if that allowlist is non-empty, the sending bot ID must be listed there before `allowBots` matters.
+    `allowFrom` does not recognize a `bot:` prefix; use the raw bot user ID or add the bot to `guilds.<id>.users`.
 
   </Accordion>
 


### PR DESCRIPTION
Issue: #58010

Summary:
- Clarify that Discord guild messaging is gated by `guilds.<id>.users` before `allowBots` applies.
- Clarify that `allowFrom` does not accept a `bot:` prefix; bot IDs should be listed as bare IDs.

Validation:
- pnpm exec oxfmt --check .worktrees/58010/docs/channels/discord.md
