### PR TITLE
fix(compaction): prioritize runtime override model in safeguard

### DIFF
--- a/src/agents/pi-hooks/compaction-safeguard.test.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.test.ts
@@ -1636,6 +1636,37 @@ describe("compaction-safeguard recent-turn preservation", () => {
 });
 
 describe("compaction-safeguard extension model fallback", () => {
+  it("prefers runtime.model override when both ctx.model and runtime.model are present", async () => {
+    const sessionManager = stubSessionManager();
+    const ctxModel = createAnthropicModelFixture({ id: "claude-opus-session" });
+    const runtimeModel = createAnthropicModelFixture({ id: "claude-sonnet-compaction" });
+    setCompactionSafeguardRuntime(sessionManager, { model: runtimeModel });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyAndHeadersMock = vi
+      .fn()
+      .mockResolvedValue({ ok: false, error: "missing auth" });
+    const mockContext = {
+      ...createCompactionContext({
+        sessionManager,
+        getApiKeyAndHeadersMock,
+      }),
+      model: ctxModel,
+    } as unknown as Partial<ExtensionContext>;
+
+    const event = createCompactionEvent({
+      messageText: "test message",
+      tokensBefore: 1000,
+    });
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+    };
+
+    expect(result).toEqual({ cancel: true });
+    expect(getApiKeyAndHeadersMock).toHaveBeenCalledWith(runtimeModel);
+    expect(getApiKeyAndHeadersMock).not.toHaveBeenCalledWith(ctxModel);
+  });
+
   it("uses runtime.model when ctx.model is undefined (compact.ts workflow)", async () => {
     // This test verifies the root-cause fix: when extensionRunner.initialize() is not called
     // (as happens in compact.ts), ctx.model is undefined but runtime.model is available.

--- a/src/agents/pi-hooks/compaction-safeguard.test.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.test.ts
@@ -1690,7 +1690,7 @@ describe("compaction-safeguard extension model fallback", () => {
 
     // KEY ASSERTION: Prove the fallback path was exercised
     // The handler should have resolved request auth with runtime.model
-    // (via ctx.model ?? runtime?.model).
+    // (via runtime?.model ?? ctx.model).
     expect(getApiKeyAndHeadersMock).toHaveBeenCalledWith(model);
 
     // Verify runtime.model is still available (for completeness)

--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -600,8 +600,9 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     ]);
     const toolFailureSection = formatToolFailuresSection(toolFailures);
 
-    // Model resolution: ctx.model is undefined in compact.ts workflow (extensionRunner.initialize() is never called).
-    // Fall back to runtime.model which is explicitly passed when building extension paths.
+    // Model resolution: runtime.model carries the resolved compaction target,
+    // including agents.defaults.compaction.model override. Prefer runtime first.
+    // ctx.model reflects the active session model and remains a compatibility fallback.
     const runtime = getCompactionSafeguardRuntime(ctx.sessionManager);
     const customInstructions = resolveCompactionInstructions(
       eventInstructions,
@@ -612,7 +613,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       identifierInstructions: runtime?.identifierInstructions,
     };
     const identifierPolicy = runtime?.identifierPolicy ?? "strict";
-    const model = ctx.model ?? runtime?.model;
+    const model = runtime?.model ?? ctx.model;
     if (!model) {
       // Log warning once per session when both models are missing (diagnostic for future issues).
       // Use a WeakSet to track which session managers have already logged the warning.


### PR DESCRIPTION
## Summary

- prefer untime.model over ctx.model inside compaction safeguard model resolution
- this preserves the session model fallback but ensures gents.defaults.compaction.model override wins when both are present
- add a regression test that proves runtime override precedence when both models exist

## Test plan

- [x] pnpm test -- src/agents/pi-hooks/compaction-safeguard.test.ts
- [x] pnpm test -- src/agents/pi-embedded-runner/run/attempt.test.ts -t "resolves compaction.model override in runtime context so all context engines use the correct model"

Fixes #59863