### PR TITLE
fix: protect active subagent sessions from maintenance pruning

### DIFF
--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -665,6 +665,20 @@ export function isSubagentSessionRunActive(childSessionKey: string): boolean {
   return Boolean(latest && typeof latest.endedAt !== "number");
 }
 
+/**
+ * Return the set of child session keys that have at least one active (non-ended) subagent run.
+ * Used by session maintenance to protect these sessions from pruning.
+ */
+export function getActiveSubagentSessionKeys(): Set<string> {
+  const keys = new Set<string>();
+  for (const entry of subagentRuns.values()) {
+    if (typeof entry.endedAt !== "number" && entry.childSessionKey) {
+      keys.add(entry.childSessionKey);
+    }
+  }
+  return keys;
+}
+
 export function shouldIgnorePostCompletionAnnounceForSession(childSessionKey: string): boolean {
   return shouldIgnorePostCompletionAnnounceForSessionFromRuns(
     subagentRegistryDeps.getSubagentRunsSnapshotForRead(subagentRuns),

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -247,6 +247,7 @@ export async function enforceSessionDiskBudget(params: {
 
   let removedFiles = 0;
   let removedEntries = 0;
+  let skippedProtected = 0;
   let freedBytes = 0;
 
   const referencedPaths = resolveReferencedSessionTranscriptPaths({
@@ -296,6 +297,7 @@ export async function enforceSessionDiskBudget(params: {
         continue;
       }
       if (params.excludeKeys?.has(key)) {
+        skippedProtected++;
         continue;
       }
       const entry = params.store[key];
@@ -376,5 +378,9 @@ export async function enforceSessionDiskBudget(params: {
     maxBytes,
     highWaterBytes,
     overBudget: true,
+    skippedProtected,
   };
+  if (skippedProtected > 0) {
+    log.info("protected active sessions from disk budget enforcement", { count: skippedProtected });
+  }
 }

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -189,6 +189,8 @@ export async function enforceSessionDiskBudget(params: {
   store: Record<string, SessionEntry>;
   storePath: string;
   activeSessionKey?: string;
+  /** Additional session keys to exclude from budget enforcement (e.g. active subagent sessions). */
+  excludeKeys?: ReadonlySet<string>;
   maintenance: SessionDiskBudgetConfig;
   warnOnly: boolean;
   dryRun?: boolean;
@@ -291,6 +293,9 @@ export async function enforceSessionDiskBudget(params: {
         break;
       }
       if (activeSessionKey && key.trim().toLowerCase() === activeSessionKey) {
+        continue;
+      }
+      if (params.excludeKeys?.has(key)) {
         continue;
       }
       const entry = params.store[key];

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -261,8 +261,10 @@ export function capEntryCount(
 
   const toRemove = sorted.slice(maxEntries);
   let removed = 0;
+  let skippedProtected = 0;
   for (const key of toRemove) {
     if (opts.excludeKeys?.has(key)) {
+      skippedProtected++;
       continue;
     }
     const entry = store[key];
@@ -274,6 +276,9 @@ export function capEntryCount(
   }
   if (removed > 0 && opts.log !== false) {
     log.info("capped session entry count", { removed, maxEntries });
+  }
+  if (skippedProtected > 0 && opts.log !== false) {
+    log.info("protected active sessions from capping", { count: skippedProtected });
   }
   return removed;
 }

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -155,13 +155,23 @@ export function resolveMaintenanceConfig(): ResolvedSessionMaintenanceConfig {
 export function pruneStaleEntries(
   store: Record<string, SessionEntry>,
   overrideMaxAgeMs?: number,
-  opts: { log?: boolean; onPruned?: (params: { key: string; entry: SessionEntry }) => void } = {},
+  opts: {
+    log?: boolean;
+    /** Session keys to exclude from pruning (e.g. active subagent sessions). */
+    excludeKeys?: ReadonlySet<string>;
+    onPruned?: (params: { key: string; entry: SessionEntry }) => void;
+  } = {},
 ): number {
   const maxAgeMs = overrideMaxAgeMs ?? resolveMaintenanceConfig().pruneAfterMs;
   const cutoffMs = Date.now() - maxAgeMs;
   let pruned = 0;
+  let skippedProtected = 0;
   for (const [key, entry] of Object.entries(store)) {
     if (entry?.updatedAt != null && entry.updatedAt < cutoffMs) {
+      if (opts.excludeKeys?.has(key)) {
+        skippedProtected++;
+        continue;
+      }
       opts.onPruned?.({ key, entry });
       delete store[key];
       pruned++;
@@ -169,6 +179,9 @@ export function pruneStaleEntries(
   }
   if (pruned > 0 && opts.log !== false) {
     log.info("pruned stale session entries", { pruned, maxAgeMs });
+  }
+  if (skippedProtected > 0 && opts.log !== false) {
+    log.info("protected active sessions from pruning", { count: skippedProtected });
   }
   return pruned;
 }
@@ -228,6 +241,8 @@ export function capEntryCount(
   overrideMax?: number,
   opts: {
     log?: boolean;
+    /** Session keys to exclude from capping (e.g. active subagent sessions). */
+    excludeKeys?: ReadonlySet<string>;
     onCapped?: (params: { key: string; entry: SessionEntry }) => void;
   } = {},
 ): number {
@@ -245,17 +260,22 @@ export function capEntryCount(
   });
 
   const toRemove = sorted.slice(maxEntries);
+  let removed = 0;
   for (const key of toRemove) {
+    if (opts.excludeKeys?.has(key)) {
+      continue;
+    }
     const entry = store[key];
     if (entry) {
       opts.onCapped?.({ key, entry });
     }
     delete store[key];
+    removed++;
   }
-  if (opts.log !== false) {
-    log.info("capped session entry count", { removed: toRemove.length, maxEntries });
+  if (removed > 0 && opts.log !== false) {
+    log.info("capped session entry count", { removed, maxEntries });
   }
-  return toRemove.length;
+  return removed;
 }
 
 async function getSessionFileSize(storePath: string): Promise<number | null> {

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -45,6 +45,24 @@ describe("pruneStaleEntries", () => {
     expect(store.old).toBeUndefined();
     expect(store.fresh).toBeDefined();
   });
+
+  it("excludeKeys protects stale entries from pruning", () => {
+    const now = Date.now();
+    const store = makeStore([
+      ["active-subagent", makeEntry(now - 31 * DAY_MS)],
+      ["old-idle", makeEntry(now - 31 * DAY_MS)],
+      ["fresh", makeEntry(now - 1 * DAY_MS)],
+    ]);
+
+    const pruned = pruneStaleEntries(store, 30 * DAY_MS, {
+      excludeKeys: new Set(["active-subagent"]),
+    });
+
+    expect(pruned).toBe(1);
+    expect(store["active-subagent"]).toBeDefined();
+    expect(store["old-idle"]).toBeUndefined();
+    expect(store.fresh).toBeDefined();
+  });
 });
 
 describe("capEntryCount", () => {
@@ -67,6 +85,29 @@ describe("capEntryCount", () => {
     expect(store.mid).toBeDefined();
     expect(store.oldest).toBeUndefined();
     expect(store.old).toBeUndefined();
+  });
+
+  it("excludeKeys protects entries from capping even when over limit", () => {
+    const now = Date.now();
+    const store = makeStore([
+      ["oldest-protected", makeEntry(now - 4 * DAY_MS)],
+      ["old", makeEntry(now - 3 * DAY_MS)],
+      ["mid", makeEntry(now - 2 * DAY_MS)],
+      ["recent", makeEntry(now - 1 * DAY_MS)],
+      ["newest", makeEntry(now)],
+    ]);
+
+    const evicted = capEntryCount(store, 3, {
+      excludeKeys: new Set(["oldest-protected"]),
+    });
+
+    // Only "old" is removed; "oldest-protected" survives despite being beyond the cap.
+    expect(evicted).toBe(1);
+    expect(store["oldest-protected"]).toBeDefined();
+    expect(store.old).toBeUndefined();
+    expect(store.mid).toBeDefined();
+    expect(store.recent).toBeDefined();
+    expect(store.newest).toBeDefined();
   });
 });
 

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -472,14 +472,29 @@ async function saveSessionStoreUnlocked(
         diskBudget,
       });
     } else {
+      // Collect session keys that back active subagent runs so they survive pruning.
+      let protectedKeys: Set<string> | undefined;
+      try {
+        const { getActiveSubagentSessionKeys } = await import("../../agents/subagent-registry.js");
+        protectedKeys = getActiveSubagentSessionKeys();
+      } catch {
+        // Subagent registry may not be initialized (e.g. during migrations or CLI commands).
+      }
+      if (opts?.activeSessionKey) {
+        protectedKeys ??= new Set();
+        protectedKeys.add(opts.activeSessionKey.trim());
+      }
+
       // Prune stale entries and cap total count before serializing.
       const removedSessionFiles = new Map<string, string | undefined>();
       const pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, {
+        excludeKeys: protectedKeys,
         onPruned: ({ entry }) => {
           rememberRemovedSessionFile(removedSessionFiles, entry);
         },
       });
       const capped = capEntryCount(store, maintenance.maxEntries, {
+        excludeKeys: protectedKeys,
         onCapped: ({ entry }) => {
           rememberRemovedSessionFile(removedSessionFiles, entry);
         },
@@ -525,6 +540,7 @@ async function saveSessionStoreUnlocked(
         store,
         storePath,
         activeSessionKey: opts?.activeSessionKey,
+        excludeKeys: protectedKeys,
         maintenance,
         warnOnly: false,
         log,


### PR DESCRIPTION
Session maintenance (pruneStaleEntries, capEntryCount, enforceSessionDiskBudget) could delete sessions that back active subagent runs, leaving tasks stuck as "running" forever with no way to recover until gateway restart.

Add excludeKeys parameter to all three pruning functions and wire it to the subagent registry via getActiveSubagentSessionKeys() so sessions with active runs are never evicted. Uses dynamic import to avoid adding a static dependency from the session store to the subagent registry.

## Summary

- **Problem:** pruneStaleEntries() and capEntryCount() delete sessions without checking if they back active subagent runs. Orphan detection only fires on gateway restart.
- **Why it matters:** Kanban tasks and subagent runs get permanently stuck as "running" when their backing session is pruned mid-execution
- **What changed:** Added excludeKeys param to pruneStaleEntries, capEntryCount, and enforceSessionDiskBudget; new getActiveSubagentSessionKeys() on subagent registry; wired at saveSessionStoreUnlocked enforce-mode via dynamic import
- **What did NOT change:** Orphan recovery flow (startup-only), Kanban/Nerve task reconciliation (separate system), controller session protection

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage

## Linked Issue/PR

- Related #59681 (prior subagent spawn fix)
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: pruneStaleEntries() and capEntryCount() in store-maintenance.ts have no exclusion mechanism
- Missing detection / guardrail: No cross-system check between session store and subagent registry before pruning
- Prior context: enforceSessionDiskBudget() already has activeSessionKey exclusion (single key), but pruneStaleEntries and capEntryCount were never given equivalent protection
- Why this regressed now: Users enabling aggressive maintenance config hit this when subagent sessions are older than the prune threshold

## Regression Test Plan (if applicable)

- [x] Unit test
- Target test: src/config/sessions/store.pruning.test.ts
- Scenario: stale/over-limit entries in excludeKeys set survive pruning

## User-visible / Behavior Changes

Sessions backing active subagent runs are now preserved during maintenance pruning. Session count may temporarily exceed maxEntries while runs are active. Log line "protected active sessions from pruning" emitted when sessions are preserved.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification (required)

- Verified: pnpm check (types, lint, format), pnpm test -- src/config/sessions (88 tests pass including 2 new)
- Edge cases: empty excludeKeys, entries not in store, subagent registry not initialized (dynamic import catch)
- Not verified: end-to-end with live gateway, controller session pruning edge case

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Session count may temporarily exceed maxEntries while subagent runs are active
  - Mitigation: Sessions only protected while runs are active; once ended, normal pruning resumes
- Risk: Dynamic import of subagent registry could fail in non-gateway contexts
  - Mitigation: Wrapped in try/catch, falls back to no exclusion (existing behavior)