### PR TITLE
fix(gateway): persist sessions.create user turns

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -860,6 +860,92 @@ function transcriptHasIdempotencyKey(transcriptPath: string, idempotencyKey: str
   }
 }
 
+function transcriptHasAssistantMessage(transcriptPath: string): boolean {
+  try {
+    const lines = fs.readFileSync(transcriptPath, "utf-8").split(/\r?\n/);
+    for (const line of lines) {
+      if (!line.trim()) {
+        continue;
+      }
+      const parsed = JSON.parse(line) as { message?: { role?: unknown } };
+      if (parsed?.message?.role === "assistant") {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function appendUserTranscriptMessage(params: {
+  message: string;
+  savedImages: SavedMedia[];
+  sessionId: string;
+  storePath: string | undefined;
+  sessionFile?: string;
+  agentId?: string;
+  createIfMissing?: boolean;
+  idempotencyKey?: string;
+  now: number;
+}): TranscriptAppendResult {
+  const transcriptPath = resolveTranscriptPath({
+    sessionId: params.sessionId,
+    storePath: params.storePath,
+    sessionFile: params.sessionFile,
+    agentId: params.agentId,
+  });
+  if (!transcriptPath) {
+    return { ok: false, error: "transcript path not resolved" };
+  }
+
+  if (!fs.existsSync(transcriptPath)) {
+    if (!params.createIfMissing) {
+      return { ok: false, error: "transcript file not found" };
+    }
+    const ensured = ensureTranscriptFile({
+      transcriptPath,
+      sessionId: params.sessionId,
+    });
+    if (!ensured.ok) {
+      return { ok: false, error: ensured.error ?? "failed to create transcript file" };
+    }
+  }
+
+  if (params.idempotencyKey && transcriptHasIdempotencyKey(transcriptPath, params.idempotencyKey)) {
+    return { ok: true };
+  }
+
+  const messageBody: Parameters<SessionManager["appendMessage"]>[0] & Record<string, unknown> = {
+    ...buildChatSendTranscriptMessage({
+      message: params.message,
+      savedImages: params.savedImages,
+      timestamp: params.now,
+    }),
+    ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
+  };
+
+  try {
+    const hadAssistantMessage = transcriptHasAssistantMessage(transcriptPath);
+    const sessionManager = SessionManager.open(transcriptPath);
+    const messageId = sessionManager.appendMessage(messageBody);
+    if (!hadAssistantMessage) {
+      // Pi defers file flushes until an assistant turn exists. Force a rewrite for
+      // first-turn gateway sends so session watchers and history readers can see
+      // the accepted user message immediately.
+      (sessionManager as unknown as { _rewriteFile: () => void })._rewriteFile();
+    }
+    emitSessionTranscriptUpdate({
+      sessionFile: transcriptPath,
+      message: messageBody,
+      messageId,
+    });
+    return { ok: true, messageId, message: messageBody };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 function appendAssistantTranscriptMessage(params: {
   message: string;
   label?: string;
@@ -1670,15 +1756,22 @@ export const chatHandlers: GatewayRequestHandlers = {
             return;
           }
           const persistedImages = await persistedImagesPromise;
-          emitSessionTranscriptUpdate({
-            sessionFile: transcriptPath,
-            sessionKey,
-            message: buildChatSendTranscriptMessage({
-              message: parsedMessage,
-              savedImages: persistedImages,
-              timestamp: now,
-            }),
+          const appended = appendUserTranscriptMessage({
+            message: parsedMessage,
+            savedImages: persistedImages,
+            sessionId: resolvedSessionId,
+            storePath: latestStorePath,
+            sessionFile: latestEntry?.sessionFile ?? entry?.sessionFile,
+            agentId,
+            createIfMissing: true,
+            idempotencyKey: clientRunId,
+            now,
           });
+          if (!appended.ok) {
+            throw new Error(
+              `failed to append user transcript: ${appended.error ?? "unknown error"}`,
+            );
+          }
         })();
         await userTranscriptUpdatePromise;
       };

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -933,10 +933,11 @@ function appendUserTranscriptMessage(params: {
       // Pi defers file flushes until an assistant turn exists. Force a rewrite for
       // first-turn gateway sends so session watchers and history readers can see
       // the accepted user message immediately.
-      (sessionManager as unknown as { _rewriteFile: () => void })._rewriteFile();
+      (sessionManager as unknown as { _rewriteFile?: () => void })._rewriteFile?.();
     }
     emitSessionTranscriptUpdate({
       sessionFile: transcriptPath,
+      sessionKey: params.sessionKey,
       message: messageBody,
       messageId,
     });
@@ -952,6 +953,7 @@ function appendAssistantTranscriptMessage(params: {
   sessionId: string;
   storePath: string | undefined;
   sessionFile?: string;
+  sessionKey: string;
   agentId?: string;
   createIfMissing?: boolean;
   idempotencyKey?: string;
@@ -1762,6 +1764,7 @@ export const chatHandlers: GatewayRequestHandlers = {
             sessionId: resolvedSessionId,
             storePath: latestStorePath,
             sessionFile: latestEntry?.sessionFile ?? entry?.sessionFile,
+            sessionKey,
             agentId,
             createIfMissing: true,
             idempotencyKey: clientRunId,

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -12,7 +12,7 @@ import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "./protocol/client-info
 import { startGatewayServerHarness, type GatewayServerHarness } from "./server.e2e-ws-harness.js";
 import { createToolSummaryPreviewTranscriptLines } from "./session-preview.test-helpers.js";
 import { performGatewaySessionReset } from "./session-reset-service.js";
-import { resolveGatewaySessionStoreTarget } from "./session-utils.js";
+import { readSessionMessages, resolveGatewaySessionStoreTarget } from "./session-utils.js";
 import {
   connectOk,
   embeddedRunMock,
@@ -197,6 +197,28 @@ async function createSessionStoreDir() {
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
   return { dir, storePath };
+}
+
+async function waitForTranscriptMessage(
+  sessionId: string,
+  storePath: string,
+  matchText: string,
+): Promise<unknown[]> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const messages = readSessionMessages(sessionId, storePath);
+    const matched = messages.some((message) => {
+      if (!message || typeof message !== "object") {
+        return false;
+      }
+      const entry = message as { role?: unknown; content?: unknown };
+      return entry.role === "user" && entry.content === matchText;
+    });
+    if (matched) {
+      return messages;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return readSessionMessages(sessionId, storePath);
 }
 
 async function writeSingleLineSession(dir: string, sessionId: string, content: string) {
@@ -492,7 +514,7 @@ describe("gateway server sessions", () => {
   });
 
   test("sessions.create can start the first agent turn from an initial task", async () => {
-    await createSessionStoreDir();
+    const { storePath } = await createSessionStoreDir();
     const { ws } = await openClient();
 
     const created = await rpcReq<{
@@ -515,6 +537,61 @@ describe("gateway server sessions", () => {
     expect(created.payload?.runStarted).toBe(true);
     expect(created.payload?.runId).toBeTruthy();
     expect(created.payload?.messageSeq).toBe(1);
+    expect(created.payload?.sessionId).toBeTruthy();
+
+    const messages = await waitForTranscriptMessage(
+      created.payload?.sessionId ?? "",
+      storePath,
+      "hello from create",
+    );
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          content: "hello from create",
+        }),
+      ]),
+    );
+
+    ws.close();
+  });
+
+  test("sessions.create persists an initial message containing a URL", async () => {
+    const { storePath } = await createSessionStoreDir();
+    const { ws } = await openClient();
+
+    const created = await rpcReq<{
+      key?: string;
+      sessionId?: string;
+      runStarted?: boolean;
+      runId?: string;
+      messageSeq?: number;
+    }>(ws, "sessions.create", {
+      agentId: "ops",
+      key: "url-case",
+      message: "visit https://example.com",
+    });
+
+    expect(created.ok).toBe(true);
+    expect(created.payload?.key).toBe("agent:ops:url-case");
+    expect(created.payload?.runStarted).toBe(true);
+    expect(created.payload?.runId).toBeTruthy();
+    expect(created.payload?.messageSeq).toBe(1);
+    expect(created.payload?.sessionId).toBeTruthy();
+
+    const messages = await waitForTranscriptMessage(
+      created.payload?.sessionId ?? "",
+      storePath,
+      "visit https://example.com",
+    );
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          content: "visit https://example.com",
+        }),
+      ]),
+    );
 
     ws.close();
   });

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -17,6 +17,7 @@ import {
   connectOk,
   embeddedRunMock,
   installGatewayTestHooks,
+  onceMessage,
   piSdkMock,
   rpcReq,
   testState,
@@ -559,6 +560,16 @@ describe("gateway server sessions", () => {
   test("sessions.create persists an initial message containing a URL", async () => {
     const { storePath } = await createSessionStoreDir();
     const { ws } = await openClient();
+    const sessionMessagePromise = onceMessage(
+      ws,
+      (message) =>
+        message.type === "event" &&
+        message.event === "session.message" &&
+        (message.payload as { sessionKey?: string } | undefined)?.sessionKey ===
+          "agent:ops:url-case",
+    );
+    const sessionsSubscribe = await rpcReq(ws, "sessions.subscribe");
+    expect(sessionsSubscribe.ok).toBe(true);
 
     const created = await rpcReq<{
       key?: string;
@@ -578,6 +589,13 @@ describe("gateway server sessions", () => {
     expect(created.payload?.runId).toBeTruthy();
     expect(created.payload?.messageSeq).toBe(1);
     expect(created.payload?.sessionId).toBeTruthy();
+
+    const sessionMessage = await sessionMessagePromise;
+    expect(sessionMessage.payload).toMatchObject({
+      sessionKey: "agent:ops:url-case",
+      messageId: expect.any(String),
+      messageSeq: 1,
+    });
 
     const messages = await waitForTranscriptMessage(
       created.payload?.sessionId ?? "",


### PR DESCRIPTION
## Summary

- Problem: `sessions.create` could start an initial turn without persisting the accepted user message into the transcript.
- Why it matters: session watchers and transcript readers could see only the session header, which matched the reported `://` symptom and also affected plain messages.
- What changed: gateway chat handling now appends the first accepted user turn to the transcript with a stable idempotency key and adds regression coverage for both plain text and URL-containing initial messages.
- What did NOT change (scope boundary): model dispatch, message parsing, and the `sessions.create` wire contract stay the same.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #59887
- Related #59887
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the eager `sessions.create`/`chat.send` path only emitted a transcript-update event for the first user turn instead of appending that turn to the transcript file.
- Missing detection / guardrail: the existing regression test only asserted `runStarted` and `messageSeq`, not that the initial user message was actually readable from the transcript.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the linked issue reported the symptom as URL-specific, but the current code path reproduces it for plain initial messages too.
- Why this regressed now: the gateway relied on `SessionManager.appendMessage()` semantics indirectly without accounting for the library's no-flush-before-assistant behavior.
- If unknown, what was ruled out: ruled out `://`-specific parsing in `sessions.create`, `chat.send`, and the gateway CLI `--params` JSON path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server.sessions.gateway-server-sessions-a.test.ts`
- Scenario the test should lock in: `sessions.create` writes the initial user turn to the transcript for both plain text and URL-containing messages.
- Why this is the smallest reliable guardrail: the bug is in the gateway-to-transcript seam, so the gateway harness test exercises the real session creation and transcript read path without broader runtime noise.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `sessions.create` now makes the initial accepted user turn visible in transcript/history readers immediately.
- Messages containing URLs like `https://example.com` now persist through the same path instead of appearing to vanish from the transcript.

## Diagram (if applicable)

```text
Before:
[sessions.create initial message] -> [session starts] -> [transcript update event only] -> [transcript file missing user turn]

After:
[sessions.create initial message] -> [session starts] -> [user turn appended to transcript] -> [watchers/history see user turn]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (darwin 25.3.0)
- Runtime/container: Node.js / pnpm local repo checkout
- Model/provider: N/A for the regression check
- Integration/channel (if any): Gateway `sessions.create`
- Relevant config (redacted): default gateway test harness session store

### Steps

1. Create a session with `sessions.create` and include an initial `message` or `task`.
2. Read the created transcript immediately.
3. Compare the transcript contents for plain text and `https://...` messages.

### Expected

- The transcript contains the first user turn.

### Actual

- Before this fix, the transcript could contain only the session header even though the run started.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test -- src/gateway/server.sessions.gateway-server-sessions-a.test.ts`
  - `pnpm build`
  - Added and passed regression checks for both `task: "hello from create"` and `message: "visit https://example.com"` through `sessions.create`
- Edge cases checked:
  - first-turn transcript persistence before any assistant reply exists
  - URL-containing initial message
  - idempotent append keyed by the gateway run id
- What you did **not** verify:
  - A fully green local `pnpm check` and `pnpm test` run was not possible because of unrelated existing failures in `extensions/diffs/src/language-hints.test.ts` and `src/tts/status-config.test.ts`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the fix uses a targeted forced transcript rewrite for pre-assistant sessions because the underlying session manager does not flush user-only sessions eagerly.
  - Mitigation: the rewrite is limited to transcripts with no assistant turn yet, and the gateway regression test now covers both plain and URL-containing initial messages.

## Additional Notes

- AI assistance: prepared with a coding agent and manually reviewed/verified before opening.

Made with [Cursor](https://cursor.com)