### PR TITLE
fix(ui): fall back to bundled logo when assistant avatars fail

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -912,6 +912,18 @@
   object-fit: contain;
 }
 
+.agent-chat__welcome-avatar--logo-fallback {
+  width: 48px;
+  height: 48px;
+  padding: 8px;
+  border-radius: var(--radius-lg);
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
+  object-fit: contain;
+  box-sizing: border-box;
+  display: block;
+}
+
 .agent-chat__badges {
   display: flex;
   gap: 8px;

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { keyed } from "lit/directives/keyed.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { getSafeLocalStorage } from "../../local-storage.ts";
 import type { AssistantIdentity } from "../assistant-identity.ts";
@@ -524,21 +525,24 @@ function renderAvatar(
   if (assistantAvatar && normalized === "assistant") {
     if (isAvatarUrl(assistantAvatar)) {
       const logoUrl = agentLogoUrl(basePath ?? "");
-      return html`<img
-        class="chat-avatar ${className}"
-        src="${assistantAvatar}"
-        alt="${assistantName}"
-        @error=${(event: Event) => {
-          const img = event.currentTarget as HTMLImageElement | null;
-          if (!img || img.dataset.fallbackApplied === "1") {
-            return;
-          }
-          img.dataset.fallbackApplied = "1";
-          img.src = logoUrl;
-          img.alt = "OpenClaw";
-          img.classList.add("chat-avatar--logo");
-        }}
-      />`;
+      return keyed(
+        `${assistantName}:${assistantAvatar}`,
+        html`<img
+          class="chat-avatar ${className}"
+          src="${assistantAvatar}"
+          alt="${assistantName}"
+          @error=${(event: Event) => {
+            const img = event.currentTarget as HTMLImageElement | null;
+            if (!img || img.dataset.fallbackApplied === "1") {
+              return;
+            }
+            img.dataset.fallbackApplied = "1";
+            img.src = logoUrl;
+            img.alt = "OpenClaw";
+            img.classList.add("chat-avatar--logo");
+          }}
+        />`,
+      );
     }
     return html`<img
       class="chat-avatar ${className} chat-avatar--logo"

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -523,10 +523,21 @@ function renderAvatar(
 
   if (assistantAvatar && normalized === "assistant") {
     if (isAvatarUrl(assistantAvatar)) {
+      const logoUrl = agentLogoUrl(basePath ?? "");
       return html`<img
         class="chat-avatar ${className}"
         src="${assistantAvatar}"
         alt="${assistantName}"
+        @error=${(event: Event) => {
+          const img = event.currentTarget as HTMLImageElement | null;
+          if (!img || img.dataset.fallbackApplied === "1") {
+            return;
+          }
+          img.dataset.fallbackApplied = "1";
+          img.src = logoUrl;
+          img.alt = "OpenClaw";
+          img.classList.add("chat-avatar--logo");
+        }}
       />`;
     }
     return html`<img

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -108,8 +108,8 @@ describe("agentLogoUrl", () => {
     expect(agentLogoUrl("/apps/openclaw/")).toBe("/apps/openclaw/favicon.svg");
   });
 
-  it("uses a route-relative fallback before basePath bootstrap finishes", () => {
-    expect(agentLogoUrl("")).toBe("favicon.svg");
+  it("uses a root-absolute fallback before basePath bootstrap finishes", () => {
+    expect(agentLogoUrl("")).toBe("/favicon.svg");
   });
 });
 

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -219,7 +219,7 @@ export function resolveAgentAvatarUrl(
 
 export function agentLogoUrl(basePath: string): string {
   const base = basePath?.trim() ? basePath.replace(/\/$/, "") : "";
-  return base ? `${base}/favicon.svg` : "favicon.svg";
+  return base ? `${base}/favicon.svg` : "/favicon.svg";
 }
 
 function isLikelyEmoji(value: string) {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -429,6 +429,10 @@ describe("chat view", () => {
 
     expect(welcomeImage?.getAttribute("src")).toBe("/favicon.svg");
     expect(welcomeImage?.getAttribute("alt")).toBe("OpenClaw");
+    expect(welcomeImage?.classList.contains("agent-chat__welcome-avatar--logo-fallback")).toBe(
+      true,
+    );
+    expect(welcomeImage?.getAttribute("style")).toBeNull();
   });
 
   it("falls back to the bundled logo in the welcome state when the assistant avatar is not a URL", () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -411,6 +411,26 @@ describe("chat view", () => {
     expect(welcomeImage?.getAttribute("src")).toBe("/avatar/main");
   });
 
+  it("falls back to the bundled logo when the welcome avatar fails to load", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          assistantName: "Open",
+          assistantAvatar: "https://clawhub.com/images/openclaw-logo.png",
+        }),
+      ),
+      container,
+    );
+
+    const welcomeImage = container.querySelector<HTMLImageElement>(".agent-chat__welcome > img");
+    expect(welcomeImage).not.toBeNull();
+    welcomeImage?.dispatchEvent(new Event("error"));
+
+    expect(welcomeImage?.getAttribute("src")).toBe("/favicon.svg");
+    expect(welcomeImage?.getAttribute("alt")).toBe("OpenClaw");
+  });
+
   it("falls back to the bundled logo in the welcome state when the assistant avatar is not a URL", () => {
     const container = document.createElement("div");
     render(
@@ -430,7 +450,7 @@ describe("chat view", () => {
     );
     expect(welcomeImage).toBeNull();
     expect(logoImage).not.toBeNull();
-    expect(logoImage?.getAttribute("src")).toBe("favicon.svg");
+    expect(logoImage?.getAttribute("src")).toBe("/favicon.svg");
   });
 
   it("keeps the welcome logo fallback under the mounted base path", () => {
@@ -480,6 +500,34 @@ describe("chat view", () => {
     );
     expect(groupedLogo).not.toBeNull();
     expect(groupedLogo?.getAttribute("src")).toBe("/openclaw/favicon.svg");
+  });
+
+  it("falls back to the bundled logo when a grouped assistant avatar fails to load", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          assistantName: "Open",
+          assistantAvatar: "https://clawhub.com/images/openclaw-logo.png",
+          messages: [
+            {
+              role: "assistant",
+              content: "hello",
+              timestamp: 1000,
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const avatar = container.querySelector<HTMLImageElement>(".chat-group.assistant .chat-avatar");
+    expect(avatar).not.toBeNull();
+    avatar?.dispatchEvent(new Event("error"));
+
+    expect(avatar?.getAttribute("src")).toBe("/favicon.svg");
+    expect(avatar?.getAttribute("alt")).toBe("OpenClaw");
+    expect(avatar?.classList.contains("chat-avatar--logo")).toBe(true);
   });
 
   it("keeps the persisted overview locale selected before i18n hydration finishes", async () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -435,6 +435,50 @@ describe("chat view", () => {
     expect(welcomeImage?.getAttribute("style")).toBeNull();
   });
 
+  it("recreates the welcome avatar when the source changes after a fallback", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          assistantName: "Open",
+          assistantAvatar: "https://example.com/avatar-a.png",
+        }),
+      ),
+      container,
+    );
+
+    const firstImage = container.querySelector<HTMLImageElement>(".agent-chat__welcome > img");
+    expect(firstImage).not.toBeNull();
+    firstImage?.dispatchEvent(new Event("error"));
+
+    expect(firstImage?.getAttribute("src")).toBe("/favicon.svg");
+    expect(firstImage?.classList.contains("agent-chat__welcome-avatar--logo-fallback")).toBe(true);
+
+    render(
+      renderChat(
+        createProps({
+          sessionKey: "next-session",
+          assistantName: "Next",
+          assistantAvatar: "https://example.com/avatar-b.png",
+        }),
+      ),
+      container,
+    );
+
+    const secondImage = container.querySelector<HTMLImageElement>(".agent-chat__welcome > img");
+    expect(secondImage).not.toBeNull();
+    expect(secondImage).not.toBe(firstImage);
+    expect(secondImage?.getAttribute("src")).toBe("https://example.com/avatar-b.png");
+    expect(secondImage?.getAttribute("alt")).toBe("Next");
+    expect(secondImage?.classList.contains("agent-chat__welcome-avatar--logo-fallback")).toBe(
+      false,
+    );
+    expect(secondImage?.getAttribute("style")).toContain("width:56px");
+
+    secondImage?.dispatchEvent(new Event("error"));
+    expect(secondImage?.getAttribute("src")).toBe("/favicon.svg");
+  });
+
   it("falls back to the bundled logo in the welcome state when the assistant avatar is not a URL", () => {
     const container = document.createElement("div");
     render(
@@ -532,6 +576,61 @@ describe("chat view", () => {
     expect(avatar?.getAttribute("src")).toBe("/favicon.svg");
     expect(avatar?.getAttribute("alt")).toBe("OpenClaw");
     expect(avatar?.classList.contains("chat-avatar--logo")).toBe(true);
+  });
+
+  it("recreates grouped assistant avatars when the source changes after a fallback", () => {
+    const container = document.createElement("div");
+    const messages = [
+      {
+        role: "assistant",
+        content: "hello",
+        timestamp: 1000,
+      },
+    ];
+
+    render(
+      renderChat(
+        createProps({
+          assistantName: "Open",
+          assistantAvatar: "https://example.com/avatar-a.png",
+          messages,
+        }),
+      ),
+      container,
+    );
+
+    const firstAvatar = container.querySelector<HTMLImageElement>(
+      ".chat-group.assistant .chat-avatar",
+    );
+    expect(firstAvatar).not.toBeNull();
+    firstAvatar?.dispatchEvent(new Event("error"));
+
+    expect(firstAvatar?.getAttribute("src")).toBe("/favicon.svg");
+    expect(firstAvatar?.classList.contains("chat-avatar--logo")).toBe(true);
+
+    render(
+      renderChat(
+        createProps({
+          assistantName: "Next",
+          assistantAvatar: "https://example.com/avatar-b.png",
+          messages,
+        }),
+      ),
+      container,
+    );
+
+    const secondAvatar = container.querySelector<HTMLImageElement>(
+      ".chat-group.assistant .chat-avatar",
+    );
+    expect(secondAvatar).not.toBeNull();
+    expect(secondAvatar).not.toBe(firstAvatar);
+    expect(secondAvatar?.getAttribute("src")).toBe("https://example.com/avatar-b.png");
+    expect(secondAvatar?.getAttribute("alt")).toBe("Next");
+    expect(secondAvatar?.classList.contains("chat-avatar--logo")).toBe(false);
+
+    secondAvatar?.dispatchEvent(new Event("error"));
+    expect(secondAvatar?.getAttribute("src")).toBe("/favicon.svg");
+    expect(secondAvatar?.classList.contains("chat-avatar--logo")).toBe(true);
   });
 
   it("keeps the persisted overview locale selected before i18n hydration finishes", async () => {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -636,6 +636,8 @@ function handleAvatarImageError(event: Event, basePath?: string) {
   img.dataset.fallbackApplied = "1";
   img.src = agentLogoUrl(basePath ?? "");
   img.alt = "OpenClaw";
+  img.removeAttribute("style");
+  img.classList.add("agent-chat__welcome-avatar--logo-fallback");
 }
 
 function renderWelcomeState(props: ChatProps): TemplateResult {
@@ -651,18 +653,16 @@ function renderWelcomeState(props: ChatProps): TemplateResult {
   return html`
     <div class="agent-chat__welcome" style="--agent-color: var(--accent)">
       <div class="agent-chat__welcome-glow"></div>
-      ${
-        avatar
-          ? html`<img
+      ${avatar
+        ? html`<img
             src=${avatar}
             alt=${name}
             style="width:56px; height:56px; border-radius:50%; object-fit:cover;"
             @error=${(event: Event) => handleAvatarImageError(event, props.basePath)}
           />`
-          : html`<div class="agent-chat__avatar agent-chat__avatar--logo">
-              <img src=${logoUrl} alt="OpenClaw" />
-            </div>`
-      }
+        : html`<div class="agent-chat__avatar agent-chat__avatar--logo">
+            <img src=${logoUrl} alt="OpenClaw" />
+          </div>`}
       <h2>${name}</h2>
       <div class="agent-chat__badges">
         <span class="agent-chat__badge"><img src=${logoUrl} alt="" /> Ready to chat</span>
@@ -753,9 +753,8 @@ function renderPinnedSection(
           >${icons.chevronDown}</span
         >
       </button>
-      ${
-        vs.pinnedExpanded
-          ? html`
+      ${vs.pinnedExpanded
+        ? html`
             <div class="agent-chat__pinned-list">
               ${entries.map(
                 ({ index, text, role }) => html`
@@ -781,8 +780,7 @@ function renderPinnedSection(
               )}
             </div>
           `
-          : nothing
-      }
+        : nothing}
     </div>
   `;
 }
@@ -815,11 +813,9 @@ function renderSlashMenu(
                   requestUpdate();
                 }}
               >
-                ${
-                  vs.slashMenuCommand?.icon
-                    ? html`<span class="slash-menu-icon">${icons[vs.slashMenuCommand.icon]}</span>`
-                    : nothing
-                }
+                ${vs.slashMenuCommand?.icon
+                  ? html`<span class="slash-menu-icon">${icons[vs.slashMenuCommand.icon]}</span>`
+                  : nothing}
                 <span class="slash-menu-name">${arg}</span>
                 <span class="slash-menu-desc">/${vs.slashMenuCommand?.name} ${arg}</span>
               </div>
@@ -861,9 +857,9 @@ function renderSlashMenu(
         ${entries.map(
           ({ cmd, globalIdx }) => html`
             <div
-              class="slash-menu-item ${
-                globalIdx === vs.slashMenuIndex ? "slash-menu-item--active" : ""
-              }"
+              class="slash-menu-item ${globalIdx === vs.slashMenuIndex
+                ? "slash-menu-item--active"
+                : ""}"
               role="option"
               aria-selected=${globalIdx === vs.slashMenuIndex}
               @click=${() => selectSlashCommand(cmd, props, requestUpdate)}
@@ -876,15 +872,11 @@ function renderSlashMenu(
               <span class="slash-menu-name">/${cmd.name}</span>
               ${cmd.args ? html`<span class="slash-menu-args">${cmd.args}</span>` : nothing}
               <span class="slash-menu-desc">${cmd.description}</span>
-              ${
-                cmd.argOptions?.length
-                  ? html`<span class="slash-menu-badge">${cmd.argOptions.length} options</span>`
-                  : cmd.executeLocal && !cmd.args
-                    ? html`
-                        <span class="slash-menu-badge">instant</span>
-                      `
-                    : nothing
-              }
+              ${cmd.argOptions?.length
+                ? html`<span class="slash-menu-badge">${cmd.argOptions.length} options</span>`
+                : cmd.executeLocal && !cmd.args
+                  ? html` <span class="slash-menu-badge">instant</span> `
+                  : nothing}
             </div>
           `,
         )}
@@ -964,46 +956,49 @@ export function renderChat(props: ChatProps) {
       @click=${handleCodeBlockCopy}
     >
       <div class="chat-thread-inner">
-        ${
-          props.loading
-            ? html`
-                <div class="chat-loading-skeleton" aria-label="Loading chat">
-                  <div class="chat-line assistant">
-                    <div class="chat-msg">
-                      <div class="chat-bubble">
-                        <div class="skeleton skeleton-line skeleton-line--long" style="margin-bottom: 8px"></div>
-                        <div class="skeleton skeleton-line skeleton-line--medium" style="margin-bottom: 8px"></div>
-                        <div class="skeleton skeleton-line skeleton-line--short"></div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="chat-line user" style="margin-top: 12px">
-                    <div class="chat-msg">
-                      <div class="chat-bubble">
-                        <div class="skeleton skeleton-line skeleton-line--medium"></div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="chat-line assistant" style="margin-top: 12px">
-                    <div class="chat-msg">
-                      <div class="chat-bubble">
-                        <div class="skeleton skeleton-line skeleton-line--long" style="margin-bottom: 8px"></div>
-                        <div class="skeleton skeleton-line skeleton-line--short"></div>
-                      </div>
+        ${props.loading
+          ? html`
+              <div class="chat-loading-skeleton" aria-label="Loading chat">
+                <div class="chat-line assistant">
+                  <div class="chat-msg">
+                    <div class="chat-bubble">
+                      <div
+                        class="skeleton skeleton-line skeleton-line--long"
+                        style="margin-bottom: 8px"
+                      ></div>
+                      <div
+                        class="skeleton skeleton-line skeleton-line--medium"
+                        style="margin-bottom: 8px"
+                      ></div>
+                      <div class="skeleton skeleton-line skeleton-line--short"></div>
                     </div>
                   </div>
                 </div>
-              `
-            : nothing
-        }
+                <div class="chat-line user" style="margin-top: 12px">
+                  <div class="chat-msg">
+                    <div class="chat-bubble">
+                      <div class="skeleton skeleton-line skeleton-line--medium"></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="chat-line assistant" style="margin-top: 12px">
+                  <div class="chat-msg">
+                    <div class="chat-bubble">
+                      <div
+                        class="skeleton skeleton-line skeleton-line--long"
+                        style="margin-bottom: 8px"
+                      ></div>
+                      <div class="skeleton skeleton-line skeleton-line--short"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            `
+          : nothing}
         ${isEmpty && !vs.searchOpen ? renderWelcomeState(props) : nothing}
-        ${
-          isEmpty && vs.searchOpen
-            ? html`
-                <div class="agent-chat__empty">No matching messages</div>
-              `
-            : nothing
-        }
+        ${isEmpty && vs.searchOpen
+          ? html` <div class="agent-chat__empty">No matching messages</div> `
+          : nothing}
         ${repeat(
           chatItems,
           (item) => item.key,
@@ -1181,9 +1176,8 @@ export function renderChat(props: ChatProps) {
     >
       ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
       ${props.error ? html`<div class="callout danger">${props.error}</div>` : nothing}
-      ${
-        props.focusMode
-          ? html`
+      ${props.focusMode
+        ? html`
             <button
               class="chat-focus-exit"
               type="button"
@@ -1194,8 +1188,7 @@ export function renderChat(props: ChatProps) {
               ${icons.x}
             </button>
           `
-          : nothing
-      }
+        : nothing}
       ${renderSearchBar(requestUpdate)} ${renderPinnedSection(props, pinned, requestUpdate)}
 
       <div class="chat-split-container ${sidebarOpen ? "chat-split-container--open" : ""}">
@@ -1206,9 +1199,8 @@ export function renderChat(props: ChatProps) {
           ${thread}
         </div>
 
-        ${
-          sidebarOpen
-            ? html`
+        ${sidebarOpen
+          ? html`
               <resizable-divider
                 .splitRatio=${splitRatio}
                 @resize=${(e: CustomEvent) => props.onSplitRatioChange?.(e.detail.splitRatio)}
@@ -1227,13 +1219,11 @@ export function renderChat(props: ChatProps) {
                 })}
               </div>
             `
-            : nothing
-        }
+          : nothing}
       </div>
 
-      ${
-        props.queue.length
-          ? html`
+      ${props.queue.length
+        ? html`
             <div class="chat-queue" role="status" aria-live="polite">
               <div class="chat-queue__title">Queued (${props.queue.length})</div>
               <div class="chat-queue__list">
@@ -1241,10 +1231,8 @@ export function renderChat(props: ChatProps) {
                   (item) => html`
                     <div class="chat-queue__item">
                       <div class="chat-queue__text">
-                        ${
-                          item.text ||
-                          (item.attachments?.length ? `Image (${item.attachments.length})` : "")
-                        }
+                        ${item.text ||
+                        (item.attachments?.length ? `Image (${item.attachments.length})` : "")}
                       </div>
                       <button
                         class="btn chat-queue__remove"
@@ -1260,20 +1248,17 @@ export function renderChat(props: ChatProps) {
               </div>
             </div>
           `
-          : nothing
-      }
+        : nothing}
       ${renderFallbackIndicator(props.fallbackStatus)}
       ${renderCompactionIndicator(props.compactionStatus)}
       ${renderContextNotice(activeSession, props.sessions?.defaults?.contextTokens ?? null)}
-      ${
-        props.showNewMessages
-          ? html`
+      ${props.showNewMessages
+        ? html`
             <button class="chat-new-messages" type="button" @click=${props.onScrollToBottom}>
               ${icons.arrowDown} New messages
             </button>
           `
-          : nothing
-      }
+        : nothing}
 
       <!-- Input bar -->
       <div class="agent-chat__input">
@@ -1287,11 +1272,9 @@ export function renderChat(props: ChatProps) {
           @change=${(e: Event) => handleFileSelect(e, props)}
         />
 
-        ${
-          vs.sttRecording && vs.sttInterimText
-            ? html`<div class="agent-chat__stt-interim">${vs.sttInterimText}</div>`
-            : nothing
-        }
+        ${vs.sttRecording && vs.sttInterimText
+          ? html`<div class="agent-chat__stt-interim">${vs.sttInterimText}</div>`
+          : nothing}
 
         <textarea
           ${ref((el) => el && adjustTextareaHeight(el as HTMLTextAreaElement))}
@@ -1319,13 +1302,12 @@ export function renderChat(props: ChatProps) {
               ${icons.paperclip}
             </button>
 
-            ${
-              isSttSupported()
-                ? html`
+            ${isSttSupported()
+              ? html`
                   <button
-                    class="agent-chat__input-btn ${
-                      vs.sttRecording ? "agent-chat__input-btn--recording" : ""
-                    }"
+                    class="agent-chat__input-btn ${vs.sttRecording
+                      ? "agent-chat__input-btn--recording"
+                      : ""}"
                     @click=${() => {
                       if (vs.sttRecording) {
                         stopStt();
@@ -1372,17 +1354,15 @@ export function renderChat(props: ChatProps) {
                     ${vs.sttRecording ? icons.micOff : icons.mic}
                   </button>
                 `
-                : nothing
-            }
+              : nothing}
             ${tokens ? html`<span class="agent-chat__token-count">${tokens}</span>` : nothing}
           </div>
 
           <div class="agent-chat__toolbar-right">
             ${nothing /* search hidden for now */}
-            ${
-              canAbort
-                ? nothing
-                : html`
+            ${canAbort
+              ? nothing
+              : html`
                   <button
                     class="btn btn--ghost"
                     @click=${props.onNewSession}
@@ -1391,8 +1371,7 @@ export function renderChat(props: ChatProps) {
                   >
                     ${icons.plus}
                   </button>
-                `
-            }
+                `}
             <button
               class="btn btn--ghost"
               @click=${() => exportMarkdown(props)}
@@ -1403,9 +1382,8 @@ export function renderChat(props: ChatProps) {
               ${icons.download}
             </button>
 
-            ${
-              canAbort && (isBusy || props.sending)
-                ? html`
+            ${canAbort && (isBusy || props.sending)
+              ? html`
                   <button
                     class="chat-send-btn chat-send-btn--stop"
                     @click=${props.onAbort}
@@ -1415,7 +1393,7 @@ export function renderChat(props: ChatProps) {
                     ${icons.stop}
                   </button>
                 `
-                : html`
+              : html`
                   <button
                     class="chat-send-btn"
                     @click=${() => {
@@ -1430,8 +1408,7 @@ export function renderChat(props: ChatProps) {
                   >
                     ${icons.send}
                   </button>
-                `
-            }
+                `}
           </div>
         </div>
       </div>

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1,4 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
+import { keyed } from "lit/directives/keyed.js";
 import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
 import type {
@@ -654,12 +655,15 @@ function renderWelcomeState(props: ChatProps): TemplateResult {
     <div class="agent-chat__welcome" style="--agent-color: var(--accent)">
       <div class="agent-chat__welcome-glow"></div>
       ${avatar
-        ? html`<img
-            src=${avatar}
-            alt=${name}
-            style="width:56px; height:56px; border-radius:50%; object-fit:cover;"
-            @error=${(event: Event) => handleAvatarImageError(event, props.basePath)}
-          />`
+        ? keyed(
+            `${props.sessionKey}:${avatar}`,
+            html`<img
+              src=${avatar}
+              alt=${name}
+              style="width:56px; height:56px; border-radius:50%; object-fit:cover;"
+              @error=${(event: Event) => handleAvatarImageError(event, props.basePath)}
+            />`,
+          )
         : html`<div class="agent-chat__avatar agent-chat__avatar--logo">
             <img src=${logoUrl} alt="OpenClaw" />
           </div>`}

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -628,6 +628,16 @@ const WELCOME_SUGGESTIONS = [
   "Check system health",
 ];
 
+function handleAvatarImageError(event: Event, basePath?: string) {
+  const img = event.currentTarget as HTMLImageElement | null;
+  if (!img || img.dataset.fallbackApplied === "1") {
+    return;
+  }
+  img.dataset.fallbackApplied = "1";
+  img.src = agentLogoUrl(basePath ?? "");
+  img.alt = "OpenClaw";
+}
+
 function renderWelcomeState(props: ChatProps): TemplateResult {
   const name = props.assistantName || "Assistant";
   const avatar = resolveAgentAvatarUrl({
@@ -647,10 +657,11 @@ function renderWelcomeState(props: ChatProps): TemplateResult {
             src=${avatar}
             alt=${name}
             style="width:56px; height:56px; border-radius:50%; object-fit:cover;"
+            @error=${(event: Event) => handleAvatarImageError(event, props.basePath)}
           />`
           : html`<div class="agent-chat__avatar agent-chat__avatar--logo">
-            <img src=${logoUrl} alt="OpenClaw" />
-          </div>`
+              <img src=${logoUrl} alt="OpenClaw" />
+            </div>`
       }
       <h2>${name}</h2>
       <div class="agent-chat__badges">


### PR DESCRIPTION
## Summary

- fall back to the bundled OpenClaw logo when the welcome avatar image fails to load
- fall back to the bundled OpenClaw logo when grouped assistant avatars fail to load
- switch the no-`basePath` logo fallback to a root-absolute path

## Root cause

When an assistant identity points at a remote avatar URL that fails to load, the UI leaves the broken `<img>` in place instead of recovering to the bundled logo. In practice this shows up as missing avatars or alt text like `Open` rendered in chat.

The existing bundled logo fallback also used `favicon.svg` when `basePath` was empty, which is route-relative and brittle before base-path bootstrap completes.

## Testing

- `pnpm exec vitest run ui/src/ui/views/agents-utils.test.ts ui/src/ui/views/chat.test.ts`
- `pnpm ui:build`
