### PR TITLE
fix(tui): strip inbound metadata from command messages before rendering (#59871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - TUI/status: route `/status` through the shared session-status command and move the old gateway-wide diagnostic summary to `/gateway-status` (`/gwstatus`). Thanks @vincentkoc.
 - Agents/history: use one shared assistant-visible sanitizer across embedded delivery and chat-history extraction so leaked `<tool_call>` and `<tool_result>` XML blocks stay hidden from user-facing replies. (#61729) Thanks @openperf.
 - Gateway/TUI: defer terminal chat finalization for per-attempt lifecycle errors so fallback retries keep streaming before the run is marked failed. (#60043) Thanks @jwchmodx.
+- TUI/command messages: strip inbound envelope metadata before rendering command/system messages so async completion notices stop leaking raw wrappers into the operator terminal. (#59985) Thanks @MoerAI.
 
 ## 2026.4.5
 

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -119,6 +119,29 @@ Actual user message`,
     expect(text).toBe("Actual user message");
   });
 
+  it("strips leading inbound metadata blocks for command messages (#59871)", () => {
+    const text = extractTextFromMessage({
+      command: true,
+      content: `Conversation info (untrusted metadata):
+\`\`\`json
+{
+  "message_id": "abc123"
+}
+\`\`\`
+
+Sender (untrusted metadata):
+\`\`\`json
+{
+  "label": "Someone"
+}
+\`\`\`
+
+Exec completed: task finished successfully`,
+    });
+
+    expect(text).toBe("Exec completed: task finished successfully");
+  });
+
   it("keeps metadata-like blocks for non-user messages", () => {
     const text = extractTextFromMessage({
       role: "assistant",

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -325,7 +325,7 @@ export function extractTextFromMessage(
   }
   const text = extractTextBlocks(record.content, opts);
   if (text) {
-    if (record.role === "user") {
+    if (record.role === "user" || record.command === true) {
       return stripLeadingInboundMetadata(text);
     }
     return text;


### PR DESCRIPTION
## Summary
Command messages (async exec completion notices, gateway system messages) rendered raw internal envelope metadata in the operator TUI because `extractTextFromMessage()` only stripped inbound metadata for `role === "user"` messages.

This PR intentionally fixes only the TUI display-layer leak. Issue #59871 also covers a separate transcript/context-injection problem that should stay open.

## Root Cause
In `src/tui/tui-formatters.ts`, `extractTextFromMessage()` conditionally calls `stripLeadingInboundMetadata()` only when `record.role === "user"`. Command messages carry `command: true` without a user role, so they bypass stripping entirely. The raw metadata blocks (conversation info, sender labels, untrusted context) are passed directly to TUI rendering.

## Changes
- `src/tui/tui-formatters.ts`: extend the strip condition to `record.role === "user" || record.command === true`
- `src/tui/tui-formatters.test.ts`: add regression coverage verifying command messages have metadata stripped
- `CHANGELOG.md`: add the user-facing TUI fix entry

## Test
```bash
pnpm test:serial src/tui/tui-formatters.test.ts
```
