### PR TITLE
sessions: classify all store backup artifacts

### DIFF
--- a/src/config/sessions/artifacts.test.ts
+++ b/src/config/sessions/artifacts.test.ts
@@ -14,6 +14,17 @@ describe("session artifact helpers", () => {
     expect(isSessionArchiveArtifactName("abc.jsonl.reset.2026-01-01T00-00-00.000Z")).toBe(true);
     expect(isSessionArchiveArtifactName("abc.jsonl.bak.2026-01-01T00-00-00.000Z")).toBe(true);
     expect(isSessionArchiveArtifactName("sessions.json.bak.1737420882")).toBe(true);
+    expect(
+      isSessionArchiveArtifactName("sessions.json.bak.session-maint-2026-04-03T00-11-27.859Z"),
+    ).toBe(true);
+    expect(
+      isSessionArchiveArtifactName("sessions.json.bak.safe-cleanup-2026-03-26T01-30-22.3NZ"),
+    ).toBe(true);
+    expect(
+      isSessionArchiveArtifactName(
+        "sessions.json.bak.pre-bot-session-detach-2026-03-31T07-50-22-248Z",
+      ),
+    ).toBe(true);
     expect(isSessionArchiveArtifactName("keep.deleted.keep.jsonl")).toBe(false);
     expect(isSessionArchiveArtifactName("abc.jsonl")).toBe(false);
   });

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -1,7 +1,7 @@
 export type SessionArchiveReason = "bak" | "reset" | "deleted";
 
 const ARCHIVE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d{3})?Z$/;
-const LEGACY_STORE_BACKUP_RE = /^sessions\.json\.bak\.\d+$/;
+const STORE_BACKUP_ARTIFACT_RE = /^sessions\.json\.bak\..+$/;
 
 function hasArchiveSuffix(fileName: string, reason: SessionArchiveReason): boolean {
   const marker = `.${reason}.`;
@@ -14,7 +14,7 @@ function hasArchiveSuffix(fileName: string, reason: SessionArchiveReason): boole
 }
 
 export function isSessionArchiveArtifactName(fileName: string): boolean {
-  if (LEGACY_STORE_BACKUP_RE.test(fileName)) {
+  if (STORE_BACKUP_ARTIFACT_RE.test(fileName)) {
     return true;
   }
   return (


### PR DESCRIPTION
## Summary
Recognize all `sessions.json.bak.*` files as session archive artifacts so session cleanup and disk-budget enforcement can account for them consistently.

## Root Cause
A local session-loss incident showed that OpenClaw core only classified legacy `sessions.json.bak.<digits>` store backups as cleanup artifacts. Newer backup names such as `sessions.json.bak.session-maint-*`, `sessions.json.bak.safe-cleanup-*`, and `sessions.json.bak.pre-bot-session-detach-*` were left outside core artifact handling.

When those files accumulated in a live `sessions/` directory, disk-budget accounting counted them toward the session directory size, but core cleanup did not recognize them as removable store-backup artifacts. That left the store permanently over budget and increased the chance that real session entries would be evicted instead.

## Fix
- broaden store-backup artifact detection from legacy numeric suffixes to all `sessions.json.bak.*` names
- add regression coverage for the backup naming patterns seen in the incident

## Validation
- `pnpm --dir /Users/xiaoliuzhuan/openclaw exec vitest run src/config/sessions/artifacts.test.ts --config vitest.unit.config.ts`