### PR TITLE
fix: improve reminder scheduling guidance for relative times

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -751,6 +751,20 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("using session_status when available");
     expect(prompt).toContain("explicit timezone or numeric UTC offset");
   });
+
+  it("keeps session_status optional in reminder guidance when the tool is unavailable", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["cron"],
+    });
+
+    expect(prompt).toContain("relative or ambiguous times");
+    expect(prompt).toContain("using session_status when available");
+    expect(prompt).not.toContain(
+      "If you need the current date, time, or day of week, run session_status",
+    );
+    expect(prompt).not.toContain("- session_status:");
+  });
 });
 
 describe("buildSubagentSystemPrompt", () => {

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -740,6 +740,17 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("## Reactions");
     expect(prompt).toContain("Reactions are enabled for Telegram in MINIMAL mode.");
   });
+
+  it("adds clear reminder/cron guidance to resolve relative times and prefer explicit timezone", () => {
+    const prompt = buildAgentSystemPrompt({ workspaceDir: "/tmp/openclaw" });
+
+    expect(prompt).toContain("relative or ambiguous times");
+    expect(prompt).toContain(
+      "first determine the current date/time from available context/tooling",
+    );
+    expect(prompt).toContain("using session_status when available");
+    expect(prompt).toContain("explicit timezone or numeric UTC offset");
+  });
 });
 
 describe("buildSubagentSystemPrompt", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -252,7 +252,7 @@ export function buildAgentSystemPrompt(params: {
     browser: "Control web browser",
     canvas: "Present/eval/snapshot the Canvas",
     nodes: "List/describe/notify/camera/screen on paired nodes",
-    cron: "Manage cron jobs and wake events (use for reminders; when scheduling a reminder, write the systemEvent text as something that will read like a reminder when it fires, and mention that it is a reminder depending on the time gap between setting and firing; include recent context in reminder text if appropriate)",
+    cron: 'Manage cron jobs and wake events (use for reminders. For relative or ambiguous times like "in 2 hours", "tomorrow morning", "after lunch", or "tonight at 8": first determine the current date/time from available context/tooling, using session_status when available, resolve to an absolute time in the user\'s timezone, then schedule. For one-shot absolute times, prefer including an explicit timezone or numeric UTC offset in the schedule. When scheduling, write the systemEvent text so it reads like a reminder when it fires and, when helpful, mention it is a reminder; include recent context if appropriate)',
     message: "Send messages and channel actions",
     gateway: "Restart, apply config, or run updates on the running OpenClaw process",
     agents_list: acpSpawnRuntimeEnabled
@@ -437,7 +437,7 @@ export function buildAgentSystemPrompt(params: {
           "- browser: control OpenClaw's dedicated browser",
           "- canvas: present/eval/snapshot the Canvas",
           "- nodes: list/describe/notify/camera/screen on paired nodes",
-          "- cron: manage cron jobs and wake events (use for reminders; when scheduling a reminder, write the systemEvent text as something that will read like a reminder when it fires, and mention that it is a reminder depending on the time gap between setting and firing; include recent context in reminder text if appropriate)",
+          "- cron: manage cron jobs and wake events (use for reminders. For relative or ambiguous times like 'in 2 hours', 'tomorrow morning', 'after lunch', or 'tonight at 8': first determine the current date/time from available context/tooling, using session_status when available, resolve to an absolute time in the user's timezone, then schedule. For one-shot absolute times, prefer including an explicit timezone or numeric UTC offset in the schedule. When scheduling, write the systemEvent text so it reads like a reminder when it fires and, when helpful, mention it is a reminder; include recent context if appropriate)",
           "- sessions_list: list sessions",
           "- sessions_history: fetch session history",
           "- sessions_send: send to another session",


### PR DESCRIPTION
## Summary
- clarify reminder scheduling guidance in the agent system prompt for relative or ambiguous times
- tell the agent to determine current date/time from available context/tooling, using `session_status` when available
- prefer explicit timezone / UTC offset for one-shot absolute reminder schedules
- add regression coverage for the new reminder guidance, including the case where `session_status` is unavailable

## Problem
Issue #10841 reports reminders being scheduled for the wrong times because the agent may not know the current time when interpreting phrases like "in 2 hours" or "tomorrow morning".

The scheduler behavior itself already expects absolute timestamps and treats ISO timestamps without an explicit timezone as UTC. The gap here is earlier: at reminder creation time, the prompt did not clearly instruct the model to resolve relative reminder phrases against the current date/time before calling `cron.add`.

## Fix
This PR keeps scope narrow and updates prompt-level guidance in `src/agents/system-prompt.ts` so the agent:
- resolves relative or ambiguous reminder phrases using current date/time from available context/tooling
- uses `session_status` when available
- resolves to an absolute time in the user's timezone before scheduling
- prefers explicit timezone or numeric UTC offset for one-shot absolute schedules

## Tests
- `corepack pnpm vitest run src/agents/system-prompt.test.ts`

Added regression coverage to verify:
- the prompt includes the new reminder guidance
- `session_status` remains optional when it is not present in the allowed tool set

## Notes
This is a prompt-level fix, not a cron engine change. It improves the model instruction path that leads to `cron.add`, while keeping scheduler behavior unchanged.
