### PR TITLE
fix(tts): use resolveConfigDir() to isolate test from host config

### DIFF
--- a/src/tts/status-config.ts
+++ b/src/tts/status-config.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import type { TtsAutoMode, TtsConfig, TtsProvider } from "../config/types.tts.js";
-import { CONFIG_DIR, resolveUserPath } from "../utils.js";
+import { resolveConfigDir, resolveUserPath } from "../utils.js";
 import { normalizeTtsAutoMode } from "./tts-auto-mode.js";
 
 const DEFAULT_TTS_MAX_LENGTH = 1500;
@@ -47,7 +47,7 @@ function resolveTtsPrefsPathValue(prefsPath: string | undefined): string {
   if (envPath) {
     return resolveUserPath(envPath);
   }
-  return path.join(CONFIG_DIR, "settings", "tts.json");
+  return path.join(resolveConfigDir(), "settings", "tts.json");
 }
 
 function readPrefs(prefsPath: string): TtsUserPrefs {


### PR DESCRIPTION
## Summary

- Problem: `resolveTtsPrefsPathValue()` uses the module-level `CONFIG_DIR` constant, which is evaluated at import time and frozen to the real `~/.openclaw/`. When tests run inside `withTempHome`, the temp HOME is set after the import, so the TTS prefs path still resolves to the host's real config directory.
- Why it matters: On machines with an existing `~/.openclaw/settings/tts.json` (e.g. with `auto: "off"`), the host prefs override the test config and cause `resolveStatusTtsSnapshot` to return `null` instead of the expected snapshot — failing the `reports auto provider when tts is on without an explicit provider` test.
- What changed: Replaced the static `CONFIG_DIR` import with `resolveConfigDir()` function call, which evaluates at call time and correctly picks up the temp HOME during tests.
- What did NOT change (scope boundary): No behavioral change in production. `CONFIG_DIR` is itself defined as `resolveConfigDir()` at module scope — this change only affects call-time resolution order.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: test isolation for TTS status snapshot
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `CONFIG_DIR` is a module-level constant (`export const CONFIG_DIR = resolveConfigDir()`). It captures the config directory path at import time, before `withTempHome` can redirect HOME to a temp directory.
- Missing detection / guardrail: No CI environment has a `~/.openclaw/settings/tts.json` with TTS disabled, so the test only fails on developer machines with specific host config.
- Prior context: The `resolveConfigDir()` function already exists and is the correct way to get the config dir at runtime.
- Why this regressed now: It was always latent — only visible when the host has a TTS prefs file that overrides the test expectations.
- If unknown, what was ruled out: N/A — root cause is clear.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Existing coverage already sufficient
- Target test or file: `src/tts/status-config.test.ts`
- Scenario the test should lock in: `resolveStatusTtsSnapshot` returns expected defaults when TTS is enabled without explicit provider, regardless of host config.
- Why this is the smallest reliable guardrail: The existing test already covers the exact scenario; the fix ensures it runs in isolation.
- Existing test that already covers this (if any): `reports auto provider when tts is on without an explicit provider` — this test was failing and now passes.

## User-visible / Behavior Changes

None

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (any machine with `~/.openclaw/settings/tts.json`)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Host has `~/.openclaw/settings/tts.json` with TTS prefs

### Steps

1. Have a `~/.openclaw/settings/tts.json` file on host
2. Run `pnpm test -- src/tts/status-config.test.ts`
3. Observe test failure: `reports auto provider when tts is on without an explicit provider`

### Expected

- Test passes (returns TTS snapshot with `autoMode: "always"`)

### Actual

- Before fix: returns `null` because host prefs file is read and overrides test config
- After fix: test passes — `resolveConfigDir()` picks up temp HOME

## Evidence

- [x] Failing test/log before + passing after

Before: `1 failed | 1183 passed (1184)` — `src/tts/status-config.test.ts` fails
After: `Test Files 1 passed (1)` — both tests pass

## Human Verification (required)

- Verified scenarios: Ran `pnpm test -- src/tts/status-config.test.ts` before and after fix
- Edge cases checked: First test (uses explicit `prefsPath`) still passes — not affected by the change
- What you did **not** verify: Full test suite rerun (pre-commit hook ran `pnpm check` which passed)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None
