### PR TITLE
Fix media-only TTS replies when assistant ends with NO_REPLY

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1310,6 +1310,7 @@ export async function runEmbeddedPiAgent(
             toolMetas: attempt.toolMetas,
             lastAssistant: attempt.lastAssistant,
             lastToolError: attempt.lastToolError,
+            pendingToolMediaReply: attempt.pendingToolMediaReply,
             config: params.config,
             isCronTrigger: params.trigger === "cron",
             sessionKey: params.sessionKey ?? params.sessionId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1368,6 +1368,7 @@ export async function runEmbeddedAttempt(
         getMessagingToolSentTexts,
         getMessagingToolSentMediaUrls,
         getMessagingToolSentTargets,
+        getPendingToolMediaReply,
         getSuccessfulCronAdds,
         didSendViaMessagingTool,
         getLastToolError,
@@ -1951,6 +1952,7 @@ export async function runEmbeddedAttempt(
         messagingToolSentTexts: getMessagingToolSentTexts(),
         messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
         messagingToolSentTargets: getMessagingToolSentTargets(),
+        pendingToolMediaReply: getPendingToolMediaReply(),
         successfulCronAdds: getSuccessfulCronAdds(),
         cloudCodeAssistFormatError: Boolean(
           lastAssistant?.errorMessage && isCloudCodeAssistFormatError(lastAssistant.errorMessage),

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -141,4 +141,22 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
       assistantTexts: ['{"action":"NO_REPLY"}'],
     });
   });
+
+  it("preserves pending tool media when the assistant ends with NO_REPLY", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["NO_REPLY"],
+      pendingToolMediaReply: {
+        mediaUrls: ["/tmp/reply.opus"],
+        audioAsVoice: true,
+      },
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({
+      mediaUrl: "/tmp/reply.opus",
+      mediaUrls: ["/tmp/reply.opus"],
+      audioAsVoice: true,
+    });
+    expect(payloads[0]?.text).toBeUndefined();
+  });
 });

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -106,6 +106,10 @@ export function buildEmbeddedRunPayloads(params: {
   toolMetas: ToolMetaEntry[];
   lastAssistant: AssistantMessage | undefined;
   lastToolError?: ToolErrorSummary;
+  pendingToolMediaReply?: {
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+  } | null;
   config?: OpenClawConfig;
   isCronTrigger?: boolean;
   sessionKey: string;
@@ -297,6 +301,26 @@ export function buildEmbeddedRunPayloads(params: {
     hasUserFacingAssistantReply = true;
   }
 
+  const pendingToolMediaUrls = params.pendingToolMediaReply?.mediaUrls?.filter(Boolean) ?? [];
+  if (pendingToolMediaUrls.length > 0 || params.pendingToolMediaReply?.audioAsVoice) {
+    const mergeTarget = [...replyItems]
+      .toReversed()
+      .find((item) => !item.isReasoning && !item.isError);
+    if (mergeTarget) {
+      mergeTarget.media = Array.from(
+        new Set([...(mergeTarget.media ?? []), ...pendingToolMediaUrls]),
+      );
+      mergeTarget.audioAsVoice =
+        mergeTarget.audioAsVoice || params.pendingToolMediaReply?.audioAsVoice;
+    } else {
+      replyItems.push({
+        text: "",
+        media: pendingToolMediaUrls.length ? pendingToolMediaUrls : undefined,
+        audioAsVoice: params.pendingToolMediaReply?.audioAsVoice,
+      });
+    }
+  }
+
   if (params.lastToolError) {
     const warningPolicy = resolveToolErrorWarningPolicy({
       lastToolError: params.lastToolError,
@@ -342,16 +366,26 @@ export function buildEmbeddedRunPayloads(params: {
 
   const hasAudioAsVoiceTag = replyItems.some((item) => item.audioAsVoice);
   return replyItems
-    .map((item) => ({
-      text: item.text?.trim() ? item.text.trim() : undefined,
-      mediaUrls: item.media?.length ? item.media : undefined,
-      mediaUrl: item.media?.[0],
-      isError: item.isError,
-      replyToId: item.replyToId,
-      replyToTag: item.replyToTag,
-      replyToCurrent: item.replyToCurrent,
-      audioAsVoice: item.audioAsVoice || Boolean(hasAudioAsVoiceTag && item.media?.length),
-    }))
+    .map((item) => {
+      const trimmedText = item.text?.trim() ? item.text.trim() : undefined;
+      const mediaUrls = item.media?.length ? item.media : undefined;
+      const normalizedText =
+        trimmedText &&
+        mediaUrls?.length &&
+        isSilentReplyPayloadText(trimmedText, SILENT_REPLY_TOKEN)
+          ? undefined
+          : trimmedText;
+      return {
+        text: normalizedText,
+        mediaUrls,
+        mediaUrl: mediaUrls?.[0],
+        isError: item.isError,
+        replyToId: item.replyToId,
+        replyToTag: item.replyToTag,
+        replyToCurrent: item.replyToCurrent,
+        audioAsVoice: item.audioAsVoice || Boolean(hasAudioAsVoiceTag && mediaUrls?.length),
+      };
+    })
     .filter((p) => {
       if (!hasOutboundReplyContent(p)) {
         return false;

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -53,6 +53,10 @@ export type EmbeddedRunAttemptResult = {
   messagingToolSentTexts: string[];
   messagingToolSentMediaUrls: string[];
   messagingToolSentTargets: MessagingToolSend[];
+  pendingToolMediaReply?: {
+    mediaUrls?: string[];
+    audioAsVoice?: boolean;
+  } | null;
   successfulCronAdds?: number;
   cloudCodeAssistFormatError: boolean;
   attemptUsage?: NormalizedUsage;

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -11,17 +11,20 @@ function createContext(
   lastAssistant: unknown,
   overrides?: {
     onAgentEvent?: (event: unknown) => void;
+    onBlockReply?: ((payload: unknown) => void) | undefined;
     onBlockReplyFlush?: () => void | Promise<void>;
   },
 ): EmbeddedPiSubscribeContext {
-  const onBlockReply = vi.fn();
+  const hasOnBlockReplyOverride = Boolean(overrides && "onBlockReply" in overrides);
+  const onBlockReply = hasOnBlockReplyOverride ? overrides?.onBlockReply : vi.fn();
+  const emitBlockReply = vi.fn();
   return {
     params: {
       runId: "run-1",
       config: {},
       sessionKey: "agent:main:main",
       onAgentEvent: overrides?.onAgentEvent,
-      onBlockReply,
+      ...(onBlockReply ? { onBlockReply } : {}),
       onBlockReplyFlush: overrides?.onBlockReplyFlush,
     },
     state: {
@@ -40,7 +43,7 @@ function createContext(
       warn: vi.fn(),
     },
     flushBlockReplyBuffer: vi.fn(),
-    emitBlockReply: onBlockReply,
+    emitBlockReply,
     resolveCompactionRetry: vi.fn(),
     maybeResolveCompactionWait: vi.fn(),
   } as unknown as EmbeddedPiSubscribeContext;
@@ -182,6 +185,18 @@ describe("handleAgentEnd", () => {
     });
     expect(ctx.state.pendingToolMediaUrls).toEqual([]);
     expect(ctx.state.pendingToolAudioAsVoice).toBe(false);
+  });
+
+  it("preserves pending tool media when no block reply callback is configured", async () => {
+    const ctx = createContext(undefined, { onBlockReply: undefined });
+    ctx.state.pendingToolMediaUrls = ["/tmp/reply.opus"];
+    ctx.state.pendingToolAudioAsVoice = true;
+
+    await handleAgentEnd(ctx);
+
+    expect(ctx.emitBlockReply).not.toHaveBeenCalled();
+    expect(ctx.state.pendingToolMediaUrls).toEqual(["/tmp/reply.opus"]);
+    expect(ctx.state.pendingToolAudioAsVoice).toBe(true);
   });
 
   it("resolves compaction wait before awaiting an async block reply flush", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -114,9 +114,11 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
   };
 
   const flushPendingMediaAndChannel = () => {
-    const pendingToolMediaReply = consumePendingToolMediaReply(ctx.state);
-    if (pendingToolMediaReply && hasAssistantVisibleReply(pendingToolMediaReply)) {
-      ctx.emitBlockReply(pendingToolMediaReply);
+    if (ctx.params.onBlockReply) {
+      const pendingToolMediaReply = consumePendingToolMediaReply(ctx.state);
+      if (pendingToolMediaReply && hasAssistantVisibleReply(pendingToolMediaReply)) {
+        ctx.emitBlockReply(pendingToolMediaReply);
+      }
     }
 
     const postMediaFlushResult = ctx.flushBlockReplyBuffer();

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -743,6 +743,17 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     getMessagingToolSentTexts: () => messagingToolSentTexts.slice(),
     getMessagingToolSentMediaUrls: () => messagingToolSentMediaUrls.slice(),
     getMessagingToolSentTargets: () => messagingToolSentTargets.slice(),
+    getPendingToolMediaReply: () => {
+      if (state.pendingToolMediaUrls.length === 0 && !state.pendingToolAudioAsVoice) {
+        return null;
+      }
+      return {
+        mediaUrls: state.pendingToolMediaUrls.length
+          ? Array.from(new Set(state.pendingToolMediaUrls))
+          : undefined,
+        audioAsVoice: state.pendingToolAudioAsVoice || undefined,
+      };
+    },
     getSuccessfulCronAdds: () => state.successfulCronAdds,
     // Returns true if any messaging tool successfully sent a message.
     // Used to suppress agent's confirmation text (e.g., "Respondi no Telegram!")


### PR DESCRIPTION
## Summary
- preserve pending tool media in the embedded runner when a successful TTS tool call is followed by `NO_REPLY`
- strip silent `NO_REPLY` text from media-bearing payloads instead of collapsing the turn into an empty reply
- add a regression test for the `assistantTexts: ["NO_REPLY"] + pending TTS media` case

## Root cause
For media-only TTS turns, the tool result was recorded successfully, but the final payload builder only looked at the assistant text/directive output. When the assistant intentionally ended with `NO_REPLY`, the media-only result could collapse into an empty outbound payload and trigger the generic no-response fallback instead of sending the generated audio reply.

## Validation
- `pnpm vitest run src/agents/pi-embedded-runner/run/payloads.test.ts`

## Notes
- this cherry-picks the runtime fix only; it does not include Dana fork bookkeeping
