### PR TITLE
perf(gateway): add OPENCLAW_SKIP_MODEL_WARMUP env to skip startup model pre-warm

### DIFF
--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -39,6 +39,7 @@ async function prewarmConfiguredPrimaryModel(params: {
   log: { warn: (msg: string) => void };
 }): Promise<void> {
   if (isTruthyEnvValue(process.env.OPENCLAW_SKIP_MODEL_WARMUP)) {
+    params.log.warn("skipping model warmup (OPENCLAW_SKIP_MODEL_WARMUP=1)");
     return;
   }
   const explicitPrimary = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model)?.trim();

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -38,6 +38,9 @@ async function prewarmConfiguredPrimaryModel(params: {
   cfg: ReturnType<typeof loadConfig>;
   log: { warn: (msg: string) => void };
 }): Promise<void> {
+  if (isTruthyEnvValue(process.env.OPENCLAW_SKIP_MODEL_WARMUP)) {
+    return;
+  }
   const explicitPrimary = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model)?.trim();
   if (!explicitPrimary) {
     return;

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -69,6 +69,7 @@ const GATEWAY_TEST_ENV_KEYS = [
   "OPENCLAW_SKIP_CHANNELS",
   "OPENCLAW_SKIP_PROVIDERS",
   "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_SKIP_MODEL_WARMUP",
   "OPENCLAW_TEST_MINIMAL_GATEWAY",
 ] as const;
 
@@ -222,6 +223,7 @@ function applyGatewaySkipEnv() {
   process.env.OPENCLAW_SKIP_CHANNELS = "1";
   process.env.OPENCLAW_SKIP_PROVIDERS = "1";
   process.env.OPENCLAW_SKIP_CRON = "1";
+  process.env.OPENCLAW_SKIP_MODEL_WARMUP = "1";
   process.env.OPENCLAW_TEST_MINIMAL_GATEWAY = "1";
   process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = tempHome
     ? path.join(tempHome, "openclaw-test-no-bundled-extensions")


### PR DESCRIPTION
## Problem

`prewarmConfiguredPrimaryModel` runs implicit provider discovery at gateway startup, sequentially loading 30+ provider plugin modules to auto-detect available API keys and build `models.json`. On standard desktop/server environments this completes in under a second, but on constrained hosts the cost is dramatically amplified.

### Android/proot: 60+ seconds wasted on startup

[andClaw](https://play.google.com/store/apps/details?id=com.coderred.andclaw) runs OpenClaw inside a proot-based Linux environment on Android. In proot, **every syscall is intercepted via ptrace**, adding significant overhead to file I/O and module loading. The impact on `prewarmConfiguredPrimaryModel` is severe:

| Step | Time (proot, Snapdragon 8 Elite) |
|------|------|
| `ensureOpenClawModelsJson` | **74s** |
| → `resolveImplicitProviders` (30 plugins × ~2s each) | 57s |
| → All 30 provider catalogs returned **null** | — |
| `resolveModel` (ModelRegistry init) | 7s |
| **Total prewarmConfiguredPrimaryModel** | **~80s** |

**The entire 60+ seconds is completely wasted** — all 30 provider catalogs return null because:
1. andClaw injects API keys via environment variables at process launch
2. `models.providers` in `openclaw.json` is intentionally left empty (keys are not persisted in config)
3. Implicit discovery cannot find any providers, so `models.json` is never written
4. This repeats on every gateway restart since the in-memory cache (`MODELS_JSON_READY_CACHE`) is cleared

### Profiling methodology

Timing was measured by injecting `console.time`/`console.timeEnd` into the dist JS files on-device and collecting via `adb logcat`. Cross-validated against native Termux execution (no proot) where the same startup path completes in ~1 second, confirming the overhead is entirely ptrace-related.

### Before vs After

| | Galaxy Z Fold 7 (Snapdragon 8 Elite) |
|--|--|
| Before | ~2 min total gateway startup |
| After (with `OPENCLAW_SKIP_MODEL_WARMUP=1`) | **~20s** total gateway startup |

## Solution

Add an `OPENCLAW_SKIP_MODEL_WARMUP` environment variable. When set to a truthy value (`1`, `true`, etc.), `prewarmConfiguredPrimaryModel` returns immediately without running provider discovery or model resolution.

- **No functional regression**: the model is still resolved lazily on the first chat request via `loadModelCatalog` / `resolveModel`
- **Only the eager startup validation is skipped** — this is a best-effort warmup that logs a warning on failure anyway
- Follows the existing `OPENCLAW_SKIP_*` env var naming convention (`OPENCLAW_SKIP_CHANNELS`, `OPENCLAW_SKIP_PROVIDERS`)

## Changes

- `src/gateway/server-startup.ts`: 3 lines added — early return in `prewarmConfiguredPrimaryModel` when `OPENCLAW_SKIP_MODEL_WARMUP` is truthy