### PR TITLE
fix(ui): make exec approval command display scrollable

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2955,6 +2955,8 @@ td.data-table-key-col {
   white-space: pre-wrap;
   font-family: var(--mono);
   font-size: 13px;
+  max-height: 200px;
+  overflow-y: auto;
 }
 
 .exec-approval-meta {


### PR DESCRIPTION
## Summary

Fixes issue where the authorization window doesn't allow scrolling when commands are too long.

## Root Cause

The exec approval dialog command display didn't have overflow handling, so when commands were too long, users couldn't scroll to see the full command text.

## Fix

Added `max-height: 200px` and `overflow-y: auto` to `.exec-approval-command` CSS class to enable scrolling for long commands.

## Changes

- `ui/src/styles/components.css`: Added scroll support to command display

## Testing

- Lint passes
- Format passes

Fixes #59987