### PR TITLE
fix: add 'file' param alias to resolvePathArg for verbose tool summaries

### DIFF
--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -177,7 +177,7 @@ export function resolvePathArg(args: unknown): string | undefined {
   if (!record) {
     return undefined;
   }
-  for (const candidate of [record.path, record.file_path, record.filePath]) {
+  for (const candidate of [record.path, record.file, record.file_path, record.filePath]) {
     if (typeof candidate !== "string") {
       continue;
     }


### PR DESCRIPTION
The Read/Edit/Write tool schemas all accept `file` as a parameter name (alongside `path`, `file_path`, `filePath`), but `resolvePathArg` only checked the latter three. When the model passes `file`, the verbose summary shows just the bare tool name (e.g. `📖 Read`) instead of including the path (e.g. `📖 Read: from ~/.openclaw/workspace/SOUL.md`).

Adds `record.file` to the candidate list.