### PR TITLE
fix: provider-agnostic dedup + filter reasoning blocks from Slack streaming

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
@@ -127,3 +127,18 @@ describe("slack draft stream initialization", () => {
     ).toBe(true);
   });
 });
+
+// Smoke-test that isSlackStreamingEnabled returns the expected value for the
+// configuration that triggers nativeStreaming (the path fixed by issue #59687).
+describe("slack native streaming reasoning leak guard (issue #59687)", () => {
+  it("confirms streaming is enabled for partial+nativeStreaming=true (the affected path)", () => {
+    // The deliverWithStreaming path is only exercised when isSlackStreamingEnabled
+    // returns true. The reasoning guard (payload.isReasoning early return) lives
+    // inside that path, so we verify the enabling condition here.
+    expect(isSlackStreamingEnabled({ mode: "partial", nativeStreaming: true })).toBe(true);
+  });
+
+  it("streaming is off when nativeStreaming is false (reasoning leak cannot occur)", () => {
+    expect(isSlackStreamingEnabled({ mode: "partial", nativeStreaming: false })).toBe(false);
+  });
+});

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -373,6 +373,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   };
 
   const deliverWithStreaming = async (payload: ReplyPayload): Promise<void> => {
+    // Filter out reasoning/thinking blocks before streaming.
+    // Extended-thinking models (e.g. Claude with thinking enabled) emit
+    // intermediate reasoning payloads that must never reach the channel.
+    // Fix for https://github.com/openclaw/openclaw/issues/59687
+    if (payload.isReasoning) {
+      return;
+    }
     const reply = resolveSendableOutboundReplyParts(payload);
     if (streamFailed || reply.hasMedia || readSlackReplyBlocks(payload)?.length || !reply.hasText) {
       await deliverNormally(payload, streamSession?.threadTs);

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -106,13 +106,16 @@ function targetsMatchForSuppression(params: {
   targetKey: string;
   targetThreadId?: string;
 }): boolean {
-  if (params.provider !== "telegram") {
-    return params.targetKey === params.originTarget;
-  }
-
-  const origin = parseExplicitTargetForChannel("telegram", params.originTarget);
-  const target = parseExplicitTargetForChannel("telegram", params.targetKey);
+  // Use provider-agnostic comparison via parseExplicitTargetForChannel so that
+  // all channels (Slack, Telegram, iMessage, …) get the same thread-aware dedup.
+  // Fix for https://github.com/openclaw/openclaw/issues/59687 — previously only
+  // Telegram received the thread-aware path; all other providers fell back to a
+  // naïve string equality check that skipped thread context entirely.
+  const origin = parseExplicitTargetForChannel(params.provider, params.originTarget);
+  const target = parseExplicitTargetForChannel(params.provider, params.targetKey);
   if (!origin || !target) {
+    // No plugin-level parsing available for this provider — fall back to plain
+    // string comparison so we don't accidentally over-suppress.
     return params.targetKey === params.originTarget;
   }
   const explicitTargetThreadId = normalizeThreadIdForComparison(params.targetThreadId);

--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -169,4 +169,45 @@ describe("shouldSuppressMessagingToolReplies", () => {
       }),
     ).toBe(true);
   });
+
+  // Slack dedup — fix for https://github.com/openclaw/openclaw/issues/59687
+  it("suppresses Slack DM replies when the tool target matches the origin user", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "slack",
+        originatingTo: "user:U12345",
+        messagingToolSentTargets: [{ tool: "message", provider: "slack", to: "user:U12345" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress Slack DM replies when the tool target is a different user", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "slack",
+        originatingTo: "user:U12345",
+        messagingToolSentTargets: [{ tool: "message", provider: "slack", to: "user:U99999" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("suppresses Slack channel replies when the tool target matches the origin channel", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "slack",
+        originatingTo: "channel:C12345",
+        messagingToolSentTargets: [{ tool: "message", provider: "slack", to: "channel:C12345" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress Slack replies when providerless target does not match origin route", () => {
+    expect(
+      shouldSuppressMessagingToolReplies({
+        messageProvider: "slack",
+        originatingTo: "user:U12345",
+        messagingToolSentTargets: [{ tool: "message", provider: "", to: "user:U99999" }],
+      }),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
Fixes #59687

## Summary

Two bugs in the Slack message delivery pipeline:

### Bug 1 — `targetsMatchForSuppression()` skips non-Telegram channels

The function hard-coded `'telegram'` as the provider when calling `parseExplicitTargetForChannel`, so thread-aware reply deduplication only worked for Telegram. When an agent called `message.send` to reply AND OpenClaw auto-delivered the response text on Slack (or any other channel), users received both messages.

**Fix:** Pass `params.provider` instead of `'telegram'` so all channels get the same dedup logic.

### Bug 2 — `deliverWithStreaming()` leaks reasoning/thinking blocks to Slack

When `nativeStreaming: true` was enabled for a Slack session, extended thinking blocks (`isReasoning: true`) from Claude were streamed to the Slack channel as visible messages.

**Fix:** Added an early return at the top of `deliverWithStreaming()` in the Slack dispatch: `if (payload.isReasoning) return;`

## Changes

- `extensions/slack/src/monitor/message-handler/dispatch.ts` — reasoning block filter
- `core/src/reply-payloads/dedupe.ts` — provider-agnostic target comparison
- 4 new Slack dedup tests + existing 14 streaming tests still pass
- 4 files changed, 72 insertions, 6 deletions