### PR TITLE
fix(cron): add null guard for job.name in printCronList

### DIFF
--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -231,7 +231,7 @@ export function printCronList(jobs: CronJob[], runtime: RuntimeEnv = defaultRunt
 
   for (const job of jobs) {
     const idLabel = pad(job.id, CRON_ID_PAD);
-    const nameLabel = pad(truncate(job.name, CRON_NAME_PAD), CRON_NAME_PAD);
+    const nameLabel = pad(truncate(job.name ?? "-", CRON_NAME_PAD), CRON_NAME_PAD);
     const scheduleLabel = pad(
       truncate(formatSchedule(job.schedule), CRON_SCHEDULE_PAD),
       CRON_SCHEDULE_PAD,


### PR DESCRIPTION
## Summary

`job.name` is typed as required in `CronJob` but can be `undefined` at runtime (e.g. jobs persisted before the field was introduced). In `printCronList`, passing `undefined` to `truncate` then `pad` causes `.padEnd` to throw.

- Add `?? "-"` fallback for `job.name`, consistent with how `job.agentId` and `job.sessionTarget` are already guarded on the same lines below

## Test plan

- [ ] Run `openclaw cron list` against a gateway that has at least one cron job with no `name` field — should render `-` instead of crashing
- [ ] Existing cron-cli tests pass

Fixes #59968

🤖 Generated with [Claude Code](https://claude.com/claude-code)