### PR TITLE
fix(pi): use resolvePathArg for read tool path alias in handler

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -25,6 +25,7 @@ import {
 } from "./pi-embedded-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
 import { consumeAdjustedParamsForToolCall } from "./pi-tools.before-tool-call.js";
+import { resolvePathArg } from "./tool-display-common.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
 
@@ -361,14 +362,7 @@ export function handleToolExecutionStart(
     toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: Date.now(), args });
 
     if (toolName === "read") {
-      const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-      const filePathValue =
-        typeof record.path === "string"
-          ? record.path
-          : typeof record.file_path === "string"
-            ? record.file_path
-            : "";
-      const filePath = filePathValue.trim();
+      const filePath = resolvePathArg(args);
       if (!filePath) {
         const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;
         ctx.log.warn(


### PR DESCRIPTION
## Summary

The diagnostic guard in `handleToolExecutionStart` for the `read` tool was manually checking only the `path` and `file_path` arg aliases, missing the `filePath` camelCase alias.

The existing `resolvePathArg` utility in `tool-display-common.ts` already handles all three aliases (`path`, `file_path`, `filePath`). This PR replaces the inline alias lookup with a call to `resolvePathArg`, fixing the missed alias and reducing duplication.

## Test plan

- [ ] Call `read` tool with `{ filePath: "..." }` — warning should no longer fire incorrectly
- [ ] Existing handler tests pass (30 tests)

Fixes #60008

🤖 Generated with [Claude Code](https://claude.com/claude-code)