### PR TITLE
fix(mattermost): prevent DM replies from threading via resolveMattermostReplyRootId

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -118,6 +118,7 @@ describe("resolveMattermostReplyRootId with block streaming payloads", () => {
     // mode, the deliver callback should still use the existing threadRootId.
     expect(
       resolveMattermostReplyRootId({
+        kind: "channel",
         threadRootId: "thread-root-1",
         replyToId: "streamed-reply-id",
       }),
@@ -129,6 +130,7 @@ describe("resolveMattermostReplyRootId with block streaming payloads", () => {
     // inbound post id as replyToId from the "all" threading mode.
     expect(
       resolveMattermostReplyRootId({
+        kind: "channel",
         replyToId: "inbound-post-for-threading",
       }),
     ).toBe("inbound-post-for-threading");
@@ -139,6 +141,7 @@ describe("resolveMattermostReplyRootId", () => {
   it("uses replyToId for top-level replies", () => {
     expect(
       resolveMattermostReplyRootId({
+        kind: "channel",
         replyToId: "inbound-post-123",
       }),
     ).toBe("inbound-post-123");
@@ -147,6 +150,7 @@ describe("resolveMattermostReplyRootId", () => {
   it("keeps the thread root when replying inside an existing thread", () => {
     expect(
       resolveMattermostReplyRootId({
+        kind: "channel",
         threadRootId: "thread-root-456",
         replyToId: "child-post-789",
       }),
@@ -154,7 +158,28 @@ describe("resolveMattermostReplyRootId", () => {
   });
 
   it("falls back to undefined when neither reply target is available", () => {
-    expect(resolveMattermostReplyRootId({})).toBeUndefined();
+    expect(resolveMattermostReplyRootId({ kind: "channel" })).toBeUndefined();
+  });
+
+  it("returns undefined for direct messages regardless of replyToId", () => {
+    // DMs must never be threaded even if a downstream payload carries replyToId.
+    // Fixes: DM replies created threads despite replyToMode always being "off" for DMs.
+    expect(
+      resolveMattermostReplyRootId({
+        kind: "direct",
+        replyToId: "triggering-post-id",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for direct messages regardless of threadRootId", () => {
+    expect(
+      resolveMattermostReplyRootId({
+        kind: "direct",
+        threadRootId: "some-thread-root",
+        replyToId: "some-post",
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -158,9 +158,15 @@ function channelChatType(kind: ChatType): "direct" | "group" | "channel" {
 }
 
 export function resolveMattermostReplyRootId(params: {
+  kind: ChatType;
   threadRootId?: string;
   replyToId?: string;
 }): string | undefined {
+  // Direct messages must never be threaded — even if a downstream payload
+  // carries a replyToId, honour the DM-always-off threading policy here.
+  if (params.kind === "direct") {
+    return undefined;
+  }
   const threadRootId = params.threadRootId?.trim();
   if (threadRootId) {
     return threadRootId;
@@ -528,6 +534,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 accountId: account.accountId,
                 agentId: route.agentId,
                 replyToId: resolveMattermostReplyRootId({
+                  kind,
                   threadRootId: threadContext.effectiveReplyToId,
                   replyToId: payload.replyToId,
                 }),
@@ -735,6 +742,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             accountId: account.accountId,
             agentId: params.route.agentId,
             replyToId: resolveMattermostReplyRootId({
+              kind: params.kind,
               threadRootId: params.effectiveReplyToId,
               replyToId: trimmedPayload.replyToId,
             }),
@@ -1446,6 +1454,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             accountId: account.accountId,
             agentId: route.agentId,
             replyToId: resolveMattermostReplyRootId({
+              kind,
               threadRootId: effectiveReplyToId,
               replyToId: payload.replyToId,
             }),


### PR DESCRIPTION
## Problem

Mattermost DM auto-replies were sent with a non-empty `root_id`, creating threads in the DM channel despite the documentation stating that direct messages ignore `replyToMode` and stay non-threaded.

The bug was in `resolveMattermostReplyRootId`: it would fall back to `payload.replyToId` regardless of chat kind. Even though `resolveMattermostEffectiveReplyToId` already correctly returns `undefined` for DMs (guarding session-key resolution), the delivery path could still reintroduce a thread root when a downstream payload carried a `replyToId` — for example, during block-streaming delivery where each block carries the inbound post ID as `replyToId`.

This caused all DM bot replies to appear as threads, making the main channel body appear empty to users.

Fixes #59981

## Fix

Add `kind: ChatType` to `resolveMattermostReplyRootId` and hard-return `undefined` when `kind === "direct"`, mirroring the guard that already existed in `resolveMattermostEffectiveReplyToId`.

Update all three delivery call sites to pass `kind`:
1. Main inbound message replies
2. Button-click interaction replies  
3. Model picker command replies

## Tests

Added two regression tests to `resolveMattermostReplyRootId`:
- DM with `replyToId` → `undefined` (was: returns `replyToId`, causing threading)
- DM with both `threadRootId` and `replyToId` → `undefined`

All 22 Mattermost monitor tests pass.

```
pnpm vitest run extensions/mattermost/src/mattermost/monitor.test.ts
✓ 22 tests passed
```