### PR TITLE
docs(contributing): add contributor credit and deduplication guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,8 @@
 - This includes auto-close labels, bug-fix evidence gates, GitHub comment/search footguns, and maintainer PR decision flow.
 - For the repo's end-to-end maintainer PR workflow, use `$openclaw-pr-maintainer` at `.agents/skills/openclaw-pr-maintainer/SKILL.md`.
 
+**Before starting new work:** search existing issues and PRs first (`gh issue list --search "..."`, `gh pr list --search "..."`). Only open a new PR if yours is clearly better; credit prior work with `Co-authored-by` and link the original issue/PR.
+
 - `/landpr` lives in the global Codex prompts (`~/.codex/prompts/landpr.md`); when landing or merging any PR, always follow that `/landpr` process.
 - Create commits with `scripts/committer "<msg>" <file...>`; avoid manual `git add`/`git commit` so staging stays scoped.
 - Follow concise, action-oriented commit messages (e.g., `CLI: add verbose flag to send`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,32 @@ Welcome to the lobster tank! 🦞
 
 ## Before You PR
 
+### Check for Existing Work
+
+Before opening a new issue or PR, **search for existing issues and PRs** that address the same problem or feature. Duplicate work wastes everyone's time — yours included.
+
+- If an existing PR is open and directionally correct, consider reviewing it or offering to help iterate on it rather than opening a competing PR.
+- If you believe your approach is significantly better, open your PR with a clear explanation of _why_ — and **acknowledge the prior work**. Link to the existing issue/PR and credit the original author:
+  - Mention "Related to #XXXX by @author" or "Builds on the approach in #XXXX" in your PR description.
+  - If your PR incorporates or duplicates ideas from a prior PR, add `Co-authored-by: Original Author <email>` to your commit message. This ensures they appear in GitHub's contributor graph.
+
+### For Maintainers: Credit and Contributor-First Practices
+
+When multiple PRs address the same issue:
+
+1. **Prefer the first contributor's PR when feasible.** If it's directionally correct, guide the author to fix issues via review comments rather than closing and rewriting from scratch. The "teach someone to fish" approach grows the contributor pool and builds long-term project health.
+
+2. **If selecting a later or better contribution over the first**, credit everyone whose PRs you close:
+   - Add `Co-authored-by: Name <email>` to the merge commit.
+   - Mention the superseded PR(s) and author(s) in the PR description: "Based on the work in #XXXX by @author".
+   - Follow the `(thanks @handle)` convention in the commit message — e.g., `fix(slack): improve delivery (#1234) (thanks @original-author)`.
+
+3. **Explain why you're superseding** when closing a PR in favor of another. A sentence or two about _why_ the rewrite was necessary (vs. iterating on the original) helps the contributor learn and doesn't leave them guessing.
+
+Credit is free to give but incredibly meaningful to receive. Small gestures compound into a reputation that makes people _want_ to contribute.
+
+### Testing and Quality
+
 - Test locally with your OpenClaw instance
 - Run tests: `pnpm build && pnpm check && pnpm test`
 - For extension/plugin changes, run the fast local lane first:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,9 @@ When multiple PRs address the same issue:
 1. **Prefer the first contributor's PR when feasible.** If it's directionally correct, guide the author to fix issues via review comments rather than closing and rewriting from scratch. The "teach someone to fish" approach grows the contributor pool and builds long-term project health.
 
 2. **If selecting a later or better contribution over the first**, credit everyone whose PRs you close:
-   - Add `Co-authored-by: Name <email>` to the merge commit.
+   - **Always** add `Co-authored-by: Name <email>` to the merge commit — this is the preferred method because it shows up in both `git log` and GitHub's contributor graph, ensuring the original author gets visible credit.
    - Mention the superseded PR(s) and author(s) in the PR description: "Based on the work in #XXXX by @author".
-   - Follow the `(thanks @handle)` convention in the commit message — e.g., `fix(slack): improve delivery (#1234) (thanks @original-author)`.
+   - Additionally, follow the `(thanks @handle)` convention in the commit message — e.g., `fix(slack): improve delivery (#1234) (thanks @original-author)` — for human-readable acknowledgment.
 
 3. **Explain why you're superseding** when closing a PR in favor of another. A sentence or two about _why_ the rewrite was necessary (vs. iterating on the original) helps the contributor learn and doesn't leave them guessing.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Before opening a new issue or PR, **search for existing issues and PRs** that ad
 - If an existing PR is open and directionally correct, consider reviewing it or offering to help iterate on it rather than opening a competing PR.
 - If you believe your approach is significantly better, open your PR with a clear explanation of _why_ — and **acknowledge the prior work**. Link to the existing issue/PR and credit the original author:
   - Mention "Related to #XXXX by @author" or "Builds on the approach in #XXXX" in your PR description.
-  - If your PR incorporates or duplicates ideas from a prior PR, add `Co-authored-by: Original Author <email>` to your commit message. This ensures they appear in GitHub's contributor graph.
+  - If your PR incorporates or duplicates ideas from a prior PR, add `Co-authored-by: Original Author <email>` to your commit message. This ensures they appear in GitHub's contributor graph. You can find the author's email from their original PR's commit history, or use `username@users.noreply.github.com` if their email is not public.
 
 ### For Maintainers: Credit and Contributor-First Practices
 


### PR DESCRIPTION
## Summary

Add two new sections to CONTRIBUTING.md under "Before You PR":

1. **Check for Existing Work** (for contributors): Search for existing issues/PRs before opening new ones. If your PR builds on or duplicates prior work, acknowledge it with links and `Co-authored-by` tags.

2. **For Maintainers: Credit and Contributor-First Practices**: Prefer iterating on the first contributor's PR when feasible. When superseding is necessary, credit all original authors in merge commits using the `(thanks @handle)` convention already established by @steipete.

## Why

Growing a healthy contributor pool requires that contributors feel their work is valued, even when their PR isn't the one that gets merged. These lightweight guidelines formalize practices that are already partially in use (see @steipete's `(thanks @handle)` commit convention) and make them consistent across all maintainers.

See discussion in #60108 for detailed examples and motivation.

## Changes

- `CONTRIBUTING.md`: +26 lines, two new subsections

## Verification

- No code changes; docs only
- Reviewed against existing CONTRIBUTING.md structure and tone

Related #60108