### PR TITLE
fix(voice-call): pin session model to responseModel to prevent LiveSessionModelSwitchError

### DIFF
--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -223,6 +223,13 @@ export async function generateVoiceResponse(
     slashIndex === -1 ? agentRuntime.defaults.provider : modelRef.slice(0, slashIndex);
   const model = slashIndex === -1 ? modelRef : modelRef.slice(slashIndex + 1);
 
+  // Pin the session to the voice responseModel to prevent LiveSessionModelSwitchError
+  if (voiceConfig.responseModel && sessionEntry) {
+    (sessionEntry as Record<string, unknown>).providerOverride = provider;
+    (sessionEntry as Record<string, unknown>).modelOverride = model;
+    await agentRuntime.session.saveSessionStore(storePath, sessionStore);
+  }
+
   // Resolve thinking level
   const thinkLevel = agentRuntime.resolveThinkingDefault({ cfg, provider, model });
 


### PR DESCRIPTION
## Summary

Fixes #60118

When the voice-call plugin's `responseModel` config is set to a fast model (e.g., `openai/gpt-4o-mini` or `openai/gpt-4.1-nano`) but the global agent default is a different model (e.g., `anthropic/claude-opus-4-6`), the embedded PI runner throws `LiveSessionModelSwitchError` and voice responses silently fail.

## Root Cause

`runEmbeddedPiAgent()` internally calls `resolveLiveSessionModelSelection()` which resolves the global default model from the session store. When this differs from the `provider`/`model` parameters passed by voice-call's response generator, it throws `LiveSessionModelSwitchError`.

## Fix

Before calling `runEmbeddedPiAgent()`, write `providerOverride` and `modelOverride` into the voice session entry so the live session model selection matches the configured `responseModel`.

## Impact

- Voice calls now correctly use the configured `responseModel` regardless of the global default
- Enables using fast models (gpt-4o-mini, gpt-4.1-nano) for voice responses while keeping heavier models as the global default
- Critical for voice call usability — the latency difference between claude-opus (~5-7s) and gpt-4.1-nano (~0.3s) makes or breaks phone conversations

## Testing

1. Set global default to `anthropic/claude-opus-4-6`
2. Set `responseModel: "openai/gpt-4.1-nano"` in voice-call config
3. Make an outbound conversation call
4. Verify: caller speaks → STT transcribes → agent responds with voice (no `LiveSessionModelSwitchError` in logs)