### PR TITLE
fix(security): align audit symlink_escape boundary with skill loader

### DIFF
--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -847,7 +847,9 @@ export async function collectWorkspaceSkillSymlinkEscapeFindings(params: {
 
   for (const workspaceDir of workspaceDirs) {
     const workspacePath = path.resolve(workspaceDir);
-    const workspaceRealPath = await fs.realpath(workspacePath).catch(() => workspacePath);
+    // Match the skill loader boundary (resolveContainedSkillPath): skills dir root, not workspace root.
+    const skillsDir = path.join(workspacePath, "skills");
+    const skillsDirRealPath = await fs.realpath(skillsDir).catch(() => skillsDir);
     const skillFilePaths = await listWorkspaceSkillMarkdownFiles(workspacePath);
 
     for (const skillFilePath of skillFilePaths) {
@@ -861,7 +863,7 @@ export async function collectWorkspaceSkillSymlinkEscapeFindings(params: {
       if (!skillRealPath) {
         continue;
       }
-      if (isPathInside(workspaceRealPath, skillRealPath)) {
+      if (isPathInside(skillsDirRealPath, skillRealPath)) {
         continue;
       }
       escapedSkillFiles.push({
@@ -879,9 +881,9 @@ export async function collectWorkspaceSkillSymlinkEscapeFindings(params: {
   findings.push({
     checkId: "skills.workspace.symlink_escape",
     severity: "warn",
-    title: "Workspace skill files resolve outside the workspace root",
+    title: "Workspace skill files resolve outside the skills directory",
     detail:
-      "Detected workspace `skills/**/SKILL.md` paths whose realpath escapes their workspace root:\n" +
+      "Detected workspace `skills/**/SKILL.md` paths whose realpath escapes the skills directory root:\n" +
       escapedSkillFiles
         .slice(0, MAX_WORKSPACE_SKILL_ESCAPE_DETAIL_ROWS)
         .map(
@@ -895,7 +897,7 @@ export async function collectWorkspaceSkillSymlinkEscapeFindings(params: {
         ? `\n- +${escapedSkillFiles.length - MAX_WORKSPACE_SKILL_ESCAPE_DETAIL_ROWS} more`
         : ""),
     remediation:
-      "Keep workspace skills inside the workspace root (replace symlinked escapes with real in-workspace files), or move trusted shared skills to managed/bundled skill locations.",
+      "Keep workspace skills inside the skills directory (replace symlinked escapes with real in-workspace files), or move trusted shared skills to managed/bundled skill locations or `skills.load.extraDirs`.",
   });
 
   return findings;

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1359,7 +1359,7 @@ description: test skill
         },
       },
       {
-        name: "does not warn for workspace skills that stay inside workspace root",
+        name: "does not warn for workspace skills that stay inside skills directory",
         supported: true,
         setup: async () => {
           const tmp = await makeTmpDir("workspace-skill-in-root");
@@ -1376,6 +1376,35 @@ description: test skill
         },
         assert: (res: SecurityAuditReport) => {
           expectNoFinding(res, "skills.workspace.symlink_escape");
+        },
+      },
+      {
+        name: "warns when skill symlink resolves inside workspace but outside skills directory",
+        supported: !isWindows,
+        setup: async () => {
+          const tmp = await makeTmpDir("workspace-skill-inside-ws-outside-skills");
+          const stateDir = path.join(tmp, "state");
+          const workspaceDir = path.join(tmp, "workspace");
+          const sharedSkillDir = path.join(workspaceDir, "shared", "skills", "my-skill");
+          await fs.mkdir(stateDir, { recursive: true, mode: 0o700 });
+          await fs.mkdir(path.join(workspaceDir, "skills", "linked-skill"), { recursive: true });
+          await fs.mkdir(sharedSkillDir, { recursive: true });
+          await fs.writeFile(
+            path.join(sharedSkillDir, "SKILL.md"),
+            "# inside workspace, outside skills dir\n",
+            "utf-8",
+          );
+          // Symlink: skills/linked-skill/SKILL.md -> ../../shared/skills/my-skill/SKILL.md
+          await fs.symlink(
+            path.join(sharedSkillDir, "SKILL.md"),
+            path.join(workspaceDir, "skills", "linked-skill", "SKILL.md"),
+          );
+          return { stateDir, workspaceDir };
+        },
+        assert: (res: SecurityAuditReport) => {
+          const finding = res.findings.find((f) => f.checkId === "skills.workspace.symlink_escape");
+          expect(finding).toBeDefined();
+          expect(finding!.severity).toBe("warn");
         },
       },
     ] as const;


### PR DESCRIPTION
## Problem

The `skills.workspace.symlink_escape` audit probe checks whether workspace skill realpaths escape the **workspace root**, but the skill loader (`resolveContainedSkillPath`) checks whether they escape the **skills directory root** (`workspace/skills/`). This creates a gap where symlinks that resolve inside the workspace but outside the skills directory pass the audit but are silently rejected at load time.

Example: `workspace/skills/my-skill -> ../shared/skills/my-skill` resolves to `workspace/shared/skills/my-skill` — inside the workspace root (audit passes ✅) but outside `workspace/skills/` (loader rejects ❌).

## Impact

We had 10 symlinked skills silently invisible for nearly a month. The daily-review cron skill stopped working reliably when v2026.3.7 shipped the loader enforcement — but `openclaw security audit` never flagged it. The model compensated by discovering the skill file through manual filesystem search ~80% of the time, masking the issue.

## Fix

Align the audit probe boundary with the loader: check against the skills directory root, not the workspace root. One-line logic change + updated finding messages + test for the gap case.

## Changes

- `audit-extra.async.ts`: resolve `skillsDir` (`workspace/skills`) instead of `workspacePath`, use it as the containment boundary
- `audit.test.ts`: add test case for symlink inside workspace but outside skills dir
- Updated finding title/detail/remediation to reference "skills directory" instead of "workspace root"
- Added `skills.load.extraDirs` mention in remediation text

## CI Note

Windows test failures in `task-owner-access.test.ts` are pre-existing timeouts, unrelated to this change.

Closes #60145