### PR TITLE
[feat subagents]: Add includeContext to sessions_spawn with safe injection and model-aware cropping of parent session context.

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -63,6 +63,7 @@ export function buildSubagentSystemPrompt(params: {
   childSessionKey: string;
   label?: string;
   task?: string;
+  sessionSummary?: string;
   /** Whether ACP-specific routing guidance should be included. Defaults to true. */
   acpEnabled?: boolean;
   /** Depth of the child being spawned (1 = sub-agent, 2 = sub-sub-agent). */
@@ -93,6 +94,19 @@ export function buildSubagentSystemPrompt(params: {
     "- Complete this task. That's your entire purpose.",
     `- You are NOT the ${parentLabel}. Don't try to be.`,
     "",
+  ];
+
+  if (params.sessionSummary) {
+    lines.push(
+      "## Parent Session Summary",
+      "The following is a summary of the parent session context to help you understand the background of your task:",
+      "",
+      params.sessionSummary,
+      "",
+    );
+  }
+
+  lines.push(
     "## Rules",
     "1. **Stay focused** - Do your assigned task, nothing else",
     `2. **Complete the task** - Your final message will be automatically reported to the ${parentLabel}`,

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -110,6 +110,8 @@ export async function loadSubagentSpawnModuleForTest(params: {
   loadConfig?: () => Record<string, unknown>;
   updateSessionStoreMock?: MockFn;
   pruneLegacyStoreKeysMock?: MockFn;
+  loadSessionEntryMock?: MockFn;
+  readSessionMessagesMock?: MockFn;
   registerSubagentRunMock?: MockFn;
   emitSessionLifecycleEventMock?: MockFn;
   hookRunner?: HookRunner;
@@ -117,6 +119,8 @@ export async function loadSubagentSpawnModuleForTest(params: {
   resolveAgentWorkspaceDir?: (cfg: Record<string, unknown>, agentId: string) => string;
   resolveSubagentSpawnModelSelection?: () => string | undefined;
   resolveSandboxRuntimeStatus?: () => { sandboxed: boolean };
+  runEmbeddedPiAgentMock?: MockFn;
+  mockSubagentSystemPrompt?: boolean;
   workspaceDir?: string;
   sessionStorePath?: string;
 }) {
@@ -146,17 +150,32 @@ export async function loadSubagentSpawnModuleForTest(params: {
   }
 
   if (params.pruneLegacyStoreKeysMock) {
+  const shouldMockSessionUtils =
+    Boolean(params.pruneLegacyStoreKeysMock) ||
+    Boolean(params.loadSessionEntryMock) ||
+    Boolean(params.readSessionMessagesMock);
+  if (shouldMockSessionUtils) {
     vi.doMock("../gateway/session-utils.js", async (importOriginal) => {
       const actual = await importOriginal<typeof import("../gateway/session-utils.js")>();
       return {
         ...actual,
-        resolveGatewaySessionStoreTarget: (targetParams: { key: string }) => ({
-          agentId: "main",
-          storePath: params.sessionStorePath ?? "/tmp/subagent-spawn-model-session.json",
-          canonicalKey: targetParams.key,
-          storeKeys: [targetParams.key],
-        }),
-        pruneLegacyStoreKeys: (...args: unknown[]) => params.pruneLegacyStoreKeysMock?.(...args),
+        ...(params.pruneLegacyStoreKeysMock
+          ? {
+              resolveGatewaySessionStoreTarget: (targetParams: { key: string }) => ({
+                agentId: "main",
+                storePath: params.sessionStorePath ?? "/tmp/subagent-spawn-model-session.json",
+                canonicalKey: targetParams.key,
+                storeKeys: [targetParams.key],
+              }),
+              pruneLegacyStoreKeys: (...args: unknown[]) => params.pruneLegacyStoreKeysMock?.(...args),
+            }
+          : {}),
+        ...(params.loadSessionEntryMock
+          ? { loadSessionEntry: (...args: unknown[]) => params.loadSessionEntryMock?.(...args) }
+          : {}),
+        ...(params.readSessionMessagesMock
+          ? { readSessionMessages: (...args: unknown[]) => params.readSessionMessagesMock?.(...args) }
+          : {}),
       };
     });
   }
@@ -173,13 +192,15 @@ export async function loadSubagentSpawnModuleForTest(params: {
     });
   }
 
-  vi.doMock("./subagent-announce.js", async (importOriginal) => {
-    const actual = await importOriginal<typeof import("./subagent-announce.js")>();
-    return {
-      ...actual,
-      buildSubagentSystemPrompt: () => "system-prompt",
-    };
-  });
+  if (params.mockSubagentSystemPrompt !== false) {
+    vi.doMock("./subagent-announce.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("./subagent-announce.js")>();
+      return {
+        ...actual,
+        buildSubagentSystemPrompt: () => "system-prompt",
+      };
+    });
+  }
 
   vi.doMock("./agent-scope.js", async (importOriginal) => {
     const actual = await importOriginal<typeof import("./agent-scope.js")>();
@@ -212,6 +233,16 @@ export async function loadSubagentSpawnModuleForTest(params: {
         params.resolveSandboxRuntimeStatus ?? actual.resolveSandboxRuntimeStatus,
     };
   });
+
+  if (params.runEmbeddedPiAgentMock) {
+    vi.doMock("./pi-embedded-runner.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("./pi-embedded-runner.js")>();
+      return {
+        ...actual,
+        runEmbeddedPiAgent: (...args: unknown[]) => params.runEmbeddedPiAgentMock?.(...args),
+      };
+    });
+  }
 
   vi.doMock("../plugins/hook-runner-global.js", () => ({
     getGlobalHookRunner: () => params.hookRunner ?? { hasHooks: () => false },

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -158,6 +158,85 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(operations.indexOf("gateway:agent")).toBeGreaterThan(operations.indexOf("store:update"));
   });
 
+  it("injects parent session summary into child system prompt when includeContext=summary", async () => {
+    const captured: { extraSystemPrompt?: string } = {};
+
+    ({ resetSubagentRegistryForTests, spawnSubagentDirect } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock: hoisted.callGatewayMock,
+      loadConfig: () => hoisted.configOverride,
+      updateSessionStoreMock: hoisted.updateSessionStoreMock,
+      pruneLegacyStoreKeysMock: hoisted.pruneLegacyStoreKeysMock,
+      registerSubagentRunMock: hoisted.registerSubagentRunMock,
+      emitSessionLifecycleEventMock: hoisted.emitSessionLifecycleEventMock,
+      resolveAgentConfig: () => undefined,
+      resolveSubagentSpawnModelSelection: () => "openai-codex/gpt-5.4",
+      resolveSandboxRuntimeStatus: () => ({ sandboxed: false }),
+      sessionStorePath: "/tmp/subagent-spawn-session-store.json",
+      mockSubagentSystemPrompt: false,
+      loadSessionEntryMock: () => ({
+        storePath: "/tmp/session-store.json",
+        entry: { sessionId: "sess-1", sessionFile: "/tmp/sess-1.jsonl" },
+      }),
+      readSessionMessagesMock: () => [
+        { role: "user", content: "user message" },
+        { role: "assistant", content: "assistant message" },
+      ],
+      runEmbeddedPiAgentMock: async () => ({
+        payloads: [{ text: "SUMMARY_TEXT" }],
+        meta: { durationMs: 1 },
+      }),
+    }));
+
+    resetSubagentRegistryForTests();
+    hoisted.callGatewayMock.mockReset();
+    hoisted.updateSessionStoreMock.mockReset();
+    hoisted.pruneLegacyStoreKeysMock.mockReset();
+    hoisted.registerSubagentRunMock.mockReset();
+    hoisted.emitSessionLifecycleEventMock.mockReset();
+    hoisted.configOverride = createConfigOverride();
+
+    hoisted.callGatewayMock.mockImplementation(async (request: any) => {
+      if (request.method === "agent") {
+        captured.extraSystemPrompt = request.params?.extraSystemPrompt;
+        return { runId: "run-1" };
+      }
+      if (request.method?.startsWith("sessions.")) {
+        return { ok: true };
+      }
+      return {};
+    });
+
+    hoisted.updateSessionStoreMock.mockImplementation(
+      async (
+        _storePath: string,
+        mutator: (store: Record<string, Record<string, unknown>>) => unknown,
+      ) => {
+        const store: Record<string, Record<string, unknown>> = {};
+        await mutator(store);
+        return store;
+      },
+    );
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "check summary injection",
+        includeContext: "summary",
+        model: "openai-codex/gpt-5.4",
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "acct-1",
+        agentTo: "user-1",
+        workspaceDir: "/tmp/requester-workspace",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(captured.extraSystemPrompt).toContain("## Parent Session Summary");
+    expect(captured.extraSystemPrompt).toContain("SUMMARY_TEXT");
+  });
+
   it("pins admin-only methods to operator.admin and preserves least-privilege for others (#59428)", async () => {
     const capturedCalls: Array<{ method?: string; scopes?: string[] }> = [];
 

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1,4 +1,6 @@
 import crypto from "node:crypto";
+import os from "node:os";
+import path from "node:path";
 import { promises as fs } from "node:fs";
 import { formatThinkingLevels, normalizeThinkLevel } from "../auto-reply/thinking.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
@@ -9,6 +11,8 @@ import { ADMIN_SCOPE, isAdminOnlyMethod } from "../gateway/method-scopes.js";
 import {
   pruneLegacyStoreKeys,
   resolveGatewaySessionStoreTarget,
+  readSessionMessages,
+  loadSessionEntry,
 } from "../gateway/session-utils.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { SubagentLifecycleHookRunner } from "../plugins/hooks.js";
@@ -19,10 +23,22 @@ import {
   parseAgentSessionKey,
 } from "../routing/session-key.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
+import { extractTextFromChatContent } from "../shared/chat-content.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
-import { resolveAgentConfig } from "./agent-scope.js";
+import {
+  resolveAgentConfig,
+  resolveAgentEffectiveModelPrimary,
+  resolveAgentDir,
+} from "./agent-scope.js";
+import { resolveContextTokensForModel } from "./context.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
-import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
+import {
+  resolveSubagentSpawnModelSelection,
+  parseModelRef,
+} from "./model-selection.js";
+import { runEmbeddedPiAgent } from "./pi-embedded-runner.js";
+import { extractAssistantText } from "./pi-embedded-utils.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import {
   mapToolContextToSpawnedRunMetadata,
@@ -67,6 +83,7 @@ const defaultSubagentSpawnDeps: SubagentSpawnDeps = {
 };
 
 let subagentSpawnDeps: SubagentSpawnDeps = defaultSubagentSpawnDeps;
+export type SpawnSubagentIncludeContext = "none" | "summary" | "full";
 
 export type SpawnSubagentParams = {
   task: string;
@@ -79,6 +96,7 @@ export type SpawnSubagentParams = {
   mode?: SpawnSubagentMode;
   cleanup?: "delete" | "keep";
   sandbox?: SpawnSubagentSandboxMode;
+  includeContext?: SpawnSubagentIncludeContext;
   expectsCompletionMessage?: boolean;
   attachments?: Array<{
     name: string;
@@ -287,6 +305,92 @@ function summarizeError(err: unknown): string {
   return "error";
 }
 
+const INCLUDE_CONTEXT_MAX_MESSAGES_FALLBACK = 60;
+const INCLUDE_CONTEXT_MAX_CHARS_FALLBACK = 24_000;
+const INCLUDE_CONTEXT_TOKENS_FALLBACK = 64_000;
+
+function clampInt(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}
+
+function resolveIncludeContextLimits(params: {
+  cfg?: unknown;
+  model?: string;
+  scale?: number;
+}): { maxMessages: number; maxChars: number } {
+  const scale =
+    typeof params.scale === "number" && Number.isFinite(params.scale)
+      ? Math.max(0.1, Math.min(1, params.scale))
+      : 1;
+  const contextTokens =
+    resolveContextTokensForModel({
+      cfg: params.cfg as any,
+      model: params.model,
+      fallbackContextTokens: INCLUDE_CONTEXT_TOKENS_FALLBACK,
+      allowAsyncLoad: false,
+    }) ?? INCLUDE_CONTEXT_TOKENS_FALLBACK;
+
+  const maxMessages = clampInt(contextTokens / 2_000, 20, 80);
+  const maxChars = clampInt(contextTokens * 2, 8_000, 50_000);
+
+  return {
+    maxMessages: clampInt(maxMessages * scale, 10, 80),
+    maxChars: clampInt(maxChars * scale, 4_000, 50_000),
+  };
+}
+
+function formatSessionTranscript(
+  messages: unknown[],
+  opts?: { cfg?: unknown; model?: string; scale?: number; maxMessages?: number; maxChars?: number },
+) {
+  const resolved = resolveIncludeContextLimits({
+    cfg: opts?.cfg,
+    model: opts?.model,
+    scale: opts?.scale,
+  });
+  const maxMessages =
+    typeof opts?.maxMessages === "number" && Number.isFinite(opts.maxMessages)
+      ? Math.max(1, Math.floor(opts.maxMessages))
+      : resolved.maxMessages || INCLUDE_CONTEXT_MAX_MESSAGES_FALLBACK;
+  const maxChars =
+    typeof opts?.maxChars === "number" && Number.isFinite(opts.maxChars)
+      ? Math.max(1, Math.floor(opts.maxChars))
+      : resolved.maxChars || INCLUDE_CONTEXT_MAX_CHARS_FALLBACK;
+
+  const recent = messages.slice(-maxMessages);
+  const lines = recent
+    .map((m: any) => {
+      const role = typeof m?.role === "string" ? m.role : "unknown";
+      if (role === "user") {
+        const raw =
+          extractTextFromChatContent(m.content, {
+            joinWith: "\n",
+            normalizeText: (text) => text.trim(),
+          }) ?? "";
+        const content = raw || "(no content)";
+        return `USER: ${content}`;
+      }
+      if (role === "assistant") {
+        const text = extractAssistantText(m);
+        const content = text || "(no content)";
+        return `ASSISTANT: ${content}`;
+      }
+      return null;
+    })
+    .filter((line): line is string => Boolean(line));
+
+  if (lines.length === 0) {
+    return undefined;
+  }
+
+  const transcript = lines.join("\n\n");
+  if (transcript.length <= maxChars) {
+    return transcript;
+  }
+  const tail = transcript.slice(transcript.length - maxChars);
+  return `...(truncated; showing last ${maxChars} chars)\n${tail}`;
+}
+
 async function ensureThreadBindingForSubagentSpawn(params: {
   hookRunner: SubagentLifecycleHookRunner | null;
   childSessionKey: string;
@@ -345,6 +449,107 @@ async function ensureThreadBindingForSubagentSpawn(params: {
       status: "error",
       error: `Thread bind failed: ${summarizeError(err)}`,
     };
+  }
+}
+
+async function getSubagentFullSessionContext(params: {
+  sessionKey: string;
+  cfg: unknown;
+  model?: string;
+}): Promise<string | undefined> {
+  const { storePath, entry } = loadSessionEntry(params.sessionKey);
+  if (!entry || !entry.sessionId) return undefined;
+
+  const messages = readSessionMessages(
+    entry.sessionId,
+    storePath,
+    entry.sessionFile,
+  );
+
+  if (!messages || messages.length === 0) return undefined;
+
+  return formatSessionTranscript(messages, { cfg: params.cfg, model: params.model, scale: 1 });
+}
+
+async function generateSubagentSessionSummary(
+  _params: SpawnSubagentParams,
+  ctx: SpawnSubagentContext,
+  requesterSessionKey: string,
+  requesterAgentId: string,
+): Promise<string | undefined> {
+  const config = loadConfig();
+  const { storePath, entry } = loadSessionEntry(requesterSessionKey);
+  if (!entry || !entry.sessionId) return undefined;
+
+  const messages = readSessionMessages(
+    entry.sessionId,
+    storePath,
+    entry.sessionFile,
+  );
+
+  if (!messages || messages.length === 0) return undefined;
+
+  const modelRef = resolveAgentEffectiveModelPrimary(config, requesterAgentId);
+
+  let provider = DEFAULT_PROVIDER;
+  let model = DEFAULT_MODEL;
+
+  if (modelRef) {
+    const parsed = parseModelRef(modelRef, DEFAULT_PROVIDER);
+    if (parsed) {
+      provider = parsed.provider;
+      model = parsed.model;
+    }
+  }
+
+  const transcript = formatSessionTranscript(messages, {
+    cfg: config,
+    model: `${provider}/${model}`,
+    scale: 0.6,
+  });
+  if (!transcript) return undefined;
+
+  const summaryPrompt = `Please provide a concise technical summary of the following conversation history to help a sub-agent understand the current context, goals, and decisions. Focus on key details and constraints.\n\nCONVERSATION HISTORY:\n${transcript}`;
+
+  const runId = crypto.randomUUID();
+  const sessionId = `summary-${runId}`;
+  const sessionFile = path.join(os.tmpdir(), `${sessionId}.jsonl`);
+
+  try {
+    const result = await runEmbeddedPiAgent({
+      sessionId,
+      runId,
+      sessionFile,
+      agentId: requesterAgentId,
+      workspaceDir: ctx.workspaceDir || os.tmpdir(),
+      agentDir: resolveAgentDir(config, requesterAgentId),
+      prompt: summaryPrompt,
+      model: model as string,
+      provider: provider as string,
+      disableTools: true,
+      timeoutMs: 30_000,
+      trigger: "memory",
+      extraSystemPrompt:
+        "You are a helpful assistant summarizing a conversation for another agent. Be concise and technical. Do not include introductory or concluding remarks.",
+    });
+
+    const summary =
+      result.payloads
+        ?.filter((payload) => payload && typeof payload === "object" && payload.isReasoning !== true)
+        .map((payload) => (typeof payload.text === "string" ? payload.text : ""))
+        .filter((text) => text.trim())
+        .join("\n")
+        .trim() ?? "";
+    return summary || undefined;
+  } catch (e) {
+    console.error(`Failed to generate subagent session summary: ${e}`);
+    return undefined;
+  } finally {
+    try {
+      await fs.rm(sessionFile, { force: true });
+    } catch {
+      // Best-effort cleanup only.
+    }
   }
 }
 
@@ -622,12 +827,29 @@ export async function spawnSubagentDirect(
   }
   const mountPathHint = sanitizeMountPathHint(params.attachMountPath);
 
+  let sessionSummary: string | undefined;
+  if (params.includeContext === "summary") {
+    sessionSummary = await generateSubagentSessionSummary(
+      params,
+      ctx,
+      requesterInternalKey,
+      requesterAgentId,
+    );
+  } else if (params.includeContext === "full") {
+    sessionSummary = await getSubagentFullSessionContext({
+      sessionKey: requesterInternalKey,
+      cfg,
+      model: resolvedModel ?? modelOverride,
+    });
+  }
+
   let childSystemPrompt = buildSubagentSystemPrompt({
     requesterSessionKey,
     requesterOrigin,
     childSessionKey,
     label: label || undefined,
     task,
+    sessionSummary,
     acpEnabled: cfg.acp?.enabled !== false && !childRuntime.sandboxed,
     childDepth,
     maxSpawnDepth,

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -94,6 +94,44 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
   });
 
+  it("forwards includeContext=summary to subagent spawn", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await tool.execute("call-summary", {
+      task: "summarize and build",
+      includeContext: "summary",
+    });
+
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "summarize and build",
+        includeContext: "summary",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("forwards includeContext=full to subagent spawn", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await tool.execute("call-full", {
+      task: "use full context",
+      includeContext: "full",
+    });
+
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "use full context",
+        includeContext: "full",
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("passes inherited workspaceDir from tool context, not from tool args", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -18,6 +18,7 @@ import {
 
 const SESSIONS_SPAWN_RUNTIMES = ["subagent", "acp"] as const;
 const SESSIONS_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
+const SESSIONS_SPAWN_INCLUDE_CONTEXT_MODES = ["none", "summary", "full"] as const;
 // Keep the schema local to avoid a circular import through acp-spawn/openclaw-tools.
 const SESSIONS_SPAWN_ACP_STREAM_TARGETS = ["parent"] as const;
 const UNSUPPORTED_SESSIONS_SPAWN_PARAM_KEYS = [
@@ -91,7 +92,16 @@ const SessionsSpawnToolSchema = Type.Object({
   thread: Type.Optional(Type.Boolean()),
   mode: optionalStringEnum(SUBAGENT_SPAWN_MODES),
   cleanup: optionalStringEnum(["delete", "keep"] as const),
-  sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
+  sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES, {
+    description:
+      "Sandbox mode: inherit (default) uses requester's sandbox status; require ensures subagent runs in a sandbox.",
+  }),
+  includeContext: optionalStringEnum(SESSIONS_SPAWN_INCLUDE_CONTEXT_MODES, {
+    description:
+      "Whether to include the current session's context in the subagent's startup. " +
+      "'none' (default) starts fresh; 'summary' generates a summary of the current session; " +
+      "'full' injects the current session transcript in text form (may be truncated).",
+  }),
   streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS),
 
   // Inline attachments (snapshot-by-value).
@@ -134,7 +144,7 @@ export function createSessionsSpawnTool(
     description:
       'Spawn an isolated session (runtime="subagent" or runtime="acp"). mode="run" is one-shot and mode="session" is persistent/thread-bound. Subagents inherit the parent workspace directory automatically.',
     parameters: SessionsSpawnToolSchema,
-    execute: async (_toolCallId, args) => {
+    execute: async (_toolCallId: string, args: unknown) => {
       const params = args as Record<string, unknown>;
       const unsupportedParam = UNSUPPORTED_SESSIONS_SPAWN_PARAM_KEYS.find((key) =>
         Object.hasOwn(params, key),
@@ -156,6 +166,7 @@ export function createSessionsSpawnTool(
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
+      const includeContext = params.includeContext as "none" | "summary" | "full" | undefined;
       const streamTo = params.streamTo === "parent" ? "parent" : undefined;
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
@@ -296,6 +307,7 @@ export function createSessionsSpawnTool(
           mode,
           cleanup,
           sandbox,
+          includeContext,
           expectsCompletionMessage: true,
           attachments,
           attachMountPath:


### PR DESCRIPTION
## Summary

2–5 bullets to summarize the problem and fix:

- Problem: Sub-agents are dispatched without awareness of the parent session context, causing misunderstanding and repeated clarification; injecting the full transcript naively is risky for performance and prompt safety.
- Why it matters: Better task grounding improves correctness while avoiding prompt injection and runaway token costs.
- What changed: Introduce includeContext option (none/summary/full); inject a parent summary (generated by the main agent’s primary model) or a model-aware cropped transcript into the child agent’s system prompt; unify tool parameter schema; add parameter-forwarding and end-to-end tests.
- What did NOT change: Default behavior remains none; ACP routing and UI remain unchanged; no external integration contracts changed.

Key code references:
- sessions-spawn-tool.ts
- subagent-spawn.ts
- subagent-announce.ts

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

- sessions_spawn gains includeContext with values:
  - none (default): do not inject parent session context
  - summary: before dispatch, run the main agent’s primary model to produce a safe summary and inject into the child system prompt
  - full: inject a cropped parent transcript based on the target model’s context window with truncation markers
- Child agent system prompt adds a “## Parent Session Summary” section when includeContext != none.
- Tool parameter schema unified with a string enum and forwarded to the spawn layer.

## Diagram

```text
User -> sessions_spawn(includeContext)
  -> includeContext=summary: runEmbeddedPiAgent(main primary, disableTools=true)
      -> buildSubagentSystemPrompt + "Parent Session Summary"
      -> callGateway("agent") spawn
  -> includeContext=full: formatSessionTranscript (dynamic crop by model context)
      -> buildSubagentSystemPrompt + "Parent Session Summary"
      -> callGateway("agent") spawn
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes (one embedded summary run when includeContext=summary)
- Data access scope changed? Yes (child agent can see the parent summary or a cropped transcript)
- Risks and mitigations:
  - Prompt injection or irrelevant content leaking from parent:
    - Mitigation: summary is generated by the main primary model with tools disabled, inject text only; full path crops by target model context and adds truncation markers.
  - Excessive system prompt length degrading quality and cost:
    - Mitigation: compute safe upper bounds from the target model’s context window and apply segment truncation.

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.
- Migration needed? `No`
If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

- Backward compatible? (`No`)
- Config/env changes? (`No`)
- Prompt injection risk:
- Backward compatible? Yes (default none preserves existing behavior)
- Config/env changes? No
- Migration needed? No
- Semantic drift (summary distortion):
  - Mitigation: Clearly state in the system prompt that “the parent session summary is for reference only”; task requirements shall still be based on current parameters and objectives. Use `full` mode when necessary.

- Prompt injection risk:
  - Mitigation: summary path uses the main model and disables tools; full path crops content and adds truncation markers.
- Cost increase:
  - Mitigation: only active when includeContext != none; summary performs a single embedded run; full path enforces strict cropping limits.
- Semantic drift (summary distortion):
  - Mitigation: system prompt instructs that the parent summary is advisory; the task requirements are driven by current parameters and goals; choose full when strict fidelity is required.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js (project default)
- Model/provider: main agent’s primary model (per project config)
- Integration/channel: N/A
- Relevant config (redacted): defaults are sufficient

### Steps

1. Install dependencies and build the project.
2. Run unit tests:
   - `vitest run --config vitest.unit.config.ts src/agents/tools/sessions-spawn-tool.test.ts src/agents/subagent-spawn.test.ts`
3. Optional local smoke test:
   - In any session, call sessions_spawn with `includeContext: "summary"` and `includeContext: "full"`.
   - Inspect the child agent’s extraSystemPrompt to confirm the “## Parent Session Summary” section with summary/cropped content.

### Expected

- includeContext is forwarded to the spawn layer.
- summary path performs exactly one embedded run with `disableTools: true`.
- full path crops to the target model’s context window and shows truncation markers when applicable.
- Child system prompt contains the “## Parent Session Summary” section.

### Actual

- Matches expected.

## Evidence

Provide at least one:

- [x] Trace/log snippets

Example (unit test assertions excerpt):

```text
expect(captured.extraSystemPrompt).toContain("## Parent Session Summary")
expect(captured.extraSystemPrompt).toContain("SUMMARY_TEXT")
expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled()
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Parameter forwarding and system prompt injection.
  - Summary generation disables tools and uses the main primary model.
  - Full transcript path applies model-aware cropping with truncation markers.
- Edge cases checked:
  - Empty sessions and sessions with only user messages.
  - Long conversations triggering cropping.
  - Fallbacks when model parsing fails.
- What you did not verify:
  - Exact context window sizes across all providers (cropping uses parsed limits and conservative bounds).

- Risk:
  - Mitigation:
