### PR TITLE
fix(tools): normalize truly empty MCP tool schemas for OpenAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Android/assistant: keep queued App Actions prompts pending when auto-send enqueue is rejected, so transient chat-health drops do not silently lose the assistant request. Thanks @obviyus.
 - Plugins/Google: separate OAuth CSRF state from PKCE code verifier during Gemini browser sign-in so state validation and token exchange use independent values. (#59116) Thanks @eleqtrizit.
 - Agents/subagents: honor `agents.defaults.subagents.allowAgents` for `sessions_spawn` and `agents_list`, so default cross-agent allowlists work without duplicating per-agent config. (#59944) Thanks @hclsys.
+- Agents/tools: normalize only truly empty MCP tool schemas to `{ type: "object", properties: {} }` so OpenAI accepts parameter-free tools without rewriting unrelated conditional schemas. (#60176) Thanks @Bartok9.
 - Plugins/browser: block SSRF redirect bypass by installing a real-time Playwright route handler before `page.goto()` so navigation to private/internal IPs is intercepted and aborted mid-redirect instead of checked post-hoc. (#58771) Thanks @pgondhi987.
 - Android/gateway: require TLS for non-loopback remote gateway endpoints while still allowing local loopback and emulator cleartext setup flows. (#58475) Thanks @eleqtrizit.
 - Exec/Windows: hide transient console windows for `runExec` and `runCommandWithTimeout` child-process launches, matching other Windows exec paths and stopping visible shell flashes during tool runs. (#59466) Thanks @lawrence3699.

--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -20,6 +20,20 @@ describe("normalizeToolParameters", () => {
     expect(parameters.properties).toEqual({});
   });
 
+  it("does not rewrite non-empty schemas that still lack type/properties", () => {
+    const tool: AnyAgentTool = {
+      name: "conditional",
+      label: "conditional",
+      description: "Conditional schema stays untouched",
+      parameters: { allOf: [] },
+      execute: vi.fn(),
+    };
+
+    const normalized = normalizeToolParameters(tool);
+
+    expect(normalized.parameters).toEqual({ allOf: [] });
+  });
+
   it("injects properties:{} for type:object schemas missing properties (MCP no-param tools)", () => {
     const tool: AnyAgentTool = {
       name: "list_regions",

--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -4,6 +4,22 @@ import { normalizeToolParameters } from "./pi-tools.schema.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 
 describe("normalizeToolParameters", () => {
+  it("normalizes truly empty schemas to type:object with properties:{} (MCP parameter-free tools)", () => {
+    const tool: AnyAgentTool = {
+      name: "get_flux_instance",
+      label: "get_flux_instance",
+      description: "Get current Flux instance status",
+      parameters: {},
+      execute: vi.fn(),
+    };
+
+    const normalized = normalizeToolParameters(tool);
+
+    const parameters = normalized.parameters as Record<string, unknown>;
+    expect(parameters.type).toBe("object");
+    expect(parameters.properties).toEqual({});
+  });
+
   it("injects properties:{} for type:object schemas missing properties (MCP no-param tools)", () => {
     const tool: AnyAgentTool = {
       name: "list_regions",

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -133,11 +133,11 @@ export function normalizeToolParameterSchema(
       ? "oneOf"
       : null;
   if (!variantKey) {
-    // Handle truly empty schemas (no type, no properties, no unions) —
-    // OpenAI requires `type: "object"` with `properties` for tool schemas.
-    // MCP tools with parameter-free schemas may return `{}` or minimal objects.
-    if (!("type" in schemaRecord) && !("properties" in schemaRecord)) {
-      return applyProviderCleaning({ type: "object", properties: {}, ...schemaRecord });
+    // Handle the proven MCP no-parameter case: a truly empty schema object.
+    // Keep other non-empty shapes unchanged so we do not silently bless
+    // unsupported top-level conditionals like `allOf`.
+    if (Object.keys(schemaRecord).length === 0) {
+      return applyProviderCleaning({ type: "object", properties: {} });
     }
     return schema;
   }

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -133,6 +133,12 @@ export function normalizeToolParameterSchema(
       ? "oneOf"
       : null;
   if (!variantKey) {
+    // Handle truly empty schemas (no type, no properties, no unions) —
+    // OpenAI requires `type: "object"` with `properties` for tool schemas.
+    // MCP tools with parameter-free schemas may return `{}` or minimal objects.
+    if (!("type" in schemaRecord) && !("properties" in schemaRecord)) {
+      return applyProviderCleaning({ type: "object", properties: {}, ...schemaRecord });
+    }
     return schema;
   }
   const variants = schemaRecord[variantKey] as unknown[];


### PR DESCRIPTION
## Summary

Fixes #60158

MCP tools with parameter-free schemas may return truly empty objects `{}` without a `type` field. The existing normalization handled `{ type: "object" }` → `{ type: "object", properties: {} }` but missed the truly empty case.

## Problem

OpenAI gpt-5.4 rejects tool schemas without `type: "object"` and `properties`, causing HTTP 400 errors:

```
Invalid schema for function 'flux-mcp__get_flux_instance':
In context=(), object schema missing properties.
```

This was happening for MCP tools like `flux-operator-mcp` that expose parameter-free tool schemas.

## Root Cause

The `normalizeToolParameterSchema` function in `pi-tools.schema.ts` handled three cases:
1. Schemas with both `type` and `properties` → pass through
2. Schemas with no `type` but with `properties` or `required` → add `type: "object"`
3. Schemas with `type` but no `properties` → add `properties: {}`

But it did **not** handle truly empty schemas `{}` that have neither `type` nor `properties`. These fell through to the final `return schema` without normalization.

## Fix

Added a condition before the final pass-through to catch empty schemas (no type, no properties, no unions) and normalize them to `{ type: "object", properties: {} }`.

## Testing

- Added test case: "normalizes truly empty schemas to type:object with properties:{} (MCP parameter-free tools)"
- All existing tests pass