### PR TITLE
fix(test): add missing mock exports to delivery-dispatch.named-agent test

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
@@ -7,6 +7,8 @@ vi.mock("../../agents/subagent-announce.js", () => ({
 }));
 vi.mock("../../agents/subagent-registry.js", () => ({
   countActiveDescendantRuns: vi.fn().mockReturnValue(0),
+  getLatestSubagentRunByChildSessionKey: vi.fn().mockReturnValue(null),
+  listDescendantRunsForRequester: vi.fn().mockReturnValue([]),
 }));
 
 describe("matchesMessagingToolDeliveryTarget", () => {


### PR DESCRIPTION
## Problem

`delivery-dispatch.named-agent.test.ts` has a `vi.mock` factory for `../../agents/subagent-registry.js` that only declares `countActiveDescendantRuns`. Two additional exports are now accessed through the test's module graph but are missing from the factory:

- `getLatestSubagentRunByChildSessionKey` — recently added to `subagent-registry.ts`, imported transitively in the test's module graph
- `listDescendantRunsForRequester` — imported by `subagent-followup.ts` which is loaded by `delivery-dispatch.ts`

vitest 4.x throws when a named export is accessed from a mocked module but is not declared in the factory:

```
Error: [vitest] No "getLatestSubagentRunByChildSessionKey" export is defined on the
"../../agents/subagent-registry.js" mock. Did you forget to return it from "vi.mock"?
```

This causes `checks-node-test-2`, `checks-node-test-4`, and all `checks-windows-node-test-*` jobs to fail across every open PR targeting main.

## Fix

Add the two missing entries to the mock factory with safe no-op defaults:

```ts
getLatestSubagentRunByChildSessionKey: vi.fn().mockReturnValue(null),
listDescendantRunsForRequester: vi.fn().mockReturnValue([]),
```

The test itself does not exercise these functions — they are only needed so vitest's module mock is complete.