### PR TITLE
fix(logging): respect logging.level when forwarding console output to file

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
@@ -7,6 +7,8 @@ vi.mock("../../agents/subagent-announce.js", () => ({
 }));
 vi.mock("../../agents/subagent-registry.js", () => ({
   countActiveDescendantRuns: vi.fn().mockReturnValue(0),
+  getLatestSubagentRunByChildSessionKey: vi.fn().mockReturnValue(null),
+  listDescendantRunsForRequester: vi.fn().mockReturnValue([]),
 }));
 
 describe("matchesMessagingToolDeliveryTarget", () => {

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -251,7 +251,7 @@ export function enableConsoleCapture(): void {
         ? formatConsoleTimestamp(getConsoleSettings().style)
         : "";
       try {
-        if (isFileLogLevelEnabled(level as LogLevel)) {
+        if (isFileLogLevelEnabled(level)) {
           const resolvedLogger = getLoggerLazy();
           // Map console levels to file logger
           if (level === "trace") {

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -5,7 +5,7 @@ import { stripAnsi } from "../terminal/ansi.js";
 import { readLoggingConfig, shouldSkipMutatingLoggingConfigRead } from "./config.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, normalizeLogLevel } from "./levels.js";
-import { getLogger, type LoggerSettings } from "./logger.js";
+import { getLogger, isFileLogLevelEnabled, type LoggerSettings } from "./logger.js";
 import { resolveNodeRequireFromMeta } from "./node-require.js";
 import { loggingState } from "./state.js";
 import { formatLocalIsoWithOffset, formatTimestamp } from "./timestamps.js";
@@ -251,20 +251,22 @@ export function enableConsoleCapture(): void {
         ? formatConsoleTimestamp(getConsoleSettings().style)
         : "";
       try {
-        const resolvedLogger = getLoggerLazy();
-        // Map console levels to file logger
-        if (level === "trace") {
-          resolvedLogger.trace(formatted);
-        } else if (level === "debug") {
-          resolvedLogger.debug(formatted);
-        } else if (level === "info") {
-          resolvedLogger.info(formatted);
-        } else if (level === "warn") {
-          resolvedLogger.warn(formatted);
-        } else if (level === "error" || level === "fatal") {
-          resolvedLogger.error(formatted);
-        } else {
-          resolvedLogger.info(formatted);
+        if (isFileLogLevelEnabled(level as LogLevel)) {
+          const resolvedLogger = getLoggerLazy();
+          // Map console levels to file logger
+          if (level === "trace") {
+            resolvedLogger.trace(formatted);
+          } else if (level === "debug") {
+            resolvedLogger.debug(formatted);
+          } else if (level === "info") {
+            resolvedLogger.info(formatted);
+          } else if (level === "warn") {
+            resolvedLogger.warn(formatted);
+          } else if (level === "error" || level === "fatal") {
+            resolvedLogger.error(formatted);
+          } else {
+            resolvedLogger.info(formatted);
+          }
         }
       } catch {
         // never block console output on logging failures


### PR DESCRIPTION
## Problem

`enableConsoleCapture()` in `src/logging/console.ts` intercepts all `console.*` calls and unconditionally forwards them to the file logger. The file logger is built via tslog's `attachTransport`, and tslog does **not** apply `minLevel` filtering to custom transports — the transport callback receives every log entry regardless of the configured minimum level.

As a result, `console.log` calls (mapped to `"info"` level) are always written to the structured JSON log file, even when the user has set `logging.level: warn` in their config. Auth provider names, email addresses, and other CLI output land in `/tmp/openclaw/openclaw-*.log` silently.

## Fix

Gate the file-logger write behind `isFileLogLevelEnabled(level)`, which already exists in `logger.ts` and evaluates the message's severity against the configured `logging.level` threshold:

```ts
if (isFileLogLevelEnabled(level as LogLevel)) {
  const resolvedLogger = getLoggerLazy();
  // ...write to file logger...
}
```

Console passthrough to stdout/stderr is **not** affected — only the structured file write is gated.

## Test

1. Set `logging.level: warn` in `openclaw.json`.
2. Run `openclaw channels list`.
3. Inspect `/tmp/openclaw/openclaw-<date>.log`.

**Before**: `info`-level entries with CLI output appear in the log.  
**After**: no `info`-level entries; only `warn`/`error`/`fatal` messages are written.

Fixes #60164