### PR TITLE
fix(models): patch pi-ai for codex-compatible proxy auth fallback [AI-assisted]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1353,6 +1353,9 @@
           "strip-ansi": "^7.2.0"
         }
       }
+    },
+    "patchedDependencies": {
+      "@mariozechner/pi-ai@0.64.0": "patches/@mariozechner__pi-ai@0.64.0.patch"
     }
   }
 }

--- a/patches/@mariozechner__pi-ai@0.64.0.patch
+++ b/patches/@mariozechner__pi-ai@0.64.0.patch
@@ -1,0 +1,51 @@
+diff --git a/dist/providers/openai-codex-responses.js b/dist/providers/openai-codex-responses.js
+index bfe654d140667f9d9ffb9cbe699af8b5b53c5223..23f1b20ae9f178ed4960d99aeafc45609a666691 100644
+--- a/dist/providers/openai-codex-responses.js
++++ b/dist/providers/openai-codex-responses.js
+@@ -78,7 +78,7 @@ export const streamOpenAICodexResponses = (model, context, options) => {
+             if (!apiKey) {
+                 throw new Error(`No API key for provider: ${model.provider}`);
+             }
+-            const accountId = extractAccountId(apiKey);
++            const accountId = extractAccountId(apiKey, model.baseUrl);
+             let body = buildRequestBody(model, context, options);
+             const nextBody = await options?.onPayload?.(body, model);
+             if (nextBody !== undefined) {
+@@ -684,7 +684,17 @@ async function parseErrorResponse(response) {
+ // ============================================================================
+ // Auth & Headers
+ // ============================================================================
+-function extractAccountId(token) {
++function isOfficialCodexBaseUrl(baseUrl) {
++    try {
++        const raw = baseUrl && baseUrl.trim().length > 0 ? baseUrl : DEFAULT_CODEX_BASE_URL;
++        const url = new URL(raw);
++        return /(^|\.)chatgpt\.com$/i.test(url.hostname);
++    }
++    catch {
++        return true;
++    }
++}
++function extractAccountId(token, baseUrl) {
+     try {
+         const parts = token.split(".");
+         if (parts.length !== 3)
+@@ -696,6 +706,8 @@ function extractAccountId(token) {
+         return accountId;
+     }
+     catch {
++        if (!isOfficialCodexBaseUrl(baseUrl))
++            return undefined;
+         throw new Error("Failed to extract accountId from token");
+     }
+ }
+@@ -711,7 +723,8 @@ function buildHeaders(initHeaders, additionalHeaders, accountId, token, sessionI
+         headers.set(key, value);
+     }
+     headers.set("Authorization", `Bearer ${token}`);
+-    headers.set("chatgpt-account-id", accountId);
++    if (accountId)
++        headers.set("chatgpt-account-id", accountId);
+     headers.set("originator", "pi");
+     const userAgent = _os ? `pi (${_os.platform()} ${_os.release()}; ${_os.arch()})` : "pi (browser)";
+     headers.set("User-Agent", userAgent);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=
 
+patchedDependencies:
+  '@mariozechner/pi-ai@0.64.0':
+    hash: 489ac92c1fe7b42975dd580a254bd5f3ef0bc51abdfe506bd34a6f3138e62556
+    path: patches/@mariozechner__pi-ai@0.64.0.patch
+
 importers:
 
   .:
@@ -55,7 +60,7 @@ importers:
         version: 0.64.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.64.0
-        version: 0.64.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+        version: 0.64.0(patch_hash=489ac92c1fe7b42975dd580a254bd5f3ef0bc51abdfe506bd34a6f3138e62556)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.64.0
         version: 0.64.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
@@ -8227,7 +8232,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.64.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.64.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.64.0(patch_hash=489ac92c1fe7b42975dd580a254bd5f3ef0bc51abdfe506bd34a6f3138e62556)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -8237,7 +8242,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.64.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.64.0(patch_hash=489ac92c1fe7b42975dd580a254bd5f3ef0bc51abdfe506bd34a6f3138e62556)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1020.0
@@ -8265,7 +8270,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.64.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.64.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.64.0(patch_hash=489ac92c1fe7b42975dd580a254bd5f3ef0bc51abdfe506bd34a6f3138e62556)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.64.0
       '@silvia-odwyer/photon-node': 0.3.4
       ajv: 8.18.0


### PR DESCRIPTION
Supersedes #48973.

The original PR branch is now conflicting with \\main\\ and I cannot push updates to the source fork from the current account. This replacement branch rebases the same dependency-patch approach onto current \\main\\ and updates the patch target to \\@mariozechner/pi-ai 0.64.0\\.

What changed:
- reapplied the codex-compatible proxy auth fallback as a pnpm patch for the current pi-ai version
- kept strict behavior for official \\chatgpt.com\\ Codex endpoints
- continued omitting \\chatgpt-account-id\\ when opaque proxy tokens cannot yield an account id on non-official base URLs

Why:
- #48973 is blocked on merge conflicts and stale CI history
- codex-lb still needs the non-official proxy fallback on current OpenClaw mainline

Validation:
- rebased the patch cleanly onto \\origin/main\\
- diff is limited to \\package.json\\, \\pnpm-lock.yaml\\, and the versioned pnpm patch file
