### PR TITLE
test: fix ui presenter next run test for multi-language environments

### DIFF
--- a/test/ui.presenter-next-run.test.ts
+++ b/test/ui.presenter-next-run.test.ts
@@ -10,7 +10,8 @@ describe("formatNextRun", () => {
   it("includes weekday and relative time", () => {
     const ts = Date.UTC(2026, 1, 23, 15, 0, 0);
     const out = formatNextRun(ts);
-    expect(out).toMatch(/^[A-Za-z]{3}, /);
+    const weekday = new Date(ts).toLocaleDateString(undefined, { weekday: "short" });
+    expect(out.slice(0, weekday.length + 2)).toBe(`${weekday}, `);
     expect(out).toContain("(");
     expect(out).toContain(")");
   });

--- a/test/ui.presenter-next-run.test.ts
+++ b/test/ui.presenter-next-run.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { t } from "../ui/src/i18n/index.ts";
 import { formatNextRun } from "../ui/src/ui/presenter.ts";
 
 describe("formatNextRun", () => {
-  it("returns n/a for nullish values", () => {
-    expect(formatNextRun(null)).toBe("n/a");
-    expect(formatNextRun(undefined)).toBe("n/a");
+  it("returns localized n/a for nullish values", () => {
+    expect(formatNextRun(null)).toBe(t("common.na"));
+    expect(formatNextRun(undefined)).toBe(t("common.na"));
   });
 
   it("includes weekday and relative time", () => {


### PR DESCRIPTION
## Summary

- Problem: The `formatNextRun` test in `test/ui.presenter-next-run.test.ts` assumed the output would always start with a 3-letter English weekday abbreviation (e.g., `Mon, `), which fails in non-English locales where `toLocaleDateString` returns localized strings.
- Why it matters: Tests should pass regardless of the developer's system language or locale settings.
- What changed: Updated the test to dynamically compute the expected weekday abbreviation using `toLocaleDateString` with the same parameters as the implementation, and then check if the output starts with it.
- What did NOT change (scope boundary): The actual implementation of `formatNextRun` in `ui/src/ui/presenter.ts` remains unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Hardcoded English regex `/^[A-Za-z]{3}, /` used to validate localized date output.
- Missing detection / guardrail: Tests were likely only run in English locales.
- Prior context: N/A
- Why this regressed now: N/A
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/ui.presenter-next-run.test.ts`
- Scenario the test should lock in: Ensure `formatNextRun` output matches the system's locale weekday format.
- Why this is the smallest reliable guardrail: Unit test directly covers the formatting logic.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: All
- Runtime/container: Node.js 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Non-English system locale (e.g., zh-CN).

### Steps

1. Set system locale to a non-English language (e.g., Chinese).
2. Run `pnpm test -- test/ui.presenter-next-run.test.ts`.

### Expected

Test passes.

### Actual

Test failed due to regex mismatch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Ran the test locally with the updated dynamic locale check.
- Edge cases checked: N/A
- What you did **not** verify: N/A

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
