### PR TITLE
fix(checks): add local heavy-check status visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -944,6 +944,7 @@
     "check:docs": "pnpm format:docs:check && pnpm lint:docs && pnpm docs:check-i18n-glossary && pnpm docs:check-links",
     "check:host-env-policy:swift": "node scripts/generate-host-env-security-policy-swift.mjs --check",
     "check:loc": "node --import tsx scripts/check-ts-max-loc.ts --max 500",
+    "check:local:status": "node scripts/local-heavy-check-status.mjs",
     "check:no-conflict-markers": "node scripts/check-no-conflict-markers.mjs",
     "config:channels:check": "node --import tsx scripts/generate-bundled-channel-config-metadata.ts --check",
     "config:channels:gen": "node --import tsx scripts/generate-bundled-channel-config-metadata.ts --write",

--- a/scripts/lib/local-heavy-check-runtime.mjs
+++ b/scripts/lib/local-heavy-check-runtime.mjs
@@ -64,9 +64,9 @@ export function acquireLocalHeavyCheckLockSync(params) {
     return () => {};
   }
 
-  const commonDir = resolveGitCommonDir(params.cwd);
-  const locksDir = path.join(commonDir, "openclaw-local-checks");
-  const lockDir = path.join(locksDir, `${params.lockName ?? "heavy-check"}.lock`);
+  const locksDir = resolveLocalHeavyChecksDir(params.cwd);
+  const lockName = params.lockName ?? "heavy-check";
+  const lockDir = path.join(locksDir, `${lockName}.lock`);
   const ownerPath = path.join(lockDir, "owner.json");
   const timeoutMs = readPositiveInt(
     env.OPENCLAW_HEAVY_CHECK_LOCK_TIMEOUT_MS,
@@ -79,15 +79,21 @@ export function acquireLocalHeavyCheckLockSync(params) {
   );
   const startedAt = Date.now();
   let waitingLogged = false;
+  let waiterStateWritten = false;
 
   fs.mkdirSync(locksDir, { recursive: true });
 
   for (;;) {
     try {
       fs.mkdirSync(lockDir);
+      if (waiterStateWritten) {
+        cleanupWaiterState(lockDir, process.pid);
+        waiterStateWritten = false;
+      }
       writeOwnerFile(ownerPath, {
         pid: process.pid,
         tool: params.toolName,
+        lockName,
         cwd: params.cwd,
         hostname: os.hostname(),
         createdAt: new Date().toISOString(),
@@ -103,11 +109,25 @@ export function acquireLocalHeavyCheckLockSync(params) {
       const owner = readOwnerFile(ownerPath);
       if (shouldReclaimLock({ owner, lockDir, staleLockMs })) {
         fs.rmSync(lockDir, { recursive: true, force: true });
+        waiterStateWritten = false;
         continue;
       }
 
+      writeWaiterState(lockDir, {
+        pid: process.pid,
+        tool: params.toolName,
+        lockName,
+        cwd: params.cwd,
+        hostname: os.hostname(),
+        createdAt: new Date(startedAt).toISOString(),
+        ownerPid: owner && typeof owner.pid === "number" ? owner.pid : null,
+        ownerTool: owner && typeof owner.tool === "string" ? owner.tool : null,
+      });
+      waiterStateWritten = true;
+
       const elapsedMs = Date.now() - startedAt;
       if (elapsedMs >= timeoutMs) {
+        cleanupWaiterState(lockDir, process.pid);
         const ownerLabel = describeOwner(owner);
         throw new Error(
           `[${params.toolName}] timed out waiting for the local heavy-check lock at ${lockDir}${
@@ -130,6 +150,46 @@ export function acquireLocalHeavyCheckLockSync(params) {
       sleepSync(pollMs);
     }
   }
+}
+
+export function resolveLocalHeavyChecksDir(cwd) {
+  return path.join(resolveGitCommonDir(cwd), "openclaw-local-checks");
+}
+
+export function listLocalHeavyChecks(cwd, env = process.env) {
+  const locksDir = resolveLocalHeavyChecksDir(cwd);
+  const staleLockMs = readPositiveInt(
+    env.OPENCLAW_HEAVY_CHECK_STALE_LOCK_MS,
+    DEFAULT_STALE_LOCK_MS,
+  );
+
+  let entries = [];
+  try {
+    entries = fs
+      .readdirSync(locksDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name.endsWith(".lock"));
+  } catch {
+    return [];
+  }
+
+  return entries
+    .map((entry) => {
+      const lockDir = path.join(locksDir, entry.name);
+      const owner = readOwnerFile(path.join(lockDir, "owner.json"));
+      const waiters = readWaiterStates(lockDir).map((waiter) => ({
+        ...waiter,
+        alive: typeof waiter.pid === "number" ? isProcessAlive(waiter.pid) : false,
+      }));
+      return {
+        lockName: entry.name.replace(/\.lock$/u, ""),
+        lockDir,
+        owner,
+        ownerAlive: owner && typeof owner.pid === "number" ? isProcessAlive(owner.pid) : false,
+        stale: shouldReclaimLock({ owner, lockDir, staleLockMs }),
+        waiters,
+      };
+    })
+    .toSorted((left, right) => left.lockName.localeCompare(right.lockName));
 }
 
 export function resolveGitCommonDir(cwd) {
@@ -168,12 +228,46 @@ function writeOwnerFile(ownerPath, owner) {
   fs.writeFileSync(ownerPath, `${JSON.stringify(owner, null, 2)}\n`, "utf8");
 }
 
+function writeWaiterState(lockDir, waiter) {
+  const waitersDir = path.join(lockDir, "waiters");
+  fs.mkdirSync(waitersDir, { recursive: true });
+  writeOwnerFile(path.join(waitersDir, `${process.pid}.json`), waiter);
+}
+
+function cleanupWaiterState(lockDir, pid) {
+  const waitersDir = path.join(lockDir, "waiters");
+  const waiterPath = path.join(waitersDir, `${pid}.json`);
+  fs.rmSync(waiterPath, { force: true });
+  try {
+    if (fs.readdirSync(waitersDir).length === 0) {
+      fs.rmdirSync(waitersDir);
+    }
+  } catch {
+    // Ignore cleanup failures for concurrent waiters.
+  }
+}
+
 function readOwnerFile(ownerPath) {
   try {
     return JSON.parse(fs.readFileSync(ownerPath, "utf8"));
   } catch {
     return null;
   }
+}
+
+function readWaiterStates(lockDir) {
+  const waitersDir = path.join(lockDir, "waiters");
+  let entries = [];
+  try {
+    entries = fs.readdirSync(waitersDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => readOwnerFile(path.join(waitersDir, entry.name)))
+    .filter(Boolean);
 }
 
 function isAlreadyExistsError(error) {

--- a/scripts/lib/local-heavy-check-runtime.mjs
+++ b/scripts/lib/local-heavy-check-runtime.mjs
@@ -99,7 +99,7 @@ export function acquireLocalHeavyCheckLockSync(params) {
         createdAt: new Date().toISOString(),
       });
       return () => {
-        fs.rmSync(lockDir, { recursive: true, force: true });
+        releaseOwnedLock(lockDir, process.pid);
       };
     } catch (error) {
       if (!isAlreadyExistsError(error)) {
@@ -245,6 +245,14 @@ function cleanupWaiterState(lockDir, pid) {
   } catch {
     // Ignore cleanup failures for concurrent waiters.
   }
+}
+
+function releaseOwnedLock(lockDir, pid) {
+  const owner = readOwnerFile(path.join(lockDir, "owner.json"));
+  if (!owner || typeof owner.pid !== "number" || owner.pid !== pid) {
+    return;
+  }
+  fs.rmSync(lockDir, { recursive: true, force: true });
 }
 
 function readOwnerFile(ownerPath) {

--- a/scripts/local-heavy-check-status.mjs
+++ b/scripts/local-heavy-check-status.mjs
@@ -1,0 +1,43 @@
+import { listLocalHeavyChecks } from "./lib/local-heavy-check-runtime.mjs";
+
+const args = process.argv.slice(2);
+const jsonOutput = args.includes("--json");
+const locks = listLocalHeavyChecks(process.cwd(), process.env);
+
+if (jsonOutput) {
+  console.log(JSON.stringify({ locks }, null, 2));
+  process.exit(0);
+}
+
+if (locks.length === 0) {
+  console.log("No local heavy checks are registered.");
+  process.exit(0);
+}
+
+for (const lock of locks) {
+  const owner = formatActor(lock.owner, lock.ownerAlive);
+  const waiters = lock.waiters
+    .map((waiter) => `  waiter: ${formatActor(waiter, waiter.alive)}`)
+    .join("\n");
+  console.log(
+    [
+      `${lock.lockName}: ${lock.stale ? "stale" : "held"}`,
+      `  owner: ${owner}`,
+      `  path: ${lock.lockDir}`,
+      waiters,
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
+}
+
+function formatActor(actor, alive) {
+  if (!actor || typeof actor !== "object") {
+    return "unknown";
+  }
+
+  const tool = typeof actor.tool === "string" ? actor.tool : "unknown-tool";
+  const pid = typeof actor.pid === "number" ? `pid ${actor.pid}` : "unknown pid";
+  const cwd = typeof actor.cwd === "string" ? actor.cwd : "unknown cwd";
+  return `${tool}, ${pid}, cwd ${cwd}, ${alive ? "alive" : "dead"}`;
+}

--- a/test/scripts/local-heavy-check-runtime.test.ts
+++ b/test/scripts/local-heavy-check-runtime.test.ts
@@ -1,11 +1,14 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   acquireLocalHeavyCheckLockSync,
   applyLocalOxlintPolicy,
   applyLocalTsgoPolicy,
+  listLocalHeavyChecks,
 } from "../../scripts/lib/local-heavy-check-runtime.mjs";
 
 const tempDirs: string[] = [];
@@ -28,6 +31,24 @@ function makeEnv(overrides: Record<string, string | undefined> = {}) {
     OPENCLAW_LOCAL_CHECK: "1",
     ...overrides,
   };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("timed out waiting for condition");
+}
+
+function waitForExit(child: ReturnType<typeof spawn>) {
+  return new Promise<{ code: number | null; signal: string | null }>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
 }
 
 describe("local-heavy-check-runtime", () => {
@@ -87,5 +108,86 @@ describe("local-heavy-check-runtime", () => {
 
     release();
     expect(fs.existsSync(lockDir)).toBe(false);
+  });
+
+  it("tracks queued waiters while a local heavy check is blocked", async () => {
+    const cwd = makeTempDir();
+    const release = acquireLocalHeavyCheckLockSync({
+      cwd,
+      env: makeEnv(),
+      lockName: "test",
+      toolName: "test",
+    });
+    const lockDir = path.join(cwd, ".git", "openclaw-local-checks", "test.lock");
+    const helperUrl = pathToFileURL(path.resolve("scripts/lib/local-heavy-check-runtime.mjs")).href;
+    const child = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "--eval",
+        [
+          `import { acquireLocalHeavyCheckLockSync } from ${JSON.stringify(helperUrl)};`,
+          `const release = acquireLocalHeavyCheckLockSync({ cwd: ${JSON.stringify(cwd)}, env: process.env, lockName: "test", toolName: "test" });`,
+          "release();",
+        ].join(" "),
+      ],
+      {
+        cwd,
+        env: makeEnv({
+          OPENCLAW_HEAVY_CHECK_LOCK_TIMEOUT_MS: "2000",
+          OPENCLAW_HEAVY_CHECK_LOCK_POLL_MS: "10",
+        }),
+        stdio: "ignore",
+      },
+    );
+
+    await waitFor(
+      () =>
+        fs.existsSync(path.join(lockDir, "waiters")) &&
+        fs.readdirSync(path.join(lockDir, "waiters")).length > 0,
+    );
+
+    const locksWhileBlocked = listLocalHeavyChecks(cwd, makeEnv());
+    expect(locksWhileBlocked).toHaveLength(1);
+    expect(locksWhileBlocked[0]?.lockName).toBe("test");
+    expect(locksWhileBlocked[0]?.waiters).toHaveLength(1);
+    expect(locksWhileBlocked[0]?.waiters[0]?.tool).toBe("test");
+
+    release();
+    const childExit = await waitForExit(child);
+    expect(childExit.code).toBe(0);
+    expect(fs.existsSync(path.join(lockDir, "waiters"))).toBe(false);
+  });
+
+  it("lists local heavy-check ownership and waiter state", () => {
+    const cwd = makeTempDir();
+    const lockDir = path.join(cwd, ".git", "openclaw-local-checks", "oxlint.lock");
+    const waitersDir = path.join(lockDir, "waiters");
+    fs.mkdirSync(waitersDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(lockDir, "owner.json"),
+      `${JSON.stringify({
+        pid: process.pid,
+        tool: "oxlint",
+        cwd,
+      })}\n`,
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(waitersDir, "999999999.json"),
+      `${JSON.stringify({
+        pid: 999_999_999,
+        tool: "test",
+        cwd,
+      })}\n`,
+      "utf8",
+    );
+
+    const locks = listLocalHeavyChecks(cwd, makeEnv());
+    expect(locks).toHaveLength(1);
+    expect(locks[0]?.lockName).toBe("oxlint");
+    expect(locks[0]?.ownerAlive).toBe(true);
+    expect(locks[0]?.waiters).toHaveLength(1);
+    expect(locks[0]?.waiters[0]?.alive).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Problem: local heavy-check locking serialized work, but it still gave poor visibility across terminals and no queued-waiter introspection.
- Why it matters: when a local shell blocks on `test`, `tsgo`, or `oxlint`, users need to know who owns the gate, whether the owner is stale, and whether other sessions are queued.
- What changed: add waiter tracking inside the local heavy-check runtime, add a `check:local:status` command to inspect current owners/waiters, and make lock release ownership-safe during handoff.
- What did NOT change (scope boundary): CI gating, Vitest worker policy, and the existing local admission-control scope.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #60273
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the first local lock layer only tracked a single owner file, so blocked sessions had no queue visibility and the releaser could race a new owner during handoff.
- Missing detection / guardrail: no waiter registration/listing and no ownership check before lock deletion.
- Prior context (`git blame`, prior PR, issue, or refactor if known): `#60273` added the initial local heavy-check lock.
- Why this regressed now: once multiple local shells started sharing the gate, lack of introspection became the next bottleneck.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/scripts/local-heavy-check-runtime.test.ts`
- Scenario the test should lock in: blocked waiters are visible, stale owners are reported, and lock handoff does not remove a newly acquired lock.
- Why this is the smallest reliable guardrail: the behavior lives in the runtime helper and can be tested directly without broader repo gates.
- Existing test that already covers this (if any): None
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Local shells can now inspect heavy-check ownership and queue state with `pnpm check:local:status`.

## Diagram (if applicable)

```text
Before:
[terminal B waits on local test lock] -> [only generic waiting message]

After:
[terminal B waits on local test lock] -> [owner + waiter state recorded]
[pnpm check:local:status] -> [held/stale owner + queued waiters]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `OPENCLAW_LOCAL_CHECK=0` for the focused test run only; status command inspected the shared repo lock state directly

### Steps

1. Hold a local heavy-check lock in one shell.
2. Start another local heavy check in a second shell.
3. Run `pnpm check:local:status`.

### Expected

- The owner is visible.
- Queued waiters are visible while blocked.
- Stale owners are flagged.

### Actual

- The helper test covers waiter registration/listing and the CLI prints current owner state from the shared repo lock directory.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `OPENCLAW_LOCAL_CHECK=0 pnpm test -- test/scripts/local-heavy-check-runtime.test.ts`; `node scripts/local-heavy-check-status.mjs`; `node scripts/local-heavy-check-status.mjs --json`.
- Edge cases checked: stale owner reporting and ownership-safe handoff deletion.
- What you did **not** verify: broader repo gates beyond the helper/runtime surface.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: status output may show dead/stale entries until the next acquisition path reclaims them.
  - Mitigation: the command marks stale owners explicitly, and the acquisition path still auto-reclaims dead owners.
