### PR TITLE
feat: add Atomic Chat local LLM provider plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Providers/StepFun: add the bundled StepFun provider plugin with standard and Step Plan endpoints, China/global onboarding choices, `step-3.5-flash` on both catalogs, and `step-3.5-flash-2603` currently exposed on Step Plan. (#60032) Thanks @hengm3467.
 - Providers/config: add `models.providers.*.request` overrides for headers and auth on model-provider paths, and full request transport overrides for media provider HTTP paths.
 - Control UI/skills: add ClawHub search, detail, and install flows directly in the Skills panel. (#60134) Thanks @samzong.
+- Providers/Atomic Chat: add bundled provider plugin for Atomic Chat, a local OpenAI-compatible LLM server, with onboarding wizard support, reachability checks, model auto-discovery, and synthetic local auth.
 
 ### Fixes
 

--- a/docs/.generated/config-baseline.core.json
+++ b/docs/.generated/config-baseline.core.json
@@ -4014,6 +4014,26 @@
       "hasChildren": true
     },
     {
+      "path": "agents.defaults.subagents.allowAgents",
+      "kind": "core",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "agents.defaults.subagents.allowAgents.*",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "agents.defaults.subagents.announceTimeoutMs",
       "kind": "core",
       "type": "integer",
@@ -15601,7 +15621,7 @@
         "models"
       ],
       "label": "Model Provider Request Overrides",
-      "help": "Optional request overrides for model-provider requests. Today this path supports header and auth overrides only; proxy and TLS transport settings are reserved for request paths that can carry them end to end.",
+      "help": "Optional request overrides for model-provider requests. Use this only for header and auth overrides today; proxy and TLS transport settings are reserved for request paths that can carry them end to end.",
       "hasChildren": true
     },
     {

--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -4013,6 +4013,26 @@
       "hasChildren": true
     },
     {
+      "path": "agents.defaults.subagents.allowAgents",
+      "kind": "core",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "agents.defaults.subagents.allowAgents.*",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "agents.defaults.subagents.announceTimeoutMs",
       "kind": "core",
       "type": "integer",
@@ -15600,7 +15620,7 @@
         "models"
       ],
       "label": "Model Provider Request Overrides",
-      "help": "Optional request overrides for model-provider requests. Today this path supports header and auth overrides only; proxy and TLS transport settings are reserved for request paths that can carry them end to end.",
+      "help": "Optional request overrides for model-provider requests. Use this only for header and auth overrides today; proxy and TLS transport settings are reserved for request paths that can carry them end to end.",
       "hasChildren": true
     },
     {
@@ -59770,6 +59790,127 @@
     },
     {
       "path": "plugins.entries.anthropic.subagent.allowModelOverride",
+      "kind": "plugin",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "access"
+      ],
+      "label": "Allow Plugin Subagent Model Override",
+      "help": "Explicitly allows this plugin to request provider/model overrides in background subagent runs. Keep false unless the plugin is trusted to steer model selection.",
+      "hasChildren": false
+    },
+    {
+      "path": "plugins.entries.atomic-chat",
+      "kind": "plugin",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "advanced"
+      ],
+      "label": "@openclaw/atomic-chat-provider",
+      "help": "OpenClaw Atomic Chat provider plugin (plugin: atomic-chat)",
+      "hasChildren": true
+    },
+    {
+      "path": "plugins.entries.atomic-chat.config",
+      "kind": "plugin",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "advanced"
+      ],
+      "label": "@openclaw/atomic-chat-provider Config",
+      "help": "Plugin-defined config payload for atomic-chat.",
+      "hasChildren": false
+    },
+    {
+      "path": "plugins.entries.atomic-chat.enabled",
+      "kind": "plugin",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "advanced"
+      ],
+      "label": "Enable @openclaw/atomic-chat-provider",
+      "hasChildren": false
+    },
+    {
+      "path": "plugins.entries.atomic-chat.hooks",
+      "kind": "plugin",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "advanced"
+      ],
+      "label": "Plugin Hook Policy",
+      "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
+      "hasChildren": true
+    },
+    {
+      "path": "plugins.entries.atomic-chat.hooks.allowPromptInjection",
+      "kind": "plugin",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "access"
+      ],
+      "label": "Allow Prompt Injection Hooks",
+      "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
+      "hasChildren": false
+    },
+    {
+      "path": "plugins.entries.atomic-chat.subagent",
+      "kind": "plugin",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "advanced"
+      ],
+      "label": "Plugin Subagent Policy",
+      "help": "Per-plugin subagent runtime controls for model override trust and allowlists. Keep this unset unless a plugin must explicitly steer subagent model selection.",
+      "hasChildren": true
+    },
+    {
+      "path": "plugins.entries.atomic-chat.subagent.allowedModels",
+      "kind": "plugin",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "access"
+      ],
+      "label": "Plugin Subagent Allowed Models",
+      "help": "Allowed override targets for trusted plugin subagent runs as canonical \"provider/model\" refs. Use \"*\" only when you intentionally allow any model.",
+      "hasChildren": true
+    },
+    {
+      "path": "plugins.entries.atomic-chat.subagent.allowedModels.*",
+      "kind": "plugin",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "plugins.entries.atomic-chat.subagent.allowModelOverride",
       "kind": "plugin",
       "type": "boolean",
       "required": false,

--- a/docs/.generated/config-baseline.plugin.json
+++ b/docs/.generated/config-baseline.plugin.json
@@ -884,6 +884,127 @@
       "hasChildren": false
     },
     {
+      "path": "plugins.entries.atomic-chat",
+      "kind": "plugin",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "advanced"
+      ],
+      "label": "@openclaw/atomic-chat-provider",
+      "help": "OpenClaw Atomic Chat provider plugin (plugin: atomic-chat)",
+      "hasChildren": true
+    },
+    {
+      "path": "plugins.entries.atomic-chat.config",
+      "kind": "plugin",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "advanced"
+      ],
+      "label": "@openclaw/atomic-chat-provider Config",
+      "help": "Plugin-defined config payload for atomic-chat.",
+      "hasChildren": false
+    },
+    {
+      "path": "plugins.entries.atomic-chat.enabled",
+      "kind": "plugin",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "advanced"
+      ],
+      "label": "Enable @openclaw/atomic-chat-provider",
+      "hasChildren": false
+    },
+    {
+      "path": "plugins.entries.atomic-chat.hooks",
+      "kind": "plugin",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "advanced"
+      ],
+      "label": "Plugin Hook Policy",
+      "help": "Per-plugin typed hook policy controls for core-enforced safety gates. Use this to constrain high-impact hook categories without disabling the entire plugin.",
+      "hasChildren": true
+    },
+    {
+      "path": "plugins.entries.atomic-chat.hooks.allowPromptInjection",
+      "kind": "plugin",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "access"
+      ],
+      "label": "Allow Prompt Injection Hooks",
+      "help": "Controls whether this plugin may mutate prompts through typed hooks. Set false to block `before_prompt_build` and ignore prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride` behavior.",
+      "hasChildren": false
+    },
+    {
+      "path": "plugins.entries.atomic-chat.subagent",
+      "kind": "plugin",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "advanced"
+      ],
+      "label": "Plugin Subagent Policy",
+      "help": "Per-plugin subagent runtime controls for model override trust and allowlists. Keep this unset unless a plugin must explicitly steer subagent model selection.",
+      "hasChildren": true
+    },
+    {
+      "path": "plugins.entries.atomic-chat.subagent.allowedModels",
+      "kind": "plugin",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "access"
+      ],
+      "label": "Plugin Subagent Allowed Models",
+      "help": "Allowed override targets for trusted plugin subagent runs as canonical \"provider/model\" refs. Use \"*\" only when you intentionally allow any model.",
+      "hasChildren": true
+    },
+    {
+      "path": "plugins.entries.atomic-chat.subagent.allowedModels.*",
+      "kind": "plugin",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "plugins.entries.atomic-chat.subagent.allowModelOverride",
+      "kind": "plugin",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "access"
+      ],
+      "label": "Allow Plugin Subagent Model Override",
+      "help": "Explicitly allows this plugin to request provider/model overrides in background subagent runs. Keep false unless the plugin is trusted to steer model selection.",
+      "hasChildren": false
+    },
+    {
       "path": "plugins.entries.bluebubbles",
       "kind": "plugin",
       "type": "object",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1223,6 +1223,7 @@
                 "group": "Providers",
                 "pages": [
                   "providers/anthropic",
+                  "providers/atomic-chat",
                   "providers/bedrock",
                   "providers/claude-max-api-proxy",
                   "providers/cloudflare-ai-gateway",

--- a/docs/providers/atomic-chat.md
+++ b/docs/providers/atomic-chat.md
@@ -1,0 +1,100 @@
+---
+summary: "Run OpenClaw with Atomic Chat (OpenAI-compatible local LLM server)"
+read_when:
+  - You want to run OpenClaw against a local Atomic Chat server
+  - You want OpenAI-compatible /v1 endpoints with your own models
+title: "Atomic Chat"
+---
+
+# Atomic Chat
+
+Atomic Chat serves local models via an **OpenAI-compatible** HTTP API.
+OpenClaw can connect to Atomic Chat using the `openai-completions` API.
+
+OpenClaw can also **auto-discover** available models from Atomic Chat when the
+server is running and you do not define an explicit
+`models.providers.atomic-chat` entry.
+
+## Quick start
+
+1. Start Atomic Chat and load a model.
+
+Your base URL should expose `/v1` endpoints (for example `/v1/models`,
+`/v1/chat/completions`). Atomic Chat commonly runs on:
+
+- `http://127.0.0.1:1337/v1`
+
+2. Run onboarding and choose `Atomic Chat`:
+
+```bash
+openclaw onboard
+```
+
+The setup wizard checks that Atomic Chat is reachable and has at least one
+model loaded. If not, it asks you to start the server or load a model first.
+
+3. Or set a model directly:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "atomic-chat/Qwen3_5-9B-Q4_K_M" },
+    },
+  },
+}
+```
+
+## Model discovery (implicit provider)
+
+When `ATOMIC_CHAT_API_KEY` is set (or an auth profile exists) and you **do
+not** define `models.providers.atomic-chat`, OpenClaw will query:
+
+- `GET http://127.0.0.1:1337/v1/models`
+
+and convert the returned IDs into model entries.
+
+If you set `models.providers.atomic-chat` explicitly, auto-discovery is
+skipped and you must define models manually.
+
+## Explicit configuration (manual models)
+
+Use explicit config when:
+
+- Atomic Chat runs on a different host/port.
+- You want to pin `contextWindow`/`maxTokens` values.
+
+```json5
+{
+  models: {
+    providers: {
+      "atomic-chat": {
+        baseUrl: "http://127.0.0.1:1337/v1",
+        apiKey: "${ATOMIC_CHAT_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "Qwen3_5-9B-Q4_K_M",
+            name: "Qwen 3.5 9B",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+## Troubleshooting
+
+- Check the server is reachable:
+
+```bash
+curl http://127.0.0.1:1337/v1/models
+```
+
+- If no models are returned, load a model in Atomic Chat first.

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -28,6 +28,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 
 - [Amazon Bedrock](/providers/bedrock)
 - [Anthropic (API + Claude Code CLI)](/providers/anthropic)
+- [Atomic Chat (local models)](/providers/atomic-chat)
 - [Cloudflare AI Gateway](/providers/cloudflare-ai-gateway)
 - [DeepSeek](/providers/deepseek)
 - [GitHub Copilot](/providers/github-copilot)

--- a/extensions/atomic-chat/README.md
+++ b/extensions/atomic-chat/README.md
@@ -1,0 +1,5 @@
+# Atomic Chat Provider
+
+Bundled OpenClaw provider plugin for [Atomic Chat](https://atomic.chat) — a local OpenAI-compatible LLM server.
+
+Default base URL: `http://127.0.0.1:1337/v1`

--- a/extensions/atomic-chat/api.ts
+++ b/extensions/atomic-chat/api.ts
@@ -1,0 +1,8 @@
+export {
+  ATOMIC_CHAT_DEFAULT_API_KEY_ENV_VAR,
+  ATOMIC_CHAT_DEFAULT_BASE_URL,
+  ATOMIC_CHAT_MODEL_PLACEHOLDER,
+  ATOMIC_CHAT_PROVIDER_LABEL,
+} from "./defaults.js";
+export { buildAtomicChatProvider } from "./models.js";
+export { configureAtomicChatNonInteractive, promptAndConfigureAtomicChat } from "./setup.js";

--- a/extensions/atomic-chat/defaults.ts
+++ b/extensions/atomic-chat/defaults.ts
@@ -1,0 +1,4 @@
+export const ATOMIC_CHAT_DEFAULT_BASE_URL = "http://127.0.0.1:1337/v1";
+export const ATOMIC_CHAT_PROVIDER_LABEL = "Atomic Chat";
+export const ATOMIC_CHAT_DEFAULT_API_KEY_ENV_VAR = "ATOMIC_CHAT_API_KEY";
+export const ATOMIC_CHAT_MODEL_PLACEHOLDER = "Qwen3_5-9B-Q4_K_M";

--- a/extensions/atomic-chat/index.ts
+++ b/extensions/atomic-chat/index.ts
@@ -1,0 +1,151 @@
+import {
+  definePluginEntry,
+  type OpenClawPluginApi,
+  type ProviderAuthContext,
+  type ProviderAuthMethodNonInteractiveContext,
+  type ProviderAuthResult,
+  type ProviderDiscoveryContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import {
+  ATOMIC_CHAT_DEFAULT_BASE_URL,
+  buildAtomicChatProvider,
+  configureAtomicChatNonInteractive,
+  promptAndConfigureAtomicChat,
+} from "./api.js";
+
+const PROVIDER_ID = "atomic-chat";
+const DEFAULT_API_KEY = "atomic-chat-local";
+
+function shouldSkipAmbientDiscovery(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(env.VITEST) || env.NODE_ENV === "test";
+}
+
+export default definePluginEntry({
+  id: "atomic-chat",
+  name: "Atomic Chat Provider",
+  description: "Bundled Atomic Chat provider plugin",
+  register(api: OpenClawPluginApi) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "Atomic Chat",
+      docsPath: "/providers/atomic-chat",
+      envVars: ["ATOMIC_CHAT_API_KEY"],
+      auth: [
+        {
+          id: "local",
+          label: "Atomic Chat",
+          hint: "Local OpenAI-compatible LLM server",
+          kind: "custom",
+          run: async (ctx: ProviderAuthContext): Promise<ProviderAuthResult> => {
+            const result = await promptAndConfigureAtomicChat({
+              cfg: ctx.config,
+              prompter: ctx.prompter,
+            });
+            return {
+              profiles: [
+                {
+                  profileId: `${PROVIDER_ID}:default`,
+                  credential: {
+                    type: "api_key",
+                    provider: PROVIDER_ID,
+                    key: DEFAULT_API_KEY,
+                  },
+                },
+              ],
+              configPatch: result.config,
+            };
+          },
+          runNonInteractive: async (ctx: ProviderAuthMethodNonInteractiveContext) => {
+            return await configureAtomicChatNonInteractive({
+              nextConfig: ctx.config,
+              opts: {
+                customBaseUrl: ctx.opts.customBaseUrl as string | undefined,
+                customModelId: ctx.opts.customModelId as string | undefined,
+              },
+              runtime: ctx.runtime,
+              agentDir: ctx.agentDir,
+            });
+          },
+        },
+      ],
+      discovery: {
+        order: "late",
+        run: async (ctx: ProviderDiscoveryContext) => {
+          const explicit = ctx.config.models?.providers?.[PROVIDER_ID];
+          const hasExplicitModels = Array.isArray(explicit?.models) && explicit.models.length > 0;
+          const apiKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+
+          if (hasExplicitModels && explicit) {
+            return {
+              provider: {
+                ...explicit,
+                baseUrl:
+                  typeof explicit.baseUrl === "string" && explicit.baseUrl.trim()
+                    ? explicit.baseUrl.trim().replace(/\/+$/, "")
+                    : ATOMIC_CHAT_DEFAULT_BASE_URL,
+                api: explicit.api ?? "openai-completions",
+                apiKey: apiKey ?? explicit.apiKey ?? DEFAULT_API_KEY,
+              },
+            };
+          }
+
+          if (!apiKey && !explicit && shouldSkipAmbientDiscovery(ctx.env)) {
+            return null;
+          }
+
+          const provider = await buildAtomicChatProvider({
+            baseUrl: explicit?.baseUrl,
+            apiKey,
+          });
+          if (provider.models.length === 0 && !apiKey && !explicit?.apiKey) {
+            return null;
+          }
+          return {
+            provider: {
+              ...provider,
+              apiKey: apiKey ?? explicit?.apiKey ?? DEFAULT_API_KEY,
+            },
+          };
+        },
+      },
+      wizard: {
+        setup: {
+          choiceId: "atomic-chat",
+          choiceLabel: "Atomic Chat",
+          choiceHint: "Local OpenAI-compatible LLM server",
+          groupId: "atomic-chat",
+          groupLabel: "Atomic Chat",
+          groupHint: "Local OpenAI-compatible LLM server",
+          methodId: "local",
+          modelSelection: {
+            promptWhenAuthChoiceProvided: true,
+            allowKeepCurrent: false,
+          },
+        },
+        modelPicker: {
+          label: "Atomic Chat (custom)",
+          hint: "Detect models from a local Atomic Chat instance",
+          methodId: "local",
+        },
+      },
+      resolveSyntheticAuth: ({ providerConfig }) => {
+        const hasApiConfig =
+          Boolean(providerConfig?.api?.trim()) ||
+          Boolean(providerConfig?.baseUrl?.trim()) ||
+          (Array.isArray(providerConfig?.models) && providerConfig.models.length > 0);
+        if (!hasApiConfig) {
+          return undefined;
+        }
+        return {
+          apiKey: DEFAULT_API_KEY,
+          source: `models.providers.${PROVIDER_ID} (synthetic local key)`,
+          mode: "api-key",
+        };
+      },
+      buildUnknownModelHint: () =>
+        "Atomic Chat requires the server to be running for provider registration. " +
+        'Start Atomic Chat or run "openclaw configure". ' +
+        "See: https://docs.openclaw.ai/providers/atomic-chat",
+    });
+  },
+});

--- a/extensions/atomic-chat/index.ts
+++ b/extensions/atomic-chat/index.ts
@@ -128,6 +128,8 @@ export default definePluginEntry({
           methodId: "local",
         },
       },
+      shouldDeferSyntheticProfileAuth: ({ resolvedApiKey }) =>
+        resolvedApiKey?.trim() === DEFAULT_API_KEY,
       resolveSyntheticAuth: ({ providerConfig }) => {
         const hasApiConfig =
           Boolean(providerConfig?.api?.trim()) ||

--- a/extensions/atomic-chat/models.ts
+++ b/extensions/atomic-chat/models.ts
@@ -1,0 +1,23 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { discoverOpenAICompatibleLocalModels } from "openclaw/plugin-sdk/provider-setup";
+import { ATOMIC_CHAT_DEFAULT_BASE_URL, ATOMIC_CHAT_PROVIDER_LABEL } from "./defaults.js";
+
+type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
+type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
+
+export async function buildAtomicChatProvider(params?: {
+  baseUrl?: string;
+  apiKey?: string;
+}): Promise<ProviderConfig> {
+  const baseUrl = (params?.baseUrl?.trim() || ATOMIC_CHAT_DEFAULT_BASE_URL).replace(/\/+$/, "");
+  const models = await discoverOpenAICompatibleLocalModels({
+    baseUrl,
+    apiKey: params?.apiKey,
+    label: ATOMIC_CHAT_PROVIDER_LABEL,
+  });
+  return {
+    baseUrl,
+    api: "openai-completions",
+    models,
+  };
+}

--- a/extensions/atomic-chat/openclaw.plugin.json
+++ b/extensions/atomic-chat/openclaw.plugin.json
@@ -1,0 +1,25 @@
+{
+  "id": "atomic-chat",
+  "enabledByDefault": true,
+  "providers": ["atomic-chat"],
+  "providerAuthEnvVars": {
+    "atomic-chat": ["ATOMIC_CHAT_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "atomic-chat",
+      "method": "local",
+      "choiceId": "atomic-chat",
+      "choiceLabel": "Atomic Chat",
+      "choiceHint": "Local OpenAI-compatible LLM server",
+      "groupId": "atomic-chat",
+      "groupLabel": "Atomic Chat",
+      "groupHint": "Local OpenAI-compatible LLM server"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/atomic-chat/package.json
+++ b/extensions/atomic-chat/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/atomic-chat-provider",
+  "version": "2026.4.2-beta.1",
+  "private": true,
+  "description": "OpenClaw Atomic Chat provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/atomic-chat/setup.ts
+++ b/extensions/atomic-chat/setup.ts
@@ -4,7 +4,11 @@ import { applyAgentDefaultModelPrimary } from "openclaw/plugin-sdk/provider-onbo
 import { discoverOpenAICompatibleLocalModels } from "openclaw/plugin-sdk/provider-setup";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { WizardCancelledError, type WizardPrompter } from "openclaw/plugin-sdk/setup";
-import { ATOMIC_CHAT_DEFAULT_BASE_URL, ATOMIC_CHAT_PROVIDER_LABEL } from "./defaults.js";
+import {
+  ATOMIC_CHAT_DEFAULT_API_KEY_ENV_VAR,
+  ATOMIC_CHAT_DEFAULT_BASE_URL,
+  ATOMIC_CHAT_PROVIDER_LABEL,
+} from "./defaults.js";
 
 const PROVIDER_ID = "atomic-chat";
 const DEFAULT_API_KEY = "atomic-chat-local";
@@ -73,7 +77,7 @@ export async function promptAndConfigureAtomicChat(params: {
           [PROVIDER_ID]: {
             baseUrl,
             api: "openai-completions",
-            apiKey: "ATOMIC_CHAT_API_KEY",
+            apiKey: ATOMIC_CHAT_DEFAULT_API_KEY_ENV_VAR,
             models,
           },
         },
@@ -112,8 +116,6 @@ export async function configureAtomicChatNonInteractive(params: {
     return params.nextConfig;
   }
 
-  await storeCredential(params.agentDir);
-
   const models = await discoverOpenAICompatibleLocalModels({
     baseUrl,
     label: ATOMIC_CHAT_PROVIDER_LABEL,
@@ -130,6 +132,8 @@ export async function configureAtomicChatNonInteractive(params: {
     return params.nextConfig;
   }
 
+  await storeCredential(params.agentDir);
+
   const defaultModelId = params.opts.customModelId?.trim() || models[0]?.id;
 
   const config: OpenClawConfig = {
@@ -142,7 +146,7 @@ export async function configureAtomicChatNonInteractive(params: {
         [PROVIDER_ID]: {
           baseUrl,
           api: "openai-completions",
-          apiKey: "ATOMIC_CHAT_API_KEY",
+          apiKey: ATOMIC_CHAT_DEFAULT_API_KEY_ENV_VAR,
           models,
         },
       },

--- a/extensions/atomic-chat/setup.ts
+++ b/extensions/atomic-chat/setup.ts
@@ -1,0 +1,158 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { upsertAuthProfileWithLock } from "openclaw/plugin-sdk/provider-auth";
+import { applyAgentDefaultModelPrimary } from "openclaw/plugin-sdk/provider-onboard";
+import { discoverOpenAICompatibleLocalModels } from "openclaw/plugin-sdk/provider-setup";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
+import { WizardCancelledError, type WizardPrompter } from "openclaw/plugin-sdk/setup";
+import { ATOMIC_CHAT_DEFAULT_BASE_URL, ATOMIC_CHAT_PROVIDER_LABEL } from "./defaults.js";
+
+const PROVIDER_ID = "atomic-chat";
+const DEFAULT_API_KEY = "atomic-chat-local";
+
+async function checkReachable(baseUrl: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${baseUrl.replace(/\/+$/, "")}/models`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function promptAndConfigureAtomicChat(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+}): Promise<{ config: OpenClawConfig }> {
+  const baseUrlRaw = await params.prompter.text({
+    message: "Atomic Chat base URL",
+    initialValue: ATOMIC_CHAT_DEFAULT_BASE_URL,
+    placeholder: ATOMIC_CHAT_DEFAULT_BASE_URL,
+    validate: (value) => (value?.trim() ? undefined : "Required"),
+  });
+  const baseUrl = String(baseUrlRaw ?? "")
+    .trim()
+    .replace(/\/+$/, "");
+
+  const reachable = await checkReachable(baseUrl);
+  if (!reachable) {
+    await params.prompter.note(
+      [
+        `Atomic Chat could not be reached at ${baseUrl}.`,
+        "Make sure Atomic Chat is running and re-run setup.",
+      ].join("\n"),
+      "Atomic Chat",
+    );
+    throw new WizardCancelledError("Atomic Chat not reachable");
+  }
+
+  const models = await discoverOpenAICompatibleLocalModels({
+    baseUrl,
+    label: ATOMIC_CHAT_PROVIDER_LABEL,
+  });
+
+  if (models.length === 0) {
+    await params.prompter.note(
+      [
+        `No models found on Atomic Chat at ${baseUrl}.`,
+        "Load a model in Atomic Chat and re-run setup.",
+      ].join("\n"),
+      "Atomic Chat",
+    );
+    throw new WizardCancelledError("No Atomic Chat models available");
+  }
+
+  return {
+    config: {
+      ...params.cfg,
+      models: {
+        ...params.cfg.models,
+        mode: params.cfg.models?.mode ?? "merge",
+        providers: {
+          ...params.cfg.models?.providers,
+          [PROVIDER_ID]: {
+            baseUrl,
+            api: "openai-completions",
+            apiKey: "ATOMIC_CHAT_API_KEY",
+            models,
+          },
+        },
+      },
+    },
+  };
+}
+
+async function storeCredential(agentDir?: string): Promise<void> {
+  await upsertAuthProfileWithLock({
+    profileId: `${PROVIDER_ID}:default`,
+    credential: { type: "api_key", provider: PROVIDER_ID, key: DEFAULT_API_KEY },
+    agentDir,
+  });
+}
+
+export async function configureAtomicChatNonInteractive(params: {
+  nextConfig: OpenClawConfig;
+  opts: { customBaseUrl?: string; customModelId?: string };
+  runtime: RuntimeEnv;
+  agentDir?: string;
+}): Promise<OpenClawConfig> {
+  const baseUrl = (params.opts.customBaseUrl?.trim() || ATOMIC_CHAT_DEFAULT_BASE_URL).replace(
+    /\/+$/,
+    "",
+  );
+
+  const reachable = await checkReachable(baseUrl);
+  if (!reachable) {
+    params.runtime.error(
+      [`Atomic Chat could not be reached at ${baseUrl}.`, "Make sure Atomic Chat is running."].join(
+        "\n",
+      ),
+    );
+    params.runtime.exit(1);
+    return params.nextConfig;
+  }
+
+  await storeCredential(params.agentDir);
+
+  const models = await discoverOpenAICompatibleLocalModels({
+    baseUrl,
+    label: ATOMIC_CHAT_PROVIDER_LABEL,
+  });
+
+  if (models.length === 0) {
+    params.runtime.error(
+      [
+        `No models found on Atomic Chat at ${baseUrl}.`,
+        "Load a model in Atomic Chat and re-run setup.",
+      ].join("\n"),
+    );
+    params.runtime.exit(1);
+    return params.nextConfig;
+  }
+
+  const defaultModelId = params.opts.customModelId?.trim() || models[0]?.id;
+
+  const config: OpenClawConfig = {
+    ...params.nextConfig,
+    models: {
+      ...params.nextConfig.models,
+      mode: params.nextConfig.models?.mode ?? "merge",
+      providers: {
+        ...params.nextConfig.models?.providers,
+        [PROVIDER_ID]: {
+          baseUrl,
+          api: "openai-completions",
+          apiKey: "ATOMIC_CHAT_API_KEY",
+          models,
+        },
+      },
+    },
+  };
+
+  if (defaultModelId) {
+    params.runtime.log(`Default Atomic Chat model: ${defaultModelId}`);
+    return applyAgentDefaultModelPrimary(config, `${PROVIDER_ID}/${defaultModelId}`);
+  }
+
+  return config;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,8 @@ importers:
 
   extensions/anthropic-vertex: {}
 
+  extensions/atomic-chat: {}
+
   extensions/bluebubbles:
     devDependencies:
       openclaw:
@@ -603,6 +605,8 @@ importers:
         version: 7.15.0
 
   extensions/speech-core: {}
+
+  extensions/stepfun: {}
 
   extensions/synology-chat: {}
 

--- a/src/agents/model-auth-markers.test.ts
+++ b/src/agents/model-auth-markers.test.ts
@@ -12,6 +12,7 @@ describe("model auth markers", () => {
   it("recognizes explicit non-secret markers", () => {
     expect(isNonSecretApiKeyMarker(NON_ENV_SECRETREF_MARKER)).toBe(true);
     expect(isNonSecretApiKeyMarker(resolveOAuthApiKeyMarker("chutes"))).toBe(true);
+    expect(isNonSecretApiKeyMarker("atomic-chat-local")).toBe(true);
     expect(isNonSecretApiKeyMarker("ollama-local")).toBe(true);
     expect(isNonSecretApiKeyMarker(GCP_VERTEX_CREDENTIALS_MARKER)).toBe(true);
   });

--- a/src/agents/model-auth-markers.ts
+++ b/src/agents/model-auth-markers.ts
@@ -3,6 +3,7 @@ import { listKnownProviderEnvApiKeyNames } from "./model-auth-env-vars.js";
 
 export const MINIMAX_OAUTH_MARKER = "minimax-oauth";
 export const OAUTH_API_KEY_MARKER_PREFIX = "oauth:";
+export const ATOMIC_CHAT_LOCAL_AUTH_MARKER = "atomic-chat-local";
 export const OLLAMA_LOCAL_AUTH_MARKER = "ollama-local";
 export const CUSTOM_LOCAL_AUTH_MARKER = "custom-local";
 export const GCP_VERTEX_CREDENTIALS_MARKER = "gcp-vertex-credentials";
@@ -80,6 +81,7 @@ export function isNonSecretApiKeyMarker(
   const isKnownMarker =
     trimmed === MINIMAX_OAUTH_MARKER ||
     isOAuthApiKeyMarker(trimmed) ||
+    trimmed === ATOMIC_CHAT_LOCAL_AUTH_MARKER ||
     trimmed === OLLAMA_LOCAL_AUTH_MARKER ||
     trimmed === CUSTOM_LOCAL_AUTH_MARKER ||
     trimmed === GCP_VERTEX_CREDENTIALS_MARKER ||

--- a/src/plugins/bundled-provider-auth-env-vars.generated.ts
+++ b/src/plugins/bundled-provider-auth-env-vars.generated.ts
@@ -2,6 +2,7 @@
 
 export const BUNDLED_PROVIDER_AUTH_ENV_VAR_CANDIDATES = {
   anthropic: ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"],
+  "atomic-chat": ["ATOMIC_CHAT_API_KEY"],
   brave: ["BRAVE_API_KEY"],
   byteplus: ["BYTEPLUS_API_KEY"],
   chutes: ["CHUTES_API_KEY", "CHUTES_OAUTH_TOKEN"],


### PR DESCRIPTION
## Summary

- Add a new bundled provider plugin for **Atomic Chat**, a local OpenAI-compatible LLM server (default `http://127.0.0.1:1337/v1`).
- The onboarding wizard checks server reachability and model availability before proceeding; if Atomic Chat is not running or has no models loaded, the user is shown a clear message and returned to provider selection.
- Uses synthetic local auth (`atomic-chat-local`) so no API key is required, matching the Ollama local provider pattern.
- Includes model auto-discovery via `GET /v1/models`, docs page, navigation updates, changelog entry, and non-secret auth marker registration.

## Changes

- **New extension**: `extensions/atomic-chat/` (8 files) — plugin manifest, setup flow with reachability/model checks, OpenAI-compatible model discovery, synthetic auth, and wizard metadata.
- **`src/agents/model-auth-markers.ts`** — register `atomic-chat-local` as a non-secret API key marker (+ test).
- **`src/plugins/bundled-provider-auth-env-vars.generated.ts`** — regenerated to include `ATOMIC_CHAT_API_KEY`.
- **`docs/.generated/config-baseline.*`** — regenerated.
- **`docs/providers/atomic-chat.md`** — new provider documentation page.
- **`docs/docs.json`**, **`docs/providers/index.md`** — navigation and provider list updates.
- **`CHANGELOG.md`** — entry under Unreleased/Changes.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` (tsgo + oxlint) passes with 0 errors
- [x] `pnpm test -- src/agents/model-auth-markers.test.ts` — 6/6 passed
- [x] Manual: `pnpm openclaw onboard` → select Atomic Chat → server not running → shows message and returns to provider selection
- [x] Manual: `pnpm openclaw onboard` → select Atomic Chat → server running, no models → shows message and returns to provider selection
- [x] Manual: `pnpm openclaw onboard` → select Atomic Chat → server running with models → configures successfully