### PR TITLE
fix: hasBackingSession correctly identifies stale cron/cli tasks

### DIFF
--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Regression tests for issue #60299:
+ * Task Maintenance never cleans up stale tasks (hasBackingSession bug)
+ *
+ * Three bad paths were identified in hasBackingSession():
+ * 1. runtime="cron" + blank childSessionKey → returned true (stale task kept alive)
+ * 2. runtime="cron" + non-empty childSessionKey → no cron branch, returned true (stale task kept alive)
+ * 3. runtime="cli" + childSessionKey pointing to a persistent channel session → returned true (stale task kept alive)
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { TaskRecord } from "./task-registry.types.js";
+
+const GRACE_EXPIRED_MS = 10 * 60_000; // 10 min >> 5 min grace
+
+function makeStaleTask(overrides: Partial<TaskRecord>): TaskRecord {
+  const now = Date.now();
+  return {
+    taskId: "task-test-" + Math.random().toString(36).slice(2),
+    runtime: "cron",
+    requesterSessionKey: "agent:main:main",
+    ownerKey: "system:cron:test",
+    scopeKind: "system",
+    task: "test task",
+    status: "running",
+    deliveryStatus: "not_applicable",
+    notifyPolicy: "silent",
+    createdAt: now - GRACE_EXPIRED_MS,
+    startedAt: now - GRACE_EXPIRED_MS,
+    lastEventAt: now - GRACE_EXPIRED_MS,
+    ...overrides,
+  };
+}
+
+/**
+ * Load a fresh copy of the maintenance module with mocked dependencies.
+ * sessionStore: the fake session store contents to return from loadSessionStore()
+ */
+async function loadMaintenanceModule(params: {
+  tasks: TaskRecord[];
+  sessionStore?: Record<string, unknown>;
+  acpEntry?: unknown;
+}) {
+  vi.resetModules();
+
+  const sessionStore = params.sessionStore ?? {};
+  const acpEntry = params.acpEntry;
+
+  const currentTasks = new Map(params.tasks.map((t) => [t.taskId, { ...t }]));
+
+  vi.doMock("../acp/runtime/session-meta.js", () => ({
+    readAcpSessionEntry: () =>
+      acpEntry !== undefined
+        ? { entry: acpEntry, storeReadFailed: false }
+        : { entry: undefined, storeReadFailed: false },
+  }));
+
+  vi.doMock("../config/sessions.js", () => ({
+    loadSessionStore: () => sessionStore,
+    resolveStorePath: () => "",
+  }));
+
+  vi.doMock("./runtime-internal.js", () => ({
+    deleteTaskRecordById: (taskId: string) => currentTasks.delete(taskId),
+    ensureTaskRegistryReady: () => {},
+    getTaskById: (taskId: string) => currentTasks.get(taskId),
+    listTaskRecords: () => params.tasks,
+    markTaskLostById: (patch: {
+      taskId: string;
+      endedAt: number;
+      lastEventAt?: number;
+      error?: string;
+      cleanupAfter?: number;
+    }) => {
+      const current = currentTasks.get(patch.taskId);
+      if (!current) {
+        return null;
+      }
+      const next = {
+        ...current,
+        status: "lost" as const,
+        endedAt: patch.endedAt,
+        lastEventAt: patch.lastEventAt ?? patch.endedAt,
+        ...(patch.error !== undefined ? { error: patch.error } : {}),
+        ...(patch.cleanupAfter !== undefined ? { cleanupAfter: patch.cleanupAfter } : {}),
+      };
+      currentTasks.set(patch.taskId, next);
+      return next;
+    },
+    maybeDeliverTaskTerminalUpdate: () => false,
+    resolveTaskForLookupToken: () => undefined,
+    setTaskCleanupAfterById: (patch: { taskId: string; cleanupAfter: number }) => {
+      const current = currentTasks.get(patch.taskId);
+      if (!current) {
+        return null;
+      }
+      const next = { ...current, cleanupAfter: patch.cleanupAfter };
+      currentTasks.set(patch.taskId, next);
+      return next;
+    },
+  }));
+
+  const mod = await import("./task-registry.maintenance.js");
+  return { mod, currentTasks };
+}
+
+describe("hasBackingSession — issue #60299 regression tests", () => {
+  it("case 1: cron task with blank childSessionKey is stale (hasBackingSession = false)", async () => {
+    // Bug: blank childSessionKey hit `return true` early — task was never marked lost.
+    const task = makeStaleTask({
+      runtime: "cron",
+      childSessionKey: undefined,
+    });
+
+    const { mod, currentTasks } = await loadMaintenanceModule({ tasks: [task] });
+
+    expect(await mod.runTaskRegistryMaintenance()).toMatchObject({ reconciled: 1 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "lost" });
+  });
+
+  it("case 2: cron task with non-empty childSessionKey is stale (hasBackingSession = false)", async () => {
+    // Bug: no cron branch existed, fell through to `return true` — task was never marked lost.
+    // Even if the key exists in the session store, cron tasks should always be considered stale.
+    const key = "agent:main:slack:channel:test-channel";
+    const task = makeStaleTask({
+      runtime: "cron",
+      childSessionKey: key,
+    });
+
+    const { mod, currentTasks } = await loadMaintenanceModule({
+      tasks: [task],
+      sessionStore: { [key]: { updatedAt: Date.now() } }, // session exists but shouldn't matter
+    });
+
+    expect(await mod.runTaskRegistryMaintenance()).toMatchObject({ reconciled: 1 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "lost" });
+  });
+
+  it("case 3: cli task with childSessionKey pointing to a live Slack channel session is stale (hasBackingSession = false)", async () => {
+    // Bug: session-store lookup returned truthy for the persistent channel session,
+    // so the task was never marked lost even though no actual task work was running.
+    const channelKey = "agent:main:slack:channel:C1234567890";
+    const task = makeStaleTask({
+      runtime: "cli",
+      ownerKey: "agent:main:main",
+      requesterSessionKey: channelKey,
+      childSessionKey: channelKey,
+    });
+
+    const { mod, currentTasks } = await loadMaintenanceModule({
+      tasks: [task],
+      sessionStore: { [channelKey]: { updatedAt: Date.now() } }, // channel session is alive
+    });
+
+    expect(await mod.runTaskRegistryMaintenance()).toMatchObject({ reconciled: 1 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "lost" });
+  });
+
+  it("case 4: subagent task with childSessionKey pointing to an actually running session is NOT stale (hasBackingSession = true)", async () => {
+    // The fix must not regress the healthy subagent case.
+    const childKey = "agent:main:subagent:abc123";
+    const task = makeStaleTask({
+      runtime: "subagent",
+      ownerKey: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+      childSessionKey: childKey,
+    });
+
+    const { mod, currentTasks } = await loadMaintenanceModule({
+      tasks: [task],
+      sessionStore: { [childKey]: { updatedAt: Date.now() } }, // subagent session is alive
+    });
+
+    expect(await mod.runTaskRegistryMaintenance()).toMatchObject({ reconciled: 0 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "running" });
+  });
+});

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -1,6 +1,7 @@
 import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
+import { deriveSessionChatType } from "../sessions/session-key-utils.js";
 import {
   deleteTaskRecordById,
   ensureTaskRegistryReady,
@@ -63,11 +64,33 @@ function hasLostGraceExpired(task: TaskRecord, now: number): boolean {
   return now - referenceAt >= TASK_RECONCILE_GRACE_MS;
 }
 
+/**
+ * Returns false if the task's runtime is cron, since cron tasks do not maintain
+ * a persistent child session — once the cron job finishes, no backing session
+ * exists and the task should be considered stale.
+ *
+ * For cli tasks, a matching session-store entry is only treated as live if the
+ * session key is an agent-scoped key (not a long-lived channel/group/direct
+ * session like a Slack or Telegram channel session whose entry persists
+ * indefinitely regardless of whether any task work is still running).
+ *
+ * For subagent and acp tasks, the backing session entry is the canonical signal.
+ */
 function hasBackingSession(task: TaskRecord): boolean {
+  // cron tasks never have a persistent backing session — the cron job fires,
+  // does its work, and exits. Any childSessionKey is a transient run key, not
+  // a long-lived session that indicates the task is still active.
+  if (task.runtime === "cron") {
+    return false;
+  }
+
   const childSessionKey = task.childSessionKey?.trim();
   if (!childSessionKey) {
+    // For runtimes other than cron, a missing key means we cannot verify
+    // liveness; be conservative and assume the task may still be running.
     return true;
   }
+
   if (task.runtime === "acp") {
     const acpEntry = readAcpSessionEntry({
       sessionKey: childSessionKey,
@@ -77,12 +100,30 @@ function hasBackingSession(task: TaskRecord): boolean {
     }
     return Boolean(acpEntry.entry);
   }
-  if (task.runtime === "subagent" || task.runtime === "cli") {
+
+  if (task.runtime === "subagent") {
     const agentId = parseAgentSessionKey(childSessionKey)?.agentId;
     const storePath = resolveStorePath(undefined, { agentId });
     const store = loadSessionStore(storePath);
     return Boolean(findSessionEntryByKey(store, childSessionKey));
   }
+
+  if (task.runtime === "cli") {
+    // For CLI tasks, the childSessionKey may point to a long-lived channel
+    // session (e.g. agent:main:slack:channel:xyz) whose entry persists in the
+    // session store indefinitely — even after the actual task work has ended.
+    // A channel/group/direct session existing in the store does NOT mean the
+    // task is still alive, so we must exclude those from the "backed" check.
+    const chatType = deriveSessionChatType(childSessionKey);
+    if (chatType === "channel" || chatType === "group" || chatType === "direct") {
+      return false;
+    }
+    const agentId = parseAgentSessionKey(childSessionKey)?.agentId;
+    const storePath = resolveStorePath(undefined, { agentId });
+    const store = loadSessionStore(storePath);
+    return Boolean(findSessionEntryByKey(store, childSessionKey));
+  }
+
   return true;
 }
 


### PR DESCRIPTION
## Summary

Fixes `hasBackingSession()` in `src/tasks/task-registry.maintenance.ts` which had three incorrect return paths causing stale tasks to never be cleaned up by `openclaw tasks maintenance --apply`.

## Root Cause

Three bad paths existed in `hasBackingSession()`:

1. **`runtime="cron"` + blank `childSessionKey`** — hit the early `return true` guard intended for unknown runtimes. Stale cron task was always treated as having a backing session.

2. **`runtime="cron"` + any `childSessionKey`** — no cron-specific branch existed, so it fell through to the final `return true`. Same result: stale cron task never marked lost.

3. **`runtime="cli"` + `childSessionKey` pointing to a persistent Slack/Telegram channel session** — the code only checked whether that session entry exists in the store. Long-lived channel sessions like `agent:main:slack:channel:*` persist indefinitely. The task was never marked lost because the channel session was always found.

In all three cases, maintenance evaluated:
- active task: yes ✓
- grace expired: yes ✓  
- backing session missing: **no** (incorrect)

Result: `stale_running` rows appeared in `openclaw tasks audit` but `maintenance --apply` refused to clean them up.

## Changes

### `src/tasks/task-registry.maintenance.ts`

- Added import for `deriveSessionChatType` from `../sessions/session-key-utils.js`
- Rewrote `hasBackingSession()` with correct runtime-specific logic:
  - **`cron`**: always returns `false` — cron tasks fire and exit; no persistent session ever backs them
  - **`subagent`**: unchanged — session store lookup is the correct liveness signal
  - **`acp`**: unchanged — ACP session store lookup is the correct liveness signal
  - **`cli`**: checks `deriveSessionChatType()` before querying the session store; returns `false` for `channel`, `group`, or `direct` session keys (long-lived channel sessions should never be treated as a task liveness signal)

### `src/tasks/task-registry.maintenance.issue-60299.test.ts` (new)

Adds 4 regression test cases per issue report:
1. `runtime="cron"`, blank `childSessionKey` → stale (`hasBackingSession = false`)
2. `runtime="cron"`, `childSessionKey` points to live channel session → stale (`hasBackingSession = false`)
3. `runtime="cli"`, `childSessionKey` points to live Slack channel session → stale (`hasBackingSession = false`)
4. `runtime="subagent"`, `childSessionKey` points to actually running subagent session → **not** stale (`hasBackingSession = true`)

## Testing

4 regression test cases added covering the exact scenarios from the issue report. All existing task-registry maintenance tests continue to pass.

Fixes #60299