### PR TITLE
fix: accept read path aliases in diagnostic guard

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -60,14 +60,19 @@ function createTestContext(): {
 }
 
 describe("handleToolExecutionStart read path checks", () => {
-  it("does not warn when read tool uses file_path alias", async () => {
+  it.each([
+    ["path", { path: "/tmp/example.txt" }],
+    ["file_path", { file_path: "/tmp/example.txt" }],
+    ["file", { file: "/tmp/example.txt" }],
+    ["filePath", { filePath: "/tmp/example.txt" }],
+  ])("does not warn when read tool uses %s alias", async (_label, args) => {
     const { ctx, warn, onBlockReplyFlush } = createTestContext();
 
     const evt: ToolExecutionStartEvent = {
       type: "tool_execution_start",
       toolName: "read",
       toolCallId: "tool-1",
-      args: { file_path: "/tmp/example.txt" },
+      args,
     };
 
     await handleToolExecutionStart(ctx, evt);
@@ -76,7 +81,7 @@ describe("handleToolExecutionStart read path checks", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
-  it("warns when read tool has neither path nor file_path", async () => {
+  it("warns when read tool has none of the supported path aliases", async () => {
     const { ctx, warn } = createTestContext();
 
     const evt: ToolExecutionStartEvent = {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -368,7 +368,11 @@ export function handleToolExecutionStart(
           ? record.path
           : typeof record.file_path === "string"
             ? record.file_path
-            : "";
+            : typeof record.file === "string"
+              ? record.file
+              : typeof record.filePath === "string"
+                ? record.filePath
+                : "";
       const filePath = filePathValue.trim();
       if (!filePath) {
         const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;


### PR DESCRIPTION
## Summary
- accept `file` and `filePath` aliases in the read-tool diagnostic guard
- keep the existing warning when no supported path alias is present
- add targeted test coverage for all supported read path aliases

## Problem
Issue #60008 reports false warnings from the embedded tool diagnostic path:

- `read tool called without path`

The `read` tool itself already accepts multiple path aliases via later normalization, but `handleToolExecutionStart()` only checked `path` and `file_path` before logging the warning. When models used `file` or `filePath`, the tool could still succeed while the diagnostic layer emitted misleading warnings.

## Fix
Narrowly update `handleToolExecutionStart()` in `src/agents/pi-embedded-subscribe.handlers.tools.ts` so the read-path diagnostic check recognizes all supported aliases:

- `path`
- `file_path`
- `file`
- `filePath`

This keeps the warning behavior intact for truly missing paths while removing false positives for valid alias usage.

## Tests
Added targeted coverage in `src/agents/pi-embedded-subscribe.handlers.tools.test.ts` to verify:
- no warning for `path`
- no warning for `file_path`
- no warning for `file`
- no warning for `filePath`
- warning still occurs when none of the supported aliases are present

Ran:
- `corepack pnpm vitest run src/agents/pi-embedded-subscribe.handlers.tools.test.ts -t "handleToolExecutionStart read path checks"`

## Notes
The broader test file currently contains unrelated failing tests on main, so validation here is intentionally scoped to the read-path diagnostic cases touched by this change.
