### PR TITLE
fix: /model and /new not changing model/auth

### DIFF
--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -10,17 +10,15 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
   resolveExternalAuthProfilesWithPlugins: () => [],
 }));
 
-async function writeAuthStore(agentDir: string) {
+async function writeAuthStore(
+  agentDir: string,
+  params: {
+    profiles: Record<string, { type: string; provider: string; key: string }>;
+    order: Record<string, string[]>;
+  },
+) {
   const authPath = path.join(agentDir, "auth-profiles.json");
-  const payload = {
-    version: 1,
-    profiles: {
-      "zai:work": { type: "api_key", provider: "zai", key: "sk-test" },
-    },
-    order: {
-      zai: ["zai:work"],
-    },
-  };
+  const payload = { version: 1, profiles: params.profiles, order: params.order };
   await fs.writeFile(authPath, JSON.stringify(payload), "utf-8");
 }
 
@@ -58,7 +56,14 @@ describe("resolveSessionAuthProfileOverride", () => {
     await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
       const agentDir = path.join(stateDir, "agent");
       await fs.mkdir(agentDir, { recursive: true });
-      await writeAuthStore(agentDir);
+      await writeAuthStore(agentDir, {
+        profiles: {
+          "zai:work": { type: "api_key", provider: "zai", key: "sk-test" },
+        },
+        order: {
+          zai: ["zai:work"],
+        },
+      });
 
       const sessionEntry: SessionEntry = {
         sessionId: "s1",
@@ -81,6 +86,93 @@ describe("resolveSessionAuthProfileOverride", () => {
 
       expect(resolved).toBe("zai:work");
       expect(sessionEntry.authProfileOverride).toBe("zai:work");
+    });
+  });
+
+  it("keeps a user-selected profile pinned across new sessions", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        profiles: {
+          "openai-codex:chatgpt": {
+            type: "api_key",
+            provider: "openai-codex",
+            key: "sk-chatgpt",
+          },
+          "openai-codex:default": {
+            type: "api_key",
+            provider: "openai-codex",
+            key: "sk-default",
+          },
+        },
+        order: {
+          "openai-codex": ["openai-codex:chatgpt", "openai-codex:default"],
+        },
+      });
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "user",
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "openai-codex",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      expect(resolved).toBe("openai-codex:default");
+      expect(sessionEntry.authProfileOverride).toBe("openai-codex:default");
+      expect(sessionEntry.authProfileOverrideSource).toBe("user");
+      expect(sessionEntry.authProfileOverrideCompactionCount).toBeUndefined();
+    });
+  });
+
+  it("still rotates auto-selected profiles on new sessions", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeAuthStore(agentDir, {
+        profiles: {
+          "zai:work": { type: "api_key", provider: "zai", key: "sk-work" },
+          "zai:backup": { type: "api_key", provider: "zai", key: "sk-backup" },
+        },
+        order: {
+          zai: ["zai:work", "zai:backup"],
+        },
+      });
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        authProfileOverride: "zai:work",
+        authProfileOverrideSource: "auto",
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "zai",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      expect(resolved).toBe("zai:backup");
+      expect(sessionEntry.authProfileOverride).toBe("zai:backup");
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
     });
   });
 });

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -134,7 +134,9 @@ export async function resolveSessionAuthProfileOverride(params: {
       : current
         ? "user"
         : undefined);
-  if (source === "user" && current && !isNewSession) {
+  // Keep explicit user profile pins stable across /new and /reset.
+  // New-session rotation is only for auto-selected profiles.
+  if (source === "user" && current) {
     return current;
   }
 

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -207,7 +207,7 @@ describe("live model switch", () => {
     });
   });
 
-  it("preserves provider when runtime model is a vendor-prefixed OpenRouter id", async () => {
+  it("falls back to the configured selection when only runtime model fields are present", async () => {
     state.loadSessionStoreMock.mockReturnValue({
       main: {
         modelProvider: "openrouter",
@@ -226,8 +226,8 @@ describe("live model switch", () => {
         defaultModel: "claude-opus-4-6",
       }),
     ).toEqual({
-      provider: "openrouter",
-      model: "anthropic/claude-haiku-4.5",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
       authProfileId: undefined,
       authProfileIdSource: undefined,
     });

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -6,7 +6,7 @@ const state = vi.hoisted(() => ({
   requestEmbeddedRunModelSwitchMock: vi.fn(),
   consumeEmbeddedRunModelSwitchMock: vi.fn(),
   resolveDefaultModelForAgentMock: vi.fn(),
-  resolvePersistedSelectedModelRefMock: vi.fn(),
+  resolvePersistedOverrideModelRefMock: vi.fn(),
   loadSessionStoreMock: vi.fn(),
   resolveStorePathMock: vi.fn(),
   updateSessionStoreMock: vi.fn(),
@@ -29,8 +29,8 @@ vi.mock("./pi-embedded-runner/runs.js", () => ({
 vi.mock("./model-selection.js", () => ({
   resolveDefaultModelForAgent: (...args: unknown[]) =>
     state.resolveDefaultModelForAgentMock(...args),
-  resolvePersistedSelectedModelRef: (...args: unknown[]) =>
-    state.resolvePersistedSelectedModelRefMock(...args),
+  resolvePersistedOverrideModelRef: (...args: unknown[]) =>
+    state.resolvePersistedOverrideModelRefMock(...args),
 }));
 
 vi.mock("../config/sessions/store.js", () => ({
@@ -64,13 +64,11 @@ describe("live model switch", () => {
     state.resolveDefaultModelForAgentMock
       .mockReset()
       .mockReturnValue({ provider: "anthropic", model: "claude-opus-4-6" });
-    state.resolvePersistedSelectedModelRefMock
+    state.resolvePersistedOverrideModelRefMock
       .mockReset()
       .mockImplementation(
         (params: {
           defaultProvider: string;
-          runtimeProvider?: string;
-          runtimeModel?: string;
           overrideProvider?: string;
           overrideModel?: string;
         }) => {
@@ -88,21 +86,6 @@ describe("live model switch", () => {
             return {
               provider: overrideModel.slice(0, slash),
               model: overrideModel.slice(slash + 1),
-            };
-          }
-          const runtimeProvider = params.runtimeProvider?.trim();
-          const runtimeModel = params.runtimeModel?.trim();
-          if (runtimeModel) {
-            if (runtimeProvider) {
-              return { provider: runtimeProvider, model: runtimeModel };
-            }
-            const slash = runtimeModel.indexOf("/");
-            if (slash <= 0 || slash === runtimeModel.length - 1) {
-              return { provider: defaultProvider, model: runtimeModel };
-            }
-            return {
-              provider: runtimeModel.slice(0, slash),
-              model: runtimeModel.slice(slash + 1),
             };
           }
           return null;

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -4,7 +4,7 @@ import type { SessionEntry } from "../config/sessions/types.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 import {
   resolveDefaultModelForAgent,
-  resolvePersistedSelectedModelRef,
+  resolvePersistedOverrideModelRef,
 } from "./model-selection.js";
 import {
   abortEmbeddedPiRun,
@@ -39,16 +39,14 @@ export function resolveLiveSessionModelSelection(params: {
     agentId,
   });
   const entry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
-  const persisted = resolvePersistedSelectedModelRef({
+  const overrideSelection = resolvePersistedOverrideModelRef({
     defaultProvider: defaultModelRef.provider,
-    runtimeProvider: entry?.modelProvider,
-    runtimeModel: entry?.model,
     overrideProvider: entry?.providerOverride,
     overrideModel: entry?.modelOverride,
   });
   const provider =
-    persisted?.provider ?? entry?.providerOverride?.trim() ?? defaultModelRef.provider;
-  const model = persisted?.model ?? defaultModelRef.model;
+    overrideSelection?.provider ?? entry?.providerOverride?.trim() ?? defaultModelRef.provider;
+  const model = overrideSelection?.model ?? defaultModelRef.model;
   const authProfileId = normalizeOptionalString(entry?.authProfileOverride);
   return {
     provider,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1285,6 +1285,50 @@ describe("runReplyAgent typing (heartbeat)", () => {
     }
   });
 
+  it("warns and suppresses replies when an explicit model selection runs on a different model", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      providerOverride: "openai-codex",
+      modelOverride: "gpt-5.3-codex-spark",
+      authProfileOverride: "openai-codex:default",
+      authProfileOverrideSource: "user",
+    };
+    const sessionStore = { main: sessionEntry };
+
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "wrong-model reply" }],
+      meta: {
+        agentMeta: {
+          provider: "openai-codex",
+          model: "gpt-5.4",
+        },
+      },
+    });
+
+    const { run } = createMinimalRun({
+      sessionEntry,
+      sessionStore,
+      sessionKey: "main",
+      runOverrides: {
+        provider: "openai-codex",
+        model: "gpt-5.3-codex-spark",
+        authProfileId: "openai-codex:default",
+        authProfileIdSource: "user",
+        exactModelSelection: true,
+      },
+    });
+    const res = await run();
+    const payload = Array.isArray(res) ? res[0] : res;
+
+    expect(payload?.text).toContain("Requested model openai-codex/gpt-5.3-codex-spark");
+    expect(payload?.text).toContain("runtime used openai-codex/gpt-5.4");
+    expect(payload?.text).not.toContain("wrong-model reply");
+    expect(sessionEntry.fallbackNoticeSelectedModel).toBe("openai-codex/gpt-5.3-codex-spark");
+    expect(sessionEntry.fallbackNoticeActiveModel).toBe("openai-codex/gpt-5.4");
+    expect(sessionEntry.fallbackNoticeReason).toBe("selected model unavailable");
+  });
+
   it("retries after compaction failure by resetting the session", async () => {
     await withTempStateDir(async (stateDir) => {
       const sessionId = "session";

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -526,6 +526,7 @@ export async function runReplyAgent(params: {
     const verboseEnabled = resolvedVerboseLevel !== "off";
     const selectedProvider = followupRun.run.provider;
     const selectedModel = followupRun.run.model;
+    const exactModelSelection = followupRun.run.exactModelSelection === true;
     const fallbackStateEntry =
       activeSessionEntry ?? (sessionKey ? activeSessionStore?.[sessionKey] : undefined);
     const fallbackTransition = resolveFallbackTransition({
@@ -586,6 +587,27 @@ export async function runReplyAgent(params: {
       cliSessionBinding,
       usageIsContextSnapshot: isCliProvider(providerUsed, cfg),
     });
+
+    const exactSelectionMismatch =
+      exactModelSelection &&
+      (providerUsed.trim() !== selectedProvider.trim() ||
+        modelUsed.trim() !== selectedModel.trim());
+    if (exactSelectionMismatch) {
+      const requestedModelRef = `${selectedProvider}/${selectedModel}`;
+      const activeModelRef = `${providerUsed}/${modelUsed}`;
+      const authProfileLabel = followupRun.run.authProfileId?.trim();
+      const authClause = authProfileLabel ? ` on ${authProfileLabel}` : "";
+      return finalizeWithFollowup(
+        {
+          text:
+            `⚠️ Requested model ${requestedModelRef}${authClause}, but runtime used ${activeModelRef}. ` +
+            "No reply was sent from the fallback model. Selection unchanged.",
+          isError: true,
+        },
+        queueKey,
+        runFollowupTurn,
+      );
+    }
 
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and

--- a/src/auto-reply/reply/directive-handling.auth-profile.ts
+++ b/src/auto-reply/reply/directive-handling.auth-profile.ts
@@ -1,6 +1,8 @@
-import { ensureAuthProfileStore } from "../../agents/auth-profiles.js";
+import { ensureAuthProfileStore, resolveAuthProfileOrder } from "../../agents/auth-profiles.js";
+import { normalizeProviderId } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import type { SessionEntry } from "../../config/sessions.js";
 
 export function resolveProfileOverride(params: {
   rawProfile?: string;
@@ -25,4 +27,133 @@ export function resolveProfileOverride(params: {
     };
   }
   return { profileId: raw };
+}
+
+function isProfileForProvider(params: {
+  profileId: string;
+  provider: string;
+  store: ReturnType<typeof ensureAuthProfileStore>;
+}): boolean {
+  const profile = params.store.profiles[params.profileId];
+  if (!profile?.provider) {
+    return false;
+  }
+  return normalizeProviderId(profile.provider) === normalizeProviderId(params.provider);
+}
+
+function decodeJwtPayload(token?: string): Record<string, unknown> | null {
+  const compact = token?.trim();
+  if (!compact) {
+    return null;
+  }
+  const parts = compact.split(".");
+  if (parts.length < 2) {
+    return null;
+  }
+  try {
+    const payload = Buffer.from(parts[1], "base64url").toString("utf8");
+    const parsed = JSON.parse(payload);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveCodexChatGPTPlanType(profile: {
+  type?: string;
+  access?: string;
+}): string | undefined {
+  if (profile.type !== "oauth") {
+    return undefined;
+  }
+  const payload = decodeJwtPayload(profile.access);
+  const auth =
+    payload && typeof payload["https://api.openai.com/auth"] === "object"
+      ? (payload["https://api.openai.com/auth"] as Record<string, unknown>)
+      : undefined;
+  const plan = typeof auth?.chatgpt_plan_type === "string" ? auth.chatgpt_plan_type : undefined;
+  return plan?.trim().toLowerCase() || undefined;
+}
+
+function formatSparkPlanError(profileId: string, planType: string): string {
+  const formattedPlan = planType.slice(0, 1).toUpperCase() + planType.slice(1);
+  return [
+    `Spark is not supported on auth profile "${profileId}" (${formattedPlan} plan).`,
+    "Model/auth unchanged.",
+    "",
+    "Use /model spark@openai-codex:default or another Spark-capable auth profile.",
+  ].join("\n");
+}
+
+export function resolveModelAuthProfile(params: {
+  rawProfile?: string;
+  provider: string;
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  sessionEntry?: Pick<SessionEntry, "authProfileOverride" | "authProfileOverrideSource">;
+}): { profileId?: string; profileOverrideSource?: "auto" | "user"; error?: string } {
+  const store = ensureAuthProfileStore(params.agentDir, {
+    allowKeychainPrompt: false,
+  });
+  const explicit = params.rawProfile?.trim();
+  if (explicit) {
+    const resolved = resolveProfileOverride({
+      rawProfile: explicit,
+      provider: params.provider,
+      cfg: params.cfg,
+      agentDir: params.agentDir,
+    });
+    return resolved.profileId
+      ? {
+          profileId: resolved.profileId,
+          profileOverrideSource: "user",
+        }
+      : { error: resolved.error };
+  }
+
+  const current = params.sessionEntry?.authProfileOverride?.trim();
+  if (current && isProfileForProvider({ profileId: current, provider: params.provider, store })) {
+    return {
+      profileId: current,
+      profileOverrideSource: params.sessionEntry?.authProfileOverrideSource ?? "user",
+    };
+  }
+
+  const order = resolveAuthProfileOrder({
+    cfg: params.cfg,
+    store,
+    provider: params.provider,
+  });
+  const first = order[0]?.trim();
+  return first ? { profileId: first, profileOverrideSource: "auto" } : {};
+}
+
+export function validateModelAuthProfileCompatibility(params: {
+  provider: string;
+  model: string;
+  profileId?: string;
+  agentDir?: string;
+}): { error?: string } {
+  const profileId = params.profileId?.trim();
+  if (!profileId) {
+    return {};
+  }
+  if (
+    normalizeProviderId(params.provider) !== "openai-codex" ||
+    params.model.trim() !== "gpt-5.3-codex-spark"
+  ) {
+    return {};
+  }
+  const store = ensureAuthProfileStore(params.agentDir, {
+    allowKeychainPrompt: false,
+  });
+  const profile = store.profiles[profileId];
+  if (!profile) {
+    return {};
+  }
+  const planType = resolveCodexChatGPTPlanType(profile);
+  if (planType && ["free", "go", "plus"].includes(planType)) {
+    return { error: formatSparkPlanError(profileId, planType) };
+  }
+  return {};
 }

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -105,12 +105,14 @@ export async function handleDirectiveOnly(
     allowedModelKeys,
     allowedModelCatalog,
     provider,
+    sessionEntry,
   });
   if (modelResolution.errorText) {
     return { text: modelResolution.errorText };
   }
   const modelSelection = modelResolution.modelSelection;
   const profileOverride = modelResolution.profileOverride;
+  const profileOverrideSource = modelResolution.profileOverrideSource;
 
   const resolvedProvider = modelSelection?.provider ?? provider;
   const resolvedModel = modelSelection?.model ?? model;
@@ -366,6 +368,7 @@ export async function handleDirectiveOnly(
         selection: modelSelection,
         profileOverride,
         markLiveSwitchPending: true,
+        profileOverrideSource,
       });
       modelSelectionUpdated = applied.updated;
     }
@@ -404,7 +407,7 @@ export async function handleDirectiveOnly(
         nextProvider: modelSelection.provider,
         nextModel: modelSelection.model,
         nextAuthProfileId: profileOverride,
-        nextAuthProfileIdSource: profileOverride ? "user" : undefined,
+        nextAuthProfileIdSource: profileOverride ? profileOverrideSource : undefined,
       });
     }
   }

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -369,6 +369,7 @@ export async function handleDirectiveOnly(
         profileOverride,
         markLiveSwitchPending: true,
         profileOverrideSource,
+        persistDefaultSelection: true,
       });
       modelSelectionUpdated = applied.updated;
     }

--- a/src/auto-reply/reply/directive-handling.model-selection.ts
+++ b/src/auto-reply/reply/directive-handling.model-selection.ts
@@ -6,7 +6,11 @@ import {
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { resolveProfileOverride } from "./directive-handling.auth-profile.js";
+import type { SessionEntry } from "../../config/sessions.js";
+import {
+  resolveModelAuthProfile,
+  validateModelAuthProfileCompatibility,
+} from "./directive-handling.auth-profile.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import { type ModelDirectiveSelection, resolveModelDirectiveSelection } from "./model-selection.js";
 
@@ -53,9 +57,11 @@ export function resolveModelSelectionFromDirective(params: {
   allowedModelKeys: Set<string>;
   allowedModelCatalog: Array<{ provider: string; id?: string; name?: string }>;
   provider: string;
+  sessionEntry?: Pick<SessionEntry, "authProfileOverride" | "authProfileOverrideSource">;
 }): {
   modelSelection?: ModelDirectiveSelection;
   profileOverride?: string;
+  profileOverrideSource?: "auto" | "user";
   errorText?: string;
 } {
   if (!params.directives.hasModelDirective || !params.directives.rawModelDirective) {
@@ -139,21 +145,33 @@ export function resolveModelSelectionFromDirective(params: {
   }
 
   let profileOverride: string | undefined;
+  let profileOverrideSource: "auto" | "user" | undefined;
   const rawProfile =
     params.directives.rawModelProfile ??
     (useStoredNumericProfile ? storedNumericProfile?.profileId : undefined);
-  if (modelSelection && rawProfile) {
-    const profileResolved = resolveProfileOverride({
+  if (modelSelection) {
+    const profileResolved = resolveModelAuthProfile({
       rawProfile,
       provider: modelSelection.provider,
       cfg: params.cfg,
       agentDir: params.agentDir,
+      sessionEntry: params.sessionEntry,
     });
     if (profileResolved.error) {
       return { errorText: profileResolved.error };
     }
+    const compatibility = validateModelAuthProfileCompatibility({
+      provider: modelSelection.provider,
+      model: modelSelection.model,
+      profileId: profileResolved.profileId,
+      agentDir: params.agentDir,
+    });
+    if (compatibility.error) {
+      return { errorText: compatibility.error };
+    }
     profileOverride = profileResolved.profileId;
+    profileOverrideSource = profileResolved.profileOverrideSource;
   }
 
-  return { modelSelection, profileOverride };
+  return { modelSelection, profileOverride, profileOverrideSource };
 }

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -545,6 +545,16 @@ describe("/model chat UX", () => {
     expect(sessionEntry.authProfileOverride).toBe("work");
   });
 
+  it("persists an explicit default-model selection", async () => {
+    const { sessionEntry } = await persistModelDirectiveForTest({
+      command: "/model claude-opus-4-5",
+      allowedModelKeys: ["anthropic/claude-opus-4-5", "openai/gpt-4o"],
+    });
+
+    expect(sessionEntry.providerOverride).toBe("anthropic");
+    expect(sessionEntry.modelOverride).toBe("claude-opus-4-5");
+  });
+
   it("ignores invalid mixed-content model directives during persistence", async () => {
     const { persisted, sessionEntry } = await persistModelDirectiveForTest({
       command: "/model 99 hello",

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -53,7 +53,27 @@ vi.mock("./queue.js", () => ({
 const TEST_AGENT_DIR = "/tmp/agent";
 const OPENAI_DATE_PROFILE_ID = "20251001";
 
-type ApiKeyProfile = { type: "api_key"; provider: string; key: string };
+type TestProfile =
+  | { type: "api_key"; provider: string; key: string }
+  | {
+      type: "oauth";
+      provider: string;
+      access: string;
+      refresh: string;
+      expires: number;
+    };
+
+function createOAuthAccessToken(planType: string) {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      "https://api.openai.com/auth": {
+        chatgpt_plan_type: planType,
+      },
+    }),
+  ).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
 
 function baseAliasIndex(): ModelAliasIndex {
   return { byAlias: new Map(), byKey: new Map() };
@@ -90,7 +110,7 @@ afterEach(() => {
   clearRuntimeAuthProfileStoreSnapshots();
 });
 
-function setAuthProfiles(profiles: Record<string, ApiKeyProfile>) {
+function setAuthProfiles(profiles: Record<string, TestProfile>) {
   replaceRuntimeAuthProfileStoreSnapshots([
     {
       agentDir: TEST_AGENT_DIR,
@@ -106,7 +126,7 @@ function createDateAuthProfiles(provider: string, id = OPENAI_DATE_PROFILE_ID) {
       provider,
       key: "sk-test",
     },
-  } satisfies Record<string, ApiKeyProfile>;
+  } satisfies Record<string, TestProfile>;
 }
 
 function createGptAliasIndex(): ModelAliasIndex {
@@ -136,7 +156,7 @@ function resolveModelSelectionForCommand(params: {
 
 async function persistModelDirectiveForTest(params: {
   command: string;
-  profiles?: Record<string, ApiKeyProfile>;
+  profiles?: Record<string, TestProfile>;
   aliasIndex?: ModelAliasIndex;
   allowedModelKeys: string[];
   sessionEntry?: SessionEntry;
@@ -362,6 +382,94 @@ describe("/model chat UX", () => {
       isDefault: false,
     });
     expect(resolved.profileOverride).toBe(OPENAI_DATE_PROFILE_ID);
+  });
+
+  it("uses the current auth profile path for bare model switches", () => {
+    setAuthProfiles({
+      "openai-codex:default": {
+        type: "oauth",
+        provider: "openai-codex",
+        access: createOAuthAccessToken("pro"),
+        refresh: "rt-test",
+        expires: Date.now() + 60_000,
+      },
+    });
+
+    const resolved = resolveModelSelectionFromDirective({
+      directives: parseInlineDirectives("/model spark"),
+      cfg: { commands: { text: true } } as unknown as OpenClawConfig,
+      agentDir: TEST_AGENT_DIR,
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.4",
+      aliasIndex: {
+        byAlias: new Map([
+          [
+            "spark",
+            { alias: "spark", ref: { provider: "openai-codex", model: "gpt-5.3-codex-spark" } },
+          ],
+        ]),
+        byKey: new Map([["openai-codex/gpt-5.3-codex-spark", ["spark"]]]),
+      },
+      allowedModelKeys: new Set(["openai-codex/gpt-5.3-codex-spark", "openai-codex/gpt-5.4"]),
+      allowedModelCatalog: [],
+      provider: "openai-codex",
+      sessionEntry: {
+        authProfileOverride: "openai-codex:default",
+        authProfileOverrideSource: "auto",
+      },
+    });
+
+    expect(resolved.errorText).toBeUndefined();
+    expect(resolved.modelSelection).toEqual({
+      provider: "openai-codex",
+      model: "gpt-5.3-codex-spark",
+      isDefault: false,
+      alias: "spark",
+    });
+    expect(resolved.profileOverride).toBe("openai-codex:default");
+    expect(resolved.profileOverrideSource).toBe("auto");
+  });
+
+  it("rejects spark on a plus auth profile and leaves the selection unchanged", () => {
+    setAuthProfiles({
+      "openai-codex:plus": {
+        type: "oauth",
+        provider: "openai-codex",
+        access: createOAuthAccessToken("plus"),
+        refresh: "rt-test",
+        expires: Date.now() + 60_000,
+      },
+    });
+
+    const resolved = resolveModelSelectionFromDirective({
+      directives: parseInlineDirectives("/model spark"),
+      cfg: { commands: { text: true } } as unknown as OpenClawConfig,
+      agentDir: TEST_AGENT_DIR,
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.4",
+      aliasIndex: {
+        byAlias: new Map([
+          [
+            "spark",
+            { alias: "spark", ref: { provider: "openai-codex", model: "gpt-5.3-codex-spark" } },
+          ],
+        ]),
+        byKey: new Map([["openai-codex/gpt-5.3-codex-spark", ["spark"]]]),
+      },
+      allowedModelKeys: new Set(["openai-codex/gpt-5.3-codex-spark", "openai-codex/gpt-5.4"]),
+      allowedModelCatalog: [],
+      provider: "openai-codex",
+      sessionEntry: {
+        authProfileOverride: "openai-codex:plus",
+        authProfileOverrideSource: "user",
+      },
+    });
+
+    expect(resolved.modelSelection).toBeUndefined();
+    expect(resolved.errorText).toContain(
+      'Spark is not supported on auth profile "openai-codex:plus" (Plus plan).',
+    );
+    expect(resolved.errorText).toContain("Model/auth unchanged.");
   });
 
   it("keeps @YYYYMMDD as part of the model when the stored numeric profile is for another provider", () => {

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -169,12 +169,14 @@ export async function persistInlineDirectives(params: {
         allowedModelKeys,
         allowedModelCatalog: [],
         provider,
+        sessionEntry,
       });
       if (modelResolution.modelSelection) {
         const { updated: modelUpdated } = applyModelOverrideToSessionEntry({
           entry: sessionEntry,
           selection: modelResolution.modelSelection,
           profileOverride: modelResolution.profileOverride,
+          profileOverrideSource: modelResolution.profileOverrideSource,
         });
         provider = modelResolution.modelSelection.provider;
         model = modelResolution.modelSelection.model;

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -177,6 +177,7 @@ export async function persistInlineDirectives(params: {
           selection: modelResolution.modelSelection,
           profileOverride: modelResolution.profileOverride,
           profileOverrideSource: modelResolution.profileOverrideSource,
+          persistDefaultSelection: true,
         });
         provider = modelResolution.modelSelection.provider;
         model = modelResolution.modelSelection.model;

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -518,6 +518,10 @@ export async function runPreparedReply(
     ({ activeSessionId, isActive, isStreaming } = queueState.busyState);
   }
   const authProfileIdSource = preparedSessionState.sessionEntry?.authProfileOverrideSource;
+  const exactModelSelection = Boolean(
+    preparedSessionState.sessionEntry?.providerOverride?.trim() ||
+      preparedSessionState.sessionEntry?.modelOverride?.trim(),
+  );
   const followupRun = {
     prompt: queuedBody,
     messageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
@@ -558,6 +562,7 @@ export async function runPreparedReply(
       skillsSnapshot,
       provider,
       model,
+      exactModelSelection,
       authProfileId,
       authProfileIdSource,
       thinkLevel: resolvedThinkLevel,

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -63,6 +63,7 @@ export type FollowupRun = {
     skillsSnapshot?: SkillSnapshot;
     provider: string;
     model: string;
+    exactModelSelection?: boolean;
     authProfileId?: string;
     authProfileIdSource?: "auto" | "user";
     thinkLevel?: ThinkLevel;

--- a/src/auto-reply/reply/session-reset-model.test.ts
+++ b/src/auto-reply/reply/session-reset-model.test.ts
@@ -191,8 +191,8 @@ describe("applyResetModelOverride", () => {
       defaultModel: "gpt-5.3-codex-spark",
     });
 
-    expect(sessionEntry.providerOverride).toBeUndefined();
-    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.providerOverride).toBe("openai-codex");
+    expect(sessionEntry.modelOverride).toBe("gpt-5.3-codex-spark");
     expect(sessionEntry.authProfileOverride).toBe("openai-codex:default");
     expect(sessionEntry.authProfileOverrideSource).toBe("user");
     expect(sessionCtx.BodyStripped).toBe("summarize");

--- a/src/auto-reply/reply/session-reset-model.test.ts
+++ b/src/auto-reply/reply/session-reset-model.test.ts
@@ -1,17 +1,49 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  replaceRuntimeAuthProfileStoreSnapshots,
+} from "../../agents/auth-profiles.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import { buildModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { applyResetModelOverride } from "./session-reset-model.js";
 
+const TEST_AGENT_DIR = "/tmp/openclaw-reset-model-test-agent";
+
 const modelCatalog: ModelCatalogEntry[] = [
   { provider: "minimax", id: "m2.7", name: "M2.7" },
   { provider: "openai", id: "gpt-4o-mini", name: "GPT-4o mini" },
+  { provider: "openai-codex", id: "gpt-5.4", name: "GPT-5.4" },
+  { provider: "openai-codex", id: "gpt-5.3-codex-spark", name: "GPT-5.3 Codex Spark" },
 ];
 
+function createOAuthAccessToken(planType: string) {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      "https://api.openai.com/auth": {
+        chatgpt_plan_type: planType,
+      },
+    }),
+  ).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
+
 function createResetFixture(entry: Partial<SessionEntry> = {}) {
-  const cfg = {} as OpenClawConfig;
+  const cfg = {
+    agents: {
+      defaults: {
+        models: {
+          "minimax/m2.7": {},
+          "openai/gpt-4o-mini": {},
+          "openai-codex/gpt-5.4": {},
+          "openai-codex/gpt-5.3-codex-spark": { alias: "spark" },
+        },
+      },
+      list: [{ id: "main", agentDir: TEST_AGENT_DIR }],
+    },
+  } as OpenClawConfig;
   const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: "openai" });
   const sessionEntry: SessionEntry = {
     sessionId: "s1",
@@ -23,7 +55,14 @@ function createResetFixture(entry: Partial<SessionEntry> = {}) {
     aliasIndex,
     sessionEntry,
     sessionStore: { "agent:main:dm:1": sessionEntry } as Record<string, SessionEntry>,
-    sessionCtx: { BodyStripped: "minimax summarize" },
+    sessionCtx: {
+      Body: "minimax summarize",
+      BodyForAgent: "minimax summarize",
+      BodyStripped: "minimax summarize",
+      BodyForCommands: "minimax summarize",
+      CommandBody: "minimax summarize",
+      RawBody: "minimax summarize",
+    },
     ctx: { ChatType: "direct" },
   };
 }
@@ -31,24 +70,42 @@ function createResetFixture(entry: Partial<SessionEntry> = {}) {
 async function applyResetFixture(params: {
   resetTriggered: boolean;
   sessionEntry?: Partial<SessionEntry>;
+  bodyStripped?: string;
+  defaultProvider?: string;
+  defaultModel?: string;
 }) {
   const fixture = createResetFixture(params.sessionEntry);
   await applyResetModelOverride({
     cfg: fixture.cfg,
+    agentId: "main",
     resetTriggered: params.resetTriggered,
-    bodyStripped: "minimax summarize",
+    bodyStripped: params.bodyStripped ?? "minimax summarize",
     sessionCtx: fixture.sessionCtx,
     ctx: fixture.ctx,
     sessionEntry: fixture.sessionEntry,
     sessionStore: fixture.sessionStore,
     sessionKey: "agent:main:dm:1",
-    defaultProvider: "openai",
-    defaultModel: "gpt-4o-mini",
+    defaultProvider: params.defaultProvider ?? "openai",
+    defaultModel: params.defaultModel ?? "gpt-4o-mini",
     aliasIndex: fixture.aliasIndex,
     modelCatalog,
   });
   return fixture;
 }
+
+beforeEach(() => {
+  clearRuntimeAuthProfileStoreSnapshots();
+  replaceRuntimeAuthProfileStoreSnapshots([
+    {
+      agentDir: TEST_AGENT_DIR,
+      store: { version: 1, profiles: {} },
+    },
+  ]);
+});
+
+afterEach(() => {
+  clearRuntimeAuthProfileStoreSnapshots();
+});
 
 describe("applyResetModelOverride", () => {
   it("selects a model hint and strips it from the body", async () => {
@@ -58,21 +115,45 @@ describe("applyResetModelOverride", () => {
 
     expect(sessionEntry.providerOverride).toBe("minimax");
     expect(sessionEntry.modelOverride).toBe("m2.7");
+    expect(sessionCtx.Body).toBe("summarize");
+    expect(sessionCtx.BodyForAgent).toBe("summarize");
     expect(sessionCtx.BodyStripped).toBe("summarize");
+    expect(sessionCtx.BodyForCommands).toBe("summarize");
+    expect(sessionCtx.CommandBody).toBe("summarize");
+    expect(sessionCtx.RawBody).toBe("summarize");
   });
 
-  it("clears auth profile overrides when reset applies a model", async () => {
+  it("preserves the current auth profile path when reset applies a model", async () => {
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        agentDir: TEST_AGENT_DIR,
+        store: {
+          version: 1,
+          profiles: {
+            "openai-codex:p1": {
+              type: "api_key",
+              provider: "openai-codex",
+              key: "sk-test-p1",
+            },
+          },
+        },
+      },
+    ]);
+
     const { sessionEntry } = await applyResetFixture({
       resetTriggered: true,
       sessionEntry: {
-        authProfileOverride: "anthropic:default",
-        authProfileOverrideSource: "user",
+        authProfileOverride: "openai-codex:p1",
+        authProfileOverrideSource: "auto",
         authProfileOverrideCompactionCount: 2,
       },
+      bodyStripped: "spark summarize",
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.4",
     });
 
-    expect(sessionEntry.authProfileOverride).toBeUndefined();
-    expect(sessionEntry.authProfileOverrideSource).toBeUndefined();
+    expect(sessionEntry.authProfileOverride).toBe("openai-codex:p1");
+    expect(sessionEntry.authProfileOverrideSource).toBe("auto");
     expect(sessionEntry.authProfileOverrideCompactionCount).toBeUndefined();
   });
 
@@ -84,5 +165,110 @@ describe("applyResetModelOverride", () => {
     expect(sessionEntry.providerOverride).toBeUndefined();
     expect(sessionEntry.modelOverride).toBeUndefined();
     expect(sessionCtx.BodyStripped).toBe("minimax summarize");
+  });
+
+  it("persists explicit auth profile overrides for alias selections", async () => {
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        agentDir: TEST_AGENT_DIR,
+        store: {
+          version: 1,
+          profiles: {
+            "openai-codex:default": {
+              type: "api_key",
+              provider: "openai-codex",
+              key: "sk-test",
+            },
+          },
+        },
+      },
+    ]);
+
+    const { sessionEntry, sessionCtx } = await applyResetFixture({
+      resetTriggered: true,
+      bodyStripped: "spark@openai-codex:default summarize",
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.3-codex-spark",
+    });
+
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.authProfileOverride).toBe("openai-codex:default");
+    expect(sessionEntry.authProfileOverrideSource).toBe("user");
+    expect(sessionCtx.BodyStripped).toBe("summarize");
+    expect(sessionCtx.BodyForAgent).toBe("summarize");
+  });
+
+  it("persists explicit auth profile overrides for provider model selections", async () => {
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        agentDir: TEST_AGENT_DIR,
+        store: {
+          version: 1,
+          profiles: {
+            "openai-codex:p1": {
+              type: "api_key",
+              provider: "openai-codex",
+              key: "sk-test-2",
+            },
+          },
+        },
+      },
+    ]);
+
+    const { sessionEntry, sessionCtx } = await applyResetFixture({
+      resetTriggered: true,
+      bodyStripped: "openai-codex gpt-5.4@openai-codex:p1 summarize",
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.3-codex-spark",
+    });
+
+    expect(sessionEntry.providerOverride).toBe("openai-codex");
+    expect(sessionEntry.modelOverride).toBe("gpt-5.4");
+    expect(sessionEntry.authProfileOverride).toBe("openai-codex:p1");
+    expect(sessionEntry.authProfileOverrideSource).toBe("user");
+    expect(sessionCtx.BodyStripped).toBe("summarize");
+    expect(sessionCtx.BodyForAgent).toBe("summarize");
+  });
+
+  it("rejects spark on an unsupported current auth profile and keeps selection unchanged", async () => {
+    replaceRuntimeAuthProfileStoreSnapshots([
+      {
+        agentDir: TEST_AGENT_DIR,
+        store: {
+          version: 1,
+          profiles: {
+            "openai-codex:plus": {
+              type: "oauth",
+              provider: "openai-codex",
+              access: createOAuthAccessToken("plus"),
+              refresh: "rt-test",
+              expires: Date.now() + 60_000,
+            },
+          },
+        },
+      },
+    ]);
+
+    const { sessionEntry, sessionCtx } = await applyResetFixture({
+      resetTriggered: true,
+      bodyStripped: "spark summarize",
+      sessionEntry: {
+        providerOverride: "openai-codex",
+        modelOverride: "gpt-5.4",
+        authProfileOverride: "openai-codex:plus",
+        authProfileOverrideSource: "user",
+      },
+      defaultProvider: "openai-codex",
+      defaultModel: "gpt-5.4",
+    });
+
+    expect(sessionEntry.providerOverride).toBe("openai-codex");
+    expect(sessionEntry.modelOverride).toBe("gpt-5.4");
+    expect(sessionEntry.authProfileOverride).toBe("openai-codex:plus");
+    expect(sessionCtx.BodyForAgent).toContain(
+      'System: Spark is not supported on auth profile "openai-codex:plus" (Plus plan).',
+    );
+    expect(sessionCtx.BodyForAgent).toContain("summarize");
   });
 });

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -1,3 +1,4 @@
+import { resolveAgentDir } from "../../agents/agent-scope.js";
 import { loadModelCatalog, type ModelCatalogEntry } from "../../agents/model-catalog.js";
 import {
   buildAllowedModelSet,
@@ -12,11 +13,16 @@ import { updateSessionStore } from "../../config/sessions.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
+import {
+  resolveModelAuthProfile,
+  validateModelAuthProfileCompatibility,
+} from "./directive-handling.auth-profile.js";
 import { resolveModelDirectiveSelection, type ModelDirectiveSelection } from "./model-selection.js";
 
 type ResetModelResult = {
   selection?: ModelDirectiveSelection;
   cleanedBody?: string;
+  errorText?: string;
 };
 
 function splitBody(body: string) {
@@ -60,18 +66,30 @@ function buildSelectionFromExplicit(params: {
 
 function applySelectionToSession(params: {
   selection: ModelDirectiveSelection;
+  profileOverride?: string;
+  profileOverrideSource?: "auto" | "user";
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
   storePath?: string;
 }) {
-  const { selection, sessionEntry, sessionStore, sessionKey, storePath } = params;
+  const {
+    selection,
+    profileOverride,
+    profileOverrideSource,
+    sessionEntry,
+    sessionStore,
+    sessionKey,
+    storePath,
+  } = params;
   if (!sessionEntry || !sessionStore || !sessionKey) {
     return;
   }
   const { updated } = applyModelOverrideToSessionEntry({
     entry: sessionEntry,
     selection,
+    profileOverride,
+    profileOverrideSource,
   });
   if (!updated) {
     return;
@@ -147,20 +165,26 @@ export async function applyResetModelOverride(params: {
     });
 
   let selection: ModelDirectiveSelection | undefined;
+  let profileOverride: string | undefined;
+  let profileOverrideSource: "auto" | "user" | undefined;
   let consumed = 0;
+  let rawProfile: string | undefined;
 
   if (providers.has(normalizeProviderId(first)) && second) {
-    const composite = `${normalizeProviderId(first)}/${second}`;
+    const [modelPart, profilePart] = second.split("@", 2);
+    const composite = `${normalizeProviderId(first)}/${modelPart}`;
     const resolved = resolveSelection(composite);
     if (resolved.selection) {
       selection = resolved.selection;
       consumed = 2;
+      rawProfile = profilePart?.trim() || undefined;
     }
   }
 
   if (!selection) {
+    const [modelPart, profilePart] = first.split("@", 2);
     selection = buildSelectionFromExplicit({
-      raw: first,
+      raw: modelPart,
       defaultProvider: params.defaultProvider,
       defaultModel: params.defaultModel,
       aliasIndex: params.aliasIndex,
@@ -168,16 +192,20 @@ export async function applyResetModelOverride(params: {
     });
     if (selection) {
       consumed = 1;
+      rawProfile = profilePart?.trim() || undefined;
     }
   }
 
   if (!selection) {
-    const resolved = resolveSelection(first);
-    const allowFuzzy = providers.has(normalizeProviderId(first)) || first.trim().length >= 6;
+    const [modelPart, profilePart] = first.split("@", 2);
+    const resolved = resolveSelection(modelPart);
+    const allowFuzzy =
+      providers.has(normalizeProviderId(modelPart)) || modelPart.trim().length >= 6;
     if (allowFuzzy) {
       selection = resolved.selection;
       if (selection) {
         consumed = 1;
+        rawProfile = profilePart?.trim() || undefined;
       }
     }
   }
@@ -187,11 +215,58 @@ export async function applyResetModelOverride(params: {
   }
 
   const cleanedBody = tokens.slice(consumed).join(" ").trim();
+  const agentDir = params.agentId ? resolveAgentDir(params.cfg, params.agentId) : undefined;
+  const resolvedProfile = resolveModelAuthProfile({
+    rawProfile,
+    provider: selection.provider,
+    cfg: params.cfg,
+    agentDir,
+    sessionEntry: params.sessionEntry,
+  });
+  if (resolvedProfile.error) {
+    const warningText = [`System: ${resolvedProfile.error}`, cleanedBody]
+      .filter(Boolean)
+      .join("\n\n");
+    params.sessionCtx.Body = warningText;
+    params.sessionCtx.BodyForAgent = warningText;
+    params.sessionCtx.BodyStripped = warningText;
+    params.sessionCtx.BodyForCommands = warningText;
+    params.sessionCtx.CommandBody = warningText;
+    params.sessionCtx.RawBody = warningText;
+    return { cleanedBody, errorText: resolvedProfile.error };
+  }
+  profileOverride = resolvedProfile.profileId;
+  profileOverrideSource = resolvedProfile.profileOverrideSource;
+  const compatibility = validateModelAuthProfileCompatibility({
+    provider: selection.provider,
+    model: selection.model,
+    profileId: profileOverride,
+    agentDir,
+  });
+  if (compatibility.error) {
+    const warningText = [`System: ${compatibility.error}`, cleanedBody]
+      .filter(Boolean)
+      .join("\n\n");
+    params.sessionCtx.Body = warningText;
+    params.sessionCtx.BodyForAgent = warningText;
+    params.sessionCtx.BodyStripped = warningText;
+    params.sessionCtx.BodyForCommands = warningText;
+    params.sessionCtx.CommandBody = warningText;
+    params.sessionCtx.RawBody = warningText;
+    return { cleanedBody, errorText: compatibility.error };
+  }
+
+  params.sessionCtx.Body = cleanedBody;
+  params.sessionCtx.BodyForAgent = cleanedBody;
   params.sessionCtx.BodyStripped = cleanedBody;
   params.sessionCtx.BodyForCommands = cleanedBody;
+  params.sessionCtx.CommandBody = cleanedBody;
+  params.sessionCtx.RawBody = cleanedBody;
 
   applySelectionToSession({
     selection,
+    profileOverride,
+    profileOverrideSource,
     sessionEntry: params.sessionEntry,
     sessionStore: params.sessionStore,
     sessionKey: params.sessionKey,

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -90,6 +90,7 @@ function applySelectionToSession(params: {
     selection,
     profileOverride,
     profileOverrideSource,
+    persistDefaultSelection: true,
   });
   if (!updated) {
     return;

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -12,6 +12,18 @@ function applyOpenAiSelection(entry: SessionEntry) {
   });
 }
 
+function applyOpenAiDefaultSelection(entry: SessionEntry) {
+  return applyModelOverrideToSessionEntry({
+    entry,
+    selection: {
+      provider: "openai",
+      model: "gpt-5.2",
+      isDefault: true,
+    },
+    persistDefaultSelection: true,
+  });
+}
+
 function expectRuntimeModelFieldsCleared(entry: SessionEntry, before: number) {
   expect(entry.providerOverride).toBe("openai");
   expect(entry.modelOverride).toBe("gpt-5.4");
@@ -147,5 +159,25 @@ describe("applyModelOverrideToSessionEntry", () => {
     });
     expect(withFlag.updated).toBe(true);
     expect(withFlagEntry.liveModelSwitchPending).toBe(true);
+  });
+
+  it("can persist an explicit default-model selection", () => {
+    const before = Date.now() - 5_000;
+    const entry: SessionEntry = {
+      sessionId: "sess-6",
+      updatedAt: before,
+      modelProvider: "openai",
+      model: "gpt-5.4",
+      contextTokens: 4_096,
+    };
+
+    const result = applyOpenAiDefaultSelection(entry);
+
+    expect(result.updated).toBe(true);
+    expect(entry.providerOverride).toBe("openai");
+    expect(entry.modelOverride).toBe("gpt-5.2");
+    expect(entry.modelProvider).toBeUndefined();
+    expect(entry.model).toBeUndefined();
+    expect(entry.contextTokens).toBeUndefined();
   });
 });

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -12,13 +12,15 @@ export function applyModelOverrideToSessionEntry(params: {
   profileOverride?: string;
   profileOverrideSource?: "auto" | "user";
   markLiveSwitchPending?: boolean;
+  persistDefaultSelection?: boolean;
 }): { updated: boolean } {
   const { entry, selection, profileOverride } = params;
   const profileOverrideSource = params.profileOverrideSource ?? "user";
+  const persistDefaultSelection = params.persistDefaultSelection === true;
   let updated = false;
   let selectionUpdated = false;
 
-  if (selection.isDefault) {
+  if (selection.isDefault && !persistDefaultSelection) {
     if (entry.providerOverride) {
       delete entry.providerOverride;
       updated = true;


### PR DESCRIPTION
## What changed

This keeps explicit `/model` and `/new` selections authoritative.

The branch does four focused things:

- persist explicit model selections even when they match the configured default model
- keep bare `/model <model>` and `/new <model>` on the current auth path instead of implicitly unpinning back to generic default resolution
- reject known unsupported Spark auth combinations up front and leave the current model/auth unchanged
- warn and suppress the reply if an explicit model selection is still executed on a different runtime model

## Why this is needed

The current behavior can claim a model switch succeeded even when the next turn still runs on another model.

In practice this showed up as:

- `/model spark` or `/new spark` saying the model switched, but the next real turn still running on `openai-codex/gpt-5.4`
- explicit selections that matched the configured default being persisted as "no override", which made later runtime selection ambiguous
- unsupported Spark auth paths falling through into confusing runtime behavior instead of failing clearly
- explicit Spark selections receiving a `gpt-5.4` reply instead of an error or warning

That makes `/model` and `/new` non-authoritative, which is exactly the opposite of what these commands need to mean.

## Root cause

- explicit default-model selections were being collapsed into cleared override state
- the current auth path was not preserved consistently for bare model switches
- runtime mismatch after an explicit selection could still deliver the fallback model's reply as if the switch had succeeded
- live selection code could still be influenced by stale runtime model state after a mismatch

## User impact

After this change:

- `/model <model>` and `/new <model>` keep the current auth path unless an explicit `@auth` override is provided
- explicit default selections stay explicit in session state
- unsupported `spark` auth paths fail early and keep the previous model/auth unchanged
- if the runtime still comes back on a different model than an explicit selection, OpenClaw warns instead of silently replying from the wrong model

## Validation

- `pnpm -C /tmp/openclaw-pr-fix test -- --run src/sessions/model-overrides.test.ts src/auto-reply/reply/session-reset-model.test.ts src/auto-reply/reply/directive-handling.model.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`
- repository commit hooks passed during commit, including `tsgo` and `lint`
