### PR TITLE
fix(model): resolve NON_PI_NATIVE provider config from models.json

### DIFF
--- a/src/agents/pi-embedded-runner/model.models-json-fallback.test.ts
+++ b/src/agents/pi-embedded-runner/model.models-json-fallback.test.ts
@@ -1,0 +1,225 @@
+import fs from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearModelsJsonProvidersCacheForTest } from "./model.js";
+
+// Mock pi-model-discovery to avoid pulling in the full PI SDK dependency chain.
+vi.mock("../pi-model-discovery.js", () => ({
+  discoverAuthStorage: vi.fn(() => ({ mocked: true })),
+  discoverModels: vi.fn(() => ({ find: vi.fn(() => null) })),
+}));
+
+vi.mock("./openrouter-model-capabilities.js", () => ({
+  getOpenRouterModelCapabilities: vi.fn(() => undefined),
+  loadOpenRouterModelCapabilities: vi.fn(async () => {}),
+}));
+
+import { discoverModels } from "../pi-model-discovery.js";
+import { resolveModel } from "./model.js";
+import { createProviderRuntimeTestMock } from "./model.provider-runtime.test-support.js";
+import { resetMockDiscoverModels } from "./model.test-harness.js";
+
+function createRuntimeHooks() {
+  return createProviderRuntimeTestMock({
+    handledDynamicProviders: [],
+  });
+}
+
+function resolveModelForTest(
+  provider: string,
+  modelId: string,
+  agentDir: string,
+  cfg?: Parameters<typeof resolveModel>[3],
+) {
+  return resolveModel(provider, modelId, agentDir, cfg, {
+    authStorage: { mocked: true } as never,
+    modelRegistry: discoverModels({ mocked: true } as never, agentDir),
+    runtimeHooks: createRuntimeHooks(),
+  });
+}
+
+describe("models.json provider config fallback", () => {
+  let agentDir: string;
+
+  beforeEach(() => {
+    agentDir = mkdtempSync(path.join(tmpdir(), "openclaw-test-models-json-"));
+    clearModelsJsonProvidersCacheForTest();
+    resetMockDiscoverModels(discoverModels);
+  });
+
+  afterEach(() => {
+    clearModelsJsonProvidersCacheForTest();
+    fs.rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  it("resolves provider config from models.json when absent from user config", () => {
+    const modelsJson = {
+      providers: {
+        kilocode: {
+          baseUrl: "https://api.kilo.ai/api/gateway/",
+          api: "openai-completions",
+          models: [
+            {
+              id: "kilocode/anthropic/claude-3.7-sonnet",
+              name: "Claude 3.7 Sonnet (Kilocode)",
+              contextWindow: 200000,
+              maxTokens: 8192,
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+            },
+          ],
+        },
+      },
+    };
+    fs.writeFileSync(path.join(agentDir, "models.json"), JSON.stringify(modelsJson));
+
+    // No kilocode in user config — should fall back to models.json.
+    const result = resolveModelForTest(
+      "kilocode",
+      "kilocode/anthropic/claude-3.7-sonnet",
+      agentDir,
+    );
+    expect(result.model).toBeDefined();
+    expect(result.model?.id).toBe("kilocode/anthropic/claude-3.7-sonnet");
+    expect(result.model?.provider).toBe("kilocode");
+  });
+
+  it("prefers user config over models.json", () => {
+    const modelsJson = {
+      providers: {
+        kilocode: {
+          baseUrl: "https://api.kilo.ai/api/gateway/",
+          api: "openai-completions",
+          models: [
+            {
+              id: "model-a",
+              name: "Model A",
+              contextWindow: 8000,
+              maxTokens: 4096,
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            },
+          ],
+        },
+      },
+    };
+    fs.writeFileSync(path.join(agentDir, "models.json"), JSON.stringify(modelsJson));
+
+    const cfg = {
+      models: {
+        providers: {
+          kilocode: {
+            baseUrl: "https://proxy.example.com/v1",
+            api: "openai-completions" as const,
+            models: [
+              {
+                id: "model-a",
+                name: "Model A Override",
+                contextWindow: 16000,
+                maxTokens: 8192,
+                reasoning: false,
+                input: ["text" as const],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const result = resolveModelForTest("kilocode", "model-a", agentDir, cfg);
+    expect(result.model).toBeDefined();
+    // Should use user config baseUrl, not models.json.
+    expect(result.model?.baseUrl).toBe("https://proxy.example.com/v1");
+  });
+
+  it("returns undefined when models.json does not exist", () => {
+    // No models.json written — should gracefully return undefined (no model).
+    const result = resolveModelForTest("kilocode", "kilocode/some-model", agentDir);
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBeDefined();
+  });
+
+  it("returns undefined when models.json is malformed", () => {
+    fs.writeFileSync(path.join(agentDir, "models.json"), "not-valid-json{{{");
+
+    const result = resolveModelForTest("kilocode", "kilocode/some-model", agentDir);
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBeDefined();
+  });
+
+  it("returns undefined when models.json has no providers key", () => {
+    fs.writeFileSync(path.join(agentDir, "models.json"), JSON.stringify({ other: "data" }));
+
+    const result = resolveModelForTest("kilocode", "kilocode/some-model", agentDir);
+    expect(result.model).toBeUndefined();
+  });
+
+  it("resolves normalized provider key from models.json", () => {
+    // Write with a differently cased key.
+    const modelsJson = {
+      providers: {
+        Kilocode: {
+          baseUrl: "https://api.kilo.ai/api/gateway/",
+          api: "openai-completions",
+          models: [
+            {
+              id: "test-model",
+              name: "Test",
+              contextWindow: 8000,
+              maxTokens: 4096,
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            },
+          ],
+        },
+      },
+    };
+    fs.writeFileSync(path.join(agentDir, "models.json"), JSON.stringify(modelsJson));
+
+    const result = resolveModelForTest("kilocode", "test-model", agentDir);
+    expect(result.model).toBeDefined();
+    expect(result.model?.id).toBe("test-model");
+  });
+
+  it("caches models.json reads across multiple resolution calls", () => {
+    const modelsJson = {
+      providers: {
+        kilocode: {
+          baseUrl: "https://api.kilo.ai/api/gateway/",
+          api: "openai-completions",
+          models: [
+            {
+              id: "model-a",
+              name: "A",
+              contextWindow: 8000,
+              maxTokens: 4096,
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            },
+          ],
+        },
+      },
+    };
+    fs.writeFileSync(path.join(agentDir, "models.json"), JSON.stringify(modelsJson));
+
+    const readSpy = vi.spyOn(fs, "readFileSync");
+
+    // Call twice — second call should use cache.
+    resolveModelForTest("kilocode", "model-a", agentDir);
+    resolveModelForTest("kilocode", "model-a", agentDir);
+
+    const modelsJsonReads = readSpy.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].endsWith("models.json"),
+    );
+    expect(modelsJsonReads.length).toBe(1);
+
+    readSpy.mockRestore();
+  });
+});

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -13,6 +15,7 @@ import {
   normalizeProviderResolvedModelWithPlugin,
 } from "../../plugins/provider-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/types.js";
+import { isRecord } from "../../utils.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
@@ -281,16 +284,59 @@ export { buildModelAliasLines };
 function resolveConfiguredProviderConfig(
   cfg: OpenClawConfig | undefined,
   provider: string,
+  agentDir?: string,
 ): InlineProviderConfig | undefined {
   const configuredProviders = cfg?.models?.providers;
-  if (!configuredProviders) {
+  if (configuredProviders) {
+    const exactProviderConfig = configuredProviders[provider];
+    if (exactProviderConfig) {
+      return exactProviderConfig;
+    }
+    const normalized = findNormalizedProviderValue(configuredProviders, provider);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  // Fall back to the generated models.json which contains implicit provider
+  // discovery results (e.g. kilocode, deepseek, ollama). These providers are
+  // NON_PI_NATIVE and may not appear in the user config but are written to
+  // models.json by ensureOpenClawModelsJson via implicit provider resolution.
+  return resolveModelsJsonProviderConfig(provider, agentDir);
+}
+
+/**
+ * Read provider config from the generated models.json file.
+ * This covers providers that were discovered via implicit provider resolution
+ * (e.g. env-var-backed providers like kilocode) but are not present in the
+ * user's openclaw.json config.
+ */
+function resolveModelsJsonProviderConfig(
+  provider: string,
+  agentDir?: string,
+): InlineProviderConfig | undefined {
+  const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
+  const modelsJsonPath = path.join(resolvedAgentDir, "models.json");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(modelsJsonPath, "utf8")) as unknown;
+  } catch {
     return undefined;
   }
-  const exactProviderConfig = configuredProviders[provider];
-  if (exactProviderConfig) {
-    return exactProviderConfig;
+  if (!isRecord(parsed) || !isRecord(parsed.providers)) {
+    return undefined;
   }
-  return findNormalizedProviderValue(configuredProviders, provider);
+  const providers = parsed.providers;
+  const exact = providers[provider];
+  if (isRecord(exact)) {
+    return exact as unknown as InlineProviderConfig;
+  }
+  // Try normalized lookup.
+  for (const [key, value] of Object.entries(providers)) {
+    if (normalizeProviderId(key) === normalizeProviderId(provider) && isRecord(value)) {
+      return value as unknown as InlineProviderConfig;
+    }
+  }
+  return undefined;
 }
 
 function applyConfiguredProviderOverrides(params: {
@@ -436,7 +482,7 @@ function resolveExplicitModelWithRegistry(params: {
   if (shouldSuppressBuiltInModel({ provider, id: modelId })) {
     return { kind: "suppressed" };
   }
-  const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
+  const providerConfig = resolveConfiguredProviderConfig(cfg, provider, agentDir);
   const inlineMatch = findInlineModelMatch({
     providers: cfg?.models?.providers ?? {},
     provider,
@@ -508,7 +554,7 @@ function resolvePluginDynamicModelWithRegistry(params: {
 }): Model<Api> | undefined {
   const { provider, modelId, modelRegistry, cfg, agentDir } = params;
   const runtimeHooks = params.runtimeHooks ?? DEFAULT_PROVIDER_RUNTIME_HOOKS;
-  const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
+  const providerConfig = resolveConfiguredProviderConfig(cfg, provider, agentDir);
   const pluginDynamicModel = runtimeHooks.runProviderDynamicModel({
     provider,
     config: cfg,
@@ -549,7 +595,7 @@ function resolveConfiguredFallbackModel(params: {
   runtimeHooks?: ProviderRuntimeHooks;
 }): Model<Api> | undefined {
   const { provider, modelId, cfg, agentDir, runtimeHooks } = params;
-  const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
+  const providerConfig = resolveConfiguredProviderConfig(cfg, provider, agentDir);
   const configuredModel = providerConfig?.models?.find((candidate) => candidate.id === modelId);
   const providerHeaders = sanitizeModelHeaders(providerConfig?.headers, {
     stripSecretRefMarkers: true,
@@ -723,7 +769,7 @@ export async function resolveModelAsync(
       modelRegistry,
     };
   }
-  const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
+  const providerConfig = resolveConfiguredProviderConfig(cfg, provider, resolvedAgentDir);
   const resolveDynamicAttempt = async (attemptOptions?: { clearHookCache?: boolean }) => {
     if (attemptOptions?.clearHookCache) {
       runtimeHooks.clearProviderRuntimeHookCache();

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -304,6 +304,41 @@ function resolveConfiguredProviderConfig(
   return resolveModelsJsonProviderConfig(provider, agentDir);
 }
 
+// ---------------------------------------------------------------------------
+// models.json provider config fallback
+// ---------------------------------------------------------------------------
+
+/**
+ * Cached parsed providers from models.json, keyed by resolved agent dir.
+ * Avoids repeated synchronous disk reads when resolveConfiguredProviderConfig
+ * is called multiple times within a single model resolution pass.
+ */
+const modelsJsonProvidersCache = new Map<string, Record<string, unknown> | null>();
+
+/** Exported for testing only — clears the models.json provider cache. */
+export function clearModelsJsonProvidersCacheForTest(): void {
+  modelsJsonProvidersCache.clear();
+}
+
+function loadModelsJsonProviders(agentDir?: string): Record<string, unknown> | null {
+  const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
+  const cached = modelsJsonProvidersCache.get(resolvedAgentDir);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const modelsJsonPath = path.join(resolvedAgentDir, "models.json");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(modelsJsonPath, "utf8")) as unknown;
+  } catch {
+    modelsJsonProvidersCache.set(resolvedAgentDir, null);
+    return null;
+  }
+  const result = isRecord(parsed) && isRecord(parsed.providers) ? parsed.providers : null;
+  modelsJsonProvidersCache.set(resolvedAgentDir, result);
+  return result;
+}
+
 /**
  * Read provider config from the generated models.json file.
  * This covers providers that were discovered via implicit provider resolution
@@ -314,18 +349,10 @@ function resolveModelsJsonProviderConfig(
   provider: string,
   agentDir?: string,
 ): InlineProviderConfig | undefined {
-  const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
-  const modelsJsonPath = path.join(resolvedAgentDir, "models.json");
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(fs.readFileSync(modelsJsonPath, "utf8")) as unknown;
-  } catch {
+  const providers = loadModelsJsonProviders(agentDir);
+  if (!providers) {
     return undefined;
   }
-  if (!isRecord(parsed) || !isRecord(parsed.providers)) {
-    return undefined;
-  }
-  const providers = parsed.providers;
   const exact = providers[provider];
   if (isRecord(exact)) {
     return exact as unknown as InlineProviderConfig;
@@ -337,6 +364,29 @@ function resolveModelsJsonProviderConfig(
     }
   }
   return undefined;
+}
+
+/**
+ * Merge user-config providers with models.json providers so that inline model
+ * lookups can also find entries from implicitly discovered providers.
+ */
+function mergedProviders(
+  cfg: OpenClawConfig | undefined,
+  agentDir?: string,
+): Record<string, InlineProviderConfig> {
+  const userProviders = (cfg?.models?.providers ?? {}) as Record<string, InlineProviderConfig>;
+  const modelsJsonProviders = loadModelsJsonProviders(agentDir);
+  if (!modelsJsonProviders) {
+    return userProviders;
+  }
+  // User config takes precedence; models.json fills in missing providers.
+  const merged: Record<string, InlineProviderConfig> = { ...userProviders };
+  for (const [key, value] of Object.entries(modelsJsonProviders)) {
+    if (!merged[key] && isRecord(value)) {
+      merged[key] = value as unknown as InlineProviderConfig;
+    }
+  }
+  return merged;
 }
 
 function applyConfiguredProviderOverrides(params: {
@@ -484,7 +534,7 @@ function resolveExplicitModelWithRegistry(params: {
   }
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider, agentDir);
   const inlineMatch = findInlineModelMatch({
-    providers: cfg?.models?.providers ?? {},
+    providers: mergedProviders(cfg, agentDir),
     provider,
     modelId,
   });
@@ -522,7 +572,7 @@ function resolveExplicitModelWithRegistry(params: {
     };
   }
 
-  const providers = cfg?.models?.providers ?? {};
+  const providers = mergedProviders(cfg, agentDir);
   const fallbackInlineMatch = findInlineModelMatch({
     providers,
     provider,


### PR DESCRIPTION
## Summary

Fixes #41870

`resolveConfiguredProviderConfig()` only checked the user config (`openclaw.json`) for provider entries. Providers discovered via implicit resolution — such as **kilocode**, **deepseek**, and **ollama** — are written to `models.json` by `ensureOpenClawModelsJson` but are not present in the user config object (`cfg.models.providers`).

This caused `resolveConfiguredFallbackModel()` to return `undefined` for these providers, making all internal routing (cron jobs, subagents, heartbeat checks) fail with `model_not_found` — even though:
- The API key is set via environment variable (e.g. `KILOCODE_API_KEY`)
- Direct HTTP passthrough requests succeed (different code path)
- The provider was correctly discovered and written to `models.json`

## Root cause

Two separate credential/config resolution paths exist:

1. **HTTP passthrough** (`resolveApiKeyForProvider` → `resolveEnvApiKey`) — checks env vars. Works.
2. **Internal model resolution** (`resolveConfiguredProviderConfig` → `cfg.models.providers`) — only checks user config. The generated `models.json` (which contains the implicit discovery results) was never consulted.

## Fix

`resolveConfiguredProviderConfig()` now falls back to reading provider config from the generated `models.json` when the user config doesn't have a matching entry. This is the same file that `ensureOpenClawModelsJson` writes after implicit provider discovery, closing the gap between the two resolution paths.

The fallback uses a synchronous `fs.readFileSync` with a try/catch (consistent with other models.json reads in the codebase) and only triggers when the user config lookup returns nothing.

## Impact

- Kilocode, DeepSeek, Ollama, and any other `NON_PI_NATIVE_MODEL_PROVIDERS` with env-var-backed credentials now resolve correctly for cron jobs, subagents, and heartbeat checks
- No change for providers already in the user config
- No change for the HTTP passthrough path (already worked)
- Backwards compatible — the models.json fallback is additive

## Test plan

- [ ] Set `KILOCODE_API_KEY` env var, configure a kilocode model for cron/subagent use
- [ ] Verify `openclaw models list --provider kilocode` no longer shows `configured,missing`
- [ ] Verify cron jobs using kilocode models run without `model_not_found`
- [ ] Verify existing providers (openai, anthropic, etc.) still resolve from user config as before

Cross-ref: Kilo-Org/kilocode#6835